### PR TITLE
feat(ssh): guide users through SSH agent setup when agent is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- SSH agent setup guidance: detect when the SSH agent is not running and offer a guided setup flow with pre-filled PowerShell commands (Windows) or shell instructions (Unix)
 - "Save & Connect" button in the connection editor to save and immediately open a terminal session
 - Serial port proxy support in the remote agent: serial ports connected to the Raspberry Pi are now accessible from the desktop app over SSH
 - 24/7 serial data buffering with 1 MiB ring buffer: data is captured continuously and replayed when a client attaches

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -63,3 +63,9 @@ pub fn list_serial_ports() -> Vec<String> {
 pub fn check_x11_available() -> bool {
     crate::utils::x11_detect::is_x_server_likely_running()
 }
+
+/// Check whether the SSH agent is running, stopped, or not installed.
+#[tauri::command]
+pub fn check_ssh_agent_status() -> String {
+    crate::utils::ssh_auth::check_ssh_agent_status()
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run() {
             commands::terminal::list_available_shells,
             commands::terminal::list_serial_ports,
             commands::terminal::check_x11_available,
+            commands::terminal::check_ssh_agent_status,
             commands::connection::load_connections_and_folders,
             commands::connection::save_connection,
             commands::connection::delete_connection,

--- a/src/components/ConnectionEditor/ConnectionEditor.css
+++ b/src/components/ConnectionEditor/ConnectionEditor.css
@@ -63,6 +63,21 @@
   font-style: italic;
 }
 
+.settings-form__hint--warning {
+  color: var(--text-warning, #cca700);
+}
+
+.settings-form__hint-action {
+  background: none;
+  border: none;
+  color: var(--focus-border);
+  cursor: pointer;
+  font-size: inherit;
+  text-decoration: underline;
+  padding: 0;
+  margin-left: 4px;
+}
+
 .connection-editor__actions {
   display: flex;
   gap: var(--spacing-sm);

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -8,9 +8,11 @@ import {
   TelnetConfig,
   SerialConfig,
   RemoteConfig,
+  ShellType,
   TerminalOptions,
   ConnectionEditorMeta,
 } from "@/types/terminal";
+import { listAvailableShells } from "@/services/api";
 import { SavedConnection } from "@/types/connection";
 import {
   ConnectionSettings,
@@ -219,6 +221,19 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
     updateExternalConnection,
   ]);
 
+  const handleSetupSshAgent = useCallback(async () => {
+    const shells = await listAvailableShells();
+    if (shells.length === 0) return;
+    addTab("Setup SSH Agent", "local", {
+      type: "local",
+      config: {
+        shellType: "powershell" as ShellType,
+        initialCommand:
+          "Start-Process powershell -Verb RunAs -ArgumentList 'Set-Service ssh-agent -StartupType Manual; Start-Service ssh-agent; ssh-add; pause'",
+      },
+    });
+  }, [addTab]);
+
   const handleSave = useCallback(() => {
     if (saveConnection()) {
       closeThisTab();
@@ -310,6 +325,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           <SshSettings
             config={connectionConfig.config}
             onChange={(config: SshConfig) => setConnectionConfig({ type: "ssh", config })}
+            onSetupAgent={handleSetupSshAgent}
           />
         )}
         {connectionConfig.type === "serial" && (

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -190,7 +190,20 @@ export function Terminal({ tabId, config, isVisible }: TerminalProps) {
           }
         };
       } catch (err) {
-        xterm.writeln(`\x1b[31mFailed to create terminal: ${err}\x1b[0m`);
+        const errStr = String(err);
+        if (errStr.includes("Agent auth failed")) {
+          xterm.writeln(`\x1b[31m${errStr}\x1b[0m`);
+          xterm.writeln("");
+          xterm.writeln("\x1b[33mThe SSH agent may not be running.\x1b[0m");
+          xterm.writeln(
+            "\x1b[33mOn Windows, open the connection editor and use the 'Setup SSH Agent' button,\x1b[0m"
+          );
+          xterm.writeln(
+            "\x1b[33mor run: Start-Process powershell -Verb RunAs -ArgumentList 'Set-Service ssh-agent -StartupType Manual; Start-Service ssh-agent'\x1b[0m"
+          );
+        } else {
+          xterm.writeln(`\x1b[31mFailed to create terminal: ${err}\x1b[0m`);
+        }
       }
     },
     [config]

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -16,6 +16,7 @@ import {
   listSerialPorts,
   listAvailableShells,
   checkX11Available,
+  checkSshAgentStatus,
   loadConnectionsAndFolders,
   saveConnection,
   deleteConnectionFromBackend,
@@ -123,6 +124,15 @@ describe("api service", () => {
 
       expect(mockedInvoke).toHaveBeenCalledWith("check_x11_available");
       expect(result).toBe(true);
+    });
+
+    it("checkSshAgentStatus returns status string", async () => {
+      mockedInvoke.mockResolvedValue("running");
+
+      const result = await checkSshAgentStatus();
+
+      expect(mockedInvoke).toHaveBeenCalledWith("check_ssh_agent_status");
+      expect(result).toBe("running");
     });
   });
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -54,6 +54,11 @@ export async function checkX11Available(): Promise<boolean> {
   return await invoke<boolean>("check_x11_available");
 }
 
+/** Check whether the SSH agent is running, stopped, or not installed. */
+export async function checkSshAgentStatus(): Promise<string> {
+  return await invoke<string>("check_ssh_agent_status");
+}
+
 // --- Connection persistence commands ---
 
 interface ConnectionData {


### PR DESCRIPTION
## Summary

- Add proactive SSH agent status detection in the connection editor — when auth method is "agent" and the service is not running, show a warning with platform-specific guidance (Windows: "Setup SSH Agent" button that opens an elevated PowerShell tab; Unix: `eval $(ssh-agent)` instructions)
- Enhance terminal error messages for agent auth failures with actionable troubleshooting steps
- Backend detection uses `OpenOptions` to probe the Windows named pipe (`\.\pipe\openssh-ssh-agent`) since `Path::exists()` does not work for named pipes

Closes #125

## Test plan

- [x] `cargo test` — 75 tests pass (including new `check_ssh_agent_status` tests)
- [x] `pnpm test` — 141 tests pass (including new `checkSshAgentStatus` API test)
- [x] `pnpm run lint` / `pnpm run format:check` / `cargo clippy` / `cargo fmt` — all clean
- [ ] Manual: Open connection editor, select SSH + Agent auth → warning appears if agent is stopped, normal hint if running
- [ ] Manual: Click "Setup SSH Agent" button → local PowerShell tab opens with elevation command
- [ ] Manual: SSH connect with agent auth when agent is stopped → helpful error in terminal