### PR TITLE
fix(backend): prevent RefCell panic on app close (exit code 101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Agent: persisting (daemon-backed) sessions now survive agent reconnects — previously the agent killed daemon subprocesses on exit instead of detaching, causing recovered sessions to appear missing after disconnect/reconnect
+- Closing the app no longer exits with code 101 — tunnel and embedded-server shutdown is now deferred off the Tauri event-loop thread, preventing a `RefCell` re-entrant borrow panic inside `tauri-runtime-wry`
 - Workspace launch: agent connection tabs (agentRef) now trigger the master password prompt upfront when their agents are disconnected and have stored credentials — previously these tabs would open as "Agent not connected" error tabs without ever asking for the password, and clicking Reconnect would immediately fail with an auth error
 - Agent error tab: the Reconnect button now unlocks the credential store and resolves the stored password before reconnecting — previously it always connected without a password, causing an immediate authentication failure
 - Terminal: connection failures (e.g. agent timeout, SSH auth errors) now show a proper error panel with the error message and a Retry button instead of raw red text in the terminal canvas.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -781,6 +781,16 @@ The first build compiles all Rust dependencies and can take several minutes. Sub
 CARGO_PROFILE_DEV_CODEGEN_UNITS=16 pnpm tauri dev
 ```
 
+### Process exit codes
+
+| Exit code | Meaning                                                                                                                                                                                          |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `0`       | Normal shutdown                                                                                                                                                                                  |
+| `1`       | Generic error (e.g. failed Tauri plugin initialisation)                                                                                                                                          |
+| `101`     | Rust panic — the backend thread aborted. Run with `RUST_BACKTRACE=1` to get a stack trace. Common causes: re-entrant `RefCell` borrow inside a Tauri event handler, or an unwrap on `None`/`Err` |
+
+The `pnpm tauri dev` harness surfaces the backend exit code as its own exit code, which is why you may see `ELIFECYCLE Command failed with exit code 101` in the terminal when the Rust side panics.
+
 ---
 
 ## Release Process

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,16 +496,23 @@ pub fn run() {
                 ..
             } = &event
             {
-                // Gracefully stop all active tunnels on window close
-                if let Some(mgr) = app_handle.try_state::<tunnel::tunnel_manager::TunnelManager>() {
-                    mgr.stop_all();
-                }
-                // Gracefully stop all running embedded servers on window close
-                if let Some(mgr) = app_handle
-                    .try_state::<embedded_servers::server_manager::EmbeddedServerManager>()
-                {
-                    mgr.stop_all();
-                }
+                // Spawn cleanup off the event-loop thread.  Calling emit() directly
+                // inside this handler would re-enter a RefCell that Tauri already
+                // holds mutably, causing a panic.  Running the work on the async
+                // runtime avoids that borrow while still performing the cleanup.
+                let handle = app_handle.clone();
+                tauri::async_runtime::spawn(async move {
+                    if let Some(mgr) =
+                        handle.try_state::<tunnel::tunnel_manager::TunnelManager>()
+                    {
+                        mgr.stop_all();
+                    }
+                    if let Some(mgr) = handle
+                        .try_state::<embedded_servers::server_manager::EmbeddedServerManager>()
+                    {
+                        mgr.stop_all();
+                    }
+                });
             }
         });
 }


### PR DESCRIPTION
## Summary

- Closing termiHub produced a Rust panic and exit code 101 on every normal shutdown
- Root cause: the `WindowEvent::Destroyed` handler called `stop_all()` → `emit_status()` → `app_handle.emit()`, which tried to re-enter a `RefCell` that `tauri-runtime-wry` already held mutably in the same call stack
- Fix: wrap the `stop_all()` calls in `tauri::async_runtime::spawn()` so they run on the tokio thread pool, completely outside the event-handler borrow scope
- Also documents process exit codes (0, 1, 101) in the Troubleshooting section of `docs/contributing.md`

## Test plan

- [ ] Launch the app in dev mode (`pnpm tauri dev`)
- [ ] Close the window — the process should exit cleanly with code 0; no panic output in the terminal
- [ ] Start one or more SSH tunnels or embedded servers, then close the app — confirm they are stopped and the process still exits with code 0
- [ ] All unit tests pass: `./scripts/test.sh`
- [ ] All quality checks pass: `./scripts/check.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)