### PR TITLE
feat(ui): Remote Agents section header with dedicated add button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- UI: Remote Agents now have their own collapsible "Remote Agents" section header in the connections sidebar, with a dedicated "+" button for adding new agents
+- UI: "Remote Agent" removed as a connection type from the connection type dropdown — agents are managed exclusively through the Remote Agents section
+- UI: The connection type selector is hidden when editing remote agent SSH transport settings (it was always "remote" and had no meaning there)
+
 ### Changed (internal)
 
 - DI testing infrastructure: extracted `LocalShellSpawner`, `SshConnector`, `SessionManagerApi`, `DaemonLauncher`, `ConnectionStoreApi`, `MonitoringManagerApi`, `EventEmitter`, and `AgentRpcClient` traits across `core`, `agent`, and `src-tauri`. Concrete types are unchanged; tests can now inject mocks without real PTY/SSH/Tauri runtimes. Tauri agent commands now depend on `Arc<dyn AgentRpcClient>` in state.

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -21,7 +21,6 @@ import {
   filterCredentialFields,
 } from "@/utils/schemaDefaults";
 import { useAvailableRuntimes } from "@/hooks/useAvailableRuntimes";
-import { useExperimentalFeatures } from "@/hooks/useExperimentalFeatures";
 import { ConnectionTerminalSettings } from "./ConnectionTerminalSettings";
 import { ConnectionAppearanceSettings } from "./ConnectionAppearanceSettings";
 import { findLeafByTab } from "@/utils/panelTree";
@@ -70,19 +69,11 @@ function hasTerminalOptions(opts: TerminalOptions): boolean {
   return Object.values(opts).some((v) => v !== undefined);
 }
 
-/** Build type options from the registry, optionally including the experimental "Remote Agent" entry. */
+/** Build type options from the registry. */
 function buildTypeOptions(
-  connectionTypes: ConnectionTypeInfo[],
-  includeRemoteAgent: boolean
+  connectionTypes: ConnectionTypeInfo[]
 ): { value: string; label: string }[] {
-  const options = connectionTypes.map((ct) => ({
-    value: ct.typeId,
-    label: ct.displayName,
-  }));
-  if (includeRemoteAgent) {
-    options.push({ value: "remote", label: "Remote Agent (Experimental)" });
-  }
-  return options;
+  return connectionTypes.map((ct) => ({ value: ct.typeId, label: ct.displayName }));
 }
 
 /** Find schema for a type ID in the connection types registry. */
@@ -129,7 +120,6 @@ interface ConnectionEditorProps {
 }
 
 export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorProps) {
-  const experimental = useExperimentalFeatures();
   const connections = useAppStore((s) => s.connections);
   const connectionTypes = useAppStore((s) => s.connectionTypes);
   const addConnection = useAppStore((s) => s.addConnection);
@@ -211,11 +201,16 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         settings: existingConnection.config.config,
       };
     }
+    // New remote agent opened via Remote Agents "+" button
+    if (editingConnectionId === "new-remote-agent") {
+      return { typeId: "remote", settings: buildDefaults(AGENT_SCHEMA) };
+    }
     // New local connection defaults to local shell
     const localType = findSchema(connectionTypes, "local");
     const defaults = localType ? buildTypeDefaults(localType, settings) : { shell: defaultShell };
     return { typeId: "local", settings: defaults };
   }, [
+    editingConnectionId,
     existingConnection,
     existingAgent,
     existingAgentDef,
@@ -283,8 +278,8 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
       // Definition mode: show only agent-reported types (no "Remote Agent" entry)
       return agentConnectionTypes.map((ct) => ({ value: ct.typeId, label: ct.displayName }));
     }
-    return buildTypeOptions(connectionTypes, experimental);
-  }, [isAgentDefinitionMode, agentConnectionTypes, connectionTypes, experimental]);
+    return buildTypeOptions(connectionTypes);
+  }, [isAgentDefinitionMode, agentConnectionTypes, connectionTypes]);
 
   // Get the current schema from the effective registry
   const currentTypeInfo = useMemo(
@@ -647,27 +642,23 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           </p>
         )}
       </label>
-      <label className="settings-form__field">
-        <span className="settings-form__label">Type</span>
-        <select
-          value={selectedType}
-          onChange={(e) => handleTypeChange(e.target.value)}
-          disabled={
-            isAgentTransportMode
-              ? !!existingAgent
-              : isAgentDefinitionMode
-                ? !!existingAgentDef
-                : false
-          }
-          data-testid="connection-editor-type-select"
-        >
-          {typeOptions.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </label>
+      {!isAgentTransportMode && (
+        <label className="settings-form__field">
+          <span className="settings-form__label">Type</span>
+          <select
+            value={selectedType}
+            onChange={(e) => handleTypeChange(e.target.value)}
+            disabled={isAgentDefinitionMode ? !!existingAgentDef : false}
+            data-testid="connection-editor-type-select"
+          >
+            {typeOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
 
       {currentSchema && (
         <ConnectionSettingsForm
@@ -753,8 +744,10 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           ? existingAgentDef
             ? "Edit Agent Connection"
             : "New Agent Connection"
-          : existingAgent
-            ? "Edit Remote Agent"
+          : isAgentTransportMode
+            ? existingAgent
+              ? "Edit Remote Agent"
+              : "New Remote Agent"
             : existingConnection
               ? "Edit Connection"
               : "New Connection"}

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -453,6 +453,10 @@ export function ConnectionList() {
     [openConnectionEditorTab]
   );
 
+  const handleNewAgent = useCallback(() => {
+    openConnectionEditorTab("new-remote-agent");
+  }, [openConnectionEditorTab]);
+
   const handlePingHost = useCallback(
     async (connection: SavedConnection) => {
       const cfg = connection.config.config as unknown as Record<string, unknown>;
@@ -524,15 +528,20 @@ export function ConnectionList() {
   );
 
   const [localCollapsed, setLocalCollapsed] = useState(false);
+  const [remoteAgentsCollapsed, setRemoteAgentsCollapsed] = useState(false);
   const rootFolders = folders.filter((f) => f.parentId === null);
   const rootConnections = connections.filter((c) => c.folderId === null);
   const LocalChevron = localCollapsed ? ChevronRight : ChevronDown;
+  const RemoteAgentsChevron = remoteAgentsCollapsed ? ChevronRight : ChevronDown;
 
   // Build expanded-section mapping for resize hook.
-  // Section 0 = Connections, sections 1..N = remote agents.
+  // Section 0 = Connections, sections 1..N = remote agents (only when not collapsed).
   const sectionsExpanded = useMemo(
-    () => [!localCollapsed, ...remoteAgents.map((a) => a.isExpanded)],
-    [localCollapsed, remoteAgents]
+    () => [
+      !localCollapsed,
+      ...(remoteAgentsCollapsed ? [] : remoteAgents.map((a) => a.isExpanded)),
+    ],
+    [localCollapsed, remoteAgentsCollapsed, remoteAgents]
   );
   const expandedCount = sectionsExpanded.filter(Boolean).length;
   const { flexValues, handleProps, sectionRefs } = useSectionResize(expandedCount);
@@ -635,33 +644,61 @@ export function ConnectionList() {
             />
           )}
         </div>
-        <SortableContext
-          items={experimental ? remoteAgents.map((a) => a.id) : []}
-          strategy={verticalListSortingStrategy}
-        >
-          {experimental &&
-            remoteAgents.map((agent, i) => {
-              const agentExpandedIdx = expandedIndexMap[i + 1];
-              return (
-                <Fragment key={agent.id}>
-                  <div
-                    className="connection-list__resize-handle"
-                    data-testid={`sidebar-group-separator-${i}`}
-                    {...getResizeHandleProps(i)}
-                  />
-                  <AgentNode
-                    agent={agent}
-                    style={
-                      agentExpandedIdx >= 0 ? { flex: flexValues[agentExpandedIdx] } : undefined
-                    }
-                    sectionRef={(el) => {
-                      if (agentExpandedIdx >= 0) sectionRefs.current[agentExpandedIdx] = el;
-                    }}
-                  />
-                </Fragment>
-              );
-            })}
-        </SortableContext>
+        {experimental && (
+          <>
+            <div
+              className="connection-list__group-header"
+              data-testid="sidebar-group-header-remote-agents"
+            >
+              <button
+                className="connection-list__group-toggle"
+                onClick={() => setRemoteAgentsCollapsed((v) => !v)}
+                data-testid="connection-list-remote-agents-toggle"
+              >
+                <RemoteAgentsChevron size={16} className="connection-tree__chevron" />
+                <span className="connection-list__group-title">Remote Agents</span>
+              </button>
+              <div className="connection-list__group-actions">
+                <button
+                  className="connection-list__add-btn"
+                  onClick={handleNewAgent}
+                  title="New Remote Agent"
+                  data-testid="connection-list-new-agent"
+                >
+                  <Plus size={16} />
+                </button>
+              </div>
+            </div>
+            {!remoteAgentsCollapsed && (
+              <SortableContext
+                items={remoteAgents.map((a) => a.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                {remoteAgents.map((agent, i) => {
+                  const agentExpandedIdx = expandedIndexMap[i + 1];
+                  return (
+                    <Fragment key={agent.id}>
+                      <div
+                        className="connection-list__resize-handle"
+                        data-testid={`sidebar-group-separator-${i}`}
+                        {...getResizeHandleProps(i)}
+                      />
+                      <AgentNode
+                        agent={agent}
+                        style={
+                          agentExpandedIdx >= 0 ? { flex: flexValues[agentExpandedIdx] } : undefined
+                        }
+                        sectionRef={(el) => {
+                          if (agentExpandedIdx >= 0) sectionRefs.current[agentExpandedIdx] = el;
+                        }}
+                      />
+                    </Fragment>
+                  );
+                })}
+              </SortableContext>
+            )}
+          </>
+        )}
         <DragOverlay>
           {draggingConnection ? (
             <div className="connection-tree__drag-overlay">

--- a/src/store/appStore.connections.test.ts
+++ b/src/store/appStore.connections.test.ts
@@ -360,6 +360,30 @@ describe("appStore — connections, folders, and special tabs", () => {
       const leaf = findLeaf(state.rootPanel, state.activePanelId!) as LeafPanel;
       expect(leaf.tabs).toHaveLength(2);
     });
+
+    it("creates a 'New Remote Agent' tab for the new-remote-agent sentinel", () => {
+      useAppStore.getState().openConnectionEditorTab("new-remote-agent");
+
+      const state = useAppStore.getState();
+      const leaf = findLeaf(state.rootPanel, state.activePanelId!) as LeafPanel;
+      expect(leaf.tabs).toHaveLength(1);
+      expect(leaf.tabs[0].contentType).toBe("connection-editor");
+      expect(leaf.tabs[0].title).toBe("New Remote Agent");
+      expect(leaf.tabs[0].connectionEditorMeta?.connectionId).toBe("new-remote-agent");
+    });
+
+    it("reuses the new-remote-agent tab when opened twice", () => {
+      useAppStore.getState().openConnectionEditorTab("new-remote-agent");
+      useAppStore.getState().addTab("Shell", "local");
+      useAppStore.getState().openConnectionEditorTab("new-remote-agent");
+
+      const state = useAppStore.getState();
+      const allLeaves = getAllLeaves(state.rootPanel);
+      const editorTabs = allLeaves.flatMap((l) =>
+        l.tabs.filter((t) => t.contentType === "connection-editor")
+      );
+      expect(editorTabs).toHaveLength(1);
+    });
   });
 
   describe("openSettingsTab", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1117,7 +1117,9 @@ export const useAppStore = create<AppState>((set, get) => {
 
         // Determine tab title
         let title = "New Connection";
-        if (connectionId !== "new") {
+        if (connectionId === "new-remote-agent") {
+          title = "New Remote Agent";
+        } else if (connectionId !== "new") {
           const conn = state.connections.find((c) => c.id === connectionId);
           if (conn) {
             title = `Edit: ${conn.name}`;


### PR DESCRIPTION
## Summary

- Adds a collapsible **Remote Agents** section header in the connections sidebar, separating agents visually from regular connections and providing its own "+" button for adding new agents
- Removes **Remote Agent** from the connection type dropdown — it was never a session type like SSH/serial/local, and is now managed exclusively through the Remote Agents section
- Hides the connection type selector entirely when editing remote agent SSH transport settings (the type was always "remote" and the dropdown served no purpose)

## Test plan

- [ ] With experimental features enabled, verify the "Remote Agents" header appears below the Connections section with a "+" button
- [ ] Click the "+" on the Remote Agents header — confirm it opens a "New Remote Agent" editor tab with no Type field and only SSH transport fields
- [ ] Confirm the connection type dropdown no longer contains a "Remote Agent" option when creating a regular connection
- [ ] Collapse and expand the Remote Agents section using the chevron toggle — agents should show/hide correctly
- [ ] Right-click an existing remote agent → Edit — confirm the editor shows "Edit Remote Agent" with no Type field
- [ ] Drag-to-reorder agents still works when the section is expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)