### PR TITLE
fix(terminal): correct default lineHeight to fix box-drawing character gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Terminal: box-drawing characters (table borders, tree views) no longer render with pixel gaps between rows — the default `lineHeight` has been corrected from 1.2 to 1.0 (#579)
+
+### Added
+
+- Terminal: `lineHeight` is now a user-configurable setting (0.8–2.0) in Appearance Settings, also available per-tab via `TerminalOptions` (#579)
+
 ### Changed
 
 - Test coverage: added 16 new test files covering previously untested services (`networkApi`, `tunnelApi`, `embeddedServerApi`, `storage`), hooks (`useConnections`, `useTerminal`, `useCredentialStoreEvents`, `useEmbeddedServerEvents`, `useTunnelEvents`, `useFileBrowser`, `useLocalFileSystem`, `useSectionResize`, `useKeyboardShortcuts`), utilities (`frontendLog`), and components (`PortableBadge`, `PortableModeSettings`) — bringing frontend unit test coverage from ~52% to ~75%

--- a/src/components/Settings/AppearanceSettings.tsx
+++ b/src/components/Settings/AppearanceSettings.tsx
@@ -64,6 +64,25 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
           <span className="settings-form__hint">Terminal font size in pixels (8–32).</span>
         </label>
       )}
+      {show("lineHeight") && (
+        <label className="settings-form__field">
+          <span className="settings-form__label">Line Height</span>
+          <input
+            type="number"
+            min={0.8}
+            max={2.0}
+            step={0.1}
+            value={settings.lineHeight ?? 1.0}
+            onChange={(e) => {
+              const val = parseFloat(e.target.value);
+              onChange({ ...settings, lineHeight: isNaN(val) ? undefined : val });
+            }}
+          />
+          <span className="settings-form__hint">
+            Terminal line height (0.8–2.0). Use 1.0 for seamless box-drawing characters.
+          </span>
+        </label>
+      )}
     </div>
   );
 }

--- a/src/components/Terminal/Terminal.line-height.test.ts
+++ b/src/components/Terminal/Terminal.line-height.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Regression test for box-drawing character gaps caused by lineHeight > 1.0.
+ *
+ * Box-drawing characters (─ │ ┌ ┐ └ ┘ ├ ┤ etc.) are designed to connect at
+ * the exact top/bottom pixel edges of a terminal cell. A lineHeight above 1.0
+ * adds extra vertical padding between rows, creating visible gaps that break
+ * table borders. This test ensures the default stays at 1.0.
+ *
+ * Manual verification: run the following in a termiHub terminal and confirm
+ * all borders are solid and connected:
+ *
+ *   printf '┌──────┐\n│ test │\n└──────┘\n'
+ */
+import { describe, it, expect } from "vitest";
+import { DEFAULT_LINE_HEIGHT } from "./Terminal";
+
+describe("Terminal line height default", () => {
+  it("defaults to 1.0 so box-drawing characters connect without gaps", () => {
+    expect(DEFAULT_LINE_HEIGHT).toBe(1.0);
+  });
+
+  it("is a number in the valid xterm.js lineHeight range (0.8–2.0)", () => {
+    expect(DEFAULT_LINE_HEIGHT).toBeGreaterThanOrEqual(0.8);
+    expect(DEFAULT_LINE_HEIGHT).toBeLessThanOrEqual(2.0);
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -18,6 +18,8 @@ const HORIZONTAL_SCROLL_COLS = 500;
 const DEFAULT_FONT_FAMILY =
   "'MesloLGS Nerd Font Mono', 'MesloLGS NF', 'CaskaydiaCove Nerd Font', 'FiraCode Nerd Font', 'Hack Nerd Font', 'Cascadia Code', 'Fira Code', Menlo, Monaco, 'Courier New', monospace";
 const DEFAULT_FONT_SIZE = 14;
+/** Line height of 1.0 ensures box-drawing characters connect without gaps. */
+export const DEFAULT_LINE_HEIGHT = 1.0;
 const DEFAULT_SCROLLBACK = 5000;
 const DEFAULT_CURSOR_STYLE = "block" as const;
 const DEFAULT_CURSOR_BLINK = true;
@@ -331,7 +333,7 @@ export function Terminal({
       theme: getXtermTheme(),
       fontFamily: tabOpts?.fontFamily || appSettings.fontFamily || DEFAULT_FONT_FAMILY,
       fontSize: baseFontSize,
-      lineHeight: 1.2,
+      lineHeight: tabOpts?.lineHeight ?? appSettings.lineHeight ?? DEFAULT_LINE_HEIGHT,
       scrollback: tabOpts?.scrollbackBuffer ?? appSettings.scrollbackBuffer ?? DEFAULT_SCROLLBACK,
       cursorBlink: tabOpts?.cursorBlink ?? appSettings.cursorBlink ?? DEFAULT_CURSOR_BLINK,
       cursorStyle: tabOpts?.cursorStyle ?? appSettings.cursorStyle ?? DEFAULT_CURSOR_STYLE,

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -127,6 +127,7 @@ export interface AppSettings {
   theme?: "dark" | "light" | "system";
   fontFamily?: string;
   fontSize?: number;
+  lineHeight?: number;
   defaultHorizontalScrolling?: boolean;
   scrollbackBuffer?: number;
   cursorStyle?: "block" | "underline" | "bar";

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -77,6 +77,7 @@ export interface TerminalOptions {
   color?: string;
   fontFamily?: string;
   fontSize?: number;
+  lineHeight?: number;
   scrollbackBuffer?: number;
   cursorStyle?: "block" | "underline" | "bar";
   cursorBlink?: boolean;

--- a/tests/manual/ui-layout.yaml
+++ b/tests/manual/ui-layout.yaml
@@ -288,3 +288,20 @@ tests:
       - "The full context menu appears again"
     verification: manual
     tags: [terminal, settings]
+
+  - id: MT-UI-31
+    name: "Box-drawing characters render without gaps"
+    pr: 579
+    platforms: [all]
+    prerequisites:
+      - app: true
+      - "Open a local terminal session"
+    instructions:
+      - "Run: printf '┌──────┐\\n│ test │\\n└──────┘\\n'"
+      - "Also run a table-rendering CLI tool, e.g.: column -t /etc/passwd | head -5"
+    expected:
+      - "All horizontal (─) and vertical (│) lines are solid and unbroken"
+      - "Corner characters (┌ ┐ └ ┘) connect seamlessly to adjacent lines"
+      - "No pixel gaps visible between rows of a box"
+    verification: manual
+    tags: [terminal, visual]


### PR DESCRIPTION
## Summary

- Fixes box-drawing characters (table borders, tree views, `─ │ ┌ ┐ └ ┘`) rendering with pixel gaps between rows
- Root cause: `lineHeight: 1.2` added 20% extra vertical padding, breaking cell-to-cell alignment that box-drawing glyphs depend on
- Default changed to `1.0`; also exposed as a user-configurable setting (0.8–2.0) in Appearance Settings

Closes #579

## Test plan

**Automated regression test** — `src/components/Terminal/Terminal.line-height.test.ts`:
- Verifies `DEFAULT_LINE_HEIGHT` is `1.0`
- Verifies value is within valid xterm.js range (0.8–2.0)

**Manual visual verification** (MT-UI-31) — run in a termiHub terminal:

```sh
printf '┌──────┐\n│ test │\n└──────┘\n'
```

Expected: all border characters connect without visible gaps. Compare to another terminal (iTerm2, Windows Terminal) — appearance should match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)