### PR TITLE
fix(ui): fix TS2556 spread error in settings test mock

### DIFF
--- a/src/store/appStore.settings.test.ts
+++ b/src/store/appStore.settings.test.ts
@@ -26,12 +26,12 @@ vi.mock("@/services/storage", () => ({
 const mockMonitoringClose = vi.fn((_sessionId: string) => Promise.resolve());
 const mockSftpClose = vi.fn((_sessionId: string) => Promise.resolve());
 
-const mockApplyTheme = vi.fn();
-const mockOnThemeChange = vi.fn(() => vi.fn());
+const mockApplyTheme = vi.fn<(setting: string | undefined) => void>();
+const mockOnThemeChange = vi.fn<(callback: () => void) => () => void>(() => vi.fn());
 
 vi.mock("@/themes", () => ({
-  applyTheme: (...args: unknown[]) => mockApplyTheme(...args),
-  onThemeChange: (...args: unknown[]) => mockOnThemeChange(...args),
+  applyTheme: (setting: string | undefined) => mockApplyTheme(setting),
+  onThemeChange: (callback: () => void) => mockOnThemeChange(callback),
 }));
 
 vi.mock("@/services/api", () => ({


### PR DESCRIPTION
## Summary
- Fixes CI failure on `main` caused by TypeScript error `TS2556` in `src/store/appStore.settings.test.ts:34`
- The `vi.mock` for `@/themes` used `...args: unknown[]` spread syntax which TypeScript rejects. Replaced with explicitly typed parameters matching the actual `applyTheme` and `onThemeChange` signatures.

## Test plan
- [x] `pnpm exec tsc --noEmit` passes cleanly
- [x] All 277 frontend tests pass
- [x] ESLint shows no new warnings/errors