### PR TITLE
docs(process): adopt TDD as the preferred workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -131,6 +131,31 @@ examples/                     # Quick-start dev environment (SSH, Telnet, virtua
 
 ### Testing
 
+#### Preferred Workflow: Test-Driven Development (TDD)
+
+The preferred approach for all bug fixes and feature work is **test-driven development**:
+
+1. **Write the test first** — design and implement a test that checks the correct behavior before touching production code.
+2. **Verify the test fails** — confirm the test fails without the fix or feature in place (red phase).
+3. **Implement the fix or feature** — make the test pass (green phase).
+4. **Commit in order** — the test commit must come **before** the implementation commit so reviewers can see the intended behavior independently of the solution.
+
+Expected commit sequence for a bug fix:
+
+```
+test(scope): add regression test for <bug description>
+fix(scope): fix <bug description> (Closes #N)
+```
+
+Expected commit sequence for a new feature:
+
+```
+test(scope): add tests for <feature name>
+feat(scope): implement <feature name> (Closes #N)
+```
+
+#### General Rules
+
 - **Automatically add tests** after every bug fix or feature implementation — do not wait for the user to ask. Tests are a mandatory part of completing any task, not an optional follow-up.
 - Test type priority (use the highest feasible option):
   1. **Unit tests** (preferred) — fast, isolated, verify specific behavior

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -392,6 +392,29 @@ Update the connection type dropdown in `src/components/Sidebar/ConnectionEditor.
 
 For the full testing strategy — including unit, integration, E2E, visual regression testing, and manual test procedures — see [Testing](testing.md).
 
+### Preferred Workflow: Test-Driven Development (TDD)
+
+The preferred approach for all bug fixes and feature work is **test-driven development**:
+
+1. **Write the test first** — design and implement a test that checks the correct behavior before touching production code.
+2. **Verify the test fails** — confirm the test fails without the fix or feature in place (red phase).
+3. **Implement the fix or feature** — make the test pass (green phase).
+4. **Commit in order** — the test commit must come **before** the implementation commit so reviewers can see the intended behavior independently of the solution.
+
+**Example commit sequence for a bug fix:**
+
+```
+test(scope): add regression test for <bug description>
+fix(scope): fix <bug description> (Closes #N)
+```
+
+**Example commit sequence for a new feature:**
+
+```
+test(scope): add tests for <feature name>
+feat(scope): implement <feature name> (Closes #N)
+```
+
 ### Running Tests
 
 The quickest way to run all tests is via the helper scripts:


### PR DESCRIPTION
## Summary

- Added a **Test-Driven Development** subsection to the `Testing` section in both `CLAUDE.md` and `docs/contributing.md`
- Documents the four-step TDD cycle: write test → verify red → implement → commit test before implementation
- Includes concrete commit sequence examples for bug fixes and new features

## Test plan

- Documentation-only change — no code modified
- Markdown linting passes (`pnpm run markdownlint` — 0 errors)

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)