### PR TITLE
test(agent): live remote-agent E2E + persistent-session disconnect fix (#995)

### DIFF
--- a/agent/src/daemon/transport.rs
+++ b/agent/src/daemon/transport.rs
@@ -80,7 +80,7 @@ where
 
 #[cfg(unix)]
 #[allow(unused_imports)]
-pub use unix_impl::{connect, endpoint_alive, session_endpoint, DaemonListener};
+pub use unix_impl::{connect, endpoint_alive, open_daemon_log, session_endpoint, DaemonListener};
 #[cfg(windows)]
 #[allow(unused_imports)]
 pub use windows_impl::{connect, endpoint_alive, session_endpoint, DaemonListener};
@@ -123,6 +123,21 @@ mod unix_impl {
         std::fs::create_dir_all(dir)?;
         std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
         Ok(())
+    }
+
+    /// Open (truncating) the daemon's per-session log file in the socket dir.
+    ///
+    /// The launcher points the detached daemon's stderr here instead of
+    /// inheriting the agent's stderr: over SSH that stderr is the exec channel,
+    /// and keeping it tethers the daemon's life to the SSH connection (a
+    /// disconnect then kills the persistent session). A sibling of the socket
+    /// (`session-{id}.log`) keeps daemon diagnostics without that coupling.
+    /// Best-effort: returns `None` if the dir or file can't be created, and the
+    /// caller falls back to a null stderr.
+    pub fn open_daemon_log(session_id: &str) -> Option<std::fs::File> {
+        let dir = socket_dir();
+        ensure_socket_dir(&dir).ok()?;
+        std::fs::File::create(dir.join(format!("session-{session_id}.log"))).ok()
     }
 
     /// A listening Unix domain socket bound to a per-user, `0o700` path.
@@ -478,6 +493,25 @@ mod tests {
         let endpoint = session_endpoint("xyz");
         assert!(endpoint.starts_with("/tmp/termihub/"), "got {endpoint}");
         assert!(endpoint.ends_with("session-xyz.sock"), "got {endpoint}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_daemon_log_creates_a_writable_sibling_of_the_socket() {
+        // The daemon logs beside its socket (never into the inherited SSH
+        // channel), so the file must land in the same per-user dir and be
+        // writable — otherwise the launcher falls back to a null stderr.
+        let session = unique_session("log");
+        let mut file = open_daemon_log(&session).expect("daemon log file");
+        use std::io::Write;
+        file.write_all(b"ok").expect("write to daemon log");
+        // Same per-user dir as the socket, with a `.log` extension.
+        let expected = session_endpoint(&session).replace(".sock", ".log");
+        assert!(
+            std::path::Path::new(&expected).exists(),
+            "missing {expected}"
+        );
+        let _ = std::fs::remove_file(&expected);
     }
 
     #[cfg(windows)]

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -138,6 +138,67 @@ pub trait DaemonLauncher: Send + Sync + 'static {
     ) -> Result<SessionBackend, anyhow::Error>;
 }
 
+/// Point a to-be-spawned daemon's stderr somewhere that outlives the agent.
+///
+/// The daemon must **not** inherit the agent's stderr: when the agent is reached
+/// over SSH that stderr is the exec channel of `termihub-agent --stdio`, and
+/// keeping it tethers the daemon's lifetime to the SSH connection — a disconnect
+/// tears the channel down and takes the persistent-session daemon with it (so a
+/// reconnect finds nothing to re-attach). A detached daemon owns its own stderr
+/// on every platform: on unix it logs to a per-session file in its socket dir
+/// (diagnostics without the coupling), falling back to null; elsewhere it is
+/// discarded to null (a Windows per-session log path is a future refinement).
+fn configure_daemon_stderr(command: &mut std::process::Command, session_id: &str) {
+    #[cfg(unix)]
+    let stderr = match crate::daemon::transport::open_daemon_log(session_id) {
+        Some(file) => std::process::Stdio::from(file),
+        None => std::process::Stdio::null(),
+    };
+    #[cfg(not(unix))]
+    let stderr = {
+        let _ = session_id;
+        std::process::Stdio::null()
+    };
+    command.stderr(stderr);
+}
+
+/// Detach a to-be-spawned daemon so it outlives the agent that spawns it — the
+/// whole point of a *persistent* session.
+///
+/// On Windows: a new process group with no console window. On unix: a fresh
+/// session via `setsid`. Being merely orphaned (the agent never waits on the
+/// child) is **not** enough on unix, because the agent is typically launched
+/// over an SSH exec channel (`termihub-agent --stdio`); when that channel closes
+/// sshd sends SIGHUP to the whole session, killing any daemon still in it, so a
+/// reconnect would find no session to re-attach. `setsid` moves the daemon out
+/// of the SSH session's process group, immunising it against that hangup.
+/// (Detaching stderr from the same channel — see [`configure_daemon_stderr`] —
+/// is the other half of surviving the disconnect.)
+fn configure_daemon_detachment(command: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::{
+            CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS,
+        };
+        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Safety: `setsid` is async-signal-safe and touches no shared state of
+        // the (forked, not-yet-exec'd) child before the following `exec`.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+}
+
 /// Production [`DaemonLauncher`] that spawns real `termihub-agent --daemon` processes.
 pub struct SystemDaemonLauncher;
 
@@ -164,21 +225,9 @@ impl DaemonLauncher for SystemDaemonLauncher {
             .env("TERMIHUB_SETTINGS", &settings_json)
             .env("TERMIHUB_BUFFER_SIZE", buffer_size_bytes.to_string())
             .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::inherit());
-
-        // On Windows, detach the daemon from the agent's console and process
-        // group so it survives the agent exiting and shows no console window.
-        // On unix the daemon detaches by being orphaned (the agent never waits
-        // on the child), so no extra flags are needed.
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt;
-            use windows_sys::Win32::System::Threading::{
-                CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS,
-            };
-            command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
-        }
+            .stdout(std::process::Stdio::null());
+        configure_daemon_stderr(&mut command, session_id);
+        configure_daemon_detachment(&mut command);
 
         let mut child = command
             .spawn()
@@ -873,6 +922,32 @@ mod tests {
 
     fn test_registry() -> Arc<ConnectionTypeRegistry> {
         Arc::new(crate::registry::build_registry())
+    }
+
+    // ── daemon detachment (issue #995) ───────────────────────────────
+
+    #[cfg(unix)]
+    #[test]
+    fn configure_daemon_detachment_starts_a_new_session() {
+        // A persistent-session daemon must survive the agent (and its SSH exec
+        // channel) going away. On unix that requires the spawned child to leave
+        // the SSH session via `setsid` — otherwise sshd's SIGHUP on disconnect
+        // kills it and a reconnect finds nothing to re-attach. Assert the child a
+        // detachment-configured Command spawns is a session leader (its session id
+        // equals its pid), which only holds after `setsid`.
+        let mut command = std::process::Command::new("sleep");
+        command.arg("30");
+        configure_daemon_detachment(&mut command);
+        let mut child = command.spawn().expect("spawn sleep");
+        let pid = child.id() as libc::pid_t;
+        // Safety: `getsid` merely reads the session id of an existing pid.
+        let sid = unsafe { libc::getsid(pid) };
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_eq!(
+            sid, pid,
+            "daemon child should be its own session leader (setsid)"
+        );
     }
 
     // ── connect_or_daemon_exit (issue #847) ──────────────────────────

--- a/docs/changes/feature/995-remote-agent-live-e2e.md
+++ b/docs/changes/feature/995-remote-agent-live-e2e.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Agent: persistent remote-agent sessions now survive an SSH disconnect and can be
+  re-attached after reconnecting. The session daemon was being killed when the SSH
+  connection dropped (it stayed in the SSH login session and inherited the SSH channel's
+  stderr); it is now fully detached from the connection, so reconnecting re-lists and
+  re-attaches the still-running session (#995).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -903,42 +903,42 @@ When adding new manual tests, add the YAML definition to the appropriate file in
 
 Mapping of manual test IDs that have been automated to their Python harness test files:
 
-| Manual Test IDs                  | E2E Test File                                                                                                          |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| MT-LOCAL-01, 07                  | `tests/system/tests/test_local_shell.py`                                                                               |
-| MT-LOCAL-09, 10                  | `tests/system/tests/test_cross_platform.py`                                                                            |
-| MT-LOCAL-02, 04, 06, 11–20       | `tests/system/tests/test_windows_shells.py` (Windows-only; WSL cases skip without WSL2)                                |
-| MT-SSH-04–06, 10–12, 20–33, 35   | `tests/system/tests/test_ssh*.py`                                                                                      |
-| MT-SSH-19 (X11 backward-compat)  | `tests/system/tests/test_connection_forms.py`                                                                          |
-| MT-SSH-08 (agent-auth warning)   | _dropped_ (`agent` is no longer a selectable SSH auth method)                                                          |
-| MT-SSH-13, 17, 34                | `tests/system/tests/test_ssh_extended.py`                                                                              |
-| SERIAL-01, 05 + custom path      | `tests/system/tests/test_serial.py`                                                                                    |
-| MT-SER-09 (live serial I/O)      | _manual_ (no host socat echo fixture in harness yet, #859)                                                             |
-| TELNET-01–03                     | `tests/system/tests/test_telnet.py`                                                                                    |
-| MT-TAB-01–05, 15, 18             | `tests/system/tests/test_tab_management.py`                                                                            |
-| MT-TAB-08–14, 19–21              | `tests/system/tests/test_tab_horizontal_scroll.py`                                                                     |
-| MT-CONN-02–07, 25–30             | `test_connection_crud.py`, `test_connection_forms.py`, `test_connection_editor.py`                                     |
-| MT-CONN-10–11, 13                | `tests/system/tests/test_export_import.py`                                                                             |
-| MT-CONN-12, 14–16 (enc. import)  | _manual_ (import opens a native OS file picker)                                                                        |
-| MT-CONN-20–22, 31                | `tests/system/tests/test_external_files.py`                                                                            |
-| MT-FB-01, 02                     | `tests/system/tests/test_file_browser_local.py`                                                                        |
-| MT-FB-03, 13, 19                 | `tests/system/tests/test_sftp_infra.py`                                                                                |
-| MT-FB-06, 17                     | _manual_ (serial not bridge-selectable; SFTP fault injection)                                                          |
-| MT-FB-05, 11, 18                 | `tests/system/tests/test_file_browser_local.py`                                                                        |
-| EDITOR-01/STATUS/INDENT/LANG     | `tests/system/tests/test_editor.py`                                                                                    |
-| #504 (terminal auto-scroll)      | `tests/system/tests/test_terminal_auto_scroll.py`                                                                      |
-| MT-UI-06–08                      | `tests/system/tests/test_ui_state.py`                                                                                  |
-| MT-UI-17, 18, 20                 | _manual_ (OS window resize / dev favicon — not bridge-drivable)                                                        |
-| MT-UI-21                         | `tests/system/tests/test_sidebar_sections.py`                                                                          |
-| MT-UI-22–25                      | _manual_ (separator size/cursor, overflow scroll — visual)                                                             |
-| MT-AGENT (create/error/setup)    | `tests/system/tests/test_remote_agent.py` (create, error dialog, setup wizard vs. the password container)              |
-| MT-AGENT (live connect/sessions) | _deferred_ (#995 — needs a deployed-agent Docker fixture)                                                              |
-| MT-CRED-04–08                    | `tests/system/tests/test_credential_store.py`                                                                          |
-| MT-RECOVERY-01–06                | `tests/system/tests/test_config_recovery.py`                                                                           |
-| MT-RECOVERY-07–12                | covered by `test_connection_crud.py` / `test_credential_store.py` / `test_export_import.py` / `test_external_files.py` |
-| MT-XPLAT-01, 02                  | `tests/system/tests/test_cross_platform.py`                                                                            |
-| MT-SVC-01, 02, 03                | `tests/system/tests/test_embedded_services.py` (SVC-01..11)                                                            |
-| MT-SVC-04, 05 (transfer)         | `tests/system/tests/test_embedded_services.py` (SVC-12 FTP, SVC-13 TFTP via curl)                                      |
-| MT-NET-01–09                     | `tests/system/tests/test_network_tools.py`                                                                             |
-| MT-NET-10, 12, 14, 17, 18        | `tests/system/tests/test_network_tools_live.py` (loopback + local stdlib servers; no Docker `network` profile)         |
-| MT-NET-13                        | _manual_ (large-range warning is a native `window.confirm()`, no `data-testid`)                                        |
+| Manual Test IDs                  | E2E Test File                                                                                                                                                                            |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MT-LOCAL-01, 07                  | `tests/system/tests/test_local_shell.py`                                                                                                                                                 |
+| MT-LOCAL-09, 10                  | `tests/system/tests/test_cross_platform.py`                                                                                                                                              |
+| MT-LOCAL-02, 04, 06, 11–20       | `tests/system/tests/test_windows_shells.py` (Windows-only; WSL cases skip without WSL2)                                                                                                  |
+| MT-SSH-04–06, 10–12, 20–33, 35   | `tests/system/tests/test_ssh*.py`                                                                                                                                                        |
+| MT-SSH-19 (X11 backward-compat)  | `tests/system/tests/test_connection_forms.py`                                                                                                                                            |
+| MT-SSH-08 (agent-auth warning)   | _dropped_ (`agent` is no longer a selectable SSH auth method)                                                                                                                            |
+| MT-SSH-13, 17, 34                | `tests/system/tests/test_ssh_extended.py`                                                                                                                                                |
+| SERIAL-01, 05 + custom path      | `tests/system/tests/test_serial.py`                                                                                                                                                      |
+| MT-SER-09 (live serial I/O)      | _manual_ (no host socat echo fixture in harness yet, #859)                                                                                                                               |
+| TELNET-01–03                     | `tests/system/tests/test_telnet.py`                                                                                                                                                      |
+| MT-TAB-01–05, 15, 18             | `tests/system/tests/test_tab_management.py`                                                                                                                                              |
+| MT-TAB-08–14, 19–21              | `tests/system/tests/test_tab_horizontal_scroll.py`                                                                                                                                       |
+| MT-CONN-02–07, 25–30             | `test_connection_crud.py`, `test_connection_forms.py`, `test_connection_editor.py`                                                                                                       |
+| MT-CONN-10–11, 13                | `tests/system/tests/test_export_import.py`                                                                                                                                               |
+| MT-CONN-12, 14–16 (enc. import)  | _manual_ (import opens a native OS file picker)                                                                                                                                          |
+| MT-CONN-20–22, 31                | `tests/system/tests/test_external_files.py`                                                                                                                                              |
+| MT-FB-01, 02                     | `tests/system/tests/test_file_browser_local.py`                                                                                                                                          |
+| MT-FB-03, 13, 19                 | `tests/system/tests/test_sftp_infra.py`                                                                                                                                                  |
+| MT-FB-06, 17                     | _manual_ (serial not bridge-selectable; SFTP fault injection)                                                                                                                            |
+| MT-FB-05, 11, 18                 | `tests/system/tests/test_file_browser_local.py`                                                                                                                                          |
+| EDITOR-01/STATUS/INDENT/LANG     | `tests/system/tests/test_editor.py`                                                                                                                                                      |
+| #504 (terminal auto-scroll)      | `tests/system/tests/test_terminal_auto_scroll.py`                                                                                                                                        |
+| MT-UI-06–08                      | `tests/system/tests/test_ui_state.py`                                                                                                                                                    |
+| MT-UI-17, 18, 20                 | _manual_ (OS window resize / dev favicon — not bridge-drivable)                                                                                                                          |
+| MT-UI-21                         | `tests/system/tests/test_sidebar_sections.py`                                                                                                                                            |
+| MT-UI-22–25                      | _manual_ (separator size/cursor, overflow scroll — visual)                                                                                                                               |
+| MT-AGENT (create/error/setup)    | `tests/system/tests/test_remote_agent.py` (create, error dialog, setup wizard vs. the password container)                                                                                |
+| MT-AGENT (live connect/sessions) | `tests/system/tests/test_remote_agent_live.py` (live connect + shells, child shell session, persistent-session reconnect, connected-agent menu — vs. the deployed-agent container, #995) |
+| MT-CRED-04–08                    | `tests/system/tests/test_credential_store.py`                                                                                                                                            |
+| MT-RECOVERY-01–06                | `tests/system/tests/test_config_recovery.py`                                                                                                                                             |
+| MT-RECOVERY-07–12                | covered by `test_connection_crud.py` / `test_credential_store.py` / `test_export_import.py` / `test_external_files.py`                                                                   |
+| MT-XPLAT-01, 02                  | `tests/system/tests/test_cross_platform.py`                                                                                                                                              |
+| MT-SVC-01, 02, 03                | `tests/system/tests/test_embedded_services.py` (SVC-01..11)                                                                                                                              |
+| MT-SVC-04, 05 (transfer)         | `tests/system/tests/test_embedded_services.py` (SVC-12 FTP, SVC-13 TFTP via curl)                                                                                                        |
+| MT-NET-01–09                     | `tests/system/tests/test_network_tools.py`                                                                                                                                               |
+| MT-NET-10, 12, 14, 17, 18        | `tests/system/tests/test_network_tools_live.py` (loopback + local stdlib servers; no Docker `network` profile)                                                                           |
+| MT-NET-13                        | _manual_ (large-range warning is a native `window.confirm()`, no `data-testid`)                                                                                                          |

--- a/tests/docker/remote-agent/.gitignore
+++ b/tests/docker/remote-agent/.gitignore
@@ -1,0 +1,3 @@
+# Agent binary staged into this build context by the harness fixture
+# (`remote_agent_fixtures`). It is a per-arch static-musl build, never committed.
+termihub-agent

--- a/tests/docker/remote-agent/Dockerfile
+++ b/tests/docker/remote-agent/Dockerfile
@@ -1,15 +1,27 @@
 # termiHub Remote Agent test container
 #
-# Provides an SSH-accessible host with the termihub-agent binary
-# pre-installed for E2E testing.
+# Provides an SSH-accessible host with the `termihub-agent` binary
+# **pre-installed** for the live-connect E2E tests (#995).
 #
-# Usage:
+# The agent binary is not committed to the repo — it is a static-musl build
+# cross-compiled for the container architecture and staged into this build
+# context by the Python harness fixture (`remote_agent_fixtures`) right before
+# the image is built. See `tests/system/termihub_harness/fixtures.py`
+# (`stage_remote_agent_binary`). The staged file is git-ignored (see the sibling
+# `.gitignore`).
+#
+# Usage (normally driven by the harness, not by hand):
+#   ./scripts/build-agents.sh --targets x86_64-unknown-linux-musl
+#   cp target/x86_64-unknown-linux-musl/release/termihub-agent \
+#      tests/docker/remote-agent/termihub-agent
+#   docker compose -f tests/docker/docker-compose.yml --profile agent build remote-agent
 #   docker compose -f tests/docker/docker-compose.yml --profile agent up -d
-#   # Connects on port 2211 (testuser/testpass)
+#   # Connects on port 2211 (testuser/testpass) with the agent already deployed.
 #
-# Note: The agent binary must be cross-compiled for Linux x86_64
-# before building this container. Use:
-#   cargo build --release -p termihub-agent --target x86_64-unknown-linux-gnu
+# The agent is installed to `~testuser/.local/bin/termihub-agent`, the POSIX
+# default path the desktop probes and launches (`$HOME/.local/bin/termihub-agent
+# --stdio`; see `src-tauri/src/terminal/backend.rs`), so a live connect finds it
+# without any setup wizard step.
 
 FROM ubuntu:24.04
 
@@ -33,13 +45,14 @@ RUN chown -R testuser:testuser /home/testuser/.ssh && \
     chmod 700 /home/testuser/.ssh && \
     chmod 600 /home/testuser/.ssh/authorized_keys
 
+# Deploy the pre-built agent binary to the POSIX default install path. The file
+# is staged into the build context by the harness fixture before `build`.
+COPY termihub-agent /home/testuser/.local/bin/termihub-agent
+RUN chown -R testuser:testuser /home/testuser/.local && \
+    chmod 755 /home/testuser/.local/bin/termihub-agent
+
 # Generate host keys
 RUN ssh-keygen -A
-
-# Note: The agent binary will be installed via the setup wizard during tests.
-# For tests that require a pre-installed agent, build and copy the binary:
-# COPY termihub-agent /usr/local/bin/termihub-agent
-# RUN chmod +x /usr/local/bin/termihub-agent
 
 EXPOSE 22
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -18,6 +18,8 @@ from termihub_harness.manual import (
 )
 
 from termihub_harness import (
+    REMOTE_AGENT_PORT,
+    REMOTE_AGENT_SERVICE,
     SSH_BANNER_PORT,
     SSH_BANNER_SERVICE,
     SSH_HOST,
@@ -35,6 +37,7 @@ from termihub_harness import (
     Bridge,
     ComposeFixture,
     ContainerRuntimeUnavailable,
+    stage_remote_agent_binary,
 )
 
 
@@ -216,6 +219,29 @@ def telnet_fixtures():
     return _ensure_services(
         [(TELNET_HOST, TELNET_SERVICE, TELNET_PORT)], label="telnet"
     )
+
+
+@pytest.fixture(scope="session")
+def remote_agent_fixtures():
+    """Deployed-agent SSH container (compose profile ``agent``, port 2211).
+
+    Unlike ``ssh_fixtures``, this bakes a freshly-built ``termihub-agent`` binary
+    into the image, so a live connect finds the agent already installed (#995).
+    Stages the per-arch static-musl binary into the build context, then builds and
+    brings up the ``remote-agent`` service. Skips the suite cleanly when no
+    container runtime is reachable *or* the agent cross-build is unavailable — the
+    same contract as the other container fixtures, so hosts without the cross
+    toolchain (or without Docker) stay green.
+    """
+    try:
+        stage_remote_agent_binary()
+        fixture = ComposeFixture()
+        fixture.ensure(
+            REMOTE_AGENT_SERVICE, ports=[(SSH_HOST, REMOTE_AGENT_PORT)], build=True
+        )
+    except ContainerRuntimeUnavailable as exc:
+        pytest.skip(f"deployed-agent container fixture unavailable: {exc}")
+    return fixture
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/tests/system/termihub_harness/__init__.py
+++ b/tests/system/termihub_harness/__init__.py
@@ -7,6 +7,8 @@ tests that run identically on Linux, Windows, and macOS (issue #802).
 
 from .bridge import Bridge, BridgeError, Driver, screenshot_to_png_bytes
 from .fixtures import (
+    REMOTE_AGENT_PORT,
+    REMOTE_AGENT_SERVICE,
     SSH_BANNER_PORT,
     SSH_BANNER_SERVICE,
     SSH_HOST,
@@ -27,6 +29,7 @@ from .fixtures import (
     ComposeFixture,
     ContainerRuntimeUnavailable,
     container_runtime,
+    stage_remote_agent_binary,
     wait_for_port,
 )
 from .manual import (
@@ -117,7 +120,10 @@ __all__ = [
     "ComposeFixture",
     "ContainerRuntimeUnavailable",
     "container_runtime",
+    "stage_remote_agent_binary",
     "wait_for_port",
+    "REMOTE_AGENT_SERVICE",
+    "REMOTE_AGENT_PORT",
     "SSH_HOST",
     "SSH_PASSWORD_SERVICE",
     "SSH_PASSWORD_PORT",

--- a/tests/system/termihub_harness/fixtures.py
+++ b/tests/system/termihub_harness/fixtures.py
@@ -19,6 +19,7 @@ TCP port** — the same signal the Rust integration tests use.
 from __future__ import annotations
 
 import os
+import platform
 import shutil
 import socket
 import subprocess
@@ -66,6 +67,29 @@ TELNET_HOST = "127.0.0.1"
 #: Service + host port for the telnet container (in.telnetd via xinetd on :23).
 TELNET_SERVICE = "telnet-server"
 TELNET_PORT = dev_local.service_port("TERMIHUB_TEST_TELNET_PORT", 2301)
+
+# ── Remote-agent fixture coordinates (mirror tests/docker/docker-compose.yml) ──
+#: Service + host port for the deployed-agent SSH container (compose profile
+#: ``agent``). Unlike ``ssh-password``, this image ships the ``termihub-agent``
+#: binary at the POSIX default install path, so a live connect finds it without
+#: running the setup wizard (see :func:`stage_remote_agent_binary` and #995).
+REMOTE_AGENT_SERVICE = "remote-agent"
+REMOTE_AGENT_PORT = dev_local.service_port("TERMIHUB_TEST_REMOTE_AGENT_PORT", 2211)
+#: Build context the harness stages the per-arch agent binary into before the
+#: image is built (git-ignored — see the sibling ``.gitignore``).
+_REMOTE_AGENT_BUILD_CONTEXT = REPO_ROOT / "tests" / "docker" / "remote-agent"
+
+#: Map a ``platform.machine()`` value to the static-musl target triple whose
+#: binary runs in a Linux container of the same architecture. Static musl is used
+#: so the binary has no glibc/arch coupling to the ``ubuntu:24.04`` base image —
+#: it runs on any Linux of the matching arch (see ``scripts/build-agents.sh``).
+_MUSL_TARGET_BY_MACHINE = {
+    "x86_64": "x86_64-unknown-linux-musl",
+    "amd64": "x86_64-unknown-linux-musl",
+    "aarch64": "aarch64-unknown-linux-musl",
+    "arm64": "aarch64-unknown-linux-musl",
+    "armv7l": "armv7-unknown-linux-musleabihf",
+}
 
 
 class ContainerRuntimeUnavailable(RuntimeError):
@@ -121,6 +145,7 @@ class ComposeFixture:
         self,
         *services: str,
         ports: Sequence[tuple[str, int]] = (),
+        build: bool = False,
         up_timeout: float = 300.0,
         ready_timeout: float = 90.0,
     ) -> None:
@@ -133,6 +158,12 @@ class ComposeFixture:
         probe of each ``(host, port)`` rather than ``--wait`` (Podman's compose
         provider may not support it). Raises :class:`ContainerRuntimeUnavailable`
         when no runtime is reachable, the compose up fails, or a port never opens.
+
+        When ``build`` is set, the image is (re)built first with ``compose build``
+        — needed for the ``remote-agent`` fixture, whose Dockerfile ``COPY``s a
+        freshly-staged agent binary that ``up -d`` alone would not pick up if the
+        image already exists (Docker rebuilds only the changed layer, so this is
+        cheap when the binary is unchanged).
         """
         runtime = container_runtime()
         if runtime is None:
@@ -145,27 +176,38 @@ class ComposeFixture:
         # host ports (see ``dev_local`` / docs "Parallel test isolation"). The
         # ``ports`` we then probe are computed from the same offset, so they match.
         project = dev_local.compose_project()
-        cmd = [
-            runtime, "compose", "-p", project,
-            "-f", str(self._compose_file), "up", "-d", *services,
-        ]
+        base = [runtime, "compose", "-p", project, "-f", str(self._compose_file)]
         env = {**os.environ, **dev_local.compose_env()}
+        services = list(services)
+        if build:
+            self._run_compose(
+                [*base, "build", *services], services, env=env, timeout=up_timeout, action="build"
+            )
+        self._run_compose(
+            [*base, "up", "-d", *services], services, env=env, timeout=up_timeout, action="up"
+        )
+        for host, port in ports:
+            wait_for_port(host, port, timeout=ready_timeout)
+
+    @staticmethod
+    def _run_compose(
+        cmd: list[str], services: list[str], *, env: dict, timeout: float, action: str
+    ) -> None:
+        """Run a compose subcommand, mapping any failure to a clean skip signal."""
         try:
             subprocess.run(
-                cmd, check=True, timeout=up_timeout, capture_output=True, text=True, env=env
+                cmd, check=True, timeout=timeout, capture_output=True, text=True, env=env
             )
         except subprocess.CalledProcessError as exc:
             raise ContainerRuntimeUnavailable(
-                f"`{runtime} compose up` failed for {list(services)} "
+                f"`compose {action}` failed for {services} "
                 f"(exit {exc.returncode}):\n{_tail(exc.stderr or exc.stdout)}"
             ) from exc
         except subprocess.TimeoutExpired as exc:
             raise ContainerRuntimeUnavailable(
-                f"`{runtime} compose up` timed out after {up_timeout}s for {list(services)}:"
+                f"`compose {action}` timed out after {timeout}s for {services}:"
                 f"\n{_tail(exc.stderr)}"
             ) from exc
-        for host, port in ports:
-            wait_for_port(host, port, timeout=ready_timeout)
 
 
 def _tail(output: Optional[str], lines: int = 15) -> str:
@@ -195,3 +237,73 @@ def wait_for_port(host: str, port: int, *, timeout: float) -> None:
     raise ContainerRuntimeUnavailable(
         f"container port {host}:{port} did not become reachable within {timeout}s: {last_error}"
     )
+
+
+def _container_musl_target() -> str:
+    """The static-musl target triple matching the container's architecture.
+
+    Docker/Podman build and run native-arch images by default, so the container
+    arch equals the host arch; map that to the musl triple whose binary runs in
+    the Linux container. Raises :class:`ContainerRuntimeUnavailable` (→ skip) on
+    an unmapped arch rather than shipping a binary that cannot execute.
+    """
+    machine = platform.machine().lower()
+    target = _MUSL_TARGET_BY_MACHINE.get(machine)
+    if target is None:
+        raise ContainerRuntimeUnavailable(
+            f"no known static-musl agent target for host architecture {machine!r} — "
+            f"supported: {sorted(set(_MUSL_TARGET_BY_MACHINE.values()))}"
+        )
+    return target
+
+
+def stage_remote_agent_binary(*, build_timeout: float = 900.0) -> Path:
+    """Build (if needed) and stage the agent binary into the remote-agent context.
+
+    Produces a static-musl ``termihub-agent`` for the container architecture via
+    ``scripts/build-agents.sh`` and copies it to
+    ``tests/docker/remote-agent/termihub-agent`` so the image ``COPY`` picks it
+    up. An existing per-target build is reused (a fresh musl cross-build is slow),
+    and the copy into the context is always refreshed so a stale image is rebuilt.
+
+    Raises :class:`ContainerRuntimeUnavailable` — turned into a ``pytest.skip`` by
+    the fixture — when the arch is unmapped or the cross-build is unavailable
+    (e.g. ``cross``/Docker not set up on this host). This keeps the deployed-agent
+    suite skipping cleanly instead of failing where the toolchain is missing.
+    """
+    target = _container_musl_target()
+    built = REPO_ROOT / "target" / target / "release" / "termihub-agent"
+    if not built.exists():
+        script = REPO_ROOT / "scripts" / "build-agents.sh"
+        try:
+            subprocess.run(
+                ["bash", str(script), "--targets", target],
+                check=True,
+                timeout=build_timeout,
+                capture_output=True,
+                text=True,
+                cwd=REPO_ROOT,
+            )
+        except FileNotFoundError as exc:
+            raise ContainerRuntimeUnavailable(
+                f"cannot build the agent binary: {exc}"
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            raise ContainerRuntimeUnavailable(
+                f"`build-agents.sh --targets {target}` failed (exit {exc.returncode}) — "
+                f"is the cross toolchain set up (`scripts/setup-agent-cross.sh`)?\n"
+                f"{_tail(exc.stderr or exc.stdout)}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise ContainerRuntimeUnavailable(
+                f"`build-agents.sh --targets {target}` timed out after {build_timeout}s:"
+                f"\n{_tail(exc.stderr)}"
+            ) from exc
+    if not built.exists():
+        raise ContainerRuntimeUnavailable(
+            f"agent binary still missing after build: {built}"
+        )
+    staged = _REMOTE_AGENT_BUILD_CONTEXT / "termihub-agent"
+    shutil.copy2(built, staged)
+    staged.chmod(0o755)
+    return staged

--- a/tests/system/termihub_harness/ui/agent.py
+++ b/tests/system/termihub_harness/ui/agent.py
@@ -37,6 +37,22 @@ class AgentUi(HarnessMixin):
 
     CTX_CONNECT = "context-agent-connect"
     CTX_SETUP = "context-agent-setup"
+    CTX_DISCONNECT = "context-agent-disconnect"
+    CTX_REFRESH = "context-agent-refresh"
+    CTX_NEW_SHELL = "context-agent-new-shell"
+    CTX_NEW_CONNECTION = "context-agent-new-connection"
+    CTX_EDIT = "context-agent-edit"
+    CTX_DELETE = "context-agent-delete"
+
+    # Agent-definition editor (opened as a tab via "New Connection"): a saved
+    # shell/serial connection under a connected agent, optionally persistent.
+    DEF_EDITOR_NAME = "connection-editor-name-input"
+    DEF_EDITOR_TYPE = "connection-editor-type-select"
+    DEF_EDITOR_PERSISTENT = "connection-editor-persistent"
+    DEF_EDITOR_SAVE = "connection-editor-save"
+
+    # Per-definition persistent-session action buttons (id suffix is the def id).
+    CTX_DEF_START_PERSISTENT = "context-agent-def-start-persistent"
 
     ERROR_TITLE = "connection-error-title"
     ERROR_SETUP_AGENT = "connection-error-setup-agent"
@@ -97,33 +113,158 @@ class AgentUi(HarnessMixin):
         return self.require_agent(name)
 
     # ── context menu ────────────────────────────────────────────────────────────
-    def open_agent_menu(self, name: str) -> None:
+    def open_agent_menu(self, name: str, *, sentinel: Optional[str] = None) -> None:
         """Right-click an agent by name and wait for its context menu to mount.
 
         Delegates to :meth:`HarnessMixin.open_named_context_menu`: the agent id is
         re-resolved by name on every poll (a save reloads the store), and the
         right-click is dispatched on the ``agent-header`` element — the actual
         ``ContextMenu.Trigger`` — only once it is in the DOM.
+
+        The menu renders a *different* item set by connection state, so the
+        readiness ``sentinel`` differs too: the default ``context-agent-connect``
+        exists only while **disconnected**; pass ``CTX_DISCONNECT`` to wait on the
+        **connected** menu.
         """
         self.open_named_context_menu(
             resolve=lambda: self.find_agent(name),
             testid_for=self.agent_header_testid,
-            sentinel=self.CTX_CONNECT,
+            sentinel=sentinel or self.CTX_CONNECT,
             what=f"the {name!r} agent context menu",
         )
 
-    def agent_menu_action(self, name: str, action_test_id: str) -> None:
-        """Right-click an agent by name and click a context-menu action."""
-        self.open_agent_menu(name)
+    def agent_menu_action(
+        self, name: str, action_test_id: str, *, sentinel: Optional[str] = None
+    ) -> None:
+        """Right-click an agent by name and click a context-menu action.
+
+        ``sentinel`` selects which menu variant to wait for; it defaults to the
+        clicked action itself, which is correct for actions that only appear in
+        one state (e.g. Disconnect / New Shell Session on a connected agent).
+        """
+        self.open_agent_menu(name, sentinel=sentinel or action_test_id)
         self.driver.click(action_test_id)
 
     def connect_agent(self, name: str) -> None:
         """Trigger a connect on an agent via its context menu."""
         self.agent_menu_action(name, self.CTX_CONNECT)
 
+    def disconnect_agent(self, name: str) -> None:
+        """Trigger a disconnect on a connected agent via its context menu."""
+        self.agent_menu_action(name, self.CTX_DISCONNECT)
+
     def open_agent_setup(self, name: str) -> None:
         """Open the agent-setup wizard via the agent's context menu."""
         self.agent_menu_action(name, self.CTX_SETUP)
+
+    def new_shell_session(self, name: str) -> None:
+        """Create a (non-persistent) shell session under a connected agent."""
+        self.agent_menu_action(name, self.CTX_NEW_SHELL)
+
+    # ── live-connection state ────────────────────────────────────────────────────
+    def agent_connection_state(self, name: str) -> Optional[str]:
+        """The ``connectionState`` of an agent (``connected`` / ``disconnected`` / …)."""
+        agent = self.find_agent(name)
+        return agent.get("connectionState") if agent else None
+
+    def wait_agent_connected(self, name: str, *, timeout: float = 40.0) -> dict[str, Any]:
+        """Wait until an agent reaches the ``connected`` state and return it.
+
+        A live connect runs an SSH handshake and an agent handshake, so this is
+        slower than a plain store update — hence the generous default timeout.
+        """
+        return self.wait(
+            lambda: (
+                agent
+                if (agent := self.find_agent(name))
+                and agent.get("connectionState") == "connected"
+                else None
+            ),
+            what=f"agent {name!r} to reach the connected state",
+            timeout=timeout,
+        )
+
+    def agent_available_shells(self, name: str) -> list[str]:
+        """The shells the connected agent reported in its capabilities."""
+        agent = self.find_agent(name) or {}
+        capabilities = agent.get("capabilities") or {}
+        shells = capabilities.get("availableShells")
+        return [s for s in shells if isinstance(s, str)] if isinstance(shells, list) else []
+
+    def _agent_keyed_dicts(self, state_key: str, agent_id: str) -> list[dict[str, Any]]:
+        """The dict entries of a ``Record<agentId, list>`` store keyed by ``agent_id``."""
+        value = self.driver.get_state(state_key)
+        items = value.get(agent_id) if isinstance(value, dict) else None
+        return [i for i in items if isinstance(i, dict)] if isinstance(items, list) else []
+
+    # ── agent-side sessions ──────────────────────────────────────────────────────
+    def agent_sessions(self, agent_id: str) -> list[dict[str, Any]]:
+        """The live sessions the agent reports for ``agent_id`` (``agentSessions``)."""
+        return self._agent_keyed_dicts("agentSessions", agent_id)
+
+    # ── saved definitions + persistent sessions ─────────────────────────────────
+    def agent_definitions(self, agent_id: str) -> list[dict[str, Any]]:
+        """Saved connection definitions under ``agent_id`` (``agentDefinitions``)."""
+        return self._agent_keyed_dicts("agentDefinitions", agent_id)
+
+    def create_agent_definition(
+        self, agent_name: str, def_name: str, *, persistent: bool = False
+    ) -> dict[str, Any]:
+        """Create a saved connection definition under a connected agent.
+
+        Opens the agent-definition editor via "New Connection", keeps the default
+        session type (the agent's first reported type — a shell on a Linux agent),
+        optionally toggles the persistent switch, saves, and returns the saved
+        definition once it lands in ``agentDefinitions``.
+        """
+        agent = self.require_agent(agent_name)
+        self.agent_menu_action(agent_name, self.CTX_NEW_CONNECTION)
+        self.wait(
+            lambda: self.driver.exists(self.DEF_EDITOR_NAME), what="the agent-definition editor"
+        )
+        self.driver.type(self.DEF_EDITOR_NAME, def_name)
+        if persistent:
+            self.driver.click(self.DEF_EDITOR_PERSISTENT)
+        self.driver.click(self.DEF_EDITOR_SAVE)
+        return self.wait(
+            lambda: next(
+                (
+                    d
+                    for d in self.agent_definitions(agent["id"])
+                    if d.get("name") == def_name
+                ),
+                None,
+            ),
+            what=f"the saved agent definition {def_name!r}",
+        )
+
+    def persistent_session_state(self, agent_id: str, def_id: str) -> Optional[str]:
+        """The ``state`` of the persistent session for ``agent_id:def_id``, if any."""
+        value = self.driver.get_state("persistentSessions")
+        if not isinstance(value, dict):
+            return None
+        entry = value.get(f"{agent_id}:{def_id}")
+        return entry.get("state") if isinstance(entry, dict) else None
+
+    def start_persistent_session(self, def_id: str) -> None:
+        """Start a persistent session via a definition's inline start button."""
+        self.driver.click(f"persistent-start-{def_id}")
+
+    def wait_persistent_running(
+        self, agent_id: str, def_id: str, *, timeout: float = 40.0
+    ) -> None:
+        """Wait until the persistent session for ``agent_id:def_id`` is live.
+
+        ``running`` (or ``attached`` once a tab attaches) is the backend-confirmed
+        live state — the store only transitions there off the
+        ``persistent-session-state-changed`` event, not synchronously on start.
+        """
+        self.wait(
+            lambda: self.persistent_session_state(agent_id, def_id)
+            in ("running", "attached"),
+            what=f"persistent session {agent_id}:{def_id} to reach the running state",
+            timeout=timeout,
+        )
 
     # ── connection-error dialog ─────────────────────────────────────────────────
     def connection_error_present(self) -> bool:

--- a/tests/system/tests/test_remote_agent_live.py
+++ b/tests/system/tests/test_remote_agent_live.py
@@ -1,0 +1,168 @@
+"""Live remote-agent success path — the deployed-agent E2E (#995).
+
+Follow-up from #974: :mod:`test_remote_agent` covers the flows reachable without
+a deployed agent (create / error dialog / setup wizard against the no-agent
+password container). This module covers the **success path**, which needs a
+remote host with the ``termihub-agent`` binary actually installed — the
+``remote-agent`` container (compose profile ``agent``, port 2211), whose image
+bakes in a freshly-built agent binary (see ``remote_agent_fixtures`` /
+``stage_remote_agent_binary``).
+
+These are the ``pending`` describes the old ``infrastructure/remote-agent.test.js``
+never implemented:
+
+* **connect a live agent and see its available shells** (folder expands to real
+  capabilities),
+* **create a shell session under a connected agent** (a working terminal tab),
+* **reconnect and re-attach persistent sessions** (a persistent session survives
+  the SSH connection dropping and reappears on reconnect),
+* the **connect / disconnect / new-session / edit / delete context menu** against
+  a *connected* agent.
+
+The suite skips cleanly when no container runtime is available or the agent
+cross-build toolchain is missing (see ``remote_agent_fixtures``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from termihub_harness import (
+    AgentUi,
+    PasswordPromptUi,
+    REMOTE_AGENT_PORT,
+    SSH_HOST,
+    SSH_PASSWORD,
+    SSH_USERNAME,
+    SettingsUi,
+    SidebarUi,
+    SystemTest,
+    TabsUi,
+    TerminalUi,
+    unique_name,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.usefixtures("remote_agent_fixtures")
+class TestRemoteAgentLive(
+    AgentUi,
+    PasswordPromptUi,
+    SettingsUi,
+    SidebarUi,
+    TabsUi,
+    TerminalUi,
+    SystemTest,
+):
+    """One app for the whole suite; each test creates its own uniquely-named agent."""
+
+    @pytest.fixture(autouse=True)
+    def _cleanup_between_tests(self):
+        yield
+        # Disconnect any agent still connected (frees the SSH + agent handshake),
+        # dismiss a leftover error dialog, and clear the tab slate.
+        self.dismiss_connection_error_if_present()
+        for agent in self.remote_agents():
+            if agent.get("connectionState") not in (None, "disconnected"):
+                self.disconnect_agent(agent["name"])
+        self.close_all_tabs()
+        self.switch_to_connections_sidebar()
+
+    def _create_and_connect(self, label: str) -> dict:
+        """Create a password-auth agent against the deployed-agent container and connect."""
+        name = unique_name(label)
+        agent = self.create_remote_agent(
+            name, host=SSH_HOST, port=REMOTE_AGENT_PORT, username=SSH_USERNAME
+        )
+        self.connect_agent(name)
+        self.handle_password_prompt(SSH_PASSWORD)
+        self.wait_agent_connected(name)
+        return agent
+
+    # ── connect + capabilities ───────────────────────────────────────────────────
+    def test_connect_shows_available_shells(self):
+        agent = self._create_and_connect("agent-live-connect")
+        # A connected agent reports its shells, which the sidebar folder renders as
+        # the "New Shell Session" targets.
+        shells = self.agent_available_shells(agent["name"])
+        assert shells, "connected agent reported no available shells"
+
+    # ── child shell session ──────────────────────────────────────────────────────
+    def test_create_shell_session_opens_terminal(self):
+        agent = self._create_and_connect("agent-live-shell")
+        before = self.tab_count()
+        self.new_shell_session(agent["name"])
+        # A remote-session tab opens and its terminal goes live over the agent.
+        self.wait(lambda: self.tab_count() > before, what="the new shell-session tab")
+        self.wait(self.has_terminal, what="the agent shell terminal session")
+        marker = unique_name("agent-echo")
+        self.run_command(f"echo {marker}")
+        assert marker in self.wait_for_output(marker)
+
+    # ── persistent session survives reconnect ────────────────────────────────────
+    def test_reconnect_reattaches_persistent_session(self):
+        agent = self._create_and_connect("agent-live-persist")
+        definition = self.create_agent_definition(
+            agent["name"], unique_name("persist-shell"), persistent=True
+        )
+        self.start_persistent_session(definition["id"])
+        self.wait_persistent_running(agent["id"], definition["id"])
+
+        # Drop the agent connection (the persistent session keeps running in the
+        # remote agent daemon), then reconnect.
+        self.disconnect_agent(agent["name"])
+        self.wait(
+            lambda: self.agent_connection_state(agent["name"]) == "disconnected",
+            what=f"agent {agent['name']!r} to disconnect",
+        )
+        self.connect_agent(agent["name"])
+        self.handle_password_prompt(SSH_PASSWORD)
+        self.wait_agent_connected(agent["name"])
+
+        # The survivor session is re-listed for the agent, linked to its definition
+        # so it can be re-attached.
+        session = self.wait(
+            lambda: next(
+                (
+                    s
+                    for s in self.agent_sessions(agent["id"])
+                    if s.get("definitionId") == definition["id"]
+                ),
+                None,
+            ),
+            what="the persistent session to be re-listed after reconnect",
+        )
+        assert session["definitionId"] == definition["id"]
+
+    # ── connected-agent context menu ─────────────────────────────────────────────
+    def test_connected_agent_context_menu(self):
+        agent = self._create_and_connect("agent-live-menu")
+        name = agent["name"]
+
+        # Connected: the menu offers disconnect / refresh / new-session / edit /
+        # delete, and hides the disconnected-only connect / setup entries.
+        self.open_agent_menu(name, sentinel=self.CTX_DISCONNECT)
+        for item in (
+            self.CTX_DISCONNECT,
+            self.CTX_REFRESH,
+            self.CTX_NEW_SHELL,
+            self.CTX_NEW_CONNECTION,
+            self.CTX_EDIT,
+            self.CTX_DELETE,
+        ):
+            assert self.driver.exists(item), f"connected agent menu missing {item}"
+        assert not self.driver.exists(self.CTX_CONNECT)
+        assert not self.driver.exists(self.CTX_SETUP)
+
+        # Disconnect via the menu, then the disconnected menu offers connect / setup
+        # again while edit / delete persist across both states.
+        self.disconnect_agent(name)
+        self.wait(
+            lambda: self.agent_connection_state(name) == "disconnected",
+            what=f"agent {name!r} to disconnect",
+        )
+        self.open_agent_menu(name, sentinel=self.CTX_CONNECT)
+        for item in (self.CTX_CONNECT, self.CTX_SETUP, self.CTX_EDIT, self.CTX_DELETE):
+            assert self.driver.exists(item), f"disconnected agent menu missing {item}"
+        assert not self.driver.exists(self.CTX_DISCONNECT)


### PR DESCRIPTION
## Summary

Closes #995 — covers the remote-agent **success path** (the old `pending` describes from `infrastructure/remote-agent.test.js`), which needs a host with the `termihub-agent` binary actually deployed. Along the way it surfaced and fixes a real bug: persistent agent sessions did not survive an SSH disconnect.

### Deployed-agent Docker fixture + live E2E
- The `remote-agent` container (compose profile `agent`, port 2211) now bakes in a freshly-built **static-musl** `termihub-agent` at `~testuser/.local/bin/termihub-agent` — the POSIX default path the desktop probes and launches, so a live connect finds it without the setup wizard.
- New session-scoped `remote_agent_fixtures` fixture cross-builds the per-arch binary (`scripts/build-agents.sh`), stages it into the build context, builds + brings up the image, and **skips cleanly** when no container runtime or cross toolchain is available.
- `AgentUi` gained connected-agent helpers (connection state, capabilities, child sessions, saved definitions, persistent-session lifecycle).
- `tests/system/tests/test_remote_agent_live.py` covers: live connect + available shells, a working child shell session, **persistent-session survives disconnect/reconnect**, and the connect/disconnect/new-session/edit/delete menu on a *connected* agent.

### Bug fix: persistent daemon survives SSH disconnect
The reconnect test surfaced that persistent-session daemons were killed on every SSH disconnect (two independent causes: SIGHUP from the SSH login session, and the daemon inheriting the SSH channel's stderr). The daemon is now fully detached on unix — `setsid` via `pre_exec` + stderr redirected to a per-session log file — mirroring the existing Windows `DETACHED_PROCESS` path. Non-unix now discards daemon stderr to null too (closes the same latent coupling).

## Test plan
- [x] `test_remote_agent_live.py` — all 4 tests pass end-to-end against a real deployed agent (Linux x86_64 / headless Linux; skips on Apple Silicon since cross-rs's musl images are amd64-only).
- [x] `cargo test -p termihub-agent` — 244 unit + integration tests pass, incl. new `configure_daemon_detachment_starts_a_new_session` (setsid) and `open_daemon_log_*` tests.
- [x] `./scripts/check.sh` — ALL CHECKS PASSED (fmt, clippy, eslint, prettier, markdownlint).

Note: there is no GitHub CI job for the Python bridge harness — the live E2E runs per-machine via `scripts/test-system-py.sh` on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)