### PR TITLE
refactor(buffer): simplify RingBuffer wrapper using HeapRb directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Agent: the hand-rolled JSON-RPC 2.0 dispatch layer (~5 k LOC) has been replaced by [`jsonrpsee`](https://crates.io/crates/jsonrpsee) 0.24. All 35 protocol methods are now registered via `RpcModule`; routing, error formatting, and response serialisation are handled by the library. Custom request/response/error structs in `core/src/protocol/` have been removed; only `JsonRpcNotification` (agent → desktop push) remains. Closes #727.
-- Core: the internal `RingBuffer` (1 MiB capture buffer used by serial sessions and the agent daemon) is now backed by the [`ringbuf`](https://crates.io/crates/ringbuf) crate (`HeapRb<u8>`) instead of a custom circular-byte-buffer implementation. Public API is unchanged.
+- Core: the internal `RingBuffer` (1 MiB capture buffer used by serial sessions and the agent daemon) is now backed by the [`ringbuf`](https://crates.io/crates/ringbuf) crate (`HeapRb<u8>`) instead of a custom circular-byte-buffer implementation. Public API is unchanged. The wrapper now uses `HeapRb` directly (no producer/consumer split) and delegates `write()` to `push_slice_overwrite`, reducing the implementation from ~60 to ~40 lines.
 
 ### Added
 

--- a/core/src/buffer/mod.rs
+++ b/core/src/buffer/mod.rs
@@ -1,6 +1,6 @@
 use ringbuf::{
-    traits::{Consumer, Observer, Producer, Split},
-    HeapCons, HeapProd, HeapRb,
+    traits::{Consumer, Observer, RingBuffer as _},
+    HeapRb,
 };
 
 /// Default buffer capacity: 1 MiB.
@@ -14,44 +14,27 @@ pub const DEFAULT_BUFFER_CAPACITY: usize = 1_048_576;
 /// Used by: serial sessions (24/7 capture), daemon PTY (output replay),
 /// and potentially desktop sessions (reconnect replay).
 pub struct RingBuffer {
-    prod: HeapProd<u8>,
-    cons: HeapCons<u8>,
-    capacity: usize,
+    rb: HeapRb<u8>,
 }
 
 impl RingBuffer {
     /// Create a new ring buffer with the given capacity in bytes.
     pub fn new(capacity: usize) -> Self {
-        let (prod, cons) = HeapRb::<u8>::new(capacity).split();
         Self {
-            prod,
-            cons,
-            capacity,
+            rb: HeapRb::<u8>::new(capacity),
         }
     }
 
     /// Append data to the buffer, overwriting oldest data if full.
     pub fn write(&mut self, data: &[u8]) {
-        if data.is_empty() {
-            return;
+        if !data.is_empty() {
+            self.rb.push_slice_overwrite(data);
         }
-        // If data exceeds capacity, keep only the most recent bytes.
-        let data = if data.len() > self.capacity {
-            &data[data.len() - self.capacity..]
-        } else {
-            data
-        };
-        // Make room by discarding oldest bytes when needed.
-        let vacant = self.prod.vacant_len();
-        if data.len() > vacant {
-            self.cons.skip(data.len() - vacant);
-        }
-        self.prod.push_slice(data);
     }
 
     /// Read all buffered data in order (oldest to newest).
     pub fn read_all(&self) -> Vec<u8> {
-        let (head, tail) = self.cons.as_slices();
+        let (head, tail) = self.rb.as_slices();
         let mut result = Vec::with_capacity(head.len() + tail.len());
         result.extend_from_slice(head);
         result.extend_from_slice(tail);
@@ -60,22 +43,22 @@ impl RingBuffer {
 
     /// Return the number of bytes currently stored.
     pub fn len(&self) -> usize {
-        self.cons.occupied_len()
+        self.rb.occupied_len()
     }
 
     /// Return true if no data is buffered.
     pub fn is_empty(&self) -> bool {
-        self.cons.is_empty()
+        self.rb.is_empty()
     }
 
     /// Clear all buffered data.
     pub fn clear(&mut self) {
-        self.cons.clear();
+        self.rb.clear();
     }
 
     /// Return the buffer capacity in bytes.
     pub fn capacity(&self) -> usize {
-        self.capacity
+        self.rb.capacity().get()
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the three-field struct (`prod: HeapProd<u8>`, `cons: HeapCons<u8>`, `capacity: usize`) with a single `rb: HeapRb<u8>` field — no split needed since `HeapRb` implements `Observer + Consumer + Producer + RingBuffer` directly for single-owner use
- Removes the `capacity` field — delegated to `Observer::capacity().get()`
- Replaces the manual skip-oldest + push-slice logic in `write()` with `push_slice_overwrite()` from the `RingBuffer` trait, which covers all three cases (data fits, data overflows, data larger than capacity)
- Drops unused imports: `HeapCons`, `HeapProd`, `Producer`, `Split`
- Net: −28 / +11 lines; all 14 buffer tests and full 354-test suite pass

## Test plan

- [x] All 14 existing buffer unit tests pass unchanged
- [x] `./scripts/test.sh` — all tests pass
- [x] `./scripts/check.sh` — fmt, lint, clippy all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)