### PR TITLE
feat(ui): dev build version indicator with git hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - UI: Connections view is now always shown on startup instead of restoring the file browser from the previous session
+
 ### Added
 
 - File browser: drag files from OS file managers (Finder, Explorer, etc.) directly onto the file browser panel to upload them (SFTP/session) or copy them (local mode). A dashed overlay confirms the drop target.
 - Terminal: drag files from OS file managers onto any terminal panel to insert their shell-safe quoted path(s) at the cursor.
+- Version display: dev builds now show a `-dev` suffix (e.g. `v0.1.0-dev`) in the status bar, Settings footer, and Update Settings panel; a git commit hash is shown alongside the version in the Settings panel and Update Settings for both dev and release builds. Dev builds are offered an update when the matching stable release (`v0.1.0`) becomes available.
 
 ### Fixed
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,14 @@
 fn main() {
+    let hash = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+
     tauri_build::build()
 }

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -30,11 +30,7 @@ pub struct AppInfo {
 pub fn get_app_info(app_handle: AppHandle) -> AppInfo {
     let base = app_handle.package_info().version.to_string();
     let is_dev = tauri::is_dev();
-    let version = if is_dev {
-        format!("{base}-dev")
-    } else {
-        base
-    };
+    let version = if is_dev { format!("{base}-dev") } else { base };
     AppInfo {
         version,
         git_hash: env!("GIT_HASH").to_string(),

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -13,6 +13,35 @@ const GITHUB_API_URL: &str = "https://api.github.com/repos/armaxri/termiHub/rele
 /// Minimum interval between automatic update checks (1 hour).
 const MIN_CHECK_INTERVAL_SECS: i64 = 3600;
 
+/// Build-time information exposed to the frontend.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppInfo {
+    /// Running version string, including `-dev` suffix for dev builds.
+    pub version: String,
+    /// Short git commit hash embedded at build time.
+    pub git_hash: String,
+    /// Whether this is a development (non-production) build.
+    pub is_dev: bool,
+}
+
+/// Return build-time info (version, git hash, dev flag) to the frontend.
+#[tauri::command]
+pub fn get_app_info(app_handle: AppHandle) -> AppInfo {
+    let base = app_handle.package_info().version.to_string();
+    let is_dev = tauri::is_dev();
+    let version = if is_dev {
+        format!("{base}-dev")
+    } else {
+        base
+    };
+    AppInfo {
+        version,
+        git_hash: env!("GIT_HASH").to_string(),
+        is_dev,
+    }
+}
+
 /// Result returned to the frontend after an update check.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -137,7 +166,12 @@ pub async fn check_for_updates(
     app_handle: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<UpdateInfo, String> {
-    let running_version = app_handle.package_info().version.to_string();
+    let base_version = app_handle.package_info().version.to_string();
+    let running_version = if tauri::is_dev() {
+        format!("{base_version}-dev")
+    } else {
+        base_version
+    };
     debug!("Checking for updates (running={running_version}, force={force})");
 
     let settings = manager.get_settings();
@@ -366,5 +400,44 @@ mod tests {
         let info = detect_from_json("1.9.9", &json);
         assert!(info.available);
         assert_eq!(info.latest_version, "2.0.0");
+    }
+
+    // ── dev build version comparison ──────────────────────────────────────────
+
+    /// The release `v0.1.0` is semver-greater than the pre-release `0.1.0-dev`,
+    /// so a dev build should be offered an update to the matching release.
+    #[test]
+    fn dev_build_offered_matching_release_as_update() {
+        let json = make_release_json("v0.1.0", false, "First stable release");
+        let info = detect_from_json("0.1.0-dev", &json);
+        assert!(info.available);
+        assert_eq!(info.latest_version, "0.1.0");
+    }
+
+    /// A dev build running ahead of any release should not be offered a downgrade.
+    #[test]
+    fn dev_build_ahead_of_release_is_up_to_date() {
+        let json = make_release_json("v0.1.0", false, "Old release");
+        let info = detect_from_json("0.2.0-dev", &json);
+        assert!(!info.available);
+    }
+
+    /// A dev build is offered a newer release when one exists.
+    #[test]
+    fn dev_build_offered_newer_release() {
+        let json = make_release_json("v0.2.0", false, "New release");
+        let info = detect_from_json("0.1.0-dev", &json);
+        assert!(info.available);
+        assert_eq!(info.latest_version, "0.2.0");
+    }
+
+    /// The `-dev` suffix is valid semver pre-release syntax and parses correctly.
+    #[test]
+    fn parse_tag_dev_suffix() {
+        let v = parse_tag("0.1.0-dev").unwrap();
+        assert_eq!(v.major, 0);
+        assert_eq!(v.minor, 1);
+        assert_eq!(v.patch, 0);
+        assert!(!v.pre.is_empty());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -480,6 +480,7 @@ pub fn run() {
             commands::portable::export_config_to_portable,
             commands::portable::import_config_from_portable,
             // Update checker
+            commands::update::get_app_info,
             commands::update::check_for_updates,
             commands::update::skip_update_version,
             commands::update::clear_skipped_version,

--- a/src/components/Settings/SettingsPanel.css
+++ b/src/components/Settings/SettingsPanel.css
@@ -114,11 +114,21 @@
 /* === Footer === */
 .settings-panel__footer {
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
   padding: var(--spacing-xs) var(--spacing-md);
   border-top: 1px solid var(--border-secondary);
   font-size: 11px;
   color: var(--text-disabled);
   text-align: center;
+}
+
+.settings-panel__footer-hash {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  opacity: 0.6;
 }
 
 /* === Form field rows for toggle + label === */

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { getVersion } from "@tauri-apps/api/app";
 import {
   Settings2,
   Palette,
@@ -30,6 +29,7 @@ import { LanguagePackagesSettings } from "./LanguagePackagesSettings";
 import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
 import { PortableModeSettings } from "./PortableModeSettings";
 import { UpdateSettings } from "./UpdateSettings";
+import { getAppInfo, type AppInfo } from "@/services/api";
 import "./SettingsPanel.css";
 
 const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
@@ -83,16 +83,15 @@ export function SettingsPanel({ isVisible }: SettingsPanelProps) {
   const [activeCategory, setActiveCategory] = useState<SettingsCategory>(loadSavedCategory);
   const [searchQuery, setSearchQuery] = useState("");
   const [isCompact, setIsCompact] = useState(false);
-  const [appVersion, setAppVersion] = useState("");
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingSettingsRef = useRef<AppSettings | null>(null);
 
-  // Load app version
   useEffect(() => {
-    getVersion()
-      .then(setAppVersion)
-      .catch(() => setAppVersion("unknown"));
+    getAppInfo()
+      .then(setAppInfo)
+      .catch(() => setAppInfo(null));
   }, []);
 
   // ResizeObserver for compact mode
@@ -278,7 +277,14 @@ export function SettingsPanel({ isVisible }: SettingsPanelProps) {
         />
         <div className="settings-panel__content">{renderContent()}</div>
       </div>
-      <div className="settings-panel__footer">termiHub v{appVersion}</div>
+      <div className="settings-panel__footer">
+        termiHub {appInfo ? `v${appInfo.version}` : ""}
+        {appInfo && (
+          <span className="settings-panel__footer-hash" title="Git commit hash">
+            {appInfo.gitHash}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Settings/UpdateSettings.css
+++ b/src/components/Settings/UpdateSettings.css
@@ -57,3 +57,9 @@
   font-size: var(--font-size-sm);
   color: var(--text-primary);
 }
+
+.update-settings__build-hash {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--text-secondary);
+}

--- a/src/components/Settings/UpdateSettings.tsx
+++ b/src/components/Settings/UpdateSettings.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { RefreshCw, Loader2 } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { getVersion } from "@tauri-apps/api/app";
-import { useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
-import { setUpdateAutoCheck } from "@/services/api";
+import { setUpdateAutoCheck, getAppInfo, type AppInfo } from "@/services/api";
 import { frontendLog } from "@/utils/frontendLog";
 import "./UpdateSettings.css";
 
@@ -31,12 +29,12 @@ export function UpdateSettings({ visibleFields }: UpdateSettingsProps) {
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const [savingAutoCheck, setSavingAutoCheck] = useState(false);
-  const [appVersion, setAppVersion] = useState("");
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
 
   useEffect(() => {
-    getVersion()
-      .then(setAppVersion)
-      .catch(() => setAppVersion("?"));
+    getAppInfo()
+      .then(setAppInfo)
+      .catch(() => setAppInfo(null));
   }, []);
 
   const autoCheck = settings.updates?.autoCheck ?? true;
@@ -86,7 +84,19 @@ export function UpdateSettings({ visibleFields }: UpdateSettingsProps) {
           <div className="update-settings__info-table">
             <div className="update-settings__row">
               <span className="update-settings__label">Current version</span>
-              <span data-testid="update-current-version">v{appVersion}</span>
+              <span data-testid="update-current-version">
+                {appInfo ? `v${appInfo.version}` : "—"}
+              </span>
+            </div>
+            <div className="update-settings__row">
+              <span className="update-settings__label">Build</span>
+              <span
+                className="update-settings__build-hash"
+                data-testid="update-build-hash"
+                title="Git commit hash"
+              >
+                {appInfo ? appInfo.gitHash : "—"}
+              </span>
             </div>
 
             <div className="update-settings__row">

--- a/src/components/StatusBar/UpdateIndicator.tsx
+++ b/src/components/StatusBar/UpdateIndicator.tsx
@@ -1,6 +1,6 @@
-import { getVersion } from "@tauri-apps/api/app";
 import { useEffect, useState } from "react";
 import { useAppStore } from "@/store/appStore";
+import { getAppInfo } from "@/services/api";
 
 /**
  * Version chip in the status bar.  Shows an amber or red dot when an update
@@ -12,8 +12,8 @@ export function UpdateIndicator() {
   const updateCheckState = useAppStore((s) => s.updateCheckState);
 
   useEffect(() => {
-    getVersion()
-      .then(setAppVersion)
+    getAppInfo()
+      .then((info) => setAppVersion(info.version))
       .catch(() => setAppVersion("?"));
   }, []);
 

--- a/src/components/UpdateNotification/UpdateNotification.tsx
+++ b/src/components/UpdateNotification/UpdateNotification.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { X, Shield, RefreshCw } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useAppStore } from "@/store/appStore";
+import { getAppInfo } from "@/services/api";
 import { frontendLog } from "@/utils/frontendLog";
 import "./UpdateNotification.css";
 
@@ -21,6 +22,13 @@ export function UpdateNotification() {
   const settings = useAppStore((s) => s.settings);
 
   const [showNotes, setShowNotes] = useState(false);
+  const [runningVersion, setRunningVersion] = useState("");
+
+  useEffect(() => {
+    getAppInfo()
+      .then((info) => setRunningVersion(info.version))
+      .catch(() => setRunningVersion(""));
+  }, []);
 
   // Reset "what's new" panel whenever the detected version changes.
   useEffect(() => {
@@ -87,7 +95,9 @@ export function UpdateNotification() {
             This release addresses a security vulnerability. Updating is strongly recommended.
           </p>
         ) : (
-          <p className="update-notification__message">You are running v0.1.0</p>
+          <p className="update-notification__message">
+            {runningVersion ? `You are running v${runningVersion}` : "A newer version is available"}
+          </p>
         )}
 
         {showNotes && updateInfo.releaseNotes && (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -828,6 +828,22 @@ export async function importConfigFromPortable(
   return await invoke<ConfigMigrationResult>("import_config_from_portable", { srcDir, files });
 }
 
+// ─── App info ──────────────────────────────────────────────────────────────
+
+export interface AppInfo {
+  /** Running version string, including `-dev` suffix for dev builds. */
+  version: string;
+  /** Short git commit hash embedded at build time. */
+  gitHash: string;
+  /** Whether this is a development (non-production) build. */
+  isDev: boolean;
+}
+
+/** Return build-time info: version (with `-dev` suffix in dev builds), git hash, and dev flag. */
+export async function getAppInfo(): Promise<AppInfo> {
+  return await invoke<AppInfo>("get_app_info");
+}
+
 // ─── Update checker ────────────────────────────────────────────────────────
 
 /** Check GitHub for a newer termiHub release. Pass `force: true` to bypass the 1-hour rate limit. */


### PR DESCRIPTION
## Summary

- Dev builds now display a `-dev` suffix on the version string (e.g. `v0.1.0-dev`) in all three locations: status bar, Settings panel footer, and Update Settings panel
- Git commit hash (embedded at build time via `build.rs`) is shown alongside the version in the Settings footer and Update Settings — available in both dev and release builds
- Update checks work correctly for dev builds: semver naturally treats `v0.1.0` (stable) as newer than `v0.1.0-dev` (pre-release), so dev builds are offered the matching stable release as an update
- Fixes the hardcoded `v0.1.0` string in the update notification popup

## How it works

`tauri::is_dev()` detects the build mode at runtime (no config needed). The git hash is captured once in `build.rs` via `git rev-parse --short HEAD` and embedded as `GIT_HASH`. A new `get_app_info` Tauri command exposes `{ version, gitHash, isDev }` to the frontend, replacing the former `getVersion()` calls.

## Test plan

- [ ] Run `pnpm tauri dev` and verify the status bar shows `v0.1.0-dev`
- [ ] Open Settings → verify footer shows `termiHub v0.1.0-dev <hash>`
- [ ] Open Settings → Updates → verify "Current version" shows `v0.1.0-dev` and "Build" row shows the git hash
- [ ] Build a release (`pnpm tauri build`) and verify the version shows `v0.1.0` without `-dev` suffix
- [ ] In a release build, verify the git hash still appears in both Settings locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)