### PR TITLE
fix(agent): correct camelCase initialize params and improve version mismatch UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Agent: fixed connection failure on freshly deployed agents — the desktop was sending `protocol_version`/`client_version` in snake_case JSON but the agent expected camelCase (`protocolVersion`/`clientVersion`), causing every connect attempt to fail with "missing field `protocolVersion`"
+- Agent: "Initialize rejected" errors (protocol version mismatch) now show a clear "Agent Version Incompatible" message with a "Setup Agent" button to re-deploy, instead of a raw internal error string
 - Agent: persisting (daemon-backed) sessions now survive agent reconnects — previously the agent killed daemon subprocesses on exit instead of detaching, causing recovered sessions to appear missing after disconnect/reconnect
 - Workspace launch: agent connection tabs (agentRef) now trigger the master password prompt upfront when their agents are disconnected and have stored credentials — previously these tabs would open as "Agent not connected" error tabs without ever asking for the password, and clicking Reconnect would immediately fail with an auth error
 - Agent error tab: the Reconnect button now unlocks the credential store and resolves the stored password before reconnecting — previously it always connected without a password, causing an immediate authentication failure

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -1143,11 +1143,11 @@ impl AgentRpcClient for AgentConnectionManager {
 /// Build the `initialize` JSON-RPC params including agent runtime settings and external files.
 fn build_initialize_params(settings: &AgentSettings, external_files: &[&str]) -> Value {
     serde_json::json!({
-        "protocol_version": "0.2.0",
+        "protocolVersion": "0.2.0",
         "client": "termihub-desktop",
-        "client_version": "0.1.0",
+        "clientVersion": "0.1.0",
         "agentSettings": settings,
-        "external_connection_files": external_files
+        "externalConnectionFiles": external_files
     })
 }
 

--- a/src/components/Sidebar/ConnectionErrorDialog.tsx
+++ b/src/components/Sidebar/ConnectionErrorDialog.tsx
@@ -56,18 +56,19 @@ export function ConnectionErrorDialog({
             </details>
           )}
           <div className="connection-error-dialog__actions">
-            {error.category === "agent-missing" && onSetupAgent && (
-              <button
-                className="connection-error-dialog__btn connection-error-dialog__btn--primary"
-                onClick={() => {
-                  onOpenChange(false);
-                  onSetupAgent();
-                }}
-                data-testid="connection-error-setup-agent"
-              >
-                Setup Agent
-              </button>
-            )}
+            {(error.category === "agent-missing" || error.category === "agent-outdated") &&
+              onSetupAgent && (
+                <button
+                  className="connection-error-dialog__btn connection-error-dialog__btn--primary"
+                  onClick={() => {
+                    onOpenChange(false);
+                    onSetupAgent();
+                  }}
+                  data-testid="connection-error-setup-agent"
+                >
+                  Setup Agent
+                </button>
+              )}
             <button
               className="connection-error-dialog__btn connection-error-dialog__btn--secondary"
               onClick={() => onOpenChange(false)}

--- a/src/utils/classifyAgentError.test.ts
+++ b/src/utils/classifyAgentError.test.ts
@@ -45,6 +45,21 @@ describe("classifyAgentError", () => {
     expect(result.category).toBe("agent-missing");
   });
 
+  it("classifies initialize rejected as agent-outdated", () => {
+    const result = classifyAgentError(
+      "Remote agent error: Initialize rejected: Invalid initialize params: missing field `protocolVersion`"
+    );
+    expect(result.category).toBe("agent-outdated");
+    expect(result.title).toBe("Agent Version Incompatible");
+  });
+
+  it("classifies unsupported protocol version as agent-outdated", () => {
+    const result = classifyAgentError(
+      "Remote agent error: Initialize rejected: Unsupported protocol version: 1.0.0 (agent supports 0.x)"
+    );
+    expect(result.category).toBe("agent-outdated");
+  });
+
   it("classifies unknown errors with raw message", () => {
     const result = classifyAgentError("Something unexpected");
     expect(result.category).toBe("unknown");

--- a/src/utils/classifyAgentError.ts
+++ b/src/utils/classifyAgentError.ts
@@ -3,7 +3,12 @@
  */
 
 /** The three specific error categories plus a generic fallback. */
-export type AgentErrorCategory = "unreachable" | "auth-failure" | "agent-missing" | "unknown";
+export type AgentErrorCategory =
+  | "unreachable"
+  | "auth-failure"
+  | "agent-missing"
+  | "agent-outdated"
+  | "unknown";
 
 export interface ClassifiedAgentError {
   category: AgentErrorCategory;
@@ -46,6 +51,16 @@ export function classifyAgentError(error: unknown): ClassifiedAgentError {
       title: "Agent Not Installed",
       message:
         "SSH connected successfully, but the termihub-agent binary could not be started on the remote host.",
+      rawError: raw,
+    };
+  }
+
+  if (raw.includes("Initialize rejected") || raw.includes("Unsupported protocol version")) {
+    return {
+      category: "agent-outdated",
+      title: "Agent Version Incompatible",
+      message:
+        "The remote agent binary is not compatible with this version of termiHub. Please re-deploy the agent to update it.",
       rawError: raw,
     };
   }


### PR DESCRIPTION
## Summary

- **Root cause fix**: `build_initialize_params` was sending `protocol_version`, `client_version`, and `external_connection_files` in snake_case JSON, but `InitializeParams` uses `#[serde(rename_all = "camelCase")]` — so the agent expected `protocolVersion`/`clientVersion`/`externalConnectionFiles`. This caused every connection attempt to fail immediately with _"Remote agent error: Initialize rejected: Invalid initialize params: missing field `protocolVersion`"_
- **UX improvement**: "Initialize rejected" and "Unsupported protocol version" errors are now classified as a new `agent-outdated` category, showing a clear _"Agent Version Incompatible"_ message and a **Setup Agent** button so the user can re-deploy without hunting for the option

## Test plan

- [ ] Connect to a remote agent — connection should succeed where it previously failed with the `protocolVersion` error
- [ ] To verify the UX path: temporarily downgrade a deployed agent to an older binary and attempt to connect — the error dialog should show "Agent Version Incompatible" with a "Setup Agent" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)