### PR TITLE
feat(ui): zoom overlay follows panel focus and tab switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Terminal: the panel zoom overlay (Cmd+Shift+Enter / Ctrl+Shift+Enter) now follows panel focus — navigating between split panels while a terminal is zoomed updates the overlay to show the active tab of the newly focused panel; switching tabs within the zoomed panel also updates the overlay to follow the new active tab
 - Shell integration (OSC 7 CWD tracking) is now **visible by default**: the setup command runs in the terminal at startup with a `# [termiHub] Shell integration: setting up OSC 7 CWD tracking` notice, instead of being silently erased. This applies to local bash, SSH, and WSL connections.
 - WSL: the setup script no longer contains erase sequences; the `source` command and the echo notice are left visible in the terminal.
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Terminal: zoom overlay no longer shows blank or garbled content after the zoomed tab changes — the `ResizeObserver` now skips fitting while the terminal element is in transit through the off-screen parking div, which previously caused the PTY to be briefly resized to 1–2 columns and the shell to redraw its prompt at that width (filling the buffer with wrapped garbage)
 - Credential store: the unlock dialog no longer appears proactively every 15 minutes after auto-lock — the store still locks automatically, but the unlock prompt is only shown when a credential is actually needed (e.g. when connecting with stored credentials)
 - Workspace launch: the master password dialog is now shown **once upfront** before any tabs open (instead of after the first connection attempt fails), and stored credentials are resolved and injected into each tab's config so all connections authenticate silently without interactive password prompts
 - Terminal: the OSC 7 shell-integration setup command is no longer visible as stray text after connecting — the backend erase calculation now uses the real terminal width (from `fitAddon.fit()` run before session creation) instead of the 80-column default, so the right number of echo lines are erased regardless of terminal width

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -746,7 +746,7 @@ See [scripts/README.md](../scripts/README.md) for all options. Reports are saved
 | Tab Management        | [`tab-management.yaml`](../tests/manual/tab-management.yaml)               | `MT-TAB`   | 7      |
 | Connection Management | [`connection-management.yaml`](../tests/manual/connection-management.yaml) | `MT-CONN`  | 10     |
 | File Browser + Editor | [`file-browser.yaml`](../tests/manual/file-browser.yaml)                   | `MT-FB`    | 10     |
-| UI / Layout           | [`ui-layout.yaml`](../tests/manual/ui-layout.yaml)                         | `MT-UI`    | 19     |
+| UI / Layout           | [`ui-layout.yaml`](../tests/manual/ui-layout.yaml)                         | `MT-UI`    | 21     |
 | Remote Agent          | [`remote-agent.yaml`](../tests/manual/remote-agent.yaml)                   | `MT-AGENT` | 2      |
 | Credential Store      | [`credential-store.yaml`](../tests/manual/credential-store.yaml)           | `MT-CRED`  | 3      |
 | Keyboard Shortcuts    | [`keyboard.yaml`](../tests/manual/keyboard.yaml)                           | `MT-KB`    | 8      |
@@ -754,7 +754,7 @@ See [scripts/README.md](../scripts/README.md) for all options. Reports are saved
 | Portable Mode         | [`portable-mode.yaml`](../tests/manual/portable-mode.yaml)                 | `MT-PORT`  | 4      |
 | Embedded Services     | [`embedded-services.yaml`](../tests/manual/embedded-services.yaml)         | `MT-SVC`   | 3      |
 | Network Tools         | [`network-tools.yaml`](../tests/manual/network-tools.yaml)                 | `MT-NET`   | 10     |
-| **Total**             |                                                                            |            | **92** |
+| **Total**             |                                                                            |            | **94** |
 
 When adding new manual tests, add the YAML definition to the appropriate file in `tests/manual/` — the YAML files are the **source of truth** for guided testing.
 

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -253,7 +253,9 @@ export function SplitView() {
             </div>
             <div className="zoom-overlay__content">
               <TerminalSearchBar tabId={zoomedTabId} />
-              <TerminalSlot tabId={zoomedTabId} isVisible={true} />
+              {/* key forces a fresh mount on each zoomed-tab change so the
+                  adoption lifecycle always matches the initial-zoom case. */}
+              <TerminalSlot key={`zoom-slot-${zoomedTabId}`} tabId={zoomedTabId} isVisible={true} />
             </div>
           </div>
         </div>
@@ -572,7 +574,7 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
  */
 function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean }) {
   const slotRef = useRef<HTMLDivElement>(null);
-  const { getElement, focusTerminal, parkingRef } = useTerminalRegistry();
+  const { getElement, focusTerminal, fitTerminal, parkingRef } = useTerminalRegistry();
   const tabColor = useAppStore((s) => s.tabColors[tabId]);
 
   useEffect(() => {
@@ -586,6 +588,11 @@ function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean 
       const termEl = getElement(tabId);
       if (termEl && termEl.parentNode !== slotEl) {
         slotEl.appendChild(termEl);
+        // Synchronous fit immediately after reparenting: getComputedStyle forces
+        // layout so proposeDimensions() sees the new container dimensions.
+        fitTerminal(tabId);
+        // RAF fit as a second pass after the browser has painted the new layout.
+        requestAnimationFrame(() => fitTerminal(tabId));
         return true;
       }
       return !!termEl;
@@ -604,7 +611,7 @@ function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean 
         parkingEl?.appendChild(termEl);
       }
     };
-  }, [tabId, getElement, parkingRef]);
+  }, [tabId, getElement, fitTerminal, parkingRef]);
 
   // Focus the terminal when it becomes visible (tab activation or initial creation)
   useEffect(() => {

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -464,8 +464,8 @@ export function Terminal({
     // Expose xterm instance on the DOM element for E2E test access
     (el as HTMLDivElement & { _xtermInstance?: XTerm })._xtermInstance = xterm;
 
-    // Register element and xterm instance with the portal registry
-    register(tabId, el, xterm);
+    // Register element, xterm instance, and fit addon with the portal registry
+    register(tabId, el, xterm, fitAddon);
 
     // Initial fit (may fail since element starts in parking)
     try {
@@ -503,7 +503,15 @@ export function Terminal({
     // After fitting, kick the SmoothScrollableElement so it recalculates
     // its viewport height — it may have cached stale dimensions from when
     // the element was in parking (hidden, zero-size).
-    const resizeObserver = new ResizeObserver(() => {
+    const resizeObserver = new ResizeObserver((entries) => {
+      // Skip fit while the element is in the off-screen parking div (1×1 px).
+      // Fitting at 1×1 would resize the PTY to ~2 cols × 1 row, causing the
+      // backend shell to redraw at that width and fill the buffer with
+      // line-wrapped garbage that persists after the element is re-adopted.
+      const entry = entries[0];
+      if (entry && (entry.contentRect.width < 10 || entry.contentRect.height < 10)) {
+        return;
+      }
       try {
         if (horizontalScrollingRef.current) {
           // Only resize PTY when rows change (window/panel resize).

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -12,6 +12,7 @@ import { useTerminalRegistry } from "./TerminalRegistry";
 import { useAppStore } from "@/store/appStore";
 import { getXtermTheme } from "@/themes";
 import { processKeyEvent, isAppShortcut, isChordPending } from "@/services/keybindings";
+import { frontendLog } from "@/utils/frontendLog";
 
 const HORIZONTAL_SCROLL_COLS = 500;
 
@@ -510,7 +511,17 @@ export function Terminal({
       // line-wrapped garbage that persists after the element is re-adopted.
       const entry = entries[0];
       if (entry && (entry.contentRect.width < 10 || entry.contentRect.height < 10)) {
+        frontendLog(
+          "terminal",
+          `ResizeObserver skipped fit (parking) tab=${tabId} rect=${entry.contentRect.width}×${entry.contentRect.height}`
+        );
         return;
+      }
+      if (entry) {
+        frontendLog(
+          "terminal",
+          `ResizeObserver fit tab=${tabId} rect=${entry.contentRect.width}×${entry.contentRect.height} xterm=${xterm.cols}×${xterm.rows}`
+        );
       }
       try {
         if (horizontalScrollingRef.current) {

--- a/src/components/Terminal/TerminalRegistry.test.tsx
+++ b/src/components/Terminal/TerminalRegistry.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
 import { TerminalPortalProvider, useTerminalRegistry } from "./TerminalRegistry";
 import { sendInput } from "@/services/api";
 
@@ -32,6 +33,11 @@ function createMockXterm(selection?: string): XTerm {
       },
     },
   } as unknown as XTerm;
+}
+
+/** Creates a minimal mock FitAddon for testing. */
+function createMockFitAddon(): FitAddon {
+  return { fit: vi.fn() } as unknown as FitAddon;
 }
 
 let container: HTMLDivElement;
@@ -73,7 +79,7 @@ describe("getTerminalSelection", () => {
     const el = document.createElement("div");
 
     act(() => {
-      registryActions.register("tab-1", el, xterm);
+      registryActions.register("tab-1", el, xterm, createMockFitAddon());
     });
 
     expect(registryActions.getTerminalSelection("tab-1")).toBeUndefined();
@@ -85,7 +91,7 @@ describe("getTerminalSelection", () => {
     const el = document.createElement("div");
 
     act(() => {
-      registryActions.register("tab-1", el, xterm);
+      registryActions.register("tab-1", el, xterm, createMockFitAddon());
     });
 
     expect(registryActions.getTerminalSelection("tab-1")).toBe("selected text");
@@ -103,7 +109,7 @@ describe("copySelectionToClipboard", () => {
     const el = document.createElement("div");
 
     act(() => {
-      registryActions.register("tab-1", el, xterm);
+      registryActions.register("tab-1", el, xterm, createMockFitAddon());
     });
 
     await act(async () => {
@@ -121,7 +127,7 @@ describe("copySelectionToClipboard", () => {
     const el = document.createElement("div");
 
     act(() => {
-      registryActions.register("tab-1", el, xterm);
+      registryActions.register("tab-1", el, xterm, createMockFitAddon());
     });
 
     await act(async () => {
@@ -188,7 +194,7 @@ describe("pasteToTerminal", () => {
     const el = document.createElement("div");
 
     act(() => {
-      registryActions.register("tab-dup", el, xterm);
+      registryActions.register("tab-dup", el, xterm, createMockFitAddon());
       registryActions.registerSession("tab-dup", "session-dup");
     });
 

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -8,6 +8,7 @@ import { readText as readClipboard } from "@tauri-apps/plugin-clipboard-manager"
 import { sendInput } from "@/services/api";
 import { SessionId } from "@/types/terminal";
 import { useAppStore } from "@/store/appStore";
+import { frontendLog } from "@/utils/frontendLog";
 
 const LARGE_PASTE_THRESHOLD = 5000;
 
@@ -105,10 +106,21 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
     const fitAddon = fitAddonRegistryRef.current.get(tabId);
     const xterm = xtermRegistryRef.current.get(tabId);
     if (!fitAddon) return;
+    const el = registryRef.current.get(tabId);
+    const w = el?.offsetWidth ?? -1;
+    const h = el?.offsetHeight ?? -1;
+    frontendLog(
+      "terminal_registry",
+      `fitTerminal tab=${tabId} el=${w}×${h} xterm=${xterm?.cols}×${xterm?.rows}`
+    );
     try {
       fitAddon.fit();
-    } catch {
-      // Container may not have dimensions yet
+      frontendLog(
+        "terminal_registry",
+        `fitTerminal after fit tab=${tabId} xterm=${xterm?.cols}×${xterm?.rows}`
+      );
+    } catch (err) {
+      frontendLog("terminal_registry", `fitTerminal fit error tab=${tabId}: ${err}`);
     }
     if (xterm) {
       requestAnimationFrame(() => xterm.scrollToBottom());

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useRef, useCallback, useMemo, ReactNode } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon, type ISearchOptions } from "@xterm/addon-search";
 import { save } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
@@ -11,8 +12,8 @@ import { useAppStore } from "@/store/appStore";
 const LARGE_PASTE_THRESHOLD = 5000;
 
 interface TerminalRegistryContextType {
-  /** Register a terminal's xterm container element and xterm instance. */
-  register: (tabId: string, element: HTMLDivElement, xterm: XTerm) => void;
+  /** Register a terminal's xterm container element, xterm instance, and fit addon. */
+  register: (tabId: string, element: HTMLDivElement, xterm: XTerm, fitAddon: FitAddon) => void;
   /** Unregister a terminal element (on terminal close). */
   unregister: (tabId: string) => void;
   /** Get the registered element for a tab. */
@@ -45,6 +46,8 @@ interface TerminalRegistryContextType {
   findPrevious: (tabId: string, query: string, options?: ISearchOptions) => boolean;
   /** Clear search decorations in the terminal. */
   clearSearchDecorations: (tabId: string) => void;
+  /** Fit the terminal to its current container dimensions. */
+  fitTerminal: (tabId: string) => void;
   /** Ref to the off-screen parking div for orphaned terminal elements. */
   parkingRef: React.RefObject<HTMLDivElement | null>;
 }
@@ -65,18 +68,24 @@ export function useTerminalRegistry() {
 export function TerminalPortalProvider({ children }: { children: ReactNode }) {
   const registryRef = useRef(new Map<string, HTMLDivElement>());
   const xtermRegistryRef = useRef(new Map<string, XTerm>());
+  const fitAddonRegistryRef = useRef(new Map<string, FitAddon>());
   const sessionRegistryRef = useRef(new Map<string, SessionId>());
   const searchAddonRegistryRef = useRef(new Map<string, SearchAddon>());
   const parkingRef = useRef<HTMLDivElement | null>(null);
 
-  const register = useCallback((tabId: string, element: HTMLDivElement, xterm: XTerm) => {
-    registryRef.current.set(tabId, element);
-    xtermRegistryRef.current.set(tabId, xterm);
-  }, []);
+  const register = useCallback(
+    (tabId: string, element: HTMLDivElement, xterm: XTerm, fitAddon: FitAddon) => {
+      registryRef.current.set(tabId, element);
+      xtermRegistryRef.current.set(tabId, xterm);
+      fitAddonRegistryRef.current.set(tabId, fitAddon);
+    },
+    []
+  );
 
   const unregister = useCallback((tabId: string) => {
     registryRef.current.delete(tabId);
     xtermRegistryRef.current.delete(tabId);
+    fitAddonRegistryRef.current.delete(tabId);
     sessionRegistryRef.current.delete(tabId);
     searchAddonRegistryRef.current.delete(tabId);
   }, []);
@@ -89,6 +98,20 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
     const xterm = xtermRegistryRef.current.get(tabId);
     if (xterm) {
       xterm.focus();
+    }
+  }, []);
+
+  const fitTerminal = useCallback((tabId: string) => {
+    const fitAddon = fitAddonRegistryRef.current.get(tabId);
+    const xterm = xtermRegistryRef.current.get(tabId);
+    if (!fitAddon) return;
+    try {
+      fitAddon.fit();
+    } catch {
+      // Container may not have dimensions yet
+    }
+    if (xterm) {
+      requestAnimationFrame(() => xterm.scrollToBottom());
     }
   }, []);
 
@@ -233,6 +256,7 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
       unregister,
       getElement,
       focusTerminal,
+      fitTerminal,
       clearTerminal,
       saveTerminalToFile,
       copyTerminalToClipboard,
@@ -253,6 +277,7 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
       unregister,
       getElement,
       focusTerminal,
+      fitTerminal,
       clearTerminal,
       saveTerminalToFile,
       copyTerminalToClipboard,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1226,14 +1226,29 @@ export const useAppStore = create<AppState>((set, get) => {
       }),
 
     setActiveTab: (tabId, panelId) =>
-      set((state) => ({
-        rootPanel: updateLeaf(state.rootPanel, panelId, (leaf) => ({
+      set((state) => {
+        const newRootPanel = updateLeaf(state.rootPanel, panelId, (leaf) => ({
           ...leaf,
           tabs: leaf.tabs.map((t) => ({ ...t, isActive: t.id === tabId })),
           activeTabId: tabId,
-        })),
-        activePanelId: panelId,
-      })),
+        }));
+
+        // If the zoom overlay is showing a tab from the same panel, follow the switch
+        let newZoomedTabId = state.zoomedTabId;
+        if (state.zoomedTabId !== null) {
+          const panelLeaf = findLeaf(state.rootPanel, panelId);
+          if (panelLeaf?.tabs.some((t) => t.id === state.zoomedTabId)) {
+            const newTab = panelLeaf.tabs.find((t) => t.id === tabId);
+            newZoomedTabId = newTab?.contentType === "terminal" ? tabId : null;
+          }
+        }
+
+        return {
+          rootPanel: newRootPanel,
+          activePanelId: panelId,
+          zoomedTabId: newZoomedTabId,
+        };
+      }),
 
     moveTab: (tabId, fromPanelId, toPanelId, newIndex) =>
       set((state) => {
@@ -1307,7 +1322,21 @@ export const useAppStore = create<AppState>((set, get) => {
         return { rootPanel, activePanelId };
       }),
 
-    setActivePanel: (panelId) => set({ activePanelId: panelId }),
+    setActivePanel: (panelId) =>
+      set((state) => {
+        // If zoom is active, follow the active tab of the newly focused panel
+        let newZoomedTabId = state.zoomedTabId;
+        if (state.zoomedTabId !== null) {
+          const panelLeaf = findLeaf(state.rootPanel, panelId);
+          if (panelLeaf?.activeTabId) {
+            const activeTab = panelLeaf.tabs.find((t) => t.id === panelLeaf.activeTabId);
+            newZoomedTabId = activeTab?.contentType === "terminal" ? panelLeaf.activeTabId : null;
+          } else {
+            newZoomedTabId = null;
+          }
+        }
+        return { activePanelId: panelId, zoomedTabId: newZoomedTabId };
+      }),
 
     splitPanelWithTab: (tabId, fromPanelId, targetPanelId, edge) =>
       set((state) => {

--- a/tests/manual/ui-layout.yaml
+++ b/tests/manual/ui-layout.yaml
@@ -305,3 +305,42 @@ tests:
       - "No pixel gaps visible between rows of a box"
     verification: manual
     tags: [terminal, visual]
+
+  - id: MT-UI-32
+    name: "Zoom overlay follows panel focus switching"
+    pr: 591
+    platforms: [all]
+    prerequisites:
+      - app: true
+      - "Open at least two terminal sessions in separate split panels (use Split Right)"
+      - "Run a command in each so both have visible output"
+    instructions:
+      - "Focus panel 1 and press Cmd+Shift+Enter (Mac) or Ctrl+Shift+Enter (Win/Linux) to open the zoom overlay for its active tab"
+      - "Press the Focus Panel Right shortcut (Cmd+Option+Right on Mac, Ctrl+Alt+Right on Win/Linux) to move focus to panel 2 while the overlay is open"
+      - "Observe the zoom overlay"
+    expected:
+      - "The zoom overlay updates to show the active terminal from panel 2"
+      - "The header title in the overlay changes to panel 2's tab name"
+      - "The terminal content from panel 2 is fully visible (no blank/empty overlay)"
+      - "The terminal responds to keyboard input"
+    verification: manual
+    tags: [terminal, zoom, panels]
+
+  - id: MT-UI-33
+    name: "Zoom overlay follows tab switching within the zoomed panel"
+    pr: 591
+    platforms: [all]
+    prerequisites:
+      - app: true
+      - "Open at least two terminal tabs in the same panel"
+      - "Run a distinct command in each tab so they have different visible output"
+    instructions:
+      - "Press Cmd+Shift+Enter (Mac) or Ctrl+Shift+Enter (Win/Linux) to open the zoom overlay for the active tab"
+      - "Press Ctrl+Tab to switch to the next tab while the overlay is open"
+      - "Observe the zoom overlay"
+    expected:
+      - "The zoom overlay updates to show the newly active tab"
+      - "The header title changes to the new tab's name"
+      - "The terminal content of the new tab is fully visible"
+    verification: manual
+    tags: [terminal, zoom, tabs]


### PR DESCRIPTION
## Summary

- When a terminal is zoomed, switching focus between split panels (Focus Panel Left/Right shortcuts) now updates the zoom overlay to show the active tab of the newly focused panel
- Switching tabs within the zoomed panel (Ctrl+Tab or tab clicks) also keeps the overlay in sync
- Fixed a bug where the zoom overlay would show blank content after the zoomed tab changes — the `ResizeObserver` now skips `fit()` while the terminal element is in transit through the off-screen 1×1 px parking div (which was causing PTY corruption at 2-column width)

## Changes

- **`src/store/appStore.ts`** — `setActivePanel` and `setActiveTab` now update `zoomedTabId` when a zoom is active
- **`src/components/SplitView/SplitView.tsx`** — Zoom overlay `TerminalSlot` uses a `key` prop tied to `zoomedTabId` so reparenting triggers a clean fit; calls `fitTerminal` synchronously and via RAF after adoption
- **`src/components/Terminal/Terminal.tsx`** — `ResizeObserver` skips `fit()` when element dimensions are <10×10 px (parking div guard)
- **`src/components/Terminal/TerminalRegistry.tsx`** — Exposes `FitAddon` via registry; adds `fitTerminal` helper

## Test plan

- [ ] MT-UI-32: Open two split panels with terminal sessions, zoom one, then use Focus Panel shortcuts — overlay should update to show the other panel's active tab
- [ ] MT-UI-33: Zoom a terminal, then use Ctrl+Tab to switch tabs — overlay should update to the new tab
- [ ] Terminal content must be fully visible (not blank) after each panel/tab switch
- [ ] Verify no PTY corruption: terminal columns/rows remain correct after switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)