### PR TITLE
feat(ui): default SSH shell integration and X11 forwarding to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- SSH: Shell Integration and X11 Forwarding now default to enabled for new connections
+- Settings: General settings now include SSH defaults section to control whether Shell Integration and X11 Forwarding are pre-enabled for new SSH connections
+- Connection editor: boolean fields in existing connections now correctly reflect their schema default when the field was never explicitly saved (previously showed unchecked regardless of the schema default)
 - File browser: toolbar now shows the current directory path on its own line, with action buttons on a second line that wraps when the panel is narrow
 
 ### Added

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -332,7 +332,7 @@ impl ConnectionType for Ssh {
                             help_text: None,
                             field_type: FieldType::Boolean,
                             required: false,
-                            default: Some(serde_json::json!(false)),
+                            default: Some(serde_json::json!(true)),
                             placeholder: None,
                             supports_env_expansion: false,
                             supports_tilde_expansion: false,

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -115,6 +115,12 @@ pub struct AppSettings {
     pub power_monitoring_enabled: bool,
     #[serde(default = "default_true")]
     pub file_browser_enabled: bool,
+    /// Default value for Shell Integration toggle in new SSH connections.
+    #[serde(default = "default_true")]
+    pub default_shell_integration: bool,
+    /// Default value for X11 Forwarding toggle in new SSH connections.
+    #[serde(default = "default_true")]
+    pub default_x11_forwarding: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layout: Option<LayoutConfig>,
     /// Credential storage mode: "master_password" or "none".
@@ -163,6 +169,8 @@ impl Default for AppSettings {
             cursor_blink: None,
             power_monitoring_enabled: true,
             file_browser_enabled: true,
+            default_shell_integration: true,
+            default_x11_forwarding: true,
             layout: None,
             credential_storage_mode: None,
             credential_auto_lock_minutes: None,
@@ -366,6 +374,8 @@ mod tests {
         let settings = AppSettings::default();
         assert!(settings.power_monitoring_enabled);
         assert!(settings.file_browser_enabled);
+        assert!(settings.default_shell_integration);
+        assert!(settings.default_x11_forwarding);
     }
 
     #[test]
@@ -374,6 +384,21 @@ mod tests {
         let settings: AppSettings = serde_json::from_str(json).unwrap();
         assert!(settings.power_monitoring_enabled);
         assert!(settings.file_browser_enabled);
+        assert!(settings.default_shell_integration);
+        assert!(settings.default_x11_forwarding);
+    }
+
+    #[test]
+    fn ssh_defaults_round_trip() {
+        let settings = AppSettings {
+            default_shell_integration: false,
+            default_x11_forwarding: false,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
+        assert!(!deserialized.default_shell_integration);
+        assert!(!deserialized.default_x11_forwarding);
     }
 
     #[test]

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -101,7 +101,12 @@ function findSchema(connectionTypes: ConnectionTypeInfo[], typeId: string) {
 /** Build default settings for a type, applying app settings defaults. */
 function buildTypeDefaults(
   typeInfo: ConnectionTypeInfo | undefined,
-  appSettings: { defaultUser?: string; defaultSshKeyPath?: string }
+  appSettings: {
+    defaultUser?: string;
+    defaultSshKeyPath?: string;
+    defaultShellIntegration?: boolean;
+    defaultX11Forwarding?: boolean;
+  }
 ): Record<string, unknown> {
   if (!typeInfo) return {};
   const defaults = buildDefaults(typeInfo.schema);
@@ -125,6 +130,18 @@ function buildTypeDefaults(
         }
         break;
       }
+    }
+  }
+  for (const group of typeInfo.schema.groups) {
+    if (group.fields.some((f) => f.key === "shellIntegration")) {
+      defaults.shellIntegration = appSettings.defaultShellIntegration ?? true;
+      break;
+    }
+  }
+  for (const group of typeInfo.schema.groups) {
+    if (group.fields.some((f) => f.key === "enableX11Forwarding")) {
+      defaults.enableX11Forwarding = appSettings.defaultX11Forwarding ?? true;
+      break;
     }
   }
   return defaults;

--- a/src/components/DynamicForm/DynamicField.test.tsx
+++ b/src/components/DynamicForm/DynamicField.test.tsx
@@ -167,6 +167,31 @@ describe("DynamicField", () => {
       renderField(field, false, vi.fn());
       expect(container.textContent).toContain("Remove on Exit");
     });
+
+    it("falls back to schema default when value is undefined", () => {
+      const field: SettingsField = {
+        key: "shellIntegration",
+        label: "Shell Integration",
+        fieldType: { type: "boolean" },
+        required: false,
+        default: true,
+      };
+      renderField(field, undefined, vi.fn());
+      const input = query("field-shellIntegration") as HTMLInputElement;
+      expect(input.checked).toBe(true);
+    });
+
+    it("falls back to false when value is undefined and no schema default", () => {
+      const field: SettingsField = {
+        key: "flag",
+        label: "Flag",
+        fieldType: { type: "boolean" },
+        required: false,
+      };
+      renderField(field, undefined, vi.fn());
+      const input = query("field-flag") as HTMLInputElement;
+      expect(input.checked).toBe(false);
+    });
   });
 
   describe("select field", () => {

--- a/src/components/DynamicForm/DynamicField.tsx
+++ b/src/components/DynamicForm/DynamicField.tsx
@@ -140,7 +140,7 @@ function BooleanField({ field, value, onChange }: FieldProps) {
       <label className="settings-form__field--checkbox" data-testid={`field-${field.key}-wrapper`}>
         <input
           type="checkbox"
-          checked={(value as boolean) ?? false}
+          checked={(value as boolean) ?? (field.default as boolean) ?? false}
           onChange={(e) => onChange(e.target.checked)}
           data-testid={`field-${field.key}`}
         />

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -119,6 +119,37 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
           </span>
         </label>
       )}
+      {(show("defaultShellIntegration") || show("defaultX11Forwarding")) && (
+        <h3 className="settings-panel__category-title">SSH Defaults</h3>
+      )}
+      {show("defaultShellIntegration") && (
+        <label className="settings-form__field settings-form__field--checkbox">
+          <input
+            type="checkbox"
+            checked={settings.defaultShellIntegration ?? true}
+            onChange={(e) => onChange({ ...settings, defaultShellIntegration: e.target.checked })}
+            data-testid="settings-default-shell-integration"
+          />
+          <span className="settings-form__label">Shell Integration by Default</span>
+          <span className="settings-form__hint">
+            Pre-enable Shell Integration (OSC 7 CWD tracking) for new SSH connections.
+          </span>
+        </label>
+      )}
+      {show("defaultX11Forwarding") && (
+        <label className="settings-form__field settings-form__field--checkbox">
+          <input
+            type="checkbox"
+            checked={settings.defaultX11Forwarding ?? true}
+            onChange={(e) => onChange({ ...settings, defaultX11Forwarding: e.target.checked })}
+            data-testid="settings-default-x11-forwarding"
+          />
+          <span className="settings-form__label">X11 Forwarding by Default</span>
+          <span className="settings-form__hint">
+            Pre-enable X11 Forwarding for new SSH connections.
+          </span>
+        </label>
+      )}
     </div>
   );
 }

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -160,6 +160,8 @@ export interface AppSettings {
   cursorBlink?: boolean;
   powerMonitoringEnabled: boolean;
   fileBrowserEnabled: boolean;
+  defaultShellIntegration?: boolean;
+  defaultX11Forwarding?: boolean;
   layout?: LayoutConfig;
   credentialStorageMode?: "master_password" | "none";
   credentialAutoLockMinutes?: number;


### PR DESCRIPTION
## Summary

- Shell Integration and X11 Forwarding now default to **enabled** for new SSH connections
- New **SSH Defaults** section in General Settings lets users change these per-installation defaults globally
- Fixed a display bug where boolean fields in existing connections always appeared unchecked when the key was absent from the saved config (regardless of the schema default)

## Changes

- `core/src/backends/ssh/mod.rs`: `enableX11Forwarding` schema default changed to `true`
- `src-tauri/src/connection/settings.rs`: added `defaultShellIntegration` and `defaultX11Forwarding` fields to `AppSettings` (both default `true` via `serde(default = "default_true")` for backward compat)
- `src/types/connection.ts`: added `defaultShellIntegration?` and `defaultX11Forwarding?` to the TypeScript `AppSettings` interface
- `src/components/Settings/GeneralSettings.tsx`: added "SSH Defaults" sub-section with two checkboxes
- `src/components/ConnectionEditor/ConnectionEditor.tsx`: `buildTypeDefaults` now applies the global SSH defaults when building initial settings for a new connection
- `src/components/DynamicForm/DynamicField.tsx`: `BooleanField` now falls back to `field.default` instead of hardcoded `false` when the value is `undefined`

## Test plan

- [ ] Create a new SSH connection — Shell Integration and X11 Forwarding checkboxes should be pre-checked
- [ ] Open an existing SSH connection that was saved before this change — Shell Integration and X11 Forwarding should now display as checked (schema default), not unchecked
- [ ] Open General Settings > SSH Defaults, uncheck "X11 Forwarding by Default", create a new SSH connection — X11 Forwarding should be unchecked in the editor
- [ ] Verify old `settings.json` without the new fields loads correctly with both defaults as `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)