### PR TITLE
feat: develop-branch build marking and dev-develop-latest agent downloads

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -124,6 +124,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TERMIHUB_DEV_BUILD: 'true'
+          TERMIHUB_BUILD_BRANCH: ${{ needs.prepare-release.outputs.branch }}
         with:
           tagName: ''
           releaseName: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Develop-branch builds are now marked in the status bar with a purple "develop" badge next to the version, and automatically download agent binaries from the `dev-develop-latest` GitHub release instead of `dev-latest`.
 - Open Connections panel: proxy sessions (desktop connections routed through a remote agent) are now shown in a "Connections via &lt;agent&gt;" section, grouped by agent, with individual Kill and Kill All buttons. They were previously invisible in the panel.
 - Serial port scan prefixes: the full list of Linux `/dev` prefixes scanned to discover serial ports (e.g. `ttyAMA*` on Raspberry Pi, `ttyTHS*` on Jetson, `ttymxc*` on i.MX, and 39 more) is now configurable via Settings → General. Built-in prefixes can be toggled on or off; custom prefixes can be added or removed. Changes take effect immediately when opening the serial port dropdown in a connection editor.
 - Persistent connections scrollback replay: when a tab re-attaches to a running persistent session, the agent queries the daemon's ring buffer via a new `MSG_QUERY_BUFFER` / `session.getBuffer` protocol exchange. The buffer lives on the agent machine and survives desktop restarts, correctly solving the offline-desktop use case. The ring buffer size is now configurable per agent in Agent Settings (1–64 MiB, default 1 MiB) (#666).

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -39,9 +39,11 @@ pub struct AppInfo {
     pub git_hash: String,
     /// Whether this is a development (non-production) build.
     pub is_dev: bool,
+    /// Git branch this binary was built from (e.g. `"main"`, `"develop"`, `"unknown"`).
+    pub build_branch: String,
 }
 
-/// Return build-time info (version, git hash, dev flag) to the frontend.
+/// Return build-time info (version, git hash, dev flag, build branch) to the frontend.
 #[tauri::command]
 pub fn get_app_info(app_handle: AppHandle) -> AppInfo {
     let base = app_handle.package_info().version.to_string();
@@ -51,6 +53,7 @@ pub fn get_app_info(app_handle: AppHandle) -> AppInfo {
         version,
         git_hash: env!("GIT_HASH").to_string(),
         is_dev,
+        build_branch: env!("TERMIHUB_BUILD_BRANCH").to_string(),
     }
 }
 

--- a/src-tauri/src/terminal/agent_binary.rs
+++ b/src-tauri/src/terminal/agent_binary.rs
@@ -192,13 +192,20 @@ where
 
 /// Return the base download URL (without arch suffix) for the current build.
 ///
-/// Debug builds and versions ending with `-dev` use the `dev-latest` tag.
-/// Release builds use `v{version}`.
+/// Dev builds (debug mode, `-dev` version suffix, or CI dev-build flag) use a
+/// branch-specific tag: `dev-develop-latest` for develop, `dev-latest` for everything
+/// else. Release builds use `v{version}`.
 ///
 /// Append an arch suffix (e.g. `"linux-arm64"`) to obtain the full URL.
 pub fn compute_download_base_url(version: &str) -> String {
-    let tag = if cfg!(debug_assertions) || version.ends_with("-dev") {
-        "dev-latest".to_string()
+    let is_dev =
+        cfg!(debug_assertions) || env!("TERMIHUB_IS_DEV_BUILD") == "1" || version.ends_with("-dev");
+    let tag = if is_dev {
+        if env!("TERMIHUB_BUILD_BRANCH") == "develop" {
+            "dev-develop-latest".to_string()
+        } else {
+            "dev-latest".to_string()
+        }
     } else {
         format!("v{version}")
     };
@@ -210,12 +217,21 @@ pub fn compute_download_url(version: &str, arch_suffix: &str) -> String {
     format!("{}{}", compute_download_base_url(version), arch_suffix)
 }
 
-// Test helpers with an explicit dev-build flag so tests are not affected by
+// Test helpers with explicit flags so tests are not affected by
 // whether the test runner itself is a debug or release build.
 #[cfg(test)]
-pub(crate) fn compute_download_base_url_impl(version: &str, is_debug_build: bool) -> String {
-    let tag = if is_debug_build || version.ends_with("-dev") {
-        "dev-latest".to_string()
+pub(crate) fn compute_download_base_url_impl(
+    version: &str,
+    is_debug_build: bool,
+    branch: &str,
+) -> String {
+    let is_dev = is_debug_build || version.ends_with("-dev");
+    let tag = if is_dev {
+        if branch == "develop" {
+            "dev-develop-latest".to_string()
+        } else {
+            "dev-latest".to_string()
+        }
     } else {
         format!("v{version}")
     };
@@ -227,10 +243,11 @@ pub(crate) fn compute_download_url_impl(
     version: &str,
     arch_suffix: &str,
     is_debug_build: bool,
+    branch: &str,
 ) -> String {
     format!(
         "{}{}",
-        compute_download_base_url_impl(version, is_debug_build),
+        compute_download_base_url_impl(version, is_debug_build, branch),
         arch_suffix
     )
 }
@@ -393,7 +410,7 @@ mod tests {
 
     #[test]
     fn compute_download_url_release_build_uses_version_tag() {
-        let url = compute_download_url_impl("1.2.3", "linux-x64", false);
+        let url = compute_download_url_impl("1.2.3", "linux-x64", false, "main");
         assert_eq!(
             url,
             "https://github.com/armaxri/termiHub/releases/download/v1.2.3/termihub-agent-linux-x64"
@@ -402,7 +419,7 @@ mod tests {
 
     #[test]
     fn compute_download_url_debug_build_uses_dev_latest() {
-        let url = compute_download_url_impl("1.2.3", "linux-x64", true);
+        let url = compute_download_url_impl("1.2.3", "linux-x64", true, "main");
         assert_eq!(
             url,
             "https://github.com/armaxri/termiHub/releases/download/dev-latest/termihub-agent-linux-x64"
@@ -411,7 +428,7 @@ mod tests {
 
     #[test]
     fn compute_download_url_dev_version_suffix_uses_dev_latest() {
-        let url = compute_download_url_impl("0.1.0-dev", "linux-arm64", false);
+        let url = compute_download_url_impl("0.1.0-dev", "linux-arm64", false, "main");
         assert_eq!(
             url,
             "https://github.com/armaxri/termiHub/releases/download/dev-latest/termihub-agent-linux-arm64"
@@ -420,7 +437,7 @@ mod tests {
 
     #[test]
     fn compute_download_url_dev_version_armv7() {
-        let url = compute_download_url_impl("2.0.0-dev", "linux-armv7", false);
+        let url = compute_download_url_impl("2.0.0-dev", "linux-armv7", false, "main");
         assert!(url.contains("dev-latest"));
         assert!(url.contains("linux-armv7"));
         assert!(!url.contains("v2.0.0"));
@@ -428,9 +445,36 @@ mod tests {
 
     #[test]
     fn compute_download_url_release_build_does_not_use_dev_latest() {
-        let url = compute_download_url_impl("1.0.0", "linux-x64", false);
+        let url = compute_download_url_impl("1.0.0", "linux-x64", false, "main");
         assert!(!url.contains("dev-latest"));
         assert!(url.contains("v1.0.0"));
+    }
+
+    #[test]
+    fn compute_download_url_develop_branch_debug_uses_dev_develop_latest() {
+        let url = compute_download_url_impl("1.2.3", "linux-x64", true, "develop");
+        assert_eq!(
+            url,
+            "https://github.com/armaxri/termiHub/releases/download/dev-develop-latest/termihub-agent-linux-x64"
+        );
+    }
+
+    #[test]
+    fn compute_download_url_develop_branch_dev_version_uses_dev_develop_latest() {
+        let url = compute_download_url_impl("0.1.0-dev", "linux-arm64", false, "develop");
+        assert_eq!(
+            url,
+            "https://github.com/armaxri/termiHub/releases/download/dev-develop-latest/termihub-agent-linux-arm64"
+        );
+    }
+
+    #[test]
+    fn compute_download_url_develop_branch_release_build_uses_version_tag() {
+        let url = compute_download_url_impl("1.2.3", "linux-x64", false, "develop");
+        assert_eq!(
+            url,
+            "https://github.com/armaxri/termiHub/releases/download/v1.2.3/termihub-agent-linux-x64"
+        );
     }
 
     #[test]

--- a/src/components/Settings/AboutSettings.test.tsx
+++ b/src/components/Settings/AboutSettings.test.tsx
@@ -31,7 +31,12 @@ describe("AboutSettings", () => {
 
     mockedInvoke.mockImplementation((cmd) => {
       if (cmd === "get_app_info")
-        return Promise.resolve({ version: "1.2.3", gitHash: "abc1234", isDev: false });
+        return Promise.resolve({
+          version: "1.2.3",
+          gitHash: "abc1234",
+          isDev: false,
+          buildBranch: "main",
+        });
       return Promise.resolve(undefined);
     });
 

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -349,3 +349,17 @@
 .update-indicator__dot--red {
   background: var(--color-error, #f44336);
 }
+
+.update-indicator__develop-badge {
+  display: inline-block;
+  margin-left: 5px;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 14px;
+  vertical-align: middle;
+  background: #7c3aed;
+  color: #fff;
+  letter-spacing: 0.03em;
+}

--- a/src/components/StatusBar/UpdateIndicator.tsx
+++ b/src/components/StatusBar/UpdateIndicator.tsx
@@ -1,24 +1,26 @@
 import { useEffect, useState } from "react";
 import { useAppStore } from "@/store/appStore";
-import { getAppInfo } from "@/services/api";
+import { getAppInfo, type AppInfo } from "@/services/api";
 
 /**
  * Version chip in the status bar.  Shows an amber or red dot when an update
  * is available.  Clicking re-shows the update notification popup.
+ * Shows a "develop" badge when running a develop-branch build.
  */
 export function UpdateIndicator() {
-  const [appVersion, setAppVersion] = useState("");
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
   const updateInfo = useAppStore((s) => s.updateInfo);
   const updateCheckState = useAppStore((s) => s.updateCheckState);
 
   useEffect(() => {
     getAppInfo()
-      .then((info) => setAppVersion(info.version))
-      .catch(() => setAppVersion("?"));
+      .then(setAppInfo)
+      .catch(() => null);
   }, []);
 
   const hasUpdate = updateCheckState === "available" && updateInfo?.available === true;
   const isSecurity = hasUpdate && updateInfo?.isSecurity === true;
+  const isDevelop = appInfo?.buildBranch === "develop";
 
   const handleClick = () => {
     if (hasUpdate) {
@@ -34,12 +36,21 @@ export function UpdateIndicator() {
       title={
         hasUpdate
           ? `termiHub v${updateInfo?.latestVersion} is available — click to view`
-          : `termiHub v${appVersion}`
+          : `termiHub v${appInfo?.version ?? ""}`
       }
       data-testid="update-indicator"
       style={{ cursor: hasUpdate ? "pointer" : "default" }}
     >
-      v{appVersion}
+      v{appInfo?.version ?? ""}
+      {isDevelop && (
+        <span
+          className="update-indicator__develop-badge"
+          data-testid="develop-branch-badge"
+          aria-label="Develop branch build"
+        >
+          develop
+        </span>
+      )}
       {hasUpdate && (
         <span
           className={`update-indicator__dot update-indicator__dot--${isSecurity ? "red" : "amber"}`}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -988,6 +988,8 @@ export interface AppInfo {
   gitHash: string;
   /** Whether this is a development (non-production) build. */
   isDev: boolean;
+  /** Git branch this binary was built from (e.g. `"main"`, `"develop"`, `"unknown"`). */
+  buildBranch: string;
 }
 
 /** Return build-time info: version (with `-dev` suffix in dev builds), git hash, and dev flag. */


### PR DESCRIPTION
## Summary

- Develop-branch CI builds now compile `TERMIHUB_BUILD_BRANCH=develop` into the desktop binary via a new CI workflow env var, fixing a gap where the app build step had no branch context
- `compute_download_base_url` uses `dev-develop-latest` for develop-branch dev builds (was always `dev-latest`), matching the tag the CI agent build job already publishes to
- `AppInfo` gains a `buildBranch` field, surfaced to the frontend via the existing `get_app_info` command
- A purple "develop" badge appears next to the version chip in the status bar for develop-branch builds

## Test plan

- [ ] Verify Rust tests pass: `cargo test -p termihub --lib terminal::agent_binary` — 22 tests, 3 are new develop-specific URL cases
- [ ] Build a local debug binary on the `develop` branch and confirm the status bar shows the "develop" badge next to the version
- [ ] Build a local debug binary on any other branch (e.g. a feature branch) and confirm no "develop" badge appears
- [ ] Verify `compute_download_base_url` returns `dev-develop-latest` URL for develop builds and `dev-latest` for main/feature builds (covered by unit tests)
- [ ] Check CI: after merging, a push to `develop` should produce a `dev-develop-latest` release with agent binaries downloadable by the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)