### PR TITLE
fix(agent): build-agents stability on ARM hosts (Apple Silicon, Raspberry Pi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Agent build: `build-agents.sh` and `setup-agent-cross.sh` now work correctly on ARM hosts (Apple Silicon, Raspberry Pi) — cross-rs Docker base images are pinned to `linux/amd64`, the container engine is auto-selected based on which engine already has the required images, missing images are caught early with a clear error, and jemalloc/QEMU noise is filtered from build output
 - Terminal: box-drawing characters (table borders, tree views) no longer render with pixel gaps between rows — the default `lineHeight` has been corrected from 1.2 to 1.0 (#579)
 
 ### Added

--- a/agent/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/agent/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
+FROM --platform=linux/amd64 ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
 # lld: system LLD linker fallback for when Rust's bundled rust-lld lacks execute
 # permission after being copied from Windows via podman cp (DrvFs strips +x bits).
 RUN dpkg --add-architecture arm64 \

--- a/agent/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/agent/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
+FROM --platform=linux/amd64 ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
 # lld: system LLD linker fallback for when Rust's bundled rust-lld lacks execute
 # permission after being copied from Windows via podman cp (DrvFs strips +x bits).
 RUN apt-get update && apt-get install -y libudev-dev lld

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -140,7 +140,12 @@ for target in "${SELECTED_TARGETS[@]}"; do
     fi
 
     echo "  Building with cross-rs..."
-    if CROSS_CONFIG=agent/Cross.toml cross build --release --target "$target" -p termihub-agent 2>&1; then
+    # Pipe through grep to suppress the jemalloc/QEMU noise printed when running
+    # amd64 containers under emulation (Apple Silicon, Raspberry Pi, etc.).
+    # The { ... || true; } group always exits 0 so that pipefail only triggers
+    # on a non-zero exit from cross itself, not from grep filtering all lines.
+    if CROSS_CONFIG=agent/Cross.toml cross build --release --target "$target" -p termihub-agent 2>&1 \
+        | { grep -v "^<jemalloc>" || true; }; then
         binary="target/$target/release/termihub-agent"
         if [ -f "$binary" ]; then
             size=$(du -h "$binary" | cut -f1)

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -62,15 +62,65 @@ if ! command -v cross >/dev/null 2>&1; then
     exit 1
 fi
 
-# If Podman is the container engine (explicit override or auto-detected), disable
-# cross-rs rootless handling.  Without this, cross-rs adds --user UID:GID to the
-# podman run command which causes the injected cargo/rustc toolchain to be
-# non-executable inside the container ("Permission denied").
-if [ "${CROSS_CONTAINER_ENGINE:-}" = "podman" ] || \
-   ( [ -z "${CROSS_CONTAINER_ENGINE:-}" ] && ! docker info >/dev/null 2>&1 && podman info >/dev/null 2>&1 ); then
-    export CROSS_CONTAINER_ENGINE=podman
+# --- Container engine detection ---
+# Auto-detect which engine to use, preferring the one that already has the
+# required cross-compilation images.  If Podman is selected, disable cross-rs
+# rootless handling — without CROSS_ROOTLESS_CONTAINER_ENGINE=false, cross-rs
+# adds --user UID:GID to the `podman run` command which makes the injected
+# cargo/rustc toolchain non-executable inside the container ("Permission denied").
+if [ "${CROSS_CONTAINER_ENGINE:-}" = "podman" ]; then
+    # Explicit override: use Podman
     export CROSS_ROOTLESS_CONTAINER_ENGINE=false
+elif [ -z "${CROSS_CONTAINER_ENGINE:-}" ]; then
+    docker_running=false
+    podman_running=false
+    docker info >/dev/null 2>&1 && docker_running=true || true
+    command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1 && podman_running=true || true
+
+    if ! $docker_running && ! $podman_running; then
+        echo "ERROR: No running container runtime found (Docker or Podman)."
+        echo "  cross-rs requires Docker or Podman. Start one and re-run."
+        exit 1
+    elif ! $docker_running && $podman_running; then
+        export CROSS_CONTAINER_ENGINE=podman
+        export CROSS_ROOTLESS_CONTAINER_ENGINE=false
+    elif $docker_running && $podman_running; then
+        # Both available — prefer the engine that already has the required images
+        images_in_docker=0
+        images_in_podman=0
+        for _t in "${SELECTED_TARGETS[@]}"; do
+            docker image inspect "localhost/termihub-cross:$_t" >/dev/null 2>&1 \
+                && images_in_docker=$((images_in_docker + 1)) || true
+            podman image inspect "localhost/termihub-cross:$_t" >/dev/null 2>&1 \
+                && images_in_podman=$((images_in_podman + 1)) || true
+        done
+        if [ "$images_in_podman" -gt "$images_in_docker" ]; then
+            export CROSS_CONTAINER_ENGINE=podman
+            export CROSS_ROOTLESS_CONTAINER_ENGINE=false
+        fi
+        # else: Docker is running and has the images (or neither does — checked below)
+    fi
+    # else: only Docker is running — use it (default, no override needed)
 fi
+
+# --- Pre-flight: verify required images exist in the selected engine ---
+_container_cmd="${CROSS_CONTAINER_ENGINE:-docker}"
+_missing_images=()
+for _t in "${SELECTED_TARGETS[@]}"; do
+    if ! "$_container_cmd" image inspect "localhost/termihub-cross:$_t" >/dev/null 2>&1; then
+        _missing_images+=("localhost/termihub-cross:$_t")
+    fi
+done
+if [ "${#_missing_images[@]}" -gt 0 ]; then
+    echo "ERROR: The following cross-compilation image(s) are missing from $_container_cmd:"
+    for _img in "${_missing_images[@]}"; do
+        echo "  $_img"
+    done
+    echo ""
+    echo "Run ./scripts/setup-agent-cross.sh to build the required images, then retry."
+    exit 1
+fi
+unset _container_cmd _missing_images _t _img
 
 # --- Build ---
 echo "=== Building agent for ${#SELECTED_TARGETS[@]} target(s) ==="


### PR DESCRIPTION
## Summary

- Pin cross-rs Docker base images to `--platform=linux/amd64` so `setup-agent-cross.sh` works on ARM hosts (Apple Silicon, Raspberry Pi) — without this, BuildKit tries to pull a nonexistent `linux/arm64` variant of the toolchain images and fails
- Improve container engine detection in `build-agents.sh`: when both Docker and Podman are available, auto-select the engine that already has the required images (previously always picked Docker, causing a confusing registry-not-found error when images were built with Podman)
- Add a pre-flight image check that fails early with a clear message pointing to `setup-agent-cross.sh` instead of letting cross-rs emit the cryptic `http://localhost/v2/` connection error
- Filter jemalloc/QEMU noise from build output — on ARM hosts, amd64 containers run via QEMU and jemalloc prints two warning lines per compiled crate, drowning out real compiler output

## Test plan

- [x] Run `./scripts/setup-agent-cross.sh` on Apple Silicon Mac — should build both images successfully
- [x] Run `./scripts/build-agents.sh` — should complete without jemalloc spam in output
- [x] Run `./scripts/build-agents.sh` before running setup — should print a clear "images missing" error
- [ ] Run with Docker stopped and Podman running — should auto-select Podman
- [x] Run with both Docker and Podman running (images in Podman only) — should auto-select Podman

🤖 Generated with [Claude Code](https://claude.com/claude-code)