### PR TITLE
fix(ui): always show connections view on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- UI: Connections view is now always shown on startup instead of restoring the file browser from the previous session
+
 ### Changed
 
 - UI: Remote Agents now have their own collapsible "Remote Agents" section header in the connections sidebar, with a dedicated "+" button for adding new agents

--- a/src/store/appStore.layout.test.ts
+++ b/src/store/appStore.layout.test.ts
@@ -215,6 +215,30 @@ describe("appStore — layout state", () => {
         sidebarVisible: true,
         statusBarVisible: true,
         hiddenActivityBarViews: [],
+        sidebarView: "tunnels",
+        sidebarCollapsed: true,
+      },
+    });
+
+    await useAppStore.getState().loadFromBackend();
+
+    expect(useAppStore.getState().sidebarView).toBe("tunnels");
+    expect(useAppStore.getState().sidebarCollapsed).toBe(true);
+  });
+
+  it("loadFromBackend resets sidebarView to connections when saved view is files", async () => {
+    const { getSettings } = await import("@/services/storage");
+    vi.mocked(getSettings).mockResolvedValueOnce({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+      layout: {
+        activityBarPosition: "left",
+        sidebarPosition: "left",
+        sidebarVisible: true,
+        statusBarVisible: true,
+        hiddenActivityBarViews: [],
         sidebarView: "files",
         sidebarCollapsed: true,
       },
@@ -222,7 +246,7 @@ describe("appStore — layout state", () => {
 
     await useAppStore.getState().loadFromBackend();
 
-    expect(useAppStore.getState().sidebarView).toBe("files");
+    expect(useAppStore.getState().sidebarView).toBe("connections");
     expect(useAppStore.getState().sidebarCollapsed).toBe(true);
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1568,7 +1568,9 @@ export const useAppStore = create<AppState>((set, get) => {
           }
         }
         const layoutConfig = settings.layout ?? DEFAULT_LAYOUT;
-        const sidebarView = (layoutConfig.sidebarView as SidebarView | undefined) ?? "connections";
+        const persistedView =
+          (layoutConfig.sidebarView as SidebarView | undefined) ?? "connections";
+        const sidebarView: SidebarView = persistedView === "files" ? "connections" : persistedView;
         const sidebarCollapsed = layoutConfig.sidebarCollapsed ?? false;
         set({
           connections,


### PR DESCRIPTION
## Summary

- On startup, the sidebar always shows the **Connections** view, even if the file browser was active when the app was last closed
- Other sidebar views (tunnels, settings, etc.) are still restored normally — only `files` is overridden
- Updated existing test and added a new regression test for the `files` → `connections` reset behaviour

## Test plan

- [ ] Open the file browser, close the app, reopen — verify connections view is shown
- [ ] Open tunnels view, close the app, reopen — verify tunnels view is restored (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)