### PR TITLE
feat(ui): multi-select connections with Shift/Ctrl for bulk move into folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Connection sidebar: connections now support multi-select — Ctrl/Cmd+Click toggles individual selection, Shift+Click range-selects, and dragging a selected group moves all selected connections into the target folder at once. Escape or clicking empty space clears the selection (#638).
+
 ### Changed
 
 - Connection sidebar: the expand/collapse chevron for folders is now displayed on the right side of the folder row. This aligns folder icons and connection icons in the same column at each indent level, making the tree hierarchy unambiguous at a glance (#640).

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -261,6 +261,17 @@
   opacity: 0.4;
 }
 
+.connection-tree__item--selected {
+  background-color: var(--bg-selected, color-mix(in srgb, var(--accent-color) 18%, transparent));
+}
+
+.connection-tree__item--selected:hover {
+  background-color: var(
+    --bg-selected-hover,
+    color-mix(in srgb, var(--accent-color) 28%, transparent)
+  );
+}
+
 .connection-tree__folder--drop-over {
   background-color: var(--bg-hover);
   outline: 1px dashed var(--accent-color);

--- a/src/components/Sidebar/ConnectionList.multiselect.test.tsx
+++ b/src/components/Sidebar/ConnectionList.multiselect.test.tsx
@@ -1,0 +1,346 @@
+/**
+ * Tests for multi-select behavior in the connection sidebar.
+ *
+ * Ctrl/Meta+Click toggles individual selection, Shift+Click range-selects,
+ * plain click single-selects, Escape and clicking empty space clear selection.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import type { SavedConnection, ConnectionFolder } from "@/types/connection";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({
+    agent,
+    sectionRef,
+  }: {
+    agent: RemoteAgentDefinition;
+    sectionRef?: (el: HTMLDivElement | null) => void;
+  }) =>
+    React.createElement("div", {
+      ref: sectionRef,
+      "data-testid": `agent-node-${agent.id}`,
+    }),
+}));
+
+function makeConnection(overrides: Partial<SavedConnection> = {}): SavedConnection {
+  const id = overrides.id ?? "conn-1";
+  return {
+    id,
+    name: `Connection ${id}`,
+    folderId: null,
+    icon: undefined,
+    sourceFile: undefined,
+    config: { type: "local", config: {} } as SavedConnection["config"],
+    terminalOptions: undefined,
+    ...overrides,
+  };
+}
+
+function makeFolder(overrides: Partial<ConnectionFolder> = {}): ConnectionFolder {
+  return {
+    id: "folder-1",
+    name: "Test Folder",
+    parentId: null,
+    isExpanded: true,
+    ...overrides,
+  };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: false,
+  fileBrowserEnabled: false,
+  experimentalFeaturesEnabled: false,
+};
+
+describe("ConnectionList — multi-select", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("plain click selects a single connection", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    act(() => {
+      item.click();
+    });
+
+    expect(item.classList.contains("connection-tree__item--selected")).toBe(true);
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+    expect(item2.classList.contains("connection-tree__item--selected")).toBe(false);
+  });
+
+  it("plain click on a different connection moves selection", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+
+    act(() => {
+      item1.click();
+    });
+    act(() => {
+      item2.click();
+    });
+
+    expect(item1.classList.contains("connection-tree__item--selected")).toBe(false);
+    expect(item2.classList.contains("connection-tree__item--selected")).toBe(true);
+  });
+
+  it("Ctrl+Click adds a second connection to the selection", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+
+    act(() => {
+      item1.click();
+    });
+    act(() => {
+      item2.dispatchEvent(new MouseEvent("click", { ctrlKey: true, bubbles: true }));
+    });
+
+    expect(item1.classList.contains("connection-tree__item--selected")).toBe(true);
+    expect(item2.classList.contains("connection-tree__item--selected")).toBe(true);
+  });
+
+  it("Ctrl+Click on an already-selected connection deselects it", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+
+    act(() => {
+      item1.click();
+    });
+    act(() => {
+      item2.dispatchEvent(new MouseEvent("click", { ctrlKey: true, bubbles: true }));
+    });
+    // Both selected; now Ctrl+Click item1 to deselect it
+    act(() => {
+      item1.dispatchEvent(new MouseEvent("click", { ctrlKey: true, bubbles: true }));
+    });
+
+    expect(item1.classList.contains("connection-tree__item--selected")).toBe(false);
+    expect(item2.classList.contains("connection-tree__item--selected")).toBe(true);
+  });
+
+  it("Meta+Click (macOS) also toggles selection", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+
+    act(() => {
+      item1.click();
+    });
+    act(() => {
+      item2.dispatchEvent(new MouseEvent("click", { metaKey: true, bubbles: true }));
+    });
+
+    expect(item1.classList.contains("connection-tree__item--selected")).toBe(true);
+    expect(item2.classList.contains("connection-tree__item--selected")).toBe(true);
+  });
+
+  it("Shift+Click selects a range of connections in order", () => {
+    useAppStore.setState({
+      connections: [
+        makeConnection({ id: "conn-1" }),
+        makeConnection({ id: "conn-2" }),
+        makeConnection({ id: "conn-3" }),
+      ],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+    const item3 = container.querySelector('[data-testid="connection-item-conn-3"]') as HTMLElement;
+
+    act(() => {
+      item1.click();
+    });
+    act(() => {
+      item3.dispatchEvent(new MouseEvent("click", { shiftKey: true, bubbles: true }));
+    });
+
+    expect(item1.classList.contains("connection-tree__item--selected")).toBe(true);
+    expect(item2.classList.contains("connection-tree__item--selected")).toBe(true);
+    expect(item3.classList.contains("connection-tree__item--selected")).toBe(true);
+  });
+
+  it("Shift+Click range works in reverse direction", () => {
+    useAppStore.setState({
+      connections: [
+        makeConnection({ id: "conn-1" }),
+        makeConnection({ id: "conn-2" }),
+        makeConnection({ id: "conn-3" }),
+      ],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+    const item3 = container.querySelector('[data-testid="connection-item-conn-3"]') as HTMLElement;
+
+    act(() => {
+      item3.click();
+    });
+    act(() => {
+      item1.dispatchEvent(new MouseEvent("click", { shiftKey: true, bubbles: true }));
+    });
+
+    expect(item1.classList.contains("connection-tree__item--selected")).toBe(true);
+    expect(item2.classList.contains("connection-tree__item--selected")).toBe(true);
+    expect(item3.classList.contains("connection-tree__item--selected")).toBe(true);
+  });
+
+  it("Escape key clears the selection", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+
+    act(() => {
+      item1.click();
+    });
+    act(() => {
+      item2.dispatchEvent(new MouseEvent("click", { ctrlKey: true, bubbles: true }));
+    });
+
+    expect(container.querySelectorAll(".connection-tree__item--selected").length).toBe(2);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(container.querySelectorAll(".connection-tree__item--selected").length).toBe(0);
+  });
+
+  it("clicking on empty space in the tree clears selection", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" })],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    act(() => {
+      item.click();
+    });
+
+    expect(item.classList.contains("connection-tree__item--selected")).toBe(true);
+
+    // Click on the tree container (empty space), not on a connection item
+    const tree = container.querySelector(".connection-list__tree") as HTMLElement;
+    act(() => {
+      tree.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(item.classList.contains("connection-tree__item--selected")).toBe(false);
+  });
+
+  it("connections inside expanded folders are included in Shift+Click range", () => {
+    const folder = makeFolder({ id: "folder-1", isExpanded: true });
+    useAppStore.setState({
+      folders: [folder],
+      connections: [
+        makeConnection({ id: "conn-1", folderId: "folder-1" }),
+        makeConnection({ id: "conn-2", folderId: "folder-1" }),
+        makeConnection({ id: "conn-3" }),
+      ],
+    });
+
+    act(() => {
+      root.render(React.createElement(ConnectionList));
+    });
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item3 = container.querySelector('[data-testid="connection-item-conn-3"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+
+    act(() => {
+      item1.click();
+    });
+    act(() => {
+      item3.dispatchEvent(new MouseEvent("click", { shiftKey: true, bubbles: true }));
+    });
+
+    expect(item1.classList.contains("connection-tree__item--selected")).toBe(true);
+    expect(item2.classList.contains("connection-tree__item--selected")).toBe(true);
+    expect(item3.classList.contains("connection-tree__item--selected")).toBe(true);
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, Fragment, useMemo } from "react";
+import { useState, useCallback, useEffect, Fragment, useMemo } from "react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import {
   DndContext,
@@ -60,6 +60,8 @@ interface TreeNodeProps {
   onDeleteFolder: (folderId: string) => void;
   onCreateSubfolder: (parentId: string, name: string) => void;
   onNewConnectionInFolder: (folderId: string) => void;
+  selectedConnectionIds: Set<string>;
+  onConnectionClick: (connectionId: string, event: React.MouseEvent) => void;
   depth: number;
 }
 
@@ -78,6 +80,8 @@ function TreeNode({
   onDeleteFolder,
   onCreateSubfolder,
   onNewConnectionInFolder,
+  selectedConnectionIds,
+  onConnectionClick,
   depth,
 }: TreeNodeProps) {
   const [creatingSubfolder, setCreatingSubfolder] = useState(false);
@@ -162,6 +166,8 @@ function TreeNode({
               onDeleteFolder={onDeleteFolder}
               onCreateSubfolder={onCreateSubfolder}
               onNewConnectionInFolder={onNewConnectionInFolder}
+              selectedConnectionIds={selectedConnectionIds}
+              onConnectionClick={onConnectionClick}
               depth={depth + 1}
             />
           ))}
@@ -170,11 +176,13 @@ function TreeNode({
               key={conn.id}
               connection={conn}
               depth={depth + 1}
+              isSelected={selectedConnectionIds.has(conn.id)}
               onConnect={onConnect}
               onEdit={onEdit}
               onDelete={onDelete}
               onDuplicate={onDuplicate}
               onPingHost={onPingHost}
+              onConnectionClick={onConnectionClick}
             />
           ))}
         </div>
@@ -186,21 +194,25 @@ function TreeNode({
 interface ConnectionItemProps {
   connection: SavedConnection;
   depth: number;
+  isSelected: boolean;
   onConnect: (connection: SavedConnection) => void;
   onEdit: (connectionId: string) => void;
   onDelete: (connectionId: string) => void;
   onDuplicate: (connectionId: string) => void;
   onPingHost: (connection: SavedConnection) => void;
+  onConnectionClick: (connectionId: string, event: React.MouseEvent) => void;
 }
 
 function ConnectionItem({
   connection,
   depth,
+  isSelected,
   onConnect,
   onEdit,
   onDelete,
   onDuplicate,
   onPingHost,
+  onConnectionClick,
 }: ConnectionItemProps) {
   const {
     attributes,
@@ -212,13 +224,18 @@ function ConnectionItem({
     data: { type: "connection", connection },
   });
 
+  let className = "connection-tree__item";
+  if (isDragging) className += " connection-tree__item--dragging";
+  if (isSelected) className += " connection-tree__item--selected";
+
   return (
     <ContextMenu.Root>
       <ContextMenu.Trigger asChild>
         <button
           ref={setDragRef}
-          className={`connection-tree__item${isDragging ? " connection-tree__item--dragging" : ""}`}
+          className={className}
           style={{ paddingLeft: `${depth * 16 + 8}px` }}
+          onClick={(e) => onConnectionClick(connection.id, e)}
           onDoubleClick={() => onConnect(connection)}
           title={`Double-click to connect: ${connection.name}`}
           data-testid={`connection-item-${connection.id}`}
@@ -285,10 +302,40 @@ function buildExpandedIndexMap(sectionsExpanded: boolean[]): { map: number[]; co
   return { map, count };
 }
 
+/**
+ * Returns connection IDs in their visual tree order (depth-first, folders before sibling
+ * connections), considering only expanded folders. Used for Shift+Click range selection.
+ */
+function computeFlatVisibleConnectionIds(
+  rootFolders: ConnectionFolder[],
+  rootConnections: SavedConnection[],
+  allFolders: ConnectionFolder[],
+  allConnections: SavedConnection[]
+): string[] {
+  const ids: string[] = [];
+
+  function traverseFolder(folder: ConnectionFolder) {
+    if (!folder.isExpanded) return;
+    const childFolders = allFolders.filter((f) => f.parentId === folder.id);
+    const folderConnections = allConnections.filter((c) => c.folderId === folder.id);
+    childFolders.forEach(traverseFolder);
+    folderConnections.forEach((c) => ids.push(c.id));
+  }
+
+  rootFolders.forEach(traverseFolder);
+  rootConnections.forEach((c) => ids.push(c.id));
+
+  return ids;
+}
+
 export function ConnectionList() {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [draggingConnection, setDraggingConnection] = useState<SavedConnection | null>(null);
   const [draggingAgentName, setDraggingAgentName] = useState<string | null>(null);
+  const [draggingSelectionCount, setDraggingSelectionCount] = useState(0);
+  const [selectedConnectionIds, setSelectedConnectionIds] = useState<Set<string>>(new Set());
+  const [lastSelectedId, setLastSelectedId] = useState<string | null>(null);
+
   const folders = useAppStore((s) => s.folders);
   const connections = useAppStore((s) => s.connections);
   const remoteAgents = useAppStore((s) => s.remoteAgents);
@@ -301,6 +348,7 @@ export function ConnectionList() {
   const addFolder = useAppStore((s) => s.addFolder);
   const duplicateConnection = useAppStore((s) => s.duplicateConnection);
   const moveConnectionToFolder = useAppStore((s) => s.moveConnectionToFolder);
+  const bulkMoveConnectionsToFolder = useAppStore((s) => s.bulkMoveConnectionsToFolder);
   const reorderRemoteAgents = useAppStore((s) => s.reorderRemoteAgents);
 
   const pointerSensor = useSensor(PointerSensor, {
@@ -309,6 +357,67 @@ export function ConnectionList() {
   const sensors = useSensors(pointerSensor);
 
   const requestPassword = useAppStore((s) => s.requestPassword);
+
+  const rootFolders = useMemo(() => folders.filter((f) => f.parentId === null), [folders]);
+  const rootConnections = useMemo(
+    () => connections.filter((c) => c.folderId === null),
+    [connections]
+  );
+
+  const flatVisibleConnectionIds = useMemo(
+    () => computeFlatVisibleConnectionIds(rootFolders, rootConnections, folders, connections),
+    [rootFolders, rootConnections, folders, connections]
+  );
+
+  // Clear selection on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setSelectedConnectionIds(new Set());
+        setLastSelectedId(null);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const handleConnectionClick = useCallback(
+    (connectionId: string, event: React.MouseEvent) => {
+      if (event.ctrlKey || event.metaKey) {
+        setSelectedConnectionIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(connectionId)) {
+            next.delete(connectionId);
+          } else {
+            next.add(connectionId);
+          }
+          return next;
+        });
+        setLastSelectedId(connectionId);
+      } else if (event.shiftKey && lastSelectedId) {
+        const anchorIdx = flatVisibleConnectionIds.indexOf(lastSelectedId);
+        const targetIdx = flatVisibleConnectionIds.indexOf(connectionId);
+        if (anchorIdx >= 0 && targetIdx >= 0) {
+          const [start, end] =
+            anchorIdx < targetIdx ? [anchorIdx, targetIdx] : [targetIdx, anchorIdx];
+          setSelectedConnectionIds(new Set(flatVisibleConnectionIds.slice(start, end + 1)));
+        }
+      } else {
+        setSelectedConnectionIds(new Set([connectionId]));
+        setLastSelectedId(connectionId);
+      }
+    },
+    [flatVisibleConnectionIds, lastSelectedId]
+  );
+
+  // Clear selection when clicking on empty tree space (not on a connection item)
+  const handleTreeAreaClick = useCallback((e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (!target.closest(".connection-tree__item")) {
+      setSelectedConnectionIds(new Set());
+      setLastSelectedId(null);
+    }
+  }, []);
 
   const handleConnect = useCallback(
     async (connection: SavedConnection) => {
@@ -486,21 +595,35 @@ export function ConnectionList() {
       const data = event.active.data.current;
       if (data?.type === "agent") {
         setDraggingConnection(null);
+        setDraggingSelectionCount(0);
         const agent = remoteAgents.find((a) => a.id === event.active.id);
         setDraggingAgentName(agent?.name ?? null);
       } else {
         setDraggingAgentName(null);
         const conn = data?.connection as SavedConnection | undefined;
-        setDraggingConnection(conn ?? null);
+        if (!conn) return;
+
+        // If dragging a selected item, drag the whole selection
+        if (selectedConnectionIds.has(conn.id) && selectedConnectionIds.size > 1) {
+          setDraggingConnection(null);
+          setDraggingSelectionCount(selectedConnectionIds.size);
+        } else {
+          // Not part of current selection — switch to single-item drag
+          setSelectedConnectionIds(new Set([conn.id]));
+          setLastSelectedId(conn.id);
+          setDraggingConnection(conn);
+          setDraggingSelectionCount(1);
+        }
       }
     },
-    [remoteAgents]
+    [remoteAgents, selectedConnectionIds]
   );
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       setDraggingConnection(null);
       setDraggingAgentName(null);
+      setDraggingSelectionCount(0);
       const { active, over } = event;
       if (!over) return;
 
@@ -519,27 +642,53 @@ export function ConnectionList() {
       }
 
       // Handle connection drag to folder/root
-      const connectionId = active.id as string;
+      const draggedConnection = active.data.current?.connection as SavedConnection | undefined;
+      if (!draggedConnection) return;
+
       const overId = over.id as string;
-      const connection = active.data.current?.connection as SavedConnection | undefined;
+      let targetFolderId: string | null | undefined;
 
       if (overId === "root") {
-        if (connection?.folderId != null) {
-          moveConnectionToFolder(connectionId, null);
-        }
+        targetFolderId = null;
       } else if (over.data.current?.type === "folder") {
-        if (connection?.folderId !== overId) {
-          moveConnectionToFolder(connectionId, overId);
-        }
+        targetFolderId = overId;
       }
+
+      if (targetFolderId === undefined) return;
+
+      // Move all selected connections, or just the dragged one if it's a single-item drag
+      const idsToMove =
+        selectedConnectionIds.has(draggedConnection.id) && selectedConnectionIds.size > 1
+          ? [...selectedConnectionIds]
+          : [draggedConnection.id];
+
+      // Skip connections already in the target folder
+      const idsToActuallyMove = idsToMove.filter((id) => {
+        const conn = connections.find((c) => c.id === id);
+        return conn?.folderId !== targetFolderId;
+      });
+
+      if (idsToActuallyMove.length === 1) {
+        moveConnectionToFolder(idsToActuallyMove[0], targetFolderId);
+      } else if (idsToActuallyMove.length > 1) {
+        bulkMoveConnectionsToFolder(idsToActuallyMove, targetFolderId);
+      }
+
+      setSelectedConnectionIds(new Set());
+      setLastSelectedId(null);
     },
-    [moveConnectionToFolder, remoteAgents, reorderRemoteAgents]
+    [
+      moveConnectionToFolder,
+      bulkMoveConnectionsToFolder,
+      remoteAgents,
+      reorderRemoteAgents,
+      selectedConnectionIds,
+      connections,
+    ]
   );
 
   const [localCollapsed, setLocalCollapsed] = useState(false);
   const [remoteAgentsCollapsed, setRemoteAgentsCollapsed] = useState(false);
-  const rootFolders = folders.filter((f) => f.parentId === null);
-  const rootConnections = connections.filter((c) => c.folderId === null);
   const LocalChevron = localCollapsed ? ChevronRight : ChevronDown;
   const RemoteAgentsChevron = remoteAgentsCollapsed ? ChevronRight : ChevronDown;
 
@@ -662,6 +811,9 @@ export function ConnectionList() {
               onDeleteFolder={handleDeleteFolder}
               onCreateSubfolder={handleCreateFolder}
               onNewConnectionInFolder={handleNewConnectionInFolder}
+              selectedConnectionIds={selectedConnectionIds}
+              onConnectionClick={handleConnectionClick}
+              onTreeAreaClick={handleTreeAreaClick}
             />
           )}
         </div>
@@ -736,7 +888,11 @@ export function ConnectionList() {
           </>
         )}
         <DragOverlay>
-          {draggingConnection ? (
+          {draggingSelectionCount > 1 ? (
+            <div className="connection-tree__drag-overlay">
+              <span>{draggingSelectionCount} connections</span>
+            </div>
+          ) : draggingConnection ? (
             <div className="connection-tree__drag-overlay">
               <ConnectionIcon
                 config={draggingConnection.config}
@@ -776,6 +932,9 @@ interface RootDropZoneProps {
   onDeleteFolder: (folderId: string) => void;
   onCreateSubfolder: (parentId: string, name: string) => void;
   onNewConnectionInFolder: (folderId: string) => void;
+  selectedConnectionIds: Set<string>;
+  onConnectionClick: (connectionId: string, event: React.MouseEvent) => void;
+  onTreeAreaClick: (event: React.MouseEvent) => void;
 }
 
 function RootDropZone({
@@ -797,6 +956,9 @@ function RootDropZone({
   onDeleteFolder,
   onCreateSubfolder,
   onNewConnectionInFolder,
+  selectedConnectionIds,
+  onConnectionClick,
+  onTreeAreaClick,
 }: RootDropZoneProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: "root",
@@ -811,6 +973,7 @@ function RootDropZone({
         <div
           ref={setNodeRef}
           className={`connection-list__tree${isConnectionOver ? " connection-tree__root-drop--over" : ""}`}
+          onClick={onTreeAreaClick}
         >
           {isCreatingFolder && (
             <InlineFolderInput
@@ -836,6 +999,8 @@ function RootDropZone({
               onDeleteFolder={onDeleteFolder}
               onCreateSubfolder={onCreateSubfolder}
               onNewConnectionInFolder={onNewConnectionInFolder}
+              selectedConnectionIds={selectedConnectionIds}
+              onConnectionClick={onConnectionClick}
               depth={0}
             />
           ))}
@@ -844,11 +1009,13 @@ function RootDropZone({
               key={conn.id}
               connection={conn}
               depth={0}
+              isSelected={selectedConnectionIds.has(conn.id)}
               onConnect={onConnect}
               onEdit={onEdit}
               onDelete={onDelete}
               onDuplicate={onDuplicate}
               onPingHost={onPingHost}
+              onConnectionClick={onConnectionClick}
             />
           ))}
         </div>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -346,6 +346,7 @@ interface AppState {
   deleteFolder: (folderId: string) => void;
   duplicateConnection: (connectionId: string) => void;
   moveConnectionToFolder: (connectionId: string, folderId: string | null) => void;
+  bulkMoveConnectionsToFolder: (connectionIds: string[], folderId: string | null) => void;
   moveConnectionToFile: (connectionId: string, targetSource: string | null) => Promise<void>;
 
   // File browser / SFTP
@@ -1901,6 +1902,22 @@ export const useAppStore = create<AppState>((set, get) => {
           .then(({ connections, folders }) => set({ connections, folders }))
           .catch((err) => console.error("Failed to persist connection move:", err));
       }
+    },
+
+    bulkMoveConnectionsToFolder: (connectionIds, folderId) => {
+      const idSet = new Set(connectionIds);
+
+      // Optimistic update for instant visual feedback
+      set((state) => ({
+        connections: state.connections.map((c) => (idSet.has(c.id) ? { ...c, folderId } : c)),
+      }));
+
+      // Persist all connections in parallel, then reload once
+      const moved = get().connections.filter((c) => idSet.has(c.id));
+      Promise.all(moved.map((conn) => persistConnection(stripPassword(conn))))
+        .then(() => loadConnections())
+        .then(({ connections, folders }) => set({ connections, folders }))
+        .catch((err) => console.error("Failed to persist bulk connection move:", err));
     },
 
     // File browser / SFTP


### PR DESCRIPTION
## Summary

- **Ctrl/Cmd+Click** toggles individual connection selection; **Shift+Click** range-selects between the last anchor and the clicked item; plain click single-selects.
- Dragging any selected connection moves **all selected connections** as a group into the target folder (or back to root).
- **Escape** or clicking empty tree space clears the selection. Selected items are highlighted with a translucent accent background.
- Added `bulkMoveConnectionsToFolder` to the appStore for efficient batch persist (single reload after all connections are persisted in parallel).

Closes #638

## Test plan

- [x] 10 automated tests covering: single select, multi-select via Ctrl+Click, deselect via Ctrl+Click, Meta+Click (macOS), Shift+Click range (forward and reverse), Escape clears, empty-space click clears, folder-spanning Shift+Click range
- [ ] Manual: open the sidebar with several connections and folders, Ctrl+Click to select multiple, drag the group into a folder — confirm all selected connections move
- [ ] Manual: Shift+Click to range-select across expanded folder contents, drag to folder
- [ ] Manual: verify the DragOverlay shows "{n} connections" when dragging a multi-selection
- [ ] Manual: verify Escape and clicking empty sidebar space deselect all

🤖 Generated with [Claude Code](https://claude.com/claude-code)