### PR TITLE
Add user and developer documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- User documentation: user guide, build instructions, serial setup, SSH configuration, and contributing guide
 - X11 forwarding for SSH connections: forward remote GUI applications to local X server
 - Environment variable placeholders in connection settings: use `${env:VAR}` syntax for shared configs
 - Tab coloring: assign colors to terminal tabs from the connection editor or via right-click context menu

--- a/README.md
+++ b/README.md
@@ -22,31 +22,15 @@ TermiHub provides a VS Code-like interface for managing multiple terminal connec
 - **Built-in editor** — Edit local and remote files with syntax highlighting
 - **Cross-platform** — Windows, Linux, and macOS
 
-## Quick Start
-
-### Prerequisites
-
-- [Node.js](https://nodejs.org/) (v18+)
-- [pnpm](https://pnpm.io/)
-- [Rust](https://www.rust-lang.org/tools/install)
-- [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)
-
-### Development
-
-```bash
-pnpm install
-pnpm tauri dev
-```
-
-### Build
-
-```bash
-pnpm tauri build
-```
-
 ## Documentation
 
-See [CLAUDE.md](CLAUDE.md) for full architecture documentation, coding standards, and contribution guidelines.
+- **[User Guide](docs/user-guide.md)** — Interface overview, connections, tabs, splits, keyboard shortcuts, file browser, editor
+- **[Building](docs/building.md)** — Platform-specific build and development instructions
+- **[Serial Setup](docs/serial-setup.md)** — Serial port configuration per platform
+- **[SSH Configuration](docs/ssh-configuration.md)** — SSH keys, X11 forwarding, SFTP
+- **[Contributing](docs/contributing.md)** — Development workflow, coding standards, architecture
+
+For the full internal architecture documentation, see [CLAUDE.md](CLAUDE.md).
 
 ## License
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,312 @@
+# Building TermiHub
+
+This guide covers how to set up a development environment and build TermiHub from source on macOS, Linux, and Windows.
+
+---
+
+## Prerequisites (All Platforms)
+
+### Node.js
+
+Install [Node.js](https://nodejs.org/) v18 or later.
+
+Verify your installation:
+
+```bash
+node --version   # v18.x or later
+```
+
+### pnpm
+
+Install [pnpm](https://pnpm.io/installation) (the package manager used by this project):
+
+```bash
+npm install -g pnpm
+```
+
+### Rust
+
+Install Rust via [rustup](https://www.rust-lang.org/tools/install):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Verify your installation:
+
+```bash
+rustc --version
+cargo --version
+```
+
+### Tauri Prerequisites
+
+Follow the [Tauri v2 prerequisites guide](https://v2.tauri.app/start/prerequisites/) for your platform. The platform-specific sections below summarize the key requirements.
+
+---
+
+## macOS
+
+### System Dependencies
+
+1. **Xcode Command Line Tools** (required for C/C++ compilation):
+
+   ```bash
+   xcode-select --install
+   ```
+
+2. No additional system libraries are needed on macOS — the required frameworks (WebKit, Security) are included with the OS.
+
+### Development
+
+```bash
+pnpm install
+pnpm tauri dev
+```
+
+### Build
+
+```bash
+pnpm tauri build
+```
+
+**Output**: `src-tauri/target/release/bundle/dmg/TermiHub_<version>_aarch64.dmg` (Apple Silicon) or `TermiHub_<version>_x64.dmg` (Intel).
+
+The build also produces a `.app` bundle in `src-tauri/target/release/bundle/macos/`.
+
+---
+
+## Linux
+
+### System Dependencies
+
+TermiHub requires several system libraries. Install them for your distribution:
+
+#### Ubuntu / Debian
+
+```bash
+sudo apt update
+sudo apt install -y \
+  libwebkit2gtk-4.1-dev \
+  build-essential \
+  curl \
+  wget \
+  file \
+  libxdo-dev \
+  libssl-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev \
+  libssh2-1-dev \
+  libudev-dev \
+  pkg-config
+```
+
+#### Fedora
+
+```bash
+sudo dnf install -y \
+  webkit2gtk4.1-devel \
+  openssl-devel \
+  curl \
+  wget \
+  file \
+  libxdo-devel \
+  libappindicator-gtk3-devel \
+  librsvg2-devel \
+  libssh2-devel \
+  systemd-devel \
+  pkg-config
+```
+
+#### Arch Linux
+
+```bash
+sudo pacman -S --needed \
+  webkit2gtk-4.1 \
+  base-devel \
+  curl \
+  wget \
+  file \
+  openssl \
+  xdotool \
+  libappindicator-gtk3 \
+  librsvg \
+  libssh2 \
+  pkg-config
+```
+
+### Development
+
+```bash
+pnpm install
+pnpm tauri dev
+```
+
+### Build
+
+```bash
+pnpm tauri build
+```
+
+**Output**: `src-tauri/target/release/bundle/deb/termihub_<version>_amd64.deb` and `src-tauri/target/release/bundle/appimage/termihub_<version>_amd64.AppImage`.
+
+---
+
+## Windows
+
+### System Dependencies
+
+1. **Visual Studio Build Tools** — Install the "Desktop development with C++" workload from [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+
+2. **WebView2** — Comes pre-installed on Windows 10 (version 1803+) and Windows 11. If missing, download from [Microsoft](https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
+
+3. **ConPTY** — Required for local terminal support. Available on Windows 10 version 1809 and later.
+
+### Development
+
+```powershell
+pnpm install
+pnpm tauri dev
+```
+
+### Build
+
+```powershell
+pnpm tauri build
+```
+
+**Output**: `src-tauri\target\release\bundle\msi\TermiHub_<version>_x64_en-US.msi` and `src-tauri\target\release\bundle\nsis\TermiHub_<version>_x64-setup.exe`.
+
+---
+
+## Development Workflow
+
+### Dev Server with Hot Reload
+
+```bash
+pnpm tauri dev
+```
+
+This starts:
+- The Vite development server for the frontend (with hot module replacement)
+- The Rust backend compiled in debug mode
+
+Frontend changes appear instantly. Rust backend changes trigger a recompile and restart.
+
+### TypeScript Check
+
+```bash
+pnpm build
+```
+
+This runs `tsc && vite build` — the TypeScript compiler checks for errors, then Vite builds the frontend.
+
+### Rust Checks
+
+```bash
+cd src-tauri
+cargo clippy
+cargo test
+```
+
+### Using the Test Environment
+
+The `examples/` directory includes Docker-based SSH and Telnet servers and virtual serial port scripts for testing without real hardware. See the [examples/README.md](../examples/README.md) for setup instructions.
+
+Quick start:
+
+```bash
+cd examples
+./start-test-environment.sh
+```
+
+This builds Docker containers, starts SSH (port 2222) and Telnet (port 2323) servers, and launches TermiHub with pre-configured test connections.
+
+---
+
+## Project Structure Overview
+
+```
+termihub/
+├── src/                  # React frontend (TypeScript)
+│   ├── components/       # UI components
+│   ├── hooks/            # React hooks
+│   ├── services/         # Tauri API wrappers
+│   ├── store/            # Zustand state management
+│   ├── types/            # TypeScript type definitions
+│   └── utils/            # Utility functions
+├── src-tauri/            # Rust backend
+│   ├── src/
+│   │   ├── terminal/     # Terminal backends (local, SSH, serial, telnet)
+│   │   ├── connection/   # Connection config and persistence
+│   │   ├── files/        # File browser and SFTP
+│   │   ├── commands/     # Tauri IPC commands
+│   │   └── events/       # Event emitters
+│   ├── Cargo.toml
+│   └── tauri.conf.json
+├── examples/             # Test environment (Docker, virtual serial)
+├── docs/                 # Documentation (this directory)
+└── package.json
+```
+
+See [CLAUDE.md](../CLAUDE.md) for the complete architecture documentation.
+
+---
+
+## Troubleshooting
+
+### `pnpm tauri dev` fails to compile Rust
+
+- Ensure all system dependencies are installed (see platform sections above)
+- Run `rustup update` to get the latest Rust toolchain
+- On Linux, verify `pkg-config` can find `libssh2`: `pkg-config --libs libssh2`
+
+### WebKitGTK not found (Linux)
+
+```
+error: could not find system library 'webkit2gtk-4.1'
+```
+
+Install the WebKitGTK development package for your distribution (see Linux section above).
+
+### `libssh2` linking errors
+
+- **Ubuntu/Debian**: `sudo apt install libssh2-1-dev`
+- **Fedora**: `sudo dnf install libssh2-devel`
+- **Arch**: `sudo pacman -S libssh2`
+- **macOS**: Handled automatically by the `ssh2` Rust crate
+
+### Serial port compilation errors (Linux)
+
+```
+error: could not find system library 'libudev'
+```
+
+Install the udev development package:
+- **Ubuntu/Debian**: `sudo apt install libudev-dev`
+- **Fedora**: `sudo dnf install systemd-devel`
+
+### ConPTY errors (Windows)
+
+- Ensure you are running Windows 10 version 1809 or later
+- Update Windows to the latest version
+
+### Frontend build errors
+
+```bash
+# Clear node_modules and reinstall
+rm -rf node_modules
+pnpm install
+
+# Check TypeScript errors
+pnpm build
+```
+
+### Rust build takes too long
+
+The first build compiles all Rust dependencies and can take several minutes. Subsequent builds are incremental and much faster. To speed up debug builds:
+
+```bash
+# Use fewer codegen units (faster compile, slower runtime — fine for dev)
+CARGO_PROFILE_DEV_CODEGEN_UNITS=16 pnpm tauri dev
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,340 @@
+# Contributing to TermiHub
+
+This guide covers the development workflow, architecture overview, and coding standards for contributing to TermiHub.
+
+---
+
+## Architecture Overview
+
+TermiHub is built with:
+
+- **Frontend**: React 18 + TypeScript, built with Vite
+- **Backend**: Rust, running inside Tauri 2
+- **IPC**: Tauri commands (frontend calls backend) and events (backend pushes to frontend)
+
+### High-Level Design
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Tauri Desktop App                     │
+│                                                         │
+│  ┌─────────────┐     ┌────────┐     ┌───────────────┐  │
+│  │  React UI   │◄───►│  IPC   │◄───►│ Rust Backend  │  │
+│  │  (xterm.js, │     │ Bridge │     │ (PTY, SSH,    │  │
+│  │   Monaco)   │     │        │     │  Serial,      │  │
+│  │             │     │        │     │  Telnet)      │  │
+│  └─────────────┘     └────────┘     └───────────────┘  │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Trait-Based Backend
+
+All terminal types implement the `TerminalBackend` trait, which provides a consistent interface for:
+- Spawning sessions
+- Sending input / receiving output
+- Resizing the terminal
+- Closing connections
+
+Current implementations: `LocalShell`, `SshConnection`, `SerialConnection`, `TelnetConnection`.
+
+Adding a new terminal type means implementing this trait and registering it with the `TerminalManager`. See [Adding a New Terminal Backend](#adding-a-new-terminal-backend) below.
+
+### State Management
+
+The frontend uses Zustand for state management with a single `appStore` that manages:
+- Panel layout (recursive tree of horizontal/vertical splits)
+- Tab state (active tab, dirty flags, colors, CWD tracking)
+- Connection and folder persistence
+- Sidebar view state
+- SFTP sessions and file browser state
+
+---
+
+## Project Structure
+
+```
+termihub/
+├── src/                  # React frontend
+│   ├── components/       # UI components (ActivityBar, Sidebar, Terminal, etc.)
+│   ├── hooks/            # React hooks (useTerminal, useKeyboardShortcuts, etc.)
+│   ├── services/         # Tauri API wrappers (api.ts, events.ts)
+│   ├── store/            # Zustand store (appStore.ts)
+│   ├── types/            # TypeScript types (terminal.ts, connection.ts)
+│   └── utils/            # Utilities (formatters, shell detection)
+├── src-tauri/            # Rust backend
+│   ├── src/
+│   │   ├── terminal/     # Terminal backends and manager
+│   │   ├── connection/   # Connection config, CRUD, persistence
+│   │   ├── files/        # File browser and SFTP
+│   │   ├── commands/     # Tauri IPC command handlers
+│   │   └── events/       # Event emitters
+│   ├── Cargo.toml
+│   └── tauri.conf.json
+├── examples/             # Docker test environment, virtual serial
+├── docs/                 # User and developer documentation
+└── package.json
+```
+
+For the full architecture documentation, including class diagrams and data flow sequences, see [CLAUDE.md](../CLAUDE.md).
+
+---
+
+## Development Setup
+
+See [Building TermiHub](building.md) for detailed instructions on:
+- Installing prerequisites (Node.js, pnpm, Rust, system libraries)
+- Platform-specific dependencies
+- Running the development server
+
+Quick start:
+
+```bash
+git clone <repo-url>
+cd termihub
+pnpm install
+pnpm tauri dev
+```
+
+---
+
+## Task Management
+
+All work is tracked in **GitHub Issues**.
+
+### Priority Labels
+
+Issues are prioritized by phase label (highest priority first):
+
+1. **`phase-5-polish`** — UX improvements, performance, cross-platform testing
+2. **`phase-6-remote-foundation`** — Remote agent protocol and backend
+3. **`phase-7-remote-agent`** — Remote agent implementation
+4. **`future`** — Post-v1 enhancements
+
+### Finding Work
+
+```bash
+# List open issues by priority
+gh issue list --label phase-5-polish
+gh issue list --label phase-6-remote-foundation
+gh issue list --label future
+```
+
+Pick the next task from the highest-priority label with open issues.
+
+### Creating Issues
+
+When you discover work during development, create a new issue:
+
+```bash
+gh issue create --title "Brief description" --label "phase-5-polish"
+```
+
+---
+
+## Git Workflow
+
+### Branch Strategy
+
+- **`main`** — Production-ready code
+- **`feature/<description>`** — New features (e.g., `feature/serial-backend`)
+- **`bugfix/<description>`** — Bug fixes (e.g., `bugfix/terminal-resize-crash`)
+
+**Never commit directly to `main`.**
+
+### Creating a Feature Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feature/my-feature
+```
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
+
+**Scopes**: `terminal`, `ssh`, `serial`, `ui`, `backend`, `sftp`, `config`, etc.
+
+**Examples:**
+
+```
+feat(terminal): add horizontal scrolling option
+
+Add per-connection horizontal scroll toggle with runtime
+switching via tab context menu.
+
+Closes #42
+```
+
+```
+fix(ssh): handle connection timeout gracefully
+
+Previously, a connection timeout would crash the app.
+Now shows an error message in the terminal.
+
+Fixes #34
+```
+
+### Pull Requests
+
+1. Push your branch: `git push -u origin feature/my-feature`
+2. Create a PR: `gh pr create`
+3. Include in the PR description:
+   - What changed and why
+   - How to test
+   - Screenshots for UI changes
+4. Reference issues: `Closes #N` or `Fixes #N`
+5. **Always merge with a merge commit** (`gh pr merge --merge`) — never squash or rebase
+
+---
+
+## Coding Standards
+
+### TypeScript / React
+
+- **No `any` types** — Use proper type definitions
+- **One component per file** — Named exports
+- **Hooks first** in component body, then event handlers, then render
+- **`PascalCase`** for components, **`camelCase`** for functions/hooks, **`UPPER_SNAKE_CASE`** for constants
+- **Props interfaces** always defined (e.g., `interface MyComponentProps { ... }`)
+- **JSDoc** for public functions
+
+### Rust
+
+- **No `.unwrap()` in production code** — Use `?` with `anyhow::Result`
+- **Add context** to errors: `.context("description")`
+- **`PascalCase`** for types/traits, **`snake_case`** for functions/modules, **`UPPER_SNAKE_CASE`** for constants
+- **Doc comments** (`///`) for public APIs
+- **`tokio`** for async, channels for communication
+
+### General
+
+- Maximum ~500 lines per file
+- Maximum ~50 lines per function
+- Clear, descriptive naming
+- Single Responsibility Principle
+
+See [CLAUDE.md](../CLAUDE.md) for detailed code examples and patterns.
+
+---
+
+## Adding a New Terminal Backend
+
+To add a new connection type (e.g., a new protocol):
+
+### 1. Implement the Backend (Rust)
+
+Create a new file in `src-tauri/src/terminal/` (e.g., `my_protocol.rs`):
+
+- Implement the `TerminalBackend` trait
+- Handle spawning, input/output, resize, and close
+- Use `anyhow::Result` for error handling
+
+### 2. Register with TerminalManager
+
+Update `src-tauri/src/terminal/manager.rs` to:
+- Add a match arm for the new connection type
+- Instantiate your backend when a session is created
+
+### 3. Add Tauri Commands
+
+Update `src-tauri/src/commands/` if any new IPC commands are needed beyond the standard terminal lifecycle.
+
+### 4. Add Configuration Types
+
+- **Rust**: Add a config struct in `src-tauri/src/connection/config.rs`
+- **TypeScript**: Add corresponding types in `src/types/terminal.ts`
+
+### 5. Create Settings UI
+
+Add a settings component in `src/components/Settings/` (e.g., `MyProtocolSettings.tsx`) and integrate it into the `ConnectionEditor`.
+
+### 6. Add to Connection Type Selector
+
+Update the connection type dropdown in `src/components/Sidebar/ConnectionEditor.tsx`.
+
+### 7. Test
+
+- Use the test environment in `examples/` if applicable
+- Test on your target platform
+- Run `cargo clippy` and `pnpm build` to check for errors
+
+---
+
+## Testing
+
+### Running Tests
+
+```bash
+# Rust tests
+cd src-tauri && cargo test
+
+# TypeScript type checking
+pnpm build
+
+# Rust linting
+cd src-tauri && cargo clippy
+```
+
+### Test Environment
+
+The `examples/` directory provides Docker-based test servers:
+
+```bash
+cd examples
+./start-test-environment.sh   # Start SSH + Telnet servers
+./stop-test-environment.sh    # Stop servers
+```
+
+See [examples/README.md](../examples/README.md) for details on:
+- SSH server (port 2222) and Telnet server (port 2323)
+- Virtual serial ports via socat
+- Pre-configured test connections
+- X11 forwarding test applications
+
+### Manual Testing
+
+For UI changes, test the following:
+- Create, edit, duplicate, and delete connections
+- Connect to each terminal type
+- Drag-and-drop tabs between panels
+- Split views (horizontal and vertical)
+- File browser (local and SFTP)
+- Keyboard shortcuts
+
+---
+
+## Changelog
+
+Update `CHANGELOG.md` for every user-facing change following [Keep a Changelog](https://keepachangelog.com/) format:
+
+- Add entries under `[Unreleased]`
+- Use categories: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
+- Write user-facing descriptions (not implementation details)
+
+**Good**: "Added support for Git Bash on Windows"
+**Bad**: "Implemented GitBashDetector class in shell_detect.rs"
+
+---
+
+## Code Review Checklist
+
+Before submitting a PR:
+
+- [ ] Code compiles without warnings (`cargo clippy`, `pnpm build`)
+- [ ] No `.unwrap()` calls in Rust production code
+- [ ] No `any` types in TypeScript
+- [ ] Commit messages follow Conventional Commits
+- [ ] `CHANGELOG.md` updated for user-facing changes
+- [ ] Tested on your primary platform
+- [ ] PR description explains what changed and how to test

--- a/docs/serial-setup.md
+++ b/docs/serial-setup.md
@@ -1,0 +1,206 @@
+# Serial Port Setup
+
+This guide covers how to configure serial port connections in TermiHub on each platform.
+
+---
+
+## Platform Setup
+
+### macOS
+
+Serial devices appear under `/dev/tty.*` when connected. Common paths:
+
+| Device | Path |
+|--------|------|
+| USB-to-serial adapter | `/dev/tty.usbserial-*` |
+| USB-to-serial (FTDI) | `/dev/tty.usbserial-FTDI*` |
+| USB-to-serial (CH340) | `/dev/tty.wchusbserial*` |
+| Arduino / similar | `/dev/tty.usbmodem*` |
+| Bluetooth serial | `/dev/tty.Bluetooth-*` |
+
+**USB driver installation**: Most modern USB-to-serial adapters work out of the box on macOS. If your device is not recognized:
+
+1. Check the chipset on the adapter (usually FTDI, CH340, CP210x, or PL2303)
+2. Download the driver from the manufacturer:
+   - [FTDI drivers](https://ftdichip.com/drivers/vcp-drivers/)
+   - [CH340 drivers](https://www.wch-ic.com/downloads/CH341SER_MAC_ZIP.html)
+   - [CP210x drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers)
+3. Install and restart your Mac
+4. The device should appear in TermiHub's port dropdown
+
+**Tip**: Run `ls /dev/tty.*` in a terminal to list all available serial devices.
+
+### Linux
+
+Serial devices appear under `/dev/ttyUSB*` or `/dev/ttyACM*`. Common paths:
+
+| Device | Path |
+|--------|------|
+| USB-to-serial adapter | `/dev/ttyUSB0` |
+| Arduino / ACM device | `/dev/ttyACM0` |
+| Built-in serial port | `/dev/ttyS0` |
+
+**Permissions**: By default, serial ports require root access. Add your user to the `dialout` group:
+
+```bash
+sudo usermod -a -G dialout $USER
+```
+
+Log out and back in for the change to take effect. Verify:
+
+```bash
+groups | grep dialout
+```
+
+**Udev rules (optional)**: Create a udev rule for persistent device names:
+
+```bash
+# Find device attributes
+udevadm info -a -n /dev/ttyUSB0 | grep -E 'idVendor|idProduct|serial'
+
+# Create rule
+sudo tee /etc/udev/rules.d/99-serial.rules << 'EOF'
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", SYMLINK+="tty_mydevice"
+EOF
+
+# Reload rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+The device will then be available as `/dev/tty_mydevice` in addition to its `/dev/ttyUSB*` path.
+
+**USB drivers**: Most chipsets are supported by the Linux kernel. If a device is not recognized, check `dmesg` output after plugging it in:
+
+```bash
+dmesg | tail -20
+```
+
+### Windows
+
+Serial devices appear as COM ports (e.g., `COM3`, `COM4`).
+
+**Finding the port**:
+
+1. Open **Device Manager** (right-click Start menu)
+2. Expand **Ports (COM & LPT)**
+3. Look for your device (e.g., "USB-SERIAL CH340 (COM3)")
+
+**Driver installation**: Windows usually installs drivers automatically via Windows Update. If not:
+
+1. Check the chipset (printed on the adapter or in Device Manager under the device's properties)
+2. Download from the manufacturer (same links as macOS section above)
+3. Install and check Device Manager again
+
+**Tip**: TermiHub auto-detects available COM ports in the connection editor. If no ports appear in the dropdown, enter the port name manually (e.g., `COM3`).
+
+---
+
+## Configuration Parameters
+
+When creating a serial connection in TermiHub, configure these parameters to match your device:
+
+| Parameter | Options | Default | Description |
+|-----------|---------|---------|-------------|
+| Port | Auto-detected or manual | — | Serial port path |
+| Baud Rate | 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600 | 9600 | Data transfer speed (bits/second) |
+| Data Bits | 5, 6, 7, 8 | 8 | Number of data bits per frame |
+| Stop Bits | 1, 2 | 1 | Number of stop bits per frame |
+| Parity | None, Odd, Even | None | Error-checking method |
+| Flow Control | None, Hardware (RTS/CTS), Software (XON/XOFF) | None | Data flow regulation |
+
+### Common Configurations
+
+**Most embedded devices** (Arduino, ESP32, STM32, etc.):
+- Baud Rate: 115200
+- Data Bits: 8
+- Stop Bits: 1
+- Parity: None
+- Flow Control: None
+
+**Legacy serial devices**:
+- Baud Rate: 9600
+- Data Bits: 8
+- Stop Bits: 1
+- Parity: None
+- Flow Control: None
+
+**Industrial equipment (Modbus RTU)**:
+- Baud Rate: 9600 or 19200
+- Data Bits: 8
+- Stop Bits: 1 or 2
+- Parity: Even or None
+- Flow Control: None
+
+Check your device's documentation for the correct settings. Mismatched baud rate is the most common cause of garbled output.
+
+---
+
+## Testing with Virtual Serial Ports
+
+TermiHub includes scripts for creating virtual serial ports, which is useful for testing without physical hardware.
+
+### Setup (Linux/macOS)
+
+Requires `socat` and Python 3:
+
+```bash
+# Install socat
+# macOS:
+brew install socat
+# Ubuntu/Debian:
+sudo apt install socat
+
+# Create virtual serial port pair
+cd examples/serial
+./setup-virtual-serial.sh
+```
+
+This creates two linked virtual ports:
+- `/tmp/termihub-serial-a` — Connect TermiHub to this port
+- `/tmp/termihub-serial-b` — Used by the echo server
+
+### Running the Echo Server
+
+```bash
+cd examples/serial
+python3 serial-echo-server.py
+```
+
+The echo server reads from port B and echoes back whatever is sent. Connect TermiHub to port A and type to test.
+
+See [examples/README.md](../examples/README.md) for full test environment setup.
+
+---
+
+## Troubleshooting
+
+### Port not appearing in dropdown
+
+- **All platforms**: Unplug and replug the device, then click **Refresh** or re-open the connection editor
+- **Linux**: Check permissions — run `ls -la /dev/ttyUSB0` and ensure your user is in the `dialout` group
+- **macOS**: Check if a driver is needed for your adapter chipset
+- **Windows**: Check Device Manager for driver issues (yellow warning triangle)
+
+### Garbled output
+
+- **Baud rate mismatch**: This is the most common cause. Verify the baud rate matches your device's configuration.
+- **Data bits / parity mismatch**: Less common, but check your device's documentation.
+
+### "Permission denied" (Linux)
+
+```bash
+# Add user to dialout group
+sudo usermod -a -G dialout $USER
+# Log out and log back in
+```
+
+### "Port is busy" / "Access denied"
+
+Another application (e.g., Arduino IDE, minicom, screen) may have the port open. Close that application first — serial ports can only be opened by one application at a time.
+
+### Device disconnects unexpectedly
+
+- Check the USB cable — loose or damaged cables cause intermittent disconnections
+- Try a different USB port
+- On Linux, check `dmesg` for USB error messages

--- a/docs/ssh-configuration.md
+++ b/docs/ssh-configuration.md
@@ -1,0 +1,294 @@
+# SSH Configuration
+
+This guide covers SSH connection setup in TermiHub, including key-based authentication, X11 forwarding, and the SFTP file browser.
+
+---
+
+## Authentication Methods
+
+TermiHub supports two SSH authentication methods:
+
+### Password Authentication
+
+When **Auth Method** is set to **Password**, TermiHub prompts for the password each time you connect. Passwords are never stored in the configuration file.
+
+### Key-Based Authentication
+
+When **Auth Method** is set to **SSH Key**, you provide a path to your private key file. This is the recommended method for frequent connections.
+
+**Settings:**
+- **Key Path** — Absolute path to your private key file (e.g., `~/.ssh/id_rsa`). The `~` prefix is expanded to your home directory.
+
+---
+
+## Setting Up SSH Keys
+
+If you don't already have an SSH key pair, generate one:
+
+### Generate a Key Pair
+
+```bash
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+When prompted:
+- **File location**: Press Enter to accept the default (`~/.ssh/id_ed25519`), or specify a custom path
+- **Passphrase**: Enter a passphrase for extra security, or press Enter for no passphrase
+
+This creates two files:
+- `~/.ssh/id_ed25519` — Your private key (keep this secret)
+- `~/.ssh/id_ed25519.pub` — Your public key (install on servers)
+
+**Note**: You can also use RSA keys (`ssh-keygen -t rsa -b 4096`). TermiHub supports both key types.
+
+### Install the Public Key on the Server
+
+Copy your public key to the remote server:
+
+```bash
+ssh-copy-id -i ~/.ssh/id_ed25519.pub user@hostname
+```
+
+Or manually append it to `~/.ssh/authorized_keys` on the server:
+
+```bash
+cat ~/.ssh/id_ed25519.pub | ssh user@hostname 'mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys'
+```
+
+### Configure in TermiHub
+
+1. Create or edit an SSH connection
+2. Set **Auth Method** to **SSH Key**
+3. Set **Key Path** to the path of your private key (e.g., `~/.ssh/id_ed25519`)
+4. Save and connect
+
+---
+
+## Platform-Specific Key Setup
+
+### macOS
+
+macOS includes a built-in SSH agent and Keychain integration.
+
+**Add your key to the SSH agent and Keychain:**
+
+```bash
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+```
+
+To load keys automatically on login, add to `~/.ssh/config`:
+
+```
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+```
+
+**Key location**: Keys are typically stored in `~/.ssh/`. Use this path in TermiHub's Key Path field.
+
+### Linux
+
+**Start the SSH agent** (if not already running):
+
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+```
+
+To start the agent automatically, add to your shell profile (`~/.bashrc` or `~/.zshrc`):
+
+```bash
+if [ -z "$SSH_AUTH_SOCK" ]; then
+  eval "$(ssh-agent -s)"
+  ssh-add ~/.ssh/id_ed25519
+fi
+```
+
+**Key permissions**: Ensure correct permissions on your key files:
+
+```bash
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/id_ed25519
+chmod 644 ~/.ssh/id_ed25519.pub
+```
+
+### Windows
+
+**Using OpenSSH Agent** (built-in to Windows 10+):
+
+1. Open **Services** (Win+R, type `services.msc`)
+2. Find **OpenSSH Authentication Agent**, set it to **Automatic**, and start it
+3. Add your key:
+
+   ```powershell
+   ssh-add $env:USERPROFILE\.ssh\id_ed25519
+   ```
+
+**Key location**: Keys are typically stored in `C:\Users\<username>\.ssh\`. In TermiHub, you can use either:
+- `~/.ssh/id_ed25519` (the `~` prefix works)
+- `C:\Users\<username>\.ssh\id_ed25519`
+
+---
+
+## X11 Forwarding
+
+X11 forwarding lets you run graphical applications on a remote server and display them on your local machine.
+
+### Enabling X11 Forwarding
+
+1. Edit an SSH connection in TermiHub
+2. Check **Enable X11 Forwarding**
+3. Save and connect
+
+When connected, run a graphical application on the remote server (e.g., `xclock`, `xeyes`, `firefox`) and its window will appear on your local display.
+
+### Platform Requirements
+
+#### macOS
+
+Install [XQuartz](https://www.xquartz.org/) (the X11 server for macOS):
+
+```bash
+brew install --cask xquartz
+```
+
+After installing, **log out and log back in** (or restart). XQuartz must be running before connecting with X11 forwarding.
+
+**Verify XQuartz is working:**
+
+```bash
+# After installing and restarting
+echo $DISPLAY
+# Should output something like: /private/tmp/com.apple.launchd.xxxx/org.xquartz:0
+```
+
+#### Linux
+
+X11 is typically pre-installed on desktop Linux distributions. Ensure `xauth` is installed:
+
+```bash
+# Ubuntu/Debian
+sudo apt install xauth
+
+# Fedora
+sudo dnf install xorg-x11-xauth
+
+# Arch
+sudo pacman -S xorg-xauth
+```
+
+No additional setup is needed — TermiHub will use your existing X11 display.
+
+#### Windows
+
+X11 forwarding is **not currently supported** on Windows. TermiHub's X11 proxy relies on Unix domain sockets, which are not available on Windows.
+
+For Windows users needing to run remote GUI applications, consider using a standalone X server like [VcXsrv](https://sourceforge.net/projects/vcxsrv/) with a standard SSH client.
+
+### Server-Side Requirements
+
+The SSH server must have X11 forwarding enabled. Check `/etc/ssh/sshd_config` on the server:
+
+```
+X11Forwarding yes
+X11DisplayOffset 10
+```
+
+The `xauth` package must also be installed on the server.
+
+---
+
+## SFTP File Browser
+
+When connected to an SSH server, TermiHub provides an integrated SFTP file browser for managing remote files.
+
+### Auto-Connect
+
+When you click on an SSH terminal tab, the file browser in the sidebar automatically connects to the remote server via SFTP. No manual connection step is needed.
+
+### Features
+
+- **Browse** remote directories
+- **Upload** files by clicking the Upload button or dragging files from your OS file manager
+- **Download** files via right-click context menu
+- **Create** files and directories
+- **Rename** and **delete** files and directories
+- **Edit** remote files in the built-in editor (changes are saved back via SFTP)
+- **Open in VS Code** — downloads the file to a temp location and opens it
+
+### File Information
+
+The file browser shows:
+- File name
+- File size (formatted as B, KB, MB)
+- File permissions in Unix `rwx` notation
+
+See the [User Guide](user-guide.md#file-browser) for more details on the file browser interface.
+
+---
+
+## Connection Settings Reference
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| Host | Server hostname or IP address | — |
+| Port | SSH port | 22 |
+| Username | Remote username | — |
+| Auth Method | `password` or `key` | password |
+| Key Path | Path to private key (when using key auth) | — |
+| Enable X11 Forwarding | Forward remote GUI apps to local display | Off |
+
+### Environment Variable Placeholders
+
+You can use `${env:VAR}` syntax in any field:
+
+```
+Host: ${env:MY_SERVER}
+Username: ${env:USER}
+Key Path: ${env:HOME}/.ssh/id_ed25519
+```
+
+This is useful for shared connection configurations where values differ per user.
+
+---
+
+## Troubleshooting
+
+### "Connection refused"
+
+- Verify the SSH server is running on the target: `systemctl status sshd`
+- Check the port is correct (default: 22)
+- Test with the standard `ssh` command: `ssh -p 22 user@host`
+- Check firewall rules on the server
+
+### "Authentication failed"
+
+- **Password auth**: Verify the username and password are correct
+- **Key auth**: Ensure the public key is in `~/.ssh/authorized_keys` on the server
+- **Key permissions**: Check that your private key file has `600` permissions
+- **Wrong key**: Verify the Key Path in TermiHub points to the correct private key
+
+### "Host key verification failed"
+
+This occurs when connecting to a new server or when the server's host key has changed. TermiHub uses the system's `known_hosts` file. To resolve:
+
+```bash
+# Connect once with standard SSH to accept the host key
+ssh user@hostname
+# Type 'yes' when prompted to add the key
+```
+
+### X11 forwarding not working
+
+- **macOS**: Ensure XQuartz is installed and running. Log out and log back in after installing XQuartz.
+- **Linux**: Ensure `xauth` is installed and `$DISPLAY` is set
+- **Server**: Check that `X11Forwarding yes` is set in `/etc/ssh/sshd_config`
+- **Server**: Ensure `xauth` is installed on the server
+- Test with standard SSH: `ssh -X user@host xclock`
+
+### SFTP connection fails
+
+- SFTP uses the same SSH connection — if SSH works, SFTP should too
+- Ensure the SSH server has SFTP enabled (check for `Subsystem sftp` in `/etc/ssh/sshd_config`)
+- Some restricted shells may block SFTP — check with your server administrator

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,381 @@
+# TermiHub User Guide
+
+This guide covers the TermiHub interface, features, and day-to-day usage.
+
+---
+
+## Interface Overview
+
+TermiHub uses a VS Code-inspired three-column layout:
+
+```
+┌──────────┬────────────────┬──────────────────────────────────────────┐
+│ Activity │    Sidebar     │           Terminal View                  │
+│   Bar    │                │  ┌──────┬──────┬──────┐                 │
+│          │  Connections   │  │ Tab1 │ Tab2 │ Tab3 │                 │
+│  [Con]   │  File Browser  │  ├──────┴──────┴──────┤                 │
+│  [File]  │  Settings      │  │                    │                 │
+│          │                │  │  Terminal Content   │                 │
+│          │                │  │                    │                 │
+│          │                │  │                    │                 │
+│          │                │  └────────────────────┘                 │
+│  [Gear]  │                │  Status Bar                             │
+└──────────┴────────────────┴──────────────────────────────────────────┘
+```
+
+### Activity Bar
+
+The narrow left-most column with icon buttons:
+
+| Icon | View | Description |
+|------|------|-------------|
+| Network | Connections | Manage and open terminal connections |
+| Folder | File Browser | Browse local and remote files |
+| Gear (bottom) | Settings menu | Import/export connections, open settings |
+
+Click an active icon to toggle (collapse/expand) the sidebar.
+
+The **gear icon** at the bottom opens a dropdown menu with:
+- **Settings** — Open the Settings tab
+- **Import Connections** — Load connections from a JSON file
+- **Export Connections** — Save all connections to a JSON file
+
+### Sidebar
+
+The middle column shows the view selected in the Activity Bar. It can be collapsed by clicking the active Activity Bar icon again.
+
+### Terminal View
+
+The main area on the right. Contains:
+- **Tab Bar** — Tabs for open terminals, editors, and settings
+- **Terminal Content** — The active terminal, editor, or settings panel
+- **Terminal Toolbar** — New Terminal (+), Split, and Close Panel buttons
+- **Status Bar** — Shows information about the active tab at the bottom
+
+---
+
+## Managing Connections
+
+### Creating a Connection
+
+1. Click the **Connections** icon in the Activity Bar
+2. Click the **+** (New Connection) button in the sidebar toolbar
+3. Fill in the connection details:
+   - **Name** — Display name for the connection
+   - **Folder** — Parent folder (or root)
+   - **Type** — Local Shell, SSH, Serial, or Telnet
+   - Type-specific settings (see below)
+4. Click **Save**
+
+### Editing and Deleting
+
+- **Right-click** a connection to open the context menu:
+  - **Connect** — Open in a new terminal tab
+  - **Ping Host** — Ping the remote host (SSH and Telnet only)
+  - **Edit** — Open the connection editor
+  - **Duplicate** — Create a copy ("Copy of &lt;name&gt;")
+  - **Delete** — Remove the connection
+
+### Connecting
+
+- **Double-click** a connection to connect immediately
+- Or right-click and select **Connect**
+
+### Organizing with Folders
+
+- Click the **folder+** icon in the toolbar to create a root-level folder
+- Right-click a folder to create subfolders or connections inside it
+- **Drag and drop** connections between folders to reorganize
+- Deleting a folder moves its children to the parent folder
+
+### Import and Export
+
+Export your connections to share them or back them up:
+
+1. Click the **gear icon** in the Activity Bar
+2. Select **Export Connections** to save to a JSON file
+3. Select **Import Connections** to load from a JSON file
+
+### External Connection Files
+
+Load shared connection configs from external JSON files (e.g., from a git repository):
+
+1. Open **Settings** from the gear menu
+2. In the **External Connection Files** section:
+   - Click **Add File** to select an existing JSON file
+   - Click **Create File** to create a new external connection file
+3. Toggle files on/off with the switch next to each file
+4. External connections appear in the connection list with a special git-folder icon
+
+External connections are read-only in the connection list — edit the JSON files directly.
+
+### Environment Variable Placeholders
+
+Use `${env:VAR}` syntax in any connection field to substitute environment variables at connect time. For example:
+
+- Host: `${env:MY_SERVER_HOST}`
+- Username: `${env:USER}`
+- Key path: `${env:HOME}/.ssh/id_rsa`
+
+This is useful for shared connection files where values differ per user.
+
+---
+
+## Connection Types
+
+### Local Shell
+
+Opens a local terminal using a shell installed on your system. TermiHub auto-detects available shells:
+
+- **macOS/Linux**: zsh, bash, sh
+- **Windows**: PowerShell, cmd, Git Bash
+
+Select the shell in the connection editor's **Shell** dropdown, which only shows shells available on your platform.
+
+### SSH
+
+Connects to a remote server via SSH. See [SSH Configuration](ssh-configuration.md) for detailed setup instructions.
+
+**Settings:**
+- **Host** — Hostname or IP address
+- **Port** — SSH port (default: 22)
+- **Username** — Remote username
+- **Auth Method** — Password (prompted each time) or SSH Key (specify key path)
+- **Enable X11 Forwarding** — Forward remote GUI applications to your local display
+
+### Telnet
+
+Connects to a remote server via the Telnet protocol.
+
+**Settings:**
+- **Host** — Hostname or IP address
+- **Port** — Telnet port (default: 23)
+
+### Serial
+
+Connects to a serial device (USB-to-serial adapters, microcontrollers, etc.). See [Serial Setup](serial-setup.md) for platform-specific instructions.
+
+**Settings:**
+- **Port** — Serial port path (auto-detected or manual entry)
+- **Baud Rate** — 9600, 19200, 38400, 57600, 115200, 230400, 460800, or 921600
+- **Data Bits** — 5, 6, 7, or 8
+- **Stop Bits** — 1 or 2
+- **Parity** — None, Odd, or Even
+- **Flow Control** — None, Hardware (RTS/CTS), or Software (XON/XOFF)
+
+---
+
+## Terminal Options
+
+Each connection has additional terminal options in the editor:
+
+- **Enable horizontal scrolling** — Adds a horizontal scrollbar for wide terminal output
+- **Tab Color** — Assign a color to the tab for visual identification
+
+Both options can also be changed at runtime via the tab's right-click context menu.
+
+---
+
+## Terminal Tabs
+
+### Tab Bar
+
+Open terminals appear as tabs at the top of the terminal view. Each tab shows:
+- A type-specific icon (terminal, wifi, cable, globe)
+- The connection name
+- An optional colored left border (if a tab color is set)
+- A red dot indicator for unsaved editor files
+
+### Tab Actions
+
+- **Click** a tab to switch to it
+- **Drag** tabs to reorder within the same panel
+- **Drag** a tab to another panel to move it there
+- **Drag** a tab to the edge of a panel to create a new split
+
+### Tab Context Menu
+
+Right-click a terminal tab for these options:
+- **Save to File** — Export the terminal buffer to a text file
+- **Copy to Clipboard** — Copy the entire terminal buffer
+- **Clear Terminal** — Clear the terminal screen
+- **Horizontal Scrolling** — Toggle horizontal scrollbar
+- **Set Color...** — Open a color picker to set the tab color
+
+---
+
+## Split Views
+
+TermiHub supports splitting the terminal area into multiple panels arranged horizontally and vertically.
+
+### Creating Splits
+
+- Click the **Split** button (columns icon) in the terminal toolbar
+- Or **drag a tab** to the top, bottom, left, or right edge of an existing panel
+
+### Managing Splits
+
+- **Drag the divider** between panels to resize them
+- **Close Panel** (X button) removes a panel — its tabs move to an adjacent panel
+- Splits can be nested: split horizontally within a vertical split, and vice versa
+
+### Cross-Panel Tab Movement
+
+Drag any tab from one panel and drop it:
+- **On the tab bar** of another panel to move it there
+- **On the edge** of another panel to create a new split with that tab
+
+Drop zones are highlighted as you drag.
+
+---
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+Shift+`` (`` ` ``) | New local terminal |
+| `Ctrl+W` / `Cmd+W` | Close active tab |
+| `Ctrl+Tab` | Next tab |
+| `Ctrl+Shift+Tab` | Previous tab |
+| `Ctrl+S` / `Cmd+S` | Save file (in editor) |
+
+On macOS, `Cmd` can be used in place of `Ctrl` for the modifier shortcuts.
+
+---
+
+## File Browser
+
+The file browser in the sidebar lets you browse local and remote filesystems.
+
+### Modes
+
+The file browser operates in three modes depending on the active terminal tab:
+
+| Active Tab | Mode | Description |
+|-----------|------|-------------|
+| Local shell | Local | Browses the local filesystem |
+| SSH | SFTP | Browses the remote server via SFTP |
+| Serial / Telnet | None | File browser unavailable |
+| Editor / Settings | Previous | Retains the last active mode |
+
+When you switch to an SSH terminal tab, the SFTP connection is established automatically.
+
+### Navigation
+
+- Click a directory to open it
+- Click the **Up** arrow to go to the parent directory
+- The browser automatically follows the active terminal's working directory
+
+### Toolbar
+
+| Button | Description |
+|--------|-------------|
+| Up arrow | Navigate to parent directory |
+| Refresh | Reload the current directory |
+| Upload | Upload a file (SFTP mode only) |
+| New File | Create an empty file |
+| New Folder | Create a new directory |
+| Disconnect | Disconnect SFTP session (SFTP only) |
+
+### File and Directory Context Menu
+
+Right-click a file or directory for options:
+
+**Files:**
+- **Edit** — Open in the built-in editor
+- **Open in VS Code** — Open in external VS Code (downloads first if remote)
+- **Download** — Download to local machine (SFTP mode only)
+- **Rename** — Rename the file
+- **Delete** — Delete the file
+
+**Directories:**
+- **Open** — Navigate into the directory
+- **Rename** — Rename the directory
+- **Delete** — Delete the directory
+
+### Drag-and-Drop Upload
+
+In SFTP mode, drag files from your operating system's file manager onto the file browser to upload them to the remote server.
+
+### File Information
+
+Each entry shows:
+- File or directory name
+- File size (formatted as B, KB, MB)
+- File permissions in `rwx` notation (SFTP mode)
+
+---
+
+## Built-in File Editor
+
+TermiHub includes a built-in file editor powered by Monaco (the same engine as VS Code).
+
+### Opening Files
+
+- Double-click a file in the file browser
+- Or right-click a file and select **Edit**
+
+Files open in a new tab in the terminal view.
+
+### Features
+
+- **Syntax highlighting** — Automatic language detection from file extension
+- **Search and replace** — Standard Ctrl+F / Ctrl+H
+- **Word wrap** — Enabled by default
+- **Dark theme** — Matches the TermiHub dark theme
+
+### Saving
+
+- Press **Ctrl+S** (or **Cmd+S** on macOS) to save
+- Or click the **Save** button in the editor toolbar
+- Unsaved changes are indicated by a red dot on the tab
+- Closing a tab with unsaved changes will prompt for confirmation
+
+### Status Bar
+
+When an editor tab is active, the status bar at the bottom shows:
+
+| Item | Description |
+|------|-------------|
+| Ln / Col | Current cursor line and column |
+| Language | Detected language mode |
+| EOL | Line ending type (LF or CRLF) — click to toggle |
+| Tab Size | Current tab size — click to cycle between 2 and 4 |
+| Encoding | File encoding (UTF-8) |
+
+### Open in VS Code
+
+If VS Code is installed, you can right-click a file in the file browser and select **Open in VS Code**. For remote (SFTP) files, TermiHub downloads the file to a temporary location first.
+
+---
+
+## Settings
+
+### Opening Settings
+
+Click the **gear icon** at the bottom of the Activity Bar, then select **Settings**. Settings open in a dedicated tab.
+
+### Configuration Directory
+
+TermiHub stores its configuration (connections, folders, settings) in a platform-specific directory. Override this by setting the `TERMIHUB_CONFIG_DIR` environment variable before launching the app:
+
+```bash
+# Example: use a project-specific config directory
+TERMIHUB_CONFIG_DIR=./my-project/termihub-config pnpm tauri dev
+```
+
+### External Connection Files
+
+See [Managing Connections > External Connection Files](#external-connection-files) above for details on loading shared connection configs from external JSON files.
+
+---
+
+## Tips and Tricks
+
+- **Quick connect**: Double-click any connection to open it immediately
+- **Organize by project**: Use folders to group connections by project or environment
+- **Color-code tabs**: Assign colors to distinguish between production, staging, and development connections
+- **Share configs**: Use external connection files in a git repository so the whole team has the same connection list
+- **Env var placeholders**: Use `${env:VAR}` in connection fields so shared configs work across different machines
+- **Split for comparison**: Split the terminal view to compare output from two sessions side by side
+- **Auto-SFTP**: The file browser automatically connects to the SFTP server when you click an SSH terminal tab — no manual connection needed


### PR DESCRIPTION
## Summary
- Add 5 documentation files in `docs/`: user guide, build instructions, serial setup, SSH configuration, and contributing guide
- Update README with links to all docs and remove redundant Quick Start section
- Add CHANGELOG entry for the new documentation

## Test plan
- [ ] Verify all internal cross-links between docs resolve correctly
- [ ] Verify keyboard shortcuts table matches `src/hooks/useKeyboardShortcuts.ts`
- [ ] Verify serial config options match `src/components/Settings/SerialSettings.tsx`
- [ ] Verify SSH settings match `src/components/Settings/SshSettings.tsx`
- [ ] Verify README renders correctly on GitHub

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)