### PR TITLE
feat(config): add ${env:VAR} placeholder expansion for connection settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Environment variable placeholders in connection settings: use `${env:VAR}` syntax for shared configs
 - Status bar shows cursor position, language, line ending, tab size, and encoding for the built-in editor
 - Double-click a file in the file browser to open it in the built-in editor
 - Right-click context menu on files and directories in the file browser

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -32,6 +32,7 @@ impl TerminalManager {
         config: ConnectionConfig,
         app_handle: AppHandle,
     ) -> Result<String, TerminalError> {
+        let config = config.expand();
         let session_id = uuid::Uuid::new_v4().to_string();
         let (output_tx, output_rx) = mpsc::channel::<Vec<u8>>();
 

--- a/src-tauri/src/utils/expand.rs
+++ b/src-tauri/src/utils/expand.rs
@@ -1,0 +1,81 @@
+use std::env;
+
+/// Replace `${env:VAR_NAME}` placeholders with the value of the environment
+/// variable `VAR_NAME`. Unknown variables are left as-is.
+pub fn expand_env_placeholders(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut rest = input;
+
+    while let Some(start) = rest.find("${env:") {
+        result.push_str(&rest[..start]);
+        let after = &rest[start + 6..]; // skip "${env:"
+        if let Some(end) = after.find('}') {
+            let var_name = &after[..end];
+            match env::var(var_name) {
+                Ok(val) => result.push_str(&val),
+                Err(_) => {
+                    // Leave placeholder as-is when variable is not set
+                    result.push_str(&rest[start..start + 6 + end + 1]);
+                }
+            }
+            rest = &after[end + 1..];
+        } else {
+            // No closing brace — push rest as-is
+            result.push_str(&rest[start..]);
+            rest = "";
+        }
+    }
+
+    result.push_str(rest);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_known_variable() {
+        env::set_var("TERMIHUB_TEST_VAR", "hello");
+        assert_eq!(expand_env_placeholders("${env:TERMIHUB_TEST_VAR}"), "hello");
+        env::remove_var("TERMIHUB_TEST_VAR");
+    }
+
+    #[test]
+    fn leaves_unknown_variable_as_is() {
+        let input = "${env:TERMIHUB_NONEXISTENT_VAR_XYZ}";
+        assert_eq!(expand_env_placeholders(input), input);
+    }
+
+    #[test]
+    fn expands_multiple_placeholders() {
+        env::set_var("TERMIHUB_TEST_A", "foo");
+        env::set_var("TERMIHUB_TEST_B", "bar");
+        assert_eq!(
+            expand_env_placeholders("${env:TERMIHUB_TEST_A}@${env:TERMIHUB_TEST_B}"),
+            "foo@bar"
+        );
+        env::remove_var("TERMIHUB_TEST_A");
+        env::remove_var("TERMIHUB_TEST_B");
+    }
+
+    #[test]
+    fn handles_no_placeholders() {
+        assert_eq!(expand_env_placeholders("plain text"), "plain text");
+    }
+
+    #[test]
+    fn handles_unclosed_brace() {
+        assert_eq!(expand_env_placeholders("${env:MISSING"), "${env:MISSING");
+    }
+
+    #[test]
+    fn handles_mixed_content() {
+        env::set_var("TERMIHUB_TEST_USER", "alice");
+        assert_eq!(
+            expand_env_placeholders("ssh ${env:TERMIHUB_TEST_USER}@host"),
+            "ssh alice@host"
+        );
+        env::remove_var("TERMIHUB_TEST_USER");
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod errors;
+pub mod expand;
 pub mod shell_detect;
 pub mod ssh_auth;
 pub mod vscode;

--- a/src/components/Sidebar/ConnectionEditor.tsx
+++ b/src/components/Sidebar/ConnectionEditor.tsx
@@ -193,6 +193,10 @@ export function ConnectionEditor() {
           />
         )}
 
+        <p className="settings-form__hint">
+          Use {"${env:VAR}"} for environment variables, e.g. {"${env:USER}"}
+        </p>
+
         <label className="settings-form__field settings-form__field--checkbox">
           <input
             type="checkbox"


### PR DESCRIPTION
## Summary
- Adds `${env:VAR}` placeholder syntax for connection settings, enabling shared config files that resolve to each user's environment at connect time
- Expansion happens in `create_session` right before routing to backends, so stored configs preserve the literal placeholders
- Includes a hint in the Connection Editor UI showing the syntax

## Details
- **New**: `src-tauri/src/utils/expand.rs` — `expand_env_placeholders()` function with 6 unit tests
- **Modified**: `ConnectionConfig` and all sub-configs get an `expand()` method
- **Modified**: `TerminalManager::create_session` calls `config.expand()` at the top
- **Modified**: `ConnectionEditor.tsx` — hint text below settings fields
- Unknown variables (e.g. `${env:NONEXISTENT}`) are left as-is (no crash)

## Test plan
- [ ] Create an SSH connection with username `${env:USER}` → connect → resolves to actual username
- [ ] Create a local shell with initial command `echo ${env:HOME}` → prints home directory
- [ ] Use an undefined variable `${env:NONEXISTENT}` → left as-is, no crash
- [ ] Verify saved connection JSON still contains literal `${env:USER}` (not expanded)
- [ ] `cargo test utils::expand` — 6 unit tests pass

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)