### PR TITLE
fix(backend): gate Windows-only code for clippy on Linux/macOS

### DIFF
--- a/src-tauri/src/terminal/local_shell.rs
+++ b/src-tauri/src/terminal/local_shell.rs
@@ -143,6 +143,7 @@ impl TerminalBackend for LocalShell {
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
 
     /// Regression test: spawning PowerShell via portable-pty must not produce

--- a/src-tauri/src/utils/shell_detect.rs
+++ b/src-tauri/src/utils/shell_detect.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 /// Well-known Git Bash installation paths on Windows.
+#[cfg(windows)]
 const GIT_BASH_PATHS: &[&str] = &[
     r"C:\Program Files\Git\bin\bash.exe",
     r"C:\Program Files (x86)\Git\bin\bash.exe",


### PR DESCRIPTION
## Summary
- Gate `GIT_BASH_PATHS` constant with `#[cfg(windows)]` since it's only used in Windows-gated code paths
- Allow `unused_imports` on test module's `use super::*` since the only test is `#[cfg(windows)]`

These issues were introduced in PR #129 and cause `cargo clippy -D warnings` to fail on Linux/macOS CI.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 71 tests pass
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)