### PR TITLE
fix(ci): fix failing test and security vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,9 +4461,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -831,7 +831,7 @@ mod tests {
             .find(|f| f.key == "enableX11Forwarding")
             .unwrap();
         assert!(matches!(x11.field_type, FieldType::Boolean));
-        assert_eq!(x11.default, Some(serde_json::json!(false)));
+        assert_eq!(x11.default, Some(serde_json::json!(true)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Test fix**: `schema_x11_is_boolean` in `core/src/backends/ssh/mod.rs` was asserting `false` as the default for X11 forwarding, but PR #617 changed the schema default to `true` without updating this test
- **Security fix**: Upgrades `rustls-webpki` from 0.103.12 to 0.103.13 to resolve [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) — reachable panic in certificate revocation list parsing

## Test plan

- [ ] CI Code Quality check passes (cargo audit no longer reports RUSTSEC-2026-0104)
- [ ] CI Run Tests passes on all platforms (Windows test failure for `schema_x11_is_boolean` resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)