### PR TITLE
feat(ui): extend zoom overlay to all tab types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UI: Input fields gain a focus glow ring (`box-shadow: 0 0 0 3px rgba(61, 125, 232, 0.22)`) across all dialogs and settings panels
 - UI: Settings nav items use rounded-pill active highlight instead of a bare left-border indicator
 - UI: Toggle switches enlarged (34 × 20 px) with smoother spring-like transition
-
-- Terminal: the panel zoom overlay (Cmd+Shift+Enter / Ctrl+Shift+Enter) now follows panel focus — navigating between split panels while a terminal is zoomed updates the overlay to show the active tab of the newly focused panel; switching tabs within the zoomed panel also updates the overlay to follow the new active tab
+- Terminal: the panel zoom overlay (Cmd+Shift+Enter / Ctrl+Shift+Enter) now works for **all tab types** — file editors, settings, log viewer, connection/tunnel/workspace editors, and network diagnostics can all be zoomed, with the same overlay look and feel (dark backdrop, header bar with icon/title/hint, close button) as terminal zoom
+- Terminal: the zoom overlay now **follows panel and tab-group focus** — switching between split panels or tab groups while a tab is zoomed moves the overlay to show the active tab of the newly focused panel/group rather than dismissing it
+- Terminal: right-clicking a non-terminal tab (file editor, settings, etc.) now shows a context menu with **Set Color…** to colorize the tab
 - Shell integration (OSC 7 CWD tracking) is now **visible by default**: the setup command runs in the terminal at startup with a `# [termiHub] Shell integration: setting up OSC 7 CWD tracking` notice, instead of being silently erased. This applies to local bash, SSH, and WSL connections.
 - WSL: the setup script no longer contains erase sequences; the `source` command and the echo notice are left visible in the terminal.
 
@@ -34,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- File editor: closing the zoom overlay no longer leaves the panel's file editor blank — the Monaco model is now preserved across overlay mount/unmount cycles (`keepCurrentModel`) so the panel editor retains its content when zoom is dismissed
+- UI: the zoom shortcut (Cmd/Ctrl+Shift+Enter) no longer inserts a blank line in Monaco-based editors — a capture-phase keyboard listener intercepts the key before Monaco's "Insert Line Above" keybinding fires
 - Terminal: zoom overlay no longer shows blank or garbled content after the zoomed tab changes — the `ResizeObserver` now skips fitting while the terminal element is in transit through the off-screen parking div, which previously caused the PTY to be briefly resized to 1–2 columns and the shell to redraw its prompt at that width (filling the buffer with wrapped garbage)
 - Credential store: the unlock dialog no longer appears proactively every 15 minutes after auto-lock — the store still locks automatically, but the unlock prompt is only shown when a credential is actually needed (e.g. when connecting with stored credentials)
 - Workspace launch: the master password dialog is now shown **once upfront** before any tabs open (instead of after the first connection attempt fails), and stored credentials are resolved and injected into each tab's config so all connections authenticate silently without interactive password prompts

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -42,13 +42,15 @@ interface FileEditorProps {
   tabId: string;
   meta: EditorTabMeta;
   isVisible: boolean;
+  /** When true, the Monaco model is preserved on unmount (used by zoom overlay instances). */
+  keepModel?: boolean;
 }
 
 /**
  * Built-in file editor using Monaco Editor.
  * Supports both local and remote (SFTP) files.
  */
-export function FileEditor({ tabId, meta, isVisible }: FileEditorProps) {
+export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEditorProps) {
   const setEditorDirty = useAppStore((s) => s.setEditorDirty);
   const setEditorStatus = useAppStore((s) => s.setEditorStatus);
   const setEditorActions = useAppStore((s) => s.setEditorActions);
@@ -294,6 +296,7 @@ export function FileEditor({ tabId, meta, isVisible }: FileEditorProps) {
           path={fileName}
           language={detectedLanguage}
           theme={monacoTheme}
+          keepCurrentModel={keepModel}
           onChange={(value) => setContent(value ?? "")}
           onMount={handleEditorMount}
           options={{

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -238,7 +238,27 @@ export function SplitView() {
         <div className="zoom-overlay" onClick={dismissZoom}>
           <div className="zoom-overlay__panel" onClick={(e) => e.stopPropagation()}>
             <div className="zoom-overlay__header">
-              <ConnectionIcon config={zoomedTab.config} size={14} className="zoom-overlay__icon" />
+              {zoomedTab.contentType === "settings" ? (
+                <SettingsIcon size={14} className="zoom-overlay__icon" />
+              ) : zoomedTab.contentType === "log-viewer" ? (
+                <ScrollText size={14} className="zoom-overlay__icon" />
+              ) : zoomedTab.contentType === "editor" ? (
+                <FileEdit size={14} className="zoom-overlay__icon" />
+              ) : zoomedTab.contentType === "connection-editor" ? (
+                <SquarePen size={14} className="zoom-overlay__icon" />
+              ) : zoomedTab.contentType === "tunnel-editor" ? (
+                <ArrowLeftRight size={14} className="zoom-overlay__icon" />
+              ) : zoomedTab.contentType === "workspace-editor" ? (
+                <LayoutGrid size={14} className="zoom-overlay__icon" />
+              ) : zoomedTab.contentType === "network-diagnostic" ? (
+                <Stethoscope size={14} className="zoom-overlay__icon" />
+              ) : (
+                <ConnectionIcon
+                  config={zoomedTab.config}
+                  size={14}
+                  className="zoom-overlay__icon"
+                />
+              )}
               <span className="zoom-overlay__title">{zoomedTab.title}</span>
               <span className="zoom-overlay__hint">
                 {isMac() ? "⌘⇧↵" : "Ctrl+Shift+Enter"} · Esc to close
@@ -252,10 +272,59 @@ export function SplitView() {
               </button>
             </div>
             <div className="zoom-overlay__content">
-              <TerminalSearchBar tabId={zoomedTabId} />
-              {/* key forces a fresh mount on each zoomed-tab change so the
-                  adoption lifecycle always matches the initial-zoom case. */}
-              <TerminalSlot key={`zoom-slot-${zoomedTabId}`} tabId={zoomedTabId} isVisible={true} />
+              {zoomedTab.contentType === "terminal" ? (
+                <>
+                  <TerminalSearchBar tabId={zoomedTabId} />
+                  {/* key forces a fresh mount on each zoomed-tab change so the
+                      adoption lifecycle always matches the initial-zoom case. */}
+                  <TerminalSlot
+                    key={`zoom-slot-${zoomedTabId}`}
+                    tabId={zoomedTabId}
+                    isVisible={true}
+                  />
+                </>
+              ) : zoomedTab.contentType === "settings" ? (
+                <SettingsPanel isVisible={true} />
+              ) : zoomedTab.contentType === "log-viewer" ? (
+                <LogViewer isVisible={true} />
+              ) : zoomedTab.contentType === "editor" && zoomedTab.editorMeta ? (
+                <FileEditor
+                  key={`zoom-${zoomedTabId}`}
+                  tabId={zoomedTabId}
+                  meta={zoomedTab.editorMeta}
+                  isVisible={true}
+                  keepModel={true}
+                />
+              ) : zoomedTab.contentType === "connection-editor" &&
+                zoomedTab.connectionEditorMeta ? (
+                <ConnectionEditor
+                  key={`zoom-${zoomedTabId}`}
+                  tabId={zoomedTabId}
+                  meta={zoomedTab.connectionEditorMeta}
+                  isVisible={true}
+                />
+              ) : zoomedTab.contentType === "tunnel-editor" && zoomedTab.tunnelEditorMeta ? (
+                <TunnelEditor
+                  key={`zoom-${zoomedTabId}`}
+                  tabId={zoomedTabId}
+                  meta={zoomedTab.tunnelEditorMeta}
+                  isVisible={true}
+                />
+              ) : zoomedTab.contentType === "workspace-editor" && zoomedTab.workspaceEditorMeta ? (
+                <WorkspaceEditor
+                  key={`zoom-${zoomedTabId}`}
+                  tabId={zoomedTabId}
+                  meta={zoomedTab.workspaceEditorMeta}
+                  isVisible={true}
+                />
+              ) : zoomedTab.contentType === "network-diagnostic" &&
+                zoomedTab.networkDiagnosticMeta ? (
+                <NetworkDiagnosticPanel
+                  key={`zoom-${zoomedTabId}`}
+                  meta={zoomedTab.networkDiagnosticMeta}
+                  isVisible={true}
+                />
+              ) : null}
             </div>
           </div>
         </div>
@@ -390,42 +459,48 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
         )}
         {panel.tabs.map((tab) =>
           tab.contentType === "settings" ? (
-            <SettingsPanel key={tab.id} isVisible={tab.id === panel.activeTabId} />
+            <SettingsPanel
+              key={tab.id}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
+            />
           ) : tab.contentType === "log-viewer" ? (
-            <LogViewer key={tab.id} isVisible={tab.id === panel.activeTabId} />
+            <LogViewer
+              key={tab.id}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
+            />
           ) : tab.contentType === "editor" && tab.editorMeta ? (
             <FileEditor
               key={tab.id}
               tabId={tab.id}
               meta={tab.editorMeta}
-              isVisible={tab.id === panel.activeTabId}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : tab.contentType === "connection-editor" && tab.connectionEditorMeta ? (
             <ConnectionEditor
               key={tab.id}
               tabId={tab.id}
               meta={tab.connectionEditorMeta}
-              isVisible={tab.id === panel.activeTabId}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : tab.contentType === "tunnel-editor" && tab.tunnelEditorMeta ? (
             <TunnelEditor
               key={tab.id}
               tabId={tab.id}
               meta={tab.tunnelEditorMeta}
-              isVisible={tab.id === panel.activeTabId}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : tab.contentType === "workspace-editor" && tab.workspaceEditorMeta ? (
             <WorkspaceEditor
               key={tab.id}
               tabId={tab.id}
               meta={tab.workspaceEditorMeta}
-              isVisible={tab.id === panel.activeTabId}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : tab.contentType === "network-diagnostic" && tab.networkDiagnosticMeta ? (
             <NetworkDiagnosticPanel
               key={tab.id}
               meta={tab.networkDiagnosticMeta}
-              isVisible={tab.id === panel.activeTabId}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : useQuickAction ? (
             <div

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -114,7 +114,22 @@ export function Tab({
   );
 
   if (!isTerminalTab) {
-    return tabElement;
+    return (
+      <ContextMenu.Root>
+        <ContextMenu.Trigger asChild>{tabElement}</ContextMenu.Trigger>
+        <ContextMenu.Portal>
+          <ContextMenu.Content className="context-menu__content">
+            <ContextMenu.Item
+              className="context-menu__item"
+              onSelect={() => onSetColor?.()}
+              data-testid="tab-context-set-color"
+            >
+              <Palette size={14} /> Set Color...
+            </ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>
+    );
   }
 
   return (

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -8,6 +8,22 @@ import { processKeyEvent, onChordStateChange, cancelChord } from "@/services/key
  * Uses the KeybindingService's chord-aware processKeyEvent() for matching.
  */
 export function useKeyboardShortcuts() {
+  // Capture-phase interception for zoom-panel: must fire before Monaco (and other
+  // editors) so they don't process the key themselves (e.g. Monaco's "Insert Line
+  // Above" on Cmd/Ctrl+Shift+Enter).  We match the key directly here to avoid
+  // calling processKeyEvent() in two phases for the same event.
+  useEffect(() => {
+    const handleZoomCapture = (e: KeyboardEvent) => {
+      if (e.key !== "Enter" || !e.shiftKey || (!e.metaKey && !e.ctrlKey) || e.altKey) return;
+      e.preventDefault();
+      e.stopPropagation();
+      cancelChord();
+      useAppStore.getState().toggleZoomActiveTab();
+    };
+    window.addEventListener("keydown", handleZoomCapture, { capture: true });
+    return () => window.removeEventListener("keydown", handleZoomCapture, { capture: true });
+  }, []);
+
   const addTab = useAppStore((s) => s.addTab);
   const rootPanel = useAppStore((s) => s.rootPanel);
   const activePanelId = useAppStore((s) => s.activePanelId);

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -257,6 +257,101 @@ describe("appStore", () => {
     });
   });
 
+  describe("toggleZoomActiveTab", () => {
+    it("zooms a terminal tab", () => {
+      useAppStore.getState().addTab("Shell", "local");
+      const state = useAppStore.getState();
+      const leaves = getAllLeaves(state.rootPanel);
+      const tabId = leaves[0].activeTabId!;
+
+      useAppStore.getState().toggleZoomActiveTab();
+
+      expect(useAppStore.getState().zoomedTabId).toBe(tabId);
+    });
+
+    it("zooms a non-terminal (editor) tab", () => {
+      useAppStore.getState().openEditorTab("/some/file.txt", false);
+      const state = useAppStore.getState();
+      const leaves = getAllLeaves(state.rootPanel);
+      const tabId = leaves[0].activeTabId!;
+
+      useAppStore.getState().toggleZoomActiveTab();
+
+      expect(useAppStore.getState().zoomedTabId).toBe(tabId);
+    });
+
+    it("dismisses zoom when already zoomed", () => {
+      useAppStore.getState().addTab("Shell", "local");
+      useAppStore.getState().toggleZoomActiveTab();
+      expect(useAppStore.getState().zoomedTabId).not.toBeNull();
+
+      useAppStore.getState().toggleZoomActiveTab();
+
+      expect(useAppStore.getState().zoomedTabId).toBeNull();
+    });
+  });
+
+  describe("setActivePanel zoom follow", () => {
+    it("follows zoom to the new panel's active tab when switching panels", () => {
+      useAppStore.getState().addTab("Shell", "local");
+      const state0 = useAppStore.getState();
+      const panel1Id = state0.activePanelId!;
+      const tab1Id = getAllLeaves(state0.rootPanel)[0].activeTabId!;
+
+      useAppStore.getState().splitPanel("horizontal");
+      useAppStore.getState().addTab("Shell 2", "local");
+      const state1 = useAppStore.getState();
+      const panel2Id = state1.activePanelId!;
+      const tab2Id = getAllLeaves(state1.rootPanel).find((l) => l.id === panel2Id)!.activeTabId!;
+
+      // Zoom the first panel's tab, then switch focus to the second panel
+      useAppStore.getState().setActivePanel(panel1Id);
+      useAppStore.getState().toggleZoomActiveTab();
+      expect(useAppStore.getState().zoomedTabId).toBe(tab1Id);
+
+      useAppStore.getState().setActivePanel(panel2Id);
+
+      expect(useAppStore.getState().zoomedTabId).toBe(tab2Id);
+    });
+
+    it("clears zoom when switching to a panel with no active tab", () => {
+      useAppStore.getState().addTab("Shell", "local");
+      const state0 = useAppStore.getState();
+      const panel1Id = state0.activePanelId!;
+      useAppStore.getState().splitPanel("horizontal");
+      const panel2Id = useAppStore.getState().activePanelId!;
+
+      useAppStore.getState().setActivePanel(panel1Id);
+      useAppStore.getState().toggleZoomActiveTab();
+      expect(useAppStore.getState().zoomedTabId).not.toBeNull();
+
+      // Close all tabs in panel 2 so it has no active tab, then switch
+      useAppStore.getState().setActivePanel(panel2Id);
+      // panel2 has no tabs → activeTabId is null → zoom clears
+      expect(useAppStore.getState().zoomedTabId).toBeNull();
+    });
+  });
+
+  describe("setActiveTab zoom follow", () => {
+    it("follows zoom to any tab type when switching in the same panel", () => {
+      useAppStore.getState().addTab("Shell", "local");
+      useAppStore.getState().openEditorTab("/file.txt", false);
+      const state = useAppStore.getState();
+      const leaves = getAllLeaves(state.rootPanel);
+      const terminalTabId = leaves[0].tabs.find((t) => t.contentType === "terminal")!.id;
+      const editorTabId = leaves[0].tabs.find((t) => t.contentType === "editor")!.id;
+
+      // Zoom the terminal tab, then switch to the editor tab
+      useAppStore.getState().setActiveTab(terminalTabId, leaves[0].id);
+      useAppStore.getState().toggleZoomActiveTab();
+      expect(useAppStore.getState().zoomedTabId).toBe(terminalTabId);
+
+      useAppStore.getState().setActiveTab(editorTabId, leaves[0].id);
+
+      expect(useAppStore.getState().zoomedTabId).toBe(editorTabId);
+    });
+  });
+
   describe("openEditorTab", () => {
     it("creates a new editor tab with the given session ID", () => {
       useAppStore.getState().openEditorTab("/remote/file.txt", true, "session-abc");

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -732,7 +732,9 @@ export const useAppStore = create<AppState>((set, get) => {
         // Follow zoom to the new group's active tab so the overlay never goes stale
         let newZoomedTabId = state.zoomedTabId;
         if (state.zoomedTabId !== null) {
-          const newActivePanel = findLeaf(targetGroup.rootPanel, targetGroup.activePanelId);
+          const newActivePanel = targetGroup.activePanelId
+            ? findLeaf(targetGroup.rootPanel, targetGroup.activePanelId)
+            : null;
           newZoomedTabId = newActivePanel?.activeTabId ?? null;
         }
         return {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -729,11 +729,18 @@ export const useAppStore = create<AppState>((set, get) => {
             ? { ...g, rootPanel: state.rootPanel, activePanelId: state.activePanelId }
             : g
         );
+        // Follow zoom to the new group's active tab so the overlay never goes stale
+        let newZoomedTabId = state.zoomedTabId;
+        if (state.zoomedTabId !== null) {
+          const newActivePanel = findLeaf(targetGroup.rootPanel, targetGroup.activePanelId);
+          newZoomedTabId = newActivePanel?.activeTabId ?? null;
+        }
         return {
           tabGroups: savedGroups,
           activeTabGroupId: groupId,
           rootPanel: targetGroup.rootPanel,
           activePanelId: targetGroup.activePanelId,
+          zoomedTabId: newZoomedTabId,
         };
       }),
 
@@ -1238,8 +1245,7 @@ export const useAppStore = create<AppState>((set, get) => {
         if (state.zoomedTabId !== null) {
           const panelLeaf = findLeaf(state.rootPanel, panelId);
           if (panelLeaf?.tabs.some((t) => t.id === state.zoomedTabId)) {
-            const newTab = panelLeaf.tabs.find((t) => t.id === tabId);
-            newZoomedTabId = newTab?.contentType === "terminal" ? tabId : null;
+            newZoomedTabId = tabId;
           }
         }
 
@@ -1324,16 +1330,10 @@ export const useAppStore = create<AppState>((set, get) => {
 
     setActivePanel: (panelId) =>
       set((state) => {
-        // If zoom is active, follow the active tab of the newly focused panel
         let newZoomedTabId = state.zoomedTabId;
         if (state.zoomedTabId !== null) {
-          const panelLeaf = findLeaf(state.rootPanel, panelId);
-          if (panelLeaf?.activeTabId) {
-            const activeTab = panelLeaf.tabs.find((t) => t.id === panelLeaf.activeTabId);
-            newZoomedTabId = activeTab?.contentType === "terminal" ? panelLeaf.activeTabId : null;
-          } else {
-            newZoomedTabId = null;
-          }
+          const newPanel = findLeaf(state.rootPanel, panelId);
+          newZoomedTabId = newPanel?.activeTabId ?? null;
         }
         return { activePanelId: panelId, zoomedTabId: newZoomedTabId };
       }),
@@ -1442,10 +1442,7 @@ export const useAppStore = create<AppState>((set, get) => {
       const leaves = getAllLeaves(rootPanel);
       const panel = leaves.find((p) => p.id === activePanelId) ?? leaves[0];
       if (panel?.activeTabId) {
-        const tab = panel.tabs.find((t) => t.id === panel.activeTabId);
-        if (tab?.contentType === "terminal") {
-          set({ zoomedTabId: panel.activeTabId });
-        }
+        set({ zoomedTabId: panel.activeTabId });
       }
     },
 


### PR DESCRIPTION
## Summary

- **All tab types support zoom overlay** — file editors, settings, log viewer, connection/tunnel/workspace editors, and network diagnostics can now be zoomed with Cmd/Ctrl+Shift+Enter, using the same dark-backdrop overlay with header bar, icon, title, hint text and close button as terminal zoom
- **Zoom follows panel/tab-group focus** — switching split panels or tab groups while zoomed now moves the overlay to the newly focused panel's active tab, rather than dismissing it; `setActivePanel` and `setActiveTabGroup` both follow zoom consistently
- **Right-click on non-terminal tabs** now shows a "Set Color…" context menu item (runtime-only, not persisted to disk)
- **Fix: blank file editor after zoom dismissal** — the overlay's `FileEditor` instance was disposing the shared Monaco model on unmount; passing `keepCurrentModel=true` to overlay instances preserves the model so the panel editor retains its content
- **Fix: stray newline in Monaco on zoom shortcut** — a capture-phase listener intercepts Cmd/Ctrl+Shift+Enter before Monaco's built-in "Insert Line Above" keybinding fires
- **Fix: double-trigger needed to zoom after tab-group switch** — `setActiveTabGroup` was leaving a stale `zoomedTabId` pointing at a tab in the old group; now it follows zoom to the new group's active tab (or clears it if the panel is empty)

## Test plan

- [ ] Open a file in the editor, press Cmd/Ctrl+Shift+Enter — zoom overlay appears with file content (no newline inserted into the file)
- [ ] Dismiss zoom — panel editor still shows the full file content (not blank)
- [ ] Open a settings/log/connection/tunnel/workspace/network-diagnostic tab and zoom it — overlay appears with matching look (backdrop, header, icon, title, hint)
- [ ] Zoom a tab, then navigate to a different split panel with focus shortcuts — overlay stays visible and switches to the new panel's active tab
- [ ] Zoom a tab, then switch tab groups — overlay follows to the new group's active tab; pressing the zoom shortcut once (not twice) toggles correctly
- [ ] Right-click a file editor or settings tab — "Set Color…" context menu item appears and opens the color picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)