### PR TITLE
style(ui): split file browser toolbar into path line and wrapping actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- File browser: toolbar now shows the current directory path on its own line, with action buttons on a second line that wraps when the panel is narrow
+
 ### Added
 
 - Remote Agents: agent runtime settings (feature toggles, session defaults, diagnostics) are now stored per-agent and configured in a dedicated "Agent" tab in the connection editor. Settings include enabling/disabling monitoring, file browser (SFTP), and Docker support; setting a default shell and starting directory; and configuring log level and verbose protocol tracing. Settings are sent to the agent on connect and can be updated live without reconnecting.

--- a/src/components/Sidebar/FileBrowser.css
+++ b/src/components/Sidebar/FileBrowser.css
@@ -24,11 +24,11 @@
 
 .file-browser__toolbar {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
   padding: var(--spacing-xs) var(--spacing-sm);
   border-bottom: 1px solid var(--border-secondary);
-  min-height: 30px;
+  gap: 2px;
 }
 
 .file-browser__path {
@@ -37,14 +37,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1;
-  margin-right: var(--spacing-xs);
+  width: 100%;
 }
 
 .file-browser__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 2px;
-  flex-shrink: 0;
 }
 
 .file-browser__btn {


### PR DESCRIPTION
## Summary

- Directory path is now always displayed on its own dedicated first line in the file browser toolbar
- Action buttons appear on the second line and wrap to additional lines when the panel width is narrow
- Improves readability when many actions are available

## Test plan

- [ ] Open the file browser and verify the current path appears on its own line above the action buttons
- [ ] Resize the sidebar to a narrow width and confirm the action buttons wrap to multiple lines instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)