### PR TITLE
fix(testing): reap leaked WebView2 hosts on Windows app teardown (Closes #1022)

### DIFF
--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -468,7 +468,10 @@ the old WebdriverIO find-by-title lookups. Tab lookups use the `TabsUi` mixin's
 ## Orchestration
 
 - `AppInstance(config_dir?)` — `start(bridge_port)`, `stop()`, `restart()`. Config
-  dir is stable across a restart so the saved last-session survives.
+  dir is stable across a restart so the saved last-session survives. On Windows
+  each instance pins its WebView2 user-data folder (via `WEBVIEW2_USER_DATA_FOLDER`)
+  so `stop()` can reap the `msedgewebview2.exe` hosts, which live outside the app
+  process tree and would otherwise leak across back-to-back runs (issue #1022).
 - `AgentInstance(host?, port?)` — `start()`, `stop()`, `restart()` for a
   `termihub-agent --listen` process, with process-tree teardown via `psutil`.
 

--- a/tests/system/termihub_harness/orchestrator.py
+++ b/tests/system/termihub_harness/orchestrator.py
@@ -127,6 +127,68 @@ def _terminate_tree(process: subprocess.Popen, timeout: float = 5.0) -> None:
             pass
 
 
+def _webview2_user_data_dir(config_dir: Path) -> Path:
+    """Per-instance WebView2 user-data folder, nested under the app config dir.
+
+    Passed to the app via ``WEBVIEW2_USER_DATA_FOLDER`` (Windows only) so every
+    launched instance pins its WebView2 host processes to a distinct folder —
+    which teardown then matches on to reap only that instance's children.
+    """
+    return config_dir / "webview2-user-data"
+
+
+def _is_webview2_for_data_dir(name: str, cmdline: list[str], user_data_dir: Path) -> bool:
+    """True if a process is a ``msedgewebview2.exe`` pinned to ``user_data_dir``.
+
+    WebView2 hosts its renderer/GPU/utility processes under
+    ``msedgewebview2.exe``. Those are launched with ``--user-data-dir=<folder>``
+    matching the app's ``WEBVIEW2_USER_DATA_FOLDER``, so matching on the folder
+    reaps exactly one instance's children — safe under parallel instances.
+    Comparison normalises path separators and case (Windows paths).
+    """
+    if (name or "").casefold() != "msedgewebview2.exe":
+        return False
+    needle = str(user_data_dir).replace("/", "\\").casefold()
+    joined = " ".join(cmdline or []).replace("/", "\\").casefold()
+    return needle in joined
+
+
+def _terminate_webview2_children(user_data_dir: Path, timeout: float = 5.0) -> None:
+    """Windows-only: reap the ``msedgewebview2.exe`` hosts for ``user_data_dir``.
+
+    WebView2's child processes live under a separate host that is *not* a
+    descendant of the app PID, so :func:`_terminate_tree` leaves them running.
+    They accumulate across app launches and eventually destabilise back-to-back
+    test runs (issue #1022). This finds the ones pinned to this instance's
+    user-data folder and terminates them, escalating to kill.
+    """
+    if platform.system() != "Windows":
+        return
+    victims = []
+    for proc in psutil.process_iter(["name", "cmdline"]):
+        try:
+            info = proc.info
+            if _is_webview2_for_data_dir(
+                info.get("name") or "", info.get("cmdline") or [], user_data_dir
+            ):
+                victims.append(proc)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    if not victims:
+        return
+    for proc in victims:
+        try:
+            proc.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    _, alive = psutil.wait_procs(victims, timeout=timeout)
+    for proc in alive:
+        try:
+            proc.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+
 class AppInstance:
     """A launchable, killable, restartable desktop app process.
 
@@ -139,6 +201,9 @@ class AppInstance:
         self._binary = app_binary_path()
         self._owns_config_dir = config_dir is None
         self._config_dir = config_dir or Path(tempfile.mkdtemp(prefix="termihub-app-config-"))
+        #: Per-instance WebView2 user-data folder (Windows), pinned via env so
+        #: teardown can reap only this instance's msedgewebview2.exe children.
+        self._webview2_data_dir = _webview2_user_data_dir(self._config_dir)
         self._process: Optional[subprocess.Popen] = None
         self._bridge_port: Optional[int] = None
         #: Captured app stdout/stderr — copied into the failure-artifact bundle.
@@ -175,6 +240,11 @@ class AppInstance:
         env = dict(os.environ)
         env["TERMIHUB_TEST_BRIDGE_PORT"] = str(bridge_port)
         env["TERMIHUB_CONFIG_DIR"] = str(self._config_dir)
+        # Pin WebView2 to a per-instance user-data folder so teardown can reap
+        # only this instance's msedgewebview2.exe hosts (issue #1022). The app
+        # (Tauri) sets no data_directory, so WebView2 honours this env var.
+        if platform.system() == "Windows":
+            env["WEBVIEW2_USER_DATA_FOLDER"] = str(self._webview2_data_dir)
         # Append so the log survives a restart() (same config dir, same file).
         self._log_file = open(self._log_path, "a", encoding="utf-8", errors="replace")
         self._process = subprocess.Popen(
@@ -217,6 +287,9 @@ class AppInstance:
         """Kill the app process tree and stop log capture."""
         if self._process is not None:
             _terminate_tree(self._process)
+            # WebView2 hosts live outside the app's process tree; reap the ones
+            # pinned to this instance so they don't pile up (issue #1022).
+            _terminate_webview2_children(self._webview2_data_dir)
             if self._process.stdout is not None:
                 try:
                     self._process.stdout.close()  # EOF so the pump thread exits

--- a/tests/system/termihub_harness/orchestrator.py
+++ b/tests/system/termihub_harness/orchestrator.py
@@ -100,6 +100,26 @@ def free_port() -> int:
         return sock.getsockname()[1]
 
 
+def _terminate_procs(procs: list, timeout: float = 5.0) -> None:
+    """Terminate a set of processes, escalating any survivors to a hard kill.
+
+    The shared shutdown ritual for both the app process tree and the out-of-tree
+    WebView2 hosts: request a graceful ``terminate()``, wait, then ``kill()``
+    whatever is still alive. Processes that vanish or deny access are ignored.
+    """
+    for proc in procs:
+        try:
+            proc.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    _, alive = psutil.wait_procs(procs, timeout=timeout)
+    for proc in alive:
+        try:
+            proc.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+
 def _terminate_tree(process: subprocess.Popen, timeout: float = 5.0) -> None:
     """Kill a process and all of its children, escalating to SIGKILL.
 
@@ -113,28 +133,7 @@ def _terminate_tree(process: subprocess.Popen, timeout: float = 5.0) -> None:
         parent = psutil.Process(process.pid)
     except psutil.NoSuchProcess:
         return
-    procs = parent.children(recursive=True) + [parent]
-    for proc in procs:
-        try:
-            proc.terminate()
-        except psutil.NoSuchProcess:
-            pass
-    _, alive = psutil.wait_procs(procs, timeout=timeout)
-    for proc in alive:
-        try:
-            proc.kill()
-        except psutil.NoSuchProcess:
-            pass
-
-
-def _webview2_user_data_dir(config_dir: Path) -> Path:
-    """Per-instance WebView2 user-data folder, nested under the app config dir.
-
-    Passed to the app via ``WEBVIEW2_USER_DATA_FOLDER`` (Windows only) so every
-    launched instance pins its WebView2 host processes to a distinct folder —
-    which teardown then matches on to reap only that instance's children.
-    """
-    return config_dir / "webview2-user-data"
+    _terminate_procs(parent.children(recursive=True) + [parent], timeout)
 
 
 def _is_webview2_for_data_dir(name: str, cmdline: list[str], user_data_dir: Path) -> bool:
@@ -165,28 +164,20 @@ def _terminate_webview2_children(user_data_dir: Path, timeout: float = 5.0) -> N
     if platform.system() != "Windows":
         return
     victims = []
-    for proc in psutil.process_iter(["name", "cmdline"]):
+    for proc in psutil.process_iter(["name"]):
         try:
-            info = proc.info
+            # Cheap name pre-filter first: reading a process's full command line
+            # (proc.cmdline()) is costly on Windows, so only pay it for the few
+            # msedgewebview2.exe hosts rather than the whole process table.
+            if (proc.info.get("name") or "").casefold() != "msedgewebview2.exe":
+                continue
             if _is_webview2_for_data_dir(
-                info.get("name") or "", info.get("cmdline") or [], user_data_dir
+                "msedgewebview2.exe", proc.cmdline(), user_data_dir
             ):
                 victims.append(proc)
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             continue
-    if not victims:
-        return
-    for proc in victims:
-        try:
-            proc.terminate()
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
-    _, alive = psutil.wait_procs(victims, timeout=timeout)
-    for proc in alive:
-        try:
-            proc.kill()
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
+    _terminate_procs(victims, timeout)
 
 
 class AppInstance:
@@ -203,7 +194,7 @@ class AppInstance:
         self._config_dir = config_dir or Path(tempfile.mkdtemp(prefix="termihub-app-config-"))
         #: Per-instance WebView2 user-data folder (Windows), pinned via env so
         #: teardown can reap only this instance's msedgewebview2.exe children.
-        self._webview2_data_dir = _webview2_user_data_dir(self._config_dir)
+        self._webview2_data_dir = self._config_dir / "webview2-user-data"
         self._process: Optional[subprocess.Popen] = None
         self._bridge_port: Optional[int] = None
         #: Captured app stdout/stderr — copied into the failure-artifact bundle.

--- a/tests/system/tests/test_orchestrator.py
+++ b/tests/system/tests/test_orchestrator.py
@@ -99,13 +99,23 @@ class _FakePopen:
 
 
 class _FakeProc:
-    """A psutil.Process stand-in recording terminate()/kill() calls."""
+    """A psutil.Process stand-in recording terminate()/kill() calls.
+
+    ``cmdline()`` is a method (not cached in ``.info``) to mirror the reaper's
+    lazy fetch — it only reads the command line for name-matched processes.
+    """
 
     def __init__(self, name, cmdline, *, survives=False):
-        self.info = {"name": name, "cmdline": cmdline}
+        self.info = {"name": name}
+        self._cmdline = cmdline
         self.survives = survives
         self.terminated = False
         self.killed = False
+        self.cmdline_read = False
+
+    def cmdline(self):
+        self.cmdline_read = True
+        return self._cmdline
 
     def terminate(self):
         self.terminated = True
@@ -193,6 +203,8 @@ def test_terminate_webview2_children_reaps_only_matching(monkeypatch):
     assert stubborn.terminated and stubborn.killed  # escalated after surviving
     assert not other_instance.terminated  # different instance — left alone
     assert not app_proc.terminated  # not a WebView2 host — left alone
+    # Name pre-filter must skip the costly cmdline read for non-WebView2 procs.
+    assert not app_proc.cmdline_read
 
 
 def _make_app(monkeypatch, tmp_path, system):

--- a/tests/system/tests/test_orchestrator.py
+++ b/tests/system/tests/test_orchestrator.py
@@ -72,3 +72,163 @@ def test_candidates_are_release_then_debug(fake_repo: Path):
     release, debug = orchestrator.app_binary_candidates()
     assert release == fake_repo / "target/release/termihub"
     assert debug == fake_repo / "target/debug/termihub"
+
+
+# ── WebView2 child reaping on Windows teardown (issue #1022) ──────────────────
+
+
+class _FakeStdout:
+    """A stdout stand-in the pump thread can iterate (empty) and close."""
+
+    def __iter__(self):
+        return iter(())
+
+    def close(self):
+        pass
+
+
+class _FakePopen:
+    """A subprocess.Popen stand-in that never really launches anything."""
+
+    def __init__(self):
+        self.pid = 4321
+        self.stdout = _FakeStdout()
+
+    def poll(self):
+        return None
+
+
+class _FakeProc:
+    """A psutil.Process stand-in recording terminate()/kill() calls."""
+
+    def __init__(self, name, cmdline, *, survives=False):
+        self.info = {"name": name, "cmdline": cmdline}
+        self.survives = survives
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+def test_is_webview2_matches_pinned_data_dir():
+    data_dir = Path(r"C:\Temp\inst-1\webview2-user-data")
+    assert orchestrator._is_webview2_for_data_dir(
+        "msedgewebview2.exe",
+        ["msedgewebview2.exe", f"--user-data-dir={data_dir}", "--type=renderer"],
+        data_dir,
+    )
+
+
+def test_is_webview2_rejects_other_process_names():
+    data_dir = Path(r"C:\Temp\inst-1\webview2-user-data")
+    # The app process itself references the folder via env but must not be reaped.
+    assert not orchestrator._is_webview2_for_data_dir(
+        "termihub.exe", ["termihub.exe", str(data_dir)], data_dir
+    )
+
+
+def test_is_webview2_rejects_other_instances_data_dir():
+    mine = Path(r"C:\Temp\inst-1\webview2-user-data")
+    theirs = Path(r"C:\Temp\inst-2\webview2-user-data")
+    assert not orchestrator._is_webview2_for_data_dir(
+        "msedgewebview2.exe",
+        ["msedgewebview2.exe", f"--user-data-dir={theirs}"],
+        mine,
+    )
+
+
+def test_is_webview2_normalises_case_and_separators():
+    # WebView2 may report the path with different casing / mixed separators.
+    data_dir = Path(r"C:\Temp\inst-1\webview2-user-data")
+    assert orchestrator._is_webview2_for_data_dir(
+        "MsEdgeWebView2.exe",
+        ["--user-data-dir=c:/temp/inst-1/webview2-user-data"],
+        data_dir,
+    )
+
+
+def test_terminate_webview2_children_noop_off_windows(monkeypatch):
+    monkeypatch.setattr(orchestrator.platform, "system", lambda: "Linux")
+
+    def _fail(*_a, **_k):
+        raise AssertionError("process_iter must not run off Windows")
+
+    monkeypatch.setattr(orchestrator.psutil, "process_iter", _fail)
+    # Must return without touching psutil at all.
+    orchestrator._terminate_webview2_children(Path("/whatever"))
+
+
+def test_terminate_webview2_children_reaps_only_matching(monkeypatch):
+    monkeypatch.setattr(orchestrator.platform, "system", lambda: "Windows")
+    data_dir = Path(r"C:\Temp\inst-1\webview2-user-data")
+
+    match = _FakeProc(
+        "msedgewebview2.exe", ["--user-data-dir=" + str(data_dir), "--type=gpu-process"]
+    )
+    stubborn = _FakeProc(
+        "msedgewebview2.exe",
+        ["--user-data-dir=" + str(data_dir), "--type=renderer"],
+        survives=True,
+    )
+    other_instance = _FakeProc(
+        "msedgewebview2.exe", [r"--user-data-dir=C:\Temp\inst-2\webview2-user-data"]
+    )
+    app_proc = _FakeProc("termihub.exe", ["termihub.exe", str(data_dir)])
+    procs = [match, stubborn, other_instance, app_proc]
+
+    monkeypatch.setattr(orchestrator.psutil, "process_iter", lambda _attrs: procs)
+    monkeypatch.setattr(
+        orchestrator.psutil,
+        "wait_procs",
+        lambda victims, timeout: ([], [p for p in victims if p.survives]),
+    )
+
+    orchestrator._terminate_webview2_children(data_dir)
+
+    assert match.terminated and not match.killed
+    assert stubborn.terminated and stubborn.killed  # escalated after surviving
+    assert not other_instance.terminated  # different instance — left alone
+    assert not app_proc.terminated  # not a WebView2 host — left alone
+
+
+def _make_app(monkeypatch, tmp_path, system):
+    """Build an AppInstance with launch fully stubbed, on the given platform."""
+    monkeypatch.setattr(orchestrator, "app_binary_path", lambda: tmp_path / "app.exe")
+    monkeypatch.setattr(orchestrator.platform, "system", lambda: system)
+    monkeypatch.setattr(orchestrator, "_terminate_webview2_children", lambda *_a, **_k: None)
+    # Never touch a real PID for the fake process on stop().
+    monkeypatch.setattr(orchestrator, "_terminate_tree", lambda *_a, **_k: None)
+    captured = {}
+
+    def _fake_popen(_argv, *, env, **_kwargs):
+        captured["env"] = env
+        return _FakePopen()
+
+    monkeypatch.setattr(orchestrator.subprocess, "Popen", _fake_popen)
+    instance = orchestrator.AppInstance(config_dir=tmp_path)
+    return instance, captured
+
+
+def test_start_pins_webview2_folder_on_windows(tmp_path, monkeypatch):
+    instance, captured = _make_app(monkeypatch, tmp_path, "Windows")
+    instance.start(9999)
+    try:
+        assert captured["env"]["WEBVIEW2_USER_DATA_FOLDER"] == str(
+            instance._webview2_data_dir
+        )
+        assert instance._webview2_data_dir == tmp_path / "webview2-user-data"
+    finally:
+        instance.stop()
+
+
+def test_start_omits_webview2_folder_off_windows(tmp_path, monkeypatch):
+    instance, captured = _make_app(monkeypatch, tmp_path, "Linux")
+    instance.start(9999)
+    try:
+        assert "WEBVIEW2_USER_DATA_FOLDER" not in captured["env"]
+    finally:
+        instance.stop()


### PR DESCRIPTION
## Summary

On Windows, each launched app instance spawns several `msedgewebview2.exe` renderer/GPU/utility processes under a host that is **not** a descendant of `termihub.exe`. `_terminate_tree` therefore missed them and they leaked across test runs (observed ~52 after ~15 launches), progressively slowing and destabilizing later instances until teardown ERRORs and cold-start timeouts appeared. Fixes #1022.

## Fix

- `AppInstance.start()` pins each instance's WebView2 user-data folder via `WEBVIEW2_USER_DATA_FOLDER` (Windows only). The app sets no Tauri `data_directory`, so wry passes an empty string to `CreateCoreWebView2EnvironmentWithOptions` and WebView2 honors the env var.
- `AppInstance.stop()` enumerates `msedgewebview2.exe` processes whose `--user-data-dir` matches this instance and terminates them (escalating to kill). Matching on the per-instance folder keeps it safe under parallel instances.
- Every teardown path (`restart`, `cleanup`, `__exit__`) funnels through `stop()`, so there is a single wiring point.

## Quality pass (`/simplify`)

- Extracted the shared terminate→wait→kill escalation into `_terminate_procs`, reused by `_terminate_tree` and the reaper.
- Name pre-filter before `proc.cmdline()` (costly on Windows) so the command line isn't read for the whole process table on every teardown — regression-tested.
- Inlined a single-use helper and dropped a redundant guard.

## Tests

TDD: the test commit precedes the fix, and all 8 new tests were confirmed to fail without the implementation. Coverage (cross-platform, via fakes — no live app launch):

- `_is_webview2_for_data_dir` match predicate: positive, wrong process name, other instance's dir, case/separator normalization.
- `_terminate_webview2_children`: reaps only matching hosts, escalates survivors to kill, no-ops off Windows, and skips the `cmdline()` read for non-WebView2 processes.
- `AppInstance.start()` pins `WEBVIEW2_USER_DATA_FOLDER` on Windows and omits it elsewhere.

`14 passed` (orchestrator) and `150 passed` (full non-integration suite).

## Test plan

- [x] `./tests/system/pytest.sh -m "not integration"` — 150 passed
- [x] Manual (Windows) — verified locally, see verification comment below: run `tests/system/tests/test_windows_shells.py` back-to-back several times and confirm no `msedgewebview2.exe` accumulation (`tasklist /FI "IMAGENAME eq msedgewebview2.exe"`) and stable runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)