### PR TITLE
fix(terminal): dynamically update horizontal scroll width on new output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double-click a connection to connect directly
 
 ### Fixed
+- Horizontal scroll width now updates dynamically as terminal output arrives
 - Key repeat not working on macOS (accent picker shown instead)
 
 ### Changed


### PR DESCRIPTION
## Summary
- Horizontal scroll width now updates automatically as terminal output arrives, without requiring a manual toggle off/on
- Uses a keyboard-idle gate (800ms) to ensure DOM style mutations never happen during key holds, preserving macOS key repeat
- Tracks output via `onWriteParsed` (dirty flag) and checks on a 500ms interval, updating only when the keyboard is idle

## How it works
- `xterm.onData` → updates `lastInputTimeRef` timestamp on every keystroke/repeat
- `xterm.onWriteParsed` → sets `contentDirtyRef = true` when new output is written
- `setInterval(500ms)` → if dirty AND keyboard idle ≥ 800ms → calls `updateHorizontalScrollWidth()`, clears dirty flag
- During key holds, `onData` fires for each repeat keeping the timestamp current, so the idle threshold is never reached and the DOM is never touched

## Test plan
- [ ] `pnpm build` — no TypeScript errors
- [ ] Open terminal → enable horizontal scrolling → run a command producing wide output (e.g. `ls -la /usr/bin`) → scrollbar should expand automatically after output settles
- [ ] Hold a key (e.g. `k`) → key should repeat without interruption
- [ ] Run `clear` → scroll width should shrink back to viewport width
- [ ] Toggle horizontal scrolling off/on → still works as before

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)