### PR TITLE
fix(files): keep file browser active when editing a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double-click a connection to connect directly
 
 ### Fixed
+- File browser now stays visible when editing a file, showing the parent directory
 - Horizontal scroll width now updates dynamically as terminal output arrives
 - Key repeat not working on macOS (accent picker shown instead)
 


### PR DESCRIPTION
## Summary
- Fix file browser showing "No filesystem available" when switching to an editor tab
- Editor tabs now derive the file browser mode from the file's location (local or SFTP remote)
- Auto-navigates to the parent directory of the file being edited

## Test plan
- [ ] Open a local file for editing → file browser shows the file's parent directory
- [ ] Open a remote (SFTP) file for editing → file browser shows the remote parent directory
- [ ] Switch between editor and terminal tabs → file browser updates correctly
- [ ] Settings tab still shows "No filesystem available" as before

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)