### PR TITLE
Fix broken logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/icons/termihub-terminal-v2.svg" width="128" height="128" alt="TermiHub">
+  <img src="public/icons/termihub-terminal-v2.svg" width="128" height="128" alt="TermiHub">
 </p>
 
 <h1 align="center">TermiHub</h1>


### PR DESCRIPTION
## Summary
- Fix the README logo path from `assets/icons/` to `public/icons/` where the SVG actually lives

Closes #152

## Test plan
- [x] Verify `public/icons/termihub-terminal-v2.svg` exists
- [ ] Confirm logo renders on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)