### PR TITLE
fix(ci): replace hardcoded --platform=linux/amd64 with $BUILDPLATFORM in agent Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Settings: "Updates" and "About" are no longer sub-tabs inside the Settings panel. They are now direct entries in the settings gear dropdown menu and open in a focused overlay panel instead.
 - CI: upgraded `docker/setup-buildx-action` from v3 to v4 and `docker/build-push-action` from v5 to v7 (Node.js 24); upgraded `pnpm/action-setup` from v5 to v6; upgraded CI Node.js version from 20 to 22 (LTS) — eliminates all "Node.js 20 actions are deprecated" warnings in GitHub Actions runs.
+- CI: replaced hardcoded `--platform=linux/amd64` with `--platform=$BUILDPLATFORM` in all three agent cross-compilation Dockerfiles — eliminates `FromPlatformFlagConstDisallowed` Docker lint warnings.
 
 ### Added
 

--- a/agent/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/agent/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
+FROM --platform=$BUILDPLATFORM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
 
 ARG OPENSSL_VERSION=3.3.2
 

--- a/agent/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/agent/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main
+FROM --platform=$BUILDPLATFORM ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main
 
 ARG OPENSSL_VERSION=3.3.2
 

--- a/agent/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/agent/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
+FROM --platform=$BUILDPLATFORM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
 
 ARG OPENSSL_VERSION=3.3.2
 


### PR DESCRIPTION
## Summary

- Replaces `--platform=linux/amd64` with `--platform=$BUILDPLATFORM` in all three agent cross-compilation Dockerfiles (`aarch64-unknown-linux-musl`, `armv7-unknown-linux-musleabihf`, `x86_64-unknown-linux-musl`)
- `$BUILDPLATFORM` is a predefined Docker ARG that resolves to the builder's native platform — semantically equivalent on amd64 CI runners, but without triggering the `FromPlatformFlagConstDisallowed` lint warning

## Test plan

- [ ] CI agent Docker image builds pass without `FromPlatformFlagConstDisallowed` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)