### PR TITLE
fix(ui): unify scrollbars into one subtle, auto-hide style

### DIFF
--- a/docs/changes/bugfix/scrollbar-consistency.md
+++ b/docs/changes/bugfix/scrollbar-consistency.md
@@ -1,0 +1,14 @@
+### Changed
+
+- UI: scrollbars are now consistent across the whole app. Every scrollable surface
+  (tabs, sidebars/lists, and terminals) uses the same subtle, auto-hide style — a thin
+  themed bar that fades in on hover/focus and fades out otherwise, matching VS Code.
+
+### Fixed
+
+- UI: the terminal tab bar's scrollbar is visible again. It had effectively disappeared
+  after the palette refresh made the thumb fainter, because the bar was pinned to a 3 px
+  height; it now uses the standard scrollbar width and hover reveal.
+- UI: the terminal's vertical scrollbar no longer stays permanently visible as a bright
+  bar that stood out from the app's other scrollbars — it auto-hides like the rest (and
+  stays pinned visible while its thumb is being dragged).

--- a/src/components/Terminal/TabBar.css
+++ b/src/components/Terminal/TabBar.css
@@ -9,10 +9,6 @@
   overflow-y: hidden;
 }
 
-.tab-bar::-webkit-scrollbar {
-  height: 3px;
-}
-
 .tab-bar__tabs {
   display: flex;
   height: 100%;

--- a/src/components/Terminal/Terminal.css
+++ b/src/components/Terminal/Terminal.css
@@ -101,9 +101,9 @@
 }
 
 /* Theme the horizontal scrollbar to match the vertical gutter thumb, and pin its
-   height to --hscroll-bar so the bottom reserve above matches exactly. Defining
-   ::-webkit-scrollbar makes it a consistent, always-visible bar (not a
-   fading overlay), matching the vertical scrollbar. */
+   height to --hscroll-bar so the bottom reserve above matches exactly. The thumb
+   is hidden until the terminal is hovered, matching the app-wide subtle,
+   auto-hide scrollbars (see global.css) and the vertical gutter thumb below. */
 .terminal-scroll-viewport.terminal-horizontal-scroll::-webkit-scrollbar {
   height: var(--hscroll-bar);
 }
@@ -113,11 +113,17 @@
 }
 
 .terminal-scroll-viewport.terminal-horizontal-scroll::-webkit-scrollbar-thumb {
-  background-color: var(--scrollbar-thumb);
+  background-color: transparent;
   border-radius: 5px;
 }
 
-.terminal-scroll-viewport.terminal-horizontal-scroll::-webkit-scrollbar-thumb:hover {
+.terminal-container:hover
+  .terminal-scroll-viewport.terminal-horizontal-scroll::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+}
+
+.terminal-container:hover
+  .terminal-scroll-viewport.terminal-horizontal-scroll::-webkit-scrollbar-thumb:hover {
   background-color: var(--scrollbar-thumb-hover);
 }
 
@@ -143,6 +149,15 @@
   border-radius: 4px;
   background-color: var(--scrollbar-thumb);
   cursor: default;
+  /* Subtle, auto-hide: fade in only while the terminal is hovered or the thumb
+     is being dragged, matching the app-wide scrollbar behaviour (global.css). */
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.terminal-container:hover .terminal-vscroll-thumb,
+.terminal-vscroll-thumb--dragging {
+  opacity: 1;
 }
 
 .terminal-vscroll-thumb:hover {

--- a/src/components/Terminal/terminalScrollbar.test.ts
+++ b/src/components/Terminal/terminalScrollbar.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { computeThumbGeometry, dragOffsetToLine, MIN_THUMB_PX } from "./terminalScrollbar";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import {
+  computeThumbGeometry,
+  dragOffsetToLine,
+  createTerminalScrollbar,
+  MIN_THUMB_PX,
+} from "./terminalScrollbar";
 
 describe("computeThumbGeometry", () => {
   it("hides the thumb when there is no scrollback", () => {
@@ -122,5 +128,62 @@ describe("dragOffsetToLine", () => {
       });
       expect(line).toBe(viewportY);
     }
+  });
+});
+
+describe("createTerminalScrollbar thumb visibility during drag", () => {
+  /** Minimal xterm stub exposing only the API the scrollbar touches. */
+  function fakeXterm(): XTerm {
+    const noopDisposable = { dispose: () => {} };
+    return {
+      rows: 24,
+      buffer: { active: { viewportY: 0, baseY: 24 } },
+      onScroll: () => noopDisposable,
+      onResize: () => noopDisposable,
+      onWriteParsed: () => noopDisposable,
+      scrollToLine: () => {},
+      scrollLines: () => {},
+    } as unknown as XTerm;
+  }
+
+  /** Build a gutter+thumb wired to a scrollbar controller, mounted in the DOM. */
+  function mountScrollbar() {
+    const gutter = document.createElement("div");
+    const thumb = document.createElement("div");
+    thumb.className = "terminal-vscroll-thumb";
+    gutter.appendChild(thumb);
+    document.body.appendChild(gutter);
+    const controller = createTerminalScrollbar({ xterm: fakeXterm(), gutter, thumb });
+    return { gutter, thumb, controller };
+  }
+
+  const isDragging = (thumb: HTMLElement): boolean =>
+    thumb.classList.contains("terminal-vscroll-thumb--dragging");
+
+  it("marks the thumb as dragging on pointerdown and clears it on pointerup", () => {
+    const { gutter, thumb, controller } = mountScrollbar();
+
+    // A drag keeps the thumb pinned visible even if the pointer later leaves
+    // the terminal (which would otherwise drop the :hover reveal).
+    thumb.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientY: 10 }));
+    expect(isDragging(thumb)).toBe(true);
+
+    window.dispatchEvent(new MouseEvent("pointerup", { bubbles: true, clientY: 40 }));
+    expect(isDragging(thumb)).toBe(false);
+
+    controller.dispose();
+    gutter.remove();
+  });
+
+  it("clears the dragging flag on dispose (torn down mid-drag)", () => {
+    const { gutter, thumb, controller } = mountScrollbar();
+
+    thumb.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientY: 10 }));
+    expect(isDragging(thumb)).toBe(true);
+
+    controller.dispose();
+    expect(isDragging(thumb)).toBe(false);
+
+    gutter.remove();
   });
 });

--- a/src/components/Terminal/terminalScrollbar.ts
+++ b/src/components/Terminal/terminalScrollbar.ts
@@ -3,9 +3,10 @@ import type { Terminal as XTerm } from "@xterm/xterm";
 /**
  * The terminal's vertical (scrollback) scrollbar — used in both normal and
  * horizontal-scroll modes so the scrollbar looks and behaves identically
- * everywhere. xterm's own overlay scrollbar is hidden; instead we render an
- * always-visible thumb inside a fixed gutter and keep it in sync with the
- * buffer via xterm's public API.
+ * everywhere. xterm's own overlay scrollbar is hidden; instead we render our
+ * own thumb inside a fixed gutter and keep it in sync with the buffer via
+ * xterm's public API. The thumb auto-hides (CSS fades it in on terminal hover
+ * or while dragging) to match the app-wide subtle scrollbar style.
  *
  * This decoupling is required by horizontal-scroll mode: there the `.xterm`
  * element is widened to the full content width and scrolled inside an inner
@@ -178,6 +179,8 @@ export function createTerminalScrollbar({
 
   const onThumbPointerUp = (e: PointerEvent): void => {
     thumb.releasePointerCapture?.(e.pointerId);
+    // Keep the thumb visible only while hovered from here on.
+    thumb.classList.remove("terminal-vscroll-thumb--dragging");
     window.removeEventListener("pointermove", onThumbPointerMove);
     window.removeEventListener("pointerup", onThumbPointerUp);
   };
@@ -190,6 +193,9 @@ export function createTerminalScrollbar({
     dragStartThumbTop = thumbTopPx;
     dragTrackHeightPx = gutter.clientHeight;
     dragThumbHeightPx = thumbHeightPx;
+    // Pin the thumb visible for the whole drag, even if the pointer slips off
+    // the terminal (which would otherwise drop the :hover reveal).
+    thumb.classList.add("terminal-vscroll-thumb--dragging");
     thumb.setPointerCapture?.(e.pointerId);
     window.addEventListener("pointermove", onThumbPointerMove);
     window.addEventListener("pointerup", onThumbPointerUp);
@@ -229,6 +235,7 @@ export function createTerminalScrollbar({
       gutter.removeEventListener("pointerdown", onGutterPointerDown);
       window.removeEventListener("pointermove", onThumbPointerMove);
       window.removeEventListener("pointerup", onThumbPointerUp);
+      thumb.classList.remove("terminal-vscroll-thumb--dragging");
       thumb.style.display = "none";
       thumb.style.transform = "";
     },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -43,9 +43,18 @@ body::after {
   background-size: 200px 200px;
 }
 
-/* Scrollbar styling */
+/* Scrollbar styling — subtle, auto-hide (VS Code style). The gutter is always
+   reserved (no layout shift), but the thumb is transparent until the scrollable
+   element is hovered or focused. Applies to every scrollable surface in the app
+   so tabs, lists, and terminals share one consistent look. */
 * {
   scrollbar-width: thin;
+  /* Firefox/Chromium standard property: hide the thumb by default. */
+  scrollbar-color: transparent transparent;
+}
+
+*:hover,
+*:focus-within {
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-bg);
 }
 
@@ -58,12 +67,18 @@ body::after {
   background: var(--scrollbar-bg);
 }
 
+/* Transparent thumb by default; revealed on hover/focus of the scroll host. */
 ::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-thumb);
+  background: transparent;
   border-radius: var(--scrollbar-width);
 }
 
-::-webkit-scrollbar-thumb:hover {
+:hover::-webkit-scrollbar-thumb,
+:focus-within::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+}
+
+:hover::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
 }
 

--- a/tests/system/tests/test_visual_rendering.py
+++ b/tests/system/tests/test_visual_rendering.py
@@ -162,9 +162,12 @@ class TestVisualRendering(
         self.wait_for_output("scrollback line 200")
         self.driver.scroll_terminal(-80)
         self.manual_observe(
-            "Look at the terminal's right edge while scrolled up into history.",
-            "A vertical scrollbar is visible with the app's unified styling -- no "
-            "flicker/flash as it appears, no jarring default-OS scrollbar.",
+            "Move the mouse over the terminal and look at its right edge while "
+            "scrolled up into history; then move the mouse away.",
+            "The vertical scrollbar is a thin, subtle themed bar that fades in "
+            "on hover and fades out when the mouse leaves (auto-hide, VS Code "
+            "style) -- no always-on bright bar, no jarring default-OS scrollbar. "
+            "Its style matches the tab-bar/list scrollbars elsewhere in the app.",
             label="scrollbar",
         )
         self.driver.scroll_terminal(to_bottom=True)


### PR DESCRIPTION
## Summary

Makes every scrollbar in the app consistent. Two issues, reported from a screenshot:

1. **Tab bar scrollbar had disappeared.** The palette refresh (`97fffa4f`) made the global thumb fainter (`rgba(121,121,121,0.4)` → `rgba(90,102,130,0.3)`) and thinner (`10px` → `8px`). Because the tab bar was pinned to a **3px** scrollbar, its thumb became effectively invisible.
2. **The terminal scrollbar looked different from the rest.** It's a custom, *always-visible* div-thumb, so it read as a bright bar that stood out from the app's faint native scrollbars.

Fix: adopt one **subtle, auto-hide (VS Code style)** scrollbar everywhere — a thin themed bar that fades in on hover/focus and hides otherwise.

- **`global.css`** — native thumbs transparent by default, revealed on hover/focus of the scroll host (both the standard `scrollbar-color` and `-webkit-scrollbar-thumb` paths, so it covers WKWebView *and* WebView2).
- **`TabBar.css`** — drop the `3px` height override so tabs inherit the standard width + hover reveal.
- **`Terminal.css` / `terminalScrollbar.ts`** — the terminal's custom vertical thumb and native horizontal bar auto-hide too; the vertical thumb stays pinned while being dragged (a `terminal-vscroll-thumb--dragging` class, so it doesn't vanish if the pointer slips off the terminal mid-drag).

## Test plan

- **Unit:** new regression tests for the vertical-thumb drag-visibility state machine (`terminalScrollbar.test.ts`). Full suite: 1990 pass. `lint` / `tsc` / `cargo fmt` / `clippy` clean.
- **Manual (updated guided test — MT-UI-35/36 in `test_visual_rendering.py`):**
  1. Open a terminal, fill past one screen of scrollback, scroll up.
  2. Move the mouse over the terminal → a thin themed vertical scrollbar fades in; move away → it fades out. No always-on bright bar, no default-OS scrollbar.
  3. With enough tabs to overflow the tab bar, hover the tab strip → a matching thin horizontal scrollbar fades in.
  4. Drag the terminal's vertical thumb and let the pointer slip off the terminal → the thumb stays visible for the whole drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)