### PR TITLE
feat(shell): visible shell integration with Shell Integration setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Shell integration (OSC 7 CWD tracking) is now **visible by default**: the setup command runs in the terminal at startup with a `# [termiHub] Shell integration: setting up OSC 7 CWD tracking` notice, instead of being silently erased. This applies to local bash, SSH, and WSL connections.
+- WSL: the setup script no longer contains erase sequences; the `source` command and the echo notice are left visible in the terminal.
+
 ### Added
 
+- Connection settings: a **Shell Integration** toggle is now available for local shell, SSH, and WSL connections (enabled by default). Disabling it skips all OSC injection at startup.
+- Connection settings: boolean fields now support an optional **help icon (?)** that opens an explanation dialog. The Shell Integration toggle uses this to explain what OSC 7 tracking is and why it's useful.
 - Tests: `core/tests/ssh_banner.rs` — two new Rust integration tests (SSH-BANNER-01, SSH-BANNER-02) for the `ssh-banner` Docker container, verifying that the pre-auth banner text is delivered and that standard SSH servers send no banner
 - Tests: ECDSA-384 and ECDSA-521 passphrase-protected key fixtures (`tests/fixtures/ssh-keys/`) and corresponding integration tests (SSH-AUTH-13, SSH-AUTH-14), completing passphrase coverage across all supported ECDSA curve sizes
 

--- a/core/src/backends/docker/mod.rs
+++ b/core/src/backends/docker/mod.rs
@@ -326,6 +326,7 @@ impl ConnectionType for Docker {
                             description: Some(
                                 "Docker image to use (e.g., ubuntu:22.04)".to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::Text,
                             required: true,
                             default: None,
@@ -341,6 +342,7 @@ impl ConnectionType for Docker {
                                 "Shell to use inside the container (leave empty for /bin/sh)"
                                     .to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::Text,
                             required: false,
                             default: None,
@@ -355,6 +357,7 @@ impl ConnectionType for Docker {
                             description: Some(
                                 "Initial working directory inside the container".to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::Text,
                             required: false,
                             default: None,
@@ -369,6 +372,7 @@ impl ConnectionType for Docker {
                             description: Some(
                                 "Remove the container when the session is closed".to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::Boolean,
                             required: false,
                             default: Some(serde_json::json!(true)),
@@ -384,6 +388,7 @@ impl ConnectionType for Docker {
                                 "Container runtime to use (Auto detects Docker or Podman)"
                                     .to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::Select {
                                 options: vec![
                                     SelectOption {
@@ -419,6 +424,7 @@ impl ConnectionType for Docker {
                             description: Some(
                                 "Environment variables to set inside the container".to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::KeyValueList,
                             required: false,
                             default: None,
@@ -431,12 +437,14 @@ impl ConnectionType for Docker {
                             key: "volumes".to_string(),
                             label: "Volumes".to_string(),
                             description: Some("Volume mounts from host to container".to_string()),
+                            help_text: None,
                             field_type: FieldType::ObjectList {
                                 fields: vec![
                                     SettingsField {
                                         key: "hostPath".to_string(),
                                         label: "Host Path".to_string(),
                                         description: Some("Path on the host machine".to_string()),
+                                        help_text: None,
                                         field_type: FieldType::Text,
                                         required: true,
                                         default: None,
@@ -449,6 +457,7 @@ impl ConnectionType for Docker {
                                         key: "containerPath".to_string(),
                                         label: "Container Path".to_string(),
                                         description: Some("Path inside the container".to_string()),
+                                        help_text: None,
                                         field_type: FieldType::Text,
                                         required: true,
                                         default: None,
@@ -463,6 +472,7 @@ impl ConnectionType for Docker {
                                         description: Some(
                                             "Mount the volume as read-only".to_string(),
                                         ),
+                                        help_text: None,
                                         field_type: FieldType::Boolean,
                                         required: false,
                                         default: Some(serde_json::json!(false)),

--- a/core/src/backends/local_shell.rs
+++ b/core/src/backends/local_shell.rs
@@ -116,6 +116,7 @@ impl ConnectionType for LocalShell {
                         key: "shell".to_string(),
                         label: "Shell".to_string(),
                         description: Some("Shell program to use".to_string()),
+                        help_text: None,
                         field_type: FieldType::Select {
                             options: shell_options,
                         },
@@ -130,6 +131,7 @@ impl ConnectionType for LocalShell {
                         key: "customShellPath".to_string(),
                         label: "Shell Executable Path".to_string(),
                         description: Some("Full path to the shell executable".to_string()),
+                        help_text: None,
                         field_type: FieldType::Text,
                         required: false,
                         default: None,
@@ -147,6 +149,7 @@ impl ConnectionType for LocalShell {
                         description: Some(
                             "Directory to start the shell in (defaults to home)".to_string(),
                         ),
+                        help_text: None,
                         field_type: FieldType::FilePath {
                             kind: FilePathKind::Directory,
                         },
@@ -161,11 +164,36 @@ impl ConnectionType for LocalShell {
                         key: "initialCommand".to_string(),
                         label: "Initial Command".to_string(),
                         description: Some("Command to run after the shell starts".to_string()),
+                        help_text: None,
                         field_type: FieldType::Text,
                         required: false,
                         default: None,
                         placeholder: None,
                         supports_env_expansion: true,
+                        supports_tilde_expansion: false,
+                        visible_when: None,
+                    },
+                    SettingsField {
+                        key: "shellIntegration".to_string(),
+                        label: "Shell Integration".to_string(),
+                        description: Some(
+                            "Inject OSC 7 CWD tracking at startup (used by the file browser)"
+                                .to_string(),
+                        ),
+                        help_text: Some(concat!(
+                            "When enabled, termiHub injects a small shell function at startup ",
+                            "that emits OSC 7 (current working directory) sequences on every prompt.\n\n",
+                            "This lets the file browser automatically follow the current directory ",
+                            "as you navigate in the shell.\n\n",
+                            "The setup runs visibly in the terminal — you can always see what ",
+                            "termiHub is doing. Disable this if you manage your own shell ",
+                            "integration or prefer a clean terminal start.",
+                        ).to_string()),
+                        field_type: FieldType::Boolean,
+                        required: false,
+                        default: Some(serde_json::json!(true)),
+                        placeholder: None,
+                        supports_env_expansion: false,
                         supports_tilde_expansion: false,
                         visible_when: None,
                     },
@@ -216,6 +244,10 @@ impl ConnectionType for LocalShell {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(String::from);
+        let shell_integration = settings
+            .get("shellIntegration")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
 
         // Resolve effective shell name for OSC 7 injection below.
         let effective_shell = shell
@@ -232,11 +264,14 @@ impl ConnectionType for LocalShell {
 
         let shell_cmd = build_shell_command(&config);
 
-        // Determine OSC 7 CWD tracking injection strategy.
-        // PowerShell: pass via -NoExit -Command so it runs silently before the
-        // interactive session starts, avoiding any visible echo in the terminal.
-        // All other shells (bash, WSL, git-bash): inject via stdin after spawn.
-        let osc7_setup = osc7_setup_command(&effective_shell, config.cols);
+        // Determine OSC 7 CWD tracking injection strategy (when shell integration is enabled).
+        // PowerShell: pass via -NoExit -Command startup args.
+        // All other shells (bash, git-bash): inject via stdin after spawn.
+        let osc7_setup = if shell_integration {
+            osc7_setup_command(&effective_shell)
+        } else {
+            None
+        };
 
         info!(
             program = %shell_cmd.program,
@@ -258,21 +293,20 @@ impl ConnectionType for LocalShell {
         for arg in &shell_cmd.args {
             command.arg(arg);
         }
-        // PowerShell / cmd: inject OSC 7 prompt hook via startup args to avoid
-        // the setup command being echoed visibly in the terminal.
+        // PowerShell / cmd: inject OSC 7 prompt hook via startup args.
         // PowerShell uses -NoExit -Command; cmd uses /K.
         match effective_shell.as_str() {
             "powershell" => {
-                if let Some(ref setup) = osc7_setup {
+                if let Some(setup) = osc7_setup {
                     command.arg("-NoExit");
                     command.arg("-Command");
-                    command.arg(setup.as_str());
+                    command.arg(setup);
                 }
             }
             "cmd" => {
-                if let Some(ref setup) = osc7_setup {
+                if let Some(setup) = osc7_setup {
                     command.arg("/K");
-                    command.arg(setup.as_str());
+                    command.arg(setup);
                 }
             }
             _ => {}
@@ -361,7 +395,7 @@ impl ConnectionType for LocalShell {
         // Inject OSC 7 PROMPT_COMMAND hook for CWD tracking via stdin.
         // Bash (and Git Bash) don't emit OSC 7 by default, so we inject a
         // PROMPT_COMMAND that emits it on each prompt. PowerShell and cmd were
-        // already handled via startup args above to avoid visible echo.
+        // already handled via startup args above.
         // Errors are non-fatal — the shell works without CWD tracking.
         let uses_startup_args = matches!(effective_shell.as_str(), "powershell" | "cmd");
         if !uses_startup_args {

--- a/core/src/backends/serial.rs
+++ b/core/src/backends/serial.rs
@@ -155,6 +155,7 @@ impl ConnectionType for Serial {
                         description: Some(
                             "Serial port device name (e.g., COM3, /dev/ttyUSB0)".to_string(),
                         ),
+                        help_text: None,
                         field_type: FieldType::Text,
                         required: true,
                         default: None,
@@ -171,6 +172,7 @@ impl ConnectionType for Serial {
                         key: "baudRate".to_string(),
                         label: "Baud Rate".to_string(),
                         description: Some("Communication speed".to_string()),
+                        help_text: None,
                         field_type: FieldType::Select {
                             options: baud_rate_options(),
                         },
@@ -185,6 +187,7 @@ impl ConnectionType for Serial {
                         key: "dataBits".to_string(),
                         label: "Data Bits".to_string(),
                         description: None,
+                        help_text: None,
                         field_type: FieldType::Select {
                             options: data_bits_options(),
                         },
@@ -199,6 +202,7 @@ impl ConnectionType for Serial {
                         key: "stopBits".to_string(),
                         label: "Stop Bits".to_string(),
                         description: None,
+                        help_text: None,
                         field_type: FieldType::Select {
                             options: stop_bits_options(),
                         },
@@ -213,6 +217,7 @@ impl ConnectionType for Serial {
                         key: "parity".to_string(),
                         label: "Parity".to_string(),
                         description: None,
+                        help_text: None,
                         field_type: FieldType::Select {
                             options: parity_options(),
                         },
@@ -227,6 +232,7 @@ impl ConnectionType for Serial {
                         key: "flowControl".to_string(),
                         label: "Flow Control".to_string(),
                         description: None,
+                        help_text: None,
                         field_type: FieldType::Select {
                             options: flow_control_options(),
                         },

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -172,6 +172,7 @@ impl ConnectionType for Ssh {
                             description: Some(
                                 "Hostname or IP address of the SSH server".to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::Text,
                             required: true,
                             default: None,
@@ -184,6 +185,7 @@ impl ConnectionType for Ssh {
                             key: "port".to_string(),
                             label: "Port".to_string(),
                             description: Some("SSH port number".to_string()),
+                            help_text: None,
                             field_type: FieldType::Port,
                             required: true,
                             default: Some(serde_json::json!(22)),
@@ -196,6 +198,7 @@ impl ConnectionType for Ssh {
                             key: "username".to_string(),
                             label: "Username".to_string(),
                             description: Some("SSH login username".to_string()),
+                            help_text: None,
                             field_type: FieldType::Text,
                             required: true,
                             default: None,
@@ -214,6 +217,7 @@ impl ConnectionType for Ssh {
                             key: "authMethod".to_string(),
                             label: "Method".to_string(),
                             description: Some("Authentication method to use".to_string()),
+                            help_text: None,
                             field_type: FieldType::Select {
                                 options: vec![
                                     SelectOption {
@@ -241,6 +245,7 @@ impl ConnectionType for Ssh {
                             key: "password".to_string(),
                             label: "Password".to_string(),
                             description: None,
+                            help_text: None,
                             field_type: FieldType::Password,
                             required: false,
                             default: None,
@@ -256,6 +261,7 @@ impl ConnectionType for Ssh {
                             key: "keyPath".to_string(),
                             label: "Key Path".to_string(),
                             description: Some("Path to SSH private key file".to_string()),
+                            help_text: None,
                             field_type: FieldType::FilePath {
                                 kind: FilePathKind::File,
                             },
@@ -273,6 +279,7 @@ impl ConnectionType for Ssh {
                             key: "savePassword".to_string(),
                             label: "Save credentials".to_string(),
                             description: Some("Store credentials for automatic login".to_string()),
+                            help_text: None,
                             field_type: FieldType::Boolean,
                             required: false,
                             default: Some(serde_json::json!(false)),
@@ -293,6 +300,7 @@ impl ConnectionType for Ssh {
                             description: Some(
                                 "Remote shell to use (leave empty for default)".to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::Text,
                             required: false,
                             default: None,
@@ -307,6 +315,7 @@ impl ConnectionType for Ssh {
                             description: Some(
                                 "Forward X11 display from remote to local".to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::Boolean,
                             required: false,
                             default: Some(serde_json::json!(false)),
@@ -321,11 +330,36 @@ impl ConnectionType for Ssh {
                             description: Some(
                                 "Additional environment variables for the remote shell".to_string(),
                             ),
+                            help_text: None,
                             field_type: FieldType::KeyValueList,
                             required: false,
                             default: None,
                             placeholder: None,
                             supports_env_expansion: true,
+                            supports_tilde_expansion: false,
+                            visible_when: None,
+                        },
+                        SettingsField {
+                            key: "shellIntegration".to_string(),
+                            label: "Shell Integration".to_string(),
+                            description: Some(
+                                "Inject OSC 7 CWD tracking at startup (used by the file browser)"
+                                    .to_string(),
+                            ),
+                            help_text: Some(concat!(
+                                "When enabled, termiHub injects a small shell function at startup ",
+                                "that emits OSC 7 (current working directory) sequences on every prompt.\n\n",
+                                "This lets the file browser automatically follow the current directory ",
+                                "as you navigate in the shell.\n\n",
+                                "The setup runs visibly in the terminal — you can always see what ",
+                                "termiHub is doing. Disable this if you manage your own shell ",
+                                "integration or prefer a clean terminal start.",
+                            ).to_string()),
+                            field_type: FieldType::Boolean,
+                            required: false,
+                            default: Some(serde_json::json!(true)),
+                            placeholder: None,
+                            supports_env_expansion: false,
                             supports_tilde_expansion: false,
                             visible_when: None,
                         },
@@ -348,6 +382,11 @@ impl ConnectionType for Ssh {
         if self.state.is_some() {
             return Err(SessionError::AlreadyExists("Already connected".to_string()));
         }
+
+        let shell_integration = settings
+            .get("shellIntegration")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
 
         let config = parse_ssh_settings(&settings);
         let config = config.expand();
@@ -425,14 +464,14 @@ impl ConnectionType for Ssh {
             }
         }
 
-        // Inject OSC 7 PROMPT_COMMAND hook for CWD tracking.
-        // The remote shell (typically bash) doesn't emit OSC 7 by default,
-        // so we inject a PROMPT_COMMAND that emits it on each prompt.
-        // Errors are non-fatal — the shell works without CWD tracking.
-        if let Some(setup) = osc7_setup_command("ssh", config.cols) {
-            let cmd = format!("{setup}\n");
-            if let Err(e) = channel.write_all(cmd.as_bytes()) {
-                debug!("Failed to inject OSC 7 hook: {e}");
+        // Inject OSC 7 PROMPT_COMMAND hook for CWD tracking when shell
+        // integration is enabled. Errors are non-fatal.
+        if shell_integration {
+            if let Some(setup) = osc7_setup_command("ssh") {
+                let cmd = format!("{setup}\n");
+                if let Err(e) = channel.write_all(cmd.as_bytes()) {
+                    debug!("Failed to inject OSC 7 hook: {e}");
+                }
             }
         }
 
@@ -698,7 +737,10 @@ mod tests {
         let schema = ssh.settings_schema();
         let group = &schema.groups[2];
         let keys: Vec<&str> = group.fields.iter().map(|f| f.key.as_str()).collect();
-        assert_eq!(keys, vec!["shell", "enableX11Forwarding", "env"]);
+        assert_eq!(
+            keys,
+            vec!["shell", "enableX11Forwarding", "env", "shellIntegration"]
+        );
     }
 
     #[test]

--- a/core/src/backends/telnet.rs
+++ b/core/src/backends/telnet.rs
@@ -146,6 +146,7 @@ impl ConnectionType for Telnet {
                         description: Some(
                             "Hostname or IP address of the telnet server".to_string(),
                         ),
+                        help_text: None,
                         field_type: FieldType::Text,
                         required: true,
                         default: None,
@@ -158,6 +159,7 @@ impl ConnectionType for Telnet {
                         key: "port".to_string(),
                         label: "Port".to_string(),
                         description: Some("TCP port number".to_string()),
+                        help_text: None,
                         field_type: FieldType::Port,
                         required: true,
                         default: Some(serde_json::json!(23)),

--- a/core/src/backends/wsl.rs
+++ b/core/src/backends/wsl.rs
@@ -389,8 +389,7 @@ fn pty_write(writer: &Arc<Mutex<Box<dyn Write + Send>>>, data: &[u8]) {
     }
 }
 
-/// Async task that silently injects the WSL OSC 7 CWD hook after the shell
-/// is ready.
+/// Async task that injects the WSL OSC 7 CWD hook after the shell is ready.
 ///
 /// # Why temp file instead of stdin injection
 ///
@@ -404,8 +403,9 @@ fn pty_write(writer: &Arc<Mutex<Box<dyn Write + Send>>>, data: &[u8]) {
 ///    in zsh regardless of terminal echo settings.
 ///
 /// Sourcing a file sidesteps both issues: the `source` line is the only
-/// thing that appears (one short, easy-to-erase line), and the file contents
-/// are read and executed entirely out of band — ZLE never sees them.
+/// thing that appears, and the file contents are read and executed entirely
+/// out of band — ZLE never sees them. The script itself prints a visible
+/// notice so the user knows what termiHub is doing.
 ///
 /// # Protocol
 ///
@@ -420,34 +420,26 @@ fn pty_write(writer: &Arc<Mutex<Box<dyn Write + Send>>>, data: &[u8]) {
 ///    `Wsl/Service/E_UNEXPECTED` on some Windows configurations when a second
 ///    WSL process starts while the first is still initializing.
 ///
-/// 3. Inject `source INIT_SCRIPT_LINUX_PATH 2>/dev/null` into the PTY.  This
-///    line is echoed/displayed (unavoidable), but it is erased by the script's
-///    own `printf` before the next prompt appears.  The `2>/dev/null` suppresses
-///    any "no such file" error from a rare UNC-visibility race condition.
+/// 3. Inject `source INIT_SCRIPT_LINUX_PATH 2>/dev/null` into the PTY. The
+///    `source` line is echoed/displayed (unavoidable), and the script's own
+///    `echo` message appears on the next line before the prompt returns.
+///    The `2>/dev/null` suppresses any "no such file" error from a rare
+///    UNC-visibility race condition.
 ///
 /// If the UNC write fails, fall back to direct injection — the setup command
 /// will be visible, but CWD tracking still works.
-async fn wsl_silent_setup(
+async fn wsl_setup(
     mut tap_rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    setup_cmd: String,
+    setup_cmd: &'static str,
     unc_prefix: String,
 ) {
     // Phase 1 — wait for the shell to be ready.
     wait_for_shell_ready(&mut tap_rx, 500, Duration::from_secs(5)).await;
 
     // Phase 2 — write the setup script via the Windows UNC path.
-    //
-    // The script ends with:
-    //   rm -f <path>           — self-cleanup
-    //   printf '\r\033[2K...'  — erase the `source <path>` display line
-    //
-    // Two cursor-ups cover: the blank line after the source newline + the
-    // `source <path>` line itself (fits in one terminal row for any reasonable
-    // prompt length).
-    let script = format!(
-        "{setup_cmd}\nrm -f {INIT_SCRIPT_LINUX_PATH}\nprintf '\\r\\033[2K\\033[A\\033[2K\\033[A\\033[2K'\n"
-    );
+    // The script self-cleans the temp file; no erase sequences are emitted.
+    let script = format!("{setup_cmd}\nrm -f {INIT_SCRIPT_LINUX_PATH}\n");
 
     // Convert the Linux path to a Windows UNC path for writing from the host.
     // e.g. /tmp/.termihub_init → \\wsl.localhost\Ubuntu\tmp\.termihub_init
@@ -466,9 +458,9 @@ async fn wsl_silent_setup(
 
     match write_result {
         Ok(()) => {
-            // Phase 3 — inject `source` (the only visible line; erased by script).
-            // The `2>/dev/null` silences any rare UNC-visibility race where the
-            // file isn't yet visible inside WSL at the moment source runs.
+            // Phase 3 — inject `source`. The line is echoed in the terminal;
+            // the script's echo message appears on the next line.
+            // The `2>/dev/null` suppresses any rare UNC-visibility race error.
             pty_write(
                 &writer,
                 format!("source {INIT_SCRIPT_LINUX_PATH} 2>/dev/null\n").as_bytes(),
@@ -476,7 +468,7 @@ async fn wsl_silent_setup(
             debug!("WSL setup: init script written via UNC and sourced");
         }
         Err(e) => {
-            // Fallback: direct injection.  Visible but functional.
+            // Fallback: direct injection.
             warn!("WSL setup: could not write init script via UNC ({e}); falling back to direct injection");
             pty_write(&writer, setup_cmd.as_bytes());
             pty_write(&writer, b"\n");
@@ -534,6 +526,7 @@ impl ConnectionType for Wsl {
                         key: "distribution".to_string(),
                         label: "Distribution".to_string(),
                         description: Some("WSL distribution to connect to".to_string()),
+                        help_text: None,
                         field_type: FieldType::Select {
                             options: distro_options,
                         },
@@ -550,6 +543,7 @@ impl ConnectionType for Wsl {
                         description: Some(
                             "Directory to start the shell in (defaults to home)".to_string(),
                         ),
+                        help_text: None,
                         field_type: FieldType::FilePath {
                             kind: FilePathKind::Directory,
                         },
@@ -564,11 +558,36 @@ impl ConnectionType for Wsl {
                         key: "initialCommand".to_string(),
                         label: "Initial Command".to_string(),
                         description: Some("Command to run after the shell starts".to_string()),
+                        help_text: None,
                         field_type: FieldType::Text,
                         required: false,
                         default: None,
                         placeholder: None,
                         supports_env_expansion: true,
+                        supports_tilde_expansion: false,
+                        visible_when: None,
+                    },
+                    SettingsField {
+                        key: "shellIntegration".to_string(),
+                        label: "Shell Integration".to_string(),
+                        description: Some(
+                            "Inject OSC 7 CWD tracking at startup (used by the file browser)"
+                                .to_string(),
+                        ),
+                        help_text: Some(concat!(
+                            "When enabled, termiHub injects a small shell function at startup ",
+                            "that emits OSC 7 (current working directory) sequences on every prompt.\n\n",
+                            "This lets the file browser automatically follow the current directory ",
+                            "as you navigate in the shell.\n\n",
+                            "The setup runs visibly in the terminal — you can always see what ",
+                            "termiHub is doing. Disable this if you manage your own shell ",
+                            "integration or prefer a clean terminal start.",
+                        ).to_string()),
+                        field_type: FieldType::Boolean,
+                        required: false,
+                        default: Some(serde_json::json!(true)),
+                        placeholder: None,
+                        supports_env_expansion: false,
                         supports_tilde_expansion: false,
                         visible_when: None,
                     },
@@ -612,6 +631,10 @@ impl ConnectionType for Wsl {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(String::from);
+        let shell_integration = settings
+            .get("shellIntegration")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
 
         let config = WslConfig {
             distribution: distribution.clone(),
@@ -651,11 +674,13 @@ impl ConnectionType for Wsl {
         for arg in &args {
             command.arg(arg);
         }
-        // Pre-set PROMPT_COMMAND via env var for silent, immediate CWD tracking.
+        // Pre-set PROMPT_COMMAND via env var for immediate CWD tracking.
         // WSL bash inherits Windows environment variables, so this fires even
         // before .bashrc runs.  The async setup task below upgrades it to the
         // full __termihub_osc7 hook (with zsh support) once the shell is ready.
-        command.env("PROMPT_COMMAND", r#"printf '\e]7;file://%s\a' "$PWD""#);
+        if shell_integration {
+            command.env("PROMPT_COMMAND", r#"printf '\e]7;file://%s\a' "$PWD""#);
+        }
         // Set TERM for the WSL environment.
         command.env("TERM", "xterm-256color");
         command.env("COLORTERM", "truecolor");
@@ -763,17 +788,15 @@ impl ConnectionType for Wsl {
             unc_prefix: unc_prefix.clone(),
         });
 
-        // Spawn the silent setup task.  It watches the tap channel for the first
-        // OSC 7 emission from the PROMPT_COMMAND env var (= shell ready, .bashrc
-        // has run, systemd startup noise is done), then writes the hook via the
-        // UNC path and sources it — no second wsl.exe process is spawned.
-        if let Some(setup_cmd) = osc7_setup_command(&shell_key, config.cols) {
-            tokio::spawn(wsl_silent_setup(
-                tap_rx,
-                setup_writer,
-                setup_cmd,
-                unc_prefix,
-            ));
+        // Spawn the setup task when shell integration is enabled.  It watches
+        // the tap channel for the first OSC 7 emission from the PROMPT_COMMAND
+        // env var (= shell ready, .bashrc has run, systemd startup noise is
+        // done), then writes the hook via the UNC path and sources it — no
+        // second wsl.exe process is spawned.
+        if shell_integration {
+            if let Some(setup_cmd) = osc7_setup_command(&shell_key) {
+                tokio::spawn(wsl_setup(tap_rx, setup_writer, setup_cmd, unc_prefix));
+            }
         }
 
         Ok(())

--- a/core/src/connection/registry.rs
+++ b/core/src/connection/registry.rs
@@ -170,6 +170,7 @@ mod tests {
                         key: "host".to_string(),
                         label: "Host".to_string(),
                         description: None,
+                        help_text: None,
                         field_type: FieldType::Text,
                         required: true,
                         default: None,

--- a/core/src/connection/schema.rs
+++ b/core/src/connection/schema.rs
@@ -40,6 +40,10 @@ pub struct SettingsField {
     /// Optional help text shown below the field.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Optional extended help text shown in a dialog when the user clicks
+    /// the help icon (?) next to the field. Supports multi-line plain text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_text: Option<String>,
     /// The input type and any type-specific constraints.
     pub field_type: FieldType,
     /// Whether this field must have a value before connecting.
@@ -154,6 +158,7 @@ mod tests {
                             key: "host".to_string(),
                             label: "Hostname".to_string(),
                             description: Some("SSH server address".to_string()),
+                            help_text: None,
                             field_type: FieldType::Text,
                             required: true,
                             default: None,
@@ -166,6 +171,7 @@ mod tests {
                             key: "port".to_string(),
                             label: "Port".to_string(),
                             description: None,
+                            help_text: None,
                             field_type: FieldType::Port,
                             required: true,
                             default: Some(serde_json::json!(22)),
@@ -184,6 +190,7 @@ mod tests {
                             key: "authMethod".to_string(),
                             label: "Auth Method".to_string(),
                             description: None,
+                            help_text: None,
                             field_type: FieldType::Select {
                                 options: vec![
                                     SelectOption {
@@ -207,6 +214,7 @@ mod tests {
                             key: "keyPath".to_string(),
                             label: "Key Path".to_string(),
                             description: None,
+                            help_text: None,
                             field_type: FieldType::FilePath {
                                 kind: FilePathKind::File,
                             },
@@ -224,6 +232,7 @@ mod tests {
                             key: "password".to_string(),
                             label: "Password".to_string(),
                             description: None,
+                            help_text: None,
                             field_type: FieldType::Password,
                             required: false,
                             default: None,
@@ -332,6 +341,7 @@ mod tests {
                 key: "name".to_string(),
                 label: "Name".to_string(),
                 description: None,
+                help_text: None,
                 field_type: FieldType::Text,
                 required: true,
                 default: None,
@@ -380,6 +390,7 @@ mod tests {
             key: "host".to_string(),
             label: "Host".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Text,
             required: true,
             default: None,
@@ -391,6 +402,7 @@ mod tests {
         let json = serde_json::to_value(&field).unwrap();
         let obj = json.as_object().unwrap();
         assert!(!obj.contains_key("description"));
+        assert!(!obj.contains_key("helpText"));
         assert!(!obj.contains_key("default"));
         assert!(!obj.contains_key("placeholder"));
         assert!(!obj.contains_key("visibleWhen"));
@@ -402,6 +414,7 @@ mod tests {
             key: "keyPath".to_string(),
             label: "Key Path".to_string(),
             description: Some("Path to key".to_string()),
+            help_text: None,
             field_type: FieldType::Text,
             required: true,
             default: None,
@@ -445,12 +458,14 @@ mod tests {
                     key: "volumes".to_string(),
                     label: "Volumes".to_string(),
                     description: None,
+                    help_text: None,
                     field_type: FieldType::ObjectList {
                         fields: vec![
                             SettingsField {
                                 key: "hostPath".to_string(),
                                 label: "Host Path".to_string(),
                                 description: None,
+                                help_text: None,
                                 field_type: FieldType::FilePath {
                                     kind: FilePathKind::Directory,
                                 },
@@ -465,6 +480,7 @@ mod tests {
                                 key: "containerPath".to_string(),
                                 label: "Container Path".to_string(),
                                 description: None,
+                                help_text: None,
                                 field_type: FieldType::Text,
                                 required: true,
                                 default: None,
@@ -477,6 +493,7 @@ mod tests {
                                 key: "readOnly".to_string(),
                                 label: "Read Only".to_string(),
                                 description: None,
+                                help_text: None,
                                 field_type: FieldType::Boolean,
                                 required: false,
                                 default: Some(serde_json::json!(false)),

--- a/core/src/connection/validation.rs
+++ b/core/src/connection/validation.rs
@@ -232,6 +232,7 @@ mod tests {
             key: key.to_string(),
             label: key.to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Text,
             required: true,
             default: None,
@@ -303,6 +304,7 @@ mod tests {
             key: "rate".to_string(),
             label: "Rate".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Number {
                 min: Some(1.0),
                 max: Some(100.0),
@@ -327,6 +329,7 @@ mod tests {
             key: "rate".to_string(),
             label: "Rate".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Number {
                 min: None,
                 max: Some(100.0),
@@ -351,6 +354,7 @@ mod tests {
             key: "rate".to_string(),
             label: "Rate".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Number {
                 min: Some(1.0),
                 max: Some(100.0),
@@ -374,6 +378,7 @@ mod tests {
             key: "rate".to_string(),
             label: "Rate".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Number {
                 min: None,
                 max: None,
@@ -398,6 +403,7 @@ mod tests {
             key: "enabled".to_string(),
             label: "Enabled".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Boolean,
             required: true,
             default: None,
@@ -419,6 +425,7 @@ mod tests {
             key: "enabled".to_string(),
             label: "Enabled".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Boolean,
             required: true,
             default: None,
@@ -439,6 +446,7 @@ mod tests {
             key: "auth".to_string(),
             label: "Auth".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Select {
                 options: vec![
                     SelectOption {
@@ -471,6 +479,7 @@ mod tests {
             key: "auth".to_string(),
             label: "Auth".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Select {
                 options: vec![SelectOption {
                     value: "key".to_string(),
@@ -496,6 +505,7 @@ mod tests {
             key: "auth".to_string(),
             label: "Auth".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Select {
                 options: vec![SelectOption {
                     value: "key".to_string(),
@@ -522,6 +532,7 @@ mod tests {
             key: "port".to_string(),
             label: "Port".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Port,
             required: true,
             default: None,
@@ -543,6 +554,7 @@ mod tests {
             key: "port".to_string(),
             label: "Port".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Port,
             required: true,
             default: None,
@@ -564,6 +576,7 @@ mod tests {
             key: "port".to_string(),
             label: "Port".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Port,
             required: true,
             default: None,
@@ -584,6 +597,7 @@ mod tests {
             key: "port".to_string(),
             label: "Port".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Port,
             required: true,
             default: None,
@@ -605,6 +619,7 @@ mod tests {
             key: "path".to_string(),
             label: "Path".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::FilePath {
                 kind: FilePathKind::File,
             },
@@ -629,6 +644,7 @@ mod tests {
                 key: "auth".to_string(),
                 label: "Auth".to_string(),
                 description: None,
+                help_text: None,
                 field_type: FieldType::Select {
                     options: vec![
                         SelectOption {
@@ -652,6 +668,7 @@ mod tests {
                 key: "password".to_string(),
                 label: "Password".to_string(),
                 description: None,
+                help_text: None,
                 field_type: FieldType::Password,
                 required: true,
                 default: None,
@@ -679,6 +696,7 @@ mod tests {
                 key: "auth".to_string(),
                 label: "Auth".to_string(),
                 description: None,
+                help_text: None,
                 field_type: FieldType::Select {
                     options: vec![SelectOption {
                         value: "password".to_string(),
@@ -696,6 +714,7 @@ mod tests {
                 key: "password".to_string(),
                 label: "Password".to_string(),
                 description: None,
+                help_text: None,
                 field_type: FieldType::Password,
                 required: true,
                 default: None,
@@ -724,6 +743,7 @@ mod tests {
             key: "env".to_string(),
             label: "Env".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::KeyValueList,
             required: false,
             default: None,
@@ -749,6 +769,7 @@ mod tests {
             key: "env".to_string(),
             label: "Env".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::KeyValueList,
             required: false,
             default: None,
@@ -772,6 +793,7 @@ mod tests {
             key: "env".to_string(),
             label: "Env".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::KeyValueList,
             required: false,
             default: None,
@@ -793,12 +815,14 @@ mod tests {
             key: "volumes".to_string(),
             label: "Volumes".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::ObjectList {
                 fields: vec![
                     SettingsField {
                         key: "hostPath".to_string(),
                         label: "Host Path".to_string(),
                         description: None,
+                        help_text: None,
                         field_type: FieldType::Text,
                         required: true,
                         default: None,
@@ -811,6 +835,7 @@ mod tests {
                         key: "containerPath".to_string(),
                         label: "Container Path".to_string(),
                         description: None,
+                        help_text: None,
                         field_type: FieldType::Text,
                         required: true,
                         default: None,
@@ -847,6 +872,7 @@ mod tests {
             key: "volumes".to_string(),
             label: "Volumes".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::ObjectList { fields: vec![] },
             required: false,
             default: None,
@@ -875,6 +901,7 @@ mod tests {
                             key: "port".to_string(),
                             label: "Port".to_string(),
                             description: None,
+                            help_text: None,
                             field_type: FieldType::Port,
                             required: true,
                             default: None,
@@ -887,6 +914,7 @@ mod tests {
                             key: "enabled".to_string(),
                             label: "Enabled".to_string(),
                             description: None,
+                            help_text: None,
                             field_type: FieldType::Boolean,
                             required: true,
                             default: None,
@@ -904,6 +932,7 @@ mod tests {
                         key: "password".to_string(),
                         label: "Password".to_string(),
                         description: None,
+                        help_text: None,
                         field_type: FieldType::Password,
                         required: false,
                         default: None,
@@ -949,6 +978,7 @@ mod tests {
             key: "pass".to_string(),
             label: "Pass".to_string(),
             description: None,
+            help_text: None,
             field_type: FieldType::Password,
             required: true,
             default: None,

--- a/core/src/session/shell.rs
+++ b/core/src/session/shell.rs
@@ -179,29 +179,25 @@ pub fn build_shell_command(config: &ShellConfig) -> ShellCommand {
 /// carries the raw Windows path with no URL encoding or slash conversion.
 ///
 /// - `"wsl:<distro>"` — OSC 7, WSL variant: `cd $HOME` guard for `/mnt/`
-///   paths; injected via stdin with a targeted line-erase sequence.
-/// - `"ssh"` — OSC 7, SSH variant: no `/mnt/` guard; injected via stdin
-///   with a targeted line-erase sequence.
-/// - `"bash"` / `"gitbash"` — OSC 7, local bash; injected via stdin with
-///   a targeted line-erase sequence.
+///   paths; injected visibly via the WSL temp-file source mechanism.
+/// - `"ssh"` — OSC 7, SSH variant: no `/mnt/` guard; injected visibly via
+///   stdin.
+/// - `"bash"` / `"gitbash"` — OSC 7, local bash; injected visibly via
+///   stdin.
 /// - `"powershell"` — OSC 9;9: overrides the `prompt` function; injected via
 ///   `-NoExit -Command` startup args (not stdin) to avoid echo.
 /// - `"cmd"` — OSC 9;9: sets the `PROMPT` variable via `/K` startup arg
 ///   (not stdin) to avoid echo.
 /// - Anything else (`"zsh"`, etc.) — `None` (zsh emits OSC 7 natively).
-///
-/// `cols` is the terminal width used to calculate how many lines the echoed
-/// setup command occupies so only those lines are erased (not the full screen).
-/// For WSL, `cols` is unused because the WSL backend injects silently.
-pub fn osc7_setup_command(shell_type: &str, cols: u16) -> Option<String> {
+pub fn osc7_setup_command(shell_type: &str) -> Option<&'static str> {
     if shell_type.starts_with("wsl:") {
-        Some(wsl_osc7_command().to_string())
+        Some(wsl_osc7_command())
     } else if matches!(shell_type, "ssh" | "bash" | "gitbash") {
-        Some(bash_osc7_command(cols))
+        Some(bash_osc7_command())
     } else if shell_type == "powershell" {
-        Some(powershell_osc9_command().to_string())
+        Some(powershell_osc9_command())
     } else if shell_type == "cmd" {
-        Some(cmd_osc9_command().to_string())
+        Some(cmd_osc9_command())
     } else {
         None
     }
@@ -327,36 +323,17 @@ pub fn initial_command_strategy(
 /// generous allowance for the shell prompt already on screen — and returns
 /// a sequence of cursor-up + erase-line pairs that removes only those lines.
 ///
-/// The returned string is suitable for embedding in `printf '...'` inside
-/// a shell command (uses `\r`, `\033` octal escapes).
-fn erase_echo_lines(cmd_len: usize, cols: u16) -> String {
-    // Allow up to 80 chars for the shell prompt visible before the echo,
-    // plus a small budget for the printf command appended after the base.
-    const OVERHEAD: usize = 80;
-    let cols = (cols as usize).max(20);
-    let lines = (cmd_len + OVERHEAD).div_ceil(cols);
-    let lines = lines.clamp(1, 10);
-
-    // Erase current line (the blank line the trailing \n moved us to),
-    // then step up and erase each echoed line.
-    let mut s = String::from(r"\r\033[2K");
-    for _ in 0..lines {
-        s.push_str(r"\033[A\033[2K");
-    }
-    s
-}
-
 /// OSC 7 setup command for WSL shells.
 ///
 /// Changes to `$HOME` when the CWD is a Windows drive mount (`/mnt/c/...`),
 /// since WSL defaults to the Windows user directory which is inaccessible
 /// through the `\\wsl$\` UNC share.
 ///
-/// This command is injected silently via the sentinel-based approach in
-/// `wsl.rs` (PTY echo is disabled before this runs), so no erase sequence
-/// is included here.
+/// Prints a visible notice so the user knows what termiHub is doing.
+/// Injected via the WSL temp-file source mechanism in `wsl.rs`.
 fn wsl_osc7_command() -> &'static str {
     concat!(
+        r#"echo '# [termiHub] Shell integration: setting up OSC 7 CWD tracking'; "#,
         r#"case "$PWD" in /mnt/[a-z]|/mnt/[a-z]/*) cd;; esac; "#,
         r#"__termihub_osc7(){ printf '\e]7;file://%s\a' "$PWD"; }; "#,
         r#"[ "$ZSH_VERSION" ] && precmd_functions+=(__termihub_osc7) || "#,
@@ -368,16 +345,18 @@ fn wsl_osc7_command() -> &'static str {
 ///
 /// Unlike [`wsl_osc7_command()`], this does not include a `cd $HOME` guard
 /// for `/mnt/` paths. Supports both bash (`PROMPT_COMMAND`) and zsh
-/// (`precmd_functions`). Ends with a targeted line-erase that removes only
-/// the echoed setup lines instead of clearing the full screen.
-fn bash_osc7_command(cols: u16) -> String {
-    const BASE: &str = concat!(
+/// (`precmd_functions`).
+///
+/// Prints a visible notice so the user knows what termiHub is doing.
+/// Injected visibly via stdin — the shell echoes the command and then the
+/// `echo` output appears before the next prompt.
+fn bash_osc7_command() -> &'static str {
+    concat!(
+        r#"echo '# [termiHub] Shell integration: setting up OSC 7 CWD tracking'; "#,
         r#"__termihub_osc7(){ printf '\e]7;file://%s\a' "$PWD"; }; "#,
         r#"[ "$ZSH_VERSION" ] && precmd_functions+=(__termihub_osc7) || "#,
-        r#"PROMPT_COMMAND="__termihub_osc7${PROMPT_COMMAND:+;$PROMPT_COMMAND}"; "#,
-    );
-    let erase = erase_echo_lines(BASE.len(), cols);
-    format!("{BASE}printf '{erase}'")
+        r#"PROMPT_COMMAND="__termihub_osc7${PROMPT_COMMAND:+;$PROMPT_COMMAND}""#,
+    )
 }
 
 /// OSC 9;9 setup command for PowerShell (both `powershell.exe` and `pwsh`).
@@ -770,7 +749,7 @@ mod tests {
 
     #[test]
     fn osc7_wsl_contains_expected_parts() {
-        let setup = osc7_setup_command("wsl:Ubuntu", 80).expect("expected Some for WSL");
+        let setup = osc7_setup_command("wsl:Ubuntu").expect("expected Some for WSL");
         assert!(
             setup.contains(r"\e]7;"),
             "expected OSC 7 escape marker, got: {setup}"
@@ -788,21 +767,21 @@ mod tests {
             setup.contains("/mnt/[a-z]") && setup.contains("cd"),
             "expected cd-home for /mnt/ paths, got: {setup}"
         );
-        // WSL injection is silent (via stty -echo sentinel in wsl.rs),
-        // so no erase sequence should be present in the command itself.
+        // Should contain visible notice message
+        assert!(
+            setup.contains("[termiHub]"),
+            "expected visible notice, got: {setup}"
+        );
+        // Must not use full screen clear
         assert!(
             !setup.contains(r"\033[2J"),
             "must not use full screen clear, got: {setup}"
-        );
-        assert!(
-            !setup.contains(r"\033[A"),
-            "WSL command must not contain erase (injection is silent), got: {setup}"
         );
     }
 
     #[test]
     fn osc7_ssh_contains_expected_parts() {
-        let setup = osc7_setup_command("ssh", 80).expect("expected Some for SSH");
+        let setup = osc7_setup_command("ssh").expect("expected Some for SSH");
         assert!(
             setup.contains(r"\e]7;"),
             "expected OSC 7 escape marker, got: {setup}"
@@ -820,11 +799,12 @@ mod tests {
             !setup.contains("/mnt/"),
             "SSH setup should not contain /mnt/ path handling, got: {setup}"
         );
-        // Should use targeted line-erase, not full screen clear
+        // Should contain visible notice message
         assert!(
-            setup.contains(r"\033[A"),
-            "expected cursor-up line-erase, got: {setup}"
+            setup.contains("[termiHub]"),
+            "expected visible notice, got: {setup}"
         );
+        // Must not use full screen clear
         assert!(
             !setup.contains(r"\033[2J"),
             "must not use full screen clear, got: {setup}"
@@ -833,7 +813,7 @@ mod tests {
 
     #[test]
     fn osc7_bash_contains_expected_parts() {
-        let setup = osc7_setup_command("bash", 80).expect("expected Some for bash");
+        let setup = osc7_setup_command("bash").expect("expected Some for bash");
         assert!(
             setup.contains(r"\e]7;"),
             "expected OSC 7 escape marker, got: {setup}"
@@ -851,7 +831,7 @@ mod tests {
 
     #[test]
     fn osc7_gitbash_contains_expected_parts() {
-        let setup = osc7_setup_command("gitbash", 80).expect("expected Some for gitbash");
+        let setup = osc7_setup_command("gitbash").expect("expected Some for gitbash");
         assert!(
             setup.contains(r"\e]7;"),
             "expected OSC 7 escape marker, got: {setup}"
@@ -864,54 +844,13 @@ mod tests {
 
     #[test]
     fn osc7_non_bash_returns_none() {
-        assert!(osc7_setup_command("zsh", 80).is_none());
-        assert!(osc7_setup_command("sh", 80).is_none());
-    }
-
-    #[test]
-    fn erase_echo_lines_erases_correct_line_count() {
-        // At 80 cols with a 168-char bash base command + 80 overhead = 248 chars
-        // ceil(248 / 80) = 4 lines → sequence contains 4 cursor-up pairs
-        let seq = erase_echo_lines(168, 80);
-        let up_count = seq.matches(r"\033[A").count();
-        assert!(
-            up_count >= 3,
-            "expected at least 3 cursor-up sequences at 80 cols, got {up_count}: {seq}"
-        );
-        // Must start with \r\033[2K
-        assert!(
-            seq.starts_with(r"\r\033[2K"),
-            "expected leading line erase: {seq}"
-        );
-    }
-
-    #[test]
-    fn erase_echo_lines_wider_terminal_fewer_lines() {
-        // At 200 cols, 168 chars fits in 2 lines (with 80-char overhead = 248 → ceil(248/200) = 2)
-        let seq_80 = erase_echo_lines(168, 80);
-        let seq_200 = erase_echo_lines(168, 200);
-        let up_80 = seq_80.matches(r"\033[A").count();
-        let up_200 = seq_200.matches(r"\033[A").count();
-        assert!(
-            up_200 <= up_80,
-            "wider terminal should need fewer or equal erase lines: {up_200} vs {up_80}"
-        );
-    }
-
-    #[test]
-    fn erase_echo_lines_clamps_to_max() {
-        // Tiny cols forces many lines, but clamp at 10
-        let seq = erase_echo_lines(1000, 20);
-        let up_count = seq.matches(r"\033[A").count();
-        assert!(
-            up_count <= 10,
-            "line count should be clamped at 10, got {up_count}"
-        );
+        assert!(osc7_setup_command("zsh").is_none());
+        assert!(osc7_setup_command("sh").is_none());
     }
 
     #[test]
     fn osc9_cmd_contains_expected_parts() {
-        let setup = osc7_setup_command("cmd", 80).expect("expected Some for cmd");
+        let setup = osc7_setup_command("cmd").expect("expected Some for cmd");
         // Must set the PROMPT variable
         assert!(
             setup.contains("PROMPT="),
@@ -933,7 +872,7 @@ mod tests {
 
     #[test]
     fn osc9_powershell_contains_expected_parts() {
-        let setup = osc7_setup_command("powershell", 80).expect("expected Some for powershell");
+        let setup = osc7_setup_command("powershell").expect("expected Some for powershell");
         // Must redefine the prompt function
         assert!(
             setup.contains("function prompt"),

--- a/core/src/session/shell.rs
+++ b/core/src/session/shell.rs
@@ -314,15 +314,6 @@ pub fn initial_command_strategy(
 // Private helpers
 // ---------------------------------------------------------------------------
 
-/// Build an ANSI sequence (in bash `printf` escape format) that erases only
-/// the terminal lines occupied by the injection echo.
-///
-/// When we write a setup command to PTY stdin, the terminal line discipline
-/// echoes every character back, wrapping at `cols` columns. This function
-/// computes exactly how many lines that echo occupies — factoring in a
-/// generous allowance for the shell prompt already on screen — and returns
-/// a sequence of cursor-up + erase-line pairs that removes only those lines.
-///
 /// OSC 7 setup command for WSL shells.
 ///
 /// Changes to `$HOME` when the CWD is a Windows drive mount (`/mnt/c/...`),

--- a/src/components/ConnectionEditor/ConnectionEditor.css
+++ b/src/components/ConnectionEditor/ConnectionEditor.css
@@ -252,3 +252,91 @@
 .settings-form__list-add:hover {
   text-decoration: underline;
 }
+
+/* Help icon button next to boolean field labels */
+.settings-form__help-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.settings-form__help-btn:hover {
+  color: var(--focus-border);
+}
+
+/* Field help dialog */
+.field-help-dialog__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.field-help-dialog__content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1001;
+  width: 360px;
+  max-width: calc(100vw - 32px);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.field-help-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.field-help-dialog__title {
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.field-help-dialog__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.field-help-dialog__close:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.field-help-dialog__body {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.field-help-dialog__body p {
+  margin: 0;
+}
+
+.field-help-dialog__body p + p {
+  margin-top: var(--spacing-sm);
+}

--- a/src/components/DynamicForm/DynamicField.tsx
+++ b/src/components/DynamicForm/DynamicField.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { HelpCircle, X } from "lucide-react";
 import type { SettingsField, FieldType } from "@/types/schema";
 import { KeyPathInput } from "@/components/Settings/KeyPathInput";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
@@ -132,16 +133,73 @@ function NumberField({
 }
 
 function BooleanField({ field, value, onChange }: FieldProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
   return (
-    <label className="settings-form__field--checkbox" data-testid={`field-${field.key}-wrapper`}>
-      <input
-        type="checkbox"
-        checked={(value as boolean) ?? false}
-        onChange={(e) => onChange(e.target.checked)}
-        data-testid={`field-${field.key}`}
-      />
-      <span className="settings-form__label">{field.label}</span>
-    </label>
+    <>
+      <label className="settings-form__field--checkbox" data-testid={`field-${field.key}-wrapper`}>
+        <input
+          type="checkbox"
+          checked={(value as boolean) ?? false}
+          onChange={(e) => onChange(e.target.checked)}
+          data-testid={`field-${field.key}`}
+        />
+        <span className="settings-form__label">{field.label}</span>
+        {field.helpText && (
+          <button
+            type="button"
+            className="settings-form__help-btn"
+            onClick={(e) => {
+              e.preventDefault();
+              setDialogOpen(true);
+            }}
+            title="Learn more"
+            data-testid={`field-${field.key}-help`}
+          >
+            <HelpCircle size={13} />
+          </button>
+        )}
+      </label>
+      {dialogOpen && field.helpText && (
+        <FieldHelpDialog
+          title={field.label}
+          text={field.helpText}
+          onClose={() => setDialogOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+interface FieldHelpDialogProps {
+  title: string;
+  text: string;
+  onClose: () => void;
+}
+
+function FieldHelpDialog({ title, text, onClose }: FieldHelpDialogProps) {
+  return (
+    <>
+      <div className="field-help-dialog__overlay" onClick={onClose} />
+      <div className="field-help-dialog__content" role="dialog" aria-modal="true">
+        <div className="field-help-dialog__header">
+          <span className="field-help-dialog__title">{title}</span>
+          <button
+            type="button"
+            className="field-help-dialog__close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X size={14} />
+          </button>
+        </div>
+        <div className="field-help-dialog__body">
+          {text.split("\n\n").map((paragraph, i) => (
+            <p key={i}>{paragraph}</p>
+          ))}
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -23,6 +23,8 @@ export interface SettingsField {
   key: string;
   label: string;
   description?: string;
+  /** Extended help text shown in a dialog when the user clicks the ? icon. */
+  helpText?: string;
   fieldType: FieldType;
   required: boolean;
   default?: unknown;


### PR DESCRIPTION
## Summary

- Adds a `help_text` field to `SettingsField` schema so settings can display inline documentation
- Makes OSC 7/9 shell integration injection visible to the user (removes silent erase sequences)
- Adds a **Shell Integration** toggle in Settings with a help dialog explaining what it does and why the setup output is shown
- Fixes orphaned `build_erase_sequence` doc comment left behind after the function was removed

## Details

Previously, the OSC 7/9 setup command injected into shells was silently erased from the terminal using cursor-up + erase-line ANSI sequences, hiding the activity from users. This change makes the injection visible (`# [termiHub] Shell integration: setting up OSC 7 CWD tracking`) so users know what is happening, and provides a settings toggle with a help dialog to explain the feature.

## Test plan

- [ ] Open a local bash/zsh terminal — verify `# [termiHub] Shell integration: setting up OSC 7 CWD tracking` appears on startup
- [ ] Open Settings → Terminal → Shell Integration; verify the toggle is present with a help (?) button
- [ ] Click the help button; verify the dialog explains OSC 7 CWD tracking
- [ ] Disable Shell Integration; reopen a terminal — verify the injection echo does **not** appear
- [ ] Re-enable Shell Integration; reopen a terminal — verify the injection echo reappears
- [ ] Verify CWD tracking (sidebar path) still works when Shell Integration is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)