### PR TITLE
fix(ci): mark main-branch CI builds as dev builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -175,6 +175,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TERMIHUB_DEV_BUILD: 'true'
         with:
           tagName: ''
           releaseName: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CI: main-branch builds are now marked as dev builds — the app version shown in the UI includes a `-dev` suffix and the `isDev` flag is set to `true` for all CI builds triggered from `main` (not just local `tauri dev` sessions). Release-tag builds are unaffected (#663).
 - CI: Windows NSIS setup installer (`termiHub-dev-windows-x64-setup.exe`) was not being uploaded to the `dev-latest` release — it is now uploaded alongside the existing MSI artifact (#664).
 - CI: `dev-latest` release is now created as a draft and published atomically once all platform builds and agent binaries finish uploading, preventing the partial-artifact state visible during builds (#664).
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -10,5 +10,17 @@ fn main() {
     println!("cargo:rustc-env=GIT_HASH={hash}");
     println!("cargo:rerun-if-changed=.git/HEAD");
 
+    // Emit a compile-time flag so CI dev builds can identify themselves at runtime.
+    // Set TERMIHUB_DEV_BUILD=true in the CI workflow to enable this.
+    let is_dev_build = matches!(
+        std::env::var("TERMIHUB_DEV_BUILD").as_deref(),
+        Ok("1") | Ok("true") | Ok("True") | Ok("TRUE")
+    );
+    println!(
+        "cargo:rustc-env=TERMIHUB_IS_DEV_BUILD={}",
+        if is_dev_build { "1" } else { "0" }
+    );
+    println!("cargo:rerun-if-env-changed=TERMIHUB_DEV_BUILD");
+
     tauri_build::build()
 }

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -20,6 +20,15 @@ fn resolve_is_dev(tauri_is_dev: bool, ci_is_dev: bool) -> bool {
     tauri_is_dev || ci_is_dev
 }
 
+/// Returns `true` when this binary was compiled as a CI dev build.
+///
+/// Set by `TERMIHUB_DEV_BUILD=true` in the CI `dev-build.yml` workflow; `build.rs`
+/// translates that into the `TERMIHUB_IS_DEV_BUILD` compile-time env var.
+#[inline]
+fn is_ci_dev_build() -> bool {
+    env!("TERMIHUB_IS_DEV_BUILD") == "1"
+}
+
 /// Build-time information exposed to the frontend.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -36,7 +45,7 @@ pub struct AppInfo {
 #[tauri::command]
 pub fn get_app_info(app_handle: AppHandle) -> AppInfo {
     let base = app_handle.package_info().version.to_string();
-    let is_dev = tauri::is_dev();
+    let is_dev = resolve_is_dev(tauri::is_dev(), is_ci_dev_build());
     let version = if is_dev { format!("{base}-dev") } else { base };
     AppInfo {
         version,
@@ -170,7 +179,8 @@ pub async fn check_for_updates(
     manager: State<'_, ConnectionManager>,
 ) -> Result<UpdateInfo, String> {
     let base_version = app_handle.package_info().version.to_string();
-    let running_version = if tauri::is_dev() {
+    let is_dev = resolve_is_dev(tauri::is_dev(), is_ci_dev_build());
+    let running_version = if is_dev {
         format!("{base_version}-dev")
     } else {
         base_version

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -13,6 +13,13 @@ const GITHUB_API_URL: &str = "https://api.github.com/repos/armaxri/termiHub/rele
 /// Minimum interval between automatic update checks (1 hour).
 const MIN_CHECK_INTERVAL_SECS: i64 = 3600;
 
+/// Returns `true` when either Tauri is in dev mode or the CI dev-build flag is set.
+///
+/// Accepts both flags as parameters so the logic is testable without a Tauri runtime.
+fn resolve_is_dev(tauri_is_dev: bool, ci_is_dev: bool) -> bool {
+    tauri_is_dev || ci_is_dev
+}
+
 /// Build-time information exposed to the frontend.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -263,6 +270,30 @@ pub fn get_update_settings(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── resolve_is_dev ────────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_is_dev_tauri_dev_mode() {
+        assert!(resolve_is_dev(true, false));
+    }
+
+    #[test]
+    fn resolve_is_dev_ci_build_flag() {
+        // CI dev builds set TERMIHUB_DEV_BUILD=true at compile time; simulate that here.
+        assert!(resolve_is_dev(false, true));
+    }
+
+    #[test]
+    fn resolve_is_dev_both_flags_set() {
+        assert!(resolve_is_dev(true, true));
+    }
+
+    #[test]
+    fn resolve_is_dev_release_build() {
+        // Neither tauri dev mode nor CI dev flag → this is a release build.
+        assert!(!resolve_is_dev(false, false));
+    }
 
     // ── parse_tag ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `build.rs` emits the `TERMIHUB_IS_DEV_BUILD` compile-time constant when `TERMIHUB_DEV_BUILD=true` is set at build time
- `update.rs` introduces `is_ci_dev_build()` (reads the constant) and `resolve_is_dev(tauri_is_dev, ci_is_dev)` (testable helper); both `get_app_info()` and `check_for_updates()` now derive `is_dev` via `resolve_is_dev(tauri::is_dev(), is_ci_dev_build())`
- `dev-build.yml` sets `TERMIHUB_DEV_BUILD: 'true'` in the Tauri build step, so every binary built from `main`/`develop` gets `is_dev=true` and shows a `-dev` version suffix in the UI
- `release.yml` is **not** changed — release-tag builds continue to compile without the flag and report a clean version with `is_dev=false`

Closes #663

## Test plan

- [ ] Unit tests: `resolve_is_dev_*` (4 tests) pass with `./scripts/test.sh`
- [ ] Existing update-check tests (`dev_build_offered_*`, `parse_tag_dev_suffix`) continue to pass
- [ ] After merging, verify the next `dev-latest` CI build reports version `0.1.0-dev` and `isDev: true` in the About page / Settings → About

🤖 Generated with [Claude Code](https://claude.com/claude-code)