### PR TITLE
Add automated unit tests and manual test plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Automated unit tests for Rust backend (~41 new tests) covering shell detection, file utilities, connection config serialization, external file management, and environment variable expansion
+- Automated unit tests for TypeScript frontend (~43 tests) covering formatters, panel tree operations, and Zustand store actions
+- Vitest test framework for frontend with jsdom environment and coverage support
+- Manual test plan document (`docs/manual-testing.md`) for features requiring hardware or live connections
 - User documentation: user guide, build instructions, serial setup, SSH configuration, and contributing guide
 - X11 forwarding for SSH connections: forward remote GUI applications to local X server
 - Environment variable placeholders in connection settings: use `${env:VAR}` syntax for shared configs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,15 +736,46 @@ Phase 1 does NOT implement credential encryption to avoid complexity. Future imp
 
 ## Testing Strategy
 
-### Frontend Testing
-- Component testing with React Testing Library
-- Integration tests for critical flows
-- Manual testing on all platforms
+### Running Automated Tests
 
-### Backend Testing
-- Unit tests for each backend implementation
-- Integration tests for Tauri commands
-- Manual testing with real serial ports, SSH servers
+**Rust backend:**
+```bash
+cd src-tauri && cargo test
+```
+
+**TypeScript frontend:**
+```bash
+pnpm test            # single run
+pnpm test:watch      # watch mode
+pnpm test:coverage   # with coverage report
+```
+
+### What's Covered by Automated Tests
+
+**Rust (~54 tests):**
+- `utils/shell_detect.rs` — `shell_to_command()` mapping for all shell types
+- `utils/expand.rs` — `${env:...}` placeholder expansion
+- `utils/x11_detect.rs` — X11 display string parsing
+- `files/utils.rs` — `format_permissions()`, `chrono_from_epoch()`
+- `files/local.rs` — filesystem operations (list, mkdir, delete, rename, read/write) via tempdir
+- `connection/config.rs` — serde round-trips for all `ConnectionConfig` variants, JSON shape verification
+- `connection/manager.rs` — `strip_ssh_password()`, `filename_from_path()`, external file save/load round-trip
+- `terminal/backend.rs` — serde round-trips for config types, `expand()` for all config variants
+
+**TypeScript (~43 tests):**
+- `utils/formatters.ts` — `formatBytes()`, `truncate()`, `formatRelativeTime()`
+- `utils/panelTree.ts` — all tree operations (create, find, update, remove, split, simplify, edgeToSplit)
+- `store/appStore.ts` — tab add/close/activate, split panel, move tab, connection CRUD, sidebar toggle
+
+### What's NOT Covered (and Why)
+
+- **Terminal rendering** — xterm.js renders to a `<canvas>`, not DOM elements, making it opaque to DOM-based test tools
+- **Real SSH/Serial/Telnet connections** — require live servers or hardware; tested manually
+- **Tauri IPC integration** — commands require a running Tauri app with an `AppHandle`; unit-testing would require refactoring production code to extract the `AppHandle` dependency
+- **E2E UI tests** — xterm.js canvas rendering + platform-specific WebDriver setup makes automated E2E impractical for this project size
+- **Cross-platform behavior** — platform-specific code paths (Windows shell detection, ConPTY) require running on each OS
+
+See [`docs/manual-testing.md`](docs/manual-testing.md) for the manual test plan covering these areas.
 
 ### Performance Testing
 - Load testing with 40 concurrent terminals

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -1,0 +1,121 @@
+# Manual Test Plan
+
+This document describes manual test procedures for features that cannot be effectively automated. Run these tests before releases and after major changes.
+
+## Test Environment Setup
+
+- Build the app with `pnpm tauri dev` (development) or `pnpm tauri build` (release)
+- For serial port tests, set up virtual serial ports with `socat` (see `examples/` and `docs/serial-setup.md`)
+- For SSH/Telnet tests, use the Docker targets in `examples/` or real remote hosts
+- For cross-platform tests, run on each target OS
+
+---
+
+## 1. Local Shell
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| LOCAL-01 | Platform shells detected | None | Open connection editor, select Local type | Shell dropdown shows shells available on current OS (zsh/bash/sh on macOS/Linux; PowerShell/cmd on Windows) |
+| LOCAL-02 | Shell spawns correctly | None | Create and connect a local shell connection | Terminal opens, shell prompt appears, commands execute |
+| LOCAL-03 | Terminal resize | Running local shell | Resize the app window or drag a split divider | Terminal re-renders correctly, no garbled output, `tput cols`/`tput lines` reports new size |
+| LOCAL-04 | Process exit detection | Running local shell | Type `exit` in the shell | Terminal shows "[Process exited with code 0]" |
+| LOCAL-05 | Initial command | None | Create a local connection with initial command "echo hello" | Terminal opens, shell starts, "hello" is printed automatically |
+| LOCAL-06 | Home directory start | None | Create and connect a new local shell | `pwd` shows user home directory, not system root |
+
+## 2. SSH
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| SSH-01 | Password auth | SSH server (e.g. Docker example) | Create SSH connection with password auth, connect | Password prompt appears, connection succeeds after entering password |
+| SSH-02 | Key auth | SSH server + key pair | Create SSH connection with key auth, set key path, connect | Connection succeeds without password prompt |
+| SSH-03 | Connection failure | None | Create SSH connection to non-existent host, connect | Error message displayed in terminal within reasonable timeout |
+| SSH-04 | Terminal resize | Connected SSH session | Resize the app window | Remote shell reports updated dimensions |
+| SSH-05 | Session output | Connected SSH session | Run commands that produce output (e.g. `ls -la`, `top`) | Output renders correctly in terminal |
+| SSH-06 | Disconnect handling | Connected SSH session | Kill the SSH server or disconnect network | Terminal shows disconnection message |
+| SSH-07 | X11 forwarding | SSH server with X11, local X server | Enable X11 forwarding, connect, run `xeyes` or `xclock` | GUI application window appears on local machine |
+
+## 3. Serial
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| SERIAL-01 | Port enumeration | Serial port or virtual port via socat | Open connection editor, select Serial type | Port dropdown lists available serial ports |
+| SERIAL-02 | Connect at common baud rates | Serial device or virtual port | Create serial connection at 9600/115200, connect | Connection opens, data exchange works |
+| SERIAL-03 | Send and receive | Connected serial session | Type characters in terminal | Characters sent to device and echoed back (if device echoes) |
+| SERIAL-04 | Disconnect handling | Connected serial session | Disconnect the serial device | Terminal shows error/disconnect message |
+| SERIAL-05 | Config parameters | Serial device | Set non-default data bits, stop bits, parity, flow control | Connection works with configured parameters |
+
+## 4. Telnet
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| TELNET-01 | Connect | Telnet server (e.g. Docker example) | Create Telnet connection, connect | Connection established, server banner displayed |
+| TELNET-02 | Send and receive | Connected Telnet session | Type commands | Commands execute and output displays |
+| TELNET-03 | Connection failure | None | Create Telnet connection to non-existent host | Error message displayed within reasonable timeout |
+
+## 5. Tab Management
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| TAB-01 | Create tabs | None | Click New Terminal multiple times | Multiple tabs appear in tab bar, most recent is active |
+| TAB-02 | Close tab | Multiple tabs open | Click X on a tab or use Ctrl+W | Tab removed, adjacent tab becomes active |
+| TAB-03 | Drag reorder | Multiple tabs open | Drag a tab to a new position in the tab bar | Tab moves to new position, order persists |
+| TAB-04 | Switch tabs | Multiple tabs open | Click different tabs, use Ctrl+Tab / Ctrl+Shift+Tab | Correct terminal displayed for each tab |
+| TAB-05 | Context menu | Tab open | Right-click a tab | Context menu with Close, Copy, Save, Clear options |
+| TAB-06 | Close last tab | Single tab in a split panel | Close the tab | Panel removed (if other panels exist) or empty panel remains |
+
+## 6. Split Views
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| SPLIT-01 | Split horizontal | Terminal open | Click split button or use toolbar | Panel splits horizontally, new empty panel appears |
+| SPLIT-02 | Split vertical | Terminal open | Hold Shift + click split (or toolbar option) | Panel splits vertically |
+| SPLIT-03 | Close panel | Multiple panels | Close all tabs in a panel | Panel removed, remaining panels resize |
+| SPLIT-04 | Resize divider | Split panels | Drag the divider between panels | Panels resize, terminals re-fit |
+| SPLIT-05 | Drag-to-split | Tab and multiple panels | Drag tab to edge of another panel | New split created, tab moves to new panel |
+| SPLIT-06 | Nested splits | Multiple panels | Create horizontal split, then split one panel vertically | Both horizontal and vertical splits coexist |
+
+## 7. Connection Management
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| CONN-01 | Create connection | None | Click + in connection list, fill form, save | Connection appears in list |
+| CONN-02 | Edit connection | Existing connection | Right-click > Edit, modify fields, save | Changes persisted, visible on next app restart |
+| CONN-03 | Delete connection | Existing connection | Right-click > Delete | Connection removed from list |
+| CONN-04 | Create folder | None | Right-click > New Subfolder (or toolbar) | Folder appears in connection tree |
+| CONN-05 | Drag between folders | Connections and folders | Drag a connection to a different folder | Connection moves to target folder |
+| CONN-06 | Import/Export | Existing connections | Export via Settings dropdown, import to fresh app | All connections and folders restored |
+| CONN-07 | External files | JSON connection file | Add external file in Settings, enable it | External connections appear in tree under folder |
+| CONN-08 | Env var placeholders | None | Create SSH connection with `${env:USER}` in username field | Placeholder expanded when connecting |
+| CONN-09 | Password not stored | SSH connection with password auth | Connect, enter password, close app, check config file | Config file contains no password field for SSH connections |
+| CONN-10 | Duplicate connection | Existing connection | Right-click > Duplicate | "Copy of <name>" appears in same folder |
+
+## 8. File Browser
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| FILE-01 | Local browse | None | Switch to Files view, select Local mode | Local filesystem tree displayed |
+| FILE-02 | SFTP browse | SSH connection | Connect SFTP via picker | Remote filesystem tree displayed |
+| FILE-03 | Upload file | SFTP connected | Right-click > Upload or drag file from OS | File appears in remote listing |
+| FILE-04 | Download file | SFTP connected | Right-click remote file > Download | File saved to local filesystem |
+| FILE-05 | Create/Rename/Delete | SFTP or local browse | Create directory, rename file, delete file | Operations succeed, listing refreshes |
+| FILE-06 | Auto-connect SFTP | SSH terminal tab open | Switch to Files view | SFTP auto-connects to the SSH host |
+| FILE-07 | Open in editor | File visible in browser | Double-click a text file | File opens in built-in editor tab |
+| FILE-08 | Open in VS Code | VS Code installed, file visible | Right-click > Open in VS Code | File opens in VS Code |
+
+## 9. Cross-Platform
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| XPLAT-01 | Platform shells | Target OS | Check available shells in connection editor | Correct shells listed (zsh/bash/sh on Unix, PowerShell/cmd/Git Bash on Windows) |
+| XPLAT-02 | Serial port paths | Serial port on target OS | Open serial port dropdown | Correct port naming convention (/dev/tty* on Unix, COM* on Windows) |
+| XPLAT-03 | X11 forwarding | macOS or Linux with X server | Enable X11 forwarding on SSH connection | X11 forwarding works (not available on Windows) |
+
+## 10. Settings & Editor
+
+| ID | Test | Prerequisites | Steps | Expected Result |
+|---|---|---|---|---|
+| SET-01 | Settings tab | None | Click gear icon in activity bar | Settings tab opens (or existing one activates) |
+| SET-02 | Editor save | File open in editor | Modify content, press Ctrl+S | File saved, dirty indicator clears |
+| SET-03 | Editor status bar | File open in editor | Move cursor around | Status bar shows line, column, language, EOL, tab size |
+| SET-04 | Tab coloring | Connection with color set | Connect to a colored connection | Tab shows assigned color |
+| SET-05 | Horizontal scrolling | Connection with horizontal scrolling enabled | Connect, produce wide output | Terminal scrolls horizontally instead of wrapping |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -40,7 +43,10 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^4.0.18",
+    "jsdom": "^28.0.0",
     "typescript": "~5.6.2",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,14 +93,35 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.1)
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18(jsdom@28.0.0))
+      jsdom:
+        specifier: ^28.0.0
+        version: 28.0.0
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
       vite:
         specifier: ^6.0.3
         version: 6.4.1
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(jsdom@28.0.0)
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
+
+  '@asamuzakjp/dom-selector@6.7.8':
+    resolution: {integrity: sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -184,6 +205,41 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@csstools/color-helpers@6.0.1':
+    resolution: {integrity: sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.1':
+    resolution: {integrity: sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.27':
+    resolution: {integrity: sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -362,6 +418,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.14.1':
+    resolution: {integrity: sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
@@ -888,6 +953,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
@@ -988,6 +1056,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1011,6 +1085,44 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@4.0.18':
+    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+    peerDependencies:
+      '@vitest/browser': 4.0.18
+      vitest: 4.0.18
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -1020,13 +1132,27 @@ packages:
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.11:
+    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -1036,11 +1162,27 @@ packages:
   caniuse-lite@1.0.30001769:
     resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1051,6 +1193,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
@@ -1060,6 +1205,13 @@ packages:
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -1068,6 +1220,13 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1091,8 +1250,54 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@28.0.0:
+    resolution: {integrity: sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1108,6 +1313,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1116,10 +1325,23 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
     hasBin: true
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
@@ -1135,6 +1357,15 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1145,6 +1376,10 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   react-colorful@5.6.1:
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
@@ -1207,10 +1442,18 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -1219,16 +1462,63 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.23:
+    resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
+
+  tldts@7.0.23:
+    resolution: {integrity: sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==}
+    hasBin: true
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1237,6 +1527,10 @@ packages:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici@7.21.0:
+    resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
+    engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1304,6 +1598,68 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.0:
+    resolution: {integrity: sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -1326,6 +1682,26 @@ packages:
         optional: true
 
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@asamuzakjp/css-color@4.1.2':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/dom-selector@6.7.8':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -1439,6 +1815,30 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@csstools/color-helpers@6.0.1': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.1
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.27': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -1541,6 +1941,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
+
+  '@exodus/bytes@1.14.1': {}
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -2004,6 +2406,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tauri-apps/api@2.10.1': {}
 
   '@tauri-apps/cli-darwin-arm64@2.10.0':
@@ -2086,6 +2490,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/prop-types@15.7.15': {}
@@ -2114,17 +2525,84 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(jsdom@28.0.0))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(jsdom@28.0.0)
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@6.4.1)':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-unicode11@0.9.0': {}
 
   '@xterm/xterm@6.0.0': {}
 
+  agent-base@7.1.4: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.11:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   baseline-browser-mapping@2.9.19: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   browserslist@4.28.1:
     dependencies:
@@ -2136,13 +2614,36 @@ snapshots:
 
   caniuse-lite@1.0.30001769: {}
 
+  chai@6.2.2: {}
+
   convert-source-map@2.0.0: {}
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.0.27
+      css-tree: 3.1.0
+      lru-cache: 11.2.6
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   detect-node-es@1.1.0: {}
 
@@ -2151,6 +2652,10 @@ snapshots:
       '@types/trusted-types': 2.0.7
 
   electron-to-chromium@1.5.286: {}
+
+  entities@6.0.1: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2183,6 +2688,12 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -2194,7 +2705,74 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  has-flag@4.0.0: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
+
+  jsdom@28.0.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.7.8
+      '@exodus/bytes': 1.14.1
+      cssstyle: 5.3.7
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      undici: 7.21.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - supports-color
 
   jsesc@3.1.0: {}
 
@@ -2204,6 +2782,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.2.6: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2212,7 +2792,23 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   marked@14.0.0: {}
+
+  mdn-data@2.12.2: {}
 
   monaco-editor@0.55.1:
     dependencies:
@@ -2225,6 +2821,14 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  obug@2.1.1: {}
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
@@ -2234,6 +2838,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  punycode@2.3.1: {}
 
   react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -2289,6 +2895,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  require-from-string@2.0.2: {}
+
   rollup@4.57.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -2320,24 +2928,64 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
 
   semver@6.3.1: {}
 
+  semver@7.7.4: {}
+
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
   state-local@1.0.7: {}
+
+  std-env@3.10.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@3.0.3: {}
+
+  tldts-core@7.0.23: {}
+
+  tldts@7.0.23:
+    dependencies:
+      tldts-core: 7.0.23
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.23
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   tslib@2.8.1: {}
 
   typescript@5.6.3: {}
+
+  undici@7.21.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -2370,6 +3018,68 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
+
+  vitest@4.0.18(jsdom@28.0.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@6.4.1)
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 6.4.1
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 28.0.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.0:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4110,6 +4110,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,3 +41,6 @@ windows = { version = "0.58", features = [
     "Win32_System_Console",
     "Win32_Foundation",
 ] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/src/connection/config.rs
+++ b/src-tauri/src/connection/config.rs
@@ -61,3 +61,127 @@ pub struct ExternalConnectionStore {
     pub folders: Vec<ConnectionFolder>,
     pub connections: Vec<SavedConnection>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal::backend::{LocalShellConfig, SshConfig, TelnetConfig, SerialConfig};
+
+    #[test]
+    fn saved_connection_local_serde_round_trip() {
+        let conn = SavedConnection {
+            id: "conn-1".to_string(),
+            name: "My Shell".to_string(),
+            config: ConnectionConfig::Local(LocalShellConfig {
+                shell_type: "zsh".to_string(),
+                initial_command: Some("ls".to_string()),
+            }),
+            folder_id: None,
+            terminal_options: None,
+        };
+        let json = serde_json::to_string(&conn).unwrap();
+        let deserialized: SavedConnection = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, "conn-1");
+        assert_eq!(deserialized.name, "My Shell");
+    }
+
+    #[test]
+    fn saved_connection_ssh_serde_round_trip() {
+        let conn = SavedConnection {
+            id: "conn-2".to_string(),
+            name: "SSH Server".to_string(),
+            config: ConnectionConfig::Ssh(SshConfig {
+                host: "example.com".to_string(),
+                port: 22,
+                username: "admin".to_string(),
+                auth_method: "password".to_string(),
+                password: Some("secret".to_string()),
+                key_path: None,
+                enable_x11_forwarding: false,
+            }),
+            folder_id: Some("folder-1".to_string()),
+            terminal_options: None,
+        };
+        let json = serde_json::to_string(&conn).unwrap();
+        let deserialized: SavedConnection = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, "conn-2");
+        if let ConnectionConfig::Ssh(ssh) = &deserialized.config {
+            assert_eq!(ssh.host, "example.com");
+            assert_eq!(ssh.port, 22);
+        } else {
+            panic!("Expected SSH config");
+        }
+    }
+
+    #[test]
+    fn saved_connection_serial_serde_round_trip() {
+        let conn = SavedConnection {
+            id: "conn-3".to_string(),
+            name: "Serial Port".to_string(),
+            config: ConnectionConfig::Serial(SerialConfig {
+                port: "/dev/ttyUSB0".to_string(),
+                baud_rate: 115200,
+                data_bits: 8,
+                stop_bits: 1,
+                parity: "none".to_string(),
+                flow_control: "none".to_string(),
+            }),
+            folder_id: None,
+            terminal_options: None,
+        };
+        let json = serde_json::to_string(&conn).unwrap();
+        let deserialized: SavedConnection = serde_json::from_str(&json).unwrap();
+        if let ConnectionConfig::Serial(serial) = &deserialized.config {
+            assert_eq!(serial.baud_rate, 115200);
+        } else {
+            panic!("Expected Serial config");
+        }
+    }
+
+    #[test]
+    fn saved_connection_telnet_serde_round_trip() {
+        let conn = SavedConnection {
+            id: "conn-4".to_string(),
+            name: "Telnet Server".to_string(),
+            config: ConnectionConfig::Telnet(TelnetConfig {
+                host: "telnet.example.com".to_string(),
+                port: 23,
+            }),
+            folder_id: None,
+            terminal_options: None,
+        };
+        let json = serde_json::to_string(&conn).unwrap();
+        let deserialized: SavedConnection = serde_json::from_str(&json).unwrap();
+        if let ConnectionConfig::Telnet(telnet) = &deserialized.config {
+            assert_eq!(telnet.host, "telnet.example.com");
+            assert_eq!(telnet.port, 23);
+        } else {
+            panic!("Expected Telnet config");
+        }
+    }
+
+    #[test]
+    fn serde_produces_correct_json_shape() {
+        let conn = SavedConnection {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            config: ConnectionConfig::Local(LocalShellConfig {
+                shell_type: "bash".to_string(),
+                initial_command: None,
+            }),
+            folder_id: None,
+            terminal_options: Some(TerminalOptions {
+                horizontal_scrolling: Some(true),
+                color: None,
+            }),
+        };
+        let json: serde_json::Value = serde_json::to_value(&conn).unwrap();
+        // Check camelCase renaming
+        assert!(json.get("folderId").is_some());
+        assert!(json.get("terminalOptions").is_some());
+        // Check tagged enum format
+        let config = json.get("config").unwrap();
+        assert_eq!(config.get("type").unwrap(), "local");
+        assert!(config.get("config").is_some());
+    }
+}

--- a/src-tauri/src/files/utils.rs
+++ b/src-tauri/src/files/utils.rs
@@ -60,3 +60,34 @@ pub fn format_permissions(perm: u32) -> String {
     }
     s
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_permissions_755() {
+        assert_eq!(format_permissions(0o755), "rwxr-xr-x");
+    }
+
+    #[test]
+    fn format_permissions_644() {
+        assert_eq!(format_permissions(0o644), "rw-r--r--");
+    }
+
+    #[test]
+    fn format_permissions_000() {
+        assert_eq!(format_permissions(0o000), "---------");
+    }
+
+    #[test]
+    fn chrono_from_epoch_zero() {
+        assert_eq!(chrono_from_epoch(0), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn chrono_from_epoch_known_timestamp() {
+        // 2024-01-15 12:30:45 UTC = 1705321845
+        assert_eq!(chrono_from_epoch(1705321845), "2024-01-15T12:30:45Z");
+    }
+}

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -148,3 +148,134 @@ pub type OutputSender = mpsc::Sender<Vec<u8>>;
 /// Channel receiver type for output data from backends (used in future phases).
 #[allow(dead_code)]
 pub type OutputReceiver = mpsc::Receiver<Vec<u8>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_config_local_serde_round_trip() {
+        let config = ConnectionConfig::Local(LocalShellConfig {
+            shell_type: "zsh".to_string(),
+            initial_command: Some("echo hello".to_string()),
+        });
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: ConnectionConfig = serde_json::from_str(&json).unwrap();
+        if let ConnectionConfig::Local(local) = deserialized {
+            assert_eq!(local.shell_type, "zsh");
+            assert_eq!(local.initial_command, Some("echo hello".to_string()));
+        } else {
+            panic!("Expected Local config");
+        }
+    }
+
+    #[test]
+    fn connection_config_ssh_serde_round_trip() {
+        let config = ConnectionConfig::Ssh(SshConfig {
+            host: "example.com".to_string(),
+            port: 2222,
+            username: "root".to_string(),
+            auth_method: "key".to_string(),
+            password: None,
+            key_path: Some("/home/user/.ssh/id_rsa".to_string()),
+            enable_x11_forwarding: true,
+        });
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: ConnectionConfig = serde_json::from_str(&json).unwrap();
+        if let ConnectionConfig::Ssh(ssh) = deserialized {
+            assert_eq!(ssh.host, "example.com");
+            assert_eq!(ssh.port, 2222);
+            assert!(ssh.enable_x11_forwarding);
+        } else {
+            panic!("Expected SSH config");
+        }
+    }
+
+    #[test]
+    fn connection_config_serial_serde_round_trip() {
+        let config = ConnectionConfig::Serial(SerialConfig {
+            port: "/dev/ttyUSB0".to_string(),
+            baud_rate: 9600,
+            data_bits: 8,
+            stop_bits: 1,
+            parity: "none".to_string(),
+            flow_control: "hardware".to_string(),
+        });
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: ConnectionConfig = serde_json::from_str(&json).unwrap();
+        if let ConnectionConfig::Serial(serial) = deserialized {
+            assert_eq!(serial.baud_rate, 9600);
+            assert_eq!(serial.flow_control, "hardware");
+        } else {
+            panic!("Expected Serial config");
+        }
+    }
+
+    #[test]
+    fn ssh_config_expand_replaces_placeholders() {
+        std::env::set_var("TERMIHUB_TEST_SSH_HOST", "192.168.1.100");
+        std::env::set_var("TERMIHUB_TEST_SSH_USER", "deploy");
+
+        let config = SshConfig {
+            host: "${env:TERMIHUB_TEST_SSH_HOST}".to_string(),
+            port: 22,
+            username: "${env:TERMIHUB_TEST_SSH_USER}".to_string(),
+            auth_method: "key".to_string(),
+            password: None,
+            key_path: Some("${env:HOME}/.ssh/id_rsa".to_string()),
+            enable_x11_forwarding: false,
+        };
+        let expanded = config.expand();
+        assert_eq!(expanded.host, "192.168.1.100");
+        assert_eq!(expanded.username, "deploy");
+
+        std::env::remove_var("TERMIHUB_TEST_SSH_HOST");
+        std::env::remove_var("TERMIHUB_TEST_SSH_USER");
+    }
+
+    #[test]
+    fn local_config_expand_replaces_initial_command() {
+        std::env::set_var("TERMIHUB_TEST_CMD", "make build");
+
+        let config = LocalShellConfig {
+            shell_type: "bash".to_string(),
+            initial_command: Some("${env:TERMIHUB_TEST_CMD}".to_string()),
+        };
+        let expanded = config.expand();
+        assert_eq!(expanded.initial_command, Some("make build".to_string()));
+
+        std::env::remove_var("TERMIHUB_TEST_CMD");
+    }
+
+    #[test]
+    fn telnet_config_expand_replaces_host() {
+        std::env::set_var("TERMIHUB_TEST_TELNET_HOST", "10.0.0.1");
+
+        let config = TelnetConfig {
+            host: "${env:TERMIHUB_TEST_TELNET_HOST}".to_string(),
+            port: 23,
+        };
+        let expanded = config.expand();
+        assert_eq!(expanded.host, "10.0.0.1");
+
+        std::env::remove_var("TERMIHUB_TEST_TELNET_HOST");
+    }
+
+    #[test]
+    fn serial_config_expand_replaces_port() {
+        std::env::set_var("TERMIHUB_TEST_SERIAL_PORT", "/dev/ttyACM0");
+
+        let config = SerialConfig {
+            port: "${env:TERMIHUB_TEST_SERIAL_PORT}".to_string(),
+            baud_rate: 115200,
+            data_bits: 8,
+            stop_bits: 1,
+            parity: "none".to_string(),
+            flow_control: "none".to_string(),
+        };
+        let expanded = config.expand();
+        assert_eq!(expanded.port, "/dev/ttyACM0");
+
+        std::env::remove_var("TERMIHUB_TEST_SERIAL_PORT");
+    }
+}

--- a/src-tauri/src/utils/shell_detect.rs
+++ b/src-tauri/src/utils/shell_detect.rs
@@ -54,3 +54,57 @@ pub fn shell_to_command(shell: &str) -> (&str, Vec<&str>) {
         _ => ("sh", vec![]),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_to_command_zsh() {
+        let (cmd, args) = shell_to_command("zsh");
+        assert_eq!(cmd, "zsh");
+        assert_eq!(args, vec!["--login"]);
+    }
+
+    #[test]
+    fn shell_to_command_bash() {
+        let (cmd, args) = shell_to_command("bash");
+        assert_eq!(cmd, "bash");
+        assert_eq!(args, vec!["--login"]);
+    }
+
+    #[test]
+    fn shell_to_command_sh() {
+        let (cmd, args) = shell_to_command("sh");
+        assert_eq!(cmd, "sh");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn shell_to_command_cmd() {
+        let (cmd, args) = shell_to_command("cmd");
+        assert_eq!(cmd, "cmd.exe");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn shell_to_command_powershell() {
+        let (cmd, args) = shell_to_command("powershell");
+        assert_eq!(cmd, "powershell.exe");
+        assert_eq!(args, vec!["-NoLogo"]);
+    }
+
+    #[test]
+    fn shell_to_command_gitbash() {
+        let (cmd, args) = shell_to_command("gitbash");
+        assert_eq!(cmd, "bash.exe");
+        assert_eq!(args, vec!["--login"]);
+    }
+
+    #[test]
+    fn shell_to_command_unknown_falls_back_to_sh() {
+        let (cmd, args) = shell_to_command("fish");
+        assert_eq!(cmd, "sh");
+        assert!(args.is_empty());
+    }
+}

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock service modules before importing the store
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [], externalSources: [] })),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() => Promise.resolve({ version: "1", externalConnectionFiles: [] })),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  saveExternalFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore } from "./appStore";
+import type { LeafPanel } from "@/types/terminal";
+import { findLeaf, getAllLeaves } from "@/utils/panelTree";
+
+describe("appStore", () => {
+  beforeEach(() => {
+    // Reset store state by getting a fresh initial state
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  describe("addTab", () => {
+    it("adds a tab to the active panel", () => {
+      const { addTab, rootPanel, activePanelId } = useAppStore.getState();
+      addTab("Test Shell", "local", { type: "local", config: { shellType: "zsh" } });
+
+      const state = useAppStore.getState();
+      const leaf = findLeaf(state.rootPanel, activePanelId!) as LeafPanel;
+      expect(leaf.tabs).toHaveLength(1);
+      expect(leaf.tabs[0].title).toBe("Test Shell");
+      expect(leaf.activeTabId).toBe(leaf.tabs[0].id);
+    });
+
+    it("sets new tab as active", () => {
+      const { addTab } = useAppStore.getState();
+      addTab("Tab 1", "local");
+      addTab("Tab 2", "local");
+
+      const state = useAppStore.getState();
+      const leaf = findLeaf(state.rootPanel, state.activePanelId!) as LeafPanel;
+      expect(leaf.tabs).toHaveLength(2);
+      expect(leaf.activeTabId).toBe(leaf.tabs[1].id);
+      expect(leaf.tabs[0].isActive).toBe(false);
+      expect(leaf.tabs[1].isActive).toBe(true);
+    });
+  });
+
+  describe("closeTab", () => {
+    it("removes tab and selects next tab", () => {
+      const { addTab } = useAppStore.getState();
+      addTab("Tab 1", "local");
+      addTab("Tab 2", "local");
+
+      const stateAfterAdd = useAppStore.getState();
+      const leaf = findLeaf(stateAfterAdd.rootPanel, stateAfterAdd.activePanelId!) as LeafPanel;
+      const tabToClose = leaf.tabs[0].id;
+
+      useAppStore.getState().closeTab(tabToClose, stateAfterAdd.activePanelId!);
+
+      const stateAfterClose = useAppStore.getState();
+      const updatedLeaf = findLeaf(stateAfterClose.rootPanel, stateAfterClose.activePanelId!) as LeafPanel;
+      expect(updatedLeaf.tabs).toHaveLength(1);
+      expect(updatedLeaf.tabs[0].title).toBe("Tab 2");
+    });
+  });
+
+  describe("setActiveTab", () => {
+    it("sets the correct tab active", () => {
+      const { addTab } = useAppStore.getState();
+      addTab("Tab 1", "local");
+      addTab("Tab 2", "local");
+
+      const state = useAppStore.getState();
+      const leaf = findLeaf(state.rootPanel, state.activePanelId!) as LeafPanel;
+      const firstTabId = leaf.tabs[0].id;
+
+      useAppStore.getState().setActiveTab(firstTabId, state.activePanelId!);
+
+      const updated = useAppStore.getState();
+      const updatedLeaf = findLeaf(updated.rootPanel, updated.activePanelId!) as LeafPanel;
+      expect(updatedLeaf.activeTabId).toBe(firstTabId);
+      expect(updatedLeaf.tabs[0].isActive).toBe(true);
+      expect(updatedLeaf.tabs[1].isActive).toBe(false);
+    });
+  });
+
+  describe("splitPanel", () => {
+    it("creates a new panel via split", () => {
+      const { splitPanel } = useAppStore.getState();
+      splitPanel("horizontal");
+
+      const state = useAppStore.getState();
+      const leaves = getAllLeaves(state.rootPanel);
+      expect(leaves).toHaveLength(2);
+    });
+  });
+
+  describe("moveTab", () => {
+    it("moves tab between panels", () => {
+      // Add a tab then split
+      const { addTab, splitPanel } = useAppStore.getState();
+      addTab("Tab 1", "local");
+      addTab("Tab 2", "local");
+
+      const stateBeforeSplit = useAppStore.getState();
+      const originalPanelId = stateBeforeSplit.activePanelId!;
+      splitPanel("horizontal");
+
+      const stateAfterSplit = useAppStore.getState();
+      const newPanelId = stateAfterSplit.activePanelId!;
+      expect(newPanelId).not.toBe(originalPanelId);
+
+      // Get the first tab from the original panel
+      const originalLeaf = findLeaf(stateAfterSplit.rootPanel, originalPanelId) as LeafPanel;
+      const tabToMove = originalLeaf.tabs[0].id;
+
+      // Move tab to new panel
+      useAppStore.getState().moveTab(tabToMove, originalPanelId, newPanelId, 0);
+
+      const finalState = useAppStore.getState();
+      const sourceLeaf = findLeaf(finalState.rootPanel, originalPanelId) as LeafPanel;
+      const targetLeaf = findLeaf(finalState.rootPanel, newPanelId) as LeafPanel;
+      expect(sourceLeaf.tabs).toHaveLength(1);
+      expect(targetLeaf.tabs).toHaveLength(1);
+      expect(targetLeaf.tabs[0].title).toBe("Tab 1");
+    });
+  });
+
+  describe("connections", () => {
+    it("adds and deletes a connection", () => {
+      const { addConnection } = useAppStore.getState();
+      addConnection({
+        id: "conn-1",
+        name: "Test Connection",
+        config: { type: "local", config: { shellType: "bash" } },
+        folderId: null,
+      });
+
+      expect(useAppStore.getState().connections).toHaveLength(1);
+      expect(useAppStore.getState().connections[0].name).toBe("Test Connection");
+
+      useAppStore.getState().deleteConnection("conn-1");
+      expect(useAppStore.getState().connections).toHaveLength(0);
+    });
+  });
+
+  describe("sidebar", () => {
+    it("toggles sidebar collapsed state", () => {
+      expect(useAppStore.getState().sidebarCollapsed).toBe(false);
+      useAppStore.getState().toggleSidebar();
+      expect(useAppStore.getState().sidebarCollapsed).toBe(true);
+      useAppStore.getState().toggleSidebar();
+      expect(useAppStore.getState().sidebarCollapsed).toBe(false);
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+
+// Mock Tauri core API to prevent import errors when modules load
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+  emit: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readTextFile: vi.fn(),
+  writeTextFile: vi.fn(),
+}));

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { formatBytes, truncate, formatRelativeTime } from "./formatters";
+
+describe("formatBytes", () => {
+  it("formats 0 bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  it("formats bytes below 1 KB", () => {
+    expect(formatBytes(512)).toBe("512 B");
+  });
+
+  it("formats exactly 1 KB", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB");
+  });
+
+  it("formats fractional KB", () => {
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("formats exactly 1 MB", () => {
+    expect(formatBytes(1048576)).toBe("1.0 MB");
+  });
+
+  it("formats exactly 1 GB", () => {
+    expect(formatBytes(1073741824)).toBe("1.0 GB");
+  });
+});
+
+describe("truncate", () => {
+  it("returns short string unchanged", () => {
+    expect(truncate("hello", 10)).toBe("hello");
+  });
+
+  it("truncates long string with ellipsis", () => {
+    const result = truncate("hello world", 6);
+    expect(result).toBe("hello\u2026");
+    expect(result.length).toBe(6);
+  });
+
+  it("returns string at exact max length unchanged", () => {
+    expect(truncate("hello", 5)).toBe("hello");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("returns 'just now' for recent timestamps", () => {
+    const now = new Date().toISOString();
+    expect(formatRelativeTime(now)).toBe("just now");
+  });
+});

--- a/src/utils/panelTree.test.ts
+++ b/src/utils/panelTree.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import type { LeafPanel, SplitContainer, TerminalTab, PanelNode } from "@/types/terminal";
+import {
+  createLeafPanel,
+  findLeaf,
+  findLeafByTab,
+  getAllLeaves,
+  updateLeaf,
+  removeLeaf,
+  splitLeaf,
+  simplifyTree,
+  edgeToSplit,
+} from "./panelTree";
+
+/** Create a minimal tab for testing. */
+function makeTab(id: string, panelId: string): TerminalTab {
+  return {
+    id,
+    sessionId: null,
+    title: id,
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: { shellType: "zsh" } },
+    panelId,
+    isActive: false,
+  };
+}
+
+/** Create a leaf with tabs for testing. */
+function makeLeaf(id: string, tabIds: string[] = []): LeafPanel {
+  const tabs = tabIds.map((tid) => makeTab(tid, id));
+  return {
+    type: "leaf",
+    id,
+    tabs,
+    activeTabId: tabs.length > 0 ? tabs[0].id : null,
+  };
+}
+
+/** Create a split container for testing. */
+function makeSplit(
+  id: string,
+  direction: "horizontal" | "vertical",
+  children: PanelNode[]
+): SplitContainer {
+  return { type: "split", id, direction, children };
+}
+
+describe("createLeafPanel", () => {
+  it("returns a leaf with unique id", () => {
+    const leaf = createLeafPanel();
+    expect(leaf.type).toBe("leaf");
+    expect(leaf.id).toBeTruthy();
+    expect(leaf.tabs).toEqual([]);
+    expect(leaf.activeTabId).toBeNull();
+  });
+
+  it("generates unique ids on successive calls", () => {
+    const a = createLeafPanel();
+    const b = createLeafPanel();
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe("findLeaf", () => {
+  it("finds a single leaf by id", () => {
+    const leaf = makeLeaf("leaf-1");
+    expect(findLeaf(leaf, "leaf-1")).toBe(leaf);
+  });
+
+  it("finds a leaf in a nested split", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const split = makeSplit("split-1", "horizontal", [leaf1, leaf2]);
+    expect(findLeaf(split, "leaf-2")).toBe(leaf2);
+  });
+
+  it("returns null for unknown id", () => {
+    const leaf = makeLeaf("leaf-1");
+    expect(findLeaf(leaf, "unknown")).toBeNull();
+  });
+});
+
+describe("findLeafByTab", () => {
+  it("finds leaf containing a tab", () => {
+    const leaf = makeLeaf("leaf-1", ["tab-a", "tab-b"]);
+    expect(findLeafByTab(leaf, "tab-b")).toBe(leaf);
+  });
+
+  it("returns null for unknown tab", () => {
+    const leaf = makeLeaf("leaf-1", ["tab-a"]);
+    expect(findLeafByTab(leaf, "tab-unknown")).toBeNull();
+  });
+});
+
+describe("getAllLeaves", () => {
+  it("returns single leaf in array", () => {
+    const leaf = makeLeaf("leaf-1");
+    expect(getAllLeaves(leaf)).toEqual([leaf]);
+  });
+
+  it("returns all leaves from nested tree", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const leaf3 = makeLeaf("leaf-3");
+    const inner = makeSplit("s-inner", "vertical", [leaf2, leaf3]);
+    const root = makeSplit("s-root", "horizontal", [leaf1, inner]);
+
+    const leaves = getAllLeaves(root);
+    expect(leaves).toHaveLength(3);
+    expect(leaves.map((l) => l.id)).toEqual(["leaf-1", "leaf-2", "leaf-3"]);
+  });
+});
+
+describe("updateLeaf", () => {
+  it("updates matching leaf", () => {
+    const leaf = makeLeaf("leaf-1", ["tab-1"]);
+    const updated = updateLeaf(leaf, "leaf-1", (l) => ({
+      ...l,
+      activeTabId: "tab-1",
+    }));
+    expect((updated as LeafPanel).activeTabId).toBe("tab-1");
+  });
+
+  it("leaves non-matching leaves unchanged", () => {
+    const leaf = makeLeaf("leaf-1");
+    const result = updateLeaf(leaf, "other", (l) => ({
+      ...l,
+      activeTabId: "changed",
+    }));
+    expect(result).toBe(leaf); // same reference
+  });
+});
+
+describe("removeLeaf", () => {
+  it("returns null when removing root leaf", () => {
+    const leaf = makeLeaf("leaf-1");
+    expect(removeLeaf(leaf, "leaf-1")).toBeNull();
+  });
+
+  it("returns non-matching leaf unchanged", () => {
+    const leaf = makeLeaf("leaf-1");
+    expect(removeLeaf(leaf, "other")).toBe(leaf);
+  });
+
+  it("unwraps single-child parent after removal", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const split = makeSplit("split-1", "horizontal", [leaf1, leaf2]);
+
+    const result = removeLeaf(split, "leaf-1");
+    // Should unwrap to just leaf-2 instead of split with one child
+    expect(result).toBe(leaf2);
+  });
+});
+
+describe("splitLeaf", () => {
+  it("wraps leaf in split container with new leaf", () => {
+    const existing = makeLeaf("leaf-1");
+    const newLeaf = makeLeaf("new-leaf");
+    const result = splitLeaf(existing, "leaf-1", newLeaf, "horizontal", "after");
+
+    expect(result.type).toBe("split");
+    const split = result as SplitContainer;
+    expect(split.direction).toBe("horizontal");
+    expect(split.children).toHaveLength(2);
+    expect((split.children[0] as LeafPanel).id).toBe("leaf-1");
+    expect((split.children[1] as LeafPanel).id).toBe("new-leaf");
+  });
+
+  it("inserts before when position is before", () => {
+    const existing = makeLeaf("leaf-1");
+    const newLeaf = makeLeaf("new-leaf");
+    const result = splitLeaf(existing, "leaf-1", newLeaf, "vertical", "before");
+
+    const split = result as SplitContainer;
+    expect((split.children[0] as LeafPanel).id).toBe("new-leaf");
+    expect((split.children[1] as LeafPanel).id).toBe("leaf-1");
+  });
+
+  it("inserts as sibling when directions match", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const split = makeSplit("split-1", "horizontal", [leaf1, leaf2]);
+    const newLeaf = makeLeaf("new-leaf");
+
+    const result = splitLeaf(split, "leaf-1", newLeaf, "horizontal", "after");
+    const container = result as SplitContainer;
+    expect(container.children).toHaveLength(3);
+    expect((container.children[0] as LeafPanel).id).toBe("leaf-1");
+    expect((container.children[1] as LeafPanel).id).toBe("new-leaf");
+    expect((container.children[2] as LeafPanel).id).toBe("leaf-2");
+  });
+});
+
+describe("simplifyTree", () => {
+  it("returns leaf unchanged", () => {
+    const leaf = makeLeaf("leaf-1");
+    expect(simplifyTree(leaf)).toBe(leaf);
+  });
+
+  it("flattens same-direction nesting", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const leaf3 = makeLeaf("leaf-3");
+    const inner = makeSplit("inner", "horizontal", [leaf2, leaf3]);
+    const outer = makeSplit("outer", "horizontal", [leaf1, inner]);
+
+    const result = simplifyTree(outer);
+    expect(result.type).toBe("split");
+    const split = result as SplitContainer;
+    expect(split.children).toHaveLength(3);
+  });
+
+  it("unwraps single-child containers", () => {
+    const leaf = makeLeaf("leaf-1");
+    const split = makeSplit("split-1", "horizontal", [leaf]);
+    const result = simplifyTree(split);
+    expect(result).toBe(leaf);
+  });
+});
+
+describe("edgeToSplit", () => {
+  it("maps left to horizontal/before", () => {
+    expect(edgeToSplit("left")).toEqual({ direction: "horizontal", position: "before" });
+  });
+
+  it("maps right to horizontal/after", () => {
+    expect(edgeToSplit("right")).toEqual({ direction: "horizontal", position: "after" });
+  });
+
+  it("maps top to vertical/before", () => {
+    expect(edgeToSplit("top")).toEqual({ direction: "vertical", position: "before" });
+  });
+
+  it("maps bottom to vertical/after", () => {
+    expect(edgeToSplit("bottom")).toEqual({ direction: "vertical", position: "after" });
+  });
+
+  it("returns null for center", () => {
+    expect(edgeToSplit("center")).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "url";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/test/**", "src/**/*.d.ts", "src/main.tsx"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add ~41 new Rust backend unit tests (54 total) covering shell detection, file utilities, connection config serialization, external file management, and env var expansion
- Add ~43 TypeScript frontend unit tests via Vitest covering formatters, panel tree operations, and Zustand store actions
- Create manual test plan (`docs/manual-testing.md`) with 50 test cases across 10 categories for features requiring hardware or live connections
- Document testing strategy in CLAUDE.md with what's covered, what isn't, and why

## Test plan
- [x] `cargo test` — 54 tests pass (0 failures)
- [x] `pnpm test` — 43 tests pass (0 failures)
- [x] `pnpm test:coverage` — reports coverage for tested utility files
- [x] No production code behavior changed (only visibility modifiers on 3 Rust functions)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)