### PR TITLE
feat(ui): add 'About termiHub' page with version and licensing info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Settings: added an "About" page (accessible from the Settings panel) showing the app name, current version, git hash, project tagline, GitHub repository link, and MIT license details (#631).
 - Connection sidebar: connections now support multi-select — Ctrl/Cmd+Click toggles individual selection, Shift+Click range-selects, and dragging a selected group moves all selected connections into the target folder at once. Escape or clicking empty space clears the selection (#638).
 - Agent setup: the setup dialog now detects the remote host's architecture automatically before opening, and defaults to downloading the agent binary from GitHub (using `dev-latest` for dev builds or `v{version}` for releases). A local file picker remains available as a fallback. The detected architecture and download URL are shown in the dialog.
 

--- a/src/components/Settings/AboutSettings.css
+++ b/src/components/Settings/AboutSettings.css
@@ -1,0 +1,49 @@
+.about-settings__hero {
+  margin-bottom: var(--spacing-xl);
+}
+
+.about-settings__app-name {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  margin-bottom: var(--spacing-xs);
+}
+
+.about-settings__tagline {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.about-settings__info-table {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.about-settings__row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  font-size: var(--font-size-sm);
+}
+
+.about-settings__label {
+  width: 80px;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.about-settings__hash {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.about-settings__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}

--- a/src/components/Settings/AboutSettings.test.tsx
+++ b/src/components/Settings/AboutSettings.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { AboutSettings } from "./AboutSettings";
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+const { invoke } = await import("@tauri-apps/api/core");
+const mockedInvoke = vi.mocked(invoke);
+
+const { openUrl } = await import("@tauri-apps/plugin-opener");
+// setup.ts mocks the entire module; vi.mocked gives typed access to the spy
+const mockedOpenUrl = vi.mocked(openUrl);
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(<AboutSettings />);
+  });
+}
+
+describe("AboutSettings", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "get_app_info")
+        return Promise.resolve({ version: "1.2.3", gitHash: "abc1234", isDev: false });
+      return Promise.resolve(undefined);
+    });
+
+    mockedOpenUrl.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the About category heading", () => {
+    render();
+    const heading = container.querySelector(".settings-panel__category-title");
+    expect(heading?.textContent).toBe("About");
+  });
+
+  it("shows the app name", () => {
+    render();
+    expect(container.textContent).toContain("termiHub");
+  });
+
+  it("shows the version after app info loads", async () => {
+    render();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector("[data-testid='about-version']")?.textContent).toContain(
+      "1.2.3"
+    );
+  });
+
+  it("shows the git hash after app info loads", async () => {
+    render();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector("[data-testid='about-git-hash']")?.textContent).toContain(
+      "abc1234"
+    );
+  });
+
+  it("shows a project description / tagline", () => {
+    render();
+    expect(container.querySelector("[data-testid='about-description']")).not.toBeNull();
+  });
+
+  it("shows the MIT license label", () => {
+    render();
+    expect(container.textContent).toContain("MIT");
+  });
+
+  it("has a GitHub repository link button", () => {
+    render();
+    const btn = container.querySelector("[data-testid='about-github-link']");
+    expect(btn).not.toBeNull();
+  });
+
+  it("opens the GitHub URL when the link button is clicked", async () => {
+    render();
+    const btn = container.querySelector("[data-testid='about-github-link']") as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    expect(mockedOpenUrl).toHaveBeenCalledWith("https://github.com/armaxri/termiHub");
+  });
+
+  it("has a link to the full license text", () => {
+    render();
+    const btn = container.querySelector("[data-testid='about-license-link']");
+    expect(btn).not.toBeNull();
+  });
+
+  it("opens the license URL when the license link is clicked", async () => {
+    render();
+    const btn = container.querySelector("[data-testid='about-license-link']") as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    expect(mockedOpenUrl).toHaveBeenCalledWith(
+      "https://github.com/armaxri/termiHub/blob/main/LICENSE"
+    );
+  });
+});

--- a/src/components/Settings/AboutSettings.tsx
+++ b/src/components/Settings/AboutSettings.tsx
@@ -1,0 +1,86 @@
+import { useState, useEffect } from "react";
+import { Github, ExternalLink } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { getAppInfo, type AppInfo } from "@/services/api";
+import { frontendLog } from "@/utils/frontendLog";
+import "./AboutSettings.css";
+
+const GITHUB_URL = "https://github.com/armaxri/termiHub";
+const LICENSE_URL = "https://github.com/armaxri/termiHub/blob/main/LICENSE";
+
+/** Settings page section showing app version, project links, and license info. */
+export function AboutSettings() {
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+
+  useEffect(() => {
+    getAppInfo()
+      .then(setAppInfo)
+      .catch((err) => frontendLog("about", `Failed to load app info: ${err}`));
+  }, []);
+
+  const handleGitHub = () => {
+    openUrl(GITHUB_URL).catch((err) => frontendLog("about", `Failed to open GitHub URL: ${err}`));
+  };
+
+  const handleLicense = () => {
+    openUrl(LICENSE_URL).catch((err) => frontendLog("about", `Failed to open license URL: ${err}`));
+  };
+
+  return (
+    <div className="settings-panel__category" data-testid="about-settings">
+      <h3 className="settings-panel__category-title">About</h3>
+
+      <div className="about-settings__hero">
+        <div className="about-settings__app-name">termiHub</div>
+        <p className="about-settings__tagline" data-testid="about-description">
+          A cross-platform terminal hub with SSH, serial, telnet, and Docker support — built with
+          Tauri and React.
+        </p>
+      </div>
+
+      <div className="settings-panel__section">
+        <div className="about-settings__info-table">
+          <div className="about-settings__row">
+            <span className="about-settings__label">Version</span>
+            <span data-testid="about-version">{appInfo ? `v${appInfo.version}` : "—"}</span>
+          </div>
+          <div className="about-settings__row">
+            <span className="about-settings__label">Build</span>
+            <span
+              className="about-settings__hash"
+              data-testid="about-git-hash"
+              title="Git commit hash"
+            >
+              {appInfo ? appInfo.gitHash : "—"}
+            </span>
+          </div>
+          <div className="about-settings__row">
+            <span className="about-settings__label">License</span>
+            <span>MIT</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="settings-panel__section">
+        <div className="about-settings__actions">
+          <button
+            className="settings-panel__btn"
+            onClick={handleGitHub}
+            data-testid="about-github-link"
+          >
+            <Github size={13} />
+            GitHub Repository
+          </button>
+          <button
+            className="settings-panel__btn"
+            onClick={handleLicense}
+            data-testid="about-license-link"
+          >
+            <ExternalLink size={13} />
+            View License
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import {
   FileJson,
   FileCode2,
   HardDrive,
+  Info,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { RefreshCw } from "lucide-react";
@@ -30,6 +31,7 @@ import { LanguagePackagesSettings } from "./LanguagePackagesSettings";
 import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
 import { PortableModeSettings } from "./PortableModeSettings";
 import { UpdateSettings } from "./UpdateSettings";
+import { AboutSettings } from "./AboutSettings";
 import { getAppInfo, type AppInfo } from "@/services/api";
 import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
 import "./SettingsPanel.css";
@@ -44,6 +46,7 @@ const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
   editor: FileCode2,
   portable: HardDrive,
   updates: RefreshCw,
+  about: Info,
 };
 
 const SAVE_DEBOUNCE_MS = 300;
@@ -292,6 +295,9 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
       if (highlightedCategories?.has("updates")) {
         sections.push(<UpdateSettings key="updates" visibleFields={visibleFields} />);
       }
+      if (highlightedCategories?.has("about")) {
+        sections.push(<AboutSettings key="about" />);
+      }
       if (sections.length === 0) {
         return <div className="settings-panel__no-results">No settings match your search.</div>;
       }
@@ -323,6 +329,8 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
         return <PortableModeSettings />;
       case "updates":
         return <UpdateSettings />;
+      case "about":
+        return <AboutSettings />;
     }
   };
 

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -7,7 +7,8 @@ export type SettingsCategory =
   | "external-files"
   | "editor"
   | "portable"
-  | "updates";
+  | "updates"
+  | "about";
 
 export interface CategoryDefinition {
   id: SettingsCategory;
@@ -32,6 +33,7 @@ export const CATEGORIES: CategoryDefinition[] = [
   { id: "editor", label: "Editor" },
   { id: "portable", label: "Portable Mode" },
   { id: "updates", label: "Updates" },
+  { id: "about", label: "About" },
 ];
 
 export const SETTINGS_REGISTRY: SettingDefinition[] = [
@@ -221,6 +223,13 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     description: "Automatically check for new releases on startup",
     category: "updates",
     keywords: ["update", "auto", "automatic", "startup", "check", "notify"],
+  },
+  {
+    id: "aboutInfo",
+    label: "About termiHub",
+    description: "Version number, GitHub repository link, license, and project information",
+    category: "about",
+    keywords: ["about", "version", "license", "mit", "github", "repository", "credits", "info"],
   },
 ];
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -87,3 +87,7 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
   readText: vi.fn().mockResolvedValue(""),
   writeText: vi.fn().mockResolvedValue(undefined),
 }));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));


### PR DESCRIPTION
## Summary

- Adds a new **About** tab to the Settings panel (after Updates) with an `Info` icon
- Displays app name, current version (from `getAppInfo()`), git hash, project tagline, GitHub repository link, and MIT license details
- Links open in the system browser via `openUrl` from `@tauri-apps/plugin-opener`
- Extends `settingsRegistry.ts` with the new `"about"` category and a searchable registry entry

## Test plan

- [x] `AboutSettings.test.tsx` — 10 unit tests covering heading, app name, version display, git hash, description, MIT label, GitHub link button, GitHub URL opened on click, license link button, license URL opened on click
- [x] Global `setup.ts` extended with `@tauri-apps/plugin-opener` mock (reusable by future tests)
- [x] Full test suite passes (`./scripts/test.sh`)
- [x] Quality checks pass (`./scripts/check.sh`)
- [ ] Manual: open Settings → click **About** in the left nav → verify version, GitHub button, and View License button all work

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)