### PR TITLE
fix(ui): WSL file browser uses WSL filesystem instead of Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows: WSL shell tabs now browse the WSL Linux filesystem (via `\\wsl$\` UNC paths) instead of the Windows filesystem
+- Windows: file browser path navigation (navigate-up, rename) now works correctly by normalizing backend paths to forward slashes
 - Powerline glyphs (e.g., agnoster zsh theme) rendering as boxes on Windows by bundling MesloLGS Nerd Font Mono
 - Windows: PowerShell and Git Bash shells launching WSL instead of the correct shell due to bare executable names being intercepted by WSL interop; now resolved via absolute paths
 - Windows: `bash` shell type on Windows now routes to Git Bash instead of being intercepted by WSL

--- a/src/utils/shell-detection.test.ts
+++ b/src/utils/shell-detection.test.ts
@@ -4,6 +4,7 @@ import {
   getDefaultShell,
   isWslShell,
   getWslDistroName,
+  wslToWindowsPath,
 } from "./shell-detection";
 import { listAvailableShells } from "@/services/api";
 
@@ -116,6 +117,22 @@ describe("shell-detection", () => {
       expect(getWslDistroName("bash")).toBeNull();
       expect(getWslDistroName("zsh")).toBeNull();
       expect(getWslDistroName("powershell")).toBeNull();
+    });
+  });
+
+  describe("wslToWindowsPath", () => {
+    it("converts a home directory path", () => {
+      expect(wslToWindowsPath("/home/user", "Ubuntu")).toBe("//wsl$/Ubuntu/home/user");
+    });
+
+    it("converts the root path", () => {
+      expect(wslToWindowsPath("/", "Debian")).toBe("//wsl$/Debian/");
+    });
+
+    it("handles distro names with version numbers", () => {
+      expect(wslToWindowsPath("/home/user/docs", "Ubuntu-22.04")).toBe(
+        "//wsl$/Ubuntu-22.04/home/user/docs"
+      );
     });
   });
 });

--- a/src/utils/shell-detection.ts
+++ b/src/utils/shell-detection.ts
@@ -32,3 +32,13 @@ export function getWslDistroName(shell: ShellType): string | null {
   }
   return shell.slice(4);
 }
+
+/**
+ * Convert a Linux filesystem path to a Windows UNC path for WSL access.
+ * Uses the `\\wsl$\<distro>` share that Windows exposes for WSL filesystems.
+ * Returns forward-slash UNC paths (e.g. `//wsl$/Ubuntu/home/user`) since
+ * the backend normalizes all paths to forward slashes.
+ */
+export function wslToWindowsPath(linuxPath: string, distro: string): string {
+  return `//wsl$/${distro}${linuxPath}`;
+}


### PR DESCRIPTION
## Summary

- WSL shell tabs now translate Linux paths (from OSC 7) to Windows UNC paths (`//wsl$/<distro>/...`) so the sidebar file browser shows the correct WSL filesystem instead of the Windows filesystem
- When no CWD is available for a WSL tab, falls back to the WSL distribution root (`//wsl$/<distro>/`) instead of the Windows home directory
- Backend now normalizes all path separators to forward slashes, fixing navigate-up and rename-parent path logic on Windows

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/files/local.rs` | Added `normalize_separators()` helper; applied to `list_dir()` and `home_dir()`; 4 unit tests |
| `src/utils/shell-detection.ts` | Added `wslToWindowsPath()` utility |
| `src/utils/shell-detection.test.ts` | 3 tests for `wslToWindowsPath` |
| `src/components/Sidebar/FileBrowser.tsx` | Updated `useFileBrowserSync` to detect WSL tabs and convert paths |
| `CHANGELOG.md` | Added entries |

## Test plan

- [x] `cargo test` — 87 tests pass (including 4 new `normalize_separators` tests)
- [x] `pnpm test` — 149 tests pass (including 3 new `wslToWindowsPath` tests)
- [x] `cargo clippy` — clean
- [x] `pnpm run lint` — no new warnings
- [x] `pnpm run format:check` / `cargo fmt --check` — clean
- [ ] Manual: open a WSL shell tab → file browser shows WSL filesystem (not Windows `C:\`)
- [ ] Manual: navigate up/down within WSL filesystem → paths display correctly
- [ ] Manual: create/rename/delete files in WSL filesystem via file browser → operations work

Closes #138