### PR TITLE
fix(ui): accept Cmd/Ctrl++ (Shift+=) as zoom-in shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Zoom In shortcut now also triggers when pressing Cmd/Ctrl+Shift+= (producing "+"), not just Cmd/Ctrl+= (#452)
 - Zoom shortcuts (Cmd/Ctrl+=/-/0) now scale the entire application UI uniformly using Tauri webview zoom, instead of only adjusting terminal font size (#447)
 - Directional panel navigation (Cmd/Ctrl+Alt+Arrow) now remembers and restores the last-focused panel when entering a split group, instead of always selecting the first/last child (#448)
 

--- a/src/services/keybindings.test.ts
+++ b/src/services/keybindings.test.ts
@@ -107,6 +107,24 @@ describe("eventMatchesCombo", () => {
     const event = makeKeyEvent("C", { ctrl: true, shift: true });
     expect(eventMatchesCombo(event, combo)).toBe(true);
   });
+
+  it("matches Shift+= (producing +) against = binding via shift-key equivalence", () => {
+    const combo: KeyCombo = { key: "=", meta: true };
+    const event = makeKeyEvent("+", { meta: true, shift: true });
+    expect(eventMatchesCombo(event, combo)).toBe(true);
+  });
+
+  it("matches Shift+- (producing _) against - binding via shift-key equivalence", () => {
+    const combo: KeyCombo = { key: "-", ctrl: true };
+    const event = makeKeyEvent("_", { ctrl: true, shift: true });
+    expect(eventMatchesCombo(event, combo)).toBe(true);
+  });
+
+  it("does not match shift-equivalent when other modifiers differ", () => {
+    const combo: KeyCombo = { key: "=", meta: true };
+    const event = makeKeyEvent("+", { ctrl: true, shift: true });
+    expect(eventMatchesCombo(event, combo)).toBe(false);
+  });
 });
 
 describe("findMatchingAction (Linux/Win context)", () => {
@@ -144,6 +162,16 @@ describe("findMatchingAction (Linux/Win context)", () => {
   it("finds paste for Ctrl+Shift+V", () => {
     const event = makeKeyEvent("V", { ctrl: true, shift: true });
     expect(findMatchingAction(event)).toBe("paste");
+  });
+
+  it("finds zoom-in for Ctrl+= (base key)", () => {
+    const event = makeKeyEvent("=", { ctrl: true });
+    expect(findMatchingAction(event)).toBe("zoom-in");
+  });
+
+  it("finds zoom-in for Ctrl+Shift+= (producing +) via shift-key equivalence", () => {
+    const event = makeKeyEvent("+", { ctrl: true, shift: true });
+    expect(findMatchingAction(event)).toBe("zoom-in");
   });
 
   it("returns null for unrecognized keys", () => {

--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -252,16 +252,40 @@ export function parseBinding(str: string): KeyCombo | KeyCombo[] {
   return parts.map(parseCombo);
 }
 
+/**
+ * Map of keys produced by holding Shift to their unshifted base key.
+ * Used so that e.g. Cmd+Shift+= (producing "+") matches a binding for "=".
+ */
+const SHIFT_KEY_TO_BASE: Record<string, string> = {
+  "+": "=",
+  _: "-",
+};
+
 /** Check if a KeyboardEvent matches a single KeyCombo. */
 export function eventMatchesCombo(event: KeyboardEvent, combo: KeyCombo): boolean {
-  if (event.key !== combo.key && event.key.toLowerCase() !== combo.key.toLowerCase()) {
-    return false;
+  const keyMatches = event.key === combo.key || event.key.toLowerCase() === combo.key.toLowerCase();
+
+  if (keyMatches) {
+    if (!!combo.ctrl !== event.ctrlKey) return false;
+    if (!!combo.shift !== event.shiftKey) return false;
+    if (!!combo.alt !== event.altKey) return false;
+    if (!!combo.meta !== event.metaKey) return false;
+    return true;
   }
-  if (!!combo.ctrl !== event.ctrlKey) return false;
-  if (!!combo.shift !== event.shiftKey) return false;
-  if (!!combo.alt !== event.altKey) return false;
-  if (!!combo.meta !== event.metaKey) return false;
-  return true;
+
+  // Check shift-equivalence: if the event key is a shifted variant of the combo key,
+  // accept the match with shift allowed even if the combo doesn't require it.
+  if (event.shiftKey && !combo.shift) {
+    const baseKey = SHIFT_KEY_TO_BASE[event.key];
+    if (baseKey && baseKey.toLowerCase() === combo.key.toLowerCase()) {
+      if (!!combo.ctrl !== event.ctrlKey) return false;
+      if (!!combo.alt !== event.altKey) return false;
+      if (!!combo.meta !== event.metaKey) return false;
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /** Get the effective combo for an action (user override or platform default). */


### PR DESCRIPTION
## Summary

- Adds shift-key equivalence matching to `eventMatchesCombo` so that pressing `Cmd++` (i.e. `Cmd+Shift+=`, which produces `key="+"`) correctly triggers zoom-in
- Also handles `_` → `-` equivalence for consistency
- Adds regression tests for the shift-key equivalence logic

Fixes #452

## Test plan

- [ ] On macOS: press `Cmd+=` → zoom in works
- [ ] On macOS: press `Cmd++` (Cmd+Shift+=) → zoom in works
- [ ] On Windows/Linux: press `Ctrl+=` → zoom in works
- [ ] On Windows/Linux: press `Ctrl++` (Ctrl+Shift+=) → zoom in works
- [ ] Zoom out (`Cmd/Ctrl+-`) still works as before
- [ ] All other keyboard shortcuts unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)