### PR TITLE
fix(ui): show Save/Discard/Cancel dialog before closing dirty file editor tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- UI: closing a file editor tab with unsaved changes now shows a "Save / Discard / Cancel" dialog before the tab is closed, matching the behavior of the settings and connection editors. Previously, a simple browser confirm appeared after the tab was already closed, making it impossible to cancel (#632).
 - Monitoring: system stats (CPU, memory, disk) are now displayed for remote shell sessions on agents that support monitoring. Previously, the monitoring panel showed nothing for remote-session tabs because the agent reported local sessions as not supporting monitoring, the desktop proxy sent the wrong host identifier, and the frontend never checked per-session capabilities (#629)
 - UI: right-clicking the header bar of the panel zoom overlay (Cmd+Shift+Enter) now opens a context menu with Rename, Save to File, Copy to Clipboard, Clear Terminal, Horizontal Scrolling, and Set Color options. Previously the zoom overlay header had no context menu at all (#635).
 - Terminal: pressing "Clear" now fully resets the terminal — the cursor is moved to position (0,0) after the buffer is wiped, preventing rendering artifacts and misaligned input that occurred when a subsequent program output was placed at the old cursor position (#634)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - UI: closing a file editor tab with unsaved changes now shows a "Save / Discard / Cancel" dialog before the tab is closed, matching the behavior of the settings and connection editors. Previously, a simple browser confirm appeared after the tab was already closed, making it impossible to cancel (#632).
+- UI: restored the dirty-state dot indicator in editor tab titles (settings, connection editor, file editor) — a small filled circle now appears before the tab name when there are unsaved changes.
 - Monitoring: system stats (CPU, memory, disk) are now displayed for remote shell sessions on agents that support monitoring. Previously, the monitoring panel showed nothing for remote-session tabs because the agent reported local sessions as not supporting monitoring, the desktop proxy sent the wrong host identifier, and the frontend never checked per-session capabilities (#629)
 - UI: right-clicking the header bar of the panel zoom overlay (Cmd+Shift+Enter) now opens a context menu with Rename, Save to File, Copy to Clipboard, Clear Terminal, Horizontal Scrolling, and Set Color options. Previously the zoom overlay header had no context menu at all (#635).
 - Terminal: pressing "Clear" now fully resets the terminal — the cursor is moved to position (0,0) after the buffer is wiped, preventing rendering artifacts and misaligned input that occurred when a subsequent program output was placed at the old cursor position (#634)

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -14,6 +14,7 @@ import {
   sftpReadFileContent,
   sftpWriteFileContent,
 } from "@/services/api";
+import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
 import "./FileEditor.css";
 
 // Use local monaco-editor package instead of CDN (important for Tauri/offline)
@@ -55,6 +56,9 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   const setEditorStatus = useAppStore((s) => s.setEditorStatus);
   const setEditorActions = useAppStore((s) => s.setEditorActions);
   const fileLanguageMappings = useAppStore((s) => s.settings.fileLanguageMappings);
+  const pendingCloseRequest = useAppStore((s) => s.pendingCloseRequest);
+  const setPendingCloseRequest = useAppStore((s) => s.setPendingCloseRequest);
+  const closeTab = useAppStore((s) => s.closeTab);
   // Subscribe to the theme setting so we re-derive the Monaco theme when the
   // user explicitly switches between dark / light / system in the settings.
   const themeSetting = useAppStore((s) => s.settings.theme);
@@ -146,6 +150,23 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
 
   // Keep saveRef up to date for Monaco keybinding
   saveRef.current = handleSave;
+
+  const handleDialogCancel = useCallback(() => {
+    setPendingCloseRequest(null);
+  }, [setPendingCloseRequest]);
+
+  const handleDialogJustClose = useCallback(() => {
+    const req = pendingCloseRequest;
+    setPendingCloseRequest(null);
+    if (req) closeTab(req.tabId, req.panelId);
+  }, [pendingCloseRequest, setPendingCloseRequest, closeTab]);
+
+  const handleDialogSaveAndClose = useCallback(async () => {
+    const req = pendingCloseRequest;
+    setPendingCloseRequest(null);
+    await handleSave();
+    if (req) closeTab(req.tabId, req.panelId);
+  }, [pendingCloseRequest, setPendingCloseRequest, handleSave, closeTab]);
 
   const handleEditorMount = useCallback(
     (editor: monaco.editor.IStandaloneCodeEditor) => {
@@ -267,6 +288,12 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
 
   return (
     <div className={`file-editor ${!isVisible ? "file-editor--hidden" : ""}`}>
+      <UnsavedChangesDialog
+        open={pendingCloseRequest?.tabId === tabId}
+        onCancel={handleDialogCancel}
+        onJustClose={handleDialogJustClose}
+        onSaveAndClose={handleDialogSaveAndClose}
+      />
       <div className="file-editor__toolbar">
         <div className="file-editor__path">
           {meta.isRemote && (

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -28,6 +28,7 @@ interface TabProps {
   onCopyToClipboard?: () => void;
   horizontalScrolling?: boolean;
   onToggleHorizontalScrolling?: () => void;
+  isDirty?: boolean;
   tabColor?: string;
   onRename?: () => void;
   onSetColor?: () => void;
@@ -43,6 +44,7 @@ export function Tab({
   onCopyToClipboard,
   horizontalScrolling,
   onToggleHorizontalScrolling,
+  isDirty,
   tabColor,
   onRename,
   onSetColor,
@@ -93,7 +95,10 @@ export function Tab({
       {remoteState && (
         <span className={`tab__state-dot tab__state-dot--${remoteState}`} title={remoteState} />
       )}
-      <span className="tab__title">{tab.title}</span>
+      <span className="tab__title">
+        {isDirty && <span className="tab__dirty-dot" />}
+        {tab.title}
+      </span>
       <button
         className="tab__close"
         onClick={(e) => {

--- a/src/components/Terminal/TabBar.close-editor.test.tsx
+++ b/src/components/Terminal/TabBar.close-editor.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TabBar } from "./TabBar";
+import { useAppStore } from "@/store/appStore";
+import { TerminalTab } from "@/types/terminal";
+
+vi.mock("./TerminalRegistry", () => ({
+  useTerminalRegistry: () => ({
+    clearTerminal: vi.fn(),
+    saveTerminalToFile: vi.fn().mockResolvedValue(undefined),
+    copyTerminalToClipboard: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  horizontalListSortingStrategy: {},
+}));
+
+vi.mock("./Tab", () => ({
+  Tab: ({ tab, onClose }: { tab: TerminalTab; onClose: () => void }) => (
+    <button data-testid={`tab-close-${tab.id}`} onClick={onClose}>
+      close
+    </button>
+  ),
+}));
+
+vi.mock("./ColorPickerDialog", () => ({
+  ColorPickerDialog: () => null,
+}));
+
+vi.mock("./RenameDialog", () => ({
+  RenameDialog: () => null,
+}));
+
+const PANEL_ID = "panel-1";
+const TAB_ID = "tab-editor-1";
+
+function makeEditorTab(id = TAB_ID): TerminalTab {
+  return {
+    id,
+    sessionId: null,
+    title: "test.txt",
+    connectionType: "local",
+    contentType: "editor",
+    config: { type: "local", config: {} },
+    panelId: PANEL_ID,
+    isActive: true,
+    editorMeta: { filePath: "/tmp/test.txt", isRemote: false },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(tabs: TerminalTab[]) {
+  act(() => {
+    root.render(<TabBar panelId={PANEL_ID} tabs={tabs} />);
+  });
+}
+
+function resetStore() {
+  useAppStore.setState({
+    editorDirtyTabs: {},
+    pendingCloseRequest: null,
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  resetStore();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("TabBar — close file editor tab with unsaved changes", () => {
+  it("routes close through setPendingCloseRequest for a dirty editor tab (no window.confirm)", () => {
+    const confirmSpy = vi.spyOn(window, "confirm");
+    const tabs = [makeEditorTab()];
+    render(tabs);
+
+    useAppStore.setState({ editorDirtyTabs: { [TAB_ID]: true } });
+
+    const closeBtn = container.querySelector(
+      `[data-testid="tab-close-${TAB_ID}"]`
+    ) as HTMLButtonElement;
+
+    act(() => {
+      closeBtn.click();
+    });
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(useAppStore.getState().pendingCloseRequest).toEqual({
+      tabId: TAB_ID,
+      panelId: PANEL_ID,
+    });
+  });
+
+  it("does not close the tab immediately when the editor tab is dirty", () => {
+    const tabs = [makeEditorTab()];
+    render(tabs);
+
+    useAppStore.setState({ editorDirtyTabs: { [TAB_ID]: true } });
+
+    // Record panels before close attempt
+    const panelsBefore = useAppStore.getState().panels;
+
+    const closeBtn = container.querySelector(
+      `[data-testid="tab-close-${TAB_ID}"]`
+    ) as HTMLButtonElement;
+
+    act(() => {
+      closeBtn.click();
+    });
+
+    // Tab should still be present (panel tree unchanged)
+    expect(useAppStore.getState().panels).toEqual(panelsBefore);
+  });
+
+  it("closes a clean editor tab directly without dialog", () => {
+    const confirmSpy = vi.spyOn(window, "confirm");
+    const tabs = [makeEditorTab()];
+    render(tabs);
+
+    // Tab is not dirty
+    useAppStore.setState({ editorDirtyTabs: { [TAB_ID]: false } });
+
+    const closeBtn = container.querySelector(
+      `[data-testid="tab-close-${TAB_ID}"]`
+    ) as HTMLButtonElement;
+
+    act(() => {
+      closeBtn.click();
+    });
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(useAppStore.getState().pendingCloseRequest).toBeNull();
+  });
+});

--- a/src/components/Terminal/TabBar.close-editor.test.tsx
+++ b/src/components/Terminal/TabBar.close-editor.test.tsx
@@ -111,7 +111,7 @@ describe("TabBar — close file editor tab with unsaved changes", () => {
     useAppStore.setState({ editorDirtyTabs: { [TAB_ID]: true } });
 
     // Record panels before close attempt
-    const panelsBefore = useAppStore.getState().panels;
+    const panelsBefore = useAppStore.getState().rootPanel;
 
     const closeBtn = container.querySelector(
       `[data-testid="tab-close-${TAB_ID}"]`
@@ -122,7 +122,7 @@ describe("TabBar — close file editor tab with unsaved changes", () => {
     });
 
     // Tab should still be present (panel tree unchanged)
-    expect(useAppStore.getState().panels).toEqual(panelsBefore);
+    expect(useAppStore.getState().rootPanel).toEqual(panelsBefore);
   });
 
   it("closes a clean editor tab directly without dialog", () => {

--- a/src/components/Terminal/TabBar.css
+++ b/src/components/Terminal/TabBar.css
@@ -91,6 +91,17 @@
   color: var(--text-primary);
 }
 
+.tab__dirty-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--text-secondary);
+  margin-right: 4px;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
 .tab__state-dot {
   display: inline-block;
   width: 7px;

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -22,6 +22,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   const tabColors = useAppStore((s) => s.tabColors);
   const setTabColor = useAppStore((s) => s.setTabColor);
   const renameTab = useAppStore((s) => s.renameTab);
+  const editorDirtyTabs = useAppStore((s) => s.editorDirtyTabs);
   const setPendingCloseRequest = useAppStore((s) => s.setPendingCloseRequest);
   const remoteStates = useAppStore((s) => s.remoteStates);
   const { clearTerminal, saveTerminalToFile, copyTerminalToClipboard } = useTerminalRegistry();
@@ -68,6 +69,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               onToggleHorizontalScrolling={() =>
                 setTabHorizontalScrolling(tab.id, !(tabHorizontalScrolling[tab.id] ?? false))
               }
+              isDirty={editorDirtyTabs[tab.id] ?? false}
               tabColor={tabColors[tab.id]}
               onRename={() => setRenameTabId(tab.id)}
               onSetColor={() => setColorPickerTabId(tab.id)}

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -36,7 +36,11 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
     const isDirty = useAppStore.getState().editorDirtyTabs[tabId];
     if (isDirty) {
       const tab = tabs.find((t) => t.id === tabId);
-      if (tab?.contentType === "connection-editor" || tab?.contentType === "settings") {
+      if (
+        tab?.contentType === "connection-editor" ||
+        tab?.contentType === "settings" ||
+        tab?.contentType === "editor"
+      ) {
         setPendingCloseRequest({ tabId, panelId });
         return;
       }


### PR DESCRIPTION
## Summary

- Routes file editor tab close through `setPendingCloseRequest` (same as settings/connection editors) instead of `window.confirm`
- Adds `UnsavedChangesDialog` to `FileEditor` with Save, Discard, and Cancel options
- Cancel keeps the tab open; the tab is no longer closed before the user responds

Fixes #632

## Test plan

- [x] Regression test added: `TabBar.close-editor.test.tsx` verifies that closing a dirty `"editor"` tab calls `setPendingCloseRequest` and not `window.confirm`
- [ ] Manual: open a file, make a change, click the tab close button — verify the Save/Discard/Cancel dialog appears *before* the tab closes
- [ ] Manual: click Cancel — verify the tab stays open with edits intact
- [ ] Manual: click Just Close — verify the tab closes and changes are discarded
- [ ] Manual: click Save & Close — verify the file is saved and the tab closes
- [ ] Manual: close a clean (unmodified) file editor tab — verify no dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)