### PR TITLE
style(ui): unify settings and connection editor visual design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Settings: all settings panels and connection editor tabs now use a consistent visual design — fields are grouped under titled category sections, boolean options use a pill toggle switch (label on top, toggle below, hint text underneath), and spacing between fields is uniform across the entire UI.
+- Connection editor: the Connection tab is now structured in named sections (General, schema-defined groups, Session, External Files), matching the look and feel of all other tabs.
+
 ### Fixed
 
 - Agent: after an agent reconnects following a power loss, terminals whose sessions were successfully recovered by the agent now resume automatically instead of always showing the "Session disconnected" overlay. Sessions that could not be recovered still show the overlay as before.

--- a/src/components/ConnectionEditor/AgentExternalFilesSettings.tsx
+++ b/src/components/ConnectionEditor/AgentExternalFilesSettings.tsx
@@ -43,52 +43,50 @@ export function AgentExternalFilesSettings({ files, onChange }: AgentExternalFil
   );
 
   return (
-    <div className="settings-form__field" data-testid="agent-external-files">
-      <span className="settings-form__label">External Connection Files</span>
+    <div className="settings-panel__category" data-testid="agent-external-files">
+      <h3 className="settings-panel__category-title">External Connection Files</h3>
       <p className="settings-form__hint">
         Load shared connection configs from files on the remote host (e.g. from a git repo). Paths
         are absolute paths on the remote machine. Changes take effect on next reconnect.
       </p>
-      {files.map((file) => (
-        <div
-          key={file.path}
-          className="settings-form__list-row"
-          data-testid="agent-external-file-row"
-        >
-          <label className="settings-form__list-checkbox">
-            <input
-              type="checkbox"
-              checked={file.enabled}
-              onChange={() => handleToggle(file.path)}
-              data-testid={`agent-external-file-toggle`}
-            />
-          </label>
-          <span
-            className="settings-form__list-input"
-            style={{
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              display: "flex",
-              alignItems: "center",
-              fontSize: "var(--font-size-sm)",
-              color: file.enabled ? "var(--text-primary)" : "var(--text-secondary)",
-            }}
-            title={file.path}
-          >
-            {file.path}
-          </span>
-          <button
-            className="settings-form__list-remove"
-            onClick={() => handleRemove(file.path)}
-            title="Remove file"
-            data-testid={`agent-external-file-remove`}
-          >
-            <Trash2 size={14} />
-          </button>
-        </div>
-      ))}
-      <div className="settings-form__list-row">
+
+      {files.length > 0 && (
+        <ul className="settings-panel__file-list">
+          {files.map((file) => (
+            <li
+              key={file.path}
+              className="settings-panel__file-item"
+              data-testid="agent-external-file-row"
+            >
+              <label className="settings-panel__toggle">
+                <input
+                  type="checkbox"
+                  checked={file.enabled}
+                  onChange={() => handleToggle(file.path)}
+                  data-testid="agent-external-file-toggle"
+                />
+                <span className="settings-panel__toggle-slider" />
+              </label>
+              <span
+                className={`settings-panel__file-path settings-panel__file-path--rtl${!file.enabled ? " settings-panel__file-path--disabled" : ""}`}
+                title={file.path}
+              >
+                {file.path}
+              </span>
+              <button
+                className="settings-panel__file-remove"
+                onClick={() => handleRemove(file.path)}
+                title="Remove file"
+                data-testid="agent-external-file-remove"
+              >
+                <Trash2 size={14} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="settings-form__list-row" style={{ marginTop: "var(--spacing-sm)" }}>
         <input
           type="text"
           className="settings-form__list-input"

--- a/src/components/ConnectionEditor/AgentSettingsForm.tsx
+++ b/src/components/ConnectionEditor/AgentSettingsForm.tsx
@@ -27,53 +27,74 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
   };
 
   return (
-    <div className="agent-settings-form">
-      <div className="agent-settings-form__section">
-        <div className="agent-settings-form__section-title">Features</div>
+    <div>
+      <div className="settings-panel__category">
+        <h3 className="settings-panel__category-title">Features</h3>
 
-        <label className="agent-settings-form__checkbox">
-          <input
-            type="checkbox"
-            checked={settings.enableMonitoring}
-            onChange={(e) => update("enableMonitoring", e.target.checked)}
-          />
-          Enable system monitoring
-        </label>
+        <div className="settings-form__field">
+          <span className="settings-form__label">System Monitoring</span>
+          <label className="settings-panel__toggle">
+            <input
+              type="checkbox"
+              checked={settings.enableMonitoring}
+              onChange={(e) => update("enableMonitoring", e.target.checked)}
+            />
+            <span className="settings-panel__toggle-slider" />
+          </label>
+          <span className="settings-form__hint">
+            Collect CPU, memory, and disk usage from the remote host.
+          </span>
+        </div>
 
-        <label className="agent-settings-form__checkbox">
-          <input
-            type="checkbox"
-            checked={settings.enableFileBrowser}
-            onChange={(e) => update("enableFileBrowser", e.target.checked)}
-          />
-          Enable file browser (SFTP)
-        </label>
+        <div className="settings-form__field">
+          <span className="settings-form__label">File Browser (SFTP)</span>
+          <label className="settings-panel__toggle">
+            <input
+              type="checkbox"
+              checked={settings.enableFileBrowser}
+              onChange={(e) => update("enableFileBrowser", e.target.checked)}
+            />
+            <span className="settings-panel__toggle-slider" />
+          </label>
+          <span className="settings-form__hint">
+            Browse and transfer files on the remote host via SFTP.
+          </span>
+        </div>
 
-        <label className="agent-settings-form__checkbox">
-          <input
-            type="checkbox"
-            checked={settings.enableDocker}
-            onChange={(e) => update("enableDocker", e.target.checked)}
-          />
-          Enable Docker session support
-        </label>
+        <div className="settings-form__field">
+          <span className="settings-form__label">Docker Sessions</span>
+          <label className="settings-panel__toggle">
+            <input
+              type="checkbox"
+              checked={settings.enableDocker}
+              onChange={(e) => update("enableDocker", e.target.checked)}
+            />
+            <span className="settings-panel__toggle-slider" />
+          </label>
+          <span className="settings-form__hint">
+            Open terminal sessions directly inside Docker containers on the remote host.
+          </span>
+        </div>
       </div>
 
-      <div className="agent-settings-form__section">
-        <div className="agent-settings-form__section-title">Session Defaults</div>
+      <div className="settings-panel__category">
+        <h3 className="settings-panel__category-title">Session Defaults</h3>
 
-        <label className="agent-settings-form__field">
-          <span className="agent-settings-form__label">
-            Default shell
+        <label className="settings-form__field">
+          <span className="settings-form__label">
+            Default Shell
             {!isConnected && (
-              <span className="agent-settings-form__hint" title="Connect to query available shells">
-                ⚠ Connect to query available shells
+              <span
+                className="settings-form__hint settings-form__hint--warning"
+                style={{ display: "inline", marginLeft: "6px", fontStyle: "normal" }}
+                title="Connect to query available shells"
+              >
+                ⚠ Connect to query shells
               </span>
             )}
           </span>
           {isConnected ? (
             <select
-              className="agent-settings-form__select"
               value={settings.defaultShell ?? ""}
               onChange={(e) => update("defaultShell", e.target.value || null)}
             >
@@ -87,32 +108,36 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
           ) : (
             <input
               type="text"
-              className="agent-settings-form__input"
               placeholder="Auto-detect"
               value={settings.defaultShell ?? ""}
               onChange={(e) => update("defaultShell", e.target.value || null)}
             />
           )}
+          <span className="settings-form__hint">
+            Shell used for new sessions. Leave empty to auto-detect.
+          </span>
         </label>
 
-        <label className="agent-settings-form__field">
-          <span className="agent-settings-form__label">Starting directory</span>
+        <label className="settings-form__field">
+          <span className="settings-form__label">Starting Directory</span>
           <input
             type="text"
-            className="agent-settings-form__input"
             value={settings.startingDirectory}
             onChange={(e) => update("startingDirectory", e.target.value)}
+            placeholder="~"
           />
+          <span className="settings-form__hint">
+            Working directory for new sessions. Leave empty for the shell default.
+          </span>
         </label>
       </div>
 
-      <div className="agent-settings-form__section">
-        <div className="agent-settings-form__section-title">Diagnostics</div>
+      <div className="settings-panel__category">
+        <h3 className="settings-panel__category-title">Diagnostics</h3>
 
-        <label className="agent-settings-form__field">
-          <span className="agent-settings-form__label">Log level</span>
+        <label className="settings-form__field">
+          <span className="settings-form__label">Log Level</span>
           <select
-            className="agent-settings-form__select"
             value={settings.logLevel}
             onChange={(e) => update("logLevel", e.target.value as AgentSettings["logLevel"])}
           >
@@ -122,16 +147,25 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
               </option>
             ))}
           </select>
+          <span className="settings-form__hint">
+            Controls the verbosity of agent-side log output.
+          </span>
         </label>
 
-        <label className="agent-settings-form__checkbox">
-          <input
-            type="checkbox"
-            checked={settings.verboseTracing}
-            onChange={(e) => update("verboseTracing", e.target.checked)}
-          />
-          Enable verbose protocol tracing
-        </label>
+        <div className="settings-form__field">
+          <span className="settings-form__label">Verbose Protocol Tracing</span>
+          <label className="settings-panel__toggle">
+            <input
+              type="checkbox"
+              checked={settings.verboseTracing}
+              onChange={(e) => update("verboseTracing", e.target.checked)}
+            />
+            <span className="settings-panel__toggle-slider" />
+          </label>
+          <span className="settings-form__hint">
+            Log every JSON-RPC message. Useful for debugging connection issues.
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ConnectionEditor/ConnectionAppearanceSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionAppearanceSettings.tsx
@@ -48,6 +48,9 @@ export function ConnectionAppearanceSettings({
             </button>
           )}
         </div>
+        <span className="settings-form__hint">
+          Accent color shown on the connection tab and sidebar entry.
+        </span>
       </div>
 
       <div className="settings-form__field">
@@ -73,6 +76,9 @@ export function ConnectionAppearanceSettings({
             </button>
           )}
         </div>
+        <span className="settings-form__hint">
+          Icon displayed on the connection tab and in the sidebar.
+        </span>
       </div>
 
       <ColorPickerDialog

--- a/src/components/ConnectionEditor/ConnectionEditor.css
+++ b/src/components/ConnectionEditor/ConnectionEditor.css
@@ -34,9 +34,6 @@
 }
 
 .connection-editor__form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
   max-width: 600px;
 }
 
@@ -112,7 +109,8 @@
 .settings-form__field {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
+  margin-bottom: var(--spacing-md);
 }
 
 .settings-form__label {
@@ -143,9 +141,10 @@
 .settings-form__hint {
   font-size: 11px;
   color: var(--text-secondary);
-  margin: 0;
-  padding: var(--spacing-xs) 0;
+  margin: 0 0 var(--spacing-sm);
+  padding: 2px 0;
   font-style: italic;
+  line-height: 1.4;
 }
 
 .settings-form__hint--warning {

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -685,44 +685,70 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   }, [selectedType, runtimesLoading, currentSchema, connSettings.runtime]);
 
   const renderConnectionContent = () => (
-    <div className="connection-editor__form">
-      <label className="settings-form__field">
-        <span className="settings-form__label">Name</span>
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Connection name"
-          autoFocus
-          className={nameError ? "settings-form__input--error" : ""}
-          data-testid="connection-editor-name-input"
-        />
-        {nameError && (
-          <p
-            className="settings-form__hint settings-form__hint--error"
-            data-testid="connection-editor-name-error"
-          >
-            {nameError}
+    <>
+      <div className="settings-panel__category">
+        <h3 className="settings-panel__category-title">General</h3>
+        <label className="settings-form__field">
+          <span className="settings-form__label">Name</span>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Connection name"
+            autoFocus
+            className={nameError ? "settings-form__input--error" : ""}
+            data-testid="connection-editor-name-input"
+          />
+          {nameError && (
+            <p
+              className="settings-form__hint settings-form__hint--error"
+              data-testid="connection-editor-name-error"
+            >
+              {nameError}
+            </p>
+          )}
+        </label>
+        {!isAgentTransportMode && (
+          <label className="settings-form__field">
+            <span className="settings-form__label">Type</span>
+            <select
+              value={selectedType}
+              onChange={(e) => handleTypeChange(e.target.value)}
+              disabled={isAgentDefinitionMode ? !!existingAgentDef : false}
+              data-testid="connection-editor-type-select"
+            >
+              {typeOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        {!isAgentTransportMode && (
+          <p className="settings-form__hint">
+            Use {"${env:VAR}"} for environment variables, e.g. {"${env:USER}"}
+            {isAgentDefinitionMode && " (resolved on the remote machine)"}
           </p>
         )}
-      </label>
-      {!isAgentTransportMode && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Type</span>
-          <select
-            value={selectedType}
-            onChange={(e) => handleTypeChange(e.target.value)}
-            disabled={isAgentDefinitionMode ? !!existingAgentDef : false}
-            data-testid="connection-editor-type-select"
-          >
-            {typeOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
-      )}
+        {!isAnyAgentMode && enabledExternalFiles.length > 0 && (
+          <label className="settings-form__field">
+            <span className="settings-form__label">Storage File</span>
+            <select
+              value={sourceFile ?? ""}
+              onChange={(e) => setSourceFile(e.target.value || null)}
+              data-testid="connection-editor-source-file"
+            >
+              <option value="">Default (connections.json)</option>
+              {enabledExternalFiles.map((f) => (
+                <option key={f.path} value={f.path}>
+                  {f.path}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </div>
 
       {currentSchema && (
         <ConnectionSettingsForm
@@ -734,40 +760,24 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
       )}
 
       {isAgentDefinitionMode && (
-        <label className="settings-form__field settings-form__field--checkbox">
-          <input
-            type="checkbox"
-            checked={persistent}
-            onChange={(e) => setPersistent(e.target.checked)}
-            data-testid="connection-editor-persistent"
-          />
-          <span className="settings-form__label">Persistent session</span>
-        </label>
-      )}
-
-      {!isAgentTransportMode && (
-        <p className="settings-form__hint">
-          Use {"${env:VAR}"} for environment variables, e.g. {"${env:USER}"}
-          {isAgentDefinitionMode && " (resolved on the remote machine)"}
-        </p>
-      )}
-
-      {!isAnyAgentMode && enabledExternalFiles.length > 0 && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Storage File</span>
-          <select
-            value={sourceFile ?? ""}
-            onChange={(e) => setSourceFile(e.target.value || null)}
-            data-testid="connection-editor-source-file"
-          >
-            <option value="">Default (connections.json)</option>
-            {enabledExternalFiles.map((f) => (
-              <option key={f.path} value={f.path}>
-                {f.path}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="settings-panel__category">
+          <h3 className="settings-panel__category-title">Session</h3>
+          <div className="settings-form__field">
+            <span className="settings-form__label">Persistent session</span>
+            <label className="settings-panel__toggle">
+              <input
+                type="checkbox"
+                checked={persistent}
+                onChange={(e) => setPersistent(e.target.checked)}
+                data-testid="connection-editor-persistent"
+              />
+              <span className="settings-panel__toggle-slider" />
+            </label>
+            <span className="settings-form__hint">
+              Keep the session alive when the tab is closed
+            </span>
+          </div>
+        </div>
       )}
 
       {isAgentTransportMode && (
@@ -778,7 +788,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           }
         />
       )}
-    </div>
+    </>
   );
 
   const renderContent = () => {

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
@@ -87,7 +87,8 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
         </select>
       </label>
 
-      <div className="settings-form__field settings-form__field--row">
+      <div className="settings-form__field">
+        <span className="settings-form__label">Cursor Blink</span>
         <label className="settings-panel__toggle">
           <input
             type="checkbox"
@@ -96,24 +97,22 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
           />
           <span className="settings-panel__toggle-slider" />
         </label>
-        <div>
-          <span className="settings-form__label">Cursor Blink</span>
-          <span className="settings-form__hint">
-            Whether the terminal cursor blinks.
-            {options.cursorBlink != null && (
-              <button
-                type="button"
-                className="settings-form__hint-action"
-                onClick={() => onChange({ ...options, cursorBlink: undefined })}
-              >
-                Reset to global default
-              </button>
-            )}
-          </span>
-        </div>
+        <span className="settings-form__hint">
+          Whether the terminal cursor blinks.
+          {options.cursorBlink != null && (
+            <button
+              type="button"
+              className="settings-form__hint-action"
+              onClick={() => onChange({ ...options, cursorBlink: undefined })}
+            >
+              Reset to global default
+            </button>
+          )}
+        </span>
       </div>
 
-      <div className="settings-form__field settings-form__field--row">
+      <div className="settings-form__field">
+        <span className="settings-form__label">Horizontal Scrolling</span>
         <label className="settings-panel__toggle">
           <input
             type="checkbox"
@@ -122,21 +121,18 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
           />
           <span className="settings-panel__toggle-slider" />
         </label>
-        <div>
-          <span className="settings-form__label">Horizontal Scrolling</span>
-          <span className="settings-form__hint">
-            Enable horizontal scrolling for this connection.
-            {options.horizontalScrolling != null && (
-              <button
-                type="button"
-                className="settings-form__hint-action"
-                onClick={() => onChange({ ...options, horizontalScrolling: undefined })}
-              >
-                Reset to global default
-              </button>
-            )}
-          </span>
-        </div>
+        <span className="settings-form__hint">
+          Enable horizontal scrolling for this connection.
+          {options.horizontalScrolling != null && (
+            <button
+              type="button"
+              className="settings-form__hint-action"
+              onClick={() => onChange({ ...options, horizontalScrolling: undefined })}
+            >
+              Reset to global default
+            </button>
+          )}
+        </span>
       </div>
     </div>
   );

--- a/src/components/DynamicForm/ConnectionSettingsForm.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.tsx
@@ -19,7 +19,8 @@ interface ConnectionSettingsFormProps {
  * Generic connection settings form renderer.
  *
  * Iterates groups and fields from the schema, evaluates visibility
- * conditions, and delegates each field to DynamicField.
+ * conditions, and delegates each field to DynamicField. Each schema group
+ * is rendered as a visual section with a category title.
  */
 export function ConnectionSettingsForm({
   schema,
@@ -35,12 +36,17 @@ export function ConnectionSettingsForm({
   );
 
   return (
-    <div className="settings-form" data-testid="connection-settings-form">
+    <div data-testid="connection-settings-form">
       {schema.groups.map((group) => {
         const visibleFields = group.fields.filter((f) => isFieldVisible(f, settings));
         if (visibleFields.length === 0) return null;
         return (
-          <div key={group.key} data-testid={`form-group-${group.key}`}>
+          <div
+            className="settings-panel__category"
+            key={group.key}
+            data-testid={`form-group-${group.key}`}
+          >
+            <h3 className="settings-panel__category-title">{group.label}</h3>
             {visibleFields.map((field) => (
               <DynamicField
                 key={field.key}

--- a/src/components/DynamicForm/DynamicField.tsx
+++ b/src/components/DynamicForm/DynamicField.tsx
@@ -18,6 +18,7 @@ interface DynamicFieldProps {
  *
  * Dispatches to the appropriate input widget (text, password, number,
  * boolean toggle, select, port, file path, key-value list, object list).
+ * Boolean fields use the toggle-row layout; all others use the column layout.
  */
 export function DynamicField({ field, value, onChange, credentialSaved }: DynamicFieldProps) {
   const handleChange = useCallback((v: unknown) => onChange(field.key, v), [field.key, onChange]);
@@ -137,14 +138,8 @@ function BooleanField({ field, value, onChange }: FieldProps) {
 
   return (
     <>
-      <label className="settings-form__field--checkbox" data-testid={`field-${field.key}-wrapper`}>
-        <input
-          type="checkbox"
-          checked={(value as boolean) ?? (field.default as boolean) ?? false}
-          onChange={(e) => onChange(e.target.checked)}
-          data-testid={`field-${field.key}`}
-        />
-        <span className="settings-form__label">{field.label}</span>
+      <span className="settings-form__label">
+        {field.label}
         {field.helpText && (
           <button
             type="button"
@@ -159,6 +154,15 @@ function BooleanField({ field, value, onChange }: FieldProps) {
             <HelpCircle size={13} />
           </button>
         )}
+      </span>
+      <label className="settings-panel__toggle">
+        <input
+          type="checkbox"
+          checked={(value as boolean) ?? (field.default as boolean) ?? false}
+          onChange={(e) => onChange(e.target.checked)}
+          data-testid={`field-${field.key}`}
+        />
+        <span className="settings-panel__toggle-slider" />
       </label>
       {dialogOpen && field.helpText && (
         <FieldHelpDialog
@@ -255,7 +259,6 @@ function FilePathField({
   onChange,
   fieldType,
 }: FieldProps & { fieldType: { type: "filePath"; kind: string } }) {
-  // Special case: SSH key path fields use the KeyPathInput combobox
   if (field.key === "keyPath") {
     return (
       <>

--- a/src/components/Settings/ExternalFilesSettings.tsx
+++ b/src/components/Settings/ExternalFilesSettings.tsx
@@ -200,42 +200,47 @@ export function ExternalFilesSettings() {
           Default settings for new SSH connections. Individual connections can override these in
           their SSH settings. Disabling a default disconnects active sessions that use the default.
         </p>
-        <ul className="settings-panel__file-list">
-          <li className="settings-panel__file-item">
-            <label className="settings-panel__toggle">
-              <input
-                type="checkbox"
-                checked={settings.powerMonitoringEnabled}
-                onChange={() =>
-                  updateSettings({
-                    ...settings,
-                    powerMonitoringEnabled: !settings.powerMonitoringEnabled,
-                  })
-                }
-                data-testid="toggle-power-monitoring"
-              />
-              <span className="settings-panel__toggle-slider" />
-            </label>
-            <span className="settings-panel__file-path">Power Monitoring</span>
-          </li>
-          <li className="settings-panel__file-item">
-            <label className="settings-panel__toggle">
-              <input
-                type="checkbox"
-                checked={settings.fileBrowserEnabled}
-                onChange={() =>
-                  updateSettings({
-                    ...settings,
-                    fileBrowserEnabled: !settings.fileBrowserEnabled,
-                  })
-                }
-                data-testid="toggle-file-browser"
-              />
-              <span className="settings-panel__toggle-slider" />
-            </label>
-            <span className="settings-panel__file-path">File Browser</span>
-          </li>
-        </ul>
+        <div className="settings-form__field">
+          <span className="settings-form__label">Power Monitoring</span>
+          <label className="settings-panel__toggle">
+            <input
+              type="checkbox"
+              checked={settings.powerMonitoringEnabled}
+              onChange={() =>
+                updateSettings({
+                  ...settings,
+                  powerMonitoringEnabled: !settings.powerMonitoringEnabled,
+                })
+              }
+              data-testid="toggle-power-monitoring"
+            />
+            <span className="settings-panel__toggle-slider" />
+          </label>
+          <span className="settings-form__hint">
+            Monitor CPU, memory, and power events via SSH agent connections.
+          </span>
+        </div>
+
+        <div className="settings-form__field">
+          <span className="settings-form__label">File Browser</span>
+          <label className="settings-panel__toggle">
+            <input
+              type="checkbox"
+              checked={settings.fileBrowserEnabled}
+              onChange={() =>
+                updateSettings({
+                  ...settings,
+                  fileBrowserEnabled: !settings.fileBrowserEnabled,
+                })
+              }
+              data-testid="toggle-file-browser"
+            />
+            <span className="settings-panel__toggle-slider" />
+          </label>
+          <span className="settings-form__hint">
+            Enable the SFTP file browser for SSH agent sessions.
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -45,111 +45,134 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
   const show = (field: string) => !visibleFields || visibleFields.has(field);
 
   return (
-    <div className="settings-panel__category">
-      <h3 className="settings-panel__category-title">General</h3>
-      {show("defaultUser") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Default User</span>
-          <input
-            type="text"
-            value={settings.defaultUser ?? ""}
-            onChange={(e) => onChange({ ...settings, defaultUser: e.target.value || undefined })}
-            placeholder="e.g. admin"
-          />
-          <span className="settings-form__hint">
-            Default username pre-filled for new SSH connections.
-          </span>
-        </label>
-      )}
-      {show("defaultSshKeyPath") && (
-        <div className="settings-form__field">
-          <span className="settings-form__label">Default SSH Key Path</span>
-          <KeyPathInput
-            value={settings.defaultSshKeyPath ?? ""}
-            onChange={(value) => onChange({ ...settings, defaultSshKeyPath: value || undefined })}
-            placeholder="~/.ssh/id_ed25519"
-            testIdPrefix="general-settings"
-          />
-          <span className="settings-form__hint">
-            Default private key path for SSH key authentication.
-          </span>
+    <>
+      <div className="settings-panel__category">
+        <h3 className="settings-panel__category-title">General</h3>
+
+        {show("defaultUser") && (
+          <label className="settings-form__field">
+            <span className="settings-form__label">Default User</span>
+            <input
+              type="text"
+              value={settings.defaultUser ?? ""}
+              onChange={(e) => onChange({ ...settings, defaultUser: e.target.value || undefined })}
+              placeholder="e.g. admin"
+            />
+            <span className="settings-form__hint">
+              Default username pre-filled for new SSH connections.
+            </span>
+          </label>
+        )}
+
+        {show("defaultSshKeyPath") && (
+          <div className="settings-form__field">
+            <span className="settings-form__label">Default SSH Key Path</span>
+            <KeyPathInput
+              value={settings.defaultSshKeyPath ?? ""}
+              onChange={(value) => onChange({ ...settings, defaultSshKeyPath: value || undefined })}
+              placeholder="~/.ssh/id_ed25519"
+              testIdPrefix="general-settings"
+            />
+            <span className="settings-form__hint">
+              Default private key path for SSH key authentication.
+            </span>
+          </div>
+        )}
+
+        {show("defaultShell") && (
+          <label className="settings-form__field">
+            <span className="settings-form__label">Default Shell</span>
+            <select
+              value={settings.defaultShell ?? ""}
+              onChange={(e) => onChange({ ...settings, defaultShell: e.target.value || undefined })}
+            >
+              <option value="">
+                Platform default (
+                {getShellLabel(platformDefaultShell, platformDefaultShell).replace(
+                  " (platform default)",
+                  ""
+                )}
+                )
+              </option>
+              {availableShells.map((shell) => (
+                <option key={shell} value={shell}>
+                  {getShellLabel(shell, platformDefaultShell)}
+                </option>
+              ))}
+            </select>
+            <span className="settings-form__hint">
+              Default shell for new local terminal sessions.
+            </span>
+          </label>
+        )}
+
+        {show("experimentalFeaturesEnabled") && (
+          <div className="settings-form__field">
+            <span className="settings-form__label">Allow Experimental Features</span>
+            <label className="settings-panel__toggle">
+              <input
+                type="checkbox"
+                checked={settings.experimentalFeaturesEnabled ?? false}
+                onChange={(e) =>
+                  onChange({ ...settings, experimentalFeaturesEnabled: e.target.checked })
+                }
+                data-testid="settings-experimental-features"
+              />
+              <span className="settings-panel__toggle-slider" />
+            </label>
+            <span className="settings-form__hint settings-form__hint--warning">
+              Enables hidden features under active development. Experimental features may change,
+              break, or be removed at any time without notice.
+            </span>
+          </div>
+        )}
+      </div>
+
+      {(show("defaultShellIntegration") || show("defaultX11Forwarding")) && (
+        <div className="settings-panel__category">
+          <h3 className="settings-panel__category-title">SSH Defaults</h3>
+
+          {show("defaultShellIntegration") && (
+            <div className="settings-form__field">
+              <span className="settings-form__label">Shell Integration by Default</span>
+              <label className="settings-panel__toggle">
+                <input
+                  type="checkbox"
+                  checked={settings.defaultShellIntegration ?? true}
+                  onChange={(e) =>
+                    onChange({ ...settings, defaultShellIntegration: e.target.checked })
+                  }
+                  data-testid="settings-default-shell-integration"
+                />
+                <span className="settings-panel__toggle-slider" />
+              </label>
+              <span className="settings-form__hint">
+                Pre-enable Shell Integration (OSC 7 CWD tracking) for new SSH connections.
+              </span>
+            </div>
+          )}
+
+          {show("defaultX11Forwarding") && (
+            <div className="settings-form__field">
+              <span className="settings-form__label">X11 Forwarding by Default</span>
+              <label className="settings-panel__toggle">
+                <input
+                  type="checkbox"
+                  checked={settings.defaultX11Forwarding ?? true}
+                  onChange={(e) =>
+                    onChange({ ...settings, defaultX11Forwarding: e.target.checked })
+                  }
+                  data-testid="settings-default-x11-forwarding"
+                />
+                <span className="settings-panel__toggle-slider" />
+              </label>
+              <span className="settings-form__hint">
+                Pre-enable X11 Forwarding for new SSH connections.
+              </span>
+            </div>
+          )}
         </div>
       )}
-      {show("defaultShell") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Default Shell</span>
-          <select
-            value={settings.defaultShell ?? ""}
-            onChange={(e) => onChange({ ...settings, defaultShell: e.target.value || undefined })}
-          >
-            <option value="">
-              Platform default (
-              {getShellLabel(platformDefaultShell, platformDefaultShell).replace(
-                " (platform default)",
-                ""
-              )}
-              )
-            </option>
-            {availableShells.map((shell) => (
-              <option key={shell} value={shell}>
-                {getShellLabel(shell, platformDefaultShell)}
-              </option>
-            ))}
-          </select>
-          <span className="settings-form__hint">
-            Default shell for new local terminal sessions.
-          </span>
-        </label>
-      )}
-      {show("experimentalFeaturesEnabled") && (
-        <label className="settings-form__field settings-form__field--checkbox">
-          <input
-            type="checkbox"
-            checked={settings.experimentalFeaturesEnabled ?? false}
-            onChange={(e) =>
-              onChange({ ...settings, experimentalFeaturesEnabled: e.target.checked })
-            }
-            data-testid="settings-experimental-features"
-          />
-          <span className="settings-form__label">Allow Experimental Features</span>
-          <span className="settings-form__hint settings-form__hint--warning">
-            Enables hidden features that are under active development. Experimental features may
-            change, break, or be removed at any time without notice and are not guaranteed to be
-            released or long-term supported.
-          </span>
-        </label>
-      )}
-      {(show("defaultShellIntegration") || show("defaultX11Forwarding")) && (
-        <h3 className="settings-panel__category-title">SSH Defaults</h3>
-      )}
-      {show("defaultShellIntegration") && (
-        <label className="settings-form__field settings-form__field--checkbox">
-          <input
-            type="checkbox"
-            checked={settings.defaultShellIntegration ?? true}
-            onChange={(e) => onChange({ ...settings, defaultShellIntegration: e.target.checked })}
-            data-testid="settings-default-shell-integration"
-          />
-          <span className="settings-form__label">Shell Integration by Default</span>
-          <span className="settings-form__hint">
-            Pre-enable Shell Integration (OSC 7 CWD tracking) for new SSH connections.
-          </span>
-        </label>
-      )}
-      {show("defaultX11Forwarding") && (
-        <label className="settings-form__field settings-form__field--checkbox">
-          <input
-            type="checkbox"
-            checked={settings.defaultX11Forwarding ?? true}
-            onChange={(e) => onChange({ ...settings, defaultX11Forwarding: e.target.checked })}
-            data-testid="settings-default-x11-forwarding"
-          />
-          <span className="settings-form__label">X11 Forwarding by Default</span>
-          <span className="settings-form__hint">
-            Pre-enable X11 Forwarding for new SSH connections.
-          </span>
-        </label>
-      )}
-    </div>
+    </>
   );
 }

--- a/src/components/Settings/PortableModeSettings.css
+++ b/src/components/Settings/PortableModeSettings.css
@@ -1,0 +1,190 @@
+/* === Key-value status rows === */
+.portable-mode__kv-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-md);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+.portable-mode__kv-label {
+  flex-shrink: 0;
+  width: 90px;
+  color: var(--text-secondary);
+}
+
+.portable-mode__kv-value {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-primary);
+}
+
+.portable-mode__kv-value--active {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-success, #7dcf88);
+}
+
+.portable-mode__kv-value--inactive {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+}
+
+.portable-mode__kv-value--path {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* === Info callout === */
+.portable-mode__info-box {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin: var(--spacing-md) 0;
+  background-color: color-mix(in srgb, var(--accent-color) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 20%, transparent);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.portable-mode__info-box svg {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--accent-color);
+}
+
+/* === Config file status list === */
+.portable-mode__file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.portable-mode__file-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: 5px var(--spacing-sm);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+}
+
+.portable-mode__file-icon--present {
+  flex-shrink: 0;
+  color: var(--color-success, #7dcf88);
+}
+
+.portable-mode__file-icon--absent {
+  flex-shrink: 0;
+  color: var(--text-disabled);
+}
+
+.portable-mode__file-name {
+  flex: 1;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+}
+
+.portable-mode__file-status {
+  font-size: 11px;
+  color: var(--text-disabled);
+}
+
+/* === Action button row === */
+.portable-mode__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-top: var(--spacing-sm);
+}
+
+/* === Migration result banner === */
+.portable-mode__result {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-top: var(--spacing-md);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+}
+
+.portable-mode__result--success {
+  background-color: color-mix(in srgb, var(--color-success, #7dcf88) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-success, #7dcf88) 25%, transparent);
+  color: var(--text-primary);
+}
+
+.portable-mode__result--error {
+  background-color: color-mix(in srgb, var(--color-error, #ef6b5a) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-error, #ef6b5a) 25%, transparent);
+  color: var(--text-primary);
+}
+
+/* === Migration dialog (file selection) === */
+.portable-mode__migration-files {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.portable-mode__migration-file {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: 3px 0;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.portable-mode__migration-file--missing {
+  opacity: 0.45;
+}
+
+.portable-mode__migration-filename {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+}
+
+.portable-mode__migration-absent {
+  font-size: 11px;
+  color: var(--text-disabled);
+  font-style: italic;
+}
+
+.portable-mode__migration-dest {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.portable-mode__migration-dest-label {
+  flex-shrink: 0;
+}
+
+.portable-mode__migration-dest-path {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}

--- a/src/components/Settings/PortableModeSettings.tsx
+++ b/src/components/Settings/PortableModeSettings.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2, XCircle, HardDrive, Info } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { listConfigFiles, exportConfigToPortable, importConfigFromPortable } from "@/services/api";
 import type { ConfigFileStatus } from "@/types/connection";
+import "./PortableModeSettings.css";
 
 const PORTABLE_FILES = [
   "connections.json",
@@ -51,14 +52,15 @@ function MigrationDialog({
   }, []);
 
   return (
-    <div className="settings-section__migration-dialog" data-testid="migration-dialog">
-      <h4 className="settings-section__migration-title">{title}</h4>
-      <p className="settings-section__migration-description">{description}</p>
-      <div className="settings-section__migration-files">
+    <div className="settings-panel__inline-dialog" data-testid="migration-dialog">
+      <h4 className="settings-panel__inline-dialog-title">{title}</h4>
+      <p className="settings-panel__inline-dialog-text">{description}</p>
+
+      <div className="portable-mode__migration-files">
         {sourceFiles.map((f) => (
           <label
             key={f.name}
-            className={`settings-section__migration-file ${!f.present ? "settings-section__migration-file--missing" : ""}`}
+            className={`portable-mode__migration-file${!f.present ? " portable-mode__migration-file--missing" : ""}`}
           >
             <input
               type="checkbox"
@@ -66,18 +68,20 @@ function MigrationDialog({
               disabled={!f.present || isRunning}
               onChange={() => toggle(f.name)}
             />
-            <span className="settings-section__migration-filename">{f.name}</span>
-            {!f.present && <span className="settings-section__migration-absent">not found</span>}
+            <span className="portable-mode__migration-filename">{f.name}</span>
+            {!f.present && <span className="portable-mode__migration-absent">not found</span>}
           </label>
         ))}
       </div>
-      <div className="settings-section__migration-dest">
-        <span className="settings-section__migration-dest-label">{targetDirLabel}:</span>
-        <code className="settings-section__migration-dest-path">{targetDir}</code>
+
+      <div className="portable-mode__migration-dest">
+        <span className="portable-mode__migration-dest-label">{targetDirLabel}:</span>
+        <code className="portable-mode__migration-dest-path">{targetDir}</code>
       </div>
-      <div className="settings-section__migration-actions">
+
+      <div className="settings-panel__inline-dialog-actions">
         <button
-          className="settings-section__btn settings-section__btn--secondary"
+          className="settings-panel__btn"
           onClick={onCancel}
           disabled={isRunning}
           data-testid="migration-cancel"
@@ -85,7 +89,7 @@ function MigrationDialog({
           Cancel
         </button>
         <button
-          className="settings-section__btn settings-section__btn--primary"
+          className="settings-panel__btn settings-panel__btn--primary"
           onClick={() => onConfirm(Array.from(selected))}
           disabled={selected.size === 0 || isRunning}
           data-testid="migration-confirm"
@@ -124,7 +128,6 @@ export function PortableModeSettings() {
   }, [isPortableMode, portableDataDir]);
 
   const handleExport = useCallback(async () => {
-    // Pick the destination portable data directory
     const dir = await open({ directory: true, multiple: false });
     if (!dir) return;
     const destDir = typeof dir === "string" ? dir : dir[0];
@@ -136,7 +139,6 @@ export function PortableModeSettings() {
   }, []);
 
   const handleImport = useCallback(async () => {
-    // Pick the source portable data directory
     const dir = await open({ directory: true, multiple: false });
     if (!dir) return;
     const srcDir = typeof dir === "string" ? dir : dir[0];
@@ -188,13 +190,13 @@ export function PortableModeSettings() {
   );
 
   return (
-    <div className="settings-section" data-testid="portable-mode-settings">
-      <h3 className="settings-section__title">Portable Mode</h3>
+    <div className="settings-panel__category" data-testid="portable-mode-settings">
+      <h3 className="settings-panel__category-title">Portable Mode</h3>
 
-      <div className="settings-section__row">
-        <span className="settings-section__label">Status</span>
+      <div className="portable-mode__kv-row">
+        <span className="portable-mode__kv-label">Status</span>
         <span
-          className={`settings-section__value ${isPortableMode ? "settings-section__value--active" : "settings-section__value--inactive"}`}
+          className={`portable-mode__kv-value ${isPortableMode ? "portable-mode__kv-value--active" : "portable-mode__kv-value--inactive"}`}
           data-testid="portable-mode-status"
         >
           <HardDrive size={14} />
@@ -204,17 +206,17 @@ export function PortableModeSettings() {
 
       {isPortableMode && portableDataDir && (
         <>
-          <div className="settings-section__row">
-            <span className="settings-section__label">Data path</span>
+          <div className="portable-mode__kv-row">
+            <span className="portable-mode__kv-label">Data path</span>
             <code
-              className="settings-section__value settings-section__value--path"
+              className="portable-mode__kv-value portable-mode__kv-value--path"
               data-testid="portable-data-dir"
             >
               {portableDataDir}
             </code>
           </div>
 
-          <div className="settings-section__info-box">
+          <div className="portable-mode__info-box">
             <Info size={14} />
             <span>
               termiHub detected a <code>portable.marker</code> file or <code>data/</code> directory
@@ -223,29 +225,29 @@ export function PortableModeSettings() {
             </span>
           </div>
 
-          <div className="settings-section__subsection">
-            <h4 className="settings-section__subtitle">Config Files</h4>
-            <div className="settings-section__file-list">
+          <div className="settings-panel__section">
+            <h4 className="settings-panel__section-title">Config Files</h4>
+            <ul className="portable-mode__file-list">
               {configFiles.map((f) => (
-                <div key={f.name} className="settings-section__file-item">
+                <li key={f.name} className="portable-mode__file-item">
                   {f.present ? (
-                    <CheckCircle2 size={13} className="settings-section__file-icon--present" />
+                    <CheckCircle2 size={13} className="portable-mode__file-icon--present" />
                   ) : (
-                    <XCircle size={13} className="settings-section__file-icon--absent" />
+                    <XCircle size={13} className="portable-mode__file-icon--absent" />
                   )}
-                  <span className="settings-section__file-name">{f.name}</span>
-                  <span className="settings-section__file-status">
+                  <span className="portable-mode__file-name">{f.name}</span>
+                  <span className="portable-mode__file-status">
                     {f.present ? "present" : "not created yet"}
                   </span>
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           </div>
         </>
       )}
 
       {!isPortableMode && (
-        <div className="settings-section__info-box">
+        <div className="portable-mode__info-box">
           <Info size={14} />
           <span>
             termiHub is running in installed mode. To enable portable mode, place a{" "}
@@ -257,7 +259,7 @@ export function PortableModeSettings() {
 
       {migrationResult && (
         <div
-          className={`settings-section__migration-result ${migrationResult.success ? "settings-section__migration-result--success" : "settings-section__migration-result--error"}`}
+          className={`portable-mode__result ${migrationResult.success ? "portable-mode__result--success" : "portable-mode__result--error"}`}
           data-testid="migration-result"
         >
           {migrationResult.success ? <CheckCircle2 size={14} /> : <XCircle size={14} />}
@@ -265,21 +267,28 @@ export function PortableModeSettings() {
         </div>
       )}
 
-      <div className="settings-section__actions">
-        <button
-          className="settings-section__btn settings-section__btn--secondary"
-          onClick={handleExport}
-          data-testid="export-config-btn"
-        >
-          Export Config to Directory
-        </button>
-        <button
-          className="settings-section__btn settings-section__btn--secondary"
-          onClick={handleImport}
-          data-testid="import-config-btn"
-        >
-          Import Config from Directory
-        </button>
+      <div className="settings-panel__section">
+        <h4 className="settings-panel__section-title">Config Migration</h4>
+        <p className="settings-panel__description">
+          Copy configuration between installed and portable mode. Use Export to move your config to
+          a portable drive, or Import to bring it back.
+        </p>
+        <div className="portable-mode__actions">
+          <button
+            className="settings-panel__btn"
+            onClick={handleExport}
+            data-testid="export-config-btn"
+          >
+            Export to Directory
+          </button>
+          <button
+            className="settings-panel__btn"
+            onClick={handleImport}
+            data-testid="import-config-btn"
+          >
+            Import from Directory
+          </button>
+        </div>
       </div>
 
       {exportDialog && (

--- a/src/components/Settings/SecuritySettings.tsx
+++ b/src/components/Settings/SecuritySettings.tsx
@@ -298,13 +298,9 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
             <div className="settings-panel__section">
               <h3 className="settings-panel__section-title">Master Password Options</h3>
 
-              <div className="settings-panel__field">
-                <label className="settings-panel__description" htmlFor="auto-lock-timeout">
-                  Lock the credential store after a period of inactivity:
-                </label>
+              <label className="settings-form__field">
+                <span className="settings-form__label">Auto-Lock Timeout</span>
                 <select
-                  id="auto-lock-timeout"
-                  className="settings-panel__inline-dialog-input"
                   data-testid="auto-lock-timeout"
                   value={settings.credentialAutoLockMinutes ?? 15}
                   onChange={(e) => handleAutoLockChange(Number(e.target.value))}
@@ -315,7 +311,10 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
                     </option>
                   ))}
                 </select>
-              </div>
+                <span className="settings-form__hint">
+                  Lock the credential store after a period of inactivity.
+                </span>
+              </label>
 
               <div className="settings-panel__field">
                 <button

--- a/src/components/Settings/SettingsPanel.css
+++ b/src/components/Settings/SettingsPanel.css
@@ -131,19 +131,6 @@
   opacity: 0.6;
 }
 
-/* === Form field rows for toggle + label === */
-.settings-form__field--row {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--spacing-sm);
-}
-
-.settings-form__field--row > div {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
 /* === Section (used by ExternalFilesSettings) === */
 .settings-panel__section {
   margin-bottom: var(--spacing-xl);

--- a/src/components/Settings/TerminalSettings.tsx
+++ b/src/components/Settings/TerminalSettings.tsx
@@ -13,7 +13,8 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
     <div className="settings-panel__category">
       <h3 className="settings-panel__category-title">Terminal</h3>
       {show("defaultHorizontalScrolling") && (
-        <div className="settings-form__field settings-form__field--row">
+        <div className="settings-form__field">
+          <span className="settings-form__label">Default Horizontal Scrolling</span>
           <label className="settings-panel__toggle">
             <input
               type="checkbox"
@@ -24,12 +25,9 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
             />
             <span className="settings-panel__toggle-slider" />
           </label>
-          <div>
-            <span className="settings-form__label">Default Horizontal Scrolling</span>
-            <span className="settings-form__hint">
-              Enable horizontal scrolling for new terminals by default.
-            </span>
-          </div>
+          <span className="settings-form__hint">
+            Enable horizontal scrolling for new terminals by default.
+          </span>
         </div>
       )}
       {show("scrollbackBuffer") && (
@@ -70,7 +68,8 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
         </label>
       )}
       {show("cursorBlink") && (
-        <div className="settings-form__field settings-form__field--row">
+        <div className="settings-form__field">
+          <span className="settings-form__label">Cursor Blink</span>
           <label className="settings-panel__toggle">
             <input
               type="checkbox"
@@ -79,10 +78,7 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
             />
             <span className="settings-panel__toggle-slider" />
           </label>
-          <div>
-            <span className="settings-form__label">Cursor Blink</span>
-            <span className="settings-form__hint">Whether the terminal cursor blinks.</span>
-          </div>
+          <span className="settings-form__hint">Whether the terminal cursor blinks.</span>
         </div>
       )}
       {show("rightClickBehavior") && (


### PR DESCRIPTION
## Summary

- All settings panels and connection editor tabs now share a consistent visual design: fields are grouped in titled category sections (`settings-panel__category`), with an uppercase underlined header per group
- Boolean/toggle fields across the entire UI now use a vertical layout matching every other field type: label on top → pill toggle below → hint text underneath (previously the toggle was placed horizontally to the left of the label, making it unclear which toggle belonged to which text)
- The Connection editor's Connection tab is now structured in named sections (General, schema-defined groups, Session, External Files), matching the look of the Agent/Terminal/Appearance tabs
- `PortableModeSettings` was fully redesigned — it previously used undefined CSS class names and rendered unstyled
- Consistent 12px spacing between all fields, 24px spacing between category groups

## Files changed

- `DynamicForm/DynamicField.tsx` + `ConnectionSettingsForm.tsx` — schema-driven forms now emit category sections with group titles; boolean fields use vertical layout
- `ConnectionEditor/AgentSettingsForm.tsx`, `ConnectionEditor.tsx`, `ConnectionTerminalSettings.tsx`, `AgentExternalFilesSettings.tsx`, `ConnectionAppearanceSettings.tsx` — all converted to design system classes
- `Settings/GeneralSettings.tsx`, `TerminalSettings.tsx`, `SecuritySettings.tsx`, `ExternalFilesSettings.tsx`, `PortableModeSettings.tsx` — same conversion
- `Settings/SettingsPanel.css` — removed now-unused `settings-form__field--row` layout rules
- `ConnectionEditor/ConnectionEditor.css` — added field spacing, removed flex wrapper from connection form
- `Settings/PortableModeSettings.css` — new file with dedicated styles for portable-mode-specific elements

## Test plan

- [ ] Open connection editor → Connection tab: verify Name / Type fields are in a "General" section, SSH schema fields each appear in their own group section, toggle fields show label above the pill toggle with hint below
- [ ] Open connection editor → Agent tab: verify Features, Session Defaults, Diagnostics sections; toggle fields vertical
- [ ] Open connection editor → Terminal tab: verify Cursor Blink and Horizontal Scrolling show label → toggle → hint
- [ ] Open Settings → General: verify all toggle fields (Experimental Features, Shell Integration, X11 Forwarding) use vertical layout
- [ ] Open Settings → Terminal: verify Horizontal Scrolling and Cursor Blink use vertical layout
- [ ] Open Settings → External Files → Advanced: verify Power Monitoring and File Browser toggles use vertical layout
- [ ] Open Settings → General → Portable Mode section: verify status, data path, config file list, and migration buttons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)