### PR TITLE
fix(ci): strip all signatures from macOS DMG for truly unsigned build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -134,9 +134,10 @@ jobs:
 
       # Tauri applies an ad-hoc ('-') signature by default on macOS. Ad-hoc signatures
       # are machine-local: on any other machine Gatekeeper treats the app as damaged
-      # rather than showing the bypassable security warning. Strip the signature so the
-      # app is fully unsigned — Gatekeeper then shows "cannot be opened because Apple
-      # cannot check it for malicious software", which users can bypass via System Settings.
+      # rather than showing the bypassable security warning. Strip ALL signatures so the
+      # app is truly unsigned — Gatekeeper then shows the bypassable "cannot be opened
+      # because Apple cannot check it for malicious software" warning instead of the
+      # hard "can't be opened" (damaged) error.
       - name: Strip ad-hoc signature from macOS DMG
         if: startsWith(matrix.os, 'macos')
         shell: bash
@@ -152,10 +153,23 @@ jobs:
           hdiutil detach "$MOUNT" -quiet
 
           APP="$WORKDIR/$APP_NAME"
+
+          # Strip signatures from all individual Mach-O files
           find "$APP" -type f \( -name "*.dylib" -o -name "*.so" \) \
             -exec codesign --remove-signature {} \; 2>/dev/null || true
           find "$APP/Contents/MacOS" -type f \
             -exec codesign --remove-signature {} \; 2>/dev/null || true
+          find "$APP/Contents/Frameworks" -type f \
+            -exec codesign --remove-signature {} \; 2>/dev/null || true
+
+          # Strip signatures from .framework bundles (must be treated as bundles, not files)
+          find "$APP" -name "*.framework" -type d \
+            -exec codesign --remove-signature {} \; 2>/dev/null || true
+
+          # Remove _CodeSignature directories (the signature manifest inside each bundle)
+          find "$APP" -name "_CodeSignature" -type d -print0 | xargs -0 rm -rf 2>/dev/null || true
+
+          # Strip the top-level app bundle signature
           codesign --remove-signature "$APP" 2>/dev/null || true
 
           rm "$DMG"


### PR DESCRIPTION
## Summary

- Extends the macOS DMG signature-stripping step to cover `Contents/Frameworks` files, `.framework` bundles, and `_CodeSignature` directories
- The previous partial strip left Gatekeeper treating the app as **damaged** ("can't be opened") instead of **unsigned** (bypassable "cannot verify" warning)
- After this fix the DMG should be truly unsigned, so the normal System Settings → Privacy & Security → Open Anyway bypass works as expected

## Root cause

Tauri applies an ad-hoc signature with `codesign --deep`, which signs:
1. The main executable(s) in `Contents/MacOS/`
2. All dylibs/frameworks in `Contents/Frameworks/`
3. `.framework` bundles as bundles
4. The top-level `.app` bundle (writes `_CodeSignature/`)

The old stripping only handled (1) and top-level dylibs — leaving (2), (3), and (4) signed. macOS Gatekeeper considers a bundle with mismatched/partial signatures as "damaged", which shows the hard "can't be opened" error with no bypass path.

## Test plan

- [ ] Download the new macOS DMG after this CI run completes
- [ ] Verify Gatekeeper shows the bypassable "cannot be opened because Apple cannot check it for malicious software" warning (not the hard "can't be opened" error)
- [ ] Confirm System Settings → Privacy & Security → Open Anyway successfully opens the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)