### PR TITLE
chore: add helper scripts for common dev tasks

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,28 @@
+# Scripts
+
+Helper scripts for common development tasks. Each script has a `.sh` (Unix/macOS) and `.cmd` (Windows) variant. All scripts can be run from anywhere in the repo.
+
+| Script | What it does |
+|--------|-------------|
+| `setup` | Install all dependencies and do an initial build |
+| `dev` | Start the app in development mode with hot-reload |
+| `build` | Build the app for production (creates platform installer) |
+| `test` | Run all unit tests (frontend + backend + agent) |
+| `check` | Read-only quality checks mirroring CI (formatting, linting, clippy) |
+| `format` | Auto-fix all formatting issues (Prettier + cargo fmt) |
+| `clean` | Remove all build artifacts for a fresh start |
+
+## Typical workflow
+
+```bash
+# First time
+./scripts/setup.sh
+
+# Daily development
+./scripts/dev.sh
+
+# Before pushing
+./scripts/format.sh
+./scripts/test.sh
+./scripts/check.sh
+```

--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -1,0 +1,8 @@
+@echo off
+REM Build the app for production (creates platform installer).
+REM Run from the repo root: scripts\build.cmd
+
+cd /d "%~dp0\.."
+
+echo Building TermiHub for production...
+call pnpm tauri build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Build the app for production (creates platform installer).
+# Run from anywhere: ./scripts/build.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Building TermiHub for production..."
+pnpm tauri build

--- a/scripts/clean.cmd
+++ b/scripts/clean.cmd
@@ -1,0 +1,22 @@
+@echo off
+REM Remove all build artifacts and caches for a fresh start.
+REM Run from the repo root: scripts\clean.cmd
+
+cd /d "%~dp0\.."
+
+echo === Cleaning frontend ===
+if exist node_modules rmdir /s /q node_modules
+if exist dist rmdir /s /q dist
+
+echo === Cleaning backend ===
+pushd src-tauri
+cargo clean
+popd
+
+echo === Cleaning agent ===
+pushd agent
+cargo clean
+popd
+
+echo.
+echo All build artifacts removed. Run scripts\setup.cmd to reinstall.

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Remove all build artifacts and caches for a fresh start.
+# Run from anywhere: ./scripts/clean.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== Cleaning frontend ==="
+rm -rf node_modules dist
+
+echo "=== Cleaning backend ==="
+(cd src-tauri && cargo clean)
+
+echo "=== Cleaning agent ==="
+(cd agent && cargo clean)
+
+echo ""
+echo "All build artifacts removed. Run ./scripts/setup.sh to reinstall."

--- a/scripts/dev.cmd
+++ b/scripts/dev.cmd
@@ -1,0 +1,8 @@
+@echo off
+REM Start the app in development mode with hot-reload.
+REM Run from the repo root: scripts\dev.cmd
+
+cd /d "%~dp0\.."
+
+echo Starting TermiHub in dev mode...
+call pnpm tauri dev

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Start the app in development mode with hot-reload.
+# Run from anywhere: ./scripts/dev.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Starting TermiHub in dev mode..."
+pnpm tauri dev

--- a/scripts/setup.cmd
+++ b/scripts/setup.cmd
@@ -1,0 +1,26 @@
+@echo off
+REM First-time project setup — installs all dependencies.
+REM Run from the repo root: scripts\setup.cmd
+
+cd /d "%~dp0\.."
+
+echo === Installing frontend dependencies ===
+call pnpm install
+if errorlevel 1 exit /b 1
+
+echo.
+echo === Building Rust backend (first compile takes a while) ===
+pushd src-tauri
+cargo build
+if errorlevel 1 (popd & exit /b 1)
+popd
+
+echo.
+echo === Building Agent ===
+pushd agent
+cargo build
+if errorlevel 1 (popd & exit /b 1)
+popd
+
+echo.
+echo Setup complete. Run scripts\dev.cmd to start the app.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# First-time project setup — installs all dependencies.
+# Run from anywhere: ./scripts/setup.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== Installing frontend dependencies ==="
+pnpm install
+
+echo ""
+echo "=== Building Rust backend (first compile takes a while) ==="
+(cd src-tauri && cargo build)
+
+echo ""
+echo "=== Building Agent ==="
+(cd agent && cargo build)
+
+echo ""
+echo "Setup complete. Run ./scripts/dev.sh to start the app."

--- a/scripts/test.cmd
+++ b/scripts/test.cmd
@@ -1,0 +1,33 @@
+@echo off
+REM Run all unit tests (frontend + backend + agent).
+REM Run from the repo root: scripts\test.cmd
+
+cd /d "%~dp0\.."
+
+set FAILED=0
+
+echo === Frontend: Vitest ===
+call pnpm test
+if errorlevel 1 set FAILED=1
+
+echo.
+echo === Backend: cargo test ===
+pushd src-tauri
+cargo test --all-features
+if errorlevel 1 set FAILED=1
+popd
+
+echo.
+echo === Agent: cargo test ===
+pushd agent
+cargo test --all-features
+if errorlevel 1 set FAILED=1
+popd
+
+echo.
+if %FAILED%==1 (
+    echo SOME TESTS FAILED.
+    exit /b 1
+) else (
+    echo ALL TESTS PASSED.
+)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Run all unit tests (frontend + backend + agent).
+# Run from anywhere: ./scripts/test.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+FAILED=0
+
+echo "=== Frontend: Vitest ==="
+if pnpm test; then
+    echo "PASS"
+else
+    FAILED=1
+fi
+
+echo ""
+echo "=== Backend: cargo test ==="
+if (cd src-tauri && cargo test --all-features); then
+    echo "PASS"
+else
+    FAILED=1
+fi
+
+echo ""
+echo "=== Agent: cargo test ==="
+if (cd agent && cargo test --all-features); then
+    echo "PASS"
+else
+    FAILED=1
+fi
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+    echo "SOME TESTS FAILED."
+    exit 1
+else
+    echo "ALL TESTS PASSED."
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/` helper scripts (`.sh` + `.cmd` pairs) for common development tasks so new contributors can get started quickly:

| Script | What it does |
|--------|-------------|
| `setup` | Install all dependencies and do an initial build |
| `dev` | Start the app in development mode with hot-reload |
| `build` | Build the app for production (creates platform installer) |
| `test` | Run all unit tests (frontend + backend + agent) |
| `clean` | Remove all build artifacts for a fresh start |

- Add `scripts/README.md` with usage overview and typical workflow

These complement the existing `format` and `check` scripts.

## Test plan

- [x] Verified scripts run correctly on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)