### PR TITLE
Suppress browser default context menu on right-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Browser's default context menu ("Print", "Save As", etc.) no longer appears on right-click; only custom app menus are shown
+
 - Windows: WSL shell tabs now browse the WSL Linux filesystem (via `\\wsl$\` UNC paths) instead of the Windows filesystem
 - Windows: file browser path navigation (navigate-up, rename) now works correctly by normalizing backend paths to forward slashes
 - Powerline glyphs (e.g., agnoster zsh theme) rendering as boxes on Windows by bundling MesloLGS Nerd Font Mono

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,14 @@ function App() {
     loadFromBackend();
   }, [loadFromBackend]);
 
+  // Suppress the browser's default context menu globally so only custom
+  // Radix UI context menus appear on right-click.
+  useEffect(() => {
+    const suppress = (e: MouseEvent) => e.preventDefault();
+    window.addEventListener("contextmenu", suppress);
+    return () => window.removeEventListener("contextmenu", suppress);
+  }, []);
+
   return (
     <div className="app">
       <div className="app__main">


### PR DESCRIPTION
## Summary

- Added a global `contextmenu` event listener in App.tsx that calls `preventDefault()` to suppress the browser's default context menu ("Print", "Save As", etc.)
- Custom Radix UI context menus on connections and tabs continue to work as before

Fixes #145

## Test plan

- [ ] Right-click on empty areas (sidebar whitespace, terminal, activity bar) → no menu appears
- [ ] Right-click on a connection → custom context menu still works
- [ ] Right-click on a tab → custom context menu still works
- [ ] 149 frontend tests pass, ESLint clean, Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)