### PR TITLE
feat(network): adopt pnet_packet for ICMP reply validation in traceroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Network tools: `pnet_packet` is now used to validate ICMP/ICMPv6 reply types in traceroute. Only Time Exceeded and Destination Unreachable packets are accepted as valid hop replies; unrelated ICMP packets received on the raw socket are silently ignored. Improves correctness and lays the groundwork for better Windows raw-socket support.
+
 - Dev scripts: `dev.sh` and `dev.cmd` now read per-checkout settings from a gitignored `dev.local.json` file (`dev_port`, `dev_name`). On Unix/macOS, setting `dev_agent_port` auto-builds the agent binary, starts a local `sshd`, and registers a "Dev Agent" entry directly in termiHub's `connections.json` — enabling zero-config local agent testing without a remote machine. Multiple parallel workspaces coexist via port-scoped agent IDs.
 - Agent: macOS is now a supported agent target (`macos-arm64`, `macos-x64`). The desktop resolves the correct binary when connecting to a macOS remote host via SSH agent mode. The agent setup dialog shows macOS arch options when connecting to a Darwin host.
 - Agent: five local TCP integration tests (`cargo test -p termihub-agent --test local_agent_integration`) that spawn the agent in `--listen` mode on localhost — no SSH, no cross-compilation, no Raspberry Pi required. These make it fast to iterate on agent behavior on any dev machine (macOS, Linux, Windows).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,10 +3891,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pnet_base"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
 name = "pnet_macros"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688b17499eee04a0408aca0aa5cba5fc86401d7216de8a63fdf7a4c227871804"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3908,7 +3929,16 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eea925b72f4bd37f8eab0f221bbe4c78b63498350c983ffa9dd4bcde7e030f56"
 dependencies = [
- "pnet_base",
+ "pnet_base 0.34.0",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
+dependencies = [
+ "pnet_base 0.35.0",
 ]
 
 [[package]]
@@ -3918,9 +3948,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a005825396b7fe7a38a8e288dbc342d5034dac80c15212436424fef8ea90ba"
 dependencies = [
  "glob",
- "pnet_base",
- "pnet_macros",
- "pnet_macros_support",
+ "pnet_base 0.34.0",
+ "pnet_macros 0.34.0",
+ "pnet_macros_support 0.34.0",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
+dependencies = [
+ "glob",
+ "pnet_base 0.35.0",
+ "pnet_macros 0.35.0",
+ "pnet_macros_support 0.35.0",
 ]
 
 [[package]]
@@ -5344,7 +5386,7 @@ checksum = "30498e9c9feba213c3df6ed675bdf75519ccbee493517e7225305898c86cac05"
 dependencies = [
  "hex",
  "parking_lot",
- "pnet_packet",
+ "pnet_packet 0.34.0",
  "rand 0.9.2",
  "socket2 0.6.2",
  "thiserror 1.0.69",
@@ -5941,6 +5983,7 @@ dependencies = [
  "futures-util",
  "hickory-resolver",
  "openssl",
+ "pnet_packet 0.35.0",
  "portable-pty",
  "rand 0.8.5",
  "serde",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 surge-ping = "0.8"
 hickory-resolver = { version = "0.26", features = ["tokio", "system-config"] }
 socket2 = { version = "0.5", features = ["all"] }
+pnet_packet = "0.35"
 rand = "0.8"
 serialport = { workspace = true, optional = true }
 portable-pty = { version = "0.8", optional = true }

--- a/core/src/network/traceroute.rs
+++ b/core/src/network/traceroute.rs
@@ -140,9 +140,8 @@ fn run_trace(
                 Ok((len, src_addr)) => {
                     // SAFETY: socket2 initializes the first `len` bytes on success;
                     // MaybeUninit<u8> and u8 share the same memory layout.
-                    let filled = unsafe {
-                        std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), len)
-                    };
+                    let filled =
+                        unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), len) };
                     if is_valid_icmp_reply(filled, dest_ip.is_ipv6()) {
                         let rtt = started.elapsed().as_secs_f64() * 1000.0;
                         *rtt_slot = Some(rtt);

--- a/core/src/network/traceroute.rs
+++ b/core/src/network/traceroute.rs
@@ -1,8 +1,10 @@
 //! Hop-by-hop traceroute using TTL-limited probes via `socket2`.
 //!
 //! Sends UDP probes with incrementing TTL values and listens for ICMP
-//! "Time Exceeded" replies. On platforms where raw sockets require elevated
-//! privileges the function returns [`NetworkError::InsufficientPrivileges`].
+//! "Time Exceeded" replies. ICMP response bytes are validated with
+//! [`pnet_packet`] to filter out unrelated ICMP packets before recording a hop.
+//! On platforms where raw sockets require elevated privileges the function
+//! returns [`NetworkError::InsufficientPrivileges`].
 
 use std::mem::MaybeUninit;
 use std::net::{IpAddr, SocketAddr};
@@ -16,6 +18,16 @@ use super::types::TracerouteHop;
 
 const PROBE_TIMEOUT_MS: u64 = 3000;
 const UDP_DEST_PORT: u16 = 33434;
+
+/// Returns `true` if `buf` (raw bytes from a raw ICMP/ICMPv6 socket) is an
+/// ICMP Time Exceeded or Destination Unreachable packet — the two types that
+/// indicate a traceroute hop or final destination reached.
+///
+/// For IPv4, `buf` includes the IP header (socket2 includes it on all
+/// platforms). For IPv6, `buf` starts directly with the ICMPv6 header.
+fn is_valid_icmp_reply(_buf: &[u8], _is_ipv6: bool) -> bool {
+    false
+}
 
 /// Run a traceroute to `host`, streaming each hop via `on_hop`.
 ///
@@ -70,7 +82,6 @@ fn run_trace(
     let dest_addr = SocketAddr::new(dest_ip, UDP_DEST_PORT);
     let dest_sock_addr = SockAddr::from(dest_addr);
 
-    // Allocate a zeroed buffer compatible with MaybeUninit<u8>.
     let mut buf = vec![MaybeUninit::new(0u8); 512];
 
     for ttl in 1..=max_hops {
@@ -101,12 +112,19 @@ fn run_trace(
 
             // Wait for ICMP Time Exceeded or Destination Unreachable.
             match recv_sock.recv_from(&mut buf) {
-                Ok((_len, src_addr)) => {
-                    let rtt = started.elapsed().as_secs_f64() * 1000.0;
-                    *rtt_slot = Some(rtt);
-                    if router_ip.is_none() {
-                        if let Some(ip) = src_addr.as_socket().map(|s| s.ip()) {
-                            router_ip = Some(ip);
+                Ok((len, src_addr)) => {
+                    // SAFETY: socket2 initializes the first `len` bytes on success;
+                    // MaybeUninit<u8> and u8 share the same memory layout.
+                    let filled = unsafe {
+                        std::slice::from_raw_parts(buf.as_ptr().cast::<u8>(), len)
+                    };
+                    if is_valid_icmp_reply(filled, dest_ip.is_ipv6()) {
+                        let rtt = started.elapsed().as_secs_f64() * 1000.0;
+                        *rtt_slot = Some(rtt);
+                        if router_ip.is_none() {
+                            if let Some(ip) = src_addr.as_socket().map(|s| s.ip()) {
+                                router_ip = Some(ip);
+                            }
                         }
                     }
                 }
@@ -161,6 +179,73 @@ async fn resolve(host: &str) -> Result<IpAddr, NetworkError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── is_valid_icmp_reply tests ─────────────────────────────────────────────
+
+    // Builds bytes as returned by a raw IPv4 ICMP socket:
+    // 20-byte IPv4 header (version=4, IHL=5, protocol=ICMP) + 8-byte ICMP header.
+    fn ipv4_icmp_bytes(icmp_type: u8) -> Vec<u8> {
+        let mut buf = vec![0u8; 28]; // 20B IPv4 header + 8B ICMP header
+        buf[0] = 0x45; // version=4, IHL=5 (20-byte header)
+        buf[9] = 1; // protocol = ICMP
+        buf[20] = icmp_type;
+        buf
+    }
+
+    // Builds raw ICMPv6 bytes as returned by a raw ICMPv6 socket (no IPv6 header).
+    fn icmpv6_bytes(icmp_type: u8) -> Vec<u8> {
+        let mut buf = vec![0u8; 8];
+        buf[0] = icmp_type;
+        buf
+    }
+
+    #[test]
+    fn icmp_time_exceeded_is_valid() {
+        // ICMP type 11 = Time Exceeded — a valid traceroute hop reply
+        assert!(is_valid_icmp_reply(&ipv4_icmp_bytes(11), false));
+    }
+
+    #[test]
+    fn icmp_dest_unreachable_is_valid() {
+        // ICMP type 3 = Destination Unreachable — final hop reached
+        assert!(is_valid_icmp_reply(&ipv4_icmp_bytes(3), false));
+    }
+
+    #[test]
+    fn icmp_echo_reply_is_not_valid() {
+        // ICMP type 0 = Echo Reply — unrelated, must be ignored
+        assert!(!is_valid_icmp_reply(&ipv4_icmp_bytes(0), false));
+    }
+
+    #[test]
+    fn empty_bytes_ipv4_is_not_valid() {
+        assert!(!is_valid_icmp_reply(&[], false));
+    }
+
+    #[test]
+    fn icmpv6_time_exceeded_is_valid() {
+        // ICMPv6 type 3 = Time Exceeded
+        assert!(is_valid_icmp_reply(&icmpv6_bytes(3), true));
+    }
+
+    #[test]
+    fn icmpv6_dest_unreachable_is_valid() {
+        // ICMPv6 type 1 = Destination Unreachable
+        assert!(is_valid_icmp_reply(&icmpv6_bytes(1), true));
+    }
+
+    #[test]
+    fn icmpv6_echo_reply_is_not_valid() {
+        // ICMPv6 type 129 = Echo Reply — unrelated, must be ignored
+        assert!(!is_valid_icmp_reply(&icmpv6_bytes(129), true));
+    }
+
+    #[test]
+    fn empty_bytes_ipv6_is_not_valid() {
+        assert!(!is_valid_icmp_reply(&[], true));
+    }
+
+    // ── Existing tests ────────────────────────────────────────────────────────
 
     #[test]
     fn traceroute_hop_has_three_rtt_slots() {

--- a/core/src/network/traceroute.rs
+++ b/core/src/network/traceroute.rs
@@ -10,6 +10,10 @@ use std::mem::MaybeUninit;
 use std::net::{IpAddr, SocketAddr};
 use std::time::{Duration, Instant};
 
+use pnet_packet::icmp::{IcmpPacket, IcmpTypes};
+use pnet_packet::icmpv6::{Icmpv6Packet, Icmpv6Types};
+use pnet_packet::ipv4::Ipv4Packet;
+use pnet_packet::Packet;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use tokio_util::sync::CancellationToken;
 
@@ -25,8 +29,29 @@ const UDP_DEST_PORT: u16 = 33434;
 ///
 /// For IPv4, `buf` includes the IP header (socket2 includes it on all
 /// platforms). For IPv6, `buf` starts directly with the ICMPv6 header.
-fn is_valid_icmp_reply(_buf: &[u8], _is_ipv6: bool) -> bool {
-    false
+fn is_valid_icmp_reply(buf: &[u8], is_ipv6: bool) -> bool {
+    if is_ipv6 {
+        Icmpv6Packet::new(buf)
+            .map(|pkt| {
+                matches!(
+                    pkt.get_icmpv6_type(),
+                    Icmpv6Types::TimeExceeded | Icmpv6Types::DestinationUnreachable
+                )
+            })
+            .unwrap_or(false)
+    } else {
+        // IPv4 raw socket: buf starts with the IP header; use it to locate the ICMP payload.
+        let Some(ip) = Ipv4Packet::new(buf) else {
+            return false;
+        };
+        let Some(pkt) = IcmpPacket::new(ip.payload()) else {
+            return false;
+        };
+        matches!(
+            pkt.get_icmp_type(),
+            IcmpTypes::TimeExceeded | IcmpTypes::DestinationUnreachable
+        )
+    }
 }
 
 /// Run a traceroute to `host`, streaming each hop via `on_hop`.
@@ -187,6 +212,8 @@ mod tests {
     fn ipv4_icmp_bytes(icmp_type: u8) -> Vec<u8> {
         let mut buf = vec![0u8; 28]; // 20B IPv4 header + 8B ICMP header
         buf[0] = 0x45; // version=4, IHL=5 (20-byte header)
+        buf[2] = 0x00; // total length = 28 (big-endian high byte)
+        buf[3] = 28; // total length = 28 (big-endian low byte)
         buf[9] = 1; // protocol = ICMP
         buf[20] = icmp_type;
         buf


### PR DESCRIPTION
## Summary

- Adds `pnet_packet = "0.35"` to `core/Cargo.toml`
- Introduces `is_valid_icmp_reply(buf, is_ipv6)` in `traceroute.rs` that uses `pnet_packet::ipv4::Ipv4Packet` + `pnet_packet::icmp::IcmpPacket` (IPv4) and `pnet_packet::icmpv6::Icmpv6Packet` (IPv6) to verify received packets are Time Exceeded or Destination Unreachable before recording a hop
- Unrelated ICMP packets that arrive on the raw receive socket (echo replies, redirects, etc.) are now silently discarded rather than mistakenly counted as traceroute hops
- Raw socket management (`socket2` for TTL, timeouts, send/receive) is unchanged
- `surge-ping` in `ping.rs` is untouched per issue guidance

Closes #733

## Test plan

- [ ] Unit tests in `core/src/network/traceroute.rs`: `cargo test -p termihub-core --lib -- network::traceroute::tests` — 11 tests, all pass
- [ ] `./scripts/test.sh` — all tests pass
- [ ] `./scripts/check.sh` — all checks pass
- [ ] Manual: run a live traceroute via the Network Tools panel on macOS/Linux (requires admin/sudo for raw socket) and verify hops are reported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)