### PR TITLE
feat(files): add right-click context menu to file browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Right-click context menu on files and directories in the file browser
 - New File button in the file browser toolbar to create empty files (local and remote)
 - Built-in file editor: edit local and remote files directly in the app with syntax highlighting, search/replace, and Ctrl+S saving
 - Open in VS Code: edit local and remote files directly from the file browser


### PR DESCRIPTION
## Summary
- Add right-click context menu to file browser entries using Radix UI ContextMenu
- Same actions as the existing three-dots menu: Open, Download, Edit, Open in VS Code, Rename, Delete
- Three-dots menu is preserved for discoverability
- Extracted shared `FileMenuItems` component to avoid duplicating menu item logic

## Test plan
- [ ] Right-click a file → context menu appears with Edit, Open in VS Code, Rename, Delete
- [ ] Right-click a directory → context menu appears with Open, Rename, Delete
- [ ] Right-click in SFTP mode → Download option appears for files
- [ ] Three-dots menu still works as before
- [ ] Context menu actions (edit, rename, delete, etc.) all function correctly
- [ ] Menu styling matches connection list context menus

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)