### PR TITLE
Add Split Down keyboard shortcut (#446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Open Settings (Cmd/Ctrl+,), Clear Terminal (Cmd/Ctrl+Shift+K), and Split Right (Cmd/Ctrl+\\) keyboard shortcuts now work (#445)
 - Zoom In (Cmd/Ctrl+=), Zoom Out (Cmd/Ctrl+-), and Reset Zoom (Cmd/Ctrl+0) keyboard shortcuts — zoom level applies across all terminal instances as a runtime offset to the configured font size (#445)
 - Find in Terminal (Cmd+F on macOS, Ctrl+Shift+F on Win/Linux) — inline search bar with case-sensitive and regex toggle, previous/next navigation, powered by @xterm/addon-search (#445)
+- Split Down keyboard shortcut (Cmd+Shift+\\ on macOS, Ctrl+Shift+\\ on Win/Linux) — splits the active panel vertically, complementing the existing Split Right shortcut (#446)
 
 - Comprehensive keyboard shortcut system with platform-aware defaults — macOS uses Cmd-based shortcuts, Windows/Linux uses Ctrl-based shortcuts; all shortcuts are centralized in a KeybindingService with 18 default bindings across 4 categories (General, Clipboard, Terminal, Navigation) (#418)
 - Keyboard shortcuts for terminal clipboard operations — macOS uses Cmd+C/V, Windows/Linux uses Ctrl+Shift+C/V; xterm.js key handler intercepts these before the terminal processes them, fixing the longstanding issue where Ctrl+V on Windows sent a raw control character instead of pasting (#418)

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -98,6 +98,11 @@ export function useKeyboardShortcuts() {
           useAppStore.getState().splitPanel("horizontal");
           break;
 
+        case "split-down":
+          e.preventDefault();
+          useAppStore.getState().splitPanel("vertical");
+          break;
+
         case "zoom-in":
           e.preventDefault();
           useAppStore.getState().zoomIn();

--- a/src/services/keybindings.test.ts
+++ b/src/services/keybindings.test.ts
@@ -131,6 +131,16 @@ describe("findMatchingAction (Linux/Win context)", () => {
     expect(findMatchingAction(event)).toBe("copy");
   });
 
+  it("finds split-right for Ctrl+\\", () => {
+    const event = makeKeyEvent("\\", { ctrl: true });
+    expect(findMatchingAction(event)).toBe("split-right");
+  });
+
+  it("finds split-down for Ctrl+Shift+\\", () => {
+    const event = makeKeyEvent("\\", { ctrl: true, shift: true });
+    expect(findMatchingAction(event)).toBe("split-down");
+  });
+
   it("finds paste for Ctrl+Shift+V", () => {
     const event = makeKeyEvent("V", { ctrl: true, shift: true });
     expect(findMatchingAction(event)).toBe("paste");
@@ -240,6 +250,25 @@ describe("getDefaultBindings", () => {
     expect(actions).toContain("focus-down");
     expect(actions).toContain("focus-left");
     expect(actions).toContain("focus-right");
+  });
+
+  it("has split-right and split-down bindings", () => {
+    const actions = DEFAULT_BINDINGS.map((b) => b.action);
+    expect(actions).toContain("split-right");
+    expect(actions).toContain("split-down");
+  });
+
+  it("split-down uses Shift modifier to distinguish from split-right", () => {
+    const binding = DEFAULT_BINDINGS.find((b) => b.action === "split-down");
+    expect(binding).toBeDefined();
+    const macCombo = binding!.macDefault as KeyCombo;
+    expect(macCombo.meta).toBe(true);
+    expect(macCombo.shift).toBe(true);
+    expect(macCombo.key).toBe("\\");
+    const winCombo = binding!.winLinuxDefault as KeyCombo;
+    expect(winCombo.ctrl).toBe(true);
+    expect(winCombo.shift).toBe(true);
+    expect(winCombo.key).toBe("\\");
   });
 
   it("does not have focus-next-panel or focus-prev-panel", () => {

--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -126,6 +126,14 @@ export const DEFAULT_BINDINGS: KeyBinding[] = [
     configurable: true,
   },
   {
+    action: "split-down",
+    label: "Split Down",
+    category: "navigation",
+    macDefault: { key: "\\", meta: true, shift: true },
+    winLinuxDefault: { key: "\\", ctrl: true, shift: true },
+    configurable: true,
+  },
+  {
     action: "focus-up",
     label: "Focus Panel Above",
     category: "navigation",


### PR DESCRIPTION
## Summary

- Add **Split Down** keybinding: `Cmd+Shift+\` (macOS) / `Ctrl+Shift+\` (Win/Linux) — splits the active panel vertically (downward)
- Complements the existing **Split Right** (`Cmd/Ctrl+\`) shortcut, mirroring the Shift modifier pattern used by VS Code

## Changes

- `src/services/keybindings.ts`: Added `split-down` binding definition with platform-specific defaults
- `src/hooks/useKeyboardShortcuts.ts`: Added `split-down` action handler calling `splitPanel("vertical")`
- `src/services/keybindings.test.ts`: Added tests verifying binding exists, has correct modifiers, and is matched by `findMatchingAction`

Closes #446

## Test plan

- [ ] Press `Cmd+Shift+\` (macOS) or `Ctrl+Shift+\` (Win/Linux) — active panel should split vertically (new panel below)
- [ ] Press `Cmd+\` / `Ctrl+\` — existing Split Right still works (new panel to the right)
- [ ] Open Keyboard Shortcuts overlay (`Cmd+K Cmd+S`) — "Split Down" should appear in the Navigation category
- [ ] Verify shortcut is rebindable in Settings > Keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)