### PR TITLE
fix(ui): settings panels always open on first category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terminal: agent-session reconnect loop now shows a "Connection failed" state briefly after each failed attempt instead of spinning "Connecting…" indefinitely with no visible feedback. The overlay cycles Connecting → Connection failed → Connecting until the session is established.
 - Terminal: when an agent reconnects while a terminal is in the retry loop (or showing "Connection failed"), the connection attempt is now restarted immediately instead of waiting for the next retry cycle — the terminal connects as soon as the agent is back.
 - Connection editor: boolean fields in existing connections now correctly reflect their schema default when the field was never explicitly saved (previously showed unchecked regardless of the schema default)
+- Settings: the Settings panel and Connection Editor no longer remember the last-selected category across opens — they always start on the first category ("General" / "Connection")
 
 ### Added
 

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -62,25 +62,6 @@ const EDITOR_ICONS: Record<EditorCategory, LucideIcon> = {
   agent: Settings,
 };
 
-const STORAGE_KEY = "termihub-editor-category";
-
-function loadSavedCategory(): EditorCategory {
-  try {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (
-      saved === "connection" ||
-      saved === "terminal" ||
-      saved === "appearance" ||
-      saved === "agent"
-    ) {
-      return saved;
-    }
-  } catch {
-    // Ignore localStorage errors
-  }
-  return "connection";
-}
-
 /** Check whether any field in TerminalOptions has a non-undefined value. */
 function hasTerminalOptions(opts: TerminalOptions): boolean {
   return Object.values(opts).some((v) => v !== undefined);
@@ -319,7 +300,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   }, [name, connections, remoteAgents, editingConnectionId, folderId]);
 
   // Category navigation
-  const [activeCategory, setActiveCategory] = useState<EditorCategory>(loadSavedCategory);
+  const [activeCategory, setActiveCategory] = useState<EditorCategory>("connection");
   const [isCompact, setIsCompact] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -397,11 +378,6 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
 
   const handleCategoryChange = useCallback((category: EditorCategory) => {
     setActiveCategory(category);
-    try {
-      localStorage.setItem(STORAGE_KEY, category);
-    } catch {
-      // Ignore localStorage errors
-    }
   }, []);
 
   const handleTypeChange = useCallback(

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -44,30 +44,7 @@ const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
   updates: RefreshCw,
 };
 
-const STORAGE_KEY = "termihub-settings-category";
 const SAVE_DEBOUNCE_MS = 300;
-
-function loadSavedCategory(): SettingsCategory {
-  try {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (
-      saved === "general" ||
-      saved === "appearance" ||
-      saved === "terminal" ||
-      saved === "keyboard" ||
-      saved === "security" ||
-      saved === "external-files" ||
-      saved === "editor" ||
-      saved === "portable" ||
-      saved === "updates"
-    ) {
-      return saved;
-    }
-  } catch {
-    // Ignore localStorage errors
-  }
-  return "general";
-}
 
 interface SettingsPanelProps {
   isVisible: boolean;
@@ -80,7 +57,7 @@ export function SettingsPanel({ isVisible }: SettingsPanelProps) {
   const settings = useAppStore((s) => s.settings);
   const updateSettings = useAppStore((s) => s.updateSettings);
 
-  const [activeCategory, setActiveCategory] = useState<SettingsCategory>(loadSavedCategory);
+  const [activeCategory, setActiveCategory] = useState<SettingsCategory>("general");
   const [searchQuery, setSearchQuery] = useState("");
   const [isCompact, setIsCompact] = useState(false);
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
@@ -108,14 +85,8 @@ export function SettingsPanel({ isVisible }: SettingsPanelProps) {
     return () => observer.disconnect();
   }, []);
 
-  // Persist active category to localStorage
   const handleCategoryChange = useCallback((category: SettingsCategory) => {
     setActiveCategory(category);
-    try {
-      localStorage.setItem(STORAGE_KEY, category);
-    } catch {
-      // Ignore localStorage errors
-    }
   }, []);
 
   // Debounced save for General/Appearance/Terminal settings


### PR DESCRIPTION
## Summary

- `SettingsPanel` and `ConnectionEditor` were persisting the last-selected sub-tab to `localStorage` and restoring it on every open
- Both dialogs now always start on their default category ("General" / "Connection") — no state is read from or written to `localStorage` for navigation

## Test plan

- [ ] Open Settings → navigate to a non-default category (e.g. Appearance) → close → reopen Settings: should land on General
- [ ] Open Connection Editor → switch to "Agent" tab → close → reopen Connection Editor: should land on Connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)