### PR TITLE
fix(ui): add right-click context menu to zoom overlay header (#635)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- UI: right-clicking a tab now correctly opens the context menu at all zoom levels. Previously, using Cmd/Ctrl + to zoom in caused right-clicks to hit the wrong element because the native webview zoom created a mismatch between pointer coordinates and DOM layout coordinates. Zoom is now applied via CSS, which keeps all coordinate APIs consistent (#635).
+- UI: right-clicking the header bar of the panel zoom overlay (Cmd+Shift+Enter) now opens a context menu with Rename, Save to File, Copy to Clipboard, Clear Terminal, Horizontal Scrolling, and Set Color options. Previously the zoom overlay header had no context menu at all (#635).
 - Terminal: pressing "Clear" now fully resets the terminal — the cursor is moved to position (0,0) after the buffer is wiped, preventing rendering artifacts and misaligned input that occurred when a subsequent program output was placed at the old cursor position (#634)
 - Files: remote zsh sessions now receive shell integration (OSC 7 CWD tracking) so the file browser follows the terminal's current directory. Previously, zsh was excluded from integration injection under the incorrect assumption that it emits OSC 7 natively; the injected hook correctly detects bash vs. zsh at runtime (#630)
 - Files: the session-mode file browser now opens in the user's home directory (`~`) instead of the filesystem root (`/`) when no CWD has been received yet (#630)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- UI: right-clicking a tab now correctly opens the context menu at all zoom levels. Previously, using Cmd/Ctrl + to zoom in caused right-clicks to hit the wrong element because the native webview zoom created a mismatch between pointer coordinates and DOM layout coordinates. Zoom is now applied via CSS, which keeps all coordinate APIs consistent (#635).
 - Terminal: pressing "Clear" now fully resets the terminal — the cursor is moved to position (0,0) after the buffer is wiped, preventing rendering artifacts and misaligned input that occurred when a subsequent program output was placed at the old cursor position (#634)
 - Files: remote zsh sessions now receive shell integration (OSC 7 CWD tracking) so the file browser follows the terminal's current directory. Previously, zsh was excluded from integration injection under the incorrect assumption that it emits OSC 7 natively; the injected hook correctly detects bash vs. zsh at runtime (#630)
 - Files: the session-mode file browser now opens in the user's home directory (`~`) instead of the filesystem root (`/`) when no CWD has been received yet (#630)

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -73,6 +73,16 @@ export function SplitView() {
   const terminalConnecting = useAppStore((s) => s.terminalConnecting);
   const terminalAutoRetryCountZoom = useAppStore((s) => s.terminalAutoRetryCount);
   const terminalWaitingForAgentZoom = useAppStore((s) => s.terminalWaitingForAgent);
+  const tabHorizontalScrollingZoom = useAppStore((s) => s.tabHorizontalScrolling);
+  const setTabHorizontalScrollingZoom = useAppStore((s) => s.setTabHorizontalScrolling);
+  const tabColorsZoom = useAppStore((s) => s.tabColors);
+  const setTabColorZoom = useAppStore((s) => s.setTabColor);
+  const renameTabZoom = useAppStore((s) => s.renameTab);
+
+  const { clearTerminal, saveTerminalToFile, copyTerminalToClipboard } = useTerminalRegistry();
+
+  const [zoomColorPickerOpen, setZoomColorPickerOpen] = useState(false);
+  const [zoomRenameOpen, setZoomRenameOpen] = useState(false);
 
   // Find the zoomed tab's metadata for the overlay header
   const zoomedTab = useMemo(() => {
@@ -247,42 +257,108 @@ export function SplitView() {
       {zoomedTabId && zoomedTab && (
         <div className="zoom-overlay" onClick={dismissZoom}>
           <div className="zoom-overlay__panel" onClick={(e) => e.stopPropagation()}>
-            <div className="zoom-overlay__header">
-              {zoomedTab.contentType === "settings" ? (
-                <SettingsIcon size={14} className="zoom-overlay__icon" />
-              ) : zoomedTab.contentType === "log-viewer" ? (
-                <ScrollText size={14} className="zoom-overlay__icon" />
-              ) : zoomedTab.contentType === "editor" ? (
-                <FileEdit size={14} className="zoom-overlay__icon" />
-              ) : zoomedTab.contentType === "connection-editor" ? (
-                <SquarePen size={14} className="zoom-overlay__icon" />
-              ) : zoomedTab.contentType === "tunnel-editor" ? (
-                <ArrowLeftRight size={14} className="zoom-overlay__icon" />
-              ) : zoomedTab.contentType === "workspace-editor" ? (
-                <LayoutGrid size={14} className="zoom-overlay__icon" />
-              ) : zoomedTab.contentType === "network-diagnostic" ? (
-                <Stethoscope size={14} className="zoom-overlay__icon" />
-              ) : zoomedTab.contentType === "agent-error" ? (
-                <WifiOff size={14} className="zoom-overlay__icon" />
-              ) : (
-                <ConnectionIcon
-                  config={zoomedTab.config}
-                  size={14}
-                  className="zoom-overlay__icon"
-                />
-              )}
-              <span className="zoom-overlay__title">{zoomedTab.title}</span>
-              <span className="zoom-overlay__hint">
-                {isMac() ? "⌘⇧↵" : "Ctrl+Shift+Enter"} · Esc to close
-              </span>
-              <button
-                className="zoom-overlay__close"
-                onClick={dismissZoom}
-                aria-label="Close zoom overlay"
-              >
-                <X size={16} />
-              </button>
-            </div>
+            <ContextMenu.Root>
+              <ContextMenu.Trigger asChild>
+                <div className="zoom-overlay__header">
+                  {zoomedTab.contentType === "settings" ? (
+                    <SettingsIcon size={14} className="zoom-overlay__icon" />
+                  ) : zoomedTab.contentType === "log-viewer" ? (
+                    <ScrollText size={14} className="zoom-overlay__icon" />
+                  ) : zoomedTab.contentType === "editor" ? (
+                    <FileEdit size={14} className="zoom-overlay__icon" />
+                  ) : zoomedTab.contentType === "connection-editor" ? (
+                    <SquarePen size={14} className="zoom-overlay__icon" />
+                  ) : zoomedTab.contentType === "tunnel-editor" ? (
+                    <ArrowLeftRight size={14} className="zoom-overlay__icon" />
+                  ) : zoomedTab.contentType === "workspace-editor" ? (
+                    <LayoutGrid size={14} className="zoom-overlay__icon" />
+                  ) : zoomedTab.contentType === "network-diagnostic" ? (
+                    <Stethoscope size={14} className="zoom-overlay__icon" />
+                  ) : zoomedTab.contentType === "agent-error" ? (
+                    <WifiOff size={14} className="zoom-overlay__icon" />
+                  ) : (
+                    <ConnectionIcon
+                      config={zoomedTab.config}
+                      size={14}
+                      className="zoom-overlay__icon"
+                    />
+                  )}
+                  <span className="zoom-overlay__title">{zoomedTab.title}</span>
+                  <span className="zoom-overlay__hint">
+                    {isMac() ? "⌘⇧↵" : "Ctrl+Shift+Enter"} · Esc to close
+                  </span>
+                  <button
+                    className="zoom-overlay__close"
+                    onClick={dismissZoom}
+                    aria-label="Close zoom overlay"
+                  >
+                    <X size={16} />
+                  </button>
+                </div>
+              </ContextMenu.Trigger>
+              <ContextMenu.Portal>
+                <ContextMenu.Content className="context-menu__content">
+                  {zoomedTab.contentType === "terminal" && (
+                    <>
+                      <ContextMenu.Item
+                        className="context-menu__item"
+                        onSelect={() => setZoomRenameOpen(true)}
+                        data-testid="zoom-context-rename"
+                      >
+                        <Pencil size={14} /> Rename
+                      </ContextMenu.Item>
+                      <ContextMenu.Separator className="context-menu__separator" />
+                      <ContextMenu.Item
+                        className="context-menu__item"
+                        onSelect={() => saveTerminalToFile(zoomedTabId)}
+                        data-testid="zoom-context-save"
+                      >
+                        <FileDown size={14} /> Save to File
+                      </ContextMenu.Item>
+                      <ContextMenu.Item
+                        className="context-menu__item"
+                        onSelect={() => copyTerminalToClipboard(zoomedTabId)}
+                        data-testid="zoom-context-copy"
+                      >
+                        <ClipboardCopy size={14} /> Copy to Clipboard
+                      </ContextMenu.Item>
+                      <ContextMenu.Item
+                        className="context-menu__item"
+                        onSelect={() => clearTerminal(zoomedTabId)}
+                        data-testid="zoom-context-clear"
+                      >
+                        <Eraser size={14} /> Clear Terminal
+                      </ContextMenu.Item>
+                      <ContextMenu.Separator className="context-menu__separator" />
+                      <ContextMenu.CheckboxItem
+                        className="context-menu__item"
+                        checked={tabHorizontalScrollingZoom[zoomedTabId] ?? false}
+                        onSelect={() =>
+                          setTabHorizontalScrollingZoom(
+                            zoomedTabId,
+                            !(tabHorizontalScrollingZoom[zoomedTabId] ?? false)
+                          )
+                        }
+                        data-testid="zoom-context-horizontal-scroll"
+                      >
+                        <ContextMenu.ItemIndicator className="context-menu__indicator">
+                          <Check size={14} />
+                        </ContextMenu.ItemIndicator>
+                        <ArrowRightLeft size={14} /> Horizontal Scrolling
+                      </ContextMenu.CheckboxItem>
+                      <ContextMenu.Separator className="context-menu__separator" />
+                    </>
+                  )}
+                  <ContextMenu.Item
+                    className="context-menu__item"
+                    onSelect={() => setZoomColorPickerOpen(true)}
+                    data-testid="zoom-context-set-color"
+                  >
+                    <Palette size={14} /> Set Color...
+                  </ContextMenu.Item>
+                </ContextMenu.Content>
+              </ContextMenu.Portal>
+            </ContextMenu.Root>
             <div className="zoom-overlay__content">
               {zoomedTab.contentType === "terminal" &&
               (terminalSpawnErrors[zoomedTabId] ||
@@ -364,6 +440,29 @@ export function SplitView() {
             </div>
           </div>
         </div>
+      )}
+      {zoomedTabId && (
+        <>
+          <ColorPickerDialog
+            open={zoomColorPickerOpen}
+            onOpenChange={(open) => {
+              if (!open) setZoomColorPickerOpen(false);
+            }}
+            currentColor={tabColorsZoom[zoomedTabId]}
+            onColorChange={(color) => setTabColorZoom(zoomedTabId, color)}
+          />
+          <RenameDialog
+            open={zoomRenameOpen}
+            onOpenChange={(open) => {
+              if (!open) setZoomRenameOpen(false);
+            }}
+            currentTitle={zoomedTab?.title ?? ""}
+            onRename={(newTitle) => {
+              renameTabZoom(zoomedTabId, newTitle);
+              setZoomRenameOpen(false);
+            }}
+          />
+        </>
       )}
     </div>
   );

--- a/src/hooks/useWebviewZoom.test.ts
+++ b/src/hooks/useWebviewZoom.test.ts
@@ -1,16 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-const mockSetZoom = vi.fn(() => Promise.resolve());
-
-vi.mock("@tauri-apps/api/webview", () => ({
-  getCurrentWebview: () => ({
-    setZoom: mockSetZoom,
-  }),
-}));
-
-vi.mock("@/utils/frontendLog", () => ({
-  frontendLog: vi.fn(),
-}));
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, Root } from "react-dom/client";
 
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>
@@ -43,40 +33,85 @@ vi.mock("@/services/api", () => ({
 }));
 
 import { useAppStore } from "@/store/appStore";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { useWebviewZoom } from "./useWebviewZoom";
+
+function ZoomHarness() {
+  useWebviewZoom();
+  return null;
+}
 
 describe("useWebviewZoom", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
   beforeEach(() => {
-    mockSetZoom.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
     useAppStore.setState(useAppStore.getInitialState());
+    document.documentElement.style.zoom = "";
   });
 
-  it("calls setZoom with the correct zoom level", async () => {
-    const zoomLevel = useAppStore.getState().zoomLevel;
-    await getCurrentWebview().setZoom(zoomLevel);
-    expect(mockSetZoom).toHaveBeenCalledWith(1.0);
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.documentElement.style.zoom = "";
   });
 
-  it("calls setZoom with updated level after zoomIn", async () => {
-    useAppStore.getState().zoomIn();
-    const zoomLevel = useAppStore.getState().zoomLevel;
-    await getCurrentWebview().setZoom(zoomLevel);
-    expect(mockSetZoom).toHaveBeenCalledWith(1.1);
+  it("does not set CSS zoom at default zoom level (1.0)", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(createElement(ZoomHarness));
+    });
+    expect(document.documentElement.style.zoom).toBe("");
   });
 
-  it("calls setZoom with updated level after zoomOut", async () => {
-    useAppStore.getState().zoomOut();
-    const zoomLevel = useAppStore.getState().zoomLevel;
-    await getCurrentWebview().setZoom(zoomLevel);
-    expect(mockSetZoom).toHaveBeenCalledWith(0.91);
+  it("sets CSS zoom after zoomIn", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(createElement(ZoomHarness));
+    });
+    act(() => {
+      useAppStore.getState().zoomIn();
+    });
+    expect(document.documentElement.style.zoom).toBe("1.1");
   });
 
-  it("calls setZoom with 1.0 after zoomReset", async () => {
-    useAppStore.getState().zoomIn();
-    useAppStore.getState().zoomIn();
-    useAppStore.getState().zoomReset();
-    const zoomLevel = useAppStore.getState().zoomLevel;
-    await getCurrentWebview().setZoom(zoomLevel);
-    expect(mockSetZoom).toHaveBeenCalledWith(1.0);
+  it("sets CSS zoom after zoomOut", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(createElement(ZoomHarness));
+    });
+    act(() => {
+      useAppStore.getState().zoomOut();
+    });
+    expect(document.documentElement.style.zoom).toBe("0.91");
+  });
+
+  it("clears CSS zoom after zoomReset", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(createElement(ZoomHarness));
+    });
+    act(() => {
+      useAppStore.getState().zoomIn();
+      useAppStore.getState().zoomIn();
+    });
+    act(() => {
+      useAppStore.getState().zoomReset();
+    });
+    expect(document.documentElement.style.zoom).toBe("");
+  });
+
+  it("clears CSS zoom on unmount", () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(createElement(ZoomHarness));
+    });
+    act(() => {
+      useAppStore.getState().zoomIn();
+    });
+    expect(document.documentElement.style.zoom).toBe("1.1");
+    act(() => root.unmount());
+    expect(document.documentElement.style.zoom).toBe("");
   });
 });

--- a/src/hooks/useWebviewZoom.ts
+++ b/src/hooks/useWebviewZoom.ts
@@ -1,29 +1,20 @@
 import { useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
-import { frontendLog } from "@/utils/frontendLog";
 
 /**
- * Applies the store's zoomLevel to the Tauri webview.
- * Falls back gracefully when not running inside Tauri.
+ * Applies the store's zoomLevel as CSS zoom on the root element.
+ *
+ * CSS zoom keeps all DOM coordinate APIs (event.clientX/Y, getBoundingClientRect)
+ * in a consistent space, which is required for Radix UI context menus and
+ * dnd-kit drag detection to work correctly at all zoom levels.
  */
 export function useWebviewZoom() {
   const zoomLevel = useAppStore((s) => s.zoomLevel);
 
   useEffect(() => {
-    let canceled = false;
-
-    (async () => {
-      try {
-        const { getCurrentWebview } = await import("@tauri-apps/api/webview");
-        if (canceled) return;
-        await getCurrentWebview().setZoom(zoomLevel);
-      } catch (err) {
-        frontendLog("zoom", `Failed to set webview zoom: ${err}`);
-      }
-    })();
-
+    document.documentElement.style.zoom = zoomLevel === 1 ? "" : String(zoomLevel);
     return () => {
-      canceled = true;
+      document.documentElement.style.zoom = "";
     };
   }, [zoomLevel]);
 }


### PR DESCRIPTION
## Summary

- Adds a right-click context menu to the header bar of the panel zoom overlay (opened via Cmd+Shift+Enter / Ctrl+Shift+Enter)
- The header had no context menu at all — right-clicking did nothing
- The new menu matches the regular tab context menu: **Rename**, **Save to File**, **Copy to Clipboard**, **Clear Terminal**, **Horizontal Scrolling** toggle, and **Set Color...**
- For non-terminal tabs (Settings, Log Viewer, Editor, etc.) only **Set Color...** is shown, consistent with Tab.tsx
- Also switches webview zoom from native `setZoom()` to CSS zoom on the root element, which keeps all DOM coordinate APIs consistent (prevents potential coordinate mismatch issues at non-100% zoom)

## Test plan

- [ ] Manual: open a terminal, press Cmd+Shift+Enter (or Ctrl+Shift+Enter) to zoom the tab to full screen
- [ ] Manual: right-click the header bar (where the tab title is shown) — context menu should appear
- [ ] Manual: verify Rename opens the rename dialog and updates the tab title
- [ ] Manual: verify Clear Terminal clears the terminal content
- [ ] Manual: verify Save to File and Copy to Clipboard work
- [ ] Manual: verify Horizontal Scrolling toggle works
- [ ] Manual: verify Set Color... opens the color picker and applies the color
- [ ] Manual: verify non-terminal tabs (e.g., Settings) show only Set Color... in the header menu

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)