### PR TITLE
feat(ui): add clear terminal via tab context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Clear terminal content via right-click context menu on tabs
 - Status bar at the bottom of the application window
 - Cross-panel tab drag-and-drop: move tabs between terminal panels by dragging
 - Split-by-drop: drag a tab to the edge of a panel to create horizontal or vertical splits

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -1,6 +1,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon } from "lucide-react";
+import * as ContextMenu from "@radix-ui/react-context-menu";
+import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon, Eraser } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { ConnectionType } from "@/types/terminal";
 
@@ -15,9 +16,10 @@ interface TabProps {
   tab: TerminalTab;
   onActivate: () => void;
   onClose: () => void;
+  onClear?: () => void;
 }
 
-export function Tab({ tab, onActivate, onClose }: TabProps) {
+export function Tab({ tab, onActivate, onClose, onClear }: TabProps) {
   const {
     attributes,
     listeners,
@@ -34,8 +36,9 @@ export function Tab({ tab, onActivate, onClose }: TabProps) {
   };
 
   const Icon = tab.contentType === "settings" ? SettingsIcon : TYPE_ICONS[tab.connectionType];
+  const isTerminalTab = tab.contentType !== "settings";
 
-  return (
+  const tabElement = (
     <div
       ref={setNodeRef}
       style={style}
@@ -57,5 +60,27 @@ export function Tab({ tab, onActivate, onClose }: TabProps) {
         <X size={14} />
       </button>
     </div>
+  );
+
+  if (!isTerminalTab) {
+    return tabElement;
+  }
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>
+        {tabElement}
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content className="context-menu__content">
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={() => onClear?.()}
+          >
+            <Eraser size={14} /> Clear Terminal
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
   );
 }

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -4,6 +4,7 @@ import {
 } from "@dnd-kit/sortable";
 import { useAppStore } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
+import { useTerminalRegistry } from "./TerminalRegistry";
 import { Tab } from "./Tab";
 import "./TabBar.css";
 
@@ -15,6 +16,7 @@ interface TabBarProps {
 export function TabBar({ panelId, tabs }: TabBarProps) {
   const setActiveTab = useAppStore((s) => s.setActiveTab);
   const closeTab = useAppStore((s) => s.closeTab);
+  const { clearTerminal } = useTerminalRegistry();
 
   return (
     <div className="tab-bar">
@@ -29,6 +31,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               tab={tab}
               onActivate={() => setActiveTab(tab.id, panelId)}
               onClose={() => closeTab(tab.id, panelId)}
+              onClear={() => clearTerminal(tab.id)}
             />
           ))}
         </div>

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -95,9 +95,6 @@ export function Terminal({ tabId, config, isVisible }: TerminalProps) {
     // Park the element so xterm.open() has a DOM parent
     parkingRef.current?.appendChild(el);
 
-    // Register with the portal registry
-    register(tabId, el);
-
     const xterm = new XTerm({
       theme: {
         background: "#1e1e1e",
@@ -137,6 +134,9 @@ export function Terminal({ tabId, config, isVisible }: TerminalProps) {
     xterm.unicode.activeVersion = "11";
 
     xterm.open(el);
+
+    // Register element and xterm instance with the portal registry
+    register(tabId, el, xterm);
 
     // Initial fit (may fail since element starts in parking)
     try {


### PR DESCRIPTION
## Summary
- Adds a right-click context menu on terminal tabs with a "Clear Terminal" action
- Extends the TerminalRegistry to store xterm instances, enabling `clearTerminal(tabId)` via `xterm.clear()`
- Settings tabs show no context menu; only terminal tabs (local, SSH, serial, telnet) get the menu

## Test plan
- [ ] Right-click a terminal tab → context menu with "Clear Terminal" appears
- [ ] Click "Clear Terminal" → terminal scrollback is cleared
- [ ] Right-click the Settings tab → no context menu appears
- [ ] Drag-and-drop tabs still works correctly
- [ ] `npm run build` passes with no errors

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)