### PR TITLE
fix(backend): restore RemoteConfig lost in merge conflict

### DIFF
--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -60,6 +60,8 @@ pub enum ConnectionConfig {
     Telnet(TelnetConfig),
     #[serde(rename = "serial")]
     Serial(SerialConfig),
+    #[serde(rename = "remote")]
+    Remote(RemoteConfig),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -100,6 +102,45 @@ pub struct SerialConfig {
     pub flow_control: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub auth_method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_path: Option<String>,
+    /// "shell" or "serial"
+    pub session_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shell: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serial_port: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baud_rate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_bits: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_bits: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parity: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flow_control: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+/// Event emitted when a remote connection's state changes.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteStateChangeEvent {
+    pub session_id: String,
+    pub state: String,
+}
+
 impl ConnectionConfig {
     /// Return a copy with all `${env:...}` placeholders expanded.
     pub fn expand(self) -> Self {
@@ -108,6 +149,7 @@ impl ConnectionConfig {
             Self::Ssh(cfg) => Self::Ssh(cfg.expand()),
             Self::Telnet(cfg) => Self::Telnet(cfg.expand()),
             Self::Serial(cfg) => Self::Serial(cfg.expand()),
+            Self::Remote(cfg) => Self::Remote(cfg.expand()),
         }
     }
 }
@@ -140,6 +182,32 @@ impl SerialConfig {
     pub fn expand(mut self) -> Self {
         self.port = expand_env_placeholders(&self.port);
         self
+    }
+}
+
+impl RemoteConfig {
+    pub fn expand(mut self) -> Self {
+        self.host = expand_env_placeholders(&self.host);
+        self.username = expand_env_placeholders(&self.username);
+        self.key_path = self.key_path.map(|s| expand_env_placeholders(&s));
+        self.password = self.password.map(|s| expand_env_placeholders(&s));
+        self.shell = self.shell.map(|s| expand_env_placeholders(&s));
+        self.serial_port = self.serial_port.map(|s| expand_env_placeholders(&s));
+        self
+    }
+
+    /// Build an `SshConfig` from this remote config for SSH connection reuse.
+    #[allow(dead_code)]
+    pub fn to_ssh_config(&self) -> SshConfig {
+        SshConfig {
+            host: self.host.clone(),
+            port: self.port,
+            username: self.username.clone(),
+            auth_method: self.auth_method.clone(),
+            password: self.password.clone(),
+            key_path: self.key_path.clone(),
+            enable_x11_forwarding: false,
+        }
     }
 }
 
@@ -281,5 +349,124 @@ mod tests {
         assert_eq!(expanded.port, "/dev/ttyACM0");
 
         std::env::remove_var("TERMIHUB_TEST_SERIAL_PORT");
+    }
+
+    #[test]
+    fn connection_config_remote_serde_round_trip() {
+        let config = ConnectionConfig::Remote(RemoteConfig {
+            host: "pi.local".to_string(),
+            port: 22,
+            username: "pi".to_string(),
+            auth_method: "key".to_string(),
+            password: None,
+            key_path: Some("/home/user/.ssh/id_rsa".to_string()),
+            session_type: "shell".to_string(),
+            shell: Some("/bin/bash".to_string()),
+            serial_port: None,
+            baud_rate: None,
+            data_bits: None,
+            stop_bits: None,
+            parity: None,
+            flow_control: None,
+            title: Some("Build session".to_string()),
+        });
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: ConnectionConfig = serde_json::from_str(&json).unwrap();
+        if let ConnectionConfig::Remote(remote) = deserialized {
+            assert_eq!(remote.host, "pi.local");
+            assert_eq!(remote.port, 22);
+            assert_eq!(remote.username, "pi");
+            assert_eq!(remote.session_type, "shell");
+            assert_eq!(remote.shell, Some("/bin/bash".to_string()));
+            assert_eq!(remote.title, Some("Build session".to_string()));
+        } else {
+            panic!("Expected Remote config");
+        }
+    }
+
+    #[test]
+    fn connection_config_remote_serial_serde_round_trip() {
+        let config = ConnectionConfig::Remote(RemoteConfig {
+            host: "pi.local".to_string(),
+            port: 22,
+            username: "pi".to_string(),
+            auth_method: "password".to_string(),
+            password: None,
+            key_path: None,
+            session_type: "serial".to_string(),
+            shell: None,
+            serial_port: Some("/dev/ttyUSB0".to_string()),
+            baud_rate: Some(115200),
+            data_bits: Some(8),
+            stop_bits: Some(1),
+            parity: Some("none".to_string()),
+            flow_control: Some("none".to_string()),
+            title: None,
+        });
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: ConnectionConfig = serde_json::from_str(&json).unwrap();
+        if let ConnectionConfig::Remote(remote) = deserialized {
+            assert_eq!(remote.session_type, "serial");
+            assert_eq!(remote.serial_port, Some("/dev/ttyUSB0".to_string()));
+            assert_eq!(remote.baud_rate, Some(115200));
+        } else {
+            panic!("Expected Remote config");
+        }
+    }
+
+    #[test]
+    fn remote_config_expand_replaces_placeholders() {
+        std::env::set_var("TERMIHUB_TEST_REMOTE_HOST", "10.0.0.50");
+        std::env::set_var("TERMIHUB_TEST_REMOTE_USER", "admin");
+
+        let config = RemoteConfig {
+            host: "${env:TERMIHUB_TEST_REMOTE_HOST}".to_string(),
+            port: 22,
+            username: "${env:TERMIHUB_TEST_REMOTE_USER}".to_string(),
+            auth_method: "key".to_string(),
+            password: None,
+            key_path: Some("${env:HOME}/.ssh/id_rsa".to_string()),
+            session_type: "shell".to_string(),
+            shell: Some("${env:SHELL}".to_string()),
+            serial_port: None,
+            baud_rate: None,
+            data_bits: None,
+            stop_bits: None,
+            parity: None,
+            flow_control: None,
+            title: None,
+        };
+        let expanded = config.expand();
+        assert_eq!(expanded.host, "10.0.0.50");
+        assert_eq!(expanded.username, "admin");
+
+        std::env::remove_var("TERMIHUB_TEST_REMOTE_HOST");
+        std::env::remove_var("TERMIHUB_TEST_REMOTE_USER");
+    }
+
+    #[test]
+    fn remote_config_json_shape_matches_frontend() {
+        let config = ConnectionConfig::Remote(RemoteConfig {
+            host: "host".to_string(),
+            port: 22,
+            username: "user".to_string(),
+            auth_method: "password".to_string(),
+            password: None,
+            key_path: None,
+            session_type: "shell".to_string(),
+            shell: None,
+            serial_port: None,
+            baud_rate: None,
+            data_bits: None,
+            stop_bits: None,
+            parity: None,
+            flow_control: None,
+            title: None,
+        });
+        let json = serde_json::to_string(&config).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "remote");
+        assert_eq!(v["config"]["sessionType"], "shell");
+        assert_eq!(v["config"]["authMethod"], "password");
     }
 }

--- a/src-tauri/src/terminal/jsonrpc.rs
+++ b/src-tauri/src/terminal/jsonrpc.rs
@@ -3,6 +3,9 @@
 //! Messages are exchanged as newline-delimited JSON (NDJSON) lines over
 //! an SSH exec channel running `termihub-agent --stdio`.
 
+// Used by remote.rs which is not yet wired into the main code path.
+#![allow(dead_code)]
+
 use std::io::{Read, Write};
 
 use serde::Serialize;
@@ -43,16 +46,11 @@ pub fn parse_message(line: &str) -> Result<JsonRpcMessage, String> {
     let obj = v.as_object().ok_or("Expected JSON object")?;
 
     if let Some(id_val) = obj.get("id") {
-        let id = id_val
-            .as_u64()
-            .ok_or("Expected numeric id")?;
+        let id = id_val.as_u64().ok_or("Expected numeric id")?;
 
         if let Some(error) = obj.get("error") {
             let error_obj = error.as_object().ok_or("Expected error object")?;
-            let code = error_obj
-                .get("code")
-                .and_then(|c| c.as_i64())
-                .unwrap_or(-1);
+            let code = error_obj.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
             let message = error_obj
                 .get("message")
                 .and_then(|m| m.as_str())
@@ -171,8 +169,7 @@ mod tests {
 
     #[test]
     fn parse_notification() {
-        let line =
-            r#"{"jsonrpc":"2.0","method":"session.output","params":{"sessionId":"abc","data":"aGVsbG8="}}"#;
+        let line = r#"{"jsonrpc":"2.0","method":"session.output","params":{"sessionId":"abc","data":"aGVsbG8="}}"#;
         match parse_message(line).unwrap() {
             JsonRpcMessage::Notification { method, params } => {
                 assert_eq!(method, "session.output");

--- a/src-tauri/src/terminal/remote.rs
+++ b/src-tauri/src/terminal/remote.rs
@@ -9,6 +9,10 @@
 //! `write_input()` and `resize()` send commands through an `mpsc` channel
 //! to avoid blocking-mode toggling and `!Send`/`!Sync` issues with ssh2.
 
+// Remote backend is implemented but not yet wired into TerminalManager's
+// main code path — suppress dead_code warnings until full integration.
+#![allow(dead_code)]
+
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};

--- a/src-tauri/src/terminal/telnet.rs
+++ b/src-tauri/src/terminal/telnet.rs
@@ -51,9 +51,7 @@ impl TelnetConnection {
                     Ok(n) => {
                         // Basic telnet IAC filtering
                         let filtered = filter_telnet_commands(&buf[..n], &mut reader);
-                        if !filtered.is_empty()
-                            && output_tx.send(filtered).is_err()
-                        {
+                        if !filtered.is_empty() && output_tx.send(filtered).is_err() {
                             break;
                         }
                     }


### PR DESCRIPTION
## Summary

- Restore `ConnectionConfig::Remote` variant, `RemoteConfig` struct, `RemoteStateChangeEvent`, and `RemoteConfig::expand()`/`to_ssh_config()` that were lost during the performance branch merge (commit c5ca83f)
- Add `Remote` match arms back to `TerminalManager::create_session()`
- Restore 4 unit tests for RemoteConfig serde round-trips and expand()
- Suppress `dead_code` warnings on `remote.rs` and `jsonrpc.rs` (not yet wired into the main code path)
- Fix pre-existing `cargo fmt` inconsistencies in `jsonrpc.rs`, `manager.rs`, and `telnet.rs`

## Test plan

- [x] `cargo test` in `src-tauri/` — 70 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test` in `agent/` — 69 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)