### PR TITLE
chore: update Cargo.lock for SSH dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,10 +5026,14 @@ name = "termihub-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "openssl",
  "portable-pty",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serialport",
+ "ssh-key",
+ "ssh2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",


### PR DESCRIPTION
## Summary

- Updates `Cargo.lock` to reflect the SSH dependencies (`ssh2`, `ssh-key`, `openssl`) added in #368

## Test plan

- [x] No code changes, lock file only

🤖 Generated with [Claude Code](https://claude.com/claude-code)