### PR TITLE
feat(ui): open settings as a tab instead of sidebar view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double-click a connection to connect directly
 
 ### Changed
+- Settings button now opens a Settings tab instead of a sidebar view
 - Moved settings button to the bottom of the activity bar, matching VS Code's layout
 - Panel layout refactored from flat array to recursive tree for flexible split arrangements
 - Connection and folder context menus now open on right-click instead of left-click

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -8,14 +8,11 @@ const TOP_ITEMS: { view: SidebarView; icon: typeof Network; label: string }[] = 
   { view: "files", icon: FolderOpen, label: "File Browser" },
 ];
 
-const BOTTOM_ITEMS: { view: SidebarView; icon: typeof Network; label: string }[] = [
-  { view: "settings", icon: Settings, label: "Settings" },
-];
-
 export function ActivityBar() {
   const sidebarView = useAppStore((s) => s.sidebarView);
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
   const setSidebarView = useAppStore((s) => s.setSidebarView);
+  const openSettingsTab = useAppStore((s) => s.openSettingsTab);
 
   return (
     <div className="activity-bar">
@@ -31,15 +28,12 @@ export function ActivityBar() {
         ))}
       </div>
       <div className="activity-bar__bottom">
-        {BOTTOM_ITEMS.map((item) => (
-          <ActivityBarItem
-            key={item.view}
-            icon={item.icon}
-            label={item.label}
-            isActive={sidebarView === item.view && !sidebarCollapsed}
-            onClick={() => setSidebarView(item.view)}
-          />
-        ))}
+        <ActivityBarItem
+          icon={Settings}
+          label="Settings"
+          isActive={false}
+          onClick={openSettingsTab}
+        />
       </div>
     </div>
   );

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -7,7 +7,6 @@ import "./Sidebar.css";
 const VIEW_TITLES = {
   connections: "Connections",
   files: "File Browser",
-  settings: "Settings",
 } as const;
 
 export function Sidebar() {
@@ -29,9 +28,6 @@ export function Sidebar() {
             : <ConnectionList />
         )}
         {sidebarView === "files" && <FileBrowser />}
-        {sidebarView === "settings" && (
-          <div className="sidebar__section">Settings (coming soon)</div>
-        )}
       </div>
     </div>
   );

--- a/src/components/SplitView/SplitView.css
+++ b/src/components/SplitView/SplitView.css
@@ -36,3 +36,20 @@
 .split-view__resize-handle[data-resize-handle-active] {
   background-color: var(--resize-handle-hover-color);
 }
+
+.settings-panel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-panel--hidden {
+  display: none;
+}
+
+.settings-panel__content {
+  color: var(--text-disabled);
+  font-size: var(--font-size-md);
+}

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -9,7 +9,7 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { Terminal as TerminalIcon, Wifi, Cable, Globe } from "lucide-react";
+import { Terminal as TerminalIcon, Wifi, Cable, Globe, Settings as SettingsIcon } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { PanelNode, LeafPanel, TerminalTab, ConnectionType, DropEdge } from "@/types/terminal";
 import { getAllLeaves, findLeafByTab } from "@/utils/panelTree";
@@ -195,13 +195,20 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
             No terminals open. Use the toolbar or double-click a connection.
           </div>
         )}
-        {panel.tabs.map((tab) => (
-          <TerminalSlot
-            key={tab.id}
-            tabId={tab.id}
-            isVisible={tab.id === panel.activeTabId}
-          />
-        ))}
+        {panel.tabs.map((tab) =>
+          tab.contentType === "settings" ? (
+            <SettingsPanel
+              key={tab.id}
+              isVisible={tab.id === panel.activeTabId}
+            />
+          ) : (
+            <TerminalSlot
+              key={tab.id}
+              tabId={tab.id}
+              isVisible={tab.id === panel.activeTabId}
+            />
+          )
+        )}
         {activeDragTab && (
           <PanelDropZone panelId={panel.id} hideEdges={hideEdges} />
         )}
@@ -255,8 +262,16 @@ function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean 
   );
 }
 
+function SettingsPanel({ isVisible }: { isVisible: boolean }) {
+  return (
+    <div className={`settings-panel ${isVisible ? "" : "settings-panel--hidden"}`}>
+      <div className="settings-panel__content">No Setting Yet!</div>
+    </div>
+  );
+}
+
 function TabDragOverlay({ tab }: { tab: TerminalTab }) {
-  const Icon = TYPE_ICONS[tab.connectionType];
+  const Icon = tab.contentType === "settings" ? SettingsIcon : TYPE_ICONS[tab.connectionType];
   return (
     <div className="tab tab--drag-overlay">
       <Icon size={14} className="tab__icon" />

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -1,6 +1,6 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { X, Terminal, Wifi, Cable, Globe } from "lucide-react";
+import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { ConnectionType } from "@/types/terminal";
 
@@ -33,7 +33,7 @@ export function Tab({ tab, onActivate, onClose }: TabProps) {
     opacity: isDragging ? 0.3 : 1,
   };
 
-  const Icon = TYPE_ICONS[tab.connectionType];
+  const Icon = tab.contentType === "settings" ? SettingsIcon : TYPE_ICONS[tab.connectionType];
 
   return (
     <div

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -82,7 +82,9 @@ export function TerminalView() {
 function TerminalHost() {
   const rootPanel = useAppStore((s) => s.rootPanel);
   const allTabs: TerminalTab[] = useMemo(() => {
-    return getAllLeaves(rootPanel).flatMap((leaf) => leaf.tabs);
+    return getAllLeaves(rootPanel)
+      .flatMap((leaf) => leaf.tabs)
+      .filter((tab) => tab.contentType === "terminal");
   }, [rootPanel]);
 
   return (

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -4,6 +4,8 @@ export type ShellType = "zsh" | "bash" | "cmd" | "powershell" | "gitbash";
 
 export type ConnectionType = "local" | "ssh" | "telnet" | "serial";
 
+export type TabContentType = "terminal" | "settings";
+
 export interface LocalShellConfig {
   shellType: ShellType;
 }
@@ -42,6 +44,7 @@ export interface TerminalTab {
   sessionId: SessionId | null;
   title: string;
   connectionType: ConnectionType;
+  contentType: TabContentType;
   config: ConnectionConfig;
   panelId: string;
   isActive: boolean;


### PR DESCRIPTION
## Summary
- Settings button in the activity bar now opens a dedicated **Settings tab** that behaves like any terminal tab (draggable, closable, appears in tab bar) but displays "No Setting Yet!" placeholder content
- Only one settings tab can exist at a time — clicking the button again reactivates the existing tab
- Introduces `TabContentType` (`"terminal" | "settings"`) on `TerminalTab` to distinguish content types without polluting `ConnectionType` which flows into the Rust backend

Closes #3

## Test plan
- [ ] Click Settings → a "Settings" tab opens with "No Setting Yet!" content
- [ ] Click Settings again → reactivates existing settings tab (no duplicate)
- [ ] Close the settings tab → it's removed like any other tab
- [ ] Drag the settings tab between panels → works with correct Settings icon
- [ ] Connections and File Browser sidebar views still work normally
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)