### PR TITLE
feat(ui): add save terminal content to file via tab context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Save terminal content to file via right-click context menu on tabs
 - Clear terminal content via right-click context menu on tabs
 - Status bar at the bottom of the application window
 - Cross-panel tab drag-and-drop: move tabs between terminal panels by dragging

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -1,7 +1,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import * as ContextMenu from "@radix-ui/react-context-menu";
-import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon, Eraser } from "lucide-react";
+import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon, Eraser, FileDown } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { ConnectionType } from "@/types/terminal";
 
@@ -17,9 +17,10 @@ interface TabProps {
   onActivate: () => void;
   onClose: () => void;
   onClear?: () => void;
+  onSave?: () => void;
 }
 
-export function Tab({ tab, onActivate, onClose, onClear }: TabProps) {
+export function Tab({ tab, onActivate, onClose, onClear, onSave }: TabProps) {
   const {
     attributes,
     listeners,
@@ -73,6 +74,12 @@ export function Tab({ tab, onActivate, onClose, onClear }: TabProps) {
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
         <ContextMenu.Content className="context-menu__content">
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={() => onSave?.()}
+          >
+            <FileDown size={14} /> Save to File
+          </ContextMenu.Item>
           <ContextMenu.Item
             className="context-menu__item"
             onSelect={() => onClear?.()}

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -16,7 +16,7 @@ interface TabBarProps {
 export function TabBar({ panelId, tabs }: TabBarProps) {
   const setActiveTab = useAppStore((s) => s.setActiveTab);
   const closeTab = useAppStore((s) => s.closeTab);
-  const { clearTerminal } = useTerminalRegistry();
+  const { clearTerminal, saveTerminalToFile } = useTerminalRegistry();
 
   return (
     <div className="tab-bar">
@@ -32,6 +32,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               onActivate={() => setActiveTab(tab.id, panelId)}
               onClose={() => closeTab(tab.id, panelId)}
               onClear={() => clearTerminal(tab.id)}
+              onSave={() => saveTerminalToFile(tab.id)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Adds a "Save to File" option to the terminal tab right-click context menu
- Extracts the full xterm buffer content (trimming trailing empty lines) and writes it to a user-chosen file via the native save dialog
- Default filename is `terminal-output.txt`; cancelling the dialog is a no-op

## Test plan
- [ ] Right-click a terminal tab → context menu shows "Save to File" above "Clear Terminal"
- [ ] Click "Save to File" → native save dialog opens with default filename `terminal-output.txt`
- [ ] Choose a location → file is written with the terminal's text content
- [ ] Cancel the dialog → nothing happens
- [ ] Settings tab still has no context menu

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)