### PR TITLE
test(testing): bind wait_for_app to the surviving startup connection (#1019)

### DIFF
--- a/tests/system/termihub_harness/bridge.py
+++ b/tests/system/termihub_harness/bridge.py
@@ -26,6 +26,13 @@ from .protocol import Command, Response, decode_response, encode_request
 
 DEFAULT_REQUEST_TIMEOUT = 10.0
 DEFAULT_APP_WAIT_TIMEOUT = 30.0
+#: After the first app connection arrives, briefly prefer a newer one that shows
+#: up within this window. An app's webview can connect and then reconnect during
+#: startup (a layout-driven remount or a page reload), so the first connection is
+#: sometimes transient and dies milliseconds later; binding the Driver to it
+#: would fail every command. The observed gap is ~20 ms, so a fraction of a
+#: second is ample headroom while keeping the per-acquire latency small.
+DEFAULT_APP_SETTLE = 0.5
 #: Cap for a single bridge frame. The default (1 MiB) is too small for a
 #: ``screenshot`` data URL of a large window, so allow generously larger frames.
 MAX_BRIDGE_FRAME_BYTES = 32 * 1024 * 1024
@@ -338,25 +345,66 @@ class Bridge:
             raise RuntimeError("bridge is not started")
         return self._port
 
-    def wait_for_app(self, timeout: float = DEFAULT_APP_WAIT_TIMEOUT) -> Driver:
+    def wait_for_app(
+        self,
+        timeout: float = DEFAULT_APP_WAIT_TIMEOUT,
+        settle: float = DEFAULT_APP_SETTLE,
+    ) -> Driver:
         """Block until the next app connects out, returning a :class:`Driver`.
 
         Each call consumes one connection in arrival order, so the first call
         returns the first app instance and a call after a restart returns the
         next one — the sequential-connection contract from issue #817.
+
+        Returns the connection that *survives* startup rather than blindly the
+        first to arrive: an app's webview can connect and then reconnect within
+        milliseconds (a layout-driven remount or a page reload), and the first,
+        transient connection then dies — so binding the Driver to it would make
+        every command fail with "bridge connection closed". After the first
+        connection arrives this prefers any newer one that shows up within
+        ``settle``, and if the current candidate has already closed it keeps
+        waiting (up to ``timeout``) for the replacement. Pass ``settle=0`` to opt
+        out (take the first arrival immediately). See :data:`DEFAULT_APP_SETTLE`.
         """
         if self._loop is None or self._conn_queue is None:
             raise RuntimeError("bridge is not started")
         cfut = asyncio.run_coroutine_threadsafe(
-            asyncio.wait_for(self._conn_queue.get(), timeout), self._loop
+            self._acquire_settled(timeout, settle), self._loop
         )
         try:
-            connection = cfut.result(timeout + 5)
+            connection = cfut.result(timeout + settle + 5)
         except asyncio.TimeoutError as exc:
             raise TimeoutError(
                 f"no app connected to the bridge within {timeout}s"
             ) from exc
         return Driver(connection, self._loop)
+
+    async def _acquire_settled(self, timeout: float, settle: float) -> "_Connection":
+        """Pop a connection, then prefer a newer/surviving one (see wait_for_app).
+
+        Runs on the bridge event loop. Blocks up to ``timeout`` for the first
+        connection, then: while the candidate is open, briefly (``settle``) take
+        any newer arrival that supersedes it; while the candidate is closed, wait
+        for its replacement until the overall ``timeout`` elapses.
+        """
+        assert self._conn_queue is not None
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + timeout
+        connection = await asyncio.wait_for(self._conn_queue.get(), timeout)
+        while True:
+            if connection._closed:
+                # The candidate is a dead transient connection — wait for the
+                # replacement up to the overall deadline.
+                window = max(0.0, deadline - loop.time())
+            else:
+                # A healthy candidate — only briefly look for a newer connection.
+                window = settle
+            if window <= 0.0:
+                return connection
+            try:
+                connection = await asyncio.wait_for(self._conn_queue.get(), window)
+            except asyncio.TimeoutError:
+                return connection
 
     def close(self) -> None:
         loop, stop = self._loop, self._stop_future

--- a/tests/system/tests/test_roundtrip.py
+++ b/tests/system/tests/test_roundtrip.py
@@ -173,3 +173,44 @@ def test_sequential_connections_survive_restart(bridge):
     with FakeApp(bridge.port, dispatcher_like(terminal_text="second\n")):
         driver_b = bridge.wait_for_app(timeout=5)
         assert "second" in driver_b.read_terminal()
+
+
+# ── Startup-reconnect resilience (#1019): bind to the surviving connection ──────
+def test_wait_for_app_prefers_a_newer_connection(bridge):
+    # Two connections arrive close together (a startup reload connects, then
+    # reconnects). wait_for_app must return the *newer* one, since the first is
+    # the transient that will be discarded — not whichever arrived first.
+    transient = FakeApp(bridge.port, dispatcher_like(terminal_text="transient\n"))
+    stable = FakeApp(bridge.port, dispatcher_like(terminal_text="stable\n"))
+    with transient, stable:  # `transient` connects first, then `stable`
+        driver = bridge.wait_for_app(timeout=5)
+        assert "stable" in driver.read_terminal()
+
+
+def test_wait_for_app_skips_a_dead_transient_connection(bridge):
+    # The first connection has already dropped by the time we acquire (the
+    # classic startup-reload race). wait_for_app must wait past the dead one and
+    # return the live replacement rather than handing back a closed socket.
+    transient = FakeApp(bridge.port, dispatcher_like(terminal_text="transient\n")).start()
+    transient.stop()  # it connected, then immediately went away
+    with FakeApp(bridge.port, dispatcher_like(terminal_text="stable\n")):
+        driver = bridge.wait_for_app(timeout=5)
+        assert "stable" in driver.read_terminal()
+
+
+def test_wait_for_app_returns_a_lone_stable_connection(bridge):
+    # The common case: exactly one connection, which stays up. The settle window
+    # must not discard it — it is returned (after the brief settle).
+    with FakeApp(bridge.port, dispatcher_like(terminal_text="only\n")):
+        driver = bridge.wait_for_app(timeout=5)
+        assert "only" in driver.read_terminal()
+
+
+def test_wait_for_app_settle_zero_takes_the_first_arrival(bridge):
+    # settle=0 opts out of the preference window: the first connection is taken
+    # immediately even when a second is already waiting behind it.
+    first = FakeApp(bridge.port, dispatcher_like(terminal_text="first\n"))
+    second = FakeApp(bridge.port, dispatcher_like(terminal_text="second\n"))
+    with first, second:
+        driver = bridge.wait_for_app(timeout=5, settle=0)
+        assert "first" in driver.read_terminal()


### PR DESCRIPTION
## Summary

The harness-side, defense-in-depth half of #1019 (the frontend half is PR #1023). Makes `Bridge.wait_for_app()` bind to the connection that **survives** startup rather than blindly the first to arrive.

### Why

An app's webview can connect and then reconnect within milliseconds during startup (a layout-driven remount or a page reload). The first connection is then transient and dies; `wait_for_app()` returned it, so the `Driver` was bound to a socket that closed moments later and every command failed with `bridge connection closed`. PR #1023 fixes the specific frontend remount that caused it; this makes the harness resilient to startup reconnects **regardless of cause**, so it recovers even if that frontend fix regresses or a new remount path appears.

### Change

`wait_for_app(timeout, settle=DEFAULT_APP_SETTLE)`:
- after the first connection arrives, briefly (`settle`, default **0.5s**) prefer any newer connection that supersedes it;
- if the current candidate has already closed, keep waiting (up to `timeout`) for its replacement;
- `settle=0` opts out (take the first arrival immediately).

The sequential-connection / restart contract (#817) is unchanged.

## Test plan
- ✅ New `FakeApp` round-trip tests (no app build): prefers-newer, skips-dead-transient, lone-stable, and `settle=0` opt-out.
- ✅ Full machinery group green (136 passed; the one `test_orchestrator` failure is the pre-existing Windows path-separator bug #1013, unrelated).
- ℹ️ Independently of the frontend fix, this branch (built from develop's unfixed `TestBridge.tsx`, which still double-connects) is expected to recover via the settle logic — the FakeApp tests simulate exactly that double-connection sequence. (The live A/B rebuild check was set up but not completed in-session.)

Closes #1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
