### PR TITLE
fix(connection): prevent connection resurrection in multi-instance import and move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Connections: importing a backup file or moving a connection to another file in one instance no longer resurrects connections that were deleted by a parallel running instance. Previously `import_json`, `import_encrypted_json`, and `move_connection_to_file` each wrote back to disk without first re-reading the current file state, causing deleted connections to reappear after the other instance restarted.
 - Connections sidebar: deleting multiple selected connections now removes all of them instead of only the one that was right-clicked.
 - Connections: changes made in one running instance (add, delete, rename) now propagate to all other running instances within ~1 second. Previously, other instances only updated on window focus.
 - Persistent sessions: "Attach new tab" no longer shows a blank terminal with no overlay. The backend now triggers a DaemonClient reconnect on attach so the scrollback buffer arrives via the notification path; if the session has already died, the placeholder tab is automatically removed instead of left in a broken state.

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -1608,4 +1608,172 @@ mod tests {
             "reorder_agents must not resurrect connections deleted by another instance; got: {names:?}"
         );
     }
+
+    // Regression: import_json did not call sync_from_disk before merging and saving.
+    // A stale instance could resurrect connections that were deleted by the active
+    // instance simply by running an import (e.g., the user imports a backup file).
+    #[test]
+    fn import_json_does_not_resurrect_connection_deleted_by_another_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_store = Arc::new(MockStore::new());
+
+        let make_conn = |name: &str| SavedConnection {
+            id: name.to_string(),
+            name: name.to_string(),
+            config: ConnectionConfig {
+                type_id: "local".to_string(),
+                settings: serde_json::json!({"shell": "bash"}),
+            },
+            folder_id: None,
+            terminal_options: None,
+            source_file: None,
+        };
+
+        // Populate with a connection, then drop the setup instance.
+        let setup = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        setup.save_connection(make_conn("Old Connection")).unwrap();
+        drop(setup);
+
+        // "Instance B" (stale) loads ["Old Connection"] into its in-memory store.
+        let instance_b = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+
+        // "Instance A" deletes "Old Connection" — disk is now empty.
+        let instance_a = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        instance_a.delete_connection("Old Connection").unwrap();
+        drop(instance_a);
+
+        // Instance B imports JSON (e.g., the user imports a backup file).
+        // Without sync_from_disk, instance_b would merge the import on top of its
+        // stale in-memory state and write ["Old Connection", "Imported"] back to disk.
+        let import_json = r#"{
+            "version": "2",
+            "children": [
+                {"type": "connection", "name": "Imported",
+                 "config": {"type": "local", "config": {"shell": "bash"}}}
+            ],
+            "agents": []
+        }"#;
+        instance_b.import_json(import_json).unwrap();
+
+        let all = instance_b.get_all().unwrap();
+        let names: Vec<&str> = all.connections.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            !names.contains(&"Old Connection"),
+            "import_json must not resurrect connections deleted by another instance; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"Imported"),
+            "imported connection must be present; got: {names:?}"
+        );
+    }
+
+    // Regression: import_encrypted_json did not call sync_from_disk before merging
+    // and saving.  Same resurrection hazard as import_json, triggered via encrypted
+    // import (e.g., the user restores from an encrypted backup).
+    #[test]
+    fn import_encrypted_json_does_not_resurrect_connection_deleted_by_another_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_store = Arc::new(MockStore::new());
+
+        let make_conn = |name: &str| SavedConnection {
+            id: name.to_string(),
+            name: name.to_string(),
+            config: ConnectionConfig {
+                type_id: "local".to_string(),
+                settings: serde_json::json!({"shell": "bash"}),
+            },
+            folder_id: None,
+            terminal_options: None,
+            source_file: None,
+        };
+
+        let setup = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        setup.save_connection(make_conn("Old Connection")).unwrap();
+        drop(setup);
+
+        let instance_b = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+
+        let instance_a = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        instance_a.delete_connection("Old Connection").unwrap();
+        drop(instance_a);
+
+        // Import via the encrypted path (no actual encryption — password is None).
+        // Without sync_from_disk, instance_b writes its stale state plus the import.
+        let import_json = r#"{
+            "version": "2",
+            "children": [
+                {"type": "connection", "name": "Imported Enc",
+                 "config": {"type": "local", "config": {"shell": "bash"}}}
+            ],
+            "agents": []
+        }"#;
+        instance_b.import_encrypted_json(import_json, None).unwrap();
+
+        let all = instance_b.get_all().unwrap();
+        let names: Vec<&str> = all.connections.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            !names.contains(&"Old Connection"),
+            "import_encrypted_json must not resurrect connections deleted by another instance; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"Imported Enc"),
+            "imported connection must be present; got: {names:?}"
+        );
+    }
+
+    // Regression: move_connection_to_file did not call sync_from_disk before
+    // removing the connection from (or adding it to) the main store.  A stale
+    // instance executing a drag-to-file move could resurrect connections that the
+    // active instance had already deleted.
+    #[test]
+    fn move_connection_to_file_does_not_resurrect_connection_deleted_by_another_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let cred_store = Arc::new(MockStore::new());
+
+        let make_conn = |name: &str| SavedConnection {
+            id: name.to_string(),
+            name: name.to_string(),
+            config: ConnectionConfig {
+                type_id: "local".to_string(),
+                settings: serde_json::json!({"shell": "bash"}),
+            },
+            folder_id: None,
+            terminal_options: None,
+            source_file: None,
+        };
+
+        // Populate with two connections.
+        let setup = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        setup.save_connection(make_conn("Connection A")).unwrap();
+        setup.save_connection(make_conn("Connection B")).unwrap();
+        drop(setup);
+
+        // "Instance B" (stale) loads ["Connection A", "Connection B"] into memory.
+        let instance_b = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+
+        // "Instance A" deletes "Connection B" — disk now has only ["Connection A"].
+        let instance_a = ConnectionManager::new_for_test(dir.path(), cred_store.clone()).unwrap();
+        instance_a.delete_connection("Connection B").unwrap();
+        drop(instance_a);
+
+        // Instance B moves "Connection A" from main to main (a round-trip move, e.g.,
+        // triggered by drag-and-drop back to the default location).
+        // Without sync_from_disk in step 1, it removes "Connection A" from its stale
+        // store {A, B} → leaves {B} → writes {B} (resurrects "Connection B").
+        // Step 2 then pushes "Connection A" back → {B, A} is written to disk.
+        instance_b
+            .move_connection_to_file("Connection A", None, None)
+            .unwrap();
+
+        let all = instance_b.get_all().unwrap();
+        let names: Vec<&str> = all.connections.iter().map(|c| c.name.as_str()).collect();
+        assert!(
+            !names.contains(&"Connection B"),
+            "move_connection_to_file must not resurrect connections deleted by another instance; got: {names:?}"
+        );
+        assert!(
+            names.contains(&"Connection A"),
+            "Connection A must still be present after the move; got: {names:?}"
+        );
+    }
 }

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -488,6 +488,7 @@ impl ConnectionManager {
         let count = imported_conns.len();
 
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
 
         // Merge: add imported folders that don't already exist (by name path)
         for folder in imported_folders {
@@ -705,6 +706,7 @@ impl ConnectionManager {
 
         // Merge connections, folders, and agents
         let mut store = self.store.lock().unwrap();
+        self.sync_from_disk(&mut store);
 
         for folder in imported_folders {
             if !store.folders.iter().any(|f| f.id == folder.id) {
@@ -757,6 +759,7 @@ impl ConnectionManager {
         let mut connection = match current_source {
             None => {
                 let mut store = self.store.lock().unwrap();
+                self.sync_from_disk(&mut store);
                 let idx = store
                     .connections
                     .iter()
@@ -779,6 +782,7 @@ impl ConnectionManager {
                     prepare_for_storage(connection.clone(), &*self.credential_store)?;
                 disk_conn.source_file = None;
                 let mut store = self.store.lock().unwrap();
+                self.sync_from_disk(&mut store);
                 store.connections.push(disk_conn);
                 self.storage
                     .save_flat(&store)

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -32,16 +32,24 @@ vi.mock("@/services/api", () => ({
   attachPersistentTab: vi.fn(() => Promise.resolve(1)),
 }));
 
-import { useAppStore } from "./appStore";
+import { useAppStore, _resetConnectionReloadSeq } from "./appStore";
 import type { LeafPanel } from "@/types/terminal";
 import { findLeaf, getAllLeaves } from "@/utils/panelTree";
 import * as api from "@/services/api";
+import * as storage from "@/services/storage";
 import type { AgentDefinitionInfo } from "@/services/api";
+
+/** Flush all pending microtasks so `void promise` side-effects settle. */
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 describe("appStore", () => {
   beforeEach(() => {
     // Reset store state by getting a fresh initial state
     useAppStore.setState(useAppStore.getInitialState());
+    // Reset the reload sequencer so sequence numbers don't bleed between tests
+    _resetConnectionReloadSeq();
   });
 
   describe("addTab", () => {
@@ -472,6 +480,90 @@ describe("appStore", () => {
         (l) => l.tabs
       ).length;
       expect(tabsAfter).toBe(tabsBefore + 1);
+    });
+  });
+
+  // Cross-instance connection propagation: when connections.json changes in
+  // another running instance the backend emits "connections-changed", which
+  // triggers reloadConnectionsFromBackend().  These tests verify the reload
+  // mechanism correctly replaces the in-store list with whatever the backend
+  // returns, and that the sequence guard prevents a stale in-flight reload from
+  // overwriting a fresher one that has already been applied.
+  describe("reloadConnectionsFromBackend", () => {
+    const makeConn = (id: string, name: string) => ({
+      id,
+      name,
+      config: { typeId: "local", settings: { shell: "bash" } },
+      folderId: null,
+      terminalOptions: null,
+      sourceFile: null,
+    });
+
+    it("replaces store connections with the fresh list returned by the backend", async () => {
+      // Seed stale in-store state that includes a connection deleted in another instance.
+      useAppStore.setState({
+        connections: [makeConn("conn-deleted", "Deleted Connection")],
+      } as Parameters<typeof useAppStore.setState>[0]);
+
+      // Backend returns a list without the deleted connection.
+      vi.mocked(storage.loadConnections).mockResolvedValueOnce({
+        connections: [makeConn("conn-kept", "Kept Connection")],
+        folders: [],
+        agents: [],
+        externalErrors: [],
+      });
+
+      useAppStore.getState().reloadConnectionsFromBackend();
+      await flushPromises();
+
+      const { connections } = useAppStore.getState();
+      const names = connections.map((c) => c.name);
+      expect(names).not.toContain("Deleted Connection");
+      expect(names).toContain("Kept Connection");
+    });
+
+    it("sequence guard drops a stale in-flight reload when a newer one already applied", async () => {
+      let resolveStale!: (v: Awaited<ReturnType<typeof storage.loadConnections>>) => void;
+      let resolveFresh!: (v: Awaited<ReturnType<typeof storage.loadConnections>>) => void;
+
+      // seq 1: stale data (the old list with the deleted connection)
+      vi.mocked(storage.loadConnections).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveStale = r;
+        })
+      );
+      // seq 2: fresh data (deleted connection removed)
+      vi.mocked(storage.loadConnections).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFresh = r;
+        })
+      );
+
+      useAppStore.getState().reloadConnectionsFromBackend(); // seq 1
+      useAppStore.getState().reloadConnectionsFromBackend(); // seq 2
+
+      // Resolve seq 2 FIRST — its result must be applied.
+      resolveFresh({
+        connections: [makeConn("conn-fresh", "Fresh Connection")],
+        folders: [],
+        agents: [],
+        externalErrors: [],
+      });
+      await flushPromises();
+
+      // Resolve seq 1 SECOND — its stale result must be dropped.
+      resolveStale({
+        connections: [makeConn("conn-stale", "Stale Connection")],
+        folders: [],
+        agents: [],
+        externalErrors: [],
+      });
+      await flushPromises();
+
+      const { connections } = useAppStore.getState();
+      const names = connections.map((c) => c.name);
+      expect(names).toContain("Fresh Connection");
+      expect(names).not.toContain("Stale Connection");
     });
   });
 });

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -493,17 +493,14 @@ describe("appStore", () => {
     const makeConn = (id: string, name: string) => ({
       id,
       name,
-      config: { typeId: "local", settings: { shell: "bash" } },
+      config: { type: "local", config: { shell: "bash" } },
       folderId: null,
-      terminalOptions: null,
       sourceFile: null,
     });
 
     it("replaces store connections with the fresh list returned by the backend", async () => {
       // Seed stale in-store state that includes a connection deleted in another instance.
-      useAppStore.setState({
-        connections: [makeConn("conn-deleted", "Deleted Connection")],
-      } as Parameters<typeof useAppStore.setState>[0]);
+      useAppStore.setState({ connections: [makeConn("conn-deleted", "Deleted Connection")] });
 
       // Backend returns a list without the deleted connection.
       vi.mocked(storage.loadConnections).mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

- Three write operations — `import_json`, `import_encrypted_json`, and `move_connection_to_file` — were missing a `sync_from_disk()` call before mutating the in-memory store and writing `connections.json`. A stale parallel instance could therefore resurrect connections that a second instance had just deleted, because the stale instance bundled its old in-memory list back to disk.
- Added `sync_from_disk(&mut store)` immediately after each lock acquisition in the affected methods, matching the pattern already used by every other write operation (`save_connection`, `delete_connection`, `save_folder`, `reorder_agents`, `update_agent_settings`, etc.).
- Added two frontend regression tests confirming that `reloadConnectionsFromBackend` correctly replaces the Zustand store with fresh backend data, and that the sequence guard discards stale in-flight reloads when a newer one has already been applied.

## Root cause

When two instances of termiHub share the same `connections.json`:

1. Both start → both load `{A, B, C}` into their in-memory stores.
2. Instance B deletes `C` → writes `{A, B}` to disk.
3. Instance A's 1-second mtime poller detects the change and reloads correctly for most paths — but if Instance A then runs an **import** or **move-to-file** operation, it skips the disk re-read and writes its stale `{A, B, C}` list back to disk, resurrecting `C`.
4. When Instance B restarts and re-reads the file, `C` is back.

## Test plan

- All three new Rust regression tests (`import_json_does_not_resurrect_*`, `import_encrypted_json_does_not_resurrect_*`, `move_connection_to_file_does_not_resurrect_*`) were written first (TDD — red phase), confirmed failing, then the fix made them pass (green phase).
- The two new frontend tests (`reloadConnectionsFromBackend` suite) pass, verifying the propagation path and sequence guard.
- Full test suite passes (`./scripts/test.sh` — ALL TESTS PASSED).
- All quality checks pass (`./scripts/check.sh` — ALL CHECKS PASSED).

### Manual test steps

1. Open two instances of termiHub pointing at the same config directory.
2. In **Instance B**, delete one or more connections.
3. In **Instance A**, perform an import (`File → Import Connections`) using any valid export file.
4. Verify the deleted connections do **not** reappear in either instance.
5. Restart Instance B — verify the deleted connections are still gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)