### PR TITLE
fix(terminal): deduplicate resize signals to reduce duplicate-line artifacts

### DIFF
--- a/src/components/Terminal/Terminal.resize-dedup.test.tsx
+++ b/src/components/Terminal/Terminal.resize-dedup.test.tsx
@@ -18,7 +18,6 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { Terminal } from "./Terminal";
 import { TerminalPortalProvider } from "./TerminalRegistry";
-import { resizeTerminal } from "@/services/api";
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 

--- a/src/components/Terminal/Terminal.resize-dedup.test.tsx
+++ b/src/components/Terminal/Terminal.resize-dedup.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Regression tests for resize deduplication in Terminal.tsx.
+ *
+ * Before the fix, every terminal session produced at least two identical
+ * resizeTerminal() calls at setup time — one from xterm.onResize (triggered by
+ * fitAddon.fit()) and one from the unconditional explicit call right after.
+ * Each extra call sends a SIGWINCH to the running process; for TUI apps like
+ * Claude Code that continuously rewrite a multi-line status bar, duplicate
+ * SIGWINCHs at the same terminal size can cause partial clears that leave
+ * ghost / duplicate lines in the output.
+ *
+ * The fix: track (lastSentCols, lastSentRows) and only call resizeTerminal
+ * when the PTY dimensions actually change.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+import { resizeTerminal } from "@/services/api";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+// Capture the onResize callback so tests can simulate terminal resize events.
+let capturedOnResize: ((dims: { cols: number; rows: number }) => void) | null = null;
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn((cb: (dims: { cols: number; rows: number }) => void) => {
+      capturedOnResize = cb;
+      return { dispose: vi.fn() };
+    });
+    onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    write = vi.fn();
+    writeln = vi.fn();
+    scrollToBottom = vi.fn();
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn(function (this: MockXTerm, cols: number, rows: number) {
+      this.cols = cols;
+      this.rows = rows;
+    });
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = { active: { viewportY: 0, baseY: 0, length: 0, getLine: vi.fn() } };
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+    modes = { bracketedPasteMode: false };
+    clearSelection = vi.fn();
+    clear = vi.fn();
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class MockFitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-unicode11", () => ({
+  Unicode11Addon: class {
+    dispose = vi.fn();
+  },
+}));
+
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: class {
+    dispose = vi.fn();
+    findNext = vi.fn();
+    findPrevious = vi.fn();
+    clearDecorations = vi.fn();
+  },
+}));
+
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+}));
+
+const mockResizeTerminal = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/services/api", () => ({
+  createTerminal: vi.fn().mockResolvedValue("session-resize-test"),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: (...args: unknown[]) => mockResizeTerminal(...args),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: vi.fn(() => vi.fn()),
+    subscribeExit: vi.fn(() => vi.fn()),
+  },
+}));
+
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const LOCAL_CONFIG = { type: "local" as const, config: {} };
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  capturedOnResize = null;
+  mockResizeTerminal.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Terminal — resize deduplication", () => {
+  it("does not send resizeTerminal when onResize fires with the same dims as session creation", async () => {
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal tabId="tab-resize-1" config={LOCAL_CONFIG} isVisible={true} />
+        </TerminalPortalProvider>
+      );
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(capturedOnResize).not.toBeNull();
+    const callCountAfterSetup = mockResizeTerminal.mock.calls.length;
+
+    // Simulate xterm.onResize firing with the SAME 80×24 dims (as at session
+    // creation).  This happens when TerminalSlot's RAF fit or the visibility
+    // effect calls fitAddon.fit() and the container hasn't changed.
+    act(() => {
+      capturedOnResize!({ cols: 80, rows: 24 });
+    });
+
+    // resizeTerminal must NOT be called again — same dims, no new SIGWINCH.
+    expect(mockResizeTerminal.mock.calls.length).toBe(callCountAfterSetup);
+  });
+
+  it("sends resizeTerminal when onResize fires with genuinely different dims", async () => {
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal tabId="tab-resize-2" config={LOCAL_CONFIG} isVisible={true} />
+        </TerminalPortalProvider>
+      );
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(capturedOnResize).not.toBeNull();
+    const callCountAfterSetup = mockResizeTerminal.mock.calls.length;
+
+    // Simulate a real resize (user dragged the splitter).
+    act(() => {
+      capturedOnResize!({ cols: 200, rows: 50 });
+    });
+
+    expect(mockResizeTerminal.mock.calls.length).toBe(callCountAfterSetup + 1);
+    expect(mockResizeTerminal).toHaveBeenLastCalledWith("session-resize-test", 200, 50);
+  });
+
+  it("does not send duplicate resizeTerminal calls at startup for a new session", async () => {
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal tabId="tab-resize-3" config={LOCAL_CONFIG} isVisible={true} />
+        </TerminalPortalProvider>
+      );
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // The startup sequence (fitAddon.fit() → onResize → explicit resize)
+    // previously sent resizeTerminal twice with the same 80×24 dims.
+    // With deduplication, at most one call should be made (and only if the
+    // container changed during the async createTerminal call).
+    const callsWithCreationDims = mockResizeTerminal.mock.calls.filter(
+      ([, cols, rows]) => cols === 80 && rows === 24
+    );
+    // At most once — not the two-or-more that the old code produced.
+    expect(callsWithCreationDims.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -211,9 +211,15 @@ export function Terminal({
 
         // ── Connection loop ────────────────────────────────────────────────
         // For workspace-restore the session already exists — skip the loop.
+        // ptyCols/ptyRows capture the dimensions passed to createTerminal so
+        // we can initialize the resize-deduplication tracking below.
+        let ptyCols = 0;
+        let ptyRows = 0;
         let sessionId: string;
         if (initialSessionIdRef.current) {
           sessionId = initialSessionIdRef.current;
+          // Workspace-restore: PTY dims unknown — leave ptyCols/ptyRows at 0
+          // so the post-setup resize always fires to re-sync xterm with the PTY.
         } else {
           let attempt = 0;
           let resolved: string | null = null;
@@ -222,6 +228,11 @@ export function Terminal({
             useAppStore.getState().setTerminalConnecting(tabId, true);
 
             try {
+              // Capture dims immediately before creating the PTY so we know
+              // what size it was created with (xterm.cols may change while
+              // createTerminal is awaiting if a container resize fires).
+              ptyCols = xterm.cols;
+              ptyRows = xterm.rows;
               resolved = await createTerminal(sessionConfig);
 
               if (isCanceled()) {
@@ -293,6 +304,17 @@ export function Terminal({
         sessionIdRef.current = sessionId;
         registerSession(tabId, sessionId);
 
+        // Resize-deduplication: track the last (cols, rows) sent to the PTY
+        // to avoid spurious SIGWINCH signals.  Multiple rapid fit() calls
+        // (slot adoption sync+RAF, ResizeObserver, visibility effect) all
+        // fire xterm.onResize, but only a genuine dimension change should
+        // trigger a PTY resize.  Initialized to the dims used to create the
+        // PTY (ptyCols/ptyRows) so the post-setup explicit resize is skipped
+        // when nothing changed; stays at 0 for workspace-restore so the
+        // first resize always fires to re-sync with the existing PTY.
+        let lastSentCols = ptyCols;
+        let lastSentRows = ptyRows;
+
         // Output batching: buffer chunks and flush in a single RAF callback
         const outputBuffer: Uint8Array[] = [];
         let rafId: number | null = null;
@@ -357,9 +379,15 @@ export function Terminal({
           }
         });
 
-        // Send resize events after fit
+        // Send resize events after fit — deduplicated to avoid SIGWINCH storms.
+        // Multiple fit() calls from TerminalSlot (sync+RAF), ResizeObserver,
+        // and the visibility effect can fire in rapid succession; only emit
+        // resizeTerminal when the dimensions actually changed.
         const onResizeDisposable = xterm.onResize(({ cols, rows }) => {
-          if (sessionIdRef.current) {
+          if (sessionIdRef.current && (cols !== lastSentCols || rows !== lastSentRows)) {
+            lastSentCols = cols;
+            lastSentRows = rows;
+            frontendLog("terminal", `resize → PTY ${cols}×${rows} tab=${tabId}`);
             resizeTerminal(sessionIdRef.current, cols, rows);
           }
         });
@@ -368,14 +396,23 @@ export function Terminal({
         // already fitted xterm to the correct dimensions while the async
         // createTerminal() was in-flight — but at that point sessionIdRef
         // was still null, so the resize was never sent to the backend PTY.
-        // Always send the current dimensions explicitly to ensure the PTY
-        // matches the visible viewport.
+        // Send explicitly only when the current dims differ from what the
+        // PTY was created with (or for workspace-restore where we don't
+        // know the PTY's current state and must always sync).
         try {
           fitAddon.fit();
         } catch {
           // Container might not have dimensions yet
         }
-        resizeTerminal(sessionId, xterm.cols, xterm.rows);
+        if (xterm.cols !== lastSentCols || xterm.rows !== lastSentRows) {
+          lastSentCols = xterm.cols;
+          lastSentRows = xterm.rows;
+          frontendLog(
+            "terminal",
+            `resize (post-setup) → PTY ${xterm.cols}×${xterm.rows} tab=${tabId}`
+          );
+          resizeTerminal(sessionId, xterm.cols, xterm.rows);
+        }
 
         // Send initial command after session connects (used by workspace launch)
         if (initialCommand && !initialSessionIdRef.current) {


### PR DESCRIPTION
## Summary

- Tracks `lastSentCols / lastSentRows` in `setupTerminal` and only calls `resizeTerminal` when the PTY dimensions actually change
- Eliminates 2–4 redundant SIGWINCH signals that previously fired at every session setup with identical dimensions, reducing duplicate-line artifacts in TUI apps (Claude Code, vim, etc.)
- Adds 3 regression tests covering no-op on same-dims, fire on changed dims, and no duplicate startup calls

Closes #624

## Root cause

On every terminal session setup the old code called `resizeTerminal()` at least twice with the same `(cols, rows)`:

1. `fitAddon.fit()` → `xterm.onResize` → `resizeTerminal(cols, rows)`
2. unconditional explicit `resizeTerminal(sessionId, xterm.cols, xterm.rows)` right after

Combined with `TerminalSlot`'s sync + RAF double-fit and the `ResizeObserver`, this produced up to 4 SIGWINCH signals at startup with the same terminal size. TUI apps like Claude Code (ink) handle each SIGWINCH by rewriting their multi-line status bar. Rapid duplicate SIGWINCHs interrupt mid-render clear-and-rewrite cycles, leaving ghost lines because cursor-up counts are calculated for a stale terminal width.

The fundamental resize race (xterm.js visual resize vs. IPC roundtrip for SIGWINCH) cannot be fully eliminated, but removing the spurious duplicates significantly reduces the opportunity for artifacts.

## ⚠️ Cleanup required before release

Two `frontendLog` debug calls were added in `Terminal.tsx`'s `setupTerminal` to trace resize events in the LogViewer:

```typescript
frontendLog("terminal", `resize → PTY ${cols}×${rows} tab=${tabId}`);
frontendLog("terminal", `resize (post-setup) → PTY ${xterm.cols}×${xterm.rows} tab=${tabId}`);
```

**These must be removed before shipping.** They are tracked in issue #624.

## Test plan

- [ ] Open a terminal tab running Claude Code — spinner/status bar should no longer duplicate during normal operation
- [ ] Drag a panel splitter while Claude Code is streaming output — verify fewer ghost lines appear during resize
- [ ] Open multiple terminal tabs; switch between them — verify no spurious SIGWINCH causes flicker in TUI apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)