### PR TITLE
refactor: DI testing infrastructure — inject traits across core, agent, and tauri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (internal)
+
+- DI testing infrastructure: extracted `LocalShellSpawner`, `SshConnector`, `SessionManagerApi`, `DaemonLauncher`, `ConnectionStoreApi`, `MonitoringManagerApi`, `EventEmitter`, and `AgentRpcClient` traits across `core`, `agent`, and `src-tauri`. Concrete types are unchanged; tests can now inject mocks without real PTY/SSH/Tauri runtimes. Tauri agent commands now depend on `Arc<dyn AgentRpcClient>` in state.
+
 ### Changed
 
 - UI: Comprehensive design refresh — new Geist typeface, deeper cool-tinted dark palette, generous border radii (4–14 px), richer multi-layer shadows, and premium `cubic-bezier(0.16, 1, 0.3, 1)` transitions throughout

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -26,7 +26,9 @@ use crate::protocol::methods::{
     SessionResizeParams,
 };
 use crate::session::definitions::{Connection, ConnectionStoreApi, Folder};
-use crate::session::manager::{SessionCreateError, SessionManager, SessionManagerApi, MAX_SESSIONS};
+use crate::session::manager::{
+    SessionCreateError, SessionManager, SessionManagerApi, MAX_SESSIONS,
+};
 
 /// The agent's protocol version.
 ///
@@ -2606,8 +2608,7 @@ mod tests {
 
     fn make_mock_dispatcher() -> Dispatcher<MockSessionManager> {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        let tmp =
-            std::env::temp_dir().join(format!("termihub-mock-{}.json", uuid::Uuid::new_v4()));
+        let tmp = std::env::temp_dir().join(format!("termihub-mock-{}.json", uuid::Uuid::new_v4()));
         let conn_store = Arc::new(ConnectionStore::new_temp(tmp));
         let monitoring_manager = Arc::new(MonitoringManager::new(tx, conn_store.clone()));
         let session_manager = Arc::new(MockSessionManager::new());
@@ -2618,12 +2619,9 @@ mod tests {
         )
     }
 
-    fn make_mock_dispatcher_failing(
-        error: SessionCreateError,
-    ) -> Dispatcher<MockSessionManager> {
+    fn make_mock_dispatcher_failing(error: SessionCreateError) -> Dispatcher<MockSessionManager> {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        let tmp =
-            std::env::temp_dir().join(format!("termihub-mock-{}.json", uuid::Uuid::new_v4()));
+        let tmp = std::env::temp_dir().join(format!("termihub-mock-{}.json", uuid::Uuid::new_v4()));
         let conn_store = Arc::new(ConnectionStore::new_temp(tmp));
         let monitoring_manager = Arc::new(MonitoringManager::new(tx, conn_store.clone()));
         let session_manager = Arc::new(MockSessionManager::with_create_error(error));
@@ -2813,8 +2811,7 @@ mod tests {
 
     #[tokio::test]
     async fn mock_session_create_limit_reached_returns_error() {
-        let mut d =
-            make_mock_dispatcher_failing(SessionCreateError::LimitReached);
+        let mut d = make_mock_dispatcher_failing(SessionCreateError::LimitReached);
         init_mock(&mut d).await;
 
         let req = make_request(
@@ -2885,7 +2882,10 @@ mod tests {
             2,
         );
         let result = d.dispatch(req).await.to_json();
-        assert!(result.get("result").is_some(), "create should succeed: {result}");
+        assert!(
+            result.get("result").is_some(),
+            "create should succeed: {result}"
+        );
 
         let conns = store.connections.lock().await;
         assert_eq!(conns.len(), 1);
@@ -2927,7 +2927,10 @@ mod tests {
 
         let req = make_request("connections.delete", json!({"id": "conn-test-1"}), 2);
         let result = d.dispatch(req).await.to_json();
-        assert!(result.get("result").is_some(), "delete should succeed: {result}");
+        assert!(
+            result.get("result").is_some(),
+            "delete should succeed: {result}"
+        );
         assert!(store.connections.lock().await.is_empty());
     }
 
@@ -2948,7 +2951,10 @@ mod tests {
             2,
         );
         let result = d.dispatch(req).await.to_json();
-        assert!(result.get("result").is_some(), "subscribe should succeed: {result}");
+        assert!(
+            result.get("result").is_some(),
+            "subscribe should succeed: {result}"
+        );
         assert_eq!(subscribed.lock().await.as_slice(), ["self"]);
     }
 

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -9,7 +9,7 @@ use base64::Engine;
 
 use crate::files::local::LocalFileBackend;
 use crate::files::{FileBackend, FileError};
-use crate::monitoring::MonitoringManager;
+use crate::monitoring::MonitoringManagerApi;
 use crate::network;
 use crate::protocol::errors;
 use crate::protocol::messages::{JsonRpcErrorResponse, JsonRpcRequest, JsonRpcResponse};
@@ -25,8 +25,8 @@ use crate::protocol::methods::{
     SessionDetachParams, SessionInputParams, SessionListEntry, SessionListResult,
     SessionResizeParams,
 };
-use crate::session::definitions::{Connection, ConnectionStore, Folder};
-use crate::session::manager::{SessionCreateError, SessionManager, MAX_SESSIONS};
+use crate::session::definitions::{Connection, ConnectionStoreApi, Folder};
+use crate::session::manager::{SessionCreateError, SessionManager, SessionManagerApi, MAX_SESSIONS};
 
 /// The agent's protocol version.
 ///
@@ -35,10 +35,14 @@ const AGENT_PROTOCOL_VERSION: &str = "0.2.0";
 
 /// Dispatcher handles incoming JSON-RPC requests and routes them
 /// to the appropriate handler function.
-pub struct Dispatcher {
-    session_manager: Arc<SessionManager>,
-    connection_store: Arc<ConnectionStore>,
-    monitoring_manager: Arc<MonitoringManager>,
+///
+/// Generic over `M: SessionManagerApi` so it can be tested with a mock
+/// session manager without spawning real backends or registries.
+/// Defaults to [`SessionManager`] in production.
+pub struct Dispatcher<M: SessionManagerApi = SessionManager> {
+    session_manager: Arc<M>,
+    connection_store: Arc<dyn ConnectionStoreApi>,
+    monitoring_manager: Arc<dyn MonitoringManagerApi>,
     initialized: bool,
     start_time: Instant,
 }
@@ -69,11 +73,11 @@ impl DispatchResult {
     }
 }
 
-impl Dispatcher {
+impl<M: SessionManagerApi> Dispatcher<M> {
     pub fn new(
-        session_manager: Arc<SessionManager>,
-        connection_store: Arc<ConnectionStore>,
-        monitoring_manager: Arc<MonitoringManager>,
+        session_manager: Arc<M>,
+        connection_store: Arc<dyn ConnectionStoreApi>,
+        monitoring_manager: Arc<dyn MonitoringManagerApi>,
     ) -> Self {
         Self {
             session_manager,
@@ -1309,7 +1313,11 @@ mod tests {
         let registry = Arc::new(crate::registry::build_registry());
         let session_manager = Arc::new(SessionManager::new(tx.clone(), registry));
         let monitoring_manager = Arc::new(MonitoringManager::new(tx, conn_store.clone()));
-        let dispatcher = Dispatcher::new(session_manager.clone(), conn_store, monitoring_manager);
+        let dispatcher = Dispatcher::new(
+            session_manager.clone(),
+            conn_store as Arc<dyn ConnectionStoreApi>,
+            monitoring_manager as Arc<dyn MonitoringManagerApi>,
+        );
         (dispatcher, session_manager)
     }
 
@@ -2455,5 +2463,512 @@ mod tests {
         let req = make_request("network.open_ports", json!({}), 1);
         let result = d.dispatch(req).await.to_json();
         assert_eq!(result["error"]["code"], errors::NOT_INITIALIZED);
+    }
+
+    // ── MockSessionManager + DI tests ──────────────────────────────
+
+    use crate::monitoring::MonitoringManager;
+    use crate::session::definitions::{
+        Connection, ConnectionSnapshot, ConnectionStore, ConnectionStoreApi, Folder, FolderSnapshot,
+    };
+    use crate::session::manager::SessionManagerApi;
+    use crate::session::types::{SessionSnapshot, SessionStatus};
+    use termihub_core::connection::ConnectionTypeRegistry;
+    use tokio::sync::Mutex as AsyncMutex;
+
+    struct MockSessionManager {
+        registry: ConnectionTypeRegistry,
+        /// When `Some`, `create()` returns this error.
+        create_error: Option<SessionCreateError>,
+        sessions: Arc<AsyncMutex<Vec<SessionSnapshot>>>,
+    }
+
+    impl MockSessionManager {
+        fn new() -> Self {
+            Self {
+                registry: crate::registry::build_registry(),
+                create_error: None,
+                sessions: Arc::new(AsyncMutex::new(Vec::new())),
+            }
+        }
+
+        fn with_create_error(error: SessionCreateError) -> Self {
+            Self {
+                registry: crate::registry::build_registry(),
+                create_error: Some(error),
+                sessions: Arc::new(AsyncMutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl SessionManagerApi for MockSessionManager {
+        fn registry(&self) -> &ConnectionTypeRegistry {
+            &self.registry
+        }
+
+        async fn create(
+            &self,
+            type_id: &str,
+            title: String,
+            _settings: serde_json::Value,
+        ) -> Result<SessionSnapshot, SessionCreateError> {
+            if let Some(ref e) = self.create_error {
+                return Err(match e {
+                    SessionCreateError::LimitReached => SessionCreateError::LimitReached,
+                    SessionCreateError::InvalidConfig(m) => {
+                        SessionCreateError::InvalidConfig(m.clone())
+                    }
+                    SessionCreateError::BackendFailed(m) => {
+                        SessionCreateError::BackendFailed(m.clone())
+                    }
+                });
+            }
+            let snapshot = SessionSnapshot {
+                id: uuid::Uuid::new_v4().to_string(),
+                title,
+                type_id: type_id.to_string(),
+                status: SessionStatus::Running,
+                created_at: chrono::Utc::now(),
+                last_activity: chrono::Utc::now(),
+                attached: false,
+            };
+            self.sessions.lock().await.push(snapshot.clone());
+            Ok(snapshot)
+        }
+
+        async fn list(&self) -> Vec<SessionSnapshot> {
+            self.sessions.lock().await.clone()
+        }
+
+        async fn get_session_type_id(&self, session_id: &str) -> Option<String> {
+            self.sessions
+                .lock()
+                .await
+                .iter()
+                .find(|s| s.id == session_id)
+                .map(|s| s.type_id.clone())
+        }
+
+        async fn close(&self, session_id: &str) -> bool {
+            let mut sessions = self.sessions.lock().await;
+            let before = sessions.len();
+            sessions.retain(|s| s.id != session_id);
+            sessions.len() < before
+        }
+
+        async fn close_all(&self) {
+            self.sessions.lock().await.clear();
+        }
+
+        async fn detach_all(&self) {}
+
+        async fn active_count(&self) -> u32 {
+            self.sessions.lock().await.len() as u32
+        }
+
+        async fn attach(&self, session_id: &str) -> Result<(), String> {
+            let sessions = self.sessions.lock().await;
+            if sessions.iter().any(|s| s.id == session_id) {
+                Ok(())
+            } else {
+                Err("Session not found".to_string())
+            }
+        }
+
+        async fn detach(&self, session_id: &str) -> Result<(), String> {
+            let sessions = self.sessions.lock().await;
+            if sessions.iter().any(|s| s.id == session_id) {
+                Ok(())
+            } else {
+                Err("Session not found".to_string())
+            }
+        }
+
+        async fn write_input(&self, session_id: &str, _data: &[u8]) -> Result<(), String> {
+            let sessions = self.sessions.lock().await;
+            if sessions.iter().any(|s| s.id == session_id) {
+                Ok(())
+            } else {
+                Err("Session not found".to_string())
+            }
+        }
+
+        async fn resize(&self, session_id: &str, _cols: u16, _rows: u16) -> Result<(), String> {
+            let sessions = self.sessions.lock().await;
+            if sessions.iter().any(|s| s.id == session_id) {
+                Ok(())
+            } else {
+                Err("Session not found".to_string())
+            }
+        }
+    }
+
+    fn make_mock_dispatcher() -> Dispatcher<MockSessionManager> {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let tmp =
+            std::env::temp_dir().join(format!("termihub-mock-{}.json", uuid::Uuid::new_v4()));
+        let conn_store = Arc::new(ConnectionStore::new_temp(tmp));
+        let monitoring_manager = Arc::new(MonitoringManager::new(tx, conn_store.clone()));
+        let session_manager = Arc::new(MockSessionManager::new());
+        Dispatcher::new(
+            session_manager,
+            conn_store as Arc<dyn ConnectionStoreApi>,
+            monitoring_manager as Arc<dyn MonitoringManagerApi>,
+        )
+    }
+
+    fn make_mock_dispatcher_failing(
+        error: SessionCreateError,
+    ) -> Dispatcher<MockSessionManager> {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let tmp =
+            std::env::temp_dir().join(format!("termihub-mock-{}.json", uuid::Uuid::new_v4()));
+        let conn_store = Arc::new(ConnectionStore::new_temp(tmp));
+        let monitoring_manager = Arc::new(MonitoringManager::new(tx, conn_store.clone()));
+        let session_manager = Arc::new(MockSessionManager::with_create_error(error));
+        Dispatcher::new(
+            session_manager,
+            conn_store as Arc<dyn ConnectionStoreApi>,
+            monitoring_manager as Arc<dyn MonitoringManagerApi>,
+        )
+    }
+
+    // ── Mock ConnectionStore and MonitoringManager for DI tests ──────
+
+    /// In-memory mock connection store (no filesystem).
+    struct MockConnectionStore {
+        connections: AsyncMutex<Vec<ConnectionSnapshot>>,
+        folders: AsyncMutex<Vec<FolderSnapshot>>,
+    }
+
+    impl MockConnectionStore {
+        fn new() -> Self {
+            Self {
+                connections: AsyncMutex::new(Vec::new()),
+                folders: AsyncMutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ConnectionStoreApi for MockConnectionStore {
+        async fn get(&self, id: &str) -> Option<ConnectionSnapshot> {
+            self.connections
+                .lock()
+                .await
+                .iter()
+                .find(|c| c.id == id)
+                .cloned()
+        }
+
+        async fn create(&self, conn: Connection) -> ConnectionSnapshot {
+            let snap = ConnectionSnapshot {
+                id: conn.id.clone(),
+                name: conn.name,
+                session_type: conn.session_type,
+                config: conn.config,
+                persistent: conn.persistent,
+                folder_id: conn.folder_id,
+                terminal_options: conn.terminal_options,
+                icon: conn.icon,
+            };
+            self.connections.lock().await.push(snap.clone());
+            snap
+        }
+
+        async fn update(
+            &self,
+            id: &str,
+            name: Option<String>,
+            _session_type: Option<String>,
+            _config: Option<serde_json::Value>,
+            _persistent: Option<bool>,
+            _folder_id: Option<Option<String>>,
+            _terminal_options: Option<Option<serde_json::Value>>,
+            _icon: Option<Option<String>>,
+        ) -> Option<ConnectionSnapshot> {
+            let mut conns = self.connections.lock().await;
+            let conn = conns.iter_mut().find(|c| c.id == id)?;
+            if let Some(n) = name {
+                conn.name = n;
+            }
+            Some(conn.clone())
+        }
+
+        async fn list(&self) -> (Vec<ConnectionSnapshot>, Vec<FolderSnapshot>) {
+            (
+                self.connections.lock().await.clone(),
+                self.folders.lock().await.clone(),
+            )
+        }
+
+        async fn delete(&self, id: &str) -> bool {
+            let mut conns = self.connections.lock().await;
+            let before = conns.len();
+            conns.retain(|c| c.id != id);
+            conns.len() < before
+        }
+
+        async fn create_folder(&self, folder: Folder) -> FolderSnapshot {
+            let snap = FolderSnapshot {
+                id: folder.id,
+                name: folder.name,
+                parent_id: folder.parent_id,
+                is_expanded: folder.is_expanded,
+            };
+            self.folders.lock().await.push(snap.clone());
+            snap
+        }
+
+        async fn update_folder(
+            &self,
+            id: &str,
+            name: Option<String>,
+            _parent_id: Option<Option<String>>,
+            _is_expanded: Option<bool>,
+        ) -> Option<FolderSnapshot> {
+            let mut folders = self.folders.lock().await;
+            let folder = folders.iter_mut().find(|f| f.id == id)?;
+            if let Some(n) = name {
+                folder.name = n;
+            }
+            Some(folder.clone())
+        }
+
+        async fn delete_folder(&self, id: &str) -> bool {
+            let mut folders = self.folders.lock().await;
+            let before = folders.len();
+            folders.retain(|f| f.id != id);
+            folders.len() < before
+        }
+    }
+
+    /// Mock monitoring manager that records calls.
+    struct MockMonitoringManager {
+        subscribed: Arc<AsyncMutex<Vec<String>>>,
+        unsubscribed: Arc<AsyncMutex<Vec<String>>>,
+        shutdown_called: Arc<AsyncMutex<bool>>,
+    }
+
+    impl MockMonitoringManager {
+        fn new() -> Self {
+            Self {
+                subscribed: Arc::new(AsyncMutex::new(Vec::new())),
+                unsubscribed: Arc::new(AsyncMutex::new(Vec::new())),
+                shutdown_called: Arc::new(AsyncMutex::new(false)),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MonitoringManagerApi for MockMonitoringManager {
+        async fn subscribe(&self, host: &str, _interval_ms: Option<u64>) -> anyhow::Result<()> {
+            self.subscribed.lock().await.push(host.to_string());
+            Ok(())
+        }
+
+        async fn unsubscribe(&self, host: &str) {
+            self.unsubscribed.lock().await.push(host.to_string());
+        }
+
+        async fn shutdown(&self) {
+            *self.shutdown_called.lock().await = true;
+        }
+    }
+
+    fn make_mock_dispatcher_with_stores(
+        conn_store: Arc<dyn ConnectionStoreApi>,
+        monitor: Arc<dyn MonitoringManagerApi>,
+    ) -> Dispatcher<MockSessionManager> {
+        let session_manager = Arc::new(MockSessionManager::new());
+        Dispatcher::new(session_manager, conn_store, monitor)
+    }
+
+    async fn init_mock(d: &mut Dispatcher<MockSessionManager>) {
+        let req = make_request("initialize", init_params(), 1);
+        let result = d.dispatch(req).await;
+        assert!(matches!(result, DispatchResult::Success(_)));
+    }
+
+    #[tokio::test]
+    async fn mock_session_create_backend_failed_returns_error() {
+        let mut d = make_mock_dispatcher_failing(SessionCreateError::BackendFailed(
+            "PTY spawn failed".to_string(),
+        ));
+        init_mock(&mut d).await;
+
+        let req = make_request(
+            "connection.create",
+            json!({"type": "local", "config": {}}),
+            2,
+        );
+        let result = d.dispatch(req).await.to_json();
+        assert_eq!(result["error"]["code"], errors::SESSION_CREATION_FAILED);
+        assert!(result["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("PTY spawn failed"));
+    }
+
+    #[tokio::test]
+    async fn mock_session_create_limit_reached_returns_error() {
+        let mut d =
+            make_mock_dispatcher_failing(SessionCreateError::LimitReached);
+        init_mock(&mut d).await;
+
+        let req = make_request(
+            "connection.create",
+            json!({"type": "local", "config": {}}),
+            2,
+        );
+        let result = d.dispatch(req).await.to_json();
+        assert_eq!(result["error"]["code"], errors::SESSION_LIMIT_REACHED);
+    }
+
+    #[tokio::test]
+    async fn mock_session_create_and_list() {
+        let mut d = make_mock_dispatcher();
+        init_mock(&mut d).await;
+
+        let req = make_request(
+            "connection.create",
+            json!({"type": "local", "title": "My Shell", "config": {}}),
+            2,
+        );
+        let create_result = d.dispatch(req).await.to_json();
+        assert!(
+            create_result.get("result").is_some(),
+            "expected session create to succeed: {create_result}"
+        );
+        let sid = create_result["result"]["session_id"].as_str().unwrap();
+
+        let req = make_request("connection.list", json!({}), 3);
+        let list_result = d.dispatch(req).await.to_json();
+        let sessions = list_result["result"]["sessions"].as_array().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["session_id"], sid);
+    }
+
+    #[tokio::test]
+    async fn mock_health_check_counts_sessions() {
+        let mut d = make_mock_dispatcher();
+        init_mock(&mut d).await;
+
+        let req = make_request(
+            "connection.create",
+            json!({"type": "local", "config": {}}),
+            2,
+        );
+        d.dispatch(req).await;
+
+        let req = make_request("health.check", json!({}), 3);
+        let result = d.dispatch(req).await.to_json();
+        assert_eq!(result["result"]["active_sessions"], 1);
+    }
+
+    // ── ConnectionStoreApi + MonitoringManagerApi DI tests ────────────
+
+    #[tokio::test]
+    async fn mock_connections_create_via_store_trait() {
+        let store = Arc::new(MockConnectionStore::new());
+        let monitor = Arc::new(MockMonitoringManager::new());
+        let mut d = make_mock_dispatcher_with_stores(
+            store.clone() as Arc<dyn ConnectionStoreApi>,
+            monitor.clone() as Arc<dyn MonitoringManagerApi>,
+        );
+        init_mock(&mut d).await;
+
+        let req = make_request(
+            "connections.create",
+            json!({"name": "My SSH", "type": "ssh", "config": {"host": "example.com"}}),
+            2,
+        );
+        let result = d.dispatch(req).await.to_json();
+        assert!(result.get("result").is_some(), "create should succeed: {result}");
+
+        let conns = store.connections.lock().await;
+        assert_eq!(conns.len(), 1);
+        assert_eq!(conns[0].name, "My SSH");
+    }
+
+    #[tokio::test]
+    async fn mock_connections_delete_via_store_trait() {
+        let store = Arc::new(MockConnectionStore::new());
+        let monitor = Arc::new(MockMonitoringManager::new());
+
+        // Pre-seed a connection
+        let conn = Connection {
+            id: "conn-test-1".to_string(),
+            name: "Test".to_string(),
+            session_type: "ssh".to_string(),
+            config: serde_json::json!({}),
+            persistent: false,
+            folder_id: None,
+            terminal_options: None,
+            icon: None,
+        };
+        store.connections.lock().await.push(ConnectionSnapshot {
+            id: conn.id.clone(),
+            name: conn.name.clone(),
+            session_type: conn.session_type.clone(),
+            config: conn.config.clone(),
+            persistent: conn.persistent,
+            folder_id: None,
+            terminal_options: None,
+            icon: None,
+        });
+
+        let mut d = make_mock_dispatcher_with_stores(
+            store.clone() as Arc<dyn ConnectionStoreApi>,
+            monitor as Arc<dyn MonitoringManagerApi>,
+        );
+        init_mock(&mut d).await;
+
+        let req = make_request("connections.delete", json!({"id": "conn-test-1"}), 2);
+        let result = d.dispatch(req).await.to_json();
+        assert!(result.get("result").is_some(), "delete should succeed: {result}");
+        assert!(store.connections.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mock_monitoring_subscribe_via_trait() {
+        let store = Arc::new(MockConnectionStore::new());
+        let monitor = Arc::new(MockMonitoringManager::new());
+        let subscribed = monitor.subscribed.clone();
+        let mut d = make_mock_dispatcher_with_stores(
+            store as Arc<dyn ConnectionStoreApi>,
+            monitor as Arc<dyn MonitoringManagerApi>,
+        );
+        init_mock(&mut d).await;
+
+        let req = make_request(
+            "connection.monitoring.subscribe",
+            json!({"host": "self"}),
+            2,
+        );
+        let result = d.dispatch(req).await.to_json();
+        assert!(result.get("result").is_some(), "subscribe should succeed: {result}");
+        assert_eq!(subscribed.lock().await.as_slice(), ["self"]);
+    }
+
+    #[tokio::test]
+    async fn mock_monitoring_unsubscribe_via_trait() {
+        let store = Arc::new(MockConnectionStore::new());
+        let monitor = Arc::new(MockMonitoringManager::new());
+        let unsubscribed = monitor.unsubscribed.clone();
+        let mut d = make_mock_dispatcher_with_stores(
+            store as Arc<dyn ConnectionStoreApi>,
+            monitor as Arc<dyn MonitoringManagerApi>,
+        );
+        init_mock(&mut d).await;
+
+        let req = make_request(
+            "connection.monitoring.unsubscribe",
+            json!({"host": "self"}),
+            2,
+        );
+        d.dispatch(req).await;
+        assert_eq!(unsubscribed.lock().await.as_slice(), ["self"]);
     }
 }

--- a/agent/src/io/stdio.rs
+++ b/agent/src/io/stdio.rs
@@ -6,10 +6,10 @@ use tracing::info;
 
 use crate::handler::dispatch::Dispatcher;
 use crate::io::transport::run_transport_loop;
-use crate::monitoring::MonitoringManager;
+use crate::monitoring::{MonitoringManager, MonitoringManagerApi};
 use crate::protocol::messages::JsonRpcNotification;
 use crate::registry::build_registry;
-use crate::session::definitions::ConnectionStore;
+use crate::session::definitions::{ConnectionStore, ConnectionStoreApi};
 use crate::session::manager::SessionManager;
 
 /// Run the NDJSON stdio transport loop.
@@ -38,8 +38,8 @@ pub async fn run_stdio_loop(shutdown: CancellationToken) -> anyhow::Result<()> {
 
     let mut dispatcher = Dispatcher::new(
         session_manager.clone(),
-        connection_store,
-        monitoring_manager.clone(),
+        connection_store.clone() as Arc<dyn ConnectionStoreApi>,
+        monitoring_manager.clone() as Arc<dyn MonitoringManagerApi>,
     );
 
     let stdin = tokio::io::stdin();

--- a/agent/src/io/tcp.rs
+++ b/agent/src/io/tcp.rs
@@ -7,10 +7,10 @@ use tracing::{info, warn};
 
 use crate::handler::dispatch::Dispatcher;
 use crate::io::transport::run_transport_loop;
-use crate::monitoring::MonitoringManager;
+use crate::monitoring::{MonitoringManager, MonitoringManagerApi};
 use crate::protocol::messages::JsonRpcNotification;
 use crate::registry::build_registry;
-use crate::session::definitions::ConnectionStore;
+use crate::session::definitions::{ConnectionStore, ConnectionStoreApi};
 use crate::session::manager::SessionManager;
 
 /// Run the NDJSON transport loop over a TCP listener.
@@ -58,7 +58,11 @@ pub async fn run_tcp_listener(addr: &str, shutdown: CancellationToken) -> anyhow
                 // replayed on attach, so these are not needed.
                 while notification_rx.try_recv().is_ok() {}
 
-                let mut dispatcher = Dispatcher::new(session_manager.clone(), connection_store.clone(), monitoring_manager.clone());
+                let mut dispatcher = Dispatcher::new(
+                    session_manager.clone(),
+                    connection_store.clone() as Arc<dyn ConnectionStoreApi>,
+                    monitoring_manager.clone() as Arc<dyn MonitoringManagerApi>,
+                );
 
                 let (reader_half, mut writer_half) = stream.into_split();
                 let mut reader = BufReader::new(reader_half);

--- a/agent/src/monitoring/mod.rs
+++ b/agent/src/monitoring/mod.rs
@@ -29,6 +29,25 @@ const DEFAULT_INTERVAL_MS: u64 = 2000;
 /// Minimum allowed collection interval in milliseconds.
 const MIN_INTERVAL_MS: u64 = 500;
 
+// ── MonitoringManagerApi trait ─────────────────────────────────────
+
+/// Abstract interface over the monitoring manager.
+///
+/// Implemented by [`MonitoringManager`] in production and by mock structs
+/// in tests. [`crate::handler::dispatch::Dispatcher`] depends on this trait
+/// so it can be tested without spawning real background tasks.
+#[async_trait::async_trait]
+pub trait MonitoringManagerApi: Send + Sync + 'static {
+    /// Start monitoring a host (or replace an existing subscription).
+    async fn subscribe(&self, host: &str, interval_ms: Option<u64>) -> Result<()>;
+
+    /// Stop monitoring a host.
+    async fn unsubscribe(&self, host: &str);
+
+    /// Cancel all subscriptions (called on agent shutdown).
+    async fn shutdown(&self);
+}
+
 /// Manages active monitoring subscriptions.
 ///
 /// Each subscription spawns a background tokio task that periodically
@@ -158,6 +177,23 @@ impl MonitoringManager {
             sub.join_handle.abort();
             debug!("Shutdown: cancelled monitoring for '{host}'");
         }
+    }
+}
+
+// ── MonitoringManagerApi impl ──────────────────────────────────────
+
+#[async_trait::async_trait]
+impl MonitoringManagerApi for MonitoringManager {
+    async fn subscribe(&self, host: &str, interval_ms: Option<u64>) -> Result<()> {
+        MonitoringManager::subscribe(self, host, interval_ms).await
+    }
+
+    async fn unsubscribe(&self, host: &str) {
+        MonitoringManager::unsubscribe(self, host).await;
+    }
+
+    async fn shutdown(&self) {
+        MonitoringManager::shutdown(self).await;
     }
 }
 

--- a/agent/src/session/definitions.rs
+++ b/agent/src/session/definitions.rs
@@ -483,7 +483,18 @@ impl ConnectionStoreApi for ConnectionStore {
         terminal_options: Option<Option<serde_json::Value>>,
         icon: Option<Option<String>>,
     ) -> Option<ConnectionSnapshot> {
-        ConnectionStore::update(self, id, name, session_type, config, persistent, folder_id, terminal_options, icon).await
+        ConnectionStore::update(
+            self,
+            id,
+            name,
+            session_type,
+            config,
+            persistent,
+            folder_id,
+            terminal_options,
+            icon,
+        )
+        .await
     }
 
     async fn list(&self) -> (Vec<ConnectionSnapshot>, Vec<FolderSnapshot>) {

--- a/agent/src/session/definitions.rs
+++ b/agent/src/session/definitions.rs
@@ -92,6 +92,57 @@ impl Folder {
     }
 }
 
+// ── ConnectionStoreApi trait ───────────────────────────────────────
+
+/// Abstract interface over the connection store.
+///
+/// Implemented by [`ConnectionStore`] in production and by mock structs in
+/// tests. [`crate::handler::dispatch::Dispatcher`] depends on this trait so
+/// it can be tested without touching the filesystem.
+#[async_trait::async_trait]
+pub trait ConnectionStoreApi: Send + Sync + 'static {
+    /// Return a connection snapshot by ID.
+    async fn get(&self, id: &str) -> Option<ConnectionSnapshot>;
+
+    /// Create a new connection and return its snapshot.
+    async fn create(&self, conn: Connection) -> ConnectionSnapshot;
+
+    /// Update an existing connection's fields. Returns `None` if not found.
+    #[allow(clippy::too_many_arguments)]
+    async fn update(
+        &self,
+        id: &str,
+        name: Option<String>,
+        session_type: Option<String>,
+        config: Option<serde_json::Value>,
+        persistent: Option<bool>,
+        folder_id: Option<Option<String>>,
+        terminal_options: Option<Option<serde_json::Value>>,
+        icon: Option<Option<String>>,
+    ) -> Option<ConnectionSnapshot>;
+
+    /// List all connections and folders.
+    async fn list(&self) -> (Vec<ConnectionSnapshot>, Vec<FolderSnapshot>);
+
+    /// Delete a connection by ID. Returns `true` if found and removed.
+    async fn delete(&self, id: &str) -> bool;
+
+    /// Create a new folder and return its snapshot.
+    async fn create_folder(&self, folder: Folder) -> FolderSnapshot;
+
+    /// Update an existing folder's fields. Returns `None` if not found.
+    async fn update_folder(
+        &self,
+        id: &str,
+        name: Option<String>,
+        parent_id: Option<Option<String>>,
+        is_expanded: Option<bool>,
+    ) -> Option<FolderSnapshot>;
+
+    /// Delete a folder by ID. Returns `true` if found and removed.
+    async fn delete_folder(&self, id: &str) -> bool;
+}
+
 /// Persistent storage format for connections.json.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct StorageFormat {
@@ -405,6 +456,60 @@ impl ConnectionStore {
                 warn!("Failed to serialize connections: {}", e);
             }
         }
+    }
+}
+
+// ── ConnectionStoreApi impl ────────────────────────────────────────
+
+#[async_trait::async_trait]
+impl ConnectionStoreApi for ConnectionStore {
+    async fn get(&self, id: &str) -> Option<ConnectionSnapshot> {
+        ConnectionStore::get(self, id).await
+    }
+
+    async fn create(&self, conn: Connection) -> ConnectionSnapshot {
+        ConnectionStore::create(self, conn).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn update(
+        &self,
+        id: &str,
+        name: Option<String>,
+        session_type: Option<String>,
+        config: Option<serde_json::Value>,
+        persistent: Option<bool>,
+        folder_id: Option<Option<String>>,
+        terminal_options: Option<Option<serde_json::Value>>,
+        icon: Option<Option<String>>,
+    ) -> Option<ConnectionSnapshot> {
+        ConnectionStore::update(self, id, name, session_type, config, persistent, folder_id, terminal_options, icon).await
+    }
+
+    async fn list(&self) -> (Vec<ConnectionSnapshot>, Vec<FolderSnapshot>) {
+        ConnectionStore::list(self).await
+    }
+
+    async fn delete(&self, id: &str) -> bool {
+        ConnectionStore::delete(self, id).await
+    }
+
+    async fn create_folder(&self, folder: Folder) -> FolderSnapshot {
+        ConnectionStore::create_folder(self, folder).await
+    }
+
+    async fn update_folder(
+        &self,
+        id: &str,
+        name: Option<String>,
+        parent_id: Option<Option<String>>,
+        is_expanded: Option<bool>,
+    ) -> Option<FolderSnapshot> {
+        ConnectionStore::update_folder(self, id, name, parent_id, is_expanded).await
+    }
+
+    async fn delete_folder(&self, id: &str) -> bool {
+        ConnectionStore::delete_folder(self, id).await
     }
 }
 

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -8,14 +8,14 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
-use base64::Engine;
 use chrono::Utc;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use crate::io::transport::NotificationSender;
-use crate::protocol::messages::JsonRpcNotification;
 use crate::session::types::{SessionBackend, SessionInfo, SessionSnapshot, SessionStatus};
+use crate::transport::JsonRpcOutputSink;
+use termihub_core::session::traits::OutputSink;
 use termihub_core::connection::{ConnectionTypeRegistry, OutputReceiver};
 
 #[cfg(unix)]
@@ -27,6 +27,61 @@ use crate::state::persistence::{AgentState, PersistedSession};
 
 /// Maximum number of concurrent sessions the agent supports.
 pub const MAX_SESSIONS: u32 = 20;
+
+// ── SessionManagerApi trait ────────────────────────────────────────
+
+/// Abstract interface over the session manager.
+///
+/// Implemented by [`SessionManager`] in production and by mock structs in
+/// tests. The [`Dispatcher`](crate::handler::dispatch::Dispatcher) depends on
+/// this trait so it can be unit-tested without real backends.
+#[async_trait::async_trait(?Send)]
+pub trait SessionManagerApi: Send + Sync + 'static {
+    /// Return the registry of available connection types.
+    fn registry(&self) -> &ConnectionTypeRegistry;
+
+    /// Create a new session.
+    async fn create(
+        &self,
+        type_id: &str,
+        title: String,
+        settings: serde_json::Value,
+    ) -> Result<SessionSnapshot, SessionCreateError>;
+
+    /// List all sessions as snapshots.
+    async fn list(&self) -> Vec<SessionSnapshot>;
+
+    /// Return the type ID for an active session.
+    async fn get_session_type_id(&self, session_id: &str) -> Option<String>;
+
+    /// Close a session; returns `true` if found and removed.
+    async fn close(&self, session_id: &str) -> bool;
+
+    /// Close all sessions (called during agent shutdown).
+    // Called on the concrete type in io/tcp.rs and io/stdio.rs; not yet via trait.
+    #[allow(dead_code)]
+    async fn close_all(&self);
+
+    /// Detach all sessions without closing them.
+    // Called on the concrete type in io/tcp.rs; not yet via trait.
+    #[allow(dead_code)]
+    async fn detach_all(&self);
+
+    /// Return the number of sessions with status `Running`.
+    async fn active_count(&self) -> u32;
+
+    /// Attach a client to an existing session.
+    async fn attach(&self, session_id: &str) -> Result<(), String>;
+
+    /// Detach the client from a session.
+    async fn detach(&self, session_id: &str) -> Result<(), String>;
+
+    /// Write input data to a session's backend.
+    async fn write_input(&self, session_id: &str, data: &[u8]) -> Result<(), String>;
+
+    /// Resize a session's terminal.
+    async fn resize(&self, session_id: &str, cols: u16, rows: u16) -> Result<(), String>;
+}
 
 /// Errors that can occur during session creation.
 #[derive(Debug)]
@@ -49,6 +104,66 @@ impl fmt::Display for SessionCreateError {
     }
 }
 
+// ── DaemonLauncher trait (Unix only) ──────────────────────────────
+
+/// Abstracts the spawning of a daemon subprocess for persistent sessions.
+///
+/// The production implementation ([`SystemDaemonLauncher`]) calls
+/// `std::process::Command` to launch `termihub-agent --daemon` and
+/// connects via a Unix socket. Tests inject a mock that returns
+/// immediately without spawning a real process.
+#[cfg(unix)]
+#[async_trait::async_trait(?Send)]
+pub trait DaemonLauncher: Send + Sync + 'static {
+    /// Spawn a daemon for the given session and return the connected backend.
+    async fn launch(
+        &self,
+        session_id: &str,
+        type_id: &str,
+        settings: &serde_json::Value,
+        notification_tx: NotificationSender,
+    ) -> Result<SessionBackend, anyhow::Error>;
+}
+
+/// Production [`DaemonLauncher`] that spawns real `termihub-agent --daemon` processes.
+#[cfg(unix)]
+pub struct SystemDaemonLauncher;
+
+#[cfg(unix)]
+#[async_trait::async_trait(?Send)]
+impl DaemonLauncher for SystemDaemonLauncher {
+    async fn launch(
+        &self,
+        session_id: &str,
+        type_id: &str,
+        settings: &serde_json::Value,
+        notification_tx: NotificationSender,
+    ) -> Result<SessionBackend, anyhow::Error> {
+        let socket_path = socket_dir().join(format!("session-{session_id}.sock"));
+        let settings_json = serde_json::to_string(settings)?;
+        let agent_exe = std::env::current_exe()?;
+
+        let _child = std::process::Command::new(&agent_exe)
+            .arg("--daemon")
+            .arg(session_id)
+            .env("TERMIHUB_SOCKET_PATH", &socket_path)
+            .env("TERMIHUB_TYPE_ID", type_id)
+            .env("TERMIHUB_SETTINGS", &settings_json)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("Failed to spawn daemon: {e}"))?;
+
+        DaemonClient::wait_for_socket(&socket_path).await?;
+        let client = DaemonClient::connect(session_id.to_string(), socket_path, notification_tx)
+            .await?;
+
+        info!("Daemon spawned for session {session_id} (type={type_id})");
+        Ok(SessionBackend::Daemon(client))
+    }
+}
+
 /// In-memory session manager.
 ///
 /// Tracks sessions in a `HashMap` protected by a `tokio::sync::Mutex`
@@ -57,6 +172,8 @@ pub struct SessionManager {
     sessions: Mutex<HashMap<String, SessionInfo>>,
     notification_tx: NotificationSender,
     registry: Arc<ConnectionTypeRegistry>,
+    #[cfg(unix)]
+    launcher: Arc<dyn DaemonLauncher>,
     #[cfg(unix)]
     state: Mutex<AgentState>,
 }
@@ -68,13 +185,26 @@ impl SessionManager {
             notification_tx,
             registry,
             #[cfg(unix)]
+            launcher: Arc::new(SystemDaemonLauncher),
+            #[cfg(unix)]
             state: Mutex::new(AgentState::load()),
         }
     }
 
-    /// Get a reference to the connection type registry.
-    pub fn registry(&self) -> &ConnectionTypeRegistry {
-        &self.registry
+    /// Create a session manager with a custom daemon launcher (for testing on Unix).
+    #[cfg(all(unix, test))]
+    pub fn with_launcher(
+        notification_tx: NotificationSender,
+        registry: Arc<ConnectionTypeRegistry>,
+        launcher: Arc<dyn DaemonLauncher>,
+    ) -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            notification_tx,
+            registry,
+            launcher,
+            state: Mutex::new(AgentState::load()),
+        }
     }
 
     /// Create a new session.
@@ -168,7 +298,7 @@ impl SessionManager {
             .await
     }
 
-    /// Spawn a daemon process and connect via DaemonClient.
+    /// Spawn a daemon process and connect via the injected [`DaemonLauncher`].
     #[cfg(unix)]
     async fn spawn_daemon_backend(
         &self,
@@ -176,34 +306,9 @@ impl SessionManager {
         type_id: &str,
         settings: &serde_json::Value,
     ) -> Result<SessionBackend, anyhow::Error> {
-        let socket_path = socket_dir().join(format!("session-{session_id}.sock"));
-
-        let settings_json = serde_json::to_string(settings)?;
-
-        let agent_exe = std::env::current_exe()?;
-
-        let _child = std::process::Command::new(&agent_exe)
-            .arg("--daemon")
-            .arg(session_id)
-            .env("TERMIHUB_SOCKET_PATH", &socket_path)
-            .env("TERMIHUB_TYPE_ID", type_id)
-            .env("TERMIHUB_SETTINGS", &settings_json)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::inherit())
-            .spawn()
-            .map_err(|e| anyhow::anyhow!("Failed to spawn daemon: {e}"))?;
-
-        DaemonClient::wait_for_socket(&socket_path).await?;
-        let client = DaemonClient::connect(
-            session_id.to_string(),
-            socket_path,
-            self.notification_tx.clone(),
-        )
-        .await?;
-
-        info!("Daemon spawned for session {session_id} (type={type_id})");
-        Ok(SessionBackend::Daemon(client))
+        self.launcher
+            .launch(session_id, type_id, settings, self.notification_tx.clone())
+            .await
     }
 
     /// Create a ConnectionType in-process and start output forwarding.
@@ -522,46 +627,86 @@ async fn resize_backend(
 // ── Output forwarding ──────────────────────────────────────────────
 
 /// Spawn a background task that reads from the ConnectionType's output
-/// channel and sends JSON-RPC notifications.
+/// channel and sends JSON-RPC notifications via [`JsonRpcOutputSink`].
 fn spawn_output_forwarder(
     mut output_rx: OutputReceiver,
     session_id: String,
     notification_tx: NotificationSender,
 ) -> tokio::task::JoinHandle<()> {
+    let sink = JsonRpcOutputSink::new(notification_tx);
     tokio::spawn(async move {
-        let b64 = base64::engine::general_purpose::STANDARD;
         loop {
             match output_rx.recv().await {
                 Some(data) => {
-                    for chunk in data.chunks(65536) {
-                        let encoded = b64.encode(chunk);
-                        let notification = JsonRpcNotification::new(
-                            "connection.output",
-                            serde_json::json!({
-                                "session_id": session_id,
-                                "data": encoded,
-                            }),
-                        );
-                        if notification_tx.send(notification).is_err() {
-                            return; // transport loop dropped
-                        }
+                    if sink.send_output(&session_id, data).is_err() {
+                        return; // transport loop dropped
                     }
                 }
                 None => {
-                    // Connection output ended.
-                    let notification = JsonRpcNotification::new(
-                        "connection.exit",
-                        serde_json::json!({
-                            "session_id": session_id,
-                            "exit_code": 0,
-                        }),
-                    );
-                    let _ = notification_tx.send(notification);
+                    let _ = sink.send_exit(&session_id, Some(0));
                     return;
                 }
             }
         }
     })
+}
+
+// ── SessionManagerApi impl ─────────────────────────────────────────
+
+#[async_trait::async_trait(?Send)]
+impl SessionManagerApi for SessionManager {
+    fn registry(&self) -> &ConnectionTypeRegistry {
+        &self.registry
+    }
+
+    async fn create(
+        &self,
+        type_id: &str,
+        title: String,
+        settings: serde_json::Value,
+    ) -> Result<SessionSnapshot, SessionCreateError> {
+        SessionManager::create(self, type_id, title, settings).await
+    }
+
+    async fn list(&self) -> Vec<SessionSnapshot> {
+        SessionManager::list(self).await
+    }
+
+    async fn get_session_type_id(&self, session_id: &str) -> Option<String> {
+        SessionManager::get_session_type_id(self, session_id).await
+    }
+
+    async fn close(&self, session_id: &str) -> bool {
+        SessionManager::close(self, session_id).await
+    }
+
+    async fn close_all(&self) {
+        SessionManager::close_all(self).await
+    }
+
+    async fn detach_all(&self) {
+        SessionManager::detach_all(self).await
+    }
+
+    async fn active_count(&self) -> u32 {
+        SessionManager::active_count(self).await
+    }
+
+    async fn attach(&self, session_id: &str) -> Result<(), String> {
+        SessionManager::attach(self, session_id).await
+    }
+
+    async fn detach(&self, session_id: &str) -> Result<(), String> {
+        SessionManager::detach(self, session_id).await
+    }
+
+    async fn write_input(&self, session_id: &str, data: &[u8]) -> Result<(), String> {
+        SessionManager::write_input(self, session_id, data).await
+    }
+
+    async fn resize(&self, session_id: &str, cols: u16, rows: u16) -> Result<(), String> {
+        SessionManager::resize(self, session_id, cols, rows).await
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────
@@ -683,5 +828,120 @@ mod tests {
         let mgr = SessionManager::new(test_notification_tx(), test_registry());
         assert!(mgr.registry().has_type("local"));
         assert!(mgr.registry().has_type("ssh"));
+    }
+
+    // ── DaemonLauncher unit tests (Unix only) ─────────────────────────
+
+    #[cfg(unix)]
+    mod daemon_launcher_tests {
+        use super::*;
+        use crate::session::types::SessionBackend;
+
+        /// Mock launcher that returns a Stub backend (no real process spawned).
+        struct MockDaemonLauncher {
+            should_fail: bool,
+            launched: Arc<Mutex<Vec<(String, String)>>>,
+        }
+
+        impl MockDaemonLauncher {
+            fn new() -> Self {
+                Self {
+                    should_fail: false,
+                    launched: Arc::new(Mutex::new(Vec::new())),
+                }
+            }
+            fn failing() -> Self {
+                Self {
+                    should_fail: true,
+                    launched: Arc::new(Mutex::new(Vec::new())),
+                }
+            }
+        }
+
+        #[async_trait::async_trait(?Send)]
+        impl DaemonLauncher for MockDaemonLauncher {
+            async fn launch(
+                &self,
+                session_id: &str,
+                type_id: &str,
+                _settings: &serde_json::Value,
+                _notification_tx: NotificationSender,
+            ) -> Result<SessionBackend, anyhow::Error> {
+                if self.should_fail {
+                    return Err(anyhow::anyhow!("mock: daemon spawn failed"));
+                }
+                self.launched
+                    .lock()
+                    .await
+                    .push((session_id.to_string(), type_id.to_string()));
+                Ok(SessionBackend::Stub)
+            }
+        }
+
+        fn make_manager_with_mock(launcher: MockDaemonLauncher) -> (SessionManager, Arc<Mutex<Vec<(String, String)>>>) {
+            let launched = launcher.launched.clone();
+            let mgr = SessionManager::with_launcher(
+                test_notification_tx(),
+                test_registry(),
+                Arc::new(launcher),
+            );
+            (mgr, launched)
+        }
+
+        #[tokio::test]
+        async fn create_persistent_session_calls_launcher() {
+            let (mgr, launched) = make_manager_with_mock(MockDaemonLauncher::new());
+            // "ssh" is a persistent type (Capabilities::persistent = true)
+            let result = mgr.create("ssh", "test SSH".to_string(), serde_json::json!({
+                "host": "example.com",
+                "username": "user",
+                "authMethod": "password",
+            })).await;
+            assert!(result.is_ok(), "expected session creation to succeed: {result:?}");
+            let log = launched.lock().await;
+            assert_eq!(log.len(), 1, "expected launcher to be called once");
+            assert_eq!(log[0].1, "ssh");
+        }
+
+        #[tokio::test]
+        async fn create_nonpersistent_session_skips_launcher() {
+            let (mgr, launched) = make_manager_with_mock(MockDaemonLauncher::new());
+            // "telnet" is non-persistent — runs in-process; launcher should not be called
+            // We can't actually connect, but create() will fail at backend level (not launcher)
+            let _ = mgr.create("telnet", "test".to_string(), serde_json::json!({
+                "host": "127.0.0.1",
+                "port": 9999,
+            })).await;
+            let log = launched.lock().await;
+            assert_eq!(log.len(), 0, "non-persistent session should not use launcher");
+        }
+
+        #[tokio::test]
+        async fn create_persistent_session_launcher_failure_propagates() {
+            let (mgr, _) = make_manager_with_mock(MockDaemonLauncher::failing());
+            let result = mgr.create("ssh", "fail test".to_string(), serde_json::json!({
+                "host": "example.com",
+                "username": "user",
+                "authMethod": "password",
+            })).await;
+            assert!(
+                matches!(result, Err(SessionCreateError::BackendFailed(_))),
+                "expected BackendFailed, got: {result:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn create_session_appears_in_list_after_launch() {
+            let (mgr, _) = make_manager_with_mock(MockDaemonLauncher::new());
+            let snapshot = mgr.create("ssh", "my-ssh".to_string(), serde_json::json!({
+                "host": "example.com",
+                "username": "user",
+                "authMethod": "password",
+            })).await.unwrap();
+            let list = mgr.list().await;
+            assert_eq!(list.len(), 1);
+            assert_eq!(list[0].id, snapshot.id);
+            assert_eq!(list[0].title, "my-ssh");
+        }
     }
 }

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -15,8 +15,8 @@ use tracing::{info, warn};
 use crate::io::transport::NotificationSender;
 use crate::session::types::{SessionBackend, SessionInfo, SessionSnapshot, SessionStatus};
 use crate::transport::JsonRpcOutputSink;
-use termihub_core::session::traits::OutputSink;
 use termihub_core::connection::{ConnectionTypeRegistry, OutputReceiver};
+use termihub_core::session::traits::OutputSink;
 
 #[cfg(unix)]
 use crate::daemon::client::DaemonClient;
@@ -156,8 +156,8 @@ impl DaemonLauncher for SystemDaemonLauncher {
             .map_err(|e| anyhow::anyhow!("Failed to spawn daemon: {e}"))?;
 
         DaemonClient::wait_for_socket(&socket_path).await?;
-        let client = DaemonClient::connect(session_id.to_string(), socket_path, notification_tx)
-            .await?;
+        let client =
+            DaemonClient::connect(session_id.to_string(), socket_path, notification_tx).await?;
 
         info!("Daemon spawned for session {session_id} (type={type_id})");
         Ok(SessionBackend::Daemon(client))
@@ -878,7 +878,9 @@ mod tests {
             }
         }
 
-        fn make_manager_with_mock(launcher: MockDaemonLauncher) -> (SessionManager, Arc<Mutex<Vec<(String, String)>>>) {
+        type LaunchedLog = Arc<Mutex<Vec<(String, String)>>>;
+
+        fn make_manager_with_mock(launcher: MockDaemonLauncher) -> (SessionManager, LaunchedLog) {
             let launched = launcher.launched.clone();
             let mgr = SessionManager::with_launcher(
                 test_notification_tx(),
@@ -892,12 +894,21 @@ mod tests {
         async fn create_persistent_session_calls_launcher() {
             let (mgr, launched) = make_manager_with_mock(MockDaemonLauncher::new());
             // "ssh" is a persistent type (Capabilities::persistent = true)
-            let result = mgr.create("ssh", "test SSH".to_string(), serde_json::json!({
-                "host": "example.com",
-                "username": "user",
-                "authMethod": "password",
-            })).await;
-            assert!(result.is_ok(), "expected session creation to succeed: {result:?}");
+            let result = mgr
+                .create(
+                    "ssh",
+                    "test SSH".to_string(),
+                    serde_json::json!({
+                        "host": "example.com",
+                        "username": "user",
+                        "authMethod": "password",
+                    }),
+                )
+                .await;
+            assert!(
+                result.is_ok(),
+                "expected session creation to succeed: {result:?}"
+            );
             let log = launched.lock().await;
             assert_eq!(log.len(), 1, "expected launcher to be called once");
             assert_eq!(log[0].1, "ssh");
@@ -908,22 +919,38 @@ mod tests {
             let (mgr, launched) = make_manager_with_mock(MockDaemonLauncher::new());
             // "telnet" is non-persistent — runs in-process; launcher should not be called
             // We can't actually connect, but create() will fail at backend level (not launcher)
-            let _ = mgr.create("telnet", "test".to_string(), serde_json::json!({
-                "host": "127.0.0.1",
-                "port": 9999,
-            })).await;
+            let _ = mgr
+                .create(
+                    "telnet",
+                    "test".to_string(),
+                    serde_json::json!({
+                        "host": "127.0.0.1",
+                        "port": 9999,
+                    }),
+                )
+                .await;
             let log = launched.lock().await;
-            assert_eq!(log.len(), 0, "non-persistent session should not use launcher");
+            assert_eq!(
+                log.len(),
+                0,
+                "non-persistent session should not use launcher"
+            );
         }
 
         #[tokio::test]
         async fn create_persistent_session_launcher_failure_propagates() {
             let (mgr, _) = make_manager_with_mock(MockDaemonLauncher::failing());
-            let result = mgr.create("ssh", "fail test".to_string(), serde_json::json!({
-                "host": "example.com",
-                "username": "user",
-                "authMethod": "password",
-            })).await;
+            let result = mgr
+                .create(
+                    "ssh",
+                    "fail test".to_string(),
+                    serde_json::json!({
+                        "host": "example.com",
+                        "username": "user",
+                        "authMethod": "password",
+                    }),
+                )
+                .await;
             assert!(
                 matches!(result, Err(SessionCreateError::BackendFailed(_))),
                 "expected BackendFailed, got: {result:?}"
@@ -933,11 +960,18 @@ mod tests {
         #[tokio::test]
         async fn create_session_appears_in_list_after_launch() {
             let (mgr, _) = make_manager_with_mock(MockDaemonLauncher::new());
-            let snapshot = mgr.create("ssh", "my-ssh".to_string(), serde_json::json!({
-                "host": "example.com",
-                "username": "user",
-                "authMethod": "password",
-            })).await.unwrap();
+            let snapshot = mgr
+                .create(
+                    "ssh",
+                    "my-ssh".to_string(),
+                    serde_json::json!({
+                        "host": "example.com",
+                        "username": "user",
+                        "authMethod": "password",
+                    }),
+                )
+                .await
+                .unwrap();
             let list = mgr.list().await;
             assert_eq!(list.len(), 1);
             assert_eq!(list[0].id, snapshot.id);

--- a/agent/src/transport.rs
+++ b/agent/src/transport.rs
@@ -19,18 +19,12 @@ use termihub_core::session::traits::OutputSink;
 /// Wraps the agent's notification channel (`NotificationSender`) and
 /// implements the core [`OutputSink`] trait. Each method constructs
 /// a JSON-RPC notification and sends it through the transport loop.
-///
-/// Not yet wired into the main session manager (Phase 5); the struct
-/// is exercised through tests and will be used once the core engine
-/// replaces the per-backend dispatch loop.
-#[allow(dead_code)]
 pub struct JsonRpcOutputSink {
     notification_tx: NotificationSender,
 }
 
 impl JsonRpcOutputSink {
     /// Create a new output sink backed by the given notification channel.
-    #[allow(dead_code)]
     pub fn new(notification_tx: NotificationSender) -> Self {
         Self { notification_tx }
     }
@@ -93,125 +87,6 @@ impl OutputSink for JsonRpcOutputSink {
         Ok(())
     }
 }
-
-// ── DaemonSpawner (Unix only) ──────────────────────────────────────
-
-#[cfg(unix)]
-#[allow(dead_code)]
-mod daemon_spawner {
-    use std::collections::HashMap;
-    use std::path::{Path, PathBuf};
-
-    use termihub_core::config::PtySize;
-    use termihub_core::errors::SessionError;
-    use termihub_core::session::shell::ShellCommand;
-    use termihub_core::session::traits::{ProcessHandle, ProcessSpawner};
-
-    use crate::daemon::client::DaemonClient;
-    use crate::io::transport::NotificationSender;
-
-    /// Spawns processes via daemon processes with Unix socket IPC.
-    ///
-    /// Each call to [`spawn_shell`](ProcessSpawner::spawn_shell) or
-    /// [`spawn_command`](ProcessSpawner::spawn_command) launches a
-    /// `termihub-agent --daemon` child process, waits for its socket,
-    /// and returns a connected [`DaemonClient`] as the process handle.
-    pub struct DaemonSpawner {
-        socket_dir: PathBuf,
-        notification_tx: NotificationSender,
-    }
-
-    impl DaemonSpawner {
-        /// Create a new spawner that places daemon sockets in `socket_dir`.
-        pub fn new(socket_dir: PathBuf, notification_tx: NotificationSender) -> Self {
-            Self {
-                socket_dir,
-                notification_tx,
-            }
-        }
-    }
-
-    impl ProcessSpawner for DaemonSpawner {
-        type Handle = DaemonClient;
-
-        fn spawn_shell(
-            &self,
-            command: &ShellCommand,
-            pty_size: PtySize,
-            env: &HashMap<String, String>,
-            _cwd: Option<&Path>,
-        ) -> Result<Self::Handle, SessionError> {
-            let session_id = uuid::Uuid::new_v4().to_string();
-            let socket_path = self.socket_dir.join(format!("session-{session_id}.sock"));
-
-            // Merge command env with extra env vars
-            let mut all_env = command.env.clone();
-            all_env.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
-            let env_json = serde_json::to_string(&all_env)
-                .map_err(|e| SessionError::SpawnFailed(format!("env serialization: {e}")))?;
-
-            let agent_exe = std::env::current_exe()
-                .map_err(|e| SessionError::SpawnFailed(format!("current_exe: {e}")))?;
-
-            std::process::Command::new(&agent_exe)
-                .arg("--daemon")
-                .arg(&session_id)
-                .env("TERMIHUB_SOCKET_PATH", &socket_path)
-                .env("TERMIHUB_SHELL", &command.program)
-                .env("TERMIHUB_COLS", pty_size.cols.to_string())
-                .env("TERMIHUB_ROWS", pty_size.rows.to_string())
-                .env("TERMIHUB_ENV", &env_json)
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::inherit())
-                .spawn()
-                .map_err(|e| SessionError::SpawnFailed(format!("daemon spawn: {e}")))?;
-
-            // Block on async socket wait + connect
-            let handle = tokio::runtime::Handle::current();
-            let tx = self.notification_tx.clone();
-
-            handle
-                .block_on(async {
-                    DaemonClient::wait_for_socket(&socket_path).await?;
-                    DaemonClient::connect(session_id, socket_path, tx).await
-                })
-                .map_err(|e| SessionError::SpawnFailed(format!("daemon connect: {e}")))
-        }
-
-        fn spawn_command(
-            &self,
-            program: &str,
-            args: &[String],
-            pty_size: PtySize,
-            env: &HashMap<String, String>,
-        ) -> Result<Self::Handle, SessionError> {
-            // Build a ShellCommand from the program/args so we can reuse spawn_shell.
-            let command = ShellCommand {
-                program: program.to_string(),
-                args: args.to_vec(),
-                env: env.clone(),
-                cwd: None,
-                cols: pty_size.cols,
-                rows: pty_size.rows,
-            };
-            self.spawn_shell(&command, pty_size, &HashMap::new(), None)
-        }
-    }
-
-    // Verify trait bounds at compile time.
-    fn _assert_spawner_send_sync<T: ProcessSpawner>() {}
-    fn _assert_handle_send<T: ProcessHandle>() {}
-
-    fn _static_assertions() {
-        _assert_spawner_send_sync::<DaemonSpawner>();
-        _assert_handle_send::<DaemonClient>();
-    }
-}
-
-#[cfg(unix)]
-#[allow(unused_imports)]
-pub use daemon_spawner::DaemonSpawner;
 
 #[cfg(test)]
 mod tests {

--- a/core/src/backends/local_shell.rs
+++ b/core/src/backends/local_shell.rs
@@ -11,11 +11,11 @@ use std::sync::{Arc, Mutex};
 
 use tracing::{debug, info};
 
+use crate::config::ShellConfig;
 use crate::connection::{
     Capabilities, Condition, ConnectionType, FieldType, FilePathKind, OutputReceiver, OutputSender,
     SelectOption, SettingsField, SettingsGroup, SettingsSchema,
 };
-use crate::config::ShellConfig;
 use crate::errors::SessionError;
 use crate::files::{FileBrowser, LocalFileBrowser};
 use crate::monitoring::MonitoringProvider;
@@ -648,10 +648,7 @@ mod tests {
 
     fn valid_settings() -> serde_json::Value {
         let shells = detect_available_shells();
-        let shell = shells
-            .first()
-            .cloned()
-            .unwrap_or_else(|| "sh".to_string());
+        let shell = shells.first().cloned().unwrap_or_else(|| "sh".to_string());
         serde_json::json!({ "shell": shell })
     }
 
@@ -864,10 +861,7 @@ mod tests {
     async fn spawn_failure_propagates_as_connect_error() {
         let mut shell = LocalShell::with_spawner(MockLocalShellSpawner::failing());
         let result = shell.connect(valid_settings()).await;
-        assert!(
-            result.is_err(),
-            "connect should fail when spawner fails"
-        );
+        assert!(result.is_err(), "connect should fail when spawner fails");
         assert!(!shell.is_connected());
     }
 
@@ -876,7 +870,10 @@ mod tests {
         let mock = MockLocalShellSpawner::new();
         let mut shell = LocalShell::with_spawner(mock);
 
-        shell.connect(valid_settings()).await.expect("first connect");
+        shell
+            .connect(valid_settings())
+            .await
+            .expect("first connect");
         let result = shell.connect(valid_settings()).await;
         assert!(result.is_err(), "second connect should fail");
 
@@ -894,10 +891,12 @@ mod tests {
         shell.resize(120, 40).expect("resize");
         shell.resize(80, 24).expect("resize");
 
-        let log = resize_log.lock().unwrap();
-        assert_eq!(log.len(), 2);
-        assert_eq!(log[0], (120, 40));
-        assert_eq!(log[1], (80, 24));
+        {
+            let log = resize_log.lock().unwrap();
+            assert_eq!(log.len(), 2);
+            assert_eq!(log[0], (120, 40));
+            assert_eq!(log[1], (80, 24));
+        }
 
         shell.disconnect().await.ok();
     }
@@ -912,7 +911,10 @@ mod tests {
         assert!(!killed.load(Ordering::SeqCst));
 
         shell.disconnect().await.expect("disconnect");
-        assert!(killed.load(Ordering::SeqCst), "kill should be called on disconnect");
+        assert!(
+            killed.load(Ordering::SeqCst),
+            "kill should be called on disconnect"
+        );
     }
 
     #[tokio::test]
@@ -924,12 +926,14 @@ mod tests {
         shell.connect(valid_settings()).await.expect("connect");
         shell.write(b"hello world").expect("write");
 
-        let log = write_log.lock().unwrap();
-        let all_bytes: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
-        assert!(
-            all_bytes.windows(11).any(|w| w == b"hello world"),
-            "write_log should contain 'hello world', got: {all_bytes:?}"
-        );
+        {
+            let log = write_log.lock().unwrap();
+            let all_bytes: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
+            assert!(
+                all_bytes.windows(11).any(|w| w == b"hello world"),
+                "write_log should contain 'hello world', got: {all_bytes:?}"
+            );
+        }
 
         shell.disconnect().await.ok();
     }
@@ -948,13 +952,15 @@ mod tests {
         shell.connect(settings).await.expect("connect");
 
         // After connect(), the OSC7 hook is written to stdin.
-        let log = write_log.lock().unwrap();
-        let all: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
-        let text = String::from_utf8_lossy(&all);
-        assert!(
-            text.contains("__termihub_osc7") || text.contains("PROMPT_COMMAND"),
-            "OSC7 hook should be written to stdin for bash, got: {text:?}"
-        );
+        {
+            let log = write_log.lock().unwrap();
+            let all: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
+            let text = String::from_utf8_lossy(&all);
+            assert!(
+                text.contains("__termihub_osc7") || text.contains("PROMPT_COMMAND"),
+                "OSC7 hook should be written to stdin for bash, got: {text:?}"
+            );
+        }
 
         shell.disconnect().await.ok();
     }
@@ -972,13 +978,15 @@ mod tests {
         });
         shell.connect(settings).await.expect("connect");
 
-        let log = write_log.lock().unwrap();
-        let all: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
-        let text = String::from_utf8_lossy(&all);
-        assert!(
-            !text.contains("__termihub_osc7"),
-            "OSC7 should not be written when shellIntegration=false, got: {text:?}"
-        );
+        {
+            let log = write_log.lock().unwrap();
+            let all: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
+            let text = String::from_utf8_lossy(&all);
+            assert!(
+                !text.contains("__termihub_osc7"),
+                "OSC7 should not be written when shellIntegration=false, got: {text:?}"
+            );
+        }
 
         shell.disconnect().await.ok();
     }

--- a/core/src/backends/local_shell.rs
+++ b/core/src/backends/local_shell.rs
@@ -1,43 +1,139 @@
 //! Local shell backend implementing [`ConnectionType`](crate::connection::ConnectionType).
 //!
-//! Uses `portable-pty` for cross-platform PTY management. This is the
-//! canonical local shell implementation, used by both the desktop and
-//! agent crates (the desktop crate previously had its own implementation
-//! in `src-tauri/src/terminal/local_shell.rs`).
+//! Uses `portable-pty` for cross-platform PTY management via the injected
+//! [`LocalShellSpawner`] trait. The default spawner (`NativeLocalShellSpawner`)
+//! calls `portable_pty::native_pty_system()`; tests inject `MockLocalShellSpawner`
+//! which returns in-memory pipes and never forks a real process.
 
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use tracing::{debug, info};
 
-use crate::config::ShellConfig;
 use crate::connection::{
     Capabilities, Condition, ConnectionType, FieldType, FilePathKind, OutputReceiver, OutputSender,
     SelectOption, SettingsField, SettingsGroup, SettingsSchema,
 };
+use crate::config::ShellConfig;
 use crate::errors::SessionError;
 use crate::files::{FileBrowser, LocalFileBrowser};
 use crate::monitoring::MonitoringProvider;
 use crate::session::shell::{
     build_shell_command, detect_available_shells, detect_default_shell, osc7_setup_command,
 };
+use crate::session::traits::{LocalShellSpawner, SpawnedShell};
 
 /// Channel capacity for output data from the PTY reader thread.
 const OUTPUT_CHANNEL_CAPACITY: usize = 64;
 
-/// Local shell backend using portable-pty, implementing [`ConnectionType`].
+// ── NativeLocalShellSpawner ────────────────────────────────────────
+
+/// Production spawner: opens a real PTY pair and forks a process using
+/// `portable_pty::native_pty_system()`.
+pub struct NativeLocalShellSpawner;
+
+impl LocalShellSpawner for NativeLocalShellSpawner {
+    fn spawn(
+        &self,
+        command: &crate::session::shell::ShellCommand,
+    ) -> Result<SpawnedShell, SessionError> {
+        use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+
+        let pty_system = native_pty_system();
+        let pty_pair = pty_system
+            .openpty(PtySize {
+                rows: command.rows,
+                cols: command.cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| SessionError::SpawnFailed(e.to_string()))?;
+
+        let mut cmd = CommandBuilder::new(&command.program);
+        for arg in &command.args {
+            cmd.arg(arg);
+        }
+        for (key, value) in &command.env {
+            cmd.env(key, value);
+        }
+        if let Some(ref cwd) = command.cwd {
+            cmd.cwd(cwd);
+        }
+
+        let child = pty_pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| SessionError::SpawnFailed(e.to_string()))?;
+        drop(pty_pair.slave);
+
+        let writer = pty_pair
+            .master
+            .take_writer()
+            .map_err(|e| SessionError::SpawnFailed(e.to_string()))?;
+        let reader = pty_pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| SessionError::SpawnFailed(e.to_string()))?;
+
+        let master = Arc::new(Mutex::new(pty_pair.master));
+        let child = Arc::new(Mutex::new(child));
+
+        let master_for_resize = master.clone();
+        let child_for_kill = child.clone();
+
+        Ok(SpawnedShell {
+            writer: Box::new(writer),
+            reader: Box::new(reader),
+            resize: Box::new(move |cols, rows| {
+                let m = master_for_resize.lock().map_err(|e| {
+                    SessionError::Io(std::io::Error::other(format!("lock failed: {e}")))
+                })?;
+                m.resize(PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .map_err(|e| SessionError::Io(std::io::Error::other(e.to_string())))
+            }),
+            kill: Box::new(move || {
+                if let Ok(mut c) = child_for_kill.lock() {
+                    let _ = c.kill();
+                }
+            }),
+        })
+    }
+}
+
+// ── ConnectedState ─────────────────────────────────────────────────
+
+/// Internal state of an active shell connection.
+struct ConnectedState {
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    resize: Box<dyn Fn(u16, u16) -> Result<(), SessionError> + Send + Sync>,
+    kill: Box<dyn Fn() + Send + Sync>,
+    alive: Arc<AtomicBool>,
+}
+
+// ── LocalShell ─────────────────────────────────────────────────────
+
+/// Local shell backend using a [`LocalShellSpawner`], implementing
+/// [`ConnectionType`].
+///
+/// Generic over `S` so tests can inject a mock spawner without forking a
+/// real PTY. The default is [`NativeLocalShellSpawner`], so callers that
+/// just use `LocalShell::new()` get the production behaviour.
 ///
 /// # Lifecycle
 ///
-/// 1. Create with [`LocalShell::new()`] (disconnected state).
+/// 1. Create with [`LocalShell::new()`] or [`LocalShell::with_spawner()`].
 /// 2. Call [`connect()`](ConnectionType::connect) with settings JSON.
 /// 3. Use [`write()`](ConnectionType::write),
 ///    [`resize()`](ConnectionType::resize),
 ///    [`subscribe_output()`](ConnectionType::subscribe_output) for I/O.
 /// 4. Call [`disconnect()`](ConnectionType::disconnect) to clean up.
-pub struct LocalShell {
+pub struct LocalShell<S: LocalShellSpawner = NativeLocalShellSpawner> {
     /// State is `None` when disconnected, `Some` when connected.
     state: Option<ConnectedState>,
     /// The output sender is stored so `subscribe_output()` can replace
@@ -46,35 +142,39 @@ pub struct LocalShell {
     output_tx: Arc<Mutex<Option<OutputSender>>>,
     /// Local file browser capability.
     file_backend: LocalFileBrowser,
+    /// Injected spawn strategy.
+    spawner: S,
 }
 
-/// Internal state of an active shell connection.
-struct ConnectedState {
-    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
-    writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    alive: Arc<AtomicBool>,
-    child: Arc<Mutex<Box<dyn portable_pty::Child + Send>>>,
-}
-
-impl LocalShell {
-    /// Create a new disconnected `LocalShell` instance.
+impl LocalShell<NativeLocalShellSpawner> {
+    /// Create a new disconnected `LocalShell` using the native PTY spawner.
     pub fn new() -> Self {
-        Self {
-            state: None,
-            output_tx: Arc::new(Mutex::new(None)),
-            file_backend: LocalFileBrowser::new(),
-        }
+        Self::with_spawner(NativeLocalShellSpawner)
     }
 }
 
-impl Default for LocalShell {
+impl Default for LocalShell<NativeLocalShellSpawner> {
     fn default() -> Self {
         Self::new()
     }
 }
 
+impl<S: LocalShellSpawner> LocalShell<S> {
+    /// Create a new disconnected `LocalShell` with an injected spawner.
+    ///
+    /// Useful in tests where `S = MockLocalShellSpawner`.
+    pub fn with_spawner(spawner: S) -> Self {
+        Self {
+            state: None,
+            output_tx: Arc::new(Mutex::new(None)),
+            file_backend: LocalFileBrowser::new(),
+            spawner,
+        }
+    }
+}
+
 #[async_trait::async_trait]
-impl ConnectionType for LocalShell {
+impl<S: LocalShellSpawner> ConnectionType for LocalShell<S> {
     fn type_id(&self) -> &str {
         "local"
     }
@@ -239,7 +339,7 @@ impl ConnectionType for LocalShell {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(String::from);
-        let _initial_command = settings
+        let initial_command = settings
             .get("initialCommand")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
@@ -258,77 +358,50 @@ impl ConnectionType for LocalShell {
         let config = ShellConfig {
             shell: Some(effective_shell.clone()),
             starting_directory,
-            initial_command: _initial_command,
+            initial_command,
             ..ShellConfig::default()
         };
 
         let shell_cmd = build_shell_command(&config);
 
-        // Determine OSC 7 CWD tracking injection strategy (when shell integration is enabled).
-        // PowerShell: pass via -NoExit -Command startup args.
-        // All other shells (bash, git-bash): inject via stdin after spawn.
+        // Determine OSC 7 CWD tracking injection strategy.
         let osc7_setup = if shell_integration {
             osc7_setup_command(&effective_shell)
         } else {
             None
         };
 
-        info!(
-            program = %shell_cmd.program,
-            "Spawning local shell"
-        );
-
-        // Spawn PTY.
-        let pty_system = native_pty_system();
-        let pty_pair = pty_system
-            .openpty(PtySize {
-                rows: shell_cmd.rows,
-                cols: shell_cmd.cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| SessionError::SpawnFailed(e.to_string()))?;
-
-        let mut command = CommandBuilder::new(&shell_cmd.program);
-        for arg in &shell_cmd.args {
-            command.arg(arg);
-        }
-        // PowerShell / cmd: inject OSC 7 prompt hook via startup args.
-        // PowerShell uses -NoExit -Command; cmd uses /K.
-        match effective_shell.as_str() {
-            "powershell" => {
-                if let Some(setup) = osc7_setup {
-                    command.arg("-NoExit");
-                    command.arg("-Command");
-                    command.arg(setup);
+        // Build the final command. For PowerShell / cmd, fold the OSC 7 setup
+        // into startup flags so it runs before the first prompt. For all other
+        // shells, keep `osc7_for_stdin` to inject via stdin after spawn.
+        let uses_startup_args = matches!(effective_shell.as_str(), "powershell" | "cmd");
+        let mut final_cmd = shell_cmd;
+        let osc7_for_stdin = if uses_startup_args {
+            if let Some(setup) = osc7_setup {
+                match effective_shell.as_str() {
+                    "powershell" => {
+                        final_cmd.args.push("-NoExit".to_string());
+                        final_cmd.args.push("-Command".to_string());
+                        final_cmd.args.push(setup.to_string());
+                    }
+                    "cmd" => {
+                        final_cmd.args.push("/K".to_string());
+                        final_cmd.args.push(setup.to_string());
+                    }
+                    _ => {}
                 }
             }
-            "cmd" => {
-                if let Some(setup) = osc7_setup {
-                    command.arg("/K");
-                    command.arg(setup);
-                }
-            }
-            _ => {}
-        }
-        for (key, value) in &shell_cmd.env {
-            command.env(key, value);
-        }
-        if let Some(ref cwd) = shell_cmd.cwd {
-            command.cwd(cwd);
-        }
+            None
+        } else {
+            osc7_setup
+        };
 
-        let child = pty_pair
-            .slave
-            .spawn_command(command)
-            .map_err(|e| SessionError::SpawnFailed(e.to_string()))?;
+        info!(program = %final_cmd.program, "Spawning local shell");
 
-        // Drop slave — we only need master.
-        drop(pty_pair.slave);
-
-        let writer = pty_pair
-            .master
-            .take_writer()
+        // Spawn PTY/process via injected spawner.
+        let spawned = self
+            .spawner
+            .spawn(&final_cmd)
             .map_err(|e| SessionError::SpawnFailed(e.to_string()))?;
 
         let alive = Arc::new(AtomicBool::new(true));
@@ -344,11 +417,7 @@ impl ConnectionType for LocalShell {
         }
 
         // Spawn reader thread: bridges sync PTY reads to async tokio channel.
-        let mut reader = pty_pair
-            .master
-            .try_clone_reader()
-            .map_err(|e| SessionError::SpawnFailed(e.to_string()))?;
-
+        let mut reader = spawned.reader;
         let alive_clone = alive.clone();
         let output_tx_clone = self.output_tx.clone();
         std::thread::spawn(move || {
@@ -362,12 +431,8 @@ impl ConnectionType for LocalShell {
                         if let Some(ref guard) = guard {
                             if let Some(ref sender) = **guard {
                                 // blocking_send blocks if channel full (backpressure).
-                                // Err means receiver dropped — subscriber replaced or
-                                // disconnected. Continue so we pick up a new sender on
-                                // the next iteration.
                                 let _ = sender.blocking_send(data);
                             } else {
-                                // No sender — disconnected.
                                 break;
                             }
                         } else {
@@ -378,32 +443,25 @@ impl ConnectionType for LocalShell {
                 }
             }
             alive_clone.store(false, Ordering::SeqCst);
-            // Drop the sender so the output channel closes, signaling
-            // consumers (e.g. the session daemon) that the shell exited.
             if let Ok(mut guard) = output_tx_clone.lock() {
                 *guard = None;
             }
         });
 
         self.state = Some(ConnectedState {
-            master: Arc::new(Mutex::new(pty_pair.master)),
-            writer: Arc::new(Mutex::new(writer)),
+            writer: Arc::new(Mutex::new(spawned.writer)),
+            resize: spawned.resize,
+            kill: spawned.kill,
             alive,
-            child: Arc::new(Mutex::new(child)),
         });
 
         // Inject OSC 7 PROMPT_COMMAND hook for CWD tracking via stdin.
-        // Bash (and Git Bash) don't emit OSC 7 by default, so we inject a
-        // PROMPT_COMMAND that emits it on each prompt. PowerShell and cmd were
-        // already handled via startup args above.
+        // PowerShell and cmd already received it via startup args above.
         // Errors are non-fatal — the shell works without CWD tracking.
-        let uses_startup_args = matches!(effective_shell.as_str(), "powershell" | "cmd");
-        if !uses_startup_args {
-            if let Some(setup) = osc7_setup {
-                let cmd = format!("{setup}\n");
-                if let Err(e) = self.write(cmd.as_bytes()) {
-                    debug!("Failed to inject OSC 7 hook: {e}");
-                }
+        if let Some(setup) = osc7_for_stdin {
+            let cmd = format!("{setup}\n");
+            if let Err(e) = self.write(cmd.as_bytes()) {
+                debug!("Failed to inject OSC 7 hook: {e}");
             }
         }
 
@@ -413,9 +471,7 @@ impl ConnectionType for LocalShell {
     async fn disconnect(&mut self) -> Result<(), SessionError> {
         if let Some(state) = self.state.take() {
             state.alive.store(false, Ordering::SeqCst);
-            if let Ok(mut child) = state.child.lock() {
-                let _ = child.kill();
-            }
+            (state.kill)();
             // Clear the sender to signal the reader thread to stop.
             if let Ok(mut guard) = self.output_tx.lock() {
                 *guard = None;
@@ -449,18 +505,7 @@ impl ConnectionType for LocalShell {
             .state
             .as_ref()
             .ok_or_else(|| SessionError::NotRunning("Not connected".to_string()))?;
-        let master = state.master.lock().map_err(|e| {
-            SessionError::Io(std::io::Error::other(format!("Failed to lock master: {e}")))
-        })?;
-        master
-            .resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| SessionError::Io(std::io::Error::other(e.to_string())))?;
-        Ok(())
+        (state.resize)(cols, rows)
     }
 
     fn subscribe_output(&self) -> OutputReceiver {
@@ -480,10 +525,114 @@ impl ConnectionType for LocalShell {
     }
 }
 
+// ── Tests ──────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
     use crate::connection::validate_settings;
+    use crate::session::shell::ShellCommand;
+    use crate::session::traits::SpawnedShell;
+
+    // ── MockLocalShellSpawner ────────────────────────────────────────
+
+    /// Logs bytes written to the spawned process's stdin.
+    struct LogWriter {
+        log: Arc<Mutex<Vec<Vec<u8>>>>,
+    }
+
+    impl Write for LogWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.log.lock().unwrap().push(buf.to_vec());
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Returns pre-loaded output bytes then EOF.
+    struct PreloadedReader {
+        cursor: std::io::Cursor<Vec<u8>>,
+    }
+
+    impl Read for PreloadedReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.cursor.read(buf)
+        }
+    }
+
+    struct MockLocalShellSpawner {
+        /// When `true`, `spawn()` returns an error.
+        should_fail: bool,
+        /// Bytes the mock reader will produce before EOF.
+        output_data: Vec<u8>,
+        /// Shared log of bytes written via the mock writer.
+        write_log: Arc<Mutex<Vec<Vec<u8>>>>,
+        /// Shared log of resize calls `(cols, rows)`.
+        resize_log: Arc<Mutex<Vec<(u16, u16)>>>,
+        /// Set to `true` when kill is invoked.
+        killed: Arc<AtomicBool>,
+    }
+
+    impl MockLocalShellSpawner {
+        fn new() -> Self {
+            Self {
+                should_fail: false,
+                output_data: Vec::new(),
+                write_log: Arc::new(Mutex::new(Vec::new())),
+                resize_log: Arc::new(Mutex::new(Vec::new())),
+                killed: Arc::new(AtomicBool::new(false)),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                should_fail: true,
+                ..Self::new()
+            }
+        }
+    }
+
+    impl LocalShellSpawner for MockLocalShellSpawner {
+        fn spawn(&self, _command: &ShellCommand) -> Result<SpawnedShell, SessionError> {
+            if self.should_fail {
+                return Err(SessionError::SpawnFailed("mock spawn failure".to_string()));
+            }
+            let write_log = self.write_log.clone();
+            let resize_log = self.resize_log.clone();
+            let killed = self.killed.clone();
+
+            Ok(SpawnedShell {
+                writer: Box::new(LogWriter { log: write_log }),
+                reader: Box::new(PreloadedReader {
+                    cursor: std::io::Cursor::new(self.output_data.clone()),
+                }),
+                resize: Box::new(move |c, r| {
+                    resize_log.lock().unwrap().push((c, r));
+                    Ok(())
+                }),
+                kill: Box::new(move || {
+                    killed.store(true, Ordering::SeqCst);
+                }),
+            })
+        }
+    }
+
+    fn valid_settings() -> serde_json::Value {
+        let shells = detect_available_shells();
+        let shell = shells
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "sh".to_string());
+        serde_json::json!({ "shell": shell })
+    }
+
+    // ── Unit tests (no real PTY) ─────────────────────────────────────
 
     #[test]
     fn type_id() {
@@ -564,7 +713,6 @@ mod tests {
                     default_opt.unwrap().label
                 );
             }
-            // Non-default shells should NOT have the suffix
             for opt in options {
                 if Some(opt.value.as_str()) != default_shell.as_deref() {
                     assert!(
@@ -687,9 +835,147 @@ mod tests {
         assert!(!shell.is_connected());
     }
 
-    // -----------------------------------------------------------------------
-    // Integration tests (spawn real shells)
-    // -----------------------------------------------------------------------
+    // ── DI unit tests (use mock spawner, no real PTY) ────────────────
+
+    #[tokio::test]
+    async fn spawn_failure_propagates_as_connect_error() {
+        let mut shell = LocalShell::with_spawner(MockLocalShellSpawner::failing());
+        let result = shell.connect(valid_settings()).await;
+        assert!(
+            result.is_err(),
+            "connect should fail when spawner fails"
+        );
+        assert!(!shell.is_connected());
+    }
+
+    #[tokio::test]
+    async fn connect_already_connected_fails_with_mock() {
+        let mock = MockLocalShellSpawner::new();
+        let mut shell = LocalShell::with_spawner(mock);
+
+        shell.connect(valid_settings()).await.expect("first connect");
+        let result = shell.connect(valid_settings()).await;
+        assert!(result.is_err(), "second connect should fail");
+
+        shell.disconnect().await.ok();
+    }
+
+    #[tokio::test]
+    async fn resize_delegated_to_spawner() {
+        let mock = MockLocalShellSpawner::new();
+        let resize_log = mock.resize_log.clone();
+
+        let mut shell = LocalShell::with_spawner(mock);
+        shell.connect(valid_settings()).await.expect("connect");
+
+        shell.resize(120, 40).expect("resize");
+        shell.resize(80, 24).expect("resize");
+
+        let log = resize_log.lock().unwrap();
+        assert_eq!(log.len(), 2);
+        assert_eq!(log[0], (120, 40));
+        assert_eq!(log[1], (80, 24));
+
+        shell.disconnect().await.ok();
+    }
+
+    #[tokio::test]
+    async fn disconnect_invokes_kill() {
+        let mock = MockLocalShellSpawner::new();
+        let killed = mock.killed.clone();
+
+        let mut shell = LocalShell::with_spawner(mock);
+        shell.connect(valid_settings()).await.expect("connect");
+        assert!(!killed.load(Ordering::SeqCst));
+
+        shell.disconnect().await.expect("disconnect");
+        assert!(killed.load(Ordering::SeqCst), "kill should be called on disconnect");
+    }
+
+    #[tokio::test]
+    async fn write_routed_through_mock_writer() {
+        let mock = MockLocalShellSpawner::new();
+        let write_log = mock.write_log.clone();
+
+        let mut shell = LocalShell::with_spawner(mock);
+        shell.connect(valid_settings()).await.expect("connect");
+        shell.write(b"hello world").expect("write");
+
+        let log = write_log.lock().unwrap();
+        let all_bytes: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
+        assert!(
+            all_bytes.windows(11).any(|w| w == b"hello world"),
+            "write_log should contain 'hello world', got: {all_bytes:?}"
+        );
+
+        shell.disconnect().await.ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn osc7_setup_injected_via_stdin_for_bash() {
+        let mock = MockLocalShellSpawner::new();
+        let write_log = mock.write_log.clone();
+
+        let mut shell = LocalShell::with_spawner(mock);
+        let settings = serde_json::json!({
+            "shell": "bash",
+            "shellIntegration": true,
+        });
+        shell.connect(settings).await.expect("connect");
+
+        // After connect(), the OSC7 hook is written to stdin.
+        let log = write_log.lock().unwrap();
+        let all: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
+        let text = String::from_utf8_lossy(&all);
+        assert!(
+            text.contains("__termihub_osc7") || text.contains("PROMPT_COMMAND"),
+            "OSC7 hook should be written to stdin for bash, got: {text:?}"
+        );
+
+        shell.disconnect().await.ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn osc7_not_injected_via_stdin_when_disabled() {
+        let mock = MockLocalShellSpawner::new();
+        let write_log = mock.write_log.clone();
+
+        let mut shell = LocalShell::with_spawner(mock);
+        let settings = serde_json::json!({
+            "shell": "bash",
+            "shellIntegration": false,
+        });
+        shell.connect(settings).await.expect("connect");
+
+        let log = write_log.lock().unwrap();
+        let all: Vec<u8> = log.iter().flat_map(|v| v.iter().copied()).collect();
+        let text = String::from_utf8_lossy(&all);
+        assert!(
+            !text.contains("__termihub_osc7"),
+            "OSC7 should not be written when shellIntegration=false, got: {text:?}"
+        );
+
+        shell.disconnect().await.ok();
+    }
+
+    #[tokio::test]
+    async fn disconnect_when_not_connected_is_noop_with_mock() {
+        let mut shell = LocalShell::with_spawner(MockLocalShellSpawner::new());
+        shell.disconnect().await.expect("should not fail");
+    }
+
+    #[tokio::test]
+    async fn is_connected_true_after_connect_with_mock() {
+        let mock = MockLocalShellSpawner::new();
+        let mut shell = LocalShell::with_spawner(mock);
+        shell.connect(valid_settings()).await.expect("connect");
+        assert!(shell.is_connected());
+        shell.disconnect().await.ok();
+    }
+
+    // ── Integration tests (spawn real shells, require PTY) ───────────
 
     #[tokio::test]
     async fn connect_and_receive_output() {
@@ -705,13 +991,9 @@ mod tests {
         shell.connect(settings).await.expect("connect failed");
         assert!(shell.is_connected());
 
-        // Subscribe to output.
         let mut rx = shell.subscribe_output();
-
-        // Write a command.
         shell.write(b"echo HELLO_TERMIHUB\n").expect("write failed");
 
-        // Read output with timeout.
         let mut output = Vec::new();
         let deadline = tokio::time::Duration::from_secs(5);
         let result = tokio::time::timeout(deadline, async {
@@ -732,10 +1014,7 @@ mod tests {
             String::from_utf8_lossy(&output)
         );
 
-        // Resize should succeed.
         shell.resize(120, 40).expect("resize failed");
-
-        // Disconnect.
         shell.disconnect().await.expect("disconnect failed");
         assert!(!shell.is_connected());
     }
@@ -767,7 +1046,7 @@ mod tests {
         shell.connect(settings).await.expect("connect failed");
 
         let _rx1 = shell.subscribe_output();
-        let mut rx2 = shell.subscribe_output(); // replaces rx1
+        let mut rx2 = shell.subscribe_output();
 
         shell.write(b"echo TEST_REPLACE\n").expect("write failed");
 
@@ -794,7 +1073,6 @@ mod tests {
     #[tokio::test]
     async fn disconnect_when_not_connected_is_noop() {
         let mut shell = LocalShell::new();
-        // Should not error.
         shell
             .disconnect()
             .await
@@ -809,7 +1087,6 @@ mod tests {
     async fn osc7_setup_injected_for_bash() {
         use std::path::Path;
 
-        // Skip if bash is not available.
         if !Path::new("/bin/bash").exists() && !Path::new("/usr/bin/bash").exists() {
             eprintln!("bash not found — skipping OSC 7 injection test");
             return;
@@ -821,7 +1098,6 @@ mod tests {
         shell.connect(settings).await.expect("connect failed");
         let mut rx = shell.subscribe_output();
 
-        // Wait for the setup command to be echoed back by the PTY.
         let mut output = Vec::new();
         let deadline = tokio::time::Duration::from_secs(5);
         let found = tokio::time::timeout(deadline, async {
@@ -846,14 +1122,12 @@ mod tests {
     }
 
     /// Old saved connections use `"shellType"` instead of `"shell"`.
-    /// Verify that `connect()` still works with the legacy key.
     #[tokio::test]
     async fn connect_with_legacy_shell_type_key() {
         let mut shell = LocalShell::new();
         let shells = detect_available_shells();
         let shell_name = shells.first().expect("at least one shell available");
 
-        // Use legacy "shellType" key instead of "shell"
         let settings = serde_json::json!({ "shellType": shell_name });
 
         shell

--- a/core/src/backends/local_shell.rs
+++ b/core/src/backends/local_shell.rs
@@ -555,38 +555,53 @@ mod tests {
         }
     }
 
-    /// Returns pre-loaded output bytes then EOF.
-    struct PreloadedReader {
-        cursor: std::io::Cursor<Vec<u8>>,
+    /// Blocks in `read()` until the sender is dropped (simulates a live process).
+    ///
+    /// When the sender is dropped (via `kill()`), `rx.recv()` returns `Err`,
+    /// and `read()` returns `Ok(0)` (EOF), allowing the reader thread to exit cleanly.
+    struct ChannelReader {
+        rx: std::sync::mpsc::Receiver<Vec<u8>>,
+        current: std::io::Cursor<Vec<u8>>,
     }
 
-    impl Read for PreloadedReader {
+    impl Read for ChannelReader {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            self.cursor.read(buf)
+            loop {
+                let n = self.current.read(buf)?;
+                if n > 0 {
+                    return Ok(n);
+                }
+                // Current buffer exhausted — wait for next chunk or EOF
+                match self.rx.recv() {
+                    Ok(chunk) => self.current = std::io::Cursor::new(chunk),
+                    // Sender dropped → signal EOF
+                    Err(_) => return Ok(0),
+                }
+            }
         }
     }
 
     struct MockLocalShellSpawner {
         /// When `true`, `spawn()` returns an error.
         should_fail: bool,
-        /// Bytes the mock reader will produce before EOF.
-        output_data: Vec<u8>,
         /// Shared log of bytes written via the mock writer.
         write_log: Arc<Mutex<Vec<Vec<u8>>>>,
         /// Shared log of resize calls `(cols, rows)`.
         resize_log: Arc<Mutex<Vec<(u16, u16)>>>,
         /// Set to `true` when kill is invoked.
         killed: Arc<AtomicBool>,
+        /// Dropping this sender signals EOF to the `ChannelReader`.
+        reader_tx: Arc<Mutex<Option<std::sync::mpsc::SyncSender<Vec<u8>>>>>,
     }
 
     impl MockLocalShellSpawner {
         fn new() -> Self {
             Self {
                 should_fail: false,
-                output_data: Vec::new(),
                 write_log: Arc::new(Mutex::new(Vec::new())),
                 resize_log: Arc::new(Mutex::new(Vec::new())),
                 killed: Arc::new(AtomicBool::new(false)),
+                reader_tx: Arc::new(Mutex::new(None)),
             }
         }
 
@@ -606,11 +621,17 @@ mod tests {
             let write_log = self.write_log.clone();
             let resize_log = self.resize_log.clone();
             let killed = self.killed.clone();
+            let reader_tx_slot = self.reader_tx.clone();
+
+            // Bounded-0 channel: no buffering; drop sender to signal EOF.
+            let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(0);
+            *reader_tx_slot.lock().unwrap() = Some(tx);
 
             Ok(SpawnedShell {
                 writer: Box::new(LogWriter { log: write_log }),
-                reader: Box::new(PreloadedReader {
-                    cursor: std::io::Cursor::new(self.output_data.clone()),
+                reader: Box::new(ChannelReader {
+                    rx,
+                    current: std::io::Cursor::new(Vec::new()),
                 }),
                 resize: Box::new(move |c, r| {
                     resize_log.lock().unwrap().push((c, r));
@@ -618,6 +639,8 @@ mod tests {
                 }),
                 kill: Box::new(move || {
                     killed.store(true, Ordering::SeqCst);
+                    // Drop the sender → ChannelReader.read() returns Ok(0) (EOF)
+                    *reader_tx_slot.lock().unwrap() = None;
                 }),
             })
         }

--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -1,0 +1,262 @@
+//! SSH connection abstraction for dependency-injected testing.
+//!
+//! Defines [`SshConnector`] — a trait that abstracts the connection +
+//! shell-channel creation step so that [`super::Ssh`] can be unit-tested
+//! without a real SSH server.
+//!
+//! # Production path
+//!
+//! [`Ssh2SshConnector`] calls [`connect_and_authenticate`] and uses
+//! libssh2 to open a PTY shell channel, including optional X11 forwarding.
+//!
+//! # Test path
+//!
+//! Inject any `Box<dyn SshConnector>` implementation that returns in-memory
+//! pipes. [`MockSshConnector`] (in `#[cfg(test)]`) provides this.
+
+use std::io::Read;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::config::SshConfig;
+use crate::errors::SessionError;
+
+// ── SshShellHandle ─────────────────────────────────────────────────
+
+/// Handles for an established SSH shell session.
+///
+/// Returned by [`SshConnector::open_shell`] and consumed by the
+/// `Ssh` backend's `connect()` method.
+pub struct SshShellHandle {
+    /// Reads from the SSH channel. In production, returns `WouldBlock`
+    /// when no data is available; the [`Ssh2SshShellReader`] wrapper
+    /// handles the retry loop.
+    pub reader: Box<dyn Read + Send>,
+    /// Writes input data to the channel (handles blocking-mode toggle internally).
+    pub write: Arc<dyn Fn(&[u8]) -> Result<(), SessionError> + Send + Sync>,
+    /// Resizes the PTY to `(cols, rows)`.
+    pub resize: Arc<dyn Fn(u16, u16) -> Result<(), SessionError> + Send + Sync>,
+    /// Switches the underlying session's blocking mode.
+    pub set_blocking: Arc<dyn Fn(bool) + Send + Sync>,
+    /// Sends EOF on the channel.
+    pub send_eof: Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>,
+    /// Closes the channel.
+    pub close: Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>,
+    /// Opaque extensions kept alive for the session lifetime (e.g. X11Forwarder).
+    pub extensions: Vec<Box<dyn std::any::Any + Send>>,
+}
+
+// ── SshConnector trait ─────────────────────────────────────────────
+
+/// SSH connection + shell-channel factory.
+///
+/// The production implementation ([`Ssh2SshConnector`]) opens a real
+/// TCP+SSH connection, authenticates, sets up an optional X11 tunnel,
+/// requests a PTY, and starts a shell. Tests inject a mock that returns
+/// in-memory pipes.
+pub trait SshConnector: Send + Sync + 'static {
+    /// Connect to the SSH server described by `config` and open a
+    /// shell channel, returning I/O handles.
+    ///
+    /// `alive` is the session's liveness flag; the connector may store
+    /// a clone for use in background threads (e.g. X11 tunnel).
+    fn open_shell(
+        &self,
+        config: &SshConfig,
+        alive: Arc<AtomicBool>,
+    ) -> Result<SshShellHandle, SessionError>;
+}
+
+// ── Ssh2SshShellReader ─────────────────────────────────────────────
+
+/// Wraps an `ssh2::Channel` to implement `Read` with non-blocking
+/// retry logic suitable for the background reader thread.
+///
+/// `ssh2` in non-blocking mode returns `WouldBlock` when no data is
+/// available. This reader sleeps briefly and retries until data arrives,
+/// the channel reaches EOF, or the session's `alive` flag is cleared.
+pub struct Ssh2SshShellReader {
+    channel: Arc<Mutex<ssh2::Channel>>,
+    alive: Arc<AtomicBool>,
+}
+
+impl Ssh2SshShellReader {
+    pub fn new(channel: Arc<Mutex<ssh2::Channel>>, alive: Arc<AtomicBool>) -> Self {
+        Self { channel, alive }
+    }
+}
+
+impl Read for Ssh2SshShellReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        loop {
+            if !self.alive.load(Ordering::SeqCst) {
+                return Ok(0);
+            }
+            let result = {
+                let mut ch = self
+                    .channel
+                    .lock()
+                    .map_err(|e| std::io::Error::other(format!("channel lock: {e}")))?;
+                ch.read(buf)
+            };
+            match result {
+                ok @ Ok(_) => return ok,
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+// ── Ssh2SshConnector (production) ─────────────────────────────────
+
+/// Production SSH connector using libssh2.
+///
+/// Calls [`connect_and_authenticate`] then opens a PTY shell channel
+/// (with optional X11 forwarding). Supports all auth methods handled
+/// by [`super::auth::connect_and_authenticate`].
+pub struct Ssh2SshConnector;
+
+impl SshConnector for Ssh2SshConnector {
+    fn open_shell(
+        &self,
+        config: &SshConfig,
+        alive: Arc<AtomicBool>,
+    ) -> Result<SshShellHandle, SessionError> {
+        use super::auth::connect_and_authenticate;
+        use super::x11::X11Forwarder;
+
+        let session = Arc::new(connect_and_authenticate(config)?);
+
+        // Optional X11 forwarding must be set up before the shell channel.
+        let mut extensions: Vec<Box<dyn std::any::Any + Send>> = Vec::new();
+        let mut x11_display: Option<u32> = None;
+        let mut x11_cookie: Option<String> = None;
+        if config.enable_x11_forwarding {
+            match X11Forwarder::start(config, alive.clone()) {
+                Ok((forwarder, display_num, cookie)) => {
+                    x11_display = Some(display_num);
+                    x11_cookie = cookie;
+                    extensions.push(Box::new(forwarder));
+                }
+                Err(e) => {
+                    tracing::warn!("X11 forwarding setup failed, continuing without it: {e}");
+                }
+            }
+        }
+
+        let mut channel = session
+            .channel_session()
+            .map_err(|e| SessionError::SpawnFailed(format!("Channel open failed: {e}")))?;
+
+        // Try to set DISPLAY via setenv before PTY/shell.
+        let mut display_set_via_env = false;
+        if let Some(display_num) = x11_display {
+            let display_val = format!("localhost:{display_num}.0");
+            if channel.setenv("DISPLAY", &display_val).is_ok() {
+                display_set_via_env = true;
+            }
+        }
+
+        // User-specified environment variables.
+        for (key, value) in &config.env {
+            let _ = channel.setenv(key, value);
+        }
+
+        channel
+            .request_pty(
+                "xterm-256color",
+                None,
+                Some((config.cols as u32, config.rows as u32, 0, 0)),
+            )
+            .map_err(|e| SessionError::SpawnFailed(format!("PTY request failed: {e}")))?;
+
+        channel
+            .shell()
+            .map_err(|e| SessionError::SpawnFailed(format!("Shell request failed: {e}")))?;
+
+        // Inject DISPLAY/xauth if setenv failed (most servers reject it).
+        if let Some(display_num) = x11_display {
+            if !display_set_via_env {
+                let _ = std::io::Write::write_all(
+                    &mut channel,
+                    format!("export DISPLAY=localhost:{display_num}.0\n").as_bytes(),
+                );
+            }
+            if let Some(ref cookie) = x11_cookie {
+                let _ = std::io::Write::write_all(
+                    &mut channel,
+                    format!(
+                        "xauth add localhost:{display_num} MIT-MAGIC-COOKIE-1 {cookie} 2>/dev/null\n"
+                    )
+                    .as_bytes(),
+                );
+            }
+        }
+
+        // Switch to non-blocking for the reader thread.
+        session.set_blocking(false);
+
+        let channel = Arc::new(Mutex::new(channel));
+        let session_for_write = session.clone();
+        let session_for_resize = session.clone();
+        let session_for_blocking = session.clone();
+        let channel_for_write = channel.clone();
+        let channel_for_resize = channel.clone();
+        let channel_for_eof = channel.clone();
+        let channel_for_close = channel.clone();
+        let session_for_close = session.clone();
+
+        Ok(SshShellHandle {
+            reader: Box::new(Ssh2SshShellReader::new(channel.clone(), alive)),
+            write: Arc::new(move |data: &[u8]| {
+                let mut ch = channel_for_write
+                    .lock()
+                    .map_err(|e| SessionError::Io(std::io::Error::other(format!("lock: {e}"))))?;
+                session_for_write.set_blocking(true);
+                let result = std::io::Write::write_all(&mut *ch, data);
+                session_for_write.set_blocking(false);
+                drop(ch);
+                result.map_err(SessionError::Io)
+            }),
+            resize: Arc::new(move |cols: u16, rows: u16| {
+                let mut ch = channel_for_resize
+                    .lock()
+                    .map_err(|e| SessionError::Io(std::io::Error::other(format!("lock: {e}"))))?;
+                session_for_resize.set_blocking(true);
+                let result = ch.request_pty_size(cols as u32, rows as u32, None, None);
+                session_for_resize.set_blocking(false);
+                drop(ch);
+                result.map_err(|e| {
+                    SessionError::Io(std::io::Error::other(format!("PTY resize failed: {e}")))
+                })
+            }),
+            set_blocking: Arc::new(move |blocking: bool| {
+                session_for_blocking.set_blocking(blocking);
+            }),
+            send_eof: Arc::new(move || {
+                let mut ch = channel_for_eof
+                    .lock()
+                    .map_err(|e| SessionError::Io(std::io::Error::other(format!("lock: {e}"))))?;
+                ch.send_eof()
+                    .map_err(|e| SessionError::Io(std::io::Error::other(e.to_string())))
+            }),
+            close: Arc::new(move || {
+                let mut ch = channel_for_close
+                    .lock()
+                    .map_err(|e| SessionError::Io(std::io::Error::other(format!("lock: {e}"))))?;
+                session_for_close.set_blocking(true);
+                let _ = ch.send_eof();
+                let result = ch.close();
+                session_for_close.set_blocking(false);
+                drop(ch);
+                result.map_err(|e| SessionError::Io(std::io::Error::other(e.to_string())))
+            }),
+            extensions,
+        })
+    }
+}

--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -22,6 +22,13 @@ use std::time::Duration;
 use crate::config::SshConfig;
 use crate::errors::SessionError;
 
+// ── Type aliases for complex closure types ─────────────────────────
+
+type WriteFn = Arc<dyn Fn(&[u8]) -> Result<(), SessionError> + Send + Sync>;
+type ResizeFn = Arc<dyn Fn(u16, u16) -> Result<(), SessionError> + Send + Sync>;
+type SetBlockingFn = Arc<dyn Fn(bool) + Send + Sync>;
+type IoFn = Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>;
+
 // ── SshShellHandle ─────────────────────────────────────────────────
 
 /// Handles for an established SSH shell session.
@@ -34,15 +41,15 @@ pub struct SshShellHandle {
     /// handles the retry loop.
     pub reader: Box<dyn Read + Send>,
     /// Writes input data to the channel (handles blocking-mode toggle internally).
-    pub write: Arc<dyn Fn(&[u8]) -> Result<(), SessionError> + Send + Sync>,
+    pub write: WriteFn,
     /// Resizes the PTY to `(cols, rows)`.
-    pub resize: Arc<dyn Fn(u16, u16) -> Result<(), SessionError> + Send + Sync>,
+    pub resize: ResizeFn,
     /// Switches the underlying session's blocking mode.
-    pub set_blocking: Arc<dyn Fn(bool) + Send + Sync>,
+    pub set_blocking: SetBlockingFn,
     /// Sends EOF on the channel.
-    pub send_eof: Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>,
+    pub send_eof: IoFn,
     /// Closes the channel.
-    pub close: Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>,
+    pub close: IoFn,
     /// Opaque extensions kept alive for the session lifetime (e.g. X11Forwarder).
     pub extensions: Vec<Box<dyn std::any::Any + Send>>,
 }

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -5,15 +5,16 @@
 //! used by both the desktop and agent crates.
 
 pub mod auth;
+pub mod connector;
 mod file_browser;
 mod monitoring;
 pub mod x11;
 
-use std::io::{Read, Write};
+use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::config::SshConfig;
 use crate::connection::{
@@ -26,10 +27,9 @@ use crate::monitoring::MonitoringProvider;
 use crate::session::shell::osc7_setup_command;
 use crate::session::ssh::validate_ssh_config;
 
-use self::auth::connect_and_authenticate;
+use self::connector::{Ssh2SshConnector, SshConnector};
 use self::file_browser::SftpFileBrowser;
 use self::monitoring::SshMonitoringProvider;
-use self::x11::X11Forwarder;
 
 /// Channel capacity for output data from the SSH reader thread.
 const OUTPUT_CHANNEL_CAPACITY: usize = 64;
@@ -46,6 +46,7 @@ const OUTPUT_CHANNEL_CAPACITY: usize = 64;
 ///    [`file_browser()`](ConnectionType::file_browser).
 /// 5. Call [`disconnect()`](ConnectionType::disconnect) to clean up.
 pub struct Ssh {
+    connector: Box<dyn SshConnector>,
     /// State is `None` when disconnected, `Some` when connected.
     state: Option<ConnectedState>,
     /// The output sender is stored so `subscribe_output()` can replace
@@ -60,16 +61,25 @@ pub struct Ssh {
 
 /// Internal state of an active SSH connection.
 struct ConnectedState {
-    session: Arc<ssh2::Session>,
-    channel: Arc<Mutex<ssh2::Channel>>,
+    write: Arc<dyn Fn(&[u8]) -> Result<(), SessionError> + Send + Sync>,
+    resize: Arc<dyn Fn(u16, u16) -> Result<(), SessionError> + Send + Sync>,
+    _send_eof: Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>,
+    close: Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>,
     alive: Arc<AtomicBool>,
-    _x11_forwarder: Option<X11Forwarder>,
+    /// Keeps opaque resources alive for the session lifetime (e.g. X11Forwarder).
+    _extensions: Vec<Box<dyn std::any::Any + Send>>,
 }
 
 impl Ssh {
-    /// Create a new disconnected `Ssh` instance.
+    /// Create a new disconnected `Ssh` instance backed by the real libssh2 connector.
     pub fn new() -> Self {
+        Self::with_connector(Box::new(Ssh2SshConnector))
+    }
+
+    /// Create a new disconnected `Ssh` instance with a custom connector (for testing).
+    pub fn with_connector(connector: Box<dyn SshConnector>) -> Self {
         Self {
+            connector,
             state: None,
             output_tx: Arc::new(Mutex::new(None)),
             monitoring_provider: None,
@@ -400,86 +410,18 @@ impl ConnectionType for Ssh {
             "Connecting SSH session"
         );
 
-        let session = connect_and_authenticate(&config)?;
-
         let alive = Arc::new(AtomicBool::new(true));
+        let handle = self.connector.open_shell(&config, alive.clone())?;
 
-        // Start X11 forwarding if enabled (before opening the shell channel).
-        let (x11_forwarder, x11_display, x11_cookie) = if config.enable_x11_forwarding {
-            match X11Forwarder::start(&config, alive.clone()) {
-                Ok((forwarder, display_num, cookie)) => {
-                    (Some(forwarder), Some(display_num), cookie)
-                }
-                Err(e) => {
-                    warn!("X11 forwarding setup failed, continuing without it: {}", e);
-                    (None, None, None)
-                }
-            }
-        } else {
-            (None, None, None)
-        };
-
-        debug!("Opening SSH shell channel");
-        let mut channel = session
-            .channel_session()
-            .map_err(|e| SessionError::SpawnFailed(format!("Channel open failed: {e}")))?;
-
-        // Try to set DISPLAY via setenv before PTY/shell.
-        let mut display_set_via_env = false;
-        if let Some(display_num) = x11_display {
-            let display_val = format!("localhost:{display_num}.0");
-            if channel.setenv("DISPLAY", &display_val).is_ok() {
-                display_set_via_env = true;
-            }
-        }
-
-        // Set user-specified environment variables.
-        for (key, value) in &config.env {
-            let _ = channel.setenv(key, value);
-        }
-
-        channel
-            .request_pty(
-                "xterm-256color",
-                None,
-                Some((config.cols as u32, config.rows as u32, 0, 0)),
-            )
-            .map_err(|e| SessionError::SpawnFailed(format!("PTY request failed: {e}")))?;
-
-        channel
-            .shell()
-            .map_err(|e| SessionError::SpawnFailed(format!("Shell request failed: {e}")))?;
-
-        // If setenv failed (most servers reject it), inject export DISPLAY after shell starts.
-        if let Some(display_num) = x11_display {
-            if !display_set_via_env {
-                let display_cmd = format!("export DISPLAY=localhost:{display_num}.0\n");
-                let _ = channel.write_all(display_cmd.as_bytes());
-            }
-            if let Some(ref cookie) = x11_cookie {
-                let xauth_cmd = format!(
-                    "xauth add localhost:{display_num} MIT-MAGIC-COOKIE-1 {cookie} 2>/dev/null\n",
-                );
-                let _ = channel.write_all(xauth_cmd.as_bytes());
-            }
-        }
-
-        // Inject OSC 7 PROMPT_COMMAND hook for CWD tracking when shell
-        // integration is enabled. Errors are non-fatal.
+        // Inject OSC 7 PROMPT_COMMAND hook for CWD tracking when enabled.
         if shell_integration {
             if let Some(setup) = osc7_setup_command("ssh") {
                 let cmd = format!("{setup}\n");
-                if let Err(e) = channel.write_all(cmd.as_bytes()) {
+                if let Err(e) = (handle.write)(cmd.as_bytes()) {
                     debug!("Failed to inject OSC 7 hook: {e}");
                 }
             }
         }
-
-        // Set non-blocking for reading.
-        session.set_blocking(false);
-
-        let channel = Arc::new(Mutex::new(channel));
-        let session = Arc::new(session);
 
         // Set up output channel.
         let (tx, _rx) = tokio::sync::mpsc::channel(OUTPUT_CHANNEL_CAPACITY);
@@ -491,21 +433,15 @@ impl ConnectionType for Ssh {
             *guard = Some(tx);
         }
 
-        // Spawn reader thread: bridges sync SSH reads to async tokio channel.
-        let channel_clone = channel.clone();
+        // Spawn reader thread: `handle.reader` blocks internally until data arrives
+        // or the `alive` flag is cleared, so no WouldBlock handling is needed here.
+        let mut reader = handle.reader;
         let alive_clone = alive.clone();
         let output_tx_clone = self.output_tx.clone();
         std::thread::spawn(move || {
             let mut buf = [0u8; 4096];
-            while alive_clone.load(Ordering::SeqCst) {
-                let result = {
-                    let mut ch = match channel_clone.lock() {
-                        Ok(ch) => ch,
-                        Err(_) => break,
-                    };
-                    ch.read(&mut buf)
-                };
-                match result {
+            loop {
+                match reader.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
                         let guard = output_tx_clone.lock().ok();
@@ -519,26 +455,23 @@ impl ConnectionType for Ssh {
                             break;
                         }
                     }
-                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                    }
                     Err(_) => break,
                 }
             }
             alive_clone.store(false, Ordering::SeqCst);
         });
 
-        // Create monitoring provider.
+        // Create monitoring and file browser providers.
         self.monitoring_provider = Some(SshMonitoringProvider::new(config.clone()));
-
-        // Create file browser provider (SFTP).
         self.file_browser_provider = Some(SftpFileBrowser::new(config));
 
         self.state = Some(ConnectedState {
-            session,
-            channel,
+            write: handle.write,
+            resize: handle.resize,
+            _send_eof: handle.send_eof,
+            close: handle.close,
             alive,
-            _x11_forwarder: x11_forwarder,
+            _extensions: handle.extensions,
         });
 
         Ok(())
@@ -554,13 +487,7 @@ impl ConnectionType for Ssh {
 
         if let Some(state) = self.state.take() {
             state.alive.store(false, Ordering::SeqCst);
-            if let Ok(mut channel) = state.channel.lock() {
-                // Switch to blocking for clean shutdown.
-                state.session.set_blocking(true);
-                let _ = channel.send_eof();
-                let _ = channel.close();
-            }
-            // Clear the sender to signal the reader thread to stop.
+            let _ = (state.close)();
             if let Ok(mut guard) = self.output_tx.lock() {
                 *guard = None;
             }
@@ -580,18 +507,7 @@ impl ConnectionType for Ssh {
             .state
             .as_ref()
             .ok_or_else(|| SessionError::NotRunning("Not connected".to_string()))?;
-        // Acquire the channel lock BEFORE toggling blocking mode so the reader
-        // thread cannot start a blocking read while we hold the session flag.
-        let mut channel = state.channel.lock().map_err(|e| {
-            SessionError::Io(std::io::Error::other(format!(
-                "Failed to lock channel: {e}"
-            )))
-        })?;
-        state.session.set_blocking(true);
-        let result = channel.write_all(data);
-        state.session.set_blocking(false);
-        drop(channel);
-        result.map_err(SessionError::Io)
+        (state.write)(data)
     }
 
     fn resize(&self, cols: u16, rows: u16) -> Result<(), SessionError> {
@@ -599,17 +515,7 @@ impl ConnectionType for Ssh {
             .state
             .as_ref()
             .ok_or_else(|| SessionError::NotRunning("Not connected".to_string()))?;
-        let mut channel = state.channel.lock().map_err(|e| {
-            SessionError::Io(std::io::Error::other(format!(
-                "Failed to lock channel: {e}"
-            )))
-        })?;
-        state.session.set_blocking(true);
-        let result = channel.request_pty_size(cols as u32, rows as u32, None, None);
-        state.session.set_blocking(false);
-        drop(channel);
-        result
-            .map_err(|e| SessionError::Io(std::io::Error::other(format!("PTY resize failed: {e}"))))
+        (state.resize)(cols, rows)
     }
 
     fn subscribe_output(&self) -> OutputReceiver {
@@ -637,6 +543,89 @@ impl ConnectionType for Ssh {
 mod tests {
     use super::*;
     use crate::connection::validate_settings;
+
+    // ── MockSshConnector ───────────────────────────────────────────────
+
+    use connector::{SshShellHandle, SshConnector};
+    use std::time::Duration;
+
+    struct MockSshConnector {
+        should_fail: bool,
+        write_log: Arc<Mutex<Vec<Vec<u8>>>>,
+        resize_log: Arc<Mutex<Vec<(u16, u16)>>>,
+    }
+
+    impl MockSshConnector {
+        fn new() -> Self {
+            Self {
+                should_fail: false,
+                write_log: Arc::new(Mutex::new(Vec::new())),
+                resize_log: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                should_fail: true,
+                write_log: Arc::new(Mutex::new(Vec::new())),
+                resize_log: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl SshConnector for MockSshConnector {
+        fn open_shell(
+            &self,
+            _config: &SshConfig,
+            alive: Arc<AtomicBool>,
+        ) -> Result<SshShellHandle, SessionError> {
+            if self.should_fail {
+                return Err(SessionError::SpawnFailed(
+                    "mock: connection refused".to_string(),
+                ));
+            }
+            let write_log = self.write_log.clone();
+            let resize_log = self.resize_log.clone();
+            let alive_for_reader = alive.clone();
+            let alive_for_close = alive.clone();
+            Ok(SshShellHandle {
+                reader: Box::new(MockReader {
+                    alive: alive_for_reader,
+                }),
+                write: Arc::new(move |data: &[u8]| {
+                    write_log.lock().unwrap().push(data.to_vec());
+                    Ok(())
+                }),
+                resize: Arc::new(move |cols, rows| {
+                    resize_log.lock().unwrap().push((cols, rows));
+                    Ok(())
+                }),
+                set_blocking: Arc::new(|_| {}),
+                send_eof: Arc::new(|| Ok(())),
+                close: Arc::new(move || {
+                    alive_for_close.store(false, Ordering::SeqCst);
+                    Ok(())
+                }),
+                extensions: Vec::new(),
+            })
+        }
+    }
+
+    /// Blocks until `alive` is cleared, then returns EOF — mirrors `Ssh2SshShellReader`.
+    struct MockReader {
+        alive: Arc<AtomicBool>,
+    }
+
+    impl Read for MockReader {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            while self.alive.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Ok(0)
+        }
+    }
+
+    // ── Original unit tests (no real connection) ───────────────────────
 
     #[test]
     fn type_id() {
@@ -1037,7 +1026,7 @@ mod tests {
         assert_eq!(config.port, 2222);
     }
 
-    // --- Async tests ---
+    // --- Async tests (validation only — no real connection) ---
 
     #[tokio::test]
     async fn connect_empty_host_fails() {
@@ -1123,5 +1112,144 @@ mod tests {
         assert_eq!(config.port, 22);
         assert_eq!(config.username, "");
         assert!(config.env.is_empty());
+    }
+
+    // ── DI unit tests (MockSshConnector — no real TCP/SSH needed) ─────
+
+    fn mock_settings() -> serde_json::Value {
+        serde_json::json!({
+            "host": "test.example.com",
+            "port": 22,
+            "username": "admin",
+            "authMethod": "password",
+            "shellIntegration": false,
+        })
+    }
+
+    #[tokio::test]
+    async fn connect_with_mock_succeeds() {
+        let mut ssh = Ssh::with_connector(Box::new(MockSshConnector::new()));
+        ssh.connect(mock_settings()).await.unwrap();
+        assert!(ssh.is_connected());
+        ssh.disconnect().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_failure_propagates_as_error() {
+        let mut ssh = Ssh::with_connector(Box::new(MockSshConnector::failing()));
+        let result = ssh.connect(mock_settings()).await;
+        assert!(result.is_err(), "expected connection failure");
+        assert!(!ssh.is_connected());
+    }
+
+    #[tokio::test]
+    async fn connect_already_connected_fails_with_mock() {
+        let mut ssh = Ssh::with_connector(Box::new(MockSshConnector::new()));
+        ssh.connect(mock_settings()).await.unwrap();
+        let result = ssh.connect(mock_settings()).await;
+        assert!(result.is_err(), "second connect should fail");
+        ssh.disconnect().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn write_delegated_to_connector() {
+        let connector = MockSshConnector::new();
+        let write_log = connector.write_log.clone();
+        let mut ssh = Ssh::with_connector(Box::new(connector));
+        ssh.connect(mock_settings()).await.unwrap();
+        ssh.write(b"hello\n").unwrap();
+        let log = write_log.lock().unwrap();
+        assert!(
+            log.iter().any(|d| d == b"hello\n"),
+            "expected write to be forwarded to connector"
+        );
+        drop(log);
+        ssh.disconnect().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn resize_delegated_to_connector() {
+        let connector = MockSshConnector::new();
+        let resize_log = connector.resize_log.clone();
+        let mut ssh = Ssh::with_connector(Box::new(connector));
+        ssh.connect(mock_settings()).await.unwrap();
+        ssh.resize(120, 40).unwrap();
+        let log = resize_log.lock().unwrap();
+        assert!(
+            log.contains(&(120, 40)),
+            "expected resize to be forwarded to connector"
+        );
+        drop(log);
+        ssh.disconnect().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn disconnect_clears_alive_flag() {
+        let mut ssh = Ssh::with_connector(Box::new(MockSshConnector::new()));
+        ssh.connect(mock_settings()).await.unwrap();
+        assert!(ssh.is_connected());
+        ssh.disconnect().await.unwrap();
+        assert!(!ssh.is_connected());
+    }
+
+    #[tokio::test]
+    async fn disconnect_when_not_connected_is_noop_with_mock() {
+        let mut ssh = Ssh::with_connector(Box::new(MockSshConnector::new()));
+        ssh.disconnect().await.expect("disconnect on unconnected should not fail");
+        assert!(!ssh.is_connected());
+    }
+
+    #[tokio::test]
+    async fn write_when_disconnected_errors_with_mock() {
+        let ssh = Ssh::with_connector(Box::new(MockSshConnector::new()));
+        let result = ssh.write(b"data");
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn resize_when_disconnected_errors_with_mock() {
+        let ssh = Ssh::with_connector(Box::new(MockSshConnector::new()));
+        let result = ssh.resize(80, 24);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn osc7_injected_when_shell_integration_enabled() {
+        if osc7_setup_command("ssh").is_none() {
+            return; // platform does not provide an OSC7 command
+        }
+        let connector = MockSshConnector::new();
+        let write_log = connector.write_log.clone();
+        let mut ssh = Ssh::with_connector(Box::new(connector));
+        let settings = serde_json::json!({
+            "host": "test.example.com",
+            "port": 22,
+            "username": "admin",
+            "authMethod": "password",
+            "shellIntegration": true,
+        });
+        ssh.connect(settings).await.unwrap();
+        let log = write_log.lock().unwrap();
+        assert!(
+            !log.is_empty(),
+            "expected OSC7 setup to be written when shell integration is enabled"
+        );
+        drop(log);
+        ssh.disconnect().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn osc7_not_injected_when_shell_integration_disabled() {
+        let connector = MockSshConnector::new();
+        let write_log = connector.write_log.clone();
+        let mut ssh = Ssh::with_connector(Box::new(connector));
+        ssh.connect(mock_settings()).await.unwrap(); // shellIntegration: false
+        let log = write_log.lock().unwrap();
+        assert!(
+            log.is_empty(),
+            "expected no writes when shell integration is disabled"
+        );
+        drop(log);
+        ssh.disconnect().await.unwrap();
     }
 }

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -59,12 +59,16 @@ pub struct Ssh {
     file_browser_provider: Option<SftpFileBrowser>,
 }
 
+type WriteFn = Arc<dyn Fn(&[u8]) -> Result<(), SessionError> + Send + Sync>;
+type ResizeFn = Arc<dyn Fn(u16, u16) -> Result<(), SessionError> + Send + Sync>;
+type IoFn = Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>;
+
 /// Internal state of an active SSH connection.
 struct ConnectedState {
-    write: Arc<dyn Fn(&[u8]) -> Result<(), SessionError> + Send + Sync>,
-    resize: Arc<dyn Fn(u16, u16) -> Result<(), SessionError> + Send + Sync>,
-    _send_eof: Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>,
-    close: Arc<dyn Fn() -> Result<(), SessionError> + Send + Sync>,
+    write: WriteFn,
+    resize: ResizeFn,
+    _send_eof: IoFn,
+    close: IoFn,
     alive: Arc<AtomicBool>,
     /// Keeps opaque resources alive for the session lifetime (e.g. X11Forwarder).
     _extensions: Vec<Box<dyn std::any::Any + Send>>,
@@ -546,7 +550,7 @@ mod tests {
 
     // ── MockSshConnector ───────────────────────────────────────────────
 
-    use connector::{SshShellHandle, SshConnector};
+    use connector::{SshConnector, SshShellHandle};
     use std::time::Duration;
 
     struct MockSshConnector {
@@ -1158,12 +1162,13 @@ mod tests {
         let mut ssh = Ssh::with_connector(Box::new(connector));
         ssh.connect(mock_settings()).await.unwrap();
         ssh.write(b"hello\n").unwrap();
-        let log = write_log.lock().unwrap();
-        assert!(
-            log.iter().any(|d| d == b"hello\n"),
-            "expected write to be forwarded to connector"
-        );
-        drop(log);
+        {
+            let log = write_log.lock().unwrap();
+            assert!(
+                log.iter().any(|d| d == b"hello\n"),
+                "expected write to be forwarded to connector"
+            );
+        }
         ssh.disconnect().await.unwrap();
     }
 
@@ -1174,12 +1179,13 @@ mod tests {
         let mut ssh = Ssh::with_connector(Box::new(connector));
         ssh.connect(mock_settings()).await.unwrap();
         ssh.resize(120, 40).unwrap();
-        let log = resize_log.lock().unwrap();
-        assert!(
-            log.contains(&(120, 40)),
-            "expected resize to be forwarded to connector"
-        );
-        drop(log);
+        {
+            let log = resize_log.lock().unwrap();
+            assert!(
+                log.contains(&(120, 40)),
+                "expected resize to be forwarded to connector"
+            );
+        }
         ssh.disconnect().await.unwrap();
     }
 
@@ -1195,7 +1201,9 @@ mod tests {
     #[tokio::test]
     async fn disconnect_when_not_connected_is_noop_with_mock() {
         let mut ssh = Ssh::with_connector(Box::new(MockSshConnector::new()));
-        ssh.disconnect().await.expect("disconnect on unconnected should not fail");
+        ssh.disconnect()
+            .await
+            .expect("disconnect on unconnected should not fail");
         assert!(!ssh.is_connected());
     }
 
@@ -1229,12 +1237,13 @@ mod tests {
             "shellIntegration": true,
         });
         ssh.connect(settings).await.unwrap();
-        let log = write_log.lock().unwrap();
-        assert!(
-            !log.is_empty(),
-            "expected OSC7 setup to be written when shell integration is enabled"
-        );
-        drop(log);
+        {
+            let log = write_log.lock().unwrap();
+            assert!(
+                !log.is_empty(),
+                "expected OSC7 setup to be written when shell integration is enabled"
+            );
+        }
         ssh.disconnect().await.unwrap();
     }
 
@@ -1244,12 +1253,13 @@ mod tests {
         let write_log = connector.write_log.clone();
         let mut ssh = Ssh::with_connector(Box::new(connector));
         ssh.connect(mock_settings()).await.unwrap(); // shellIntegration: false
-        let log = write_log.lock().unwrap();
-        assert!(
-            log.is_empty(),
-            "expected no writes when shell integration is disabled"
-        );
-        drop(log);
+        {
+            let log = write_log.lock().unwrap();
+            assert!(
+                log.is_empty(),
+                "expected no writes when shell integration is disabled"
+            );
+        }
         ssh.disconnect().await.unwrap();
     }
 }

--- a/core/src/session/traits.rs
+++ b/core/src/session/traits.rs
@@ -16,6 +16,7 @@
 //! dynamic dispatch overhead in hot paths.
 
 use std::collections::HashMap;
+use std::io::{Read, Write};
 use std::path::Path;
 
 use crate::config::PtySize;
@@ -124,6 +125,46 @@ pub trait ProcessHandle: Send {
 
     /// Check whether the process is still running.
     fn is_alive(&self) -> bool;
+}
+
+// ── LocalShell PTY injection ───────────────────────────────────────
+
+/// Handles returned after a successful [`LocalShellSpawner::spawn`] call.
+///
+/// The caller stores the writer in `ConnectedState` (for `write()`),
+/// hands the reader to the output-reader thread, and stores the closures
+/// for resize and kill.
+pub struct SpawnedShell {
+    /// Synchronous writer for sending data to the shell's PTY input.
+    pub writer: Box<dyn Write + Send>,
+    /// Synchronous reader from the shell's PTY output.
+    ///
+    /// Consumed by the background reader thread spawned in `connect()`.
+    pub reader: Box<dyn Read + Send>,
+    /// Resize the PTY to the given `(cols, rows)`.
+    pub resize: Box<dyn Fn(u16, u16) -> Result<(), SessionError> + Send + Sync>,
+    /// Kill the shell process.
+    pub kill: Box<dyn Fn() + Send + Sync>,
+}
+
+/// PTY / process spawn abstraction for the local shell backend.
+///
+/// # Production implementation
+///
+/// `NativeLocalShellSpawner` (in `core::backends::local_shell`) calls
+/// `portable_pty::native_pty_system()` and spawns a real process.
+///
+/// # Test implementation
+///
+/// Inject a mock that returns in-memory pipes so unit tests never fork
+/// a real PTY or process.
+pub trait LocalShellSpawner: Send + Sync + 'static {
+    /// Spawn the shell described by `command` and return I/O handles.
+    ///
+    /// `command` is fully resolved: program, arguments (including any
+    /// shell-type-specific startup flags already added by the caller),
+    /// environment variables, working directory, and PTY dimensions.
+    fn spawn(&self, command: &ShellCommand) -> Result<SpawnedShell, SessionError>;
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -7,8 +7,8 @@ use tracing::{debug, info};
 use crate::session::manager::SessionManager;
 use crate::terminal::agent_deploy::{AgentDeployConfig, AgentDeployResult, AgentProbeResult};
 use crate::terminal::agent_manager::{
-    AgentCapabilities, AgentConnectResult, AgentConnectionManager, AgentConnectionsData,
-    AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo,
+    AgentCapabilities, AgentConnectResult, AgentConnectionsData, AgentDefinitionInfo,
+    AgentFolderInfo, AgentRpcClient, AgentSessionInfo,
 };
 use crate::terminal::agent_setup::{AgentSetupConfig, AgentSetupResult};
 use crate::terminal::backend::RemoteAgentConfig;
@@ -22,7 +22,7 @@ use crate::terminal::backend::RemoteAgentConfig;
 pub async fn connect_agent(
     agent_id: String,
     config: RemoteAgentConfig,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentConnectResult, String> {
     info!(agent_id, host = %config.host, "Connecting to remote agent");
     let manager = agent_manager.inner().clone();
@@ -38,7 +38,7 @@ pub async fn connect_agent(
 #[tauri::command]
 pub fn disconnect_agent(
     agent_id: String,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<(), String> {
     info!(agent_id, "Disconnecting remote agent");
     agent_manager
@@ -54,7 +54,7 @@ pub fn disconnect_agent(
 pub async fn shutdown_agent(
     agent_id: String,
     reason: Option<String>,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<u32, String> {
     info!(agent_id, "Shutting down remote agent");
     let manager = agent_manager.inner().clone();
@@ -70,7 +70,7 @@ pub async fn shutdown_agent(
 #[tauri::command]
 pub fn get_agent_capabilities(
     agent_id: String,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentCapabilities, String> {
     agent_manager
         .get_capabilities(&agent_id)
@@ -83,7 +83,7 @@ pub fn get_agent_capabilities(
 #[tauri::command]
 pub async fn list_agent_sessions(
     agent_id: String,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<Vec<AgentSessionInfo>, String> {
     debug!(agent_id, "Listing agent sessions");
     let manager = agent_manager.inner().clone();
@@ -100,7 +100,7 @@ pub async fn list_agent_sessions(
 #[tauri::command]
 pub async fn list_agent_definitions(
     agent_id: String,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<Vec<AgentDefinitionInfo>, String> {
     debug!(agent_id, "Listing agent definitions");
     let manager = agent_manager.inner().clone();
@@ -120,7 +120,7 @@ pub async fn list_agent_definitions(
 pub async fn save_agent_definition(
     agent_id: String,
     definition: Value,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentDefinitionInfo, String> {
     debug!(agent_id, "Saving agent definition");
     let manager = agent_manager.inner().clone();
@@ -140,7 +140,7 @@ pub async fn save_agent_definition(
 pub async fn delete_agent_definition(
     agent_id: String,
     definition_id: String,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<(), String> {
     info!(agent_id, definition_id, "Deleting agent definition");
     let manager = agent_manager.inner().clone();
@@ -159,7 +159,7 @@ pub async fn delete_agent_definition(
 #[tauri::command]
 pub async fn list_agent_connections(
     agent_id: String,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentConnectionsData, String> {
     debug!(agent_id, "Listing agent connections and folders");
     let manager = agent_manager.inner().clone();
@@ -179,7 +179,7 @@ pub async fn list_agent_connections(
 pub async fn update_agent_definition(
     agent_id: String,
     params: Value,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentDefinitionInfo, String> {
     debug!(agent_id, "Updating agent definition");
     let manager = agent_manager.inner().clone();
@@ -200,7 +200,7 @@ pub async fn create_agent_folder(
     agent_id: String,
     name: String,
     parent_id: Option<String>,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentFolderInfo, String> {
     debug!(agent_id, %name, "Creating agent folder");
     let manager = agent_manager.inner().clone();
@@ -220,7 +220,7 @@ pub async fn create_agent_folder(
 pub async fn update_agent_folder(
     agent_id: String,
     params: Value,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentFolderInfo, String> {
     debug!(agent_id, "Updating agent folder");
     let manager = agent_manager.inner().clone();
@@ -240,7 +240,7 @@ pub async fn update_agent_folder(
 pub async fn delete_agent_folder(
     agent_id: String,
     folder_id: String,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<(), String> {
     info!(agent_id, folder_id, "Deleting agent folder");
     let manager = agent_manager.inner().clone();
@@ -326,7 +326,7 @@ pub async fn update_agent(
     config: RemoteAgentConfig,
     deploy_config: AgentDeployConfig,
     app_handle: tauri::AppHandle,
-    agent_manager: State<'_, Arc<AgentConnectionManager>>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentDeployResult, String> {
     info!(agent_id, host = %config.host, "Updating agent on remote host");
     let manager = agent_manager.inner().clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ use monitoring::MonitoringManager;
 use network::NetworkManager;
 use session::manager::SessionManager;
 use session::registry::build_desktop_registry;
-use terminal::agent_manager::AgentConnectionManager;
+use terminal::agent_manager::{AgentConnectionManager, AgentRpcClient};
 use utils::log_capture::{create_log_buffer, LogCaptureLayer};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -200,7 +200,8 @@ pub fn run() {
                 });
             }
 
-            let agent_manager = Arc::new(AgentConnectionManager::new(app.handle().clone()));
+            let agent_manager: Arc<dyn AgentRpcClient> =
+                Arc::new(AgentConnectionManager::new(app.handle().clone()));
 
             // Build the desktop ConnectionType registry and create the SessionManager.
             let registry = build_desktop_registry();

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -112,10 +112,7 @@ pub struct SessionManager {
 
 impl SessionManager {
     /// Create a new session manager with the given registry and agent manager.
-    pub fn new(
-        registry: ConnectionTypeRegistry,
-        agent_manager: Arc<dyn AgentRpcClient>,
-    ) -> Self {
+    pub fn new(registry: ConnectionTypeRegistry, agent_manager: Arc<dyn AgentRpcClient>) -> Self {
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
             registry: Arc::new(registry),
@@ -209,14 +206,8 @@ impl SessionManager {
         let sessions_clone = self.sessions.clone();
         let sid = session_id.clone();
         tokio::spawn(async move {
-            Self::run_output_reader(
-                sid,
-                output_rx,
-                emitter,
-                sessions_clone,
-                has_initial_command,
-            )
-            .await;
+            Self::run_output_reader(sid, output_rx, emitter, sessions_clone, has_initial_command)
+                .await;
         });
 
         // Send initial command after a short delay.
@@ -784,9 +775,11 @@ mod tests {
 
         SessionManager::emit_and_cleanup("sess-exit", Vec::new(), &emitter, &sessions).await;
 
-        let exits = emitter.exits.lock().unwrap();
-        assert_eq!(exits.len(), 1);
-        assert_eq!(exits[0].session_id, "sess-exit");
+        {
+            let exits = emitter.exits.lock().unwrap();
+            assert_eq!(exits.len(), 1);
+            assert_eq!(exits[0].session_id, "sess-exit");
+        }
         // Session should be removed after cleanup
         assert!(!sessions.lock().await.contains_key("sess-exit"));
     }
@@ -796,17 +789,14 @@ mod tests {
         let emitter = MockEventEmitter::new();
         let sessions = sessions_with_mock("sess-data").await;
 
-        SessionManager::emit_and_cleanup(
-            "sess-data",
-            b"final bytes".to_vec(),
-            &emitter,
-            &sessions,
-        )
-        .await;
+        SessionManager::emit_and_cleanup("sess-data", b"final bytes".to_vec(), &emitter, &sessions)
+            .await;
 
-        let outputs = emitter.outputs.lock().unwrap();
-        assert_eq!(outputs.len(), 1);
-        assert_eq!(outputs[0].data, b"final bytes");
+        {
+            let outputs = emitter.outputs.lock().unwrap();
+            assert_eq!(outputs.len(), 1);
+            assert_eq!(outputs[0].data, b"final bytes");
+        }
     }
 
     #[tokio::test]
@@ -828,12 +818,21 @@ mod tests {
         )
         .await;
 
-        let outputs = emitter.outputs.lock().unwrap();
-        let combined: Vec<u8> = outputs.iter().flat_map(|e| e.data.iter().copied()).collect();
-        assert!(combined.windows(5).any(|w| w == b"hello"), "expected 'hello' in output");
-
-        let exits = emitter.exits.lock().unwrap();
-        assert_eq!(exits.len(), 1);
+        {
+            let outputs = emitter.outputs.lock().unwrap();
+            let combined: Vec<u8> = outputs
+                .iter()
+                .flat_map(|e| e.data.iter().copied())
+                .collect();
+            assert!(
+                combined.windows(5).any(|w| w == b"hello"),
+                "expected 'hello' in output"
+            );
+        }
+        {
+            let exits = emitter.exits.lock().unwrap();
+            assert_eq!(exits.len(), 1);
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -12,14 +12,14 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 use serde::Serialize;
-use tauri::{AppHandle, Emitter};
+use tauri::Emitter;
 use termihub_core::connection::{ConnectionType, ConnectionTypeInfo, ConnectionTypeRegistry};
 use termihub_core::files::FileEntry;
 use termihub_core::output::coalescer::OutputCoalescer;
 use termihub_core::output::screen_clear::contains_screen_clear;
 use tracing::{error, info};
 
-use crate::terminal::agent_manager::AgentConnectionManager;
+use crate::terminal::agent_manager::AgentRpcClient;
 use crate::utils::errors::TerminalError;
 
 use super::remote_proxy::RemoteProxy;
@@ -56,6 +56,32 @@ pub struct TerminalErrorEvent {
     pub message: String,
 }
 
+// ── EventEmitter trait ─────────────────────────────────────────────
+
+/// Abstracts frontend event delivery for dependency injection in tests.
+///
+/// The production implementation wraps `tauri::AppHandle` and emits
+/// Tauri events to the webview. Test implementations record emitted
+/// events for assertions without requiring a real Tauri runtime.
+pub trait EventEmitter: Clone + Send + Sync + 'static {
+    /// Emit a terminal output chunk. Returns `false` if delivery failed
+    /// (e.g., the webview was closed), signalling the reader to stop.
+    fn emit_output(&self, event: &TerminalOutputEvent) -> bool;
+
+    /// Emit a session exit notification.
+    fn emit_exit(&self, event: &TerminalExitEvent);
+}
+
+impl<R: tauri::Runtime> EventEmitter for tauri::AppHandle<R> {
+    fn emit_output(&self, event: &TerminalOutputEvent) -> bool {
+        self.emit("terminal-output", event).is_ok()
+    }
+
+    fn emit_exit(&self, event: &TerminalExitEvent) {
+        let _ = self.emit("terminal-exit", event);
+    }
+}
+
 /// Information about an active session.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -81,14 +107,14 @@ struct SessionEntry {
 pub struct SessionManager {
     sessions: Arc<Mutex<HashMap<String, SessionEntry>>>,
     registry: Arc<ConnectionTypeRegistry>,
-    agent_manager: Arc<AgentConnectionManager>,
+    agent_manager: Arc<dyn AgentRpcClient>,
 }
 
 impl SessionManager {
     /// Create a new session manager with the given registry and agent manager.
     pub fn new(
         registry: ConnectionTypeRegistry,
-        agent_manager: Arc<AgentConnectionManager>,
+        agent_manager: Arc<dyn AgentRpcClient>,
     ) -> Self {
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
@@ -104,12 +130,12 @@ impl SessionManager {
     /// the registry.
     ///
     /// Returns the session ID on success.
-    pub async fn create_connection(
+    pub async fn create_connection<E: EventEmitter>(
         &self,
         type_id: &str,
         settings: serde_json::Value,
         agent_id: Option<&str>,
-        app_handle: AppHandle,
+        emitter: E,
     ) -> Result<String, TerminalError> {
         // Enforce session limit.
         {
@@ -186,7 +212,7 @@ impl SessionManager {
             Self::run_output_reader(
                 sid,
                 output_rx,
-                app_handle,
+                emitter,
                 sessions_clone,
                 has_initial_command,
             )
@@ -453,10 +479,10 @@ impl SessionManager {
     ///
     /// Coalesces pending output chunks into a single event (up to
     /// `MAX_COALESCE_BYTES`) to reduce IPC overhead.
-    async fn run_output_reader(
+    async fn run_output_reader<E: EventEmitter>(
         session_id: String,
         mut output_rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
-        app_handle: AppHandle,
+        emitter: E,
         sessions: Arc<Mutex<HashMap<String, SessionEntry>>>,
         wait_for_clear: bool,
     ) {
@@ -480,7 +506,7 @@ impl SessionManager {
                     }
                     Ok(None) => {
                         // Channel closed during startup.
-                        Self::emit_and_cleanup(&session_id, buffer, &app_handle, &sessions).await;
+                        Self::emit_and_cleanup(&session_id, buffer, &emitter, &sessions).await;
                         return;
                     }
                     Err(_) => break, // Timeout
@@ -493,7 +519,7 @@ impl SessionManager {
                     session_id: session_id.clone(),
                     data: buffer,
                 };
-                if app_handle.emit("terminal-output", &event).is_err() {
+                if !emitter.emit_output(&event) {
                     return;
                 }
             }
@@ -517,21 +543,21 @@ impl SessionManager {
                     session_id: session_id.clone(),
                     data,
                 };
-                if let Err(e) = app_handle.emit("terminal-output", &event) {
-                    error!("Failed to emit terminal-output event: {e}");
+                if !emitter.emit_output(&event) {
+                    error!("Failed to emit terminal-output event");
                     break;
                 }
             }
         }
 
-        Self::emit_and_cleanup(&session_id, Vec::new(), &app_handle, &sessions).await;
+        Self::emit_and_cleanup(&session_id, Vec::new(), &emitter, &sessions).await;
     }
 
     /// Emit remaining data (if any), send the exit event, and remove the session.
-    async fn emit_and_cleanup(
+    async fn emit_and_cleanup<E: EventEmitter>(
         session_id: &str,
         data: Vec<u8>,
-        app_handle: &AppHandle,
+        emitter: &E,
         sessions: &Arc<Mutex<HashMap<String, SessionEntry>>>,
     ) {
         if !data.is_empty() {
@@ -539,14 +565,14 @@ impl SessionManager {
                 session_id: session_id.to_string(),
                 data,
             };
-            let _ = app_handle.emit("terminal-output", &event);
+            emitter.emit_output(&event);
         }
 
         let exit_event = TerminalExitEvent {
             session_id: session_id.to_string(),
             exit_code: None,
         };
-        let _ = app_handle.emit("terminal-exit", &exit_event);
+        emitter.emit_exit(&exit_event);
 
         {
             let mut sessions = sessions.lock().await;
@@ -635,6 +661,40 @@ mod tests {
         sessions
     }
 
+    // ── MockEventEmitter ─────────────────────────────────────────────
+
+    #[derive(Clone, Default)]
+    struct MockEventEmitter {
+        outputs: std::sync::Arc<std::sync::Mutex<Vec<TerminalOutputEvent>>>,
+        exits: std::sync::Arc<std::sync::Mutex<Vec<TerminalExitEvent>>>,
+        fail_output: bool,
+    }
+
+    impl MockEventEmitter {
+        fn new() -> Self {
+            Self::default()
+        }
+        fn failing() -> Self {
+            Self {
+                fail_output: true,
+                ..Self::default()
+            }
+        }
+    }
+
+    impl EventEmitter for MockEventEmitter {
+        fn emit_output(&self, event: &TerminalOutputEvent) -> bool {
+            if self.fail_output {
+                return false;
+            }
+            self.outputs.lock().unwrap().push(event.clone());
+            true
+        }
+        fn emit_exit(&self, event: &TerminalExitEvent) {
+            self.exits.lock().unwrap().push(event.clone());
+        }
+    }
+
     /// Test that file browser access returns an error when the connection
     /// has no file browser capability.
     #[tokio::test]
@@ -713,5 +773,89 @@ mod tests {
         let settings = serde_json::json!({"runtime": "docker"});
         let title = SessionManager::build_title("docker", &settings, None);
         assert_eq!(title, "Docker: unknown");
+    }
+
+    // ── EventEmitter DI tests ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn emit_and_cleanup_sends_exit_event() {
+        let emitter = MockEventEmitter::new();
+        let sessions = sessions_with_mock("sess-exit").await;
+
+        SessionManager::emit_and_cleanup("sess-exit", Vec::new(), &emitter, &sessions).await;
+
+        let exits = emitter.exits.lock().unwrap();
+        assert_eq!(exits.len(), 1);
+        assert_eq!(exits[0].session_id, "sess-exit");
+        // Session should be removed after cleanup
+        assert!(!sessions.lock().await.contains_key("sess-exit"));
+    }
+
+    #[tokio::test]
+    async fn emit_and_cleanup_flushes_remaining_data() {
+        let emitter = MockEventEmitter::new();
+        let sessions = sessions_with_mock("sess-data").await;
+
+        SessionManager::emit_and_cleanup(
+            "sess-data",
+            b"final bytes".to_vec(),
+            &emitter,
+            &sessions,
+        )
+        .await;
+
+        let outputs = emitter.outputs.lock().unwrap();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].data, b"final bytes");
+    }
+
+    #[tokio::test]
+    async fn run_output_reader_emits_chunks_and_exit() {
+        let emitter = MockEventEmitter::new();
+        let sessions = sessions_with_mock("sess-stream").await;
+        let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(10);
+
+        tx.send(b"hello ".to_vec()).await.unwrap();
+        tx.send(b"world".to_vec()).await.unwrap();
+        drop(tx); // signal EOF
+
+        SessionManager::run_output_reader(
+            "sess-stream".to_string(),
+            rx,
+            emitter.clone(),
+            sessions.clone(),
+            false,
+        )
+        .await;
+
+        let outputs = emitter.outputs.lock().unwrap();
+        let combined: Vec<u8> = outputs.iter().flat_map(|e| e.data.iter().copied()).collect();
+        assert!(combined.windows(5).any(|w| w == b"hello"), "expected 'hello' in output");
+
+        let exits = emitter.exits.lock().unwrap();
+        assert_eq!(exits.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn run_output_reader_stops_on_emitter_failure() {
+        let emitter = MockEventEmitter::failing();
+        let sessions = sessions_with_mock("sess-fail").await;
+        let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(10);
+
+        tx.send(b"data".to_vec()).await.unwrap();
+
+        // run_output_reader should return quickly when emit_output returns false
+        SessionManager::run_output_reader(
+            "sess-fail".to_string(),
+            rx,
+            emitter.clone(),
+            sessions,
+            false,
+        )
+        .await;
+
+        // No outputs recorded (emitter failed)
+        let outputs = emitter.outputs.lock().unwrap();
+        assert!(outputs.is_empty());
     }
 }

--- a/src-tauri/src/session/remote_proxy.rs
+++ b/src-tauri/src/session/remote_proxy.rs
@@ -618,10 +618,7 @@ mod tests {
             Ok(())
         }
 
-        fn list_sessions(
-            &self,
-            _agent_id: &str,
-        ) -> Result<Vec<AgentSessionInfo>, TerminalError> {
+        fn list_sessions(&self, _agent_id: &str) -> Result<Vec<AgentSessionInfo>, TerminalError> {
             Ok(vec![])
         }
 
@@ -676,11 +673,7 @@ mod tests {
             })
         }
 
-        fn delete_definition(
-            &self,
-            _agent_id: &str,
-            _def_id: &str,
-        ) -> Result<(), TerminalError> {
+        fn delete_definition(&self, _agent_id: &str, _def_id: &str) -> Result<(), TerminalError> {
             Ok(())
         }
 
@@ -811,7 +804,10 @@ mod tests {
         let mut proxy = RemoteProxy::new("agent-1".to_string(), mock.clone());
 
         let settings = json!({ "type": "local", "config": {} });
-        proxy.connect(settings).await.expect("connect should succeed");
+        proxy
+            .connect(settings)
+            .await
+            .expect("connect should succeed");
 
         let sessions = mock.created_sessions.lock().unwrap();
         assert_eq!(sessions.len(), 1);
@@ -823,7 +819,10 @@ mod tests {
     async fn connect_twice_returns_error() {
         let mut proxy = make_proxy();
         let settings = json!({ "type": "local", "config": {} });
-        proxy.connect(settings.clone()).await.expect("first connect");
+        proxy
+            .connect(settings.clone())
+            .await
+            .expect("first connect");
         let result = proxy.connect(settings).await;
         assert!(result.is_err(), "second connect should fail");
 

--- a/src-tauri/src/session/remote_proxy.rs
+++ b/src-tauri/src/session/remote_proxy.rs
@@ -22,7 +22,7 @@ use termihub_core::errors::{CoreError, FileError, SessionError};
 use termihub_core::files::{FileBrowser, FileEntry};
 use termihub_core::monitoring::{MonitoringProvider, MonitoringReceiver};
 
-use crate::terminal::agent_manager::AgentConnectionManager;
+use crate::terminal::agent_manager::AgentRpcClient;
 use crate::terminal::backend::OUTPUT_CHANNEL_CAPACITY;
 
 /// A [`ConnectionType`] implementation that proxies all operations to a
@@ -34,7 +34,7 @@ pub struct RemoteProxy {
     agent_id: String,
     /// The remote session ID assigned by the agent after `connection.create`.
     remote_session_id: Mutex<Option<String>>,
-    agent_manager: Arc<AgentConnectionManager>,
+    agent_manager: Arc<dyn AgentRpcClient>,
     /// The type_id of the remote connection (e.g., "local", "ssh").
     remote_type_id: Mutex<String>,
     /// Capabilities reported by the agent for this connection type.
@@ -55,7 +55,7 @@ impl RemoteProxy {
     /// Call [`connect()`](ConnectionType::connect) with settings JSON
     /// containing `type` and connection-specific parameters to establish
     /// the remote session.
-    pub fn new(agent_id: String, agent_manager: Arc<AgentConnectionManager>) -> Self {
+    pub fn new(agent_id: String, agent_manager: Arc<dyn AgentRpcClient>) -> Self {
         Self {
             agent_id,
             remote_session_id: Mutex::new(None),
@@ -315,7 +315,7 @@ impl ConnectionType for RemoteProxy {
 pub struct RemoteFileBrowserProxy {
     agent_id: String,
     remote_session_id: String,
-    agent_manager: Arc<AgentConnectionManager>,
+    agent_manager: Arc<dyn AgentRpcClient>,
 }
 
 #[async_trait::async_trait]
@@ -438,7 +438,7 @@ impl FileBrowser for RemoteFileBrowserProxy {
 pub struct RemoteMonitoringProxy {
     agent_id: String,
     remote_session_id: String,
-    agent_manager: Arc<AgentConnectionManager>,
+    agent_manager: Arc<dyn AgentRpcClient>,
 }
 
 #[async_trait::async_trait]
@@ -495,9 +495,286 @@ fn base64_decode(input: &str) -> Result<Vec<u8>, FileError> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::sync::Mutex;
 
-    /// Compile-time verification that `RemoteProxy` is Send.
+    use serde_json::json;
+
+    use super::*;
+    use crate::terminal::agent_manager::{
+        AgentCapabilities, AgentConnectResult, AgentConnectionsData, AgentDefinitionInfo,
+        AgentFolderInfo, AgentRpcClient, AgentSessionInfo,
+    };
+    use crate::terminal::backend::{OutputSender, RemoteAgentConfig};
+    use crate::utils::errors::TerminalError;
+    use termihub_core::monitoring::MonitoringSender;
+
+    // ── MockAgentRpcClient ────────────────────────────────────────────
+
+    /// Minimal in-memory mock of `AgentRpcClient` for unit tests.
+    ///
+    /// `create_session` records calls and returns a canned session.
+    /// All other mutating methods succeed silently. `is_connected` returns
+    /// `true` once at least one `create_session` call has been recorded.
+    struct MockAgentRpcClient {
+        created_sessions: Mutex<Vec<(String, String, serde_json::Value)>>,
+        send_request_result: Option<serde_json::Value>,
+    }
+
+    impl MockAgentRpcClient {
+        fn new() -> Self {
+            Self {
+                created_sessions: Mutex::new(Vec::new()),
+                send_request_result: None,
+            }
+        }
+    }
+
+    impl AgentRpcClient for MockAgentRpcClient {
+        fn connect_agent(
+            &self,
+            _agent_id: &str,
+            _config: &RemoteAgentConfig,
+        ) -> Result<AgentConnectResult, TerminalError> {
+            Ok(AgentConnectResult {
+                capabilities: AgentCapabilities {
+                    connection_types: vec![],
+                    max_sessions: 10,
+                    available_shells: vec![],
+                    available_serial_ports: vec![],
+                    docker_available: false,
+                    available_docker_images: vec![],
+                },
+                agent_version: "mock".to_string(),
+                protocol_version: "0.2.0".to_string(),
+            })
+        }
+
+        fn disconnect_agent(&self, _agent_id: &str) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn is_connected(&self, _agent_id: &str) -> bool {
+            !self.created_sessions.lock().unwrap().is_empty()
+        }
+
+        fn get_capabilities(&self, _agent_id: &str) -> Option<AgentCapabilities> {
+            None
+        }
+
+        fn shutdown_agent(
+            &self,
+            _agent_id: &str,
+            _reason: Option<&str>,
+        ) -> Result<u32, TerminalError> {
+            Ok(0)
+        }
+
+        fn send_request(
+            &self,
+            _agent_id: &str,
+            _method: &str,
+            _params: serde_json::Value,
+        ) -> Result<serde_json::Value, TerminalError> {
+            Ok(self
+                .send_request_result
+                .clone()
+                .unwrap_or(serde_json::Value::Null))
+        }
+
+        fn create_session(
+            &self,
+            agent_id: &str,
+            session_type: &str,
+            config: serde_json::Value,
+            _title: Option<&str>,
+        ) -> Result<AgentSessionInfo, TerminalError> {
+            self.created_sessions.lock().unwrap().push((
+                agent_id.to_string(),
+                session_type.to_string(),
+                config,
+            ));
+            Ok(AgentSessionInfo {
+                session_id: "mock-session-1".to_string(),
+                title: "Mock Session".to_string(),
+                session_type: session_type.to_string(),
+                status: "running".to_string(),
+                attached: false,
+            })
+        }
+
+        fn attach_session(
+            &self,
+            _agent_id: &str,
+            _remote_session_id: &str,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn close_session(
+            &self,
+            _agent_id: &str,
+            _remote_session_id: &str,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn list_sessions(
+            &self,
+            _agent_id: &str,
+        ) -> Result<Vec<AgentSessionInfo>, TerminalError> {
+            Ok(vec![])
+        }
+
+        fn list_connections_and_folders(
+            &self,
+            _agent_id: &str,
+        ) -> Result<AgentConnectionsData, TerminalError> {
+            Ok(AgentConnectionsData {
+                connections: vec![],
+                folders: vec![],
+            })
+        }
+
+        fn list_definitions(
+            &self,
+            _agent_id: &str,
+        ) -> Result<Vec<AgentDefinitionInfo>, TerminalError> {
+            Ok(vec![])
+        }
+
+        fn save_definition(
+            &self,
+            _agent_id: &str,
+            _definition: serde_json::Value,
+        ) -> Result<AgentDefinitionInfo, TerminalError> {
+            Ok(AgentDefinitionInfo {
+                id: "mock-def".to_string(),
+                name: "Mock".to_string(),
+                session_type: "local".to_string(),
+                config: serde_json::Value::Null,
+                persistent: false,
+                folder_id: None,
+                terminal_options: None,
+                icon: None,
+            })
+        }
+
+        fn update_definition(
+            &self,
+            _agent_id: &str,
+            _params: serde_json::Value,
+        ) -> Result<AgentDefinitionInfo, TerminalError> {
+            Ok(AgentDefinitionInfo {
+                id: "mock-def".to_string(),
+                name: "Updated".to_string(),
+                session_type: "local".to_string(),
+                config: serde_json::Value::Null,
+                persistent: false,
+                folder_id: None,
+                terminal_options: None,
+                icon: None,
+            })
+        }
+
+        fn delete_definition(
+            &self,
+            _agent_id: &str,
+            _def_id: &str,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn create_folder(
+            &self,
+            _agent_id: &str,
+            _name: &str,
+            _parent_id: Option<&str>,
+        ) -> Result<AgentFolderInfo, TerminalError> {
+            Ok(AgentFolderInfo {
+                id: "mock-folder".to_string(),
+                name: "Mock Folder".to_string(),
+                parent_id: None,
+                is_expanded: false,
+            })
+        }
+
+        fn update_folder(
+            &self,
+            _agent_id: &str,
+            _params: serde_json::Value,
+        ) -> Result<AgentFolderInfo, TerminalError> {
+            Ok(AgentFolderInfo {
+                id: "mock-folder".to_string(),
+                name: "Updated Folder".to_string(),
+                parent_id: None,
+                is_expanded: false,
+            })
+        }
+
+        fn delete_folder(&self, _agent_id: &str, _folder_id: &str) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn register_session_output(
+            &self,
+            _agent_id: &str,
+            _remote_session_id: &str,
+            _output_tx: OutputSender,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn unregister_session_output(
+            &self,
+            _agent_id: &str,
+            _remote_session_id: &str,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn register_monitoring_output(
+            &self,
+            _agent_id: &str,
+            _remote_session_id: &str,
+            _monitoring_tx: MonitoringSender,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn unregister_monitoring_output(
+            &self,
+            _agent_id: &str,
+            _remote_session_id: &str,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn send_session_input(
+            &self,
+            _agent_id: &str,
+            _remote_session_id: &str,
+            _data: &[u8],
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+
+        fn resize_session(
+            &self,
+            _agent_id: &str,
+            _remote_session_id: &str,
+            _cols: u16,
+            _rows: u16,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+    }
+
+    fn make_proxy() -> RemoteProxy {
+        RemoteProxy::new("agent-1".to_string(), Arc::new(MockAgentRpcClient::new()))
+    }
+
+    // ── Compile-time trait checks ─────────────────────────────────────
+
     fn _assert_send<T: Send>() {}
 
     #[test]
@@ -515,11 +792,94 @@ mod tests {
         _assert_send::<RemoteMonitoringProxy>();
     }
 
-    /// Compile-time verification that `file_browser()` returns a trait
-    /// reference (not `None` unconditionally) — i.e. the `Option<&dyn
-    /// FileBrowser>` return compiles from `Option<RemoteFileBrowserProxy>`.
     fn _assert_file_browser_compiles(proxy: &RemoteProxy) {
         let _: Option<&dyn FileBrowser> = proxy.file_browser();
         let _: Option<&dyn MonitoringProvider> = proxy.monitoring();
+    }
+
+    // ── Behaviour tests using MockAgentRpcClient ──────────────────────
+
+    #[test]
+    fn new_proxy_is_not_connected() {
+        let proxy = make_proxy();
+        assert!(!proxy.is_connected());
+    }
+
+    #[tokio::test]
+    async fn connect_calls_create_and_attach_session() {
+        let mock = Arc::new(MockAgentRpcClient::new());
+        let mut proxy = RemoteProxy::new("agent-1".to_string(), mock.clone());
+
+        let settings = json!({ "type": "local", "config": {} });
+        proxy.connect(settings).await.expect("connect should succeed");
+
+        let sessions = mock.created_sessions.lock().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].0, "agent-1");
+        assert_eq!(sessions[0].1, "local");
+    }
+
+    #[tokio::test]
+    async fn connect_twice_returns_error() {
+        let mut proxy = make_proxy();
+        let settings = json!({ "type": "local", "config": {} });
+        proxy.connect(settings.clone()).await.expect("first connect");
+        let result = proxy.connect(settings).await;
+        assert!(result.is_err(), "second connect should fail");
+
+        proxy.disconnect().await.ok();
+    }
+
+    #[tokio::test]
+    async fn disconnect_clears_connected_state() {
+        let mut proxy = make_proxy();
+        let settings = json!({ "type": "local", "config": {} });
+        proxy.connect(settings).await.expect("connect");
+
+        proxy.disconnect().await.expect("disconnect");
+
+        // is_connected checks both local flag and mock.is_connected()
+        // After disconnect the local flag is false.
+        assert!(!proxy.is_connected());
+    }
+
+    #[tokio::test]
+    async fn write_after_connect_succeeds() {
+        let mut proxy = make_proxy();
+        proxy
+            .connect(json!({ "type": "local", "config": {} }))
+            .await
+            .expect("connect");
+
+        let result = proxy.write(b"hello");
+        assert!(result.is_ok());
+
+        proxy.disconnect().await.ok();
+    }
+
+    #[tokio::test]
+    async fn resize_after_connect_succeeds() {
+        let mut proxy = make_proxy();
+        proxy
+            .connect(json!({ "type": "local", "config": {} }))
+            .await
+            .expect("connect");
+
+        let result = proxy.resize(120, 40);
+        assert!(result.is_ok());
+
+        proxy.disconnect().await.ok();
+    }
+
+    #[test]
+    fn write_before_connect_returns_error() {
+        let proxy = make_proxy();
+        assert!(proxy.write(b"data").is_err());
+    }
+
+    #[test]
+    fn resize_before_connect_returns_error() {
+        let proxy = make_proxy();
+        assert!(proxy.resize(80, 24).is_err());
     }
 }

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -176,6 +176,154 @@ struct AgentConnection {
     protocol_version: String,
 }
 
+/// Abstract interface over an agent connection manager.
+///
+/// Implemented by [`AgentConnectionManager`] in production and by mock
+/// structs in tests. Consumers (e.g. [`RemoteProxy`]) depend on this trait
+/// so they can be tested without real SSH connections.
+///
+/// [`RemoteProxy`]: crate::session::remote_proxy::RemoteProxy
+// Methods called through Arc<AgentConnectionManager> in commands; will be
+// routed through the trait once Tauri commands use Arc<dyn AgentRpcClient>.
+#[allow(dead_code)]
+pub trait AgentRpcClient: Send + Sync + 'static {
+    /// Connect to a remote agent via SSH.
+    fn connect_agent(
+        &self,
+        agent_id: &str,
+        config: &RemoteAgentConfig,
+    ) -> Result<AgentConnectResult, TerminalError>;
+
+    /// Disconnect an agent.
+    fn disconnect_agent(&self, agent_id: &str) -> Result<(), TerminalError>;
+
+    /// Check if an agent is connected.
+    fn is_connected(&self, agent_id: &str) -> bool;
+
+    /// Get the capabilities of a connected agent.
+    fn get_capabilities(&self, agent_id: &str) -> Option<AgentCapabilities>;
+
+    /// Gracefully shut down a remote agent and disconnect.
+    fn shutdown_agent(&self, agent_id: &str, reason: Option<&str>) -> Result<u32, TerminalError>;
+
+    /// Send a JSON-RPC request to an agent and wait for the response.
+    fn send_request(
+        &self,
+        agent_id: &str,
+        method: &str,
+        params: Value,
+    ) -> Result<Value, TerminalError>;
+
+    /// Create a session on the agent.
+    fn create_session(
+        &self,
+        agent_id: &str,
+        session_type: &str,
+        config: Value,
+        title: Option<&str>,
+    ) -> Result<AgentSessionInfo, TerminalError>;
+
+    /// Attach to a session on the agent.
+    fn attach_session(&self, agent_id: &str, remote_session_id: &str) -> Result<(), TerminalError>;
+
+    /// Close a session on the agent.
+    fn close_session(&self, agent_id: &str, remote_session_id: &str) -> Result<(), TerminalError>;
+
+    /// List sessions on the agent.
+    fn list_sessions(&self, agent_id: &str) -> Result<Vec<AgentSessionInfo>, TerminalError>;
+
+    /// List saved connections and folders on the agent.
+    fn list_connections_and_folders(
+        &self,
+        agent_id: &str,
+    ) -> Result<AgentConnectionsData, TerminalError>;
+
+    /// List saved session definitions on the agent (backward compat).
+    fn list_definitions(&self, agent_id: &str) -> Result<Vec<AgentDefinitionInfo>, TerminalError>;
+
+    /// Save a session definition on the agent.
+    fn save_definition(
+        &self,
+        agent_id: &str,
+        definition: Value,
+    ) -> Result<AgentDefinitionInfo, TerminalError>;
+
+    /// Update a saved connection definition on the agent.
+    fn update_definition(
+        &self,
+        agent_id: &str,
+        params: Value,
+    ) -> Result<AgentDefinitionInfo, TerminalError>;
+
+    /// Delete a session definition on the agent.
+    fn delete_definition(&self, agent_id: &str, def_id: &str) -> Result<(), TerminalError>;
+
+    /// Create a folder on the agent.
+    fn create_folder(
+        &self,
+        agent_id: &str,
+        name: &str,
+        parent_id: Option<&str>,
+    ) -> Result<AgentFolderInfo, TerminalError>;
+
+    /// Update a folder on the agent.
+    fn update_folder(
+        &self,
+        agent_id: &str,
+        params: Value,
+    ) -> Result<AgentFolderInfo, TerminalError>;
+
+    /// Delete a folder on the agent.
+    fn delete_folder(&self, agent_id: &str, folder_id: &str) -> Result<(), TerminalError>;
+
+    /// Register an output sender for a session.
+    fn register_session_output(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+        output_tx: OutputSender,
+    ) -> Result<(), TerminalError>;
+
+    /// Unregister a session's output sender.
+    fn unregister_session_output(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+    ) -> Result<(), TerminalError>;
+
+    /// Register a monitoring channel for a remote session.
+    fn register_monitoring_output(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+        monitoring_tx: MonitoringSender,
+    ) -> Result<(), TerminalError>;
+
+    /// Unregister the monitoring channel for a remote session.
+    fn unregister_monitoring_output(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+    ) -> Result<(), TerminalError>;
+
+    /// Send input to a session (fire-and-forget).
+    fn send_session_input(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+        data: &[u8],
+    ) -> Result<(), TerminalError>;
+
+    /// Resize a session (fire-and-forget).
+    fn resize_session(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), TerminalError>;
+}
+
 /// Manages connections to remote agents.
 ///
 /// Each agent is identified by its `agent_id` string. Multiple sessions
@@ -764,6 +912,180 @@ impl AgentConnectionManager {
                 rows,
             })
             .map_err(|_| TerminalError::ResizeFailed("Agent I/O thread gone".to_string()))
+    }
+}
+
+// ── AgentRpcClient impl ────────────────────────────────────────────
+
+impl AgentRpcClient for AgentConnectionManager {
+    fn connect_agent(
+        &self,
+        agent_id: &str,
+        config: &RemoteAgentConfig,
+    ) -> Result<AgentConnectResult, TerminalError> {
+        AgentConnectionManager::connect_agent(self, agent_id, config)
+    }
+
+    fn disconnect_agent(&self, agent_id: &str) -> Result<(), TerminalError> {
+        AgentConnectionManager::disconnect_agent(self, agent_id)
+    }
+
+    fn is_connected(&self, agent_id: &str) -> bool {
+        AgentConnectionManager::is_connected(self, agent_id)
+    }
+
+    fn get_capabilities(&self, agent_id: &str) -> Option<AgentCapabilities> {
+        AgentConnectionManager::get_capabilities(self, agent_id)
+    }
+
+    fn shutdown_agent(&self, agent_id: &str, reason: Option<&str>) -> Result<u32, TerminalError> {
+        AgentConnectionManager::shutdown_agent(self, agent_id, reason)
+    }
+
+    fn send_request(
+        &self,
+        agent_id: &str,
+        method: &str,
+        params: Value,
+    ) -> Result<Value, TerminalError> {
+        AgentConnectionManager::send_request(self, agent_id, method, params)
+    }
+
+    fn create_session(
+        &self,
+        agent_id: &str,
+        session_type: &str,
+        config: Value,
+        title: Option<&str>,
+    ) -> Result<AgentSessionInfo, TerminalError> {
+        AgentConnectionManager::create_session(self, agent_id, session_type, config, title)
+    }
+
+    fn attach_session(&self, agent_id: &str, remote_session_id: &str) -> Result<(), TerminalError> {
+        AgentConnectionManager::attach_session(self, agent_id, remote_session_id)
+    }
+
+    fn close_session(&self, agent_id: &str, remote_session_id: &str) -> Result<(), TerminalError> {
+        AgentConnectionManager::close_session(self, agent_id, remote_session_id)
+    }
+
+    fn list_sessions(&self, agent_id: &str) -> Result<Vec<AgentSessionInfo>, TerminalError> {
+        AgentConnectionManager::list_sessions(self, agent_id)
+    }
+
+    fn list_connections_and_folders(
+        &self,
+        agent_id: &str,
+    ) -> Result<AgentConnectionsData, TerminalError> {
+        AgentConnectionManager::list_connections_and_folders(self, agent_id)
+    }
+
+    fn list_definitions(&self, agent_id: &str) -> Result<Vec<AgentDefinitionInfo>, TerminalError> {
+        AgentConnectionManager::list_definitions(self, agent_id)
+    }
+
+    fn save_definition(
+        &self,
+        agent_id: &str,
+        definition: Value,
+    ) -> Result<AgentDefinitionInfo, TerminalError> {
+        AgentConnectionManager::save_definition(self, agent_id, definition)
+    }
+
+    fn update_definition(
+        &self,
+        agent_id: &str,
+        params: Value,
+    ) -> Result<AgentDefinitionInfo, TerminalError> {
+        AgentConnectionManager::update_definition(self, agent_id, params)
+    }
+
+    fn delete_definition(&self, agent_id: &str, def_id: &str) -> Result<(), TerminalError> {
+        AgentConnectionManager::delete_definition(self, agent_id, def_id)
+    }
+
+    fn create_folder(
+        &self,
+        agent_id: &str,
+        name: &str,
+        parent_id: Option<&str>,
+    ) -> Result<AgentFolderInfo, TerminalError> {
+        AgentConnectionManager::create_folder(self, agent_id, name, parent_id)
+    }
+
+    fn update_folder(
+        &self,
+        agent_id: &str,
+        params: Value,
+    ) -> Result<AgentFolderInfo, TerminalError> {
+        AgentConnectionManager::update_folder(self, agent_id, params)
+    }
+
+    fn delete_folder(&self, agent_id: &str, folder_id: &str) -> Result<(), TerminalError> {
+        AgentConnectionManager::delete_folder(self, agent_id, folder_id)
+    }
+
+    fn register_session_output(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+        output_tx: OutputSender,
+    ) -> Result<(), TerminalError> {
+        AgentConnectionManager::register_session_output(
+            self,
+            agent_id,
+            remote_session_id,
+            output_tx,
+        )
+    }
+
+    fn unregister_session_output(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+    ) -> Result<(), TerminalError> {
+        AgentConnectionManager::unregister_session_output(self, agent_id, remote_session_id)
+    }
+
+    fn register_monitoring_output(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+        monitoring_tx: MonitoringSender,
+    ) -> Result<(), TerminalError> {
+        AgentConnectionManager::register_monitoring_output(
+            self,
+            agent_id,
+            remote_session_id,
+            monitoring_tx,
+        )
+    }
+
+    fn unregister_monitoring_output(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+    ) -> Result<(), TerminalError> {
+        AgentConnectionManager::unregister_monitoring_output(self, agent_id, remote_session_id)
+    }
+
+    fn send_session_input(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+        data: &[u8],
+    ) -> Result<(), TerminalError> {
+        AgentConnectionManager::send_session_input(self, agent_id, remote_session_id, data)
+    }
+
+    fn resize_session(
+        &self,
+        agent_id: &str,
+        remote_session_id: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), TerminalError> {
+        AgentConnectionManager::resize_session(self, agent_id, remote_session_id, cols, rows)
     }
 }
 


### PR DESCRIPTION
## Summary

- Extracted 8 injectable traits (`LocalShellSpawner`, `SshConnector`, `SessionManagerApi`, `DaemonLauncher`, `ConnectionStoreApi`, `MonitoringManagerApi`, `EventEmitter`, `AgentRpcClient`) so unit tests can run without real PTY/SSH/Tauri runtimes
- All production concrete types are unchanged; traits use UFCS delegation to avoid duplication
- Tauri agent commands and state registration now use `Arc<dyn AgentRpcClient>` throughout
- Fixed a race condition in `MockLocalShellSpawner` (replaced `PreloadedReader` with a channel-based `ChannelReader` that blocks until `kill()` drops the sender)
- Added `MockAgentRpcClient`, `MockEventEmitter`, `MockConnectionStore`, `MockMonitoringManager`, and `MockDaemonLauncher` with ~40 new unit tests across all three crates

## Test plan

- [ ] `./scripts/test.sh` — all tests pass
- [ ] `./scripts/check.sh` — clippy and formatting clean
- [ ] Manual: connect a local shell session, connect via SSH agent, verify output/resize/disconnect all work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)