### PR TITLE
feat(editor): show editor status in status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Status bar shows cursor position, language, line ending, tab size, and encoding for the built-in editor
 - Double-click a file in the file browser to open it in the built-in editor
 - Right-click context menu on files and directories in the file browser
 - New File button in the file browser toolbar to create empty files (local and remote)

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -29,3 +29,23 @@
   flex: 1;
   justify-content: flex-end;
 }
+
+.status-bar__item {
+  padding: 0 6px;
+  white-space: nowrap;
+}
+
+.status-bar__item--interactive {
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  padding: 0 6px;
+  border-radius: var(--radius-sm);
+}
+
+.status-bar__item--interactive:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -1,15 +1,44 @@
+import { useAppStore } from "@/store/appStore";
 import "./StatusBar.css";
 
 /**
  * Status bar displayed at the bottom of the application window.
- * Provides left, center, and right sections for future status items.
+ * Shows editor status (cursor position, language, EOL, tab size, encoding)
+ * when an editor tab is active.
  */
 export function StatusBar() {
+  const editorStatus = useAppStore((s) => s.editorStatus);
+  const editorActions = useAppStore((s) => s.editorActions);
+
   return (
     <div className="status-bar">
       <div className="status-bar__section status-bar__section--left" />
       <div className="status-bar__section status-bar__section--center" />
-      <div className="status-bar__section status-bar__section--right" />
+      <div className="status-bar__section status-bar__section--right">
+        {editorStatus && (
+          <>
+            <span className="status-bar__item">
+              Ln {editorStatus.line}, Col {editorStatus.column}
+            </span>
+            <button
+              className="status-bar__item status-bar__item--interactive"
+              onClick={() => editorActions?.cycleTabSize()}
+              title="Toggle tab size"
+            >
+              Spaces: {editorStatus.tabSize}
+            </button>
+            <span className="status-bar__item">{editorStatus.encoding}</span>
+            <button
+              className="status-bar__item status-bar__item--interactive"
+              onClick={() => editorActions?.toggleEol()}
+              title="Toggle line endings"
+            >
+              {editorStatus.eol}
+            </button>
+            <span className="status-bar__item">{editorStatus.language}</span>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { TerminalTab, LeafPanel, PanelNode, ConnectionType, ConnectionConfig, SshConfig, DropEdge, TabContentType, TerminalOptions, EditorTabMeta } from "@/types/terminal";
+import { TerminalTab, LeafPanel, PanelNode, ConnectionType, ConnectionConfig, SshConfig, DropEdge, TabContentType, TerminalOptions, EditorTabMeta, EditorStatus, EditorActions } from "@/types/terminal";
 import { SavedConnection, ConnectionFolder, FileEntry, ExternalConnectionSource, AppSettings } from "@/types/connection";
 import {
   loadConnections,
@@ -204,6 +204,12 @@ interface AppState {
   // VS Code availability
   vscodeAvailable: boolean;
   checkVscodeAvailability: () => Promise<void>;
+
+  // Editor status bar
+  editorStatus: EditorStatus | null;
+  setEditorStatus: (status: EditorStatus | null) => void;
+  editorActions: EditorActions | null;
+  setEditorActions: (actions: EditorActions | null) => void;
 }
 
 let tabCounter = 0;
@@ -1042,6 +1048,12 @@ export const useAppStore = create<AppState>((set, get) => {
         console.error("Failed to check VS Code availability:", err);
       }
     },
+
+    // Editor status bar
+    editorStatus: null,
+    setEditorStatus: (status) => set({ editorStatus: status }),
+    editorActions: null,
+    setEditorActions: (actions) => set({ editorActions: actions }),
   };
 });
 

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -78,3 +78,17 @@ export interface SplitContainer {
 
 export type PanelNode = LeafPanel | SplitContainer;
 export type DropEdge = 'left' | 'right' | 'top' | 'bottom' | 'center';
+
+export interface EditorStatus {
+  line: number;
+  column: number;
+  language: string;
+  eol: "LF" | "CRLF";
+  tabSize: number;
+  encoding: string;
+}
+
+export interface EditorActions {
+  cycleTabSize: () => void;
+  toggleEol: () => void;
+}


### PR DESCRIPTION
## Summary
- Display cursor position, language, line endings, tab size, and encoding in the status bar when an editor tab is active
- Tab size (Spaces: 2/4) and EOL (LF/CRLF) are clickable to toggle values directly from the status bar
- Status bar items automatically appear/disappear when switching between editor and terminal tabs

## Test plan
- [ ] Open a `.ts` file → status bar shows: `Ln 1, Col 1  Spaces: 4  UTF-8  LF  typescript`
- [ ] Move cursor → Ln/Col updates in real-time
- [ ] Click "Spaces: 4" → changes to "Spaces: 2", editor indentation updates
- [ ] Click "LF" → changes to "CRLF"
- [ ] Switch to a terminal tab → status bar items disappear
- [ ] Switch back to editor tab → items reappear with correct values
- [ ] Close editor tab → status bar clears

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)