### PR TITLE
test(testing): add optional Git Bash coverage to the Windows-shells bridge suite (Closes #1016)

### DIFF
--- a/tests/system/termihub_harness/git_bash.py
+++ b/tests/system/termihub_harness/git_bash.py
@@ -1,0 +1,52 @@
+"""Git Bash detection for the Windows-only shell suite (#1016).
+
+The Windows-shells port (``tests/system/tests/test_windows_shells.py``) can drive
+a local connection with ``shell="gitbash"``, but Git Bash — unlike PowerShell and
+cmd.exe — is only present when Git for Windows is installed. The backend detects
+it by probing a fixed set of install paths (``GIT_BASH_PATHS`` in
+``core/src/session/shell.rs``); if none exist, ``gitbash`` never appears among the
+detected shells and the editor's ``field-shell`` dropdown omits it.
+
+So the suite gates its Git Bash case on the host directly — exactly as the backend
+does — by checking the same paths. :func:`git_bash_installed_at` is a pure
+function of its path list (no I/O beyond ``os.path.exists``), so it is unit-tested
+on any host; :func:`detect_git_bash` is the thin Windows-only wrapper that feeds
+it :data:`GIT_BASH_PATHS` and returns ``False`` off Windows.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Iterable
+
+# Mirror of the Rust ``GIT_BASH_PATHS`` (``core/src/session/shell.rs``): the fixed
+# install locations the backend probes for Git Bash. Keep in lockstep with the
+# backend so the Python gate and the app agree on availability.
+GIT_BASH_PATHS: tuple[str, ...] = (
+    r"C:\Program Files\Git\bin\bash.exe",
+    r"C:\Program Files (x86)\Git\bin\bash.exe",
+)
+
+
+def git_bash_installed_at(paths: Iterable[str]) -> bool:
+    """Whether any of ``paths`` names an existing file (a Git Bash executable).
+
+    Pure over its input (only ``os.path.exists``), mirroring the backend's
+    ``GIT_BASH_PATHS.iter().any(|p| Path::new(p).exists())`` so the gate and the
+    app agree on what counts as an installed Git Bash.
+    """
+    return any(os.path.exists(path) for path in paths)
+
+
+def detect_git_bash() -> bool:
+    """Return whether Git Bash is installed, or ``False`` off Windows.
+
+    Probes :data:`GIT_BASH_PATHS` with :func:`git_bash_installed_at`. Git Bash is
+    a Windows-only shell (an MSYS bash bundled with Git for Windows), so on any
+    non-Windows host this short-circuits to ``False`` and the suite skips its
+    Git Bash case cleanly.
+    """
+    if not sys.platform.startswith("win"):
+        return False
+    return git_bash_installed_at(GIT_BASH_PATHS)

--- a/tests/system/tests/test_git_bash_detect.py
+++ b/tests/system/tests/test_git_bash_detect.py
@@ -1,0 +1,45 @@
+"""Unit tests for the Git Bash detector (#1016).
+
+Machinery group (no app, no Windows): :func:`git_bash_installed_at` is a pure
+function of its path list, so both the present and absent cases are asserted on
+any host against real temp files. This mirrors the backend's
+``GIT_BASH_PATHS.iter().any(...)`` probe in ``core/src/session/shell.rs`` so the
+Python gate and the backend agree on what counts as an installed Git Bash.
+"""
+
+from __future__ import annotations
+
+from termihub_harness.git_bash import (
+    GIT_BASH_PATHS,
+    detect_git_bash,
+    git_bash_installed_at,
+)
+
+
+def test_reports_installed_when_a_path_exists(tmp_path):
+    bash = tmp_path / "bash.exe"
+    bash.write_text("")
+    missing = tmp_path / "nope.exe"
+    assert git_bash_installed_at([str(missing), str(bash)]) is True
+
+
+def test_reports_absent_when_no_path_exists(tmp_path):
+    assert git_bash_installed_at([str(tmp_path / "a.exe"), str(tmp_path / "b.exe")]) is False
+
+
+def test_empty_path_list_is_absent():
+    assert git_bash_installed_at([]) is False
+
+
+def test_paths_mirror_the_backend_install_locations():
+    # The gate probes exactly the two fixed locations the Rust backend checks.
+    assert GIT_BASH_PATHS == (
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+    )
+
+
+def test_detect_returns_false_off_windows(monkeypatch):
+    # The path gate short-circuits on non-Windows hosts (Git Bash is Windows-only).
+    monkeypatch.setattr("termihub_harness.git_bash.sys.platform", "linux")
+    assert detect_git_bash() is False

--- a/tests/system/tests/test_windows_shells.py
+++ b/tests/system/tests/test_windows_shells.py
@@ -43,6 +43,7 @@ from termihub_harness import (
     TerminalUi,
     unique_name,
 )
+from termihub_harness.git_bash import detect_git_bash
 from termihub_harness.shell import is_absolute_path
 from termihub_harness.wsl import detect_wsl_distros
 
@@ -101,6 +102,17 @@ skip_without_wsl = pytest.mark.skipif(
     not _WSL_DISTROS, reason="no WSL2 distribution installed on this host"
 )
 
+# Git Bash — unlike PowerShell and cmd.exe, which the local backend always detects
+# on Windows — is only present when Git for Windows is installed, so it appears
+# among the detected shells (and in the editor's `field-shell` dropdown) only then.
+# Probe the same install paths the backend checks so the gate and the app agree,
+# and skip the Git Bash case cleanly when it is absent (mirrors `skip_without_wsl`).
+_HAS_GIT_BASH = detect_git_bash() if _IS_WINDOWS else False
+
+skip_without_git_bash = pytest.mark.skipif(
+    not _HAS_GIT_BASH, reason="Git Bash (Git for Windows) is not installed on this host"
+)
+
 
 @skip_on_non_windows
 class TestWindowsShells(
@@ -131,6 +143,23 @@ class TestWindowsShells(
 
         self.wait(self.has_terminal, what="the cmd.exe shell to be readable")
         marker = "WIN_CMD_MARKER"
+        self.run_command(f"echo {marker}")
+        assert marker in self.wait_for_output(marker)
+
+    # ── MT-LOCAL-15: a saved Git Bash connection spawns and echoes a POSIX marker
+    #    (skips when Git for Windows is not installed) ─────────────────────────────
+    @skip_without_git_bash
+    def test_gitbash_session_renders_and_accepts_input(self):
+        self.close_all_tabs()
+        name = unique_name("win-gitbash")
+        self.create_local_connection(name, shell="gitbash")
+        self.switch_to_connections_sidebar()
+        self.connect_connection(name)
+
+        self.wait(self.has_terminal, what="the Git Bash shell to be readable")
+        # Git Bash is an MSYS bash, so the POSIX `echo` builtin works — unlike the
+        # PowerShell/cmd cases, this asserts the *POSIX* dialect actually runs.
+        marker = "WIN_GITBASH_MARKER"
         self.run_command(f"echo {marker}")
         assert marker in self.wait_for_output(marker)
 


### PR DESCRIPTION
## Summary

Restores the old **MT-LOCAL-15** ("Saved Git Bash launches Git Bash") as an automated bridge test. The Windows-shells port (#975, PR #1011) covers PowerShell and cmd.exe — the two shells the local backend always detects on Windows — but Git Bash is detected only when Git for Windows is installed, so it had no automated equivalent.

- Adds `tests/system/termihub_harness/git_bash.py`, a detection helper that mirrors the sibling `wsl.py`: it probes the same `GIT_BASH_PATHS` the Rust backend checks (`core/src/session/shell.rs`) so the test gate and the app agree on availability. `git_bash_installed_at` is pure over its path list (unit-testable on any host); `detect_git_bash` is the Windows-only wrapper.
- Adds `test_gitbash_session_renders_and_accepts_input` to `TestWindowsShells`, gated by `skip_without_git_bash` (mirrors `skip_without_wsl`). When Git Bash is present, it creates a local connection with `shell="gitbash"`, connects, and asserts a POSIX marker echoes — proving the MSYS bash dialect actually runs, unlike the PowerShell/cmd cases. When absent, it skips cleanly.

Follow-up to #975.

## Test plan

- [x] Unit tests: `./pytest.sh tests/test_git_bash_detect.py` → 5 passed (pure detector, both present/absent + off-Windows cases).
- [x] Integration: `./scripts/test-system-py.sh --skip-build -k test_gitbash_session_renders_and_accepts_input` on a Windows host **with Git for Windows installed** → 1 passed (Git Bash session spawns and echoes the marker end-to-end).
- [x] The case skips cleanly when Git Bash is not installed (gate mirrors the WSL gate).

Test-only change — no changelog fragment or manual-test doc update needed.

Closes #1016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)