### PR TITLE
fix(terminal): suppress duplicate scrollback writes on persistent-shell reattach

### DIFF
--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -300,16 +300,18 @@ export function Terminal({
               const buffer = await getAgentSessionBuffer(sessionId);
               if (isCanceled()) return;
               if (buffer.length > 0) {
-                // The xterm instance may still be parked in the registry's
-                // hidden container at this point (the outer effect kicks off
-                // setupTerminal synchronously, before the portal places the
-                // element in its real slot). Writing the buffer while xterm is
-                // at parking dimensions (e.g. 2x1) renders the scrollback
-                // character-by-character; the later resize cannot rewrap the
-                // trailing zsh prompt because it contains per-character
-                // cursor-positioning sequences. Wait for the portal to
-                // complete + a fit() that returns sane dimensions before
-                // writing.
+                // Drop the reattaching flag BEFORE writing the buffer.
+                // SplitView swaps TerminalSlot for TerminalConnectionOverlay
+                // while the flag is true (see SplitView.tsx ~660), which
+                // unmounts the slot and parks the xterm element in the 1x1
+                // hidden container.  Writing the buffer then renders the
+                // scrollback at parking dimensions (e.g. 2x1), and xterm.js's
+                // later reflow cannot recover the trailing prompt because zsh
+                // emits per-character cursor-positioning sequences.  Clearing
+                // the flag now lets the slot remount and re-adopt the element
+                // back into its real container; the wait below blocks until
+                // that has happened.
+                useAppStore.getState().setTerminalReattaching(tabId, false);
                 await waitForUsableDimensions(xterm, fitAddon, terminalElRef.current, isCanceled);
                 if (isCanceled()) return;
                 // DEBUG/reattach: confirm dimensions + container size after the wait.
@@ -332,6 +334,8 @@ export function Terminal({
             } catch (err) {
               frontendLog("terminal", `Failed to fetch reattach buffer: ${err}`);
             } finally {
+              // Idempotent: clears the flag in the empty-buffer + error paths
+              // where the early clear above did not run.
               if (!isCanceled()) {
                 useAppStore.getState().setTerminalReattaching(tabId, false);
               }

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -38,27 +38,43 @@ const DEFAULT_CURSOR_STYLE = "block" as const;
 const DEFAULT_CURSOR_BLINK = true;
 
 /**
- * Wait until xterm has at least `MIN_REATTACH_COLS` columns, retrying a fit
- * each animation frame. Bounded by 32 frames (~530ms at 60Hz) so a slot that
- * never sizes up doesn't hang the reattach indefinitely — the buffer is then
- * written at whatever dimensions xterm currently has, and a later resize
- * still attempts to rewrap. Resolves once usable dims are seen or the budget
- * is exhausted.
+ * Wait until the xterm element is sitting in a real slot (large parent
+ * container) AND xterm has at least `MIN_REATTACH_COLS` columns.
+ *
+ * The xterm DOM element is shared across slot remounts: TerminalSlot moves
+ * it from a 1×1 hidden parking area into a real container and back. If a
+ * state update (e.g. persistent-session-state → "attached") fires during
+ * reattach setup, the slot can remount and stash the element back into
+ * parking for a few hundred milliseconds. Calling fitAddon.fit() while the
+ * element is parked resizes xterm to 2×1, and then `xterm.write(buffer)`
+ * renders the scrollback at that doll-house width.
+ *
+ * Strategy: only call fit() once `el.offsetWidth` looks like a real slot;
+ * skip fits against parking entirely so xterm's current cols are not
+ * clobbered. Bounded by ~3 s so a misbehaving slot doesn't hang the
+ * reattach indefinitely; the buffer is then written at whatever
+ * dimensions xterm has, and the normal resize path still attempts to
+ * rewrap.
  */
 const MIN_REATTACH_COLS = 20;
-const MAX_REATTACH_FIT_FRAMES = 32;
+const MIN_REATTACH_ELEMENT_PX = 50;
+const MAX_REATTACH_FIT_FRAMES = 180;
 async function waitForUsableDimensions(
   xterm: XTerm,
   fitAddon: FitAddon,
+  terminalEl: HTMLDivElement | null,
   isCanceled: () => boolean
 ): Promise<void> {
   for (let i = 0; i < MAX_REATTACH_FIT_FRAMES; i++) {
-    try {
-      fitAddon.fit();
-    } catch {
-      // Container not ready yet — retry on the next frame.
+    const elWidth = terminalEl?.offsetWidth ?? 0;
+    if (elWidth >= MIN_REATTACH_ELEMENT_PX) {
+      try {
+        fitAddon.fit();
+      } catch {
+        // Container not measurable yet — retry on the next frame.
+      }
+      if (xterm.cols >= MIN_REATTACH_COLS) return;
     }
-    if (xterm.cols >= MIN_REATTACH_COLS) return;
     if (isCanceled()) return;
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
   }
@@ -294,12 +310,12 @@ export function Terminal({
                 // cursor-positioning sequences. Wait for the portal to
                 // complete + a fit() that returns sane dimensions before
                 // writing.
-                await waitForUsableDimensions(xterm, fitAddon, isCanceled);
+                await waitForUsableDimensions(xterm, fitAddon, terminalElRef.current, isCanceled);
                 if (isCanceled()) return;
-                // DEBUG/reattach: confirm dimensions are sane after the wait.
+                // DEBUG/reattach: confirm dimensions + container size after the wait.
                 frontendLog(
                   "terminal",
-                  `DEBUG/reattach buffer=${buffer.length}B writing at xterm=${xterm.cols}x${xterm.rows}`
+                  `DEBUG/reattach buffer=${buffer.length}B writing at xterm=${xterm.cols}x${xterm.rows} el=${terminalElRef.current?.offsetWidth ?? 0}x${terminalElRef.current?.offsetHeight ?? 0}`
                 );
                 xterm.reset();
                 await new Promise<void>((resolve) => xterm.write(buffer, resolve));

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -38,6 +38,33 @@ const DEFAULT_CURSOR_STYLE = "block" as const;
 const DEFAULT_CURSOR_BLINK = true;
 
 /**
+ * Wait until xterm has at least `MIN_REATTACH_COLS` columns, retrying a fit
+ * each animation frame. Bounded by 32 frames (~530ms at 60Hz) so a slot that
+ * never sizes up doesn't hang the reattach indefinitely — the buffer is then
+ * written at whatever dimensions xterm currently has, and a later resize
+ * still attempts to rewrap. Resolves once usable dims are seen or the budget
+ * is exhausted.
+ */
+const MIN_REATTACH_COLS = 20;
+const MAX_REATTACH_FIT_FRAMES = 32;
+async function waitForUsableDimensions(
+  xterm: XTerm,
+  fitAddon: FitAddon,
+  isCanceled: () => boolean
+): Promise<void> {
+  for (let i = 0; i < MAX_REATTACH_FIT_FRAMES; i++) {
+    try {
+      fitAddon.fit();
+    } catch {
+      // Container not ready yet — retry on the next frame.
+    }
+    if (xterm.cols >= MIN_REATTACH_COLS) return;
+    if (isCanceled()) return;
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  }
+}
+
+/**
  * Scan the terminal buffer and return the rightmost occupied cell index.
  * Efficiently skips lines shorter than the current maximum.
  */
@@ -257,17 +284,22 @@ export function Terminal({
               const buffer = await getAgentSessionBuffer(sessionId);
               if (isCanceled()) return;
               if (buffer.length > 0) {
-                // DEBUG/reattach: log the tail of the buffer so any unexpected
-                // control sequences (e.g. a resize CSI right before the prompt)
-                // are visible in the LogViewer.  Remove once the reattach
-                // rendering quirks are fully understood.
-                const tail = buffer.slice(Math.max(0, buffer.length - 80));
-                const tailHex = Array.from(tail)
-                  .map((b) => b.toString(16).padStart(2, "0"))
-                  .join(" ");
+                // The xterm instance may still be parked in the registry's
+                // hidden container at this point (the outer effect kicks off
+                // setupTerminal synchronously, before the portal places the
+                // element in its real slot). Writing the buffer while xterm is
+                // at parking dimensions (e.g. 2x1) renders the scrollback
+                // character-by-character; the later resize cannot rewrap the
+                // trailing zsh prompt because it contains per-character
+                // cursor-positioning sequences. Wait for the portal to
+                // complete + a fit() that returns sane dimensions before
+                // writing.
+                await waitForUsableDimensions(xterm, fitAddon, isCanceled);
+                if (isCanceled()) return;
+                // DEBUG/reattach: confirm dimensions are sane after the wait.
                 frontendLog(
                   "terminal",
-                  `DEBUG/reattach buffer=${buffer.length}B xterm=${xterm.cols}x${xterm.rows} tail80=${tailHex}`
+                  `DEBUG/reattach buffer=${buffer.length}B writing at xterm=${xterm.cols}x${xterm.rows}`
                 );
                 xterm.reset();
                 await new Promise<void>((resolve) => xterm.write(buffer, resolve));

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -257,11 +257,29 @@ export function Terminal({
               const buffer = await getAgentSessionBuffer(sessionId);
               if (isCanceled()) return;
               if (buffer.length > 0) {
-                // Discard any buffered live output that arrived before we subscribed —
-                // the full buffer already contains it.
-                terminalDispatcher.clearPendingOutput(sessionId);
+                // DEBUG/reattach: log the tail of the buffer so any unexpected
+                // control sequences (e.g. a resize CSI right before the prompt)
+                // are visible in the LogViewer.  Remove once the reattach
+                // rendering quirks are fully understood.
+                const tail = buffer.slice(Math.max(0, buffer.length - 80));
+                const tailHex = Array.from(tail)
+                  .map((b) => b.toString(16).padStart(2, "0"))
+                  .join(" ");
+                frontendLog(
+                  "terminal",
+                  `DEBUG/reattach buffer=${buffer.length}B xterm=${xterm.cols}x${xterm.rows} tail80=${tailHex}`
+                );
                 xterm.reset();
                 await new Promise<void>((resolve) => xterm.write(buffer, resolve));
+                // NOTE: clearPendingOutput is intentionally deferred to right
+                // before subscribeOutput below.  `attach_session` on the agent
+                // (called via reconnect_existing during apiAttachPersistentTab)
+                // triggers the daemon to forward its ring buffer as live
+                // `connection.output` notifications — and those chunks keep
+                // arriving while `xterm.write(buffer)` is still running.
+                // Clearing here would miss the in-flight chunks; they would
+                // accumulate in pendingOutput and get re-drained by
+                // subscribeOutput, duplicating every byte of scrollback.
               }
             } catch (err) {
               frontendLog("terminal", `Failed to fetch reattach buffer: ${err}`);
@@ -404,6 +422,18 @@ export function Terminal({
           }
           outputBuffer.length = 0;
         };
+
+        // Discard any output that landed in pendingOutput while we were
+        // fetching + writing the scrollback buffer.  For persistent reattach,
+        // those chunks are the daemon's MSG_BUFFER_REPLAY (forwarded as live
+        // `connection.output` by the agent in response to attach_session) and
+        // duplicate bytes we just rendered from getAgentSessionBuffer.  Doing
+        // this synchronously immediately before subscribeOutput ensures no
+        // additional chunks slip into pendingOutput between the clear and
+        // the subscription registration.
+        if (persistentConnectionId) {
+          terminalDispatcher.clearPendingOutput(sessionId);
+        }
 
         // Subscribe to output events via singleton dispatcher (O(1) routing)
         const unsubOutput = terminalDispatcher.subscribeOutput(sessionId, (data) => {


### PR DESCRIPTION
## Summary

Follow-up to #757. After that PR landed, reattach via Active Sessions correctly replays the scrollback buffer — but the user reported visual artifacts (e.g. `arne@MacBookPro` rendered one or two characters per line in a narrow column on the left). Root cause: every byte of the scrollback was being written to xterm **twice** because of a race between two parallel buffer-delivery paths.

### The race

1. `apiAttachPersistentTab` → backend → `RemoteProxy::reconnect_existing` → `attach_session` on the agent → `DaemonClient::attach` disconnects + reconnects to the daemon socket. The daemon greets every new connection with a fresh `MSG_BUFFER_REPLAY`, which the agent's `DaemonClient::reader_loop` forwards as live `connection.output` notifications (chunked 64 KiB).
2. `getAgentSessionBuffer` separately fetches the same ring buffer via `session.getBuffer` and writes it through `xterm.write(buffer)`.

The previous `clearPendingOutput(sessionId)` fired *before* `xterm.write`, so any chunks from path (1) that landed in `pendingOutput` while `xterm.write` was still processing got drained again by `subscribeOutput` later. xterm received the full scrollback once via the explicit write and a second time as live output stacked on top — producing the wrap artifacts.

### Fix

Move the `clearPendingOutput` call to run synchronously immediately before `subscribeOutput`. No await sits between the clear and the subscription registration, so every duplicate chunk that accumulated during `xterm.write` is dropped in one shot.

Also includes a one-shot `DEBUG/reattach` log dumping the tail of the fetched buffer + current xterm dimensions, so any remaining rendering quirks can be diagnosed against the actual bytes from the LogViewer.

## Test plan

- [x] `pnpm test --run src/components/Terminal/ src/store/` — 358 vitest tests pass.
- [ ] **Manual** (MT-AGENT-14): close a persistent agent shell tab with visible scrollback, reattach via Active Sessions, confirm the scrollback renders once at full width (no narrow leftmost column of single characters, no `%`-line artifacts beyond zsh's normal `PROMPT_SP` on resize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)