### PR TITLE
fix(ui): add context menu to empty connection area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sidebar: right-clicking on the empty area of the connection list now opens a context menu with **New Connection** and **New Folder** options
 - Agent: ARMv7 (arm32) support — a new `termihub-agent-linux-armv7` binary is now built and released for 32-bit ARM devices such as older Raspberry Pi models (Pi 2 B, Pi 1 B+). Includes cross-compilation Dockerfile, Cross.toml entry, updated build and setup scripts, and CI pipeline changes.
 - Update checker (Variant A — notify only): termiHub now checks the GitHub Releases API on startup (with a 5-second delay) and every 24 hours for new versions. When a newer release is found, an amber dot appears on the version chip in the status bar and a non-blocking notification popup offers to open the GitHub downloads page. Security releases (marked `<!-- security -->` in the release notes) show a red dot and cannot be silently skipped. Users can skip a specific version, clear a skipped version, or disable automatic checks entirely in **Settings → Updates**.
 - Connection settings: a **Shell Integration** toggle is now available for local shell, SSH, and WSL connections (enabled by default). Disabling it skips all OSC injection at startup.

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -619,6 +619,8 @@ export function ConnectionList() {
                 setCreatingFolder(false);
               }}
               onCancelCreateFolder={() => setCreatingFolder(false)}
+              onNewConnection={handleNewConnection}
+              onNewFolder={() => setCreatingFolder(true)}
               rootFolders={rootFolders}
               rootConnections={rootConnections}
               folders={folders}
@@ -688,6 +690,8 @@ interface RootDropZoneProps {
   isCreatingFolder: boolean;
   onCreateFolder: (name: string) => void;
   onCancelCreateFolder: () => void;
+  onNewConnection: () => void;
+  onNewFolder: () => void;
   rootFolders: ConnectionFolder[];
   rootConnections: SavedConnection[];
   folders: ConnectionFolder[];
@@ -707,6 +711,8 @@ function RootDropZone({
   isCreatingFolder,
   onCreateFolder,
   onCancelCreateFolder,
+  onNewConnection,
+  onNewFolder,
   rootFolders,
   rootConnections,
   folders,
@@ -729,45 +735,71 @@ function RootDropZone({
   const isConnectionOver = isOver && active?.data.current?.type !== "agent";
 
   return (
-    <div
-      ref={setNodeRef}
-      className={`connection-list__tree${isConnectionOver ? " connection-tree__root-drop--over" : ""}`}
-    >
-      {isCreatingFolder && (
-        <InlineFolderInput depth={0} onConfirm={onCreateFolder} onCancel={onCancelCreateFolder} />
-      )}
-      {rootFolders.map((folder) => (
-        <TreeNode
-          key={folder.id}
-          folder={folder}
-          connections={connections.filter((c) => c.folderId === folder.id)}
-          childFolders={folders.filter((f) => f.parentId === folder.id)}
-          allFolders={folders}
-          allConnections={connections}
-          onToggle={onToggle}
-          onConnect={onConnect}
-          onEdit={onEdit}
-          onDelete={onDelete}
-          onDuplicate={onDuplicate}
-          onPingHost={onPingHost}
-          onDeleteFolder={onDeleteFolder}
-          onCreateSubfolder={onCreateSubfolder}
-          onNewConnectionInFolder={onNewConnectionInFolder}
-          depth={0}
-        />
-      ))}
-      {rootConnections.map((conn) => (
-        <ConnectionItem
-          key={conn.id}
-          connection={conn}
-          depth={0}
-          onConnect={onConnect}
-          onEdit={onEdit}
-          onDelete={onDelete}
-          onDuplicate={onDuplicate}
-          onPingHost={onPingHost}
-        />
-      ))}
-    </div>
+    <ContextMenu.Root>
+      <ContextMenu.Trigger asChild>
+        <div
+          ref={setNodeRef}
+          className={`connection-list__tree${isConnectionOver ? " connection-tree__root-drop--over" : ""}`}
+        >
+          {isCreatingFolder && (
+            <InlineFolderInput
+              depth={0}
+              onConfirm={onCreateFolder}
+              onCancel={onCancelCreateFolder}
+            />
+          )}
+          {rootFolders.map((folder) => (
+            <TreeNode
+              key={folder.id}
+              folder={folder}
+              connections={connections.filter((c) => c.folderId === folder.id)}
+              childFolders={folders.filter((f) => f.parentId === folder.id)}
+              allFolders={folders}
+              allConnections={connections}
+              onToggle={onToggle}
+              onConnect={onConnect}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onDuplicate={onDuplicate}
+              onPingHost={onPingHost}
+              onDeleteFolder={onDeleteFolder}
+              onCreateSubfolder={onCreateSubfolder}
+              onNewConnectionInFolder={onNewConnectionInFolder}
+              depth={0}
+            />
+          ))}
+          {rootConnections.map((conn) => (
+            <ConnectionItem
+              key={conn.id}
+              connection={conn}
+              depth={0}
+              onConnect={onConnect}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onDuplicate={onDuplicate}
+              onPingHost={onPingHost}
+            />
+          ))}
+        </div>
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content className="context-menu__content">
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={onNewConnection}
+            data-testid="context-root-new-connection"
+          >
+            <Plus size={14} /> New Connection
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={onNewFolder}
+            data-testid="context-root-new-folder"
+          >
+            <FolderPlus size={14} /> New Folder
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
   );
 }


### PR DESCRIPTION
## Summary

- Right-clicking on empty space in the connection list now opens a context menu with **New Connection** and **New Folder** options
- Previously, no context menu appeared when right-clicking on the background/empty area of the connection list
- Folders and connections still show their own context menus unchanged (Radix stops propagation at nested triggers)

## Implementation

Wrapped `RootDropZone`'s inner div in a `ContextMenu.Root` using the existing `@radix-ui/react-context-menu` pattern already used throughout the sidebar. Added `onNewConnection` and `onNewFolder` props to `RootDropZoneProps`.

## Test plan

- [ ] Right-click on empty space in the connection list → context menu appears with "New Connection" and "New Folder"
- [ ] Select "New Connection" → connection editor opens
- [ ] Select "New Folder" → inline folder name input appears
- [ ] Right-click on an existing connection → connection context menu still appears (unchanged)
- [ ] Right-click on an existing folder → folder context menu still appears (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)