### PR TITLE
feat(files): add Open in VS Code for local and remote files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Open in VS Code: edit local and remote files directly from the file browser
 - External connection files: load shared connection configs from JSON files via Settings
 - Per-connection horizontal scrolling option with runtime toggle via tab context menu
 - Example directory with Docker-based SSH and Telnet test targets

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,6 +63,9 @@ pub fn run() {
             commands::files::local_mkdir,
             commands::files::local_delete,
             commands::files::local_rename,
+            commands::files::vscode_available,
+            commands::files::vscode_open_local,
+            commands::files::vscode_open_remote,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/utils/errors.rs
+++ b/src-tauri/src/utils/errors.rs
@@ -28,6 +28,9 @@ pub enum TerminalError {
     #[error("Telnet error: {0}")]
     TelnetError(String),
 
+    #[error("Editor error: {0}")]
+    EditorError(String),
+
     #[error("SFTP session not found: {0}")]
     SftpSessionNotFound(String),
 

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod errors;
 pub mod shell_detect;
 pub mod ssh_auth;
+pub mod vscode;

--- a/src-tauri/src/utils/vscode.rs
+++ b/src-tauri/src/utils/vscode.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+/// Check if VS Code CLI (`code`) is available on PATH.
+pub fn is_vscode_available() -> bool {
+    Command::new("code")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Open a file in VS Code (fire-and-forget, no waiting).
+pub fn open_in_vscode(path: &str) -> Result<(), std::io::Error> {
+    Command::new("code").arg(path).spawn().map(|_| ())
+}
+
+/// Open a file in VS Code and wait for the editor tab to close.
+pub fn open_in_vscode_wait(path: &str) -> Result<(), std::io::Error> {
+    let status = Command::new("code").arg("--wait").arg(path).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other("VS Code exited with error"))
+    }
+}

--- a/src/hooks/useFileBrowser.ts
+++ b/src/hooks/useFileBrowser.ts
@@ -34,6 +34,7 @@ export function useFileBrowser() {
     createDirectory: async () => {},
     deleteEntry: async () => {},
     renameEntry: async () => {},
+    openInVscode: async () => {},
     mode: "none" as const,
   };
 }

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -7,6 +7,7 @@ import {
   sftpMkdir,
   sftpDelete,
   sftpRename,
+  vscodeOpenRemote,
 } from "@/services/api";
 
 /**
@@ -88,6 +89,14 @@ export function useFileSystem() {
     [sftpSessionId, refreshSftp]
   );
 
+  const openInVscode = useCallback(
+    async (remotePath: string) => {
+      if (!sftpSessionId) return;
+      await vscodeOpenRemote(sftpSessionId, remotePath);
+    },
+    [sftpSessionId]
+  );
+
   return {
     fileEntries,
     currentPath,
@@ -102,5 +111,6 @@ export function useFileSystem() {
     createDirectory,
     deleteEntry,
     renameEntry,
+    openInVscode,
   };
 }

--- a/src/hooks/useLocalFileSystem.ts
+++ b/src/hooks/useLocalFileSystem.ts
@@ -4,6 +4,7 @@ import {
   localMkdir,
   localDelete,
   localRename,
+  vscodeOpenLocal,
 } from "@/services/api";
 
 /**
@@ -62,6 +63,10 @@ export function useLocalFileSystem() {
     [refreshLocal]
   );
 
+  const openInVscode = useCallback(async (path: string) => {
+    await vscodeOpenLocal(path);
+  }, []);
+
   return {
     fileEntries,
     currentPath,
@@ -76,5 +81,6 @@ export function useLocalFileSystem() {
     createDirectory,
     deleteEntry,
     renameEntry,
+    openInVscode,
   };
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -171,3 +171,20 @@ export async function localDelete(path: string, isDirectory: boolean): Promise<v
 export async function localRename(oldPath: string, newPath: string): Promise<void> {
   await invoke("local_rename", { oldPath, newPath });
 }
+
+// --- VS Code integration ---
+
+/** Check if VS Code CLI (`code`) is available on PATH. */
+export async function vscodeAvailable(): Promise<boolean> {
+  return await invoke<boolean>("vscode_available");
+}
+
+/** Open a local file in VS Code (fire-and-forget). */
+export async function vscodeOpenLocal(path: string): Promise<void> {
+  await invoke("vscode_open_local", { path });
+}
+
+/** Open a remote file in VS Code: download, edit, re-upload. */
+export async function vscodeOpenRemote(sessionId: string, remotePath: string): Promise<void> {
+  await invoke("vscode_open_remote", { sessionId, remotePath });
+}

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -33,3 +33,18 @@ export async function onTerminalExit(
     callback(session_id, exit_code);
   });
 }
+
+interface VscodeEditCompletePayload {
+  remotePath: string;
+  success: boolean;
+  error: string | null;
+}
+
+/** Subscribe to VS Code edit-complete events (remote file re-upload). */
+export async function onVscodeEditComplete(
+  callback: (remotePath: string, success: boolean, error: string | null) => void
+): Promise<UnlistenFn> {
+  return await listen<VscodeEditCompletePayload>("vscode-edit-complete", (event) => {
+    callback(event.payload.remotePath, event.payload.success, event.payload.error);
+  });
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -12,7 +12,7 @@ import {
   saveExternalFile,
   reloadExternalConnections as reloadExternalSources,
 } from "@/services/storage";
-import { sftpOpen, sftpClose, sftpListDir, localListDir } from "@/services/api";
+import { sftpOpen, sftpClose, sftpListDir, localListDir, vscodeAvailable as checkVscode } from "@/services/api";
 import {
   createLeafPanel,
   findLeaf,
@@ -197,6 +197,10 @@ interface AppState {
   // File browser mode
   fileBrowserMode: "local" | "sftp" | "none";
   setFileBrowserMode: (mode: "local" | "sftp" | "none") => void;
+
+  // VS Code availability
+  vscodeAvailable: boolean;
+  checkVscodeAvailability: () => Promise<void>;
 }
 
 let tabCounter = 0;
@@ -552,6 +556,8 @@ export const useAppStore = create<AppState>((set, get) => {
       } catch (err) {
         console.error("Failed to load connections from backend:", err);
       }
+      // Check VS Code availability in the background
+      get().checkVscodeAvailability();
     },
 
     updateSettings: async (newSettings) => {
@@ -979,6 +985,17 @@ export const useAppStore = create<AppState>((set, get) => {
     // File browser mode
     fileBrowserMode: "none",
     setFileBrowserMode: (mode) => set({ fileBrowserMode: mode }),
+
+    // VS Code availability
+    vscodeAvailable: false,
+    checkVscodeAvailability: async () => {
+      try {
+        const available = await checkVscode();
+        set({ vscodeAvailable: available });
+      } catch (err) {
+        console.error("Failed to check VS Code availability:", err);
+      }
+    },
   };
 });
 


### PR DESCRIPTION
## Summary
- Adds "Open in VS Code" context menu item in the file browser for non-directory files
- **Local files**: opens directly with `code <path>` (fire-and-forget)
- **Remote (SFTP) files**: downloads to temp, opens with `code --wait`, re-uploads the modified file when the editor tab closes
- Menu item only appears when VS Code CLI (`code`) is detected on PATH

## Implementation
- **Rust**: new `utils/vscode.rs` module with detection/open helpers; 3 new Tauri commands (`vscode_available`, `vscode_open_local`, `vscode_open_remote`); `EditorError` variant
- **Frontend**: API wrappers, `vscode-edit-complete` event listener, `openInVscode` in file system hooks, `vscodeAvailable` store state checked on app load

## Test plan
- [ ] File browser (local mode) → right-click file → "Open in VS Code" visible → opens file in VS Code
- [ ] File browser (SFTP mode) → right-click file → "Open in VS Code" → file opens → edit and close tab → file re-uploaded (verify content changed on remote)
- [ ] VS Code not installed → "Open in VS Code" menu item does not appear
- [ ] SFTP session lost during edit → error event emitted, no crash
- [ ] `cargo build` passes
- [ ] `pnpm build` passes

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)