### PR TITLE
fix(ci): re-sign macOS DMG inside-out for consistent ad-hoc signature

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -133,13 +133,15 @@ jobs:
           prerelease: false
           args: --target ${{ matrix.rust_target }} ${{ matrix.extra_args }}
 
-      # Tauri applies an ad-hoc ('-') signature by default on macOS. Ad-hoc signatures
-      # are machine-local: on any other machine Gatekeeper treats the app as damaged
-      # rather than showing the bypassable security warning. Strip ALL signatures so the
-      # app is truly unsigned — Gatekeeper then shows the bypassable "cannot be opened
-      # because Apple cannot check it for malicious software" warning instead of the
-      # hard "can't be opened" (damaged) error.
-      - name: Strip ad-hoc signature from macOS DMG
+      # Tauri's internal ad-hoc signing can leave the bundle in an inconsistent state
+      # (inner components signed in the wrong order), which Gatekeeper classifies as
+      # "damaged" — no bypass path exists for that error. A *fully consistent* ad-hoc
+      # signature instead triggers "unverified developer", which users can bypass via
+      # System Settings → Privacy & Security → Open Anyway (the standard one-time flow).
+      # We re-sign the entire bundle ourselves, inside-out, to guarantee consistency.
+      # Ad-hoc signatures are also required by the Apple Silicon kernel — a completely
+      # unsigned binary is killed immediately at exec time on M1/M2/M3/M4.
+      - name: Re-sign macOS DMG with consistent ad-hoc signature
         if: startsWith(matrix.os, 'macos')
         shell: bash
         run: |
@@ -150,41 +152,37 @@ jobs:
 
           hdiutil attach "$DMG" -mountpoint "$MOUNT" -nobrowse -quiet
           APP_NAME=$(ls "$MOUNT" | grep '\.app$' | head -n 1)
-          # Use ditto to preserve macOS metadata (resource forks, symlinks, xattrs)
           ditto "$MOUNT/$APP_NAME" "$WORKDIR/$APP_NAME"
           hdiutil detach "$MOUNT" -quiet
 
           APP="$WORKDIR/$APP_NAME"
 
-          # Strip signatures from every Mach-O binary in the bundle, regardless of
-          # location or extension. Using `file` detects actual Mach-O files without
-          # relying on paths like Contents/MacOS or extensions like .dylib.
+          # Sign inside-out: individual Mach-O files first, then nested bundles,
+          # then the top-level app. This matches the required codesign ordering and
+          # produces a CodeResources manifest that is consistent with all signed content.
+
+          # 1. Sign all individual Mach-O binaries (dylibs, executables, helpers)
           while IFS= read -r -d '' f; do
             if file "$f" 2>/dev/null | grep -q 'Mach-O'; then
-              codesign --remove-signature "$f" 2>/dev/null || true
+              codesign -s - --force "$f" 2>/dev/null || true
             fi
           done < <(find "$APP" -type f -print0)
 
-          # Strip all nested bundle types as bundles (frameworks, plugins, helper apps,
-          # XPC services, app extensions). These need bundle-level stripping in addition
-          # to having their inner binaries stripped above.
+          # 2. Sign nested bundle types as bundles (frameworks, plugins, XPC services)
           while IFS= read -r -d '' bundle; do
-            codesign --remove-signature "$bundle" 2>/dev/null || true
+            codesign -s - --force "$bundle" 2>/dev/null || true
           done < <(find "$APP" -mindepth 1 -type d \( \
             -name "*.framework" -o -name "*.app" -o \
             -name "*.bundle" -o -name "*.appex" -o -name "*.xpc" \) -print0)
 
-          # Remove all _CodeSignature directories (signature manifests)
-          find "$APP" -name "_CodeSignature" -type d -print0 | xargs -0 rm -rf 2>/dev/null || true
+          # 3. Sign the top-level app bundle (no --deep; inner content already signed)
+          codesign -s - --force "$APP"
 
-          # Strip the top-level app bundle
-          codesign --remove-signature "$APP" 2>/dev/null || true
-
-          # Diagnostic: confirm the app is now unsigned
-          echo "=== Signature state after stripping ==="
-          codesign -dv "$APP" 2>&1 && echo "WARNING: app still has a signature" || echo "OK: app is unsigned"
-          echo "=== Remaining _CodeSignature dirs ==="
-          find "$APP" -name "_CodeSignature" -type d 2>/dev/null || echo "(none)"
+          # Diagnostic: Gatekeeper assessment — expect "accepted" for ad-hoc
+          echo "=== Gatekeeper assessment ==="
+          spctl --assess --type exec "$APP" 2>&1 || true
+          echo "=== Signature info ==="
+          codesign -dv "$APP" 2>&1 || true
 
           rm "$DMG"
           hdiutil create -volname "termiHub" -srcfolder "$APP" -ov -format UDZO "$DMG"
@@ -343,10 +341,9 @@ jobs:
             echo "| Linux x64 | \`termiHub-dev-linux-x64.AppImage\`, \`termiHub-dev-linux-x64.deb\` |"
             echo "| Linux ARM64 | \`termiHub-dev-linux-arm64.deb\`, \`termiHub-dev-linux-arm64.rpm\` |"
             echo ""
-            echo "> **macOS — security warning on first launch.** These builds are unsigned (no Apple Developer"
-            echo "> account). macOS will block the app with _\"cannot be opened because Apple cannot check it"
-            echo "> for malicious software\"_. To bypass: open **System Settings → Privacy \& Security** and"
-            echo "> click **Open Anyway**. This is a one-time step per download."
+            echo "> **macOS — one-time security confirmation required.** These builds are not notarized (no Apple"
+            echo "> Developer account). On first launch macOS will warn that the developer cannot be verified."
+            echo "> Open **System Settings → Privacy \& Security** and click **Open Anyway**. This is a one-time step."
             echo ""
             echo "### Agent Binaries (Static musl)"
             echo "| Target | Artifact |"


### PR DESCRIPTION
Mirrors PR #700 (targeting `main`) into `develop`. See #700 for the full explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)