### PR TITLE
Add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,75 @@
+# Auto detect text files and normalize line endings to LF on checkin
+* text=auto eol=lf
+
+# Source code
+*.rs text eol=lf
+*.toml text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.vue text eol=lf
+
+# Documentation
+*.md text eol=lf
+*.txt text eol=lf
+
+# Configuration files
+*.yml text eol=lf
+*.yaml text eol=lf
+*.conf text eol=lf
+*.config text eol=lf
+*.ini text eol=lf
+*.gitignore text eol=lf
+*.gitattributes text eol=lf
+.editorconfig text eol=lf
+
+# Shell scripts
+*.sh text eol=lf
+*.bash text eol=lf
+
+# Python scripts
+*.py text eol=lf
+
+# Docker
+Dockerfile text eol=lf
+docker-compose.yml text eol=lf
+
+# Windows-specific files (use CRLF)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary files (do not modify)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.svg binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.exe binary
+*.dll binary
+*.so binary
+*.dylib binary
+*.a binary
+*.lib binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.bz2 binary
+*.7z binary
+*.rar binary
+
+# Lock files (preserve exactly as-is)
+package-lock.json binary
+pnpm-lock.yaml -text
+Cargo.lock -text


### PR DESCRIPTION
## Changes

- Added comprehensive .gitattributes file to enforce consistent line endings across platforms
- Unix (LF) line endings for all source code, configuration, and documentation files  
- Windows (CRLF) line endings only for .bat, .cmd, and .ps1 files
- Binary file handling for images, executables, and archives
- Lock file preservation

## Benefits

- Ensures cross-platform consistency (Windows, Linux, macOS)
- Prevents line ending issues in diffs and merges
- Follows best practices for cross-platform development

## Testing

Ran git add --renormalize . to verify - all existing files already had consistent line endings (no changes needed).