### PR TITLE
fix(ui): raise Vitest testTimeout to absorb Windows CI runner starvation (Closes #1025)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -394,6 +394,17 @@ vi.mock("@tauri-apps/api/fs", () => ({
 }));
 ```
 
+### 6. Component-test timeout (Windows CI flake, #1025)
+
+The global Vitest `testTimeout` is raised to **15000ms** in `vitest.config.ts`
+(the default is 5000ms). The React-DOM `createRoot` component tests are otherwise
+instant — immediately-resolving mocks, no real timers — but the `windows-latest`
+CI runner has been observed spending 240s+ on environment setup alone, starving
+those tests enough to trip the 5s default (originally seen in
+`HttpMonitorPanel.race.test.tsx`). The larger budget absorbs that runner jitter
+without masking genuine hangs. If a test legitimately needs to run longer, prefer
+a per-`it` override (`it("…", async () => { … }, 30000)`) over lowering the global.
+
 ## Test Scripts for package.json
 
 ```json

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,12 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     exclude: ["tests/e2e/**", "node_modules/**"],
+    // The default 5000ms testTimeout is too tight for the React-DOM `createRoot`
+    // component tests when the runner is starved: the Windows CI job has been seen
+    // spending 240s+ just on environment setup, leaving otherwise-instant tests
+    // (immediately-resolving mocks, no real timers) to trip the timeout under load.
+    // Bumping to 15s absorbs that jitter without hiding genuine hangs. See #1025.
+    testTimeout: 15000,
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary

Fixes the flaky `HttpMonitorPanel.race.test.tsx` timeout on the `windows-latest` CI runner (#1025). The failure was environmental, not a logic bug: the runner was starved (240s+ on Vitest environment setup alone), which left otherwise-instant React-DOM `createRoot` tests — immediately-resolving mocks, no real timers — to trip the default **5000ms** `testTimeout`.

Rather than scope the fix to one file, the root cause (runner starvation) can hit any of the 60+ `createRoot` component tests, so the global `testTimeout` is raised to **15000ms**. This absorbs runner jitter without hiding genuine hangs — a real deadlock still fails, just after 15s instead of 5s.

## Changes

- `vitest.config.ts` — global `testTimeout: 15000` with a comment explaining the Windows-load rationale (was the 5000ms default).
- `docs/testing.md` — added a "Component-test timeout (Windows CI flake, #1025)" regression note under Testing Best Practices, recommending per-`it` overrides over lowering the global.

## Why not TDD

The "bug" is CI runner starvation, which can't be reproduced as a deterministic failing unit test — the fix is a timeout budget. It's verified by the existing suite continuing to pass.

## Test plan

- [x] `pnpm vitest run src/components/NetworkTools/HttpMonitorPanel.race.test.tsx` → 3/3 pass (~1.3s)
- [x] `./scripts/test.sh` — full frontend + backend + agent suite passes
- [x] `./scripts/check.sh` — formatting, lint, clippy pass
- [ ] Confirm no recurrence of the flake across repeated `windows-latest` CI runs (acceptance criterion — observable only post-merge)

Closes #1025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
