### PR TITLE
chore(backend): ignore quick-xml DoS advisories until upstream bump

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,4 +7,14 @@
 # key format parsing). We only extract raw RSA key components and rebuild
 # them via OpenSSL — we never perform RSA encryption/decryption through
 # this crate, so the timing sidechannel does not apply.
-ignore = ["RUSTSEC-2023-0071"]
+#
+# RUSTSEC-2026-0194 / RUSTSEC-2026-0195: DoS advisories in `quick-xml` <0.41
+# (quadratic parse of duplicate attribute names; unbounded namespace-declaration
+# allocation). `quick-xml` is a transitive dependency of `plist` <- `tauri-utils`
+# <- `tauri`. `plist 1.9.0` (the latest release) pins `quick-xml = "^0.39.2"`,
+# so the patched >=0.41.0 cannot be selected until plist/tauri adopt it upstream.
+# Both advisories are DoS-only and require feeding untrusted XML to the parser;
+# `plist` is used only by tauri to read its own bundle metadata, never external
+# user input, so the practical attack surface is nil. Remove once upstream
+# updates quick-xml — tracked in #1037.
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2026-0194", "RUSTSEC-2026-0195"]

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -7,4 +7,14 @@
 # key format parsing). We only extract raw RSA key components and rebuild
 # them via OpenSSL — we never perform RSA encryption/decryption through
 # this crate, so the timing sidechannel does not apply.
-ignore = ["RUSTSEC-2023-0071"]
+#
+# RUSTSEC-2026-0194 / RUSTSEC-2026-0195: DoS advisories in `quick-xml` <0.41
+# (quadratic parse of duplicate attribute names; unbounded namespace-declaration
+# allocation). `quick-xml` is a transitive dependency of `plist` <- `tauri-utils`
+# <- `tauri`. `plist 1.9.0` (the latest release) pins `quick-xml = "^0.39.2"`,
+# so the patched >=0.41.0 cannot be selected until plist/tauri adopt it upstream.
+# Both advisories are DoS-only and require feeding untrusted XML to the parser;
+# `plist` is used only by tauri to read its own bundle metadata, never external
+# user input, so the practical attack surface is nil. Remove once upstream
+# updates quick-xml — tracked in #1037.
+ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2026-0194", "RUSTSEC-2026-0195"]


### PR DESCRIPTION
## Summary

`cargo audit` (the **Rust Code Quality** and **Security Audit** CI jobs) currently hard-fails on two DoS advisories in **quick-xml 0.39.4**:

- **RUSTSEC-2026-0194** — quadratic run time when checking a start tag for duplicate attribute names
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS)

Both are fixed in quick-xml **>=0.41.0**, but the bump is **blocked upstream**:

```
quick-xml 0.39.4  <-  plist 1.9.0  <-  tauri-utils 2.9.2  <-  tauri 2.11.2
```

`plist 1.9.0` (the latest published release) pins `quick-xml = "^0.39.2"`, which excludes 0.41 — the resolver rejects `cargo update -p quick-xml --precise 0.41.0`. Nothing in our `Cargo.toml`/`Cargo.lock` can resolve it until `plist`/`tauri` adopt quick-xml >=0.41 upstream.

## Change

Add both advisory IDs to the `ignore` list in `.cargo/audit.toml` and `src-tauri/.cargo/audit.toml` (matching the existing `RUSTSEC-2023-0071` pattern), with a justification comment and a pointer to the tracking issue.

**Justification:** Both advisories are DoS-only and require feeding untrusted XML to the parser. `plist` is used only by tauri to read its own bundle metadata (Info.plist / config), never external user input — so the practical attack surface for termiHub is nil.

## Test plan

- `cargo audit` from the repo root (the path both CI jobs use) now exits **0** — verified locally with cargo-audit 0.22.2.
- No unit test applies (audit config). CI's `cargo audit` steps are the gate.

Removal of these ignores once upstream updates quick-xml is tracked in #1037.

Refs #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)