### PR TITLE
feat(ui): OS file drag-and-drop into file browser and terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File browser: drag files from OS file managers (Finder, Explorer, etc.) directly onto the file browser panel to upload them (SFTP/session) or copy them (local mode). A dashed overlay confirms the drop target.
 - Terminal: drag files from OS file managers onto any terminal panel to insert their shell-safe quoted path(s) at the cursor.
 
+### Fixed
+
+- File browser: delete confirmation now uses a themed in-app dialog instead of the native OS `window.confirm()` popup
+
 ### Changed
 
 - UI: Remote Agents now have their own collapsible "Remote Agents" section header in the connections sidebar, with a dedicated "+" button for adding new agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- File browser: drag files from OS file managers (Finder, Explorer, etc.) directly onto the file browser panel to upload them (SFTP/session) or copy them (local mode). A dashed overlay confirms the drop target.
+- Terminal: drag files from OS file managers onto any terminal panel to insert their shell-safe quoted path(s) at the cursor.
+
 ### Changed (internal)
 
 - DI testing infrastructure: extracted `LocalShellSpawner`, `SshConnector`, `SessionManagerApi`, `DaemonLauncher`, `ConnectionStoreApi`, `MonitoringManagerApi`, `EventEmitter`, and `AgentRpcClient` traits across `core`, `agent`, and `src-tauri`. Concrete types are unchanged; tests can now inject mocks without real PTY/SSH/Tauri runtimes. Tauri agent commands now depend on `Arc<dyn AgentRpcClient>` in state.

--- a/src/components/Sidebar/ConfirmDeleteDialog.test.tsx
+++ b/src/components/Sidebar/ConfirmDeleteDialog.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";

--- a/src/components/Sidebar/ConfirmDeleteDialog.test.tsx
+++ b/src/components/Sidebar/ConfirmDeleteDialog.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+describe("ConfirmDeleteDialog", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders with the provided message when open", () => {
+    render(
+      <ConfirmDeleteDialog
+        open={true}
+        message='Delete file "notes.txt"?'
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    const dialog = document.querySelector('[data-testid="confirm-delete-dialog"]');
+    expect(dialog).toBeTruthy();
+    expect(dialog?.textContent).toContain('Delete file "notes.txt"?');
+  });
+
+  it("does not render content when closed", () => {
+    render(
+      <ConfirmDeleteDialog
+        open={false}
+        message="Delete 3 items?"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(document.querySelector('[data-testid="confirm-delete-dialog"]')).toBeNull();
+  });
+
+  it("calls onConfirm when Delete button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDeleteDialog
+        open={true}
+        message='Delete file "test.txt"?'
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    act(() => {
+      (document.querySelector('[data-testid="confirm-delete-confirm"]') as HTMLElement).click();
+    });
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when Cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDeleteDialog
+        open={true}
+        message='Delete directory "mydir"?'
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+
+    act(() => {
+      (document.querySelector('[data-testid="confirm-delete-cancel"]') as HTMLElement).click();
+    });
+
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("shows multi-item delete message", () => {
+    render(
+      <ConfirmDeleteDialog
+        open={true}
+        message="Delete 5 items?"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(document.querySelector('[data-testid="confirm-delete-dialog"]')?.textContent).toContain(
+      "Delete 5 items?"
+    );
+  });
+});

--- a/src/components/Sidebar/ConfirmDeleteDialog.tsx
+++ b/src/components/Sidebar/ConfirmDeleteDialog.tsx
@@ -1,0 +1,80 @@
+import * as Dialog from "@radix-ui/react-dialog";
+
+interface ConfirmDeleteDialogProps {
+  open: boolean;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/** Themed confirmation dialog for destructive delete actions in the file browser. */
+export function ConfirmDeleteDialog({
+  open,
+  message,
+  onConfirm,
+  onCancel,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="shortcuts-overlay__backdrop" />
+        <Dialog.Content
+          className="confirm-delete-dialog"
+          data-testid="confirm-delete-dialog"
+          style={{
+            position: "fixed",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: "380px",
+            padding: "var(--spacing-lg, 16px)",
+            backgroundColor: "var(--bg-secondary)",
+            border: "1px solid var(--border-primary)",
+            borderRadius: "var(--radius-lg, 8px)",
+            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)",
+            zIndex: 1001,
+          }}
+        >
+          <Dialog.Title
+            style={{ margin: "0 0 var(--spacing-md, 12px) 0", color: "var(--text-primary)" }}
+          >
+            Confirm Delete
+          </Dialog.Title>
+          <Dialog.Description style={{ color: "var(--text-secondary)", marginBottom: "16px" }}>
+            {message}
+          </Dialog.Description>
+          <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end" }}>
+            <button
+              onClick={onCancel}
+              data-testid="confirm-delete-cancel"
+              style={{
+                padding: "4px 16px",
+                border: "1px solid var(--border-primary)",
+                borderRadius: "var(--radius-md, 4px)",
+                background: "transparent",
+                color: "var(--text-primary)",
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={onConfirm}
+              data-testid="confirm-delete-confirm"
+              style={{
+                padding: "4px 16px",
+                border: "none",
+                borderRadius: "var(--radius-md, 4px)",
+                background: "var(--color-error)",
+                color: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/Sidebar/FileBrowser.css
+++ b/src/components/Sidebar/FileBrowser.css
@@ -2,6 +2,24 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
+}
+
+.file-browser__drag-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  background: rgba(0, 0, 0, 0.55);
+  border: 2px dashed var(--text-accent);
+  color: var(--text-accent);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  pointer-events: none;
+  z-index: 100;
 }
 
 .file-browser__toolbar {

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -7,6 +7,12 @@ import { FileBrowser, FileMenuItems, MultiSelectMenuItems } from "./FileBrowser"
 import type { TerminalTab, LeafPanel } from "@/types/terminal";
 import type { FileEntry } from "@/types/connection";
 
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    onDragDropEvent: vi.fn(() => Promise.resolve(vi.fn())),
+  }),
+}));
+
 vi.mock("@/themes", () => ({
   applyTheme: vi.fn(),
   onThemeChange: vi.fn(() => vi.fn()),

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -39,6 +39,7 @@ import { getWslDistroName, wslToWindowsPath, windowsToWslPath } from "@/utils/sh
 import { formatBytes } from "@/utils/formatters";
 import { resolveFeatureEnabled } from "@/utils/featureFlags";
 import { useOsFileDrop } from "@/hooks/useOsFileDrop";
+import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
 import "./FileBrowser.css";
 
 interface FileRowProps {
@@ -701,6 +702,10 @@ export function FileBrowser() {
   const [newFileName, setNewFileName] = useState<string | null>(null);
   const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
   const [lastClickedPath, setLastClickedPath] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<{
+    message: string;
+    onConfirm: () => void;
+  } | null>(null);
 
   // Listen for VS Code edit-complete events (remote file re-upload)
   useEffect(() => {
@@ -779,14 +784,14 @@ export function FileBrowser() {
           break;
         }
         case "delete": {
-          const ok = window.confirm(
-            `Delete ${entry.isDirectory ? "directory" : "file"} "${entry.name}"?`
-          );
-          if (ok) {
-            deleteEntry(entry.path, entry.isDirectory).catch((err: unknown) =>
-              console.error("Delete failed:", err)
-            );
-          }
+          setDeleteConfirm({
+            message: `Delete ${entry.isDirectory ? "directory" : "file"} "${entry.name}"?`,
+            onConfirm: () => {
+              deleteEntry(entry.path, entry.isDirectory).catch((err: unknown) =>
+                console.error("Delete failed:", err)
+              );
+            },
+          });
           break;
         }
       }
@@ -854,14 +859,16 @@ export function FileBrowser() {
           cutEntry(entries);
           break;
         case "delete": {
-          const ok = window.confirm(`Delete ${entries.length} items?`);
-          if (ok) {
-            Promise.all(entries.map((e) => deleteEntry(e.path, e.isDirectory))).catch(
-              (err: unknown) => console.error("Delete failed:", err)
-            );
-            setSelectedPaths(new Set());
-            setLastClickedPath(null);
-          }
+          setDeleteConfirm({
+            message: `Delete ${entries.length} items?`,
+            onConfirm: () => {
+              Promise.all(entries.map((e) => deleteEntry(e.path, e.isDirectory))).catch(
+                (err: unknown) => console.error("Delete failed:", err)
+              );
+              setSelectedPaths(new Set());
+              setLastClickedPath(null);
+            },
+          });
           break;
         }
       }
@@ -1174,6 +1181,15 @@ export function FileBrowser() {
           </ContextMenu.Content>
         </ContextMenu.Portal>
       </ContextMenu.Root>
+      <ConfirmDeleteDialog
+        open={deleteConfirm !== null}
+        message={deleteConfirm?.message ?? ""}
+        onConfirm={() => {
+          deleteConfirm?.onConfirm();
+          setDeleteConfirm(null);
+        }}
+        onCancel={() => setDeleteConfirm(null)}
+      />
     </div>
   );
 }

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manager";
@@ -38,6 +38,7 @@ import type { ConnectionTypeInfo } from "@/services/api";
 import { getWslDistroName, wslToWindowsPath, windowsToWslPath } from "@/utils/shell-detection";
 import { formatBytes } from "@/utils/formatters";
 import { resolveFeatureEnabled } from "@/utils/featureFlags";
+import { useOsFileDrop } from "@/hooks/useOsFileDrop";
 import "./FileBrowser.css";
 
 interface FileRowProps {
@@ -666,6 +667,7 @@ export function FileBrowser() {
     refresh,
     downloadFile,
     uploadFile,
+    uploadFileFromPath,
     createDirectory,
     createFile,
     deleteEntry,
@@ -676,6 +678,19 @@ export function FileBrowser() {
     pasteEntry,
     mode,
   } = useFileBrowser();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleOsDrop = useCallback(
+    async (paths: string[]) => {
+      for (const path of paths) {
+        await uploadFileFromPath(path);
+      }
+    },
+    [uploadFileFromPath]
+  );
+
+  const { isDragOver } = useOsFileDrop(containerRef, handleOsDrop);
 
   const disconnectSftp = useAppStore((s) => s.disconnectSftp);
   const vscodeAvailable = useAppStore((s) => s.vscodeAvailable);
@@ -938,7 +953,16 @@ export function FileBrowser() {
   const selectedEntries = sortedEntries.filter((e) => selectedPaths.has(e.path));
 
   return (
-    <div className="file-browser">
+    <div
+      className={`file-browser${isDragOver ? " file-browser--drag-over" : ""}`}
+      ref={containerRef}
+    >
+      {isDragOver && (
+        <div className="file-browser__drag-overlay">
+          <Upload size={24} />
+          <span>{mode === "local" ? "Drop to copy here" : "Drop to upload"}</span>
+        </div>
+      )}
       <div className="file-browser__toolbar">
         <span
           className="file-browser__path"

--- a/src/components/Terminal/TerminalView.css
+++ b/src/components/Terminal/TerminalView.css
@@ -50,4 +50,22 @@
 .terminal-view__content {
   flex: 1;
   overflow: hidden;
+  position: relative;
+}
+
+.terminal-view__drag-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  background: rgba(0, 0, 0, 0.55);
+  border: 2px dashed var(--text-accent);
+  color: var(--text-accent);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  pointer-events: none;
+  z-index: 100;
 }

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo } from "react";
-import { Plus, Columns2, Rows2, X, PanelLeft } from "lucide-react";
+import { useEffect, useMemo, useRef, useCallback } from "react";
+import { Plus, Columns2, Rows2, X, PanelLeft, FileInput } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
-import { useAppStore } from "@/store/appStore";
+import { useAppStore, getActiveTab } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
 import { getAllLeaves } from "@/utils/panelTree";
 import { TerminalPortalProvider } from "./TerminalRegistry";
@@ -10,7 +10,17 @@ import { Terminal } from "./Terminal";
 import { TabGroupChips } from "./TabGroupChips";
 import { SplitView } from "@/components/SplitView";
 import { terminalDispatcher } from "@/services/events";
+import { sendInput } from "@/services/api";
+import { useOsFileDrop } from "@/hooks/useOsFileDrop";
 import "./TerminalView.css";
+
+/** Shell-safe quoting for a file path dropped onto a terminal. */
+function quotePath(path: string): string {
+  if (/^[A-Za-z]:/.test(path) || path.includes("\\")) {
+    return `"${path.replace(/"/g, '\\"')}"`;
+  }
+  return `'${path.replace(/'/g, "'\\''")}'`;
+}
 
 export function TerminalView() {
   // Initialize the singleton event dispatcher once.
@@ -67,6 +77,20 @@ export function TerminalView() {
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
   const isMac = navigator.platform.toUpperCase().includes("MAC");
   const sidebarToggleTitle = `Toggle Sidebar (${isMac ? "Cmd" : "Ctrl"}+B)`;
+
+  const terminalContentRef = useRef<HTMLDivElement>(null);
+  const activeSessionId = useAppStore((s) => getActiveTab(s)?.sessionId ?? null);
+
+  const handleTerminalDrop = useCallback(
+    async (paths: string[]) => {
+      if (!activeSessionId || paths.length === 0) return;
+      const text = paths.map(quotePath).join(" ");
+      await sendInput(activeSessionId, text);
+    },
+    [activeSessionId]
+  );
+
+  const { isDragOver: isTerminalDragOver } = useOsFileDrop(terminalContentRef, handleTerminalDrop);
 
   const allLeaves = getAllLeaves(rootPanel);
 
@@ -139,7 +163,13 @@ export function TerminalView() {
             </button>
           </div>
         </div>
-        <div className="terminal-view__content">
+        <div className="terminal-view__content" ref={terminalContentRef}>
+          {isTerminalDragOver && activeSessionId && (
+            <div className="terminal-view__drag-overlay">
+              <FileInput size={24} />
+              <span>Drop to insert path</span>
+            </div>
+          )}
           <TerminalHost />
           <SplitView />
         </div>

--- a/src/hooks/useFileBrowser.ts
+++ b/src/hooks/useFileBrowser.ts
@@ -37,6 +37,7 @@ export function useFileBrowser() {
     refresh: async () => {},
     downloadFile: async () => {},
     uploadFile: async () => {},
+    uploadFileFromPath: async () => {},
     createDirectory: async () => {},
     createFile: async () => {},
     deleteEntry: async () => {},

--- a/src/hooks/useFileSystem.test.ts
+++ b/src/hooks/useFileSystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>

--- a/src/hooks/useFileSystem.test.ts
+++ b/src/hooks/useFileSystem.test.ts
@@ -68,6 +68,31 @@ describe("useFileSystem (SFTP) — navigateUp path logic", () => {
   });
 });
 
+// Pure logic tests for uploadFileFromPath remote path building
+function buildSftpRemotePath(currentPath: string, localPath: string): string {
+  const parts = localPath.replace(/\\/g, "/").split("/");
+  const fileName = parts[parts.length - 1] || "upload";
+  return currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
+}
+
+describe("useFileSystem (SFTP) — uploadFileFromPath path logic", () => {
+  it("builds remote path at root", () => {
+    expect(buildSftpRemotePath("/", "/home/user/report.pdf")).toBe("/report.pdf");
+  });
+
+  it("builds remote path in subdirectory", () => {
+    expect(buildSftpRemotePath("/uploads", "/home/user/image.png")).toBe("/uploads/image.png");
+  });
+
+  it("handles Windows-style backslash local paths", () => {
+    expect(buildSftpRemotePath("/remote", "C:\\Users\\Alice\\doc.txt")).toBe("/remote/doc.txt");
+  });
+
+  it("falls back to 'upload' when no filename segment", () => {
+    expect(buildSftpRemotePath("/remote", "")).toBe("/remote/upload");
+  });
+});
+
 import { useAppStore } from "@/store/appStore";
 
 describe("useFileSystem (SFTP) — store integration", () => {

--- a/src/hooks/useFileSystem.test.ts
+++ b/src/hooks/useFileSystem.test.ts
@@ -93,7 +93,100 @@ describe("useFileSystem (SFTP) — uploadFileFromPath path logic", () => {
   });
 });
 
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { sftpUpload } from "@/services/api";
+import { useFileSystem } from "./useFileSystem";
 import { useAppStore } from "@/store/appStore";
+
+describe("useFileSystem (SFTP) — uploadFileFromPath API call", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("calls sftpUpload with the correct remote path", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/uploads" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("/local/image.png");
+    });
+
+    expect(vi.mocked(sftpUpload)).toHaveBeenCalledWith(
+      "sess-1",
+      "/local/image.png",
+      "/uploads/image.png"
+    );
+  });
+
+  it("calls sftpUpload with root-level remote path when currentPath is /", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("/local/report.pdf");
+    });
+
+    expect(vi.mocked(sftpUpload)).toHaveBeenCalledWith(
+      "sess-1",
+      "/local/report.pdf",
+      "/report.pdf"
+    );
+  });
+
+  it("does nothing when sftpSessionId is null", async () => {
+    useAppStore.setState({ sftpSessionId: null, currentPath: "/uploads" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("/local/file.txt");
+    });
+
+    expect(vi.mocked(sftpUpload)).not.toHaveBeenCalled();
+  });
+});
 
 describe("useFileSystem (SFTP) — store integration", () => {
   beforeEach(() => {

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -61,6 +61,18 @@ export function useFileSystem() {
     refreshSftp();
   }, [sftpSessionId, currentPath, refreshSftp]);
 
+  const uploadFileFromPath = useCallback(
+    async (localPath: string) => {
+      if (!sftpSessionId) return;
+      const parts = localPath.replace(/\\/g, "/").split("/");
+      const fileName = parts[parts.length - 1] || "upload";
+      const remotePath = currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
+      await sftpUpload(sftpSessionId, localPath, remotePath);
+      refreshSftp();
+    },
+    [sftpSessionId, currentPath, refreshSftp]
+  );
+
   const createDirectory = useCallback(
     async (name: string) => {
       if (!sftpSessionId) return;
@@ -187,6 +199,7 @@ export function useFileSystem() {
     refresh,
     downloadFile,
     uploadFile,
+    uploadFileFromPath,
     createDirectory,
     createFile,
     deleteEntry,

--- a/src/hooks/useLocalFileSystem.test.ts
+++ b/src/hooks/useLocalFileSystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>

--- a/src/hooks/useLocalFileSystem.test.ts
+++ b/src/hooks/useLocalFileSystem.test.ts
@@ -159,3 +159,97 @@ describe("useLocalFileSystem — store integration", () => {
     expect(useAppStore.getState().localCurrentPath).toBe("/test/path");
   });
 });
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { localCopyFile } from "@/services/api";
+import { useLocalFileSystem } from "./useLocalFileSystem";
+
+describe("useLocalFileSystem — uploadFileFromPath API call", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("calls localCopyFile with the correct destination path", async () => {
+    useAppStore.setState({ localCurrentPath: "/destination/dir" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useLocalFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("/source/photo.jpg");
+    });
+
+    expect(vi.mocked(localCopyFile)).toHaveBeenCalledWith(
+      "/source/photo.jpg",
+      "/destination/dir/photo.jpg",
+      false
+    );
+  });
+
+  it("skips copy when source and destination are the same path", async () => {
+    useAppStore.setState({ localCurrentPath: "/source" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useLocalFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("/source/photo.jpg");
+    });
+
+    expect(vi.mocked(localCopyFile)).not.toHaveBeenCalled();
+  });
+
+  it("handles Windows-style backslash source path", async () => {
+    useAppStore.setState({ localCurrentPath: "/uploads" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useLocalFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("C:\\Users\\Alice\\report.docx");
+    });
+
+    expect(vi.mocked(localCopyFile)).toHaveBeenCalledWith(
+      "C:\\Users\\Alice\\report.docx",
+      "/uploads/report.docx",
+      false
+    );
+  });
+});

--- a/src/hooks/useLocalFileSystem.ts
+++ b/src/hooks/useLocalFileSystem.ts
@@ -93,6 +93,19 @@ export function useLocalFileSystem() {
     await vscodeOpenLocal(path);
   }, []);
 
+  const uploadFileFromPath = useCallback(
+    async (localPath: string) => {
+      const parts = localPath.replace(/\\/g, "/").split("/");
+      const fileName = parts[parts.length - 1] || "file";
+      const base = currentPath.endsWith("/") ? currentPath.slice(0, -1) : currentPath;
+      const destPath = base ? `${base}/${fileName}` : `/${fileName}`;
+      if (localPath === destPath) return;
+      await localCopyFile(localPath, destPath, false);
+      refreshLocal();
+    },
+    [currentPath, refreshLocal]
+  );
+
   const downloadFile = useCallback(async (filePath: string, fileName: string) => {
     const localPath = await save({ title: "Save file as...", defaultPath: fileName });
     if (!localPath) return;
@@ -172,6 +185,7 @@ export function useLocalFileSystem() {
     uploadFile: async () => {
       /* no-op: files are already local */
     },
+    uploadFileFromPath,
     createDirectory,
     createFile,
     deleteEntry,

--- a/src/hooks/useOsFileDrop.test.ts
+++ b/src/hooks/useOsFileDrop.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Pure position-hit-test logic extracted from useOsFileDrop.
+ * Physical pixels are converted to logical CSS pixels by dividing by devicePixelRatio.
+ */
+function isPhysicalPosOver(
+  pos: { x: number; y: number },
+  rect: { left: number; top: number; right: number; bottom: number },
+  devicePixelRatio: number
+): boolean {
+  const logX = pos.x / devicePixelRatio;
+  const logY = pos.y / devicePixelRatio;
+  return logX >= rect.left && logX <= rect.right && logY >= rect.top && logY <= rect.bottom;
+}
+
+describe("useOsFileDrop — hit-test logic", () => {
+  const rect = { left: 100, top: 100, right: 300, bottom: 300 };
+
+  it("returns true when position is inside element at dpr=1", () => {
+    expect(isPhysicalPosOver({ x: 200, y: 200 }, rect, 1)).toBe(true);
+  });
+
+  it("returns false when position is outside element at dpr=1", () => {
+    expect(isPhysicalPosOver({ x: 50, y: 50 }, rect, 1)).toBe(false);
+  });
+
+  it("converts physical to logical at dpr=2 (inside)", () => {
+    // Physical (400,400) / 2 → logical (200,200), which is inside [100,300]
+    expect(isPhysicalPosOver({ x: 400, y: 400 }, rect, 2)).toBe(true);
+  });
+
+  it("converts physical to logical at dpr=2 (outside)", () => {
+    // Physical (100,100) / 2 → logical (50,50), which is outside
+    expect(isPhysicalPosOver({ x: 100, y: 100 }, rect, 2)).toBe(false);
+  });
+
+  it("returns true at element edges", () => {
+    expect(isPhysicalPosOver({ x: 100, y: 100 }, rect, 1)).toBe(true);
+    expect(isPhysicalPosOver({ x: 300, y: 300 }, rect, 1)).toBe(true);
+  });
+
+  it("returns false just outside element edges", () => {
+    expect(isPhysicalPosOver({ x: 99, y: 200 }, rect, 1)).toBe(false);
+    expect(isPhysicalPosOver({ x: 301, y: 200 }, rect, 1)).toBe(false);
+  });
+});
+
+/**
+ * Shell-safe quoting logic — mirrors quotePath() in TerminalView.tsx.
+ */
+function quotePath(path: string): string {
+  if (/^[A-Za-z]:/.test(path) || path.includes("\\")) {
+    return `"${path.replace(/"/g, '\\"')}"`;
+  }
+  return `'${path.replace(/'/g, "'\\''")}'`;
+}
+
+describe("quotePath — terminal path insertion", () => {
+  it("wraps a simple unix path in single quotes", () => {
+    expect(quotePath("/home/user/file.txt")).toBe("'/home/user/file.txt'");
+  });
+
+  it("wraps a path with spaces in single quotes", () => {
+    expect(quotePath("/home/user/my file.txt")).toBe("'/home/user/my file.txt'");
+  });
+
+  it("escapes single quotes inside unix paths", () => {
+    expect(quotePath("/home/user/it's here.txt")).toBe("'/home/user/it'\\''s here.txt'");
+  });
+
+  it("wraps a Windows path in double quotes", () => {
+    expect(quotePath("C:\\Users\\Alice\\document.docx")).toBe('"C:\\Users\\Alice\\document.docx"');
+  });
+
+  it("escapes double quotes inside Windows paths", () => {
+    expect(quotePath('C:\\Users\\Alice\\"weird".txt')).toBe('"C:\\Users\\Alice\\\\"weird\\".txt"');
+  });
+
+  it("treats drive-letter paths as Windows even without backslash", () => {
+    expect(quotePath("C:/Users/Alice/file.txt")).toBe('"C:/Users/Alice/file.txt"');
+  });
+});

--- a/src/hooks/useOsFileDrop.ts
+++ b/src/hooks/useOsFileDrop.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+/**
+ * Listens for OS-level file drag-and-drop events (Finder, Explorer, etc.) over a
+ * given container element. Returns isDragOver for visual feedback and calls onDrop
+ * with the file paths when files are released inside the element's bounding rect.
+ *
+ * Position-based hit testing is used because Tauri intercepts OS file drops at the
+ * native level before they reach the webview, so standard HTML5 drag events are
+ * not fired for OS file drops across all platforms.
+ */
+export function useOsFileDrop(
+  containerRef: RefObject<HTMLElement | null>,
+  onDrop: (paths: string[]) => void
+): { isDragOver: boolean } {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const onDropRef = useRef(onDrop);
+  onDropRef.current = onDrop;
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+
+    const isOver = (pos: { x: number; y: number } | undefined): boolean => {
+      const el = containerRef.current;
+      if (!pos || !el) return false;
+      // DragDropEvent position is PhysicalPosition (device pixels); convert to logical CSS pixels.
+      const logX = pos.x / window.devicePixelRatio;
+      const logY = pos.y / window.devicePixelRatio;
+      const rect = el.getBoundingClientRect();
+      return logX >= rect.left && logX <= rect.right && logY >= rect.top && logY <= rect.bottom;
+    };
+
+    getCurrentWindow()
+      .onDragDropEvent((event) => {
+        const payload = event.payload;
+        if (payload.type === "enter" || payload.type === "over") {
+          setIsDragOver(isOver(payload.position));
+        } else if (payload.type === "drop") {
+          if (isOver(payload.position)) {
+            setIsDragOver(false);
+            onDropRef.current(payload.paths);
+          } else {
+            setIsDragOver(false);
+          }
+        } else {
+          setIsDragOver(false);
+        }
+      })
+      .then((fn) => {
+        unlisten = fn;
+      });
+
+    return () => {
+      if (unlisten) unlisten();
+      setIsDragOver(false);
+    };
+  }, [containerRef]);
+
+  return { isDragOver };
+}

--- a/src/hooks/useSessionFileSystem.test.ts
+++ b/src/hooks/useSessionFileSystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>

--- a/src/hooks/useSessionFileSystem.test.ts
+++ b/src/hooks/useSessionFileSystem.test.ts
@@ -99,7 +99,100 @@ describe("useSessionFileSystem — path construction", () => {
   });
 });
 
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { sessionWriteFile } from "@/services/api";
+import { useSessionFileSystem } from "./useSessionFileSystem";
 import { useAppStore } from "@/store/appStore";
+
+describe("useSessionFileSystem — uploadFileFromPath API call", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("calls sessionWriteFile with the correct remote path", async () => {
+    useAppStore.setState({ sessionFileBrowserId: "sess-1", sessionCurrentPath: "/remote/dir" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useSessionFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("/local/data.csv");
+    });
+
+    expect(vi.mocked(sessionWriteFile)).toHaveBeenCalledWith(
+      "sess-1",
+      "/remote/dir/data.csv",
+      expect.any(Array)
+    );
+  });
+
+  it("calls sessionWriteFile with root-level path when sessionCurrentPath is /", async () => {
+    useAppStore.setState({ sessionFileBrowserId: "sess-1", sessionCurrentPath: "/" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useSessionFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("/local/config.json");
+    });
+
+    expect(vi.mocked(sessionWriteFile)).toHaveBeenCalledWith(
+      "sess-1",
+      "/config.json",
+      expect.any(Array)
+    );
+  });
+
+  it("does nothing when sessionFileBrowserId is null", async () => {
+    useAppStore.setState({ sessionFileBrowserId: null, sessionCurrentPath: "/remote/dir" });
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useSessionFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+
+    await act(async () => {
+      await uploadFn!("/local/file.txt");
+    });
+
+    expect(vi.mocked(sessionWriteFile)).not.toHaveBeenCalled();
+  });
+});
 
 describe("useSessionFileSystem — store integration", () => {
   beforeEach(() => {

--- a/src/hooks/useSessionFileSystem.ts
+++ b/src/hooks/useSessionFileSystem.ts
@@ -71,6 +71,21 @@ export function useSessionFileSystem() {
     refreshSession();
   }, [sessionFileBrowserId, sessionCurrentPath, refreshSession]);
 
+  const uploadFileFromPath = useCallback(
+    async (localPath: string) => {
+      if (!sessionFileBrowserId) return;
+      const { readFile } = await import("@tauri-apps/plugin-fs");
+      const data = await readFile(localPath);
+      const parts = localPath.replace(/\\/g, "/").split("/");
+      const fileName = parts[parts.length - 1] || "upload";
+      const remotePath =
+        sessionCurrentPath === "/" ? `/${fileName}` : `${sessionCurrentPath}/${fileName}`;
+      await sessionWriteFile(sessionFileBrowserId, remotePath, Array.from(data));
+      refreshSession();
+    },
+    [sessionFileBrowserId, sessionCurrentPath, refreshSession]
+  );
+
   const createDirectory = useCallback(
     async (name: string) => {
       if (!sessionFileBrowserId) return;
@@ -192,6 +207,7 @@ export function useSessionFileSystem() {
     refresh,
     downloadFile,
     uploadFile,
+    uploadFileFromPath,
     createDirectory,
     createFile,
     deleteEntry,


### PR DESCRIPTION
## Summary

- Drop files from Finder/Explorer onto the **file browser** panel → uploads them (SFTP/session) or copies them (local mode); dashed overlay confirms the active drop target
- Drop files from Finder/Explorer onto any **terminal panel** → inserts shell-safe quoted path(s) at the cursor (works for all connection types)
- New `useOsFileDrop` hook wraps Tauri 2's `onDragDropEvent` with `PhysicalPosition` hit-testing (standard HTML5 drag events are not fired for OS file drops on all WebView backends)
- New `uploadFileFromPath(localPath)` method added to all three file system hooks (SFTP, session, local) and exposed through `useFileBrowser`

## Test plan

- [ ] Drag a file from Finder/Explorer onto the **file browser** in SFTP mode → file appears in the current remote directory
- [ ] Drag a file onto the file browser in **session** mode → file appears in the current remote directory
- [ ] Drag a file onto the file browser in **local** mode → file is copied into the current local directory
- [ ] Drag a file onto the file browser in **none** mode → nothing happens (no overlay, no error)
- [ ] Drag multiple files at once onto the file browser → all files are uploaded/copied
- [ ] Drag a file onto a **local terminal** → quoted path is inserted at the cursor
- [ ] Drag a file onto an **SSH terminal** → quoted path is inserted at the cursor
- [ ] Drag a Windows path (backslashes/drive letter) onto a terminal → double-quoted path inserted
- [ ] Drag a Unix path with spaces onto a terminal → single-quoted path inserted
- [ ] Drag onto terminal when **no session is active** → no overlay, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)