### PR TITLE
feat(terminal): inset terminal text 8px from container edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Terminal: added a small horizontal inset (8 px) inside the terminal viewport so the first and last characters of each line are no longer flush against the container edge or the vertical scrollbar. This makes it easier to drag-select characters at the line edges. xterm's FitAddon reads the padding so column counts remain accurate; horizontal-scroll mode keeps zero padding to avoid clipping the imperatively sized canvas.
+
 ### Fixed
 
 - Agent persistent shells: re-attaching to a session via the sidebar's **Active Sessions** double-click no longer spawns a fresh shell on the agent — the desktop now adopts the existing agent session and replays its scrollback buffer into the new tab. Previously the handler called `addTab` without the agent's `sessionId` or the persistent connection ID, so `createTerminal` spawned a new session and the original daemon-side ring buffer was orphaned. A new agent protocol field (`definition_id`) lets the desktop recover the persistent connection ID from a discovered session after both agent and desktop restarts; a new `adopt_persistent_session` backend command and `adoptAndAttachAgentPersistentSession` store action wire this into the existing scrollback-replay path. Sessions created before this version (without `definition_id` on the wire) fall back to the previous behaviour (reattach without buffer replay) until the next restart.

--- a/src/components/Terminal/Terminal.css
+++ b/src/components/Terminal/Terminal.css
@@ -21,6 +21,21 @@
 
 .terminal-container .xterm {
   height: 100%;
+  box-sizing: border-box;
+  /* Small inset so the first/last characters aren't flush against the
+     container edge or the scrollbar, which makes them hard to select.
+     FitAddon reads this padding via getComputedStyle on the .xterm element
+     and subtracts it from the available width, so column counts stay
+     accurate. */
+  padding: 0 8px;
+}
+
+/* In horizontal-scroll mode we set xterm width imperatively to the content
+   width, which would clip with border-box + padding. Disable the side
+   padding for that mode; the horizontal scrollbar already gives the user a
+   clear handle on the edges. */
+.terminal-horizontal-scroll .xterm {
+  padding: 0;
 }
 
 .terminal-container .xterm-viewport {


### PR DESCRIPTION
## Summary

- Add 8 px horizontal padding inside the `.xterm` element so the first and last characters of each line are no longer flush against the container edge or the vertical scrollbar, making it easier to drag-select edge characters.
- xterm's FitAddon reads the padding via `getComputedStyle` and subtracts it from the available width, so column/row counts stay accurate.
- Horizontal-scroll mode keeps zero padding to avoid clipping the imperatively sized canvas.

## Test plan

- [ ] Open a normal terminal tab and confirm there is a small gap between the text and both the left edge and the vertical scrollbar.
- [ ] Drag-select the very first character on a line and the very last character on a wide line — selection should be easy to initiate without grabbing the container edge or the scrollbar.
- [ ] Resize the window and confirm the column count still matches the available content area (no clipping at the right edge).
- [ ] Toggle horizontal-scroll mode on a tab and confirm content is not clipped (no padding applied in this mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)