### PR TITLE
fix(ui): multi-select delete and real-time cross-instance connection sync

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -209,10 +209,10 @@ Use these skills with `/skill-name` during development:
 ## Git Workflow
 
 - **Always pull `origin/main` before starting new work**: run `git fetch origin && git checkout origin/main` before creating a feature branch — never branch from a stale local `main`
-- **Branch from `main`**: `feature/<description>` or `bugfix/<description>`
-- **Never commit directly to `main`**
-- **Never push directly to `main`**: all changes must be submitted via pull request — no exceptions, even for documentation-only changes
-- **Every change requires a PR**: create a feature or bugfix branch, push it to `origin`, and open a pull request. Direct pushes to `main` are prohibited.
+- **Always create a new branch before any work**: never commit to `main` or `develop` — every fix, feature, or doc change must start on a dedicated `feature/<description>` or `bugfix/<description>` branch. If you are already on `main` or `develop` when you begin, create and switch to a new branch first.
+- **Never commit directly to `main` or `develop`**
+- **Never push directly to `main` or `develop`**: all changes must be submitted via pull request — no exceptions, even for documentation-only changes
+- **Every change requires a PR**: create a feature or bugfix branch, push it to `origin`, and open a pull request. Direct pushes to `main` or `develop` are prohibited.
 - **Conventional Commits**: `type(scope): subject` — types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
 - **Scopes**: `terminal`, `ssh`, `serial`, `ui`, `backend`, `sftp`, `config`, `agent`, `credential`, `tunnel`, `workspace`, `network`, `embedded-servers`
 - **Always merge with a merge commit** (`gh pr merge --merge`) — never squash or rebase, never rebase branches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Connections sidebar: deleting multiple selected connections now removes all of them instead of only the one that was right-clicked.
+- Connections: changes made in one running instance (add, delete, rename) now propagate to all other running instances within ~1 second. Previously, other instances only updated on window focus.
+
 ### Changed
 
 - Settings: "Updates" and "About" are no longer sub-tabs inside the Settings panel. They are now direct entries in the settings gear dropdown menu and open in a focused overlay panel instead.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,6 +107,9 @@ pub fn run() {
             };
             std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
 
+            // Capture path for the connections file watcher before config_dir is moved.
+            let connections_file = config_dir.join("connections.json");
+
             // Initialise the network manager with the config dir and app handle.
             if let Some(net_mgr) = app.try_state::<NetworkManager>() {
                 // SAFETY: NetworkManager is only initialised once at startup.
@@ -325,6 +328,33 @@ pub fn run() {
 
             // Store recovery warnings so the frontend can retrieve them
             app.manage(Mutex::new(recovery_warnings));
+
+            // Watch connections.json for changes made by other running instances.
+            // Each instance polls independently; when any instance writes the file,
+            // all others detect the mtime change and reload within ~1 second.
+            {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    use std::time::SystemTime;
+                    let mut last_mtime: Option<SystemTime> = std::fs::metadata(&connections_file)
+                        .ok()
+                        .and_then(|m| m.modified().ok());
+                    let mut interval =
+                        tokio::time::interval(std::time::Duration::from_secs(1));
+                    interval
+                        .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                    loop {
+                        interval.tick().await;
+                        let current_mtime = std::fs::metadata(&connections_file)
+                            .ok()
+                            .and_then(|m| m.modified().ok());
+                        if current_mtime != last_mtime && current_mtime.is_some() {
+                            last_mtime = current_mtime;
+                            let _ = handle.emit("connections-changed", ());
+                        }
+                    }
+                });
+            }
 
             Ok(())
         })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { useSidebarResize } from "@/hooks/useSidebarResize";
 import { useAppStore } from "@/store/appStore";
 import { getCliWorkspace } from "@/services/workspaceApi";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { listen } from "@tauri-apps/api/event";
 import "./App.css";
 
 interface ErrorBoundaryState {
@@ -147,6 +148,17 @@ function App() {
     });
     return () => {
       void unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  // Reload connections when another running instance modifies connections.json.
+  // The backend polls the file's mtime every second and emits this event on change.
+  useEffect(() => {
+    const unlistenPromise = listen<void>("connections-changed", () => {
+      useAppStore.getState().reloadConnectionsFromBackend();
+    });
+    return () => {
+      void unlistenPromise.then((fn) => fn());
     };
   }, []);
 

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -322,6 +322,7 @@ export function ConnectionList() {
   const addTab = useAppStore((s) => s.addTab);
   const openConnectionEditorTab = useAppStore((s) => s.openConnectionEditorTab);
   const deleteConnection = useAppStore((s) => s.deleteConnection);
+  const bulkDeleteConnections = useAppStore((s) => s.bulkDeleteConnections);
   const deleteFolder = useAppStore((s) => s.deleteFolder);
   const addFolder = useAppStore((s) => s.addFolder);
   const duplicateConnection = useAppStore((s) => s.duplicateConnection);
@@ -481,9 +482,14 @@ export function ConnectionList() {
 
   const handleDelete = useCallback(
     (connectionId: string) => {
-      deleteConnection(connectionId);
+      if (selectedConnectionIds.size > 1 && selectedConnectionIds.has(connectionId)) {
+        bulkDeleteConnections([...selectedConnectionIds]);
+        clearConnectionSelection();
+      } else {
+        deleteConnection(connectionId);
+      }
     },
-    [deleteConnection]
+    [deleteConnection, bulkDeleteConnections, selectedConnectionIds, clearConnectionSelection]
   );
 
   const handleDuplicate = useCallback(

--- a/src/store/appStore.connections.test.ts
+++ b/src/store/appStore.connections.test.ts
@@ -379,6 +379,67 @@ describe("appStore — connections, folders, and special tabs", () => {
     });
   });
 
+  describe("bulkDeleteConnections", () => {
+    it("removes all specified connections from state immediately (optimistic)", () => {
+      const c1 = makeConnection({ id: "c-1" });
+      const c2 = makeConnection({ id: "c-2" });
+      const c3 = makeConnection({ id: "c-3" });
+      useAppStore.setState({ connections: [c1, c2, c3] });
+
+      useAppStore.getState().bulkDeleteConnections(["c-1", "c-2"]);
+
+      const remaining = useAppStore.getState().connections;
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe("c-3");
+    });
+
+    it("calls removeConnection for each deleted connection", async () => {
+      const c1 = makeConnection({ id: "c-1", sourceFile: "a.json" });
+      const c2 = makeConnection({ id: "c-2", sourceFile: undefined });
+      useAppStore.setState({ connections: [c1, c2] });
+
+      useAppStore.getState().bulkDeleteConnections(["c-1", "c-2"]);
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(vi.mocked(removeConnection)).toHaveBeenCalledWith("c-1", "a.json");
+      expect(vi.mocked(removeConnection)).toHaveBeenCalledWith("c-2", undefined);
+    });
+
+    it("reloads from backend once after all deletions complete", async () => {
+      const c1 = makeConnection({ id: "c-1" });
+      const c2 = makeConnection({ id: "c-2" });
+      useAppStore.setState({ connections: [c1, c2] });
+      vi.mocked(loadConnections).mockResolvedValueOnce({
+        connections: [],
+        folders: [],
+        agents: [],
+        externalErrors: [],
+      });
+
+      useAppStore.getState().bulkDeleteConnections(["c-1", "c-2"]);
+
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(vi.mocked(loadConnections)).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not affect connections not in the delete list", () => {
+      const c1 = makeConnection({ id: "c-1" });
+      const c2 = makeConnection({ id: "c-2" });
+      const c3 = makeConnection({ id: "c-3" });
+      useAppStore.setState({ connections: [c1, c2, c3] });
+
+      useAppStore.getState().bulkDeleteConnections(["c-1"]);
+
+      const remaining = useAppStore.getState().connections;
+      expect(remaining.map((c) => c.id)).toEqual(["c-2", "c-3"]);
+    });
+  });
+
   describe("duplicateConnection", () => {
     it("creates a copy with 'Copy of' prefix", () => {
       const conn = makeConnection({ id: "c-1", name: "My Connection" });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -381,6 +381,7 @@ interface AppState {
   addConnection: (connection: SavedConnection) => void;
   updateConnection: (connection: SavedConnection) => void;
   deleteConnection: (connectionId: string) => void;
+  bulkDeleteConnections: (connectionIds: string[]) => void;
   addFolder: (folder: ConnectionFolder) => void;
   deleteFolder: (folderId: string) => void;
   duplicateConnection: (connectionId: string) => void;
@@ -2204,6 +2205,24 @@ export const useAppStore = create<AppState>((set, get) => {
           return applyConnectionReload();
         })
         .catch((err) => console.error("Failed to persist connection deletion:", err));
+    },
+
+    bulkDeleteConnections: (connectionIds) => {
+      const idSet = new Set(connectionIds);
+      const toDelete = get().connections.filter((c) => idSet.has(c.id));
+      frontendLog(
+        "connection_sync",
+        `bulkDeleteConnections: removing ${connectionIds.join(", ")} optimistically`
+      );
+      set((state) => ({
+        connections: state.connections.filter((c) => !idSet.has(c.id)),
+      }));
+      Promise.all(toDelete.map((c) => removeConnection(c.id, c.sourceFile)))
+        .then(() => {
+          frontendLog("connection_sync", `bulkDeleteConnections: backend confirmed, reloading`);
+          return applyConnectionReload();
+        })
+        .catch((err) => console.error("Failed to persist bulk connection deletion:", err));
     },
 
     addFolder: (folder) => {

--- a/tests/manual/connection-management.yaml
+++ b/tests/manual/connection-management.yaml
@@ -143,6 +143,42 @@ tests:
       - "Folder assignment persists correctly"
     verification: manual
 
+  # --- Multi-select delete (bugfix/multi-connection-delete) ---
+
+  - id: MT-CONN-33
+    name: "Delete multiple selected connections"
+    platforms: [all]
+    prerequisites:
+      - app: true
+    instructions:
+      - "Create at least three connections in the sidebar"
+      - "Click the first connection to select it"
+      - "Ctrl+Click (or Cmd+Click on macOS) to add two more to the selection"
+      - "Right-click one of the selected connections and choose Delete"
+    expected:
+      - "All selected connections are removed from the sidebar immediately"
+      - "Unselected connections remain untouched"
+    verification: manual
+
+  # --- Cross-instance connection sync (bugfix/multi-connection-delete) ---
+
+  - id: MT-CONN-34
+    name: "Connection changes sync across parallel instances"
+    platforms: [all]
+    prerequisites:
+      - app: true
+    instructions:
+      - "Launch two separate termiHub instances pointing at the same config directory"
+      - "In instance A, add a new connection"
+      - "Observe instance B within 2 seconds"
+      - "In instance A, delete that connection"
+      - "Observe instance B within 2 seconds"
+    expected:
+      - "The new connection appears in instance B's sidebar within ~1 second"
+      - "The deleted connection disappears from instance B's sidebar within ~1 second"
+      - "No manual window-focus switch is required to trigger the update"
+    verification: manual
+
   # --- Drag connection out of folder (#394) ---
 
   - id: MT-CONN-32


### PR DESCRIPTION
## Summary

- **Multi-select delete**: right-clicking Delete on a multi-selection now removes all selected connections, not just the one that was right-clicked. A new `bulkDeleteConnections` store action handles the optimistic removal and parallel backend persistence.
- **Cross-instance sync**: each instance now polls `connections.json` mtime every second and emits a `connections-changed` event when it detects a change. All instances reload immediately, so adds, deletes, and renames appear in parallel instances within ~1 second — no window-focus switch required.

## Test plan

- [ ] MT-CONN-33: Ctrl/Cmd+Click to select 3+ connections → right-click one → Delete → all selected connections disappear, others remain
- [ ] MT-CONN-34: Open two instances against the same config dir → add a connection in instance A → appears in instance B within ~1 s → delete it in instance A → disappears from instance B within ~1 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)