### PR TITLE
feat(workspace): agent connection support with graceful error recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Terminal: connection failures (e.g. agent timeout, SSH auth errors) now show a proper error panel with the error message and a Retry button instead of raw red text in the terminal canvas.
 - UI: Connections view is now always shown on startup instead of restoring the file browser from the previous session
 - UI: Resize handle between Connections and Remote Agent sections no longer shows a resize cursor when the agent is not expanded (cursor was misleading — dragging appeared broken)
 - UI: Added resize separator above the "Remote Agents" header to resize the Connections section against the entire Remote Agents section; individual agent resize handles now appear only between agents (not before the first one)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Workspace launch: agent connection tabs (agentRef) now trigger the master password prompt upfront when their agents are disconnected and have stored credentials — previously these tabs would open as "Agent not connected" error tabs without ever asking for the password, and clicking Reconnect would immediately fail with an auth error
+- Agent error tab: the Reconnect button now unlocks the credential store and resolves the stored password before reconnecting — previously it always connected without a password, causing an immediate authentication failure
 - Terminal: connection failures (e.g. agent timeout, SSH auth errors) now show a proper error panel with the error message and a Retry button instead of raw red text in the terminal canvas.
 - UI: Connections view is now always shown on startup instead of restoring the file browser from the previous session
 - UI: Resize handle between Connections and Remote Agent sections no longer shows a resize cursor when the agent is not expanded (cursor was misleading — dragging appeared broken)

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -1,15 +1,28 @@
 use serde::{Deserialize, Serialize};
 
+/// Reference to a remote agent connection definition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRef {
+    /// The remote agent's ID.
+    pub agent_id: String,
+    /// The definition ID on that agent.
+    pub definition_id: String,
+}
+
 /// A tab definition within a workspace leaf panel.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceTabDef {
-    /// Reference to a saved connection by ID (preferred).
+    /// Reference to a saved connection by ID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_ref: Option<String>,
     /// Inline connection config as fallback when no saved connection is referenced.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_config: Option<serde_json::Value>,
+    /// Reference to a remote agent definition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_ref: Option<AgentRef>,
     /// Optional title override for the tab.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -170,6 +183,7 @@ mod tests {
                 tabs: vec![WorkspaceTabDef {
                     connection_ref: Some(connection_ref.to_string()),
                     inline_config: None,
+                    agent_ref: None,
                     title: None,
                     initial_command: None,
                 }],
@@ -193,6 +207,7 @@ mod tests {
                                 tabs: vec![WorkspaceTabDef {
                                     connection_ref: Some("conn-1".to_string()),
                                     inline_config: None,
+                                    agent_ref: None,
                                     title: Some("Server".to_string()),
                                     initial_command: Some("cd /app && npm start".to_string()),
                                 }],
@@ -202,6 +217,7 @@ mod tests {
                                     WorkspaceTabDef {
                                         connection_ref: Some("conn-2".to_string()),
                                         inline_config: None,
+                                        agent_ref: None,
                                         title: None,
                                         initial_command: None,
                                     },
@@ -211,6 +227,7 @@ mod tests {
                                             "type": "local",
                                             "config": { "shell": "zsh" }
                                         })),
+                                        agent_ref: None,
                                         title: Some("Local Shell".to_string()),
                                         initial_command: None,
                                     },
@@ -247,6 +264,7 @@ mod tests {
             tabs: vec![WorkspaceTabDef {
                 connection_ref: Some("conn-1".to_string()),
                 inline_config: None,
+                agent_ref: None,
                 title: None,
                 initial_command: None,
             }],
@@ -270,6 +288,7 @@ mod tests {
                     tabs: vec![WorkspaceTabDef {
                         connection_ref: Some("conn-1".to_string()),
                         inline_config: None,
+                        agent_ref: None,
                         title: None,
                         initial_command: None,
                     }],
@@ -278,6 +297,7 @@ mod tests {
                     tabs: vec![WorkspaceTabDef {
                         connection_ref: Some("conn-2".to_string()),
                         inline_config: None,
+                        agent_ref: None,
                         title: None,
                         initial_command: None,
                     }],
@@ -308,6 +328,7 @@ mod tests {
                 "type": "local",
                 "config": { "shell": "bash" }
             })),
+            agent_ref: None,
             title: Some("My Shell".to_string()),
             initial_command: Some("ls -la".to_string()),
         };
@@ -325,13 +346,51 @@ mod tests {
         let tab = WorkspaceTabDef {
             connection_ref: Some("conn-1".to_string()),
             inline_config: None,
+            agent_ref: None,
             title: None,
             initial_command: None,
         };
         let json = serde_json::to_string(&tab).unwrap();
         assert!(!json.contains("inlineConfig"));
+        assert!(!json.contains("agentRef"));
         assert!(!json.contains("title"));
         assert!(!json.contains("initialCommand"));
+    }
+
+    #[test]
+    fn workspace_tab_def_agent_ref_round_trip() {
+        let tab = WorkspaceTabDef {
+            connection_ref: None,
+            inline_config: None,
+            agent_ref: Some(AgentRef {
+                agent_id: "agent-1".to_string(),
+                definition_id: "def-42".to_string(),
+            }),
+            title: Some("My Remote Shell".to_string()),
+            initial_command: None,
+        };
+        let json = serde_json::to_string(&tab).unwrap();
+        assert!(json.contains("agentRef"));
+        assert!(json.contains("agentId"));
+        assert!(json.contains("definitionId"));
+        assert!(!json.contains("connectionRef"));
+        let deserialized: WorkspaceTabDef = serde_json::from_str(&json).unwrap();
+        let agent_ref = deserialized.agent_ref.unwrap();
+        assert_eq!(agent_ref.agent_id, "agent-1");
+        assert_eq!(agent_ref.definition_id, "def-42");
+    }
+
+    #[test]
+    fn workspace_tab_def_agent_ref_omitted_when_none() {
+        let tab = WorkspaceTabDef {
+            connection_ref: Some("conn-1".to_string()),
+            inline_config: None,
+            agent_ref: None,
+            title: None,
+            initial_command: None,
+        };
+        let json = serde_json::to_string(&tab).unwrap();
+        assert!(!json.contains("agentRef"));
     }
 
     #[test]
@@ -393,12 +452,14 @@ mod tests {
                                 WorkspaceTabDef {
                                     connection_ref: Some("a".to_string()),
                                     inline_config: None,
+                                    agent_ref: None,
                                     title: None,
                                     initial_command: None,
                                 },
                                 WorkspaceTabDef {
                                     connection_ref: Some("b".to_string()),
                                     inline_config: None,
+                                    agent_ref: None,
                                     title: None,
                                     initial_command: None,
                                 },
@@ -408,6 +469,7 @@ mod tests {
                             tabs: vec![WorkspaceTabDef {
                                 connection_ref: Some("c".to_string()),
                                 inline_config: None,
+                                agent_ref: None,
                                 title: None,
                                 initial_command: None,
                             }],
@@ -419,6 +481,7 @@ mod tests {
                     tabs: vec![WorkspaceTabDef {
                         connection_ref: Some("d".to_string()),
                         inline_config: None,
+                        agent_ref: None,
                         title: None,
                         initial_command: None,
                     }],
@@ -483,6 +546,7 @@ mod tests {
                     tabs: vec![WorkspaceTabDef {
                         connection_ref: Some("conn-1".to_string()),
                         inline_config: None,
+                        agent_ref: None,
                         title: None,
                         initial_command: None,
                     }],
@@ -491,6 +555,7 @@ mod tests {
                     tabs: vec![WorkspaceTabDef {
                         connection_ref: Some("conn-2".to_string()),
                         inline_config: None,
+                        agent_ref: None,
                         title: None,
                         initial_command: None,
                     }],

--- a/src-tauri/src/workspace/manager.rs
+++ b/src-tauri/src/workspace/manager.rs
@@ -355,6 +355,7 @@ mod tests {
                     tabs: vec![WorkspaceTabDef {
                         connection_ref: Some("conn-1".to_string()),
                         inline_config: None,
+                        agent_ref: None,
                         title: None,
                         initial_command: None,
                     }],
@@ -376,6 +377,7 @@ mod tests {
                         tabs: vec![WorkspaceTabDef {
                             connection_ref: Some("conn-1".to_string()),
                             inline_config: None,
+                            agent_ref: None,
                             title: None,
                             initial_command: None,
                         }],
@@ -388,6 +390,7 @@ mod tests {
                         tabs: vec![WorkspaceTabDef {
                             connection_ref: Some("conn-2".to_string()),
                             inline_config: None,
+                            agent_ref: None,
                             title: None,
                             initial_command: None,
                         }],
@@ -455,6 +458,7 @@ mod tests {
                             tabs: vec![WorkspaceTabDef {
                                 connection_ref: Some("conn-1".to_string()),
                                 inline_config: None,
+                                agent_ref: None,
                                 title: None,
                                 initial_command: None,
                             }],
@@ -463,6 +467,7 @@ mod tests {
                             tabs: vec![WorkspaceTabDef {
                                 connection_ref: Some("conn-2".to_string()),
                                 inline_config: None,
+                                agent_ref: None,
                                 title: None,
                                 initial_command: None,
                             }],

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -27,6 +27,7 @@ import {
   Check,
   Palette,
   Stethoscope,
+  WifiOff,
   X,
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
@@ -47,6 +48,7 @@ import { TunnelEditor } from "@/components/TunnelEditor";
 import { WorkspaceEditor } from "@/components/WorkspaceEditor";
 import { NetworkDiagnosticPanel } from "@/components/NetworkTools/NetworkDiagnosticPanel";
 import { TerminalSearchBar } from "@/components/Terminal/TerminalSearchBar";
+import { AgentErrorTab } from "@/components/Terminal/AgentErrorTab";
 import { PanelDropZone } from "./PanelDropZone";
 import "./SplitView.css";
 
@@ -252,6 +254,8 @@ export function SplitView() {
                 <LayoutGrid size={14} className="zoom-overlay__icon" />
               ) : zoomedTab.contentType === "network-diagnostic" ? (
                 <Stethoscope size={14} className="zoom-overlay__icon" />
+              ) : zoomedTab.contentType === "agent-error" ? (
+                <WifiOff size={14} className="zoom-overlay__icon" />
               ) : (
                 <ConnectionIcon
                   config={zoomedTab.config}
@@ -322,6 +326,13 @@ export function SplitView() {
                 <NetworkDiagnosticPanel
                   key={`zoom-${zoomedTabId}`}
                   meta={zoomedTab.networkDiagnosticMeta}
+                  isVisible={true}
+                />
+              ) : zoomedTab.contentType === "agent-error" && zoomedTab.agentErrorMeta ? (
+                <AgentErrorTab
+                  key={`zoom-${zoomedTabId}`}
+                  tabId={zoomedTabId}
+                  meta={zoomedTab.agentErrorMeta}
                   isVisible={true}
                 />
               ) : null}
@@ -500,6 +511,13 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
             <NetworkDiagnosticPanel
               key={tab.id}
               meta={tab.networkDiagnosticMeta}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
+            />
+          ) : tab.contentType === "agent-error" && tab.agentErrorMeta ? (
+            <AgentErrorTab
+              key={tab.id}
+              tabId={tab.id}
+              meta={tab.agentErrorMeta}
               isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : useQuickAction ? (

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -49,6 +49,7 @@ import { WorkspaceEditor } from "@/components/WorkspaceEditor";
 import { NetworkDiagnosticPanel } from "@/components/NetworkTools/NetworkDiagnosticPanel";
 import { TerminalSearchBar } from "@/components/Terminal/TerminalSearchBar";
 import { AgentErrorTab } from "@/components/Terminal/AgentErrorTab";
+import { TerminalSpawnErrorOverlay } from "@/components/Terminal/TerminalSpawnErrorOverlay";
 import { PanelDropZone } from "./PanelDropZone";
 import "./SplitView.css";
 
@@ -65,6 +66,7 @@ export function SplitView() {
   const setDraggingTabId = useAppStore((s) => s.setDraggingTabId);
   const zoomedTabId = useAppStore((s) => s.zoomedTabId);
   const setZoomedTabId = useAppStore((s) => s.setZoomedTabId);
+  const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
 
   // Find the zoomed tab's metadata for the overlay header
   const zoomedTab = useMemo(() => {
@@ -276,7 +278,15 @@ export function SplitView() {
               </button>
             </div>
             <div className="zoom-overlay__content">
-              {zoomedTab.contentType === "terminal" ? (
+              {zoomedTab.contentType === "terminal" && terminalSpawnErrors[zoomedTabId] ? (
+                <TerminalSpawnErrorOverlay
+                  key={`zoom-${zoomedTabId}`}
+                  tabId={zoomedTabId}
+                  error={terminalSpawnErrors[zoomedTabId]}
+                  tabTitle={zoomedTab.title}
+                  isVisible={true}
+                />
+              ) : zoomedTab.contentType === "terminal" ? (
                 <>
                   <TerminalSearchBar tabId={zoomedTabId} />
                   {/* key forces a fresh mount on each zoomed-tab change so the
@@ -411,6 +421,7 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
   const setTabHorizontalScrolling = useAppStore((s) => s.setTabHorizontalScrolling);
   const tabColors = useAppStore((s) => s.tabColors);
   const setTabColor = useAppStore((s) => s.setTabColor);
+  const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
   const rightClickBehavior = useAppStore((s) => s.settings.rightClickBehavior);
   const useQuickAction =
     rightClickBehavior === "quickAction" || (!rightClickBehavior && isWindows());
@@ -518,6 +529,14 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
               key={tab.id}
               tabId={tab.id}
               meta={tab.agentErrorMeta}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
+            />
+          ) : tab.contentType === "terminal" && terminalSpawnErrors[tab.id] ? (
+            <TerminalSpawnErrorOverlay
+              key={tab.id}
+              tabId={tab.id}
+              error={terminalSpawnErrors[tab.id]}
+              tabTitle={tab.title}
               isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : useQuickAction ? (

--- a/src/components/Terminal/AgentErrorTab.css
+++ b/src/components/Terminal/AgentErrorTab.css
@@ -1,0 +1,124 @@
+.agent-error-tab {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--terminal-bg);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+}
+
+.agent-error-tab--hidden {
+  display: none;
+}
+
+.agent-error-tab__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-lg);
+  padding: var(--spacing-xl);
+  text-align: center;
+}
+
+.agent-error-tab__icon {
+  color: var(--color-warning, #e8a838);
+  opacity: 0.85;
+}
+
+.agent-error-tab__heading {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.agent-error-tab__details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  max-width: 480px;
+  width: 100%;
+}
+
+.agent-error-tab__row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  background-color: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+}
+
+.agent-error-tab__label {
+  color: var(--text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.agent-error-tab__value {
+  color: var(--text-primary);
+  text-align: right;
+  word-break: break-all;
+}
+
+.agent-error-tab__value--error {
+  color: var(--color-error, #e05252);
+}
+
+.agent-error-tab__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  min-height: 48px;
+}
+
+.agent-error-tab__reconnect-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background-color: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    opacity var(--transition-fast);
+}
+
+.agent-error-tab__reconnect-btn:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+}
+
+.agent-error-tab__reconnect-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.agent-error-tab__reconnect-error {
+  color: var(--color-error, #e05252);
+  font-size: var(--font-size-xs, var(--font-size-sm));
+  max-width: 480px;
+  text-align: center;
+}
+
+@keyframes agent-error-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.agent-error-tab__spin {
+  animation: agent-error-spin 1s linear infinite;
+}

--- a/src/components/Terminal/AgentErrorTab.tsx
+++ b/src/components/Terminal/AgentErrorTab.tsx
@@ -1,0 +1,82 @@
+import { useState, useCallback } from "react";
+import { WifiOff, RefreshCw } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { AgentErrorMeta } from "@/types/terminal";
+import "./AgentErrorTab.css";
+
+interface AgentErrorTabProps {
+  tabId: string;
+  meta: AgentErrorMeta;
+  isVisible: boolean;
+}
+
+/**
+ * Shown in place of a terminal when a workspace agent connection cannot be established.
+ * Styled like a terminal so it fits naturally in split panels and the zoom overlay.
+ * The reconnect button re-attempts the full agent session and, on success, replaces
+ * all error tabs for that agent with live terminal tabs.
+ */
+export function AgentErrorTab({ tabId: _tabId, meta, isVisible }: AgentErrorTabProps) {
+  const [isReconnecting, setIsReconnecting] = useState(false);
+  const [reconnectError, setReconnectError] = useState<string | null>(null);
+
+  const connectRemoteAgent = useAppStore((s) => s.connectRemoteAgent);
+  const resolveAgentErrorTabs = useAppStore((s) => s.resolveAgentErrorTabs);
+
+  const handleReconnect = useCallback(async () => {
+    setIsReconnecting(true);
+    setReconnectError(null);
+    try {
+      await connectRemoteAgent(meta.agentId);
+      resolveAgentErrorTabs(meta.agentId);
+    } catch (err) {
+      setReconnectError(String(err));
+      setIsReconnecting(false);
+    }
+  }, [meta.agentId, connectRemoteAgent, resolveAgentErrorTabs]);
+
+  return (
+    <div
+      className={`agent-error-tab${isVisible ? "" : " agent-error-tab--hidden"}`}
+      data-testid="agent-error-tab"
+    >
+      <div className="agent-error-tab__body">
+        <WifiOff size={32} className="agent-error-tab__icon" />
+
+        <p className="agent-error-tab__heading">Agent connection unavailable</p>
+
+        <div className="agent-error-tab__details">
+          <div className="agent-error-tab__row">
+            <span className="agent-error-tab__label">Agent</span>
+            <span className="agent-error-tab__value">{meta.agentName}</span>
+          </div>
+          <div className="agent-error-tab__row">
+            <span className="agent-error-tab__label">Connection</span>
+            <span className="agent-error-tab__value">{meta.definitionName}</span>
+          </div>
+          <div className="agent-error-tab__row">
+            <span className="agent-error-tab__label">Reason</span>
+            <span className="agent-error-tab__value agent-error-tab__value--error">
+              {meta.error}
+            </span>
+          </div>
+        </div>
+
+        <div className="agent-error-tab__actions">
+          <button
+            className="agent-error-tab__reconnect-btn"
+            onClick={handleReconnect}
+            disabled={isReconnecting}
+            data-testid="agent-error-reconnect-btn"
+          >
+            <RefreshCw size={14} className={isReconnecting ? "agent-error-tab__spin" : ""} />
+            {isReconnecting ? "Reconnecting…" : "Reconnect"}
+          </button>
+          {reconnectError && (
+            <span className="agent-error-tab__reconnect-error">{reconnectError}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Terminal/AgentErrorTab.tsx
+++ b/src/components/Terminal/AgentErrorTab.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { WifiOff, RefreshCw } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { AgentErrorMeta } from "@/types/terminal";
+import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
 import "./AgentErrorTab.css";
 
 interface AgentErrorTabProps {
@@ -27,7 +28,35 @@ export function AgentErrorTab({ tabId: _tabId, meta, isVisible }: AgentErrorTabP
     setIsReconnecting(true);
     setReconnectError(null);
     try {
-      await connectRemoteAgent(meta.agentId);
+      const storeState = useAppStore.getState();
+      const agent = storeState.remoteAgents.find((a) => a.id === meta.agentId);
+      let password: string | undefined;
+
+      if (agent) {
+        const needsStoredCredential =
+          agent.config.authMethod === "password" ||
+          (agent.config.authMethod === "key" && agent.config.savePassword);
+        if (needsStoredCredential) {
+          const credStatus = storeState.credentialStoreStatus;
+          if (credStatus?.mode === "master_password" && credStatus?.status === "locked") {
+            const unlocked = await useAppStore.getState().requestUnlock();
+            if (!unlocked) {
+              setIsReconnecting(false);
+              return;
+            }
+          }
+          const resolution = await resolveConnectionCredential(
+            meta.agentId,
+            agent.config.authMethod,
+            agent.config.savePassword
+          );
+          if (resolution.usedStoredCredential && resolution.password) {
+            password = resolution.password;
+          }
+        }
+      }
+
+      await connectRemoteAgent(meta.agentId, password);
       resolveAgentErrorTabs(meta.agentId);
     } catch (err) {
       setReconnectError(String(err));

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -118,6 +118,7 @@ export function Terminal({
   existingSessionId,
   initialCommand,
 }: TerminalProps) {
+  const retryCount = useAppStore((s) => s.terminalRetryCounters[tabId] ?? 0);
   const terminalElRef = useRef<HTMLDivElement | null>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -316,20 +317,7 @@ export function Terminal({
           }
         };
       } catch (err) {
-        const errStr = String(err);
-        if (errStr.includes("Agent auth failed")) {
-          xterm.writeln(`\x1b[31m${errStr}\x1b[0m`);
-          xterm.writeln("");
-          xterm.writeln("\x1b[33mThe SSH agent may not be running.\x1b[0m");
-          xterm.writeln(
-            "\x1b[33mOn Windows, open the connection editor and use the 'Setup SSH Agent' button,\x1b[0m"
-          );
-          xterm.writeln(
-            "\x1b[33mor run: Start-Process powershell -Verb RunAs -ArgumentList 'Set-Service ssh-agent -StartupType Manual; Start-Service ssh-agent'\x1b[0m"
-          );
-        } else {
-          xterm.writeln(`\x1b[31mFailed to create terminal: ${err}\x1b[0m`);
-        }
+        useAppStore.getState().setTerminalSpawnError(tabId, String(err));
       }
     },
     // initialSessionIdRef and initialCommand are intentionally excluded: they are
@@ -574,6 +562,7 @@ export function Terminal({
     pasteToTerminal,
     registerSearchAddon,
     parkingRef,
+    retryCount,
   ]);
 
   // Re-fit and focus when visibility changes

--- a/src/components/Terminal/TerminalSpawnErrorOverlay.css
+++ b/src/components/Terminal/TerminalSpawnErrorOverlay.css
@@ -1,0 +1,153 @@
+.terminal-spawn-error {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--terminal-bg);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+}
+
+.terminal-spawn-error--hidden {
+  display: none;
+}
+
+.terminal-spawn-error__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xl);
+  text-align: center;
+}
+
+.terminal-spawn-error__icon {
+  color: var(--color-error, #e05252);
+  opacity: 0.8;
+  flex-shrink: 0;
+}
+
+.terminal-spawn-error__heading {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.terminal-spawn-error__subheading {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.terminal-spawn-error__error-box {
+  max-width: 520px;
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--color-error-muted, rgba(224, 82, 82, 0.25));
+  border-radius: var(--radius-sm);
+  text-align: left;
+}
+
+.terminal-spawn-error__error-text {
+  color: var(--color-error, #e05252);
+  word-break: break-word;
+  white-space: pre-wrap;
+  font-size: var(--font-size-xs, var(--font-size-sm));
+  line-height: 1.5;
+}
+
+.terminal-spawn-error__hint {
+  max-width: 520px;
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--bg-secondary, rgba(255, 255, 255, 0.04));
+  border-radius: var(--radius-sm);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.terminal-spawn-error__hint-title {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-warning, #e8a838);
+  margin: 0;
+}
+
+.terminal-spawn-error__hint p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs, var(--font-size-sm));
+  line-height: 1.5;
+}
+
+.terminal-spawn-error__hint-code {
+  display: block;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background-color: var(--bg-tertiary, rgba(0, 0, 0, 0.2));
+  border-radius: var(--radius-xs, var(--radius-sm));
+  font-size: var(--font-size-xs, var(--font-size-sm));
+  color: var(--text-secondary);
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
+.terminal-spawn-error__hint-text {
+  max-width: 520px;
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs, var(--font-size-sm));
+  margin: 0;
+  line-height: 1.5;
+}
+
+.terminal-spawn-error__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+}
+
+.terminal-spawn-error__retry-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background-color: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    opacity var(--transition-fast);
+}
+
+.terminal-spawn-error__retry-btn:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+}
+
+.terminal-spawn-error__retry-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+@keyframes terminal-spawn-error-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.terminal-spawn-error__spin {
+  animation: terminal-spawn-error-spin 1s linear infinite;
+}

--- a/src/components/Terminal/TerminalSpawnErrorOverlay.tsx
+++ b/src/components/Terminal/TerminalSpawnErrorOverlay.tsx
@@ -1,0 +1,88 @@
+import { useState, useCallback } from "react";
+import { ServerCrash, RefreshCw } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import "./TerminalSpawnErrorOverlay.css";
+
+interface TerminalSpawnErrorOverlayProps {
+  tabId: string;
+  error: string;
+  tabTitle: string;
+  isVisible: boolean;
+}
+
+const SSH_AGENT_PATTERN = "Agent auth failed";
+const TIMEOUT_PATTERN = "timed out";
+
+/**
+ * Shown over a terminal slot when the PTY spawn fails.
+ * The retry button increments the terminal's retry counter, causing the
+ * Terminal component to tear down the failed xterm and start a fresh attempt.
+ */
+export function TerminalSpawnErrorOverlay({
+  tabId,
+  error,
+  tabTitle,
+  isVisible,
+}: TerminalSpawnErrorOverlayProps) {
+  const [retrying, setRetrying] = useState(false);
+  const retryTerminalSpawn = useAppStore((s) => s.retryTerminalSpawn);
+
+  const handleRetry = useCallback(() => {
+    setRetrying(true);
+    retryTerminalSpawn(tabId);
+  }, [tabId, retryTerminalSpawn]);
+
+  const isAgentAuth = error.includes(SSH_AGENT_PATTERN);
+  const isTimeout = error.includes(TIMEOUT_PATTERN);
+
+  return (
+    <div
+      className={`terminal-spawn-error${isVisible ? "" : " terminal-spawn-error--hidden"}`}
+      data-testid="terminal-spawn-error-overlay"
+    >
+      <div className="terminal-spawn-error__body">
+        <ServerCrash size={32} className="terminal-spawn-error__icon" />
+
+        <p className="terminal-spawn-error__heading">Connection Failed</p>
+        <p className="terminal-spawn-error__subheading">{tabTitle}</p>
+
+        <div className="terminal-spawn-error__error-box">
+          <span className="terminal-spawn-error__error-text">{error}</span>
+        </div>
+
+        {isAgentAuth && (
+          <div className="terminal-spawn-error__hint">
+            <p className="terminal-spawn-error__hint-title">SSH Agent not running</p>
+            <p>
+              Open the connection editor and use the <strong>Setup SSH Agent</strong> button, or
+              run:
+            </p>
+            <code className="terminal-spawn-error__hint-code">
+              Start-Process powershell -Verb RunAs -ArgumentList &apos;Set-Service ssh-agent
+              -StartupType Manual; Start-Service ssh-agent&apos;
+            </code>
+          </div>
+        )}
+
+        {isTimeout && !isAgentAuth && (
+          <p className="terminal-spawn-error__hint-text">
+            The remote agent did not respond in time. Check that the host is reachable and the agent
+            binary is installed.
+          </p>
+        )}
+
+        <div className="terminal-spawn-error__actions">
+          <button
+            className="terminal-spawn-error__retry-btn"
+            onClick={handleRetry}
+            disabled={retrying}
+            data-testid="terminal-spawn-error-retry-btn"
+          >
+            <RefreshCw size={14} className={retrying ? "terminal-spawn-error__spin" : ""} />
+            {retrying ? "Connecting…" : "Retry"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WorkspaceEditor/ConnectionPicker.tsx
+++ b/src/components/WorkspaceEditor/ConnectionPicker.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { X } from "lucide-react";
+import { X, AlertTriangle } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { WorkspaceTabDef } from "@/types/workspace";
 
@@ -11,6 +11,8 @@ interface ConnectionPickerProps {
 export function ConnectionPicker({ onSelect, onCancel }: ConnectionPickerProps) {
   const connections = useAppStore((s) => s.connections);
   const folders = useAppStore((s) => s.folders);
+  const remoteAgents = useAppStore((s) => s.remoteAgents);
+  const agentDefinitions = useAppStore((s) => s.agentDefinitions);
   const [search, setSearch] = useState("");
 
   const filtered = useMemo(() => {
@@ -38,10 +40,23 @@ export function ConnectionPicker({ onSelect, onCancel }: ConnectionPickerProps) 
     return { groups, ungrouped };
   }, [filtered, folders]);
 
+  const filteredAgents = useMemo(() => {
+    if (!search) return remoteAgents;
+    const term = search.toLowerCase();
+    return remoteAgents.filter((a) => a.name.toLowerCase().includes(term));
+  }, [remoteAgents, search]);
+
   const handleSelectConnection = (connectionId: string, connectionName: string) => {
     onSelect({
       connectionRef: connectionId,
       title: connectionName,
+    });
+  };
+
+  const handleSelectAgentDef = (agentId: string, definitionId: string, definitionName: string) => {
+    onSelect({
+      agentRef: { agentId, definitionId },
+      title: definitionName,
     });
   };
 
@@ -51,6 +66,9 @@ export function ConnectionPicker({ onSelect, onCancel }: ConnectionPickerProps) 
       title: "Local Shell",
     });
   };
+
+  const hasConnections = filtered.length > 0;
+  const hasAgents = filteredAgents.length > 0;
 
   return (
     <div className="connection-picker__overlay" data-testid="connection-picker">
@@ -71,7 +89,7 @@ export function ConnectionPicker({ onSelect, onCancel }: ConnectionPickerProps) 
           type="text"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search connections..."
+          placeholder="Search connections…"
           autoFocus
           data-testid="connection-picker-search"
         />
@@ -115,8 +133,74 @@ export function ConnectionPicker({ onSelect, onCancel }: ConnectionPickerProps) 
             </div>
           ))}
 
-          {filtered.length === 0 && (
+          {hasAgents && (
+            <div className="connection-picker__group">
+              <div className="connection-picker__group-name">Remote Agents</div>
+              {filteredAgents.map((agent) => {
+                const isConnected = agent.connectionState === "connected";
+                const defs = agentDefinitions[agent.id] ?? [];
+
+                if (!isConnected) {
+                  return (
+                    <div
+                      key={agent.id}
+                      className="connection-picker__agent-offline"
+                      data-testid={`connection-picker-agent-offline-${agent.id}`}
+                    >
+                      <div className="connection-picker__agent-header">
+                        <span className="connection-picker__item-name">{agent.name}</span>
+                        <AlertTriangle
+                          size={13}
+                          className="connection-picker__agent-warning-icon"
+                        />
+                      </div>
+                      <span className="connection-picker__agent-warning">
+                        Agent not connected — available connections cannot be displayed
+                      </span>
+                    </div>
+                  );
+                }
+
+                if (defs.length === 0) {
+                  return (
+                    <div
+                      key={agent.id}
+                      className="connection-picker__agent-offline"
+                      data-testid={`connection-picker-agent-empty-${agent.id}`}
+                    >
+                      <span className="connection-picker__item-name">{agent.name}</span>
+                      <span className="connection-picker__agent-warning">
+                        No connection definitions configured on this agent
+                      </span>
+                    </div>
+                  );
+                }
+
+                return (
+                  <div key={agent.id} className="connection-picker__agent-group">
+                    <div className="connection-picker__agent-name">{agent.name}</div>
+                    {defs.map((def) => (
+                      <button
+                        key={def.id}
+                        className="connection-picker__item connection-picker__item--agent"
+                        onClick={() => handleSelectAgentDef(agent.id, def.id, def.name)}
+                        data-testid={`connection-picker-agent-def-${def.id}`}
+                      >
+                        <span className="connection-picker__item-name">{def.name}</span>
+                        <span className="connection-picker__item-type">{def.sessionType}</span>
+                      </button>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {!hasConnections && !hasAgents && (
             <div className="connection-picker__empty">No connections match your search.</div>
+          )}
+          {!hasConnections && filtered.length === 0 && connections.length > 0 && hasAgents && (
+            <div className="connection-picker__empty">No saved connections match your search.</div>
           )}
         </div>
       </div>

--- a/src/components/WorkspaceEditor/WorkspaceEditor.css
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.css
@@ -610,6 +610,48 @@
   font-size: 12px;
 }
 
+.connection-picker__agent-group {
+  margin-top: 2px;
+}
+
+.connection-picker__agent-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  padding: 4px 8px 2px 16px;
+  opacity: 0.8;
+}
+
+.connection-picker__item--agent {
+  padding-left: 24px;
+}
+
+.connection-picker__agent-offline {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 8px;
+  opacity: 0.7;
+}
+
+.connection-picker__agent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.connection-picker__agent-warning-icon {
+  color: var(--color-warning, #e8a838);
+  flex-shrink: 0;
+}
+
+.connection-picker__agent-warning {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
 /* Size Editing */
 .layout-split-container__child {
   display: flex;

--- a/src/store/appStore.credential.test.ts
+++ b/src/store/appStore.credential.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CredentialStoreStatusInfo } from "@/types/credential";
-import type { SavedConnection } from "@/types/connection";
+import type { SavedConnection, RemoteAgentDefinition } from "@/types/connection";
 import type { WorkspaceDefinition } from "@/types/workspace";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -331,5 +331,140 @@ describe("launchWorkspace — credential store pre-unlock", () => {
     await useAppStore.getState().launchWorkspace("ws-3");
 
     expect(mockRequestUnlock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("launchWorkspace — agentRef credential store pre-unlock", () => {
+  const disconnectedAgent: RemoteAgentDefinition = {
+    id: "agent-1",
+    name: "My Remote Agent",
+    config: {
+      host: "remote.example.com",
+      port: 22,
+      username: "user",
+      authMethod: "password",
+      savePassword: true,
+    },
+    isExpanded: false,
+    connectionState: "disconnected",
+  };
+
+  const workspaceWithAgentRef: WorkspaceDefinition = {
+    id: "ws-agent-1",
+    name: "Agent Workspace",
+    tabGroups: [
+      {
+        name: "Main",
+        layout: {
+          type: "leaf",
+          tabs: [{ agentRef: { agentId: "agent-1", definitionId: "def-shell" } }],
+        },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAppStore.setState({
+      credentialStoreStatus: null,
+      unlockDialogOpen: false,
+      activeWorkspaceName: null,
+      connections: [],
+      remoteAgents: [],
+      agentDefinitions: {},
+    });
+  });
+
+  it("prompts for unlock when store is locked and workspace has an agentRef with stored credential", async () => {
+    mockedInvoke.mockResolvedValueOnce(workspaceWithAgentRef);
+    const mockRequestUnlock = vi.fn().mockResolvedValue(true);
+    const mockConnectAgent = vi.fn().mockResolvedValue({ capabilities: {} });
+    mockedInvoke.mockResolvedValueOnce("stored-agent-pass"); // resolve_credential
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+      remoteAgents: [disconnectedAgent],
+      requestUnlock: mockRequestUnlock,
+      connectRemoteAgent: mockConnectAgent,
+    });
+
+    await useAppStore.getState().launchWorkspace("ws-agent-1");
+
+    expect(mockRequestUnlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls connectRemoteAgent with the resolved password after unlock for agentRef tabs", async () => {
+    mockedInvoke.mockResolvedValueOnce(workspaceWithAgentRef);
+    mockedInvoke.mockResolvedValueOnce("stored-agent-pass"); // resolve_credential
+    const mockRequestUnlock = vi.fn().mockResolvedValue(true);
+    const mockConnectAgent = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+      remoteAgents: [disconnectedAgent],
+      requestUnlock: mockRequestUnlock,
+      connectRemoteAgent: mockConnectAgent,
+    });
+
+    await useAppStore.getState().launchWorkspace("ws-agent-1");
+
+    expect(mockConnectAgent).toHaveBeenCalledWith("agent-1", "stored-agent-pass");
+    expect(useAppStore.getState().activeWorkspaceName).toBe("Agent Workspace");
+  });
+
+  it("aborts workspace launch if unlock is dismissed for agentRef tab", async () => {
+    mockedInvoke.mockResolvedValueOnce(workspaceWithAgentRef);
+    const mockRequestUnlock = vi.fn().mockResolvedValue(false);
+    const mockConnectAgent = vi.fn();
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+      remoteAgents: [disconnectedAgent],
+      requestUnlock: mockRequestUnlock,
+      connectRemoteAgent: mockConnectAgent,
+    });
+
+    await useAppStore.getState().launchWorkspace("ws-agent-1");
+
+    expect(mockRequestUnlock).toHaveBeenCalledTimes(1);
+    expect(mockConnectAgent).not.toHaveBeenCalled();
+    expect(useAppStore.getState().activeWorkspaceName).toBeNull();
+  });
+
+  it("still opens workspace with agent-error tabs if agent connection fails", async () => {
+    mockedInvoke.mockResolvedValueOnce(workspaceWithAgentRef);
+    mockedInvoke.mockResolvedValueOnce("stored-agent-pass"); // resolve_credential
+    const mockRequestUnlock = vi.fn().mockResolvedValue(true);
+    const mockConnectAgent = vi.fn().mockRejectedValue(new Error("SSH auth failed"));
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+      remoteAgents: [disconnectedAgent],
+      requestUnlock: mockRequestUnlock,
+      connectRemoteAgent: mockConnectAgent,
+    });
+
+    await useAppStore.getState().launchWorkspace("ws-agent-1");
+
+    // Workspace should still open even if agent connection failed
+    expect(useAppStore.getState().activeWorkspaceName).toBe("Agent Workspace");
+  });
+
+  it("skips unlock and connect for already-connected agents", async () => {
+    const connectedAgent: RemoteAgentDefinition = {
+      ...disconnectedAgent,
+      connectionState: "connected",
+    };
+    mockedInvoke.mockResolvedValueOnce(workspaceWithAgentRef);
+    const mockRequestUnlock = vi.fn().mockResolvedValue(true);
+    const mockConnectAgent = vi.fn();
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+      remoteAgents: [connectedAgent],
+      requestUnlock: mockRequestUnlock,
+      connectRemoteAgent: mockConnectAgent,
+    });
+
+    await useAppStore.getState().launchWorkspace("ws-agent-1");
+
+    expect(mockRequestUnlock).not.toHaveBeenCalled();
+    expect(mockConnectAgent).not.toHaveBeenCalled();
+    expect(useAppStore.getState().activeWorkspaceName).toBe("Agent Workspace");
   });
 });

--- a/src/store/appStore.terminalSpawnError.test.ts
+++ b/src/store/appStore.terminalSpawnError.test.ts
@@ -66,10 +66,9 @@ describe("terminal spawn error state", () => {
     // Add a terminal tab via addTab so we have a valid panelId
     const panelId = store.activePanelId!;
     store.addTab("Test", "local");
-    const tab =
-      useAppStore.getState().rootPanel.type === "leaf"
-        ? useAppStore.getState().rootPanel.tabs.at(-1)!
-        : null;
+    const rootPanel = useAppStore.getState().rootPanel;
+    const leafTabs = rootPanel.type === "leaf" ? rootPanel.tabs : [];
+    const tab = leafTabs.length > 0 ? leafTabs[leafTabs.length - 1] : null;
     expect(tab).not.toBeNull();
 
     useAppStore.getState().setTerminalSpawnError(tab!.id, "error");

--- a/src/store/appStore.terminalSpawnError.test.ts
+++ b/src/store/appStore.terminalSpawnError.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore } from "./appStore";
+
+describe("terminal spawn error state", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  it("setTerminalSpawnError sets an error for a tab", () => {
+    useAppStore.getState().setTerminalSpawnError("tab-1", "Connection refused");
+    expect(useAppStore.getState().terminalSpawnErrors["tab-1"]).toBe("Connection refused");
+  });
+
+  it("setTerminalSpawnError with null clears the error", () => {
+    useAppStore.getState().setTerminalSpawnError("tab-1", "some error");
+    useAppStore.getState().setTerminalSpawnError("tab-1", null);
+    expect(useAppStore.getState().terminalSpawnErrors["tab-1"]).toBeUndefined();
+  });
+
+  it("retryTerminalSpawn clears error and increments counter", () => {
+    useAppStore.getState().setTerminalSpawnError("tab-1", "timeout");
+    useAppStore.getState().retryTerminalSpawn("tab-1");
+    expect(useAppStore.getState().terminalSpawnErrors["tab-1"]).toBeUndefined();
+    expect(useAppStore.getState().terminalRetryCounters["tab-1"]).toBe(1);
+  });
+
+  it("retryTerminalSpawn increments counter on each call", () => {
+    useAppStore.getState().retryTerminalSpawn("tab-1");
+    useAppStore.getState().retryTerminalSpawn("tab-1");
+    expect(useAppStore.getState().terminalRetryCounters["tab-1"]).toBe(2);
+  });
+
+  it("closeTab removes spawn error and retry counter", () => {
+    const store = useAppStore.getState();
+    // Add a terminal tab via addTab so we have a valid panelId
+    const panelId = store.activePanelId!;
+    store.addTab("Test", "local");
+    const tab =
+      useAppStore.getState().rootPanel.type === "leaf"
+        ? useAppStore.getState().rootPanel.tabs.at(-1)!
+        : null;
+    expect(tab).not.toBeNull();
+
+    useAppStore.getState().setTerminalSpawnError(tab!.id, "error");
+    useAppStore.getState().retryTerminalSpawn(tab!.id);
+    useAppStore.getState().setTerminalSpawnError(tab!.id, "error again");
+
+    useAppStore.getState().closeTab(tab!.id, panelId);
+
+    expect(useAppStore.getState().terminalSpawnErrors[tab!.id]).toBeUndefined();
+    expect(useAppStore.getState().terminalRetryCounters[tab!.id]).toBeUndefined();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2769,25 +2769,62 @@ export const useAppStore = create<AppState>((set, get) => {
           getWorkspaceLeaves(g.layout).flatMap((leaf) => leaf.tabs)
         );
 
+        // Collect disconnected agents referenced by agentRef tabs that use stored credentials.
+        const referencedAgentIds = new Set(
+          allTabDefs.filter((t) => t.agentRef).map((t) => t.agentRef!.agentId)
+        );
+        const disconnectedAgentsNeedingCreds = state.remoteAgents.filter((agent) => {
+          if (!referencedAgentIds.has(agent.id)) return false;
+          if (agent.connectionState === "connected") return false;
+          return (
+            agent.config.authMethod === "password" ||
+            (agent.config.authMethod === "key" && agent.config.savePassword)
+          );
+        });
+
         // Before opening any tabs, check whether the credential store needs to be
         // unlocked for any connection in this workspace. If so, prompt once upfront
         // so that all tabs can connect immediately after unlock rather than failing
         // and prompting individually.
         const credStatus = state.credentialStoreStatus;
         if (credStatus?.mode === "master_password" && credStatus?.status === "locked") {
-          const needsStoredCredential = allTabDefs.some((tabDef) => {
-            if (!tabDef.connectionRef) return false;
-            const saved = state.connections.find((c) => c.id === tabDef.connectionRef);
-            if (!saved) return false;
-            const cfg = saved.config.config as Record<string, unknown>;
-            const authMethod = cfg.authMethod as string | undefined;
-            const savePassword = cfg.savePassword as boolean | undefined;
-            return authMethod === "password" || (authMethod === "key" && savePassword);
-          });
+          const needsStoredCredential =
+            allTabDefs.some((tabDef) => {
+              if (!tabDef.connectionRef) return false;
+              const saved = state.connections.find((c) => c.id === tabDef.connectionRef);
+              if (!saved) return false;
+              const cfg = saved.config.config as Record<string, unknown>;
+              const authMethod = cfg.authMethod as string | undefined;
+              const savePassword = cfg.savePassword as boolean | undefined;
+              return authMethod === "password" || (authMethod === "key" && savePassword);
+            }) || disconnectedAgentsNeedingCreds.length > 0;
           if (needsStoredCredential) {
             const unlocked = await get().requestUnlock();
             if (!unlocked) return;
           }
+        }
+
+        // Connect any disconnected agents that have stored credentials so that
+        // buildTabGroupsFromWorkspace can resolve their tabs to live terminals.
+        if (disconnectedAgentsNeedingCreds.length > 0) {
+          await Promise.all(
+            disconnectedAgentsNeedingCreds.map(async (agent) => {
+              try {
+                const resolution = await resolveConnectionCredential(
+                  agent.id,
+                  agent.config.authMethod,
+                  agent.config.savePassword
+                );
+                const password =
+                  resolution.usedStoredCredential && resolution.password
+                    ? resolution.password
+                    : undefined;
+                await get().connectRemoteAgent(agent.id, password);
+              } catch {
+                // Connection failure is surfaced as agent-error tabs below
+              }
+            })
+          );
         }
 
         // After the store is unlocked (or was already unlocked), resolve stored
@@ -2816,13 +2853,15 @@ export const useAppStore = create<AppState>((set, get) => {
           })
         );
 
+        // Re-read agent state so newly-connected agents are reflected in tab resolution.
+        const freshState = get();
         const agentContext = {
-          agents: state.remoteAgents.map((a) => ({
+          agents: freshState.remoteAgents.map((a) => ({
             id: a.id,
             name: a.name,
             connected: a.connectionState === "connected",
           })),
-          definitions: state.agentDefinitions,
+          definitions: freshState.agentDefinitions,
         };
 
         const builtGroups = buildTabGroupsFromWorkspace(

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -403,6 +403,8 @@ interface AppState {
   updateAgentFolder: (agentId: string, params: Record<string, unknown>) => Promise<void>;
   deleteAgentFolder: (agentId: string, folderId: string) => Promise<void>;
   toggleAgentFolder: (agentId: string, folderId: string) => void;
+  /** Convert all agent-error tabs for the given agent into live terminal tabs after reconnect. */
+  resolveAgentErrorTabs: (agentId: string) => void;
 
   // Local file browser state
   localFileEntries: FileEntry[];
@@ -2218,6 +2220,49 @@ export const useAppStore = create<AppState>((set, get) => {
       }
     },
 
+    resolveAgentErrorTabs: (agentId) => {
+      const defs = get().agentDefinitions[agentId] ?? [];
+
+      const convertPanel = (panel: PanelNode): PanelNode => {
+        if (panel.type === "split") {
+          return { ...panel, children: panel.children.map(convertPanel) };
+        }
+        const updatedTabs = panel.tabs.map((tab) => {
+          if (tab.contentType !== "agent-error" || tab.agentErrorMeta?.agentId !== agentId) {
+            return tab;
+          }
+          const def = defs.find((d) => d.id === tab.agentErrorMeta!.definitionId);
+          if (!def) return tab; // definition still missing — keep error tab
+          const config: ConnectionConfig = {
+            type: "remote-session",
+            config: {
+              agentId,
+              sessionType: def.sessionType,
+              shell: def.config["shell"] as string | undefined,
+              serialPort: def.config["port"] as string | undefined,
+              persistent: def.persistent,
+              title: def.name,
+            },
+          };
+          return {
+            ...tab,
+            contentType: "terminal" as const,
+            connectionType: "remote-session" as const,
+            config,
+            sessionId: null,
+            agentErrorMeta: undefined,
+            initialCommand: tab.agentErrorMeta!.initialCommand,
+          };
+        });
+        return { ...panel, tabs: updatedTabs };
+      };
+
+      set((s) => ({
+        rootPanel: convertPanel(s.rootPanel),
+        tabGroups: s.tabGroups.map((g) => ({ ...g, rootPanel: convertPanel(g.rootPanel) })),
+      }));
+    },
+
     // Local file browser state
     localFileEntries: [],
     localCurrentPath: "/",
@@ -2736,10 +2781,20 @@ export const useAppStore = create<AppState>((set, get) => {
           })
         );
 
+        const agentContext = {
+          agents: state.remoteAgents.map((a) => ({
+            id: a.id,
+            name: a.name,
+            connected: a.connectionState === "connected",
+          })),
+          definitions: state.agentDefinitions,
+        };
+
         const builtGroups = buildTabGroupsFromWorkspace(
           definition.tabGroups,
           resolvedConnections,
-          state.defaultShell
+          state.defaultShell,
+          agentContext
         );
         if (builtGroups.length === 0) return;
         const firstGroup = builtGroups[0];

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -374,6 +374,12 @@ interface AppState {
   tabColors: Record<string, string>;
   setTabColor: (tabId: string, color: string | null) => void;
 
+  // Per-tab terminal spawn errors (runtime-only, cleared on retry or tab close)
+  terminalSpawnErrors: Record<string, string>;
+  terminalRetryCounters: Record<string, number>;
+  setTerminalSpawnError: (tabId: string, error: string | null) => void;
+  retryTerminalSpawn: (tabId: string) => void;
+
   // Remote connection states
   remoteStates: Record<string, string>;
   setRemoteState: (sessionId: string, state: string) => void;
@@ -1208,6 +1214,8 @@ export const useAppStore = create<AppState>((set, get) => {
         const { [tabId]: _removedColor, ...remainingColors } = state.tabColors;
         const { [tabId]: _removedOpts, ...remainingOpts } = state.tabTerminalOptions;
         const { [tabId]: _removedSearch, ...remainingSearch } = state.terminalSearchVisible;
+        const { [tabId]: _removedSpawnErr, ...remainingSpawnErrors } = state.terminalSpawnErrors;
+        const { [tabId]: _removedRetry, ...remainingRetryCounters } = state.terminalRetryCounters;
 
         let rootPanel = updateLeaf(state.rootPanel, panelId, (leaf) =>
           removeTabFromLeaf(leaf, tabId)
@@ -1235,6 +1243,8 @@ export const useAppStore = create<AppState>((set, get) => {
             tabColors: remainingColors,
             tabTerminalOptions: remainingOpts,
             terminalSearchVisible: remainingSearch,
+            terminalSpawnErrors: remainingSpawnErrors,
+            terminalRetryCounters: remainingRetryCounters,
           };
         }
 
@@ -1247,6 +1257,8 @@ export const useAppStore = create<AppState>((set, get) => {
           tabColors: remainingColors,
           tabTerminalOptions: remainingOpts,
           terminalSearchVisible: remainingSearch,
+          terminalSpawnErrors: remainingSpawnErrors,
+          terminalRetryCounters: remainingRetryCounters,
         };
       }),
 
@@ -1941,6 +1953,29 @@ export const useAppStore = create<AppState>((set, get) => {
           return { tabColors: remaining };
         }
         return { tabColors: { ...state.tabColors, [tabId]: color } };
+      }),
+
+    // Per-tab terminal spawn errors (runtime-only)
+    terminalSpawnErrors: {},
+    terminalRetryCounters: {},
+    setTerminalSpawnError: (tabId, error) =>
+      set((state) => {
+        if (error === null) {
+          const { [tabId]: _removed, ...remaining } = state.terminalSpawnErrors;
+          return { terminalSpawnErrors: remaining };
+        }
+        return { terminalSpawnErrors: { ...state.terminalSpawnErrors, [tabId]: error } };
+      }),
+    retryTerminalSpawn: (tabId) =>
+      set((state) => {
+        const { [tabId]: _removed, ...remaining } = state.terminalSpawnErrors;
+        return {
+          terminalSpawnErrors: remaining,
+          terminalRetryCounters: {
+            ...state.terminalRetryCounters,
+            [tabId]: (state.terminalRetryCounters[tabId] ?? 0) + 1,
+          },
+        };
       }),
 
     // Remote connection states

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -23,6 +23,7 @@ export type ConnectionType =
 
 export type TabContentType =
   | "terminal"
+  | "agent-error"
   | "settings"
   | "editor"
   | "connection-editor"
@@ -70,6 +71,16 @@ export interface NetworkDiagnosticMeta {
   prefillHost?: string;
   /** Connection ID that triggered this diagnostic (for context). */
   connectionId?: string;
+}
+
+/** Metadata for an agent-error tab shown when a workspace agent connection fails. */
+export interface AgentErrorMeta {
+  agentId: string;
+  agentName: string;
+  definitionId: string;
+  definitionName: string;
+  error: string;
+  initialCommand?: string;
 }
 
 export interface TerminalOptions {
@@ -133,6 +144,9 @@ export interface TerminalTab {
   tunnelEditorMeta?: TunnelEditorMeta;
   workspaceEditorMeta?: WorkspaceEditorMeta;
   networkDiagnosticMeta?: NetworkDiagnosticMeta;
+  agentErrorMeta?: AgentErrorMeta;
+  /** Set when this tab was launched from a workspace agentRef — enables proper workspace capture. */
+  workspaceAgentRef?: { agentId: string; definitionId: string };
   /** Optional command to send after the terminal session connects. */
   initialCommand?: string;
 }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -1,9 +1,11 @@
 /** A tab definition within a workspace leaf panel. */
 export interface WorkspaceTabDef {
-  /** Reference to a saved connection by ID (preferred). */
+  /** Reference to a saved connection by ID. */
   connectionRef?: string;
   /** Inline connection config as fallback when no saved connection is referenced. */
   inlineConfig?: { type: string; config: Record<string, unknown> };
+  /** Reference to a remote agent definition (agentId + definitionId on that agent). */
+  agentRef?: { agentId: string; definitionId: string };
   /** Optional title override for the tab. */
   title?: string;
   /** Optional command to run after the session connects. */

--- a/src/utils/workspaceLayout.test.ts
+++ b/src/utils/workspaceLayout.test.ts
@@ -951,3 +951,106 @@ describe("captureAllTabGroups", () => {
     expect(defs[0].color).toBe("#abc");
   });
 });
+
+// --- agentRef resolution ---
+
+describe("agentRef workspace tab resolution", () => {
+  const agentContext = {
+    agents: [
+      { id: "agent-1", name: "Pi Server", connected: true },
+      { id: "agent-2", name: "Work Server", connected: false },
+    ],
+    definitions: {
+      "agent-1": [
+        {
+          id: "def-shell",
+          name: "Bash Shell",
+          sessionType: "shell",
+          persistent: false,
+          config: { shell: "/bin/bash" },
+        },
+      ],
+    },
+  };
+
+  it("resolves agentRef to terminal tab when agent is connected", () => {
+    const layout: WorkspaceLayoutNode = {
+      type: "leaf",
+      tabs: [{ agentRef: { agentId: "agent-1", definitionId: "def-shell" } }],
+    };
+    const panel = buildPanelTreeFromWorkspace(layout, [], "zsh", agentContext);
+    expect(panel.type).toBe("leaf");
+    if (panel.type === "leaf") {
+      const tab = panel.tabs[0];
+      expect(tab.contentType).toBe("terminal");
+      expect(tab.connectionType).toBe("remote-session");
+      expect(tab.config.config).toMatchObject({ agentId: "agent-1", sessionType: "shell" });
+      expect(tab.workspaceAgentRef).toEqual({ agentId: "agent-1", definitionId: "def-shell" });
+      expect(tab.agentErrorMeta).toBeUndefined();
+    }
+  });
+
+  it("resolves agentRef to agent-error tab when agent is disconnected", () => {
+    const layout: WorkspaceLayoutNode = {
+      type: "leaf",
+      tabs: [{ agentRef: { agentId: "agent-2", definitionId: "def-shell" } }],
+    };
+    const panel = buildPanelTreeFromWorkspace(layout, [], "zsh", agentContext);
+    expect(panel.type).toBe("leaf");
+    if (panel.type === "leaf") {
+      const tab = panel.tabs[0];
+      expect(tab.contentType).toBe("agent-error");
+      expect(tab.agentErrorMeta?.agentId).toBe("agent-2");
+      expect(tab.agentErrorMeta?.error).toContain("not connected");
+      expect(tab.workspaceAgentRef).toEqual({ agentId: "agent-2", definitionId: "def-shell" });
+    }
+  });
+
+  it("resolves agentRef to agent-error tab when definition is not found", () => {
+    const layout: WorkspaceLayoutNode = {
+      type: "leaf",
+      tabs: [{ agentRef: { agentId: "agent-1", definitionId: "missing-def" } }],
+    };
+    const panel = buildPanelTreeFromWorkspace(layout, [], "zsh", agentContext);
+    expect(panel.type).toBe("leaf");
+    if (panel.type === "leaf") {
+      const tab = panel.tabs[0];
+      expect(tab.contentType).toBe("agent-error");
+      expect(tab.agentErrorMeta?.error).toContain("not found");
+    }
+  });
+
+  it("resolves agentRef to agent-error tab when agent context is absent", () => {
+    const layout: WorkspaceLayoutNode = {
+      type: "leaf",
+      tabs: [{ agentRef: { agentId: "agent-1", definitionId: "def-shell" } }],
+    };
+    const panel = buildPanelTreeFromWorkspace(layout, [], "zsh");
+    expect(panel.type).toBe("leaf");
+    if (panel.type === "leaf") {
+      expect(panel.tabs[0].contentType).toBe("agent-error");
+    }
+  });
+
+  it("captures agent-error tab back as agentRef", () => {
+    const layout: WorkspaceLayoutNode = {
+      type: "leaf",
+      tabs: [
+        {
+          agentRef: { agentId: "agent-2", definitionId: "def-shell" },
+          title: "My Shell",
+          initialCommand: "ls",
+        },
+      ],
+    };
+    const panel = buildPanelTreeFromWorkspace(layout, [], "zsh", agentContext);
+    const captured = captureCurrentLayout(panel, []);
+    expect(captured.type).toBe("leaf");
+    if (captured.type === "leaf") {
+      const tabDef = captured.tabs[0];
+      expect(tabDef.agentRef).toEqual({ agentId: "agent-2", definitionId: "def-shell" });
+      expect(tabDef.title).toBe("My Shell");
+      expect(tabDef.initialCommand).toBe("ls");
+    }
+  });
+});

--- a/src/utils/workspaceLayout.ts
+++ b/src/utils/workspaceLayout.ts
@@ -9,8 +9,29 @@ import {
   WorkspaceTabDef,
   WorkspaceTabGroupDef,
 } from "@/types/workspace";
-import { PanelNode, ConnectionConfig, TerminalTab, TabGroup } from "@/types/terminal";
+import {
+  PanelNode,
+  ConnectionConfig,
+  TerminalTab,
+  TabGroup,
+  AgentErrorMeta,
+} from "@/types/terminal";
 import { SavedConnection } from "@/types/connection";
+
+/** Minimal agent state passed in during workspace launch to resolve agentRef tabs. */
+export interface AgentContext {
+  agents: Array<{ id: string; name: string; connected: boolean }>;
+  definitions: Record<
+    string,
+    Array<{
+      id: string;
+      name: string;
+      sessionType: string;
+      persistent: boolean;
+      config: Record<string, unknown>;
+    }>
+  >;
+}
 
 /** Get all leaf nodes from a workspace layout tree. */
 export function getWorkspaceLeaves(node: WorkspaceLayoutNode): WorkspaceLeafNode[] {
@@ -388,33 +409,62 @@ function generateTabId(): string {
   return `ws-tab-${tabIdCounter}`;
 }
 
+type ResolvedTab =
+  | {
+      kind: "terminal";
+      config: ConnectionConfig;
+      title: string;
+      connectionType: string;
+      workspaceAgentRef?: { agentId: string; definitionId: string };
+    }
+  | {
+      kind: "agent-error";
+      title: string;
+      agentErrorMeta: AgentErrorMeta;
+      workspaceAgentRef: { agentId: string; definitionId: string };
+    };
+
 /**
  * Build a PanelNode tree from a workspace layout definition.
  * Resolves connection refs to saved connections, falling back to inline configs.
+ * When agentContext is provided, agentRef tabs are resolved to terminal or agent-error tabs.
  */
 export function buildPanelTreeFromWorkspace(
   layout: WorkspaceLayoutNode,
   savedConnections: SavedConnection[],
-  defaultShell: string
+  defaultShell: string,
+  agentContext?: AgentContext
 ): PanelNode {
   if (layout.type === "leaf") {
     const panelId = generatePanelId();
     const tabs: TerminalTab[] = layout.tabs.map((tabDef) => {
       const tabId = generateTabId();
-      const { config, title, connectionType } = resolveTabConfig(
-        tabDef,
-        savedConnections,
-        defaultShell
-      );
+      const resolved = resolveTabConfig(tabDef, savedConnections, defaultShell, agentContext);
+      if (resolved.kind === "agent-error") {
+        return {
+          id: tabId,
+          sessionId: null,
+          title: resolved.title,
+          connectionType: "remote-session",
+          contentType: "agent-error" as const,
+          config: { type: "remote-session", config: {} },
+          panelId,
+          isActive: false,
+          agentErrorMeta: resolved.agentErrorMeta,
+          workspaceAgentRef: resolved.workspaceAgentRef,
+          initialCommand: resolved.agentErrorMeta.initialCommand,
+        };
+      }
       return {
         id: tabId,
         sessionId: null,
-        title,
-        connectionType,
+        title: resolved.title,
+        connectionType: resolved.connectionType,
         contentType: "terminal" as const,
-        config,
+        config: resolved.config,
         panelId,
         isActive: false,
+        workspaceAgentRef: resolved.workspaceAgentRef,
         initialCommand: tabDef.initialCommand,
       };
     });
@@ -437,7 +487,7 @@ export function buildPanelTreeFromWorkspace(
     id: generatePanelId(),
     direction: layout.direction,
     children: layout.children.map((child) =>
-      buildPanelTreeFromWorkspace(child, savedConnections, defaultShell)
+      buildPanelTreeFromWorkspace(child, savedConnections, defaultShell, agentContext)
     ),
     ...(layout.sizes ? { sizes: [...layout.sizes] } : {}),
   };
@@ -446,13 +496,79 @@ export function buildPanelTreeFromWorkspace(
 function resolveTabConfig(
   tabDef: WorkspaceTabDef,
   savedConnections: SavedConnection[],
-  defaultShell: string
-): { config: ConnectionConfig; title: string; connectionType: string } {
+  defaultShell: string,
+  agentContext?: AgentContext
+): ResolvedTab {
+  // Resolve agentRef tabs
+  if (tabDef.agentRef) {
+    const { agentId, definitionId } = tabDef.agentRef;
+    const agent = agentContext?.agents.find((a) => a.id === agentId);
+    const agentName = agent?.name ?? agentId;
+    const workspaceAgentRef = { agentId, definitionId };
+
+    if (agent?.connected) {
+      const defs = agentContext?.definitions[agentId] ?? [];
+      const def = defs.find((d) => d.id === definitionId);
+      if (def) {
+        const config: ConnectionConfig = {
+          type: "remote-session",
+          config: {
+            agentId,
+            sessionType: def.sessionType,
+            shell: def.config["shell"] as string | undefined,
+            serialPort: def.config["port"] as string | undefined,
+            persistent: def.persistent,
+            title: def.name,
+          },
+        };
+        return {
+          kind: "terminal",
+          config,
+          title: tabDef.title ?? def.name,
+          connectionType: "remote-session",
+          workspaceAgentRef,
+        };
+      }
+      // Definition not found on connected agent — show error
+      return {
+        kind: "agent-error",
+        title: tabDef.title ?? definitionId,
+        workspaceAgentRef,
+        agentErrorMeta: {
+          agentId,
+          agentName,
+          definitionId,
+          definitionName: tabDef.title ?? definitionId,
+          error: `Connection definition "${definitionId}" was not found on agent "${agentName}".`,
+          initialCommand: tabDef.initialCommand,
+        },
+      };
+    }
+
+    // Agent not connected or not found
+    return {
+      kind: "agent-error",
+      title: tabDef.title ?? agentName,
+      workspaceAgentRef,
+      agentErrorMeta: {
+        agentId,
+        agentName,
+        definitionId,
+        definitionName: tabDef.title ?? definitionId,
+        error: agent
+          ? `Agent "${agentName}" is not connected.`
+          : `Agent "${agentName}" was not found.`,
+        initialCommand: tabDef.initialCommand,
+      },
+    };
+  }
+
   // Try to resolve by connection ref
   if (tabDef.connectionRef) {
     const saved = savedConnections.find((c) => c.id === tabDef.connectionRef);
     if (saved) {
       return {
+        kind: "terminal",
         config: saved.config,
         title: tabDef.title ?? saved.name,
         connectionType: saved.config.type,
@@ -463,6 +579,7 @@ function resolveTabConfig(
   // Fall back to inline config
   if (tabDef.inlineConfig) {
     return {
+      kind: "terminal",
       config: tabDef.inlineConfig as ConnectionConfig,
       title: tabDef.title ?? "Terminal",
       connectionType: (tabDef.inlineConfig as ConnectionConfig).type ?? "local",
@@ -471,6 +588,7 @@ function resolveTabConfig(
 
   // Default: local shell
   return {
+    kind: "terminal",
     config: { type: "local", config: { shell: defaultShell } },
     title: tabDef.title ?? "Terminal",
     connectionType: "local",
@@ -480,6 +598,7 @@ function resolveTabConfig(
 /**
  * Capture the current live panel tree as a workspace layout definition.
  * Matches tabs to saved connection IDs where possible.
+ * Agent-error tabs are preserved as agentRef entries so they survive workspace save/reload.
  */
 export function captureCurrentLayout(
   rootPanel: PanelNode,
@@ -489,7 +608,7 @@ export function captureCurrentLayout(
     return {
       type: "leaf",
       tabs: rootPanel.tabs
-        .filter((tab) => tab.contentType === "terminal")
+        .filter((tab) => tab.contentType === "terminal" || tab.contentType === "agent-error")
         .map((tab) => captureTab(tab, savedConnections)),
     };
   }
@@ -503,6 +622,15 @@ export function captureCurrentLayout(
 }
 
 function captureTab(tab: TerminalTab, savedConnections: SavedConnection[]): WorkspaceTabDef {
+  // Agent-error tabs and workspace-launched agent terminal tabs capture as agentRef
+  if (tab.workspaceAgentRef) {
+    return {
+      agentRef: tab.workspaceAgentRef,
+      title: tab.title,
+      initialCommand: tab.initialCommand ?? tab.agentErrorMeta?.initialCommand,
+    };
+  }
+
   // Try to match to a saved connection by config type and matching fields
   const matchedConnection = savedConnections.find(
     (c) =>
@@ -535,14 +663,21 @@ function generateWorkspaceGroupId(): string {
 /**
  * Build an array of TabGroup objects from workspace tab group definitions.
  * Each group gets a fresh ID and a newly-built PanelNode tree.
+ * Pass agentContext to resolve agentRef tabs into terminal or agent-error tabs.
  */
 export function buildTabGroupsFromWorkspace(
   tabGroupDefs: WorkspaceTabGroupDef[],
   savedConnections: SavedConnection[],
-  defaultShell: string
+  defaultShell: string,
+  agentContext?: AgentContext
 ): TabGroup[] {
   return tabGroupDefs.map((def) => {
-    const rootPanel = buildPanelTreeFromWorkspace(def.layout, savedConnections, defaultShell);
+    const rootPanel = buildPanelTreeFromWorkspace(
+      def.layout,
+      savedConnections,
+      defaultShell,
+      agentContext
+    );
     const firstLeaf =
       rootPanel.type === "leaf" ? rootPanel : getAllWorkspaceLeafPanels(rootPanel)[0];
     return {


### PR DESCRIPTION
## Summary

- **WorkspaceTabDef `agentRef`**: Workspaces can now reference remote agent connection definitions by `agentId` + `definitionId`. The field is added to both Rust (`config.rs`) and TypeScript (`workspace.ts`).
- **Graceful restore**: On workspace launch, `agentRef` tabs are resolved: connected agent + found definition → live terminal tab; otherwise → `AgentErrorTab` so the rest of the workspace still opens cleanly. Agent-error tabs are preserved in workspace capture so they survive save/reload.
- **AgentErrorTab**: Terminal-styled error panel showing agent name, connection name, and failure reason. A "Reconnect" button re-attempts the full agent session; on success all error tabs for that agent are converted to live terminals; on failure the reason is updated. Participates in the zoom overlay identically to other tab types.
- **ConnectionPicker agent support**: The workspace connection picker now lists Remote Agents below saved connections. Connected agents show their definitions as selectable items; disconnected agents show an inline warning that options cannot be displayed until connected.
- **Credential store pre-unlock for agentRef tabs**: `launchWorkspace` now detects disconnected agents with stored credentials and prompts for the master password once upfront before building tabs, then auto-connects those agents — so they open as live terminals instead of agent-error tabs. Agent context is re-read from fresh store state after auto-connect.
- **AgentErrorTab Reconnect credential flow**: The Reconnect button now mirrors `AgentNode.handleConnect` — it unlocks the credential store if needed, resolves the stored password, and passes it to `connectRemoteAgent`. Previously it always connected without a password, causing an immediate auth failure.

## Test plan

- [ ] Open workspace editor, click "Add Connection" — Remote Agents section appears at the bottom
- [ ] With a disconnected agent: warning "Agent not connected — available connections cannot be displayed" appears
- [ ] With a connected agent: its definitions appear and can be selected; workspace saves with `agentRef`
- [ ] Launch a workspace containing an `agentRef` tab while the agent is disconnected and uses a stored password → master password dialog appears upfront; after unlock the agent auto-connects and the tab opens as a live terminal
- [ ] Launch a workspace with `agentRef` tab while agent is already connected → opens immediately as live terminal, no password prompt
- [ ] Launch a workspace with `agentRef` tab and dismiss the master password dialog → workspace launch is aborted (no tabs opened)
- [ ] Launch a workspace where the agent connection fails despite correct credentials → `AgentErrorTab` appears; rest of workspace opens normally
- [ ] Click "Reconnect" on an `AgentErrorTab` with a stored password and locked credential store → master password dialog appears; after unlock the agent connects and the error tab is replaced with a live terminal
- [ ] Click "Reconnect" with agent unreachable → error message updates with new reason
- [ ] Press `Ctrl+Shift+Enter` on an agent-error tab → zoom overlay opens showing the error content
- [ ] Save workspace while some tabs are in error state → reload shows error tabs again (not blank tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)