### PR TITLE
feat(ui): confirmation dialog when closing tab via keyboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- UI: confirmation dialog when closing a tab or tab group via keyboard shortcut (`close-tab` / `close-tab-group`). Default Cancel button focus protects against accidental Enter. The X-button on tabs is unaffected. A new "Confirm Close Tab on Shortcut" toggle in **Settings → General** disables the dialog. Closes #750.
 - Network tools: the Port Scanner now accepts CIDR ranges (e.g. `192.168.0.0/24`), single IP/host names, or a comma-separated mix of the two as its target. Results are grouped per host when multiple targets are scanned. Backed by the `ipnet` crate; capped at 65 536 expanded hosts per scan to prevent runaway internet-scale scans. Closes #732.
 - Connection Editor: the dynamic connection form now uses `react-hook-form` for field state management and `zod` for client-side validation. Invalid port values (out of 1–65535), empty required text fields, and out-of-range numbers now show inline error messages next to the relevant field without requiring a connection attempt.
 - Network tools: `pnet_packet` is now used to validate ICMP/ICMPv6 reply types in traceroute. Only Time Exceeded and Destination Unreachable packets are accepted as valid hop replies; unrelated ICMP packets received on the raw socket are silently ignored. Improves correctness and lays the groundwork for better Windows raw-socket support.

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -140,6 +140,10 @@ pub struct AppSettings {
     pub power_monitoring_enabled: bool,
     #[serde(default = "default_true")]
     pub file_browser_enabled: bool,
+    /// Show a confirmation dialog when the user presses the close-tab or
+    /// close-tab-group keyboard shortcut. The X-button on a tab is not affected.
+    #[serde(default = "default_true")]
+    pub confirm_close_tab_on_shortcut: bool,
     /// Default value for Shell Integration toggle in new SSH connections.
     #[serde(default = "default_true")]
     pub default_shell_integration: bool,
@@ -198,6 +202,7 @@ impl Default for AppSettings {
             cursor_blink: None,
             power_monitoring_enabled: true,
             file_browser_enabled: true,
+            confirm_close_tab_on_shortcut: true,
             default_shell_integration: true,
             default_x11_forwarding: true,
             layout: None,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { RecoveryDialog } from "@/components/Settings/RecoveryDialog";
 import { ShortcutsOverlay } from "@/components/KeyboardShortcuts/ShortcutsOverlay";
 import { OverlayViewPanel } from "@/components/Settings/OverlayViewPanel";
 import { LargePasteDialog } from "@/components/Terminal/LargePasteDialog";
+import { ConfirmCloseTabDialog } from "@/components/Terminal/ConfirmCloseTabDialog";
 import { UpdateNotification } from "@/components/UpdateNotification/UpdateNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useTunnelEvents } from "@/hooks/useTunnelEvents";
@@ -247,6 +248,7 @@ function App() {
           onCancel={closeLargePasteDialog}
         />
         <UpdateNotification />
+        <ConfirmCloseTabDialog />
       </div>
     </ErrorBoundary>
   );

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -106,6 +106,27 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
           </label>
         )}
 
+        {show("confirmCloseTabOnShortcut") && (
+          <div className="settings-form__field">
+            <span className="settings-form__label">Confirm Close Tab on Shortcut</span>
+            <label className="settings-panel__toggle">
+              <input
+                type="checkbox"
+                checked={settings.confirmCloseTabOnShortcut ?? true}
+                onChange={(e) =>
+                  onChange({ ...settings, confirmCloseTabOnShortcut: e.target.checked })
+                }
+                data-testid="settings-confirm-close-tab-on-shortcut"
+              />
+              <span className="settings-panel__toggle-slider" />
+            </label>
+            <span className="settings-form__hint">
+              Ask for confirmation when closing a tab or tab group via keyboard shortcut. The X
+              button on tabs is unaffected.
+            </span>
+          </div>
+        )}
+
         {show("experimentalFeaturesEnabled") && (
           <div className="settings-form__field">
             <span className="settings-form__label">Allow Experimental Features</span>

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -199,6 +199,23 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     ],
   },
   {
+    id: "confirmCloseTabOnShortcut",
+    label: "Confirm Close Tab on Shortcut",
+    description: "Ask for confirmation when closing a tab via keyboard shortcut",
+    category: "general",
+    keywords: [
+      "confirm",
+      "close",
+      "tab",
+      "shortcut",
+      "keyboard",
+      "dialog",
+      "ctrl+w",
+      "cmd+w",
+      "prompt",
+    ],
+  },
+  {
     id: "experimentalFeaturesEnabled",
     label: "Allow Experimental Features",
     description:

--- a/src/components/Terminal/ConfirmCloseTabDialog.test.tsx
+++ b/src/components/Terminal/ConfirmCloseTabDialog.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+import { ConfirmCloseTabDialog } from "./ConfirmCloseTabDialog";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+describe("ConfirmCloseTabDialog", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when no pending request", () => {
+    render(<ConfirmCloseTabDialog />);
+    expect(document.querySelector('[data-testid="confirm-close-tab-dialog"]')).toBeNull();
+  });
+
+  it("shows the tab label in the description when kind is 'tab'", () => {
+    render(<ConfirmCloseTabDialog />);
+
+    act(() => {
+      useAppStore.getState().setPendingShortcutCloseConfirm({
+        kind: "tab",
+        tabId: "tab-1",
+        panelId: "panel-1",
+        label: "my-server",
+      });
+    });
+
+    const dialog = document.querySelector('[data-testid="confirm-close-tab-dialog"]');
+    expect(dialog).toBeTruthy();
+    expect(dialog?.textContent).toContain("my-server");
+  });
+
+  it("Cancel button clears the request and does not close the tab", () => {
+    useAppStore.getState().addTab("Tab A", "local");
+    const panel = getAllLeaves(useAppStore.getState().rootPanel)[0];
+    const tabId = panel.tabs[0].id;
+
+    render(<ConfirmCloseTabDialog />);
+
+    act(() => {
+      useAppStore.getState().setPendingShortcutCloseConfirm({
+        kind: "tab",
+        tabId,
+        panelId: panel.id,
+        label: "Tab A",
+      });
+    });
+
+    act(() => {
+      (document.querySelector('[data-testid="confirm-close-tab-cancel"]') as HTMLElement).click();
+    });
+
+    expect(useAppStore.getState().pendingShortcutCloseConfirm).toBeNull();
+    expect(getAllLeaves(useAppStore.getState().rootPanel)[0].tabs).toHaveLength(1);
+  });
+
+  it("Confirm button closes the tab and clears the request", () => {
+    useAppStore.getState().addTab("Tab A", "local");
+    const panel = getAllLeaves(useAppStore.getState().rootPanel)[0];
+    const tabId = panel.tabs[0].id;
+
+    render(<ConfirmCloseTabDialog />);
+
+    act(() => {
+      useAppStore.getState().setPendingShortcutCloseConfirm({
+        kind: "tab",
+        tabId,
+        panelId: panel.id,
+        label: "Tab A",
+      });
+    });
+
+    act(() => {
+      (document.querySelector('[data-testid="confirm-close-tab-confirm"]') as HTMLElement).click();
+    });
+
+    expect(useAppStore.getState().pendingShortcutCloseConfirm).toBeNull();
+    expect(getAllLeaves(useAppStore.getState().rootPanel)[0].tabs).toHaveLength(0);
+  });
+
+  it("for tab-group kind, confirm closes the tab group", () => {
+    useAppStore.getState().addTabGroup("Group Beta");
+    const groupsBefore = useAppStore.getState().tabGroups.length;
+    const targetId = useAppStore.getState().activeTabGroupId;
+
+    render(<ConfirmCloseTabDialog />);
+
+    act(() => {
+      useAppStore.getState().setPendingShortcutCloseConfirm({
+        kind: "tab-group",
+        tabGroupId: targetId,
+        label: "Group Beta",
+      });
+    });
+
+    const dialog = document.querySelector('[data-testid="confirm-close-tab-dialog"]');
+    expect(dialog?.textContent).toContain("Group Beta");
+
+    act(() => {
+      (
+        document.querySelector('[data-testid="confirm-close-tab-group-confirm"]') as HTMLElement
+      ).click();
+    });
+
+    expect(useAppStore.getState().tabGroups).toHaveLength(groupsBefore - 1);
+    expect(useAppStore.getState().pendingShortcutCloseConfirm).toBeNull();
+  });
+});

--- a/src/components/Terminal/ConfirmCloseTabDialog.tsx
+++ b/src/components/Terminal/ConfirmCloseTabDialog.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useAppStore } from "@/store/appStore";
+
+/**
+ * Confirmation dialog shown when the user presses the close-tab or
+ * close-tab-group keyboard shortcut while
+ * `settings.confirmCloseTabOnShortcut` is enabled.
+ *
+ * Reads `pendingShortcutCloseConfirm` from the store; renders nothing when
+ * no request is pending. Confirm closes the tab/group; Cancel (Esc, backdrop
+ * click, button) clears the request and leaves the tab open.
+ */
+export function ConfirmCloseTabDialog() {
+  const request = useAppStore((s) => s.pendingShortcutCloseConfirm);
+  const setRequest = useAppStore((s) => s.setPendingShortcutCloseConfirm);
+  const closeTab = useAppStore((s) => s.closeTab);
+  const closeTabGroup = useAppStore((s) => s.closeTabGroup);
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Focus the safe (Cancel) button when the dialog opens so an accidental
+  // Enter press does not close the tab.
+  useEffect(() => {
+    if (request) {
+      // Defer to ensure the button is mounted.
+      requestAnimationFrame(() => cancelBtnRef.current?.focus());
+    }
+  }, [request]);
+
+  if (!request) return null;
+
+  const handleCancel = () => setRequest(null);
+  const handleConfirm = () => {
+    if (request.kind === "tab") {
+      closeTab(request.tabId, request.panelId);
+    } else {
+      closeTabGroup(request.tabGroupId);
+    }
+    setRequest(null);
+  };
+
+  const title = request.kind === "tab" ? "Close tab?" : "Close tab group?";
+  const description =
+    request.kind === "tab"
+      ? `Close "${request.label}"? Any work in this tab will be lost.`
+      : `Close tab group "${request.label}" and all tabs inside it?`;
+  const confirmLabel = request.kind === "tab" ? "Close tab" : "Close group";
+  const confirmTestId =
+    request.kind === "tab" ? "confirm-close-tab-confirm" : "confirm-close-tab-group-confirm";
+
+  return (
+    <Dialog.Root open={true} onOpenChange={(isOpen) => !isOpen && handleCancel()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="shortcuts-overlay__backdrop" />
+        <Dialog.Content
+          className="confirm-close-tab-dialog"
+          data-testid="confirm-close-tab-dialog"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              // Enter on the dialog content triggers confirm; focused Cancel button
+              // does not bubble its own Enter here because we attach to content.
+              if (document.activeElement === cancelBtnRef.current) return;
+              e.preventDefault();
+              handleConfirm();
+            }
+          }}
+          style={{
+            position: "fixed",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: "380px",
+            padding: "var(--spacing-lg, 16px)",
+            backgroundColor: "var(--bg-secondary)",
+            border: "1px solid var(--border-primary)",
+            borderRadius: "var(--radius-lg, 8px)",
+            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)",
+            zIndex: 1001,
+          }}
+        >
+          <Dialog.Title
+            style={{ margin: "0 0 var(--spacing-md, 12px) 0", color: "var(--text-primary)" }}
+          >
+            {title}
+          </Dialog.Title>
+          <Dialog.Description style={{ color: "var(--text-secondary)", marginBottom: "16px" }}>
+            {description}
+          </Dialog.Description>
+          <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end" }}>
+            <button
+              ref={cancelBtnRef}
+              onClick={handleCancel}
+              data-testid="confirm-close-tab-cancel"
+              style={{
+                padding: "4px 16px",
+                border: "1px solid var(--border-primary)",
+                borderRadius: "var(--radius-md, 4px)",
+                background: "transparent",
+                color: "var(--text-primary)",
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              data-testid={confirmTestId}
+              style={{
+                padding: "4px 16px",
+                border: "none",
+                borderRadius: "var(--radius-md, 4px)",
+                background: "var(--color-error)",
+                color: "#fff",
+                cursor: "pointer",
+              }}
+            >
+              {confirmLabel}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -157,10 +157,37 @@ describe("useKeyboardShortcuts", () => {
   });
 
   describe("close-tab", () => {
-    it("closes the active tab in the active panel", () => {
+    it("opens the confirmation dialog instead of closing immediately when the setting is enabled (default)", () => {
+      useAppStore.getState().addTab("Tab A", "local");
+      const panel = getAllLeaves(useAppStore.getState().rootPanel)[0];
+      useAppStore.getState().setActivePanel(panel.id);
+
+      act(() => {
+        root.render(createElement(KeyboardHarness));
+      });
+      mockProcessKeyEvent.mockReturnValue("close-tab");
+
+      fireKey("w");
+
+      // The tab must NOT be closed yet — the dialog should be open instead.
+      expect(getAllLeaves(useAppStore.getState().rootPanel)[0].tabs).toHaveLength(1);
+      const confirm = useAppStore.getState().pendingShortcutCloseConfirm;
+      expect(confirm).not.toBeNull();
+      expect(confirm?.kind).toBe("tab");
+      if (confirm?.kind === "tab") {
+        expect(confirm.tabId).toBe(panel.activeTabId);
+        expect(confirm.panelId).toBe(panel.id);
+        expect(confirm.label).toBe("Tab A");
+      }
+    });
+
+    it("closes the active tab immediately when the confirm setting is disabled", () => {
       useAppStore.getState().addTab("Tab A", "local");
       const panelId = getAllLeaves(useAppStore.getState().rootPanel)[0].id;
       useAppStore.getState().setActivePanel(panelId);
+      useAppStore.setState((state) => ({
+        settings: { ...state.settings, confirmCloseTabOnShortcut: false },
+      }));
 
       act(() => {
         root.render(createElement(KeyboardHarness));
@@ -170,6 +197,50 @@ describe("useKeyboardShortcuts", () => {
       fireKey("w");
 
       expect(getAllLeaves(useAppStore.getState().rootPanel)[0].tabs).toHaveLength(0);
+      expect(useAppStore.getState().pendingShortcutCloseConfirm).toBeNull();
+    });
+  });
+
+  describe("close-tab-group", () => {
+    it("opens the confirmation dialog instead of closing immediately when the setting is enabled (default)", () => {
+      useAppStore.getState().addTabGroup();
+      const groups = useAppStore.getState().tabGroups;
+      const activeId = useAppStore.getState().activeTabGroupId;
+      const activeGroup = groups.find((g) => g.id === activeId)!;
+
+      act(() => {
+        root.render(createElement(KeyboardHarness));
+      });
+      mockProcessKeyEvent.mockReturnValue("close-tab-group");
+
+      const groupsBefore = useAppStore.getState().tabGroups.length;
+      fireKey("F4");
+
+      expect(useAppStore.getState().tabGroups).toHaveLength(groupsBefore);
+      const confirm = useAppStore.getState().pendingShortcutCloseConfirm;
+      expect(confirm).not.toBeNull();
+      expect(confirm?.kind).toBe("tab-group");
+      if (confirm?.kind === "tab-group") {
+        expect(confirm.tabGroupId).toBe(activeGroup.id);
+      }
+    });
+
+    it("closes the tab group immediately when the confirm setting is disabled", () => {
+      useAppStore.getState().addTabGroup();
+      const groupsBefore = useAppStore.getState().tabGroups.length;
+      useAppStore.setState((state) => ({
+        settings: { ...state.settings, confirmCloseTabOnShortcut: false },
+      }));
+
+      act(() => {
+        root.render(createElement(KeyboardHarness));
+      });
+      mockProcessKeyEvent.mockReturnValue("close-tab-group");
+
+      fireKey("F4");
+
+      expect(useAppStore.getState().tabGroups).toHaveLength(groupsBefore - 1);
+      expect(useAppStore.getState().pendingShortcutCloseConfirm).toBeNull();
     });
   });
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -63,8 +63,19 @@ export function useKeyboardShortcuts() {
         case "close-tab": {
           e.preventDefault();
           const panel = allLeaves.find((p) => p.id === activePanelId);
-          if (panel?.activeTabId) {
-            closeTab(panel.activeTabId, panel.id);
+          if (!panel?.activeTabId) break;
+          const tabId = panel.activeTabId;
+          const confirmEnabled = useAppStore.getState().settings.confirmCloseTabOnShortcut ?? true;
+          if (confirmEnabled) {
+            const activeTab = panel.tabs.find((t) => t.id === tabId);
+            useAppStore.getState().setPendingShortcutCloseConfirm({
+              kind: "tab",
+              tabId,
+              panelId: panel.id,
+              label: activeTab?.title ?? "this tab",
+            });
+          } else {
+            closeTab(tabId, panel.id);
           }
           break;
         }
@@ -178,8 +189,17 @@ export function useKeyboardShortcuts() {
 
         case "close-tab-group": {
           e.preventDefault();
-          const { tabGroups, activeTabGroupId } = useAppStore.getState();
-          if (tabGroups.length > 1) {
+          const { tabGroups, activeTabGroupId, settings } = useAppStore.getState();
+          if (tabGroups.length <= 1) break;
+          const confirmEnabled = settings.confirmCloseTabOnShortcut ?? true;
+          if (confirmEnabled) {
+            const activeGroup = tabGroups.find((g) => g.id === activeTabGroupId);
+            useAppStore.getState().setPendingShortcutCloseConfirm({
+              kind: "tab-group",
+              tabGroupId: activeTabGroupId,
+              label: activeGroup?.name ?? "this tab group",
+            });
+          } else {
             useAppStore.getState().closeTabGroup(activeTabGroupId);
           }
           break;

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -317,6 +317,21 @@ interface AppState {
   setEditorDirty: (tabId: string, dirty: boolean) => void;
   pendingCloseRequest: { tabId: string; panelId: string } | null;
   setPendingCloseRequest: (req: { tabId: string; panelId: string } | null) => void;
+  /**
+   * Confirmation request shown when the user closes a tab (or tab group) via
+   * keyboard shortcut while `settings.confirmCloseTabOnShortcut` is enabled.
+   * Null when no dialog is open.
+   */
+  pendingShortcutCloseConfirm:
+    | { kind: "tab"; tabId: string; panelId: string; label: string }
+    | { kind: "tab-group"; tabGroupId: string; label: string }
+    | null;
+  setPendingShortcutCloseConfirm: (
+    req:
+      | { kind: "tab"; tabId: string; panelId: string; label: string }
+      | { kind: "tab-group"; tabGroupId: string; label: string }
+      | null
+  ) => void;
   closeTab: (tabId: string, panelId: string) => void;
   setActiveTab: (tabId: string, panelId: string) => void;
   moveTab: (tabId: string, fromPanelId: string, toPanelId: string, newIndex: number) => void;
@@ -1625,6 +1640,9 @@ export const useAppStore = create<AppState>((set, get) => {
     pendingCloseRequest: null,
     setPendingCloseRequest: (req) => set({ pendingCloseRequest: req }),
 
+    pendingShortcutCloseConfirm: null,
+    setPendingShortcutCloseConfirm: (req) => set({ pendingShortcutCloseConfirm: req }),
+
     closeTab: (tabId, panelId) =>
       set((state) => {
         // Clean up per-tab state for the closed tab
@@ -1908,12 +1926,14 @@ export const useAppStore = create<AppState>((set, get) => {
       externalConnectionFiles: [],
       powerMonitoringEnabled: true,
       fileBrowserEnabled: true,
+      confirmCloseTabOnShortcut: true,
     },
     savedSettings: {
       version: "1",
       externalConnectionFiles: [],
       powerMonitoringEnabled: true,
       fileBrowserEnabled: true,
+      confirmCloseTabOnShortcut: true,
     },
 
     // Layout

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -194,6 +194,12 @@ export interface AppSettings {
   cursorBlink?: boolean;
   powerMonitoringEnabled: boolean;
   fileBrowserEnabled: boolean;
+  /**
+   * Show a confirmation dialog when the user closes a tab via the
+   * close-tab or close-tab-group keyboard shortcut. Defaults to true.
+   * The X-button on tabs always closes immediately and is unaffected by this setting.
+   */
+  confirmCloseTabOnShortcut?: boolean;
   defaultShellIntegration?: boolean;
   defaultX11Forwarding?: boolean;
   layout?: LayoutConfig;


### PR DESCRIPTION
## Summary

- Pressing the `close-tab` or `close-tab-group` keyboard shortcut now opens a confirmation dialog instead of closing the tab immediately. The X-button on tabs is unaffected.
- New `confirmCloseTabOnShortcut` setting (default **on**) persisted via `AppSettings`, with a toggle in **Settings → General**.
- The dialog focuses the Cancel button on open so an accidental Enter does not close the tab.

Closes #750.

## Test plan

- [x] Unit: `useKeyboardShortcuts.test.ts` — close-tab and close-tab-group go through `pendingShortcutCloseConfirm` when enabled; bypass when disabled
- [x] Unit: `ConfirmCloseTabDialog.test.tsx` — render gating, label, Cancel keeps tab, Confirm closes tab, Confirm closes tab-group
- [x] `./scripts/test.sh` — all 1527 frontend tests + Rust workspace tests pass
- [x] `./scripts/check.sh` — ESLint, Prettier, markdownlint, `cargo fmt`, `cargo clippy` all clean
- [ ] Manual (macOS): open multiple tabs, press `Cmd+W` → dialog appears with the tab title, Esc/Cancel keeps the tab, Enter on the focused Cancel button keeps the tab, clicking "Close tab" closes it
- [ ] Manual: with two tab groups, press the close-tab-group shortcut → dialog appears with the group name; Confirm removes the group
- [ ] Manual: disable "Confirm Close Tab on Shortcut" in Settings → General → keyboard shortcut closes immediately
- [ ] Manual: X button on a tab still closes immediately regardless of the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)