### PR TITLE
feat(ui): move Updates and About to overlay panels in settings menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Settings: "Updates" and "About" are no longer sub-tabs inside the Settings panel. They are now direct entries in the settings gear dropdown menu and open in a focused overlay panel instead.
+
 ### Added
 
 - Develop-branch builds are now marked in the status bar with a purple "develop" badge next to the version, and automatically download agent binaries from the `dev-develop-latest` GitHub release instead of `dev-latest`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { UnlockDialog } from "@/components/UnlockDialog";
 import { MasterPasswordSetup } from "@/components/MasterPasswordSetup";
 import { RecoveryDialog } from "@/components/Settings/RecoveryDialog";
 import { ShortcutsOverlay } from "@/components/KeyboardShortcuts/ShortcutsOverlay";
+import { OverlayViewPanel } from "@/components/Settings/OverlayViewPanel";
 import { LargePasteDialog } from "@/components/Terminal/LargePasteDialog";
 import { UpdateNotification } from "@/components/UpdateNotification/UpdateNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -223,6 +224,7 @@ function App() {
           warnings={recoveryWarnings}
         />
         <ShortcutsOverlay open={shortcutsOverlayOpen} onOpenChange={setShortcutsOverlayOpen} />
+        <OverlayViewPanel />
         <LargePasteDialog
           open={largePasteDialog.open}
           charCount={largePasteDialog.charCount}

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -12,6 +12,8 @@ import {
   LayoutDashboard,
   Stethoscope,
   Activity,
+  RefreshCw,
+  Info,
 } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as ContextMenu from "@radix-ui/react-context-menu";
@@ -55,6 +57,7 @@ export function ActivityBar({ horizontal }: ActivityBarProps) {
   const setSidebarView = useAppStore((s) => s.setSidebarView);
   const openSettingsTab = useAppStore((s) => s.openSettingsTab);
   const openLogViewerTab = useAppStore((s) => s.openLogViewerTab);
+  const openOverlayView = useAppStore((s) => s.openOverlayView);
   const activityBarPosition = useAppStore((s) => s.layoutConfig.activityBarPosition);
   const hiddenActivityBarViews = useAppStore(
     (s) => s.layoutConfig.hiddenActivityBarViews ?? EMPTY_HIDDEN_VIEWS
@@ -175,6 +178,23 @@ export function ActivityBar({ horizontal }: ActivityBarProps) {
                   >
                     <Download size={14} />
                     Export Connections
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator className="settings-menu__separator" />
+                  <DropdownMenu.Item
+                    className="settings-menu__item"
+                    onSelect={() => openOverlayView("updates")}
+                    data-testid="settings-menu-updates"
+                  >
+                    <RefreshCw size={14} />
+                    Updates
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className="settings-menu__item"
+                    onSelect={() => openOverlayView("about")}
+                    data-testid="settings-menu-about"
+                  >
+                    <Info size={14} />
+                    About termiHub
                   </DropdownMenu.Item>
                 </DropdownMenu.Content>
               </DropdownMenu.Portal>

--- a/src/components/Settings/OverlayViewPanel.css
+++ b/src/components/Settings/OverlayViewPanel.css
@@ -1,0 +1,64 @@
+.overlay-view {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.overlay-view__panel {
+  display: flex;
+  flex-direction: column;
+  width: min(640px, calc(100% - 48px));
+  max-height: calc(100% - 48px);
+  background: var(--bg-primary);
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.overlay-view__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  background: var(--tab-bar-bg);
+  border-bottom: 1px solid var(--panel-border);
+  flex-shrink: 0;
+}
+
+.overlay-view__icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.overlay-view__title {
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  flex: 1;
+}
+
+.overlay-view__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  padding: 2px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.overlay-view__close:hover {
+  background: var(--tab-hover-bg);
+  color: var(--text-primary);
+}
+
+.overlay-view__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px;
+}

--- a/src/components/Settings/OverlayViewPanel.tsx
+++ b/src/components/Settings/OverlayViewPanel.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { RefreshCw, Info, X } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { UpdateSettings } from "./UpdateSettings";
+import { AboutSettings } from "./AboutSettings";
+import "./OverlayViewPanel.css";
+
+const VIEW_META = {
+  updates: { label: "Updates", Icon: RefreshCw },
+  about: { label: "About termiHub", Icon: Info },
+} as const;
+
+/** Full-screen overlay that shows the Updates or About view, opened from the settings menu. */
+export function OverlayViewPanel() {
+  const overlayView = useAppStore((s) => s.overlayView);
+  const closeOverlayView = useAppStore((s) => s.closeOverlayView);
+
+  useEffect(() => {
+    if (!overlayView) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeOverlayView();
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [overlayView, closeOverlayView]);
+
+  if (!overlayView) return null;
+
+  const { label, Icon } = VIEW_META[overlayView];
+
+  return (
+    <div className="overlay-view" onClick={closeOverlayView}>
+      <div className="overlay-view__panel" onClick={(e) => e.stopPropagation()}>
+        <div className="overlay-view__header">
+          <Icon size={14} className="overlay-view__icon" />
+          <span className="overlay-view__title">{label}</span>
+          <button className="overlay-view__close" onClick={closeOverlayView} aria-label="Close">
+            <X size={14} />
+          </button>
+        </div>
+        <div className="overlay-view__content">
+          {overlayView === "updates" && <UpdateSettings />}
+          {overlayView === "about" && <AboutSettings />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -9,10 +9,8 @@ import {
   FileJson,
   FileCode2,
   HardDrive,
-  Info,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { RefreshCw } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { applyTheme } from "@/themes/engine";
 import { AppSettings } from "@/types/connection";
@@ -31,8 +29,6 @@ import { LanguagePackagesSettings } from "./LanguagePackagesSettings";
 import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
 import { SerialPortSettings } from "./SerialPortSettings";
 import { PortableModeSettings } from "./PortableModeSettings";
-import { UpdateSettings } from "./UpdateSettings";
-import { AboutSettings } from "./AboutSettings";
 import { getAppInfo, type AppInfo } from "@/services/api";
 import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
 import "./SettingsPanel.css";
@@ -46,8 +42,6 @@ const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
   "external-files": FileJson,
   editor: FileCode2,
   portable: HardDrive,
-  updates: RefreshCw,
-  about: Info,
 };
 
 const SAVE_DEBOUNCE_MS = 300;
@@ -294,12 +288,6 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
       if (highlightedCategories?.has("portable")) {
         sections.push(<PortableModeSettings key="portable" />);
       }
-      if (highlightedCategories?.has("updates")) {
-        sections.push(<UpdateSettings key="updates" visibleFields={visibleFields} />);
-      }
-      if (highlightedCategories?.has("about")) {
-        sections.push(<AboutSettings key="about" />);
-      }
       if (sections.length === 0) {
         return <div className="settings-panel__no-results">No settings match your search.</div>;
       }
@@ -334,10 +322,6 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
         );
       case "portable":
         return <PortableModeSettings />;
-      case "updates":
-        return <UpdateSettings />;
-      case "about":
-        return <AboutSettings />;
     }
   };
 

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -6,9 +6,7 @@ export type SettingsCategory =
   | "security"
   | "external-files"
   | "editor"
-  | "portable"
-  | "updates"
-  | "about";
+  | "portable";
 
 export interface CategoryDefinition {
   id: SettingsCategory;
@@ -32,8 +30,6 @@ export const CATEGORIES: CategoryDefinition[] = [
   { id: "external-files", label: "External Files" },
   { id: "editor", label: "Editor" },
   { id: "portable", label: "Portable Mode" },
-  { id: "updates", label: "Updates" },
-  { id: "about", label: "About" },
 ];
 
 export const SETTINGS_REGISTRY: SettingDefinition[] = [
@@ -231,27 +227,6 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     description: "Export or import configuration between installed and portable mode",
     category: "portable",
     keywords: ["export", "import", "migrate", "copy", "transfer", "backup", "portable"],
-  },
-  {
-    id: "updateStatus",
-    label: "Update Status",
-    description: "Check whether a new version of termiHub is available",
-    category: "updates",
-    keywords: ["update", "version", "upgrade", "release", "check", "new version"],
-  },
-  {
-    id: "updateAutoCheck",
-    label: "Auto-Check for Updates",
-    description: "Automatically check for new releases on startup",
-    category: "updates",
-    keywords: ["update", "auto", "automatic", "startup", "check", "notify"],
-  },
-  {
-    id: "aboutInfo",
-    label: "About termiHub",
-    description: "Version number, GitHub repository link, license, and project information",
-    category: "about",
-    keywords: ["about", "version", "license", "mit", "github", "repository", "credits", "info"],
   },
 ];
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -329,6 +329,11 @@ interface AppState {
   shortcutsOverlayOpen: boolean;
   setShortcutsOverlayOpen: (open: boolean) => void;
 
+  // Standalone overlay views (updates, about) — opened from the settings menu
+  overlayView: "updates" | "about" | null;
+  openOverlayView: (view: "updates" | "about") => void;
+  closeOverlayView: () => void;
+
   // Panel zoom overlay (runtime-only) — temporarily expand the active terminal tab to full view
   zoomedTabId: string | null;
   setZoomedTabId: (tabId: string | null) => void;
@@ -1856,6 +1861,11 @@ export const useAppStore = create<AppState>((set, get) => {
     // Shortcuts overlay
     shortcutsOverlayOpen: false,
     setShortcutsOverlayOpen: (open) => set({ shortcutsOverlayOpen: open }),
+
+    // Standalone overlay views
+    overlayView: null,
+    openOverlayView: (view) => set({ overlayView: view }),
+    closeOverlayView: () => set({ overlayView: null }),
 
     // Panel zoom overlay
     zoomedTabId: null,


### PR DESCRIPTION
## Summary

- **Updates** and **About** are removed as sub-tabs from the Settings panel nav sidebar
- Both are now direct entries at the bottom of the settings gear dropdown menu (separated from Import/Export)
- Selecting either opens a focused overlay panel (fixed-position backdrop + centered card, same visual style as the existing zoom overlay) — no need to open the full Settings tab first
- Escape or clicking the backdrop dismisses the overlay

## Implementation

- `settingsRegistry.ts` — removed `updates` and `about` categories and their settings definitions
- `SettingsPanel.tsx` — removed `UpdateSettings`/`AboutSettings` from nav, search results, and render switch
- `appStore.ts` — added `overlayView`, `openOverlayView`, `closeOverlayView` state
- `OverlayViewPanel.tsx` + `OverlayViewPanel.css` — new standalone overlay component mounted in `App.tsx`
- `ActivityBar.tsx` — added "Updates" and "About termiHub" items with icons to the gear dropdown

## Test plan

- [ ] Open the settings gear dropdown — confirm "Updates" and "About termiHub" appear at the bottom with a separator above them
- [ ] Click "Updates" — overlay opens centered on screen; shows update check UI; Escape dismisses it; clicking the backdrop dismisses it
- [ ] Click "About termiHub" — overlay opens with app version and links; same dismiss behaviour
- [ ] Open Settings panel (via "Settings" menu item) — confirm Updates and About no longer appear in the left nav sidebar
- [ ] Run settings search — confirm searching "update" or "about" returns no results (they're not in the registry)
- [ ] Verify no visual regressions in the rest of the Settings panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)