### PR TITLE
feat(agent): build Windows agent binaries (#761)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Build tooling: the remote-agent build pipeline can now produce Windows agent binaries. `scripts/build-agents.sh --native --targets x86_64-pc-windows-msvc` (and the new `scripts/build-agents.cmd --native`) build `termihub-agent.exe` for `x86_64-pc-windows-msvc`, with best-effort `aarch64-pc-windows-msvc` support. Because cross-rs cannot target the MSVC ABI, Windows agents are built natively on a Windows host with the MSVC toolchain; the scripts fail fast with a clear message when a Windows target is requested without `--native` or on a non-Windows host. Part of #771 (Closes #761).
 - Keyboard shortcuts: terminal-focus pass-through. When a terminal pane has focus, common shell, tmux, vim, and SSH-to-remote keys (`Ctrl+<letter>`, `Ctrl+\`, `Ctrl+[`, `Ctrl+]`, `Alt+<letter>`) are sent to the PTY instead of triggering an app shortcut, even if the user has rebound an action to one of those combos. Toggle in Settings → Keyboard Shortcuts → "Pass through shell keys when terminal is focused" (on by default).
 - Keyboard shortcuts: "Reset to Safer Defaults" button in Settings → Keyboard Shortcuts clears all user overrides and re-applies the new conflict-avoiding defaults.
 - Documentation: [`docs/keyboard-shortcuts.md`](docs/keyboard-shortcuts.md) describes the conflict-avoidance defaults, pass-through behavior, and SSH-to-remote implications.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -747,14 +747,14 @@ See [scripts/README.md](../scripts/README.md) for all options. Reports are saved
 | Connection Management | [`connection-management.yaml`](../tests/manual/connection-management.yaml) | `MT-CONN`  | 10      |
 | File Browser + Editor | [`file-browser.yaml`](../tests/manual/file-browser.yaml)                   | `MT-FB`    | 10      |
 | UI / Layout           | [`ui-layout.yaml`](../tests/manual/ui-layout.yaml)                         | `MT-UI`    | 22      |
-| Remote Agent          | [`remote-agent.yaml`](../tests/manual/remote-agent.yaml)                   | `MT-AGENT` | 9       |
+| Remote Agent          | [`remote-agent.yaml`](../tests/manual/remote-agent.yaml)                   | `MT-AGENT` | 10      |
 | Credential Store      | [`credential-store.yaml`](../tests/manual/credential-store.yaml)           | `MT-CRED`  | 3       |
 | Keyboard Shortcuts    | [`keyboard.yaml`](../tests/manual/keyboard.yaml)                           | `MT-KB`    | 12      |
 | Cross-Platform        | [`cross-platform.yaml`](../tests/manual/cross-platform.yaml)               | `MT-XPLAT` | 1       |
 | Portable Mode         | [`portable-mode.yaml`](../tests/manual/portable-mode.yaml)                 | `MT-PORT`  | 4       |
 | Embedded Services     | [`embedded-services.yaml`](../tests/manual/embedded-services.yaml)         | `MT-SVC`   | 3       |
 | Network Tools         | [`network-tools.yaml`](../tests/manual/network-tools.yaml)                 | `MT-NET`   | 11      |
-| **Total**             |                                                                            |            | **118** |
+| **Total**             |                                                                            |            | **119** |
 
 When adding new manual tests, add the YAML definition to the appropriate file in `tests/manual/` — the YAML files are the **source of truth** for guided testing.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,9 +14,9 @@ Helper scripts for common development tasks. Each script has a `.sh` (Unix/macOS
 | `test-system`         | Start Docker infra + virtual serial ports and run system-level E2E tests                                                   |
 | `test-system-mac`     | macOS system test orchestration: Docker containers, unit tests, Rust integration tests (no E2E)                            |
 | `test-system-linux`   | Linux system test orchestration: Docker containers, unit tests, integration tests, E2E tests                               |
-| `test-system-windows` | Windows system test orchestration via WSL/Git Bash: Docker or Podman, unit tests, integration tests, E2E                  |
+| `test-system-windows` | Windows system test orchestration via WSL/Git Bash: Docker or Podman, unit tests, integration tests, E2E                   |
 | `setup-agent-cross`   | Install cross-compilation toolchains for building the agent for 2 Linux targets (musl)                                     |
-| `build-agents`        | Cross-compile the remote agent for Linux targets (x64/ARM64, static musl binaries)                                         |
+| `build-agents`        | Build the remote agent: Linux targets via cross-rs (musl), or macOS/Windows targets natively (`--native`)                  |
 | `release-check`       | Validate release readiness — version consistency, changelog, tests, quality checks, git state, branch, and code markers    |
 | `smoke-test`          | Post-install smoke test — launches the built app, verifies basic UI functionality, and confirms clean shutdown             |
 | `test-manual.py`      | Guided manual test runner — walks through manual tests from `tests/manual/*.yaml` with platform filtering and JSON reports |
@@ -69,6 +69,7 @@ scripts\test-system.cmd                                                  REM Del
 ./scripts/setup-agent-cross.sh        # Install cross-compilation toolchains
 ./scripts/build-agents.sh             # Build agent for all Linux targets
 ./scripts/build-agents.sh --targets aarch64-unknown-linux-musl  # Build specific target
+./scripts/build-agents.sh --native --targets x86_64-pc-windows-msvc  # Windows x64 (run on Windows)
 
 # Guided manual tests
 python scripts/test-manual.py                     # Run all manual tests for current platform

--- a/scripts/build-agents.cmd
+++ b/scripts/build-agents.cmd
@@ -1,30 +1,93 @@
 @echo off
-REM Cross-compile the remote agent (termihub-agent) for Linux targets (musl, static).
-REM Uses cross-rs exclusively.
+REM Build the remote agent (termihub-agent) for Linux and Windows targets.
 REM
-REM Usage: scripts\build-agents.cmd [--help]
+REM Default mode cross-compiles the Linux musl targets via cross-rs.
+REM --native builds the Windows MSVC targets natively with cargo:
+REM   - x86_64-pc-windows-msvc (required)  -> termihub-agent.exe
+REM   - aarch64-pc-windows-msvc (best effort, needs the ARM64 MSVC build tools)
+REM cross-rs cannot build the MSVC ABI, so Windows agents must be built natively
+REM on a Windows host with the MSVC toolchain (Visual Studio Build Tools).
 REM
-REM Prerequisites: Rust, Docker Desktop or Podman Desktop (running), cross-rs
+REM Usage: scripts\build-agents.cmd [--native] [--help]
+REM
+REM Prerequisites (default Linux mode): Rust, Docker/Podman (running), cross-rs.
 REM Run scripts\setup-agent-cross.cmd first to install required toolchains.
+REM Prerequisites (--native Windows mode): Rust + MSVC toolchain only.
 
 if "%~1"=="--help" goto :usage
 if "%~1"=="-h" goto :usage
+if "%~1"=="--native" goto :native_start
 goto :start
 
 :usage
-echo Usage: build-agents.cmd
+echo Usage: build-agents.cmd [--native]
 echo.
-echo Cross-compile the remote agent for Linux targets using cross-rs (static musl binaries).
+echo Default: cross-compile the agent for Linux targets via cross-rs (static musl).
+echo --native: build the Windows MSVC agent (.exe) natively with cargo.
 echo.
-echo Targets:
+echo Linux targets (default, cross-rs):
 echo   x86_64-unknown-linux-musl       Static x64 binaries (musl)
 echo   aarch64-unknown-linux-musl      Static ARM64 binaries (musl)
 echo   armv7-unknown-linux-musleabihf  Static ARMv7 binaries (musl, older Raspberry Pi)
 echo.
-echo Prerequisites:
+echo Windows targets (--native, build on a Windows host with MSVC tools):
+echo   x86_64-pc-windows-msvc          Windows x64 (emits termihub-agent.exe)
+echo   aarch64-pc-windows-msvc         Windows ARM64 (best effort - needs ARM64 MSVC tools)
+echo.
+echo Prerequisites (Linux mode):
 echo   - Rust toolchain (rustup)
 echo   - Docker Desktop or Podman Desktop (must be running)
 echo   - cross-rs (install via scripts\setup-agent-cross.cmd)
+echo.
+echo Prerequisites (--native Windows mode):
+echo   - Rust toolchain (rustup)
+echo   - MSVC toolchain (Visual Studio Build Tools); ARM64 tools for aarch64
+exit /b 0
+
+REM ------------------------------------------------------------------ REM
+REM Native Windows MSVC build (cargo, no cross-rs / container runtime)    REM
+REM ------------------------------------------------------------------ REM
+:native_start
+cd /d "%~dp0\.."
+
+echo === Building Windows agent natively (MSVC) ===
+echo.
+
+set BUILT=0
+set FAILED=0
+
+REM x64 is required; arm64 is best effort (warns instead of failing if the
+REM ARM64 MSVC build tools are not installed).
+call :build_native x86_64-pc-windows-msvc required
+call :build_native aarch64-pc-windows-msvc besteffort
+
+echo.
+echo === Summary ===
+echo Built: %BUILT%  Failed: %FAILED%
+
+if %FAILED% gtr 0 exit /b 1
+exit /b 0
+
+:build_native
+echo --- %1 ---
+
+REM Ensure the Rust std for the target is installed
+rustup target add %1 >nul 2>&1
+
+echo   Building with cargo (native)...
+cargo build --release --target %1 -p termihub-agent
+if errorlevel 1 (
+    if "%2"=="besteffort" (
+        echo   WARNING: %1 build failed ^(best effort^) - skipping. Install the ARM64 MSVC build tools to enable it.
+        exit /b 0
+    )
+    echo   FAILED: %1
+    set /a FAILED+=1
+    exit /b 0
+)
+
+echo   -^> target\%1\release\termihub-agent.exe
+set /a BUILT+=1
 exit /b 0
 
 :start

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -1,16 +1,53 @@
 #!/usr/bin/env bash
-# Build the remote agent (termihub-agent) for Linux and macOS targets.
-# Linux targets use cross-rs (static musl). macOS targets use native cargo.
-# Multiple targets are built in parallel by default, each in its own
+# Build the remote agent (termihub-agent) for Linux, macOS, and Windows targets.
+# Linux targets use cross-rs (static musl). macOS and Windows targets use native
+# cargo. Multiple targets are built in parallel by default, each in its own
 # CARGO_TARGET_DIR to avoid cargo's workspace build lock.
+#
+# Build-host strategy
+# -------------------
+# - Linux musl targets: cross-rs (Docker/Podman) from any host.
+# - macOS targets: native cargo, must run on a Mac (--native).
+# - Windows MSVC targets (*-pc-windows-msvc): native cargo, must run on a Windows
+#   host with the MSVC toolchain (Visual Studio Build Tools) installed. cross-rs
+#   does NOT support the MSVC ABI, so these cannot be built via Docker/Podman.
+#   Requesting a Windows target on a non-Windows host (or without --native) fails
+#   fast with a clear message. Windows binaries are emitted as `termihub-agent.exe`
+#   (CI renames artifacts to termihub-agent-windows-x64 / -windows-arm64).
 #
 # Usage: ./scripts/build-agents.sh [--targets <list>] [--sequential] [--native] [--dev] [--help]
 #
 # Run ./scripts/setup-agent-cross.sh first for Linux cross-compilation
-# (not needed for --native or for macOS native builds).
+# (not needed for --native, macOS, or Windows native builds).
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
+
+# --- Helpers ---
+# True if the target triple is a Windows MSVC target.
+is_windows_target() {
+    case "$1" in
+    *-pc-windows-msvc) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# Binary file name cargo emits for a target (Windows appends .exe).
+agent_binary_name() {
+    if is_windows_target "$1"; then
+        echo "termihub-agent.exe"
+    else
+        echo "termihub-agent"
+    fi
+}
+
+# True if the current host is Windows (Git Bash / MSYS / Cygwin).
+host_is_windows() {
+    case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
 
 # --- Defaults ---
 ALL_TARGETS=(
@@ -47,8 +84,8 @@ while [[ $# -gt 0 ]]; do
             cat <<'USAGE'
 Usage: build-agents.sh [OPTIONS]
 
-Build the remote agent for Linux and macOS targets.
-Linux builds use cross-rs (static musl). macOS uses native cargo.
+Build the remote agent for Linux, macOS, and Windows targets.
+Linux builds use cross-rs (static musl). macOS and Windows use native cargo.
 Multiple targets are built in parallel by default.
 
 Options:
@@ -57,7 +94,7 @@ Options:
   --sequential       Build targets one at a time (useful for debugging)
   --native           Build using the local cargo toolchain instead of cross-rs/Docker.
                      Defaults to the host target triple. Faster for local development;
-                     no container runtime required. Required for macOS targets.
+                     no container runtime required. Required for macOS and Windows targets.
   --dev              Build in debug profile (omits --release). Much faster to compile;
                      binary lands in target/<triple>/debug/ instead of release/.
   --help, -h         Show this help message
@@ -71,12 +108,18 @@ macOS targets (--native only, build on a Mac):
   aarch64-apple-darwin            Apple Silicon (M1/M2/M3/M4)
   x86_64-apple-darwin             Intel Mac
 
+Windows targets (--native only, build on a Windows host with MSVC tools):
+  x86_64-pc-windows-msvc          Windows x64 (emits termihub-agent.exe)
+  aarch64-pc-windows-msvc         Windows ARM64 (best effort — requires the
+                                  ARM64 MSVC build tools to be installed)
+
 Examples:
   ./scripts/build-agents.sh                                   # all Linux targets
   ./scripts/build-agents.sh --targets aarch64-unknown-linux-musl
   ./scripts/build-agents.sh --sequential
   ./scripts/build-agents.sh --native --dev                    # current host (fast)
   ./scripts/build-agents.sh --native --targets aarch64-apple-darwin  # macOS ARM64
+  ./scripts/build-agents.sh --native --targets x86_64-pc-windows-msvc  # Windows x64
 USAGE
             exit 0
             ;;
@@ -100,6 +143,25 @@ if [ ${#SELECTED_TARGETS[@]} -eq 0 ]; then
         SELECTED_TARGETS=("${ALL_TARGETS[@]}")
     fi
 fi
+
+# --- Windows target validation ---
+# MSVC targets cannot be built via cross-rs (no MSVC ABI support) and require a
+# Windows host with the MSVC toolchain. Fail fast with a clear message instead of
+# letting cargo/cross emit a confusing linker error.
+for target in "${SELECTED_TARGETS[@]}"; do
+    if is_windows_target "$target"; then
+        if [ "$NATIVE" = false ]; then
+            echo "ERROR: Windows target '$target' requires --native."
+            echo "  cross-rs cannot build MSVC targets. Re-run on a Windows host with --native."
+            exit 1
+        fi
+        if ! host_is_windows; then
+            echo "ERROR: Windows target '$target' can only be built on a Windows host."
+            echo "  Current host: $(uname -s). Build Windows agents on a Windows runner."
+            exit 1
+        fi
+    fi
+done
 
 # --- Profile setup ---
 if [ "$DEV" = true ]; then
@@ -188,6 +250,15 @@ if [ "$NATIVE" = false ]; then
             rustup target add "$target"
         fi
     done
+else
+    # --- Native mode: ensure the Rust std for each requested target is present ---
+    # (e.g. cross-compiling aarch64-pc-windows-msvc from an x64 Windows host).
+    for target in "${SELECTED_TARGETS[@]}"; do
+        if ! rustup target list --installed | grep -q "^${target}$"; then
+            echo "  Adding Rust target $target..."
+            rustup target add "$target"
+        fi
+    done
 fi
 
 # --- Build ---
@@ -221,7 +292,7 @@ if [ "$SEQUENTIAL" = true ] || [ "${#SELECTED_TARGETS[@]}" -le 1 ]; then
         fi
 
         if [ "$build_exit" -eq 0 ]; then
-            binary="target/$target/$PROFILE_DIR/termihub-agent"
+            binary="target/$target/$PROFILE_DIR/$(agent_binary_name "$target")"
             if [ -f "$binary" ]; then
                 size=$(du -h "$binary" | cut -f1)
                 results+=("  OK    $target  ($size)")
@@ -330,9 +401,10 @@ else
 
         if [ "${_exit_codes[$i]}" -eq 0 ]; then
             cross_dir="${_cross_dirs[$i]}"
-            src_binary="$cross_dir/$target/$PROFILE_DIR/termihub-agent"
+            binary_name="$(agent_binary_name "$target")"
+            src_binary="$cross_dir/$target/$PROFILE_DIR/$binary_name"
             dst_dir="target/$target/$PROFILE_DIR"
-            dst_binary="$dst_dir/termihub-agent"
+            dst_binary="$dst_dir/$binary_name"
 
             if [ -f "$src_binary" ]; then
                 mkdir -p "$dst_dir"

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -242,24 +242,19 @@ if [ "$NATIVE" = false ]; then
         exit 1
     fi
     unset _container_cmd _missing_images _t _img
-
-    # --- Ensure Rust targets are installed (before any parallel work starts) ---
-    for target in "${SELECTED_TARGETS[@]}"; do
-        if ! rustup target list --installed | grep -q "^${target}$"; then
-            echo "  Adding Rust target $target..."
-            rustup target add "$target"
-        fi
-    done
-else
-    # --- Native mode: ensure the Rust std for each requested target is present ---
-    # (e.g. cross-compiling aarch64-pc-windows-msvc from an x64 Windows host).
-    for target in "${SELECTED_TARGETS[@]}"; do
-        if ! rustup target list --installed | grep -q "^${target}$"; then
-            echo "  Adding Rust target $target..."
-            rustup target add "$target"
-        fi
-    done
 fi
+
+# --- Ensure the Rust std for each requested target is installed ---
+# Needed in both modes: cross-rs Linux targets and native macOS/Windows targets
+# (e.g. cross-compiling aarch64-pc-windows-msvc from an x64 Windows host).
+_installed_targets=$(rustup target list --installed)
+for target in "${SELECTED_TARGETS[@]}"; do
+    if ! grep -q "^${target}$" <<<"$_installed_targets"; then
+        echo "  Adding Rust target $target..."
+        rustup target add "$target"
+    fi
+done
+unset _installed_targets
 
 # --- Build ---
 built=0

--- a/scripts/setup-agent-cross.cmd
+++ b/scripts/setup-agent-cross.cmd
@@ -3,6 +3,10 @@ REM Install toolchains and build custom cross-rs images needed to cross-compile
 REM the remote agent for Linux targets (static musl binaries) on Windows.
 REM Run once before using build-agents.cmd.
 REM
+REM Not needed for the native Windows agent: build-agents.cmd --native builds the
+REM *-pc-windows-msvc target with cargo and only needs the MSVC build tools
+REM (Visual Studio Build Tools) - no cross-rs / container runtime required.
+REM
 REM Usage: scripts\setup-agent-cross.cmd [--help]
 REM
 REM Prerequisites: Rust toolchain (rustup), Docker Desktop or Podman Desktop
@@ -16,6 +20,9 @@ echo Usage: setup-agent-cross.cmd
 echo.
 echo Installs the cross-compilation toolchains required by build-agents.cmd
 echo and builds the custom cross-rs Docker images needed for each target.
+echo.
+echo Not needed for the native Windows agent: build-agents.cmd --native builds
+echo the *-pc-windows-msvc target with cargo and only needs the MSVC build tools.
 echo.
 echo Windows:
 echo   - cross-rs (via cargo install) for all targets

--- a/scripts/setup-agent-cross.sh
+++ b/scripts/setup-agent-cross.sh
@@ -2,6 +2,11 @@
 # Install toolchains needed to cross-compile the remote agent for Linux
 # targets (static musl binaries). Run once before using build-agents.sh.
 #
+# Native targets (macOS *-apple-darwin, Windows *-pc-windows-msvc) do NOT use
+# this script: they are built with native cargo (build-agents.sh --native) and
+# only need the platform's own toolchain — Xcode CLT on macOS, the MSVC build
+# tools (Visual Studio Build Tools) on Windows.
+#
 # Usage: ./scripts/setup-agent-cross.sh [--help]
 set -euo pipefail
 
@@ -10,6 +15,10 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Usage: setup-agent-cross.sh
 
 Installs the cross-compilation toolchains required by build-agents.sh.
+
+Not needed for native targets: macOS (*-apple-darwin) and Windows
+(*-pc-windows-msvc) agents are built with `build-agents.sh --native` and only
+require the platform's native toolchain (Xcode CLT / MSVC build tools).
 
 All platforms:
   - cross-rs (via cargo install) for all targets

--- a/tests/manual/remote-agent.yaml
+++ b/tests/manual/remote-agent.yaml
@@ -157,3 +157,22 @@ tests:
       - "Subsequent input continues in the same shell (e.g. `pwd` reports the same cwd as before)"
       - "The state dot stays green throughout — no duplicate session is created on the agent"
     verification: manual
+
+  # --- Windows agent binary build (#761) ---
+
+  - id: MT-AGENT-15
+    name: "Build the Windows agent binary natively (MSVC)"
+    pr: 761
+    platforms: [windows]
+    prerequisites:
+      - app: false
+    instructions:
+      - "On a Windows host with the Rust toolchain and the MSVC build tools (Visual Studio Build Tools) installed"
+      - "Run `scripts\\build-agents.cmd --native` (or `bash scripts/build-agents.sh --native --targets x86_64-pc-windows-msvc` from Git Bash)"
+      - "Optionally also build ARM64: `bash scripts/build-agents.sh --native --targets aarch64-pc-windows-msvc` (requires the ARM64 MSVC build tools)"
+    expected:
+      - "`target/x86_64-pc-windows-msvc/release/termihub-agent.exe` is produced and the summary reports `Built: 1`"
+      - "The script never invokes cross-rs / Docker for the Windows target (native cargo only)"
+      - "Requesting a Windows target without `--native`, or on a non-Windows host, fails fast with a clear error message"
+      - "ARM64 is best effort — if the ARM64 MSVC tools are missing, `.cmd --native` prints a WARNING and skips it without failing the run"
+    verification: manual


### PR DESCRIPTION
## Summary

Adds Windows MSVC targets to the remote-agent build pipeline so we can produce `termihub-agent.exe` binaries deployable to Windows hosts. This is the first link in the Phase 1 chain of #771.

Build-host strategy (chosen: **native-only**): MSVC cannot be built via cross-rs/Docker, so Windows agents are built natively with `cargo` on a Windows host with the MSVC toolchain. The scripts fail fast with a clear message when a Windows target is requested without `--native` or on a non-Windows host.

## Changes

- **`scripts/build-agents.sh`**
  - Documented the build-host strategy in the header (Linux → cross-rs; macOS/Windows → native cargo).
  - Added `is_windows_target` / `agent_binary_name` / `host_is_windows` helpers so Windows artifacts resolve as `termihub-agent.exe` in both the sequential and parallel build paths.
  - Fail-fast guards for `*-pc-windows-msvc` targets requested without `--native` or on a non-Windows host.
  - Consolidated the Rust-target install loop so it runs once in both cross and native modes (cached `rustup target list`).
  - `--help` lists `x86_64-pc-windows-msvc` and best-effort `aarch64-pc-windows-msvc`.
- **`scripts/build-agents.cmd`** — new `--native` mode builds the Windows agent with cargo (x64 required; arm64 best-effort — warns and skips if the ARM64 MSVC tools are missing). Default mode still cross-compiles Linux.
- **`scripts/setup-agent-cross.{sh,cmd}`** — note that native macOS/Windows builds don't use the cross-rs setup, only the platform's native toolchain (MSVC build tools).
- **Docs/tests** — CHANGELOG entry, `scripts/README.md`, and manual test `MT-AGENT-15` in `remote-agent.yaml` (counts updated in `docs/testing.md`).

## Acceptance criteria

- [x] `build-agents.sh` builds a Windows `x86_64-pc-windows-msvc` agent `.exe` (`--native` on a Windows host)
- [x] `aarch64-pc-windows-msvc` supported best-effort (documented requirement: ARM64 MSVC build tools)
- [x] Output is `termihub-agent.exe`, consistent with the `<os>-<arch>` (`windows-x64` / `windows-arm64`) scheme in `agent_binary.rs`; CI renames the uploaded artifact (separate issue)
- [x] Build approach documented in the script comments and `--help`

## Out of scope (separate #771 links)

- CI artifact wiring / release packaging
- Remote OS/arch detection
- End-to-end MSVC runtime compilation (the agent crate is structured for it — `nix`/`libc` are `cfg(unix)`-gated, no jemalloc — but full Windows runtime support is later in the chain)

## Test plan

- Verified both fail-fast guards fire on macOS (non-Windows host); `--help` and existing Linux/macOS flows unchanged.
- `bash -n`, `prettier --check`, and `markdownlint` all pass; all manual-test YAML parses.
- **Manual (Windows host, `MT-AGENT-15`)**: on a Windows host with Rust + MSVC build tools, run `scripts\build-agents.cmd --native` (or `bash scripts/build-agents.sh --native --targets x86_64-pc-windows-msvc`) and confirm `target/x86_64-pc-windows-msvc/release/termihub-agent.exe` is produced with `Built: 1`, no cross-rs/Docker invoked, and arm64 is best-effort.

Part of #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)