### PR TITLE
docs(concept): elevated (sudo) SFTP editing + early read-only detection (#970)

### DIFF
--- a/docs/concepts/backlog/elevated-sftp-editing/behavior.md
+++ b/docs/concepts/backlog/elevated-sftp-editing/behavior.md
@@ -1,0 +1,172 @@
+# Behavior — Elevated SFTP Editing + Early Read-Only Detection
+
+**GitHub Issue:** [#970](https://github.com/armaxri/termiHub/issues/970)
+
+Companion to [`concept.md`](concept.md). State machines and sequence diagrams for read-only
+detection on open, the elevated-save flow, and the sudo prompt / retry / failure paths.
+
+---
+
+## Editor writability state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Probing: content loaded
+    Probing --> Writable: writable / unknown
+    Probing --> ReadOnlyShell: not writable + shell available
+    Probing --> ReadOnlyNoShell: not writable + SFTP-only
+
+    Writable --> Writable: edit
+    Writable --> [*]: save (direct) OK
+    Writable --> SaveFailed: save (direct) fails
+
+    ReadOnlyShell --> ReadOnlyShell: edit (buffer only)
+    ReadOnlyShell --> Prompting: Edit/Save with sudo
+    Prompting --> Elevated: password accepted
+    Prompting --> ReadOnlyShell: cancel
+    Prompting --> Prompting: wrong password (retry < 3)
+    Prompting --> SaveFailed: 3 failures / non-password error
+
+    Elevated --> Elevated: edit / save OK
+    Elevated --> SaveFailed: elevated save fails
+
+    ReadOnlyNoShell --> ReadOnlyNoShell: edit (buffer only)
+    ReadOnlyNoShell --> SaveCopy: Save a copy...
+    SaveCopy --> [*]: written to writable path / downloaded
+
+    SaveFailed --> ReadOnlyShell: dismiss (cached pw cleared if wrong)
+    SaveFailed --> Elevated: dismiss (still elevated)
+    SaveFailed --> Writable: dismiss (was direct save)
+```
+
+Notes:
+
+- **Unknown** writability (no permission bits, no probe) collapses into `Writable` — today's
+  optimistic behavior. A failed direct save then routes to `SaveFailed`, whose banner offers
+  **Retry with sudo** (transition into `Prompting`) when a shell is available.
+
+---
+
+## Read-only detection on open
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as FileEditor.tsx
+    participant API as api.ts
+    participant CMD as commands/files.rs
+    participant SFTP as files/sftp.rs (russh-sftp)
+
+    U->>FE: open /etc/nginx/nginx.conf
+    par load content
+        FE->>API: sftpReadFileContent(session, path)
+        API->>CMD: sftp_read_file_content
+        CMD->>SFTP: read_file_content()
+        SFTP-->>FE: file content
+    and probe writability
+        FE->>API: sftpCheckWritable(session, path)
+        API->>CMD: sftp_check_writable
+        CMD->>SFTP: open(path, WRITE) then close
+        alt server: PERMISSION_DENIED
+            SFTP-->>FE: writable = false
+        else open ok
+            SFTP-->>FE: writable = true
+        else cannot determine
+            SFTP-->>FE: writable = unknown
+        end
+    end
+
+    alt writable = false and shell available
+        FE-->>U: Read-only badge + banner + "Edit with sudo"
+    else writable = false and SFTP-only
+        FE-->>U: Read-only badge + banner + "Save a copy..."
+    else
+        FE-->>U: normal editor (no badge)
+    end
+```
+
+---
+
+## Elevated save flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as FileEditor.tsx
+    participant DLG as SudoPromptDialog
+    participant API as api.ts
+    participant CMD as commands/files.rs
+    participant SFTP as files/sftp.rs
+    participant SSH as SshSession (exec channel)
+    participant H as Remote host
+
+    U->>FE: Save with sudo
+    alt no cached password
+        FE->>DLG: open prompt (host, user, file)
+        DLG-->>FE: password + cache scope
+    else cached password
+        FE->>FE: use cached password
+    end
+
+    FE->>API: sftpWriteFileContentElevated(session, path, content, pw)
+    API->>CMD: sftp_write_file_content_elevated
+    CMD->>SFTP: write buffer to /tmp/termihub-<uuid>
+    SFTP->>H: SFTP create + write_all (temp)
+    CMD->>SSH: exec: sudo -S -p '' sh -c 'cat "$TMP" > "$DEST" && rm -f "$TMP"'
+    CMD->>SSH: stdin: <password>\n
+    SSH->>H: run as root
+    alt exit 0
+        H-->>FE: ok
+        FE->>FE: savedContent = content; keep sudo marker
+        opt cache scope = credential store
+            FE->>CMD: store SudoPassword credential
+        end
+        FE-->>U: saved
+    else incorrect password
+        H-->>FE: error: incorrect password
+        FE->>FE: discard cached pw
+        FE->>DLG: re-open prompt (retry)
+    else other failure
+        H-->>FE: error (sudo not permitted / requiretty / write error)
+        SSH->>H: rm -f $TMP (cleanup)
+        FE-->>U: #969 save-error banner (no retry loop)
+    end
+```
+
+---
+
+## Sudo prompt + retry / failure
+
+```mermaid
+flowchart TD
+    Start([Save with sudo]) --> Cached{Cached password?}
+    Cached -->|yes| Try[Run elevated save]
+    Cached -->|no| Prompt[Show sudo prompt]
+    Prompt --> Cancel{Cancel?}
+    Cancel -->|yes| Abort([Back to read-only state])
+    Cancel -->|no| Try
+    Try --> Result{Result}
+    Result -->|ok| Done([Saved · sudo marker stays])
+    Result -->|incorrect password| Attempts{attempts < 3?}
+    Attempts -->|yes| Prompt
+    Attempts -->|no| Fail
+    Result -->|sudo not permitted / requiretty / write error| Fail[#969 save-error banner]
+    Fail --> Abort
+```
+
+---
+
+## Capability + cache-scope decision
+
+```mermaid
+flowchart LR
+    RO{File read-only?} -->|no| Direct[Direct save]
+    RO -->|yes| Shell{Shell / exec available?}
+    Shell -->|no| Copy[SFTP-only: Save a copy / download]
+    Shell -->|yes| Store{Credential store unlocked?}
+    Store -->|yes| Choice[Offer: session OR persist]
+    Store -->|no| SessionOnly[Session-only cache]
+    Choice --> Elevate[Elevated save]
+    SessionOnly --> Elevate
+```

--- a/docs/concepts/backlog/elevated-sftp-editing/concept.md
+++ b/docs/concepts/backlog/elevated-sftp-editing/concept.md
@@ -1,0 +1,328 @@
+# Elevated (sudo) SFTP Editing + Early Read-Only Detection
+
+**GitHub Issue:** [#970](https://github.com/armaxri/termiHub/issues/970)
+
+> **Folder-form concept** (AI-driven concept workflow). Visual surfaces live in
+> [`mockups/`](mockups/), behavior diagrams in [`behavior.md`](behavior.md), and the
+> concept↔code reconciliation ledger in [`sync.md`](sync.md). The concept is the source of
+> truth; run `/sync-concept elevated-sftp-editing` to reconcile it with the implementation.
+
+---
+
+## Overview
+
+When a user opens a remote file over an **SFTP file connection** they sometimes lack write
+permission for it — typically root/admin-owned files on a Raspberry Pi or server (e.g.
+`/etc/nginx/nginx.conf`). Today the editor only discovers this **at save time**: the write fails
+and (after [#969](https://github.com/armaxri/termiHub/issues/969)) surfaces a "permission denied"
+banner. The user has already edited the file and now cannot save their work without leaving
+termiHub.
+
+This concept designs two complementary improvements:
+
+1. **Early read-only detection** — determine writability **at open time** from SFTP permission
+   bits and flag it clearly (badge + banner), before the user invests effort in edits they cannot
+   save.
+2. **Elevated (sudo) save** — when the connection also has shell access, let the user authorize a
+   privileged write so the file can be saved anyway, via `sudo` on the remote host.
+
+```mermaid
+flowchart LR
+    Open[Open remote file] --> Probe{Probe writability}
+    Probe -->|writable| Normal[Normal editing]
+    Probe -->|read-only + shell| RO1[Read-only badge<br/>Edit with sudo]
+    Probe -->|read-only, SFTP-only| RO2[Read-only badge<br/>Save a copy fallback]
+    RO1 --> Elevate[Authorize sudo] --> ElevSave[Save via sudo]
+```
+
+### Goals
+
+- Tell the user a file is read-only **before** they edit it.
+- Let users save admin-owned files without dropping to a terminal, when a shell is available.
+- Be explicit and honest about the privileged context (a persistent `sudo` marker, named targets
+  in the prompt).
+- Handle the sudo password securely (in-memory by default, optional credential-store persistence).
+- Degrade gracefully when elevation isn't possible (SFTP-only connections).
+
+### Non-Goals
+
+- Editing local files as another user / `sudo` for local files (this concept is remote-only).
+- Changing file ownership or permissions from the editor (`chmod`/`chown`).
+- A general remote-command console — elevation is scoped to the save operation only.
+- Detecting writability via true ownership (uid/gid) — `russh-sftp` does not expose owner ids;
+  detection uses permission bits plus a best-effort probe (see Implementation Details).
+
+---
+
+## UI Interface
+
+The visual surfaces are specified by the mockups — open them in a browser to review layout and
+states. This section describes them; the mockups are authoritative for layout.
+
+| Mockup                                                     | Shows                                                                                                                       |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [`mockups/editor-states.html`](mockups/editor-states.html) | Writable baseline, read-only detected, elevated-edit mode, elevated-save failure, and the SFTP-only (no elevation) fallback |
+| [`mockups/sudo-prompt.html`](mockups/sudo-prompt.html)     | Sudo password prompt: initial, incorrect-password retry, and persist-to-credential-store option                             |
+
+### Read-only badge
+
+A **Read-only** badge (lucide `Lock`, warning color) appears in the existing
+`.file-editor__toolbar` next to the `Remote` badge whenever the open file is not writable by the
+connecting user. Its tooltip shows the parsed permission string (e.g. `-rw-r--r--`). The badge is
+purely informational; it never blocks reading or navigating.
+
+### Read-only info banner
+
+Under the toolbar, a dismissible `.file-editor__readonly-banner` (mirrors the #969
+`.file-editor__save-error` banner, warning color instead of error) explains the cause in plain
+language and offers the relevant action inline:
+
+- **Shell available:** "You don't have write access to this file (`-rw-r--r--`). Saving directly
+  will fail. **Edit with sudo** to save through privilege elevation."
+- **SFTP-only:** "…This is an SFTP-only connection, so sudo elevation isn't available. **Save a
+  copy…**"
+
+### Edit-with-sudo affordance
+
+When a file is read-only **and** the connection exposes a shell channel, the toolbar's **Save**
+button is replaced by an **Edit with sudo** button (lucide `ShieldCheck`, accent outline). The
+same action is reachable from the banner link. Activating it opens the sudo prompt (if needed) and
+puts the editor into **elevated edit mode**.
+
+### Elevated edit mode
+
+Once elevation is authorized for the tab:
+
+- A persistent **sudo** marker (accent color) sits in the toolbar for the whole elevated session,
+  so the privileged context is never hidden.
+- The Save button reads **Save with sudo** and writes via the elevated path.
+- The buffer is fully editable (Monaco is no longer dimmed).
+
+### Sudo password prompt
+
+A modal dialog (built on the shared `.menu` primitive) that:
+
+- Names the exact target: host, user, and file path being written as root.
+- Has a masked password field.
+- Defaults to **Remember for this session** (in-memory cache for the tab's connection).
+- When the credential store is **Unlocked**, offers a second choice to **Save in credential
+  store** under a dedicated sudo-password key.
+- On wrong password, re-prompts (matching sudo's three-attempt loop) before giving up.
+
+### SFTP-only fallback
+
+For pure SFTP connections (no shell), there is no `sudo` path. The read-only state is still shown,
+Save stays disabled, and the banner offers **Save a copy…** (write to a writable remote path, or
+download to the local disk via the existing download command).
+
+---
+
+## General Handling
+
+### Workflow A — open a read-only file (shell available)
+
+1. User opens `/etc/nginx/nginx.conf` from the file browser.
+2. The editor loads the content **and** probes writability (see Implementation Details).
+3. Probe returns _not writable_ → Read-only badge + banner; toolbar shows **Edit with sudo**.
+4. User edits the buffer (allowed — edits are local until save).
+5. User clicks **Edit with sudo** (or **Save with sudo**) → sudo prompt appears.
+6. User enters the password, chooses cache scope, confirms.
+7. termiHub writes the buffer to a temp path via SFTP, then runs
+   `sudo tee`/`sudo mv` over an exec channel to move it into place.
+8. Success → `savedContent` updates, dirty flag clears, sudo marker stays for the session.
+
+### Workflow B — open a read-only file (SFTP-only)
+
+1–3 as above, except the probe also reports no shell capability. 4. Banner explains elevation is unavailable; Save is disabled. 5. User picks **Save a copy…** → choose a writable remote path or download locally.
+
+### Workflow C — writable file (no change)
+
+Probe reports writable (or returns unknown and the optimistic-write succeeds) → editor behaves
+exactly as today. This concept must not add friction to the common case.
+
+### Edge cases
+
+| Case                                                                             | Handling                                                                                                                                                                                       |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Permission bits unavailable (`permissions: null`)                                | Treat as **unknown**, not read-only. No badge. Fall back to today's behavior: attempt the write, surface the #969 error if it fails, and _then_ offer **Retry with sudo** in the error banner. |
+| Owner write bit set but file still unwritable (parent dir, immutable, full disk) | The optimistic probe/write fails; surface via the #969 error banner with a **Retry with sudo** action. Early detection is best-effort, not a guarantee.                                        |
+| User is root already                                                             | Write succeeds directly; no elevation needed. The probe sees a writable result, no badge.                                                                                                      |
+| `sudo` not installed / user not in sudoers                                       | Elevated save fails with a clear message ("sudo: command not found" / "user is not in the sudoers file"). No retry loop for non-password failures.                                             |
+| `sudo` requires a TTY (`requiretty`)                                             | Use `sudo -S` reading the password from stdin on a non-PTY exec channel; if the host enforces `requiretty`, report it and suggest the user disable it or use the terminal.                     |
+| Cached session password becomes wrong (changed remotely)                         | First elevated save fails → discard the cache, re-prompt.                                                                                                                                      |
+| Connection drops mid-save                                                        | Temp file may remain on the remote; the elevated command cleans up its own temp file on failure (`rm -f` in the same command). Report the failure via the #969 banner.                         |
+| Scratch buffer saved to a read-only remote path                                  | Same detection applies once a destination is chosen; offer sudo on the chosen path.                                                                                                            |
+| Symlink to a root-owned file                                                     | Permission string is for the link target after `stat`; elevation writes the resolved target via `sudo tee`.                                                                                    |
+
+### Security considerations
+
+- **Password handling:** the sudo password is sent only over the already-authenticated, encrypted
+  SSH channel via `sudo -S` (stdin). It is never written to the remote disk and never logged.
+- **In-memory by default:** the default cache scope is the in-memory session, cleared on
+  disconnect / app exit. Persistence is opt-in and only when the credential store is unlocked.
+- **Credential store reuse:** persisted sudo passwords use the existing AES-GCM master-password
+  store via a new `CredentialType::SudoPassword` key, inheriting auto-lock and removal semantics.
+- **Explicit consent:** the prompt always names host, user, and target file, so the user knows
+  exactly what privileged write they authorize. The persistent `sudo` marker keeps it visible.
+- **Audit:** elevated writes go through `sudo`, so they appear in the remote host's normal sudo
+  audit log (`/var/log/auth.log`). termiHub adds a frontend LogViewer DEBUG entry per elevated
+  save (without the password).
+- **No command injection:** the remote path is passed as an argument to `tee`, never interpolated
+  into a shell string; the temp path is a termiHub-generated name. (See Implementation Details for
+  argument construction.)
+
+---
+
+## States & Sequences
+
+See [`behavior.md`](behavior.md) for the full Mermaid state machines and sequence diagrams:
+
+- Editor writability state machine (open → probe → writable / read-only / elevated).
+- Read-only detection sequence on open.
+- Elevated-save sequence (temp upload → `sudo tee`/`mv` → result).
+- Sudo prompt + retry / failure flow.
+
+---
+
+## Preliminary Implementation Details
+
+Based on the architecture at the concept's base commit. References real modules so implementation
+can follow directly. The concept is authoritative; if a constraint makes the design wrong, change
+the concept (not silently the code).
+
+### Current write path (today)
+
+```mermaid
+flowchart LR
+    FE["FileEditor.tsx<br/>handleSave()"] --> API["api.ts<br/>sftpWriteFileContent()"]
+    API --> CMD["commands/files.rs<br/>sftp_write_file_content"]
+    CMD --> SESS["files/sftp.rs<br/>SftpSession::write_file_content()"]
+    SESS --> RUSSH["russh-sftp<br/>create() + write_all()"]
+```
+
+Key facts gathered from the code:
+
+- **Frontend editor:** `src/components/FileEditor/FileEditor.tsx`. `handleSave()` calls
+  `sftpWriteFileContent(meta.sftpSessionId, meta.filePath, content)`. Save errors already surface
+  in the dismissible `.file-editor__save-error` banner via `formatSaveError()` (#969). The toolbar
+  already renders a `Remote` badge — the read-only badge slots in beside it.
+- **Tauri command:** `src-tauri/src/commands/files.rs` — `sftp_write_file_content(session_id,
+remote_path, content)` and `sftp_read_file_content(...)`, plus `sftp_list_dir`, `sftp_stat`,
+  `sftp_download`.
+- **SFTP session:** `src-tauri/src/files/sftp.rs` — `SftpSession` wraps a `russh_sftp` client and
+  the underlying `SshSession`; `SftpManager` keys sessions by UUID. Write goes through
+  `write_file_content` → `write_bytes` (`sftp.create()` + `write_all`).
+- **File metadata:** `core/src/files/mod.rs` `FileEntry { name, path, is_directory, size,
+modified, permissions: Option<String> }`. `permissions` is the `rwxrwxrwx` string from
+  `core/src/files/utils.rs::format_permissions(u32)`. **No uid/gid** is exposed by `russh-sftp`.
+- **Frontend types:** `src/types/connection.ts::FileEntry` (mirrors the Rust struct) and
+  `src/types/terminal.ts::EditorTabMeta { filePath, isRemote, sftpSessionId?, scratch?,
+scratchContent? }`.
+- **Credential store:** `src-tauri/src/credential/` — `CredentialStore` trait (`get`/`set`/
+  `remove`), `CredentialKey { connection_id, credential_type }`, `CredentialType { Password,
+KeyPassphrase }`, `CredentialManager` with master-password AES-GCM store and auto-lock.
+- **SSH exec capability:** `core/src/backends/ssh/` — the same `SshSession`
+  (`russh::client::Handle`) can open additional channels. SFTP uses its own channel/subsystem; an
+  **exec channel** (`channel_open_session()` + `channel.exec(...)`) on the same connection runs
+  remote commands. The monitoring provider already uses this pattern
+  (`core/src/backends/ssh/monitoring.rs` runs periodic `stat` via an exec helper). This is the
+  hook for running `sudo`.
+
+### 1. Early read-only detection
+
+**Step 1 — surface writability to the frontend.** Add an optional, best-effort writability hint.
+Two layers:
+
+- **Cheap (permission bits):** extend `FileEntry` with `writable: Option<bool>` derived from the
+  permission string. Because `russh-sftp` gives no uid/gid, the backend cannot know if the
+  connecting user _is_ the owner. The conservative rule: parse the `rwxrwxrwx` string and treat the
+  file as **not writable** only when _none_ of owner/group/other has the write bit (i.e. the file
+  is read-only for everyone, e.g. `-r--r--r--` or `-rw-r--r--` owned by another user). This is a
+  hint, not a guarantee — see Step 2.
+- **Accurate (probe):** add an `sftp_check_writable(session_id, remote_path)` command. Most robust
+  option is an **SFTP `open` for write without truncate** (open the existing file with write flags
+  and immediately close, no data written) — if the server returns `SFTP_FX_PERMISSION_DENIED` the
+  file is not writable for this user; success means writable. This sidesteps the uid/gid gap and
+  works on SFTP-only connections. Implement in `src-tauri/src/files/sftp.rs` using the
+  `russh_sftp` open-flags API.
+
+The probe (accurate) is preferred when available; the permission bits (cheap) drive the file
+browser's at-a-glance display without an extra round-trip.
+
+**Step 2 — wire into the editor.** `FileEditor.tsx` calls `sftp_check_writable` in the load
+`useEffect` (in parallel with the existing read). New state `writable: boolean | "unknown"`. When
+`false`, render the read-only badge + banner and switch the toolbar action set. `"unknown"` keeps
+today's optimistic behavior. Add `frontendLog("file_editor", ...)` traces for the probe result.
+
+### 2. Elevated (sudo) save
+
+**Capability detection.** The editor needs to know whether the file connection has an associated
+shell. Add a backend helper that reports, for a given SFTP session / connection, whether an exec
+channel can be opened on the same `SshSession`. SFTP-only connections (no SSH credentials for a
+shell, or a relay without exec) report `false` → SFTP-only fallback.
+
+**Elevated write command.** Add `sftp_write_file_content_elevated(session_id, remote_path, content,
+sudo_password)` in `src-tauri/src/commands/files.rs`, implemented in `files/sftp.rs`:
+
+1. Write the buffer to a termiHub-generated temp path under a writable dir (e.g.
+   `/tmp/termihub-<uuid>`) via the normal SFTP `create()` + `write_all()`.
+2. Open an exec channel on the same `SshSession` and run a single composed command that moves the
+   temp file into place as root and cleans up, reading the password from stdin:
+
+   ```text
+   sudo -S -p '' /bin/sh -c 'cat "$TMP" > "$DEST" && rm -f "$TMP"'
+   ```
+
+   The password is written to the channel's stdin (one line). `$DEST`/`$TMP` are passed as a
+   here-doc / single-quoted literals built in Rust (never string-interpolated from user text) to
+   avoid injection. Using `cat > dest` (rather than `mv`) preserves the destination file's
+   existing owner, mode, and ACLs.
+
+3. Inspect the exit status and stderr: success → ok; `incorrect password` → typed error so the
+   frontend can re-prompt; other → pass through to the #969 banner. Always attempt `rm -f $TMP` on
+   the remote even on failure.
+
+This reuses the existing exec pattern from `core/src/backends/ssh/monitoring.rs`; factor a small
+`ssh_exec_with_stdin` helper if one does not already exist.
+
+**Frontend.** `api.ts` gains `sftpWriteFileContentElevated(...)`. A new `SudoPromptDialog`
+component (built like `UnsavedChangesDialog` in `src/components/ConnectionEditor/`) collects the
+password and cache choice. `FileEditor.tsx` gains `elevated: boolean` + `sudoPassword` (held only
+in component state / store, never persisted to disk by the component) and routes `handleSave` to
+the elevated command when in elevated mode. On `incorrect password`, re-open the prompt; on three
+failures, surface via the existing save-error banner.
+
+### 3. Sudo password caching
+
+- **Session cache:** keep the password in the backend session/connection state (or a short-lived
+  in-memory map keyed by connection id), cleared on disconnect. Never serialized.
+- **Persistent cache (opt-in):** add `CredentialType::SudoPassword` to
+  `src-tauri/src/credential/types.rs`; store/retrieve via the existing `CredentialManager` keyed by
+  `connection_id`. Only offered when `CredentialStore::status()` is `Unlocked`. Removed with the
+  connection's other credentials via `remove_all_for_connection`.
+
+### Affected modules summary
+
+| Area                   | File(s)                                                | Change                                                                      |
+| ---------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Writability hint       | `core/src/files/mod.rs`, `core/src/files/utils.rs`     | Add `FileEntry.writable: Option<bool>` + permission-bit derivation          |
+| Probe + elevated write | `src-tauri/src/files/sftp.rs`                          | `check_writable`, `write_file_content_elevated`, exec-with-stdin helper     |
+| Capability detection   | `src-tauri/src/files/sftp.rs` / ssh backend            | report exec-channel availability per session                                |
+| Commands               | `src-tauri/src/commands/files.rs`                      | `sftp_check_writable`, `sftp_write_file_content_elevated`, capability query |
+| Credential type        | `src-tauri/src/credential/types.rs`                    | `CredentialType::SudoPassword`                                              |
+| Frontend API           | `src/services/api.ts`                                  | new wrappers                                                                |
+| Frontend types         | `src/types/connection.ts`, `src/types/terminal.ts`     | `FileEntry.writable`, editor elevated state                                 |
+| Editor UI              | `src/components/FileEditor/FileEditor.tsx` + `.css`    | badge, banner, elevate button, sudo marker                                  |
+| Sudo dialog            | `src/components/FileEditor/SudoPromptDialog.tsx` (new) | password prompt + cache choice                                              |
+
+### Testing strategy (for the eventual implementation)
+
+- **Rust unit:** `format_permissions` → `writable` derivation; elevated-command composition
+  (argument quoting, temp-path generation) without a live host.
+- **Integration (Docker):** `tests/docker/` already has SSH variants; add a root-owned file and
+  assert: probe reports not-writable; elevated save with correct password succeeds; wrong password
+  fails with the typed error; SFTP-only variant reports no-shell.
+- **Frontend (Vitest):** `FileEditor` renders the read-only badge/banner when `writable=false`,
+  routes save to the elevated path in elevated mode, and re-prompts on `incorrect password`.
+- **Manual:** macOS (no E2E) — verify the prompt, marker, and retry against a real Raspberry Pi;
+  document steps in `docs/testing.md`.

--- a/docs/concepts/backlog/elevated-sftp-editing/mockups/editor-states.html
+++ b/docs/concepts/backlog/elevated-sftp-editing/mockups/editor-states.html
@@ -1,0 +1,460 @@
+<!doctype html>
+<!--
+  Concept: Elevated (sudo) SFTP editing + early read-only detection — Editor states.
+  Layout-altitude mockup. Self-contained (links only the shared mockup.css).
+  Reuses the REAL FileEditor BEM class names (.file-editor__toolbar,
+  .file-editor__remote-badge, .file-editor__save-btn, .file-editor__save-error)
+  so the mockup DOM matches the live app and doubles as an implementation target.
+  Proposed new classes (read-only badge, elevate button, banner) are added in the
+  inline <style> below and mirror the existing FileEditor.css conventions.
+  Icons use the inline lucide v0.563 sprite — never unicode glyphs.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Elevated SFTP Editing — Editor states (mockup)</title>
+    <link rel="stylesheet" href="../../../_assets/mockup.css" />
+    <style>
+      /* ── Real FileEditor classes (mirror src/components/FileEditor/FileEditor.css) ── */
+      .file-editor {
+        display: flex;
+        flex-direction: column;
+        height: 320px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border-primary);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
+      .file-editor__toolbar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 10px;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-secondary);
+      }
+      .file-editor__path {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+        flex: 1;
+      }
+      .file-editor__remote-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        font-size: 11px;
+        white-space: nowrap;
+      }
+      .file-editor__filepath {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        color: var(--text-secondary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .file-editor__save-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 12px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-primary);
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        font-size: 12px;
+        cursor: pointer;
+      }
+      .file-editor__save-btn:disabled {
+        color: var(--text-disabled);
+        cursor: default;
+      }
+      .file-editor__editor-container {
+        flex: 1;
+        padding: 12px 14px;
+        font-family: var(--font-mono);
+        font-size: 12px;
+        color: var(--text-primary);
+        line-height: 1.6;
+        white-space: pre;
+        overflow: hidden;
+      }
+      .file-editor__editor-container .ln {
+        color: var(--text-disabled);
+        margin-right: 14px;
+        user-select: none;
+      }
+      .file-editor__editor-container--readonly {
+        opacity: 0.85;
+      }
+      .file-editor__save-error {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 7px 10px;
+        background: rgba(239, 107, 90, 0.12);
+        border-bottom: 1px solid var(--color-error);
+        color: var(--color-error);
+        font-size: 12px;
+      }
+      .file-editor__save-error-text {
+        flex: 1;
+      }
+      .file-editor__save-error-dismiss {
+        background: none;
+        border: none;
+        color: inherit;
+        cursor: pointer;
+        font-size: 14px;
+        line-height: 1;
+      }
+
+      /* ── Proposed new classes for this concept ── */
+      .file-editor__readonly-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        background: rgba(212, 168, 67, 0.16);
+        border: 1px solid var(--color-warning);
+        color: var(--color-warning);
+        font-size: 11px;
+        white-space: nowrap;
+      }
+      .file-editor__elevate-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 12px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--accent-color);
+        background: transparent;
+        color: var(--text-accent);
+        font-size: 12px;
+        cursor: pointer;
+      }
+      .file-editor__elevated-mark {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        background: rgba(61, 125, 232, 0.16);
+        border: 1px solid var(--accent-color);
+        color: var(--text-accent);
+        font-size: 11px;
+      }
+      /* Read-only info banner shown under the toolbar at open time. */
+      .file-editor__readonly-banner {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 7px 10px;
+        background: rgba(212, 168, 67, 0.1);
+        border-bottom: 1px solid var(--color-warning);
+        color: var(--color-warning);
+        font-size: 12px;
+      }
+      .file-editor__readonly-banner-text {
+        flex: 1;
+      }
+      .file-editor__readonly-banner code {
+        font-family: var(--font-mono);
+        color: var(--text-secondary);
+      }
+      .file-editor__elevate-link {
+        background: none;
+        border: none;
+        color: var(--text-accent);
+        cursor: pointer;
+        font-size: 12px;
+        padding: 0;
+      }
+      .col-states {
+        display: flex;
+        flex-direction: column;
+        gap: 22px;
+      }
+      .col-states > * {
+        flex: none;
+      }
+    </style>
+  </head>
+  <body class="mockup-doc">
+    <!-- Inline lucide sprite (real lucide v0.563 geometry). Only used symbols. -->
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="i-globe" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+        <path d="M2 12h20" />
+      </symbol>
+      <symbol id="i-save" viewBox="0 0 24 24">
+        <path
+          d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"
+        />
+        <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+        <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+      </symbol>
+      <symbol id="i-lock" viewBox="0 0 24 24">
+        <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </symbol>
+      <symbol id="i-shield" viewBox="0 0 24 24">
+        <path
+          d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+        />
+      </symbol>
+      <symbol id="i-alert" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" x2="12" y1="8" y2="12" />
+        <line x1="12" x2="12.01" y1="16" y2="16" />
+      </symbol>
+      <symbol id="i-x" viewBox="0 0 24 24">
+        <path d="M18 6 6 18" />
+        <path d="m6 6 12 12" />
+      </symbol>
+    </svg>
+
+    <h1>Elevated SFTP Editing — Editor states</h1>
+    <p class="mockup-meta">
+      Layout-altitude mockup ·
+      <code>docs/concepts/backlog/elevated-sftp-editing/mockups/editor-states.html</code>
+    </p>
+
+    <div class="col-states">
+      <!-- State 1: writable file (baseline, unchanged) -->
+      <section class="mockup-section">
+        <h2>1 · Writable file (baseline)</h2>
+        <div class="mockup-note">
+          Owner write bit set, or no permission info available → editor behaves exactly as today.
+          No new chrome.
+        </div>
+        <div class="file-editor">
+          <div class="file-editor__toolbar">
+            <div class="file-editor__path">
+              <span class="file-editor__remote-badge">
+                <svg class="li"><use href="#i-globe" /></svg> Remote
+              </span>
+              <span class="file-editor__filepath">/home/pi/notes.txt</span>
+            </div>
+            <button class="file-editor__save-btn">
+              <svg class="li"><use href="#i-save" /></svg> Save
+            </button>
+          </div>
+          <div class="file-editor__editor-container">
+<span class="ln">1</span>Shopping list
+<span class="ln">2</span>- coffee
+<span class="ln">3</span><span class="cursor"></span></div>
+        </div>
+      </section>
+
+      <!-- State 2: read-only detected at open -->
+      <section class="mockup-section">
+        <h2>2 · Read-only detected at open time</h2>
+        <div class="mockup-note">
+          Permission probe at load finds the file is not writable. A warning badge sits in the
+          toolbar, an info banner explains why, and Save is replaced by an
+          <strong>Edit with sudo</strong> affordance (only when a shell is available on the
+          connection).
+        </div>
+        <div class="file-editor">
+          <div class="file-editor__toolbar">
+            <div class="file-editor__path">
+              <span class="file-editor__remote-badge">
+                <svg class="li"><use href="#i-globe" /></svg> Remote
+              </span>
+              <span class="file-editor__readonly-badge">
+                <svg class="li"><use href="#i-lock" /></svg> Read-only
+                <span class="callout">A</span>
+              </span>
+              <span class="file-editor__filepath">/etc/nginx/nginx.conf</span>
+            </div>
+            <button class="file-editor__elevate-btn">
+              <svg class="li"><use href="#i-shield" /></svg> Edit with sudo
+              <span class="callout">B</span>
+            </button>
+          </div>
+          <div class="file-editor__readonly-banner">
+            <svg class="li"><use href="#i-lock" /></svg>
+            <span class="file-editor__readonly-banner-text">
+              You don't have write access to this file
+              (<code>-rw-r--r--</code>). Saving directly will fail.
+              <button class="file-editor__elevate-link">Edit with sudo</button>
+              to save through privilege elevation.
+              <span class="callout">C</span>
+            </span>
+          </div>
+          <div class="file-editor__editor-container file-editor__editor-container--readonly">
+<span class="ln">1</span>user www-data;
+<span class="ln">2</span>worker_processes auto;
+<span class="ln">3</span>pid /run/nginx.pid;<span class="cursor"></span></div>
+        </div>
+        <div class="legend">
+          <ul>
+            <li>
+              <span class="callout">A</span> Read-only badge (lucide <code>Lock</code>) in warning
+              color, with the parsed permission string as a tooltip.
+            </li>
+            <li>
+              <span class="callout">B</span> <strong>Edit with sudo</strong> button (lucide
+              <code>ShieldCheck</code>) replaces Save when the file is read-only and the connection
+              has shell access. Hidden for SFTP-only connections (see banner in state 5).
+            </li>
+            <li>
+              <span class="callout">C</span> Dismissible info banner: explains the cause and offers
+              the same elevate action inline.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- State 3: elevated edit mode (sudo authorized) -->
+      <section class="mockup-section">
+        <h2>3 · Elevated edit mode (sudo authorized)</h2>
+        <div class="mockup-note">
+          After the user authorizes elevation (see sudo-prompt mockup), the buffer becomes editable.
+          The toolbar shows a persistent <strong>sudo</strong> marker so it is always obvious the
+          next save runs as root.
+        </div>
+        <div class="file-editor">
+          <div class="file-editor__toolbar">
+            <div class="file-editor__path">
+              <span class="file-editor__remote-badge">
+                <svg class="li"><use href="#i-globe" /></svg> Remote
+              </span>
+              <span class="file-editor__elevated-mark">
+                <svg class="li"><use href="#i-shield" /></svg> sudo
+                <span class="callout">D</span>
+              </span>
+              <span class="file-editor__filepath">/etc/nginx/nginx.conf</span>
+            </div>
+            <button class="file-editor__save-btn">
+              <svg class="li"><use href="#i-save" /></svg> Save with sudo
+              <span class="callout">E</span>
+            </button>
+          </div>
+          <div class="file-editor__editor-container">
+<span class="ln">1</span>user www-data;
+<span class="ln">2</span>worker_processes 4;
+<span class="ln">3</span>pid /run/nginx.pid;<span class="cursor"></span></div>
+        </div>
+        <div class="legend">
+          <ul>
+            <li>
+              <span class="callout">D</span> Persistent <strong>sudo</strong> marker (accent color)
+              — visible for the whole elevated session so the privileged context is never hidden.
+            </li>
+            <li>
+              <span class="callout">E</span> Save button label becomes <strong>Save with sudo</strong>
+              to confirm the write path before the user commits.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- State 4: elevated save failed -->
+      <section class="mockup-section">
+        <h2>4 · Elevated save failed (retry)</h2>
+        <div class="mockup-note">
+          Wrong password, sudo not permitted, or the remote command failed. The existing
+          save-error banner (#969) carries the elevated context and lets the user re-enter the
+          password or fall back.
+        </div>
+        <div class="file-editor">
+          <div class="file-editor__toolbar">
+            <div class="file-editor__path">
+              <span class="file-editor__remote-badge">
+                <svg class="li"><use href="#i-globe" /></svg> Remote
+              </span>
+              <span class="file-editor__elevated-mark">
+                <svg class="li"><use href="#i-shield" /></svg> sudo
+              </span>
+              <span class="file-editor__filepath">/etc/nginx/nginx.conf</span>
+            </div>
+            <button class="file-editor__save-btn">
+              <svg class="li"><use href="#i-save" /></svg> Save with sudo
+            </button>
+          </div>
+          <div class="file-editor__save-error">
+            <svg class="li"><use href="#i-alert" /></svg>
+            <span class="file-editor__save-error-text">
+              Elevated save failed — sudo: incorrect password. Your changes are kept; retry to
+              re-enter the password.
+              <span class="callout">F</span>
+            </span>
+            <button class="file-editor__save-error-dismiss">
+              <svg class="li"><use href="#i-x" /></svg>
+            </button>
+          </div>
+          <div class="file-editor__editor-container">
+<span class="ln">1</span>user www-data;
+<span class="ln">2</span>worker_processes 4;
+<span class="ln">3</span>pid /run/nginx.pid;<span class="cursor"></span></div>
+        </div>
+        <div class="legend">
+          <ul>
+            <li>
+              <span class="callout">F</span> Reuses the #969 dismissible save-error banner; the
+              buffer and unsaved changes are preserved. Clicking Save re-opens the sudo prompt.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- State 5: read-only, no shell (SFTP-only) -->
+      <section class="mockup-section">
+        <h2>5 · Read-only, no elevation available (SFTP-only)</h2>
+        <div class="mockup-note">
+          The connection is a pure SFTP connection (no shell channel to run sudo). The read-only
+          state is still surfaced, but no elevate affordance is offered — only an honest
+          explanation and a Download / Save-As fallback.
+        </div>
+        <div class="file-editor">
+          <div class="file-editor__toolbar">
+            <div class="file-editor__path">
+              <span class="file-editor__remote-badge">
+                <svg class="li"><use href="#i-globe" /></svg> Remote
+              </span>
+              <span class="file-editor__readonly-badge">
+                <svg class="li"><use href="#i-lock" /></svg> Read-only
+              </span>
+              <span class="file-editor__filepath">/etc/hosts</span>
+            </div>
+            <button class="file-editor__save-btn" disabled>
+              <svg class="li"><use href="#i-save" /></svg> Save
+            </button>
+          </div>
+          <div class="file-editor__readonly-banner">
+            <svg class="li"><use href="#i-lock" /></svg>
+            <span class="file-editor__readonly-banner-text">
+              You don't have write access (<code>-rw-r--r--</code>). This is an SFTP-only connection,
+              so sudo elevation isn't available.
+              <button class="file-editor__elevate-link">Save a copy…</button>
+              <span class="callout">G</span>
+            </span>
+          </div>
+          <div class="file-editor__editor-container file-editor__editor-container--readonly">
+<span class="ln">1</span>127.0.0.1   localhost
+<span class="ln">2</span>::1         localhost<span class="cursor"></span></div>
+        </div>
+        <div class="legend">
+          <ul>
+            <li>
+              <span class="callout">G</span> No <strong>Edit with sudo</strong> button — instead a
+              <strong>Save a copy…</strong> fallback writes to a writable path or downloads locally.
+              Save stays disabled.
+            </li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/concepts/backlog/elevated-sftp-editing/mockups/sudo-prompt.html
+++ b/docs/concepts/backlog/elevated-sftp-editing/mockups/sudo-prompt.html
@@ -1,0 +1,271 @@
+<!doctype html>
+<!--
+  Concept: Elevated (sudo) SFTP editing — Sudo password prompt.
+  Layout-altitude mockup. Self-contained (links only the shared mockup.css).
+  Reuses the shared .menu / .btn primitives from mockup.css for the dialog and
+  buttons. Icons use the inline lucide v0.563 sprite — never unicode glyphs.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Elevated SFTP Editing — Sudo prompt (mockup)</title>
+    <link rel="stylesheet" href="../../../_assets/mockup.css" />
+    <style>
+      .dialog-stage {
+        display: flex;
+        gap: 24px;
+        flex-wrap: wrap;
+      }
+      /* Reuse the .menu primitive but widen it for the form. */
+      .sudo-dialog.menu {
+        width: 360px;
+      }
+      .sudo-dialog__body {
+        padding: 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .sudo-dialog__intro {
+        color: var(--text-secondary);
+        font-size: 12px;
+        line-height: 1.55;
+      }
+      .sudo-dialog__intro code {
+        font-family: var(--font-mono);
+        color: var(--text-primary);
+      }
+      .sudo-dialog__field {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+      .sudo-dialog__label {
+        font-size: 12px;
+        color: var(--text-secondary);
+      }
+      .sudo-dialog__input {
+        padding: 7px 10px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-primary);
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        font-family: var(--font-mono);
+        font-size: 12px;
+      }
+      .sudo-dialog__input--error {
+        border-color: var(--color-error);
+      }
+      .sudo-dialog__remember {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 12px;
+        color: var(--text-secondary);
+      }
+      .sudo-dialog__remember .check {
+        width: 14px;
+        height: 14px;
+        border: 1px solid var(--text-secondary);
+        border-radius: 3px;
+        display: inline-grid;
+        place-items: center;
+      }
+      .sudo-dialog__remember--on .check {
+        background: var(--accent-color);
+        border-color: var(--accent-color);
+        color: #fff;
+      }
+      .sudo-dialog__error {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        color: var(--color-error);
+        font-size: 12px;
+      }
+      .sudo-dialog__locked {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        color: var(--color-warning);
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body class="mockup-doc">
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="i-shield" viewBox="0 0 24 24">
+        <path
+          d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+        />
+        <path d="m9 12 2 2 4-4" />
+      </symbol>
+      <symbol id="i-key" viewBox="0 0 24 24">
+        <path
+          d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4"
+        />
+        <path d="m21 2-9.6 9.6" />
+        <circle cx="7.5" cy="15.5" r="5.5" />
+      </symbol>
+      <symbol id="i-alert" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" x2="12" y1="8" y2="12" />
+        <line x1="12" x2="12.01" y1="16" y2="16" />
+      </symbol>
+      <symbol id="i-lock" viewBox="0 0 24 24">
+        <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </symbol>
+    </svg>
+
+    <h1>Elevated SFTP Editing — Sudo password prompt</h1>
+    <p class="mockup-meta">
+      Layout-altitude mockup ·
+      <code>docs/concepts/backlog/elevated-sftp-editing/mockups/sudo-prompt.html</code>
+    </p>
+
+    <div class="dialog-stage">
+      <!-- State 1: initial prompt -->
+      <section class="mockup-section">
+        <h2>1 · Initial prompt</h2>
+        <div class="mockup-note">
+          Shown when the user triggers <strong>Edit with sudo</strong> or
+          <strong>Save with sudo</strong> and no cached password is available.
+        </div>
+        <div class="menu sudo-dialog">
+          <div class="menu__title">
+            <svg class="li"><use href="#i-shield" /></svg> Authorize elevated save
+          </div>
+          <div class="sudo-dialog__body">
+            <div class="sudo-dialog__intro">
+              termiHub will run <code>sudo</code> on <code>pi@raspberrypi</code> to write
+              <code>/etc/nginx/nginx.conf</code> as root.
+              <span class="callout">A</span>
+            </div>
+            <div class="sudo-dialog__field">
+              <span class="sudo-dialog__label">sudo password for pi</span>
+              <input class="sudo-dialog__input" type="password" value="••••••••" />
+            </div>
+            <label class="sudo-dialog__remember sudo-dialog__remember--on">
+              <span class="check">✓</span>
+              Remember for this session
+              <span class="callout">B</span>
+            </label>
+          </div>
+          <div class="menu__footer">
+            <button class="btn btn--primary">
+              <svg class="li"><use href="#i-key" /></svg> Authorize &amp; save
+            </button>
+            <button class="btn">Cancel</button>
+          </div>
+        </div>
+        <div class="legend">
+          <ul>
+            <li>
+              <span class="callout">A</span> Always names the exact command target (host, user,
+              file) so the user knows what they are authorizing.
+            </li>
+            <li>
+              <span class="callout">B</span> Default: cache in the in-memory session only. If the
+              credential store is unlocked, an optional second choice can persist it (state 3).
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- State 2: wrong password -->
+      <section class="mockup-section">
+        <h2>2 · Incorrect password</h2>
+        <div class="mockup-note">
+          Sudo rejected the password. The field is highlighted; the dialog stays open for a retry
+          (matches sudo's three-attempt behavior).
+        </div>
+        <div class="menu sudo-dialog">
+          <div class="menu__title">
+            <svg class="li"><use href="#i-shield" /></svg> Authorize elevated save
+          </div>
+          <div class="sudo-dialog__body">
+            <div class="sudo-dialog__intro">
+              termiHub will run <code>sudo</code> on <code>pi@raspberrypi</code> to write
+              <code>/etc/nginx/nginx.conf</code> as root.
+            </div>
+            <div class="sudo-dialog__field">
+              <span class="sudo-dialog__label">sudo password for pi</span>
+              <input class="sudo-dialog__input sudo-dialog__input--error" type="password" value="••" />
+            </div>
+            <div class="sudo-dialog__error">
+              <svg class="li"><use href="#i-alert" /></svg> Sorry, try again (attempt 2 of 3).
+              <span class="callout">C</span>
+            </div>
+          </div>
+          <div class="menu__footer">
+            <button class="btn btn--primary">
+              <svg class="li"><use href="#i-key" /></svg> Authorize &amp; save
+            </button>
+            <button class="btn">Cancel</button>
+          </div>
+        </div>
+        <div class="legend">
+          <ul>
+            <li>
+              <span class="callout">C</span> Re-prompt loop. After the third failure the dialog
+              closes and the editor shows the elevated-save-failed banner (editor-states state 4).
+              A wrong cached password is discarded automatically.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- State 3: credential store available -->
+      <section class="mockup-section">
+        <h2>3 · Persist offered (credential store unlocked)</h2>
+        <div class="mockup-note">
+          When the master-password credential store is unlocked, the user may opt to persist the
+          sudo password under a dedicated credential key so it survives app restarts.
+        </div>
+        <div class="menu sudo-dialog">
+          <div class="menu__title">
+            <svg class="li"><use href="#i-shield" /></svg> Authorize elevated save
+          </div>
+          <div class="sudo-dialog__body">
+            <div class="sudo-dialog__intro">
+              termiHub will run <code>sudo</code> on <code>pi@raspberrypi</code> to write
+              <code>/etc/nginx/nginx.conf</code> as root.
+            </div>
+            <div class="sudo-dialog__field">
+              <span class="sudo-dialog__label">sudo password for pi</span>
+              <input class="sudo-dialog__input" type="password" value="••••••••" />
+            </div>
+            <div class="menu__row menu__row--selected">
+              <span class="radio"></span> Remember for this session only
+            </div>
+            <div class="menu__row">
+              <span class="radio"></span> Save in credential store (until removed)
+              <span class="callout">D</span>
+            </div>
+            <div class="sudo-dialog__locked">
+              <svg class="li"><use href="#i-lock" /></svg> Credential store: Unlocked
+            </div>
+          </div>
+          <div class="menu__footer">
+            <button class="btn btn--primary">
+              <svg class="li"><use href="#i-key" /></svg> Authorize &amp; save
+            </button>
+            <button class="btn">Cancel</button>
+          </div>
+        </div>
+        <div class="legend">
+          <ul>
+            <li>
+              <span class="callout">D</span> Persisted under a new
+              <code>CredentialType::SudoPassword</code> key, keyed by connection id. Hidden /
+              disabled when the credential store is Locked or Unavailable — only the session option
+              remains.
+            </li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/concepts/backlog/elevated-sftp-editing/sync.md
+++ b/docs/concepts/backlog/elevated-sftp-editing/sync.md
@@ -1,0 +1,33 @@
+# Sync Ledger — Elevated SFTP Editing
+
+**Last synced:** `6e5d9586` (base develop commit at concept creation)
+**Status:** concept only — not yet implemented
+
+This ledger is maintained by the `/sync-concept elevated-sftp-editing` skill. It records the last
+commit at which the concept artifacts and the code were reconciled, plus any open divergences. The
+concept is the source of truth; code is fixed to match by default.
+
+## Open divergences
+
+| #   | Artifact claim                                                          | Code reality                                                        | Type    | Recommendation                              |
+| --- | ----------------------------------------------------------------------- | ------------------------------------------------------------------- | ------- | ------------------------------------------- |
+| 1   | Early read-only detection (probe + `FileEntry.writable`, badge, banner) | Not implemented — save failure is only surfaced at save time (#969) | Missing | Implement per `concept.md` §1, then re-sync |
+| 2   | Elevated (sudo) save via exec channel + temp upload                     | Not implemented — only direct SFTP `create`/`write_all`             | Missing | Implement per `concept.md` §2, then re-sync |
+| 3   | `CredentialType::SudoPassword` for opt-in persistence                   | Only `Password` and `KeyPassphrase` exist                           | Missing | Implement per `concept.md` §3, then re-sync |
+| 4   | `SudoPromptDialog` component                                            | No such component                                                   | Missing | Build alongside the elevated-save UI        |
+
+## Notes / known constraints
+
+- `russh-sftp` (v2.3) exposes permission bits but **no uid/gid**, so writability detection relies
+  on permission bits plus a best-effort SFTP write-open probe rather than true ownership. The
+  concept already accounts for this (`writable: Option<bool>` with an `unknown` state).
+- The mockups add proposed BEM classes (`.file-editor__readonly-badge`, `.file-editor__elevate-btn`,
+  `.file-editor__elevated-mark`, `.file-editor__readonly-banner`) inline; when implemented these
+  should be moved into `src/components/FileEditor/FileEditor.css` and mirrored back into
+  `docs/concepts/_assets/mockup.css`.
+
+## Resolved
+
+| Date | #   | Resolution |
+| ---- | --- | ---------- |
+| —    | —   | —          |

--- a/docs/concepts/mockups-index.html
+++ b/docs/concepts/mockups-index.html
@@ -29,6 +29,11 @@
         <li><a href="backlog/broadcast-input/mockups/toolbar.html">toolbar.html</a></li>
       </ul></div>
       <div class="idx-group">
+        <h2><code>backlog/elevated-sftp-editing</code></h2><ul>
+        <li><a href="backlog/elevated-sftp-editing/mockups/editor-states.html">editor-states.html</a></li>
+        <li><a href="backlog/elevated-sftp-editing/mockups/sudo-prompt.html">sudo-prompt.html</a></li>
+      </ul></div>
+      <div class="idx-group">
         <h2><code>backlog/embedded-unix-windows</code></h2><ul>
         <li><a href="backlog/embedded-unix-windows/mockups/embedded-unix-dialogs.html">embedded-unix-dialogs.html</a></li>
         <li><a href="backlog/embedded-unix-windows/mockups/embedded-unix-settings.html">embedded-unix-settings.html</a></li>


### PR DESCRIPTION
## Summary

Design-only concept (issue #970) for two follow-ups to #969 (which made failed SFTP saves surface an error instead of failing silently):

1. **Early read-only detection** — determine writability at open time and flag it with a read-only badge + info banner, before the user edits a file they can't save.
2. **Elevated (sudo) save** — when the SFTP connection also has shell access, let the user authorize a privileged write so admin-owned files (e.g. `/etc/nginx/nginx.conf` on a Pi) can still be saved, via `sudo` over an exec channel on the same SSH connection.

No production code changes — this is a folder-form concept per the AI-driven concept workflow.

## Artifacts added

`docs/concepts/backlog/elevated-sftp-editing/`

- `concept.md` — Overview, UI Interface (points at mockups), General Handling (workflows, edge cases, security), Preliminary Implementation Details referencing real modules (`FileEditor.tsx`, `files/sftp.rs`, `core/src/files`, the SSH exec channel pattern from `monitoring.rs`, and the credential store).
- `behavior.md` — Mermaid state machine + sequence diagrams (read-only detection on open, elevated-save flow, sudo prompt retry/failure, capability/cache-scope decision).
- `mockups/editor-states.html` — writable baseline, read-only detected, elevated-edit mode, elevated-save failure, and the SFTP-only fallback. Reuses real FileEditor BEM classes and lucide v0.563 icons.
- `mockups/sudo-prompt.html` — initial prompt, incorrect-password retry, and persist-to-credential-store option.
- `sync.md` — concept↔code reconciliation ledger (last-synced `6e5d9586`, status: concept only, not yet implemented).

Mockups index regenerated (`docs/concepts/mockups-index.html`).

## Key UX / flow decisions

- **Read-only is best-effort, not a wall.** `russh-sftp` exposes permission bits but no uid/gid, so detection combines a permission-bit hint with an SFTP write-open probe; an `unknown` result keeps today's optimistic behavior and falls back to the #969 error banner (which then offers Retry with sudo).
- **Privileged context is always visible** — a persistent `sudo` toolbar marker, and the prompt names host/user/file before the user authorizes.
- **Password handling is in-memory by default** (cleared on disconnect); persistence is opt-in and only when the credential store is unlocked, via a new `CredentialType::SudoPassword`.
- **Honest degradation for SFTP-only connections** — no fake sudo affordance; offers Save a copy / download instead.
- **Elevated write preserves the destination's owner/mode** by piping the temp file with `sudo tee`/`cat >` rather than `mv`, with no shell interpolation of user-controlled paths.

## Verification

- `markdownlint-cli2` on the new docs: 0 errors.
- Mockup screenshot rendering (headless Chrome) was unavailable in this sandboxed environment; fidelity was instead ensured by reusing the real FileEditor BEM class names from the app and copying real lucide v0.563 `<symbol>` geometry (no unicode glyphs), per the concept-workflow rules.

## Open questions

- Should elevation also be offered for **local** files (sudo for `localWriteFile`)? Currently scoped out as remote-only.
- Whether to surface the read-only `writable` hint in the **file browser** tree (cheap permission-bit version) in addition to the editor.

Closes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)
