### PR TITLE
fix(ui): reset cursor and erase screen after terminal clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Serial: pressing "Clear" on a serial (or any) terminal tab now fully resets the cursor to the home position and erases any visible rendering artifacts — previously the cursor stayed at its old position and partial text fragments could remain on screen (#634).
 - Agent/Serial: the auto-reconnect overlay now shows a "Stop" button so users can cancel reconnection at any time and return to the disconnect overlay (#627).
 - Agent/Serial: the error that triggered the auto-reconnect is now displayed inside the reconnecting spinner overlay so users can see what went wrong while retrying (#627).
 - Agent: the backend reconnect loop now checks the disconnect flag every 100 ms during its backoff sleep, so calling "Disconnect" from the UI stops the reconnection immediately instead of waiting up to 30 s per attempt (#627).

--- a/src/components/Terminal/TerminalRegistry.test.tsx
+++ b/src/components/Terminal/TerminalRegistry.test.tsx
@@ -26,6 +26,9 @@ function createMockXterm(selection?: string): XTerm {
   return {
     hasSelection: vi.fn(() => selection !== undefined),
     getSelection: vi.fn(() => selection ?? ""),
+    clear: vi.fn(),
+    write: vi.fn(),
+    scrollToBottom: vi.fn(),
     buffer: {
       active: {
         length: 1,
@@ -283,5 +286,45 @@ describe("pasteToTerminal", () => {
 
     expect(sendInput).toHaveBeenCalledTimes(1);
     expect(sendInput).toHaveBeenCalledWith("session-dup", "hello");
+  });
+});
+
+describe("clearTerminal", () => {
+  it("does nothing when no terminal is registered for the tabId", () => {
+    // Should not throw
+    act(() => {
+      registryActions.clearTerminal("nonexistent");
+    });
+  });
+
+  it("calls xterm.clear() to wipe the buffer", () => {
+    const xterm = createMockXterm();
+    const el = document.createElement("div");
+
+    act(() => {
+      registryActions.register("tab-clear", el, xterm, createMockFitAddon());
+    });
+
+    act(() => {
+      registryActions.clearTerminal("tab-clear");
+    });
+
+    expect(xterm.clear).toHaveBeenCalledOnce();
+  });
+
+  it("resets cursor to home position after clearing to eliminate rendering artifacts", () => {
+    const xterm = createMockXterm();
+    const el = document.createElement("div");
+
+    act(() => {
+      registryActions.register("tab-clear", el, xterm, createMockFitAddon());
+    });
+
+    act(() => {
+      registryActions.clearTerminal("tab-clear");
+    });
+
+    // \x1b[2J clears the visible screen, \x1b[H moves cursor to (0,0)
+    expect(xterm.write).toHaveBeenCalledWith("\x1b[2J\x1b[H");
   });
 });

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -131,6 +131,9 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
     const xterm = xtermRegistryRef.current.get(tabId);
     if (xterm) {
       xterm.clear();
+      // Reset cursor to home (0,0) and erase visible screen to eliminate rendering artifacts
+      xterm.write("\x1b[2J\x1b[H");
+      requestAnimationFrame(() => xterm.scrollToBottom());
     }
   }, []);
 


### PR DESCRIPTION
## Summary

- `clearTerminal()` in `TerminalRegistry.tsx` previously called only `xterm.clear()`, which clears the scrollback buffer but does **not** reset the cursor position or erase the visible screen
- After `xterm.clear()`, we now write `\x1b[2J\x1b[H` (erase display + cursor home) to move the cursor to (0, 0) and eliminate any visible rendering artifacts
- Also scrolls to bottom via `requestAnimationFrame` for consistency with `fitTerminal`

## Test plan

- [ ] Open a serial (or any) terminal tab and type several lines of text
- [ ] Press "Clear" via the tab context menu
- [ ] Verify the terminal is blank with no artifacts and the cursor is at the top-left (column 0, row 0)
- [ ] Continue typing — input should appear at the start of the line, not offset from an old cursor position

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)