### PR TITLE
fix(backend): run SSH/SFTP-blocking commands off the sync command thread (#828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Terminal: added a small horizontal inset (8 px) inside the terminal viewport so the first and last characters of each line are no longer flush against the container edge or the vertical scrollbar. This makes it easier to drag-select characters at the line edges. xterm's FitAddon reads the padding so column counts remain accurate; horizontal-scroll mode keeps zero padding to avoid clipping the imperatively sized canvas.
 
+### Fixed
+
+- Backend: fixed latent process aborts when triggering SSH/SFTP work from synchronous code paths. **"Open in VS Code" on a remote (SFTP) file** and **starting an SSH tunnel** (including auto-start tunnels at launch) could abort the whole app, because they drove the blocking SSH/SFTP connect (which uses `tokio::task::block_in_place` internally) from the synchronous Tauri command thread or a raw `std::thread` — neither of which carries the Tokio runtime context that `block_in_place` requires. These paths now run on `spawn_blocking` threads (mirroring monitoring/SFTP file-browser), so the connect happens off the command thread with a valid runtime context. (Closes #828)
+
 ### Added
 
 - Remote agent (Windows): `#[cfg(windows)]` integration tests for the ConPTY-backed local-shell path. The agent's Windows shell flow goes through `NativeLocalShellSpawner` → `portable_pty::native_pty_system()` → ConPTY, which behaves differently from Unix PTYs around resize and teardown. The new tests pin the shell to `powershell` and `cmd` and exercise spawn, I/O round-trip, back-to-back resizes, and clean teardown so regressions in ConPTY shell defaults fail fast on the Windows CI matrix. `NativeLocalShellSpawner` also gained a doc-comment block describing the ConPTY-specific behavior (`ResizePseudoConsole` firing `WINDOW_BUFFER_SIZE_EVENT`, `ClosePseudoConsole` on drop). Two manual tests (MT-AGENT-21 / MT-AGENT-22) cover the same flow end-to-end through the agent. Part of #771 (Closes #765).

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -282,7 +282,10 @@ pub async fn vscode_open_remote(
         let remote_path = remote_path.clone();
         let temp_path_str = temp_path_str.clone();
         tokio::task::spawn_blocking(move || {
-            session.lock().unwrap().read_file(&remote_path, &temp_path_str)
+            session
+                .lock()
+                .unwrap()
+                .read_file(&remote_path, &temp_path_str)
         })
         .await
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))??;
@@ -291,7 +294,6 @@ pub async fn vscode_open_remote(
     // Wait for VS Code to close, then re-upload — on a blocking-pool thread so
     // the SFTP write's `block_in_place` has a runtime context (a raw
     // `std::thread` would have none and abort the process).
-    let remote_path_clone = remote_path.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let result = vscode::open_in_vscode_wait(&temp_path_str);
 
@@ -300,23 +302,23 @@ pub async fn vscode_open_remote(
                 // Re-upload the edited file
                 let upload_result = {
                     let session = session_arc.lock().unwrap();
-                    session.write_file(&temp_path_str, &remote_path_clone)
+                    session.write_file(&temp_path_str, &remote_path)
                 };
                 match upload_result {
                     Ok(_) => VscodeEditCompleteEvent {
-                        remote_path: remote_path_clone,
+                        remote_path,
                         success: true,
                         error: None,
                     },
                     Err(e) => VscodeEditCompleteEvent {
-                        remote_path: remote_path_clone,
+                        remote_path,
                         success: false,
                         error: Some(format!("Upload failed: {}", e)),
                     },
                 }
             }
             Err(e) => VscodeEditCompleteEvent {
-                remote_path: remote_path_clone,
+                remote_path,
                 success: false,
                 error: Some(format!("VS Code error: {}", e)),
             },

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -245,14 +245,20 @@ pub fn vscode_open_local(path: String) -> Result<(), TerminalError> {
 }
 
 /// Open a remote file in VS Code: download, open with --wait, re-upload on close.
+///
+/// `async` + `spawn_blocking`: the SFTP read/write use `block_in_place`
+/// internally, which aborts the process on the synchronous Tauri command thread
+/// (and on a raw `std::thread`, which has no runtime context). Both the initial
+/// download and the background wait/re-upload therefore run on `spawn_blocking`
+/// threads, which carry a Tokio runtime context. Mirrors `monitoring_open`. See #828.
 #[tauri::command]
-pub fn vscode_open_remote(
+pub async fn vscode_open_remote(
     session_id: String,
     remote_path: String,
     manager: State<'_, SftpManager>,
     app_handle: tauri::AppHandle,
 ) -> Result<(), TerminalError> {
-    // Get a clone of the session Arc before spawning the background thread
+    // Get a clone of the session Arc before spawning the background task
     let session_arc = manager.get_session(&session_id)?;
 
     // Extract the filename from the remote path
@@ -269,15 +275,24 @@ pub fn vscode_open_remote(
     let temp_path = temp_dir.join(format!("{}-{}", uuid::Uuid::new_v4(), filename));
     let temp_path_str = temp_path.to_string_lossy().to_string();
 
-    // Download the remote file to temp
+    // Download the remote file to temp on a blocking-pool thread (the SFTP read
+    // uses `block_in_place`, which is invalid on the command thread).
     {
-        let session = session_arc.lock().unwrap();
-        session.read_file(&remote_path, &temp_path_str)?;
+        let session = session_arc.clone();
+        let remote_path = remote_path.clone();
+        let temp_path_str = temp_path_str.clone();
+        tokio::task::spawn_blocking(move || {
+            session.lock().unwrap().read_file(&remote_path, &temp_path_str)
+        })
+        .await
+        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))??;
     }
 
-    // Spawn a background thread to wait for VS Code to close
+    // Wait for VS Code to close, then re-upload — on a blocking-pool thread so
+    // the SFTP write's `block_in_place` has a runtime context (a raw
+    // `std::thread` would have none and abort the process).
     let remote_path_clone = remote_path.clone();
-    std::thread::spawn(move || {
+    tauri::async_runtime::spawn_blocking(move || {
         let result = vscode::open_in_vscode_wait(&temp_path_str);
 
         let event = match result {

--- a/src-tauri/src/commands/tunnel.rs
+++ b/src-tauri/src/commands/tunnel.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use tauri::State;
 
 use crate::tunnel::config::{TunnelConfig, TunnelState};
@@ -6,7 +8,9 @@ use crate::utils::errors::TerminalError;
 
 /// Get all saved tunnel configurations.
 #[tauri::command]
-pub fn get_tunnels(manager: State<'_, TunnelManager>) -> Result<Vec<TunnelConfig>, TerminalError> {
+pub fn get_tunnels(
+    manager: State<'_, Arc<TunnelManager>>,
+) -> Result<Vec<TunnelConfig>, TerminalError> {
     manager.get_tunnels()
 }
 
@@ -14,7 +18,7 @@ pub fn get_tunnels(manager: State<'_, TunnelManager>) -> Result<Vec<TunnelConfig
 #[tauri::command]
 pub fn save_tunnel(
     config: TunnelConfig,
-    manager: State<'_, TunnelManager>,
+    manager: State<'_, Arc<TunnelManager>>,
 ) -> Result<(), TerminalError> {
     manager.save_tunnel(config)
 }
@@ -23,7 +27,7 @@ pub fn save_tunnel(
 #[tauri::command]
 pub fn delete_tunnel(
     tunnel_id: String,
-    manager: State<'_, TunnelManager>,
+    manager: State<'_, Arc<TunnelManager>>,
 ) -> Result<(), TerminalError> {
     manager.delete_tunnel(&tunnel_id)
 }
@@ -31,25 +35,34 @@ pub fn delete_tunnel(
 /// Get the current status of all tunnels.
 #[tauri::command]
 pub fn get_tunnel_statuses(
-    manager: State<'_, TunnelManager>,
+    manager: State<'_, Arc<TunnelManager>>,
 ) -> Result<Vec<TunnelState>, TerminalError> {
     manager.get_statuses()
 }
 
 /// Start a tunnel by ID.
+///
+/// `async` + `spawn_blocking`: starting a tunnel performs the SSH handshake,
+/// which uses `block_in_place` internally (`utils::ssh_auth`). That is only
+/// valid on a Tokio runtime worker — invoking it from a synchronous command
+/// (which Tauri runs on the main thread) aborts the process. Mirrors
+/// `monitoring_open`. See #828.
 #[tauri::command]
-pub fn start_tunnel(
+pub async fn start_tunnel(
     tunnel_id: String,
-    manager: State<'_, TunnelManager>,
+    manager: State<'_, Arc<TunnelManager>>,
 ) -> Result<(), TerminalError> {
-    manager.start_tunnel(&tunnel_id)
+    let manager = (*manager).clone();
+    tokio::task::spawn_blocking(move || manager.start_tunnel(&tunnel_id))
+        .await
+        .map_err(|e| TerminalError::TunnelError(format!("Task join error: {e}")))?
 }
 
 /// Stop an active tunnel by ID.
 #[tauri::command]
 pub fn stop_tunnel(
     tunnel_id: String,
-    manager: State<'_, TunnelManager>,
+    manager: State<'_, Arc<TunnelManager>>,
 ) -> Result<(), TerminalError> {
     manager.stop_tunnel(&tunnel_id)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -229,18 +229,21 @@ pub fn run() {
                 Ok(manager) => {
                     recovery_warnings.extend(manager.take_recovery_warnings());
 
-                    // Auto-start tunnels in a background thread
+                    // Auto-start tunnels on a blocking-pool thread. The SSH
+                    // handshake uses `block_in_place` internally, which needs a
+                    // Tokio runtime context — a raw `std::thread` has none and
+                    // would abort the process (#828).
                     let handle = app.handle().clone();
-                    std::thread::spawn(move || {
+                    tauri::async_runtime::spawn_blocking(move || {
                         std::thread::sleep(std::time::Duration::from_millis(500));
                         if let Some(mgr) =
-                            handle.try_state::<tunnel::tunnel_manager::TunnelManager>()
+                            handle.try_state::<Arc<tunnel::tunnel_manager::TunnelManager>>()
                         {
                             mgr.start_auto_tunnels();
                         }
                     });
 
-                    app.manage(manager);
+                    app.manage(Arc::new(manager));
                 }
                 Err(e) => {
                     tracing::error!("Failed to initialize tunnel manager: {e}");
@@ -574,7 +577,7 @@ pub fn run() {
                 let handle = app_handle.clone();
                 tauri::async_runtime::spawn(async move {
                     if let Some(mgr) =
-                        handle.try_state::<tunnel::tunnel_manager::TunnelManager>()
+                        handle.try_state::<Arc<tunnel::tunnel_manager::TunnelManager>>()
                     {
                         mgr.stop_all();
                     }

--- a/src-tauri/src/utils/ssh_auth.rs
+++ b/src-tauri/src/utils/ssh_auth.rs
@@ -65,4 +65,39 @@ mod tests {
             unsafe { std::env::set_var("SSH_AUTH_SOCK", val) };
         }
     }
+
+    /// Regression guard for #828.
+    ///
+    /// [`connect_and_authenticate`]/[`connect_with_registry`] run the async
+    /// russh connect via `tokio::task::block_in_place` +
+    /// `Handle::current().block_on(..)`. Both require a Tokio runtime context on
+    /// the calling thread. A `spawn_blocking` thread carries that context; a
+    /// synchronous `#[tauri::command]` (which Tauri runs on the main thread) and
+    /// a raw `std::thread` do not — invoking these helpers there aborts the
+    /// whole process. The fix is to drive such work from an `async` command via
+    /// `spawn_blocking` (mirroring `monitoring_open`). This locks in the thread
+    /// invariant the fix depends on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ssh_helpers_require_a_runtime_context() {
+        // A `spawn_blocking` thread carries the runtime context — SSH/SFTP work
+        // runs here after the fix.
+        let in_spawn_blocking =
+            tokio::task::spawn_blocking(|| tokio::runtime::Handle::try_current().is_ok())
+                .await
+                .expect("spawn_blocking join");
+        assert!(
+            in_spawn_blocking,
+            "spawn_blocking threads must carry a Tokio runtime context"
+        );
+
+        // A raw std::thread does not — this is the #828 crash path the buggy
+        // sync commands hit.
+        let on_raw_thread = std::thread::spawn(|| tokio::runtime::Handle::try_current().is_ok())
+            .join()
+            .expect("thread join");
+        assert!(
+            !on_raw_thread,
+            "a raw std::thread must lack a Tokio runtime context"
+        );
+    }
 }

--- a/src-tauri/src/utils/ssh_auth.rs
+++ b/src-tauri/src/utils/ssh_auth.rs
@@ -14,10 +14,13 @@ use crate::utils::errors::TerminalError;
 
 /// Connect to an SSH server and authenticate, returning the session.
 ///
-/// Internally runs the async [`core_connect`] on the current Tokio runtime
-/// via [`tokio::task::block_in_place`], so it is safe to call from both
-/// Tokio worker threads (sync commands) and `spawn_blocking` threads
-/// (monitoring, SFTP commands).
+/// Internally runs the async [`core_connect`] on the current Tokio runtime via
+/// [`tokio::task::block_in_place`] + [`tokio::runtime::Handle::current`]. **Both
+/// require a multi-threaded Tokio runtime worker context on the calling thread**
+/// — call this only from inside `spawn_blocking` or an async task (as the
+/// monitoring/SFTP commands do). Calling it from a synchronous `#[tauri::command]`
+/// (which Tauri runs on the main thread) or a raw `std::thread` aborts the whole
+/// process (#828).
 pub fn connect_and_authenticate(config: &SshConfig) -> Result<SshSession, TerminalError> {
     tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(core_connect(config)))
         .map(|(session, _registry)| session)
@@ -28,6 +31,10 @@ pub fn connect_and_authenticate(config: &SshConfig) -> Result<SshSession, Termin
 ///
 /// Used by the tunnel session pool so the remote-forward tunnel can receive
 /// incoming server-initiated channels.
+///
+/// Same runtime-context requirement as [`connect_and_authenticate`]: call only
+/// from inside `spawn_blocking` or an async task, never from a synchronous
+/// command thread or a raw `std::thread` (#828).
 pub fn connect_with_registry(
     config: &SshConfig,
 ) -> Result<(SshSession, ForwardedChannelRegistry), TerminalError> {

--- a/tests/manual/file-browser.yaml
+++ b/tests/manual/file-browser.yaml
@@ -101,6 +101,7 @@ tests:
   - id: MT-FB-15
     name: "Open in VS Code — SFTP edit and re-upload"
     pr: 51
+    regression_pr: 828
     platforms: [all]
     prerequisites:
       - app: true
@@ -110,7 +111,9 @@ tests:
       - "Click 'Open in VS Code'"
       - "Edit the file in VS Code and close the tab"
     expected:
+      - "App stays running when the file is downloaded (no crash; regression #828)"
       - "File re-uploaded (verify content changed on remote)"
+      - "App stays running through the background re-upload (no crash; regression #828)"
     verification: manual
 
   - id: MT-FB-16


### PR DESCRIPTION
## Summary

Fixes the latent `block_in_place` process-abort bug class from #828.

`utils::ssh_auth::connect_and_authenticate` / `connect_with_registry` (and the SFTP session methods) run async russh code via `tokio::task::block_in_place` + `Handle::current().block_on(..)`, which require a Tokio runtime **worker** context. A synchronous `#[tauri::command]` (Tauri runs these on the main thread) and a raw `std::thread` have none — invoking that code there aborts the whole process:

```
thread 'main' panicked at src-tauri/src/utils/ssh_auth.rs (tokio::task::block_in_place)
fatal runtime error: failed to initiate panic, error 5, aborting
```

The SFTP file-browser path was fixed in #825; this PR fixes the remaining instances found by audit.

## Audit result — 3 affected sites

All other sync commands are local-only. `agent_setup` already threads an explicit runtime handle and is its own subsystem (out of scope).

1. **`vscode_open_remote`** — sync command doing a direct SFTP `read_file`, **and** a raw `std::thread` doing the background `write_file`.
2. **`start_tunnel`** — `connect_with_registry` runs for every tunnel type (local/remote/dynamic).
3. **Auto-start tunnels at launch** — a raw `std::thread` → `start_auto_tunnels` → `start_tunnel`.

## Fixes (mirroring `monitoring_open`)

- `vscode_open_remote` → `async`; initial download via `spawn_blocking`, background wait/re-upload via `tauri::async_runtime::spawn_blocking` (instead of a raw thread with no runtime context).
- `start_tunnel` → `async` + `spawn_blocking`. `TunnelManager` is now managed as `Arc<TunnelManager>` so a handle can move into the blocking task.
- Auto-start moved from a raw `std::thread` to `async_runtime::spawn_blocking`.
- Corrected the `ssh_auth` doc comments, which previously (and incorrectly) claimed these helpers were safe to call from synchronous commands.

## Tests

- New regression guard `ssh_helpers_require_a_runtime_context` in `ssh_auth.rs` locking in the thread-context invariant the fix depends on.
- `start_tunnel` behavior is regression-covered by the existing `tests/system/tests/test_ssh_tunnels.py`.
- Strengthened manual test `MT-FB-15` (Open in VS Code over SFTP) to assert the app stays running through download and background re-upload.
- `CHANGELOG.md` updated under `[Unreleased]`.

`./scripts/check.sh` passes (Prettier, markdownlint, ESLint, cargo fmt, clippy). Desktop crate unit tests (579) pass.

> Note: 5 `core/tests/ssh_auth.rs` integration tests fail locally due to a misbehaving `ssh-keys` Docker container / an ECDSA-521 key-parse issue from the russh upgrade — pre-existing and unrelated (`core/` is byte-identical to `develop` on this branch).

## Test plan

- [ ] SFTP file browser → right-click a file → **Open in VS Code** → app stays running, file downloads, edit + close re-uploads without crashing (MT-FB-15).
- [ ] Create + start an SSH tunnel → app stays running, tunnel reaches connected/connecting.
- [ ] Configure an auto-start tunnel, relaunch the app → no crash at launch.

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)