### PR TITLE
feat(files): add New File button to file browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New File button in the file browser toolbar to create empty files (local and remote)
 - Built-in file editor: edit local and remote files directly in the app with syntax highlighting, search/replace, and Ctrl+S saving
 - Open in VS Code: edit local and remote files directly from the file browser
 - External connection files: load shared connection configs from JSON files via Settings

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -18,6 +18,7 @@ import {
   MonitorOff,
   CodeXml,
   FileEdit,
+  FilePlus,
 } from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
 import { useFileBrowser } from "@/hooks/useFileBrowser";
@@ -289,6 +290,7 @@ export function FileBrowser() {
     downloadFile,
     uploadFile,
     createDirectory,
+    createFile,
     deleteEntry,
     renameEntry,
     openInVscode,
@@ -298,6 +300,7 @@ export function FileBrowser() {
   const disconnectSftp = useAppStore((s) => s.disconnectSftp);
   const vscodeAvailable = useAppStore((s) => s.vscodeAvailable);
   const [newDirName, setNewDirName] = useState<string | null>(null);
+  const [newFileName, setNewFileName] = useState<string | null>(null);
 
   // Listen for VS Code edit-complete events (remote file re-upload)
   useEffect(() => {
@@ -378,6 +381,15 @@ export function FileBrowser() {
     }
   }, [newDirName, createDirectory]);
 
+  const handleCreateFile = useCallback(() => {
+    if (newFileName && newFileName.trim()) {
+      createFile(newFileName.trim()).catch((err: unknown) =>
+        console.error("Create file failed:", err)
+      );
+      setNewFileName(null);
+    }
+  }, [newFileName, createFile]);
+
   // "none" mode — show placeholder
   if (mode === "none") {
     return (
@@ -443,6 +455,13 @@ export function FileBrowser() {
           )}
           <button
             className="file-browser__btn"
+            onClick={() => setNewFileName("")}
+            title="New File"
+          >
+            <FilePlus size={14} />
+          </button>
+          <button
+            className="file-browser__btn"
             onClick={() => setNewDirName("")}
             title="New Folder"
           >
@@ -464,6 +483,25 @@ export function FileBrowser() {
         <div className="file-browser__error">
           <AlertCircle size={14} />
           <span>{error}</span>
+        </div>
+      )}
+
+      {newFileName !== null && (
+        <div className="file-browser__new-dir">
+          <input
+            className="file-browser__new-dir-input"
+            placeholder="File name"
+            value={newFileName}
+            onChange={(e) => setNewFileName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCreateFile();
+              if (e.key === "Escape") setNewFileName(null);
+            }}
+            autoFocus
+          />
+          <button className="file-browser__btn" onClick={handleCreateFile} title="Create">
+            <FilePlus size={14} />
+          </button>
         </div>
       )}
 

--- a/src/hooks/useFileBrowser.ts
+++ b/src/hooks/useFileBrowser.ts
@@ -32,6 +32,7 @@ export function useFileBrowser() {
     downloadFile: async () => {},
     uploadFile: async () => {},
     createDirectory: async () => {},
+    createFile: async () => {},
     deleteEntry: async () => {},
     renameEntry: async () => {},
     openInVscode: async () => {},

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -7,6 +7,7 @@ import {
   sftpMkdir,
   sftpDelete,
   sftpRename,
+  sftpWriteFileContent,
   vscodeOpenRemote,
 } from "@/services/api";
 
@@ -69,6 +70,16 @@ export function useFileSystem() {
     [sftpSessionId, currentPath, refreshSftp]
   );
 
+  const createFile = useCallback(
+    async (name: string) => {
+      if (!sftpSessionId) return;
+      const filePath = currentPath === "/" ? `/${name}` : `${currentPath}/${name}`;
+      await sftpWriteFileContent(sftpSessionId, filePath, "");
+      refreshSftp();
+    },
+    [sftpSessionId, currentPath, refreshSftp]
+  );
+
   const deleteEntry = useCallback(
     async (path: string, isDirectory: boolean) => {
       if (!sftpSessionId) return;
@@ -109,6 +120,7 @@ export function useFileSystem() {
     downloadFile,
     uploadFile,
     createDirectory,
+    createFile,
     deleteEntry,
     renameEntry,
     openInVscode,

--- a/src/hooks/useLocalFileSystem.ts
+++ b/src/hooks/useLocalFileSystem.ts
@@ -4,6 +4,7 @@ import {
   localMkdir,
   localDelete,
   localRename,
+  localWriteFile,
   vscodeOpenLocal,
 } from "@/services/api";
 
@@ -45,6 +46,15 @@ export function useLocalFileSystem() {
     [currentPath, refreshLocal]
   );
 
+  const createFile = useCallback(
+    async (name: string) => {
+      const filePath = currentPath === "/" ? `/${name}` : `${currentPath}/${name}`;
+      await localWriteFile(filePath, "");
+      refreshLocal();
+    },
+    [currentPath, refreshLocal]
+  );
+
   const deleteEntry = useCallback(
     async (path: string, isDirectory: boolean) => {
       await localDelete(path, isDirectory);
@@ -79,6 +89,7 @@ export function useLocalFileSystem() {
     downloadFile: async () => { /* no-op: files are already local */ },
     uploadFile: async () => { /* no-op: files are already local */ },
     createDirectory,
+    createFile,
     deleteEntry,
     renameEntry,
     openInVscode,


### PR DESCRIPTION
## Summary
- Add a "New File" button to the file browser toolbar for creating empty files
- Works for both local and remote (SFTP) filesystems
- Uses the same inline input pattern as the existing "New Folder" feature (Enter to confirm, Escape to cancel)

## Changes
- `useLocalFileSystem` / `useFileSystem` hooks: add `createFile` function (writes empty content)
- `useFileBrowser`: expose `createFile` in the unified hook interface
- `FileBrowser.tsx`: add `FilePlus` toolbar button and inline input row for file name

## Test plan
- [ ] Click "New File" button → inline input appears → type name → Enter → file created and list refreshes
- [ ] Press Escape in the input → cancels without creating
- [ ] Works in local file browser mode
- [ ] Works in SFTP file browser mode
- [ ] "New Folder" still works as before

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)