### PR TITLE
fix(agent): add authMethod default, build --native/--dev flags, and reconnect improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Agent: external connection files — agent transport settings now support configuring a list of remote file paths. Enabled files are passed to the agent at connect time via the `initialize` JSON-RPC call; the agent loads connections from those files and merges them into the connection list as read-only entries tagged with their source file path.
 - Agent: ARMv7 (arm32) support — a new `termihub-agent-linux-armv7` binary is now built and released for 32-bit ARM devices such as older Raspberry Pi models (Pi 2 B, Pi 1 B+). Includes cross-compilation Dockerfile, Cross.toml entry, updated build and setup scripts, and CI pipeline changes.
 - Update checker (Variant A — notify only): termiHub now checks the GitHub Releases API on startup (with a 5-second delay) and every 24 hours for new versions. When a newer release is found, an amber dot appears on the version chip in the status bar and a non-blocking notification popup offers to open the GitHub downloads page. Security releases (marked `<!-- security -->` in the release notes) show a red dot and cannot be silently skipped. Users can skip a specific version, clear a skipped version, or disable automatic checks entirely in **Settings → Updates**.
 - Connection settings: a **Shell Integration** toggle is now available for local shell, SSH, and WSL connections (enabled by default). Disabling it skips all OSC injection at startup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Agent: persisting (daemon-backed) sessions now survive agent reconnects — previously the agent killed daemon subprocesses on exit instead of detaching, causing recovered sessions to appear missing after disconnect/reconnect
+
 ### Changed
 
 - UI: Remote Agents now have their own collapsible "Remote Agents" section header in the connections sidebar, with a dedicated "+" button for adding new agents

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -199,6 +199,12 @@ impl<M: SessionManagerApi> Dispatcher<M> {
 
         self.initialized = true;
 
+        if !params.external_connection_files.is_empty() {
+            self.connection_store
+                .load_external_files(&params.external_connection_files)
+                .await;
+        }
+
         let docker_available = detect_docker_available();
         let connection_types = self.session_manager.registry().available_types();
 
@@ -2670,6 +2676,7 @@ mod tests {
                 folder_id: conn.folder_id,
                 terminal_options: conn.terminal_options,
                 icon: conn.icon,
+                source_file: None,
             };
             self.connections.lock().await.push(snap.clone());
             snap
@@ -2917,6 +2924,7 @@ mod tests {
             folder_id: None,
             terminal_options: None,
             icon: None,
+            source_file: None,
         });
 
         let mut d = make_mock_dispatcher_with_stores(

--- a/agent/src/protocol/methods.rs
+++ b/agent/src/protocol/methods.rs
@@ -494,10 +494,10 @@ mod tests {
     #[test]
     fn initialize_params_with_external_files() {
         let json = json!({
-            "protocol_version": "0.2.0",
+            "protocolVersion": "0.2.0",
             "client": "termihub-desktop",
-            "client_version": "1.0.0",
-            "external_connection_files": [
+            "clientVersion": "1.0.0",
+            "externalConnectionFiles": [
                 "/home/pi/team-connections.json",
                 "/opt/shared-connections.json"
             ]

--- a/agent/src/protocol/methods.rs
+++ b/agent/src/protocol/methods.rs
@@ -24,6 +24,9 @@ pub struct InitializeParams {
     pub protocol_version: String,
     pub client: String,
     pub client_version: String,
+    /// Paths on the remote host to load as read-only external connection files.
+    #[serde(default)]
+    pub external_connection_files: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -442,6 +445,30 @@ mod tests {
         let params: InitializeParams = serde_json::from_value(json).unwrap();
         assert_eq!(params.protocol_version, "0.1.0");
         assert_eq!(params.client, "termihub-desktop");
+        assert!(params.external_connection_files.is_empty());
+    }
+
+    #[test]
+    fn initialize_params_with_external_files() {
+        let json = json!({
+            "protocol_version": "0.2.0",
+            "client": "termihub-desktop",
+            "client_version": "1.0.0",
+            "external_connection_files": [
+                "/home/pi/team-connections.json",
+                "/opt/shared-connections.json"
+            ]
+        });
+        let params: InitializeParams = serde_json::from_value(json).unwrap();
+        assert_eq!(params.external_connection_files.len(), 2);
+        assert_eq!(
+            params.external_connection_files[0],
+            "/home/pi/team-connections.json"
+        );
+        assert_eq!(
+            params.external_connection_files[1],
+            "/opt/shared-connections.json"
+        );
     }
 
     #[test]

--- a/agent/src/session/definitions.rs
+++ b/agent/src/session/definitions.rs
@@ -283,7 +283,7 @@ impl ConnectionStore {
         let default_conn = Connection {
             id: format!("conn-{}", uuid::Uuid::new_v4()),
             name: "Default Shell".to_string(),
-            session_type: "shell".to_string(),
+            session_type: "local".to_string(),
             config: serde_json::json!({ "shell": shell }),
             persistent: false,
             folder_id: None,

--- a/agent/src/session/definitions.rs
+++ b/agent/src/session/definitions.rs
@@ -42,6 +42,10 @@ pub struct ConnectionSnapshot {
     pub terminal_options: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
+    /// Path of the external file this connection was loaded from.
+    /// `None` means the primary `connections.json` store.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_file: Option<String>,
 }
 
 impl Connection {
@@ -55,6 +59,7 @@ impl Connection {
             folder_id: self.folder_id.clone(),
             terminal_options: self.terminal_options.clone(),
             icon: self.icon.clone(),
+            source_file: None,
         }
     }
 }
@@ -141,6 +146,14 @@ pub trait ConnectionStoreApi: Send + Sync + 'static {
 
     /// Delete a folder by ID. Returns `true` if found and removed.
     async fn delete_folder(&self, id: &str) -> bool;
+
+    /// Load connections from external files on the remote host.
+    ///
+    /// External connections are read-only: they appear in `list()` results
+    /// tagged with their source path, but `create`/`update`/`delete` always
+    /// operate on the primary store. Calling this again replaces the previous
+    /// external set.
+    async fn load_external_files(&self, _paths: &[String]) {}
 }
 
 /// Persistent storage format for connections.json.
@@ -157,6 +170,8 @@ pub struct ConnectionStore {
     connections: Mutex<HashMap<String, Connection>>,
     folders: Mutex<HashMap<String, Folder>>,
     file_path: PathBuf,
+    /// Read-only connections loaded from external files, tagged with their source path.
+    external_snapshots: Mutex<Vec<ConnectionSnapshot>>,
 }
 
 impl ConnectionStore {
@@ -168,6 +183,7 @@ impl ConnectionStore {
             connections: Mutex::new(connections),
             folders: Mutex::new(folders),
             file_path,
+            external_snapshots: Mutex::new(Vec::new()),
         }
     }
 
@@ -178,6 +194,7 @@ impl ConnectionStore {
             connections: Mutex::new(HashMap::new()),
             folders: Mutex::new(HashMap::new()),
             file_path,
+            external_snapshots: Mutex::new(Vec::new()),
         }
     }
 
@@ -241,13 +258,52 @@ impl ConnectionStore {
         Some(snapshot)
     }
 
-    /// List all connections and folders.
+    /// List all connections and folders, including read-only external file connections.
     pub async fn list(&self) -> (Vec<ConnectionSnapshot>, Vec<FolderSnapshot>) {
         let conns = self.connections.lock().await;
         let folders = self.folders.lock().await;
-        let conn_list = conns.values().map(|c| c.snapshot()).collect();
+        let external = self.external_snapshots.lock().await;
+        let mut conn_list: Vec<ConnectionSnapshot> = conns.values().map(|c| c.snapshot()).collect();
+        conn_list.extend(external.iter().cloned());
         let folder_list = folders.values().map(|f| f.snapshot()).collect();
         (conn_list, folder_list)
+    }
+
+    /// Load connections from external files on the remote host.
+    ///
+    /// Replaces the current external connection set. Files that cannot be read
+    /// or parsed are skipped with a warning.
+    pub async fn load_external_files(&self, paths: &[String]) {
+        let mut external = self.external_snapshots.lock().await;
+        external.clear();
+        for path in paths {
+            match std::fs::read_to_string(path) {
+                Ok(contents) => match serde_json::from_str::<StorageFormat>(&contents) {
+                    Ok(storage) => {
+                        info!(
+                            "Loaded {} connections from external file {}",
+                            storage.connections.len(),
+                            path
+                        );
+                        for conn in storage.connections {
+                            external.push(ConnectionSnapshot {
+                                id: conn.id,
+                                name: conn.name,
+                                session_type: conn.session_type,
+                                config: conn.config,
+                                persistent: conn.persistent,
+                                folder_id: conn.folder_id,
+                                terminal_options: conn.terminal_options,
+                                icon: conn.icon,
+                                source_file: Some(path.clone()),
+                            });
+                        }
+                    }
+                    Err(e) => warn!("Failed to parse external connections from {}: {}", path, e),
+                },
+                Err(e) => warn!("Could not read external connection file {}: {}", path, e),
+            }
+        }
     }
 
     /// Delete a connection by ID. Returns `true` if found and deleted.
@@ -521,6 +577,10 @@ impl ConnectionStoreApi for ConnectionStore {
 
     async fn delete_folder(&self, id: &str) -> bool {
         ConnectionStore::delete_folder(self, id).await
+    }
+
+    async fn load_external_files(&self, paths: &[String]) {
+        ConnectionStore::load_external_files(self, paths).await
     }
 }
 
@@ -945,7 +1005,7 @@ mod tests {
         let (conns, _) = store.list().await;
         assert_eq!(conns.len(), 1);
         assert_eq!(conns[0].name, "Default Shell");
-        assert_eq!(conns[0].session_type, "shell");
+        assert_eq!(conns[0].session_type, "local");
         assert!(conns[0].id.starts_with("conn-"));
     }
 
@@ -1018,5 +1078,127 @@ mod tests {
         let folder: Folder = serde_json::from_str(json).unwrap();
         assert_eq!(folder.parent_id, None);
         assert!(!folder.is_expanded);
+    }
+
+    // ── External files ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn load_external_files_merges_connections_with_source_tag() {
+        let tmp = TempDir::new().unwrap();
+        let primary_path = tmp.path().join("connections.json");
+        let external_path = tmp.path().join("external.json");
+
+        let external_data = json!({
+            "connections": [
+                {
+                    "id": "ext-1",
+                    "name": "External Shell",
+                    "session_type": "local",
+                    "config": {},
+                    "persistent": false
+                }
+            ],
+            "folders": []
+        });
+        fs::write(
+            &external_path,
+            serde_json::to_string(&external_data).unwrap(),
+        )
+        .unwrap();
+
+        let store = ConnectionStore::new_temp(primary_path);
+        store
+            .create(make_connection("primary-1", "Primary Shell", false))
+            .await;
+
+        // Before loading, only primary connection is listed
+        let (conns, _) = store.list().await;
+        assert_eq!(conns.len(), 1);
+        assert_eq!(conns[0].source_file, None);
+
+        // Load external file
+        let ext_path_str = external_path.to_string_lossy().to_string();
+        store
+            .load_external_files(std::slice::from_ref(&ext_path_str))
+            .await;
+
+        let (conns, _) = store.list().await;
+        assert_eq!(conns.len(), 2);
+
+        let ext = conns.iter().find(|c| c.id == "ext-1").unwrap();
+        assert_eq!(ext.name, "External Shell");
+        assert_eq!(ext.source_file, Some(ext_path_str));
+
+        let primary = conns.iter().find(|c| c.id == "primary-1").unwrap();
+        assert_eq!(primary.source_file, None);
+    }
+
+    #[tokio::test]
+    async fn load_external_files_replaces_previous_set() {
+        let tmp = TempDir::new().unwrap();
+        let primary_path = tmp.path().join("connections.json");
+        let file_a = tmp.path().join("a.json");
+        let file_b = tmp.path().join("b.json");
+
+        let make_ext = |id: &str, name: &str| {
+            json!({
+                "connections": [{"id": id, "name": name, "session_type": "local", "config": {}, "persistent": false}],
+                "folders": []
+            })
+        };
+        fs::write(
+            &file_a,
+            serde_json::to_string(&make_ext("a-1", "A")).unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &file_b,
+            serde_json::to_string(&make_ext("b-1", "B")).unwrap(),
+        )
+        .unwrap();
+
+        let store = ConnectionStore::new_temp(primary_path);
+
+        store
+            .load_external_files(&[file_a.to_string_lossy().to_string()])
+            .await;
+        let (conns, _) = store.list().await;
+        assert_eq!(conns.len(), 1);
+        assert_eq!(conns[0].id, "a-1");
+
+        // Loading again replaces the previous external set
+        store
+            .load_external_files(&[file_b.to_string_lossy().to_string()])
+            .await;
+        let (conns, _) = store.list().await;
+        assert_eq!(conns.len(), 1);
+        assert_eq!(conns[0].id, "b-1");
+    }
+
+    #[tokio::test]
+    async fn load_external_files_skips_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let primary_path = tmp.path().join("connections.json");
+        let store = ConnectionStore::new_temp(primary_path);
+
+        store
+            .load_external_files(&["/nonexistent/path.json".to_string()])
+            .await;
+
+        let (conns, _) = store.list().await;
+        assert!(conns.is_empty());
+    }
+
+    #[tokio::test]
+    async fn primary_connections_have_no_source_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("connections.json");
+        let store = ConnectionStore::new_temp(path);
+        store
+            .create(make_connection("conn-1", "Shell", false))
+            .await;
+
+        let (conns, _) = store.list().await;
+        assert_eq!(conns[0].source_file, None);
     }
 }

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -390,10 +390,14 @@ impl SessionManager {
     }
 
     /// Close all sessions. Called during agent shutdown.
+    ///
+    /// Daemon-backed sessions are detached (not killed) so they survive
+    /// the agent process exit and can be recovered on the next run.
+    /// In-process sessions are disconnected normally.
     pub async fn close_all(&self) {
         let mut sessions = self.sessions.lock().await;
         for (_, mut info) in sessions.drain() {
-            close_backend(&mut info.backend).await;
+            shutdown_backend(&mut info.backend).await;
         }
     }
 
@@ -542,6 +546,33 @@ async fn close_backend(backend: &mut SessionBackend) {
         #[cfg(unix)]
         SessionBackend::Daemon(ref mut client) => {
             client.close().await;
+        }
+        SessionBackend::InProcess {
+            connection,
+            output_task,
+        } => {
+            if let Err(e) = connection.disconnect().await {
+                warn!("Disconnect error: {e}");
+            }
+            if let Some(task) = output_task.take() {
+                task.abort();
+            }
+        }
+        #[cfg(test)]
+        SessionBackend::Stub => {}
+    }
+}
+
+/// Shut down a backend during agent exit.
+///
+/// Daemon backends are detached (not killed) so the daemon process
+/// survives and can be recovered when the agent restarts. In-process
+/// backends are disconnected normally.
+async fn shutdown_backend(backend: &mut SessionBackend) {
+    match backend {
+        #[cfg(unix)]
+        SessionBackend::Daemon(ref mut client) => {
+            client.detach().await;
         }
         SessionBackend::InProcess {
             connection,
@@ -976,6 +1007,30 @@ mod tests {
             assert_eq!(list.len(), 1);
             assert_eq!(list[0].id, snapshot.id);
             assert_eq!(list[0].title, "my-ssh");
+        }
+
+        /// Regression: close_all() must drain the in-memory session list
+        /// even with the new shutdown_backend behaviour (detach daemons, don't kill).
+        #[tokio::test]
+        async fn close_all_drains_daemon_sessions() {
+            let (mgr, _) = make_manager_with_mock(MockDaemonLauncher::new());
+            mgr.create(
+                "ssh",
+                "session-a".to_string(),
+                serde_json::json!({
+                    "host": "example.com",
+                    "username": "user",
+                    "authMethod": "password",
+                }),
+            )
+            .await
+            .unwrap();
+            assert_eq!(mgr.list().await.len(), 1);
+            mgr.close_all().await;
+            assert!(
+                mgr.list().await.is_empty(),
+                "close_all() must remove sessions from the in-memory list"
+            );
         }
     }
 }

--- a/core/src/backends/local_shell.rs
+++ b/core/src/backends/local_shell.rs
@@ -260,7 +260,8 @@ impl ConnectionType for LocalShell {
             starting_directory,
             initial_command: _initial_command,
             ..ShellConfig::default()
-        };
+        }
+        .expand();
 
         let shell_cmd = build_shell_command(&config);
 

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -272,6 +272,22 @@ impl Default for TelnetConfig {
 
 // --- Expand methods ---
 
+impl ShellConfig {
+    /// Return a copy with all `${env:...}` placeholders and `~` expanded.
+    pub fn expand(mut self) -> Self {
+        self.shell = self
+            .shell
+            .map(|s| expand::expand_tilde(&expand::expand_env_placeholders(&s)));
+        self.starting_directory = self
+            .starting_directory
+            .map(|s| expand::expand_tilde(&expand::expand_env_placeholders(&s)));
+        self.initial_command = self
+            .initial_command
+            .map(|s| expand::expand_env_placeholders(&s));
+        self
+    }
+}
+
 impl WslConfig {
     /// Return a copy with all `${env:...}` placeholders and `~` expanded.
     pub fn expand(mut self) -> Self {

--- a/docs/concepts/remote-agent-update-strategy.md
+++ b/docs/concepts/remote-agent-update-strategy.md
@@ -1,0 +1,666 @@
+# Remote Agent Update Strategy
+
+---
+
+## Overview
+
+When a termiHub desktop connects to a remote host it deploys a `termihub-agent` binary and
+communicates with it over a JSON-RPC channel (see
+[Remote Protocol](../remote-protocol.md)). As the desktop application evolves, the agent
+binary needs to be kept in sync — but a remote agent may be **shared by multiple desktop
+instances** running different versions, and updating it can disrupt sessions that are still
+active.
+
+This concept designs a coordinated update strategy for remote agents. It covers:
+
+- How a host detects that an agent needs updating
+- Four update approaches, with trade-offs for each
+- A recommended phased adoption path
+- How the agent can self-check for updates via GitHub
+- UI surfaces for communicating update status and coordinating the update
+
+### Current Baseline
+
+The existing implementation already handles single-host updates:
+
+1. **Probe** — on connection, the desktop runs `termihub-agent --version` and compares
+   semver against `env!("CARGO_PKG_VERSION")` from `src-tauri/Cargo.toml`
+2. **Compatibility rule** — `agent.minor ≥ desktop.minor` (same major required); an agent
+   that is _ahead_ of the desktop is considered compatible
+3. **Update** — `update_agent()` sends `agent.shutdown` RPC, waits 500 ms, then
+   redeploys the binary via SFTP
+
+The gap: there is **no coordination** when multiple desktops are connected. If Host A
+updates the agent, Host B's active sessions are silently killed mid-use.
+
+### Goals
+
+- Prevent silent session termination when one host updates a shared agent
+- Allow agents on production servers to stay on a predictable upgrade schedule
+- Enable agent self-update (GitHub-sourced) as an optional background mechanism
+- Keep the update UX consistent and visible across all connected hosts
+
+### Non-Goals
+
+- Side-by-side versioned agents running on the same host (see trade-off analysis below)
+- Automatic rollback after a bad update
+- Windows or macOS agent targets (currently Linux-only)
+- Enterprise MDM / centralised fleet management
+
+---
+
+## UI Interface
+
+### Connection Panel — Agent Version Badge
+
+Each remote agent entry in the sidebar shows a version chip and update state:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Remote Agents                               [+]     │
+│  ─────────────────────────────────────────────────  │
+│  ● prod-server-1       v0.3.0  ✓ Up to date         │
+│  ● staging-server      v0.2.1  ↑ Update available   │
+│  ● dev-box             v0.1.0  ✗ Incompatible        │
+└─────────────────────────────────────────────────────┘
+```
+
+Badge colours:
+
+| State              | Colour | Icon |
+| ------------------ | ------ | ---- |
+| Up to date         | Grey   | ✓    |
+| Update available   | Amber  | ↑    |
+| Update required    | Red    | ✗    |
+| Update in progress | Blue   | ↻    |
+
+### Update Prompt Dialog
+
+When the user clicks "Update available" or triggers an update manually:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Update agent on prod-server-1                                [×]    │
+│  ─────────────────────────────────────────────────────────────────   │
+│  Installed:  v0.2.1                                                  │
+│  Available:  v0.3.0                                                  │
+│                                                                      │
+│  ⚠  2 other host(s) are currently connected to this agent:           │
+│     • staging-pc (connected 43 min ago)                              │
+│     • macbook-anne (connected 2 h ago)                               │
+│                                                                      │
+│  They will receive a disconnect notice and reconnect automatically.  │
+│                                                                      │
+│  [Cancel]                         [Notify Others & Update]           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+If no other hosts are connected, the warning section is omitted and "Update" is shown directly.
+
+### Incoming Update Notification (on other hosts)
+
+When Host A initiates a coordinated update, connected hosts see:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ℹ  Agent on prod-server-1 is being updated by another host   [×]   │
+│  ─────────────────────────────────────────────────────────────────   │
+│  Sessions will be paused briefly. Reconnecting automatically…        │
+│  ████████░░░░░░░░░░░░  Waiting for update…                          │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+After the agent restarts, the host reconnects silently and sessions resume.
+
+### Deferred Update Banner (Approach 4)
+
+When an update is pending but sessions are still active:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ↑  Agent update pending on prod-server-1 — applying on last disconnect
+│     [Apply Now]   [Dismiss]                                   [×]   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Self-Update Notification (Approach 1 — agent-initiated)
+
+The agent notifies all connected hosts that it has detected a newer version:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ↑  termihub-agent v0.3.0 is available on prod-server-1       [×]   │
+│  ─────────────────────────────────────────────────────────────────   │
+│  Installed: v0.2.1 · This host: v0.3.0                              │
+│                                                                      │
+│  [Update Agent]                                    [Remind Me Later] │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## General Handling
+
+### Version Compatibility Rule (recap)
+
+```
+Compatible   ↔  agent.major == desktop.major AND agent.minor >= desktop.minor
+AgentTooOld  ↔  agent.major == desktop.major AND agent.minor <  desktop.minor
+MajorMismatch↔  agent.major != desktop.major
+```
+
+Because the rule requires `agent.minor ≥ desktop.minor`, updating the agent to a newer
+version never breaks an older desktop — the backward-compat guarantee is one-directional
+(newer agent, older desktop is fine).
+
+### What "connected host" means
+
+A connected host is any desktop that holds an active JSON-RPC channel to the agent. The
+agent can determine this from its internal session table. The `initialize` handshake already
+carries `client` and `client_version` fields; the agent can maintain a live registry of
+connected clients.
+
+### Update Source
+
+Agent binaries are published to GitHub Releases as part of the existing CI workflow (see
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml)):
+
+- `termihub-agent-linux-x64`
+- `termihub-agent-linux-arm64`
+- `termihub-agent-linux-armv7`
+
+The GitHub Releases API endpoint used:
+
+```
+GET https://api.github.com/repos/armaxri/termiHub/releases/latest
+```
+
+Binary download URL pattern:
+
+```
+https://github.com/armaxri/termiHub/releases/download/v{version}/termihub-agent-{arch}
+```
+
+### Desktop-side binary resolution (existing)
+
+The desktop resolves the agent binary via a three-step chain
+(`src-tauri/src/terminal/agent_binary.rs`):
+
+1. Local cache: `~/.cache/termihub/agent-binaries/<version>/termihub-agent-<arch>`
+2. Bundled resource in the Tauri app bundle
+3. Download from GitHub Releases (cached after first download)
+
+---
+
+## Approach Comparison
+
+### Approach 1 — Agent Self-Update (GitHub Polling)
+
+The agent periodically queries the GitHub Releases API for a newer binary, downloads it,
+and replaces itself when no sessions are active.
+
+```
+agent (running) → poll github/releases every N hours
+  → newer version found → wait for zero active sessions
+  → download new binary → exec-replace self
+  → daemon process survives → sessions reconnect
+```
+
+**Pros:**
+
+- No host intervention needed; useful when no host is actively connected
+- Works on a predictable schedule regardless of desktop availability
+
+**Cons:**
+
+- Agent needs outbound internet access (unavailable in air-gapped or strict firewall envs)
+- Which version to target is ambiguous: "latest" may be newer than any connected desktop
+- Security: downloading and exec-replacing a binary requires integrity verification
+- Self-updates do not prevent a host from also triggering an update simultaneously
+
+**Verdict:** useful as a background hygiene option (off by default), but unsuitable as the
+primary update path. Best paired with Approach 3 or 4 where the host remains in control.
+
+---
+
+### Approach 2 — Host-Triggered with Connected-Host Guard (Minimal Enhancement)
+
+Before updating, the host queries a new RPC method to learn which other clients are
+currently connected. If others are present, the user is warned. The update still performs a
+hard shutdown.
+
+```
+host → version mismatch detected on probe → offer Update button
+  → call agent.list_connections
+  → 0 other hosts: update immediately (existing flow)
+  → N other hosts: warn user → user confirms → update (others are kicked)
+```
+
+**New RPC method:** `agent.list_connections`
+
+Response:
+
+```json
+{
+  "connections": [
+    { "client": "termihub-desktop", "client_version": "0.3.0", "connected_since": "..." },
+    { "client": "termihub-desktop", "client_version": "0.2.1", "connected_since": "..." }
+  ]
+}
+```
+
+**Pros:**
+
+- Minimal protocol change (one new read-only RPC method + guard in the existing update flow)
+- User retains full control; no automatic behaviour change
+- Prevents the silent session kill problem
+
+**Cons:**
+
+- Other hosts still lose their sessions (hard cutover); no graceful handoff
+- Requires the agent to track connected client identities
+
+**Verdict:** low effort, high value — this should be the **minimum viable improvement**
+shipped as Phase 1.
+
+---
+
+### Approach 3 — Coordinated Update via Broadcast Notification
+
+The updating host asks the agent to broadcast an `agent.update_pending` notification to
+all connected clients. Each client shows a notice, cleanly disconnects, and queues a
+reconnect. After all clients acknowledge or a timeout elapses, the update proceeds.
+
+```
+Host A → agent.request_update (new RPC method)
+  → agent broadcasts agent.update_pending notification to all clients
+  → Host B, C: show "update in progress" notice, disconnect cleanly
+  → host ack timeout: 10 s
+  → agent shuts down → Host A redeploys new binary
+  → all hosts reconnect automatically to new version
+```
+
+**New RPC methods / notifications:**
+
+- `agent.request_update` (request, from updating host) — triggers the broadcast
+- `agent.update_pending` (notification, from agent to all clients) — carries estimated
+  restart time and updating-host info
+
+**Pros:**
+
+- Clean UX for all parties; no surprise session termination
+- Reconnect is automatic; users see a brief pause at most
+- Consistent with the existing Tauri event system on the frontend
+
+**Cons:**
+
+- Requires protocol additions on both agent and all desktop versions
+- Timeout and failure paths must be handled (what if Host B never acks?)
+- Older desktop versions that don't understand the new notification will still be cut off
+
+**Verdict:** best end-user experience for the multi-host scenario; reasonable effort.
+Recommended as **Phase 2**.
+
+---
+
+### Approach 4 — Deferred Update (Apply on Last Disconnect)
+
+The agent accepts "an update is available" as a signal but does not apply it until the
+last session closes naturally. On reaching zero active sessions, the daemon applies the
+pending update.
+
+```
+Host A requests update → agent marks pending_update_path = /tmp/termihub-agent-new
+  → active sessions continue unaffected
+  → last session closes (naturally or by user)
+  → daemon: exec new binary; daemon itself survives (existing detach model)
+  → next host that connects gets the new version
+```
+
+The existing daemon architecture (`--daemon` mode, detach-on-shutdown behaviour introduced
+in commit `7c52017`) already handles the process restart with session persistence, making
+this a natural extension.
+
+**Pros:**
+
+- Zero forced disconnects under any circumstances
+- No broadcast protocol required
+- Aligns perfectly with the existing daemon session-persistence model
+- Useful for production servers with long-running sessions (days/weeks)
+
+**Cons:**
+
+- Update may be delayed indefinitely if sessions are persistent
+- No guarantee of _when_ the update actually applies (may be surprising)
+- Requires "pending update" state in the agent's state persistence (`state.json`)
+
+**Verdict:** best fit for production servers; elegant given the daemon model. Recommended
+as a **Phase 3 option** alongside or instead of Approach 3.
+
+---
+
+### Approach 5 — Side-by-Side Versioned Agents (Rejected)
+
+Run multiple agent versions simultaneously on different ports or sockets; each desktop
+connects to its compatible version; the daemon retires old versions when they have no
+clients.
+
+**Verdict:** over-engineered for this use case. The backward-compat semver rule already
+means a newer agent serves older desktops correctly. The complexity of port/socket
+management and version discovery outweighs any benefit. **Not recommended.**
+
+---
+
+## Approach Comparison Table
+
+| Aspect                       | 1: Self-Update       | 2: Guard + Warn  | 3: Broadcast + Ack | 4: Deferred           |
+| ---------------------------- | -------------------- | ---------------- | ------------------ | --------------------- |
+| **Session disruption**       | Low (waits for idle) | Hard cutover     | Graceful notice    | None                  |
+| **Host coordination**        | None (agent-driven)  | Host-driven      | Multi-host aware   | Multi-host aware      |
+| **Internet access required** | Yes (agent → GH)     | No               | No                 | No                    |
+| **Protocol changes**         | None                 | 1 new RPC method | 2 new RPC methods  | 1 new RPC method      |
+| **Daemon integration**       | Required             | Not needed       | Not needed         | Required              |
+| **Predictability**           | Schedule-based       | User-triggered   | User-triggered     | Session-driven        |
+| **Best for**                 | Unattended servers   | All environments | Multi-user agents  | Long-running sessions |
+| **Recommended phase**        | Optional add-on      | Phase 1          | Phase 2            | Phase 3               |
+| **Implementation effort**    | Medium               | Low              | Medium             | Medium                |
+
+---
+
+## States & Sequences
+
+### Agent Version State Machine (per connection)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Probing : Host connects via SSH
+
+    Probing --> Compatible : agent.minor >= desktop.minor\n(same major)
+    Probing --> AgentTooOld : agent.minor < desktop.minor
+    Probing --> MajorMismatch : agent.major != desktop.major
+    Probing --> NotInstalled : binary not found
+
+    Compatible --> Connected : Initialize handshake OK
+    AgentTooOld --> UpdateOffered : Show update badge in sidebar
+    MajorMismatch --> BlockedReinstall : Show error;\nrequire manual redeploy
+    NotInstalled --> DeployOffered : Show deploy button
+
+    UpdateOffered --> Updating : User confirms update
+    DeployOffered --> Updating : User deploys
+
+    Updating --> Connected : Deploy succeeds;\nre-probe passes
+    Updating --> UpdateFailed : Deploy fails
+
+    UpdateFailed --> UpdateOffered : Show error;\nretry available
+
+    Connected --> Disconnected : Session ends / network drop
+    Disconnected --> Probing : User reconnects
+```
+
+### Approach 2: Host-Triggered Update with Guard
+
+```mermaid
+sequenceDiagram
+    participant HA as Host A (desktop)
+    participant Agent as termihub-agent
+    participant HB as Host B (desktop)
+
+    HA->>Agent: probe → version mismatch detected
+    HA->>Agent: agent.list_connections
+    Agent-->>HA: [{ client: "Host B", version: "0.2.1" }]
+
+    Note over HA: Show warning dialog\n"1 other host connected"
+
+    HA->>Agent: update_agent (shutdown RPC)
+    Agent-->>HB: connection dropped (no notice)
+    Note over HB: Session lost — user surprised
+
+    HA->>HA: redeploy new binary via SFTP
+    HA->>Agent: reconnect to new version
+    Note over HB: User manually reconnects
+```
+
+### Approach 3: Coordinated Broadcast Update
+
+```mermaid
+sequenceDiagram
+    participant HA as Host A (desktop)
+    participant Agent as termihub-agent
+    participant HB as Host B (desktop)
+    participant HC as Host C (desktop)
+
+    HA->>Agent: agent.request_update
+    Agent-->>HB: notification: agent.update_pending\n{ estimated_restart: "10s", requested_by: "Host A" }
+    Agent-->>HC: notification: agent.update_pending
+
+    Note over HB: Show "agent updating" notice;\nqueue reconnect
+    Note over HC: Show "agent updating" notice;\nqueue reconnect
+
+    HB-->>Agent: clean disconnect
+    HC-->>Agent: clean disconnect
+
+    Note over Agent: All clients disconnected\n(or 10s timeout elapsed)
+
+    HA->>Agent: agent.shutdown (graceful)
+    HA->>HA: redeploy new binary via SFTP
+
+    HB->>Agent: auto-reconnect (new version)
+    HC->>Agent: auto-reconnect (new version)
+    HA->>Agent: reconnect (updating host)
+
+    Note over HA,HC: All hosts on new version;\nsessions resume
+```
+
+### Approach 4: Deferred Update via Daemon
+
+```mermaid
+sequenceDiagram
+    participant HA as Host A (desktop)
+    participant Daemon as daemon process
+    participant Agent as agent worker
+    participant HB as Host B (desktop)
+
+    HA->>Agent: agent.request_deferred_update\n{ binary_path: "/tmp/termihub-agent-new" }
+    Agent-->>HA: { status: "pending", active_sessions: 2 }
+    Note over Agent: pending_update_path = /tmp/termihub-agent-new
+
+    Note over HB,Agent: Sessions continue unaffected
+
+    HB->>Agent: session ends naturally
+    Note over Agent: 1 active session remaining
+
+    HA->>Agent: final session ends
+    Note over Agent: 0 active sessions\npending_update_path set
+
+    Agent->>Daemon: notify: applying pending update
+    Daemon->>Agent: exec new binary (daemon survives)
+
+    Note over Daemon: New agent version starts\nunder same daemon
+
+    HA->>Agent: reconnect → new version v0.3.0
+    HB->>Agent: reconnect → new version v0.3.0
+```
+
+### Agent Self-Update Flow (Approach 1 — optional)
+
+```mermaid
+flowchart TD
+    A[Agent periodic timer fires\nevery 24 hours] --> B[GET github.com/releases/latest]
+    B --> C{API success?}
+    C -->|No| D[Log warning;\nretry next cycle]
+    C -->|Yes| E{latest > installed?}
+    E -->|No| F[No action;\nupdate last_check_time]
+    E -->|Yes| G{active sessions > 0?}
+    G -->|Yes| H[Notify connected hosts:\nagent.update_available]
+    H --> I[Wait for sessions to drain\nor host to trigger update]
+    G -->|No| J[Download new binary\nfrom GitHub Releases]
+    I --> G
+    J --> K{Download + verify\nintegrity OK?}
+    K -->|No| L[Log error;\nretry next cycle]
+    K -->|Yes| M[Write to pending path\nin state.json]
+    M --> N[Exec-replace self\nvia daemon restart]
+```
+
+---
+
+## Preliminary Implementation Details
+
+### Phase 1 — Approach 2: Connected-Host Guard
+
+**Agent side** (`agent/src/`):
+
+New RPC method `agent.list_connections` added to `handler/dispatch.rs`:
+
+```rust
+pub async fn list_connections(state: Arc<AppState>) -> Result<ListConnectionsResult, AgentError> {
+    let clients = state.connection_registry.list().await;
+    Ok(ListConnectionsResult { connections: clients })
+}
+```
+
+`SessionRegistry` (or a new `ConnectionRegistry`) tracks each connected client's metadata
+received during `initialize`:
+
+```rust
+pub struct ConnectedClient {
+    pub client_id: String,
+    pub client: String,          // "termihub-desktop"
+    pub client_version: String,
+    pub connected_since: DateTime<Utc>,
+}
+```
+
+**Desktop side** (`src-tauri/src/terminal/agent_deploy.rs`):
+
+`update_agent()` gains a pre-check step:
+
+```rust
+let connections = agent_rpc.list_connections(&agent_id).await?;
+if !connections.is_empty() {
+    // Return connections list to caller; UI shows the warning dialog
+    return Ok(AgentDeployResult::OtherHostsConnected(connections));
+}
+// proceed with existing update logic
+```
+
+New Tauri command variant `update_agent_force` bypasses the guard after user confirms.
+
+**Frontend** (`src/components/`):
+
+- Update `RemoteAgentsSidebar` (or equivalent) to show version badge per agent
+- Add `UpdateAgentDialog.tsx` that renders the connected-hosts warning
+- Wire `agent.list_connections` result into the dialog state before showing
+
+---
+
+### Phase 2 — Approach 3: Broadcast Notification
+
+**New protocol messages** (`agent/src/protocol/methods.rs`):
+
+```rust
+pub const AGENT_REQUEST_UPDATE: &str = "agent.request_update";
+pub const AGENT_UPDATE_PENDING: &str = "agent.update_pending";  // notification
+```
+
+`agent.update_pending` notification payload:
+
+```rust
+#[derive(Serialize)]
+pub struct UpdatePendingNotification {
+    pub requested_by_version: String,
+    pub estimated_restart_secs: u32,
+}
+```
+
+**Agent handler** (`agent/src/handler/dispatch.rs`):
+
+On receiving `agent.request_update`:
+
+1. Collect all active client channels from `ConnectionRegistry`
+2. Send `agent.update_pending` notification to every channel except the requester
+3. Start a 10-second timeout
+4. On timeout or all non-requester clients disconnected: signal the requester to proceed
+
+**Desktop side** — new Tauri event `remote-agent-update-pending` forwarded from the
+agent notification to the frontend via the existing event bridge.
+
+**Frontend** — `UpdatePendingToast.tsx` shown on receiving `remote-agent-update-pending`;
+triggers graceful session suspension and queues reconnect after 15 seconds.
+
+---
+
+### Phase 3 — Approach 4: Deferred Update via Daemon
+
+The agent's `state.json` persistence (`agent/src/state/`) gains:
+
+```json
+{
+  "pending_update": {
+    "binary_path": "/tmp/termihub-agent-0.3.0",
+    "requested_by": "Host A",
+    "requested_at": "2026-04-19T10:00:00Z"
+  }
+}
+```
+
+New RPC method `agent.request_deferred_update`:
+
+1. Downloads (or accepts) new binary path
+2. Persists `pending_update` to state
+3. Registers a zero-session callback in `SessionManager`
+
+Zero-session callback in `SessionManager`:
+
+```rust
+if self.active_sessions() == 0 {
+    if let Some(update) = self.state.pending_update.take() {
+        self.state.save().await?;
+        daemon.exec_replace(&update.binary_path).await?;
+    }
+}
+```
+
+Daemon exec-replace uses the existing detach mechanism (commit `7c52017`) to survive the
+agent worker process restart.
+
+---
+
+### Approach 1 Add-on: Agent Self-Update (optional)
+
+Enabled via `agent.enable_self_update: true` in the agent's config or as a flag passed
+during `initialize`. When enabled:
+
+- Agent runs a 24-hour timer
+- Queries `https://api.github.com/repos/armaxri/termiHub/releases/latest`
+- Compares `tag_name` semver against `env!("CARGO_PKG_VERSION")`
+- If newer: notifies connected hosts via `agent.update_available` notification (new)
+- If no hosts connected and Approach 4 is also enabled: auto-downloads and defers update
+
+Binary integrity verification: SHA-256 checksum published as a release asset
+(`termihub-agent-linux-x64.sha256`) and verified before exec-replace.
+
+---
+
+### Config / State Schema
+
+Agent `state.json` additions:
+
+```json
+{
+  "update": {
+    "self_update_enabled": false,
+    "last_check_time": null,
+    "pending_update": null
+  }
+}
+```
+
+Desktop connection config (`RemoteAgentConfig`) additions:
+
+```rust
+pub struct RemoteAgentConfig {
+    // ... existing fields ...
+    pub allow_self_update: bool,       // Phase 1 add-on
+    pub update_strategy: UpdateStrategy, // "immediate" | "coordinated" | "deferred"
+}
+```

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -3,9 +3,9 @@
 # Uses cross-rs for all targets. Multiple targets are built in parallel by default,
 # each in its own CARGO_TARGET_DIR to avoid cargo's workspace build lock.
 #
-# Usage: ./scripts/build-agents.sh [--targets <list>] [--sequential] [--help]
+# Usage: ./scripts/build-agents.sh [--targets <list>] [--sequential] [--native] [--dev] [--help]
 #
-# Run ./scripts/setup-agent-cross.sh first to install required toolchains.
+# Run ./scripts/setup-agent-cross.sh first to install required toolchains (not needed for --native).
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -18,6 +18,8 @@ ALL_TARGETS=(
 )
 SELECTED_TARGETS=()
 SEQUENTIAL=false
+NATIVE=false
+DEV=false
 
 # --- Argument parsing ---
 while [[ $# -gt 0 ]]; do
@@ -31,6 +33,14 @@ while [[ $# -gt 0 ]]; do
             SEQUENTIAL=true
             shift
             ;;
+        --native)
+            NATIVE=true
+            shift
+            ;;
+        --dev)
+            DEV=true
+            shift
+            ;;
         --help|-h)
             cat <<'USAGE'
 Usage: build-agents.sh [OPTIONS]
@@ -39,11 +49,16 @@ Cross-compile the remote agent for Linux targets (static musl binaries).
 Multiple targets are built in parallel by default.
 
 Options:
-  --targets <list>   Comma-separated list of targets to build (default: all)
+  --targets <list>   Comma-separated list of targets to build (default: all, or host for --native)
   --sequential       Build targets one at a time (useful for debugging)
+  --native           Build using the local cargo toolchain instead of cross-rs/Docker.
+                     Defaults to the host target triple. Faster for local development on
+                     the target machine; no container runtime required.
+  --dev              Build in debug profile (omits --release). Much faster to compile;
+                     binary lands in target/<triple>/debug/ instead of release/.
   --help, -h         Show this help message
 
-Targets:
+Targets (cross-rs mode only):
   x86_64-unknown-linux-musl       Static x64 binaries (musl)
   aarch64-unknown-linux-musl      Static ARM64 binaries (musl)
   armv7-unknown-linux-musleabihf  Static ARMv7 binaries (musl, older Raspberry Pi)
@@ -52,6 +67,8 @@ Examples:
   ./scripts/build-agents.sh
   ./scripts/build-agents.sh --targets aarch64-unknown-linux-musl
   ./scripts/build-agents.sh --sequential
+  ./scripts/build-agents.sh --native --dev
+  ./scripts/build-agents.sh --native --targets aarch64-unknown-linux-gnu
 USAGE
             exit 0
             ;;
@@ -64,22 +81,44 @@ USAGE
 done
 
 if [ ${#SELECTED_TARGETS[@]} -eq 0 ]; then
-    SELECTED_TARGETS=("${ALL_TARGETS[@]}")
+    if [ "$NATIVE" = true ]; then
+        host_triple=$(rustc -vV 2>/dev/null | awk '/^host:/{print $2}')
+        if [ -z "$host_triple" ]; then
+            echo "ERROR: Could not determine host target triple from rustc."
+            exit 1
+        fi
+        SELECTED_TARGETS=("$host_triple")
+    else
+        SELECTED_TARGETS=("${ALL_TARGETS[@]}")
+    fi
 fi
 
-# --- Detect cross-rs ---
-if ! command -v cross >/dev/null 2>&1; then
-    echo "ERROR: cross-rs not found. Run ./scripts/setup-agent-cross.sh first."
-    exit 1
+# --- Profile setup ---
+if [ "$DEV" = true ]; then
+    PROFILE_FLAG=""
+    PROFILE_DIR="debug"
+else
+    PROFILE_FLAG="--release"
+    PROFILE_DIR="release"
 fi
 
-# --- Container engine detection ---
+# --- Detect cross-rs (skipped for --native) ---
+if [ "$NATIVE" = false ]; then
+    if ! command -v cross >/dev/null 2>&1; then
+        echo "ERROR: cross-rs not found. Run ./scripts/setup-agent-cross.sh first."
+        exit 1
+    fi
+fi
+
+# --- Container engine detection (skipped for --native) ---
 # Auto-detect which engine to use, preferring the one that already has the
 # required cross-compilation images.  If Podman is selected, disable cross-rs
 # rootless handling — without CROSS_ROOTLESS_CONTAINER_ENGINE=false, cross-rs
 # adds --user UID:GID to the `podman run` command which makes the injected
 # cargo/rustc toolchain non-executable inside the container ("Permission denied").
-if [ "${CROSS_CONTAINER_ENGINE:-}" = "podman" ]; then
+if [ "$NATIVE" = true ]; then
+    : # No container engine needed
+elif [ "${CROSS_CONTAINER_ENGINE:-}" = "podman" ]; then
     # Explicit override: use Podman
     export CROSS_ROOTLESS_CONTAINER_ENGINE=false
 elif [ -z "${CROSS_CONTAINER_ENGINE:-}" ]; then
@@ -114,32 +153,34 @@ elif [ -z "${CROSS_CONTAINER_ENGINE:-}" ]; then
     # else: only Docker is running — use it (default, no override needed)
 fi
 
-# --- Pre-flight: verify required images exist in the selected engine ---
-_container_cmd="${CROSS_CONTAINER_ENGINE:-docker}"
-_missing_images=()
-for _t in "${SELECTED_TARGETS[@]}"; do
-    if ! "$_container_cmd" image inspect "localhost/termihub-cross:$_t" >/dev/null 2>&1; then
-        _missing_images+=("localhost/termihub-cross:$_t")
-    fi
-done
-if [ "${#_missing_images[@]}" -gt 0 ]; then
-    echo "ERROR: The following cross-compilation image(s) are missing from $_container_cmd:"
-    for _img in "${_missing_images[@]}"; do
-        echo "  $_img"
+# --- Pre-flight: verify required images exist in the selected engine (skipped for --native) ---
+if [ "$NATIVE" = false ]; then
+    _container_cmd="${CROSS_CONTAINER_ENGINE:-docker}"
+    _missing_images=()
+    for _t in "${SELECTED_TARGETS[@]}"; do
+        if ! "$_container_cmd" image inspect "localhost/termihub-cross:$_t" >/dev/null 2>&1; then
+            _missing_images+=("localhost/termihub-cross:$_t")
+        fi
     done
-    echo ""
-    echo "Run ./scripts/setup-agent-cross.sh to build the required images, then retry."
-    exit 1
-fi
-unset _container_cmd _missing_images _t _img
-
-# --- Ensure Rust targets are installed (before any parallel work starts) ---
-for target in "${SELECTED_TARGETS[@]}"; do
-    if ! rustup target list --installed | grep -q "^${target}$"; then
-        echo "  Adding Rust target $target..."
-        rustup target add "$target"
+    if [ "${#_missing_images[@]}" -gt 0 ]; then
+        echo "ERROR: The following cross-compilation image(s) are missing from $_container_cmd:"
+        for _img in "${_missing_images[@]}"; do
+            echo "  $_img"
+        done
+        echo ""
+        echo "Run ./scripts/setup-agent-cross.sh to build the required images, then retry."
+        exit 1
     fi
-done
+    unset _container_cmd _missing_images _t _img
+
+    # --- Ensure Rust targets are installed (before any parallel work starts) ---
+    for target in "${SELECTED_TARGETS[@]}"; do
+        if ! rustup target list --installed | grep -q "^${target}$"; then
+            echo "  Adding Rust target $target..."
+            rustup target add "$target"
+        fi
+    done
+fi
 
 # --- Build ---
 built=0
@@ -155,15 +196,24 @@ if [ "$SEQUENTIAL" = true ] || [ "${#SELECTED_TARGETS[@]}" -le 1 ]; then
 
     for target in "${SELECTED_TARGETS[@]}"; do
         echo "--- $target ---"
-        echo "  Building with cross-rs..."
 
         build_exit=0
-        CROSS_CONFIG=agent/Cross.toml cross build --release --target "$target" -p termihub-agent 2>&1 \
-            | { grep -v "<jemalloc>:" || true; } \
-            || build_exit=$?
+        if [ "$NATIVE" = true ]; then
+            echo "  Building with cargo (native)..."
+            # shellcheck disable=SC2086
+            cargo build $PROFILE_FLAG --target "$target" -p termihub-agent 2>&1 \
+                | { grep -v "<jemalloc>:" || true; } \
+                || build_exit=$?
+        else
+            echo "  Building with cross-rs..."
+            # shellcheck disable=SC2086
+            CROSS_CONFIG=agent/Cross.toml cross build $PROFILE_FLAG --target "$target" -p termihub-agent 2>&1 \
+                | { grep -v "<jemalloc>:" || true; } \
+                || build_exit=$?
+        fi
 
         if [ "$build_exit" -eq 0 ]; then
-            binary="target/$target/release/termihub-agent"
+            binary="target/$target/$PROFILE_DIR/termihub-agent"
             if [ -f "$binary" ]; then
                 size=$(du -h "$binary" | cut -f1)
                 results+=("  OK    $target  ($size)")
@@ -211,11 +261,18 @@ else
         # it switches to full block buffering, silencing output until the buffer
         # fills. awk with fflush() flushes after every line regardless of whether
         # stdout is a terminal or a pipe, keeping output immediate.
-        # The subshell inherits pipefail so cross's exit code propagates through
-        # the awk stage to the background job's exit status.
+        # The subshell inherits pipefail so cross's/cargo's exit code propagates
+        # through the awk stage to the background job's exit status.
         {
-            CARGO_TARGET_DIR="$cross_dir" CROSS_CONFIG=agent/Cross.toml \
-                cross build --release --target "$target" -p termihub-agent 2>&1 \
+            if [ "$NATIVE" = true ]; then
+                # shellcheck disable=SC2086
+                CARGO_TARGET_DIR="$cross_dir" \
+                    cargo build $PROFILE_FLAG --target "$target" -p termihub-agent 2>&1
+            else
+                # shellcheck disable=SC2086
+                CARGO_TARGET_DIR="$cross_dir" CROSS_CONFIG=agent/Cross.toml \
+                    cross build $PROFILE_FLAG --target "$target" -p termihub-agent 2>&1
+            fi \
                 | awk -v prefix="[$target] " '
                     {
                         # \r in the stream is cargo'\''s in-place progress marker.
@@ -265,8 +322,8 @@ else
 
         if [ "${_exit_codes[$i]}" -eq 0 ]; then
             cross_dir="${_cross_dirs[$i]}"
-            src_binary="$cross_dir/$target/release/termihub-agent"
-            dst_dir="target/$target/release"
+            src_binary="$cross_dir/$target/$PROFILE_DIR/termihub-agent"
+            dst_dir="target/$target/$PROFILE_DIR"
             dst_binary="$dst_dir/termihub-agent"
 
             if [ -f "$src_binary" ]; then

--- a/src-tauri/src/connection/config.rs
+++ b/src-tauri/src/connection/config.rs
@@ -307,6 +307,7 @@ mod tests {
                 key_path: Some("~/.ssh/id_ed25519".to_string()),
                 save_password: None,
                 agent_path: None,
+                external_connection_files: vec![],
             },
         };
         let json = serde_json::to_string(&agent).unwrap();

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -1097,6 +1097,7 @@ mod tests {
                 key_path: None,
                 save_password,
                 agent_path: None,
+                external_connection_files: vec![],
             },
         }
     }

--- a/src-tauri/src/session/remote_proxy.rs
+++ b/src-tauri/src/session/remote_proxy.rs
@@ -653,6 +653,7 @@ mod tests {
                 folder_id: None,
                 terminal_options: None,
                 icon: None,
+                source_file: None,
             })
         }
 
@@ -670,6 +671,7 @@ mod tests {
                 folder_id: None,
                 terminal_options: None,
                 icon: None,
+                source_file: None,
             })
         }
 

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -80,6 +80,9 @@ pub struct AgentDefinitionInfo {
     pub terminal_options: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
+    /// Source file path on the remote host, or `None` for the primary store.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_file: Option<String>,
 }
 
 /// Info about a folder on the agent.
@@ -116,6 +119,7 @@ fn parse_agent_definition(v: &Value) -> Option<AgentDefinitionInfo> {
             }
         }),
         icon: v["icon"].as_str().map(|s| s.to_string()),
+        source_file: v["source_file"].as_str().map(|s| s.to_string()),
     })
 }
 
@@ -388,6 +392,13 @@ impl AgentConnectionManager {
         })?;
 
         // 3. Blocking handshake: initialize
+        let enabled_external_files: Vec<&str> = config
+            .external_connection_files
+            .iter()
+            .filter(|f| f.enabled)
+            .map(|f| f.path.as_str())
+            .collect();
+
         let mut request_id: u64 = 0;
         request_id += 1;
         jsonrpc::write_request(
@@ -397,7 +408,8 @@ impl AgentConnectionManager {
             serde_json::json!({
                 "protocol_version": "0.2.0",
                 "client": "termihub-desktop",
-                "client_version": "0.1.0"
+                "client_version": "0.1.0",
+                "external_connection_files": enabled_external_files
             }),
         )
         .map_err(|e| {
@@ -1584,6 +1596,67 @@ mod tests {
         assert!(parse_agent_definition(&wire).is_none());
     }
 
+    /// parse_agent_definition reads the source_file field for external connections.
+    #[test]
+    fn parse_definition_with_source_file() {
+        let wire = json!({
+            "id": "ext-1",
+            "name": "Team Shell",
+            "session_type": "local",
+            "source_file": "/home/pi/team-connections.json"
+        });
+        let def = parse_agent_definition(&wire).unwrap();
+        assert_eq!(
+            def.source_file,
+            Some("/home/pi/team-connections.json".to_string())
+        );
+    }
+
+    /// Primary connections have no source_file.
+    #[test]
+    fn parse_definition_without_source_file() {
+        let wire = json!({"id": "conn-1", "name": "Shell", "session_type": "local"});
+        let def = parse_agent_definition(&wire).unwrap();
+        assert_eq!(def.source_file, None);
+    }
+
+    /// source_file is omitted from JSON when None.
+    #[test]
+    fn definition_info_source_file_omitted_when_none() {
+        let def = AgentDefinitionInfo {
+            id: "conn-1".to_string(),
+            name: "Test".to_string(),
+            session_type: "shell".to_string(),
+            config: json!({}),
+            persistent: false,
+            folder_id: None,
+            terminal_options: None,
+            icon: None,
+            source_file: None,
+        };
+        let v = serde_json::to_value(&def).unwrap();
+        assert!(v.get("sourceFile").is_none());
+    }
+
+    /// source_file is camelCase in JSON when present.
+    #[test]
+    fn definition_info_source_file_camel_case() {
+        let def = AgentDefinitionInfo {
+            id: "ext-1".to_string(),
+            name: "External".to_string(),
+            session_type: "local".to_string(),
+            config: json!({}),
+            persistent: false,
+            folder_id: None,
+            terminal_options: None,
+            icon: None,
+            source_file: Some("/home/pi/team.json".to_string()),
+        };
+        let v = serde_json::to_value(&def).unwrap();
+        assert_eq!(v["sourceFile"], "/home/pi/team.json");
+        assert!(v.get("source_file").is_none());
+    }
+
     /// Regression: parse_agent_folder reads snake_case fields from agent wire format.
     #[test]
     fn parse_folder_from_snake_case_wire_format() {
@@ -1621,6 +1694,7 @@ mod tests {
             folder_id: Some("folder-1".to_string()),
             terminal_options: None,
             icon: None,
+            source_file: None,
         };
         let v = serde_json::to_value(&def).unwrap();
         assert_eq!(v["sessionType"], "shell");
@@ -1660,6 +1734,7 @@ mod tests {
                 folder_id: None,
                 terminal_options: None,
                 icon: None,
+                source_file: None,
             }],
             folders: vec![AgentFolderInfo {
                 id: "folder-1".to_string(),

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -207,11 +207,16 @@ impl AgentConnectionManager {
             .lock()
             .map_err(|e| TerminalError::RemoteError(format!("Lock failed: {}", e)))?;
 
-        if agents.contains_key(agent_id) {
-            return Err(TerminalError::RemoteError(format!(
-                "Agent {} is already connected",
-                agent_id
-            )));
+        // Evict a dead entry left behind when the I/O thread exits without
+        // removing itself (e.g. reconnection failed after a dropped connection).
+        if let Some(existing) = agents.get(agent_id) {
+            if existing.alive.load(Ordering::SeqCst) {
+                return Err(TerminalError::RemoteError(format!(
+                    "Agent {} is already connected",
+                    agent_id
+                )));
+            }
+            agents.remove(agent_id);
         }
 
         // Emit connecting state

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -28,6 +28,7 @@ pub struct RemoteAgentConfig {
     pub host: String,
     pub port: u16,
     pub username: String,
+    #[serde(default = "default_auth_method")]
     pub auth_method: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
@@ -42,6 +43,10 @@ pub struct RemoteAgentConfig {
     /// where `~/.local/bin` may not be on the PATH.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_path: Option<String>,
+}
+
+fn default_auth_method() -> String {
+    "password".to_string()
 }
 
 impl RemoteAgentConfig {
@@ -407,6 +412,19 @@ mod tests {
             config.agent_version_command(),
             "/opt/termihub-agent --version 2>/dev/null"
         );
+    }
+
+    /// Regression: configs saved without `authMethod` (e.g. created by an old
+    /// version) must deserialize successfully and default to "password".
+    #[test]
+    fn remote_agent_config_auth_method_defaults_to_password() {
+        let json = r#"{
+            "host": "pi.local",
+            "port": 22,
+            "username": "pi"
+        }"#;
+        let config: RemoteAgentConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.auth_method, "password");
     }
 
     #[test]

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -21,6 +21,14 @@ pub use termihub_core::config::SshConfig;
 /// Uses `~/.local/bin` so setup works without privilege escalation.
 const DEFAULT_AGENT_PATH: &str = "~/.local/bin/termihub-agent";
 
+/// An external connection file configured for a remote agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalAgentFile {
+    /// Absolute path on the remote host.
+    pub path: String,
+    pub enabled: bool,
+}
+
 /// SSH transport configuration for a remote agent (no session details).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -43,6 +51,9 @@ pub struct RemoteAgentConfig {
     /// where `~/.local/bin` may not be on the PATH.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_path: Option<String>,
+    /// External connection files to load on the remote host.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_connection_files: Vec<ExternalAgentFile>,
 }
 
 fn default_auth_method() -> String {
@@ -152,6 +163,7 @@ mod tests {
             key_path: Some("/home/user/.ssh/id_rsa".to_string()),
             save_password: None,
             agent_path: None,
+            external_connection_files: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: RemoteAgentConfig = serde_json::from_str(&json).unwrap();
@@ -180,6 +192,7 @@ mod tests {
             key_path: Some("${env:HOME}/.ssh/id_rsa".to_string()),
             save_password: None,
             agent_path: None,
+            external_connection_files: vec![],
         };
         let expanded = config.expand();
         assert_eq!(expanded.host, "10.0.0.99");
@@ -200,6 +213,7 @@ mod tests {
             key_path: Some("/home/.ssh/id_rsa".to_string()),
             save_password: None,
             agent_path: None,
+            external_connection_files: vec![],
         };
         let ssh = agent.to_ssh_config();
         assert_eq!(ssh.host, "pi.local");
@@ -220,6 +234,7 @@ mod tests {
             key_path: None,
             save_password: Some(true),
             agent_path: None,
+            external_connection_files: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: RemoteAgentConfig = serde_json::from_str(&json).unwrap();
@@ -237,6 +252,7 @@ mod tests {
             key_path: None,
             save_password: None,
             agent_path: None,
+            external_connection_files: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -257,6 +273,7 @@ mod tests {
             key_path: None,
             save_password: Some(true),
             agent_path: None,
+            external_connection_files: vec![],
         };
         let ssh = agent.to_ssh_config();
         assert_eq!(ssh.save_password, Some(true));
@@ -335,6 +352,7 @@ mod tests {
             key_path: None,
             save_password: None,
             agent_path: None,
+            external_connection_files: vec![],
         };
         assert_eq!(
             config.agent_exec_command(),
@@ -353,6 +371,7 @@ mod tests {
             key_path: None,
             save_password: None,
             agent_path: Some("~/bin/termihub-agent".to_string()),
+            external_connection_files: vec![],
         };
         assert_eq!(
             config.agent_exec_command(),
@@ -371,6 +390,7 @@ mod tests {
             key_path: None,
             save_password: None,
             agent_path: Some("/usr/local/bin/termihub-agent".to_string()),
+            external_connection_files: vec![],
         };
         assert_eq!(
             config.agent_exec_command(),
@@ -389,6 +409,7 @@ mod tests {
             key_path: None,
             save_password: None,
             agent_path: None,
+            external_connection_files: vec![],
         };
         assert_eq!(
             config.agent_version_command(),
@@ -407,6 +428,7 @@ mod tests {
             key_path: None,
             save_password: None,
             agent_path: Some("/opt/termihub-agent".to_string()),
+            external_connection_files: vec![],
         };
         assert_eq!(
             config.agent_version_command(),
@@ -467,6 +489,7 @@ mod tests {
                 key_path: None,
                 save_password: None,
                 agent_path,
+                external_connection_files: vec![],
             };
             let cmd = config.agent_exec_command();
             let binary = cmd.split_whitespace().next().unwrap();
@@ -495,6 +518,7 @@ mod tests {
             key_path: None,
             save_password: None,
             agent_path: None,
+            external_connection_files: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -502,5 +526,67 @@ mod tests {
             v.get("agentPath").is_none(),
             "agentPath should be omitted when None, got: {json}"
         );
+    }
+
+    #[test]
+    fn external_connection_files_serde_round_trip() {
+        let config = RemoteAgentConfig {
+            host: "pi.local".to_string(),
+            port: 22,
+            username: "pi".to_string(),
+            auth_method: "key".to_string(),
+            password: None,
+            key_path: None,
+            save_password: None,
+            agent_path: None,
+            external_connection_files: vec![
+                ExternalAgentFile {
+                    path: "/home/pi/team-connections.json".to_string(),
+                    enabled: true,
+                },
+                ExternalAgentFile {
+                    path: "/home/pi/extra.json".to_string(),
+                    enabled: false,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: RemoteAgentConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.external_connection_files.len(), 2);
+        assert_eq!(
+            deserialized.external_connection_files[0].path,
+            "/home/pi/team-connections.json"
+        );
+        assert!(deserialized.external_connection_files[0].enabled);
+        assert!(!deserialized.external_connection_files[1].enabled);
+    }
+
+    #[test]
+    fn external_connection_files_empty_omitted_in_json() {
+        let config = RemoteAgentConfig {
+            host: "pi.local".to_string(),
+            port: 22,
+            username: "pi".to_string(),
+            auth_method: "key".to_string(),
+            password: None,
+            key_path: None,
+            save_password: None,
+            agent_path: None,
+            external_connection_files: vec![],
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            v.get("externalConnectionFiles").is_none(),
+            "externalConnectionFiles should be omitted when empty, got: {json}"
+        );
+    }
+
+    /// Configs saved before this field existed must deserialize successfully.
+    #[test]
+    fn external_connection_files_defaults_when_missing() {
+        let json = r#"{"host":"pi.local","port":22,"username":"pi","authMethod":"key"}"#;
+        let config: RemoteAgentConfig = serde_json::from_str(json).unwrap();
+        assert!(config.external_connection_files.is_empty());
     }
 }

--- a/src/components/ConnectionEditor/AgentExternalFilesSettings.tsx
+++ b/src/components/ConnectionEditor/AgentExternalFilesSettings.tsx
@@ -1,0 +1,115 @@
+import { useState, useCallback } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { ExternalAgentFile } from "@/types/terminal";
+
+interface AgentExternalFilesSettingsProps {
+  files: ExternalAgentFile[];
+  onChange: (files: ExternalAgentFile[]) => void;
+}
+
+/**
+ * UI for managing external connection file paths on a remote agent.
+ *
+ * Unlike the local ExternalFilesSettings, paths are entered manually (no file
+ * picker) because the paths refer to locations on the remote host machine.
+ * Changes take effect on the next reconnect.
+ */
+export function AgentExternalFilesSettings({ files, onChange }: AgentExternalFilesSettingsProps) {
+  const [newPath, setNewPath] = useState("");
+
+  const handleAdd = useCallback(() => {
+    const trimmed = newPath.trim();
+    if (!trimmed) return;
+    if (files.some((f) => f.path === trimmed)) {
+      setNewPath("");
+      return;
+    }
+    onChange([...files, { path: trimmed, enabled: true }]);
+    setNewPath("");
+  }, [newPath, files, onChange]);
+
+  const handleRemove = useCallback(
+    (path: string) => {
+      onChange(files.filter((f) => f.path !== path));
+    },
+    [files, onChange]
+  );
+
+  const handleToggle = useCallback(
+    (path: string) => {
+      onChange(files.map((f) => (f.path === path ? { ...f, enabled: !f.enabled } : f)));
+    },
+    [files, onChange]
+  );
+
+  return (
+    <div className="settings-form__field" data-testid="agent-external-files">
+      <span className="settings-form__label">External Connection Files</span>
+      <p className="settings-form__hint">
+        Load shared connection configs from files on the remote host (e.g. from a git repo). Paths
+        are absolute paths on the remote machine. Changes take effect on next reconnect.
+      </p>
+      {files.map((file) => (
+        <div
+          key={file.path}
+          className="settings-form__list-row"
+          data-testid="agent-external-file-row"
+        >
+          <label className="settings-form__list-checkbox">
+            <input
+              type="checkbox"
+              checked={file.enabled}
+              onChange={() => handleToggle(file.path)}
+              data-testid={`agent-external-file-toggle`}
+            />
+          </label>
+          <span
+            className="settings-form__list-input"
+            style={{
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              display: "flex",
+              alignItems: "center",
+              fontSize: "var(--font-size-sm)",
+              color: file.enabled ? "var(--text-primary)" : "var(--text-secondary)",
+            }}
+            title={file.path}
+          >
+            {file.path}
+          </span>
+          <button
+            className="settings-form__list-remove"
+            onClick={() => handleRemove(file.path)}
+            title="Remove file"
+            data-testid={`agent-external-file-remove`}
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      ))}
+      <div className="settings-form__list-row">
+        <input
+          type="text"
+          className="settings-form__list-input"
+          value={newPath}
+          onChange={(e) => setNewPath(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleAdd();
+          }}
+          placeholder="/home/user/team-connections.json"
+          data-testid="agent-external-file-input"
+        />
+        <button
+          className="settings-form__list-browse"
+          onClick={handleAdd}
+          disabled={!newPath.trim()}
+          data-testid="agent-external-file-add"
+          title="Add external connection file path"
+        >
+          <Plus size={12} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -361,6 +361,12 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   const handleTypeChange = useCallback(
     (typeId: string) => {
       setSelectedType(typeId);
+      if (typeId === "remote") {
+        // "remote" is not in the registry; seed defaults from AGENT_SCHEMA so
+        // required fields like authMethod are present from the start.
+        setConnSettings(buildDefaults(AGENT_SCHEMA));
+        return;
+      }
       const typeInfo = findSchema(effectiveRegistry, typeId);
       const defaults = buildTypeDefaults(typeInfo, settings);
       setConnSettings(defaults);

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -703,9 +703,10 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         </label>
       )}
 
-      {!isAnyAgentMode && (
+      {!isAgentTransportMode && (
         <p className="settings-form__hint">
           Use {"${env:VAR}"} for environment variables, e.g. {"${env:USER}"}
+          {isAgentDefinitionMode && " (resolved on the remote machine)"}
         </p>
       )}
 

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -4,6 +4,7 @@ import type { LucideIcon } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import {
   ConnectionConfig,
+  ExternalAgentFile,
   RemoteAgentConfig,
   ShellType,
   TerminalOptions,
@@ -24,6 +25,7 @@ import { useAvailableRuntimes } from "@/hooks/useAvailableRuntimes";
 import { useExperimentalFeatures } from "@/hooks/useExperimentalFeatures";
 import { ConnectionTerminalSettings } from "./ConnectionTerminalSettings";
 import { ConnectionAppearanceSettings } from "./ConnectionAppearanceSettings";
+import { AgentExternalFilesSettings } from "./AgentExternalFilesSettings";
 import { findLeafByTab } from "@/utils/panelTree";
 import "./ConnectionEditor.css";
 
@@ -726,6 +728,15 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
             ))}
           </select>
         </label>
+      )}
+
+      {isAgentTransportMode && (
+        <AgentExternalFilesSettings
+          files={(connSettings.externalConnectionFiles as ExternalAgentFile[]) ?? []}
+          onChange={(files) =>
+            setConnSettings((prev) => ({ ...prev, externalConnectionFiles: files }))
+          }
+        />
       )}
     </div>
   );

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -179,15 +179,28 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   );
   const effectiveRegistry = isAgentDefinitionMode ? agentConnectionTypes : connectionTypes;
 
+  /** Normalize legacy session-type aliases to the canonical registry ID. */
+  function normalizeAgentTypeId(typeId: string, types: typeof agentConnectionTypes): string {
+    if (types.some((ct) => ct.typeId === typeId)) return typeId;
+    const aliases: Record<string, string> = { shell: "local" };
+    return aliases[typeId] ?? typeId;
+  }
+
   const defaultShell = useAppStore((s) => s.defaultShell);
 
   // Derive initial typeId and settings from existing connection or defaults
   const initialTypeAndSettings = useMemo(() => {
     // Agent definition: existing or new
     if (existingAgentDef) {
+      const typeId = normalizeAgentTypeId(existingAgentDef.sessionType, agentConnectionTypes);
+      const typeInfo = agentConnectionTypes.find((ct) => ct.typeId === typeId);
       return {
-        typeId: existingAgentDef.sessionType,
-        settings: existingAgentDef.config,
+        typeId,
+        settings: Object.keys(existingAgentDef.config as Record<string, unknown>).length
+          ? (existingAgentDef.config as Record<string, unknown>)
+          : typeInfo
+            ? buildDefaults(typeInfo.schema)
+            : {},
       };
     }
     if (isAgentDefinitionMode) {
@@ -195,7 +208,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
       if (firstType) {
         return { typeId: firstType.typeId, settings: buildDefaults(firstType.schema) };
       }
-      return { typeId: "shell", settings: {} };
+      return { typeId: "", settings: {} };
     }
     // Agent transport
     if (existingAgent && !meta.agentDefinitionId) {
@@ -658,13 +671,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         <select
           value={selectedType}
           onChange={(e) => handleTypeChange(e.target.value)}
-          disabled={
-            isAgentTransportMode
-              ? !!existingAgent
-              : isAgentDefinitionMode
-                ? !!existingAgentDef
-                : false
-          }
+          disabled={isAgentTransportMode ? !!existingAgent : false}
           data-testid="connection-editor-type-select"
         >
           {typeOptions.map((opt) => (

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -333,6 +333,7 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
   const [creatingFolder, setCreatingFolder] = useState(false);
 
   const isConnected = agent.connectionState === "connected";
+  const isReconnecting = agent.connectionState === "reconnecting";
   const Chevron = agent.isExpanded ? ChevronDown : ChevronRight;
 
   // Derived: root-level folders and definitions (no parent/folder)
@@ -587,7 +588,7 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
 
         <ContextMenu.Portal>
           <ContextMenu.Content className="context-menu__content">
-            {!isConnected ? (
+            {!isConnected && !isReconnecting ? (
               <>
                 <ContextMenu.Item
                   className="context-menu__item"
@@ -693,8 +694,19 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
 
       {agent.isExpanded && (
         <div className="connection-list__tree">
-          {isConnected ? (
+          {isConnected || isReconnecting ? (
             <>
+              {/* Reconnecting banner */}
+              {isReconnecting && (
+                <div
+                  className="agent-node__hint agent-node__hint--reconnecting"
+                  style={{ paddingLeft: 24 }}
+                >
+                  <RefreshCw size={12} />
+                  Reconnecting…
+                </div>
+              )}
+
               {/* Active sessions section */}
               {agentSessions.length > 0 && (
                 <>

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -29,6 +29,7 @@ import {
   Folder,
   FolderPlus,
   Zap,
+  Copy,
 } from "lucide-react";
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { useAppStore } from "@/store/appStore";
@@ -83,6 +84,7 @@ interface AgentConnectionItemProps {
   depth: number;
   onOpen: (def: AgentDefinitionInfo) => void;
   onEdit: (def: AgentDefinitionInfo) => void;
+  onDuplicate: (def: AgentDefinitionInfo) => void;
 }
 
 function AgentConnectionItem({
@@ -91,6 +93,7 @@ function AgentConnectionItem({
   depth,
   onOpen,
   onEdit,
+  onDuplicate,
 }: AgentConnectionItemProps) {
   const deleteAgentDef = useAppStore((s) => s.deleteAgentDef);
 
@@ -132,6 +135,14 @@ function AgentConnectionItem({
             <Pencil size={14} />
             Edit
           </ContextMenu.Item>
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={() => onDuplicate(definition)}
+            data-testid="context-agent-def-duplicate"
+          >
+            <Copy size={14} />
+            Duplicate
+          </ContextMenu.Item>
           <ContextMenu.Separator className="context-menu__separator" />
           <ContextMenu.Item
             className="context-menu__item context-menu__item--danger"
@@ -157,6 +168,7 @@ interface AgentFolderNodeProps {
   onOpenDefinition: (def: AgentDefinitionInfo) => void;
   onNewConnection: (folderId: string | null) => void;
   onEditDefinition: (def: AgentDefinitionInfo) => void;
+  onDuplicateDefinition: (def: AgentDefinitionInfo) => void;
 }
 
 function AgentFolderNode({
@@ -168,6 +180,7 @@ function AgentFolderNode({
   onOpenDefinition,
   onNewConnection,
   onEditDefinition,
+  onDuplicateDefinition,
 }: AgentFolderNodeProps) {
   const toggleAgentFolder = useAppStore((s) => s.toggleAgentFolder);
   const createAgentFolder = useAppStore((s) => s.createAgentFolder);
@@ -251,6 +264,7 @@ function AgentFolderNode({
               onOpenDefinition={onOpenDefinition}
               onNewConnection={onNewConnection}
               onEditDefinition={onEditDefinition}
+              onDuplicateDefinition={onDuplicateDefinition}
             />
           ))}
           {childDefinitions.map((def) => (
@@ -261,6 +275,7 @@ function AgentFolderNode({
               depth={depth + 1}
               onOpen={onOpenDefinition}
               onEdit={onEditDefinition}
+              onDuplicate={onDuplicateDefinition}
             />
           ))}
         </div>
@@ -501,6 +516,14 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
     [agent.id, openAgentDefinitionEditorTab]
   );
 
+  const duplicateAgentDef = useAppStore((s) => s.duplicateAgentDef);
+  const handleDuplicateDefinition = useCallback(
+    (def: AgentDefinitionInfo) => {
+      duplicateAgentDef(agent.id, def.id);
+    },
+    [agent.id, duplicateAgentDef]
+  );
+
   const hasContent =
     agentSessions.length > 0 || agentDefinitions.length > 0 || agentFolders.length > 0;
 
@@ -727,6 +750,7 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                   onOpenDefinition={handleOpenDefinition}
                   onNewConnection={handleNewConnection}
                   onEditDefinition={handleEditDefinition}
+                  onDuplicateDefinition={handleDuplicateDefinition}
                 />
               ))}
 
@@ -739,6 +763,7 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                   depth={1}
                   onOpen={handleOpenDefinition}
                   onEdit={handleEditDefinition}
+                  onDuplicate={handleDuplicateDefinition}
                 />
               ))}
 

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -306,6 +306,14 @@
   user-select: none;
 }
 
+.agent-node__hint--reconnecting {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--state-connecting);
+  padding: 4px 0;
+}
+
 .agent-node__section-label {
   display: flex;
   align-items: center;

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -46,9 +46,12 @@ export function TerminalView() {
         session_id,
         state as "disconnected" | "connecting" | "connected" | "reconnecting"
       );
-      // Auto-refresh sessions when agent reconnects
       if (state === "connected") {
         store.refreshAgentSessions(session_id);
+      } else if (state === "disconnected") {
+        // Active sessions are gone; clear them so stale entries don't linger.
+        // Saved connections (definitions/folders) are kept — they live on disk.
+        store.clearAgentSessions(session_id);
       }
     }).then((fn) => {
       unlisten = fn;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -482,6 +482,8 @@ export interface AgentDefinitionInfo {
   folderId: string | null;
   terminalOptions?: TerminalOptions;
   icon?: string;
+  /** Source file path on the remote host, or undefined for the primary store. */
+  sourceFile?: string;
 }
 
 /** Info about a folder on an agent. */

--- a/src/store/appStore.agentConnections.test.ts
+++ b/src/store/appStore.agentConnections.test.ts
@@ -312,4 +312,56 @@ describe("appStore — agent connection management", () => {
       expect(result.map((a) => a.id)).toEqual(["a1", "a2"]);
     });
   });
+
+  describe("clearAgentSessions", () => {
+    it("empties agentSessions for the given agent", () => {
+      useAppStore.setState({
+        agentSessions: {
+          [AGENT_ID]: [
+            { sessionId: "s1", title: "shell", type: "shell", status: "running", attached: false },
+          ],
+        },
+      });
+
+      useAppStore.getState().clearAgentSessions(AGENT_ID);
+
+      expect(useAppStore.getState().agentSessions[AGENT_ID]).toEqual([]);
+    });
+
+    it("does not clear definitions or folders", () => {
+      const def = makeDefinition({ id: "d1" });
+      const folder = makeFolder({ id: "f1" });
+      useAppStore.setState({
+        agentSessions: {
+          [AGENT_ID]: [
+            { sessionId: "s1", title: "shell", type: "shell", status: "running", attached: false },
+          ],
+        },
+        agentDefinitions: { [AGENT_ID]: [def] },
+        agentFolders: { [AGENT_ID]: [folder] },
+      });
+
+      useAppStore.getState().clearAgentSessions(AGENT_ID);
+
+      expect(useAppStore.getState().agentSessions[AGENT_ID]).toEqual([]);
+      expect(useAppStore.getState().agentDefinitions[AGENT_ID]).toEqual([def]);
+      expect(useAppStore.getState().agentFolders[AGENT_ID]).toEqual([folder]);
+    });
+
+    it("does not affect other agents", () => {
+      useAppStore.setState({
+        agentSessions: {
+          [AGENT_ID]: [
+            { sessionId: "s1", title: "shell", type: "shell", status: "running", attached: false },
+          ],
+          "other-agent": [{ sessionId: "s2", title: "shell", type: "shell", status: "running" }],
+        },
+      });
+
+      useAppStore.getState().clearAgentSessions(AGENT_ID);
+
+      expect(useAppStore.getState().agentSessions[AGENT_ID]).toEqual([]);
+      expect(useAppStore.getState().agentSessions["other-agent"]).toHaveLength(1);
+    });
+  });
 });

--- a/src/store/appStore.agentConnections.test.ts
+++ b/src/store/appStore.agentConnections.test.ts
@@ -355,7 +355,9 @@ describe("appStore — agent connection management", () => {
           [AGENT_ID]: [
             { sessionId: "s1", title: "shell", type: "shell", status: "running", attached: false },
           ],
-          "other-agent": [{ sessionId: "s2", title: "shell", type: "shell", status: "running" }],
+          "other-agent": [
+            { sessionId: "s2", title: "shell", type: "shell", status: "running", attached: false },
+          ],
         },
       });
 

--- a/src/store/appStore.credential.test.ts
+++ b/src/store/appStore.credential.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CredentialStoreStatusInfo } from "@/types/credential";
 import type { SavedConnection, RemoteAgentDefinition } from "@/types/connection";
+import { DEFAULT_AGENT_SETTINGS } from "@/types/connection";
 import type { WorkspaceDefinition } from "@/types/workspace";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -345,6 +346,7 @@ describe("launchWorkspace — agentRef credential store pre-unlock", () => {
       authMethod: "password",
       savePassword: true,
     },
+    agentSettings: DEFAULT_AGENT_SETTINGS,
     isExpanded: false,
     connectionState: "disconnected",
   };

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -395,6 +395,7 @@ interface AppState {
     state: RemoteAgentDefinition["connectionState"]
   ) => void;
   setAgentCapabilities: (agentId: string, capabilities: AgentCapabilities) => void;
+  clearAgentSessions: (agentId: string) => void;
   refreshAgentSessions: (agentId: string) => Promise<void>;
   saveAgentDef: (agentId: string, definition: Record<string, unknown>) => Promise<void>;
   duplicateAgentDef: (agentId: string, definitionId: string) => Promise<void>;
@@ -2074,6 +2075,12 @@ export const useAppStore = create<AppState>((set, get) => {
         remoteAgents: state.remoteAgents.map((a) =>
           a.id === agentId ? { ...a, connectionState } : a
         ),
+      }));
+    },
+
+    clearAgentSessions: (agentId) => {
+      set((s) => ({
+        agentSessions: { ...s.agentSessions, [agentId]: [] },
       }));
     },
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -397,6 +397,7 @@ interface AppState {
   setAgentCapabilities: (agentId: string, capabilities: AgentCapabilities) => void;
   refreshAgentSessions: (agentId: string) => Promise<void>;
   saveAgentDef: (agentId: string, definition: Record<string, unknown>) => Promise<void>;
+  duplicateAgentDef: (agentId: string, definitionId: string) => Promise<void>;
   updateAgentDef: (agentId: string, params: Record<string, unknown>) => Promise<void>;
   deleteAgentDef: (agentId: string, definitionId: string) => Promise<void>;
   createAgentFolder: (agentId: string, name: string, parentId?: string | null) => Promise<void>;
@@ -2113,6 +2114,22 @@ export const useAppStore = create<AppState>((set, get) => {
       } catch (err) {
         console.error(`Failed to save agent definition on ${agentId}:`, err);
       }
+    },
+
+    duplicateAgentDef: async (agentId, definitionId) => {
+      const original = useAppStore
+        .getState()
+        .agentDefinitions[agentId]?.find((d) => d.id === definitionId);
+      if (!original) return;
+      await useAppStore.getState().saveAgentDef(agentId, {
+        name: `Copy of ${original.name}`,
+        type: original.sessionType,
+        config: original.config,
+        persistent: original.persistent,
+        folder_id: original.folderId,
+        terminal_options: original.terminalOptions ?? null,
+        icon: original.icon ?? null,
+      });
     },
 
     deleteAgentDef: async (agentId, definitionId) => {

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -83,6 +83,13 @@ export interface TerminalOptions {
   cursorBlink?: boolean;
 }
 
+/** An external connection file configured for a remote agent. */
+export interface ExternalAgentFile {
+  /** Absolute path on the remote host. */
+  path: string;
+  enabled: boolean;
+}
+
 /** SSH transport configuration for a remote agent (no session details). */
 export interface RemoteAgentConfig {
   host: string;
@@ -94,6 +101,8 @@ export interface RemoteAgentConfig {
   savePassword?: boolean;
   /** Path to the agent binary on the remote host (default: ~/.local/bin/termihub-agent). */
   agentPath?: string;
+  /** External connection files to load on the remote host (read-only). */
+  externalConnectionFiles?: ExternalAgentFile[];
 }
 
 /** Key-value pair for Docker environment variables. */


### PR DESCRIPTION
## Summary

- **fix(agent):** seed `authMethod` default when creating/loading remote agents (original bugfix)
- **fix(agent):** evict dead connection entry on reconnect; duplicate action for remote agent connections
- **fix(agent):** detach daemon sessions on shutdown so they survive reconnect
- **fix(agent):** keep connections visible during reconnect, clear sessions on disconnect
- **feat(agent):** `${env:VAR}` expansion in agent connection definitions
- **feat(agent):** external connection files support for remote agents
- **feat(agent):** add `--native` and `--dev` flags to `build-agents.sh` for faster local agent development
- **docs(concept):** remote agent update strategy concept document

## Test plan

- [ ] Create a new remote agent connection — verify `authMethod` field is pre-populated (no missing auth method error)
- [ ] Disconnect and reconnect a remote agent — verify daemon-backed sessions survive and reappear
- [ ] While an agent is reconnecting, verify the sidebar shows cached connections with a "Reconnecting…" banner rather than going blank
- [ ] On disconnection, verify sessions are cleared but connection definitions remain visible
- [ ] Test `./scripts/build-agents.sh --native --dev` on a Linux machine — verify it uses `cargo build` without `--release` and skips Docker
- [ ] Test `./scripts/build-agents.sh --native` — verify it detects the host triple automatically
- [ ] Test `./scripts/build-agents.sh --dev` — verify it builds via cross-rs in debug profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)