### PR TITLE
ci: reserve shared cache budget for PR-blocking builds (#1006)

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -102,6 +102,17 @@ jobs:
           # full release builds on push to develop/main warm the cache that PR
           # builds restore, so PRs don't start from a cold Rust cache.
           shared-key: tauri-${{ matrix.rust_target }}
+          # Budget guard (#1006): only the three targets the PR Build workflow
+          # (build.yml) actually restores — Linux x64, macOS arm64, Windows x64 —
+          # are worth persisting into the shared 10 GB repo cache. The two
+          # dev-build-only targets (linux-arm64, macos-x64) are never restored by
+          # any PR, so saving them just crowds out the PR-blocking caches and
+          # forces LRU eviction of the Windows PR cache. Those two post-merge
+          # builds run cold instead — non-blocking.
+          save-if: >-
+            ${{ matrix.rust_target == 'x86_64-unknown-linux-gnu'
+              || matrix.rust_target == 'aarch64-apple-darwin'
+              || matrix.rust_target == 'x86_64-pc-windows-msvc' }}
 
       - name: Install system dependencies (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
@@ -264,6 +275,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: dev-agent-${{ matrix.target }}
+          # Budget guard (#1006): agent binaries are built only post-merge and are
+          # never restored by a PR build. Persisting them spent ~2 GB of the shared
+          # 10 GB repo cache budget, evicting the PR-blocking Windows cache. Don't
+          # save — these non-blocking cross builds run cold. (The cross image itself
+          # is still reused via the Docker buildx gha cache below.)
+          save-if: false
 
       - name: Install cross-rs
         run: |
@@ -326,6 +343,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: dev-agent-${{ matrix.target }}
+          # Budget guard (#1006): macOS agent binaries are built only post-merge and
+          # are never restored by a PR build. Don't persist them into the shared
+          # 10 GB repo cache budget — they crowd out the PR-blocking Windows cache.
+          # These non-blocking native builds run cold instead.
+          save-if: false
 
       - name: Build agent
         env:


### PR DESCRIPTION
## Problem

PR builds on **Windows repeatedly take >15 min** (measured 15m54s) while Linux/macOS finish in ~4.5 min on the same run. Root cause: the repo's GitHub Actions cache is permanently **over GitHub's 10 GB hard limit** (measured **10.6 GB**), so caches are constantly LRU-evicted.

The PR Build workflow's Windows job restores `shared-key: tauri-x86_64-pc-windows-msvc`. That cache is the recurring eviction casualty (currently absent), so Windows PRs compile all Rust dependencies **cold** every time.

| Job (same run) | Duration | Cache |
|---|---|---|
| Ubuntu | 4m29s | warm |
| macOS arm | 4m49s | warm |
| **Windows** | **15m54s** | **evicted → cold** |

## Why the budget overflows

PR-essential caches total only ~6.2 GB, but ~4.8 GB of **post-merge-only** caches share the same 10 GB budget and force the eviction churn:

| Post-merge-only cache | Size | Restored by any PR? |
|---|---|---|
| `tauri` linux-arm64 + macos-x64 | ~1.4 GB | ❌ not in the PR matrix |
| `dev-agent` ×5 | ~2.0 GB | ❌ agent binaries only |
| buildkit blobs | ~0.4 GB | ❌ |

## Fix

Policy: **only PR-blocking caches persist in the shared 10 GB repo cache budget.**

- `build-app`: scope `save-if` to the three targets the PR Build workflow actually restores (linux-x64, macos-arm64, windows-x64); stop persisting the two dev-build-only targets.
- `build-agents-linux` / `build-agents-macos`: `save-if: false`.

Frees **~3.4 GB (10.6 → ~7.2 GB)**, leaving headroom so the PR-blocking Windows cache survives. Those targets build cold post-merge, which is non-blocking. The orphaned dead caches were also purged manually so the headroom takes effect immediately.

## Test plan

Workflow YAML has no unit-test harness; verification is observational:

- [ ] After merge, `gh api repos/:owner/:repo/actions/cache/usage` reports total well under 10 GB (~7 GB).
- [ ] The next push to `develop` re-creates `tauri-x86_64-pc-windows-msvc` and it is **not** evicted before the next PR.
- [ ] A subsequent PR's Windows Build job drops from ~16 min back to ~4.5–8 min (warm cache restore).
- [ ] Post-merge dev-build still succeeds for all platforms/agents (now cold for linux-arm64, macos-x64, and agents).

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)