### PR TITLE
fix: prevent connection resurrection from stale reloads, agent writes, and credential-store spurious prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Open Connections panel: proxy session titles now show the actual connection info (e.g. "SSH: user@host", "Serial: /dev/ttyUSB0") instead of the generic "Remote: &lt;agent-id&gt;" label. The agent context is already conveyed by the section header.
+- Connections: running two termiHub instances simultaneously no longer causes deleted connections to reappear. Each write operation now reloads from disk before modifying in-memory state, preventing the stale second instance from overwriting changes made by the first.
+- Connections: agent reconnect operations (which trigger internal settings updates) no longer resurrect connections deleted by another instance — `update_agent_settings` and `reorder_agents` now also reload from disk before writing.
+- Connections: switching between termiHub windows can no longer resurrect deleted connections — the window-focus reload now runs through the same versioned-reload guard as all other state changes, so a stale focus event cannot overwrite a more recent correction.
+- Credential store: saving a serial or local connection no longer triggers the credential-store unlock dialog. The credential migration path now only runs for SSH connections (those with an `authMethod` setting), so non-SSH connection types can be saved without touching the credential store.
+- SSH connections: the Save & Connect flow in the Connection Editor no longer shows a password prompt when a stored credential already exists — it reads the stored password or key passphrase from the credential store and uses it directly.
+- SSH connections: connecting via the sidebar with key authentication and `savePassword=true` now correctly prompts for the key passphrase when none is stored, preventing a silent auth failure.
 - CI: main-branch builds are now marked as dev builds — the app version shown in the UI includes a `-dev` suffix and the `isDev` flag is set to `true` for all CI builds triggered from `main` (not just local `tauri dev` sessions). Release-tag builds are unaffected (#663).
 - CI: Windows NSIS setup installer (`termiHub-dev-windows-x64-setup.exe`) was not being uploaded to the `dev-latest` release — it is now uploaded alongside the existing MSI artifact (#664).
 - CI: `dev-latest` release is now created as a draft and published atomically once all platform builds and agent binaries finish uploading, preventing the partial-artifact state visible during builds (#664).

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -129,6 +129,27 @@ impl ConnectionManager {
         })
     }
 
+    /// Create a manager backed by files in `dir` with the given credential store.
+    /// Only available in tests; production code must use `new()`.
+    #[cfg(test)]
+    pub fn new_for_test(
+        dir: &std::path::Path,
+        credential_store: Arc<dyn CredentialStore>,
+    ) -> Result<Self> {
+        let storage = ConnectionStorage::new_for_test(dir.join("connections.json"));
+        let settings_storage = SettingsStorage::new_for_test(dir.join("settings.json"));
+        let conn_result = storage.load_with_recovery()?;
+        let settings_result = settings_storage.load_with_recovery()?;
+        Ok(Self {
+            store: Mutex::new(conn_result.data),
+            storage,
+            settings: Mutex::new(settings_result.data),
+            settings_storage,
+            credential_store,
+            recovery_warnings: Mutex::new(Vec::new()),
+        })
+    }
+
     /// Drain and return any recovery warnings collected during initialization.
     pub fn take_recovery_warnings(&self) -> Vec<RecoveryWarning> {
         self.recovery_warnings
@@ -137,9 +158,13 @@ impl ConnectionManager {
             .unwrap_or_default()
     }
 
-    /// Get all connections, folders, and agents (flat in-memory view).
+    /// Get all connections, folders, and agents, reloading from disk first.
+    ///
+    /// Reloading on every read ensures that a second instance's changes (adds,
+    /// deletes, renames) are immediately visible without requiring a restart.
     pub fn get_all(&self) -> Result<FlatConnectionStore> {
-        let store = self.store.lock().unwrap();
+        let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
         Ok(FlatConnectionStore {
             connections: store.connections.clone(),
             folders: store.folders.clone(),
@@ -147,10 +172,25 @@ impl ConnectionManager {
         })
     }
 
+    /// Reload the in-memory store from disk before a mutation.
+    ///
+    /// This prevents a second instance from restoring connections (or other data)
+    /// that were deleted by the first instance since startup.  Called at the top
+    /// of every write operation that holds `self.store`'s lock.
+    ///
+    /// Errors are intentionally swallowed: if the disk read fails we fall back to
+    /// the current in-memory state rather than aborting an otherwise valid write.
+    fn sync_from_disk(&self, store: &mut FlatConnectionStore) {
+        if let Ok(result) = self.storage.load_with_recovery() {
+            *store = result.data;
+        }
+    }
+
     /// Save (add or update) a remote agent. Passwords are stripped before persisting.
     pub fn save_agent(&self, agent: SavedRemoteAgent) -> Result<()> {
         let agent = prepare_agent_for_storage(agent, &*self.credential_store)?;
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
 
         if let Some(existing) = store.agents.iter_mut().find(|a| a.id == agent.id) {
             *existing = agent;
@@ -166,6 +206,7 @@ impl ConnectionManager {
     /// Reorder remote agents by providing a list of agent IDs in the desired order.
     pub fn reorder_agents(&self, agent_ids: &[String]) -> Result<()> {
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
 
         // Build the reordered list: place agents in the order given by agent_ids,
         // then append any agents not mentioned (shouldn't happen, but be safe).
@@ -190,6 +231,7 @@ impl ConnectionManager {
     /// Update only the agent runtime settings for an existing agent.
     pub fn update_agent_settings(&self, agent_id: &str, settings: AgentSettings) -> Result<()> {
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
         if let Some(agent) = store.agents.iter_mut().find(|a| a.id == agent_id) {
             agent.agent_settings = settings;
             self.storage
@@ -204,6 +246,7 @@ impl ConnectionManager {
     pub fn delete_agent(&self, id: &str) -> Result<()> {
         self.credential_store.remove_all_for_connection(id)?;
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
         store.agents.retain(|a| a.id != id);
         self.storage
             .save_flat(&store)
@@ -220,6 +263,7 @@ impl ConnectionManager {
         let connection = prepare_for_storage(connection, &*self.credential_store)?;
         let old_id = connection.id.clone();
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
         let FlatConnectionStore {
             connections,
             folders,
@@ -247,9 +291,18 @@ impl ConnectionManager {
         // Deduplicate sibling names (may rename the connection and change its ID)
         deduplicate_sibling_names(connections, folders);
 
-        // Migrate credentials from old path-ID to new path-ID (if changed)
+        // Migrate credentials from old path-ID to new path-ID (if changed).
+        // Only attempt migration for connections that use authMethod-based auth
+        // (i.e. SSH). Other types (serial, local, telnet, …) never store
+        // credentials, so calling get() on a locked store would spuriously
+        // emit credential-store-unlock-needed and open the unlock dialog.
         let new_id = &connections[save_idx].id;
-        if *new_id != old_id {
+        let might_have_credentials = connections[save_idx]
+            .config
+            .settings
+            .get("authMethod")
+            .is_some();
+        if *new_id != old_id && might_have_credentials {
             let _ = migrate_credential(&old_id, new_id, &*self.credential_store);
         }
 
@@ -262,6 +315,7 @@ impl ConnectionManager {
     pub fn delete_connection(&self, id: &str) -> Result<()> {
         self.credential_store.remove_all_for_connection(id)?;
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
         store.connections.retain(|c| c.id != id);
         self.storage
             .save_flat(&store)
@@ -274,6 +328,7 @@ impl ConnectionManager {
     /// connections and folders, migrating credentials as needed.
     pub fn save_folder(&self, folder: ConnectionFolder) -> Result<()> {
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
 
         // Check if this is a rename (collect info before mutating)
         let rename_info: Option<(String, String)> = store
@@ -331,6 +386,7 @@ impl ConnectionManager {
     /// credentials.
     pub fn delete_folder(&self, id: &str) -> Result<()> {
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
 
         let parent_id = store
             .folders
@@ -344,7 +400,9 @@ impl ConnectionManager {
                 let old_id = conn.id.clone();
                 conn.folder_id = parent_id.clone();
                 conn.id = compute_connection_id(parent_id.as_deref(), &conn.name);
-                let _ = migrate_credential(&old_id, &conn.id, &*self.credential_store);
+                if conn.config.settings.get("authMethod").is_some() {
+                    let _ = migrate_credential(&old_id, &conn.id, &*self.credential_store);
+                }
             }
         }
 
@@ -761,7 +819,9 @@ fn recompute_descendant_ids(
             let old_conn_id = conn.id.clone();
             conn.folder_id = Some(new_folder_id.to_string());
             conn.id = compute_connection_id(Some(new_folder_id), &conn.name);
-            let _ = migrate_credential(&old_conn_id, &conn.id, credential_store);
+            if conn.config.settings.get("authMethod").is_some() {
+                let _ = migrate_credential(&old_conn_id, &conn.id, credential_store);
+            }
         }
     }
 
@@ -1079,6 +1139,60 @@ mod tests {
         }
     }
 
+    /// Mock that records every `get()` call — used to assert no get() is made
+    /// when saving credential-free connection types (serial, local, …).
+    struct SpyStore {
+        get_calls: Mutex<Vec<CredentialKey>>,
+    }
+
+    impl SpyStore {
+        fn new() -> Self {
+            Self {
+                get_calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn get_call_count(&self) -> usize {
+            self.get_calls.lock().unwrap().len()
+        }
+    }
+
+    impl CredentialStore for SpyStore {
+        fn get(&self, key: &CredentialKey) -> Result<Option<String>> {
+            self.get_calls.lock().unwrap().push(key.clone());
+            Ok(None)
+        }
+        fn set(&self, _key: &CredentialKey, _value: &str) -> Result<()> {
+            Ok(())
+        }
+        fn remove(&self, _key: &CredentialKey) -> Result<()> {
+            Ok(())
+        }
+        fn remove_all_for_connection(&self, _connection_id: &str) -> Result<()> {
+            Ok(())
+        }
+        fn list_keys(&self) -> Result<Vec<CredentialKey>> {
+            Ok(Vec::new())
+        }
+        fn status(&self) -> CredentialStoreStatus {
+            CredentialStoreStatus::Unlocked
+        }
+    }
+
+    fn make_serial_conn(id: &str) -> SavedConnection {
+        SavedConnection {
+            id: id.to_string(),
+            name: "Serial".to_string(),
+            config: ConnectionConfig {
+                type_id: "serial".to_string(),
+                settings: serde_json::json!({"port": "/dev/ttyUSB0", "baudRate": "115200"}),
+            },
+            folder_id: None,
+            terminal_options: None,
+            source_file: None,
+        }
+    }
+
     fn make_local_conn(id: &str) -> SavedConnection {
         SavedConnection {
             id: id.to_string(),
@@ -1305,5 +1419,193 @@ mod tests {
         let preview = preview_import_json(json).unwrap();
         assert_eq!(preview.connection_count, 0);
         assert!(!preview.has_encrypted_credentials);
+    }
+
+    // Regression: migrate_credential itself calls get() on the store for every
+    // ID change. On a locked master-password store, get() fails and emits
+    // credential-store-unlock-needed, opening the unlock dialog spuriously.
+    // The callers of migrate_credential must guard the call with an authMethod
+    // check so credential-free connections (serial, local, …) never touch the
+    // store.
+    #[test]
+    fn migrate_credential_calls_get_on_store() {
+        let store = SpyStore::new();
+        migrate_credential("old-id", "new-id", &store).unwrap();
+        // Two get() calls: one for Password, one for KeyPassphrase
+        assert_eq!(
+            store.get_call_count(),
+            2,
+            "migrate_credential must call get() — callers must guard it for non-SSH types"
+        );
+    }
+
+    #[test]
+    fn prepare_for_storage_does_not_call_get_for_serial_connection() {
+        let store = SpyStore::new();
+        let conn = make_serial_conn("serial-1");
+        prepare_for_storage(conn, &store).unwrap();
+        assert_eq!(
+            store.get_call_count(),
+            0,
+            "prepare_for_storage must not call get() for serial connections"
+        );
+    }
+
+    #[test]
+    fn prepare_for_storage_does_not_call_get_for_local_connection() {
+        let store = SpyStore::new();
+        let conn = make_local_conn("local-1");
+        prepare_for_storage(conn, &store).unwrap();
+        assert_eq!(store.get_call_count(), 0);
+    }
+
+    // Regression: with two concurrent instances both loading the same connections.json at
+    // startup, the stale instance could resurrect connections that the active instance
+    // had already deleted.  The fix is for every mutation to reload from disk before
+    // modifying in-memory state (sync_from_disk).
+    #[test]
+    fn save_connection_does_not_resurrect_connection_deleted_by_another_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_store = Arc::new(MockStore::new());
+
+        // Helper: make a connection with a distinct name (ID is computed from name)
+        let make_conn = |name: &str| SavedConnection {
+            id: format!("conn-{}", name),
+            name: name.to_string(),
+            config: ConnectionConfig {
+                type_id: "serial".to_string(),
+                settings: serde_json::json!({"port": "/dev/ttyUSB0", "baudRate": "115200"}),
+            },
+            folder_id: None,
+            terminal_options: None,
+            source_file: None,
+        };
+
+        // ── Populate initial state ─────────────────────────────────────────────────
+        // save_connection recomputes the ID from the name, so after saving
+        // "Old Port" the on-disk (and in-memory) ID becomes "Old Port".
+        let setup = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        setup.save_connection(make_conn("Old Port")).unwrap();
+        drop(setup);
+
+        // ── "Instance B" starts and loads ["Old Port"] into its in-memory store ───
+        let instance_b = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+
+        // ── "Instance A" deletes "Old Port" → file now contains [] ────────────────
+        let instance_a = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        instance_a.delete_connection("Old Port").unwrap();
+        drop(instance_a);
+
+        // ── Instance B (stale in-memory state) saves a brand-new connection ───────
+        // Without sync_from_disk, instance_b still has ["Old Port"] in memory and
+        // would write ["Old Port", "New Port"] to disk, resurrecting the deletion.
+        instance_b.save_connection(make_conn("New Port")).unwrap();
+
+        // ── Verify the final state ────────────────────────────────────────────────
+        let all = instance_b.get_all().unwrap();
+        let names: Vec<&str> = all.connections.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            !names.contains(&"Old Port"),
+            "deleted connection must not be resurrected; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"New Port"),
+            "newly saved connection must be present; got: {names:?}"
+        );
+    }
+
+    // Regression: update_agent_settings did not call sync_from_disk before saving.
+    // An old parallel instance with stale in-memory connections could resurrect
+    // connections deleted by the active instance, simply by updating an agent's
+    // runtime settings (which happens automatically on connect/disconnect).
+    #[test]
+    fn update_agent_settings_does_not_resurrect_connections_deleted_by_another_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_store = Arc::new(MockStore::new());
+
+        let make_conn = |name: &str| SavedConnection {
+            id: name.to_string(),
+            name: name.to_string(),
+            config: ConnectionConfig {
+                type_id: "local".to_string(),
+                settings: serde_json::json!({"shell": "bash"}),
+            },
+            folder_id: None,
+            terminal_options: None,
+            source_file: None,
+        };
+
+        // Populate with a connection and an agent
+        let setup = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        setup.save_connection(make_conn("Old Connection")).unwrap();
+        setup
+            .save_agent(make_agent("agent-1", "password", None, None))
+            .unwrap();
+        drop(setup);
+
+        // "Instance B" (old) loads the stale state into memory
+        let instance_b = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+
+        // "Instance A" (new) deletes the connection — disk is now empty of connections
+        let instance_a = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        instance_a.delete_connection("Old Connection").unwrap();
+        drop(instance_a);
+
+        // Instance B updates agent settings (e.g., on agent reconnect).
+        // Without sync_from_disk this writes its stale in-memory connections back to disk.
+        instance_b
+            .update_agent_settings("agent-1", AgentSettings::default())
+            .unwrap();
+
+        let all = instance_b.get_all().unwrap();
+        let names: Vec<&str> = all.connections.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            !names.contains(&"Old Connection"),
+            "update_agent_settings must not resurrect connections deleted by another instance; got: {names:?}"
+        );
+    }
+
+    // Regression: reorder_agents did not call sync_from_disk before saving.
+    // Same resurrection hazard as update_agent_settings.
+    #[test]
+    fn reorder_agents_does_not_resurrect_connections_deleted_by_another_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_store = Arc::new(MockStore::new());
+
+        let make_conn = |name: &str| SavedConnection {
+            id: name.to_string(),
+            name: name.to_string(),
+            config: ConnectionConfig {
+                type_id: "local".to_string(),
+                settings: serde_json::json!({"shell": "bash"}),
+            },
+            folder_id: None,
+            terminal_options: None,
+            source_file: None,
+        };
+
+        let setup = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        setup.save_connection(make_conn("Old Connection")).unwrap();
+        setup
+            .save_agent(make_agent("agent-1", "password", None, None))
+            .unwrap();
+        drop(setup);
+
+        let instance_b = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+
+        let instance_a = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        instance_a.delete_connection("Old Connection").unwrap();
+        drop(instance_a);
+
+        // Instance B reorders agents (e.g., drag-and-drop in UI).
+        // Without sync_from_disk this writes stale in-memory connections back to disk.
+        instance_b.reorder_agents(&["agent-1".to_string()]).unwrap();
+
+        let all = instance_b.get_all().unwrap();
+        let names: Vec<&str> = all.connections.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            !names.contains(&"Old Connection"),
+            "reorder_agents must not resurrect connections deleted by another instance; got: {names:?}"
+        );
     }
 }

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -240,6 +240,13 @@ impl SettingsStorage {
         })
     }
 
+    /// Create a storage instance pointing directly at `file_path`.
+    /// Only available in tests; production code must go through `new()`.
+    #[cfg(test)]
+    pub fn new_for_test(file_path: PathBuf) -> Self {
+        Self { file_path }
+    }
+
     /// Load with recovery: on parse failure, backs up the corrupt file and resets to defaults.
     ///
     /// Since `AppSettings` uses `#[serde(default)]`, partial field corruption is handled

--- a/src-tauri/src/connection/storage.rs
+++ b/src-tauri/src/connection/storage.rs
@@ -188,6 +188,13 @@ impl ConnectionStorage {
         };
         self.save_store(&store)
     }
+
+    /// Create a storage instance pointing directly at `file_path`.
+    /// Only available in tests; production code must go through `new()`.
+    #[cfg(test)]
+    pub fn new_for_test(file_path: std::path::PathBuf) -> Self {
+        Self { file_path }
+    }
 }
 
 /// Recursively recover valid tree nodes from a JSON array,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { useWebviewZoom } from "@/hooks/useWebviewZoom";
 import { useSidebarResize } from "@/hooks/useSidebarResize";
 import { useAppStore } from "@/store/appStore";
 import { getCliWorkspace } from "@/services/workspaceApi";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import "./App.css";
 
 interface ErrorBoundaryState {
@@ -132,6 +133,21 @@ function App() {
       }
     })();
   }, [loadFromBackend]);
+
+  // Reload connections whenever this window regains focus so that changes made
+  // in a parallel instance (add, delete, rename) are immediately visible here.
+  // Uses the versioned reload guard so a stale focus reload cannot override a
+  // more recent mutation's correction.
+  useEffect(() => {
+    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+      if (focused) {
+        useAppStore.getState().reloadConnectionsFromBackend();
+      }
+    });
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, []);
 
   // Schedule update check: 5-second delay on startup, then every 24 hours.
   useEffect(() => {

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -153,6 +153,209 @@ describe("ConnectionEditor — credential hint", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Realistic SSH type with authMethod selector and conditional password field.
+// Used for Save & Connect credential-store tests.
+// ---------------------------------------------------------------------------
+
+const SSH_TYPE_FULL: ConnectionTypeInfo = {
+  typeId: "ssh",
+  displayName: "SSH",
+  icon: "ssh",
+  schema: {
+    groups: [
+      {
+        key: "conn",
+        label: "Connection",
+        fields: [
+          { key: "host", label: "Host", fieldType: { type: "text" }, required: true },
+          { key: "username", label: "Username", fieldType: { type: "text" }, required: true },
+          {
+            key: "authMethod",
+            label: "Auth Method",
+            fieldType: {
+              type: "select",
+              options: [
+                { value: "password", label: "Password" },
+                { value: "key", label: "Key" },
+                { value: "agent", label: "Agent" },
+              ],
+            },
+            required: true,
+            default: "password",
+          },
+          {
+            key: "password",
+            label: "Password",
+            fieldType: { type: "password" },
+            required: false,
+            visibleWhen: { field: "authMethod", equals: "password" },
+          },
+          {
+            key: "savePassword",
+            label: "Save Password",
+            fieldType: { type: "boolean" },
+            required: false,
+          },
+        ],
+      },
+    ],
+  },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+/** Existing SSH connection — password auth, savePassword=true, password stripped from storage. */
+const SSH_CONN_PASSWORD: SavedConnection = {
+  id: "ssh-pw-conn",
+  name: "My SSH Server",
+  config: {
+    type: "ssh",
+    config: { host: "192.168.1.1", username: "admin", authMethod: "password", savePassword: true },
+  },
+  folderId: null,
+};
+
+/** Existing SSH connection — key auth, savePassword=true (passphrase stored). */
+const SSH_CONN_KEY: SavedConnection = {
+  id: "ssh-key-conn",
+  name: "My Key SSH",
+  config: {
+    type: "ssh",
+    config: { host: "192.168.1.2", username: "admin", authMethod: "key", savePassword: true },
+  },
+  folderId: null,
+};
+
+describe("ConnectionEditor — Save & Connect credential handling", () => {
+  function renderFor(connId: string) {
+    act(() => {
+      root.render(
+        <ConnectionEditor
+          tabId="tab-sc-1"
+          meta={{ connectionId: connId, folderId: null }}
+          isVisible={true}
+        />
+      );
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetRuntimeCache();
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      connections: [SSH_CONN_PASSWORD, SSH_CONN_KEY],
+      connectionTypes: [SSH_TYPE_FULL],
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("uses stored credential without prompting when password is already in the vault", async () => {
+    // Regression: handleSaveAndConnect previously always prompted for the
+    // password because connSettings.password is stripped from storage, even
+    // when the vault already holds a valid credential. It must check the
+    // store first and skip the dialog when a credential is found.
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "resolve_credential") return Promise.resolve("vault-secret");
+      if (cmd === "save_connection") return Promise.resolve();
+      if (cmd === "load_connections_and_folders")
+        return Promise.resolve({ connections: [SSH_CONN_PASSWORD, SSH_CONN_KEY], folders: [] });
+      return Promise.resolve(null);
+    });
+
+    renderFor(SSH_CONN_PASSWORD.id);
+
+    // Flush initial effects (credential hint resolution, etc.)
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const btn = container.querySelector(
+      '[data-testid="connection-editor-save-connect"]'
+    ) as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+
+    await act(async () => {
+      btn.click();
+    });
+    // Extra flush to let the async handleSaveAndConnect finish
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The password dialog must NOT have opened — the vault credential was used
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+
+  it("prompts for password when no stored credential exists", async () => {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "resolve_credential") return Promise.resolve(null);
+      if (cmd === "save_connection") return Promise.resolve();
+      if (cmd === "load_connections_and_folders")
+        return Promise.resolve({ connections: [SSH_CONN_PASSWORD, SSH_CONN_KEY], folders: [] });
+      return Promise.resolve(null);
+    });
+
+    renderFor(SSH_CONN_PASSWORD.id);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const btn = container.querySelector(
+      '[data-testid="connection-editor-save-connect"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // No stored credential → password dialog must appear
+    expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+  });
+
+  it("does not prompt for key auth (no password field visible)", async () => {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "resolve_credential") return Promise.resolve(null);
+      if (cmd === "save_connection") return Promise.resolve();
+      if (cmd === "load_connections_and_folders")
+        return Promise.resolve({ connections: [SSH_CONN_PASSWORD, SSH_CONN_KEY], folders: [] });
+      return Promise.resolve(null);
+    });
+
+    renderFor(SSH_CONN_KEY.id);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const btn = container.querySelector(
+      '[data-testid="connection-editor-save-connect"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Key auth: password field hidden → findPasswordPromptInfo returns null → no dialog
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Minimal connection type used for dirty-state tests (no auth, no credentials)
 // ---------------------------------------------------------------------------
 

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -11,6 +11,7 @@ import {
   ConnectionEditorMeta,
 } from "@/types/terminal";
 import { listAvailableShells, resolveCredential } from "@/services/api";
+import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
 import type { ConnectionTypeInfo } from "@/services/api";
 import {
   SavedConnection,
@@ -674,11 +675,32 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
       if (promptInfo) {
         const host = (connSettings[promptInfo.hostKey] as string) ?? "";
         const username = (connSettings[promptInfo.usernameKey] as string) ?? "";
-        const password = await requestPassword(host, username);
-        if (password === null) return;
+
+        // Before prompting, check whether the credential store already has a
+        // credential for this connection. This avoids re-entering a password
+        // when the user only changed a non-credential field and clicks Save & Connect.
+        const authMethod = connSettings.authMethod as string | undefined;
+        let resolvedPassword: string | null = null;
+        if (authMethod) {
+          const savePasswordFlag = connSettings.savePassword as boolean | undefined;
+          const resolution = await resolveConnectionCredential(
+            saved.id,
+            authMethod,
+            savePasswordFlag
+          );
+          if (resolution.usedStoredCredential && resolution.password) {
+            resolvedPassword = resolution.password;
+          }
+        }
+
+        if (!resolvedPassword) {
+          resolvedPassword = await requestPassword(host, username);
+          if (resolvedPassword === null) return;
+        }
+
         config = {
           ...config,
-          config: { ...config.config, [promptInfo.passwordKey]: password },
+          config: { ...config.config, [promptInfo.passwordKey]: resolvedPassword },
         } as ConnectionConfig;
       }
     }

--- a/src/components/Sidebar/ConnectionList.credential.test.tsx
+++ b/src/components/Sidebar/ConnectionList.credential.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Tests for credential prompting behavior in ConnectionList.handleConnect.
+ *
+ * The dialog must appear in exactly two cases:
+ *   1. authMethod="password" with no stored credential (or stale one)
+ *   2. authMethod="key" + savePassword=true with no stored passphrase
+ *
+ * All other cases (valid stored credential, key without savePassword, agent
+ * auth, non-SSH connection types) must NOT show a dialog.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import type { SavedConnection, RemoteAgentDefinition } from "@/types/connection";
+import { resolveCredential, storeCredential } from "@/services/api";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({ agent }: { agent: RemoteAgentDefinition }) =>
+    React.createElement("div", { "data-testid": `agent-node-${agent.id}` }),
+}));
+
+const mockedResolveCredential = vi.mocked(resolveCredential);
+const mockedStoreCredential = vi.mocked(storeCredential);
+
+function makeSshConn(id: string, authMethod: string, savePassword?: boolean): SavedConnection {
+  return {
+    id,
+    name: `SSH ${id}`,
+    folderId: null,
+    config: {
+      type: "ssh",
+      config: {
+        host: "host.example.com",
+        username: "user",
+        authMethod,
+        ...(savePassword !== undefined ? { savePassword } : {}),
+      },
+    },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(connections: SavedConnection[]) {
+  useAppStore.setState({
+    ...useAppStore.getInitialState(),
+    connections,
+    credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+  });
+  act(() => {
+    root.render(<ConnectionList />);
+  });
+}
+
+async function clickConnectButton(id: string) {
+  const item = container.querySelector(
+    `[data-testid="connection-item-${id}"]`
+  ) as HTMLElement | null;
+  if (!item) throw new Error(`connection item for ${id} not found`);
+  await act(async () => {
+    item.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+  mockedResolveCredential.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("ConnectionList — password dialog conditions", () => {
+  it("shows dialog for password auth when no credential is stored", async () => {
+    const conn = makeSshConn("pw-no-cred", "password");
+    render([conn]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await clickConnectButton(conn.id);
+
+    expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+  });
+
+  it("does not show dialog for password auth when stored credential exists", async () => {
+    mockedResolveCredential.mockResolvedValue("stored-secret");
+    const conn = makeSshConn("pw-with-cred", "password");
+    render([conn]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await clickConnectButton(conn.id);
+
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+
+  it("shows dialog for key auth + savePassword when no passphrase is stored", async () => {
+    // Regression: previously key+savePassword+no-stored-passphrase silently
+    // fell through to connect without the passphrase, causing auth failure.
+    // Now it must prompt so the user can provide (and optionally save) it.
+    const conn = makeSshConn("key-no-pass", "key", true);
+    render([conn]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await clickConnectButton(conn.id);
+
+    expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+  });
+
+  it("does not show dialog for key auth + savePassword when passphrase is stored", async () => {
+    mockedResolveCredential.mockResolvedValue("stored-passphrase");
+    const conn = makeSshConn("key-with-pass", "key", true);
+    render([conn]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await clickConnectButton(conn.id);
+
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+
+  it("does not show dialog for key auth without savePassword", async () => {
+    const conn = makeSshConn("key-no-save", "key", false);
+    render([conn]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await clickConnectButton(conn.id);
+
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+
+  it("does not show dialog for agent auth", async () => {
+    const conn = makeSshConn("agent-auth", "agent");
+    render([conn]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await clickConnectButton(conn.id);
+
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+
+  it("stores passphrase as key_passphrase type when user opts in for key auth", async () => {
+    const conn = makeSshConn("key-store-test", "key", true);
+    render([conn]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await clickConnectButton(conn.id);
+    // Dialog is open — simulate the user entering a passphrase and opting to save
+    await act(async () => {
+      useAppStore.getState().submitPassword("my-passphrase", true);
+      await Promise.resolve();
+    });
+
+    expect(mockedStoreCredential).toHaveBeenCalledWith(conn.id, "key_passphrase", "my-passphrase");
+  });
+
+  it("does not show dialog for a local (non-SSH) connection", async () => {
+    const conn: SavedConnection = {
+      id: "local-conn",
+      name: "Local Shell",
+      folderId: null,
+      config: { type: "local", config: { shell: "bash" } },
+    };
+    render([conn]);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await clickConnectButton(conn.id);
+
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -444,6 +444,19 @@ export function ConnectionList() {
               frontendLog("connection_list", `Failed to store credential: ${err}`);
             });
           }
+        } else if (authMethod === "key" && savePassword) {
+          // Key auth with passphrase storage opted in but no passphrase stored yet —
+          // prompt for the passphrase so the backend can unlock the key.
+          const host = cfg.host as string;
+          const username = (cfg.username as string) ?? "";
+          const passphrase = await requestPassword(host, username);
+          if (passphrase === null) return;
+          config = { ...config, config: { ...cfg, password: passphrase } } as typeof config;
+          if (useAppStore.getState().passwordPromptShouldSave) {
+            await storeCredential(connection.id, "key_passphrase", passphrase).catch((err) => {
+              frontendLog("connection_list", `Failed to store key passphrase: ${err}`);
+            });
+          }
         }
       }
 

--- a/src/store/appStore.connections.test.ts
+++ b/src/store/appStore.connections.test.ts
@@ -31,8 +31,13 @@ vi.mock("@/services/api", () => ({
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
 }));
 
-import { useAppStore } from "./appStore";
-import { persistConnection } from "@/services/storage";
+import { useAppStore, _resetConnectionReloadSeq } from "./appStore";
+import {
+  persistConnection,
+  loadConnections,
+  removeConnection,
+  persistFolder,
+} from "@/services/storage";
 import type { LeafPanel } from "@/types/terminal";
 import { findLeaf, getAllLeaves } from "@/utils/panelTree";
 import type { SavedConnection, ConnectionFolder } from "@/types/connection";
@@ -60,6 +65,18 @@ function makeFolder(overrides: Partial<ConnectionFolder> = {}): ConnectionFolder
 describe("appStore — connections, folders, and special tabs", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
+    _resetConnectionReloadSeq();
+    vi.mocked(loadConnections).mockReset();
+    vi.mocked(loadConnections).mockResolvedValue({
+      connections: [],
+      folders: [],
+      agents: [],
+      externalErrors: [],
+    });
+    vi.mocked(removeConnection).mockReset();
+    vi.mocked(removeConnection).mockResolvedValue(undefined);
+    vi.mocked(persistFolder).mockReset();
+    vi.mocked(persistFolder).mockResolvedValue(undefined);
   });
 
   describe("toggleFolder", () => {
@@ -202,6 +219,163 @@ describe("appStore — connections, folders, and special tabs", () => {
       const connections = useAppStore.getState().connections;
       expect(connections.find((c) => c.id === "c-1")?.folderId).toBeNull();
       expect(connections.find((c) => c.id === "c-2")?.folderId).toBe("f-2");
+    });
+  });
+
+  describe("deleteConnection", () => {
+    it("removes the connection from state immediately (optimistic)", () => {
+      const conn = makeConnection({ id: "c-1" });
+      useAppStore.setState({ connections: [conn] });
+
+      useAppStore.getState().deleteConnection("c-1");
+
+      expect(useAppStore.getState().connections).toHaveLength(0);
+    });
+
+    it("does not affect other connections", () => {
+      const conn1 = makeConnection({ id: "c-1" });
+      const conn2 = makeConnection({ id: "c-2" });
+      useAppStore.setState({ connections: [conn1, conn2] });
+
+      useAppStore.getState().deleteConnection("c-1");
+
+      const remaining = useAppStore.getState().connections;
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe("c-2");
+    });
+
+    it("reloads authoritative state from backend after deletion completes", async () => {
+      const survivor = makeConnection({ id: "c-2", name: "Survivor" });
+      const deleted = makeConnection({ id: "c-1", name: "To Delete" });
+      useAppStore.setState({ connections: [deleted, survivor] });
+
+      vi.mocked(loadConnections).mockResolvedValueOnce({
+        connections: [survivor],
+        folders: [],
+        agents: [],
+        externalErrors: [],
+      });
+
+      useAppStore.getState().deleteConnection("c-1");
+
+      // Flush: removeConnection → loadConnections → set
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(vi.mocked(removeConnection)).toHaveBeenCalledWith("c-1", undefined);
+      expect(vi.mocked(loadConnections)).toHaveBeenCalled();
+      const final = useAppStore.getState().connections;
+      expect(final).toHaveLength(1);
+      expect(final[0].id).toBe("c-2");
+    });
+
+    // Regression: without the fix, a concurrent addFolder call would trigger
+    // loadConnections while removeConnection was still in-flight, reading stale
+    // disk state and resurrecting the deleted connection. The fix chains
+    // loadConnections after removeConnection so the final authoritative read
+    // always runs after the deletion is committed.
+    it("does not resurrect deleted connection when a concurrent addFolder reloads connections", async () => {
+      const deleted = makeConnection({ id: "c-del", name: "Deleted" });
+      useAppStore.setState({ connections: [deleted] });
+
+      // addFolder's loadConnections returns stale data (deletion not yet on disk)
+      vi.mocked(loadConnections).mockResolvedValueOnce({
+        connections: [deleted],
+        folders: [],
+        agents: [],
+        externalErrors: [],
+      });
+      // deleteConnection's loadConnections returns authoritative data (deletion committed)
+      vi.mocked(loadConnections).mockResolvedValueOnce({
+        connections: [],
+        folders: [],
+        agents: [],
+        externalErrors: [],
+      });
+
+      useAppStore.getState().deleteConnection("c-del");
+      useAppStore.getState().addFolder(makeFolder({ id: "f-new" }));
+
+      // Flush all promise chains
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(useAppStore.getState().connections.find((c) => c.id === "c-del")).toBeUndefined();
+    });
+
+    // Regression: if a concurrent operation's loadConnections resolves AFTER
+    // deleteConnection's loadConnections but with stale data (connection still
+    // present on disk when the concurrent op ran), the stale result permanently
+    // overrides the delete correction.
+    //
+    // Scenario: persistFolder (fast) completes before removeConnection (slow),
+    // so addFolder's reload gets a lower sequence number. It resolves with stale
+    // data AFTER deleteConnection's clean reload — and without the version-counter
+    // guard, it overwrites the corrected state and resurrects the deleted connection.
+    it("does not resurrect deleted connection when a concurrent reload resolves last with stale data", async () => {
+      const deleted = makeConnection({ id: "c-del", name: "Deleted" });
+      useAppStore.setState({ connections: [deleted] });
+
+      // Make removeConnection slow (async) so persistFolder completes first,
+      // causing addFolder's loadConnections to be initiated before deleteConnection's.
+      let resolveRemove!: () => void;
+      vi.mocked(removeConnection).mockImplementationOnce(
+        () => new Promise<void>((resolve) => (resolveRemove = resolve))
+      );
+
+      // Track which loadConnections call belongs to which action.
+      // addFolder fires loadConnections first (persistFolder fast),
+      // deleteConnection fires second (after manual resolveRemove).
+      let resolveAddFolderReload!: (val: Awaited<ReturnType<typeof loadConnections>>) => void;
+      let resolveDeleteReload!: (val: Awaited<ReturnType<typeof loadConnections>>) => void;
+      let lcCount = 0;
+      vi.mocked(loadConnections).mockImplementation(
+        () =>
+          new Promise<Awaited<ReturnType<typeof loadConnections>>>((resolve) => {
+            lcCount++;
+            if (lcCount === 1) {
+              resolveAddFolderReload = resolve; // addFolder's stale reload
+            } else {
+              resolveDeleteReload = resolve; // deleteConnection's clean reload
+            }
+          })
+      );
+
+      useAppStore.getState().deleteConnection("c-del");
+      useAppStore.getState().addFolder(makeFolder({ id: "f-new" }));
+
+      // persistFolder is already resolved (mock default) → addFolder's .then fires
+      // → loadConnections #1 (addFolder, stale) initiated (lower seq)
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Manually complete removeConnection → deleteConnection's .then fires
+      // → loadConnections #2 (deleteConnection, clean) initiated (higher seq)
+      resolveRemove();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Resolve deleteConnection's clean reload FIRST
+      resolveDeleteReload({ connections: [], folders: [], agents: [], externalErrors: [] });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Resolve addFolder's stale reload SECOND (includes the deleted connection)
+      resolveAddFolderReload({
+        connections: [deleted],
+        folders: [],
+        agents: [],
+        externalErrors: [],
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Without version-counter: addFolder's stale result wins (applied last) → c-del is back
+      // With version-counter:    addFolder's seq < deleteConnection's seq → dropped → c-del stays gone
+      expect(useAppStore.getState().connections.find((c) => c.id === "c-del")).toBeUndefined();
     });
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -370,6 +370,8 @@ interface AppState {
   loadFromBackend: () => Promise<void>;
   updateSettings: (settings: AppSettings) => Promise<void>;
   reloadExternalConnections: () => Promise<void>;
+  /** Reload connections from the backend using the versioned reload guard. */
+  reloadConnectionsFromBackend: () => void;
   toggleFolder: (folderId: string) => void;
   addConnection: (connection: SavedConnection) => void;
   updateConnection: (connection: SavedConnection) => void;
@@ -680,7 +682,43 @@ function generateGroupId(): string {
   return `group-${Date.now()}-${groupCounter}-${Math.random().toString(36).slice(2, 6)}`;
 }
 
+// Monotonically increasing counters for connection-state reloads.
+// `_connReloadSeq` increments each time a reload is initiated; `_connAppliedSeq`
+// tracks the highest sequence whose result has been applied to the store.
+// This prevents a stale concurrent reload (lower seq) from overwriting a fresher
+// correction (higher seq) that happened to resolve first.
+let _connReloadSeq = 0;
+let _connAppliedSeq = 0;
+
+/** @internal Reset reload sequencer — for tests only. */
+export function _resetConnectionReloadSeq(): void {
+  _connReloadSeq = 0;
+  _connAppliedSeq = 0;
+}
+
 export const useAppStore = create<AppState>((set, get) => {
+  // Reload connections from the backend, applying the result only if this
+  // reload was initiated more recently than the last applied one.
+  function applyConnectionReload(): Promise<void> {
+    const mySeq = ++_connReloadSeq;
+    frontendLog("connection_sync", `reload initiated (seq=${mySeq})`);
+    return loadConnections().then(({ connections, folders }) => {
+      if (mySeq >= _connAppliedSeq) {
+        _connAppliedSeq = mySeq;
+        frontendLog(
+          "connection_sync",
+          `reload applied (seq=${mySeq}, conns=${connections.length}, folders=${folders.length})`
+        );
+        set({ connections, folders });
+      } else {
+        frontendLog(
+          "connection_sync",
+          `reload dropped (seq=${mySeq} superseded by applied=${_connAppliedSeq})`
+        );
+      }
+    });
+  }
+
   const initialPanel = createLeafPanel();
   const initialGroupId = generateGroupId();
   const initialGroup: TabGroup = {
@@ -2121,11 +2159,16 @@ export const useAppStore = create<AppState>((set, get) => {
       });
     },
 
+    reloadConnectionsFromBackend: () => {
+      frontendLog("connection_sync", "focus reload: triggered by external event");
+      void applyConnectionReload();
+    },
+
     addConnection: (connection) => {
       set((state) => ({ connections: [...state.connections, connection] }));
+      frontendLog("connection_sync", `addConnection: persisting ${connection.id}`);
       persistConnection(stripPassword(connection))
-        .then(() => loadConnections())
-        .then(({ connections, folders }) => set({ connections, folders }))
+        .then(() => applyConnectionReload())
         .catch((err) => console.error("Failed to persist new connection:", err));
     },
 
@@ -2133,27 +2176,31 @@ export const useAppStore = create<AppState>((set, get) => {
       set((state) => ({
         connections: state.connections.map((c) => (c.id === connection.id ? connection : c)),
       }));
+      frontendLog("connection_sync", `updateConnection: persisting ${connection.id}`);
       persistConnection(stripPassword(connection))
-        .then(() => loadConnections())
-        .then(({ connections, folders }) => set({ connections, folders }))
+        .then(() => applyConnectionReload())
         .catch((err) => console.error("Failed to persist connection update:", err));
     },
 
     deleteConnection: (connectionId) => {
       const conn = get().connections.find((c) => c.id === connectionId);
+      frontendLog("connection_sync", `deleteConnection: removing ${connectionId} optimistically`);
       set((state) => ({
         connections: state.connections.filter((c) => c.id !== connectionId),
       }));
-      removeConnection(connectionId, conn?.sourceFile).catch((err) =>
-        console.error("Failed to persist connection deletion:", err)
-      );
+      removeConnection(connectionId, conn?.sourceFile)
+        .then(() => {
+          frontendLog("connection_sync", `deleteConnection: backend confirmed, reloading`);
+          return applyConnectionReload();
+        })
+        .catch((err) => console.error("Failed to persist connection deletion:", err));
     },
 
     addFolder: (folder) => {
       set((state) => ({ folders: [...state.folders, folder] }));
+      frontendLog("connection_sync", `addFolder: persisting ${folder.id}`);
       persistFolder(folder)
-        .then(() => loadConnections())
-        .then(({ connections, folders }) => set({ connections, folders }))
+        .then(() => applyConnectionReload())
         .catch((err) => console.error("Failed to persist new folder:", err));
     },
 
@@ -2172,9 +2219,9 @@ export const useAppStore = create<AppState>((set, get) => {
 
         return { folders, connections };
       });
+      frontendLog("connection_sync", `deleteFolder: removing ${folderId}`);
       removeFolder(folderId)
-        .then(() => loadConnections())
-        .then(({ connections, folders }) => set({ connections, folders }))
+        .then(() => applyConnectionReload())
         .catch((err) => console.error("Failed to persist folder deletion:", err));
     },
 
@@ -2188,9 +2235,9 @@ export const useAppStore = create<AppState>((set, get) => {
         name: `Copy of ${original.name}`,
       };
       set((s) => ({ connections: [...s.connections, duplicate] }));
+      frontendLog("connection_sync", `duplicateConnection: persisting copy of ${connectionId}`);
       persistConnection(stripPassword(duplicate))
-        .then(() => loadConnections())
-        .then(({ connections, folders }) => set({ connections, folders }))
+        .then(() => applyConnectionReload())
         .catch((err) => console.error("Failed to persist duplicated connection:", err));
     },
 
@@ -2219,9 +2266,9 @@ export const useAppStore = create<AppState>((set, get) => {
       // (e.g., when moving a connection into a folder with a same-named sibling)
       const moved = get().connections.find((c) => c.id === connectionId);
       if (moved) {
+        frontendLog("connection_sync", `moveConnectionToFolder: persisting ${connectionId}`);
         persistConnection(stripPassword(moved))
-          .then(() => loadConnections())
-          .then(({ connections, folders }) => set({ connections, folders }))
+          .then(() => applyConnectionReload())
           .catch((err) => console.error("Failed to persist connection move:", err));
       }
     },
@@ -2236,9 +2283,12 @@ export const useAppStore = create<AppState>((set, get) => {
 
       // Persist all connections in parallel, then reload once
       const moved = get().connections.filter((c) => idSet.has(c.id));
+      frontendLog(
+        "connection_sync",
+        `bulkMoveConnectionsToFolder: persisting ${moved.length} connections`
+      );
       Promise.all(moved.map((conn) => persistConnection(stripPassword(conn))))
-        .then(() => loadConnections())
-        .then(({ connections, folders }) => set({ connections, folders }))
+        .then(() => applyConnectionReload())
         .catch((err) => console.error("Failed to persist bulk connection move:", err));
     },
 


### PR DESCRIPTION
## Summary

- **Connection resurrection (Rust)**: every write operation (`save_connection`, `delete_connection`, `save_agent`, `delete_agent`, `save_folder`, `delete_folder`, `reorder_agents`, `update_agent_settings`, `get_all`) now calls `sync_from_disk()` before touching in-memory state, so a stale parallel instance can no longer overwrite deletions made by the active one
- **Connection resurrection (JS)**: a monotonically increasing sequence counter ensures that only the most recently *initiated* reload's result is applied to the store — a stale concurrent reload (e.g. from `addFolder`) cannot overwrite a fresher correction (e.g. from `deleteConnection`)
- **Connection resurrection (focus handler)**: the window-focus reload in `App.tsx` now routes through `reloadConnectionsFromBackend()`, which uses the same version-guarded `applyConnectionReload()` path as all other state changes, instead of writing directly to the store
- **Credential store spurious unlock**: credential migration in `save_connection`, `delete_folder`, and `recompute_descendant_ids` is now guarded by an `authMethod` check, so serial/local/telnet connections never touch the credential store and the unlock dialog no longer pops up when saving them
- **Save & Connect stored credential**: the Connection Editor now checks the credential store before prompting for a password — if a stored credential exists it is used directly
- **SSH key passphrase**: connecting via the sidebar with key auth and `savePassword=true` now correctly prompts for the passphrase when none is stored, preventing a silent auth failure

## Test plan

- [x] Rust regression tests: `save_connection_does_not_resurrect_connection_deleted_by_another_instance`, `update_agent_settings_does_not_resurrect_connections_deleted_by_another_instance`, `reorder_agents_does_not_resurrect_connections_deleted_by_another_instance`
- [x] Rust SpyStore tests: verify `prepare_for_storage` never calls `get()` on the credential store for serial/local connections
- [x] JS regression test: stale concurrent reload from `addFolder` does not resurrect a connection deleted by `deleteConnection`
- [x] Frontend tests: `ConnectionEditor` Save & Connect uses stored credential; `ConnectionList` key-passphrase prompt flow
- [ ] Manual: delete a connection in window A, switch focus to window B — deleted connection should not reappear
- [ ] Manual: delete a connection, then add a folder — deleted connection should not reappear
- [ ] Manual: save a serial or local connection — no credential-store unlock dialog should appear
- [ ] Manual: SSH Save & Connect with an existing stored password — no prompt should appear
- [ ] Manual: SSH key auth connect via sidebar with `savePassword=true` and no stored passphrase — prompt should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)