### PR TITLE
feat(agent): parallel cross-compilation for multiple targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Agent build: `build-agents.sh` now builds multiple targets in parallel (each in its own `CARGO_TARGET_DIR` to avoid cargo build lock contention); add `--sequential` flag to opt out
 - Agent build: `build-agents.sh` and `setup-agent-cross.sh` now work correctly on ARM hosts (Apple Silicon, Raspberry Pi) — cross-rs Docker base images are pinned to `linux/amd64`, the container engine is auto-selected based on which engine already has the required images, missing images are caught early with a clear error, and jemalloc/QEMU noise is filtered from build output
 - Terminal: box-drawing characters (table borders, tree views) no longer render with pixel gaps between rows — the default `lineHeight` has been corrected from 1.2 to 1.0 (#579)
 

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -157,7 +157,7 @@ if [ "$SEQUENTIAL" = true ] || [ "${#SELECTED_TARGETS[@]}" -le 1 ]; then
 
         build_exit=0
         CROSS_CONFIG=agent/Cross.toml cross build --release --target "$target" -p termihub-agent 2>&1 \
-            | { grep -v "^<jemalloc>" || true; } \
+            | { grep -v "<jemalloc>:" || true; } \
             || build_exit=$?
 
         if [ "$build_exit" -eq 0 ]; then
@@ -215,7 +215,7 @@ else
             CARGO_TARGET_DIR="$cross_dir" CROSS_CONFIG=agent/Cross.toml \
                 cross build --release --target "$target" -p termihub-agent 2>&1 \
                 | awk -v prefix="[$target] " \
-                      '!/^<jemalloc>/ { print prefix $0; fflush() }'
+                      '/<jemalloc>:/ { next } { print prefix $0; fflush() }'
         } &
 
         _pids[$i]=$!

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -214,8 +214,26 @@ else
         {
             CARGO_TARGET_DIR="$cross_dir" CROSS_CONFIG=agent/Cross.toml \
                 cross build --release --target "$target" -p termihub-agent 2>&1 \
-                | awk -v prefix="[$target] " \
-                      '/<jemalloc>:/ { next } { print prefix $0; fflush() }'
+                | awk -v prefix="[$target] " '
+                    {
+                        # Cargo uses \r (no \n) for in-place progress updates.
+                        # jemalloc output (which does have \n) therefore lands on
+                        # the same awk record as the preceding cargo progress text.
+                        # Replace \r with \n first so we can process each visual
+                        # line independently, then strip only the jemalloc portion.
+                        gsub(/\r/, "\n")
+                        n = split($0, segs, "\n")
+                        for (i = 1; i <= n; i++) {
+                            seg = segs[i]
+                            if (seg == "") continue
+                            p = index(seg, "<jemalloc>:")
+                            if (p > 0) seg = substr(seg, 1, p - 1)
+                            if (seg ~ /^[[:space:]]*$/) continue
+                            print prefix seg
+                            fflush()
+                        }
+                    }
+                '
         } &
 
         _pids[$i]=$!

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -216,20 +216,26 @@ else
                 cross build --release --target "$target" -p termihub-agent 2>&1 \
                 | awk -v prefix="[$target] " '
                     {
-                        # Cargo uses \r (no \n) for in-place progress updates.
-                        # jemalloc output (which does have \n) therefore lands on
-                        # the same awk record as the preceding cargo progress text.
-                        # Replace \r with \n first so we can process each visual
-                        # line independently, then strip only the jemalloc portion.
+                        # \r in the stream is cargo'\''s in-place progress marker.
+                        # Replace with \n to split the record into visual segments,
+                        # then restore the in-place behaviour per segment type.
                         gsub(/\r/, "\n")
                         n = split($0, segs, "\n")
                         for (i = 1; i <= n; i++) {
                             seg = segs[i]
                             if (seg == "") continue
+                            # Strip jemalloc text fused with cargo progress
                             p = index(seg, "<jemalloc>:")
                             if (p > 0) seg = substr(seg, 1, p - 1)
-                            if (seg ~ /^[[:space:]]*$/) continue
-                            print prefix seg
+                            sub(/[[:space:]]+$/, "", seg)
+                            if (seg == "") continue
+                            # Progress lines (NNN: or NNN/NNN: crates…) overwrite
+                            # in place; everything else is a permanent new line.
+                            if (seg ~ /^[[:space:]]*[0-9]+(\/[0-9]+)?: /) {
+                                printf "\r%s%s", prefix, seg
+                            } else {
+                                printf "\r%s%s\n", prefix, seg
+                            }
                             fflush()
                         }
                     }

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Cross-compile the remote agent (termihub-agent) for Linux targets (musl, static).
-# Uses cross-rs for all targets.
+# Uses cross-rs for all targets. Multiple targets are built in parallel by default,
+# each in its own CARGO_TARGET_DIR to avoid cargo's workspace build lock.
 #
-# Usage: ./scripts/build-agents.sh [--targets <list>] [--help]
+# Usage: ./scripts/build-agents.sh [--targets <list>] [--sequential] [--help]
 #
 # Run ./scripts/setup-agent-cross.sh first to install required toolchains.
 set -euo pipefail
@@ -15,6 +16,7 @@ ALL_TARGETS=(
     aarch64-unknown-linux-musl
 )
 SELECTED_TARGETS=()
+SEQUENTIAL=false
 
 # --- Argument parsing ---
 while [[ $# -gt 0 ]]; do
@@ -24,14 +26,20 @@ while [[ $# -gt 0 ]]; do
             IFS=',' read -ra SELECTED_TARGETS <<< "$1"
             shift
             ;;
+        --sequential)
+            SEQUENTIAL=true
+            shift
+            ;;
         --help|-h)
             cat <<'USAGE'
 Usage: build-agents.sh [OPTIONS]
 
 Cross-compile the remote agent for Linux targets (static musl binaries).
+Multiple targets are built in parallel by default.
 
 Options:
   --targets <list>   Comma-separated list of targets to build (default: all)
+  --sequential       Build targets one at a time (useful for debugging)
   --help, -h         Show this help message
 
 Targets:
@@ -41,6 +49,7 @@ Targets:
 Examples:
   ./scripts/build-agents.sh
   ./scripts/build-agents.sh --targets aarch64-unknown-linux-musl
+  ./scripts/build-agents.sh --sequential
 USAGE
             exit 0
             ;;
@@ -122,48 +131,128 @@ if [ "${#_missing_images[@]}" -gt 0 ]; then
 fi
 unset _container_cmd _missing_images _t _img
 
-# --- Build ---
-echo "=== Building agent for ${#SELECTED_TARGETS[@]} target(s) ==="
-echo ""
-
-built=0
-failed=0
-results=()
-
+# --- Ensure Rust targets are installed (before any parallel work starts) ---
 for target in "${SELECTED_TARGETS[@]}"; do
-    echo "--- $target ---"
-
-    # Ensure Rust target is installed
     if ! rustup target list --installed | grep -q "^${target}$"; then
         echo "  Adding Rust target $target..."
         rustup target add "$target"
     fi
+done
 
-    echo "  Building with cross-rs..."
-    # Pipe through grep to suppress the jemalloc/QEMU noise printed when running
-    # amd64 containers under emulation (Apple Silicon, Raspberry Pi, etc.).
-    # The { ... || true; } group always exits 0 so that pipefail only triggers
-    # on a non-zero exit from cross itself, not from grep filtering all lines.
-    if CROSS_CONFIG=agent/Cross.toml cross build --release --target "$target" -p termihub-agent 2>&1 \
-        | { grep -v "^<jemalloc>" || true; }; then
-        binary="target/$target/release/termihub-agent"
-        if [ -f "$binary" ]; then
-            size=$(du -h "$binary" | cut -f1)
-            results+=("  OK    $target  ($size)")
-            echo "  -> $binary ($size)"
-            built=$((built + 1))
+# --- Build ---
+built=0
+failed=0
+results=()
+
+if [ "$SEQUENTIAL" = true ] || [ "${#SELECTED_TARGETS[@]}" -le 1 ]; then
+    # ------------------------------------------------------------------ #
+    # Sequential build                                                     #
+    # ------------------------------------------------------------------ #
+    echo "=== Building agent for ${#SELECTED_TARGETS[@]} target(s) ==="
+    echo ""
+
+    for target in "${SELECTED_TARGETS[@]}"; do
+        echo "--- $target ---"
+        echo "  Building with cross-rs..."
+
+        build_exit=0
+        CROSS_CONFIG=agent/Cross.toml cross build --release --target "$target" -p termihub-agent 2>&1 \
+            | { grep -v "^<jemalloc>" || true; } \
+            || build_exit=$?
+
+        if [ "$build_exit" -eq 0 ]; then
+            binary="target/$target/release/termihub-agent"
+            if [ -f "$binary" ]; then
+                size=$(du -h "$binary" | cut -f1)
+                results+=("  OK    $target  ($size)")
+                echo "  -> $binary ($size)"
+                built=$((built + 1))
+            else
+                results+=("  FAIL  $target  (binary not found)")
+                echo "  FAILED: binary not found"
+                failed=$((failed + 1))
+            fi
         else
-            results+=("  FAIL  $target  (binary not found)")
-            echo "  FAILED: binary not found"
+            results+=("  FAIL  $target")
+            echo "  FAILED"
             failed=$((failed + 1))
         fi
-    else
-        results+=("  FAIL  $target")
-        echo "  FAILED"
-        failed=$((failed + 1))
-    fi
+        echo ""
+    done
+
+else
+    # ------------------------------------------------------------------ #
+    # Parallel build                                                       #
+    #                                                                      #
+    # Each target gets its own CARGO_TARGET_DIR so the builds don't       #
+    # contend on the workspace-level cargo build lock (target/.cargo-lock) #
+    # and can run in truly separate Docker containers simultaneously.      #
+    # Binaries are copied to target/<target>/release/ when done.          #
+    # ------------------------------------------------------------------ #
+    echo "=== Building agent for ${#SELECTED_TARGETS[@]} target(s) in parallel ==="
     echo ""
-done
+
+    declare -A _pids=()
+    declare -A _tmpfiles=()
+    declare -A _cross_dirs=()
+    _tmpfile_list=()
+
+    # Clean up temp files on exit (normal or interrupted)
+    trap 'rm -f "${_tmpfile_list[@]:-}"' EXIT
+
+    for target in "${SELECTED_TARGETS[@]}"; do
+        cross_dir="target/cross/$target"
+        _cross_dirs[$target]=$cross_dir
+
+        tmpfile=$(mktemp)
+        _tmpfiles[$target]=$tmpfile
+        _tmpfile_list+=("$tmpfile")
+
+        {
+            CARGO_TARGET_DIR="$cross_dir" CROSS_CONFIG=agent/Cross.toml \
+                cross build --release --target "$target" -p termihub-agent 2>&1 \
+                | { grep -v "^<jemalloc>" || true; }
+        } > "$tmpfile" &
+
+        _pids[$target]=$!
+        echo "  $target: building... (PID ${_pids[$target]})"
+    done
+    echo ""
+
+    for target in "${SELECTED_TARGETS[@]}"; do
+        echo "--- $target ---"
+
+        build_exit=0
+        wait "${_pids[$target]}" || build_exit=$?
+
+        cat "${_tmpfiles[$target]}"
+
+        if [ "$build_exit" -eq 0 ]; then
+            cross_dir="${_cross_dirs[$target]}"
+            src_binary="$cross_dir/$target/release/termihub-agent"
+            dst_dir="target/$target/release"
+            dst_binary="$dst_dir/termihub-agent"
+
+            if [ -f "$src_binary" ]; then
+                mkdir -p "$dst_dir"
+                cp "$src_binary" "$dst_binary"
+                size=$(du -h "$dst_binary" | cut -f1)
+                results+=("  OK    $target  ($size)")
+                echo "  -> $dst_binary ($size)"
+                built=$((built + 1))
+            else
+                results+=("  FAIL  $target  (binary not found)")
+                echo "  FAILED: binary not found"
+                failed=$((failed + 1))
+            fi
+        else
+            results+=("  FAIL  $target")
+            echo "  FAILED"
+            failed=$((failed + 1))
+        fi
+        echo ""
+    done
+fi
 
 # --- Summary ---
 echo "=== Summary ==="

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -192,20 +192,23 @@ else
     echo "=== Building agent for ${#SELECTED_TARGETS[@]} target(s) in parallel ==="
     echo ""
 
-    declare -A _pids=()
-    declare -A _tmpfiles=()
-    declare -A _cross_dirs=()
+    # Parallel indexed arrays (bash 3.2 compatible — no declare -A needed).
+    # Index i matches SELECTED_TARGETS[i] throughout.
+    _pids=()
+    _tmpfiles=()
+    _cross_dirs=()
     _tmpfile_list=()
 
     # Clean up temp files on exit (normal or interrupted)
     trap 'rm -f "${_tmpfile_list[@]:-}"' EXIT
 
-    for target in "${SELECTED_TARGETS[@]}"; do
+    for i in "${!SELECTED_TARGETS[@]}"; do
+        target="${SELECTED_TARGETS[$i]}"
         cross_dir="target/cross/$target"
-        _cross_dirs[$target]=$cross_dir
+        _cross_dirs[$i]=$cross_dir
 
         tmpfile=$(mktemp)
-        _tmpfiles[$target]=$tmpfile
+        _tmpfiles[$i]=$tmpfile
         _tmpfile_list+=("$tmpfile")
 
         {
@@ -214,21 +217,22 @@ else
                 | { grep -v "^<jemalloc>" || true; }
         } > "$tmpfile" &
 
-        _pids[$target]=$!
-        echo "  $target: building... (PID ${_pids[$target]})"
+        _pids[$i]=$!
+        echo "  $target: building... (PID ${_pids[$i]})"
     done
     echo ""
 
-    for target in "${SELECTED_TARGETS[@]}"; do
+    for i in "${!SELECTED_TARGETS[@]}"; do
+        target="${SELECTED_TARGETS[$i]}"
         echo "--- $target ---"
 
         build_exit=0
-        wait "${_pids[$target]}" || build_exit=$?
+        wait "${_pids[$i]}" || build_exit=$?
 
-        cat "${_tmpfiles[$target]}"
+        cat "${_tmpfiles[$i]}"
 
         if [ "$build_exit" -eq 0 ]; then
-            cross_dir="${_cross_dirs[$target]}"
+            cross_dir="${_cross_dirs[$i]}"
             src_binary="$cross_dir/$target/release/termihub-agent"
             dst_dir="target/$target/release"
             dst_binary="$dst_dir/termihub-agent"

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -195,43 +195,44 @@ else
     # Parallel indexed arrays (bash 3.2 compatible — no declare -A needed).
     # Index i matches SELECTED_TARGETS[i] throughout.
     _pids=()
-    _tmpfiles=()
     _cross_dirs=()
-    _tmpfile_list=()
-
-    # Clean up temp files on exit (normal or interrupted)
-    trap 'rm -f "${_tmpfile_list[@]:-}"' EXIT
+    _exit_codes=()
 
     for i in "${!SELECTED_TARGETS[@]}"; do
         target="${SELECTED_TARGETS[$i]}"
         cross_dir="target/cross/$target"
         _cross_dirs[$i]=$cross_dir
 
-        tmpfile=$(mktemp)
-        _tmpfiles[$i]=$tmpfile
-        _tmpfile_list+=("$tmpfile")
-
+        # Stream output live with a [target] prefix so interleaved lines from
+        # concurrent builds are identifiable. The subshell inherits pipefail so
+        # cross's exit code propagates through the grep and sed stages.
         {
             CARGO_TARGET_DIR="$cross_dir" CROSS_CONFIG=agent/Cross.toml \
                 cross build --release --target "$target" -p termihub-agent 2>&1 \
-                | { grep -v "^<jemalloc>" || true; }
-        } > "$tmpfile" &
+                | { grep -v "^<jemalloc>" || true; } \
+                | sed "s/^/[$target] /"
+        } &
 
         _pids[$i]=$!
         echo "  $target: building... (PID ${_pids[$i]})"
     done
     echo ""
 
+    # Wait for every build to finish and collect its exit code.
+    # By waiting in order we don't suppress streaming output from still-running
+    # targets — their output continues flowing while we block on an earlier wait.
+    for i in "${!SELECTED_TARGETS[@]}"; do
+        _exit_codes[$i]=0
+        wait "${_pids[$i]}" || _exit_codes[$i]=$?
+    done
+    echo ""
+
+    # All builds finished — print clean per-target results with no streaming mix.
     for i in "${!SELECTED_TARGETS[@]}"; do
         target="${SELECTED_TARGETS[$i]}"
         echo "--- $target ---"
 
-        build_exit=0
-        wait "${_pids[$i]}" || build_exit=$?
-
-        cat "${_tmpfiles[$i]}"
-
-        if [ "$build_exit" -eq 0 ]; then
+        if [ "${_exit_codes[$i]}" -eq 0 ]; then
             cross_dir="${_cross_dirs[$i]}"
             src_binary="$cross_dir/$target/release/termihub-agent"
             dst_dir="target/$target/release"

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -204,13 +204,18 @@ else
         _cross_dirs[$i]=$cross_dir
 
         # Stream output live with a [target] prefix so interleaved lines from
-        # concurrent builds are identifiable. The subshell inherits pipefail so
-        # cross's exit code propagates through the grep and sed stages.
+        # concurrent builds are identifiable. A single awk replaces the former
+        # grep|sed two-stage pipe: when grep's stdout is a pipe (not a terminal)
+        # it switches to full block buffering, silencing output until the buffer
+        # fills. awk with fflush() flushes after every line regardless of whether
+        # stdout is a terminal or a pipe, keeping output immediate.
+        # The subshell inherits pipefail so cross's exit code propagates through
+        # the awk stage to the background job's exit status.
         {
             CARGO_TARGET_DIR="$cross_dir" CROSS_CONFIG=agent/Cross.toml \
                 cross build --release --target "$target" -p termihub-agent 2>&1 \
-                | { grep -v "^<jemalloc>" || true; } \
-                | sed "s/^/[$target] /"
+                | awk -v prefix="[$target] " \
+                      '!/^<jemalloc>/ { print prefix $0; fflush() }'
         } &
 
         _pids[$i]=$!


### PR DESCRIPTION
## Summary

- Builds all targets in parallel by default — each gets its own `CARGO_TARGET_DIR` (`target/cross/<target>/`) so the two cross-rs Docker containers run simultaneously without serializing on the workspace-level cargo build lock (`target/.cargo-lock`)
- Binaries are copied to the standard `target/<target>/release/` location after each parallel build completes
- `rustup target add` is moved before the build loop so it doesn't block parallel container startup
- `--sequential` flag available for debugging interleaved output

## Test plan

- [ ] Run `./scripts/build-agents.sh` — both containers should start simultaneously; verify output interleaves from both targets followed by sequential result display
- [ ] Run `./scripts/build-agents.sh --sequential` — should build one target at a time as before
- [ ] Run `./scripts/build-agents.sh --targets x86_64-unknown-linux-musl` — single target, uses sequential path
- [ ] Verify binaries appear at `target/x86_64-unknown-linux-musl/release/termihub-agent` and `target/aarch64-unknown-linux-musl/release/termihub-agent` after parallel build

🤖 Generated with [Claude Code](https://claude.com/claude-code)