### PR TITLE
Add full indent selection to editor status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Editor indent selector now supports tabs and configurable sizes (1, 2, 4, 8) via a dropdown menu in the status bar
 - Connection editor now opens as a tab in the main panel area instead of the sidebar, providing more space for settings forms
 - Remote Agent connections are now functional — connect to `termihub-agent` running on remote hosts with auto-reconnect and visual status indicators
 - Terminal output events now use a singleton dispatcher with O(1) Map-based routing instead of per-terminal global listeners (O(N) fan-out)

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -21,12 +21,14 @@ loader.config({ monaco });
 function readEditorStatus(editor: monaco.editor.IStandaloneCodeEditor): EditorStatus {
   const pos = editor.getPosition();
   const model = editor.getModel();
+  const options = model?.getOptions();
   return {
     line: pos?.lineNumber ?? 1,
     column: pos?.column ?? 1,
     language: model?.getLanguageId() ?? "plaintext",
     eol: model?.getEOL() === "\r\n" ? "CRLF" : "LF",
-    tabSize: (model?.getOptions().tabSize ?? 4) as number,
+    tabSize: (options?.tabSize ?? 4) as number,
+    insertSpaces: (options?.insertSpaces ?? true) as boolean,
     encoding: "UTF-8",
   };
 }
@@ -140,12 +142,10 @@ export function FileEditor({ tabId, meta, isVisible }: FileEditorProps) {
 
       // Register actions for status bar interactions
       setEditorActions({
-        cycleTabSize: () => {
+        setIndent: (tabSize: number, insertSpaces: boolean) => {
           const model = editor.getModel();
           if (!model) return;
-          const current = (model.getOptions().tabSize ?? 4) as number;
-          const next = current === 4 ? 2 : 4;
-          model.updateOptions({ tabSize: next });
+          model.updateOptions({ tabSize, insertSpaces });
           setEditorStatus(readEditorStatus(editor));
         },
         toggleEol: () => {
@@ -169,12 +169,10 @@ export function FileEditor({ tabId, meta, isVisible }: FileEditorProps) {
     if (isVisible && editorRef.current) {
       setEditorStatus(readEditorStatus(editorRef.current));
       setEditorActions({
-        cycleTabSize: () => {
+        setIndent: (tabSize: number, insertSpaces: boolean) => {
           const model = editorRef.current?.getModel();
           if (!model) return;
-          const current = (model.getOptions().tabSize ?? 4) as number;
-          const next = current === 4 ? 2 : 4;
-          model.updateOptions({ tabSize: next });
+          model.updateOptions({ tabSize, insertSpaces });
           if (editorRef.current) setEditorStatus(readEditorStatus(editorRef.current));
         },
         toggleEol: () => {

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -49,3 +49,43 @@
   background-color: var(--bg-hover);
   color: var(--text-primary);
 }
+
+/* Indent selection dropdown */
+.indent-menu__content {
+  min-width: 160px;
+  background-color: var(--bg-dropdown);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-xs) 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+}
+
+.indent-menu__label {
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  user-select: none;
+}
+
+.indent-menu__item {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  outline: none;
+}
+
+.indent-menu__item:hover,
+.indent-menu__item[data-highlighted] {
+  background-color: var(--accent-color);
+  color: #ffffff;
+}
+
+.indent-menu__separator {
+  height: 1px;
+  background-color: var(--border-primary);
+  margin: var(--spacing-xs) 0;
+}

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -1,5 +1,8 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { useAppStore } from "@/store/appStore";
 import "./StatusBar.css";
+
+const INDENT_SIZES = [1, 2, 4, 8] as const;
 
 /**
  * Status bar displayed at the bottom of the application window.
@@ -9,6 +12,12 @@ import "./StatusBar.css";
 export function StatusBar() {
   const editorStatus = useAppStore((s) => s.editorStatus);
   const editorActions = useAppStore((s) => s.editorActions);
+
+  const indentLabel = editorStatus
+    ? editorStatus.insertSpaces
+      ? `Spaces: ${editorStatus.tabSize}`
+      : `Tab Size: ${editorStatus.tabSize}`
+    : "";
 
   return (
     <div className="status-bar">
@@ -20,14 +29,53 @@ export function StatusBar() {
             <span className="status-bar__item">
               Ln {editorStatus.line}, Col {editorStatus.column}
             </span>
-            <button
-              className="status-bar__item status-bar__item--interactive"
-              onClick={() => editorActions?.cycleTabSize()}
-              title="Toggle tab size"
-              data-testid="status-bar-tab-size"
-            >
-              Spaces: {editorStatus.tabSize}
-            </button>
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger asChild>
+                <button
+                  className="status-bar__item status-bar__item--interactive"
+                  title="Select indentation"
+                  data-testid="status-bar-tab-size"
+                >
+                  {indentLabel}
+                </button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className="indent-menu__content"
+                  side="top"
+                  align="start"
+                  sideOffset={4}
+                >
+                  <DropdownMenu.Label className="indent-menu__label">
+                    Indent Using Spaces
+                  </DropdownMenu.Label>
+                  {INDENT_SIZES.map((size) => (
+                    <DropdownMenu.Item
+                      key={`spaces-${size}`}
+                      className="indent-menu__item"
+                      onSelect={() => editorActions?.setIndent(size, true)}
+                      data-testid={`indent-spaces-${size}`}
+                    >
+                      {size} {size === 1 ? "Space" : "Spaces"}
+                    </DropdownMenu.Item>
+                  ))}
+                  <DropdownMenu.Separator className="indent-menu__separator" />
+                  <DropdownMenu.Label className="indent-menu__label">
+                    Indent Using Tabs
+                  </DropdownMenu.Label>
+                  {INDENT_SIZES.map((size) => (
+                    <DropdownMenu.Item
+                      key={`tabs-${size}`}
+                      className="indent-menu__item"
+                      onSelect={() => editorActions?.setIndent(size, false)}
+                      data-testid={`indent-tabs-${size}`}
+                    >
+                      Tab Size: {size}
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
             <span className="status-bar__item">{editorStatus.encoding}</span>
             <button
               className="status-bar__item status-bar__item--interactive"

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -112,10 +112,11 @@ export interface EditorStatus {
   language: string;
   eol: "LF" | "CRLF";
   tabSize: number;
+  insertSpaces: boolean;
   encoding: string;
 }
 
 export interface EditorActions {
-  cycleTabSize: () => void;
+  setIndent: (tabSize: number, insertSpaces: boolean) => void;
   toggleEol: () => void;
 }


### PR DESCRIPTION
## Summary
- Replace the simple 2↔4 tab size cycling button with a dropdown menu in the status bar
- Support indent using spaces (1, 2, 4, 8) and indent using tabs (1, 2, 4, 8)
- Add `insertSpaces` field to `EditorStatus` type and `setIndent(tabSize, insertSpaces)` action to `EditorActions`
- Status bar label shows "Spaces: N" or "Tab Size: N" depending on the active indent mode

Closes #105

## Test plan
- [x] `pnpm test` — all 140 tests pass
- [x] ESLint + Prettier — clean
- [ ] Manual: open a file in the editor, click the indent indicator in the status bar
  - Dropdown appears with "Indent Using Spaces" (1/2/4/8) and "Indent Using Tabs" (1/2/4/8)
  - Selecting an option updates the editor behavior and the status bar label
  - Label correctly shows "Spaces: N" or "Tab Size: N"

🤖 Generated with [Claude Code](https://claude.com/claude-code)