### PR TITLE
fix(ui): set color-scheme on root so WebKit renders scrollbars in theme mode

### DIFF
--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -4,6 +4,7 @@ import { ThemeDefinition } from "./types";
 export const darkTheme: ThemeDefinition = {
   id: "dark",
   name: "Dark",
+  colorScheme: "dark",
   colors: {
     // Backgrounds
     bgPrimary: "#1e1e1e",

--- a/src/themes/engine.ts
+++ b/src/themes/engine.ts
@@ -98,12 +98,15 @@ function resolveTheme(setting: string | undefined): ThemeDefinition {
 }
 
 /** Write all theme colors as CSS custom properties on the document root. */
-function setCssVariables(colors: ThemeColors): void {
+function setCssVariables(theme: ThemeDefinition): void {
   if (typeof document === "undefined") return;
   const root = document.documentElement;
   for (const [key, cssVar] of Object.entries(COLOR_TO_CSS_VAR)) {
-    root.style.setProperty(cssVar, colors[key as keyof ThemeColors]);
+    root.style.setProperty(cssVar, theme.colors[key as keyof ThemeColors]);
   }
+  // Tell WebKit which color scheme is active so system UI elements (scrollbars,
+  // form controls) render in the matching dark/light style.
+  root.style.colorScheme = theme.colorScheme;
 }
 
 /** Remove the current matchMedia listener if one exists. */
@@ -124,13 +127,13 @@ function removeMediaListener(): void {
 export function applyTheme(setting: string | undefined): void {
   removeMediaListener();
   currentTheme = resolveTheme(setting);
-  setCssVariables(currentTheme.colors);
+  setCssVariables(currentTheme);
 
   if (setting === "system" && typeof window !== "undefined") {
     mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     mediaListener = ((e: MediaQueryListEvent) => {
       currentTheme = e.matches ? darkTheme : lightTheme;
-      setCssVariables(currentTheme.colors);
+      setCssVariables(currentTheme);
       for (const cb of changeCallbacks) cb();
     }) as EventListener;
     mediaQuery.addEventListener("change", mediaListener);

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -4,6 +4,7 @@ import { ThemeDefinition } from "./types";
 export const lightTheme: ThemeDefinition = {
   id: "light",
   name: "Light",
+  colorScheme: "light",
   colors: {
     // Backgrounds
     bgPrimary: "#ffffff",

--- a/src/themes/solarized-dark.ts
+++ b/src/themes/solarized-dark.ts
@@ -4,6 +4,7 @@ import { ThemeDefinition } from "./types";
 export const solarizedDarkTheme: ThemeDefinition = {
   id: "solarized-dark",
   name: "Solarized Dark",
+  colorScheme: "dark",
   colors: {
     // Backgrounds — derived from the Solarized base0x monotone ramp
     bgPrimary: "#002b36", // base03

--- a/src/themes/solarized-light.ts
+++ b/src/themes/solarized-light.ts
@@ -4,6 +4,7 @@ import { ThemeDefinition } from "./types";
 export const solarizedLightTheme: ThemeDefinition = {
   id: "solarized-light",
   name: "Solarized Light",
+  colorScheme: "light",
   colors: {
     // Backgrounds — derived from the Solarized base0x monotone ramp
     bgPrimary: "#fdf6e3", // base3

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -84,5 +84,7 @@ export interface ThemeColors {
 export interface ThemeDefinition {
   id: string;
   name: string;
+  /** Controls the CSS `color-scheme` property so WebKit renders system UI (scrollbars, inputs) in the matching mode. */
+  colorScheme: "dark" | "light";
   colors: ThemeColors;
 }


### PR DESCRIPTION
## Summary

- Adds `colorScheme: "dark" | "light"` to `ThemeDefinition`
- Applies `document.documentElement.style.colorScheme` in `applyTheme` / `setCssVariables` so WebKit knows which mode is active
- Annotates all four built-in themes with the correct value

## Root cause

WebKit (WKWebView used by Tauri on macOS) uses the CSS `color-scheme` property to decide how to render system UI elements — scrollbars, form controls, selection highlights — that aren't fully covered by custom CSS. Without it, WebKit falls back to the OS system appearance. When the OS is in light mode but the app is in dark theme, scrollbars rendered white/light-grey instead of matching the theme.

The custom `::-webkit-scrollbar` CSS in `global.css` sets the thumb colour correctly, but `color-scheme` also controls the scrollbar *track* and system-level overlay scrollbars on macOS, so both are needed.

## Test plan

- [ ] Launch the app in dark theme on macOS — scrollbars should be dark-tinted, not white
- [ ] Switch to light theme — scrollbars should be light
- [ ] Switch to Solarized Dark / Solarized Light — scrollbars match each theme
- [ ] Verify on Windows/Linux — no regression (setting `color-scheme` is a no-op for non-WebKit renderers that already respect custom scrollbar CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)