### PR TITLE
VS Code-style full-area drop preview for tab splits

### DIFF
--- a/src/components/SplitView/PanelDropZone.css
+++ b/src/components/SplitView/PanelDropZone.css
@@ -9,14 +9,9 @@
 .panel-drop-zone__center {
   position: absolute;
   pointer-events: auto;
-  border: 2px dashed transparent;
-  border-radius: var(--radius-sm);
-  transition:
-    background-color 150ms ease,
-    border-color 150ms ease;
 }
 
-/* Edge zones — 20% strips from each side */
+/* Edge zones — invisible hit areas (20% strips from each side) */
 .panel-drop-zone__edge--left {
   top: 0;
   left: 0;
@@ -45,7 +40,7 @@
   height: 20%;
 }
 
-/* Center zone — the remaining middle area */
+/* Center zone — invisible hit area (remaining middle) */
 .panel-drop-zone__center {
   top: 20%;
   left: 20%;
@@ -53,14 +48,62 @@
   bottom: 20%;
 }
 
-/* Highlight when hovering over an edge zone */
-.panel-drop-zone__edge--active {
+/* ── Preview overlay ─────────────────────────────────────────────────── */
+/* Shows the full resulting area, like VS Code's split preview.         */
+
+.panel-drop-zone__preview {
+  position: absolute;
+  pointer-events: none;
   background-color: rgba(38, 132, 255, 0.15);
-  border-color: rgba(38, 132, 255, 0.5);
+  border: 2px solid rgba(38, 132, 255, 0.5);
+  border-radius: var(--radius-sm);
+  transition:
+    top 150ms ease,
+    left 150ms ease,
+    right 150ms ease,
+    bottom 150ms ease,
+    width 150ms ease,
+    height 150ms ease;
 }
 
-/* Highlight when hovering over center zone */
-.panel-drop-zone__center--active {
+/* Left split — highlight left 50% */
+.panel-drop-zone__preview--left {
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 50%;
+}
+
+/* Right split — highlight right 50% */
+.panel-drop-zone__preview--right {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 50%;
+}
+
+/* Top split — highlight top 50% */
+.panel-drop-zone__preview--top {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+}
+
+/* Bottom split — highlight bottom 50% */
+.panel-drop-zone__preview--bottom {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+}
+
+/* Center (tab move) — highlight entire panel */
+.panel-drop-zone__preview--center {
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   background-color: rgba(38, 132, 255, 0.08);
   border-color: rgba(38, 132, 255, 0.3);
 }

--- a/src/components/SplitView/PanelDropZone.tsx
+++ b/src/components/SplitView/PanelDropZone.tsx
@@ -1,6 +1,9 @@
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { DropEdge } from "@/types/terminal";
 import "./PanelDropZone.css";
+
+type ActiveZone = DropEdge | "center" | null;
 
 interface PanelDropZoneProps {
   panelId: string;
@@ -12,40 +15,73 @@ const EDGES: DropEdge[] = ["left", "right", "top", "bottom"];
 
 /** Drop zone overlay for a leaf panel — shown only during active drag. */
 export function PanelDropZone({ panelId, hideEdges }: PanelDropZoneProps) {
+  const [activeZone, setActiveZone] = useState<ActiveZone>(null);
+
   return (
     <div className="panel-drop-zone">
-      {!hideEdges && EDGES.map((edge) => <EdgeZone key={edge} panelId={panelId} edge={edge} />)}
-      <CenterZone panelId={panelId} />
+      {!hideEdges &&
+        EDGES.map((edge) => (
+          <EdgeZone key={edge} panelId={panelId} edge={edge} setActiveZone={setActiveZone} />
+        ))}
+      <CenterZone panelId={panelId} setActiveZone={setActiveZone} />
+      <DropPreview activeZone={activeZone} />
     </div>
   );
 }
 
-function EdgeZone({ panelId, edge }: { panelId: string; edge: DropEdge }) {
+function EdgeZone({
+  panelId,
+  edge,
+  setActiveZone,
+}: {
+  panelId: string;
+  edge: DropEdge;
+  setActiveZone: Dispatch<SetStateAction<ActiveZone>>;
+}) {
   const { setNodeRef, isOver } = useDroppable({
     id: `edge-${panelId}-${edge}`,
     data: { type: "edge", panelId, edge },
   });
 
+  useEffect(() => {
+    if (isOver) {
+      setActiveZone(edge);
+    } else {
+      setActiveZone((prev) => (prev === edge ? null : prev));
+    }
+  }, [isOver, edge, setActiveZone]);
+
   return (
-    <div
-      ref={setNodeRef}
-      className={`panel-drop-zone__edge panel-drop-zone__edge--${edge} ${
-        isOver ? "panel-drop-zone__edge--active" : ""
-      }`}
-    />
+    <div ref={setNodeRef} className={`panel-drop-zone__edge panel-drop-zone__edge--${edge}`} />
   );
 }
 
-function CenterZone({ panelId }: { panelId: string }) {
+function CenterZone({
+  panelId,
+  setActiveZone,
+}: {
+  panelId: string;
+  setActiveZone: Dispatch<SetStateAction<ActiveZone>>;
+}) {
   const { setNodeRef, isOver } = useDroppable({
     id: `center-${panelId}`,
     data: { type: "center", panelId },
   });
 
-  return (
-    <div
-      ref={setNodeRef}
-      className={`panel-drop-zone__center ${isOver ? "panel-drop-zone__center--active" : ""}`}
-    />
-  );
+  useEffect(() => {
+    if (isOver) {
+      setActiveZone("center");
+    } else {
+      setActiveZone((prev) => (prev === "center" ? null : prev));
+    }
+  }, [isOver, setActiveZone]);
+
+  return <div ref={setNodeRef} className="panel-drop-zone__center" />;
+}
+
+/** Full-area preview overlay showing where the dropped tab will land. */
+function DropPreview({ activeZone }: { activeZone: ActiveZone }) {
+  if (!activeZone) return null;
+
+  return <div className={`panel-drop-zone__preview panel-drop-zone__preview--${activeZone}`} />;
 }


### PR DESCRIPTION
## Summary
- Replace small drop zone highlighting with a full-area preview overlay that shows the entire resulting area when splitting panels
- Edge drops now highlight 50% of the panel (left/right/top/bottom), matching the actual split result
- Center drops highlight the full panel with a subtler style
- Drop hit areas remain unchanged — only the visual feedback is improved

## Test plan
- [ ] Drag a tab over a panel's left/right/top/bottom edges and verify the corresponding 50% of the panel highlights
- [ ] Drag a tab over the center of a panel and verify the entire panel highlights with a subtle overlay
- [ ] Verify smooth transitions when moving between different drop zones
- [ ] Verify the drop behavior itself is unchanged (splits and tab moves work as before)
- [ ] Verify single-tab panels still hide edge zones (only center drop available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)