### PR TITLE
docs(concept): reconcile ssh-jump-host concept with the implemented editor UI (#937)

### DIFF
--- a/docs/concepts/backlog/ssh-jump-host/concept.md
+++ b/docs/concepts/backlog/ssh-jump-host/concept.md
@@ -39,38 +39,51 @@ Add a first-class SSH gateway / jump host option directly in the SSH connection 
 The visual surfaces are specified by the mockups — open them in a browser to review layout and
 states. This section describes them; the mockups are authoritative for layout.
 
-| Mockup                                                                           | Shows                                                                                                               |
-| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| [`mockups/ssh-jump-host-editor.html`](mockups/ssh-jump-host-editor.html)         | Connection editor "Jump Host" collapsible section: collapsed, saved-connection mode, inline mode, multi-hop + error |
-| [`mockups/ssh-jump-host-indicators.html`](mockups/ssh-jump-host-indicators.html) | Sidebar hop badges + tooltip, status-bar hop-chain display, and the jump-host context menu                          |
+| Mockup                                                                           | Shows                                                                                                   |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| [`mockups/ssh-jump-host-editor.html`](mockups/ssh-jump-host-editor.html)         | Connection editor "Jump Host" category: disabled, saved-connection mode, inline mode, multi-hop + error |
+| [`mockups/ssh-jump-host-indicators.html`](mockups/ssh-jump-host-indicators.html) | Sidebar hop badges + tooltip, status-bar hop-chain display, and the jump-host context menu              |
 
 ### Connection Editor — Jump Host Section
 
-A new collapsible **"Jump Host"** section appears in the SSH connection editor, between the
-Authentication and Advanced groups. Collapsed by default; a single **"Connect through a jump host"**
-checkbox expands the body. See `mockups/ssh-jump-host-editor.html` states 1–4.
+A **"Jump Host"** section appears in the SSH connection editor as a flat category
+(`settings-panel__category`, the same pattern as the other editor categories — "General",
+"SSH Agent", "Session"), after the connection/authentication fields and before the SSH Agent
+category. A single **"Connect through a jump host"** checkbox (with the `ArrowLeftRight` icon)
+reveals the body. The section has no separate "Advanced" group and is not a collapsible chevron
+group — the connection editor uses flat categories throughout. See
+`mockups/ssh-jump-host-editor.html` states 1–4.
+
+Each hop carries a **source segmented control** ("Saved connection" / "Inline configuration")
+selecting one of the two modes below. The "Saved connection" option is disabled when there are no
+other SSH connections to reference. A per-hop **Connect Timeout (s)** field applies to either mode
+(blank = the default SSH connect timeout).
 
 #### Mode 1: Saved Connection Reference
 
 The user selects an existing SSH connection from a dropdown. This is the quickest option when the
 bastion host is already configured as a saved connection. The dropdown only shows SSH-type saved
-connections and displays the full path (folder / name) to disambiguate connections with the same
-name. See state 2.
+connections and displays the full path (`folder / sub / name`) to disambiguate connections with the
+same name; the connection being edited is excluded so it cannot reference itself. A reference whose
+target was deleted/renamed is shown as `… (not found)` and flagged by validation. See state 2.
 
 #### Mode 2: Inline Configuration
 
 The user configures the gateway directly within the connection editor (host, port, username, auth
-method, key), without needing a separate saved connection. Useful for one-off gateways or when the
-bastion host isn't worth saving standalone. See state 3.
+method, key/password), without needing a separate saved connection. Useful for one-off gateways or
+when the bastion host isn't worth saving standalone. See state 3.
 
 #### Multi-Hop Chaining
 
-Clicking "Add another hop" appends an additional jump host entry. Hops are numbered and ordered from
-outermost (first connection) to innermost (closest to target), each with its own Remove control. A
-**"Connection path"** summary line at the bottom (`You → edge-gateway → internal-bastion → target`)
-provides a visual summary of the full hop chain for easy verification. When the chain is invalid
-(missing/deleted reference, circular reference, missing inline fields), an inline **validation
-error** is shown in the error color and Save is blocked. See state 4.
+Clicking "Add another hop" appends an additional jump host entry. A lone hop renders as a plain
+field group; as soon as there are two or more hops, each renders as a **numbered, removable hop
+card** ("Hop 1 (outermost)", "Hop 2 (intermediate)", …, "Hop N (innermost)") with its own Remove
+control. Hops are ordered from outermost (first connection) to innermost (closest to target). A
+**"Connection path"** summary line (`You → edge-gateway → internal-bastion → target`) provides a
+visual summary of the full hop chain for easy verification, with the target node in the accent
+color. Non-blocking **warnings** (e.g. deep chains) appear as hints; when the chain is invalid
+(missing/deleted reference, circular reference, missing inline host/username), an inline
+**validation error** block is shown in the error color and Save is blocked. See state 4.
 
 ### Connection Sidebar — Visual Indicator
 
@@ -316,57 +329,74 @@ struct PooledSession {
 
 #### Connection Editor Changes
 
-Extend the SSH settings schema to include the jump host section:
+The SSH connection settings carry a single `proxyJump` array of hop configs — there is **no**
+separate `jumpHostEnabled` flag and **no** `source` discriminator field. Both are derived state:
+
+- **Enabled** ⇔ the `proxyJump` array is non-empty. Ticking "Connect through a jump host" seeds one
+  default inline hop; unticking clears the array (emits `undefined`).
+- **Mode** ⇔ a hop is "saved" iff it carries a `connectionId`; otherwise it is "inline". Switching
+  the source toggle sets/clears `connectionId` (and clears stale inline `host`/`username`).
 
 ```typescript
-// New fields in SSH connection settings schema
-interface JumpHostEntry {
-  /** "saved" or "inline" */
-  source: "saved" | "inline";
-  /** Connection ID when source is "saved" */
+// In src/types/connection.ts — one entry per hop, ordered outermost → innermost.
+interface JumpHostConfig {
+  /** Reference to a saved SSH connection; present ⇒ "saved" mode, absent ⇒ "inline". */
   connectionId?: string;
-  /** Inline config fields when source is "inline" */
-  host?: string;
-  port?: number;
-  username?: string;
-  authMethod?: string;
+  host: string;
+  port: number;
+  username: string;
+  /** "key" | "password" | "agent". */
+  authMethod: string;
   password?: string;
   keyPath?: string;
-  savePassword?: boolean;
+  /** Per-hop connect/handshake timeout (s); unset ⇒ default SSH connect timeout (#951). */
+  connectTimeoutSecs?: number;
 }
 
-// Added to SSH connection config
+// SSH connection settings (no `jumpHostEnabled`): the chain lives in `proxyJump`.
 interface SshConnectionConfig {
   // ... existing fields ...
-  jumpHostEnabled: boolean;
-  jumpHosts: JumpHostEntry[];
+  /** OpenSSH `-J` / ProxyJump chain; empty/absent ⇒ direct connection. */
+  proxyJump?: JumpHostConfig[];
 }
 ```
+
+> The Rust model serializes the chain as `proxyJump` with a serde `alias = "jumpHosts"`; the
+> frontend tolerates both keys (`getJumpHosts` in `src/utils/jumpHost.ts`).
 
 #### New Components
 
 ```
 src/components/ConnectionEditor/
-  JumpHostSection.tsx        # Collapsible jump host configuration section
-  JumpHostEntry.tsx          # Single hop entry (saved ref or inline config)
+  JumpHostSection.tsx        # Jump host editor category (enable checkbox, hops, path, validation)
+  JumpHostEntry.tsx          # Single hop entry (source toggle + saved dropdown or inline fields)
   JumpHostPathDisplay.tsx    # Visual "You → hop1 → hop2 → target" display
+src/utils/
+  jumpHost.ts                # Chain extraction + display helpers (badge/status/path/gateway/deps)
+  validateProxyJump.ts       # Save-time validation (inline fields, missing/non-SSH refs, cycles, depth)
 ```
 
-`JumpHostSection.tsx` follows the collapsible group pattern already used in the connection editor (Authentication, Advanced). Each `JumpHostEntry` renders either a saved connection dropdown or inline SSH fields.
+`JumpHostSection.tsx` follows the flat `settings-panel__category` pattern used by the other editor
+categories (General, SSH Agent, Session). Each `JumpHostEntry` renders the source segmented control
+and then either a saved-connection dropdown or the inline SSH fields, plus the per-hop connect
+timeout.
 
 #### Sidebar Visual Indicator
 
-Modify the connection tree rendering in `src/components/Sidebar/` to show a hop badge (lucide
-`arrow-left-right` icon) on connections with jump hosts configured:
+The connection tree rendering in `src/components/Sidebar/ConnectionList.tsx` shows a hop badge
+(lucide `ArrowLeftRight`) on connections whose config has a non-empty `proxyJump` chain, using the
+`hasJumpHost` / `getJumpHosts` / `jumpHostTooltip` helpers from `src/utils/jumpHost.ts`. Multi-hop
+connections add a small hop-count label:
 
 ```typescript
-// In connection tree item rendering
-{connection.config.jumpHosts?.length > 0 && (
+// In connection tree item rendering (ConnectionList.tsx)
+{hasJumpHost(connection.config) && (
   <span
-    className="connection-item__jump-badge"
-    title={`Via: ${jumpHostNames.join(" → ")}`}
+    className="connection-tree__jump-badge"
+    title={jumpHostTooltip(getJumpHosts(connection.config), connection.name)}
   >
     <ArrowLeftRight size={12} />
+    {hopCount > 1 && <span className="connection-tree__hop-count">{hopCount}</span>}
   </span>
 )}
 ```
@@ -377,17 +407,24 @@ Minimal changes needed — the jump host config is part of the connection config
 
 #### API Layer (`src/services/api.ts`)
 
-No new Tauri commands needed for basic jump host support — the jump host config is part of the SSH connection config that flows through the existing `connect_session` command. The backend resolves and connects through the chain internally.
+No new Tauri commands needed for jump host support — the jump host config is part of the SSH
+connection config that flows through the existing connect command. The backend resolves and connects
+through the chain internally (`src-tauri/src/connection/jump_host_resolver.rs`), and is the
+authoritative safety net for cycles/missing references at connect time.
 
-New command only for validation:
+Save-time validation is done **client-side** by `validateProxyJump` (`src/utils/validateProxyJump.ts`)
+rather than via a round-trip Tauri command — it returns `{ errors, warnings }`, where `errors` block
+Save and `warnings` are advisory:
 
 ```typescript
-/** Validate a jump host chain (check for circular refs, missing connections). */
-export function validateJumpHostChain(
-  connectionId: string,
-  jumpHosts: JumpHostEntry[]
-): Promise<ValidationResult>;
+export function validateProxyJump(
+  hops: JumpHostConfig[],
+  ctx?: { connections: SavedConnection[]; currentConnectionId?: string }
+): { errors: string[]; warnings: string[] };
 ```
+
+Reference and circular-chain checks run only when `ctx` (the saved connections) is supplied; inline
+hops are validated for required host/username regardless.
 
 #### Types (`src/types/connection.ts`)
 
@@ -496,5 +533,11 @@ flag as the rest of `ssh_advanced.rs`.
 
 ## Implementation Status
 
-Not started — this is a `backlog/` concept. Once implementation begins, run
-`/sync-concept ssh-jump-host` after each change to keep [`sync.md`](sync.md) current.
+Substantially implemented. The core connect path (russh chain over `channel_open_direct_tcpip`),
+session pooling (#924), the connection-editor "Jump Host" category with saved/inline modes,
+multi-hop cards, per-hop connect timeout (#951), client-side validation, deletion protection
+(#941), and the visual indicators (sidebar badge, status-bar chain, context menu, connection-path
+dialog) have shipped. The editor UI was reconciled with these artifacts in #937 (see
+[`sync.md`](sync.md), Resolved R1–R5). Remaining open items are connect-time per-hop error UX and
+the per-terminal reconnection banner (tracked in [`sync.md`](sync.md) Open divergences). Run
+`/sync-concept ssh-jump-host` after each further change to keep [`sync.md`](sync.md) current.

--- a/docs/concepts/backlog/ssh-jump-host/mockups/ssh-jump-host-editor.html
+++ b/docs/concepts/backlog/ssh-jump-host/mockups/ssh-jump-host-editor.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- SSH Jump Host — connection editor "Jump Host" collapsible section. Layout altitude, real class names + lucide icons. -->
+<!-- SSH Jump Host — connection editor "Jump Host" category. Layout altitude, real class names + lucide icons. -->
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -29,38 +29,24 @@
         padding-bottom: 6px;
         border-bottom: 1px solid var(--border-secondary);
       }
-      /* Collapsible group header (clickable) */
-      .collapsible {
-        border: 1px solid var(--border-primary);
-        border-radius: var(--radius-md);
-        background: var(--bg-secondary);
+      /* Flat editor category — mirrors the real .settings-panel__category /
+         .settings-panel__category-title (the editor has no collapsible groups). */
+      .category {
         margin: 0 0 18px;
       }
-      .collapsible__header {
+      .category__title {
         display: flex;
         align-items: center;
-        gap: 8px;
-        padding: 9px 12px;
-        cursor: pointer;
-        user-select: none;
-      }
-      .collapsible__header .li {
-        color: var(--text-secondary);
-      }
-      .collapsible__title {
-        font-size: 11px;
+        gap: 6px;
+        font-size: 13px;
         font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        color: var(--text-secondary);
+        color: var(--text-primary);
+        margin: 0 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 1px solid var(--border-secondary);
       }
-      .collapsible__chevron {
-        margin-left: auto;
-        color: var(--text-secondary);
-      }
-      .collapsible__body {
-        padding: 12px;
-        border-top: 1px solid var(--border-secondary);
+      .category__body {
+        padding: 0;
       }
       .field {
         display: flex;
@@ -290,6 +276,10 @@
         <path d="m16 21 4-4-4-4" />
         <path d="M20 17H4" />
       </symbol>
+      <symbol id="i-arrow-right" viewBox="0 0 24 24">
+        <path d="M5 12h14" />
+        <path d="m12 5 7 7-7 7" />
+      </symbol>
       <symbol id="i-server" viewBox="0 0 24 24">
         <rect width="20" height="8" x="2" y="2" rx="2" ry="2" />
         <rect width="20" height="8" x="2" y="14" rx="2" ry="2" />
@@ -320,19 +310,20 @@
     </p>
 
     <div class="mockup-note">
-      The Connection Editor opens as a tab in the main area. The new <strong>Jump Host</strong>
-      collapsible group sits between Authentication and Advanced. Four states below: collapsed,
-      saved-connection mode, inline mode, and multi-hop with a connection-path summary + validation
-      error.
+      The Connection Editor opens as a tab in the main area. The <strong>Jump Host</strong> category
+      is a flat <code>settings-panel__category</code> (the editor has no collapsible groups), after
+      the connection/authentication fields and before the SSH Agent category. Four states below:
+      disabled, saved-connection mode, inline mode, and multi-hop with a connection-path summary +
+      validation error.
     </div>
 
     <!-- ── State 1: collapsed ─────────────────────────────────────────── -->
     <section class="mockup-section">
-      <h2>1 · Jump Host section collapsed (default)</h2>
+      <h2>1 · Jump Host section disabled (default)</h2>
       <div class="mockup-note">
-        Full app shell. The editor tab is active; the Jump Host group
-        <span class="callout">A</span> is collapsed — only its header row with the "Connect through
-        a jump host" checkbox (unchecked) is visible.
+        Full app shell. The editor tab is active; the Jump Host category
+        <span class="callout">A</span> shows only its title and the "Connect through a jump host"
+        checkbox (unchecked) — the body stays hidden until it is enabled.
       </div>
       <div class="app" style="height: 520px">
         <div class="app__body">
@@ -411,34 +402,26 @@
                 </div>
               </div>
 
-              <!-- Jump Host group: collapsed -->
-              <div class="collapsible">
-                <div class="collapsible__header">
+              <!-- Jump Host category: disabled (only title + checkbox) -->
+              <div class="category">
+                <div class="category__title">
                   <span class="callout">A</span>
                   <svg class="li"><use href="#i-arrow-left-right" /></svg>
-                  <span class="collapsible__title">Jump Host</span>
-                  <span class="collapsible__chevron">
-                    <svg class="li"><use href="#i-chevron-right" /></svg>
-                  </span>
+                  Jump Host
                 </div>
-                <div class="collapsible__body" style="padding-top: 10px; padding-bottom: 10px">
-                  <div class="checkrow" style="margin: 0">
-                    <span
-                      class="checkbox"
-                      style="background: none; border-color: var(--text-secondary)"
-                    ></span>
-                    Connect through a jump host
-                  </div>
+                <div class="checkrow" style="margin: 0">
+                  <span
+                    class="checkbox"
+                    style="background: none; border-color: var(--text-secondary)"
+                  ></span>
+                  Connect through a jump host
                 </div>
               </div>
 
-              <div class="collapsible">
-                <div class="collapsible__header">
+              <div class="category">
+                <div class="category__title">
                   <svg class="li"><use href="#i-settings" /></svg>
-                  <span class="collapsible__title">Advanced</span>
-                  <span class="collapsible__chevron">
-                    <svg class="li"><use href="#i-chevron-right" /></svg>
-                  </span>
+                  Session
                 </div>
               </div>
             </div>
@@ -458,9 +441,10 @@
       <div class="legend">
         <ul>
           <li>
-            <span class="callout">A</span> Jump Host collapsible group — lucide
-            <code>ArrowLeftRight</code> header icon, sits between Authentication and Advanced.
-            Collapsed: only the enable checkbox shows.
+            <span class="callout">A</span> Jump Host category — flat
+            <code>settings-panel__category</code> with the lucide <code>ArrowLeftRight</code> icon
+            on its checkbox label, after the auth fields and before the SSH Agent / Session
+            categories. Disabled: only the title + enable checkbox show.
           </li>
         </ul>
       </div>
@@ -468,21 +452,18 @@
 
     <!-- ── State 2: saved-connection mode ─────────────────────────────── -->
     <section class="mockup-section">
-      <h2>2 · Expanded — saved connection reference</h2>
+      <h2>2 · Enabled — saved connection reference</h2>
       <div class="mockup-note">
-        Checkbox enabled <span class="callout">B</span> expands the body. Source segmented control
-        <span class="callout">C</span> is set to "Saved connection"; the Gateway dropdown
+        Checkbox enabled <span class="callout">B</span> reveals the body. Source segmented control
+        <span class="callout">C</span> is set to "Saved connection"; the Connection dropdown
         <span class="callout">D</span> lists SSH-type saved connections by full path.
       </div>
-      <div class="collapsible" style="max-width: 620px">
-        <div class="collapsible__header">
+      <div class="category" style="max-width: 620px">
+        <div class="category__title">
           <svg class="li"><use href="#i-arrow-left-right" /></svg>
-          <span class="collapsible__title">Jump Host</span>
-          <span class="collapsible__chevron"
-            ><svg class="li"><use href="#i-chevron-down" /></svg
-          ></span>
+          Jump Host
         </div>
-        <div class="collapsible__body">
+        <div class="category__body">
           <div class="checkrow">
             <span class="callout">B</span>
             <span class="checkbox"
@@ -499,7 +480,7 @@
             </span>
           </div>
           <div class="field">
-            <span class="field__label">Gateway</span>
+            <span class="field__label">Connection</span>
             <span class="select">
               <span
                 ><span class="callout" style="margin-right: 6px">D</span>Work / bastion.example.com
@@ -508,15 +489,19 @@
               <svg class="li"><use href="#i-chevron-down" /></svg>
             </span>
           </div>
+          <div class="field">
+            <span class="field__label">Timeout (s)</span>
+            <span class="input input--sm">20</span>
+          </div>
           <button class="add-hop">
             <svg class="li"><use href="#i-plus" /></svg> Add another hop
           </button>
           <div class="path-line">
-            <span class="path-line__label">Connection path:</span>
+            <span class="path-line__label">Connection path</span>
             You
-            <svg class="li"><use href="#i-arrow-left-right" /></svg>
+            <svg class="li"><use href="#i-arrow-right" /></svg>
             bastion.example.com
-            <svg class="li"><use href="#i-arrow-left-right" /></svg>
+            <svg class="li"><use href="#i-arrow-right" /></svg>
             <span class="path-line__target">app-server.internal</span>
           </div>
         </div>
@@ -528,11 +513,11 @@
           </li>
           <li>
             <span class="callout">C</span> Source segmented control: Saved connection / Inline
-            configuration.
+            configuration. "Saved connection" is disabled when there are no other SSH connections.
           </li>
           <li>
-            <span class="callout">D</span> Gateway dropdown — SSH-type saved connections only, shown
-            as <code>folder / name</code>.
+            <span class="callout">D</span> Connection dropdown — SSH-type saved connections only,
+            shown as <code>folder / sub / name</code> (the edited connection excluded).
           </li>
         </ul>
       </div>
@@ -545,15 +530,12 @@
         Source toggled to "Inline configuration" <span class="callout">E</span> reveals direct SSH
         fields <span class="callout">F</span> for a one-off gateway.
       </div>
-      <div class="collapsible" style="max-width: 620px">
-        <div class="collapsible__header">
+      <div class="category" style="max-width: 620px">
+        <div class="category__title">
           <svg class="li"><use href="#i-arrow-left-right" /></svg>
-          <span class="collapsible__title">Jump Host</span>
-          <span class="collapsible__chevron"
-            ><svg class="li"><use href="#i-chevron-down" /></svg
-          ></span>
+          Jump Host
         </div>
-        <div class="collapsible__body">
+        <div class="category__body">
           <div class="checkrow">
             <span class="checkbox"
               ><svg class="li"><use href="#i-check" /></svg
@@ -600,15 +582,19 @@
               <span class="browse-btn">Browse</span>
             </div>
           </div>
-          <button class="add-hop" style="margin-top: 10px">
+          <div class="field" style="margin-top: 10px">
+            <span class="field__label">Timeout (s)</span>
+            <span class="input input--sm" style="color: var(--text-secondary)">Default (20 s)</span>
+          </div>
+          <button class="add-hop" style="margin-top: 4px">
             <svg class="li"><use href="#i-plus" /></svg> Add another hop
           </button>
           <div class="path-line">
-            <span class="path-line__label">Connection path:</span>
+            <span class="path-line__label">Connection path</span>
             You
-            <svg class="li"><use href="#i-arrow-left-right" /></svg>
+            <svg class="li"><use href="#i-arrow-right" /></svg>
             bastion.example.com
-            <svg class="li"><use href="#i-arrow-left-right" /></svg>
+            <svg class="li"><use href="#i-arrow-right" /></svg>
             <span class="path-line__target">app-server.internal</span>
           </div>
         </div>
@@ -633,15 +619,12 @@
         <span class="callout">I</span>, and an inline validation error
         <span class="callout">J</span> (referenced gateway was deleted) that blocks Save.
       </div>
-      <div class="collapsible" style="max-width: 620px">
-        <div class="collapsible__header">
+      <div class="category" style="max-width: 620px">
+        <div class="category__title">
           <svg class="li"><use href="#i-arrow-left-right" /></svg>
-          <span class="collapsible__title">Jump Host</span>
-          <span class="collapsible__chevron"
-            ><svg class="li"><use href="#i-chevron-down" /></svg
-          ></span>
+          Jump Host
         </div>
-        <div class="collapsible__body">
+        <div class="category__body">
           <div class="checkrow">
             <span class="checkbox"
               ><svg class="li"><use href="#i-check" /></svg
@@ -662,11 +645,11 @@
               <span class="field__label">Source</span>
               <span class="seg">
                 <span class="seg__opt seg__opt--active">Saved connection</span>
-                <span class="seg__opt">Inline</span>
+                <span class="seg__opt">Inline configuration</span>
               </span>
             </div>
             <div class="field" style="margin-bottom: 0">
-              <span class="field__label">Gateway</span>
+              <span class="field__label">Connection</span>
               <span class="select"
                 >Work / edge-gateway.example.com (SSH)
                 <svg class="li"><use href="#i-chevron-down" /></svg
@@ -677,7 +660,7 @@
           <div class="hop-card">
             <div class="hop-card__head">
               <svg class="li"><use href="#i-server" /></svg>
-              Hop 2
+              Hop 2 (innermost)
               <button class="hop-card__remove">
                 <svg class="li"><use href="#i-trash" /></svg> Remove
               </button>
@@ -686,16 +669,16 @@
               <span class="field__label">Source</span>
               <span class="seg">
                 <span class="seg__opt seg__opt--active">Saved connection</span>
-                <span class="seg__opt">Inline</span>
+                <span class="seg__opt">Inline configuration</span>
               </span>
             </div>
             <div class="field" style="margin-bottom: 0">
-              <span class="field__label">Gateway</span>
+              <span class="field__label">Connection</span>
               <span
                 class="select"
                 style="border-color: var(--color-error); color: var(--color-error)"
               >
-                ⟨deleted⟩ internal-bastion <svg class="li"><use href="#i-chevron-down" /></svg>
+                internal-bastion (not found) <svg class="li"><use href="#i-chevron-down" /></svg>
               </span>
             </div>
           </div>
@@ -706,20 +689,20 @@
 
           <div class="path-line">
             <span class="callout" style="margin-right: 4px">I</span>
-            <span class="path-line__label">Connection path:</span>
+            <span class="path-line__label">Connection path</span>
             You
-            <svg class="li"><use href="#i-arrow-left-right" /></svg>
+            <svg class="li"><use href="#i-arrow-right" /></svg>
             edge-gateway
-            <svg class="li"><use href="#i-arrow-left-right" /></svg>
+            <svg class="li"><use href="#i-arrow-right" /></svg>
             internal-bastion
-            <svg class="li"><use href="#i-arrow-left-right" /></svg>
+            <svg class="li"><use href="#i-arrow-right" /></svg>
             <span class="path-line__target">app-server.internal</span>
           </div>
 
           <div class="validation-error">
             <span class="callout">J</span>
             <svg class="li"><use href="#i-circle-alert" /></svg>
-            Hop 2: referenced connection "internal-bastion" not found. Pick an existing SSH
+            Hop 2: referenced connection not found (it may have been deleted). Pick an existing SSH
             connection or switch to inline configuration.
           </div>
 
@@ -735,7 +718,7 @@
           <li><span class="callout">H</span> Per-hop Remove control (error color).</li>
           <li>
             <span class="callout">I</span> Connection-path summary — <code>You → … → target</code>,
-            hops joined by the <code>ArrowLeftRight</code> icon (target in accent).
+            hops joined by the directional <code>ArrowRight</code> icon (target in accent).
           </li>
           <li>
             <span class="callout">J</span> Inline validation error (error color) — deleted/missing

--- a/docs/concepts/backlog/ssh-jump-host/sync.md
+++ b/docs/concepts/backlog/ssh-jump-host/sync.md
@@ -1,19 +1,46 @@
 # Sync Ledger — SSH Jump Host
 
-**Last synced:** never (concept not yet implemented)
-**Status:** diverged (entirely missing — backlog feature)
+**Last synced:** 2026-06-30 at commit `be96039d`
+**Status:** in-sync (editor UI reconciled; remaining items are deferred phases, not divergences)
 
 This ledger is maintained by the `/sync-concept ssh-jump-host` skill. It records the last
 commit at which the concept artifacts and the code were reconciled, plus any open divergences.
 
 ## Open divergences
 
-| #   | Artifact claim               | Code reality              | Type    | Recommendation                                 |
-| --- | ---------------------------- | ------------------------- | ------- | ---------------------------------------------- |
-| 1   | Entire feature (per concept) | Not implemented — backlog | Missing | Implement per `concept.md` order, then re-sync |
+| #   | Artifact claim                                                                                                            | Code reality                                                                                                                                    | Type    | Recommendation                                                          |
+| --- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------- |
+| 1   | "Jump host unreachable / target unreachable / per-hop auth failed" connect-time error UX (concept §Edge Cases)            | Backend resolves and connects the chain; the granular per-hop connect-time error toasts in the concept are not yet surfaced verbatim in the UI. | Missing | Leave open — connect-time error UX polish is a later refinement (#933). |
+| 2   | Reconnection banner "Connection lost (jump host disconnected). [Reconnect]" per terminal (concept §Reconnection Behavior) | Gateway-drop handling exists at the pool level; the dedicated per-terminal jump-host reconnection banner copy is not yet a distinct surface.    | Missing | Leave open — reconnection-UX is a later phase, tracked separately.      |
+
+Neither open item is a contradiction between the concept and shipped code — they are
+not-yet-built refinements of the same design. The editor UI (the subject of #937) is now
+reconciled.
+
+## Resolved
+
+| Date       | #   | Resolution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------- | --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-30 | R1  | **Collapsible group → flat editor category.** Concept (and editor mockup states 1–4) showed a _collapsible_ "Jump Host" group with a chevron, between "Authentication" and an "Advanced" group. The connection editor has no collapsible groups or "Advanced" group — it renders flat `settings-panel__category` blocks. **Concept + mockup updated to match the flat category** (titled "Jump Host", after the connection/auth fields, before the SSH Agent category). Edited `concept.md` and `mockups/ssh-jump-host-editor.html`.                        |
+| 2026-06-30 | R2  | **Data model: no `source` / `jumpHostEnabled` fields.** Concept Impl Details proposed a `JumpHostEntry.source: "saved" \| "inline"` discriminator and an `SshConnectionConfig.jumpHostEnabled: boolean` flag. The shipped model has neither: a hop is "saved" iff it carries `connectionId` (otherwise inline), and the section is "enabled" iff the `proxyJump` array is non-empty. The cleaner derived model is what shipped; **concept Impl Details updated** to describe `JumpHostConfig` (no `source`, no `jumpHostEnabled`) and the derivation rules. |
+| 2026-06-30 | R3  | **Per-hop connect timeout (#951) was undocumented.** Each hop has an optional `connectTimeoutSecs` field (per-hop connect/handshake timeout, falling back to the default). **Documented** in `concept.md` and added to the inline-mode editor mockup.                                                                                                                                                                                                                                                                                                       |
+| 2026-06-30 | R4  | **Path separator icon.** Concept editor mockup joined connection-path nodes with the `ArrowLeftRight` icon; the shipped `JumpHostPathDisplay` uses a directional `ArrowRight`. **Mockup updated** to `ArrowRight` for the path line (the sidebar/badge keeps `ArrowLeftRight`, which matches the code).                                                                                                                                                                                                                                                     |
+| 2026-06-30 | R5  | **Path-line label.** Concept used `Connection path:` (trailing colon) with monospace node text; code renders a `Connection path` label with the chain. Treated as cosmetic; mockup label aligned to `Connection path` (no behavioral change).                                                                                                                                                                                                                                                                                                               |
+| 2026-06-30 | —   | Indicators mockup (sidebar hop badge + hop-count + tooltip, status-bar `Route` hop chain, context-menu "Open Jump Host Terminal" / "Show Connection Path", connection-path dialog) — **verified matching** the shipped `ConnectionList.tsx`, `ConnectionPathDialog.tsx`, `StatusBar.tsx`, and `src/utils/jumpHost.ts`. No change needed.                                                                                                                                                                                                                    |
 
 ## Notes
 
+- 2026-06-30 (#937): Editor-UI reconciliation pass. The "Jump Host" connection-editor section
+  shipped across #922/#923/#925 (+ #940 saved-connection mode, #941 deletion protection, #951
+  per-hop timeout). It is a **flat `settings-panel__category`** with an enable checkbox, a
+  per-hop **source segmented control** (Saved connection / Inline configuration), a saved-SSH
+  dropdown (folder-path labelled), inline SSH fields, a per-hop connect-timeout field, an
+  "Add another hop" control rendering numbered removable hop cards for multi-hop chains, a
+  `Connection path` summary line, non-blocking warnings, and blocking validation errors that
+  disable Save. Components: `JumpHostSection.tsx`, `JumpHostEntry.tsx`, `JumpHostPathDisplay.tsx`;
+  helpers `src/utils/jumpHost.ts`, `src/utils/validateProxyJump.ts`; wiring in
+  `ConnectionEditor.tsx`. The concept and editor mockup were updated to reflect the flat-category
+  layout and the derived data model; see Resolved R1–R5.
 - 2026-06-30 (#924): **Phase 3 — session pooling** implemented. The reference-counted SSH session
   pool moved into the core crate as a generic `RefPool<T>` (`core/src/backends/ssh/session_pool.rs`)
   with single-flight creation; `SshGateway` + the process-wide `shared_gateway_pool()` pool jump-host
@@ -22,16 +49,12 @@ commit at which the concept artifacts and the code were reconciled, plus any ope
   tunnel manager both acquire gateways from this one pool, so connections sharing a bastion reuse one
   gateway session; SSH tunnels with a `proxyJump` chain now connect through (and pool) the gateway.
   Covered by pool unit tests, `gateway_pool_key` unit tests, and the `SSH-JUMP-03` Docker integration
-  test. A full `/sync-concept ssh-jump-host` pass (covering phases 1–4 together) is still pending.
+  test.
 - 2026-06-29 (#872): Concept refined to match the real SSH stack — termiHub uses **russh 0.61**
   (async), not `ssh2`/libssh2. Backend impl details rewritten around `channel_open_direct_tcpip` +
   `channel.into_stream()` + `russh::client::connect_stream` (already used by the tunnel forwarders
   and SFTP/X11), the config field renamed to `proxy_jump` (OpenSSH `-J` style), and a concrete
   `SSH-JUMP-01` test-conversion plan added against the existing `ssh-jumphost-bastion` /
-  `ssh-jumphost-target` Docker fixtures. No code yet — still a backlog concept.
-
-## Resolved
-
-| Date | #   | Resolution |
-| ---- | --- | ---------- |
-| —    | —   | —          |
+  `ssh-jumphost-target` Docker fixtures.
+  </content>
+  </invoke>


### PR DESCRIPTION
## Summary

Runs `/sync-concept ssh-jump-host` and reconciles the folder-form concept
(`docs/concepts/backlog/ssh-jump-host/`) with the shipped "Jump Host"
connection-editor section (#922/#923/#925 + #940 saved-connection mode, #941
deletion protection, #951 per-hop timeout). Docs-only — no code changes.

The implemented editor diverged from the concept in deliberate, correct ways, so
per the sync-concept skill the **concept artifacts were updated to match the code**
(and recorded in `sync.md`), rather than changing code.

## What diverged → how it was reconciled (artifact updates)

- **Collapsible group → flat category (R1).** Concept + editor mockup showed a
  collapsible "Jump Host" group with a chevron, between "Authentication" and an
  "Advanced" group. The editor has no collapsibles and no "Advanced" group — it
  renders flat `settings-panel__category` blocks. Concept text + all four mockup
  states rewritten as a flat category.
- **Data model: no `source` / `jumpHostEnabled` (R2).** Concept proposed a
  `JumpHostEntry.source` discriminator and an `SshConnectionConfig.jumpHostEnabled`
  flag. The shipped model has neither: a hop is "saved" iff it has `connectionId`,
  and the section is enabled iff the `proxyJump` array is non-empty. Impl Details
  updated to the derived model (`JumpHostConfig`, `proxyJump`).
- **Per-hop connect timeout (R3).** `connectTimeoutSecs` (#951) was undocumented —
  added to the concept and the inline-mode mockup.
- **Path separator icon (R4).** Mockup joined path nodes with `ArrowLeftRight`;
  `JumpHostPathDisplay` uses the directional `ArrowRight`. Mockup updated (the
  sidebar badge keeps `ArrowLeftRight`, matching the code).
- **Path-line label + dropdown label (R5).** Aligned cosmetic copy
  (`Connection path`, "Connection" dropdown, validation-error wording) to the code.
- **Verified matching:** indicators mockup (sidebar hop badge + hop-count +
  tooltip, status-bar `Route` hop chain, context-menu "Open Jump Host Terminal" /
  "Show Connection Path", connection-path dialog) already matches
  `ConnectionList.tsx`, `ConnectionPathDialog.tsx`, `StatusBar.tsx`, and
  `src/utils/jumpHost.ts`. No change needed. `behavior.md` diagrams remain accurate
  and were left unchanged.

## Left as open divergences (deferred phases, not contradictions)

Recorded in `sync.md` Open divergences:

1. Connect-time per-hop error UX (granular "hop N unreachable / auth failed" toasts).
2. Per-terminal jump-host reconnection banner copy.

Both are not-yet-built refinements of the same design, not concept↔code conflicts.

## Notes

- `sync.md` updated: last-synced commit `be96039d`, status in-sync for the editor
  UI, Resolved R1–R5 + the two open items.
- Docs-only reconciliation, so no CHANGELOG entry.
- markdownlint/Chrome screenshot tooling is unavailable in this worktree
  (node_modules not installed, headless-Chrome render blocked); edits follow the
  existing artifact conventions and `.markdownlint.json` (MD013 off) and were
  Prettier-formatted by the auto-format hook.

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)