### PR TITLE
feat(ui): augment DynamicForm with react-hook-form + zod (#731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Connection Editor: the dynamic connection form now uses `react-hook-form` for field state management and `zod` for client-side validation. Invalid port values (out of 1–65535), empty required text fields, and out-of-range numbers now show inline error messages next to the relevant field without requiring a connection attempt.
 - Dev scripts: `dev.sh` and `dev.cmd` now read per-checkout settings from a gitignored `dev.local.json` file (`dev_port`, `dev_name`). On Unix/macOS, setting `dev_agent_port` auto-builds the agent binary, starts a local `sshd`, and registers a "Dev Agent" entry directly in termiHub's `connections.json` — enabling zero-config local agent testing without a remote machine. Multiple parallel workspaces coexist via port-scoped agent IDs.
 - Agent: macOS is now a supported agent target (`macos-arm64`, `macos-x64`). The desktop resolves the correct binary when connecting to a macOS remote host via SSH agent mode. The agent setup dialog shows macOS arch options when connecting to a Darwin host.
 - Agent: five local TCP integration tests (`cargo test -p termihub-agent --test local_agent_integration`) that spawn the agent in `--listen` mode on localhost — no SSH, no cross-compilation, no Raspberry Pi required. These make it fast to iterate on agent behavior on any dev machine (macOS, Linux, Windows).

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@hookform/resolvers": "^5.2.2",
     "@lucide/lab": "^0.1.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-context-menu": "^2.2.16",
@@ -50,9 +51,11 @@
     "react": "^18.3.1",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.75.0",
     "react-resizable-panels": "^4.6.2",
     "react-virtuoso": "^4.18.1",
     "shiki": "^4.0.2",
+    "zod": "^4.4.3",
     "zustand": "^5.0.11"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.75.0(react@18.3.1))
       '@lucide/lab':
         specifier: ^0.1.2
         version: 0.1.2
@@ -99,6 +102,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.75.0
+        version: 7.75.0(react@18.3.1)
       react-resizable-panels:
         specifier: ^4.6.2
         version: 4.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -108,6 +114,9 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@18.3.28)(react@18.3.1)
@@ -793,6 +802,11 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1567,6 +1581,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
@@ -3602,6 +3619,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.75.0:
+    resolution: {integrity: sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -4357,6 +4380,9 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@5.0.11:
     resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
     engines: {node: '>=12.20.0'}
@@ -4909,6 +4935,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@hookform/resolvers@5.2.2(react-hook-form@7.75.0(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.75.0(react@18.3.1)
 
   '@humanfs/core@0.19.1': {}
 
@@ -5624,6 +5655,8 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -8024,6 +8057,10 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-hook-form@7.75.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-is@18.3.1: {}
 
   react-is@19.2.6: {}
@@ -8788,6 +8825,8 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod@4.4.3: {}
 
   zustand@5.0.11(@types/react@18.3.28)(react@18.3.1):
     optionalDependencies:

--- a/src/components/DynamicForm/ConnectionSettingsForm.test.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.test.tsx
@@ -9,6 +9,11 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn().mockResolvedValue(null),
 }));
 
+// Mock serial port listing
+vi.mock("@/services/api", () => ({
+  listSerialPorts: vi.fn().mockResolvedValue([]),
+}));
+
 // Mock KeyPathInput
 vi.mock("@/components/Settings/KeyPathInput", () => ({
   KeyPathInput: ({ value }: { value: string }) => (
@@ -171,5 +176,76 @@ describe("ConnectionSettingsForm", () => {
     renderForm({ groups: [] }, {}, vi.fn());
     expect(query("connection-settings-form")).toBeTruthy();
     expect(queryAll("[data-testid^='form-group-']").length).toBe(0);
+  });
+
+  it("shows credential saved hint for empty password fields when enabled", () => {
+    const schema: SettingsSchema = {
+      groups: [
+        {
+          key: "auth",
+          label: "Auth",
+          fields: [
+            {
+              key: "password",
+              label: "Password",
+              fieldType: { type: "password" },
+              required: false,
+            },
+          ],
+        },
+      ],
+    };
+    act(() => {
+      root.render(
+        <ConnectionSettingsForm
+          schema={schema}
+          settings={{}}
+          onChange={vi.fn()}
+          credentialSavedHint={true}
+        />
+      );
+    });
+    expect(query("field-password-credential-saved")).toBeTruthy();
+  });
+
+  it("shows validation error for invalid port", async () => {
+    await act(async () => {
+      renderForm(SSH_SCHEMA, { authMethod: "key", port: 22, host: "h" }, vi.fn());
+    });
+    const portInput = query("field-port") as HTMLInputElement;
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value"
+    )?.set;
+    await act(async () => {
+      nativeInputValueSetter?.call(portInput, "0");
+      portInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(query("field-port-error")).toBeTruthy();
+  });
+
+  it("clears validation error when field becomes valid", async () => {
+    await act(async () => {
+      renderForm(SSH_SCHEMA, { authMethod: "key", port: 22, host: "" }, vi.fn());
+    });
+    const hostInput = query("field-host") as HTMLInputElement;
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value"
+    )?.set;
+
+    // Trigger error
+    await act(async () => {
+      nativeInputValueSetter?.call(hostInput, "");
+      hostInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    // Fix the value
+    await act(async () => {
+      nativeInputValueSetter?.call(hostInput, "fixed-host");
+      hostInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(query("field-host-error")).toBeNull();
   });
 });

--- a/src/components/DynamicForm/ConnectionSettingsForm.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, useWatch, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { SettingsSchema } from "@/types/schema";
 import { isFieldVisible } from "@/utils/schemaDefaults";
@@ -47,11 +47,15 @@ export function ConnectionSettingsForm({
   });
 
   // Reset the form when the connection type changes (schema groups differ).
+  // isResetting suppresses the watch callback that reset fires synchronously,
+  // preventing a spurious onChange call back to the parent on type switch.
   const schemaKey = schema.groups.map((g) => g.key).join("|");
   const prevSchemaKey = useRef(schemaKey);
+  const isResetting = useRef(false);
   useEffect(() => {
     if (prevSchemaKey.current !== schemaKey) {
       prevSchemaKey.current = schemaKey;
+      isResetting.current = true;
       reset(settings);
     }
     // Only trigger on schema change, not on every settings update.
@@ -61,13 +65,17 @@ export function ConnectionSettingsForm({
   // Propagate every form value change to the parent.
   useEffect(() => {
     const subscription = watch((values) => {
+      if (isResetting.current) {
+        isResetting.current = false;
+        return;
+      }
       onChange(values as Record<string, unknown>);
     });
     return () => subscription.unsubscribe();
   }, [watch, onChange]);
 
   // Live form values used for visibleWhen evaluation.
-  const watchedValues = watch();
+  const watchedValues = useWatch({ control });
 
   return (
     <div data-testid="connection-settings-form">

--- a/src/components/DynamicForm/ConnectionSettingsForm.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.tsx
@@ -1,6 +1,9 @@
-import { useCallback } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import type { SettingsSchema } from "@/types/schema";
 import { isFieldVisible } from "@/utils/schemaDefaults";
+import { settingsSchemaToZod } from "./settingsSchemaToZod";
 import { DynamicField } from "./DynamicField";
 
 interface ConnectionSettingsFormProps {
@@ -22,11 +25,11 @@ interface ConnectionSettingsFormProps {
 }
 
 /**
- * Generic connection settings form renderer.
+ * Generic connection settings form renderer backed by react-hook-form and zod.
  *
- * Iterates groups and fields from the schema, evaluates visibility
- * conditions, and delegates each field to DynamicField. Each schema group
- * is rendered as a visual section with a category title.
+ * Manages field state, dirty tracking, and client-side validation internally.
+ * Changes are propagated to the parent via `onChange` on every field update.
+ * Backend validation in Agent.connect remains authoritative; zod is UX only.
  */
 export function ConnectionSettingsForm({
   schema,
@@ -35,17 +38,41 @@ export function ConnectionSettingsForm({
   credentialSavedHint,
   availablePorts,
 }: ConnectionSettingsFormProps) {
-  const handleFieldChange = useCallback(
-    (key: string, value: unknown) => {
-      onChange({ ...settings, [key]: value });
-    },
-    [settings, onChange]
-  );
+  const zodSchema = useMemo(() => settingsSchemaToZod(schema), [schema]);
+
+  const { control, watch, reset } = useForm<Record<string, unknown>>({
+    defaultValues: settings,
+    resolver: zodResolver(zodSchema),
+    mode: "onChange",
+  });
+
+  // Reset the form when the connection type changes (schema groups differ).
+  const schemaKey = schema.groups.map((g) => g.key).join("|");
+  const prevSchemaKey = useRef(schemaKey);
+  useEffect(() => {
+    if (prevSchemaKey.current !== schemaKey) {
+      prevSchemaKey.current = schemaKey;
+      reset(settings);
+    }
+    // Only trigger on schema change, not on every settings update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [schemaKey]);
+
+  // Propagate every form value change to the parent.
+  useEffect(() => {
+    const subscription = watch((values) => {
+      onChange(values as Record<string, unknown>);
+    });
+    return () => subscription.unsubscribe();
+  }, [watch, onChange]);
+
+  // Live form values used for visibleWhen evaluation.
+  const watchedValues = watch();
 
   return (
     <div data-testid="connection-settings-form">
       {schema.groups.map((group) => {
-        const visibleFields = group.fields.filter((f) => isFieldVisible(f, settings));
+        const visibleFields = group.fields.filter((f) => isFieldVisible(f, watchedValues));
         if (visibleFields.length === 0) return null;
         return (
           <div
@@ -55,15 +82,22 @@ export function ConnectionSettingsForm({
           >
             <h3 className="settings-panel__category-title">{group.label}</h3>
             {visibleFields.map((field) => (
-              <DynamicField
+              <Controller
                 key={field.key}
-                field={field}
-                value={settings[field.key]}
-                onChange={handleFieldChange}
-                credentialSaved={
-                  credentialSavedHint && field.fieldType.type === "password" && !settings[field.key]
-                }
-                availablePorts={availablePorts}
+                name={field.key}
+                control={control}
+                render={({ field: rhfField, fieldState }) => (
+                  <DynamicField
+                    field={field}
+                    value={rhfField.value}
+                    onChange={rhfField.onChange}
+                    error={fieldState.error?.message}
+                    credentialSaved={
+                      credentialSavedHint && field.fieldType.type === "password" && !rhfField.value
+                    }
+                    availablePorts={availablePorts}
+                  />
+                )}
               />
             ))}
           </div>

--- a/src/components/DynamicForm/DynamicField.test.tsx
+++ b/src/components/DynamicForm/DynamicField.test.tsx
@@ -45,8 +45,8 @@ function query(testId: string): HTMLElement | null {
 function renderField(
   field: SettingsField,
   value: unknown,
-  onChange: (k: string, v: unknown) => void,
-  opts: { availablePorts?: string[] } = {}
+  onChange: (v: unknown) => void,
+  opts: { availablePorts?: string[]; error?: string } = {}
 ) {
   act(() => {
     root.render(
@@ -55,6 +55,7 @@ function renderField(
         value={value}
         onChange={onChange}
         availablePorts={opts.availablePorts}
+        error={opts.error}
       />
     );
   });
@@ -114,7 +115,7 @@ describe("DynamicField", () => {
         nativeInputValueSetter?.call(input, "new");
         input.dispatchEvent(new Event("input", { bubbles: true }));
       });
-      expect(onChange).toHaveBeenCalledWith("host", "new");
+      expect(onChange).toHaveBeenCalledWith("new");
     });
 
     it("renders placeholder", () => {
@@ -319,7 +320,7 @@ describe("DynamicField", () => {
       act(() => {
         (query("field-envVars-add") as HTMLElement).click();
       });
-      expect(onChange).toHaveBeenCalledWith("envVars", [{ key: "", value: "" }]);
+      expect(onChange).toHaveBeenCalledWith([{ key: "", value: "" }]);
     });
 
     it("removes item on click", () => {
@@ -332,7 +333,7 @@ describe("DynamicField", () => {
       act(() => {
         (query("field-envVars-remove-0") as HTMLElement).click();
       });
-      expect(onChange).toHaveBeenCalledWith("envVars", [{ key: "B", value: "2" }]);
+      expect(onChange).toHaveBeenCalledWith([{ key: "B", value: "2" }]);
     });
   });
 
@@ -406,7 +407,7 @@ describe("DynamicField", () => {
         select.value = "/dev/ttyS0";
         select.dispatchEvent(new Event("change", { bubbles: true }));
       });
-      expect(onChange).toHaveBeenCalledWith("port", "/dev/ttyS0");
+      expect(onChange).toHaveBeenCalledWith("/dev/ttyS0");
     });
 
     it("uses provided availablePorts instead of calling listSerialPorts", async () => {
@@ -487,9 +488,7 @@ describe("DynamicField", () => {
       act(() => {
         (query("field-volumes-add") as HTMLElement).click();
       });
-      expect(onChange).toHaveBeenCalledWith("volumes", [
-        { hostPath: "", containerPath: "", readOnly: false },
-      ]);
+      expect(onChange).toHaveBeenCalledWith([{ hostPath: "", containerPath: "", readOnly: false }]);
     });
 
     it("removes item on click", () => {
@@ -502,9 +501,22 @@ describe("DynamicField", () => {
       act(() => {
         (query("field-volumes-remove-0") as HTMLElement).click();
       });
-      expect(onChange).toHaveBeenCalledWith("volumes", [
+      expect(onChange).toHaveBeenCalledWith([
         { hostPath: "/c", containerPath: "/d", readOnly: true },
       ]);
+    });
+  });
+
+  describe("error prop", () => {
+    it("displays inline error message when error is provided", () => {
+      renderField(textField("host"), "", vi.fn(), { error: "Host is required" });
+      expect(container.textContent).toContain("Host is required");
+      expect(query("field-host-error")).toBeTruthy();
+    });
+
+    it("does not render error element when error is undefined", () => {
+      renderField(textField("host"), "example.com", vi.fn());
+      expect(query("field-host-error")).toBeNull();
     });
   });
 });

--- a/src/components/DynamicForm/DynamicField.tsx
+++ b/src/components/DynamicForm/DynamicField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { HelpCircle, X } from "lucide-react";
 import type { SettingsField, FieldType } from "@/types/schema";
@@ -9,7 +9,9 @@ import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
 interface DynamicFieldProps {
   field: SettingsField;
   value: unknown;
-  onChange: (key: string, value: unknown) => void;
+  onChange: (value: unknown) => void;
+  /** Validation error message to display inline below the field. */
+  error?: string;
   /** When true, shows a "Password saved in credential store" hint below password fields. */
   credentialSaved?: boolean;
   /**
@@ -31,14 +33,21 @@ export function DynamicField({
   field,
   value,
   onChange,
+  error,
   credentialSaved,
   availablePorts,
 }: DynamicFieldProps) {
-  const handleChange = useCallback((v: unknown) => onChange(field.key, v), [field.key, onChange]);
-
   return (
     <div className="settings-form__field" data-testid={`dynamic-field-${field.key}`}>
-      {renderFieldInput(field, field.fieldType, value, handleChange, availablePorts)}
+      {renderFieldInput(field, field.fieldType, value, onChange, availablePorts)}
+      {error && (
+        <p
+          className="settings-form__hint settings-form__hint--error"
+          data-testid={`field-${field.key}-error`}
+        >
+          {error}
+        </p>
+      )}
       {field.description && <p className="settings-form__hint">{field.description}</p>}
       {credentialSaved && (
         <p

--- a/src/components/DynamicForm/settingsSchemaToZod.test.ts
+++ b/src/components/DynamicForm/settingsSchemaToZod.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import { settingsSchemaToZod } from "./settingsSchemaToZod";
+import type { SettingsSchema } from "@/types/schema";
+
+function makeSchema(fields: SettingsSchema["groups"][0]["fields"]): SettingsSchema {
+  return { groups: [{ key: "g", label: "Group", fields }] };
+}
+
+describe("settingsSchemaToZod", () => {
+  describe("port field", () => {
+    it("accepts valid ports (1–65535)", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([{ key: "port", label: "Port", fieldType: { type: "port" }, required: true }])
+      );
+      expect(zod.safeParse({ port: 1 }).success).toBe(true);
+      expect(zod.safeParse({ port: 22 }).success).toBe(true);
+      expect(zod.safeParse({ port: 65535 }).success).toBe(true);
+    });
+
+    it("rejects port 0 and 65536", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([{ key: "port", label: "Port", fieldType: { type: "port" }, required: true }])
+      );
+      expect(zod.safeParse({ port: 0 }).success).toBe(false);
+      expect(zod.safeParse({ port: 65536 }).success).toBe(false);
+    });
+
+    it("rejects non-integer port", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([{ key: "port", label: "Port", fieldType: { type: "port" }, required: true }])
+      );
+      expect(zod.safeParse({ port: 22.5 }).success).toBe(false);
+    });
+
+    it("optional port accepts undefined", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([{ key: "port", label: "Port", fieldType: { type: "port" }, required: false }])
+      );
+      expect(zod.safeParse({}).success).toBe(true);
+      expect(zod.safeParse({ port: undefined }).success).toBe(true);
+      expect(zod.safeParse({ port: 22 }).success).toBe(true);
+      expect(zod.safeParse({ port: 0 }).success).toBe(false);
+    });
+  });
+
+  describe("number field", () => {
+    it("applies min and max bounds", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          {
+            key: "timeout",
+            label: "Timeout",
+            fieldType: { type: "number", min: 0, max: 300 },
+            required: true,
+          },
+        ])
+      );
+      expect(zod.safeParse({ timeout: 0 }).success).toBe(true);
+      expect(zod.safeParse({ timeout: 300 }).success).toBe(true);
+      expect(zod.safeParse({ timeout: -1 }).success).toBe(false);
+      expect(zod.safeParse({ timeout: 301 }).success).toBe(false);
+    });
+
+    it("optional number accepts undefined", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          {
+            key: "timeout",
+            label: "Timeout",
+            fieldType: { type: "number", min: 0 },
+            required: false,
+          },
+        ])
+      );
+      expect(zod.safeParse({}).success).toBe(true);
+      expect(zod.safeParse({ timeout: 30 }).success).toBe(true);
+    });
+  });
+
+  describe("text field", () => {
+    it("required text field rejects empty string", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([{ key: "host", label: "Host", fieldType: { type: "text" }, required: true }])
+      );
+      expect(zod.safeParse({ host: "" }).success).toBe(false);
+      expect(zod.safeParse({ host: "example.com" }).success).toBe(true);
+    });
+
+    it("optional text field accepts undefined and empty string", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([{ key: "host", label: "Host", fieldType: { type: "text" }, required: false }])
+      );
+      expect(zod.safeParse({}).success).toBe(true);
+      expect(zod.safeParse({ host: "" }).success).toBe(true);
+    });
+  });
+
+  describe("password field", () => {
+    it("required password rejects empty string", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          { key: "pass", label: "Password", fieldType: { type: "password" }, required: true },
+        ])
+      );
+      expect(zod.safeParse({ pass: "" }).success).toBe(false);
+      expect(zod.safeParse({ pass: "secret" }).success).toBe(true);
+    });
+  });
+
+  describe("boolean field", () => {
+    it("accepts true/false and undefined", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          { key: "flag", label: "Flag", fieldType: { type: "boolean" }, required: false },
+        ])
+      );
+      expect(zod.safeParse({ flag: true }).success).toBe(true);
+      expect(zod.safeParse({ flag: false }).success).toBe(true);
+      expect(zod.safeParse({}).success).toBe(true);
+    });
+  });
+
+  describe("select field", () => {
+    it("accepts any string", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          {
+            key: "auth",
+            label: "Auth",
+            fieldType: { type: "select", options: [{ value: "key", label: "Key" }] },
+            required: true,
+          },
+        ])
+      );
+      expect(zod.safeParse({ auth: "key" }).success).toBe(true);
+      expect(zod.safeParse({ auth: "password" }).success).toBe(true);
+    });
+  });
+
+  describe("keyValueList field", () => {
+    it("accepts array of key-value pairs and undefined", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          { key: "env", label: "Env", fieldType: { type: "keyValueList" }, required: false },
+        ])
+      );
+      expect(zod.safeParse({ env: [{ key: "A", value: "1" }] }).success).toBe(true);
+      expect(zod.safeParse({ env: [] }).success).toBe(true);
+      expect(zod.safeParse({}).success).toBe(true);
+    });
+  });
+
+  describe("objectList field", () => {
+    it("accepts array of objects and undefined", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          {
+            key: "volumes",
+            label: "Volumes",
+            fieldType: { type: "objectList", fields: [] },
+            required: false,
+          },
+        ])
+      );
+      expect(zod.safeParse({ volumes: [{ host: "/a", container: "/b" }] }).success).toBe(true);
+      expect(zod.safeParse({ volumes: [] }).success).toBe(true);
+      expect(zod.safeParse({}).success).toBe(true);
+    });
+  });
+
+  describe("multiple fields", () => {
+    it("validates all fields in the schema", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          { key: "host", label: "Host", fieldType: { type: "text" }, required: true },
+          { key: "port", label: "Port", fieldType: { type: "port" }, required: true },
+        ])
+      );
+      expect(zod.safeParse({ host: "example.com", port: 22 }).success).toBe(true);
+      expect(zod.safeParse({ host: "", port: 22 }).success).toBe(false);
+      expect(zod.safeParse({ host: "example.com", port: 0 }).success).toBe(false);
+    });
+
+    it("collects fields from all groups", () => {
+      const schema: SettingsSchema = {
+        groups: [
+          {
+            key: "g1",
+            label: "G1",
+            fields: [{ key: "host", label: "Host", fieldType: { type: "text" }, required: true }],
+          },
+          {
+            key: "g2",
+            label: "G2",
+            fields: [{ key: "port", label: "Port", fieldType: { type: "port" }, required: true }],
+          },
+        ],
+      };
+      const zod = settingsSchemaToZod(schema);
+      expect(zod.safeParse({ host: "example.com", port: 22 }).success).toBe(true);
+      expect(zod.safeParse({ host: "example.com", port: 0 }).success).toBe(false);
+    });
+  });
+});

--- a/src/components/DynamicForm/settingsSchemaToZod.ts
+++ b/src/components/DynamicForm/settingsSchemaToZod.ts
@@ -8,8 +8,8 @@ import type { SettingsField, SettingsSchema } from "@/types/schema";
  * bounds. Backend validation in Agent.connect remains authoritative; this
  * schema is for UX feedback only.
  */
-export function settingsSchemaToZod(schema: SettingsSchema): z.ZodObject<z.ZodRawShape> {
-  const shape: z.ZodRawShape = {};
+export function settingsSchemaToZod(schema: SettingsSchema) {
+  const shape: Record<string, z.ZodTypeAny> = {};
   for (const group of schema.groups) {
     for (const field of group.fields) {
       shape[field.key] = fieldToZod(field);

--- a/src/components/DynamicForm/settingsSchemaToZod.ts
+++ b/src/components/DynamicForm/settingsSchemaToZod.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import type { SettingsField, SettingsSchema } from "@/types/schema";
+
+/**
+ * Convert a SettingsSchema into a zod object schema for client-side validation.
+ *
+ * Maps each field type to its corresponding zod validator with appropriate
+ * bounds. Backend validation in Agent.connect remains authoritative; this
+ * schema is for UX feedback only.
+ */
+export function settingsSchemaToZod(schema: SettingsSchema): z.ZodObject<z.ZodRawShape> {
+  const shape: z.ZodRawShape = {};
+  for (const group of schema.groups) {
+    for (const field of group.fields) {
+      shape[field.key] = fieldToZod(field);
+    }
+  }
+  return z.object(shape);
+}
+
+function fieldToZod(field: SettingsField): z.ZodTypeAny {
+  const ft = field.fieldType;
+
+  switch (ft.type) {
+    case "port": {
+      const portSchema = z
+        .number()
+        .int("Must be an integer")
+        .min(1, "Port must be between 1 and 65535")
+        .max(65535, "Port must be between 1 and 65535");
+      return field.required ? portSchema : portSchema.optional();
+    }
+
+    case "number": {
+      let num = z.number();
+      if (ft.min !== undefined) num = num.min(ft.min, `Must be at least ${ft.min}`);
+      if (ft.max !== undefined) num = num.max(ft.max, `Must be at most ${ft.max}`);
+      return field.required ? num : num.optional();
+    }
+
+    case "boolean":
+      return z.boolean().optional();
+
+    case "select":
+      return z.string();
+
+    case "text":
+    case "password":
+    case "filePath":
+    case "serialPort":
+      return field.required
+        ? z.string().min(1, `${field.label} is required`)
+        : z.string().optional();
+
+    case "keyValueList":
+      return z.array(z.object({ key: z.string(), value: z.string() })).optional();
+
+    case "objectList":
+      return z.array(z.record(z.string(), z.unknown())).optional();
+
+    default:
+      return z.unknown();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `react-hook-form` for form state management and `zod` for client-side validation to the dynamic connection settings form
- Introduces `settingsSchemaToZod` which converts `SettingsSchema` to a zod object schema (`port` → int 1–65535, `number` → min/max bounds, required text/password → non-empty, etc.)
- Refactors `ConnectionSettingsForm` to use `useForm` + `zodResolver` + `Controller`; field state is now owned by RHF internally and changes are propagated to the parent via the existing `onChange` callback
- Updates `DynamicField`'s `onChange` signature from `(key, value)` to `(value)` now that `Controller` handles key routing; adds an `error?: string` prop that renders an inline validation message below the field
- Keeps `DynamicField`'s renderers and visual layout exactly as-is; backend validation in `Agent.connect` remains authoritative — zod is UX only

Follows TDD: test commit `30b95ea` precedes implementation commit `5c7ff7b`.

## Test plan

- [x] All 1516 unit tests pass (`pnpm test`)
- [x] All CI quality checks pass (`./scripts/check.sh`)
- [ ] Open the connection editor for each connection type (SSH, serial, telnet, local, Docker, WSL) and verify all fields render and save correctly
- [ ] For an SSH connection, set Port to `0` → confirm red error message "Port must be between 1 and 65535" appears inline; set to `22` → error disappears
- [ ] Clear the Host field on a required-host connection → confirm error message appears; re-fill → error clears
- [ ] Switch connection type (e.g. SSH → Local) → confirm form resets to new defaults and previous validation errors do not bleed over
- [ ] Verify `visibleWhen` fields still show/hide correctly as the controlling field value changes (e.g. SSH auth method key ↔ password)

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)