### PR TITLE
fix(ui): fix misleading resize cursor and add outer separator for Remote Agents section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - UI: Connections view is now always shown on startup instead of restoring the file browser from the previous session
+- UI: Resize handle between Connections and Remote Agent sections no longer shows a resize cursor when the agent is not expanded (cursor was misleading — dragging appeared broken)
+- UI: Added resize separator above the "Remote Agents" header to resize the Connections section against the entire Remote Agents section; individual agent resize handles now appear only between agents (not before the first one)
 
 ### Added
 

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -15,14 +15,25 @@
   overflow: hidden;
 }
 
+/* Wrapper for the entire Remote Agents section (header + agents) */
+.connection-list__remote-agents {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
 /* Resize handle between sidebar sections */
 .connection-list__resize-handle {
   height: 1px;
   background-color: var(--border-primary);
-  cursor: ns-resize;
   flex-shrink: 0;
   position: relative;
   transition: background-color var(--transition-fast);
+}
+
+.connection-list__resize-handle--resizable {
+  cursor: ns-resize;
 }
 
 .connection-list__resize-handle::before {
@@ -34,7 +45,7 @@
   right: 0;
 }
 
-.connection-list__resize-handle:hover,
+.connection-list__resize-handle--resizable:hover,
 .connection-list__resize-handle--active {
   background-color: var(--resize-handle-hover-color);
 }

--- a/src/components/Sidebar/ConnectionList.resize.test.tsx
+++ b/src/components/Sidebar/ConnectionList.resize.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Regression tests for the resize handle --resizable class.
+ *
+ * There are two levels of resize handles:
+ * - Outer (sidebar-outer-separator): between Connections and the entire Remote Agents section.
+ *   Resizable whenever connections is expanded and experimental features are enabled.
+ * - Inner (sidebar-group-separator-N): between individual agents inside the Remote Agents section.
+ *   Resizable only when both adjacent agents are expanded.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({
+    agent,
+    style,
+    sectionRef,
+  }: {
+    agent: RemoteAgentDefinition;
+    style?: React.CSSProperties;
+    sectionRef?: (el: HTMLDivElement | null) => void;
+  }) =>
+    React.createElement("div", {
+      ref: sectionRef,
+      "data-testid": `agent-node-${agent.id}`,
+      style,
+    }),
+}));
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: "agent-1",
+    name: "Test Agent",
+    config: {
+      host: "10.0.0.1",
+      port: 22,
+      username: "user",
+      authMethod: "password",
+    },
+    connectionState: "disconnected",
+    isExpanded: false,
+    ...overrides,
+  };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: true,
+  fileBrowserEnabled: true,
+  experimentalFeaturesEnabled: true,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+describe("ConnectionList – outer resize handle (connections vs remote agents)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("outer separator is present when experimental features are enabled", () => {
+    useAppStore.setState({ remoteAgents: [makeAgent()] });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    expect(container.querySelector('[data-testid="sidebar-outer-separator"]')).toBeTruthy();
+  });
+
+  it("outer separator has --resizable class when connections is expanded", () => {
+    useAppStore.setState({ remoteAgents: [makeAgent()] });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const sep = container.querySelector('[data-testid="sidebar-outer-separator"]');
+    expect(sep?.classList.contains("connection-list__resize-handle--resizable")).toBe(true);
+  });
+
+  it("outer separator is resizable regardless of whether the agent is expanded", () => {
+    useAppStore.setState({ remoteAgents: [makeAgent({ isExpanded: false })] });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const sep = container.querySelector('[data-testid="sidebar-outer-separator"]');
+    expect(sep?.classList.contains("connection-list__resize-handle--resizable")).toBe(true);
+  });
+});
+
+describe("ConnectionList – inner resize handles (between agents)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("no inner separator when there is only one agent", () => {
+    useAppStore.setState({ remoteAgents: [makeAgent({ isExpanded: true })] });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    expect(container.querySelector('[data-testid="sidebar-group-separator-0"]')).toBeNull();
+  });
+
+  it("inner separator appears between two agents", () => {
+    useAppStore.setState({
+      remoteAgents: [
+        makeAgent({ id: "a1", isExpanded: true }),
+        makeAgent({ id: "a2", isExpanded: true }),
+      ],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    expect(container.querySelector('[data-testid="sidebar-group-separator-0"]')).toBeTruthy();
+  });
+
+  it("inner separator has --resizable class only when both adjacent agents are expanded", () => {
+    useAppStore.setState({
+      remoteAgents: [
+        makeAgent({ id: "a1", isExpanded: true }),
+        makeAgent({ id: "a2", isExpanded: true }),
+      ],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const sep = container.querySelector('[data-testid="sidebar-group-separator-0"]');
+    expect(sep?.classList.contains("connection-list__resize-handle--resizable")).toBe(true);
+  });
+
+  it("inner separator does NOT have --resizable class when the second agent is collapsed", () => {
+    useAppStore.setState({
+      remoteAgents: [
+        makeAgent({ id: "a1", isExpanded: true }),
+        makeAgent({ id: "a2", isExpanded: false }),
+      ],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const sep = container.querySelector('[data-testid="sidebar-group-separator-0"]');
+    expect(sep?.classList.contains("connection-list__resize-handle--resizable")).toBe(false);
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -276,6 +276,15 @@ function ConnectionItem({
   );
 }
 
+function buildExpandedIndexMap(sectionsExpanded: boolean[]): { map: number[]; count: number } {
+  const map: number[] = [];
+  let count = 0;
+  for (const isExpanded of sectionsExpanded) {
+    map.push(isExpanded ? count++ : -1);
+  }
+  return { map, count };
+}
+
 export function ConnectionList() {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [draggingConnection, setDraggingConnection] = useState<SavedConnection | null>(null);
@@ -534,42 +543,52 @@ export function ConnectionList() {
   const LocalChevron = localCollapsed ? ChevronRight : ChevronDown;
   const RemoteAgentsChevron = remoteAgentsCollapsed ? ChevronRight : ChevronDown;
 
-  // Build expanded-section mapping for resize hook.
-  // Section 0 = Connections, sections 1..N = remote agents (only when not collapsed).
-  const sectionsExpanded = useMemo(
-    () => [
-      !localCollapsed,
-      ...(remoteAgentsCollapsed ? [] : remoteAgents.map((a) => a.isExpanded)),
-    ],
-    [localCollapsed, remoteAgentsCollapsed, remoteAgents]
+  const outerSectionsExpanded = useMemo(
+    () => [!localCollapsed, experimental] as boolean[],
+    [localCollapsed, experimental]
   );
-  const expandedCount = sectionsExpanded.filter(Boolean).length;
-  const { flexValues, handleProps, sectionRefs } = useSectionResize(expandedCount);
+  const { map: outerExpandedIndexMap, count: outerExpandedCount } = useMemo(
+    () => buildExpandedIndexMap(outerSectionsExpanded),
+    [outerSectionsExpanded]
+  );
+  const {
+    flexValues: outerFlexValues,
+    handleProps: outerHandleProps,
+    sectionRefs: outerSectionRefs,
+  } = useSectionResize(outerExpandedCount);
+  const outerConnIdx = outerExpandedIndexMap[0];
+  const outerRemoteIdx = outerExpandedIndexMap[1];
+  const outerResizeProps =
+    outerConnIdx >= 0 && outerRemoteIdx >= 0 && outerRemoteIdx === outerConnIdx + 1
+      ? outerHandleProps(outerConnIdx)
+      : {};
+  const isOuterResizable = "onMouseDown" in outerResizeProps;
 
-  // Map each section index to its expanded-section index (or -1 if collapsed).
-  const expandedIndexMap = useMemo(() => {
-    const map: number[] = [];
-    let ei = 0;
-    for (const isExpanded of sectionsExpanded) {
-      map.push(isExpanded ? ei++ : -1);
-    }
-    return map;
-  }, [sectionsExpanded]);
+  const innerSectionsExpanded = useMemo(
+    () => (remoteAgentsCollapsed ? [] : remoteAgents.map((a) => a.isExpanded)),
+    [remoteAgentsCollapsed, remoteAgents]
+  );
+  const { map: innerExpandedIndexMap, count: innerExpandedCount } = useMemo(
+    () => buildExpandedIndexMap(innerSectionsExpanded),
+    [innerSectionsExpanded]
+  );
+  const {
+    flexValues: innerFlexValues,
+    handleProps: innerHandleProps,
+    sectionRefs: innerSectionRefs,
+  } = useSectionResize(innerExpandedCount);
 
-  /** Props for a resize handle between section `i` and section `i+1`. */
-  const getResizeHandleProps = useCallback(
-    (sectionIndex: number) => {
-      const eiAbove = expandedIndexMap[sectionIndex];
-      const eiBelow = expandedIndexMap[sectionIndex + 1];
+  const getInnerResizeHandleProps = useCallback(
+    (agentIndex: number) => {
+      const eiAbove = innerExpandedIndexMap[agentIndex - 1];
+      const eiBelow = innerExpandedIndexMap[agentIndex];
       if (eiAbove >= 0 && eiBelow >= 0 && eiBelow === eiAbove + 1) {
-        return handleProps(eiAbove);
+        return innerHandleProps(eiAbove);
       }
       return {};
     },
-    [expandedIndexMap, handleProps]
+    [innerExpandedIndexMap, innerHandleProps]
   );
-
-  const connExpandedIdx = expandedIndexMap[0];
 
   return (
     <div className="connection-list">
@@ -581,10 +600,10 @@ export function ConnectionList() {
       >
         <div
           ref={(el) => {
-            if (connExpandedIdx >= 0) sectionRefs.current[connExpandedIdx] = el;
+            if (outerConnIdx >= 0) outerSectionRefs.current[outerConnIdx] = el;
           }}
           className={`connection-list__group${!localCollapsed ? " connection-list__group--expanded" : ""}`}
-          style={connExpandedIdx >= 0 ? { flex: flexValues[connExpandedIdx] } : undefined}
+          style={outerConnIdx >= 0 ? { flex: outerFlexValues[outerConnIdx] } : undefined}
         >
           <div
             className="connection-list__group-header"
@@ -649,56 +668,71 @@ export function ConnectionList() {
         {experimental && (
           <>
             <div
-              className="connection-list__group-header"
-              data-testid="sidebar-group-header-remote-agents"
+              className={`connection-list__resize-handle${isOuterResizable ? " connection-list__resize-handle--resizable" : ""}`}
+              data-testid="sidebar-outer-separator"
+              {...outerResizeProps}
+            />
+            <div
+              ref={(el) => {
+                if (outerRemoteIdx >= 0) outerSectionRefs.current[outerRemoteIdx] = el;
+              }}
+              className="connection-list__remote-agents"
+              style={outerRemoteIdx >= 0 ? { flex: outerFlexValues[outerRemoteIdx] } : undefined}
             >
-              <button
-                className="connection-list__group-toggle"
-                onClick={() => setRemoteAgentsCollapsed((v) => !v)}
-                data-testid="connection-list-remote-agents-toggle"
+              <div
+                className="connection-list__group-header"
+                data-testid="sidebar-group-header-remote-agents"
               >
-                <RemoteAgentsChevron size={16} className="connection-tree__chevron" />
-                <span className="connection-list__group-title">Remote Agents</span>
-              </button>
-              <div className="connection-list__group-actions">
                 <button
-                  className="connection-list__add-btn"
-                  onClick={handleNewAgent}
-                  title="New Remote Agent"
-                  data-testid="connection-list-new-agent"
+                  className="connection-list__group-toggle"
+                  onClick={() => setRemoteAgentsCollapsed((v) => !v)}
+                  data-testid="connection-list-remote-agents-toggle"
                 >
-                  <Plus size={16} />
+                  <RemoteAgentsChevron size={16} className="connection-tree__chevron" />
+                  <span className="connection-list__group-title">Remote Agents</span>
                 </button>
+                <div className="connection-list__group-actions">
+                  <button
+                    className="connection-list__add-btn"
+                    onClick={handleNewAgent}
+                    title="New Remote Agent"
+                    data-testid="connection-list-new-agent"
+                  >
+                    <Plus size={16} />
+                  </button>
+                </div>
               </div>
+              {!remoteAgentsCollapsed && (
+                <SortableContext
+                  items={remoteAgents.map((a) => a.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {remoteAgents.map((agent, i) => {
+                    const innerIdx = innerExpandedIndexMap[i];
+                    const innerResizeProps = i > 0 ? getInnerResizeHandleProps(i) : {};
+                    const isInnerResizable = "onMouseDown" in innerResizeProps;
+                    return (
+                      <Fragment key={agent.id}>
+                        {i > 0 && (
+                          <div
+                            className={`connection-list__resize-handle${isInnerResizable ? " connection-list__resize-handle--resizable" : ""}`}
+                            data-testid={`sidebar-group-separator-${i - 1}`}
+                            {...innerResizeProps}
+                          />
+                        )}
+                        <AgentNode
+                          agent={agent}
+                          style={innerIdx >= 0 ? { flex: innerFlexValues[innerIdx] } : undefined}
+                          sectionRef={(el) => {
+                            if (innerIdx >= 0) innerSectionRefs.current[innerIdx] = el;
+                          }}
+                        />
+                      </Fragment>
+                    );
+                  })}
+                </SortableContext>
+              )}
             </div>
-            {!remoteAgentsCollapsed && (
-              <SortableContext
-                items={remoteAgents.map((a) => a.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                {remoteAgents.map((agent, i) => {
-                  const agentExpandedIdx = expandedIndexMap[i + 1];
-                  return (
-                    <Fragment key={agent.id}>
-                      <div
-                        className="connection-list__resize-handle"
-                        data-testid={`sidebar-group-separator-${i}`}
-                        {...getResizeHandleProps(i)}
-                      />
-                      <AgentNode
-                        agent={agent}
-                        style={
-                          agentExpandedIdx >= 0 ? { flex: flexValues[agentExpandedIdx] } : undefined
-                        }
-                        sectionRef={(el) => {
-                          if (agentExpandedIdx >= 0) sectionRefs.current[agentExpandedIdx] = el;
-                        }}
-                      />
-                    </Fragment>
-                  );
-                })}
-              </SortableContext>
-            )}
           </>
         )}
         <DragOverlay>


### PR DESCRIPTION
## Summary

- **Bug fix**: The resize handle between Connections and Remote Agents always showed `cursor: ns-resize` via CSS, even when no drag handler was attached (agents start with `isExpanded: false`). Dragging appeared silently broken. Fixed by moving the cursor style to a `--resizable` modifier class that is only applied when the `onMouseDown` handler is actually active.
- **New feature**: Added a resize separator **above** the "Remote Agents" header, allowing the user to resize the Connections section against the entire Remote Agents block as a whole.
- **Refactor**: Replaced the single `useSectionResize` (which tracked connections + all agents in one flat flex system) with two independent levels — outer (connections ↔ remote agents wrapper) and inner (between individual agents). Inner separators now only appear *between* agents, not before the first one. Extracted a `buildExpandedIndexMap` helper to eliminate duplicated loop logic.

## Test plan

- [ ] Open the sidebar with at least one remote agent configured (not yet connected) — the separator between Connections and Remote Agents should show no resize cursor
- [ ] Click "Connect" on an agent — after connecting, the outer separator (above the "Remote Agents" header) should show a resize cursor and be draggable to resize Connections vs Remote Agents
- [ ] With the agent connected and expanded, drag the outer separator up/down — confirm both sections resize
- [ ] With two agents both expanded, confirm the separator *between* them is draggable
- [ ] Collapse one of two expanded agents — confirm the separator between them loses the resize cursor
- [ ] Collapse the Connections section — confirm the outer separator loses the resize cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)