### PR TITLE
fix(backend): remove WSL distros from local shell list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- WSL distributions no longer appear in the local shell connection dropdown on Windows — they are now only available through the dedicated WSL connection type (#400)
 - Local shell connections now display the correct shell-specific icons (PowerShell, Git Bash, WSL) in the sidebar and tab bar — the frontend icon resolution and config creation used a legacy `shellType` key that didn't match the backend schema's `shell` key; old saved connections with `shellType` are handled via backward-compatible fallback (#397)
 - Connections can now be dragged out of a folder back to the root level — the folder drop target was covering the entire folder subtree (header + children), preventing the root drop zone from receiving the drop; now only the folder header row is a drop target (#394)
 - Duplicate connection names now auto-renamed with `(1)`, `(2)` suffixes in all scenarios: adding, renaming, duplicating, folder deletion, and import — the frontend now reloads from the backend after every persist operation to sync dedup renames; the backend also deduplicates when folder deletion reparents children (#388)

--- a/core/src/session/shell.rs
+++ b/core/src/session/shell.rs
@@ -216,7 +216,10 @@ pub fn detect_wsl_distros() -> Vec<String> {
 /// Detect available shells on the current platform.
 ///
 /// On Unix, checks standard paths (`/bin/zsh`, `/usr/bin/bash`, etc.).
-/// On Windows, includes PowerShell, cmd, Git Bash, and WSL distributions.
+/// On Windows, includes PowerShell, cmd, and Git Bash.
+///
+/// WSL distributions are not included here — they are handled by the
+/// dedicated WSL connection type (see `backends::wsl`).
 pub fn detect_available_shells() -> Vec<String> {
     let mut shells = Vec::new();
 
@@ -248,11 +251,6 @@ pub fn detect_available_shells() -> Vec<String> {
                 shells.push("gitbash".to_string());
                 break;
             }
-        }
-
-        // Detect WSL distributions
-        for distro in detect_wsl_distros() {
-            shells.push(format!("wsl:{distro}"));
         }
     }
 
@@ -806,6 +804,18 @@ mod tests {
             "expected powershell in detected shells: {:?}",
             shells
         );
+    }
+
+    /// Regression test for #400: WSL distros must not appear in local shells.
+    #[test]
+    fn detect_available_shells_excludes_wsl() {
+        let shells = detect_available_shells();
+        for shell in &shells {
+            assert!(
+                !shell.starts_with("wsl:"),
+                "WSL distro '{shell}' should not appear in local shells (issue #400)"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes WSL distribution detection from `detect_available_shells()` so WSL distros no longer appear in the local shell connection dropdown on Windows
- WSL connections are properly handled by the dedicated WSL connection type (`backends::wsl`)
- Keeps backward-compatible `wsl:` prefix handling in `shell_to_command()` for any existing saved connections
- Adds regression test asserting no `wsl:*` entries in local shell list

Fixes #400

## Test plan

- [ ] On Windows with WSL installed, verify the local shell dropdown shows only PowerShell, cmd, and Git Bash (no `wsl:...` entries)
- [ ] Verify WSL distributions still appear when creating a WSL connection type
- [ ] Verify existing saved connections using `wsl:` shell prefix still work