### PR TITLE
feat(serial): replace port text field with detected-port dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Serial: the port field in the serial connection editor is now a dropdown populated with currently detected serial ports. If the previously configured port is no longer detected (e.g. USB adapter unplugged), it still appears in the list marked as "(not connected)". When editing a serial session on a remote agent, the dropdown shows the ports detected on the remote machine.
 - Terminal: a unified "Connecting…" overlay now appears on every terminal tab while the backend session is being established, for all connection types (SSH, Telnet, serial, agent sessions). The overlay shows a spinner and a Cancel button (which closes the tab). If the initial connection fails, the overlay transitions to an error state with a Retry button and contextual hints for common failure modes (SSH agent not running, timeout, serial port not found, port permission denied, port in use).
 - Terminal: for agent-mediated sessions (sessions running on a remote agent), connection failures trigger automatic background retry instead of showing an error immediately. The overlay shows the current attempt number. The user can cancel at any time by closing the tab.
 - Terminal: tabs that are created while their parent agent is still connecting now show a "Waiting for agent…" spinner overlay and automatically start their session once the agent connects, instead of failing immediately with an error.

--- a/core/src/backends/serial.rs
+++ b/core/src/backends/serial.rs
@@ -153,10 +153,11 @@ impl ConnectionType for Serial {
                         key: "port".to_string(),
                         label: "Port".to_string(),
                         description: Some(
-                            "Serial port device name (e.g., COM3, /dev/ttyUSB0)".to_string(),
+                            "Select a detected serial port, or type a device path directly."
+                                .to_string(),
                         ),
                         help_text: None,
-                        field_type: FieldType::Text,
+                        field_type: FieldType::SerialPort,
                         required: true,
                         default: None,
                         placeholder: if cfg!(windows) {
@@ -485,7 +486,7 @@ mod tests {
         assert!(port_field.required);
         assert!(port_field.supports_env_expansion);
         assert!(!port_field.supports_tilde_expansion);
-        assert!(matches!(port_field.field_type, FieldType::Text));
+        assert!(matches!(port_field.field_type, FieldType::SerialPort));
     }
 
     #[test]

--- a/core/src/connection/schema.rs
+++ b/core/src/connection/schema.rs
@@ -107,6 +107,11 @@ pub enum FieldType {
     },
     /// Port number input (constrained to 1..=65535).
     Port,
+    /// Serial device path picker — renders a dropdown populated from `list_serial_ports`.
+    ///
+    /// The value is stored as a plain string so that a previously configured port
+    /// that is currently unplugged can still be preserved in settings.
+    SerialPort,
     /// File or directory path picker.
     FilePath {
         /// Whether to accept files, directories, or both.
@@ -313,6 +318,13 @@ mod tests {
         let ft = FieldType::Port;
         let json = serde_json::to_value(&ft).unwrap();
         assert_eq!(json, serde_json::json!({"type": "port"}));
+    }
+
+    #[test]
+    fn field_type_serial_port_serialization() {
+        let ft = FieldType::SerialPort;
+        let json = serde_json::to_value(&ft).unwrap();
+        assert_eq!(json, serde_json::json!({"type": "serialPort"}));
     }
 
     #[test]

--- a/core/src/connection/validation.rs
+++ b/core/src/connection/validation.rs
@@ -86,7 +86,7 @@ fn validate_field_type(
     errors: &mut Vec<ValidationError>,
 ) {
     match field_type {
-        FieldType::Text | FieldType::Password => {
+        FieldType::Text | FieldType::Password | FieldType::SerialPort => {
             if !value.is_string() {
                 errors.push(ValidationError {
                     field: key.to_string(),
@@ -952,6 +952,47 @@ mod tests {
         });
         let errors = validate_settings(&schema, &settings);
         assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn serial_port_valid() {
+        let field = SettingsField {
+            key: "port".to_string(),
+            label: "Port".to_string(),
+            description: None,
+            help_text: None,
+            field_type: FieldType::SerialPort,
+            required: true,
+            default: None,
+            placeholder: None,
+            supports_env_expansion: false,
+            supports_tilde_expansion: false,
+            visible_when: None,
+        };
+        let schema = schema_with_fields(vec![field]);
+        let errors = validate_settings(&schema, &serde_json::json!({"port": "/dev/ttyUSB0"}));
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn serial_port_wrong_type() {
+        let field = SettingsField {
+            key: "port".to_string(),
+            label: "Port".to_string(),
+            description: None,
+            help_text: None,
+            field_type: FieldType::SerialPort,
+            required: true,
+            default: None,
+            placeholder: None,
+            supports_env_expansion: false,
+            supports_tilde_expansion: false,
+            visible_when: None,
+        };
+        let schema = schema_with_fields(vec![field]);
+        let errors = validate_settings(&schema, &serde_json::json!({"port": 42}));
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("must be a string"));
     }
 
     #[test]

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -730,6 +730,11 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           settings={connSettings}
           onChange={setConnSettings}
           credentialSavedHint={credentialSavedHint}
+          availablePorts={
+            isAgentDefinitionMode
+              ? (existingAgent?.capabilities?.availableSerialPorts ?? [])
+              : undefined
+          }
         />
       )}
 

--- a/src/components/DynamicForm/ConnectionSettingsForm.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.tsx
@@ -13,6 +13,12 @@ interface ConnectionSettingsFormProps {
    * and will not be overwritten unless the user types a new value).
    */
   credentialSavedHint?: boolean;
+  /**
+   * Pre-supplied serial port names for `serialPort` fields.
+   * Pass the remote agent's `availableSerialPorts` here when editing an
+   * agent definition so the dropdown reflects the remote machine's ports.
+   */
+  availablePorts?: string[];
 }
 
 /**
@@ -26,6 +32,7 @@ export function ConnectionSettingsForm({
   settings,
   onChange,
   credentialSavedHint,
+  availablePorts,
 }: ConnectionSettingsFormProps) {
   const handleFieldChange = useCallback(
     (key: string, value: unknown) => {
@@ -50,6 +57,7 @@ export function ConnectionSettingsForm({
                 credentialSaved={
                   credentialSavedHint && field.fieldType.type === "password" && !settings[field.key]
                 }
+                availablePorts={availablePorts}
               />
             ))}
           </div>

--- a/src/components/DynamicForm/DynamicField.test.tsx
+++ b/src/components/DynamicForm/DynamicField.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
+import { listSerialPorts } from "@/services/api";
 import { createRoot, Root } from "react-dom/client";
 import type { SettingsField } from "@/types/schema";
 import { DynamicField } from "./DynamicField";
@@ -7,6 +8,11 @@ import { DynamicField } from "./DynamicField";
 // Mock Tauri dialog
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock serial port listing
+vi.mock("@/services/api", () => ({
+  listSerialPorts: vi.fn().mockResolvedValue(["/dev/ttyUSB0", "/dev/ttyS0"]),
 }));
 
 // Mock KeyPathInput to avoid heavy dependencies in unit tests
@@ -39,10 +45,18 @@ function query(testId: string): HTMLElement | null {
 function renderField(
   field: SettingsField,
   value: unknown,
-  onChange: (k: string, v: unknown) => void
+  onChange: (k: string, v: unknown) => void,
+  opts: { availablePorts?: string[] } = {}
 ) {
   act(() => {
-    root.render(<DynamicField field={field} value={value} onChange={onChange} />);
+    root.render(
+      <DynamicField
+        field={field}
+        value={value}
+        onChange={onChange}
+        availablePorts={opts.availablePorts}
+      />
+    );
   });
 }
 
@@ -319,6 +333,107 @@ describe("DynamicField", () => {
         (query("field-envVars-remove-0") as HTMLElement).click();
       });
       expect(onChange).toHaveBeenCalledWith("envVars", [{ key: "B", value: "2" }]);
+    });
+  });
+
+  describe("serialPort field", () => {
+    const serialPortField: SettingsField = {
+      key: "port",
+      label: "Port",
+      fieldType: { type: "serialPort" },
+      required: true,
+    };
+
+    it("renders a select with detected ports", async () => {
+      await act(async () => {
+        renderField(serialPortField, "/dev/ttyUSB0", vi.fn());
+      });
+      const select = query("field-port") as HTMLSelectElement;
+      expect(select.tagName).toBe("SELECT");
+      expect(select.value).toBe("/dev/ttyUSB0");
+      const optionValues = Array.from(select.options).map((o) => o.value);
+      expect(optionValues).toContain("/dev/ttyUSB0");
+      expect(optionValues).toContain("/dev/ttyS0");
+    });
+
+    it("shows disconnected option when current value is not in detected ports", async () => {
+      await act(async () => {
+        renderField(serialPortField, "/dev/ttyUSB1", vi.fn());
+      });
+      const disconnected = query("field-port-disconnected") as HTMLOptionElement;
+      expect(disconnected).toBeTruthy();
+      expect(disconnected.value).toBe("/dev/ttyUSB1");
+      expect(disconnected.text).toContain("not connected");
+      const select = query("field-port") as HTMLSelectElement;
+      expect(select.value).toBe("/dev/ttyUSB1");
+    });
+
+    it("does not show disconnected option when current value is in detected ports", async () => {
+      await act(async () => {
+        renderField(serialPortField, "/dev/ttyUSB0", vi.fn());
+      });
+      expect(query("field-port-disconnected")).toBeNull();
+    });
+
+    it("shows available ports and placeholder when value is empty", async () => {
+      await act(async () => {
+        renderField(serialPortField, "", vi.fn());
+      });
+      const select = query("field-port") as HTMLSelectElement;
+      const optionValues = Array.from(select.options).map((o) => o.value);
+      expect(optionValues).toContain("/dev/ttyUSB0");
+      expect(optionValues).toContain("/dev/ttyS0");
+      // Placeholder option present with empty value
+      expect(optionValues).toContain("");
+      // No disconnected option since value is empty
+      expect(query("field-port-disconnected")).toBeNull();
+    });
+
+    it("calls listSerialPorts on mount", async () => {
+      await act(async () => {
+        renderField(serialPortField, "", vi.fn());
+      });
+      expect(listSerialPorts).toHaveBeenCalled();
+    });
+
+    it("calls onChange with port value on selection", async () => {
+      const onChange = vi.fn();
+      await act(async () => {
+        renderField(serialPortField, "/dev/ttyUSB0", onChange);
+      });
+      const select = query("field-port") as HTMLSelectElement;
+      await act(async () => {
+        select.value = "/dev/ttyS0";
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      expect(onChange).toHaveBeenCalledWith("port", "/dev/ttyS0");
+    });
+
+    it("uses provided availablePorts instead of calling listSerialPorts", async () => {
+      const callCountBefore = (listSerialPorts as ReturnType<typeof vi.fn>).mock.calls.length;
+      await act(async () => {
+        renderField(serialPortField, "/dev/ttyAMA0", vi.fn(), {
+          availablePorts: ["/dev/ttyAMA0", "/dev/ttyAMA1"],
+        });
+      });
+      expect((listSerialPorts as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callCountBefore);
+      const select = query("field-port") as HTMLSelectElement;
+      const optionValues = Array.from(select.options).map((o) => o.value);
+      expect(optionValues).toContain("/dev/ttyAMA0");
+      expect(optionValues).toContain("/dev/ttyAMA1");
+      expect(optionValues).not.toContain("/dev/ttyUSB0");
+    });
+
+    it("shows disconnected option from availablePorts when value is not in supplied list", async () => {
+      await act(async () => {
+        renderField(serialPortField, "/dev/ttyAMA2", vi.fn(), {
+          availablePorts: ["/dev/ttyAMA0"],
+        });
+      });
+      const disconnected = query("field-port-disconnected") as HTMLOptionElement;
+      expect(disconnected).toBeTruthy();
+      expect(disconnected.value).toBe("/dev/ttyAMA2");
+      expect(disconnected.text).toContain("not connected");
     });
   });
 

--- a/src/components/DynamicForm/DynamicField.tsx
+++ b/src/components/DynamicForm/DynamicField.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { HelpCircle, X } from "lucide-react";
 import type { SettingsField, FieldType } from "@/types/schema";
 import { KeyPathInput } from "@/components/Settings/KeyPathInput";
+import { listSerialPorts } from "@/services/api";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
 
 interface DynamicFieldProps {
@@ -11,6 +12,12 @@ interface DynamicFieldProps {
   onChange: (key: string, value: unknown) => void;
   /** When true, shows a "Password saved in credential store" hint below password fields. */
   credentialSaved?: boolean;
+  /**
+   * Pre-supplied list of serial port names for `serialPort` fields.
+   * When provided, the field shows these instead of querying the local system.
+   * Use this to pass ports from a remote agent's capabilities.
+   */
+  availablePorts?: string[];
 }
 
 /**
@@ -19,12 +26,18 @@ interface DynamicFieldProps {
  * Dispatches to the appropriate input widget (text, password, number,
  * boolean toggle, select, port, file path, key-value list, object list).
  */
-export function DynamicField({ field, value, onChange, credentialSaved }: DynamicFieldProps) {
+export function DynamicField({
+  field,
+  value,
+  onChange,
+  credentialSaved,
+  availablePorts,
+}: DynamicFieldProps) {
   const handleChange = useCallback((v: unknown) => onChange(field.key, v), [field.key, onChange]);
 
   return (
     <div className="settings-form__field" data-testid={`dynamic-field-${field.key}`}>
-      {renderFieldInput(field, field.fieldType, value, handleChange)}
+      {renderFieldInput(field, field.fieldType, value, handleChange, availablePorts)}
       {field.description && <p className="settings-form__hint">{field.description}</p>}
       {credentialSaved && (
         <p
@@ -42,7 +55,8 @@ function renderFieldInput(
   field: SettingsField,
   fieldType: FieldType,
   value: unknown,
-  onChange: (v: unknown) => void
+  onChange: (v: unknown) => void,
+  availablePorts?: string[]
 ): React.ReactNode {
   switch (fieldType.type) {
     case "text":
@@ -57,6 +71,15 @@ function renderFieldInput(
       return <SelectField field={field} value={value} onChange={onChange} fieldType={fieldType} />;
     case "port":
       return <PortField field={field} value={value} onChange={onChange} />;
+    case "serialPort":
+      return (
+        <SerialPortField
+          field={field}
+          value={value}
+          onChange={onChange}
+          availablePorts={availablePorts}
+        />
+      );
     case "filePath":
       return (
         <FilePathField field={field} value={value} onChange={onChange} fieldType={fieldType} />
@@ -245,6 +268,57 @@ function PortField({ field, value, onChange }: FieldProps) {
         placeholder={field.placeholder}
         data-testid={`field-${field.key}`}
       />
+    </>
+  );
+}
+
+function SerialPortField({
+  field,
+  value,
+  onChange,
+  availablePorts: propPorts,
+}: FieldProps & { availablePorts?: string[] }) {
+  const [detectedPorts, setDetectedPorts] = useState<string[]>([]);
+  const currentValue = (value as string) ?? "";
+
+  useEffect(() => {
+    if (propPorts !== undefined) return;
+    listSerialPorts()
+      .then(setDetectedPorts)
+      .catch(() => setDetectedPorts([]));
+  }, [propPorts]);
+
+  const availablePorts = propPorts ?? detectedPorts;
+  const isDisconnected = currentValue !== "" && !availablePorts.includes(currentValue);
+
+  return (
+    <>
+      <span className="settings-form__label">{field.label}</span>
+      <select
+        value={currentValue}
+        onChange={(e) => onChange(e.target.value || undefined)}
+        data-testid={`field-${field.key}`}
+      >
+        {currentValue === "" && (
+          <option value="" disabled>
+            {availablePorts.length === 0 ? "No ports detected" : "Select a port…"}
+          </option>
+        )}
+        {isDisconnected && (
+          <option
+            value={currentValue}
+            style={{ color: "var(--text-disabled)" }}
+            data-testid={`field-${field.key}-disconnected`}
+          >
+            {currentValue} (not connected)
+          </option>
+        )}
+        {availablePorts.map((port) => (
+          <option key={port} value={port}>
+            {port}
+          </option>
+        ))}
+      </select>
     </>
   );
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -60,6 +60,7 @@ export type FieldType =
   | { type: "boolean" }
   | { type: "select"; options: SelectOption[] }
   | { type: "port" }
+  | { type: "serialPort" }
   | { type: "filePath"; kind: FilePathKind }
   | { type: "keyValueList" }
   | { type: "objectList"; fields: SettingsField[] };


### PR DESCRIPTION
## Summary

- Adds a new `FieldType::SerialPort` schema type (Rust + TypeScript) for serial device path fields
- The serial port field in the connection editor is now a `<select>` dropdown populated from currently detected serial ports via `listSerialPorts()`
- If the configured port is not currently detected (e.g. USB adapter unplugged), it still appears in the list greyed out and labelled "(not connected)" — the setting is preserved without data loss
- When editing a serial session on a remote agent, the dropdown shows ports from `agent.capabilities.availableSerialPorts` (detected at agent connect time) instead of querying the local machine

## Test plan

- [ ] Open a serial connection in the editor — port field shows a dropdown with currently detected ports
- [ ] With a port configured but the USB adapter unplugged, open the editor — the configured port appears in the list as `<port> (not connected)`, other detected ports are shown normally
- [ ] Connect to a remote agent, create a new serial session definition — the port dropdown shows the remote machine's ports, not local ports
- [ ] Rebuild agent binary (`cargo build -p termihub-agent`) to pick up `FieldType::SerialPort`; unupdated agents fall back to the old text field until rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)