### PR TITLE
feat(ci): publish rolling dev build artifacts on push to main

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,282 @@
+name: Dev Build
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: write
+
+jobs:
+  # ── 1. Create a fresh rolling dev release ──────────────────────────────────
+  prepare-release:
+    name: Prepare Dev Release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.vars.outputs.tag }}
+      branch: ${{ steps.vars.outputs.branch }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set release variables
+        id: vars
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          if [ "$BRANCH" = "main" ]; then
+            TAG="dev-latest"
+          else
+            TAG="dev-${BRANCH}-latest"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Delete existing dev release (if any)
+        run: gh release delete "${{ steps.vars.outputs.tag }}" --yes --cleanup-tag 2>/dev/null || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Write release notes
+        run: |
+          BRANCH="${{ steps.vars.outputs.branch }}"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          {
+            echo "## ⚠️ Dev Build — Not for Production Use"
+            echo ""
+            echo "This is an automated development build from the \`${BRANCH}\` branch."
+            echo ""
+            echo "**Commit**: [\`${SHORT_SHA}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+            echo "**Built**: ${DATE}"
+            echo ""
+            echo "These artifacts are rebuilt automatically on every push to \`${BRANCH}\` and overwrite the previous build. They may be unstable or contain incomplete features. **Do not use in production.**"
+            echo ""
+            echo "### Desktop Installers"
+            echo "| Platform | Artifact |"
+            echo "|----------|---------|"
+            echo "| macOS Intel | \`termiHub-dev-macos-x64.dmg\` |"
+            echo "| macOS Apple Silicon | \`termiHub-dev-macos-arm64.dmg\` |"
+            echo "| Windows x64 | \`termiHub-dev-windows-x64.msi\` |"
+            echo "| Linux x64 | \`termiHub-dev-linux-x64.AppImage\`, \`termiHub-dev-linux-x64.deb\` |"
+            echo "| Linux ARM64 | \`termiHub-dev-linux-arm64.deb\`, \`termiHub-dev-linux-arm64.rpm\` |"
+            echo ""
+            echo "### Agent Binaries (Static musl)"
+            echo "| Target | Artifact |"
+            echo "|--------|---------|"
+            echo "| Linux x64 | \`termihub-agent-dev-linux-x64\` |"
+            echo "| Linux ARM64 | \`termihub-agent-dev-linux-arm64\` |"
+            echo "| Linux ARMv7 | \`termihub-agent-dev-linux-armv7\` |"
+          } > release_notes.md
+
+      - name: Create dev release
+        run: |
+          BRANCH="${{ steps.vars.outputs.branch }}"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          gh release create "${{ steps.vars.outputs.tag }}" \
+            --prerelease \
+            --title "Dev Build — not for production use (${BRANCH} @ ${SHORT_SHA})" \
+            --notes-file release_notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── 2. Build and upload desktop app artifacts ──────────────────────────────
+  build-app:
+    name: Build App - ${{ matrix.platform }}
+    needs: prepare-release
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS Intel
+          - platform: macos-x64
+            os: macos-latest
+            rust_target: x86_64-apple-darwin
+            file_ext: .dmg
+            bundle_path: dmg
+
+          # macOS Apple Silicon
+          - platform: macos-arm64
+            os: macos-latest
+            rust_target: aarch64-apple-darwin
+            file_ext: .dmg
+            bundle_path: dmg
+
+          # Windows x64
+          - platform: windows-x64
+            os: windows-latest
+            rust_target: x86_64-pc-windows-msvc
+            file_ext: .msi
+            bundle_path: msi
+
+          # Linux x64
+          - platform: linux-x64
+            os: ubuntu-latest
+            rust_target: x86_64-unknown-linux-gnu
+            file_ext: .AppImage
+            bundle_path: appimage
+
+          # Linux ARM64 — AppImage not supported on ARM64 (linuxdeploy is x86_64-only)
+          - platform: linux-arm64
+            os: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            file_ext: .deb
+            bundle_path: deb
+            extra_args: '--bundles deb,rpm'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: dev-build-${{ matrix.platform }}
+
+      - name: Install system dependencies (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            libssl-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libudev-dev \
+            patchelf
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ''
+          releaseName: ''
+          releaseBody: ''
+          releaseDraft: false
+          prerelease: false
+          args: --target ${{ matrix.rust_target }} ${{ matrix.extra_args }}
+
+      - name: Upload primary artifact to dev release
+        shell: bash
+        run: |
+          ARTIFACT=$(find "target/${{ matrix.rust_target }}/release/bundle/${{ matrix.bundle_path }}" -name "*${{ matrix.file_ext }}" | head -n 1)
+          if [ -z "$ARTIFACT" ]; then
+            echo "Error: No artifact found matching *${{ matrix.file_ext }} in bundle/${{ matrix.bundle_path }}"
+            exit 1
+          fi
+          DEST="termiHub-dev-${{ matrix.platform }}${{ matrix.file_ext }}"
+          cp "$ARTIFACT" "$DEST"
+          gh release upload "${{ needs.prepare-release.outputs.tag }}" "$DEST" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload .deb to dev release (Linux x64 only)
+        if: matrix.platform == 'linux-x64'
+        shell: bash
+        run: |
+          DEB=$(find "target/${{ matrix.rust_target }}/release/bundle/deb" -name "*.deb" | head -n 1)
+          if [ -n "$DEB" ]; then
+            DEST="termiHub-dev-${{ matrix.platform }}.deb"
+            cp "$DEB" "$DEST"
+            gh release upload "${{ needs.prepare-release.outputs.tag }}" "$DEST" --clobber
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload .rpm to dev release (Linux ARM64 only)
+        if: matrix.platform == 'linux-arm64'
+        shell: bash
+        run: |
+          RPM=$(find "target/${{ matrix.rust_target }}/release/bundle/rpm" -name "*.rpm" | head -n 1)
+          if [ -n "$RPM" ]; then
+            DEST="termiHub-dev-${{ matrix.platform }}.rpm"
+            cp "$RPM" "$DEST"
+            gh release upload "${{ needs.prepare-release.outputs.tag }}" "$DEST" --clobber
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── 3. Build and upload agent binaries ────────────────────────────────────
+  build-agents:
+    name: Agent Binary (${{ matrix.target }})
+    needs: prepare-release
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            artifact_name: termihub-agent-dev-linux-x64
+          - target: aarch64-unknown-linux-musl
+            artifact_name: termihub-agent-dev-linux-arm64
+          - target: armv7-unknown-linux-musleabihf
+            artifact_name: termihub-agent-dev-linux-armv7
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: dev-agent-${{ matrix.target }}
+
+      - name: Install cross-rs
+        run: |
+          curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz \
+            | sudo tar xz -C /usr/local/bin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build custom cross-rs image
+        uses: docker/build-push-action@v5
+        with:
+          context: agent/docker
+          file: agent/docker/Dockerfile.${{ matrix.target }}
+          tags: localhost/termihub-cross:${{ matrix.target }}
+          load: true
+          cache-from: type=gha,scope=dev-agent-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=dev-agent-${{ matrix.target }}
+
+      - name: Build agent
+        run: CROSS_CONFIG=agent/Cross.toml cross build --release --target ${{ matrix.target }} -p termihub-agent
+
+      - name: Upload agent binary to dev release
+        run: |
+          cp "target/${{ matrix.target }}/release/termihub-agent" "${{ matrix.artifact_name }}"
+          gh release upload "${{ needs.prepare-release.outputs.tag }}" "${{ matrix.artifact_name }}" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CI: dev build artifacts are now published automatically on every push to `main` as a rolling GitHub pre-release tagged `dev-latest`, providing downloadable installers for all supported platforms and agent binaries without building from source (#637)
 - Serial: the port field in the serial connection editor is now a dropdown populated with currently detected serial ports. If the previously configured port is no longer detected (e.g. USB adapter unplugged), it still appears in the list marked as "(not connected)". When editing a serial session on a remote agent, the dropdown shows the ports detected on the remote machine.
 - Terminal: a unified "Connecting…" overlay now appears on every terminal tab while the backend session is being established, for all connection types (SSH, Telnet, serial, agent sessions). The overlay shows a spinner and a Cancel button (which closes the tab). If the initial connection fails, the overlay transitions to an error state with a Retry button and contextual hints for common failure modes (SSH agent not running, timeout, serial port not found, port permission denied, port in use).
 - Terminal: for agent-mediated sessions (sessions running on a remote agent), connection failures trigger automatic background retry instead of showing an error immediately. The overlay shows the current attempt number. The user can cancel at any time by closing the tab.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dev-build.yml` — a new CI workflow that builds and publishes pre-release artifacts on every push to `main` (and `develop` if the branch exists)
- The workflow creates/overwrites a rolling GitHub pre-release tagged `dev-latest` so only the latest build is kept
- Builds desktop installers for all 5 supported platforms (macOS x64/arm64, Windows x64, Linux x64, Linux arm64) and static musl agent binaries for x86_64, aarch64, and armv7

## Workflow design

1. **`prepare-release`** — deletes the existing `dev-latest` release + tag (if any) and creates a fresh pre-release with descriptive notes
2. **`build-app`** (5-way matrix, runs in parallel) — builds the Tauri installer for each platform and uploads it as `termiHub-dev-<platform>.<ext>`
3. **`build-agents`** (3-way matrix, runs in parallel) — cross-compiles static musl agent binaries using the existing custom Docker images and uploads them as `termihub-agent-dev-linux-<arch>`

Artifacts are clearly labelled as dev builds in both the release title and description. The release is marked `--prerelease` so it never appears as the "latest stable" release on the repo's releases page.

Closes #637

## Test plan

- [ ] Merge to `main` and verify the `Dev Build` workflow triggers
- [ ] Confirm a `dev-latest` pre-release is created/updated on the [Releases page](https://github.com/armaxri/termiHub/releases)
- [ ] Confirm all platform installers and agent binaries appear as release assets
- [ ] Trigger a second push; verify the old `dev-latest` release is replaced (not duplicated)
- [ ] Confirm the release is marked as Pre-release and **not** set as Latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)