### PR TITLE
Move settings button to bottom of activity bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double-click a connection to connect directly
 
 ### Changed
+- Moved settings button to the bottom of the activity bar, matching VS Code's layout
 - Panel layout refactored from flat array to recursive tree for flexible split arrangements
 - Connection and folder context menus now open on right-click instead of left-click
 - Shell type dropdown in connection editor now only shows shells available on the current platform

--- a/src/components/ActivityBar/ActivityBar.css
+++ b/src/components/ActivityBar/ActivityBar.css
@@ -16,6 +16,13 @@
   width: 100%;
 }
 
+.activity-bar__bottom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
 .activity-bar__item {
   position: relative;
   width: 100%;

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -3,9 +3,12 @@ import { useAppStore, SidebarView } from "@/store/appStore";
 import { ActivityBarItem } from "./ActivityBarItem";
 import "./ActivityBar.css";
 
-const ITEMS: { view: SidebarView; icon: typeof Network; label: string }[] = [
+const TOP_ITEMS: { view: SidebarView; icon: typeof Network; label: string }[] = [
   { view: "connections", icon: Network, label: "Connections" },
   { view: "files", icon: FolderOpen, label: "File Browser" },
+];
+
+const BOTTOM_ITEMS: { view: SidebarView; icon: typeof Network; label: string }[] = [
   { view: "settings", icon: Settings, label: "Settings" },
 ];
 
@@ -17,7 +20,18 @@ export function ActivityBar() {
   return (
     <div className="activity-bar">
       <div className="activity-bar__top">
-        {ITEMS.map((item) => (
+        {TOP_ITEMS.map((item) => (
+          <ActivityBarItem
+            key={item.view}
+            icon={item.icon}
+            label={item.label}
+            isActive={sidebarView === item.view && !sidebarCollapsed}
+            onClick={() => setSidebarView(item.view)}
+          />
+        ))}
+      </div>
+      <div className="activity-bar__bottom">
+        {BOTTOM_ITEMS.map((item) => (
           <ActivityBarItem
             key={item.view}
             icon={item.icon}


### PR DESCRIPTION
## Summary
- Split activity bar items into top (Connections, File Browser) and bottom (Settings) sections
- Added `.activity-bar__bottom` CSS class; existing `justify-content: space-between` on the parent handles the spacing
- Updated CHANGELOG.md

## Test plan
- [ ] `npm run build` passes without errors
- [ ] Settings gear icon appears at the bottom of the activity bar
- [ ] Connections and File Browser icons remain at the top
- [ ] Clicking the settings icon still toggles the sidebar settings view

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)