### PR TITLE
fix(backend): allow dead_code in daemon_spawner module

### DIFF
--- a/agent/src/transport.rs
+++ b/agent/src/transport.rs
@@ -97,6 +97,7 @@ impl OutputSink for JsonRpcOutputSink {
 // ── DaemonSpawner (Unix only) ──────────────────────────────────────
 
 #[cfg(unix)]
+#[allow(dead_code)]
 mod daemon_spawner {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
@@ -202,7 +203,6 @@ mod daemon_spawner {
     fn _assert_spawner_send_sync<T: ProcessSpawner>() {}
     fn _assert_handle_send<T: ProcessHandle>() {}
 
-    #[allow(dead_code)]
     fn _static_assertions() {
         _assert_spawner_send_sync::<DaemonSpawner>();
         _assert_handle_send::<DaemonClient>();


### PR DESCRIPTION
## Summary
- Add `#[allow(dead_code)]` to the `daemon_spawner` module since it's infrastructure code not yet called from the main agent code
- This fixes the remaining Rust Code Quality CI failure on main after #349 was merged

The `DaemonSpawner` struct and its methods are used only in compile-time trait assertions. Clippy flags `DaemonSpawner::new` as dead code because nothing calls it yet. The module will be integrated when desktop transport adapters are connected.

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes locally
- [x] `cargo fmt --all -- --check` passes