### PR TITLE
fix(ui): restore "(default)" label on default shell in connection editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Default local shell no longer labeled with "(default)" in the connection editor after schema-driven form refactor — the shell option label in the backend schema now includes the suffix again
+
 ### Changed
 
 - **Breaking**: Replaced typed `ConnectionConfig` enum (Rust) and discriminated union (TypeScript) with a generic `{type, config}` struct/interface — removes `LocalShellConfig`, `RemoteSessionConfig`, `SshConfig` (TS), `TelnetConfig`, `SerialConfig`, `DockerConfig` type definitions and per-type `expand()` impls; on-disk JSON format is preserved (no data migration required); removes `fromConnectionConfig()`/`toConnectionConfig()` helper functions (#363)


### PR DESCRIPTION
## Summary
- The schema-driven form refactor (#362) lost the `(default)` suffix on the user's default shell in the connection editor dropdown — the Rust schema builder was setting each shell option's label to just the raw shell name
- Adds the `(default)` suffix back in the `LocalShell::settings_schema()` option builder
- Adds a regression test verifying the default shell gets the label and non-default shells don't

## Test plan
- [x] `cargo test -p termihub-core --all-features backends::local_shell::tests` — all 18 tests pass
- [x] `cargo clippy -p termihub-core --all-targets --all-features` — clean
- [ ] Open connection editor for a local shell — the shell dropdown should show e.g. "zsh (default)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)