### PR TITLE
feat(files): double-click file to open in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Double-click a file in the file browser to open it in the built-in editor
 - Right-click context menu on files and directories in the file browser
 - New File button in the file browser toolbar to create empty files (local and remote)
 - Built-in file editor: edit local and remote files directly in the app with syntax highlighting, search/replace, and Ctrl+S saving

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -109,7 +109,13 @@ function FileRow({ entry, mode, vscodeAvailable, onNavigate, onContextAction }: 
         <div className="file-browser__row-wrapper">
           <button
             className="file-browser__row"
-            onDoubleClick={() => entry.isDirectory && onNavigate(entry)}
+            onDoubleClick={() => {
+              if (entry.isDirectory) {
+                onNavigate(entry);
+              } else {
+                onContextAction(entry, "edit");
+              }
+            }}
           >
             {entry.isDirectory ? (
               <Folder size={16} className="file-browser__icon file-browser__icon--folder" />


### PR DESCRIPTION
## Summary
- Double-clicking a file in the file browser now opens it in the built-in editor
- Double-clicking a directory still navigates into it as before

## Test plan
- [ ] Double-click a file in local file browser → opens in editor tab
- [ ] Double-click a file in SFTP file browser → opens in editor tab
- [ ] Double-click a directory → navigates into it (unchanged behavior)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)