### PR TITLE
Remove plaintext SSH password storage, prompt at connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double-click a connection to connect directly
 
 ### Changed
+- SSH password authentication now prompts for password at each connection instead of storing it
 - Moved Import/Export connections from connection list toolbar to the Settings gear dropdown menu
 - Settings button now opens a Settings tab instead of a sidebar view
 - Moved settings button to the bottom of the activity bar, matching VS Code's layout
 - Panel layout refactored from flat array to recursive tree for flexible split arrangements
 - Connection and folder context menus now open on right-click instead of left-click
 - Shell type dropdown in connection editor now only shows shells available on the current platform
+
+### Security
+- Removed plaintext SSH password storage from connections file

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { ActivityBar } from "@/components/ActivityBar";
 import { Sidebar } from "@/components/Sidebar";
 import { StatusBar } from "@/components/StatusBar";
 import { TerminalView } from "@/components/Terminal";
+import { PasswordPrompt } from "@/components/PasswordPrompt";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useAppStore } from "@/store/appStore";
 import "./App.css";
@@ -23,6 +24,7 @@ function App() {
         <TerminalView />
       </div>
       <StatusBar />
+      <PasswordPrompt />
     </div>
   );
 }

--- a/src/components/PasswordPrompt/PasswordPrompt.css
+++ b/src/components/PasswordPrompt/PasswordPrompt.css
@@ -1,0 +1,86 @@
+.password-prompt__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.password-prompt__content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1001;
+  width: 360px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.password-prompt__title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.password-prompt__description {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.password-prompt__input {
+  width: 100%;
+  height: 30px;
+  font-size: var(--font-size-sm);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--spacing-sm);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.password-prompt__input:focus {
+  border-color: var(--focus-border);
+}
+
+.password-prompt__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+.password-prompt__btn {
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-sm);
+  border: none;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.password-prompt__btn--primary {
+  background-color: var(--accent-color);
+  color: #ffffff;
+}
+
+.password-prompt__btn--primary:hover {
+  background-color: var(--accent-hover);
+}
+
+.password-prompt__btn--secondary {
+  background-color: transparent;
+  color: var(--text-secondary);
+}
+
+.password-prompt__btn--secondary:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}

--- a/src/components/PasswordPrompt/PasswordPrompt.tsx
+++ b/src/components/PasswordPrompt/PasswordPrompt.tsx
@@ -1,0 +1,70 @@
+import { useState, useCallback, useEffect } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useAppStore } from "@/store/appStore";
+import "./PasswordPrompt.css";
+
+/**
+ * Global dialog that prompts the user for an SSH password at connect time.
+ */
+export function PasswordPrompt() {
+  const open = useAppStore((s) => s.passwordPromptOpen);
+  const host = useAppStore((s) => s.passwordPromptHost);
+  const username = useAppStore((s) => s.passwordPromptUsername);
+  const submitPassword = useAppStore((s) => s.submitPassword);
+  const dismissPasswordPrompt = useAppStore((s) => s.dismissPasswordPrompt);
+
+  const [password, setPassword] = useState("");
+
+  // Reset field when the dialog opens
+  useEffect(() => {
+    if (open) setPassword("");
+  }, [open]);
+
+  const handleSubmit = useCallback(() => {
+    submitPassword(password);
+  }, [password, submitPassword]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") handleSubmit();
+    },
+    [handleSubmit]
+  );
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(v) => { if (!v) dismissPasswordPrompt(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="password-prompt__overlay" />
+        <Dialog.Content className="password-prompt__content">
+          <Dialog.Title className="password-prompt__title">SSH Password</Dialog.Title>
+          <Dialog.Description className="password-prompt__description">
+            Enter password for {username}@{host}
+          </Dialog.Description>
+          <input
+            className="password-prompt__input"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Password"
+            autoFocus
+          />
+          <div className="password-prompt__actions">
+            <button
+              className="password-prompt__btn password-prompt__btn--secondary"
+              onClick={dismissPasswordPrompt}
+            >
+              Cancel
+            </button>
+            <button
+              className="password-prompt__btn password-prompt__btn--primary"
+              onClick={handleSubmit}
+            >
+              Connect
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/PasswordPrompt/index.ts
+++ b/src/components/PasswordPrompt/index.ts
@@ -1,0 +1,1 @@
+export { PasswordPrompt } from "./PasswordPrompt";

--- a/src/components/Settings/SshSettings.tsx
+++ b/src/components/Settings/SshSettings.tsx
@@ -45,14 +45,9 @@ export function SshSettings({ config, onChange }: SshSettingsProps) {
         </select>
       </label>
       {config.authMethod === "password" && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Password</span>
-          <input
-            type="password"
-            value={config.password ?? ""}
-            onChange={(e) => onChange({ ...config, password: e.target.value })}
-          />
-        </label>
+        <p className="settings-form__hint">
+          You will be prompted for a password each time you connect.
+        </p>
       )}
       {config.authMethod === "key" && (
         <label className="settings-form__field">

--- a/src/components/Sidebar/ConnectionEditor.css
+++ b/src/components/Sidebar/ConnectionEditor.css
@@ -41,6 +41,14 @@
   font-size: var(--font-size-sm);
 }
 
+.settings-form__hint {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin: 0;
+  padding: var(--spacing-xs) 0;
+  font-style: italic;
+}
+
 .connection-editor__actions {
   display: flex;
   gap: var(--spacing-sm);

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -142,11 +142,22 @@ function ConnectionPicker() {
 
   const sshConnections = connections.filter((c) => c.config.type === "ssh");
 
-  const handleConnect = useCallback(() => {
+  const requestPassword = useAppStore((s) => s.requestPassword);
+
+  const handleConnect = useCallback(async () => {
     const conn = sshConnections.find((c) => c.id === selectedId);
     if (!conn) return;
-    connectSftp(conn.config.config as SshConfig);
-  }, [selectedId, sshConnections, connectSftp]);
+
+    let sshConfig = conn.config.config as SshConfig;
+
+    if (sshConfig.authMethod === "password") {
+      const password = await requestPassword(sshConfig.host, sshConfig.username);
+      if (password === null) return;
+      sshConfig = { ...sshConfig, password };
+    }
+
+    connectSftp(sshConfig);
+  }, [selectedId, sshConnections, connectSftp, requestPassword]);
 
   return (
     <div className="file-browser__picker">


### PR DESCRIPTION
## Summary
- Removes the password input field from the SSH connection editor — passwords are no longer stored in `connections.json`
- Adds a PasswordPrompt dialog (Radix UI) that appears when connecting to SSH password-auth connections (terminal or SFTP)
- Strips SSH passwords in both frontend and backend persistence (save, update, duplicate, import, export), and migrates existing stored passwords on startup

## Test plan
- [ ] Create an SSH connection with password auth → no password field in editor, hint text shown instead
- [ ] Right-click → Connect on a password-auth SSH connection → password dialog appears
- [ ] Enter password and click Connect → SSH terminal opens normally
- [ ] Click Cancel in password dialog → no tab is created
- [ ] SSH key-auth connections → no password dialog, connects directly
- [ ] SFTP connect to password-auth SSH → password dialog appears
- [ ] Inspect `connections.json` → no `password` field present for any SSH connection
- [ ] Export connections → no passwords in exported JSON
- [ ] Existing connections with stored passwords → passwords stripped on app startup

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)