### PR TITLE
fix(backend): silence noisy russh debug logs in app log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Logging: the desktop app's tracing subscriber had no log-level filter, so noisy third-party dependencies — most notably `russh`, which emits per-packet `DEBUG`/`TRACE` cipher logs — flooded the LogViewer and console even while the app was idle (e.g. during background SSH monitoring polls). A default `EnvFilter` now keeps termiHub's own crates and `frontend::*` events at `DEBUG` while raising third-party crates to `INFO` and `russh` to `WARN`. The level can still be overridden via the `RUST_LOG` environment variable.
 - Connection Editor: name conflict validation no longer crosses entity types. Connections, remote agents, and agent session definitions now each validate uniqueness only against their own peers (connections vs. other connections in the same folder, agents vs. other agents, definitions vs. other definitions on the same agent). Previously, naming a connection the same as an existing remote agent (or vice-versa) raised a spurious "already exists" error even though the two are stored independently.
 - Monitoring: macOS memory usage was reported as ~100% due to a bug in `sysinfo` 0.33 where `available_memory()` incorrectly subtracted compressed pages. Upgraded `sysinfo` from 0.33 to 0.38 which uses Apple's XNU-documented formula and matches Activity Monitor within ~4%.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 semver = "1"
 dirs = "6"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["registry", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["registry", "fmt", "env-filter"] }
 chrono = "0.4"
 argon2 = "0.5"
 aes-gcm = "0.10"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ use network::NetworkManager;
 use session::manager::SessionManager;
 use session::registry::build_desktop_registry;
 use terminal::agent_manager::{AgentConnectionManager, AgentRpcClient};
-use utils::log_capture::{create_log_buffer, LogCaptureLayer};
+use utils::log_capture::{create_log_buffer, default_env_filter, LogCaptureLayer};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -37,6 +37,7 @@ pub fn run() {
     let app_handle_slot = capture_layer.app_handle_slot();
 
     tracing_subscriber::registry()
+        .with(default_env_filter())
         .with(tracing_subscriber::fmt::layer())
         .with(capture_layer)
         .init();

--- a/src-tauri/src/utils/log_capture.rs
+++ b/src-tauri/src/utils/log_capture.rs
@@ -6,10 +6,26 @@ use tauri::{AppHandle, Emitter};
 use tracing::field::{Field, Visit};
 use tracing::Level;
 use tracing_subscriber::layer::Context;
-use tracing_subscriber::Layer;
+use tracing_subscriber::{EnvFilter, Layer};
 
 /// Maximum number of log entries retained in the ring buffer.
 const MAX_BUFFER_SIZE: usize = 2000;
+
+/// Default tracing filter directive.
+///
+/// Keeps termiHub's own crates (and `frontend::*` events bridged from the UI)
+/// at `DEBUG` so the LogViewer stays useful, while silencing noisy third-party
+/// dependencies — most notably `russh`, which emits per-packet `DEBUG`/`TRACE`
+/// cipher logs that otherwise flood the log even while the app is idle.
+const DEFAULT_LOG_DIRECTIVE: &str = "info,termihub=debug,termihub_lib=debug,termihub_core=debug,termihub_agent=debug,frontend=debug,russh=warn";
+
+/// Build the tracing [`EnvFilter`] used by the application.
+///
+/// Honors the `RUST_LOG` environment variable when set; otherwise falls back to
+/// [`DEFAULT_LOG_DIRECTIVE`].
+pub fn default_env_filter() -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(DEFAULT_LOG_DIRECTIVE))
+}
 
 /// A single captured log entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -245,5 +261,32 @@ mod tests {
         assert_eq!(entries[0].level, "INFO");
         assert_eq!(entries[0].target, "test_target");
         assert!(entries[0].message.contains("hello from tracing"));
+    }
+
+    #[test]
+    fn default_filter_silences_russh_but_keeps_app_debug() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let buffer = create_log_buffer();
+        let layer = LogCaptureLayer::new(buffer.clone());
+
+        let subscriber = tracing_subscriber::registry()
+            .with(default_env_filter())
+            .with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        // Noisy dependency spam (the bug): must be filtered out.
+        tracing::debug!(target: "russh::cipher", "reading, seqn = 603");
+        tracing::trace!(target: "russh::client::encrypted", "process_packet");
+        // Application-level debug (frontend bridge): must be kept.
+        tracing::debug!(target: "frontend::terminal", "frontend debug message");
+
+        let entries = buffer.lock().unwrap().get_recent(10);
+        assert_eq!(
+            entries.len(),
+            1,
+            "only the frontend debug entry should survive the filter, got: {entries:?}"
+        );
+        assert_eq!(entries[0].target, "frontend::terminal");
     }
 }


### PR DESCRIPTION
## Summary

The desktop app's LogViewer (and console) was continuously flooded with `russh` `DEBUG`/`TRACE` cipher output even while the app was idle:

```
DEBUG russh::cipher: reading, seqn = 603
TRACE russh::client::encrypted: client_read_encrypted, buf = [...]
TRACE russh::session: adjust_window_size, channel = 2, ...
```

These bursts coincide with background SSH **monitoring polls** (`connection.monitoring.data` notifications).

## Root cause

The tracing subscriber in `src-tauri/src/lib.rs` was registered with **no `EnvFilter`**, so both the console `fmt` layer and the LogViewer capture layer received every `TRACE`/`DEBUG` event from all third-party dependencies. `russh` logs per-packet cipher activity on every SSH read.

## Fix

- Add a `default_env_filter()` helper (`src-tauri/src/utils/log_capture.rs`) with directive:
  `info,termihub=debug,termihub_lib=debug,termihub_core=debug,termihub_agent=debug,frontend=debug,russh=warn`
  — termiHub's own crates and the `frontend::*` bridge stay at `DEBUG` (LogViewer remains useful); third-party crates are raised to `INFO`, `russh` to `WARN`.
- Apply it at the registry level so it governs all layers uniformly.
- Honors `RUST_LOG` when set, so verbosity is still tunable on demand.
- Enable the `env-filter` feature on `tracing-subscriber`.

## Test plan

- [x] `default_filter_silences_russh_but_keeps_app_debug` — regression test: emits `russh::cipher` DEBUG / `russh::client::encrypted` TRACE plus a `frontend::terminal` DEBUG through the real filter+capture pipeline and asserts only the frontend entry survives.
- [x] `./scripts/test.sh` — all unit tests pass
- [x] `./scripts/check.sh` — fmt, clippy, ESLint, markdownlint pass

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)