### PR TITLE
feat(agent): add ARMv7 (arm32) support for older Raspberry Pi

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -27,6 +27,8 @@ jobs:
             artifact_name: termihub-agent-linux-x64
           - target: aarch64-unknown-linux-musl
             artifact_name: termihub-agent-linux-arm64
+          - target: armv7-unknown-linux-musleabihf
+            artifact_name: termihub-agent-linux-armv7
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,8 @@ jobs:
             artifact_name: termihub-agent-linux-x64
           - target: aarch64-unknown-linux-musl
             artifact_name: termihub-agent-linux-arm64
+          - target: armv7-unknown-linux-musleabihf
+            artifact_name: termihub-agent-linux-armv7
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Agent: ARMv7 (arm32) support — a new `termihub-agent-linux-armv7` binary is now built and released for 32-bit ARM devices such as older Raspberry Pi models (Pi 2 B, Pi 1 B+). Includes cross-compilation Dockerfile, Cross.toml entry, updated build and setup scripts, and CI pipeline changes.
 - Update checker (Variant A — notify only): termiHub now checks the GitHub Releases API on startup (with a 5-second delay) and every 24 hours for new versions. When a newer release is found, an amber dot appears on the version chip in the status bar and a non-blocking notification popup offers to open the GitHub downloads page. Security releases (marked `<!-- security -->` in the release notes) show a red dot and cannot be silently skipped. Users can skip a specific version, clear a skipped version, or disable automatic checks entirely in **Settings → Updates**.
 - Connection settings: a **Shell Integration** toggle is now available for local shell, SSH, and WSL connections (enabled by default). Disabling it skips all OSC injection at startup.
 - Connection settings: boolean fields now support an optional **help icon (?)** that opens an explanation dialog. The Shell Integration toggle uses this to explain what OSC 7 tracking is and why it's useful.

--- a/agent/Cross.toml
+++ b/agent/Cross.toml
@@ -15,3 +15,6 @@ image = "localhost/termihub-cross:x86_64-unknown-linux-musl"
 
 [target.aarch64-unknown-linux-musl]
 image = "localhost/termihub-cross:aarch64-unknown-linux-musl"
+
+[target.armv7-unknown-linux-musleabihf]
+image = "localhost/termihub-cross:armv7-unknown-linux-musleabihf"

--- a/agent/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/agent/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -1,0 +1,39 @@
+FROM --platform=linux/amd64 ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main
+
+ARG OPENSSL_VERSION=3.3.2
+
+# Pre-build static OpenSSL cross-compiled for armv7 musl.  OPENSSL_NO_VENDOR
+# causes openssl-sys to skip its bundled compilation and use these libs instead,
+# moving the ~2 min OpenSSL build cost from every cargo run into this cached layer.
+# lld: system LLD linker fallback for when Rust's bundled rust-lld lacks execute
+# permission after being copied from Windows via podman cp (DrvFs strips +x bits).
+RUN dpkg --add-architecture armhf \
+    && apt-get update \
+    && apt-get install -y libudev-dev:armhf lld perl make curl \
+    && printf '#!/bin/sh\nPKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 exec pkg-config "$@"\n' \
+       > /usr/local/bin/arm-linux-gnueabihf-pkg-config \
+    && chmod +x /usr/local/bin/arm-linux-gnueabihf-pkg-config \
+    && curl -fsSL https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C /tmp \
+    && cd /tmp/openssl-${OPENSSL_VERSION} \
+    && CROSS_COMPILE=armv7-linux-musleabihf- \
+       ./Configure no-shared no-zlib no-tests --libdir=lib linux-armv4 --prefix=/opt/openssl \
+    && make -j$(nproc) \
+    && make install_sw \
+    && rm -rf /tmp/openssl-${OPENSSL_VERSION}
+
+ENV OPENSSL_NO_VENDOR=1 \
+    OPENSSL_STATIC=1 \
+    OPENSSL_LIB_DIR=/opt/openssl/lib \
+    OPENSSL_INCLUDE_DIR=/opt/openssl/include
+
+# Podman+Windows fix: cross-rs copies the Rust toolchain from the Windows
+# filesystem via `podman cp`, which strips execute bits from ELF binaries
+# (DrvFs->container limitation).  This entrypoint runs a tight background loop
+# that restores +x on any injected bin/ files before the build command runs.
+RUN printf '#!/bin/sh\n( while true; do find /cross /root -maxdepth 12 -path "*/bin/*" -type f ! -perm /0111 -exec chmod +x {} + 2>/dev/null || true; sleep 1; done ) &\nexec "$@"\n' > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+# Default CMD keeps the container alive in TTY mode (CROSS_REMOTE=1 on Windows).
+# When cross-rs detects a TTY it omits the explicit "sleep infinity" command and
+# relies on the image CMD instead; without this the container exits immediately.
+CMD ["sleep", "infinity"]

--- a/agent/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/agent/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -15,7 +15,7 @@ RUN dpkg --add-architecture armhf \
     && chmod +x /usr/local/bin/arm-linux-gnueabihf-pkg-config \
     && curl -fsSL https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C /tmp \
     && cd /tmp/openssl-${OPENSSL_VERSION} \
-    && CROSS_COMPILE=armv7-linux-musleabihf- \
+    && CROSS_COMPILE=arm-linux-musleabihf- \
        ./Configure no-shared no-zlib no-tests --libdir=lib linux-armv4 --prefix=/opt/openssl \
     && make -j$(nproc) \
     && make install_sw \

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -483,10 +483,11 @@ The remote agent (`termihub-agent`) runs on Linux hosts (servers, ARM devices, N
 
 ### Targets
 
-| Triple                       | Arch  | libc | Use Case                                         |
-| ---------------------------- | ----- | ---- | ------------------------------------------------ |
-| `x86_64-unknown-linux-musl`  | x64   | musl | Standard servers, static portable binary         |
-| `aarch64-unknown-linux-musl` | ARM64 | musl | ARM64 servers, Raspberry Pi 3/4/5, static binary |
+| Triple                           | Arch  | libc | Use Case                                           |
+| -------------------------------- | ----- | ---- | -------------------------------------------------- |
+| `x86_64-unknown-linux-musl`      | x64   | musl | Standard servers, static portable binary           |
+| `aarch64-unknown-linux-musl`     | ARM64 | musl | ARM64 servers, Raspberry Pi 3/4/5, static binary   |
+| `armv7-unknown-linux-musleabihf` | ARMv7 | musl | ARMv7 devices, older Raspberry Pi (Pi 2 / Pi 1 B+) |
 
 ### Quick Start
 

--- a/scripts/build-agents.cmd
+++ b/scripts/build-agents.cmd
@@ -19,6 +19,7 @@ echo.
 echo Targets:
 echo   x86_64-unknown-linux-musl       Static x64 binaries (musl)
 echo   aarch64-unknown-linux-musl      Static ARM64 binaries (musl)
+echo   armv7-unknown-linux-musleabihf  Static ARMv7 binaries (musl, older Raspberry Pi)
 echo.
 echo Prerequisites:
 echo   - Rust toolchain (rustup)
@@ -29,7 +30,7 @@ exit /b 0
 :start
 cd /d "%~dp0\.."
 
-echo === Building agent for 2 Linux targets ===
+echo === Building agent for 3 Linux targets ===
 echo.
 
 REM Verify cross-rs
@@ -121,6 +122,7 @@ set FAILED=0
 for %%T in (
     x86_64-unknown-linux-musl
     aarch64-unknown-linux-musl
+    armv7-unknown-linux-musleabihf
 ) do (
     call :build_target %%T
 )

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -14,6 +14,7 @@ cd "$(git rev-parse --show-toplevel)"
 ALL_TARGETS=(
     x86_64-unknown-linux-musl
     aarch64-unknown-linux-musl
+    armv7-unknown-linux-musleabihf
 )
 SELECTED_TARGETS=()
 SEQUENTIAL=false
@@ -45,6 +46,7 @@ Options:
 Targets:
   x86_64-unknown-linux-musl       Static x64 binaries (musl)
   aarch64-unknown-linux-musl      Static ARM64 binaries (musl)
+  armv7-unknown-linux-musleabihf  Static ARMv7 binaries (musl, older Raspberry Pi)
 
 Examples:
   ./scripts/build-agents.sh

--- a/scripts/setup-agent-cross.cmd
+++ b/scripts/setup-agent-cross.cmd
@@ -20,7 +20,7 @@ echo.
 echo Windows:
 echo   - cross-rs (via cargo install) for all targets
 echo   - Verifies Docker Desktop or Podman Desktop is available
-echo   - Adds Rust targets for both architectures
+echo   - Adds Rust targets for all architectures
 echo   - Builds localhost/termihub-cross:^<target^> images with libudev-dev
 echo.
 echo Prerequisites:
@@ -38,6 +38,7 @@ echo --- Adding Rust targets ---
 for %%T in (
     x86_64-unknown-linux-musl
     aarch64-unknown-linux-musl
+    armv7-unknown-linux-musleabihf
 ) do (
     rustup target add %%T
 )
@@ -89,6 +90,7 @@ set BUILD_FAILED=0
 for %%T in (
     x86_64-unknown-linux-musl
     aarch64-unknown-linux-musl
+    armv7-unknown-linux-musleabihf
 ) do (
     call :build_image %%T
 )

--- a/scripts/setup-agent-cross.sh
+++ b/scripts/setup-agent-cross.sh
@@ -28,6 +28,7 @@ fi
 TARGETS=(
     x86_64-unknown-linux-musl
     aarch64-unknown-linux-musl
+    armv7-unknown-linux-musleabihf
 )
 
 echo "=== Agent Cross-Compilation Setup ==="


### PR DESCRIPTION
## Summary

- Adds `armv7-unknown-linux-musleabihf` as a third cross-compilation target alongside x64 and arm64
- New `Dockerfile.armv7-unknown-linux-musleabihf` pre-builds static OpenSSL for armv7 musl (mirrors the aarch64 Dockerfile pattern)
- `Cross.toml`, build scripts (`.sh` + `.cmd`), and setup scripts updated to include the new target
- CI workflows (`agent.yml`, `release.yml`) extended — produces `termihub-agent-linux-armv7` artifact on every build and release
- `docs/contributing.md` targets table updated; `CHANGELOG.md` entry added
- No source code changes needed — `agent_binary.rs` already maps `armv7l`/`armhf` → `linux-armv7` (with tests)

## Test plan

- [ ] Run `./scripts/setup-agent-cross.sh` — verify the `localhost/termihub-cross:armv7-unknown-linux-musleabihf` Docker image builds successfully
- [ ] Run `./scripts/build-agents.sh --targets armv7-unknown-linux-musleabihf` — verify binary is produced and runs on an ARMv7 device (or via QEMU)
- [ ] Confirm CI matrix passes for all three targets after merge
- [ ] On an older Raspberry Pi (armv7l): connect via SSH in termiHub and verify the agent is auto-deployed from the new `termihub-agent-linux-armv7` release asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)