### PR TITLE
chore(ci): make tauri-action build-only in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: v${{ needs.create-release.outputs.version }}
+          tagName: ''
+          releaseName: ''
+          releaseBody: ''
+          releaseDraft: false
+          prerelease: false
           args: --target ${{ matrix.rust_target }} ${{ matrix.extra_args }}
 
       - name: Find and rename release artifact


### PR DESCRIPTION
## Summary

- Clears `tagName`, `releaseName`, `releaseBody`, `releaseDraft`, and `prerelease` in the `tauri-apps/tauri-action@v0` step inside `build-and-upload`
- This makes tauri-action **build-only** — it no longer tries to create or update the GitHub Release

## Why

When `tagName` is set, tauri-action attempts to create/update the release AND upload artifacts. With 5 matrix jobs running in parallel, this caused:
- Race conditions (5 jobs simultaneously trying to manage the same release)
- Potential double-uploads (tauri-action uploads + the explicit `gh release upload` step)

The `create-release` job already creates the release via `gh release create`. Each `build-and-upload` job uploads its artifact via `gh release upload`. Tauri-action should only build.

This matches the pattern already used in `dev-build.yml`.

## Test plan

- [ ] Trigger a release tag and verify artifacts are uploaded exactly once per platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)