### PR TITLE
feat(backend): add StatsCollector trait and CpuDeltaTracker (#314)

### DIFF
--- a/core/src/monitoring/mod.rs
+++ b/core/src/monitoring/mod.rs
@@ -105,7 +105,9 @@ mod tests {
         assert!(tracker.update(first).is_none());
 
         // delta total = 200-100 = 100, delta idle = (110+20)-(70+10) = 50, active = 50
-        let pct = tracker.update(second).expect("should return Some on second call");
+        let pct = tracker
+            .update(second)
+            .expect("should return Some on second call");
         assert!((pct - 50.0).abs() < 0.01);
     }
 


### PR DESCRIPTION
## Summary

- Add `StatsCollector` trait to `core::monitoring` — a sync `Send` interface for collecting `SystemStats`, unifying the pattern used by both the desktop (SSH exec) and agent (local `/proc` or SSH jump) crates
- Add `CpuDeltaTracker` helper struct that encapsulates the `Option<CpuCounters>` state management for computing CPU usage deltas, replacing duplicated logic in consumers
- Both items are re-exported from `core::monitoring` for direct use

Part of the shared-rust-core effort (parent #277).

Closes #314

## Test plan

- [x] 4 unit tests for `CpuDeltaTracker` (first call returns `None`, second call returns correct percentage, multiple updates advance state correctly, `Default` impl matches `new()`)
- [x] All existing monitoring parser tests continue to pass (19 total)
- [x] `cargo clippy` clean, `cargo fmt` clean
- [x] `./scripts/check.sh` passes
- [x] `./scripts/test.sh` passes (all frontend + backend + agent tests)