### PR TITLE
feat(config): allow parallel dev instances via configurable port

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,7 @@ Helper scripts for common development tasks. Each script has a `.sh` (Unix/macOS
 | Script                | What it does                                                                                                               |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `setup`               | Install all dependencies and do an initial build                                                                           |
-| `dev`                 | Start the app in development mode with hot-reload                                                                          |
+| `dev`                 | Start the app in dev mode with hot-reload; accepts an optional port argument (default 1420)                                |
 | `build`               | Build the app for production (creates platform installer); on macOS also cross-compiles agent for Linux x86_64 + aarch64   |
 | `test`                | Run all unit tests (frontend + backend + agent)                                                                            |
 | `check`               | Read-only quality checks mirroring CI (formatting, linting, clippy)                                                        |
@@ -29,6 +29,10 @@ Helper scripts for common development tasks. Each script has a `.sh` (Unix/macOS
 
 # Daily development
 ./scripts/dev.sh
+
+# Run a second instance in parallel (e.g. two checkouts side-by-side)
+./scripts/dev.sh 1422            # explicit port argument
+echo 1422 > dev.local            # or set a per-checkout default (gitignored)
 
 # Before pushing
 ./scripts/format.sh

--- a/scripts/dev.cmd
+++ b/scripts/dev.cmd
@@ -1,8 +1,23 @@
 @echo off
 REM Start the app in development mode with hot-reload.
-REM Run from the repo root: scripts\dev.cmd
+REM Run from the repo root: scripts\dev.cmd [PORT]
+REM
+REM Port resolution order (first match wins):
+REM   1. CLI argument:      scripts\dev.cmd 1422
+REM   2. dev.local file:    echo 1422 > dev.local   (gitignored -- per-checkout setting)
+REM   3. Default:           1420
+REM
+REM Multiple instances can run in parallel by using different ports.
 
 cd /d "%~dp0\.."
+
+REM Resolve dev port
+set DEV_PORT=1420
+if not "%~1"=="" (
+    set DEV_PORT=%~1
+) else if exist dev.local (
+    set /p DEV_PORT=<dev.local
+)
 
 if not exist node_modules (
     echo node_modules missing, running pnpm install...
@@ -12,7 +27,8 @@ if not exist node_modules (
 )
 
 REM Kill any process occupying the Vite dev server port (leftover from a previous run)
-node scripts\internal\kill-port.cjs 1420
+node scripts\internal\kill-port.cjs %DEV_PORT%
 
-echo Starting termiHub in dev mode...
-call pnpm tauri dev
+echo Starting termiHub in dev mode (port %DEV_PORT%)...
+set TERMIHUB_DEV_PORT=%DEV_PORT%
+call pnpm tauri dev --config "{\"build\":{\"devUrl\":\"http://localhost:%DEV_PORT%\"}}"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,9 +1,27 @@
 #!/usr/bin/env bash
 # Start the app in development mode with hot-reload.
-# Run from anywhere: ./scripts/dev.sh
+# Run from anywhere: ./scripts/dev.sh [PORT]
+#
+# Port resolution order (first match wins):
+#   1. CLI argument:      ./scripts/dev.sh 1422
+#   2. dev.local file:    echo 1422 > dev.local   (gitignored — per-checkout setting)
+#   3. Default:           1420
+#
+# Multiple instances can run in parallel by using different ports.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
+
+# Resolve dev port
+DEV_PORT=1420
+if [ -n "${1:-}" ] && [[ "$1" =~ ^[0-9]+$ ]]; then
+    DEV_PORT="$1"
+elif [ -f "dev.local" ]; then
+    _CONF_PORT="$(tr -d '[:space:]' < dev.local)"
+    if [[ "$_CONF_PORT" =~ ^[0-9]+$ ]]; then
+        DEV_PORT="$_CONF_PORT"
+    fi
+fi
 
 if [ ! -d node_modules ]; then
     echo "node_modules missing, running pnpm install..."
@@ -12,7 +30,7 @@ if [ ! -d node_modules ]; then
 fi
 
 # Kill any process occupying the Vite dev server port (leftover from a previous run)
-node scripts/internal/kill-port.cjs 1420
+node scripts/internal/kill-port.cjs "$DEV_PORT"
 
-echo "Starting termiHub in dev mode..."
-pnpm tauri dev
+echo "Starting termiHub in dev mode (port $DEV_PORT)..."
+TERMIHUB_DEV_PORT="$DEV_PORT" pnpm tauri dev --config "{\"build\":{\"devUrl\":\"http://localhost:$DEV_PORT\"}}"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import { fileURLToPath } from "url";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+// Allow running multiple dev instances in parallel by setting TERMIHUB_DEV_PORT.
+// The HMR websocket uses devPort + 1. See scripts/dev.sh for how to configure this.
+// @ts-expect-error process is a nodejs global
+const devPort = parseInt(process.env.TERMIHUB_DEV_PORT ?? "1420", 10);
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
@@ -26,14 +30,14 @@ export default defineConfig(async () => ({
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
-    port: 1420,
+    port: devPort,
     strictPort: true,
     host: host || false,
     hmr: host
       ? {
           protocol: "ws",
           host,
-          port: 1421,
+          port: devPort + 1,
         }
       : undefined,
     watch: {


### PR DESCRIPTION
## Summary

- `dev.sh` / `dev.cmd` now accept an optional port argument; they also read a `dev.local` file (already gitignored via `*.local`) as a per-checkout default; fallback is `1420`
- `TERMIHUB_DEV_PORT` env var is exported so Vite picks up the right port; a `--config` override is passed to `tauri dev` at runtime so `tauri.conf.json` needs no changes
- Vite's HMR WebSocket port follows as `devPort + 1`

**Usage:**
```bash
# explicit port argument
./scripts/dev.sh 1422

# or write a per-checkout default (gitignored)
echo 1422 > dev.local
./scripts/dev.sh
```

## Test plan

- [ ] `./scripts/dev.sh` starts on port 1420 (default unchanged)
- [ ] `./scripts/dev.sh 1422` starts on port 1422 without conflicting with another instance on 1420
- [ ] `echo 1424 > dev.local && ./scripts/dev.sh` starts on port 1424
- [ ] CLI argument takes priority over `dev.local`
- [ ] Two instances run in parallel without port collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)