### PR TITLE
ci: remove push triggers from Build and Agent workflows

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -7,12 +7,6 @@ on:
       - 'agent/**'
       - 'core/**'
       - 'Cargo.toml'
-  push:
-    branches: [ main, develop ]
-    paths:
-      - 'agent/**'
-      - 'core/**'
-      - 'Cargo.toml'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build
 on:
   pull_request:
     branches: [ main, develop ]
-  push:
-    branches: [ main, develop ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Removes the `push` trigger from `build.yml` — `Build` now only runs on pull requests targeting `main`/`develop`
- Removes the `push` trigger from `agent.yml` — `Agent` now only runs on pull requests touching `agent/**`, `core/**`, or `Cargo.toml`

## Why

`Dev Build` already performs a full 5-platform Tauri build **plus** 3-target agent cross-compilation on every push to `main`/`develop` and publishes a dev release. Running `Build` and `Agent` on the same push events duplicated that work with no additional coverage:

| Before | Jobs per push to main/develop |
|---|---|
| Build (push) | 5 Tauri builds |
| Dev Build (push) | 5 Tauri builds + 3 agent builds |
| Agent (push, when paths match) | 3 agent builds |
| **Total** | **10–13 build jobs** |

| After | Jobs per push to main/develop |
|---|---|
| Dev Build (push) | 5 Tauri builds + 3 agent builds |
| **Total** | **8 build jobs** |

PR validation is unchanged — both workflows still run on `pull_request` so every branch is verified before merge.

Mirrors #691 (same change targeting `main`).

## Test plan

- [ ] Verify a push to `develop` only triggers `Dev Build` (not `Build` or `Agent`)
- [ ] Verify a pull request targeting `develop` still triggers `Build` and `Agent` (for path-matching changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)