### PR TITLE
feat(ui): move import/export to settings gear dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double-click a connection to connect directly
 
 ### Changed
+- Moved Import/Export connections from connection list toolbar to the Settings gear dropdown menu
 - Settings button now opens a Settings tab instead of a sidebar view
 - Moved settings button to the bottom of the activity bar, matching VS Code's layout
 - Panel layout refactored from flat array to recursive tree for flexible split arrangements

--- a/src/components/ActivityBar/ActivityBar.css
+++ b/src/components/ActivityBar/ActivityBar.css
@@ -50,3 +50,39 @@
   width: 2px;
   background-color: var(--activity-bar-indicator);
 }
+
+/* Settings dropdown menu */
+.settings-menu__content {
+  min-width: 180px;
+  background-color: var(--bg-dropdown);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-xs) 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+}
+
+.settings-menu__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  outline: none;
+}
+
+.settings-menu__item:hover,
+.settings-menu__item[data-highlighted] {
+  background-color: var(--accent-color);
+  color: #ffffff;
+}
+
+.settings-menu__separator {
+  height: 1px;
+  background-color: var(--border-primary);
+  margin: var(--spacing-xs) 0;
+}

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -1,4 +1,9 @@
-import { Network, FolderOpen, Settings } from "lucide-react";
+import { useCallback } from "react";
+import { Network, FolderOpen, Settings, Download, Upload } from "lucide-react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { save, open } from "@tauri-apps/plugin-dialog";
+import { writeTextFile, readTextFile } from "@tauri-apps/plugin-fs";
+import { exportConnections, importConnections } from "@/services/storage";
 import { useAppStore, SidebarView } from "@/store/appStore";
 import { ActivityBarItem } from "./ActivityBarItem";
 import "./ActivityBar.css";
@@ -13,6 +18,36 @@ export function ActivityBar() {
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
   const setSidebarView = useAppStore((s) => s.setSidebarView);
   const openSettingsTab = useAppStore((s) => s.openSettingsTab);
+  const loadFromBackend = useAppStore((s) => s.loadFromBackend);
+
+  const handleExport = useCallback(async () => {
+    try {
+      const json = await exportConnections();
+      const filePath = await save({
+        defaultPath: "termihub-connections.json",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (!filePath) return;
+      await writeTextFile(filePath, json);
+    } catch (err) {
+      console.error("Failed to export connections:", err);
+    }
+  }, []);
+
+  const handleImport = useCallback(async () => {
+    try {
+      const filePath = await open({
+        multiple: false,
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (!filePath) return;
+      const json = await readTextFile(filePath);
+      await importConnections(json);
+      await loadFromBackend();
+    } catch (err) {
+      console.error("Failed to import connections:", err);
+    }
+  }, [loadFromBackend]);
 
   return (
     <div className="activity-bar">
@@ -28,12 +63,48 @@ export function ActivityBar() {
         ))}
       </div>
       <div className="activity-bar__bottom">
-        <ActivityBarItem
-          icon={Settings}
-          label="Settings"
-          isActive={false}
-          onClick={openSettingsTab}
-        />
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <button
+              className="activity-bar__item"
+              title="Settings"
+              aria-label="Settings"
+            >
+              <Settings size={24} strokeWidth={1.5} />
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              className="settings-menu__content"
+              side="right"
+              align="end"
+              sideOffset={4}
+            >
+              <DropdownMenu.Item
+                className="settings-menu__item"
+                onSelect={openSettingsTab}
+              >
+                <Settings size={14} />
+                Settings
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator className="settings-menu__separator" />
+              <DropdownMenu.Item
+                className="settings-menu__item"
+                onSelect={handleImport}
+              >
+                <Upload size={14} />
+                Import Connections
+              </DropdownMenu.Item>
+              <DropdownMenu.Item
+                className="settings-menu__item"
+                onSelect={handleExport}
+              >
+                <Download size={14} />
+                Export Connections
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
       </div>
     </div>
   );

--- a/src/components/Settings/SettingsPanel.css
+++ b/src/components/Settings/SettingsPanel.css
@@ -1,0 +1,16 @@
+.settings-panel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-panel--hidden {
+  display: none;
+}
+
+.settings-panel__content {
+  color: var(--text-disabled);
+  font-size: var(--font-size-md);
+}

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -1,0 +1,16 @@
+import "./SettingsPanel.css";
+
+interface SettingsPanelProps {
+  isVisible: boolean;
+}
+
+/**
+ * Settings tab content.
+ */
+export function SettingsPanel({ isVisible }: SettingsPanelProps) {
+  return (
+    <div className={`settings-panel ${isVisible ? "" : "settings-panel--hidden"}`}>
+      <div className="settings-panel__content">No Setting Yet!</div>
+    </div>
+  );
+}

--- a/src/components/Settings/index.ts
+++ b/src/components/Settings/index.ts
@@ -2,3 +2,4 @@ export { ConnectionSettings } from "./ConnectionSettings";
 export { SshSettings } from "./SshSettings";
 export { SerialSettings } from "./SerialSettings";
 export { TelnetSettings } from "./TelnetSettings";
+export { SettingsPanel } from "./SettingsPanel";

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -25,17 +25,12 @@ import {
   Pencil,
   Trash2,
   Copy,
-  Download,
-  Upload,
   Check,
   X,
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionType } from "@/types/terminal";
 import { SavedConnection, ConnectionFolder } from "@/types/connection";
-import { exportConnections, importConnections } from "@/services/storage";
-import { save, open } from "@tauri-apps/plugin-dialog";
-import { writeTextFile, readTextFile } from "@tauri-apps/plugin-fs";
 import "./ConnectionList.css";
 
 const TYPE_ICONS: Record<ConnectionType, typeof Terminal> = {
@@ -307,7 +302,6 @@ export function ConnectionList() {
   const deleteConnection = useAppStore((s) => s.deleteConnection);
   const deleteFolder = useAppStore((s) => s.deleteFolder);
   const addFolder = useAppStore((s) => s.addFolder);
-  const loadFromBackend = useAppStore((s) => s.loadFromBackend);
   const duplicateConnection = useAppStore((s) => s.duplicateConnection);
   const moveConnectionToFolder = useAppStore((s) => s.moveConnectionToFolder);
 
@@ -374,35 +368,6 @@ export function ConnectionList() {
     [setEditingConnection]
   );
 
-  const handleExport = useCallback(async () => {
-    try {
-      const json = await exportConnections();
-      const filePath = await save({
-        defaultPath: "termihub-connections.json",
-        filters: [{ name: "JSON", extensions: ["json"] }],
-      });
-      if (!filePath) return;
-      await writeTextFile(filePath, json);
-    } catch (err) {
-      console.error("Failed to export connections:", err);
-    }
-  }, []);
-
-  const handleImport = useCallback(async () => {
-    try {
-      const filePath = await open({
-        multiple: false,
-        filters: [{ name: "JSON", extensions: ["json"] }],
-      });
-      if (!filePath) return;
-      const json = await readTextFile(filePath);
-      await importConnections(json);
-      await loadFromBackend();
-    } catch (err) {
-      console.error("Failed to import connections:", err);
-    }
-  }, [loadFromBackend]);
-
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const conn = event.active.data.current?.connection as SavedConnection | undefined;
     setDraggingConnection(conn ?? null);
@@ -432,20 +397,6 @@ export function ConnectionList() {
   return (
     <div className="connection-list">
       <div className="connection-list__header">
-        <button
-          className="connection-list__add-btn"
-          onClick={handleImport}
-          title="Import Connections"
-        >
-          <Upload size={16} />
-        </button>
-        <button
-          className="connection-list__add-btn"
-          onClick={handleExport}
-          title="Export Connections"
-        >
-          <Download size={16} />
-        </button>
         <button
           className="connection-list__add-btn"
           onClick={() => setCreatingFolder(true)}

--- a/src/components/SplitView/SplitView.css
+++ b/src/components/SplitView/SplitView.css
@@ -37,19 +37,3 @@
   background-color: var(--resize-handle-hover-color);
 }
 
-.settings-panel {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.settings-panel--hidden {
-  display: none;
-}
-
-.settings-panel__content {
-  color: var(--text-disabled);
-  font-size: var(--font-size-md);
-}

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -15,6 +15,7 @@ import { PanelNode, LeafPanel, TerminalTab, ConnectionType, DropEdge } from "@/t
 import { getAllLeaves, findLeafByTab } from "@/utils/panelTree";
 import { useTerminalRegistry } from "@/components/Terminal/TerminalRegistry";
 import { TabBar } from "@/components/Terminal/TabBar";
+import { SettingsPanel } from "@/components/Settings";
 import { PanelDropZone } from "./PanelDropZone";
 import "./SplitView.css";
 
@@ -259,14 +260,6 @@ function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean 
       ref={slotRef}
       className={`terminal-container ${isVisible ? "" : "terminal-container--hidden"}`}
     />
-  );
-}
-
-function SettingsPanel({ isVisible }: { isVisible: boolean }) {
-  return (
-    <div className={`settings-panel ${isVisible ? "" : "settings-panel--hidden"}`}>
-      <div className="settings-panel__content">No Setting Yet!</div>
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Moved Import/Export connection buttons from the connection list toolbar to a dropdown menu on the Settings gear button in the activity bar
- Clicking the gear now shows a Radix DropdownMenu with "Settings" (opens settings tab), a separator, then "Import Connections" and "Export Connections"
- Extracted the inline `SettingsPanel` from `SplitView.tsx` into its own component under `src/components/Settings/`

## Test plan
- [ ] Click the Settings gear in the activity bar → dropdown menu appears with three items
- [ ] Click "Settings" → settings tab opens
- [ ] Click "Import Connections" → file open dialog, imports JSON, connection list refreshes
- [ ] Click "Export Connections" → file save dialog, saves JSON
- [ ] Connection list toolbar no longer has Import/Export buttons (only New Folder and New Connection remain)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)