### PR TITLE
test(testing): fix Windows path separator in orchestrator test (Closes #1013)

### DIFF
--- a/tests/system/tests/test_orchestrator.py
+++ b/tests/system/tests/test_orchestrator.py
@@ -61,8 +61,11 @@ def test_no_build_raises_with_both_paths(fake_repo: Path):
     with pytest.raises(FileNotFoundError) as exc:
         orchestrator.app_binary_path()
     # The error names both the release and debug locations it looked in.
-    assert "target/release" in str(exc.value)
-    assert "target/debug" in str(exc.value)
+    # Path objects render with OS-native separators (backslashes on Windows),
+    # so normalize before the substring check to stay separator-agnostic.
+    message = str(exc.value).replace("\\", "/")
+    assert "target/release" in message
+    assert "target/debug" in message
 
 
 def test_candidates_are_release_then_debug(fake_repo: Path):


### PR DESCRIPTION
## Summary

`tests/system/tests/test_orchestrator.py::test_no_build_raises_with_both_paths` failed on Windows hosts. The test asserts that the `FileNotFoundError` message names both looked-in locations, but `app_binary_path()` builds that message from `Path` objects, which render with **backslashes** on Windows (`target\release`, `target\debug`). The forward-slash substring assertions therefore never matched.

## Fix

Normalize the message with `str(exc.value).replace("\\", "/")` before the substring checks so the assertions are separator-agnostic and pass on both Windows and POSIX.

## Test plan

- [x] `./pytest.sh tests/test_orchestrator.py::test_no_build_raises_with_both_paths` passes on Windows
- [x] Full `tests/test_orchestrator.py` module: 6 passed

Test-only change (no user-facing behavior), so no changelog fragment.

Closes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)