### PR TITLE
docs(test): fix markdownlint MD022 in test-bridge.md

### DIFF
--- a/docs/test-bridge.md
+++ b/docs/test-bridge.md
@@ -231,6 +231,7 @@ Because `dragTo` awaits real frames, it is async like every command; assert the
 result from state (e.g. `rootPanel` tab order) rather than scraping the DOM. It
 still injects **synthetic** events — it exercises dnd-kit's app logic, not the
 native OS drag pipeline (see [Not covered](#not-covered)).
+
 ### Reading form values (`getValue` vs `getAttribute`)
 
 A React-**controlled** `<input>`/`<select>` updates the DOM _property_ `.value`,


### PR DESCRIPTION
## Summary

The `### Reading form values (\`getValue\` vs \`getAttribute\`)` heading in `docs/test-bridge.md` (added with the testbridge `getValue` work, #834) is missing a blank line above it, which fails **markdownlint MD022** (`blanks-around-headings`). CI's `code-quality` job runs `pnpm run markdownlint`, so this currently makes the lint job red for **every** branch cut from `develop`.

This adds the missing blank line. One-line, docs-only.

## Test plan
- [x] `pnpm run markdownlint` → **0 errors** (was 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)