### PR TITLE
Add language mode selector to editor status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Editor language mode can now be changed via a searchable dropdown in the status bar
 - Editor indent selector now supports tabs and configurable sizes (1, 2, 4, 8) via a dropdown menu in the status bar
 - Connection editor now opens as a tab in the main panel area instead of the sidebar, providing more space for settings forms
 - Remote Agent connections are now functional — connect to `termihub-agent` running on remote hosts with auto-reconnect and visual status indicators

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -89,3 +89,74 @@
   background-color: var(--border-primary);
   margin: var(--spacing-xs) 0;
 }
+
+/* Language selection dropdown */
+.lang-menu__content {
+  min-width: 220px;
+  background-color: var(--bg-dropdown);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-xs) 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+}
+
+.lang-menu__search-wrapper {
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+.lang-menu__search {
+  width: 100%;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.lang-menu__search:focus {
+  border-color: var(--accent-color);
+}
+
+.lang-menu__list {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.lang-menu__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  outline: none;
+}
+
+.lang-menu__item:hover,
+.lang-menu__item[data-highlighted] {
+  background-color: var(--accent-color);
+  color: #ffffff;
+}
+
+.lang-menu__item-id {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  margin-left: var(--spacing-sm);
+}
+
+.lang-menu__item:hover .lang-menu__item-id,
+.lang-menu__item[data-highlighted] .lang-menu__item-id {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lang-menu__empty {
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  text-align: center;
+}

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -106,10 +106,16 @@ export interface SplitContainer {
 export type PanelNode = LeafPanel | SplitContainer;
 export type DropEdge = "left" | "right" | "top" | "bottom" | "center";
 
+export interface LanguageInfo {
+  id: string;
+  name: string;
+}
+
 export interface EditorStatus {
   line: number;
   column: number;
   language: string;
+  availableLanguages: LanguageInfo[];
   eol: "LF" | "CRLF";
   tabSize: number;
   insertSpaces: boolean;
@@ -119,4 +125,5 @@ export interface EditorStatus {
 export interface EditorActions {
   setIndent: (tabSize: number, insertSpaces: boolean) => void;
   toggleEol: () => void;
+  setLanguage: (languageId: string) => void;
 }


### PR DESCRIPTION
## Summary
- Replace the static language label in the status bar with a searchable dropdown menu
- Lists all Monaco-supported languages (70+), sorted alphabetically with search filtering
- Add `setLanguage` action to `EditorActions` and `LanguageInfo` type to `EditorStatus`
- Monaco language list is cached after first access for performance

Closes #104

## Test plan
- [x] `pnpm test` — all 140 tests pass
- [x] ESLint + Prettier — clean
- [ ] Manual: open a file in the editor, click the language name in the status bar
  - Dropdown appears with a search input and all available languages
  - Typing filters the list in real-time
  - Selecting a language updates syntax highlighting and the status bar label
  - Dropdown closes on selection or clicking outside

🤖 Generated with [Claude Code](https://claude.com/claude-code)