### PR TITLE
feat(ui): add copy terminal content to clipboard via tab context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Copy terminal content to clipboard via right-click context menu on tabs
 - Save terminal content to file via right-click context menu on tabs
 - Clear terminal content via right-click context menu on tabs
 - Status bar at the bottom of the application window

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -1,7 +1,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import * as ContextMenu from "@radix-ui/react-context-menu";
-import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon, Eraser, FileDown } from "lucide-react";
+import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon, Eraser, FileDown, ClipboardCopy } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { ConnectionType } from "@/types/terminal";
 
@@ -18,9 +18,10 @@ interface TabProps {
   onClose: () => void;
   onClear?: () => void;
   onSave?: () => void;
+  onCopyToClipboard?: () => void;
 }
 
-export function Tab({ tab, onActivate, onClose, onClear, onSave }: TabProps) {
+export function Tab({ tab, onActivate, onClose, onClear, onSave, onCopyToClipboard }: TabProps) {
   const {
     attributes,
     listeners,
@@ -79,6 +80,12 @@ export function Tab({ tab, onActivate, onClose, onClear, onSave }: TabProps) {
             onSelect={() => onSave?.()}
           >
             <FileDown size={14} /> Save to File
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={() => onCopyToClipboard?.()}
+          >
+            <ClipboardCopy size={14} /> Copy to Clipboard
           </ContextMenu.Item>
           <ContextMenu.Item
             className="context-menu__item"

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -16,7 +16,7 @@ interface TabBarProps {
 export function TabBar({ panelId, tabs }: TabBarProps) {
   const setActiveTab = useAppStore((s) => s.setActiveTab);
   const closeTab = useAppStore((s) => s.closeTab);
-  const { clearTerminal, saveTerminalToFile } = useTerminalRegistry();
+  const { clearTerminal, saveTerminalToFile, copyTerminalToClipboard } = useTerminalRegistry();
 
   return (
     <div className="tab-bar">
@@ -33,6 +33,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               onClose={() => closeTab(tab.id, panelId)}
               onClear={() => clearTerminal(tab.id)}
               onSave={() => saveTerminalToFile(tab.id)}
+              onCopyToClipboard={() => copyTerminalToClipboard(tab.id)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Add "Copy to Clipboard" action to the terminal tab right-click context menu, placed between "Save to File" and "Clear Terminal"
- Extract shared buffer-reading logic into a `getTerminalContent` helper to avoid duplication with the existing "Save to File" feature
- Uses the standard Web Clipboard API (`navigator.clipboard.writeText()`), no additional dependencies needed

Closes #7

## Test plan
- [ ] Right-click a terminal tab → context menu shows "Save to File", "Copy to Clipboard", "Clear Terminal" in that order
- [ ] Click "Copy to Clipboard" → paste elsewhere to verify terminal content is on the clipboard
- [ ] "Save to File" still works as before (regression check)
- [ ] Settings tab has no context menu (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)