### PR TITLE
feat(config): add LayoutConfig type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Concept document for SSH key passphrase handling: encryption detection, runtime passphrase prompting, session caching, and secure storage options (#121)
 - Concept document for cross-platform testing: platform-specific test matrix, CI E2E expansion to Windows, release verification checklists, and platform-aware test infrastructure (#15)
 - Concept document for credential encryption: OS keychain integration, master password portable storage, encrypted import/export, and migration from plaintext (#25)
+- `LayoutConfig` type definitions (TypeScript + Rust) with `DEFAULT_LAYOUT` constant and `LAYOUT_PRESETS` (default, focus, zen) — foundation for customizable UI layout (#237)
 
 ### Fixed
 

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -19,6 +19,16 @@ fn default_true() -> bool {
     true
 }
 
+/// Layout configuration for UI section positioning and visibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LayoutConfig {
+    pub activity_bar_position: String,
+    pub sidebar_position: String,
+    pub sidebar_visible: bool,
+    pub status_bar_visible: bool,
+}
+
 /// Application-wide settings persisted to disk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -49,6 +59,8 @@ pub struct AppSettings {
     pub power_monitoring_enabled: bool,
     #[serde(default = "default_true")]
     pub file_browser_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layout: Option<LayoutConfig>,
 }
 
 impl Default for AppSettings {
@@ -68,6 +80,7 @@ impl Default for AppSettings {
             cursor_blink: None,
             power_monitoring_enabled: true,
             file_browser_enabled: true,
+            layout: None,
         }
     }
 }
@@ -186,6 +199,31 @@ mod tests {
         let settings: AppSettings = serde_json::from_str(json).unwrap();
         assert!(!settings.power_monitoring_enabled);
         assert!(!settings.file_browser_enabled);
+    }
+
+    #[test]
+    fn deserialize_without_layout_field() {
+        let json = r#"{"version":"1","externalConnectionFiles":[]}"#;
+        let settings: AppSettings = serde_json::from_str(json).unwrap();
+        assert!(settings.layout.is_none());
+    }
+
+    #[test]
+    fn deserialize_with_layout_field() {
+        let json = r#"{
+            "version": "1",
+            "externalConnectionFiles": [],
+            "layout": {
+                "activityBarPosition": "right",
+                "sidebarPosition": "left",
+                "sidebarVisible": true,
+                "statusBarVisible": false
+            }
+        }"#;
+        let settings: AppSettings = serde_json::from_str(json).unwrap();
+        let layout = settings.layout.unwrap();
+        assert_eq!(layout.activity_bar_position, "right");
+        assert!(!layout.status_bar_visible);
     }
 
     #[test]

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -53,6 +53,44 @@ export interface RemoteAgentDefinition {
   capabilities?: AgentCapabilities;
 }
 
+export type ActivityBarPosition = "left" | "right" | "top" | "hidden";
+export type SidebarPosition = "left" | "right";
+
+export interface LayoutConfig {
+  activityBarPosition: ActivityBarPosition;
+  sidebarPosition: SidebarPosition;
+  sidebarVisible: boolean;
+  statusBarVisible: boolean;
+}
+
+export const DEFAULT_LAYOUT: LayoutConfig = {
+  activityBarPosition: "left",
+  sidebarPosition: "left",
+  sidebarVisible: true,
+  statusBarVisible: true,
+};
+
+export const LAYOUT_PRESETS: Record<string, LayoutConfig> = {
+  default: {
+    activityBarPosition: "left",
+    sidebarPosition: "left",
+    sidebarVisible: true,
+    statusBarVisible: true,
+  },
+  focus: {
+    activityBarPosition: "left",
+    sidebarPosition: "left",
+    sidebarVisible: false,
+    statusBarVisible: true,
+  },
+  zen: {
+    activityBarPosition: "hidden",
+    sidebarPosition: "left",
+    sidebarVisible: false,
+    statusBarVisible: false,
+  },
+};
+
 export interface AppSettings {
   version: string;
   externalConnectionFiles: ExternalFileConfig[];
@@ -68,6 +106,7 @@ export interface AppSettings {
   cursorBlink?: boolean;
   powerMonitoringEnabled: boolean;
   fileBrowserEnabled: boolean;
+  layout?: LayoutConfig;
 }
 
 export interface FileEntry {


### PR DESCRIPTION
## Summary
- Add `LayoutConfig` type definitions to both TypeScript and Rust as foundation for customizable UI layout (#237, part of #196)
- Add `ActivityBarPosition` and `SidebarPosition` types, `DEFAULT_LAYOUT` constant, and `LAYOUT_PRESETS` (default, focus, zen)
- Extend `AppSettings` with optional `layout` field (backward-compatible — existing settings files load without changes)

## Test plan
- [x] `cargo test` passes — includes two new backward-compatibility tests (`deserialize_without_layout_field`, `deserialize_with_layout_field`)
- [x] `pnpm build` passes — TypeScript compiles successfully
- [x] Existing settings files without `layout` field still deserialize correctly