### PR TITLE
fix(ui): resolve TypeScript compilation errors breaking CI

### DIFF
--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -214,7 +214,12 @@ describe("api service", () => {
 
   describe("settings commands", () => {
     it("getSettings returns settings object", async () => {
-      const settings = { version: "1", externalConnectionFiles: [] };
+      const settings = {
+        version: "1",
+        externalConnectionFiles: [],
+        powerMonitoringEnabled: true,
+        fileBrowserEnabled: true,
+      };
       mockedInvoke.mockResolvedValue(settings);
 
       const result = await getSettings();
@@ -225,7 +230,12 @@ describe("api service", () => {
 
     it("saveSettings invokes with settings object", async () => {
       mockedInvoke.mockResolvedValue(undefined);
-      const settings = { version: "1", externalConnectionFiles: [] };
+      const settings = {
+        version: "1",
+        externalConnectionFiles: [],
+        powerMonitoringEnabled: true,
+        fileBrowserEnabled: true,
+      };
 
       await saveSettings(settings);
 

--- a/src/store/appStore.settings.test.ts
+++ b/src/store/appStore.settings.test.ts
@@ -23,17 +23,17 @@ vi.mock("@/services/storage", () => ({
   reloadExternalConnections: vi.fn(() => Promise.resolve([])),
 }));
 
-const mockMonitoringClose = vi.fn(() => Promise.resolve());
-const mockSftpClose = vi.fn(() => Promise.resolve());
+const mockMonitoringClose = vi.fn((_sessionId: string) => Promise.resolve());
+const mockSftpClose = vi.fn((_sessionId: string) => Promise.resolve());
 
 vi.mock("@/services/api", () => ({
   sftpOpen: vi.fn(),
-  sftpClose: (...args: unknown[]) => mockSftpClose(...args),
+  sftpClose: (sessionId: string) => mockSftpClose(sessionId),
   sftpListDir: vi.fn(),
   localListDir: vi.fn(),
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
   monitoringOpen: vi.fn(),
-  monitoringClose: (...args: unknown[]) => mockMonitoringClose(...args),
+  monitoringClose: (sessionId: string) => mockMonitoringClose(sessionId),
   monitoringFetchStats: vi.fn(),
 }));
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -57,7 +57,7 @@ import {
   AgentSessionInfo,
   AgentDefinitionInfo,
 } from "@/services/api";
-import { RemoteAgentConfig, SshConfig } from "@/types/terminal";
+import { RemoteAgentConfig } from "@/types/terminal";
 import { SystemStats } from "@/types/monitoring";
 import {
   createLeafPanel,


### PR DESCRIPTION
## Summary
- Remove duplicate `SshConfig` import in `appStore.ts` (imported on both line 9 and line 60 from `@/types/terminal`)
- Add missing `powerMonitoringEnabled` and `fileBrowserEnabled` properties to `AppSettings` test fixtures in `api.test.ts`
- Fix spread argument type errors in `appStore.settings.test.ts` by using typed `sessionId: string` parameters instead of `...args: unknown[]` spread

## Test plan
- [x] `pnpm exec tsc --noEmit` passes with zero errors
- [x] `pnpm test` — all 228 tests pass