### PR TITLE
fix(session): fix blank terminal on persistent-session re-attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Connections sidebar: deleting multiple selected connections now removes all of them instead of only the one that was right-clicked.
 - Connections: changes made in one running instance (add, delete, rename) now propagate to all other running instances within ~1 second. Previously, other instances only updated on window focus.
+- Persistent sessions: "Attach new tab" no longer shows a blank terminal with no overlay. The backend now triggers a DaemonClient reconnect on attach so the scrollback buffer arrives via the notification path; if the session has already died, the placeholder tab is automatically removed instead of left in a broken state.
 
 ### Changed
 

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1767,6 +1767,229 @@ mod tests {
         );
     }
 
+    // ── SpyAgent for attach_persistent_tab regression tests ──────────
+
+    type AttachLog = std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>>;
+
+    /// An `AgentRpcClient` implementation that records `attach_session` calls.
+    struct SpyAgent {
+        attach_calls: AttachLog,
+    }
+
+    impl SpyAgent {
+        fn new() -> (Self, AttachLog) {
+            let calls: AttachLog = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            (
+                Self {
+                    attach_calls: calls.clone(),
+                },
+                calls,
+            )
+        }
+    }
+
+    impl AgentRpcClient for SpyAgent {
+        fn connect_agent(
+            &self,
+            _: &str,
+            _: &RemoteAgentConfig,
+            _: Option<&AgentSettings>,
+        ) -> Result<AgentConnectResult, TerminalError> {
+            unimplemented!()
+        }
+        fn disconnect_agent(&self, _: &str) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn is_connected(&self, _: &str) -> bool {
+            false
+        }
+        fn get_capabilities(&self, _: &str) -> Option<AgentCapabilities> {
+            None
+        }
+        fn shutdown_agent(&self, _: &str, _: Option<&str>) -> Result<u32, TerminalError> {
+            unimplemented!()
+        }
+        fn send_request(&self, _: &str, _: &str, _: Value) -> Result<Value, TerminalError> {
+            unimplemented!()
+        }
+        fn create_session(
+            &self,
+            _: &str,
+            _: &str,
+            _: Value,
+            _: Option<&str>,
+        ) -> Result<AgentSessionInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn attach_session(&self, agent_id: &str, remote_sid: &str) -> Result<(), TerminalError> {
+            self.attach_calls
+                .lock()
+                .unwrap()
+                .push((agent_id.to_string(), remote_sid.to_string()));
+            Ok(())
+        }
+        fn close_session(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn list_sessions(&self, _: &str) -> Result<Vec<AgentSessionInfo>, TerminalError> {
+            unimplemented!()
+        }
+        fn list_connections_and_folders(
+            &self,
+            _: &str,
+        ) -> Result<AgentConnectionsData, TerminalError> {
+            unimplemented!()
+        }
+        fn list_definitions(&self, _: &str) -> Result<Vec<AgentDefinitionInfo>, TerminalError> {
+            unimplemented!()
+        }
+        fn save_definition(&self, _: &str, _: Value) -> Result<AgentDefinitionInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn update_definition(
+            &self,
+            _: &str,
+            _: Value,
+        ) -> Result<AgentDefinitionInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn delete_definition(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn create_folder(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+        ) -> Result<AgentFolderInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn update_folder(&self, _: &str, _: Value) -> Result<AgentFolderInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn delete_folder(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn register_session_output(
+            &self,
+            _: &str,
+            _: &str,
+            _: OutputSender,
+        ) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn unregister_session_output(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn register_monitoring_output(
+            &self,
+            _: &str,
+            _: &str,
+            _: MonitoringSender,
+        ) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn unregister_monitoring_output(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn send_session_input(&self, _: &str, _: &str, _: &[u8]) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn resize_session(&self, _: &str, _: &str, _: u16, _: u16) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn apply_agent_settings(&self, _: &str, _: &AgentSettings) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+    }
+
+    /// Regression test: `attach_persistent_tab` must call `attach_session` on the
+    /// agent manager for remote-agent sessions so the DaemonClient reconnects and
+    /// sends a fresh buffer replay via the notification path.
+    ///
+    /// Without the fix, the DaemonClient could be stale and
+    /// `get_remote_session_buffer` would time out, leaving the new tab blank.
+    #[tokio::test]
+    async fn attach_persistent_tab_triggers_daemon_reattach_for_agent_session() {
+        let (spy, attach_calls) = SpyAgent::new();
+
+        let mut registry = ConnectionTypeRegistry::new();
+        registry.register(
+            "mock",
+            "Mock",
+            "mock",
+            Box::new(|| Box::new(MockConnection)),
+        );
+        let manager = SessionManager::new(registry, Arc::new(spy));
+        let emitter = MockPersistentEmitter::new();
+
+        let session_id = manager
+            .start_persistent_session(
+                "conn-1",
+                "mock",
+                serde_json::json!({}),
+                None,
+                emitter.clone(),
+            )
+            .await
+            .unwrap();
+
+        // Mark the session as agent-mediated.
+        {
+            let mut sessions = manager.sessions.lock().await;
+            let entry = sessions.get_mut(&session_id).unwrap();
+            entry.info.agent_id = Some("agent-1".to_string());
+            entry.remote_session_id = Some("remote-1".to_string());
+        }
+
+        manager
+            .attach_persistent_tab("conn-1", "tab-1", emitter.clone())
+            .await
+            .unwrap();
+
+        // spawn_blocking runs in a separate thread; give it a moment.
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        let calls = attach_calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "attach_session must be called once for agent sessions"
+        );
+        assert_eq!(calls[0].0, "agent-1");
+        assert_eq!(calls[0].1, "remote-1");
+    }
+
+    /// Regression: `attach_persistent_tab` must NOT call `attach_session` for
+    /// local (non-agent) sessions where there is no agent_id or remote_session_id.
+    #[tokio::test]
+    async fn attach_persistent_tab_skips_daemon_reattach_for_local_session() {
+        // NullAgent.attach_session panics (unimplemented!), so if it were called
+        // by the local-session path this test would fail.
+        let manager = make_test_manager();
+        let emitter = MockPersistentEmitter::new();
+
+        manager
+            .start_persistent_session(
+                "conn-local",
+                "mock",
+                serde_json::json!({}),
+                None,
+                emitter.clone(),
+            )
+            .await
+            .unwrap();
+
+        // Should succeed without panicking (no attach_session call).
+        manager
+            .attach_persistent_tab("conn-local", "tab-1", emitter.clone())
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        // No assertion needed: if NullAgent.attach_session were called it would panic.
+    }
+
     /// Tauri events are consumed by the TypeScript frontend which uses snake_case
     /// property names in the payload interface.  Verify that `SessionMonitoringStatsEvent`
     /// serialises `session_id` as `session_id` (not `sessionId`) so the frontend's

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -641,7 +641,7 @@ impl SessionManager {
         tab_id: &str,
         emitter: E,
     ) -> Result<u32, TerminalError> {
-        let count = {
+        let (count, session_id) = {
             let mut ps = self.persistent_sessions.lock().await;
             let record = ps.get_mut(connection_id).ok_or_else(|| {
                 TerminalError::SessionNotFound(format!(
@@ -659,21 +659,42 @@ impl SessionManager {
                 }
             }
             record.attached_tabs.insert(tab_id.to_string());
-            record.attached_tabs.len() as u32
+            (record.attached_tabs.len() as u32, record.session_id.clone())
         };
 
-        let (sid, state) = {
-            let ps = self.persistent_sessions.lock().await;
-            let record = ps.get(connection_id).unwrap();
-            (
-                record.session_id.clone(),
-                if count > 0 { "attached" } else { "running" }.to_string(),
-            )
+        // Kick off a background reconnect of the DaemonClient so the daemon sends a
+        // fresh buffer replay as a connection.output notification. The new tab's
+        // Terminal component receives the scrollback when it calls subscribeOutput,
+        // which flushes pendingOutput — even when the DaemonClient went stale.
+        let agent_info = {
+            let sessions = self.sessions.lock().await;
+            sessions.get(&session_id).and_then(|e| {
+                e.info
+                    .agent_id
+                    .as_deref()
+                    .zip(e.remote_session_id.as_deref())
+                    .map(|(aid, rsid)| (aid.to_string(), rsid.to_string()))
+            })
         };
+        if let Some((agent_id, remote_sid)) = agent_info {
+            let am = self.agent_manager.clone();
+            // Detached task — the JoinHandle is intentionally dropped here so
+            // attach_persistent_tab returns immediately without waiting for the SSH
+            // round-trip. Dropping a tokio JoinHandle does not cancel the task.
+            let _reattach = tokio::task::spawn_blocking(move || {
+                if let Err(e) = am.attach_session(&agent_id, &remote_sid) {
+                    warn!(
+                        error = %e,
+                        "attach_persistent_tab: daemon client reattach failed"
+                    );
+                }
+            });
+        }
 
+        let state = if count > 0 { "attached" } else { "running" }.to_string();
         emitter.emit_persistent_state(&PersistentSessionStateEvent {
             connection_id: connection_id.to_string(),
-            session_id: Some(sid),
+            session_id: Some(session_id),
             state,
             attached_tab_count: count,
             error_message: None,

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -12,7 +12,6 @@ import {
   resizeTerminal,
   closeTerminal,
   detachPersistentTab,
-  getAgentSessionBuffer,
 } from "@/services/api";
 import { terminalDispatcher } from "@/services/events";
 import { useTerminalRegistry } from "./TerminalRegistry";
@@ -228,18 +227,16 @@ export function Terminal({
         let sessionId: string;
         if (initialSessionIdRef.current) {
           sessionId = initialSessionIdRef.current;
-          // For persistent re-attach, replay buffered output before subscribing
-          // to live events so the scrollback is visible from the start.
+          // Buffer replay for persistent re-attach arrives via the
+          // connection.output notification path triggered by attach_persistent_tab
+          // on the backend (DaemonClient reconnect). subscribeOutput below will
+          // flush any replay already in pendingOutput, or deliver it directly
+          // when it arrives. No direct pull here to avoid racing with the
+          // notification and displaying content twice.
           if (persistentConnectionId) {
-            try {
-              const buf = await getAgentSessionBuffer(sessionId);
-              if (buf.length > 0) {
-                xterm.write(buf);
-              }
-            } catch {
-              // Non-fatal: continue without replay if fetch fails.
-            }
+            frontendLog("terminal", `Reattaching persistent session ${sessionId}`);
           }
+          if (isCanceled()) return;
         } else {
           let attempt = 0;
           let resolved: string | null = null;

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -29,11 +29,14 @@ vi.mock("@/services/api", () => ({
   sftpListDir: vi.fn(),
   localListDir: vi.fn(),
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  attachPersistentTab: vi.fn(() => Promise.resolve(1)),
 }));
 
 import { useAppStore } from "./appStore";
 import type { LeafPanel } from "@/types/terminal";
 import { findLeaf, getAllLeaves } from "@/utils/panelTree";
+import * as api from "@/services/api";
+import type { AgentDefinitionInfo } from "@/services/api";
 
 describe("appStore", () => {
   beforeEach(() => {
@@ -411,6 +414,64 @@ describe("appStore", () => {
       const leaves = getAllLeaves(state.rootPanel);
       const logTabs = leaves.flatMap((l) => l.tabs).filter((t) => t.contentType === "log-viewer");
       expect(logTabs).toHaveLength(1);
+    });
+  });
+
+  describe("attachAgentPersistentSession", () => {
+    const def: AgentDefinitionInfo = {
+      id: "conn1",
+      name: "Test Shell",
+      sessionType: "local",
+      config: {},
+      persistent: true,
+      folderId: null,
+    };
+
+    beforeEach(() => {
+      // Seed a running persistent session so the attach path can proceed.
+      useAppStore.setState({
+        persistentSessions: {
+          "agent1:conn1": {
+            connectionId: "agent1:conn1",
+            sessionId: "session-1",
+            state: "running",
+            attachedTabIds: [],
+          },
+        },
+      });
+    });
+
+    it("removes the tab when attach_persistent_tab fails (regression: no blank terminal)", async () => {
+      vi.mocked(api.attachPersistentTab).mockRejectedValueOnce(
+        new Error("Session no longer alive")
+      );
+
+      const tabsBefore = getAllLeaves(useAppStore.getState().rootPanel).flatMap(
+        (l) => l.tabs
+      ).length;
+
+      await useAppStore.getState().attachAgentPersistentSession("agent1", def);
+
+      const tabsAfter = getAllLeaves(useAppStore.getState().rootPanel).flatMap(
+        (l) => l.tabs
+      ).length;
+      // The broken tab must have been removed — net tab count unchanged.
+      expect(tabsAfter).toBe(tabsBefore);
+    });
+
+    it("keeps the tab when attach_persistent_tab succeeds", async () => {
+      vi.mocked(api.attachPersistentTab).mockResolvedValueOnce(1);
+
+      const tabsBefore = getAllLeaves(useAppStore.getState().rootPanel).flatMap(
+        (l) => l.tabs
+      ).length;
+
+      await useAppStore.getState().attachAgentPersistentSession("agent1", def);
+
+      const tabsAfter = getAllLeaves(useAppStore.getState().rootPanel).flatMap(
+        (l) => l.tabs
+      ).length;
+      expect(tabsAfter).toBe(tabsBefore + 1);
     });
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1198,6 +1198,8 @@ export const useAppStore = create<AppState>((set, get) => {
         entry.sessionId,
         connectionId
       );
+      // Resolve the actual panel the tab landed in so we can close it on failure.
+      const actualPanelId = findLeafByTab(get().rootPanel, tabId)?.id;
       try {
         await apiAttachPersistentTab(connectionId, tabId);
         set((state) => {
@@ -1218,6 +1220,10 @@ export const useAppStore = create<AppState>((set, get) => {
           "app_store",
           `attach_persistent_tab failed for ${connectionId}: ${err instanceof Error ? err.message : String(err)}`
         );
+        // Session is gone — remove the tab so the user does not see a blank terminal.
+        if (actualPanelId) {
+          get().closeTab(tabId, actualPanelId);
+        }
       }
     },
 


### PR DESCRIPTION
## Summary

- **Stale DaemonClient on re-attach**: `attach_persistent_tab` now calls `agent_manager.attach_session` in a `spawn_blocking` task so the DaemonClient reconnects and the daemon replays the ring buffer as a `connection.output` notification. The new tab receives scrollback through the existing notification/`subscribeOutput` path.
- **Double-content race eliminated**: Removed the `getAgentSessionBuffer` direct-pull call from `Terminal.tsx`; buffer replay now arrives exclusively via the notification path, avoiding the race where content was delivered twice (or not at all when the pull timed out on a stale connection).
- **Dead session leaves no blank tab**: If `apiAttachPersistentTab` rejects (session already gone), `attachAgentPersistentSession` in `appStore.ts` now closes the placeholder tab immediately instead of leaving a blank, unresponsive terminal.

## Test plan

- [ ] Regression tests pass (`./scripts/test.sh`): `SpyAgent` + 2 Rust tests in `manager.rs`, 2 frontend tests in `appStore.test.ts`
- [ ] Manual: connect to a remote persistent session (agent), type some output, close the tab, click "Attach new tab" — scrollback should replay and new input should work
- [ ] Manual: start a persistent session, stop the agent process (kill daemon), click "Attach new tab" — tab should be removed rather than showing a blank terminal
- [ ] Manual: local persistent session (no agent) re-attach continues to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)