### PR TITLE
feat(ssh): connect SSH sessions through a ProxyJump chain (Closes #922)

### DIFF
--- a/core/src/backends/ssh/auth.rs
+++ b/core/src/backends/ssh/auth.rs
@@ -101,6 +101,22 @@ async fn do_connect_and_authenticate(
         }
     }
 
+    handshake_and_authenticate(config, tokio_tcp).await
+}
+
+/// Run the SSH handshake over an established byte stream and authenticate.
+///
+/// Shared by the direct-TCP path ([`do_connect_and_authenticate`]) and the
+/// jump-host path ([`connect_and_authenticate_over_channel`]). The transport is
+/// any async byte stream: a [`tokio::net::TcpStream`] for a direct connection, or
+/// a forwarded `direct-tcpip` channel stream for a hop.
+async fn handshake_and_authenticate<S>(
+    config: &SshConfig,
+    stream: S,
+) -> Result<(SshSession, ForwardedChannelRegistry), SessionError>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
     let russh_config = Arc::new(russh::client::Config {
         // SSH-level keepalives: send every 30 s, abort after 3 unanswered.
         keepalive_interval: Some(Duration::from_secs(30)),
@@ -110,13 +126,27 @@ async fn do_connect_and_authenticate(
 
     let (handler, registry) = TermiHubHandler::new();
 
-    let mut session = russh::client::connect_stream(russh_config, tokio_tcp, handler)
+    let mut session = russh::client::connect_stream(russh_config, stream, handler)
         .await
         .map_err(|e| SessionError::SpawnFailed(format!("SSH handshake failed: {e}")))?;
 
     authenticate(&mut session, config).await?;
 
     Ok((session, registry))
+}
+
+/// Establish and authenticate an SSH session over an existing forwarded channel.
+///
+/// The `channel` must be a `direct-tcpip` channel opened on a previous hop's
+/// session (via [`channel_open_direct_tcpip`](russh::client::Handle::channel_open_direct_tcpip))
+/// targeting the next hop or the final target `host:port`. The russh handshake
+/// runs over the channel's byte stream — the same `into_stream()` transport that
+/// SFTP, X11, and the tunnel forwarders use. Used by the jump-host connect path.
+pub async fn connect_and_authenticate_over_channel(
+    config: &SshConfig,
+    channel: russh::Channel<russh::client::Msg>,
+) -> Result<(SshSession, ForwardedChannelRegistry), SessionError> {
+    handshake_and_authenticate(config, channel.into_stream()).await
 }
 
 /// Perform SSH authentication on an already-connected session.

--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -148,13 +148,25 @@ impl SshConnector for RusshSshConnector {
         alive: Arc<AtomicBool>,
     ) -> Result<SshShellHandle, SessionError> {
         use super::auth::connect_and_authenticate;
+        use super::jump_host::connect_through_jump_hosts;
         use super::x11::X11Forwarder;
         use russh::ChannelMsg;
 
-        let (mut session, registry) = connect_and_authenticate(config).await?;
-
-        // Optional X11 forwarding (must be set up before opening the shell channel).
+        // Opaque resources kept alive for the session lifetime.
         let mut extensions: Vec<Box<dyn std::any::Any + Send>> = Vec::new();
+
+        // Connect directly, or through a ProxyJump chain when one is configured.
+        let (mut session, registry) = if config.proxy_jump.is_empty() {
+            connect_and_authenticate(config).await?
+        } else {
+            let conn = connect_through_jump_hosts(config).await?;
+            // Retain the bastion/intermediate hop sessions: dropping them would
+            // close the direct-tcpip channels that carry the target session.
+            for hop in conn.intermediates {
+                extensions.push(Box::new(hop));
+            }
+            (conn.session, conn.registry)
+        };
         let mut x11_display: Option<u32> = None;
         let mut x11_cookie: Option<String> = None;
         if config.enable_x11_forwarding {

--- a/core/src/backends/ssh/jump_host.rs
+++ b/core/src/backends/ssh/jump_host.rs
@@ -1,0 +1,89 @@
+//! SSH jump host (`ProxyJump`) connection support.
+//!
+//! Establishes an authenticated SSH session on a target host that is only
+//! reachable through one or more bastion hops, mirroring OpenSSH's `-J` /
+//! `ProxyJump`. Each hop is connected in turn; the connection to hop N+1 (or the
+//! final target) is tunnelled over a `direct-tcpip` channel opened on hop N's
+//! session — the same primitive the SSH tunnel forwarders use.
+
+use crate::config::SshConfig;
+use crate::errors::SessionError;
+
+use super::auth::{connect_and_authenticate, connect_and_authenticate_over_channel};
+use super::handler::{ForwardedChannelRegistry, SshSession};
+
+/// An authenticated SSH session on the target, reached through a jump-host chain.
+///
+/// The intermediate hop sessions are retained in [`intermediates`](Self::intermediates):
+/// dropping them would tear down the `direct-tcpip` channels that carry the
+/// target session, so the caller must keep this struct (or at least
+/// `intermediates`) alive for the lifetime of [`session`](Self::session).
+pub struct JumpHostConnection {
+    /// Authenticated session on the final target host.
+    pub session: SshSession,
+    /// Forwarded-channel registry for the target session (X11 / remote forwards).
+    pub registry: ForwardedChannelRegistry,
+    /// Bastion / intermediate hop sessions kept alive to hold the chain open.
+    pub intermediates: Vec<SshSession>,
+}
+
+/// Connect to `target` through its [`SshConfig::proxy_jump`] chain.
+///
+/// Hops are ordered outermost → innermost (`ssh -J edge,bastion` ⇒
+/// `[edge, bastion]`). The first hop is reached by a direct TCP connection; every
+/// subsequent hop and the final target are reached over a `direct-tcpip` channel
+/// opened on the preceding hop's session.
+///
+/// Returns an error if the chain is empty — callers should only invoke this when
+/// `proxy_jump` is non-empty.
+pub async fn connect_through_jump_hosts(
+    target: &SshConfig,
+) -> Result<JumpHostConnection, SessionError> {
+    let hops = &target.proxy_jump;
+    let first = hops
+        .first()
+        .ok_or_else(|| SessionError::SpawnFailed("Jump host chain is empty".to_string()))?;
+
+    // First hop: an ordinary direct TCP connection.
+    let (mut current, _registry) = connect_and_authenticate(&first.to_ssh_config()).await?;
+    let mut intermediates: Vec<SshSession> = Vec::new();
+
+    // Each subsequent hop: open a direct-tcpip channel on the current session to
+    // the next hop, then handshake/authenticate the next session over it.
+    for (idx, hop) in hops.iter().enumerate().skip(1) {
+        let cfg = hop.to_ssh_config();
+        let channel = current
+            .channel_open_direct_tcpip(&cfg.host, cfg.port as u32, "localhost", 0)
+            .await
+            .map_err(|e| {
+                SessionError::SpawnFailed(format!(
+                    "Jump host hop {} ({}:{}) channel failed: {e}",
+                    idx + 1,
+                    cfg.host,
+                    cfg.port
+                ))
+            })?;
+        let (next, _registry) = connect_and_authenticate_over_channel(&cfg, channel).await?;
+        intermediates.push(current);
+        current = next;
+    }
+
+    // Final hop → target: tunnel the target session over the innermost hop.
+    let channel = current
+        .channel_open_direct_tcpip(&target.host, target.port as u32, "localhost", 0)
+        .await
+        .map_err(|e| {
+            SessionError::SpawnFailed(format!(
+                "Direct-tcpip channel to target {}:{} failed: {e}",
+                target.host, target.port
+            ))
+        })?;
+    let (session, registry) = connect_and_authenticate_over_channel(target, channel).await?;
+    intermediates.push(current);
+
+    Ok(JumpHostConnection {
+        session,
+        registry,
+        intermediates,
+    })
+}

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod connector;
 mod file_browser;
 pub mod handler;
+pub mod jump_host;
 mod legacy_pem;
 mod monitoring;
 pub mod x11;
@@ -18,7 +19,7 @@ use std::sync::{Arc, Mutex};
 
 use tracing::{debug, info};
 
-use crate::config::SshConfig;
+use crate::config::{JumpHostConfig, SshConfig};
 use crate::connection::{
     Capabilities, Condition, ConnectionType, FieldType, FilePathKind, OutputReceiver, OutputSender,
     SelectOption, SettingsField, SettingsGroup, SettingsSchema,
@@ -153,6 +154,14 @@ pub fn parse_ssh_settings(settings: &serde_json::Value) -> SshConfig {
         })
         .unwrap_or_default();
 
+    // Jump host (ProxyJump) chain, stored inline as an array of hop objects.
+    // Accepts the legacy `jumpHosts` key as well as `proxyJump`.
+    let proxy_jump = settings
+        .get("proxyJump")
+        .or_else(|| settings.get("jumpHosts"))
+        .and_then(|v| serde_json::from_value::<Vec<JumpHostConfig>>(v.clone()).ok())
+        .unwrap_or_default();
+
     SshConfig {
         host: str_field("host"),
         port,
@@ -169,6 +178,7 @@ pub fn parse_ssh_settings(settings: &serde_json::Value) -> SshConfig {
         enable_file_browser: opt_bool("enableFileBrowser"),
         save_password: opt_bool("savePassword"),
         connect_timeout_secs: opt_u64("connectTimeoutSecs"),
+        proxy_jump,
     }
 }
 
@@ -800,6 +810,39 @@ mod tests {
         });
         let config = parse_ssh_settings(&settings);
         assert_eq!(config.connect_timeout_secs, Some(5));
+    }
+
+    #[test]
+    fn parse_ssh_settings_reads_proxy_jump() {
+        let settings = serde_json::json!({
+            "host": "target.internal",
+            "username": "deploy",
+            "authMethod": "key",
+            "proxyJump": [
+                {
+                    "host": "bastion.example.com",
+                    "port": 2222,
+                    "username": "admin",
+                    "authMethod": "key",
+                    "keyPath": "~/.ssh/bastion"
+                }
+            ],
+        });
+        let config = parse_ssh_settings(&settings);
+        assert_eq!(config.proxy_jump.len(), 1);
+        assert_eq!(config.proxy_jump[0].host, "bastion.example.com");
+        assert_eq!(config.proxy_jump[0].port, 2222);
+    }
+
+    #[test]
+    fn parse_ssh_settings_proxy_jump_defaults_empty() {
+        let settings = serde_json::json!({
+            "host": "h",
+            "username": "u",
+            "authMethod": "password",
+        });
+        let config = parse_ssh_settings(&settings);
+        assert!(config.proxy_jump.is_empty());
     }
 
     #[test]

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -220,6 +220,77 @@ impl Default for DockerConfig {
     }
 }
 
+/// Configuration for a single jump host (bastion) hop in a `ProxyJump` chain.
+///
+/// Mirrors OpenSSH's `-J` / `ProxyJump` directive: a hop is itself a minimal SSH
+/// connection used purely as transport to reach the next hop (or the target).
+///
+/// Core only uses the inline connection fields here. A hop sourced from a saved
+/// connection (referenced by `connection_id`) is resolved to these inline values
+/// by the desktop layer *before* the config reaches core (Phase 4) — `connection_id`
+/// is carried only so the stored config round-trips.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JumpHostConfig {
+    /// Reference to a saved SSH connection ID (resolved to the inline fields by
+    /// the desktop layer; unused by core).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_id: Option<String>,
+    pub host: String,
+    #[serde(default = "default_ssh_port")]
+    pub port: u16,
+    pub username: String,
+    pub auth_method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_path: Option<String>,
+}
+
+impl Default for JumpHostConfig {
+    fn default() -> Self {
+        Self {
+            connection_id: None,
+            host: String::new(),
+            port: default_ssh_port(),
+            username: String::new(),
+            auth_method: String::new(),
+            password: None,
+            key_path: None,
+        }
+    }
+}
+
+impl JumpHostConfig {
+    /// Build a minimal [`SshConfig`] for establishing this hop, reusing the
+    /// standard connect/auth machinery. Terminal-only fields (cols/rows/shell)
+    /// are irrelevant for a transport hop and left at their defaults.
+    pub fn to_ssh_config(&self) -> SshConfig {
+        SshConfig {
+            host: self.host.clone(),
+            port: self.port,
+            username: self.username.clone(),
+            auth_method: self.auth_method.clone(),
+            password: self.password.clone(),
+            key_path: self.key_path.clone(),
+            ..SshConfig::default()
+        }
+    }
+
+    /// Return a copy with all `${VAR}` placeholders and `~` expanded in the
+    /// inline connection fields.
+    pub fn expand(mut self) -> Self {
+        self.host = expand_config_value(&self.host);
+        self.username = expand_config_value(&self.username);
+        self.key_path = self.key_path.map(|s| {
+            let stripped = s.trim().trim_matches('"').trim_matches('\'');
+            expand_config_value(stripped)
+        });
+        self.password = self.password.map(|s| expand_config_value(&s));
+        self
+    }
+}
+
 /// Unified SSH session configuration.
 ///
 /// Superset of desktop `SshConfig` and agent `SshSessionConfig`.
@@ -254,6 +325,11 @@ pub struct SshConfig {
     /// failing. `None` falls back to [`DEFAULT_SSH_CONNECT_TIMEOUT_SECS`] (#841).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connect_timeout_secs: Option<u64>,
+    /// Optional jump host (`ProxyJump`) chain, ordered outermost → innermost
+    /// (`ssh -J edge,bastion` ⇒ `[edge, bastion]`). Empty means a direct
+    /// connection. Accepts the legacy `jumpHosts` key for forward compatibility.
+    #[serde(default, alias = "jumpHosts", skip_serializing_if = "Vec::is_empty")]
+    pub proxy_jump: Vec<JumpHostConfig>,
 }
 
 impl SshConfig {
@@ -284,6 +360,7 @@ impl Default for SshConfig {
             enable_file_browser: None,
             save_password: None,
             connect_timeout_secs: None,
+            proxy_jump: Vec::new(),
         }
     }
 }
@@ -395,6 +472,7 @@ impl SshConfig {
             expand_config_value(stripped)
         });
         self.password = self.password.map(|s| expand_config_value(&s));
+        self.proxy_jump = self.proxy_jump.into_iter().map(|h| h.expand()).collect();
         self
     }
 }
@@ -898,6 +976,7 @@ mod tests {
             enable_file_browser: Some(false),
             save_password: None,
             connect_timeout_secs: Some(15),
+            proxy_jump: Vec::new(),
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let back: SshConfig = serde_json::from_str(&json).unwrap();
@@ -915,6 +994,112 @@ mod tests {
         assert_eq!(back.enable_file_browser, Some(false));
         assert!(back.save_password.is_none());
         assert_eq!(back.connect_timeout_secs, Some(15));
+    }
+
+    // --- jump host (ProxyJump) tests ---
+
+    #[test]
+    fn ssh_config_proxy_jump_roundtrip() {
+        let cfg = SshConfig {
+            host: "target.internal".into(),
+            username: "deploy".into(),
+            auth_method: "key".into(),
+            proxy_jump: vec![JumpHostConfig {
+                host: "bastion.example.com".into(),
+                port: 2222,
+                username: "admin".into(),
+                auth_method: "key".into(),
+                key_path: Some("~/.ssh/bastion".into()),
+                ..Default::default()
+            }],
+            ..SshConfig::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        // Field serializes camelCase.
+        assert!(json.contains("\"proxyJump\""));
+        let back: SshConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.proxy_jump.len(), 1);
+        assert_eq!(back.proxy_jump[0].host, "bastion.example.com");
+        assert_eq!(back.proxy_jump[0].port, 2222);
+        assert_eq!(back.proxy_jump[0].username, "admin");
+        assert_eq!(
+            back.proxy_jump[0].key_path.as_deref(),
+            Some("~/.ssh/bastion")
+        );
+    }
+
+    #[test]
+    fn ssh_config_empty_proxy_jump_is_omitted() {
+        let json = serde_json::to_string(&SshConfig::default()).unwrap();
+        assert!(!json.contains("proxyJump"));
+    }
+
+    #[test]
+    fn ssh_config_proxy_jump_defaults_when_absent() {
+        let json = r#"{ "host": "h", "username": "u", "authMethod": "password" }"#;
+        let cfg: SshConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.proxy_jump.is_empty());
+    }
+
+    #[test]
+    fn ssh_config_accepts_legacy_jump_hosts_alias() {
+        // The earlier draft used `jumpHosts`; it must still deserialize.
+        let json = r#"{
+            "host": "h", "username": "u", "authMethod": "key",
+            "jumpHosts": [
+                { "host": "bastion", "port": 22, "username": "admin", "authMethod": "agent" }
+            ]
+        }"#;
+        let cfg: SshConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.proxy_jump.len(), 1);
+        assert_eq!(cfg.proxy_jump[0].host, "bastion");
+    }
+
+    #[test]
+    fn jump_host_config_port_defaults_to_22() {
+        let json = r#"{ "host": "bastion", "username": "admin", "authMethod": "key" }"#;
+        let hop: JumpHostConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(hop.port, 22);
+    }
+
+    #[test]
+    fn jump_host_config_to_ssh_config_copies_connection_fields() {
+        let hop = JumpHostConfig {
+            host: "bastion".into(),
+            port: 2200,
+            username: "admin".into(),
+            auth_method: "password".into(),
+            password: Some("secret".into()),
+            key_path: None,
+            connection_id: Some("saved-id".into()),
+        };
+        let cfg = hop.to_ssh_config();
+        assert_eq!(cfg.host, "bastion");
+        assert_eq!(cfg.port, 2200);
+        assert_eq!(cfg.username, "admin");
+        assert_eq!(cfg.auth_method, "password");
+        assert_eq!(cfg.password.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn ssh_config_expand_expands_inline_jump_hosts() {
+        // SAFETY: test-only env var, single value.
+        unsafe { std::env::set_var("THUB_JUMP_TEST_HOST", "bastion.expanded") };
+        let cfg = SshConfig {
+            host: "target".into(),
+            username: "u".into(),
+            auth_method: "key".into(),
+            proxy_jump: vec![JumpHostConfig {
+                host: "${THUB_JUMP_TEST_HOST}".into(),
+                username: "admin".into(),
+                auth_method: "key".into(),
+                ..Default::default()
+            }],
+            ..SshConfig::default()
+        }
+        .expand();
+        assert_eq!(cfg.proxy_jump[0].host, "bastion.expanded");
+        unsafe { std::env::remove_var("THUB_JUMP_TEST_HOST") };
     }
 
     // --- camelCase field name tests ---

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -64,6 +64,15 @@ pub fn expand_config_value(value: &str) -> String {
         .into_owned()
 }
 
+/// Expand `${VAR}` placeholders and `~` in an optional SSH key path, stripping
+/// any surrounding quotes first — users often paste paths like `"C:\...\key"`.
+fn expand_key_path(key_path: Option<String>) -> Option<String> {
+    key_path.map(|s| {
+        let stripped = s.trim().trim_matches('"').trim_matches('\'');
+        expand_config_value(stripped)
+    })
+}
+
 /// Terminal dimensions (columns x rows).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct PtySize {
@@ -282,10 +291,7 @@ impl JumpHostConfig {
     pub fn expand(mut self) -> Self {
         self.host = expand_config_value(&self.host);
         self.username = expand_config_value(&self.username);
-        self.key_path = self.key_path.map(|s| {
-            let stripped = s.trim().trim_matches('"').trim_matches('\'');
-            expand_config_value(stripped)
-        });
+        self.key_path = expand_key_path(self.key_path);
         self.password = self.password.map(|s| expand_config_value(&s));
         self
     }
@@ -466,11 +472,7 @@ impl SshConfig {
     pub fn expand(mut self) -> Self {
         self.host = expand_config_value(&self.host);
         self.username = expand_config_value(&self.username);
-        self.key_path = self.key_path.map(|s| {
-            // Strip surrounding quotes — users often paste paths like "C:\...\key"
-            let stripped = s.trim().trim_matches('"').trim_matches('\'');
-            expand_config_value(stripped)
-        });
+        self.key_path = expand_key_path(self.key_path);
         self.password = self.password.map(|s| expand_config_value(&s));
         self.proxy_jump = self.proxy_jump.into_iter().map(|h| h.expand()).collect();
         self

--- a/core/tests/ssh_advanced.rs
+++ b/core/tests/ssh_advanced.rs
@@ -12,46 +12,70 @@
 mod common;
 
 use common::{
-    require_docker, ssh_exec, ssh_key_config, ssh_password_config, PORT_SSH_BASTION,
+    require_docker, ssh_exec, ssh_key_config, ssh_keys_dir, ssh_password_config, PORT_SSH_BASTION,
     PORT_SSH_RESTRICTED, PORT_SSH_TUNNEL,
 };
 use termihub_core::backends::ssh::auth::connect_and_authenticate;
+use termihub_core::backends::ssh::jump_host::connect_through_jump_hosts;
+use termihub_core::config::{JumpHostConfig, SshConfig};
 
-// ── SSH-JUMP-01: 2-hop ProxyJump chain ───────────────────────────────
+// ── SSH-JUMP-01: ProxyJump through a bastion to an internal target ─────
 
+/// Drive termiHub's own jump-host connect path end-to-end: connect to the
+/// internal target (`termihub-ssh-target`, reachable *only* via the bastion on
+/// the isolated `jumphost-net`) by configuring a one-hop `proxy_jump` chain
+/// through the bastion (published on port 2204). A successful, authenticated
+/// session on the target — which has no host port — proves the hop forwarded
+/// the SSH handshake correctly, replacing the earlier `ssh`-shell-out
+/// reachability check (#872).
 #[tokio::test]
 async fn ssh_jump_01_two_hop_proxy_jump() {
     require_docker!(PORT_SSH_BASTION);
 
-    // Step 1: Connect to the bastion host.
-    let bastion_config = ssh_key_config(PORT_SSH_BASTION, "ed25519");
-    let (bastion_session, _) = connect_and_authenticate(&bastion_config)
+    let key = ssh_keys_dir().join("ed25519");
+    let key = key.to_str().expect("key path is valid UTF-8").to_string();
+
+    // Target on jumphost-net, reached via a single ProxyJump hop (the bastion).
+    let target = SshConfig {
+        host: "termihub-ssh-target".to_string(),
+        port: 22,
+        username: "testuser".to_string(),
+        auth_method: "key".to_string(),
+        key_path: Some(key.clone()),
+        proxy_jump: vec![JumpHostConfig {
+            host: "127.0.0.1".to_string(),
+            port: PORT_SSH_BASTION,
+            username: "testuser".to_string(),
+            auth_method: "key".to_string(),
+            key_path: Some(key),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Step 1: Connect to the target *through* the jump host using termiHub's
+    // own ProxyJump implementation.
+    let conn = connect_through_jump_hosts(&target)
         .await
-        .expect("SSH-JUMP-01: Bastion connection should succeed");
+        .expect("SSH-JUMP-01: jump-host connection to target should succeed");
 
-    // Step 2: Verify the bastion can reach the internal target by executing an
-    // SSH command through the bastion to the target — exercising the same
-    // network path a ProxyJump connection would use. This is a fixture-level
-    // reachability check, not a test of a termiHub jump-host feature: the SSH
-    // backend has no first-class ProxyJump config yet (tracked separately); the
-    // raw `channel_open_direct_tcpip` primitive it would build on is checked in
-    // step 3.
-    let output = ssh_exec(
-        &bastion_session,
-        "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-         -i /home/testuser/.ssh/ed25519 \
-         testuser@termihub-ssh-target 'cat /home/testuser/marker.txt'",
-    )
-    .await
-    .expect("SSH-JUMP-01: SSH through bastion to target should succeed");
-
+    // Step 2: Read the target's marker over the jumped session. The target is
+    // unreachable except through the bastion, so reading it confirms the chain
+    // landed on the right host.
+    let output = ssh_exec(&conn.session, "cat /home/testuser/marker.txt")
+        .await
+        .expect("SSH-JUMP-01: exec on target via jump host should succeed");
     assert!(
         output.contains("JUMPHOST_TARGET_REACHED"),
         "SSH-JUMP-01: Expected marker 'JUMPHOST_TARGET_REACHED', got: {output}"
     );
 
-    // Step 3: Also verify direct-tcpip channel creation works
-    // (this is the underlying mechanism for ProxyJump).
+    // Step 3: Low-level regression guard — the `channel_open_direct_tcpip`
+    // primitive the jump path is built on still works directly on the bastion.
+    let bastion_config = ssh_key_config(PORT_SSH_BASTION, "ed25519");
+    let (bastion_session, _) = connect_and_authenticate(&bastion_config)
+        .await
+        .expect("SSH-JUMP-01: Bastion connection should succeed");
     let _channel = bastion_session
         .channel_open_direct_tcpip("termihub-ssh-target", 22, "localhost", 0)
         .await


### PR DESCRIPTION
## Summary

Phase 1 of the SSH jump-host feature designed in #872: first-class **ProxyJump** (OpenSSH `-J`) support in termiHub's core SSH backend. A user-configurable jump-host chain can now reach a target that is only accessible through one or more bastions — built on the same `channel_open_direct_tcpip` primitive the SSH tunnel forwarders already use.

This is the unblocked foundation; the connection-editor UI (#923), session pooling (#924), multi-hop UI + validation (#925), and indicators (#926) build on it.

## What's included

- **Config** (`core/src/config/mod.rs`): new `JumpHostConfig` and `SshConfig.proxy_jump` (chain ordered outermost → innermost), serialized as `proxyJump` with a `jumpHosts` alias for forward-compat. `expand()` expands inline hop fields; `parse_ssh_settings` reads the chain.
- **Auth** (`core/src/backends/ssh/auth.rs`): factored the russh handshake into a transport-generic `handshake_and_authenticate<S>` and added `connect_and_authenticate_over_channel`, which runs the handshake over a forwarded `direct-tcpip` channel stream (the same `into_stream()` transport SFTP/X11/tunnels use).
- **Jump path** (`core/src/backends/ssh/jump_host.rs`, new): `connect_through_jump_hosts` walks the chain, opening a direct-tcpip channel on each hop to reach the next hop/target. Intermediate hop sessions are returned so the caller keeps them alive (dropping them would close the carrying channels).
- **Wiring** (`connector.rs`): the shell connector uses the jump path when `proxy_jump` is set, retaining intermediate sessions in the session's `extensions`.

## How the russh stack made this clean

termiHub uses **russh 0.61**, where `connect_stream` accepts any `AsyncRead + AsyncWrite` and a forwarded channel already exposes that via `into_stream()`. So session-over-channel needed no new crate and no custom adapter — see the corrected design notes in the concept (#921).

## Test plan

- **Unit tests** (config serde round-trip, `jumpHosts` alias, `expand()` of inline hops, `parse_ssh_settings`): `cargo test -p termihub-core --features ssh --lib` → 447 passed.
- **Integration** — `SSH-JUMP-01` rewritten to drive `connect_through_jump_hosts` end-to-end through the `ssh-jumphost-bastion` / `ssh-jumphost-target` Docker fixtures (target has no host port, reachable only via the bastion), replacing the old `ssh`-shell-out reachability check. Verified passing against live Docker:
  ```
  test ssh_jump_01_two_hop_proxy_jump ... ok
  ```
- Full workspace: `cargo test --workspace` (588 core + 597 desktop + 242 agent) green; `cargo clippy --workspace --all-targets --all-features -D warnings` and `cargo fmt --check` clean.
- `/simplify` run on the diff → extracted a shared `expand_key_path` helper (separate commit); no other changes warranted.

## Scope notes

- **No CHANGELOG entry**: there is no UI to configure a jump host yet (Phase 2, #923), so this is not user-facing. The entry will land with the UI.
- **SFTP / monitoring / tunnels through a jump host** are intentionally deferred — they call `connect_and_authenticate` directly and require the shared session pool (Phase 3, #924). The jump path is wired at the shell connector because that's where intermediate sessions can be kept alive.
- Per-hop connect timeouts are a later refinement (the first hop uses the standard connect timeout).
- Concept `sync.md` reconciliation will run via `/sync-concept ssh-jump-host` once the concept PR #921 and this both land.

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)