### PR TITLE
fix(terminal): persistent session reattach — show overlay and detect dead session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connections: changes made in one running instance (add, delete, rename) now propagate to all other running instances within ~1 second. Previously, other instances only updated on window focus.
 - Persistent sessions: "Attach new tab" now correctly restores the terminal scrollback. The frontend explicitly fetches the ring-buffer snapshot from the agent on reattach, resets xterm, and writes the snapshot before subscribing to live output — ensuring the cached history is always visible and never raced by live events. A "Restoring session…" spinner overlay is shown during the fetch.
 - Persistent sessions: "Attach new tab" no longer shows a blank terminal with no overlay. The backend now triggers a DaemonClient reconnect on attach so the scrollback buffer arrives via the notification path; if the session has already died, the placeholder tab is automatically removed instead of left in a broken state.
+- Persistent sessions: "Restoring session…" overlay is now correctly displayed while the scrollback buffer is being fetched on reattach. The SplitView rendering condition was missing the `terminalReattaching` flag, so the overlay was never shown and the terminal appeared blank and non-interactive during the fetch window.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persistent sessions: "Attach new tab" now correctly restores the terminal scrollback. The frontend explicitly fetches the ring-buffer snapshot from the agent on reattach, resets xterm, and writes the snapshot before subscribing to live output — ensuring the cached history is always visible and never raced by live events. A "Restoring session…" spinner overlay is shown during the fetch.
 - Persistent sessions: "Attach new tab" no longer shows a blank terminal with no overlay. The backend now triggers a DaemonClient reconnect on attach so the scrollback buffer arrives via the notification path; if the session has already died, the placeholder tab is automatically removed instead of left in a broken state.
 - Persistent sessions: "Restoring session…" overlay is now correctly displayed while the scrollback buffer is being fetched on reattach. The SplitView rendering condition was missing the `terminalReattaching` flag, so the overlay was never shown and the terminal appeared blank and non-interactive during the fetch window.
+- Persistent sessions: after reattaching to a session whose shell had already exited (e.g. crash while the tab was closed), the terminal now shows "[Process exited]" instead of appearing interactive but silently dropping all input. The fix buffers the `terminal-exit` event in the frontend dispatcher so it is delivered even if it fires before the reattaching tab subscribes.
 
 ### Changed
 

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -73,6 +73,7 @@ export function SplitView() {
   const terminalConnecting = useAppStore((s) => s.terminalConnecting);
   const terminalAutoRetryCountZoom = useAppStore((s) => s.terminalAutoRetryCount);
   const terminalWaitingForAgentZoom = useAppStore((s) => s.terminalWaitingForAgent);
+  const terminalReattachingZoom = useAppStore((s) => s.terminalReattaching);
   const tabHorizontalScrollingZoom = useAppStore((s) => s.tabHorizontalScrolling);
   const setTabHorizontalScrollingZoom = useAppStore((s) => s.setTabHorizontalScrolling);
   const tabColorsZoom = useAppStore((s) => s.tabColors);
@@ -364,7 +365,8 @@ export function SplitView() {
               (terminalSpawnErrors[zoomedTabId] ||
                 terminalConnecting[zoomedTabId] ||
                 (terminalAutoRetryCountZoom[zoomedTabId] ?? 0) > 0 ||
-                !!terminalWaitingForAgentZoom[zoomedTabId]) ? (
+                !!terminalWaitingForAgentZoom[zoomedTabId] ||
+                !!terminalReattachingZoom[zoomedTabId]) ? (
                 <TerminalConnectionOverlay
                   key={`zoom-${zoomedTabId}`}
                   tabId={zoomedTabId}
@@ -539,6 +541,7 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
   const terminalConnecting = useAppStore((s) => s.terminalConnecting);
   const terminalAutoRetryCount = useAppStore((s) => s.terminalAutoRetryCount);
   const terminalWaitingForAgent = useAppStore((s) => s.terminalWaitingForAgent);
+  const terminalReattaching = useAppStore((s) => s.terminalReattaching);
   const rightClickBehavior = useAppStore((s) => s.settings.rightClickBehavior);
   const useQuickAction =
     rightClickBehavior === "quickAction" || (!rightClickBehavior && isWindows());
@@ -653,7 +656,8 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
             (terminalSpawnErrors[tab.id] ||
               terminalConnecting[tab.id] ||
               (terminalAutoRetryCount[tab.id] ?? 0) > 0 ||
-              !!terminalWaitingForAgent[tab.id]) ? (
+              !!terminalWaitingForAgent[tab.id] ||
+              !!terminalReattaching[tab.id]) ? (
             <TerminalConnectionOverlay
               key={tab.id}
               tabId={tab.id}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -231,6 +231,12 @@ export function Terminal({
           if (persistentConnectionId) {
             // Show the reattaching overlay while we fetch and replay the scrollback buffer.
             useAppStore.getState().setTerminalReattaching(tabId, true);
+            // Clear any exit that arrived for this session before we subscribed.
+            // This prevents a stale exit from a previous attachment (e.g. temporary
+            // agent-connection drop that was since recovered) from firing as "[Process
+            // exited]" on the new tab.  Any exit that fires AFTER this point will be
+            // buffered and delivered when subscribeExit is called below.
+            terminalDispatcher.clearPendingExit(sessionId);
             frontendLog("terminal", `Reattaching persistent session ${sessionId}, fetching buffer`);
             try {
               const buffer = await getAgentSessionBuffer(sessionId);

--- a/src/services/events.test.ts
+++ b/src/services/events.test.ts
@@ -372,7 +372,111 @@ describe("events service", () => {
       expect(cb).toHaveBeenCalledTimes(2);
     });
 
-    it("does not buffer output for sessions that already have a subscriber", async () => {
+    it("buffers exit event for sessions with no subscriber", async () => {
+      const handlers: Record<string, (event: unknown) => void> = {};
+      mockedListen.mockImplementation((eventName, handler) => {
+        handlers[eventName as string] = handler as (event: unknown) => void;
+        return Promise.resolve(vi.fn());
+      });
+
+      await dispatcher.init();
+
+      // Fire exit before any subscriber — should not throw
+      handlers["terminal-exit"]({
+        payload: { session_id: "sess-unsubbed", exit_code: 1 },
+      });
+    });
+
+    it("delivers buffered exit when subscriber registers after exit fired", async () => {
+      const handlers: Record<string, (event: unknown) => void> = {};
+      mockedListen.mockImplementation((eventName, handler) => {
+        handlers[eventName as string] = handler as (event: unknown) => void;
+        return Promise.resolve(vi.fn());
+      });
+
+      await dispatcher.init();
+
+      // Fire exit BEFORE any subscriber
+      handlers["terminal-exit"]({
+        payload: { session_id: "sess-pre-exit", exit_code: 42 },
+      });
+
+      // Now subscribe — should receive the buffered exit immediately
+      const cb = vi.fn();
+      dispatcher.subscribeExit("sess-pre-exit", cb);
+
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith(42);
+    });
+
+    it("delivers buffered null exit code when exit_code is null", async () => {
+      const handlers: Record<string, (event: unknown) => void> = {};
+      mockedListen.mockImplementation((eventName, handler) => {
+        handlers[eventName as string] = handler as (event: unknown) => void;
+        return Promise.resolve(vi.fn());
+      });
+
+      await dispatcher.init();
+
+      handlers["terminal-exit"]({
+        payload: { session_id: "sess-null", exit_code: null },
+      });
+
+      const cb = vi.fn();
+      dispatcher.subscribeExit("sess-null", cb);
+
+      expect(cb).toHaveBeenCalledWith(null);
+    });
+
+    it("does not re-deliver buffered exit on a second subscribeExit call", async () => {
+      const handlers: Record<string, (event: unknown) => void> = {};
+      mockedListen.mockImplementation((eventName, handler) => {
+        handlers[eventName as string] = handler as (event: unknown) => void;
+        return Promise.resolve(vi.fn());
+      });
+
+      await dispatcher.init();
+
+      handlers["terminal-exit"]({
+        payload: { session_id: "sess-once", exit_code: 0 },
+      });
+
+      const cb1 = vi.fn();
+      dispatcher.subscribeExit("sess-once", cb1);
+      expect(cb1).toHaveBeenCalledTimes(1);
+
+      // Second subscriber for same session should NOT get the already-consumed exit
+      const cb2 = vi.fn();
+      dispatcher.subscribeExit("sess-once", cb2);
+      expect(cb2).not.toHaveBeenCalled();
+    });
+
+    it("clearPendingExit discards buffered exit so a subsequent subscriber does not see it", async () => {
+      const handlers: Record<string, (event: unknown) => void> = {};
+      mockedListen.mockImplementation((eventName, handler) => {
+        handlers[eventName as string] = handler as (event: unknown) => void;
+        return Promise.resolve(vi.fn());
+      });
+
+      await dispatcher.init();
+
+      handlers["terminal-exit"]({
+        payload: { session_id: "sess-cleared", exit_code: 5 },
+      });
+
+      dispatcher.clearPendingExit("sess-cleared");
+
+      const cb = vi.fn();
+      dispatcher.subscribeExit("sess-cleared", cb);
+
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("clearPendingExit does not affect other sessions", async () => {
+      expect(() => dispatcher.clearPendingExit("nonexistent-session")).not.toThrow();
+    });
+
+    it("does not buffer exit for sessions that already have a subscriber", async () => {
       const handlers: Record<string, (event: unknown) => void> = {};
       mockedListen.mockImplementation((eventName, handler) => {
         handlers[eventName as string] = handler as (event: unknown) => void;

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -64,6 +64,8 @@ export class TerminalOutputDispatcher {
   private agentStateCallbacks = new Map<string, (state: string) => void>();
   /** Buffer output for sessions whose subscriber hasn't registered yet. */
   private pendingOutput = new Map<string, Uint8Array[]>();
+  /** Buffer exit events for sessions whose subscriber hasn't registered yet. */
+  private pendingExit = new Map<string, number | null>();
   private unlistenOutput: UnlistenFn | null = null;
   private unlistenExit: UnlistenFn | null = null;
   private unlistenRemoteState: UnlistenFn | null = null;
@@ -117,8 +119,12 @@ export class TerminalOutputDispatcher {
     const unlistenExit = await listen<TerminalExitPayload>("terminal-exit", (event) => {
       const { session_id, exit_code } = event.payload;
       const cbs = this.exitCallbacks.get(session_id);
-      if (cbs) {
+      if (cbs && cbs.size > 0) {
         for (const cb of cbs) cb(exit_code);
+      } else {
+        // Buffer the exit for sessions whose subscriber hasn't registered yet
+        // (e.g. race between session death and tab reattach setup).
+        this.pendingExit.set(session_id, exit_code);
       }
     });
 
@@ -208,6 +214,12 @@ export class TerminalOutputDispatcher {
       this.exitCallbacks.set(sessionId, cbs);
     }
     cbs.add(callback);
+    // Fire any exit that arrived before this subscriber registered
+    if (this.pendingExit.has(sessionId)) {
+      const exitCode = this.pendingExit.get(sessionId)!;
+      this.pendingExit.delete(sessionId);
+      callback(exitCode);
+    }
     return () => {
       const set = this.exitCallbacks.get(sessionId);
       if (set) {
@@ -215,6 +227,11 @@ export class TerminalOutputDispatcher {
         if (set.size === 0) this.exitCallbacks.delete(sessionId);
       }
     };
+  }
+
+  /** Discard any buffered exit for a session (call at the start of a fresh reattach to clear stale exits). */
+  clearPendingExit(sessionId: string): void {
+    this.pendingExit.delete(sessionId);
   }
 
   /** Discard any buffered output for a session (call before writing cached buffer to avoid duplication). */
@@ -262,6 +279,7 @@ export class TerminalOutputDispatcher {
     this.remoteStateCallbacks.clear();
     this.agentStateCallbacks.clear();
     this.pendingOutput.clear();
+    this.pendingExit.clear();
     this.initPromise = null;
   }
 }


### PR DESCRIPTION
## Summary

**Fix 1 — Overlay never shown during buffer fetch**
- The `terminalReattaching` flag was missing from both SplitView overlay conditions (zoom panel + main panel), so the "Restoring session…" spinner was never rendered while the scrollback buffer was being fetched on reattach
- Without the overlay, users saw a blank, non-interactive terminal for the entire fetch window (xterm was reset but nothing was written yet, and `onData` wasn't wired up yet)

**Fix 2 — "[Process exited]" missing when session dies while tab is closed**
- When a persistent session's shell crashes while its tab is closed, the `terminal-exit` event fires with no frontend subscriber and is permanently lost
- On the next "Attach", the scrollback buffer replays (showing crash output) but the frontend never learns the session is dead — the terminal appeared interactive while silently dropping all input
- Fix: buffer `terminal-exit` events in `TerminalOutputDispatcher` (mirroring the existing `pendingOutput` buffering for output events); `subscribeExit` now immediately fires any buffered exit; `clearPendingExit` is called at reattach start to discard exits from a previously-recovered agent-connection blip

## Test plan

- [ ] Start a persistent agent session, type some output, close the tab
- [ ] Click "Attach" — "Restoring session…" spinner overlay should appear immediately
- [ ] After fetch completes: overlay dismisses, terminal shows restored scrollback, input works
- [ ] Kill the shell inside the session while the tab is closed, then click "Attach" — terminal should show the crash output and a "[Process exited]" line; input should be non-functional (correct)
- [ ] 1480 unit tests pass (`./scripts/test.sh`)
- [ ] All quality checks pass (`./scripts/check.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)