### PR TITLE
fix(ui): copy tab content no longer wraps lines or pads with trailing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Terminal: "Copy tab content" no longer pads lines with trailing spaces or wraps long lines at the visible terminal width — content is now copied as logical lines, matching what horizontal scrolling would show (#636)
 - Agent: after an agent reconnects following a power loss, terminals whose sessions were successfully recovered by the agent now resume automatically instead of always showing the "Session disconnected" overlay. Sessions that could not be recovered still show the overlay as before.
 - Terminal: clicking "Reconnect" after a session disconnect now immediately shows the "Connecting…" overlay with no blank gap between the disconnect overlay disappearing and the connection attempt starting. Previously, the overlay was not set until after a React render cycle, leaving a brief window with no visible feedback.
 - Terminal: agent-session reconnect loop now shows a "Connection failed" state briefly after each failed attempt instead of spinning "Connecting…" indefinitely with no visible feedback. The overlay cycles Connecting → Connection failed → Connecting until the session is established.

--- a/src/components/Terminal/TerminalRegistry.test.tsx
+++ b/src/components/Terminal/TerminalRegistry.test.tsx
@@ -138,6 +138,85 @@ describe("copySelectionToClipboard", () => {
   });
 });
 
+describe("copyTerminalToClipboard", () => {
+  it("trims trailing spaces from each line", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const xterm = {
+      buffer: {
+        active: {
+          length: 2,
+          getLine: vi.fn((i: number) => {
+            if (i === 0)
+              return {
+                isWrapped: false,
+                translateToString: (trimRight?: boolean) => (trimRight ? "hello" : "hello     "),
+              };
+            if (i === 1)
+              return {
+                isWrapped: false,
+                translateToString: (trimRight?: boolean) => (trimRight ? "world" : "world     "),
+              };
+            return null;
+          }),
+        },
+      },
+    } as unknown as XTerm;
+
+    const el = document.createElement("div");
+    act(() => {
+      registryActions.register("tab-trim", el, xterm, createMockFitAddon());
+    });
+
+    await act(async () => {
+      await registryActions.copyTerminalToClipboard("tab-trim");
+    });
+
+    expect(writeText).toHaveBeenCalledWith("hello\nworld\n");
+  });
+
+  it("joins wrapped continuation rows into a single logical line", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    // Simulates "Hello World" in a 10-column terminal:
+    // row 0: "Hello Worl" fills the terminal width (isWrapped=false)
+    // row 1: "d         " is the continuation (isWrapped=true)
+    const xterm = {
+      buffer: {
+        active: {
+          length: 2,
+          getLine: vi.fn((i: number) => {
+            if (i === 0)
+              return {
+                isWrapped: false,
+                translateToString: (_trimRight?: boolean) => "Hello Worl",
+              };
+            if (i === 1)
+              return {
+                isWrapped: true,
+                translateToString: (trimRight?: boolean) => (trimRight ? "d" : "d         "),
+              };
+            return null;
+          }),
+        },
+      },
+    } as unknown as XTerm;
+
+    const el = document.createElement("div");
+    act(() => {
+      registryActions.register("tab-wrap", el, xterm, createMockFitAddon());
+    });
+
+    await act(async () => {
+      await registryActions.copyTerminalToClipboard("tab-wrap");
+    });
+
+    expect(writeText).toHaveBeenCalledWith("Hello World\n");
+  });
+});
+
 describe("pasteToTerminal", () => {
   it("reads clipboard and sends text as input via registered session", async () => {
     mockReadClipboard.mockResolvedValue("pasted text");

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -142,7 +142,12 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
     const lines: string[] = [];
     for (let i = 0; i < buffer.length; i++) {
       const line = buffer.getLine(i);
-      lines.push(line ? line.translateToString() : "");
+      const text = line ? line.translateToString(true) : "";
+      if (line?.isWrapped && lines.length > 0) {
+        lines[lines.length - 1] += text;
+      } else {
+        lines.push(text);
+      }
     }
 
     // Trim trailing empty lines


### PR DESCRIPTION
## Summary

- Fixes `getTerminalContent` in `TerminalRegistry.tsx` to call `translateToString(true)` instead of `translateToString()`, eliminating trailing space padding on each line
- Checks `line.isWrapped` to join wrapped buffer rows back into the original logical line rather than inserting a newline at the terminal column boundary

## Test plan

- [ ] Added two regression tests in `TerminalRegistry.test.tsx`:
  - `trims trailing spaces from each line` — verifies `translateToString(true)` is used
  - `joins wrapped continuation rows into a single logical line` — verifies `isWrapped` handling

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)