### PR TITLE
feat(terminal): add tab coloring with color picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Environment variable placeholders in connection settings: use `${env:VAR}` syntax for shared configs
+- Tab coloring: assign colors to terminal tabs from the connection editor or via right-click context menu
 - Status bar shows cursor position, language, line ending, tab size, and encoding for the built-in editor
 - Double-click a file in the file browser to open it in the built-in editor
 - Right-click context menu on files and directories in the file browser

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "^0.563.0",
     "monaco-editor": "^0.55.1",
     "react": "^18.3.1",
+    "react-colorful": "^5.6.1",
     "react-dom": "^18.3.1",
     "react-resizable-panels": "^4.6.2",
     "react-virtuoso": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-colorful:
+        specifier: ^5.6.1
+        version: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1142,6 +1145,12 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  react-colorful@5.6.1:
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -2225,6 +2234,11 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:

--- a/src-tauri/src/connection/config.rs
+++ b/src-tauri/src/connection/config.rs
@@ -8,6 +8,8 @@ use crate::terminal::backend::ConnectionConfig;
 pub struct TerminalOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub horizontal_scrolling: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
 }
 
 /// A saved connection with a name and optional folder assignment.

--- a/src/components/Sidebar/ConnectionEditor.css
+++ b/src/components/Sidebar/ConnectionEditor.css
@@ -91,3 +91,17 @@
   background-color: var(--bg-hover);
   color: var(--text-primary);
 }
+
+.connection-editor__color-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.connection-editor__color-preview {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  border: 1px solid var(--border-primary);
+}

--- a/src/components/Sidebar/ConnectionEditor.tsx
+++ b/src/components/Sidebar/ConnectionEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionType, ConnectionConfig, LocalShellConfig, SshConfig, TelnetConfig, SerialConfig, TerminalOptions } from "@/types/terminal";
 import { ConnectionSettings, SshSettings, SerialSettings, TelnetSettings } from "@/components/Settings";
+import { ColorPickerDialog } from "@/components/Terminal/ColorPickerDialog";
 import { getDefaultShell } from "@/utils/shell-detection";
 import "./ConnectionEditor.css";
 
@@ -83,6 +84,7 @@ export function ConnectionEditor() {
   const [terminalOptions, setTerminalOptions] = useState<TerminalOptions>(
     existingConnection?.terminalOptions ?? {}
   );
+  const [colorPickerOpen, setColorPickerOpen] = useState(false);
 
   const handleTypeChange = useCallback((type: ConnectionType) => {
     setConnectionConfig(getDefaultConfigs(defaultShell)[type]);
@@ -91,7 +93,7 @@ export function ConnectionEditor() {
   const handleSave = useCallback(() => {
     if (!name.trim()) return;
 
-    const opts = terminalOptions.horizontalScrolling ? terminalOptions : undefined;
+    const opts = (terminalOptions.horizontalScrolling || terminalOptions.color) ? terminalOptions : undefined;
 
     if (extFilePath) {
       // Saving to an external source
@@ -205,6 +207,40 @@ export function ConnectionEditor() {
           />
           <span className="settings-form__label">Enable horizontal scrolling</span>
         </label>
+
+        <div className="settings-form__field">
+          <span className="settings-form__label">Tab Color</span>
+          <div className="connection-editor__color-row">
+            {terminalOptions.color && (
+              <div
+                className="connection-editor__color-preview"
+                style={{ backgroundColor: terminalOptions.color }}
+              />
+            )}
+            <button
+              className="connection-editor__btn connection-editor__btn--secondary"
+              type="button"
+              onClick={() => setColorPickerOpen(true)}
+            >
+              {terminalOptions.color ? "Change" : "Set Color"}
+            </button>
+            {terminalOptions.color && (
+              <button
+                className="connection-editor__btn connection-editor__btn--secondary"
+                type="button"
+                onClick={() => setTerminalOptions({ ...terminalOptions, color: undefined })}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+        <ColorPickerDialog
+          open={colorPickerOpen}
+          onOpenChange={setColorPickerOpen}
+          currentColor={terminalOptions.color}
+          onColorChange={(color) => setTerminalOptions({ ...terminalOptions, color: color ?? undefined })}
+        />
 
         <div className="connection-editor__actions">
           <button className="connection-editor__btn connection-editor__btn--secondary" onClick={handleCancel}>

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -234,6 +234,7 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
 function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean }) {
   const slotRef = useRef<HTMLDivElement>(null);
   const { getElement, parkingRef } = useTerminalRegistry();
+  const tabColor = useAppStore((s) => s.tabColors[tabId]);
 
   useEffect(() => {
     const slotEl = slotRef.current;
@@ -267,6 +268,7 @@ function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean 
     <div
       ref={slotRef}
       className={`terminal-container ${isVisible ? "" : "terminal-container--hidden"}`}
+      style={tabColor ? { border: `2px solid ${tabColor}` } : undefined}
     />
   );
 }

--- a/src/components/Terminal/ColorPickerDialog.css
+++ b/src/components/Terminal/ColorPickerDialog.css
@@ -1,0 +1,110 @@
+.color-picker__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.color-picker__content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1001;
+  width: 280px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.color-picker__title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.color-picker__presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.color-picker__swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-sm);
+  border: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  transition: border-color var(--transition-fast);
+}
+
+.color-picker__swatch:hover {
+  border-color: var(--text-secondary);
+}
+
+.color-picker__swatch--active {
+  border-color: var(--text-primary);
+}
+
+.color-picker__picker {
+  width: 100% !important;
+  height: 150px !important;
+}
+
+.color-picker__hex-input {
+  width: 100%;
+  height: 30px;
+  font-size: var(--font-size-sm);
+  font-family: monospace;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--spacing-sm);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.color-picker__hex-input:focus {
+  border-color: var(--focus-border);
+}
+
+.color-picker__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+.color-picker__btn {
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-sm);
+  border: none;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.color-picker__btn--primary {
+  background-color: var(--accent-color);
+  color: #ffffff;
+}
+
+.color-picker__btn--primary:hover {
+  background-color: var(--accent-hover);
+}
+
+.color-picker__btn--secondary {
+  background-color: transparent;
+  color: var(--text-secondary);
+}
+
+.color-picker__btn--secondary:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}

--- a/src/components/Terminal/ColorPickerDialog.tsx
+++ b/src/components/Terminal/ColorPickerDialog.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { HexColorPicker } from "react-colorful";
+import "./ColorPickerDialog.css";
+
+const PRESET_COLORS = [
+  "#ef4444", // red
+  "#f97316", // orange
+  "#eab308", // yellow
+  "#22c55e", // green
+  "#06b6d4", // cyan
+  "#3b82f6", // blue
+  "#8b5cf6", // purple
+  "#ec4899", // pink
+];
+
+interface ColorPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentColor: string | undefined;
+  onColorChange: (color: string | null) => void;
+}
+
+/**
+ * Dialog for picking a tab color with preset swatches and a full color picker.
+ */
+export function ColorPickerDialog({ open, onOpenChange, currentColor, onColorChange }: ColorPickerDialogProps) {
+  const [selectedColor, setSelectedColor] = useState(currentColor ?? "#3b82f6");
+
+  // Reset when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSelectedColor(currentColor ?? "#3b82f6");
+    }
+  }, [open, currentColor]);
+
+  const handleApply = () => {
+    onColorChange(selectedColor);
+    onOpenChange(false);
+  };
+
+  const handleClear = () => {
+    onColorChange(null);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="color-picker__overlay" />
+        <Dialog.Content className="color-picker__content">
+          <Dialog.Title className="color-picker__title">Tab Color</Dialog.Title>
+
+          <div className="color-picker__presets">
+            {PRESET_COLORS.map((color) => (
+              <button
+                key={color}
+                className={`color-picker__swatch ${selectedColor === color ? "color-picker__swatch--active" : ""}`}
+                style={{ backgroundColor: color }}
+                onClick={() => setSelectedColor(color)}
+                title={color}
+              />
+            ))}
+          </div>
+
+          <HexColorPicker
+            className="color-picker__picker"
+            color={selectedColor}
+            onChange={setSelectedColor}
+          />
+
+          <input
+            className="color-picker__hex-input"
+            type="text"
+            value={selectedColor}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (/^#[0-9a-fA-F]{0,6}$/.test(v)) setSelectedColor(v);
+            }}
+            maxLength={7}
+          />
+
+          <div className="color-picker__actions">
+            <button
+              className="color-picker__btn color-picker__btn--secondary"
+              onClick={handleClear}
+            >
+              Clear
+            </button>
+            <button
+              className="color-picker__btn color-picker__btn--primary"
+              onClick={handleApply}
+            >
+              Apply
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -1,7 +1,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import * as ContextMenu from "@radix-ui/react-context-menu";
-import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon, FileEdit, Eraser, FileDown, ClipboardCopy, ArrowRightLeft, Check } from "lucide-react";
+import { X, Terminal, Wifi, Cable, Globe, Settings as SettingsIcon, FileEdit, Eraser, FileDown, ClipboardCopy, ArrowRightLeft, Check, Palette } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { ConnectionType } from "@/types/terminal";
 
@@ -22,9 +22,11 @@ interface TabProps {
   horizontalScrolling?: boolean;
   onToggleHorizontalScrolling?: () => void;
   isDirty?: boolean;
+  tabColor?: string;
+  onSetColor?: () => void;
 }
 
-export function Tab({ tab, onActivate, onClose, onClear, onSave, onCopyToClipboard, horizontalScrolling, onToggleHorizontalScrolling, isDirty }: TabProps) {
+export function Tab({ tab, onActivate, onClose, onClear, onSave, onCopyToClipboard, horizontalScrolling, onToggleHorizontalScrolling, isDirty, tabColor, onSetColor }: TabProps) {
   const {
     attributes,
     listeners,
@@ -38,6 +40,7 @@ export function Tab({ tab, onActivate, onClose, onClear, onSave, onCopyToClipboa
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.3 : 1,
+    ...(tabColor ? { borderLeft: `3px solid ${tabColor}` } : {}),
   };
 
   const Icon = tab.contentType === "settings" ? SettingsIcon
@@ -112,6 +115,13 @@ export function Tab({ tab, onActivate, onClose, onClear, onSave, onCopyToClipboa
             </ContextMenu.ItemIndicator>
             <ArrowRightLeft size={14} /> Horizontal Scrolling
           </ContextMenu.CheckboxItem>
+          <ContextMenu.Separator className="context-menu__separator" />
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={() => onSetColor?.()}
+          >
+            <Palette size={14} /> Set Color...
+          </ContextMenu.Item>
         </ContextMenu.Content>
       </ContextMenu.Portal>
     </ContextMenu.Root>

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   SortableContext,
   horizontalListSortingStrategy,
@@ -6,6 +7,7 @@ import { useAppStore } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
 import { useTerminalRegistry } from "./TerminalRegistry";
 import { Tab } from "./Tab";
+import { ColorPickerDialog } from "./ColorPickerDialog";
 import "./TabBar.css";
 
 interface TabBarProps {
@@ -18,8 +20,12 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   const closeTab = useAppStore((s) => s.closeTab);
   const tabHorizontalScrolling = useAppStore((s) => s.tabHorizontalScrolling);
   const setTabHorizontalScrolling = useAppStore((s) => s.setTabHorizontalScrolling);
+  const tabColors = useAppStore((s) => s.tabColors);
+  const setTabColor = useAppStore((s) => s.setTabColor);
   const editorDirtyTabs = useAppStore((s) => s.editorDirtyTabs);
   const { clearTerminal, saveTerminalToFile, copyTerminalToClipboard } = useTerminalRegistry();
+
+  const [colorPickerTabId, setColorPickerTabId] = useState<string | null>(null);
 
   const handleCloseTab = (tabId: string) => {
     if (editorDirtyTabs[tabId]) {
@@ -47,10 +53,20 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               horizontalScrolling={tabHorizontalScrolling[tab.id] ?? false}
               onToggleHorizontalScrolling={() => setTabHorizontalScrolling(tab.id, !(tabHorizontalScrolling[tab.id] ?? false))}
               isDirty={editorDirtyTabs[tab.id] ?? false}
+              tabColor={tabColors[tab.id]}
+              onSetColor={() => setColorPickerTabId(tab.id)}
             />
           ))}
         </div>
       </SortableContext>
+      <ColorPickerDialog
+        open={colorPickerTabId !== null}
+        onOpenChange={(open) => { if (!open) setColorPickerTabId(null); }}
+        currentColor={colorPickerTabId ? tabColors[colorPickerTabId] : undefined}
+        onColorChange={(color) => {
+          if (colorPickerTabId) setTabColor(colorPickerTabId, color);
+        }}
+      />
     </div>
   );
 }

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -14,6 +14,7 @@ export interface EditorTabMeta {
 
 export interface TerminalOptions {
   horizontalScrolling?: boolean;
+  color?: string;
 }
 
 export interface LocalShellConfig {


### PR DESCRIPTION
## Summary

- Add the ability to assign colors to terminal tabs, displayed as a colored left border on the tab and a colored frame around the terminal
- Colors can be configured in the connection editor (persisted with the connection) or via right-click context menu on running terminals (runtime override)
- Uses `react-colorful` (~2KB, zero deps) for the color picker widget with 8 preset swatches and a full hex color picker

## Test plan

- [ ] Right-click a terminal tab → "Set Color..." → pick a color → verify tab shows colored left border and terminal has colored frame
- [ ] Clear the color → verify indicators are removed
- [ ] Edit a connection → set a color → connect → verify tab starts with that color
- [ ] Close and reopen a colored connection → verify color persists
- [ ] Override a persisted color via context menu → verify runtime color takes effect
- [ ] Verify `cargo check` and `tsc --noEmit` pass cleanly

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)