### PR TITLE
feat(ui): add ping host context menu for SSH/Telnet connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Ping host via right-click context menu on SSH and Telnet connections
 - Copy terminal content to clipboard via right-click context menu on tabs
 - Save terminal content to file via right-click context menu on tabs
 - Clear terminal content via right-click context menu on tabs

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -64,6 +64,8 @@ pub enum ConnectionConfig {
 #[serde(rename_all = "camelCase")]
 pub struct LocalShellConfig {
     pub shell_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_command: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -8,6 +8,7 @@ export type TabContentType = "terminal" | "settings";
 
 export interface LocalShellConfig {
   shellType: ShellType;
+  initialCommand?: string;
 }
 
 export interface SshConfig {


### PR DESCRIPTION
## Summary
- Adds a **Ping Host** option to the right-click context menu on SSH and Telnet connections
- Clicking it opens a new local shell terminal tab running `ping <host>`
- Adds `initialCommand` support to `LocalShellConfig` so local shells can auto-run a command on spawn

## Details
- Frontend: `initialCommand?: string` on `LocalShellConfig`, "Ping Host" menu item with `Activity` icon between "Connect" and "Edit"
- Backend: `initial_command: Option<String>` on Rust `LocalShellConfig`, sent to PTY via delayed write (200ms) after shell initialization
- `initialCommand` is skipped during serialization when null to keep `connections.json` clean

Closes #8

## Test plan
- [ ] Right-click an SSH connection with a host configured → "Ping Host" appears between "Connect" and "Edit"
- [ ] Right-click a Telnet connection → "Ping Host" appears
- [ ] Right-click a Local or Serial connection → no "Ping Host" item
- [ ] Click "Ping Host" → new terminal tab opens titled "Ping <host>" running `ping <host>`
- [ ] Existing "Connect" action still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)