### PR TITLE
Fix new tabs showing system root instead of home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double-click a connection to connect directly
 
 ### Fixed
+- New terminal tabs now start in the user's home directory instead of the system root
 - File browser now stays visible when editing a file, showing the parent directory
 - Horizontal scroll width now updates dynamically as terminal output arrives
 - Key repeat not working on macOS (accent picker shown instead)

--- a/src-tauri/src/terminal/local_shell.rs
+++ b/src-tauri/src/terminal/local_shell.rs
@@ -40,6 +40,16 @@ impl LocalShell {
         command.env("TERM", "xterm-256color");
         command.env("COLORTERM", "truecolor");
 
+        // Start in user's home directory (falls back to process CWD if unavailable)
+        #[cfg(unix)]
+        if let Ok(home) = std::env::var("HOME") {
+            command.cwd(home);
+        }
+        #[cfg(windows)]
+        if let Ok(home) = std::env::var("USERPROFILE") {
+            command.cwd(home);
+        }
+
         let child = pty_pair
             .slave
             .spawn_command(command)


### PR DESCRIPTION
## Summary
- New terminal tabs started in `/` because the PTY inherited the Tauri process's CWD
- Set the shell's initial working directory to `$HOME` (Unix) or `%USERPROFILE%` (Windows) via `CommandBuilder::cwd()`
- File browser now shows the home directory immediately instead of the system root

## Test plan
- [ ] Open the app and create a new local shell tab — verify it starts in `~`
- [ ] Verify the file browser shows the home directory after the first prompt
- [ ] Test on macOS/Linux (uses `$HOME`) and Windows (uses `%USERPROFILE%`) if possible

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)