### PR TITLE
docs(concept): release planning, dependency management, and in-field update mechanism

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -31,6 +31,20 @@ Concept for built-in VNC session support. Defines how to embed remote graphical 
 
 Concept for a package manager for extensions and tools. Builds on the plugin system concept to add repository browsing, dependency resolution, automatic updates, and tool packages (CLI utilities). Covers two package types (plugins and tools), static HTTPS repository format, multi-source priority resolution, download verification, PATH management for tool binaries, disk usage tracking, and offline mode.
 
+### release-planning-and-dependency-management.md
+
+Concept for structured release planning, dependency vulnerability monitoring, and security
+response workflows. Defines release types (security patch, bug-fix, minor, major) with SLA
+targets, Dependabot configuration for npm and Cargo, hardened CI audit checks, and a hotfix
+branching model for emergency security patches.
+
+### in-field-update-mechanism.md
+
+Concept for notifying installed users of available updates and delivering them in-app. Compares
+three variants — notify-only (Phase 1), download-and-prompt (Phase 2), fully automatic (Phase 3)
+— with full codebase impact and code signing requirement analysis. Proposes a phased adoption
+path starting with minimal notify-only implementation.
+
 ## Handled Concepts
 
 The following live in [`handled/`](handled/) because their concept issues are closed.

--- a/docs/concepts/in-field-update-mechanism.md
+++ b/docs/concepts/in-field-update-mechanism.md
@@ -1,0 +1,592 @@
+# In-Field Update Mechanism
+
+---
+
+## Overview
+
+Users who have installed termiHub have no way to discover that a new version is available without
+manually checking the GitHub releases page. For a security-sensitive tool that manages SSH
+credentials, serial connections, and tunnels, silent outdatedness is a real risk: a critical
+security patch may sit uninstalled on user machines for weeks or months.
+
+This concept designs an update awareness and delivery system for termiHub installations. Three
+implementation variants are defined and compared — from a minimal notification-only approach to
+a fully automatic silent updater — so that the implementation choice can be made with full
+visibility of the trade-offs involved. A phased adoption path is proposed, starting with the
+lowest-complexity variant and progressively enhancing it.
+
+### Goals
+
+- Ensure users know when a new version of termiHub is available
+- Prioritize security patches — they must not be suppressible by "skip this version"
+- Provide a clear path from minimal implementation to full in-app update delivery
+- Document code signing requirements and infrastructure costs for each variant
+- Keep the update check privacy-respecting and transparent to users
+
+### Non-Goals
+
+- Release planning and dependency management (see
+  [Release Planning and Dependency Management](./release-planning-and-dependency-management.md))
+- Automatic rollback in case of bad updates (out of scope for initial phases)
+- Delta/differential updates (full installer replacement only)
+- Update channels (stable/beta selection) — noted as a future extension
+- Enterprise managed-update or MDM integration
+
+---
+
+## UI Interface
+
+The update UI adapts to which variant is implemented. All variants share a common entry point in
+the status bar and a Settings page section. Higher variants add progressive capability on top.
+
+### Shared: Status Bar Update Indicator
+
+A version chip in the bottom status bar serves as the primary visual anchor for update
+awareness:
+
+```
+┌────────────────────────────────────────────────────────────────────────────────┐
+│  ● SSH: server-1  ● Local Shell  ●●● Tabs (3)          v0.1.0 ● [CPU 12%]    │
+│                                                          ───────               │
+│                                                          Update dot appears    │
+│                                                          when update available │
+└────────────────────────────────────────────────────────────────────────────────┘
+```
+
+When an update is available, a colored dot (amber for regular updates, red for security patches)
+appears beside the version number. Clicking the version chip opens the update notification popup.
+
+### Shared: Update Notification Popup
+
+A non-blocking popup appears once when an update is detected (startup or background check):
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ●  termiHub v0.2.0 is available                              [×]    │
+│  ─────────────────────────────────────────────────────────────────   │
+│  You are running v0.1.0                                              │
+│                                                                      │
+│  [What's New]          [Open Downloads Page]    [Skip This Version]  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+For security patches the popup is styled differently and "Skip This Version" is absent:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  🔒  Security update: termiHub v0.1.1                         [×]    │
+│  ─────────────────────────────────────────────────────────────────   │
+│  This release addresses a security vulnerability. Updating is        │
+│  strongly recommended.                                               │
+│                                                                      │
+│  [What's New]                              [Open Downloads Page]     │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Shared: Settings > Updates Page
+
+A dedicated section under Settings provides full update control:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Settings                                              Updates        │
+│  ────────────────────────────────────────────────────────────────    │
+│  General                                                             │
+│  Terminal                  Current version      v0.1.0               │
+│  SSH                       Latest version       v0.2.0  ● Available  │
+│  Appearance                Last checked         2026-04-17 14:32     │
+│  Updates  ◄                                                          │
+│  Advanced                  [Check Now]          [Open Downloads Page]│
+│                                                                      │
+│                            ─────────────────────────────────────     │
+│                            Auto-check for updates                    │
+│                            ● On startup    ○ Never                   │
+│                                                                      │
+│                            Skipped version: v0.1.1   [Clear]        │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Variant B Addition: Download Progress
+
+Variant B adds a download progress row to both the popup and the settings page:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ●  termiHub v0.2.0 is ready to install                      [×]    │
+│  ─────────────────────────────────────────────────────────────────   │
+│  Download complete  ████████████████████████████████  100%          │
+│                                                                      │
+│  [Install and Restart]             [Later]    [Skip This Version]    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Status bar during download:
+
+```
+│  v0.1.0 ↓ 34%                                                       │
+```
+
+### Variant C Addition: Post-Launch Banner
+
+After a silent auto-install, a one-time info banner appears on next launch:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ℹ  termiHub was updated to v0.2.0 — What's New    [Dismiss]   [×]  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Settings > Updates gets a rollback row:
+
+```
+│  Previous version: v0.1.0                                           │
+│  [Restore Previous Version]                                         │
+```
+
+---
+
+## General Handling
+
+### Update Check Endpoint
+
+**All variants** use the GitHub Releases API as the update source — no custom server
+infrastructure is required for basic update detection:
+
+```
+GET https://api.github.com/repos/armaxri/termiHub/releases/latest
+```
+
+Response fields used:
+
+| Field                           | Purpose                                   |
+| ------------------------------- | ----------------------------------------- |
+| `tag_name`                      | Latest version string (e.g., `"v0.2.0"`)  |
+| `prerelease`                    | Skip pre-releases on stable channel       |
+| `body`                          | Release notes (shown in "What's New")     |
+| `assets[].browser_download_url` | Download links per platform (Variant B/C) |
+| `html_url`                      | GitHub releases page URL (Variant A)      |
+
+The version in the response is compared against the running app version using semver comparison.
+If `latest > running`, an update is available.
+
+A **security release** is detected by checking whether the release body contains the keyword
+`<!-- security -->` (a convention the release workflow adds, or detectable via the `security`
+GitHub label on the associated PR/issue). Security releases bypass the "skip this version"
+suppression.
+
+### Check Frequency
+
+- **On startup**: once, after a 5-second delay (avoid blocking startup UX)
+- **While running**: every 24 hours, only if the app has been continuously open
+- **Manual**: "Check Now" button in Settings > Updates always triggers an immediate check
+- **Rate limit**: if the last check was less than 1 hour ago (excluding manual), skip
+
+The last check timestamp and the result are persisted in the app config file alongside other
+settings.
+
+### Skip Version Behavior
+
+| Situation                       | Behavior                                                         |
+| ------------------------------- | ---------------------------------------------------------------- |
+| User clicks "Skip This Version" | Persisted to config; no more notifications for that version      |
+| A newer version is released     | Skip record is ignored; notification resumes for new version     |
+| Next major version              | Skip record is cleared (major version change resets suppression) |
+| Security release                | Skip is ignored regardless; notification always shown            |
+
+### Privacy Considerations
+
+The update check sends a standard HTTPS GET to `api.github.com` with:
+
+- The `User-Agent` header identifying termiHub and its version
+- No personal data, no telemetry, no identifiers beyond what any browser would send to GitHub
+
+Users who disable auto-checking ("Never" in settings) can still use the manual "Check Now" button.
+This should be documented in the app's privacy note.
+
+### Platform Detection
+
+The running platform (`darwin-aarch64`, `darwin-x86_64`, `windows-x86_64`, `linux-x86_64`,
+`linux-aarch64`) is needed by Variants B and C to select the correct download asset. For
+Variant A the platform does not matter — the download page link is the same for all.
+
+Tauri exposes `std::env::consts::OS` and `std::env::consts::ARCH` on the backend for platform
+detection.
+
+---
+
+## Variant Comparison
+
+| Aspect                     | A: Notify Only                             | B: Download + Prompt               | C: Fully Automatic                   |
+| -------------------------- | ------------------------------------------ | ---------------------------------- | ------------------------------------ |
+| **User friction**          | Medium (browser download + manual install) | Low (one "Install" click)          | Minimal (nothing required)           |
+| **Code complexity**        | Low                                        | High                               | Very High                            |
+| **New Tauri plugin**       | None                                       | `tauri-plugin-updater`             | `tauri-plugin-updater`               |
+| **Code signing required**  | No                                         | Yes — macOS + Windows              | Yes — macOS + Windows                |
+| **Update manifest needed** | No (GitHub API)                            | Yes (signed manifest JSON)         | Yes (signed manifest JSON)           |
+| **Rollback support**       | N/A (user reinstalls old version)          | Not included                       | Required for safety                  |
+| **Privacy impact**         | Minimal (GitHub API request)               | Same                               | Same                                 |
+| **Platform parity**        | Full (all 5 platforms equal)               | Near-full                          | Near-full (Linux auto-update harder) |
+| **Infrastructure cost**    | $0 (GitHub API is free)                    | ~$0 if manifest on GitHub Releases | Same                                 |
+| **Certificate cost**       | $0                                         | macOS $99/yr + Windows $200–600/yr | Same                                 |
+| **Estimated impl effort**  | 1–2 days                                   | 1–2 weeks                          | 3–5 weeks                            |
+| **Recommended for**        | Phase 1 (now)                              | Phase 2 (optional)                 | Phase 3 (optional)                   |
+
+### Code Signing Deep-Dive
+
+Code signing is required by macOS and Windows for Variants B and C because the OS must verify
+the downloaded installer before executing it as part of the in-app update flow.
+
+**macOS:**
+
+- Requires an Apple Developer Program membership ($99/year)
+- All distributed binaries must be signed and notarized with Apple's servers
+- Tauri already supports macOS code signing via `APPLE_CERTIFICATE` and related CI secrets
+- Notarization adds ~5 minutes to the release CI pipeline
+- Without signing: macOS Gatekeeper blocks the installer from running silently
+
+**Windows:**
+
+- Requires a code signing certificate from a trusted CA:
+  - OV (Organization Validation): $200–400/year, works for signing
+  - EV (Extended Validation): $400–600/year, immediately trusted by SmartScreen
+  - Standard OV certificates trigger SmartScreen warnings initially (reputation builds over time)
+- Tauri supports Windows signing via `TAURI_SIGNING_PRIVATE_KEY` CI secrets
+- Without signing: Windows SmartScreen may block the installer silently in B/C flows
+
+**Linux:**
+
+- No OS-level signing requirement for AppImage or .deb/.rpm
+- GPG signing is conventional for package repos but optional for direct downloads
+- Auto-update on Linux is feasible without code signing
+
+### Update Manifest Format (Variants B and C)
+
+Tauri's updater plugin requires a JSON manifest at a stable URL:
+
+```json
+{
+  "version": "0.2.0",
+  "notes": "See full release notes at https://github.com/armaxri/termiHub/releases/tag/v0.2.0",
+  "pub_date": "2026-04-17T12:00:00Z",
+  "platforms": {
+    "darwin-aarch64": {
+      "url": "https://github.com/armaxri/termiHub/releases/download/v0.2.0/termiHub_0.2.0_aarch64.dmg",
+      "signature": "<ed25519-signature>"
+    },
+    "darwin-x86_64": {
+      "url": "https://github.com/armaxri/termiHub/releases/download/v0.2.0/termiHub_0.2.0_x64.dmg",
+      "signature": "<ed25519-signature>"
+    },
+    "windows-x86_64": {
+      "url": "https://github.com/armaxri/termiHub/releases/download/v0.2.0/termiHub_0.2.0_x64-setup.msi",
+      "signature": "<ed25519-signature>"
+    },
+    "linux-x86_64": {
+      "url": "https://github.com/armaxri/termiHub/releases/download/v0.2.0/termiHub_0.2.0_amd64.AppImage",
+      "signature": "<ed25519-signature>"
+    }
+  }
+}
+```
+
+The manifest can be published as a release asset (`latest.json`) during the release CI workflow
+and hosted at a stable URL (e.g., via GitHub Pages or a simple CDN).
+
+---
+
+## Phased Approach
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Phase 1 — Variant A: Notify Only                   (Recommended Now)  │
+│                                                                         │
+│  • GitHub API check on startup                                          │
+│  • Status bar update dot                                                │
+│  • Non-blocking toast notification                                      │
+│  • Settings > Updates page                                              │
+│  • Security patch bypass of skip                                        │
+│  • No code signing needed, no new infrastructure                        │
+│  • Effort: ~1–2 days                                                    │
+└─────────────────────────────────────────────────────────────────────────┘
+          │
+          │  (optional future step)
+          ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Phase 2 — Variant B: Download + Prompt             (Optional)         │
+│                                                                         │
+│  • Everything in Phase 1, plus:                                         │
+│  • tauri-plugin-updater integration                                     │
+│  • Signed update manifest on GitHub Releases                            │
+│  • In-app download with progress indicator                              │
+│  • "Install and Restart" prompt                                         │
+│  • Requires code signing (macOS + Windows)                              │
+│  • Effort: ~1–2 weeks + certificate setup time                          │
+└─────────────────────────────────────────────────────────────────────────┘
+          │
+          │  (optional future step — evaluate after Phase 2 user feedback)
+          ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│  Phase 3 — Variant C: Fully Automatic               (Optional)         │
+│                                                                         │
+│  • Everything in Phase 2, plus:                                         │
+│  • Silent background download + auto-install on next restart            │
+│  • Post-launch "updated to vX.Y.Z" banner                               │
+│  • Rollback to previous version from Settings                           │
+│  • Note: likely overkill for a developer/ops tool where users           │
+│    prefer to control when updates happen                                │
+│  • Effort: ~3–5 weeks additional                                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The decision of when (or whether) to advance from Phase 1 to Phase 2 should be driven by user
+feedback: if users report that manual re-download is a significant friction point, Phase 2 is
+worthwhile. For a developer tool with technically sophisticated users, Phase 1 may be sufficient
+long-term.
+
+---
+
+## States & Sequences
+
+### Update Availability State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+
+    Idle --> Checking : App launch (5s delay)\nor 24h interval\nor manual "Check Now"
+
+    Checking --> UpToDate : running == latest
+    Checking --> UpdateAvailable : latest > running
+    Checking --> CheckFailed : Network error /\nAPI unavailable
+
+    CheckFailed --> Idle : Silent fail;\nretry next cycle
+
+    UpToDate --> Idle : No action;\nschedule next check
+
+    UpdateAvailable --> Notified : Show dot + toast
+    Notified --> Skipped : User clicks\n"Skip This Version"\n(not security)
+    Notified --> Dismissed : User dismisses\nnotification
+    Notified --> Downloading : Variant B/C:\n"Download" triggered
+    Notified --> OpenedBrowser : Variant A:\n"Open Downloads Page"
+
+    Skipped --> Idle : Persist skip to config
+    Dismissed --> Idle : Show dot only;\nno re-toast until\nnew version
+    OpenedBrowser --> Idle
+
+    Downloading --> DownloadComplete : Download successful
+    Downloading --> DownloadFailed : Network error
+    DownloadFailed --> Notified : Show error;\noffer retry
+    DownloadComplete --> ReadyToInstall : Variant B: show prompt
+    DownloadComplete --> PendingRestart : Variant C: silent
+
+    ReadyToInstall --> Installing : User confirms
+    ReadyToInstall --> Idle : User clicks "Later"
+
+    Installing --> [*] : App restarts
+    PendingRestart --> [*] : Next app launch\ntriggers install
+```
+
+### Variant A: Notify-Only User Journey
+
+```mermaid
+flowchart TD
+    A[App starts] --> B[5-second delay]
+    B --> C{Last check\n< 1 hour ago?}
+    C -->|Yes| D[Skip check]
+    C -->|No| E[GET github.com/releases/latest]
+    E --> F{API success?}
+    F -->|No| G[Silent fail;\nlog to LogViewer]
+    F -->|Yes| H{latest > running?}
+    H -->|No| I[Update last_check_time\nStatus: Up to date]
+    H -->|Yes| J{Security release?}
+    J -->|Yes| K[Show security popup\nno skip option\nRed dot in status bar]
+    J -->|No| L{Version already\nskipped?}
+    L -->|Yes| M[Show amber dot only\nno popup]
+    L -->|No| N[Show update popup\nAmber dot in status bar]
+
+    K --> O[User clicks\nOpen Downloads Page]
+    N --> O
+    N --> P[User clicks\nSkip This Version]
+    N --> Q[User dismisses popup]
+
+    O --> R[Open GitHub Releases\nin default browser]
+    P --> S[Persist skipped version\nto config]
+    Q --> T[Dot remains;\nno re-popup this session]
+```
+
+### Variant B: Download and Prompt Sequence
+
+```mermaid
+sequenceDiagram
+    participant UI as React Frontend
+    participant Store as Zustand Store
+    participant Tauri as Tauri Backend
+    participant Plugin as tauri-plugin-updater
+    participant GH as GitHub / Manifest
+
+    UI->>Tauri: check_for_updates()
+    Tauri->>GH: GET update manifest
+    GH-->>Tauri: { version, platforms, signatures }
+    Tauri->>Tauri: semver compare;\nverify signature
+    Tauri-->>Store: updateAvailable: true,\nlatestVersion: "0.2.0"
+    Store-->>UI: re-render status bar dot + popup
+
+    UI->>Tauri: download_update()
+    Tauri->>Plugin: start download
+    Plugin->>GH: Download installer asset
+    loop Download progress
+        Plugin-->>Tauri: progress event (bytes downloaded)
+        Tauri-->>Store: downloadProgress: 0..100
+        Store-->>UI: update progress bar
+    end
+    Plugin-->>Tauri: download complete; installer staged
+    Tauri-->>Store: readyToInstall: true
+    Store-->>UI: show "Install and Restart" dialog
+
+    UI->>Tauri: install_update()
+    Tauri->>Plugin: apply update + restart
+    Note over Tauri,Plugin: App process exits;\ninstaller runs;\napp relaunches at new version
+```
+
+### Security Update Skip Bypass
+
+```mermaid
+flowchart TD
+    A[Update detected] --> B[Parse GitHub Release body]
+    B --> C{Contains\nsecurity marker?}
+    C -->|Yes| D[Mark as security release]
+    C -->|No| E[Mark as regular release]
+
+    D --> F[Show security popup\nred dot\nno Skip option]
+    E --> G{User previously\nskipped this version?}
+    G -->|Yes| H[Show amber dot only\nsilent — no popup]
+    G -->|No| I[Show regular popup\namber dot\nSkip option available]
+```
+
+---
+
+## Preliminary Implementation Details
+
+### Variant A — Phase 1 (Notify Only)
+
+**Backend** (`src-tauri/src/`):
+
+New file: `src-tauri/src/commands/update.rs`
+
+```rust
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateInfo {
+    pub available: bool,
+    pub latest_version: String,
+    pub release_url: String,
+    pub release_notes: String,
+    pub is_security: bool,
+}
+
+#[tauri::command]
+pub async fn check_for_updates(app_version: String) -> Result<UpdateInfo, String> {
+    // GET https://api.github.com/repos/armaxri/termiHub/releases/latest
+    // Compare semver, detect security marker, return UpdateInfo
+}
+```
+
+- Uses `reqwest` (already a workspace dependency)
+- Security detection: check if release body contains `<!-- security -->` marker (convention to
+  add to release workflow)
+- Persisted state: extend existing app config JSON with `last_update_check` and
+  `skipped_update_version` fields
+
+**Frontend**:
+
+New components:
+
+- `src/components/StatusBar/UpdateIndicator.tsx` — version chip with optional dot badge;
+  `onClick` opens update popup
+- `src/components/UpdateNotification/UpdateNotification.tsx` — toast/dialog with action buttons
+- New section in `src/components/Settings/` (existing settings layout) for the Updates page
+
+Zustand store additions in `src/store/appStore.ts`:
+
+```typescript
+updateAvailable: boolean;
+latestVersion: string | null;
+latestReleaseUrl: string | null;
+latestReleaseNotes: string | null;
+isSecurityUpdate: boolean;
+updateCheckState: "idle" | "checking" | "up-to-date" | "available" | "error";
+skippedVersion: string | null;
+```
+
+New Tauri event or invoke call on startup (after 5-second delay) and a 24-hour interval via
+`setInterval`.
+
+**No infrastructure changes required.** The GitHub Releases API is unauthenticated for public
+repositories (rate limit: 60 req/hour per IP — well within normal usage).
+
+---
+
+### Variant B — Phase 2 (Download + Prompt)
+
+**Additional dependencies**:
+
+- `src-tauri/Cargo.toml`: add `tauri-plugin-updater`
+- `tauri.conf.json`: add updater plugin configuration with endpoint URL and public key
+
+**Update manifest**:
+
+A `latest.json` manifest is generated and signed during the release CI workflow
+(`.github/workflows/release.yml`). The signing private key is stored as a GitHub Actions secret.
+The manifest is uploaded as a release asset or to a GitHub Pages endpoint.
+
+**Additional Tauri commands**:
+
+- `download_update()` — starts download, emits `update-download-progress` events
+- `install_update()` — applies the downloaded update and restarts
+
+**Frontend additions**:
+
+- Progress bar component in `UpdateNotification.tsx`
+- Status bar shows download percentage during active download
+
+**Code signing CI secrets** to add (platform-specific):
+
+- `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_TEAM_ID` (macOS)
+- `TAURI_SIGNING_PRIVATE_KEY`, `WINDOWS_CERTIFICATE` (Windows)
+
+---
+
+### Variant C — Phase 3 (Fully Automatic)
+
+Built on top of Phase 2. Additional work:
+
+- Auto-trigger download on update detection (no user prompt for download)
+- Persist "pending update" state across app restarts
+- On next launch: apply pending update before showing main UI, then show "updated to vX.Y.Z"
+  banner
+- Settings > Updates: show previous version with a "Restore" button
+- Rollback: re-download the previous installer asset from GitHub Releases, run it
+
+Rollback is the main complexity driver for Phase 3. A simpler approach: link to the previous
+GitHub Release for manual rollback, rather than implementing automatic rollback.
+
+---
+
+### Config Schema Extension
+
+The app config JSON (existing settings persistence) gains update-related fields:
+
+```json
+{
+  "updates": {
+    "auto_check": true,
+    "last_check_time": "2026-04-17T14:32:00Z",
+    "skipped_version": null,
+    "pending_install_version": null
+  }
+}
+```
+
+`pending_install_version` is only used by Variant C to persist a staged update across restarts.

--- a/docs/concepts/release-planning-and-dependency-management.md
+++ b/docs/concepts/release-planning-and-dependency-management.md
@@ -1,0 +1,438 @@
+# Release Planning and Dependency Management
+
+---
+
+## Overview
+
+termiHub is a cross-platform desktop application built on a Rust + npm ecosystem — both of which
+have active security vulnerability databases (RUSTSEC, npm advisories) and frequent dependency
+releases. As the application matures beyond its initial v0.1.0 beta, ad-hoc release timing and
+manual dependency updates become a liability: security patches can be delayed, breaking changes
+can accumulate unnoticed, and there is no shared understanding among contributors of when and why
+a release happens.
+
+This concept defines a structured approach to release cadence, dependency monitoring, and security
+response for termiHub's ongoing development lifecycle.
+
+### Goals
+
+- Define clear release types with associated triggers and response time targets
+- Automate dependency vulnerability detection using GitHub-native tooling
+- Establish a security response workflow that can produce a patch release within 72 hours of a
+  confirmed high-severity CVE
+- Keep the five version-bearing config files (`package.json`, `tauri.conf.json`,
+  `src-tauri/Cargo.toml`, `agent/Cargo.toml`, `core/Cargo.toml`) consistent at all times
+- Minimize manual monitoring burden through automation
+
+### Non-Goals
+
+- Automated version bumping or changelog generation (always requires human review)
+- In-app update delivery to end users (covered in the separate
+  [In-Field Update Mechanism](./in-field-update-mechanism.md) concept)
+- Commercial SLA guarantees or enterprise support contracts
+- Backporting fixes to older release branches (single main release line only)
+
+---
+
+## Interface: Maintainer Tooling
+
+This concept describes developer and maintainer workflows, not end-user UI. The relevant
+interfaces are GitHub-hosted tooling and local scripts.
+
+### GitHub Security Tab
+
+GitHub provides a **Security** tab on every repository with the following features — all free for
+public repositories:
+
+```
+Repository: armaxri/termiHub
+┌─────────────────────────────────────────────────────────────────────┐
+│  < > Code  Issues  Pull Requests  Actions  Security  Insights       │
+│                                  ─────────                          │
+│  Security Overview                                                  │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │ ✓ Dependabot alerts        3 active (1 critical, 2 medium)  │   │
+│  │ ✓ Code scanning            No alerts                        │   │
+│  │ ✓ Secret scanning          No secrets detected              │   │
+│  │ ✓ Security advisories      Manage private advisories        │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Dependabot Alerts** (requires `dependabot.yml` in `.github/`):
+
+- Monitors `package.json` (npm) and `Cargo.toml` (cargo/crates.io) for known CVEs
+- Alerts are triggered by the GitHub Advisory Database and RUSTSEC
+- Each alert shows severity, affected package, fix version, and a one-click PR option
+- Alerts can be dismissed with a reason (tolerated risk, not applicable, etc.)
+
+**Dependabot Version Updates** (also via `dependabot.yml`):
+
+- Automatically opens PRs to update outdated dependencies on a schedule
+- Separate from security alerts — these are regular version bumps
+- CI runs against each PR; maintainer reviews and merges
+
+**Security Advisories**:
+
+- Maintainers can draft private security advisories before public disclosure
+- Useful for coordinating responsible disclosure of vulnerabilities found in termiHub itself
+
+### GitHub Milestones
+
+Each planned release is tracked as a GitHub Milestone:
+
+```
+Milestones
+├── v0.2.0  (12 open, 3 closed)   Due: 2026-06-30
+├── v0.1.1  ( 2 open, 0 closed)   Due: as needed (security/bugfix)
+└── Backlog (no due date)
+```
+
+Issues and PRs are assigned to milestones. The milestone completion percentage provides a
+at-a-glance view of release readiness. Security patches bypass normal milestones and use a
+dedicated `hotfix/*` branch.
+
+### Release Check Script
+
+The existing `scripts/release-check.sh` already validates:
+
+- Version consistency across all 5 config files
+- CHANGELOG.md has a dated entry for the current version
+- No stale `[Unreleased]` content
+- Tests pass, quality checks pass
+- Git state is clean on `main` or a `release/*` branch
+
+This script is the final gate before tagging a release.
+
+### CHANGELOG.md Workflow
+
+CHANGELOG follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format already in
+use. The **Security** subsection (already supported) must be used for all security-related fixes:
+
+```markdown
+## [0.1.1] - 2026-05-12
+
+### Security
+
+- Update `ssh2` crate to 0.9.5 to address RUSTSEC-2026-0042 (key exchange timing oracle)
+```
+
+---
+
+## General Handling
+
+### Release Types and Cadence
+
+| Release Type       | Version Bump             | Trigger                                               | Target Turnaround             |
+| ------------------ | ------------------------ | ----------------------------------------------------- | ----------------------------- |
+| **Security patch** | `x.y.Z`                  | Confirmed CVE / Dependabot High or Critical alert     | 48–72 hours from confirmation |
+| **Bug-fix patch**  | `x.y.Z`                  | Accumulated bug fixes, typically 3–5 issues           | Monthly                       |
+| **Minor release**  | `x.Y.0`                  | New features merged to main, milestone complete       | Quarterly                     |
+| **Major release**  | `X.0.0`                  | Breaking API/config changes, major architecture shift | As needed                     |
+| **Pre-release**    | `x.y.z-beta.N` / `-rc.N` | Major releases requiring external testing             | Before every major            |
+
+**Security patches** bypass the normal milestone and review cycle. A single developer can
+prepare and ship a security patch without waiting for other pending work.
+
+**Bug-fix patches** are batched. A patch is cut when enough fixes accumulate or a regression
+is significant enough to warrant immediate action. Monthly cadence is a guideline, not a hard
+rule.
+
+**Minor releases** align with quarterly milestones. Feature development is gated on the
+current milestone. When a milestone closes (all `Ready2Implement` issues resolved), the minor
+release is prepared.
+
+### Dependency Update Workflow
+
+Dependabot opens PRs automatically. The review policy by change type:
+
+| Dependabot PR Type        | Review Policy                | Merge Condition                           |
+| ------------------------- | ---------------------------- | ----------------------------------------- |
+| Security fix (any semver) | Immediate review, prioritize | CI must pass; merge same day              |
+| Patch update (`x.y.Z`)    | Light review                 | Auto-merge if CI passes (optional policy) |
+| Minor update (`x.Y.0`)    | Standard review              | Maintainer approves; check changelog      |
+| Major update (`X.0.0`)    | Full review, test            | Manual verification required              |
+
+Dependabot PRs that fail CI are not merged until the failure is understood. Breaking changes in
+major dependency updates require a dedicated test pass on all supported platforms.
+
+### Security Response Process
+
+When a vulnerability is detected (Dependabot alert, manual discovery, or responsible disclosure
+from an external researcher):
+
+1. **Triage**: Assess severity and applicability. Is the vulnerable code path reachable in
+   termiHub? Which platforms are affected?
+2. **Classify**: High/Critical → security patch release. Medium/Low → next patch cycle.
+3. **Branch**: Create `hotfix/<advisory-id>` from the latest release tag (not `main`).
+4. **Fix and audit**: Apply the fix, run `cargo audit` and `pnpm audit` to clean state.
+5. **Test**: Run full test suite on all platforms via CI. Smoke test affected functionality.
+6. **Release**: Bump patch version in all 5 files, update CHANGELOG Security section, tag.
+7. **Communicate**: GitHub Release notes describe the CVE and fix. Dependabot alert is
+   resolved/dismissed.
+8. **Merge back**: Merge `hotfix/*` back to `main` to keep history consistent.
+
+### Version Consistency Rule
+
+All five files must always carry the same version string. The `release-check.sh` script
+enforces this before any tag is pushed. A pre-commit hook or CI check should catch drift early.
+
+### Hotfix vs. Normal Branch
+
+```
+        main ──────────────────────────────────────────────────────►
+               \                          ↑ merge hotfix back
+                feature/...     tag: v0.1.1
+                                    |
+           v0.1.0 ──────── hotfix/RUSTSEC-2026-0042 ──► tag v0.1.1
+```
+
+Hotfixes branch from the **latest release tag**, not from `main`, to avoid including
+unreleased feature work in the patch.
+
+---
+
+## States & Sequences
+
+### Release Lifecycle State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Planning
+
+    Planning --> Development : Milestone opened,\nissues assigned
+    Development --> CodeFreeze : All milestone issues closed,\nno blocking PRs
+    CodeFreeze --> RCTesting : rc.1 tag pushed,\nCI green on all platforms
+    RCTesting --> Development : Regression found\nduring RC testing
+    RCTesting --> Release : Manual test pass complete,\nrelease-check.sh green
+    Release --> PostRelease : Tag pushed, GitHub Release\ncreated, artifacts uploaded
+    PostRelease --> Planning : Monitoring stable,\nnext milestone opened
+
+    Development --> SecurityPatch : CVE confirmed\n(High or Critical)
+    SecurityPatch --> Release : hotfix/* CI green,\nchangelog updated
+
+    state SecurityPatch {
+        [*] --> Triage
+        Triage --> Hotfix : Applicable to termiHub
+        Triage --> Dismissed : Not applicable / false positive
+        Hotfix --> Verified : cargo audit clean,\npnpm audit clean
+        Verified --> [*]
+    }
+```
+
+### Dependency Alert Response Flowchart
+
+```mermaid
+flowchart TD
+    A[Dependabot Alert\nor cargo audit / pnpm audit] --> B{Severity?}
+    B -->|Critical / High| C[Immediate triage]
+    B -->|Medium| D[Schedule for next\npatch release]
+    B -->|Low| E[Add to backlog,\nmonitor]
+
+    C --> F{Applicable to\ntermiHub?}
+    F -->|Yes| G[Create hotfix branch\nfrom latest tag]
+    F -->|No / False positive| H[Dismiss with reason\nin GitHub alert]
+
+    G --> I[Apply fix]
+    I --> J[Run cargo audit\n+ pnpm audit]
+    J --> K{Audit clean?}
+    K -->|No| I
+    K -->|Yes| L[CI full test run\nall platforms]
+    L --> M{Tests pass?}
+    M -->|No| I
+    M -->|Yes| N[Bump patch version\nupdate CHANGELOG Security]
+    N --> O[Tag + release\nGitHub Release]
+    O --> P[Merge hotfix\nback to main]
+    P --> Q[Resolve Dependabot\nalert]
+```
+
+### Emergency Security Patch Sequence
+
+```mermaid
+sequenceDiagram
+    participant DA as Dependabot
+    participant GH as GitHub Security
+    participant Dev as Maintainer
+    participant CI as GitHub Actions
+    participant Rel as GitHub Release
+
+    DA->>GH: New CVE alert (High severity)
+    GH->>Dev: Email / notification
+
+    Dev->>Dev: Triage: is termiHub affected?
+    Dev->>GH: Create draft Security Advisory (private)
+
+    Dev->>Dev: git checkout -b hotfix/CVE-XXXX latest-tag
+    Dev->>Dev: Apply dependency update / fix
+    Dev->>Dev: cargo audit, pnpm audit → clean
+
+    Dev->>CI: Push hotfix branch → triggers build + tests
+    CI-->>Dev: All platforms green
+
+    Dev->>Dev: Bump patch version (5 files)\nUpdate CHANGELOG Security section
+    Dev->>CI: Push version bump commit
+
+    Dev->>Dev: git tag vX.Y.Z → push tag
+    CI->>Rel: release.yml triggered:\nbuild artifacts, create GitHub Release
+
+    Dev->>GH: Publish Security Advisory\nlink to GitHub Release
+    Dev->>Dev: Merge hotfix back to main
+```
+
+### Normal Minor Release Sequence
+
+```mermaid
+sequenceDiagram
+    participant MS as GitHub Milestone
+    participant Dev as Maintainer
+    participant Script as release-check.sh
+    participant CI as GitHub Actions
+    participant Rel as GitHub Release
+
+    MS->>Dev: Milestone 100% closed\n(all issues resolved)
+
+    Dev->>Dev: git fetch origin\ngit checkout origin/main
+    Dev->>Dev: Verify CHANGELOG [Unreleased]\ncontains all milestone changes
+
+    Dev->>Script: ./scripts/release-check.sh
+    Script-->>Dev: ✓ Version consistent\n✓ CHANGELOG dated\n✓ Tests pass\n✓ Quality clean
+
+    Dev->>Dev: Close [Unreleased] → [X.Y.0] - DATE\nBump version in 5 files
+
+    Dev->>CI: Push version bump to main
+    CI-->>Dev: Build + quality checks pass
+
+    Dev->>Dev: git tag vX.Y.0 → push tag
+    CI->>Rel: release.yml triggered:\nbuild all platforms, upload artifacts
+
+    Dev->>MS: Close milestone\nOpen next milestone
+```
+
+---
+
+## Preliminary Implementation Details
+
+### 1. Enable Dependabot
+
+Create `.github/dependabot.yml`:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "frontend"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "rust"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+```
+
+Major version updates are excluded from automated PRs — they require deliberate evaluation.
+
+### 2. Harden CI Security Checks
+
+In `.github/workflows/code-quality.yml`, remove `continue-on-error: true` from the audit steps
+so that a known CVE blocks merging:
+
+```yaml
+# Before
+- run: cargo audit
+  continue-on-error: true # ← remove this
+
+# After
+- run: cargo audit # ← now blocking
+```
+
+Similarly harden `pnpm audit`:
+
+```yaml
+- run: pnpm audit --audit-level=high # block on high+, warn on moderate
+```
+
+### 3. Optional: cargo-deny
+
+`cargo-deny` provides finer-grained control beyond `cargo audit`:
+
+- License compliance checking (prevent GPL deps in a proprietary build)
+- Duplicate dependency detection
+- Advisory database (RUSTSEC) with allow/deny lists
+
+Add to `code-quality.yml` if license compliance becomes a concern:
+
+```yaml
+- uses: EmbarkStudios/cargo-deny-action@v1
+  with:
+    command: check advisories licenses
+```
+
+### 4. GitHub Milestones
+
+Create milestones in the GitHub UI (or via `gh` CLI) for each planned release cycle:
+
+```bash
+gh api repos/{owner}/{repo}/milestones \
+  --method POST \
+  -f title="v0.2.0" \
+  -f due_on="2026-06-30T00:00:00Z" \
+  -f description="Q2 2026 minor release"
+```
+
+### 5. Branch Protection Enhancements
+
+In GitHub repository settings → Branch protection rules for `main`:
+
+- Require status checks to pass: `cargo audit`, `pnpm audit`, `clippy`, `tests`
+- Require a pull request before merging (already assumed)
+- Restrict who can push to `main` (maintainers only)
+
+### 6. Release Label Convention
+
+Add GitHub labels to support release triage:
+
+| Label             | Color     | Meaning                                  |
+| ----------------- | --------- | ---------------------------------------- |
+| `security`        | Red       | Fix addresses a CVE or security advisory |
+| `breaking-change` | Orange    | Requires major version bump              |
+| `dependencies`    | Blue-grey | Automated dependency update              |
+| `hotfix`          | Dark red  | Emergency patch, bypasses milestone      |
+
+These labels are applied to PRs and auto-included in GitHub Release notes via the release
+workflow's existing changelog extraction logic.
+
+### 7. Hotfix Branch Convention
+
+Hotfix branches follow the pattern:
+
+```
+hotfix/<advisory-id>          # e.g. hotfix/RUSTSEC-2026-0042
+hotfix/<cve-id>               # e.g. hotfix/CVE-2026-12345
+hotfix/<short-description>    # e.g. hotfix/ssh2-key-exchange
+```
+
+They are branched from the latest release tag, not from `main`:
+
+```bash
+git checkout -b hotfix/RUSTSEC-2026-0042 v0.1.0
+```
+
+The `release-check.sh` script already allows `release/*` branches — extend it to also accept
+`hotfix/*` branches as valid release origins.


### PR DESCRIPTION
## Summary

- Adds `docs/concepts/release-planning-and-dependency-management.md` — defines release types (security patch, bug-fix, minor, major) with SLA targets, Dependabot configuration for npm and Cargo, CI audit hardening, GitHub milestone workflow, and a hotfix branching model for emergency security patches
- Adds `docs/concepts/in-field-update-mechanism.md` — compares three update delivery variants (notify-only, download+prompt, fully automatic) with full codebase impact, code signing requirements, infrastructure cost analysis, and a phased adoption roadmap
- Updates `docs/concepts/README.md` with entries for both new documents

## Key design decisions documented

**Release planning**: Hotfixes branch from the latest release *tag* (not `main`) to avoid shipping unreleased feature work in a security patch. Dependabot major-version PRs are excluded from auto-open to require deliberate evaluation.

**In-field updates**: The concept deliberately defers the final variant choice. Phase 1 (notify-only) requires no code signing and no new infrastructure. Phase 2 (download+prompt) requires `tauri-plugin-updater` plus macOS/Windows code signing certificates. Phase 3 (fully automatic) adds rollback complexity that is likely overkill for a developer tool.

## Test plan

- [ ] Verify both concept documents render correctly in GitHub markdown preview
- [ ] Confirm all Mermaid diagrams parse without errors
- [ ] Confirm `pnpm run markdownlint` passes on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)