### PR TITLE
refactor(agent): consolidate the named-context-menu helper, drop dead connect_connection (#1001)

### DIFF
--- a/tests/system/termihub_harness/ui/agent.py
+++ b/tests/system/termihub_harness/ui/agent.py
@@ -100,22 +100,17 @@ class AgentUi(HarnessMixin):
     def open_agent_menu(self, name: str) -> None:
         """Right-click an agent by name and wait for its context menu to mount.
 
-        The agent id is re-resolved by name on every poll (a save reloads the
-        store), and the context menu is dispatched on the ``agent-header`` element
-        — the actual ``ContextMenu.Trigger`` — only once it is in the DOM.
+        Delegates to :meth:`HarnessMixin.open_named_context_menu`: the agent id is
+        re-resolved by name on every poll (a save reloads the store), and the
+        right-click is dispatched on the ``agent-header`` element — the actual
+        ``ContextMenu.Trigger`` — only once it is in the DOM.
         """
-
-        def menu_open() -> bool:
-            agent = self.find_agent(name)
-            if agent is None:
-                return False
-            header = self.agent_header_testid(agent["id"])
-            if not self.driver.exists(header):
-                return False
-            self.driver.context_menu(header)
-            return self.driver.exists(self.CTX_CONNECT)
-
-        self.wait(menu_open, what=f"the {name!r} agent context menu")
+        self.open_named_context_menu(
+            resolve=lambda: self.find_agent(name),
+            testid_for=self.agent_header_testid,
+            sentinel=self.CTX_CONNECT,
+            what=f"the {name!r} agent context menu",
+        )
 
     def agent_menu_action(self, name: str, action_test_id: str) -> None:
         """Right-click an agent by name and click a context-menu action."""

--- a/tests/system/termihub_harness/ui/base.py
+++ b/tests/system/termihub_harness/ui/base.py
@@ -14,7 +14,7 @@ real ``SystemTest`` members during method resolution.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 from ..bridge import Driver
 
@@ -43,3 +43,44 @@ class HarnessMixin:
         empty string, absent → ``None``), so a non-``None`` value means disabled.
         """
         return self.driver.get_attribute(test_id, "disabled") is not None
+
+    def open_named_context_menu(
+        self,
+        *,
+        resolve: Callable[[], Optional[dict[str, Any]]],
+        testid_for: Callable[[str], str],
+        sentinel: str,
+        what: str,
+    ) -> None:
+        """Right-click a store item resolved by name and wait for its menu to mount.
+
+        This is the harness's most race-sensitive gesture, shared by every
+        name-addressed context menu (connections, remote agents, …). A save makes
+        the store update *before* the sidebar settles: it reloads from disk a few
+        times, and an item's **id can change** across that reload. So the id is
+        re-resolved on every poll (never cached) via ``resolve`` and the
+        right-click is dispatched on ``testid_for(item["id"])`` — the actual
+        ``ContextMenu.Trigger`` — only once that element is in the DOM, otherwise
+        the gesture races a reload that replaced or unmounted it. The poll
+        succeeds when ``sentinel`` (a menu item testid) appears, i.e. the menu is
+        actually open.
+
+        Args:
+            resolve: Re-reads the store and returns the item dict (must carry an
+                ``"id"``) or ``None`` while it is not yet present.
+            testid_for: Builds the trigger element's testid from the item id.
+            sentinel: A menu-item testid that exists only once the menu is open.
+            what: Human-readable subject for the :meth:`wait` timeout message.
+        """
+
+        def menu_open() -> bool:
+            item = resolve()
+            if item is None:
+                return False
+            trigger = testid_for(item["id"])
+            if not self.driver.exists(trigger):
+                return False
+            self.driver.context_menu(trigger)
+            return self.driver.exists(sentinel)
+
+        self.wait(menu_open, what=what)

--- a/tests/system/termihub_harness/ui/connections.py
+++ b/tests/system/termihub_harness/ui/connections.py
@@ -157,27 +157,6 @@ class ConnectionsUi(HarnessMixin):
         self.require_connection(name)
         return name
 
-    def connect_connection(self, name: str) -> None:
-        """Open a session for an existing connection by double-clicking its item.
-
-        The connection list opens a session on *double*-click (single-click only
-        selects/edits), so this resolves the connection's id by name on every
-        poll — a save can reload connections from disk and reassign ids — and
-        double-clicks the current item once it is in the DOM.
-        """
-
-        def opened() -> bool:
-            conn = self.find_connection(name)
-            if conn is None:
-                return False
-            item = connection_item_testid(conn["id"])
-            if not self.driver.exists(item):
-                return False
-            self.driver.double_click(item)
-            return True
-
-        self.wait(opened, what=f"the {name!r} connection to open")
-
     def create_ssh_connection(
         self,
         name: str,
@@ -322,25 +301,18 @@ class ConnectionsUi(HarnessMixin):
     def open_connection_menu(self, name: str) -> None:
         """Right-click a connection by name and wait for its menu to mount.
 
-        A save makes the store update *before* the sidebar settles: it reloads
-        connections from disk a few times, and a connection's **id can change**
-        across that reload. So the connection id is re-resolved by name on every
-        poll (never cached) and the right-click is dispatched only once the
-        *current* item is in the DOM — otherwise the gesture races a reload that
-        replaced or unmounted the element.
+        Delegates to :meth:`HarnessMixin.open_named_context_menu`: the connection
+        id is re-resolved by name on every poll (a save reloads connections from
+        disk a few times and an id can change across that reload), and the
+        right-click is dispatched only once the *current* item is in the DOM —
+        otherwise the gesture races a reload that replaced or unmounted it.
         """
-
-        def menu_open() -> bool:
-            conn = self.find_connection(name)
-            if conn is None:
-                return False
-            item = connection_item_testid(conn["id"])
-            if not self.driver.exists(item):
-                return False
-            self.driver.context_menu(item)
-            return self.driver.exists(self.CTX_EDIT)
-
-        self.wait(menu_open, what=f"the {name!r} connection context menu")
+        self.open_named_context_menu(
+            resolve=lambda: self.find_connection(name),
+            testid_for=connection_item_testid,
+            sentinel=self.CTX_EDIT,
+            what=f"the {name!r} connection context menu",
+        )
 
     def connection_context_action(self, name: str, action_test_id: str) -> None:
         """Right-click a connection by name and click a context-menu action."""

--- a/tests/system/tests/test_ui_helpers.py
+++ b/tests/system/tests/test_ui_helpers.py
@@ -120,13 +120,14 @@ def test_open_named_context_menu_waits_for_resolve_then_a_mounted_trigger():
     # DOM. Only once both hold is the right-click dispatched — never on a stale id.
     driver = MenuDriver(present=set(), sentinel="ctx-edit")
     harness = FakeHarness(driver)
-    polls = {"n": 0}
+    poll = 0
 
     def resolve():
-        polls["n"] += 1
-        if polls["n"] == 1:
+        nonlocal poll
+        poll += 1
+        if poll == 1:
             return None  # store not loaded yet
-        if polls["n"] == 2:
+        if poll == 2:
             return {"id": "9"}  # resolved, but trigger still unmounted (below)
         driver._present.add("trigger-9")  # trigger mounts from the 3rd poll on
         return {"id": "9"}

--- a/tests/system/tests/test_ui_helpers.py
+++ b/tests/system/tests/test_ui_helpers.py
@@ -9,6 +9,7 @@ import pytest
 from termihub_harness import find_connection, find_folder
 from termihub_harness.bridge import BridgeError
 from termihub_harness.ui import connection_item_testid, folder_toggle_testid, iter_tabs
+from termihub_harness.ui.base import HarnessMixin
 
 
 class StubDriver:
@@ -23,6 +24,48 @@ class StubDriver:
         if path not in self._state:
             raise BridgeError("getState", f'state path "{path}" does not resolve')
         return self._state[path]
+
+
+class MenuDriver:
+    """Driver stub for ``open_named_context_menu``: tracks ``exists``/``context_menu``.
+
+    The sentinel testid only starts to "exist" *after* ``context_menu`` is
+    dispatched on the trigger, mirroring the real app: a right-click is what
+    mounts the menu (and therefore its sentinel item).
+    """
+
+    def __init__(self, *, present, sentinel):
+        self._present = set(present)
+        self._sentinel = sentinel
+        self.context_menu_calls: list[str] = []
+
+    def exists(self, test_id: str) -> bool:
+        return test_id in self._present
+
+    def context_menu(self, test_id: str) -> None:
+        self.context_menu_calls.append(test_id)
+        self._present.add(self._sentinel)
+
+
+class FakeHarness(HarnessMixin):
+    """Concrete ``HarnessMixin`` with an eager ``wait`` for unit tests (no app).
+
+    ``wait`` polls the predicate synchronously up to ``_MAX_POLLS`` times — the
+    mutable ``MenuDriver`` / closure state flips truthy within a few polls, so no
+    real timing is involved.
+    """
+
+    _MAX_POLLS = 50
+
+    def __init__(self, driver):
+        self.driver = driver
+
+    def wait(self, predicate, *, timeout=0, interval=0, what=""):
+        for _ in range(self._MAX_POLLS):
+            result = predicate()
+            if result:
+                return result
+        raise AssertionError(f"timed out waiting for {what}")
 
 
 def test_find_connection_matches_by_name():
@@ -56,6 +99,45 @@ def test_lookups_are_resilient_to_unresolved_state():
 )
 def test_testid_builders(builder, value, expected):
     assert builder(value) == expected
+
+
+def test_open_named_context_menu_dispatches_on_the_resolved_trigger():
+    # Item resolves to id "1"; its trigger is mounted, so the menu is dispatched
+    # exactly once on that trigger and the helper returns when the sentinel mounts.
+    driver = MenuDriver(present={"trigger-1"}, sentinel="ctx-edit")
+    harness = FakeHarness(driver)
+    harness.open_named_context_menu(
+        resolve=lambda: {"id": "1"},
+        testid_for=lambda item_id: f"trigger-{item_id}",
+        sentinel="ctx-edit",
+        what="the menu",
+    )
+    assert driver.context_menu_calls == ["trigger-1"]
+
+
+def test_open_named_context_menu_waits_for_resolve_then_a_mounted_trigger():
+    # First poll: item unresolved. Then resolved but its trigger not yet in the
+    # DOM. Only once both hold is the right-click dispatched — never on a stale id.
+    driver = MenuDriver(present=set(), sentinel="ctx-edit")
+    harness = FakeHarness(driver)
+    polls = {"n": 0}
+
+    def resolve():
+        polls["n"] += 1
+        if polls["n"] == 1:
+            return None  # store not loaded yet
+        if polls["n"] == 2:
+            return {"id": "9"}  # resolved, but trigger still unmounted (below)
+        driver._present.add("trigger-9")  # trigger mounts from the 3rd poll on
+        return {"id": "9"}
+
+    harness.open_named_context_menu(
+        resolve=resolve,
+        testid_for=lambda item_id: f"trigger-{item_id}",
+        sentinel="ctx-edit",
+        what="the menu",
+    )
+    assert driver.context_menu_calls == ["trigger-9"]
 
 
 def test_iter_tabs_flattens_a_split_tree_in_order():


### PR DESCRIPTION
## Summary

Consolidates the harness's most race-sensitive gesture and removes a dead duplicate. **Test-harness-only — no production impact** (per #1001).

`AgentUi.open_agent_menu` and `ConnectionsUi.open_connection_menu` implemented the same race-sensitive pattern verbatim (re-resolve the item id by name on every poll, dispatch the context menu only once the trigger is mounted, then wait for a sentinel menu item). A future fix to that contract had to be applied in two — soon three — places and could silently drift.

## Changes

- **Extract** `HarnessMixin.open_named_context_menu(*, resolve, testid_for, sentinel, what)` (`ui/base.py`) — single owner of the resolve-each-poll / dispatch-once-mounted / wait-for-sentinel contract.
- **Delegate** `AgentUi.open_agent_menu` and `ConnectionsUi.open_connection_menu` to it (~30 lines of duplicated polling removed).
- **Remove** the first, shadowed `ConnectionsUi.connect_connection` definition — Python kept only the second, so the first was dead code.

## Test plan

- New unit tests in `tests/test_ui_helpers.py` pin the helper's contract against a stub driver (`MenuDriver`/`FakeHarness`): the right-click is dispatched exactly once on the resolved trigger, and only after the item resolves *and* its trigger is mounted (never on a stale id).
- Written test-first: the new tests fail without the helper (red), pass after (green).
- `./pytest.sh tests/test_ui_helpers.py` → 9 passed; full suite still collects cleanly (443 tests).
- `/simplify` run on the diff; applied one finding (dict-counter → `nonlocal`).

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)