### PR TITLE
fix(network): remove redundant closure in Windows open_ports (Closes #1012)

### DIFF
--- a/core/src/network/open_ports/windows.rs
+++ b/core/src/network/open_ports/windows.rs
@@ -52,7 +52,7 @@ fn parse_netstat_output(text: &str) -> Result<Vec<OpenPort>, NetworkError> {
                     continue;
                 }
                 let pid: Option<u32> = cols[4].parse().ok();
-                let process = pid.and_then(|p| lookup_process_name(p));
+                let process = pid.and_then(lookup_process_name);
 
                 ports.push(OpenPort {
                     protocol,
@@ -64,7 +64,7 @@ fn parse_netstat_output(text: &str) -> Result<Vec<OpenPort>, NetworkError> {
             Protocol::Udp => {
                 // UDP has no state column.
                 let pid: Option<u32> = cols[3].parse().ok();
-                let process = pid.and_then(|p| lookup_process_name(p));
+                let process = pid.and_then(lookup_process_name);
 
                 ports.push(OpenPort {
                     protocol,


### PR DESCRIPTION
## Summary

Fixes the `clippy::redundant_closure` hard error that fails the `-D warnings` gate on current clippy toolchains (observed on Rust 1.93.1). This is a **Windows-only** module, so it only surfaces when clippy runs on Windows (Windows CI #804 or a developer's Windows checkout).

Both call sites in `core/src/network/open_ports/windows.rs` now pass the function reference directly:

- `pid.and_then(|p| lookup_process_name(p))` → `pid.and_then(lookup_process_name)` (TCP, line 55)
- same transformation for the UDP branch (line 67)

## Test plan

- No unit test is feasible for a clippy lint — the `-D warnings` clippy gate (`./scripts/check.sh` / Windows CI #804) is the verification.
- Local clippy could not be run in this environment (NASM not installed, blocking the transitive `aws-lc-sys` build) — CI will confirm the gate now passes.

Closes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)