### PR TITLE
fix(ui): exclude OS metadata files from SSH key picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SSH key picker: OS metadata files (`.DS_Store`, `.localized` on macOS; `Thumbs.db`, `desktop.ini` on Windows; `.directory` on Linux/KDE) are now excluded from the key file list
 - Agent: persisting (daemon-backed) sessions now survive agent reconnects — previously the agent killed daemon subprocesses on exit instead of detaching, causing recovered sessions to appear missing after disconnect/reconnect
 - Workspace launch: agent connection tabs (agentRef) now trigger the master password prompt upfront when their agents are disconnected and have stored credentials — previously these tabs would open as "Agent not connected" error tabs without ever asking for the password, and clicking Reconnect would immediately fail with an auth error
 - Agent error tab: the Reconnect button now unlocks the credential store and resolves the stored password before reconnecting — previously it always connected without a password, causing an immediate authentication failure

--- a/src/hooks/useSshKeyFiles.test.ts
+++ b/src/hooks/useSshKeyFiles.test.ts
@@ -23,6 +23,20 @@ describe("useSshKeyFiles", () => {
       expect(isBlockedFile("environment")).toBe(true);
     });
 
+    it("blocks OS metadata files on macOS", () => {
+      expect(isBlockedFile(".DS_Store")).toBe(true);
+      expect(isBlockedFile(".localized")).toBe(true);
+    });
+
+    it("blocks OS metadata files on Windows", () => {
+      expect(isBlockedFile("Thumbs.db")).toBe(true);
+      expect(isBlockedFile("desktop.ini")).toBe(true);
+    });
+
+    it("blocks OS metadata files on Linux/KDE", () => {
+      expect(isBlockedFile(".directory")).toBe(true);
+    });
+
     it("blocks .old, .bak, and .log extensions", () => {
       expect(isBlockedFile("id_rsa.old")).toBe(true);
       expect(isBlockedFile("id_rsa.bak")).toBe(true);

--- a/src/hooks/useSshKeyFiles.ts
+++ b/src/hooks/useSshKeyFiles.ts
@@ -17,6 +17,14 @@ const BLOCKLIST = new Set([
   "authorized_keys2",
   "config",
   "environment",
+  // macOS metadata
+  ".DS_Store",
+  ".localized",
+  // Windows metadata
+  "Thumbs.db",
+  "desktop.ini",
+  // KDE/Linux metadata
+  ".directory",
 ]);
 
 /** File extensions that indicate non-key files */


### PR DESCRIPTION
## Summary

- `.DS_Store` and `.localized` (macOS), `Thumbs.db` and `desktop.ini` (Windows), and `.directory` (KDE/Linux) were appearing in the SSH key file picker alongside actual private keys
- Added all of these to the `BLOCKLIST` in `useSshKeyFiles.ts`
- Added regression tests for each platform's metadata files

## Test plan

- [ ] Open the SSH connection editor on macOS — `.DS_Store` should not appear in the key file dropdown
- [ ] Verify existing key files (`id_ed25519`, `id_rsa`, etc.) still appear as expected
- [ ] All unit tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)