### PR TITLE
perf(agent): faster builds — pre-built OpenSSL + Docker layer caching

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -47,8 +47,18 @@ jobs:
           curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz \
             | sudo tar xz -C /usr/local/bin
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build custom cross-rs image
-        run: docker build -t localhost/termihub-cross:${{ matrix.target }} -f agent/docker/Dockerfile.${{ matrix.target }} agent/docker
+        uses: docker/build-push-action@v5
+        with:
+          context: agent/docker
+          file: agent/docker/Dockerfile.${{ matrix.target }}
+          tags: localhost/termihub-cross:${{ matrix.target }}
+          load: true
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
 
       - name: Build
         run: CROSS_CONFIG=agent/Cross.toml cross build --release --target ${{ matrix.target }} -p termihub-agent

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,8 +229,18 @@ jobs:
           curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz \
             | sudo tar xz -C /usr/local/bin
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build custom cross-rs image
-        run: docker build -t localhost/termihub-cross:${{ matrix.target }} -f agent/docker/Dockerfile.${{ matrix.target }} agent/docker
+        uses: docker/build-push-action@v5
+        with:
+          context: agent/docker
+          file: agent/docker/Dockerfile.${{ matrix.target }}
+          tags: localhost/termihub-cross:${{ matrix.target }}
+          load: true
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
 
       - name: Build agent
         run: CROSS_CONFIG=agent/Cross.toml cross build --release --target ${{ matrix.target }} -p termihub-agent

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -22,7 +22,6 @@ termihub-core = { path = "../core", features = [
     "ssh",
     "telnet",
     "docker",
-    "wsl",
 ] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/agent/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/agent/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -15,7 +15,7 @@ RUN dpkg --add-architecture arm64 \
     && chmod +x /usr/local/bin/aarch64-linux-gnu-pkg-config \
     && curl -fsSL https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C /tmp \
     && cd /tmp/openssl-${OPENSSL_VERSION} \
-    && CC=aarch64-linux-musl-gcc CROSS_COMPILE=aarch64-linux-musl- \
+    && CROSS_COMPILE=aarch64-linux-musl- \
        ./Configure no-shared no-zlib no-tests --libdir=lib linux-aarch64 --prefix=/opt/openssl \
     && make -j$(nproc) \
     && make install_sw \

--- a/agent/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/agent/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -1,12 +1,30 @@
 FROM --platform=linux/amd64 ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
+
+ARG OPENSSL_VERSION=3.3.2
+
+# Pre-build static OpenSSL cross-compiled for aarch64 musl.  OPENSSL_NO_VENDOR
+# causes openssl-sys to skip its bundled compilation and use these libs instead,
+# moving the ~2 min OpenSSL build cost from every cargo run into this cached layer.
 # lld: system LLD linker fallback for when Rust's bundled rust-lld lacks execute
 # permission after being copied from Windows via podman cp (DrvFs strips +x bits).
 RUN dpkg --add-architecture arm64 \
     && apt-get update \
-    && apt-get install -y libudev-dev:arm64 lld \
+    && apt-get install -y libudev-dev:arm64 lld perl make curl \
     && printf '#!/bin/sh\nPKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 exec pkg-config "$@"\n' \
        > /usr/local/bin/aarch64-linux-gnu-pkg-config \
-    && chmod +x /usr/local/bin/aarch64-linux-gnu-pkg-config
+    && chmod +x /usr/local/bin/aarch64-linux-gnu-pkg-config \
+    && curl -fsSL https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C /tmp \
+    && cd /tmp/openssl-${OPENSSL_VERSION} \
+    && CC=aarch64-linux-musl-gcc CROSS_COMPILE=aarch64-linux-musl- \
+       ./Configure no-shared no-zlib no-tests --libdir=lib linux-aarch64 --prefix=/opt/openssl \
+    && make -j$(nproc) \
+    && make install_sw \
+    && rm -rf /tmp/openssl-${OPENSSL_VERSION}
+
+ENV OPENSSL_NO_VENDOR=1 \
+    OPENSSL_STATIC=1 \
+    OPENSSL_LIB_DIR=/opt/openssl/lib \
+    OPENSSL_INCLUDE_DIR=/opt/openssl/include
 
 # Podman+Windows fix: cross-rs copies the Rust toolchain from the Windows
 # filesystem via `podman cp`, which strips execute bits from ELF binaries

--- a/agent/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/agent/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -1,7 +1,25 @@
 FROM --platform=linux/amd64 ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
+
+ARG OPENSSL_VERSION=3.3.2
+
+# Pre-build static OpenSSL with the musl toolchain.  OPENSSL_NO_VENDOR causes
+# openssl-sys to skip its bundled compilation and use these libs instead, moving
+# the ~2 min OpenSSL build cost from every cargo run into this cached image layer.
 # lld: system LLD linker fallback for when Rust's bundled rust-lld lacks execute
 # permission after being copied from Windows via podman cp (DrvFs strips +x bits).
-RUN apt-get update && apt-get install -y libudev-dev lld
+RUN apt-get update && apt-get install -y libudev-dev lld perl make curl \
+ && curl -fsSL https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C /tmp \
+ && cd /tmp/openssl-${OPENSSL_VERSION} \
+ && CC=x86_64-linux-musl-gcc \
+    ./Configure no-shared no-zlib no-tests --libdir=lib linux-x86_64 --prefix=/opt/openssl \
+ && make -j$(nproc) \
+ && make install_sw \
+ && rm -rf /tmp/openssl-${OPENSSL_VERSION}
+
+ENV OPENSSL_NO_VENDOR=1 \
+    OPENSSL_STATIC=1 \
+    OPENSSL_LIB_DIR=/opt/openssl/lib \
+    OPENSSL_INCLUDE_DIR=/opt/openssl/include
 
 # Podman+Windows fix: cross-rs copies the Rust toolchain from the Windows
 # filesystem via `podman cp`, which strips execute bits from ELF binaries


### PR DESCRIPTION
## Summary

- **Pre-build OpenSSL in cross-rs Docker images** (`Dockerfile.x86_{64,aarch64}-unknown-linux-musl`): compiles OpenSSL 3.3.2 as a static musl library during image build and sets `OPENSSL_NO_VENDOR=1`, so `openssl-sys` skips vendored C compilation at cargo build time. Saves ~2-3 min per target on cold cargo cache (first build, or after `clean.sh`).
- **Cache Docker layers in CI** (`agent.yml`, `release.yml`): replaces `docker build` with `docker/build-push-action@v5` + GitHub Actions layer cache (`type=gha`). The cross-rs image is no longer rebuilt from scratch on every CI run — saves ~2-4 min per target per run. Cache is shared between `agent.yml` and `release.yml` via the same scope key.
- **Remove `wsl` feature from agent crate** (`agent/Cargo.toml`): the agent is a Linux-only binary; WSL only runs on Windows and the backend is already gated `#[cfg(windows)]` in core, so this feature was a no-op that added unnecessary semantic noise.

## Test plan

- [ ] Push a change to `agent/` and verify CI agent build passes with the new Docker caching step
- [ ] Confirm a second CI run is faster (Docker image layers served from GHA cache, no apt install + OpenSSL compilation)
- [ ] Locally: run `./scripts/clean.sh` then `./scripts/build-agents.sh` and verify the build does not recompile OpenSSL from source (no `openssl-sys` C compilation log output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)