### PR TITLE
CWD-aware file browser for active terminal tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Sidebar file browser automatically shows the working directory of the active terminal tab
+- Local filesystem browsing with rename, delete, and create directory support
+- Auto-connect SFTP when switching to SSH terminal tabs
 - Ping host via right-click context menu on SSH and Telnet connections
 - Copy terminal content to clipboard via right-click context menu on tabs
 - Save terminal content to file via right-click context menu on tabs

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,6 +1,7 @@
 use tauri::State;
 
-use crate::files::sftp::{FileEntry, SftpManager};
+use crate::files::FileEntry;
+use crate::files::sftp::SftpManager;
 use crate::terminal::backend::SshConfig;
 use crate::utils::errors::TerminalError;
 
@@ -97,4 +98,30 @@ pub fn sftp_rename(
     let session = manager.get_session(&session_id)?;
     let session = session.lock().unwrap();
     session.rename(&old_path, &new_path)
+}
+
+// --- Local filesystem commands ---
+
+/// List directory contents on the local filesystem.
+#[tauri::command]
+pub fn local_list_dir(path: String) -> Result<Vec<FileEntry>, TerminalError> {
+    crate::files::local::list_dir(&path)
+}
+
+/// Create a directory on the local filesystem.
+#[tauri::command]
+pub fn local_mkdir(path: String) -> Result<(), TerminalError> {
+    crate::files::local::mkdir(&path)
+}
+
+/// Delete a file or directory on the local filesystem.
+#[tauri::command]
+pub fn local_delete(path: String, is_directory: bool) -> Result<(), TerminalError> {
+    crate::files::local::delete(&path, is_directory)
+}
+
+/// Rename a file or directory on the local filesystem.
+#[tauri::command]
+pub fn local_rename(old_path: String, new_path: String) -> Result<(), TerminalError> {
+    crate::files::local::rename(&old_path, &new_path)
 }

--- a/src-tauri/src/files/local.rs
+++ b/src-tauri/src/files/local.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+
+use super::FileEntry;
+use super::utils::chrono_from_epoch;
+use crate::utils::errors::TerminalError;
+
+/// List directory contents, filtering out `.` and `..`.
+pub fn list_dir(path: &str) -> Result<Vec<FileEntry>, TerminalError> {
+    let dir = Path::new(path);
+    let entries = std::fs::read_dir(dir)?;
+
+    let mut result = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().to_string();
+
+        if name == "." || name == ".." {
+            continue;
+        }
+
+        let metadata = entry.metadata()?;
+        let is_directory = metadata.is_dir();
+        let size = metadata.len();
+
+        let modified = metadata
+            .modified()
+            .ok()
+            .and_then(|t| {
+                t.duration_since(std::time::UNIX_EPOCH)
+                    .ok()
+                    .map(|d| chrono_from_epoch(d.as_secs()))
+            })
+            .unwrap_or_default();
+
+        let permissions = get_permissions(&metadata);
+
+        let full_path = entry.path().to_string_lossy().to_string();
+
+        result.push(FileEntry {
+            name,
+            path: full_path,
+            is_directory,
+            size,
+            modified,
+            permissions,
+        });
+    }
+
+    Ok(result)
+}
+
+/// Create a directory.
+pub fn mkdir(path: &str) -> Result<(), TerminalError> {
+    std::fs::create_dir(path)?;
+    Ok(())
+}
+
+/// Delete a file or directory.
+pub fn delete(path: &str, is_directory: bool) -> Result<(), TerminalError> {
+    if is_directory {
+        std::fs::remove_dir_all(path)?;
+    } else {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+/// Rename a file or directory.
+pub fn rename(old_path: &str, new_path: &str) -> Result<(), TerminalError> {
+    std::fs::rename(old_path, new_path)?;
+    Ok(())
+}
+
+/// Get permission string from metadata (Unix only).
+#[cfg(unix)]
+fn get_permissions(metadata: &std::fs::Metadata) -> Option<String> {
+    use std::os::unix::fs::PermissionsExt;
+    use super::utils::format_permissions;
+    Some(format_permissions(metadata.permissions().mode()))
+}
+
+/// On non-Unix platforms, permissions are not available in rwx format.
+#[cfg(not(unix))]
+fn get_permissions(_metadata: &std::fs::Metadata) -> Option<String> {
+    None
+}

--- a/src-tauri/src/files/mod.rs
+++ b/src-tauri/src/files/mod.rs
@@ -1,1 +1,17 @@
+pub mod local;
 pub mod sftp;
+pub mod utils;
+
+use serde::Serialize;
+
+/// A file or directory entry returned to the frontend.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileEntry {
+    pub name: String,
+    pub path: String,
+    pub is_directory: bool,
+    pub size: u64,
+    pub modified: String,
+    pub permissions: Option<String>,
+}

--- a/src-tauri/src/files/utils.rs
+++ b/src-tauri/src/files/utils.rs
@@ -1,0 +1,62 @@
+/// Format a Unix timestamp (seconds since epoch) as ISO 8601.
+pub fn chrono_from_epoch(secs: u64) -> String {
+    use std::time::{Duration, UNIX_EPOCH};
+    let dt = UNIX_EPOCH + Duration::from_secs(secs);
+    match dt.duration_since(UNIX_EPOCH) {
+        Ok(d) => {
+            let total_secs = d.as_secs();
+            let days = total_secs / 86400;
+            let remaining = total_secs % 86400;
+            let hours = remaining / 3600;
+            let minutes = (remaining % 3600) / 60;
+            let seconds = remaining % 60;
+
+            let (year, month, day) = days_to_ymd(days);
+            format!(
+                "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+                year, month, day, hours, minutes, seconds
+            )
+        }
+        Err(_) => String::new(),
+    }
+}
+
+/// Convert days since Unix epoch to (year, month, day).
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from http://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+/// Format Unix permission bits as rwxrwxrwx string.
+pub fn format_permissions(perm: u32) -> String {
+    let mut s = String::with_capacity(9);
+    let bits = [
+        (0o400, 'r'),
+        (0o200, 'w'),
+        (0o100, 'x'),
+        (0o040, 'r'),
+        (0o020, 'w'),
+        (0o010, 'x'),
+        (0o004, 'r'),
+        (0o002, 'w'),
+        (0o001, 'x'),
+    ];
+    for (bit, ch) in bits {
+        if perm & bit != 0 {
+            s.push(ch);
+        } else {
+            s.push('-');
+        }
+    }
+    s
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,10 @@ pub fn run() {
             commands::files::sftp_mkdir,
             commands::files::sftp_delete,
             commands::files::sftp_rename,
+            commands::files::local_list_dir,
+            commands::files::local_mkdir,
+            commands::files::local_delete,
+            commands::files::local_rename,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/Sidebar/FileBrowser.css
+++ b/src/components/Sidebar/FileBrowser.css
@@ -280,3 +280,16 @@
 .file-browser__new-dir-input:focus {
   border-color: var(--text-accent);
 }
+
+/* Placeholder for unsupported connection types */
+.file-browser__placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}

--- a/src/hooks/useFileBrowser.ts
+++ b/src/hooks/useFileBrowser.ts
@@ -1,0 +1,39 @@
+import { useAppStore } from "@/store/appStore";
+import { useFileSystem } from "./useFileSystem";
+import { useLocalFileSystem } from "./useLocalFileSystem";
+
+/**
+ * Unified file browser hook that delegates to local or SFTP based on mode.
+ * Both hooks are always called to satisfy Rules of Hooks.
+ */
+export function useFileBrowser() {
+  const fileBrowserMode = useAppStore((s) => s.fileBrowserMode);
+  const sftp = useFileSystem();
+  const local = useLocalFileSystem();
+
+  if (fileBrowserMode === "local") {
+    return { ...local, mode: "local" as const };
+  }
+
+  if (fileBrowserMode === "sftp") {
+    return { ...sftp, mode: "sftp" as const };
+  }
+
+  // "none" mode — return disconnected defaults
+  return {
+    fileEntries: [],
+    currentPath: "/",
+    isConnected: false,
+    isLoading: false,
+    error: null,
+    navigateTo: async () => {},
+    navigateUp: async () => {},
+    refresh: async () => {},
+    downloadFile: async () => {},
+    uploadFile: async () => {},
+    createDirectory: async () => {},
+    deleteEntry: async () => {},
+    renameEntry: async () => {},
+    mode: "none" as const,
+  };
+}

--- a/src/hooks/useLocalFileSystem.ts
+++ b/src/hooks/useLocalFileSystem.ts
@@ -1,0 +1,80 @@
+import { useCallback } from "react";
+import { useAppStore } from "@/store/appStore";
+import {
+  localMkdir,
+  localDelete,
+  localRename,
+} from "@/services/api";
+
+/**
+ * Hook for local filesystem operations.
+ * Same shape as useFileSystem for SFTP.
+ */
+export function useLocalFileSystem() {
+  const fileEntries = useAppStore((s) => s.localFileEntries);
+  const currentPath = useAppStore((s) => s.localCurrentPath);
+  const isLoading = useAppStore((s) => s.localFileLoading);
+  const error = useAppStore((s) => s.localFileError);
+  const navigateLocal = useAppStore((s) => s.navigateLocal);
+  const refreshLocal = useAppStore((s) => s.refreshLocal);
+
+  const navigateTo = useCallback(
+    (path: string) => {
+      navigateLocal(path);
+    },
+    [navigateLocal]
+  );
+
+  const navigateUp = useCallback(() => {
+    if (currentPath === "/") return;
+    const parentPath = currentPath.split("/").slice(0, -1).join("/") || "/";
+    navigateTo(parentPath);
+  }, [currentPath, navigateTo]);
+
+  const refresh = useCallback(() => {
+    refreshLocal();
+  }, [refreshLocal]);
+
+  const createDirectory = useCallback(
+    async (name: string) => {
+      const dirPath = currentPath === "/" ? `/${name}` : `${currentPath}/${name}`;
+      await localMkdir(dirPath);
+      refreshLocal();
+    },
+    [currentPath, refreshLocal]
+  );
+
+  const deleteEntry = useCallback(
+    async (path: string, isDirectory: boolean) => {
+      await localDelete(path, isDirectory);
+      refreshLocal();
+    },
+    [refreshLocal]
+  );
+
+  const renameEntry = useCallback(
+    async (oldPath: string, newName: string) => {
+      const parentDir = oldPath.split("/").slice(0, -1).join("/") || "/";
+      const newPath = parentDir === "/" ? `/${newName}` : `${parentDir}/${newName}`;
+      await localRename(oldPath, newPath);
+      refreshLocal();
+    },
+    [refreshLocal]
+  );
+
+  return {
+    fileEntries,
+    currentPath,
+    isConnected: true,
+    isLoading,
+    error,
+    navigateTo,
+    navigateUp,
+    refresh,
+    downloadFile: async () => { /* no-op: files are already local */ },
+    uploadFile: async () => { /* no-op: files are already local */ },
+    createDirectory,
+    deleteEntry,
+    renameEntry,
+  };
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -121,3 +121,25 @@ export async function sftpDelete(sessionId: string, path: string, isDirectory: b
 export async function sftpRename(sessionId: string, oldPath: string, newPath: string): Promise<void> {
   await invoke("sftp_rename", { sessionId, oldPath, newPath });
 }
+
+// --- Local filesystem commands ---
+
+/** List directory contents on the local filesystem. */
+export async function localListDir(path: string): Promise<FileEntry[]> {
+  return await invoke<FileEntry[]>("local_list_dir", { path });
+}
+
+/** Create a directory on the local filesystem. */
+export async function localMkdir(path: string): Promise<void> {
+  await invoke("local_mkdir", { path });
+}
+
+/** Delete a file or directory on the local filesystem. */
+export async function localDelete(path: string, isDirectory: boolean): Promise<void> {
+  await invoke("local_delete", { path, isDirectory });
+}
+
+/** Rename a file or directory on the local filesystem. */
+export async function localRename(oldPath: string, newPath: string): Promise<void> {
+  await invoke("local_rename", { oldPath, newPath });
+}


### PR DESCRIPTION
## Summary
- Sidebar file browser automatically shows the working directory of the active terminal tab via OSC 7 escape sequence tracking
- Local filesystem browsing with rename, delete, and create directory support for local shell tabs
- Auto-connect SFTP when switching to SSH terminal tabs; serial/telnet tabs show a "no filesystem" placeholder

## Changes
- **Rust backend**: New local filesystem backend (`list_dir`, `mkdir`, `delete`, `rename`), shared `FileEntry` type and date/permission utilities extracted from SFTP module
- **OSC 7 handler**: Terminal.tsx registers an xterm parser handler for `\e]7;file://host/path\a` to track per-tab CWD
- **Store**: Added `tabCwds` map, local file state, `fileBrowserMode`, `sftpConnectedHost`, and `getActiveTab` helper
- **Hooks**: New `useLocalFileSystem` and `useFileBrowser` (unified hook delegating to local/sftp/none)
- **FileBrowser**: Mode-aware rendering — local mode hides Upload/Download/Disconnect; SFTP auto-connects on tab switch; "none" mode shows placeholder

## Test plan
- [ ] Open a local zsh terminal → `cd /tmp` → sidebar file browser shows `/tmp` contents
- [ ] Open a second local shell tab → switch between tabs → file browser follows each tab's CWD
- [ ] Open an SSH terminal → file browser auto-connects SFTP (with password prompt) and shows remote CWD
- [ ] Open a serial terminal → file browser shows "no filesystem" placeholder
- [ ] Switch sidebar to connections view → switch tabs → switch back to files → correct CWD shown
- [ ] Right-click rename/delete on local files → operations work and list refreshes
- [ ] Create directory via toolbar button → works for both local and SFTP modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)