### PR TITLE
Fix CI: add system dependencies to Rust quality job

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,6 +21,18 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            libssl-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary

- Add Ubuntu system dependencies (WebKitGTK, GTK3, libssl, etc.) to the `rust-quality` job in `code-quality.yml`
- The clippy and cargo test steps need these libraries to compile the project — without them, the build fails on `glib-sys` and `libudev-sys` build scripts

## Test plan

- [ ] CI `Rust Code Quality` job should now pass (clippy can compile the project)
- [ ] CI `Run Tests (ubuntu-latest)` should continue passing (already had these deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)