### PR TITLE
chore(ci): retry flaky pnpm setup to harden Windows builds

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,23 @@
+name: 'Setup pnpm (with retry)'
+description: >-
+  Install pnpm via pnpm/action-setup, retrying the occasionally-flaky
+  self-installer. The installer (run via npm) intermittently exits non-zero on
+  GitHub runners — Windows especially — which would otherwise fail the whole job
+  on a transient hiccup. The pnpm version is read from package.json as usual.
+
+runs:
+  using: 'composite'
+  steps:
+    - id: attempt-1
+      uses: pnpm/action-setup@v6
+      continue-on-error: true
+
+    - name: Retry pnpm install (attempt 2)
+      id: attempt-2
+      if: steps.attempt-1.outcome == 'failure'
+      uses: pnpm/action-setup@v6
+      continue-on-error: true
+
+    - name: Retry pnpm install (final attempt)
+      if: steps.attempt-1.outcome == 'failure' && steps.attempt-2.outcome == 'failure'
+      uses: pnpm/action-setup@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -95,7 +95,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -169,7 +169,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: ./.github/actions/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Hardens the `Setup pnpm` step so a transient self-installer flake **retries instead of failing the job**.

`pnpm/action-setup@v6` runs its installer via npm, which intermittently exits non-zero on GitHub runners — Windows especially. It just failed a real build (PR #821, *Build on windows-latest*) at `Setup pnpm`:

```
##[group]Running self-installer...
added 1 package, and audited 2 packages in 7s
Something went wrong, self-installer exits with code 1
```

Nothing was wrong with the code — it's a CI infrastructure hiccup.

## Change

- New local composite action **`.github/actions/setup-pnpm`** that wraps `pnpm/action-setup@v6` and retries up to **3 attempts** (first two with `continue-on-error`, the last fails hard if pnpm genuinely can't install).
- All **7** `Setup pnpm` steps — across `build.yml`, `code-quality.yml`, `release.yml`, `dev-build.yml` — now use it.
- The pnpm version is still read from `package.json` (no inputs changed), so behavior is identical on the happy path.

## Why a composite action

DRYs the retry across all 7 call sites and keeps each workflow step a one-liner (`uses: ./.github/actions/setup-pnpm`). Every job already checks out the repo before `Setup pnpm`, so the local action path resolves.

## Test plan

- [x] All workflow + action YAML parses.
- [x] This PR's own CI exercises the composite action on every platform (incl. the Windows build that was flaking) — green CI here *is* the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
