### PR TITLE
feat(ui): move folder chevron to right side for clear hierarchy (#640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Connection sidebar: the expand/collapse chevron for folders is now displayed on the right side of the folder row. This aligns folder icons and connection icons in the same column at each indent level, making the tree hierarchy unambiguous at a glance (#640).
 - Settings: all settings panels and connection editor tabs now use a consistent visual design — fields are grouped under titled category sections, boolean options use a pill toggle switch (label on top, toggle below, hint text underneath), and spacing between fields is uniform across the entire UI.
 - Connection editor: the Connection tab is now structured in named sections (General, schema-defined groups, Session, External Files), matching the look and feel of all other tabs.
 

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -208,9 +208,9 @@ function AgentFolderNode({
             style={{ paddingLeft: `${depth * 16 + 8}px` }}
             onClick={() => toggleAgentFolder(agentId, folder.id)}
           >
-            <Chevron size={16} className="connection-tree__chevron" />
             <Folder size={16} />
             <span className="connection-tree__label">{folder.name}</span>
+            <Chevron size={16} className="connection-tree__chevron" />
           </button>
         </ContextMenu.Trigger>
         <ContextMenu.Portal>

--- a/src/components/Sidebar/ConnectionList.folder-chevron.test.tsx
+++ b/src/components/Sidebar/ConnectionList.folder-chevron.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Regression tests for folder chevron placement in the connection sidebar.
+ *
+ * The expand/collapse chevron must appear on the RIGHT side of the folder row
+ * so the icon column (folder icon, connection icon) aligns cleanly at each
+ * indent level. Previously the chevron was the first element, making child
+ * connection icons appear at the same depth as the parent folder icon.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import type { ConnectionFolder } from "@/types/connection";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({
+    agent,
+    sectionRef,
+  }: {
+    agent: RemoteAgentDefinition;
+    sectionRef?: (el: HTMLDivElement | null) => void;
+  }) =>
+    React.createElement("div", {
+      ref: sectionRef,
+      "data-testid": `agent-node-${agent.id}`,
+    }),
+}));
+
+function makeFolder(overrides: Partial<ConnectionFolder> = {}): ConnectionFolder {
+  return {
+    id: "folder-1",
+    name: "Test Folder",
+    parentId: null,
+    isExpanded: false,
+    ...overrides,
+  };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: false,
+  fileBrowserEnabled: false,
+  experimentalFeaturesEnabled: false,
+};
+
+describe("ConnectionList — folder chevron placement", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders chevron as the last child of the folder button", () => {
+    useAppStore.setState({ folders: [makeFolder()] });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const folderButton = container.querySelector('[data-testid="folder-toggle-folder-1"]');
+    expect(folderButton).not.toBeNull();
+
+    const children = Array.from(folderButton!.children);
+    const chevronIdx = children.findIndex((el) =>
+      el.classList.contains("connection-tree__chevron")
+    );
+
+    expect(chevronIdx).toBeGreaterThan(-1);
+    expect(chevronIdx).toBe(children.length - 1);
+  });
+
+  it("does not render chevron as the first child of the folder button", () => {
+    useAppStore.setState({ folders: [makeFolder()] });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const folderButton = container.querySelector('[data-testid="folder-toggle-folder-1"]');
+    expect(folderButton).not.toBeNull();
+
+    const firstChild = folderButton!.children[0];
+    expect(firstChild.classList.contains("connection-tree__chevron")).toBe(false);
+  });
+
+  it("renders chevron at last position for a nested subfolder", () => {
+    const parent = makeFolder({ id: "folder-parent", name: "Parent", isExpanded: true });
+    const child = makeFolder({ id: "folder-child", name: "Child", parentId: "folder-parent" });
+    useAppStore.setState({ folders: [parent, child] });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const childButton = container.querySelector('[data-testid="folder-toggle-folder-child"]');
+    expect(childButton).not.toBeNull();
+
+    const children = Array.from(childButton!.children);
+    const chevronIdx = children.findIndex((el) =>
+      el.classList.contains("connection-tree__chevron")
+    );
+
+    expect(chevronIdx).toBe(children.length - 1);
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -101,9 +101,9 @@ function TreeNode({
             style={{ paddingLeft: `${depth * 16 + 8}px` }}
             data-testid={`folder-toggle-${folder.id}`}
           >
-            <Chevron size={16} className="connection-tree__chevron" />
             <Folder size={16} />
             <span className="connection-tree__label">{folder.name}</span>
+            <Chevron size={16} className="connection-tree__chevron" />
           </button>
         </ContextMenu.Trigger>
         <ContextMenu.Portal>


### PR DESCRIPTION
## Summary

- Moves the expand/collapse chevron from the leading (left) position to the trailing (right) position in folder rows in the connection sidebar
- Applies to both local connection folders (`TreeNode`) and agent folders (`AgentFolderNode`)
- No padding/indentation changes — folder icons and connection icons now align cleanly in the same column per depth level

## Test plan

- [x] Automated regression tests added (`ConnectionList.folder-chevron.test.tsx`) — verify chevron is last child of folder button for root and nested folders
- [ ] Open the connection sidebar with at least one folder containing connections — verify folder icon and connection icon sit in the same column, with the chevron arrow on the right
- [ ] Toggle a folder open/closed — verify the chevron switches between right-pointing and down-pointing correctly
- [ ] Verify the same for agent folders (remote agents section)

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)