### PR TITLE
feat(backend): add CredentialManager and Tauri commands for credential store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Customize Layout dialog: preset cards (Default, Focus, Zen) with mini schematics, Activity Bar/Sidebar/Status Bar visibility and position controls with immediate-apply changes (#242)
 - Layout Preview in Customize Layout dialog: live miniature schematic showing Activity Bar, Sidebar, Terminal Area, and Status Bar positions — updates in real-time as layout settings change (#243)
 - `MasterPasswordStore` credential backend — encrypts all credentials into a single file using Argon2id key derivation and AES-256-GCM authenticated encryption, with setup/unlock/lock/change-password lifecycle and atomic file writes (#251)
+- `CredentialManager` runtime wrapper with `StorageMode` switching, settings-based initialization, and Tauri IPC commands for credential store status, lock/unlock, setup, password change, backend switching with credential migration, and keychain availability check (#252)
 
 ### Fixed
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -83,6 +83,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -689,6 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2950,6 +2972,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4900,7 +4933,9 @@ dependencies = [
 name = "termihub"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
+ "argon2",
  "base64 0.22.1",
  "chrono",
  "dirs",
@@ -4926,6 +4961,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "windows 0.58.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -6549,6 +6585,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -7,7 +7,7 @@ use tracing::{debug, info};
 use crate::connection::config::{ConnectionFolder, SavedConnection, SavedRemoteAgent};
 use crate::connection::manager::{self, ConnectionManager};
 use crate::connection::settings::AppSettings;
-use crate::credential::CredentialStore;
+use crate::credential::CredentialManager;
 
 /// Response containing all connections (unified), folders, and agents.
 #[derive(Serialize)]
@@ -155,7 +155,7 @@ pub fn save_external_file(
     name: String,
     folders: Vec<ConnectionFolder>,
     connections: Vec<SavedConnection>,
-    credential_store: State<'_, Arc<dyn CredentialStore>>,
+    credential_store: State<'_, Arc<CredentialManager>>,
 ) -> Result<(), String> {
     manager::save_external_file(&file_path, &name, folders, connections, &**credential_store)
         .map_err(|e| e.to_string())

--- a/src-tauri/src/commands/credential.rs
+++ b/src-tauri/src/commands/credential.rs
@@ -1,0 +1,273 @@
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+use tracing::{debug, info, warn};
+
+use crate::credential::{
+    CredentialManager, CredentialStore, CredentialStoreStatus, KeychainStore, StorageMode,
+};
+
+/// Event emitted when the credential store is locked.
+const EVENT_STORE_LOCKED: &str = "credential-store-locked";
+/// Event emitted when the credential store is unlocked.
+const EVENT_STORE_UNLOCKED: &str = "credential-store-unlocked";
+/// Event emitted when the credential store status changes (mode switch, setup, etc.).
+const EVENT_STORE_STATUS_CHANGED: &str = "credential-store-status-changed";
+
+/// Status information about the credential store, returned to the frontend.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialStoreStatusInfo {
+    /// Current storage mode: `"keychain"`, `"master_password"`, or `"none"`.
+    pub mode: String,
+    /// Current status: `"unlocked"`, `"locked"`, or `"unavailable"`.
+    pub status: String,
+    /// Whether the OS keychain is accessible on this system.
+    pub keychain_available: bool,
+}
+
+/// Result of switching credential stores, returned to the frontend.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwitchResult {
+    /// Number of credentials successfully migrated.
+    pub migrated_count: u32,
+    /// Warnings for credentials that failed to migrate.
+    pub warnings: Vec<String>,
+}
+
+fn status_to_string(status: &CredentialStoreStatus) -> &'static str {
+    match status {
+        CredentialStoreStatus::Unlocked => "unlocked",
+        CredentialStoreStatus::Locked => "locked",
+        CredentialStoreStatus::Unavailable => "unavailable",
+    }
+}
+
+fn emit_status_changed(app_handle: &AppHandle, manager: &CredentialManager) {
+    let info = build_status_info(manager);
+    if let Err(e) = app_handle.emit(EVENT_STORE_STATUS_CHANGED, &info) {
+        warn!("Failed to emit {}: {}", EVENT_STORE_STATUS_CHANGED, e);
+    }
+}
+
+fn build_status_info(manager: &CredentialManager) -> CredentialStoreStatusInfo {
+    CredentialStoreStatusInfo {
+        mode: manager.get_mode().to_settings_str().to_string(),
+        status: status_to_string(&manager.status()).to_string(),
+        keychain_available: KeychainStore::is_available(),
+    }
+}
+
+/// Get the current credential store status.
+#[tauri::command]
+pub fn get_credential_store_status(
+    manager: State<'_, Arc<CredentialManager>>,
+) -> Result<CredentialStoreStatusInfo, String> {
+    debug!("Getting credential store status");
+    Ok(build_status_info(&manager))
+}
+
+/// Unlock the master password credential store.
+///
+/// This is async because Argon2id key derivation is CPU-intensive.
+#[tauri::command]
+pub async fn unlock_credential_store(
+    password: String,
+    app_handle: AppHandle,
+    manager: State<'_, Arc<CredentialManager>>,
+) -> Result<(), String> {
+    info!("Unlocking credential store");
+
+    let result = manager
+        .with_master_password_store(|store| {
+            if store.is_unlocked() {
+                return Err("Store is already unlocked".to_string());
+            }
+            store.unlock(&password).map_err(|e| e.to_string())
+        })
+        .ok_or_else(|| "Credential store is not in master password mode".to_string())?;
+
+    result?;
+
+    if let Err(e) = app_handle.emit(EVENT_STORE_UNLOCKED, ()) {
+        warn!("Failed to emit {}: {}", EVENT_STORE_UNLOCKED, e);
+    }
+    emit_status_changed(&app_handle, &manager);
+    Ok(())
+}
+
+/// Lock the master password credential store.
+#[tauri::command]
+pub fn lock_credential_store(
+    app_handle: AppHandle,
+    manager: State<'_, Arc<CredentialManager>>,
+) -> Result<(), String> {
+    info!("Locking credential store");
+
+    manager
+        .with_master_password_store(|store| {
+            store.lock();
+        })
+        .ok_or_else(|| "Credential store is not in master password mode".to_string())?;
+
+    if let Err(e) = app_handle.emit(EVENT_STORE_LOCKED, ()) {
+        warn!("Failed to emit {}: {}", EVENT_STORE_LOCKED, e);
+    }
+    emit_status_changed(&app_handle, &manager);
+    Ok(())
+}
+
+/// Set up a new master password for the credential store.
+///
+/// This creates the initial encrypted credentials file. The store must
+/// be in master password mode and not already set up.
+///
+/// This is async because Argon2id key derivation is CPU-intensive.
+#[tauri::command]
+pub async fn setup_master_password(
+    password: String,
+    app_handle: AppHandle,
+    manager: State<'_, Arc<CredentialManager>>,
+) -> Result<(), String> {
+    info!("Setting up master password");
+
+    let result = manager
+        .with_master_password_store(|store| store.setup(&password).map_err(|e| e.to_string()))
+        .ok_or_else(|| "Credential store is not in master password mode".to_string())?;
+
+    result?;
+
+    if let Err(e) = app_handle.emit(EVENT_STORE_UNLOCKED, ()) {
+        warn!("Failed to emit {}: {}", EVENT_STORE_UNLOCKED, e);
+    }
+    emit_status_changed(&app_handle, &manager);
+    Ok(())
+}
+
+/// Change the master password for the credential store.
+///
+/// Verifies the current password, then re-encrypts all credentials
+/// with the new password. The store must be unlocked.
+///
+/// This is async because Argon2id key derivation is CPU-intensive.
+#[tauri::command]
+pub async fn change_master_password(
+    current_password: String,
+    new_password: String,
+    app_handle: AppHandle,
+    manager: State<'_, Arc<CredentialManager>>,
+) -> Result<(), String> {
+    info!("Changing master password");
+
+    let result = manager
+        .with_master_password_store(|store| {
+            store
+                .change_password(&current_password, &new_password)
+                .map_err(|e| e.to_string())
+        })
+        .ok_or_else(|| "Credential store is not in master password mode".to_string())?;
+
+    result?;
+
+    emit_status_changed(&app_handle, &manager);
+    Ok(())
+}
+
+/// Switch the credential storage backend.
+///
+/// Optionally migrates existing credentials to the new store.
+/// When switching to master password mode, a `master_password` must be provided
+/// to set up the new encrypted store.
+#[tauri::command]
+pub async fn switch_credential_store(
+    new_mode: String,
+    master_password: Option<String>,
+    app_handle: AppHandle,
+    manager: State<'_, Arc<CredentialManager>>,
+) -> Result<SwitchResult, String> {
+    let target_mode = StorageMode::from_settings_str(Some(&new_mode));
+    let current_mode = manager.get_mode();
+
+    info!(
+        from = current_mode.to_settings_str(),
+        to = target_mode.to_settings_str(),
+        "Switching credential store"
+    );
+
+    if current_mode == target_mode {
+        return Ok(SwitchResult {
+            migrated_count: 0,
+            warnings: vec!["Already using this storage mode".to_string()],
+        });
+    }
+
+    // Collect credentials from the current store for migration
+    let keys_to_migrate = manager.list_keys().unwrap_or_default();
+    let mut credentials_to_migrate = Vec::new();
+    for key in &keys_to_migrate {
+        if let Ok(Some(value)) = manager.get(key) {
+            credentials_to_migrate.push((key.clone(), value));
+        }
+    }
+
+    // Switch to the new backend
+    manager
+        .switch_store(target_mode.clone())
+        .map_err(|e| e.to_string())?;
+
+    // If switching to master password mode, set up the new store
+    if target_mode == StorageMode::MasterPassword {
+        let password = master_password
+            .ok_or("Master password is required when switching to master password mode")?;
+
+        let setup_result = manager
+            .with_master_password_store(|store| {
+                if store.has_credentials_file() {
+                    // File exists — unlock instead of setup
+                    store.unlock(&password).map_err(|e| e.to_string())
+                } else {
+                    store.setup(&password).map_err(|e| e.to_string())
+                }
+            })
+            .ok_or_else(|| "Failed to access master password store after switch".to_string())?;
+
+        setup_result?;
+    }
+
+    // Migrate credentials to the new store
+    let mut migrated_count = 0u32;
+    let mut warnings = Vec::new();
+
+    for (key, value) in &credentials_to_migrate {
+        match manager.set(key, value) {
+            Ok(()) => {
+                migrated_count += 1;
+            }
+            Err(e) => {
+                warnings.push(format!("Failed to migrate {}: {}", key, e));
+            }
+        }
+    }
+
+    if migrated_count > 0 {
+        debug!(
+            migrated_count,
+            warning_count = warnings.len(),
+            "Credential migration complete"
+        );
+    }
+
+    emit_status_changed(&app_handle, &manager);
+    Ok(SwitchResult {
+        migrated_count,
+        warnings,
+    })
+}
+
+/// Check whether the OS keychain is accessible.
+#[tauri::command]
+pub fn check_keychain_available() -> bool {
+    KeychainStore::is_available()
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod connection;
+pub mod credential;
 pub mod files;
 pub mod logs;
 pub mod monitoring;

--- a/src-tauri/src/credential/manager.rs
+++ b/src-tauri/src/credential/manager.rs
@@ -1,0 +1,232 @@
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+use anyhow::Result;
+
+use super::types::{CredentialKey, CredentialStoreStatus, StorageMode};
+use super::{CredentialStore, KeychainStore, MasterPasswordStore, NullStore};
+
+/// Internal storage backend enum, allowing direct access to
+/// backend-specific methods without trait-object downcasting.
+enum StoreBackend {
+    Null(NullStore),
+    Keychain(KeychainStore),
+    MasterPassword(MasterPasswordStore),
+}
+
+/// Manages the active credential store backend and allows runtime switching.
+///
+/// Wraps the active [`CredentialStore`] implementation behind a [`RwLock`]
+/// so the backend can be swapped at runtime (e.g., when the user changes
+/// the credential storage mode in settings). Implements [`CredentialStore`]
+/// itself so it can be passed to [`ConnectionManager`] transparently.
+pub struct CredentialManager {
+    inner: RwLock<StoreBackend>,
+    config_dir: PathBuf,
+}
+
+impl CredentialManager {
+    /// Create a new credential manager with the given storage mode.
+    ///
+    /// The `config_dir` is used to locate the `credentials.enc` file
+    /// for [`MasterPasswordStore`].
+    pub fn new(mode: StorageMode, config_dir: PathBuf) -> Self {
+        let backend = Self::create_backend(&mode, &config_dir);
+        Self {
+            inner: RwLock::new(backend),
+            config_dir,
+        }
+    }
+
+    /// Return the current storage mode.
+    pub fn get_mode(&self) -> StorageMode {
+        let inner = self.inner.read().expect("credential manager lock poisoned");
+        match *inner {
+            StoreBackend::Null(_) => StorageMode::None,
+            StoreBackend::Keychain(_) => StorageMode::Keychain,
+            StoreBackend::MasterPassword(_) => StorageMode::MasterPassword,
+        }
+    }
+
+    /// Switch to a new storage backend.
+    ///
+    /// Locks the current store (if master password), then replaces the backend.
+    /// Callers are responsible for migrating credentials before switching.
+    pub fn switch_store(&self, new_mode: StorageMode) -> Result<()> {
+        let new_backend = Self::create_backend(&new_mode, &self.config_dir);
+        let mut inner = self
+            .inner
+            .write()
+            .expect("credential manager lock poisoned");
+
+        // Lock the old master password store if applicable
+        if let StoreBackend::MasterPassword(ref old_store) = *inner {
+            old_store.lock();
+        }
+
+        *inner = new_backend;
+        Ok(())
+    }
+
+    /// Execute a closure with a reference to the inner [`MasterPasswordStore`],
+    /// if the current backend is master password mode.
+    ///
+    /// Returns `None` if the current backend is not [`StorageMode::MasterPassword`].
+    pub fn with_master_password_store<F, R>(&self, f: F) -> Option<R>
+    where
+        F: FnOnce(&MasterPasswordStore) -> R,
+    {
+        let inner = self.inner.read().expect("credential manager lock poisoned");
+        match *inner {
+            StoreBackend::MasterPassword(ref store) => Some(f(store)),
+            _ => None,
+        }
+    }
+
+    /// Create the appropriate backend for the given mode.
+    fn create_backend(mode: &StorageMode, config_dir: &Path) -> StoreBackend {
+        match mode {
+            StorageMode::Keychain => StoreBackend::Keychain(KeychainStore),
+            StorageMode::MasterPassword => {
+                let file_path = config_dir.join("credentials.enc");
+                StoreBackend::MasterPassword(MasterPasswordStore::new(file_path))
+            }
+            StorageMode::None => StoreBackend::Null(NullStore),
+        }
+    }
+}
+
+impl CredentialStore for CredentialManager {
+    fn get(&self, key: &CredentialKey) -> Result<Option<String>> {
+        let inner = self.inner.read().expect("credential manager lock poisoned");
+        match *inner {
+            StoreBackend::Null(ref s) => s.get(key),
+            StoreBackend::Keychain(ref s) => s.get(key),
+            StoreBackend::MasterPassword(ref s) => s.get(key),
+        }
+    }
+
+    fn set(&self, key: &CredentialKey, value: &str) -> Result<()> {
+        let inner = self.inner.read().expect("credential manager lock poisoned");
+        match *inner {
+            StoreBackend::Null(ref s) => s.set(key, value),
+            StoreBackend::Keychain(ref s) => s.set(key, value),
+            StoreBackend::MasterPassword(ref s) => s.set(key, value),
+        }
+    }
+
+    fn remove(&self, key: &CredentialKey) -> Result<()> {
+        let inner = self.inner.read().expect("credential manager lock poisoned");
+        match *inner {
+            StoreBackend::Null(ref s) => s.remove(key),
+            StoreBackend::Keychain(ref s) => s.remove(key),
+            StoreBackend::MasterPassword(ref s) => s.remove(key),
+        }
+    }
+
+    fn remove_all_for_connection(&self, connection_id: &str) -> Result<()> {
+        let inner = self.inner.read().expect("credential manager lock poisoned");
+        match *inner {
+            StoreBackend::Null(ref s) => s.remove_all_for_connection(connection_id),
+            StoreBackend::Keychain(ref s) => s.remove_all_for_connection(connection_id),
+            StoreBackend::MasterPassword(ref s) => s.remove_all_for_connection(connection_id),
+        }
+    }
+
+    fn list_keys(&self) -> Result<Vec<CredentialKey>> {
+        let inner = self.inner.read().expect("credential manager lock poisoned");
+        match *inner {
+            StoreBackend::Null(ref s) => s.list_keys(),
+            StoreBackend::Keychain(ref s) => s.list_keys(),
+            StoreBackend::MasterPassword(ref s) => s.list_keys(),
+        }
+    }
+
+    fn status(&self) -> CredentialStoreStatus {
+        let inner = self.inner.read().expect("credential manager lock poisoned");
+        match *inner {
+            StoreBackend::Null(ref s) => s.status(),
+            StoreBackend::Keychain(ref s) => s.status(),
+            StoreBackend::MasterPassword(ref s) => s.status(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credential::types::CredentialType;
+
+    #[test]
+    fn new_creates_null_store_for_none_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::None, dir.path().to_path_buf());
+        assert_eq!(mgr.get_mode(), StorageMode::None);
+        assert_eq!(mgr.status(), CredentialStoreStatus::Unavailable);
+    }
+
+    #[test]
+    fn new_creates_master_password_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::MasterPassword, dir.path().to_path_buf());
+        assert_eq!(mgr.get_mode(), StorageMode::MasterPassword);
+        // Not set up yet, so unavailable
+        assert_eq!(mgr.status(), CredentialStoreStatus::Unavailable);
+    }
+
+    #[test]
+    fn switch_store_changes_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::None, dir.path().to_path_buf());
+        assert_eq!(mgr.get_mode(), StorageMode::None);
+
+        mgr.switch_store(StorageMode::MasterPassword).unwrap();
+        assert_eq!(mgr.get_mode(), StorageMode::MasterPassword);
+
+        mgr.switch_store(StorageMode::None).unwrap();
+        assert_eq!(mgr.get_mode(), StorageMode::None);
+    }
+
+    #[test]
+    fn credential_store_trait_delegates_to_null() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::None, dir.path().to_path_buf());
+        let key = CredentialKey::new("conn-1", CredentialType::Password);
+
+        // NullStore always returns None/Ok
+        assert_eq!(mgr.get(&key).unwrap(), None);
+        assert!(mgr.set(&key, "secret").is_ok());
+        assert_eq!(mgr.get(&key).unwrap(), None); // NullStore doesn't persist
+    }
+
+    #[test]
+    fn credential_store_trait_delegates_to_master_password() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::MasterPassword, dir.path().to_path_buf());
+
+        // Set up the master password store
+        mgr.with_master_password_store(|s| s.setup("test-pw"))
+            .unwrap()
+            .unwrap();
+
+        let key = CredentialKey::new("conn-1", CredentialType::Password);
+        mgr.set(&key, "my-secret").unwrap();
+        assert_eq!(mgr.get(&key).unwrap(), Some("my-secret".to_string()));
+    }
+
+    #[test]
+    fn with_master_password_store_returns_none_for_null() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::None, dir.path().to_path_buf());
+        let result = mgr.with_master_password_store(|_| 42);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn with_master_password_store_returns_some_for_master_password() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::MasterPassword, dir.path().to_path_buf());
+        let result = mgr.with_master_password_store(|_| 42);
+        assert_eq!(result, Some(42));
+    }
+}

--- a/src-tauri/src/credential/mod.rs
+++ b/src-tauri/src/credential/mod.rs
@@ -1,13 +1,13 @@
 pub mod keychain;
+pub mod manager;
 pub mod master_password;
 pub mod null;
 pub mod types;
 
-use std::path::PathBuf;
-
 use anyhow::Result;
 
 pub use keychain::KeychainStore;
+pub use manager::CredentialManager;
 pub use master_password::MasterPasswordStore;
 pub use null::NullStore;
 pub use types::{CredentialKey, CredentialStoreStatus, CredentialType, StorageMode};
@@ -35,23 +35,4 @@ pub trait CredentialStore: Send + Sync {
 
     /// Return the current status of the credential store.
     fn status(&self) -> CredentialStoreStatus;
-}
-
-/// Create a credential store for the given storage mode.
-///
-/// When `mode` is [`StorageMode::MasterPassword`], a `credentials_file` path
-/// must be provided; it will be used as the encrypted credentials file location.
-/// If `None` is passed, the store falls back to [`NullStore`].
-pub fn create_credential_store(
-    mode: StorageMode,
-    credentials_file: Option<PathBuf>,
-) -> Box<dyn CredentialStore> {
-    match mode {
-        StorageMode::Keychain => Box::new(KeychainStore),
-        StorageMode::MasterPassword => match credentials_file {
-            Some(path) => Box::new(MasterPasswordStore::new(path)),
-            None => Box::new(NullStore),
-        },
-        StorageMode::None => Box::new(NullStore),
-    }
 }

--- a/src-tauri/src/credential/types.rs
+++ b/src-tauri/src/credential/types.rs
@@ -64,6 +64,29 @@ pub enum StorageMode {
     None,
 }
 
+impl StorageMode {
+    /// Parse the `credential_storage_mode` setting string into a [`StorageMode`].
+    ///
+    /// Accepts `"keychain"`, `"master_password"`, `"none"`, or `None` (which
+    /// maps to [`StorageMode::None`]).
+    pub fn from_settings_str(s: Option<&str>) -> Self {
+        match s {
+            Some("keychain") => StorageMode::Keychain,
+            Some("master_password") => StorageMode::MasterPassword,
+            _ => StorageMode::None,
+        }
+    }
+
+    /// Return the settings string representation of this storage mode.
+    pub fn to_settings_str(&self) -> &str {
+        match self {
+            StorageMode::Keychain => "keychain",
+            StorageMode::MasterPassword => "master_password",
+            StorageMode::None => "none",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,5 +118,55 @@ mod tests {
     fn credential_key_display_key_passphrase() {
         let key = CredentialKey::new("conn-abc123", CredentialType::KeyPassphrase);
         assert_eq!(key.to_string(), "conn-abc123:key_passphrase");
+    }
+
+    #[test]
+    fn storage_mode_from_settings_str_keychain() {
+        assert_eq!(
+            StorageMode::from_settings_str(Some("keychain")),
+            StorageMode::Keychain
+        );
+    }
+
+    #[test]
+    fn storage_mode_from_settings_str_master_password() {
+        assert_eq!(
+            StorageMode::from_settings_str(Some("master_password")),
+            StorageMode::MasterPassword
+        );
+    }
+
+    #[test]
+    fn storage_mode_from_settings_str_none_string() {
+        assert_eq!(
+            StorageMode::from_settings_str(Some("none")),
+            StorageMode::None
+        );
+    }
+
+    #[test]
+    fn storage_mode_from_settings_str_none_option() {
+        assert_eq!(StorageMode::from_settings_str(None), StorageMode::None);
+    }
+
+    #[test]
+    fn storage_mode_from_settings_str_unknown() {
+        assert_eq!(
+            StorageMode::from_settings_str(Some("unknown")),
+            StorageMode::None
+        );
+    }
+
+    #[test]
+    fn storage_mode_to_settings_str_round_trip() {
+        for mode in &[
+            StorageMode::Keychain,
+            StorageMode::MasterPassword,
+            StorageMode::None,
+        ] {
+            let s = mode.to_settings_str();
+            let parsed = StorageMode::from_settings_str(Some(s));
+            assert_eq!(&parsed, mode);
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,5 @@
 mod commands;
 mod connection;
-// Partially consumed — `CredentialStore`, `NullStore`, `CredentialKey`, `CredentialType`
-// are active; remaining items are foundation for future credential backends (#25).
-#[allow(dead_code)]
 mod credential;
 mod files;
 mod monitoring;
@@ -12,11 +9,14 @@ mod utils;
 
 use std::sync::Arc;
 
-use tauri::{Manager, RunEvent, WindowEvent};
+use tauri::{Emitter, Manager, RunEvent, WindowEvent};
+use tracing::info;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 use connection::manager::ConnectionManager;
+use connection::settings::SettingsStorage;
+use credential::{CredentialManager, StorageMode};
 use files::sftp::SftpManager;
 use monitoring::MonitoringManager;
 use terminal::agent_manager::AgentConnectionManager;
@@ -55,12 +55,54 @@ pub fn run() {
                 *handle = Some(app.handle().clone());
             }
 
-            let credential_store: Arc<dyn credential::CredentialStore> =
-                Arc::new(credential::NullStore);
-            let connection_manager = ConnectionManager::new(app.handle(), credential_store.clone())
-                .expect("Failed to initialize connection manager");
-            app.manage(credential_store);
+            // Load settings to determine the credential storage mode
+            let config_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
+                Ok(dir) => std::path::PathBuf::from(dir),
+                Err(_) => app
+                    .handle()
+                    .path()
+                    .app_config_dir()
+                    .expect("Failed to resolve app config directory"),
+            };
+            std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
+
+            let settings_storage =
+                SettingsStorage::new(app.handle()).expect("Failed to initialize settings storage");
+            let settings = settings_storage.load().expect("Failed to load settings");
+
+            let storage_mode =
+                StorageMode::from_settings_str(settings.credential_storage_mode.as_deref());
+            info!(
+                mode = storage_mode.to_settings_str(),
+                "Initializing credential store"
+            );
+
+            let credential_manager = CredentialManager::new(storage_mode.clone(), config_dir);
+
+            // If master password mode with an existing credentials file,
+            // the store starts locked — emit an event so the UI can prompt
+            let needs_locked_event = storage_mode == StorageMode::MasterPassword
+                && credential_manager
+                    .with_master_password_store(|s| s.has_credentials_file())
+                    .unwrap_or(false);
+
+            let credential_manager = Arc::new(credential_manager);
+            let connection_manager = ConnectionManager::new(
+                app.handle(),
+                credential_manager.clone() as Arc<dyn credential::CredentialStore>,
+            )
+            .expect("Failed to initialize connection manager");
+            app.manage(credential_manager.clone());
             app.manage(connection_manager);
+
+            if needs_locked_event {
+                let handle = app.handle().clone();
+                // Emit after setup is complete so the frontend can receive it
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    let _ = handle.emit("credential-store-locked", ());
+                });
+            }
 
             let agent_manager = Arc::new(AgentConnectionManager::new(app.handle().clone()));
             app.manage(agent_manager);
@@ -154,6 +196,13 @@ pub fn run() {
             commands::tunnel::get_tunnel_statuses,
             commands::tunnel::start_tunnel,
             commands::tunnel::stop_tunnel,
+            commands::credential::get_credential_store_status,
+            commands::credential::unlock_credential_store,
+            commands::credential::lock_credential_store,
+            commands::credential::setup_master_password,
+            commands::credential::change_master_password,
+            commands::credential::switch_credential_store,
+            commands::credential::check_keychain_available,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")


### PR DESCRIPTION
## Summary

- Add `CredentialManager` wrapper with runtime backend switching (`NullStore`, `KeychainStore`, `MasterPasswordStore`) via internal enum — implements `CredentialStore` trait so `ConnectionManager` uses it transparently
- Add `StorageMode::from_settings_str()` / `to_settings_str()` helpers for parsing settings strings
- Add 7 Tauri IPC commands: `get_credential_store_status`, `unlock_credential_store`, `lock_credential_store`, `setup_master_password`, `change_master_password`, `switch_credential_store`, `check_keychain_available`
- Wire up settings-based initialization in `lib.rs` — reads `credentialStorageMode` from settings on startup and creates the correct backend
- Emit `credential-store-locked` / `credential-store-unlocked` / `credential-store-status-changed` events to the frontend
- Replace hardcoded `NullStore` with `CredentialManager` as the app-wide credential store

Closes #252

## Test plan

- [x] `cargo test` — 275 tests pass (6 ignored keychain integration tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: verify app starts correctly with default settings (no credential mode configured)
- [ ] Manual: verify app starts correctly with `credentialStorageMode: "master_password"` in settings and an existing `credentials.enc` file (should emit locked event)