### PR TITLE
Rename TermiHub to termiHub across the project

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
-# TermiHub — Claude Code Instructions
+# termiHub — Claude Code Instructions
 
-TermiHub is a cross-platform terminal hub built with Tauri 2 (Rust backend) + React 18 (TypeScript frontend). It supports local shells, SSH, serial, and telnet connections with VS Code-inspired UI, split views, drag-and-drop tabs, and SFTP file browsing. See [docs/architecture.md](../docs/architecture.md) for the full architecture documentation.
+termiHub is a cross-platform terminal hub built with Tauri 2 (Rust backend) + React 18 (TypeScript frontend). It supports local shells, SSH, serial, and telnet connections with VS Code-inspired UI, split views, drag-and-drop tabs, and SFTP file browsing. See [docs/architecture.md](../docs/architecture.md) for the full architecture documentation.
 
 ---
 
@@ -79,7 +79,7 @@ examples/                     # Docker test environment (SSH, Telnet, virtual se
 - Doc comments (`///`) for public APIs
 - `tokio` for async, channels for communication
 - Naming: `PascalCase` types/traits, `snake_case` functions/modules, `UPPER_SNAKE_CASE` constants
-- **Cross-platform awareness**: TermiHub builds on Windows, macOS, and Linux. Gate platform-specific code with `#[cfg(windows)]`, `#[cfg(unix)]`, etc. — on functions, imports, and tests. CI runs on all platforms, so ungated platform-specific code will fail the build.
+- **Cross-platform awareness**: termiHub builds on Windows, macOS, and Linux. Gate platform-specific code with `#[cfg(windows)]`, `#[cfg(unix)]`, etc. — on functions, imports, and tests. CI runs on all platforms, so ungated platform-specific code will fail the build.
 
 ### Testing
 - Every bug fix and feature should include verification that the change works correctly, in order of preference:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,25 +18,25 @@ jobs:
           - platform: 'macos-latest'
             os: macos-latest
             rust_target: 'x86_64-apple-darwin'
-            artifact_name: 'TermiHub-macOS-x64'
+            artifact_name: 'termiHub-macOS-x64'
           - platform: 'macos-latest-arm'
             os: macos-latest
             rust_target: 'aarch64-apple-darwin'
-            artifact_name: 'TermiHub-macOS-arm64'
+            artifact_name: 'termiHub-macOS-arm64'
           - platform: 'ubuntu-latest'
             os: ubuntu-latest
             rust_target: 'x86_64-unknown-linux-gnu'
-            artifact_name: 'TermiHub-Linux-x64'
+            artifact_name: 'termiHub-Linux-x64'
           - platform: 'ubuntu-latest-arm64'
             os: ubuntu-latest
             rust_target: 'aarch64-unknown-linux-gnu'
-            artifact_name: 'TermiHub-Linux-arm64'
+            artifact_name: 'termiHub-Linux-arm64'
             # AppImage can't be cross-compiled (linuxdeploy is x86_64-only)
             extra_args: '--bundles deb,rpm'
           - platform: 'windows-latest'
             os: windows-latest
             rust_target: 'x86_64-pc-windows-msvc'
-            artifact_name: 'TermiHub-Windows-x64'
+            artifact_name: 'termiHub-Windows-x64'
 
     steps:
       - name: Checkout code
@@ -165,7 +165,7 @@ jobs:
           echo "| Platform | Size |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|------|" >> $GITHUB_STEP_SUMMARY
 
-          for dir in TermiHub-*; do
+          for dir in termiHub-*; do
             if [ -d "$dir" ]; then
               size=$(du -sh "$dir" | cut -f1)
               echo "| $dir | $size |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
-          release_name: TermiHub v${{ steps.get_version.outputs.version }}
+          release_name: termiHub v${{ steps.get_version.outputs.version }}
           body_path: release_notes.md
           draft: false
           prerelease: false
@@ -206,7 +206,7 @@ jobs:
           fi
 
           # Rename to include platform
-          FILENAME="TermiHub-${{ needs.create-release.outputs.version }}-${{ matrix.platform }}${{ matrix.file_ext }}"
+          FILENAME="termiHub-${{ needs.create-release.outputs.version }}-${{ matrix.platform }}${{ matrix.file_ext }}"
           mv "$ARTIFACT" "$FILENAME"
 
           echo "artifact_path=$FILENAME" >> $GITHUB_OUTPUT
@@ -228,7 +228,7 @@ jobs:
         run: |
           DEB_FILE=$(find src-tauri/target/${{ matrix.rust_target }}/release/bundle/deb -name "*.deb" | head -n 1)
           if [ -n "$DEB_FILE" ]; then
-            DEB_FILENAME="TermiHub-${{ needs.create-release.outputs.version }}-${{ matrix.platform }}.deb"
+            DEB_FILENAME="termiHub-${{ needs.create-release.outputs.version }}-${{ matrix.platform }}.deb"
             mv "$DEB_FILE" "$DEB_FILENAME"
 
             gh release upload v${{ needs.create-release.outputs.version }} "$DEB_FILENAME"
@@ -266,5 +266,5 @@ jobs:
           echo "Release v${{ needs.create-release.outputs.version }} published successfully!"
           # Add Discord/Slack webhook here if desired
           # curl -X POST -H 'Content-type: application/json' \
-          #   --data '{"text":"TermiHub v${{ needs.create-release.outputs.version }} released!"}' \
+          #   --data '{"text":"termiHub v${{ needs.create-release.outputs.version }} released!"}' \
           #   ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Auto-extract port from host field: pasting `192.168.0.2:2222` or `[::1]:22` into the host field of SSH, Telnet, or Agent settings automatically splits the value into host and port on blur (#185)
 
+### Changed
+
+- Renamed "TermiHub" to "termiHub" throughout the project (documentation, window title, CI artifacts, scripts) to reflect the intended lowercase branding
+
 ### Fixed
 
 - SSH terminals with zsh Agnoster theme no longer show a jarring black rectangle behind the user@host prompt segment; ANSI black now matches the terminal background (#197)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="public/icons/termihub-terminal-v2.svg" width="128" height="128" alt="TermiHub">
+  <img src="public/icons/termihub-terminal-v2.svg" width="128" height="128" alt="termiHub">
 </p>
 
-<h1 align="center">TermiHub</h1>
+<h1 align="center">termiHub</h1>
 
 <p align="center">
 A modern, cross-platform terminal hub for embedded development workflows.
@@ -16,7 +16,7 @@ A modern, cross-platform terminal hub for embedded development workflows.
 
 ---
 
-TermiHub provides a VS Code-like interface for managing multiple terminal connections with support for split views, drag-and-drop tabs, and organized connection management. Built with [Tauri](https://tauri.app/), [React](https://react.dev/), and [Rust](https://www.rust-lang.org/).
+termiHub provides a VS Code-like interface for managing multiple terminal connections with support for split views, drag-and-drop tabs, and organized connection management. Built with [Tauri](https://tauri.app/), [React](https://react.dev/), and [Rust](https://www.rust-lang.org/).
 
 ## Features
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "termihub-agent"
 version = "0.1.0"
-description = "Remote agent for TermiHub — manages persistent terminal sessions on Raspberry Pi"
+description = "Remote agent for termiHub — manages persistent terminal sessions on Raspberry Pi"
 authors = ["Arne Maximilian Richter <armaxri@gmail.com>"]
 edition = "2021"
 

--- a/agent/install.sh
+++ b/agent/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# TermiHub Agent installer
+# termiHub Agent installer
 # Installs the binary and systemd service on a Raspberry Pi (or any Linux host).
 
 BINARY="target/release/termihub-agent"

--- a/agent/src/protocol/errors.rs
+++ b/agent/src/protocol/errors.rs
@@ -18,7 +18,7 @@ pub const INVALID_PARAMS: i64 = -32602;
 /// Internal JSON-RPC error.
 pub const INTERNAL_ERROR: i64 = -32603;
 
-// Application error codes (TermiHub-specific).
+// Application error codes (termiHub-specific).
 
 /// No session with the given ID.
 pub const SESSION_NOT_FOUND: i64 = -32001;

--- a/agent/systemd/termihub-agent.service
+++ b/agent/systemd/termihub-agent.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=TermiHub Remote Agent
+Description=termiHub Remote Agent
 Documentation=https://github.com/armaxri/termiHub
 After=network.target
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# TermiHub Architecture Documentation
+# termiHub Architecture Documentation
 
 > Based on the [arc42](https://arc42.org) template for software architecture documentation.
 
@@ -25,7 +25,7 @@
 
 ### Requirements Overview
 
-**TermiHub** is a modern, cross-platform terminal hub designed for embedded development workflows. It provides a VS Code-like interface for managing multiple terminal connections with support for split views, drag-and-drop tabs, and organized connection management.
+**termiHub** is a modern, cross-platform terminal hub designed for embedded development workflows. It provides a VS Code-like interface for managing multiple terminal connections with support for split views, drag-and-drop tabs, and organized connection management.
 
 **Core capabilities:**
 
@@ -93,13 +93,13 @@
 
 ### Business Context
 
-The following diagram shows TermiHub in its operational environment — an embedded development workflow where a developer interacts with multiple systems simultaneously.
+The following diagram shows termiHub in its operational environment — an embedded development workflow where a developer interacts with multiple systems simultaneously.
 
 ```mermaid
 graph TB
     DEV[Developer]
 
-    subgraph "TermiHub"
+    subgraph "termiHub"
         APP[Desktop Application]
     end
 
@@ -130,7 +130,7 @@ graph TB
 
 ```mermaid
 graph LR
-    subgraph "TermiHub Process"
+    subgraph "termiHub Process"
         WV[WebView<br/>React UI]
         IPC[Tauri IPC<br/>Commands + Events]
         RUST[Rust Backend]
@@ -469,7 +469,7 @@ sequenceDiagram
 ```mermaid
 graph TB
     subgraph "Developer Machine"
-        subgraph "TermiHub Application"
+        subgraph "termiHub Application"
             WV[WebView / React UI]
             RS[Rust Backend]
         end
@@ -514,7 +514,7 @@ The `scripts/` directory provides cross-platform helper scripts (`.sh` + `.cmd` 
 ```mermaid
 graph TB
     subgraph "Developer Machine"
-        APP[TermiHub Desktop]
+        APP[termiHub Desktop]
     end
 
     subgraph "Raspberry Pi"
@@ -717,7 +717,7 @@ graph TD
 | Connection failure | Reliability | SSH server becomes unreachable | Error shown in terminal, app stays stable | No crash, clear error message |
 | New protocol | Extensibility | Developer adds WebSocket backend | Only new files + manager registration needed | < 3 existing files modified |
 | Cross-platform use | Portability | User runs on Linux after using on Windows | Same features and behavior | All connection types available |
-| First-time user | Usability | User familiar with VS Code opens TermiHub | Can create and manage terminals | No documentation needed for basic use |
+| First-time user | Usability | User familiar with VS Code opens termiHub | Can create and manage terminals | No documentation needed for basic use |
 
 ---
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,6 +1,6 @@
-# Building TermiHub
+# Building termiHub
 
-This guide covers how to set up a development environment and build TermiHub from source on macOS, Linux, and Windows.
+This guide covers how to set up a development environment and build termiHub from source on macOS, Linux, and Windows.
 
 ---
 
@@ -80,7 +80,7 @@ The build also produces a `.app` bundle in `src-tauri/target/release/bundle/maco
 
 ### System Dependencies
 
-TermiHub requires several system libraries. Install them for your distribution:
+termiHub requires several system libraries. Install them for your distribution:
 
 #### Ubuntu / Debian
 
@@ -238,7 +238,7 @@ cd examples
 ./start-test-environment.sh
 ```
 
-This builds Docker containers, starts SSH (port 2222) and Telnet (port 2323) servers, and launches TermiHub with pre-configured test connections.
+This builds Docker containers, starts SSH (port 2222) and Telnet (port 2323) servers, and launches termiHub with pre-configured test connections.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,12 +1,12 @@
-# Contributing to TermiHub
+# Contributing to termiHub
 
-This guide covers the development workflow, architecture overview, and coding standards for contributing to TermiHub.
+This guide covers the development workflow, architecture overview, and coding standards for contributing to termiHub.
 
 ---
 
 ## Architecture Overview
 
-TermiHub is built with:
+termiHub is built with:
 
 - **Frontend**: React 18 + TypeScript, built with Vite
 - **Backend**: Rust, running inside Tauri 2
@@ -84,7 +84,7 @@ For the full architecture documentation, including class diagrams and data flow 
 
 ## Development Setup
 
-See [Building TermiHub](building.md) for detailed instructions on:
+See [Building termiHub](building.md) for detailed instructions on:
 - Installing prerequisites (Node.js, pnpm, Rust, system libraries)
 - Platform-specific dependencies
 - Running the development server

--- a/docs/manual-tests-input.md
+++ b/docs/manual-tests-input.md
@@ -36,7 +36,7 @@ Each section groups related tests by feature area. Individual test items referen
 
 ### macOS key repeat fix (PR #48)
 
-- [ ] Launch TermiHub on macOS — open a local shell terminal
+- [ ] Launch termiHub on macOS — open a local shell terminal
 - [ ] Hold any letter key (e.g., `k`) — verify key repeats continuously
 - [ ] Verify accent picker no longer appears when holding letter keys
 - [ ] Verify system-wide setting is unchanged: `defaults read -g ApplePressAndHoldEnabled`
@@ -450,8 +450,8 @@ Each section groups related tests by feature area. Individual test items referen
 ### Custom app icon (PR #70)
 
 - [ ] `ls -la src-tauri/icons/` — all 16 PNGs + .icns + .ico present with reasonable sizes
-- [ ] Open `public/termihub.svg` in browser — shows TermiHub icon
-- [ ] `pnpm tauri dev` — app icon in dock/taskbar is the custom icon, favicon in browser tab is TermiHub
+- [ ] Open `public/termihub.svg` in browser — shows termiHub icon
+- [ ] `pnpm tauri dev` — app icon in dock/taskbar is the custom icon, favicon in browser tab is termiHub
 - [ ] `icon/` directory is gone
 - [ ] README renders correctly on GitHub with centered icon
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-TermiHub targets 40 concurrent terminal sessions. This guide covers how to profile the application, what metrics to capture, and how to detect regressions.
+termiHub targets 40 concurrent terminal sessions. This guide covers how to profile the application, what metrics to capture, and how to detect regressions.
 
 ## Architecture Optimizations
 

--- a/docs/raspberry-pi.md
+++ b/docs/raspberry-pi.md
@@ -2,7 +2,7 @@
 
 ## Installation on Raspberry Pi
 
-TermiHub builds for ARM64 Linux, which includes:
+termiHub builds for ARM64 Linux, which includes:
 - Raspberry Pi 3 (64-bit OS)
 - Raspberry Pi 4
 - Raspberry Pi 5
@@ -26,10 +26,10 @@ uname -m
 
 ```bash
 # Download the latest .deb for ARM64
-wget https://github.com/armaxri/termiHub/releases/latest/download/TermiHub-X.X.X-linux-arm64.deb
+wget https://github.com/armaxri/termiHub/releases/latest/download/termiHub-X.X.X-linux-arm64.deb
 
 # Install
-sudo dpkg -i TermiHub-X.X.X-linux-arm64.deb
+sudo dpkg -i termiHub-X.X.X-linux-arm64.deb
 
 # Fix dependencies if needed
 sudo apt-get install -f
@@ -39,18 +39,18 @@ sudo apt-get install -f
 
 ```bash
 # Download AppImage
-wget https://github.com/armaxri/termiHub/releases/latest/download/TermiHub-X.X.X-linux-arm64.AppImage
+wget https://github.com/armaxri/termiHub/releases/latest/download/termiHub-X.X.X-linux-arm64.AppImage
 
 # Make executable
-chmod +x TermiHub-X.X.X-linux-arm64.AppImage
+chmod +x termiHub-X.X.X-linux-arm64.AppImage
 
 # Run
-./TermiHub-X.X.X-linux-arm64.AppImage
+./termiHub-X.X.X-linux-arm64.AppImage
 ```
 
 ### System Dependencies
 
-TermiHub requires WebKitGTK and GTK3:
+termiHub requires WebKitGTK and GTK3:
 
 ```bash
 sudo apt-get update
@@ -109,7 +109,7 @@ sudo systemctl edit termihub-agent
 
 #### Connecting from the Desktop
 
-When the agent runs with `--listen`, connect from TermiHub desktop via:
+When the agent runs with `--listen`, connect from termiHub desktop via:
 
 - **SSH port forward**: `ssh -L 7685:127.0.0.1:7685 pi@raspberrypi` then connect to `localhost:7685`
 - **Direct LAN**: Start with `--listen 0.0.0.0:7685` and connect to the Pi's IP address
@@ -171,7 +171,7 @@ groups $USER  # Should include 'dialout'
 
 ### Building from Source on Raspberry Pi
 
-If you want to build TermiHub directly on your Raspberry Pi:
+If you want to build termiHub directly on your Raspberry Pi:
 
 ```bash
 # Install Rust
@@ -206,7 +206,7 @@ pnpm run build
 
 ### Remote Access Setup
 
-To access the TermiHub agent from your development machine:
+To access the termiHub agent from your development machine:
 
 1. **Ensure SSH is enabled** on Raspberry Pi:
 ```bash
@@ -219,7 +219,7 @@ sudo systemctl start ssh
 hostname -I
 ```
 
-3. **Connect from TermiHub on your PC**:
+3. **Connect from termiHub on your PC**:
 - Add new SSH connection
 - Enter Raspberry Pi IP and credentials
 - Enable X11 forwarding if needed
@@ -230,10 +230,10 @@ hostname -I
 **Using .deb package**:
 ```bash
 # Download new version
-wget https://github.com/armaxri/termiHub/releases/latest/download/TermiHub-X.X.X-linux-arm64.deb
+wget https://github.com/armaxri/termiHub/releases/latest/download/termiHub-X.X.X-linux-arm64.deb
 
 # Update
-sudo dpkg -i TermiHub-X.X.X-linux-arm64.deb
+sudo dpkg -i termiHub-X.X.X-linux-arm64.deb
 ```
 
 **Using AppImage**:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This document describes how to create a new TermiHub release.
+This document describes how to create a new termiHub release.
 
 ## Pre-Release Checklist
 

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -1,6 +1,6 @@
 # Remote Session Management Protocol
 
-Protocol specification for communication between the TermiHub desktop app and remote Raspberry Pi agents.
+Protocol specification for communication between the termiHub desktop app and remote Raspberry Pi agents.
 
 **Version**: 0.1.0
 **Status**: Draft
@@ -26,7 +26,7 @@ Protocol specification for communication between the TermiHub desktop app and re
 
 ## Overview
 
-The remote session management protocol enables the TermiHub desktop app to manage persistent terminal sessions on a remote Raspberry Pi agent. Sessions survive desktop disconnects, allowing users to reconnect to long-running processes (overnight test runs, serial monitoring) without losing state.
+The remote session management protocol enables the termiHub desktop app to manage persistent terminal sessions on a remote Raspberry Pi agent. Sessions survive desktop disconnects, allowing users to reconnect to long-running processes (overnight test runs, serial monitoring) without losing state.
 
 ### Goals
 
@@ -861,7 +861,7 @@ Agent → Desktop:
 The protocol relies entirely on the SSH transport for encryption and authentication. No additional encryption or authentication layer is implemented at the protocol level.
 
 - **Encryption**: All messages are encrypted by the SSH channel
-- **Authentication**: SSH key-based or password authentication (same as existing SSH connections in TermiHub)
+- **Authentication**: SSH key-based or password authentication (same as existing SSH connections in termiHub)
 - **Authorization**: The agent trusts any client that successfully authenticates over SSH — no additional authorization model
 
 ### Agent Security

--- a/docs/serial-setup.md
+++ b/docs/serial-setup.md
@@ -1,6 +1,6 @@
 # Serial Port Setup
 
-This guide covers how to configure serial port connections in TermiHub on each platform.
+This guide covers how to configure serial port connections in termiHub on each platform.
 
 ---
 
@@ -26,7 +26,7 @@ Serial devices appear under `/dev/tty.*` when connected. Common paths:
    - [CH340 drivers](https://www.wch-ic.com/downloads/CH341SER_MAC_ZIP.html)
    - [CP210x drivers](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers)
 3. Install and restart your Mac
-4. The device should appear in TermiHub's port dropdown
+4. The device should appear in termiHub's port dropdown
 
 **Tip**: Run `ls /dev/tty.*` in a terminal to list all available serial devices.
 
@@ -92,13 +92,13 @@ Serial devices appear as COM ports (e.g., `COM3`, `COM4`).
 2. Download from the manufacturer (same links as macOS section above)
 3. Install and check Device Manager again
 
-**Tip**: TermiHub auto-detects available COM ports in the connection editor. If no ports appear in the dropdown, enter the port name manually (e.g., `COM3`).
+**Tip**: termiHub auto-detects available COM ports in the connection editor. If no ports appear in the dropdown, enter the port name manually (e.g., `COM3`).
 
 ---
 
 ## Configuration Parameters
 
-When creating a serial connection in TermiHub, configure these parameters to match your device:
+When creating a serial connection in termiHub, configure these parameters to match your device:
 
 | Parameter | Options | Default | Description |
 |-----------|---------|---------|-------------|
@@ -138,7 +138,7 @@ Check your device's documentation for the correct settings. Mismatched baud rate
 
 ## Testing with Virtual Serial Ports
 
-TermiHub includes scripts for creating virtual serial ports, which is useful for testing without physical hardware.
+termiHub includes scripts for creating virtual serial ports, which is useful for testing without physical hardware.
 
 ### Setup (Linux/macOS)
 
@@ -157,7 +157,7 @@ cd examples/serial
 ```
 
 This creates two linked virtual ports:
-- `/tmp/termihub-serial-a` — Connect TermiHub to this port
+- `/tmp/termihub-serial-a` — Connect termiHub to this port
 - `/tmp/termihub-serial-b` — Used by the echo server
 
 ### Running the Echo Server
@@ -167,7 +167,7 @@ cd examples/serial
 python3 serial-echo-server.py
 ```
 
-The echo server reads from port B and echoes back whatever is sent. Connect TermiHub to port A and type to test.
+The echo server reads from port B and echoes back whatever is sent. Connect termiHub to port A and type to test.
 
 See [examples/README.md](../examples/README.md) for full test environment setup.
 

--- a/docs/ssh-configuration.md
+++ b/docs/ssh-configuration.md
@@ -1,16 +1,16 @@
 # SSH Configuration
 
-This guide covers SSH connection setup in TermiHub, including key-based authentication, X11 forwarding, and the SFTP file browser.
+This guide covers SSH connection setup in termiHub, including key-based authentication, X11 forwarding, and the SFTP file browser.
 
 ---
 
 ## Authentication Methods
 
-TermiHub supports two SSH authentication methods:
+termiHub supports two SSH authentication methods:
 
 ### Password Authentication
 
-When **Auth Method** is set to **Password**, TermiHub prompts for the password each time you connect. Passwords are never stored in the configuration file.
+When **Auth Method** is set to **Password**, termiHub prompts for the password each time you connect. Passwords are never stored in the configuration file.
 
 ### Key-Based Authentication
 
@@ -39,7 +39,7 @@ This creates two files:
 - `~/.ssh/id_ed25519` — Your private key (keep this secret)
 - `~/.ssh/id_ed25519.pub` — Your public key (install on servers)
 
-**Note**: You can also use RSA keys (`ssh-keygen -t rsa -b 4096`). TermiHub supports both key types.
+**Note**: You can also use RSA keys (`ssh-keygen -t rsa -b 4096`). termiHub supports both key types.
 
 ### Install the Public Key on the Server
 
@@ -55,7 +55,7 @@ Or manually append it to `~/.ssh/authorized_keys` on the server:
 cat ~/.ssh/id_ed25519.pub | ssh user@hostname 'mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys'
 ```
 
-### Configure in TermiHub
+### Configure in termiHub
 
 1. Create or edit an SSH connection
 2. Set **Auth Method** to **SSH Key**
@@ -85,7 +85,7 @@ Host *
   IdentityFile ~/.ssh/id_ed25519
 ```
 
-**Key location**: Keys are typically stored in `~/.ssh/`. Use this path in TermiHub's Key Path field.
+**Key location**: Keys are typically stored in `~/.ssh/`. Use this path in termiHub's Key Path field.
 
 ### Linux
 
@@ -125,7 +125,7 @@ chmod 644 ~/.ssh/id_ed25519.pub
    ssh-add $env:USERPROFILE\.ssh\id_ed25519
    ```
 
-**Key location**: Keys are typically stored in `C:\Users\<username>\.ssh\`. In TermiHub, you can use either:
+**Key location**: Keys are typically stored in `C:\Users\<username>\.ssh\`. In termiHub, you can use either:
 - `~/.ssh/id_ed25519` (the `~` prefix works)
 - `C:\Users\<username>\.ssh\id_ed25519`
 
@@ -137,7 +137,7 @@ X11 forwarding lets you run graphical applications on a remote server and displa
 
 ### Enabling X11 Forwarding
 
-1. Edit an SSH connection in TermiHub
+1. Edit an SSH connection in termiHub
 2. Check **Enable X11 Forwarding**
 3. Save and connect
 
@@ -178,11 +178,11 @@ sudo dnf install xorg-x11-xauth
 sudo pacman -S xorg-xauth
 ```
 
-No additional setup is needed — TermiHub will use your existing X11 display.
+No additional setup is needed — termiHub will use your existing X11 display.
 
 #### Windows
 
-X11 forwarding is **not currently supported** on Windows. TermiHub's X11 proxy relies on Unix domain sockets, which are not available on Windows.
+X11 forwarding is **not currently supported** on Windows. termiHub's X11 proxy relies on Unix domain sockets, which are not available on Windows.
 
 For Windows users needing to run remote GUI applications, consider using a standalone X server like [VcXsrv](https://sourceforge.net/projects/vcxsrv/) with a standard SSH client.
 
@@ -201,7 +201,7 @@ The `xauth` package must also be installed on the server.
 
 ## SFTP File Browser
 
-When connected to an SSH server, TermiHub provides an integrated SFTP file browser for managing remote files.
+When connected to an SSH server, termiHub provides an integrated SFTP file browser for managing remote files.
 
 ### Auto-Connect
 
@@ -267,11 +267,11 @@ This is useful for shared connection configurations where values differ per user
 - **Password auth**: Verify the username and password are correct
 - **Key auth**: Ensure the public key is in `~/.ssh/authorized_keys` on the server
 - **Key permissions**: Check that your private key file has `600` permissions
-- **Wrong key**: Verify the Key Path in TermiHub points to the correct private key
+- **Wrong key**: Verify the Key Path in termiHub points to the correct private key
 
 ### "Host key verification failed"
 
-This occurs when connecting to a new server or when the server's host key has changed. TermiHub uses the system's `known_hosts` file. To resolve:
+This occurs when connecting to a new server or when the server's host key has changed. termiHub uses the system's `known_hosts` file. To resolve:
 
 ```bash
 # Connect once with standard SSH to accept the host key

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,8 +1,8 @@
-# Testing Strategy for TermiHub
+# Testing Strategy for termiHub
 
 ## Overview
 
-TermiHub uses a multi-layered testing approach to ensure quality across the entire stack.
+termiHub uses a multi-layered testing approach to ensure quality across the entire stack.
 
 ## Testing Layers
 
@@ -522,7 +522,7 @@ Install the recommended VS Code extensions (already configured in `.vscode/exten
 
 ## Performance Testing
 
-TermiHub includes an automated E2E performance test suite that validates 40 concurrent terminals:
+termiHub includes an automated E2E performance test suite that validates 40 concurrent terminals:
 
 ```bash
 # Run the performance test suite (requires built app + tauri-driver; Linux/Windows only)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,12 +1,12 @@
-# TermiHub User Guide
+# termiHub User Guide
 
-This guide covers the TermiHub interface, features, and day-to-day usage.
+This guide covers the termiHub interface, features, and day-to-day usage.
 
 ---
 
 ## Interface Overview
 
-TermiHub uses a VS Code-inspired three-column layout:
+termiHub uses a VS Code-inspired three-column layout:
 
 ```
 ┌──────────┬────────────────┬──────────────────────────────────────────┐
@@ -125,7 +125,7 @@ This is useful for shared connection files where values differ per user.
 
 ### Local Shell
 
-Opens a local terminal using a shell installed on your system. TermiHub auto-detects available shells:
+Opens a local terminal using a shell installed on your system. termiHub auto-detects available shells:
 
 - **macOS/Linux**: zsh, bash, sh
 - **Windows**: PowerShell, cmd, Git Bash
@@ -206,7 +206,7 @@ Right-click a terminal tab for these options:
 
 ## Split Views
 
-TermiHub supports splitting the terminal area into multiple panels arranged horizontally and vertically.
+termiHub supports splitting the terminal area into multiple panels arranged horizontally and vertically.
 
 ### Creating Splits
 
@@ -308,7 +308,7 @@ Each entry shows:
 
 ## Built-in File Editor
 
-TermiHub includes a built-in file editor powered by Monaco (the same engine as VS Code).
+termiHub includes a built-in file editor powered by Monaco (the same engine as VS Code).
 
 ### Opening Files
 
@@ -322,7 +322,7 @@ Files open in a new tab in the terminal view.
 - **Syntax highlighting** — Automatic language detection from file extension
 - **Search and replace** — Standard Ctrl+F / Ctrl+H
 - **Word wrap** — Enabled by default
-- **Dark theme** — Matches the TermiHub dark theme
+- **Dark theme** — Matches the termiHub dark theme
 
 ### Saving
 
@@ -345,7 +345,7 @@ When an editor tab is active, the status bar at the bottom shows:
 
 ### Open in VS Code
 
-If VS Code is installed, you can right-click a file in the file browser and select **Open in VS Code**. For remote (SFTP) files, TermiHub downloads the file to a temporary location first.
+If VS Code is installed, you can right-click a file in the file browser and select **Open in VS Code**. For remote (SFTP) files, termiHub downloads the file to a temporary location first.
 
 ---
 
@@ -357,7 +357,7 @@ Click the **gear icon** at the bottom of the Activity Bar, then select **Setting
 
 ### Configuration Directory
 
-TermiHub stores its configuration (connections, folders, settings) in a platform-specific directory. Override this by setting the `TERMIHUB_CONFIG_DIR` environment variable before launching the app:
+termiHub stores its configuration (connections, folders, settings) in a platform-specific directory. Override this by setting the `TERMIHUB_CONFIG_DIR` environment variable before launching the app:
 
 ```bash
 # Example: use a project-specific config directory

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
-# TermiHub Examples & Test Environment
+# termiHub Examples & Test Environment
 
-This directory provides Docker-based test targets and scripts for testing all TermiHub connection types without external infrastructure.
+This directory provides Docker-based test targets and scripts for testing all termiHub connection types without external infrastructure.
 
 ## Prerequisites
 
@@ -10,7 +10,7 @@ This directory provides Docker-based test targets and scripts for testing all Te
 
 ## Quick Start
 
-Start the Docker test environment and launch TermiHub with pre-configured test connections:
+Start the Docker test environment and launch termiHub with pre-configured test connections:
 
 ```bash
 ./scripts/start-test-environment.sh
@@ -20,7 +20,7 @@ This will:
 
 1. Build and start a Docker container with SSH and Telnet servers
 2. Wait for the services to be ready
-3. Launch TermiHub with `TERMIHUB_CONFIG_DIR` pointing to `examples/config/`
+3. Launch termiHub with `TERMIHUB_CONFIG_DIR` pointing to `examples/config/`
 
 When you're done, stop the test containers:
 
@@ -63,7 +63,7 @@ Quick version:
 # Terminal 2: Start echo server
 python3 serial/serial-echo-server.py
 
-# Terminal 3: Connect TermiHub to /tmp/termihub-serial-a
+# Terminal 3: Connect termiHub to /tmp/termihub-serial-a
 ```
 
 ## Directory Structure
@@ -120,10 +120,10 @@ Install `socat` for virtual serial port testing:
 
 ## Config Directory Override
 
-The start script uses the `TERMIHUB_CONFIG_DIR` environment variable to point TermiHub at the example config. You can use this independently:
+The start script uses the `TERMIHUB_CONFIG_DIR` environment variable to point termiHub at the example config. You can use this independently:
 
 ```bash
 TERMIHUB_CONFIG_DIR=/path/to/custom/config pnpm tauri dev
 ```
 
-When unset, TermiHub uses the default Tauri config directory.
+When unset, termiHub uses the default Tauri config directory.

--- a/examples/docker/Dockerfile.e2e-runner
+++ b/examples/docker/Dockerfile.e2e-runner
@@ -1,4 +1,4 @@
-# Dockerfile.e2e-runner — E2E test runner for TermiHub.
+# Dockerfile.e2e-runner — E2E test runner for termiHub.
 #
 # Provides: Ubuntu 22.04, Rust stable, Node.js 20, pnpm, Tauri build deps,
 #           WebKitGTK runtime, Xvfb, socat, python3, tauri-driver.

--- a/examples/docker/docker-compose.e2e.yml
+++ b/examples/docker/docker-compose.e2e.yml
@@ -1,7 +1,7 @@
-# docker-compose.e2e.yml — E2E test environment for TermiHub.
+# docker-compose.e2e.yml — E2E test environment for termiHub.
 #
 # Services:
-#   e2e-runner:   Builds and tests TermiHub (Linux) inside Docker.
+#   e2e-runner:   Builds and tests termiHub (Linux) inside Docker.
 #   test-target:  SSH + Telnet server for infrastructure tests.
 #
 # Usage:

--- a/examples/docker/e2e-entrypoint.sh
+++ b/examples/docker/e2e-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # e2e-entrypoint.sh — Entrypoint for the E2E runner container.
 #
-# Builds TermiHub (Linux), starts Xvfb, sets up port-forwards and virtual
+# Builds termiHub (Linux), starts Xvfb, sets up port-forwards and virtual
 # serial ports, then runs the infrastructure E2E test suite.
 #
 # Environment variables (set by docker-compose or host script):
@@ -11,7 +11,7 @@
 #
 set -euo pipefail
 
-echo "=== TermiHub E2E Runner ==="
+echo "=== termiHub E2E Runner ==="
 echo "  Platform: $(uname -m)"
 echo "  Node:     $(node --version)"
 echo "  Rust:     $(rustc --version)"
@@ -172,7 +172,7 @@ if [ "$SKIP_BUILD" -eq 0 ]; then
     pnpm install --frozen-lockfile
 
     echo ""
-    echo "=== Building TermiHub (Linux release) ==="
+    echo "=== Building termiHub (Linux release) ==="
     pnpm tauri build
 else
     echo ""

--- a/examples/scripts/setup-virtual-serial.sh
+++ b/examples/scripts/setup-virtual-serial.sh
@@ -5,7 +5,7 @@
 # This creates two linked pseudo-terminals:
 #   /tmp/termihub-serial-a  <-->  /tmp/termihub-serial-b
 #
-# Connect TermiHub to one end and the echo server (or another tool) to the other.
+# Connect termiHub to one end and the echo server (or another tool) to the other.
 #
 set -euo pipefail
 
@@ -28,7 +28,7 @@ rm -f "$PTY_A" "$PTY_B"
 echo "Creating virtual serial port pair..."
 echo "  $PTY_A  <-->  $PTY_B"
 echo ""
-echo "Connect TermiHub to $PTY_A and the echo server to $PTY_B (or vice versa)."
+echo "Connect termiHub to $PTY_A and the echo server to $PTY_B (or vice versa)."
 echo "Press Ctrl+C to stop."
 echo ""
 

--- a/examples/scripts/start-test-environment.sh
+++ b/examples/scripts/start-test-environment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Start the Docker test environment and launch TermiHub with test config.
+# Start the Docker test environment and launch termiHub with test config.
 #
 set -euo pipefail
 
@@ -59,7 +59,7 @@ echo ""
 echo "==========================================="
 echo ""
 
-# --- Launch TermiHub with test config ---
-echo "Launching TermiHub with test configuration..."
+# --- Launch termiHub with test config ---
+echo "Launching termiHub with test configuration..."
 cd "$PROJECT_DIR"
 TERMIHUB_CONFIG_DIR="$CONFIG_DIR" pnpm tauri dev

--- a/examples/serial/README.md
+++ b/examples/serial/README.md
@@ -1,6 +1,6 @@
 # Serial Port Testing
 
-This directory contains tools for testing TermiHub's serial port functionality without physical hardware.
+This directory contains tools for testing termiHub's serial port functionality without physical hardware.
 
 ## Virtual Serial Port Pair
 
@@ -14,7 +14,7 @@ This creates two pseudo-terminals:
 
 | Path | Purpose |
 |------|---------|
-| `/tmp/termihub-serial-a` | Connect TermiHub here |
+| `/tmp/termihub-serial-a` | Connect termiHub here |
 | `/tmp/termihub-serial-b` | Connect the echo server (or another tool) here |
 
 ### Prerequisites
@@ -39,11 +39,11 @@ By default it listens on `/tmp/termihub-serial-b`. Pass a custom path as the fir
 python3 serial-echo-server.py /dev/pts/5
 ```
 
-## Configuring TermiHub
+## Configuring termiHub
 
 1. Start the virtual serial pair (keep the terminal open)
 2. Start the echo server in another terminal (keep it open)
-3. In TermiHub, create a Serial connection:
+3. In termiHub, create a Serial connection:
    - **Port**: `/tmp/termihub-serial-a`
    - **Baud rate**: 9600 (any rate works with virtual ports)
    - **Data bits**: 8

--- a/examples/serial/serial-echo-server.py
+++ b/examples/serial/serial-echo-server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Simple serial echo server for testing TermiHub serial connections.
+Simple serial echo server for testing termiHub serial connections.
 
 Reads from a virtual serial port and echoes each line back with a prefix.
 Useful with the virtual serial pair created by setup-virtual-serial.sh.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/termihub.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TermiHub</title>
+    <title>termiHub</title>
   </head>
 
   <body>

--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -11,5 +11,5 @@ if not exist node_modules (
     echo.
 )
 
-echo Building TermiHub for production...
+echo Building termiHub for production...
 call pnpm tauri build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,12 +12,12 @@ if [ ! -d node_modules ]; then
     echo ""
 fi
 
-echo "Building TermiHub for production..."
+echo "Building termiHub for production..."
 pnpm tauri build
 
 # --- Cross-compile agent binaries for Linux (macOS only) ---
 #
-# TermiHub connects to remote hosts (Raspberry Pi, servers) that need the
+# termiHub connects to remote hosts (Raspberry Pi, servers) that need the
 # agent binary.  Building both architectures alongside the desktop app
 # means users always have matching binaries ready for upload.
 #

--- a/scripts/dev.cmd
+++ b/scripts/dev.cmd
@@ -11,5 +11,5 @@ if not exist node_modules (
     echo.
 )
 
-echo Starting TermiHub in dev mode...
+echo Starting termiHub in dev mode...
 call pnpm tauri dev

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -11,5 +11,5 @@ if [ ! -d node_modules ]; then
     echo ""
 fi
 
-echo "Starting TermiHub in dev mode..."
+echo "Starting termiHub in dev mode..."
 pnpm tauri dev

--- a/scripts/test-system.sh
+++ b/scripts/test-system.sh
@@ -214,7 +214,7 @@ APP_BINARY="./src-tauri/target/release/termihub"
 
 if [ "$SKIP_BUILD" -eq 0 ]; then
     echo ""
-    echo "=== Building TermiHub ==="
+    echo "=== Building termiHub ==="
     pnpm tauri build
 elif [ ! -f "$APP_BINARY" ]; then
     echo ""

--- a/src-tauri/src/terminal/agent_setup.rs
+++ b/src-tauri/src/terminal/agent_setup.rs
@@ -488,7 +488,7 @@ fail() {
 }
 
 echo ""
-echo "\360\237\232\200 === TermiHub Agent Setup ==="
+echo "\360\237\232\200 === termiHub Agent Setup ==="
 echo ""
 
 # --- Step 1: Verify uploaded binary ---
@@ -549,7 +549,7 @@ printf "\342\234\205 Verifying installation... "
 # --- Step 7: Optional systemd service ---
 if [ "$INSTALL_SERVICE" = true ]; then
     echo "\342\232\231\357\270\217  Installing systemd service..."
-    printf '[Unit]\nDescription=TermiHub Agent\nAfter=network.target\n\n[Service]\nExecStart=%s --listen 127.0.0.1:7685\nRestart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n' "$INSTALL_PATH" \
+    printf '[Unit]\nDescription=termiHub Agent\nAfter=network.target\n\n[Service]\nExecStart=%s --listen 127.0.0.1:7685\nRestart=on-failure\n\n[Install]\nWantedBy=multi-user.target\n' "$INSTALL_PATH" \
         | $SUDO tee /etc/systemd/system/termihub-agent.service > /dev/null
     $SUDO systemctl daemon-reload
     printf "  \342\234\223 Service registered\n"
@@ -680,7 +680,7 @@ mod tests {
         assert!(script.contains("INSTALL_PATH=\"/usr/local/bin/termihub-agent\""));
         assert!(script.contains("INSTALL_SERVICE=false"));
         assert!(script.contains("--version"));
-        assert!(script.contains("=== TermiHub Agent Setup ==="));
+        assert!(script.contains("=== termiHub Agent Setup ==="));
         assert!(script.contains("=== Setup Complete ==="));
         assert!(script.contains("=== Setup Failed ==="));
         // Service is disabled at runtime via the INSTALL_SERVICE variable

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "TermiHub",
+        "title": "termiHub",
         "width": 1280,
         "height": 800,
         "minWidth": 800,

--- a/tests/e2e/performance-stress.test.js
+++ b/tests/e2e/performance-stress.test.js
@@ -1,7 +1,7 @@
 // Performance stress test: 40 concurrent terminals.
 // Covers: PERF-01, PERF-02, PERF-03, PERF-04.
 //
-// Validates that TermiHub can handle its design target of 40 simultaneous
+// Validates that termiHub can handle its design target of 40 simultaneous
 // local shell terminals without crashing, and logs creation throughput,
 // tab-switch latency, and cleanup timing as performance baselines.
 

--- a/tests/e2e/performance.test.js
+++ b/tests/e2e/performance.test.js
@@ -1,4 +1,4 @@
-// Performance tests for TermiHub.
+// Performance tests for termiHub.
 // Validates the app can handle 40 concurrent terminals without degradation.
 // Run with: pnpm test:e2e:perf
 


### PR DESCRIPTION
## Summary

- Renamed all occurrences of "TermiHub" (capital T) to "termiHub" (lowercase t) across 39 files to reflect the intended branding — emphasizing simplicity and leanness
- Covers documentation, window title, CI artifact names, release filenames, scripts, agent config, and source comments
- `TERMIHUB_*` environment variables (e.g., `TERMIHUB_CONFIG_DIR`) are unchanged — they follow standard ALL_CAPS convention

## Test plan

- [x] `./scripts/check.sh` — all checks pass (formatting, linting, clippy)
- [x] `./scripts/test.sh` — all 457 tests pass (215 frontend + 152 backend + 90 agent)
- [x] Verified no remaining `TermiHub` occurrences in tracked files
- [x] Verified `TERMIHUB_*` env vars are preserved