### PR TITLE
chore(ci): opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -14,6 +14,9 @@ on:
       - 'core/**'
       - 'Cargo.toml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build (${{ matrix.target }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build on ${{ matrix.platform }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Rust Backend Quality Checks
   rust-quality:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # ── 1. Create a fresh rolling dev release ──────────────────────────────────
   prepare-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'  # Triggers on version tags like v0.1.0, v1.2.3, etc.
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   create-release:
     name: Create Release


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a top-level workflow env variable to all five CI workflow files (`agent.yml`, `build.yml`, `code-quality.yml`, `dev-build.yml`, `release.yml`)
- Resolves the deprecation warning: *"Node.js 20 actions are deprecated … actions/checkout@v4"*
- Prepares for the June 2, 2026 forced migration to Node.js 24 on GitHub-hosted runners

## Test plan

- [ ] Verify no Node.js 20 deprecation warnings appear in subsequent CI runs
- [ ] Confirm all jobs in the affected workflows complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)