### PR TITLE
fix(credential): show unlock dialog on demand, not on auto-lock timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Credential store: the unlock dialog no longer appears proactively every 15 minutes after auto-lock — the store still locks automatically, but the unlock prompt is only shown when a credential is actually needed (e.g. when connecting with stored credentials)
 - Agent build: `build-agents.sh` now builds multiple targets in parallel (each in its own `CARGO_TARGET_DIR` to avoid cargo build lock contention); add `--sequential` flag to opt out
 - Agent build: `build-agents.sh` and `setup-agent-cross.sh` now work correctly on ARM hosts (Apple Silicon, Raspberry Pi) — cross-rs Docker base images are pinned to `linux/amd64`, the container engine is auto-selected based on which engine already has the required images, missing images are caught early with a clear error, and jemalloc/QEMU noise is filtered from build output
 - Terminal: box-drawing characters (table borders, tree views) no longer render with pixel gaps between rows — the default `lineHeight` has been corrected from 1.2 to 1.0 (#579)

--- a/src-tauri/src/credential/manager.rs
+++ b/src-tauri/src/credential/manager.rs
@@ -2,10 +2,15 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
+use tauri::{AppHandle, Emitter};
+use tracing::warn;
 
 use super::auto_lock::AutoLockTimer;
 use super::types::{CredentialKey, CredentialStoreStatus, StorageMode};
 use super::{CredentialStore, MasterPasswordStore, NullStore};
+
+/// Event emitted when a credential is requested but the store is locked.
+const EVENT_STORE_UNLOCK_NEEDED: &str = "credential-store-unlock-needed";
 
 /// Internal storage backend enum, allowing direct access to
 /// backend-specific methods without trait-object downcasting.
@@ -24,6 +29,7 @@ pub struct CredentialManager {
     inner: RwLock<StoreBackend>,
     config_dir: PathBuf,
     auto_lock_timer: RwLock<Option<Arc<AutoLockTimer>>>,
+    app_handle: RwLock<Option<AppHandle>>,
 }
 
 impl CredentialManager {
@@ -37,6 +43,7 @@ impl CredentialManager {
             inner: RwLock::new(backend),
             config_dir,
             auto_lock_timer: RwLock::new(None),
+            app_handle: RwLock::new(None),
         }
     }
 
@@ -120,6 +127,23 @@ impl CredentialManager {
         }
     }
 
+    /// Set the app handle used for emitting events.
+    pub fn set_app_handle(&self, handle: AppHandle) {
+        let mut guard = self.app_handle.write().expect("app_handle lock poisoned");
+        *guard = Some(handle);
+    }
+
+    /// Emit the unlock-needed event so the UI can prompt the user.
+    fn emit_unlock_needed(&self) {
+        if let Ok(guard) = self.app_handle.read() {
+            if let Some(ref handle) = *guard {
+                if let Err(e) = handle.emit(EVENT_STORE_UNLOCK_NEEDED, ()) {
+                    warn!("Failed to emit {EVENT_STORE_UNLOCK_NEEDED}: {e}");
+                }
+            }
+        }
+    }
+
     /// Record credential activity on the auto-lock timer.
     fn record_activity(&self) {
         if let Ok(guard) = self.auto_lock_timer.read() {
@@ -144,12 +168,19 @@ impl CredentialManager {
 impl CredentialStore for CredentialManager {
     fn get(&self, key: &CredentialKey) -> Result<Option<String>> {
         let inner = self.inner.read().expect("credential manager lock poisoned");
+        let is_master_password_mode = matches!(*inner, StoreBackend::MasterPassword(_));
         let result = match *inner {
             StoreBackend::Null(ref s) => s.get(key),
             StoreBackend::MasterPassword(ref s) => s.get(key),
         };
         drop(inner);
-        self.record_activity();
+        if result.is_err() && is_master_password_mode {
+            // Credential access failed — almost certainly because the store is locked.
+            // Notify the UI so it can prompt the user to unlock on demand.
+            self.emit_unlock_needed();
+        } else {
+            self.record_activity();
+        }
         result
     }
 
@@ -266,6 +297,22 @@ mod tests {
         let key = CredentialKey::new("conn-1", CredentialType::Password);
         mgr.set(&key, "my-secret").unwrap();
         assert_eq!(mgr.get(&key).unwrap(), Some("my-secret".to_string()));
+    }
+
+    #[test]
+    fn get_on_locked_store_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::MasterPassword, dir.path().to_path_buf());
+
+        // Set up and then lock the master password store
+        mgr.with_master_password_store(|s| s.setup("test-pw"))
+            .unwrap()
+            .unwrap();
+        mgr.with_master_password_store(|s| s.lock()).unwrap();
+
+        let key = CredentialKey::new("conn-1", CredentialType::Password);
+        // get() must fail when locked; without an app_handle the emit is silently skipped
+        assert!(mgr.get(&key).is_err());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -159,6 +159,7 @@ pub fn run() {
                     .unwrap_or(false);
 
             let credential_manager = Arc::new(credential_manager);
+            credential_manager.set_app_handle(app.handle().clone());
 
             // Set up auto-lock timer for master password mode
             let auto_lock_minutes = settings.credential_auto_lock_minutes.or(Some(15));

--- a/src/hooks/useCredentialStoreEvents.test.ts
+++ b/src/hooks/useCredentialStoreEvents.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/services/events", () => ({
   onCredentialStoreLocked: vi.fn(),
   onCredentialStoreUnlocked: vi.fn(),
   onCredentialStoreStatusChanged: vi.fn(),
+  onCredentialStoreUnlockNeeded: vi.fn(),
 }));
 
 vi.mock("@/services/storage", () => ({
@@ -43,6 +44,7 @@ import {
   onCredentialStoreLocked,
   onCredentialStoreUnlocked,
   onCredentialStoreStatusChanged,
+  onCredentialStoreUnlockNeeded,
 } from "@/services/events";
 import { useAppStore } from "@/store/appStore";
 import { useCredentialStoreEvents } from "./useCredentialStoreEvents";
@@ -50,6 +52,7 @@ import { useCredentialStoreEvents } from "./useCredentialStoreEvents";
 const mockOnLocked = vi.mocked(onCredentialStoreLocked);
 const mockOnUnlocked = vi.mocked(onCredentialStoreUnlocked);
 const mockOnStatusChanged = vi.mocked(onCredentialStoreStatusChanged);
+const mockOnUnlockNeeded = vi.mocked(onCredentialStoreUnlockNeeded);
 
 function HookConsumer() {
   useCredentialStoreEvents();
@@ -62,9 +65,11 @@ describe("useCredentialStoreEvents", () => {
   let lockedHandler: (() => void) | undefined;
   let unlockedHandler: (() => void) | undefined;
   let statusChangedHandler: ((status: unknown) => void) | undefined;
+  let unlockNeededHandler: (() => void) | undefined;
   const unlistenLocked = vi.fn();
   const unlistenUnlocked = vi.fn();
   const unlistenStatusChanged = vi.fn();
+  const unlistenUnlockNeeded = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -82,6 +87,10 @@ describe("useCredentialStoreEvents", () => {
       statusChangedHandler = cb as (status: unknown) => void;
       return Promise.resolve(unlistenStatusChanged);
     });
+    mockOnUnlockNeeded.mockImplementation((cb) => {
+      unlockNeededHandler = cb;
+      return Promise.resolve(unlistenUnlockNeeded);
+    });
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -93,7 +102,7 @@ describe("useCredentialStoreEvents", () => {
     container.remove();
   });
 
-  it("registers all three event listeners on mount", async () => {
+  it("registers all four event listeners on mount", async () => {
     await act(async () => {
       root.render(createElement(HookConsumer));
     });
@@ -101,9 +110,10 @@ describe("useCredentialStoreEvents", () => {
     expect(mockOnLocked).toHaveBeenCalledTimes(1);
     expect(mockOnUnlocked).toHaveBeenCalledTimes(1);
     expect(mockOnStatusChanged).toHaveBeenCalledTimes(1);
+    expect(mockOnUnlockNeeded).toHaveBeenCalledTimes(1);
   });
 
-  it("opens unlock dialog when locked event fires", async () => {
+  it("does NOT open unlock dialog when locked event fires (auto-lock is silent)", async () => {
     await act(async () => {
       root.render(createElement(HookConsumer));
     });
@@ -114,6 +124,20 @@ describe("useCredentialStoreEvents", () => {
       lockedHandler?.();
     });
 
+    expect(useAppStore.getState().unlockDialogOpen).toBe(false);
+  });
+
+  it("opens unlock dialog when unlock-needed event fires", async () => {
+    await act(async () => {
+      root.render(createElement(HookConsumer));
+    });
+
+    expect(useAppStore.getState().unlockDialogOpen).toBe(false);
+
+    await act(async () => {
+      unlockNeededHandler?.();
+    });
+
     expect(useAppStore.getState().unlockDialogOpen).toBe(true);
   });
 
@@ -122,13 +146,13 @@ describe("useCredentialStoreEvents", () => {
       root.render(createElement(HookConsumer));
     });
 
-    // First open it
+    // Open it via the unlock-needed event (demand-driven)
     await act(async () => {
-      lockedHandler?.();
+      unlockNeededHandler?.();
     });
     expect(useAppStore.getState().unlockDialogOpen).toBe(true);
 
-    // Then close it
+    // Then close it when the store is unlocked
     await act(async () => {
       unlockedHandler?.();
     });
@@ -161,5 +185,6 @@ describe("useCredentialStoreEvents", () => {
     expect(unlistenLocked).toHaveBeenCalledTimes(1);
     expect(unlistenUnlocked).toHaveBeenCalledTimes(1);
     expect(unlistenStatusChanged).toHaveBeenCalledTimes(1);
+    expect(unlistenUnlockNeeded).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/useCredentialStoreEvents.ts
+++ b/src/hooks/useCredentialStoreEvents.ts
@@ -4,6 +4,7 @@ import {
   onCredentialStoreLocked,
   onCredentialStoreUnlocked,
   onCredentialStoreStatusChanged,
+  onCredentialStoreUnlockNeeded,
 } from "@/services/events";
 
 /**
@@ -19,11 +20,14 @@ export function useCredentialStoreEvents(): void {
     let unlistenLocked: (() => void) | null = null;
     let unlistenUnlocked: (() => void) | null = null;
     let unlistenStatusChanged: (() => void) | null = null;
+    let unlistenUnlockNeeded: (() => void) | null = null;
 
     const setup = async () => {
+      // When the store locks (e.g. auto-lock timer), just refresh status silently.
+      // Do NOT open the unlock dialog proactively — only do so when credentials
+      // are actually needed (see unlock-needed handler below).
       unlistenLocked = await onCredentialStoreLocked(() => {
         loadCredentialStoreStatus();
-        setUnlockDialogOpen(true);
       });
 
       unlistenUnlocked = await onCredentialStoreUnlocked(() => {
@@ -34,6 +38,12 @@ export function useCredentialStoreEvents(): void {
       unlistenStatusChanged = await onCredentialStoreStatusChanged((status) => {
         setCredentialStoreStatus(status);
       });
+
+      // Open the unlock dialog only when a credential access is attempted
+      // while the store is locked (demand-driven unlock).
+      unlistenUnlockNeeded = await onCredentialStoreUnlockNeeded(() => {
+        setUnlockDialogOpen(true);
+      });
     };
 
     setup();
@@ -42,6 +52,7 @@ export function useCredentialStoreEvents(): void {
       unlistenLocked?.();
       unlistenUnlocked?.();
       unlistenStatusChanged?.();
+      unlistenUnlockNeeded?.();
     };
   }, [setCredentialStoreStatus, loadCredentialStoreStatus, setUnlockDialogOpen]);
 }

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -348,6 +348,13 @@ export async function onCredentialStoreStatusChanged(
   });
 }
 
+/** Subscribe to credential store unlock-needed events (fired when a credential is requested while locked). */
+export async function onCredentialStoreUnlockNeeded(callback: () => void): Promise<UnlistenFn> {
+  return await listen("credential-store-unlock-needed", () => {
+    callback();
+  });
+}
+
 /** Subscribe to embedded server status change events. */
 export async function onEmbeddedServerStatusChanged(
   callback: (state: ServerState) => void


### PR DESCRIPTION
## Summary

- The unlock dialog was firing proactively every time the 15-minute auto-lock timer expired, interrupting users even when they weren't using any credentials
- The store still locks after 15 minutes of inactivity (status bar icon updates) — but no dialog opens
- The dialog now appears only when a credential access is actually attempted while the store is locked (e.g. connecting via SSH with a stored password)

## How it works

A new `credential-store-unlock-needed` backend event is emitted from `CredentialManager::get()` whenever a credential fetch fails in master-password mode (which always means the store is locked). The frontend listens for this event and opens the unlock dialog on demand instead of reacting to the generic `credential-store-locked` event.

## Test plan

- [ ] Set auto-lock to a short value (e.g. 1 minute) and wait — the store should lock and the status bar icon should update, but **no dialog should appear**
- [ ] With the store locked, try to connect to an SSH host that uses a stored password — the unlock dialog should appear at that point
- [ ] Unlock, connect successfully, re-lock manually via the status bar icon — no dialog
- [ ] On app startup with an existing locked credential file — unlock dialog still appears (handled by `appStore.ts loadFromBackend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)