### PR TITLE
style(ui): highlight active tab and add split view border (#189, #190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Split view panels now have a visible 1px border between them, making it easier to distinguish adjacent panels (#189)
+- Active tabs now show a colored top border: bright blue in the focused panel, dimmed in unfocused panels, following VS Code's tab highlight pattern (#190)
 
 ### Added
 

--- a/docs/manual-tests-input.md
+++ b/docs/manual-tests-input.md
@@ -441,6 +441,13 @@ Each section groups related tests by feature area. Individual test items referen
 - [x] Connections and File Browser icons remain at the top
 - [x] Clicking the settings icon still toggles the sidebar settings view
 
+### Highlight selected tab with top border accent (PR #190)
+
+- [ ] Open multiple tabs in a single panel — active tab should have a blue top border, inactive tabs should have no top border
+- [ ] Split the view into two panels — focused panel's active tab has a bright blue border, unfocused panel's active tab has a dimmer (gray) border
+- [ ] Click between panels to switch focus — borders update: focused panel gets bright blue, previously focused panel dims
+- [ ] Close all tabs in one panel — remaining panel's active tab still shows bright blue border
+
 ### Clear separation between split view panels (PR #189)
 
 - [ ] Open a split view (drag a tab to the edge of a panel) — verify a visible 1px line appears between adjacent panels

--- a/src/components/Terminal/TabBar.css
+++ b/src/components/Terminal/TabBar.css
@@ -26,13 +26,15 @@
   padding: 0 var(--spacing-md);
   min-width: 100px;
   max-width: 200px;
+  border-top: 2px solid transparent;
   border-right: 1px solid var(--tab-border);
   color: var(--text-secondary);
   font-size: var(--font-size-sm);
   cursor: pointer;
   transition:
     background-color var(--transition-fast),
-    color var(--transition-fast);
+    color var(--transition-fast),
+    border-top-color var(--transition-fast);
   white-space: nowrap;
   user-select: none;
 }
@@ -44,8 +46,13 @@
 .tab--active {
   background-color: var(--tab-active-bg);
   color: var(--text-primary);
+  border-top-color: var(--tab-active-border);
   border-bottom: 1px solid var(--tab-active-bg);
   margin-bottom: -1px;
+}
+
+.tab-bar:not(.tab-bar--focused) .tab--active {
+  border-top-color: var(--text-disabled);
 }
 
 .tab__icon {

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -14,6 +14,7 @@ interface TabBarProps {
 }
 
 export function TabBar({ panelId, tabs }: TabBarProps) {
+  const isFocused = useAppStore((s) => s.activePanelId === panelId);
   const setActiveTab = useAppStore((s) => s.setActiveTab);
   const closeTab = useAppStore((s) => s.closeTab);
   const tabHorizontalScrolling = useAppStore((s) => s.tabHorizontalScrolling);
@@ -38,7 +39,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   const renameTabData = renameTabId ? tabs.find((t) => t.id === renameTabId) : null;
 
   return (
-    <div className="tab-bar">
+    <div className={`tab-bar${isFocused ? " tab-bar--focused" : ""}`}>
       <SortableContext items={tabs.map((t) => t.id)} strategy={horizontalListSortingStrategy}>
         <div className="tab-bar__tabs">
           {tabs.map((tab) => (

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -25,6 +25,7 @@
   --tab-bg: #2d2d2d;
   --tab-active-bg: #1e1e1e;
   --tab-border: #252526;
+  --tab-active-border: var(--accent-color);
   --tab-height: 35px;
 
   /* Text colors */


### PR DESCRIPTION
## Summary

- Add a visible 1px border between split view panels so adjacent panels are clearly separated (#189)
- Add a colored top border to the active tab following VS Code's pattern: bright blue (`--accent-color`) in the focused panel, dimmed (`--text-disabled`) in unfocused panels (#190)

## Test plan

- [ ] Open multiple tabs in a single panel — active tab should have a blue top border, inactive tabs should have no top border
- [ ] Split the view into two panels — focused panel's active tab has a bright blue border, unfocused panel's active tab has a dimmer (gray) border
- [ ] Click between panels to switch focus — borders update accordingly
- [ ] Open a split view (drag a tab to the edge) — verify a visible 1px line appears between adjacent panels
- [ ] Single-panel mode — verify the left border blends naturally against the sidebar edge

Closes #189
Closes #190