### PR TITLE
Add coverage directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+coverage
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary
- Add `coverage/` to `.gitignore` to prevent Vitest coverage reports from being committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)