### PR TITLE
Fix macOS key repeat (accent picker override)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drag-and-drop connections between folders to reorganize them
 - Double-click a connection to connect directly
 
+### Fixed
+- Key repeat not working on macOS (accent picker shown instead)
+
 ### Changed
 - SSH password authentication now prompts for password at each connection instead of storing it
 - Moved Import/Export connections from connection list toolbar to the Settings gear dropdown menu

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4099,6 +4099,7 @@ name = "termihub"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "objc2-foundation",
  "portable-pty",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,9 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-foundation = { version = "0.3", features = ["NSUserDefaults", "NSString"] }
+
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = [
     "Win32_System_Console",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,13 @@ pub fn run() {
         .manage(TerminalManager::new())
         .manage(SftpManager::new())
         .setup(|app| {
+            #[cfg(target_os = "macos")]
+            {
+                use objc2_foundation::{NSString, NSUserDefaults};
+                let defaults = NSUserDefaults::standardUserDefaults();
+                defaults.setBool_forKey(false, &NSString::from_str("ApplePressAndHoldEnabled"));
+            }
+
             let connection_manager = ConnectionManager::new(app.handle())
                 .expect("Failed to initialize connection manager");
             app.manage(connection_manager);


### PR DESCRIPTION
## Summary
- Disable macOS accent character picker (`ApplePressAndHoldEnabled = false`) in TermiHub's own `NSUserDefaults` at app startup
- Uses `objc2-foundation` (already a transitive dependency) with `NSUserDefaults` and `NSString` features, gated behind `#[cfg(target_os = "macos")]`
- Holding a key now repeats it instead of showing the accent popup — matches behavior of VS Code, iTerm2, Hyper, and Warp

## Test plan
- [ ] Launch TermiHub on macOS → open a local shell terminal
- [ ] Hold any letter key (e.g., `k`) → verify key repeats continuously
- [ ] Verify accent picker no longer appears when holding letter keys
- [ ] Verify system-wide setting is unchanged: `defaults read -g ApplePressAndHoldEnabled`
- [ ] Verify the app still builds on non-macOS (the code is `cfg`-gated)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)