### PR TITLE
feat(ui): add right-click paste to terminal context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Right-click "Paste" option in the terminal context menu — reads clipboard text and sends it as terminal input (#416)
 - File browser CWD tracking for bash/WSL sessions — the app now injects an OSC 7 `PROMPT_COMMAND` hook when spawning bash, Git Bash, or WSL sessions, so the file browser automatically follows the terminal's working directory; zsh already emits OSC 7 natively and is unaffected (#408)
 - Right-click context menu on the terminal area with "Copy Selection" to copy only the selected text, plus "Copy All" for the entire buffer — previously only the tab context menu's "Copy to Clipboard" (entire history) was available (#407)
 - Guided manual test runner (`python scripts/test-manual.py`) — a cross-platform CLI tool that walks developers through manual test items one at a time with platform filtering, lazy infrastructure setup (Docker, virtual serial ports), automated verification checks, interactive pass/fail/skip collection, resume support, and JSON report generation; test definitions live in `tests/manual/*.yaml` covering 176 test items across 11 categories (#384)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -738,7 +738,7 @@ See [scripts/README.md](../scripts/README.md) for all options. Reports are saved
 | Local Shell            | [`local-shell.yaml`](../tests/manual/local-shell.yaml)                     | `MT-LOCAL`    | 20      |
 | SSH                    | [`ssh.yaml`](../tests/manual/ssh.yaml)                                     | `MT-SSH`      | 35      |
 | Serial                 | [`serial.yaml`](../tests/manual/serial.yaml)                               | `MT-SER`      | 2       |
-| Tab Management         | [`tab-management.yaml`](../tests/manual/tab-management.yaml)               | `MT-TAB`      | 17      |
+| Tab Management         | [`tab-management.yaml`](../tests/manual/tab-management.yaml)               | `MT-TAB`      | 18      |
 | Connection Management  | [`connection-management.yaml`](../tests/manual/connection-management.yaml) | `MT-CONN`     | 32      |
 | File Browser + Editor  | [`file-browser.yaml`](../tests/manual/file-browser.yaml)                   | `MT-FB`       | 20      |
 | UI / Layout            | [`ui-layout.yaml`](../tests/manual/ui-layout.yaml)                         | `MT-UI`       | 25      |
@@ -746,6 +746,6 @@ See [scripts/README.md](../scripts/README.md) for all options. Reports are saved
 | Credential Store       | [`credential-store.yaml`](../tests/manual/credential-store.yaml)           | `MT-CRED`     | 8       |
 | Cross-Platform         | [`cross-platform.yaml`](../tests/manual/cross-platform.yaml)               | `MT-XPLAT`    | 3       |
 | Configuration Recovery | [`config-recovery.yaml`](../tests/manual/config-recovery.yaml)             | `MT-RECOVERY` | 12      |
-| **Total**              |                                                                            |               | **182** |
+| **Total**              |                                                                            |               | **183** |
 
 When adding new manual tests, add the YAML definition to the appropriate file in `tests/manual/` — the YAML files are the **source of truth** for guided testing.

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -19,6 +19,7 @@ import {
   Pencil,
   FileDown,
   ClipboardCopy,
+  ClipboardPaste,
   Copy,
   Eraser,
   ArrowRightLeft,
@@ -194,6 +195,7 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
     copyTerminalToClipboard,
     getTerminalSelection,
     copySelectionToClipboard,
+    pasteToTerminal,
   } = useTerminalRegistry();
 
   const [colorPickerTabId, setColorPickerTabId] = useState<string | null>(null);
@@ -273,6 +275,13 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
                     onSelect={() => copyTerminalToClipboard(tab.id)}
                   >
                     <ClipboardCopy size={14} /> Copy All
+                  </ContextMenu.Item>
+                  <ContextMenu.Item
+                    className="context-menu__item"
+                    onSelect={() => pasteToTerminal(tab.id)}
+                    data-testid="terminal-context-paste"
+                  >
+                    <ClipboardPaste size={14} /> Paste
                   </ContextMenu.Item>
                   <ContextMenu.Separator className="context-menu__separator" />
                   <ContextMenu.Item

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -114,7 +114,8 @@ export function Terminal({ tabId, config, isVisible, existingSessionId }: Termin
   const lastInputTimeRef = useRef(0);
   const contentDirtyRef = useRef(false);
   const pendingCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const { register, unregister, parkingRef } = useTerminalRegistry();
+  const { register, unregister, registerSession, unregisterSession, parkingRef } =
+    useTerminalRegistry();
 
   const setupTerminal = useCallback(
     async (xterm: XTerm, fitAddon: FitAddon, isCanceled: () => boolean) => {
@@ -144,6 +145,7 @@ export function Terminal({ tabId, config, isVisible, existingSessionId }: Termin
         }
 
         sessionIdRef.current = sessionId;
+        registerSession(tabId, sessionId);
 
         // Output batching: buffer chunks and flush in a single RAF callback
         const outputBuffer: Uint8Array[] = [];
@@ -182,6 +184,7 @@ export function Terminal({ tabId, config, isVisible, existingSessionId }: Termin
         const unsubExit = terminalDispatcher.subscribeExit(sessionId, () => {
           xterm.writeln("\r\n\x1b[90m[Process exited]\x1b[0m");
           sessionIdRef.current = null;
+          unregisterSession(tabId);
         });
 
         // Send user input to backend
@@ -244,7 +247,7 @@ export function Terminal({ tabId, config, isVisible, existingSessionId }: Termin
         }
       }
     },
-    [config, existingSessionId]
+    [config, existingSessionId, tabId, registerSession, unregisterSession]
   );
 
   // Create the terminal element, xterm instance, and register

--- a/src/components/Terminal/TerminalRegistry.test.tsx
+++ b/src/components/Terminal/TerminalRegistry.test.tsx
@@ -3,10 +3,15 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { TerminalPortalProvider, useTerminalRegistry } from "./TerminalRegistry";
+import { sendInput } from "@/services/api";
 
 vi.mock("@/themes", () => ({
   applyTheme: vi.fn(),
   onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/api", () => ({
+  sendInput: vi.fn().mockResolvedValue(undefined),
 }));
 
 /** Creates a mock xterm instance with configurable selection state. */
@@ -118,5 +123,53 @@ describe("copySelectionToClipboard", () => {
     });
 
     expect(writeText).toHaveBeenCalledWith("hello world");
+  });
+});
+
+describe("pasteToTerminal", () => {
+  it("reads clipboard and sends text as input via registered session", async () => {
+    const readText = vi.fn().mockResolvedValue("pasted text");
+    Object.assign(navigator, { clipboard: { readText } });
+
+    act(() => {
+      registryActions.registerSession("tab-1", "session-1");
+    });
+
+    await act(async () => {
+      await registryActions.pasteToTerminal("tab-1");
+    });
+
+    expect(readText).toHaveBeenCalled();
+    expect(sendInput).toHaveBeenCalledWith("session-1", "pasted text");
+  });
+
+  it("does not send input when clipboard is empty", async () => {
+    const readText = vi.fn().mockResolvedValue("");
+    Object.assign(navigator, { clipboard: { readText } });
+    vi.mocked(sendInput).mockClear();
+
+    act(() => {
+      registryActions.registerSession("tab-1", "session-1");
+    });
+
+    await act(async () => {
+      await registryActions.pasteToTerminal("tab-1");
+    });
+
+    expect(readText).toHaveBeenCalled();
+    expect(sendInput).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no session is registered for the tab", async () => {
+    const readText = vi.fn().mockResolvedValue("pasted text");
+    Object.assign(navigator, { clipboard: { readText } });
+    vi.mocked(sendInput).mockClear();
+
+    await act(async () => {
+      await registryActions.pasteToTerminal("tab-no-session");
+    });
+
+    expect(readText).not.toHaveBeenCalled();
+    expect(sendInput).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -2,6 +2,8 @@ import { createContext, useContext, useRef, useCallback, useMemo, ReactNode } fr
 import { Terminal as XTerm } from "@xterm/xterm";
 import { save } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { sendInput } from "@/services/api";
+import { SessionId } from "@/types/terminal";
 
 interface TerminalRegistryContextType {
   /** Register a terminal's xterm container element and xterm instance. */
@@ -22,6 +24,12 @@ interface TerminalRegistryContextType {
   getTerminalSelection: (tabId: string) => string | undefined;
   /** Copy the current text selection to the clipboard (no-op if nothing selected). */
   copySelectionToClipboard: (tabId: string) => Promise<void>;
+  /** Associate a backend session ID with a tab for paste support. */
+  registerSession: (tabId: string, sessionId: SessionId) => void;
+  /** Remove the session ID association for a tab. */
+  unregisterSession: (tabId: string) => void;
+  /** Paste clipboard text into a terminal by sending it as input. */
+  pasteToTerminal: (tabId: string) => Promise<void>;
   /** Ref to the off-screen parking div for orphaned terminal elements. */
   parkingRef: React.RefObject<HTMLDivElement | null>;
 }
@@ -42,6 +50,7 @@ export function useTerminalRegistry() {
 export function TerminalPortalProvider({ children }: { children: ReactNode }) {
   const registryRef = useRef(new Map<string, HTMLDivElement>());
   const xtermRegistryRef = useRef(new Map<string, XTerm>());
+  const sessionRegistryRef = useRef(new Map<string, SessionId>());
   const parkingRef = useRef<HTMLDivElement | null>(null);
 
   const register = useCallback((tabId: string, element: HTMLDivElement, xterm: XTerm) => {
@@ -52,6 +61,7 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
   const unregister = useCallback((tabId: string) => {
     registryRef.current.delete(tabId);
     xtermRegistryRef.current.delete(tabId);
+    sessionRegistryRef.current.delete(tabId);
   }, []);
 
   const getElement = useCallback((tabId: string) => {
@@ -133,6 +143,23 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
     [getTerminalSelection]
   );
 
+  const registerSession = useCallback((tabId: string, sessionId: SessionId) => {
+    sessionRegistryRef.current.set(tabId, sessionId);
+  }, []);
+
+  const unregisterSession = useCallback((tabId: string) => {
+    sessionRegistryRef.current.delete(tabId);
+  }, []);
+
+  const pasteToTerminal = useCallback(async (tabId: string) => {
+    const sessionId = sessionRegistryRef.current.get(tabId);
+    if (!sessionId) return;
+    const text = await navigator.clipboard.readText();
+    if (text) {
+      await sendInput(sessionId, text);
+    }
+  }, []);
+
   const ctx = useMemo(
     () => ({
       register,
@@ -144,6 +171,9 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
       copyTerminalToClipboard,
       getTerminalSelection,
       copySelectionToClipboard,
+      registerSession,
+      unregisterSession,
+      pasteToTerminal,
       parkingRef,
     }),
     [
@@ -156,6 +186,9 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
       copyTerminalToClipboard,
       getTerminalSelection,
       copySelectionToClipboard,
+      registerSession,
+      unregisterSession,
+      pasteToTerminal,
     ]
   );
 

--- a/tests/manual/tab-management.yaml
+++ b/tests/manual/tab-management.yaml
@@ -224,3 +224,22 @@ tests:
     expected:
       - "New split created, tab moves to new panel"
     verification: manual
+
+  # --- Right-click paste (PR #416) ---
+
+  - id: MT-TAB-18
+    name: "Right-click Paste sends clipboard text to terminal"
+    pr: 416
+    platforms: [all]
+    prerequisites:
+      - app: true
+    instructions:
+      - "Copy some text to the clipboard (e.g. 'echo hello')"
+      - "Open a local terminal"
+      - "Right-click inside the terminal area"
+      - "Click 'Paste' in the context menu"
+    expected:
+      - "Context menu shows 'Paste' item with clipboard icon"
+      - "Clipboard text appears in the terminal as typed input"
+    verification: manual
+    tags: [clipboard]


### PR DESCRIPTION
## Summary

- Adds a **Paste** option to the terminal right-click context menu that reads clipboard text via `navigator.clipboard.readText()` and sends it as input to the active terminal session
- Introduces a session ID registry in `TerminalRegistry` so paste can resolve the backend session — the Zustand store's `tab.sessionId` is `null` for terminals created via the normal async flow, so a separate registry was needed
- Includes 3 unit tests and 1 manual test item (MT-TAB-18)

Closes #416

## Test plan

- [x] All 490 unit tests pass (`pnpm test`)
- [x] TypeScript compiles cleanly (`pnpm tsc --noEmit`)
- [x] All quality checks pass (`./scripts/check.sh`)
- [ ] Manual: open a local terminal, copy text to clipboard, right-click inside terminal, click "Paste" — text appears as typed input
- [ ] Manual: verify "Paste" is a no-op after the process has exited (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)