### PR TITLE
fix(scripts): auto-install node_modules if missing

### DIFF
--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -4,5 +4,12 @@ REM Run from the repo root: scripts\build.cmd
 
 cd /d "%~dp0\.."
 
+if not exist node_modules (
+    echo node_modules missing, running pnpm install...
+    call pnpm install
+    if errorlevel 1 exit /b 1
+    echo.
+)
+
 echo Building TermiHub for production...
 call pnpm tauri build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,5 +5,11 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+if [ ! -d node_modules ]; then
+    echo "node_modules missing, running pnpm install..."
+    pnpm install
+    echo ""
+fi
+
 echo "Building TermiHub for production..."
 pnpm tauri build

--- a/scripts/check.cmd
+++ b/scripts/check.cmd
@@ -5,6 +5,13 @@ REM Mirrors the CI Code Quality checks locally without modifying files.
 
 cd /d "%~dp0\.."
 
+if not exist node_modules (
+    echo node_modules missing, running pnpm install...
+    call pnpm install
+    if errorlevel 1 exit /b 1
+    echo.
+)
+
 set FAILED=0
 
 echo === Frontend: Prettier ===

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+if [ ! -d node_modules ]; then
+    echo "node_modules missing, running pnpm install..."
+    pnpm install
+    echo ""
+fi
+
 FAILED=0
 
 echo "=== Frontend: Prettier ==="

--- a/scripts/dev.cmd
+++ b/scripts/dev.cmd
@@ -4,5 +4,12 @@ REM Run from the repo root: scripts\dev.cmd
 
 cd /d "%~dp0\.."
 
+if not exist node_modules (
+    echo node_modules missing, running pnpm install...
+    call pnpm install
+    if errorlevel 1 exit /b 1
+    echo.
+)
+
 echo Starting TermiHub in dev mode...
 call pnpm tauri dev

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,5 +5,11 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+if [ ! -d node_modules ]; then
+    echo "node_modules missing, running pnpm install..."
+    pnpm install
+    echo ""
+fi
+
 echo "Starting TermiHub in dev mode..."
 pnpm tauri dev

--- a/scripts/format.cmd
+++ b/scripts/format.cmd
@@ -5,6 +5,13 @@ REM Fixes all auto-fixable formatting issues across the entire codebase.
 
 cd /d "%~dp0\.."
 
+if not exist node_modules (
+    echo node_modules missing, running pnpm install...
+    call pnpm install
+    if errorlevel 1 exit /b 1
+    echo.
+)
+
 echo === Frontend: Prettier ===
 call pnpm exec prettier --write "src/**/*.{ts,tsx,css}"
 if errorlevel 1 exit /b 1

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+if [ ! -d node_modules ]; then
+    echo "node_modules missing, running pnpm install..."
+    pnpm install
+    echo ""
+fi
+
 echo "=== Frontend: Prettier ==="
 pnpm exec prettier --write "src/**/*.{ts,tsx,css}"
 

--- a/scripts/test.cmd
+++ b/scripts/test.cmd
@@ -4,6 +4,13 @@ REM Run from the repo root: scripts\test.cmd
 
 cd /d "%~dp0\.."
 
+if not exist node_modules (
+    echo node_modules missing, running pnpm install...
+    call pnpm install
+    if errorlevel 1 exit /b 1
+    echo.
+)
+
 set FAILED=0
 
 echo === Frontend: Vitest ===

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+if [ ! -d node_modules ]; then
+    echo "node_modules missing, running pnpm install..."
+    pnpm install
+    echo ""
+fi
+
 FAILED=0
 
 echo "=== Frontend: Vitest ==="


### PR DESCRIPTION
## Summary

- All scripts that depend on pnpm (`dev`, `build`, `test`, `check`, `format`) now check for `node_modules` and run `pnpm install` automatically if missing
- Prevents the "command not found" error that occurs after running `clean.sh`

## Test plan

- [x] Verified `./scripts/clean.sh` followed by `./scripts/dev.sh` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)