### PR TITLE
fix(ui): fix TypeScript errors causing CI build and quality failures

### DIFF
--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -153,12 +153,9 @@ export function Terminal({
   // instance) can consult current state without being recreated on every render.
   useEffect(() => {
     isViewModeRef.current = useAppStore.getState().terminalViewMode[tabId] ?? false;
-    return useAppStore.subscribe(
-      (state) => state.terminalViewMode[tabId] ?? false,
-      (viewMode) => {
-        isViewModeRef.current = viewMode;
-      }
-    );
+    return useAppStore.subscribe((state) => {
+      isViewModeRef.current = state.terminalViewMode[tabId] ?? false;
+    });
   }, [tabId]);
 
   const setupTerminal = useCallback(

--- a/src/components/Terminal/TerminalView.agent-disconnect.test.ts
+++ b/src/components/Terminal/TerminalView.agent-disconnect.test.ts
@@ -600,7 +600,6 @@ function injectTabIntoPanel(
   }
   return {
     ...node,
-    first: injectTabIntoPanel(node.first, panelId, tab),
-    second: injectTabIntoPanel(node.second, panelId, tab),
+    children: node.children.map((child) => injectTabIntoPanel(child, panelId, tab)),
   };
 }


### PR DESCRIPTION
## Summary

- **Terminal.tsx**: Changed `useAppStore.subscribe(selector, listener)` to the single-argument form `useAppStore.subscribe(listener)`, which is the correct Zustand v4 API (the two-argument selector overload requires the `subscribeWithSelector` middleware which this store doesn't use)
- **TerminalView.agent-disconnect.test.ts**: Updated the `injectTabIntoPanel` test helper to use `SplitContainer.children` (array) instead of the removed `first`/`second` properties, matching the current type definition

## Test plan

- [x] `pnpm exec tsc --noEmit` — no errors
- [x] `pnpm test` — 89 test files, 1311 tests all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)