### PR TITLE
fix(config): handle duplicate connection names in all scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Duplicate connection names now auto-renamed with `(1)`, `(2)` suffixes in all scenarios: adding, renaming, duplicating, folder deletion, and import — the frontend now reloads from the backend after every persist operation to sync dedup renames; the backend also deduplicates when folder deletion reparents children (#388)
 - Grey screen / app crash when dragging a connection into a folder that already contains a connection with the same name — the backend now recomputes the connection's path-based ID after a folder change and correctly migrates credentials; the frontend reloads connections after a move to sync dedup renames
 - System crash when creating a connection with a duplicate name — the connection editor now validates names in real-time and shows a red-bordered input with an error message when a duplicate is detected; validation is scoped per folder so the same name is allowed in different folders (#380)
 - Default local shell no longer labeled with "(default)" in the connection editor after schema-driven form refactor — the shell option label in the backend schema now includes the suffix again

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -344,6 +344,18 @@ impl ConnectionManager {
         }
 
         store.folders.retain(|f| f.id != id);
+
+        // Deduplicate names — reparented children may collide with existing
+        // siblings in the parent folder
+        {
+            let FlatConnectionStore {
+                connections,
+                folders,
+                ..
+            } = &mut *store;
+            deduplicate_sibling_names(connections, folders);
+        }
+
         self.storage
             .save_flat(&store)
             .context("Failed to persist after folder delete")


### PR DESCRIPTION
## Summary

- **Backend**: Added `deduplicate_sibling_names()` call to `delete_folder` so reparented children don't collide with existing siblings in the parent folder
- **Frontend**: All store operations (`addConnection`, `updateConnection`, `duplicateConnection`, `addFolder`, `deleteFolder`) now reload from the backend after persisting to sync any dedup renames — matching the pattern already used by `moveConnectionToFolder`
- **Tests**: Added regression tests for folder-deletion dedup scenarios (connections and subfolders)

Closes #388

## Test plan

- [ ] Create two connections with the same name in the same folder → second should auto-rename to `Name (1)`
- [ ] Drag a connection into a folder with a same-named sibling → moved connection gets renamed
- [ ] Delete a folder containing a connection whose name matches one in the parent → reparented connection gets renamed
- [ ] Import connections with duplicate names → imported connections get renamed
- [ ] Duplicate a connection → "Copy of" prefixed copy appears, no naming conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)