### PR TITLE
fix(ui): zoom scales entire app via Tauri webview zoom (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Zoom shortcuts (Cmd/Ctrl+=/-/0) now scale the entire application UI uniformly using Tauri webview zoom, instead of only adjusting terminal font size (#447)
 - Directional panel navigation (Cmd/Ctrl+Alt+Arrow) now remembers and restores the last-focused panel when entering a split group, instead of always selecting the first/last child (#448)
 
 ### Changed
@@ -20,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Open Settings (Cmd/Ctrl+,), Clear Terminal (Cmd/Ctrl+Shift+K), and Split Right (Cmd/Ctrl+\\) keyboard shortcuts now work (#445)
-- Zoom In (Cmd/Ctrl+=), Zoom Out (Cmd/Ctrl+-), and Reset Zoom (Cmd/Ctrl+0) keyboard shortcuts — zoom level applies across all terminal instances as a runtime offset to the configured font size (#445)
+- Zoom In (Cmd/Ctrl+=), Zoom Out (Cmd/Ctrl+-), and Reset Zoom (Cmd/Ctrl+0) keyboard shortcuts — zoom scales the entire application UI via Tauri webview zoom (#445)
 - Find in Terminal (Cmd+F on macOS, Ctrl+Shift+F on Win/Linux) — inline search bar with case-sensitive and regex toggle, previous/next navigation, powered by @xterm/addon-search (#445)
 - Split Down keyboard shortcut (Cmd+Shift+\\ on macOS, Ctrl+Shift+\\ on Win/Linux) — splits the active panel vertically, complementing the existing Split Right shortcut (#446)
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "fs:allow-read-text-file",
     "clipboard-manager:default",
     "clipboard-manager:allow-read-text",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "core:webview:allow-set-webview-zoom"
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { LargePasteDialog } from "@/components/Terminal/LargePasteDialog";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useTunnelEvents } from "@/hooks/useTunnelEvents";
 import { useCredentialStoreEvents } from "@/hooks/useCredentialStoreEvents";
+import { useWebviewZoom } from "@/hooks/useWebviewZoom";
 import { useAppStore } from "@/store/appStore";
 import "./App.css";
 
@@ -87,6 +88,7 @@ function App() {
   useKeyboardShortcuts();
   useTunnelEvents();
   useCredentialStoreEvents();
+  useWebviewZoom();
   const loadFromBackend = useAppStore((s) => s.loadFromBackend);
   const layoutConfig = useAppStore((s) => s.layoutConfig);
   const unlockDialogOpen = useAppStore((s) => s.unlockDialogOpen);

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -279,12 +279,11 @@ export function Terminal({ tabId, config, isVisible, existingSessionId }: Termin
 
     const appSettings = useAppStore.getState().settings;
     const tabOpts = useAppStore.getState().tabTerminalOptions[tabId];
-    const currentZoomDelta = useAppStore.getState().zoomDelta;
     const baseFontSize = tabOpts?.fontSize ?? appSettings.fontSize ?? DEFAULT_FONT_SIZE;
     const xterm = new XTerm({
       theme: getXtermTheme(),
       fontFamily: tabOpts?.fontFamily || appSettings.fontFamily || DEFAULT_FONT_FAMILY,
-      fontSize: baseFontSize + currentZoomDelta,
+      fontSize: baseFontSize,
       lineHeight: 1.2,
       scrollback: tabOpts?.scrollbackBuffer ?? appSettings.scrollbackBuffer ?? DEFAULT_SCROLLBACK,
       cursorBlink: tabOpts?.cursorBlink ?? appSettings.cursorBlink ?? DEFAULT_CURSOR_BLINK,
@@ -490,7 +489,6 @@ export function Terminal({ tabId, config, isVisible, existingSessionId }: Termin
   const cursorStyle = useAppStore((s) => s.settings.cursorStyle);
   const scrollbackBuffer = useAppStore((s) => s.settings.scrollbackBuffer);
   const tabTermOpts = useAppStore((s) => s.tabTerminalOptions[tabId]);
-  const zoomDelta = useAppStore((s) => s.zoomDelta);
 
   useEffect(() => {
     const xterm = xtermRef.current;
@@ -499,7 +497,7 @@ export function Terminal({ tabId, config, isVisible, existingSessionId }: Termin
 
     xterm.options.theme = getXtermTheme();
     xterm.options.fontFamily = tabTermOpts?.fontFamily || fontFamily || DEFAULT_FONT_FAMILY;
-    xterm.options.fontSize = (tabTermOpts?.fontSize ?? fontSize ?? DEFAULT_FONT_SIZE) + zoomDelta;
+    xterm.options.fontSize = tabTermOpts?.fontSize ?? fontSize ?? DEFAULT_FONT_SIZE;
     xterm.options.cursorBlink = tabTermOpts?.cursorBlink ?? cursorBlink ?? DEFAULT_CURSOR_BLINK;
     xterm.options.cursorStyle = tabTermOpts?.cursorStyle ?? cursorStyle ?? DEFAULT_CURSOR_STYLE;
     xterm.options.scrollback =
@@ -515,17 +513,7 @@ export function Terminal({ tabId, config, isVisible, existingSessionId }: Termin
         // Ignore fit errors
       }
     }
-  }, [
-    theme,
-    fontFamily,
-    fontSize,
-    cursorBlink,
-    cursorStyle,
-    scrollbackBuffer,
-    tabTermOpts,
-    tabId,
-    zoomDelta,
-  ]);
+  }, [theme, fontFamily, fontSize, cursorBlink, cursorStyle, scrollbackBuffer, tabTermOpts, tabId]);
 
   // Terminal renders nothing — TerminalSlot handles display
   return null;

--- a/src/hooks/useWebviewZoom.test.ts
+++ b/src/hooks/useWebviewZoom.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSetZoom = vi.fn(() => Promise.resolve());
+
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    setZoom: mockSetZoom,
+  }),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore } from "@/store/appStore";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+
+describe("useWebviewZoom", () => {
+  beforeEach(() => {
+    mockSetZoom.mockClear();
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  it("calls setZoom with the correct zoom level", async () => {
+    const zoomLevel = useAppStore.getState().zoomLevel;
+    await getCurrentWebview().setZoom(zoomLevel);
+    expect(mockSetZoom).toHaveBeenCalledWith(1.0);
+  });
+
+  it("calls setZoom with updated level after zoomIn", async () => {
+    useAppStore.getState().zoomIn();
+    const zoomLevel = useAppStore.getState().zoomLevel;
+    await getCurrentWebview().setZoom(zoomLevel);
+    expect(mockSetZoom).toHaveBeenCalledWith(1.1);
+  });
+
+  it("calls setZoom with updated level after zoomOut", async () => {
+    useAppStore.getState().zoomOut();
+    const zoomLevel = useAppStore.getState().zoomLevel;
+    await getCurrentWebview().setZoom(zoomLevel);
+    expect(mockSetZoom).toHaveBeenCalledWith(0.91);
+  });
+
+  it("calls setZoom with 1.0 after zoomReset", async () => {
+    useAppStore.getState().zoomIn();
+    useAppStore.getState().zoomIn();
+    useAppStore.getState().zoomReset();
+    const zoomLevel = useAppStore.getState().zoomLevel;
+    await getCurrentWebview().setZoom(zoomLevel);
+    expect(mockSetZoom).toHaveBeenCalledWith(1.0);
+  });
+});

--- a/src/hooks/useWebviewZoom.ts
+++ b/src/hooks/useWebviewZoom.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { useAppStore } from "@/store/appStore";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * Applies the store's zoomLevel to the Tauri webview.
+ * Falls back gracefully when not running inside Tauri.
+ */
+export function useWebviewZoom() {
+  const zoomLevel = useAppStore((s) => s.zoomLevel);
+
+  useEffect(() => {
+    let canceled = false;
+
+    (async () => {
+      try {
+        const { getCurrentWebview } = await import("@tauri-apps/api/webview");
+        if (canceled) return;
+        await getCurrentWebview().setZoom(zoomLevel);
+      } catch (err) {
+        frontendLog("zoom", `Failed to set webview zoom: ${err}`);
+      }
+    })();
+
+    return () => {
+      canceled = true;
+    };
+  }, [zoomLevel]);
+}

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -218,6 +218,45 @@ describe("appStore", () => {
     });
   });
 
+  describe("zoom", () => {
+    it("initializes zoomLevel to 1.0", () => {
+      expect(useAppStore.getState().zoomLevel).toBe(1.0);
+    });
+
+    it("zoomIn multiplies by 1.1", () => {
+      useAppStore.getState().zoomIn();
+      expect(useAppStore.getState().zoomLevel).toBeCloseTo(1.1, 2);
+    });
+
+    it("zoomOut divides by 1.1", () => {
+      useAppStore.getState().zoomOut();
+      expect(useAppStore.getState().zoomLevel).toBeCloseTo(0.91, 2);
+    });
+
+    it("zoomReset sets level back to 1.0", () => {
+      useAppStore.getState().zoomIn();
+      useAppStore.getState().zoomIn();
+      useAppStore.getState().zoomReset();
+      expect(useAppStore.getState().zoomLevel).toBe(1.0);
+    });
+
+    it("caps zoomLevel at 3.0", () => {
+      // Zoom in many times to exceed cap
+      for (let i = 0; i < 30; i++) {
+        useAppStore.getState().zoomIn();
+      }
+      expect(useAppStore.getState().zoomLevel).toBeLessThanOrEqual(3.0);
+    });
+
+    it("floors zoomLevel at 0.5", () => {
+      // Zoom out many times to exceed floor
+      for (let i = 0; i < 30; i++) {
+        useAppStore.getState().zoomOut();
+      }
+      expect(useAppStore.getState().zoomLevel).toBeGreaterThanOrEqual(0.5);
+    });
+  });
+
   describe("openLogViewerTab", () => {
     it("creates a log-viewer tab", () => {
       useAppStore.getState().openLogViewerTab();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -203,8 +203,8 @@ interface AppState {
   chordPending: string | null;
   setChordPending: (pending: string | null) => void;
 
-  // Zoom (runtime-only, not persisted)
-  zoomDelta: number;
+  // Zoom (runtime-only, not persisted) — scale factor for webview zoom
+  zoomLevel: number;
   zoomIn: () => void;
   zoomOut: () => void;
   zoomReset: () => void;
@@ -956,11 +956,13 @@ export const useAppStore = create<AppState>((set, get) => {
     chordPending: null,
     setChordPending: (pending) => set({ chordPending: pending }),
 
-    // Zoom (runtime-only, not persisted)
-    zoomDelta: 0,
-    zoomIn: () => set((s) => ({ zoomDelta: Math.min(s.zoomDelta + 1, 20) })),
-    zoomOut: () => set((s) => ({ zoomDelta: Math.max(s.zoomDelta - 1, -10) })),
-    zoomReset: () => set({ zoomDelta: 0 }),
+    // Zoom (runtime-only, not persisted) — scale factor for webview zoom
+    zoomLevel: 1.0,
+    zoomIn: () =>
+      set((s) => ({ zoomLevel: Math.min(parseFloat((s.zoomLevel * 1.1).toFixed(2)), 3.0) })),
+    zoomOut: () =>
+      set((s) => ({ zoomLevel: Math.max(parseFloat((s.zoomLevel / 1.1).toFixed(2)), 0.5) })),
+    zoomReset: () => set({ zoomLevel: 1.0 }),
 
     // Terminal search (runtime-only)
     terminalSearchVisible: {},


### PR DESCRIPTION
## Summary

- Replace terminal-only font-size zoom (`zoomDelta`) with Tauri's native webview zoom API (`getCurrentWebview().setZoom()`), so Cmd+/Cmd-/Cmd+0 scales the entire UI uniformly — sidebar, activity bar, status bar, file editor, settings, and terminals
- Rename store `zoomDelta` → `zoomLevel` (multiplicative scale factor: 0.5–3.0)
- Add `useWebviewZoom` hook mounted in `App` that applies the zoom level via Tauri API
- Remove `zoomDelta` from `Terminal.tsx` font size calculations

Fixes #447

## Test plan

- [x] All unit tests pass (`./scripts/test.sh`)
- [x] All quality checks pass (`./scripts/check.sh`)
- [ ] Manual: launch app, press Cmd+/- and verify the entire UI (sidebar, tabs, terminal, status bar) zooms together
- [ ] Manual: verify Cmd+0 resets to default zoom
- [ ] Manual: verify zoom bounds (max 3x, min 0.5x) are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)