### PR TITLE
docs(concept): X server provisioning for SSH X11 forwarding (Closes #1044)

### DIFF
--- a/docs/concepts/backlog/x-server-provisioning/behavior.md
+++ b/docs/concepts/backlog/x-server-provisioning/behavior.md
@@ -1,0 +1,260 @@
+# X Server Provisioning — Behavior
+
+Behavior diagrams for the [x-server-provisioning concept](concept.md). State machines, sequences,
+and flows live here; visual layout lives in [`mockups/`](mockups/).
+
+> **Transport note.** termiHub forwards X11 via **reverse SSH port-forwarding**
+> (`tcpip_forward`), not the native `x11-req` channel, because russh does not expose `x11-req`.
+> That transport half already exists (`core/src/backends/ssh/x11.rs`). These diagrams cover only
+> the **provisioning half** — ensuring a local X server exists for that transport to proxy into.
+
+---
+
+## Top-level: ensure a server when an X11 session opens
+
+```mermaid
+flowchart TD
+    A[User opens SSH connection\nwith enableX11Forwarding] --> B{Reachable local\nX server detected?}
+    B -->|Yes| Z[Adopt existing server\nDISPLAY + cookie]
+    B -->|No| C{provideXServerAutomatically\nenabled?}
+    C -->|No| W[Warn: no X server;\nforwarding will not display]
+    C -->|Yes| D{Platform?}
+    D -->|Windows| E[Provision VcXsrv\nsee 'Windows provisioning']
+    D -->|macOS| F[Guided XQuartz install\nsee 'macOS']
+    D -->|Linux| G[Classify gap + hint\nsee 'Linux']
+    E --> Z
+    F --> Z
+    G --> H{Server now\nreachable?}
+    H -->|Yes| Z
+    H -->|No| W
+    Z --> Y[Transport half proxies\nremote X clients to display :N]
+    style E fill:#e87d0d,stroke:#333,color:#fff
+```
+
+## Per-platform decision
+
+```mermaid
+flowchart LR
+    subgraph WIN[Windows]
+        W1[No native X server] --> W2[Download/adopt VcXsrv\nspawn + manage]
+    end
+    subgraph MAC[macOS]
+        M1[No embeddable server] --> M2[Detect XQuartz]
+        M2 -->|present| M3[open -a XQuartz]
+        M2 -->|missing| M4[Guided install\nbrew / .pkg / link]
+    end
+    subgraph LIN[Linux]
+        L1[Xorg / XWayland\nalmost always present] --> L2[Detect + adopt]
+        L2 -->|gap| L3[Targeted hint\nno bundle]
+    end
+    style W2 fill:#e87d0d,stroke:#333,color:#fff
+```
+
+## Windows provisioning workflow (VcXsrv)
+
+```mermaid
+flowchart TD
+    A[ensure_x_server: Windows] --> B{VcXsrv reachable\nat 127.0.0.1:6000?}
+    B -->|Yes| Z[Adopt external server]
+    B -->|No| C{Pinned VcXsrv\nextracted in data dir?}
+    C -->|Yes| L[Launch managed server]
+    C -->|No| D{Bundled with app?}
+    D -->|Yes| K[Copy into place] --> L
+    D -->|No| E[Show consent prompt]
+    E -->|Not now| W[Skip: no server]
+    E -->|Download & Enable| F[Download pinned .zip\nfrom GitHub releases]
+    F --> G[Verify SHA-256]
+    G -->|mismatch| G2[Discard + retry once] --> F
+    G -->|ok| H[Extract → atomic rename]
+    H --> L
+    L --> M[Generate MIT-MAGIC-COOKIE-1\nwrite .Xauthority]
+    M --> N["vcxsrv.exe :0 -multiwindow\n-clipboard -auth <file>"]
+    N --> O[Register managed server\ndisplay :0 + cookie]
+    O --> Z
+    style F fill:#e87d0d,stroke:#333,color:#fff
+    style L fill:#e87d0d,stroke:#333,color:#fff
+```
+
+## Binary resolution order (mirrors agent_setup.rs)
+
+```mermaid
+flowchart LR
+    A[Need VcXsrv] --> B{cache\nvcxsrv-version/}
+    B -->|hit| Z[Use path]
+    B -->|miss| C{bundled\nwith app}
+    C -->|hit| Y[Copy to cache] --> Z
+    C -->|miss| D[Download pinned zip] --> E[Verify sha256] --> F[Unzip] --> Z
+```
+
+## X server lifecycle state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Absent
+
+    Absent --> Adopted: external server\ndetected on :0/6000
+    Absent --> Downloading: provision consented
+    Downloading --> Verifying: zip fetched
+    Verifying --> Downloading: checksum mismatch\n(retry once)
+    Verifying --> Extracting: checksum ok
+    Extracting --> Starting: files in place
+    Starting --> Running: process up + reachable
+    Starting --> Failed: spawn/port error
+
+    Running --> Running: new X11 session\nadopts same server
+    Running --> Idle: last X11 session closed
+    Idle --> Running: new X11 session opens
+    Idle --> Stopped: stopXServerWhenIdle\nor app exit
+    Adopted --> [*]: app exit\n(external left running)
+    Running --> Stopped: app exit\n(managed killed)
+    Failed --> Absent: user retries
+    Stopped --> [*]
+```
+
+## Session open sequence (Windows, managed server)
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Conn as connector.rs (X11 startup)
+    participant Orch as ensure_x_server()
+    participant Mgr as XServerManager
+    participant Acq as acquire.rs
+    participant VcX as vcxsrv.exe
+    participant Fwd as X11Forwarder (transport)
+
+    User->>Conn: Open SSH conn (enableX11Forwarding)
+    Conn->>Orch: ensure_x_server()
+    Orch->>Mgr: status()
+    alt server already running/adopted
+        Mgr-->>Orch: Running(:0, cookie)
+    else must provision
+        Orch->>User: consent prompt (download ~N MB?)
+        User-->>Orch: Download & Enable
+        Orch->>Acq: resolve VcXsrv (cache→bundled→download+verify+unzip)
+        Acq-->>Orch: path
+        Orch->>Mgr: start(path)
+        Mgr->>Mgr: gen cookie + write .Xauthority
+        Mgr->>VcX: spawn :0 -multiwindow -auth <file>
+        Mgr-->>Orch: Running(:0, cookie)
+    end
+    Orch-->>Conn: LocalXServerInfo(:0, cookie)
+    Conn->>Fwd: start forwarding to display :0 (known cookie)
+    Note over Fwd,VcX: remote GUI apps now render as native windows
+```
+
+## Detection decision flow (`detect_local_x_server`)
+
+```mermaid
+flowchart TD
+    A[detect_local_x_server] --> M{Managed server\nregistered?}
+    M -->|Yes| R1[Return Tcp 127.0.0.1:6000\n+ known cookie]
+    M -->|No| B{DISPLAY set?}
+    B -->|Yes| R2[Parse DISPLAY → info]
+    B -->|No| U{Unix?}
+    U -->|Yes| S[Scan /tmp/.X11-unix]
+    U -->|No: Windows| T{TCP 127.0.0.1:6000\nopen?}
+    S -->|found| R3[UnixSocket info]
+    S -->|none| N[None]
+    T -->|open| R4[Tcp info\ncookie via xauth or none]
+    T -->|closed| N
+    style M fill:#e87d0d,stroke:#333,color:#fff
+    style T fill:#e87d0d,stroke:#333,color:#fff
+```
+
+## macOS guided install sequence
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Orch as ensure_x_server()
+    participant FS as /opt/X11 probe
+    participant Inst as installer / brew
+    participant XQ as XQuartz
+
+    Orch->>FS: exists(/opt/X11 & XQuartz.app)?
+    alt present
+        Orch->>XQ: open -a XQuartz
+        Orch-->>User: ready (DISPLAY via ssh -X/-Y)
+    else missing
+        Orch->>User: prompt (Install XQuartz?)
+        User-->>Orch: Install (brew | .pkg)
+        Orch->>Inst: brew install --cask xquartz\nOR installer -pkg … -target / (admin)
+        Inst-->>Orch: installed
+        Orch->>XQ: open -a XQuartz
+    end
+```
+
+## Idle shutdown sequence
+
+```mermaid
+sequenceDiagram
+    participant S1 as X11 session A
+    participant S2 as X11 session B
+    participant Mgr as XServerManager
+    participant VcX as vcxsrv.exe
+
+    S1->>Mgr: register (refcount 1)
+    S2->>Mgr: register (refcount 2, adopts same server)
+    S1->>Mgr: close (refcount 1)
+    S2->>Mgr: close (refcount 0)
+    alt stopXServerWhenIdle = on
+        Mgr->>VcX: terminate
+        Note over Mgr,VcX: managed server stopped when idle
+    else keep running
+        Note over Mgr,VcX: stays up until app exit
+    end
+```
+
+## Architecture overview
+
+```mermaid
+flowchart TB
+    subgraph FE[Frontend]
+        SET[Settings toggle\nprovideXServerAutomatically]
+        PRMPT[First-run consent + progress]
+        OC[Open Connections\n'X Servers' section]
+    end
+    subgraph IPC[Tauri commands / events]
+        CMD[x_server_status / _ensure / _stop\n_install_dependency]
+        EVT[progress events\ndownload / verifying / status]
+    end
+    subgraph BE[Backend]
+        ORCH[orchestrator.rs\nensure_x_server]
+        MGR[manager.rs\nspawn/supervise/reuse]
+        ACQ[acquire.rs\nresolve+download+verify+unzip]
+        AUTH[auth.rs\ncookie + .Xauthority]
+        DET[x11.rs\nmanaged-aware detection]
+        PORT[portable.rs\nstorage path]
+    end
+    SET --> CMD
+    PRMPT --> CMD
+    OC --> CMD
+    CMD --> ORCH
+    ORCH --> MGR
+    MGR --> ACQ
+    MGR --> AUTH
+    ACQ --> PORT
+    ORCH --> DET
+    MGR --> EVT
+    EVT --> PRMPT
+    style MGR fill:#e87d0d,stroke:#333,color:#fff
+    style ORCH fill:#e87d0d,stroke:#333,color:#fff
+```
+
+## Edge cases
+
+| Scenario                                             | Behavior                                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| User already runs VcXsrv / X410 / Xming on `:0`      | Adopt it (TCP 6000 probe); do not spawn a duplicate                             |
+| Port 6000 taken by a non-X process                   | Pick the next free display number; register that display                        |
+| Download fails / checksum mismatch                   | Discard, retry once, then surface an actionable error (never run a bad binary)  |
+| Offline, pinned version already cached               | No network call; launch from cache                                              |
+| Portable install                                     | Store VcXsrv under `<data>/xserver/…` next to the exe; nothing outside app tree |
+| Managed VcXsrv dies mid-session                      | `ensure_running()` restarts it on next use                                      |
+| App exit with sessions still open                    | Managed server killed (no orphan); adopted external server left running         |
+| macOS without XQuartz, user declines install         | Session opens without GUI display; clear hint shown, no silent failure          |
+| Linux Wayland-only session without XWayland          | Detect gap; hint to install `xwayland`; do not bundle                           |
+| Flatpak/Snap sandbox blocks the X socket             | Detect; hint to adjust sandbox `--socket=x11`; packaging-level fix              |
+| macOS/Linux forwarding on a headless client box      | No local display to forward to; surface that it is a setup limitation           |
+| `provideXServerAutomatically` off, no server present | Warn only; never download/install                                               |

--- a/docs/concepts/backlog/x-server-provisioning/concept.md
+++ b/docs/concepts/backlog/x-server-provisioning/concept.md
@@ -1,0 +1,253 @@
+# Provide a Local X Server for SSH X11 Forwarding (MobaXterm-style)
+
+**GitHub Issue:** [#1044](https://github.com/armaxri/termiHub/issues/1044)
+
+> **Folder-form concept** (AI-driven concept workflow). Visual surfaces live in
+> [`mockups/`](mockups/), behavior diagrams in [`behavior.md`](behavior.md), and the
+> concept↔code reconciliation ledger in [`sync.md`](sync.md). The concept is the source of
+> truth; run `/sync-concept x-server-provisioning` to reconcile it with the implementation.
+
+---
+
+## Overview
+
+When a user opens an SSH connection with **X11 forwarding** enabled, a remote GUI program
+(`xclock`, `wireshark`, a vendor tool) is an _X client_ — it needs a running **X server on the
+local machine** to draw into. Today termiHub forwards the X protocol correctly but assumes the
+user has already installed and configured a local X server. On Windows that is almost never true,
+and on macOS it requires a manual XQuartz install. The result: X11 forwarding "silently does
+nothing" for most users.
+
+This concept adds a subsystem that **ensures a usable local X server exists** before an
+X11-forwarding session starts, so remote GUI apps open as **independent native windows** with zero
+manual setup — the model popularized by **MobaXterm** ("the app provides the X server; the user
+never installs one").
+
+### The two halves of X11 forwarding
+
+```mermaid
+flowchart LR
+    subgraph Remote["Remote host (SSH server)"]
+        APP["GUI app\n(X client)"]
+    end
+    subgraph Local["Local machine (termiHub)"]
+        FWD["Transport half\n(already implemented)\ncore/src/backends/ssh/x11.rs"]
+        XSRV["Local X server\n(THIS CONCEPT ensures it)"]
+        WIN["Native OS windows"]
+    end
+    APP -- "X11 protocol over SSH" --> FWD
+    FWD -- "proxied to display :N" --> XSRV
+    XSRV --> WIN
+    style XSRV fill:#e87d0d,stroke:#333,color:#fff
+```
+
+The **transport half** exists: `enable_x11_forwarding` sets up reverse port-forwarding, injects
+`DISPLAY` + an `xauth` cookie on the remote shell, and proxies X channels to a local display
+(`connector.rs`, tested via `tests/docker/ssh-x11/`). This concept specifies the **provisioning
+half**: detect-or-provide the local X server the transport half proxies into.
+
+### Goals
+
+- Make remote GUI apps "just work" as native windows when X11 forwarding is enabled — no manual
+  X-server install on the common path.
+- On **Windows**, bundle/auto-download and manage a real X server (VcXsrv) transparently.
+- On **macOS**, detect XQuartz and offer a guided, consent-based install when it is missing.
+- On **Linux**, detect the already-present Xorg/XWayland and give a targeted hint only in the rare
+  gap cases.
+- Reuse an already-running user X server instead of spawning a duplicate.
+- Surface the managed server in the **Open Connections** panel so it can be inspected and killed
+  like any other connection.
+
+### Non-Goals
+
+- Rendering remote GUIs _inside_ termiHub's own window (they stay independent OS windows).
+- Native `x11-req` SSH channel support (the existing reverse-port-forward transport is sufficient;
+  see [behavior.md](behavior.md) note).
+- Implementing an X server ourselves — **no embeddable X-server library exists**; we ship/spawn an
+  external binary (this is what MobaXterm does with its "MobaX" X.Org fork).
+- Bundling an X server on macOS or Linux (not possible / not advisable respectively).
+- Wayland-native remote display (out of scope; XWayland covers forwarded X11 clients).
+
+---
+
+## UI Interface
+
+The visual surfaces are specified by the mockups — open them in a browser to review layout and
+states. This section describes them; the mockups are authoritative for layout.
+
+| Mockup                                                           | Shows                                                                             |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [`mockups/provisioning.html`](mockups/provisioning.html)         | Settings toggle, first-run download-consent prompt, downloading progress, running |
+| [`mockups/open-connections.html`](mockups/open-connections.html) | The "X Servers" section in the Open Connections panel (status + stop control)     |
+
+### Settings
+
+A schema-driven setting **`provideXServerAutomatically`** (rendered by `DynamicForm`, default
+**on** for Windows) controls whether termiHub may provision an X server. A companion
+**`stopXServerWhenIdle`** setting (default **on**) controls whether the managed server is stopped
+once the last X11-forwarding session closes. The existing per-connection **X11 Forwarding**
+toggle (`enableX11Forwarding`, already in the SSH schema) is unchanged — it decides _whether_ a
+connection forwards; the new settings decide _how_ the local server is provided.
+
+### First-run consent prompt
+
+The first time a user opens an X11-forwarding connection on a platform with no reachable X server,
+termiHub shows a consent card (mockup `provisioning.html`, state 2) before downloading anything:
+
+- **Windows:** "termiHub needs a local X server to show remote GUI apps. Download and set up
+  VcXsrv (~N MB)?" → **Download & Enable** / **Not now**.
+- **macOS:** "Remote GUI forwarding needs XQuartz. Install it?" → **Install XQuartz** (Homebrew or
+  notarized `.pkg`) / **Open xquartz.org** / **Not now**.
+- **Linux:** normally no prompt (server already present). In a gap case (Wayland-only without
+  XWayland, sandboxed socket), a targeted hint is shown instead of a download.
+
+Nothing is downloaded or installed without explicit consent.
+
+### Progress & running states
+
+While provisioning, the card shows a labelled progress line — `Downloading… → Verifying… →
+Starting…` (mockup `provisioning.html`, state 3) — driven by backend events. Once running, the
+card collapses to a confirmation (state 4) and the session proceeds.
+
+### Open Connections panel — "X Servers" section
+
+The managed (or adopted) X server appears as a new **"X Servers"** section in the Open Connections
+modal (`OpenConnectionsModal.tsx`), consistent with the panel's role as the one place to inspect
+and kill everything. It shows the server kind (managed VcXsrv / adopted external / XQuartz), the
+display number, and the count of sessions depending on it, with a **Stop** / **Kill all**
+control. See `mockups/open-connections.html`.
+
+### Status feedback
+
+When a GUI forward is active, the status bar shows an unobtrusive indicator (X server running on
+`:N`). Debug detail is emitted via `frontendLog` (never `console.*`).
+
+---
+
+## General Handling
+
+Detailed flows, the per-platform decision tree, lifecycle, and detection are diagrammed in
+[`behavior.md`](behavior.md). Key rules:
+
+- **Provision is lazy & consent-gated.** Nothing is downloaded/installed until a user opens an
+  X11-forwarding connection _and_ confirms the prompt. A user who never uses X11 forwarding never
+  downloads an X server.
+- **Reuse before spawn.** If a reachable X server already exists (`DISPLAY` set, `/tmp/.X11-unix`
+  socket on Unix, or TCP `127.0.0.1:6000` open on Windows), termiHub **adopts** it instead of
+  starting its own.
+- **One shared managed server per termiHub instance**, reused by all X11 sessions (display `:0`,
+  port 6000). Not one server per connection.
+- **Idle shutdown (Windows managed server).** When the last X11-forwarding session closes and
+  `stopXServerWhenIdle` is on, the managed server is stopped; it is always stopped on app exit
+  (no orphan `vcxsrv.exe`).
+- **Per-platform strategy:** Windows → provide (bundle/download VcXsrv); macOS → detect + guided
+  install XQuartz (cannot bundle); Linux → detect + guide (never bundle).
+- **Failure is actionable, never silent.** If provisioning fails at any stage, the session surfaces
+  a clear error with a retry/skip path rather than forwarding into a void.
+- **Security:** the managed server uses `MIT-MAGIC-COOKIE-1` auth by default (not `-ac`), matching
+  the cookie the transport half installs on the remote side.
+
+---
+
+## Preliminary Implementation Details
+
+Based on the current project architecture at concept-creation time; the codebase may evolve before
+implementation. Architecture and sequence diagrams live in [`behavior.md`](behavior.md).
+
+### New and Modified Files
+
+| File                                                      | Change                                                                      |
+| --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `src-tauri/src/terminal/xserver/mod.rs`                   | **New** — X server provisioning module root                                 |
+| `src-tauri/src/terminal/xserver/acquire.rs`               | **New (Windows)** — resolve VcXsrv: cache → bundled → download+verify+unzip |
+| `src-tauri/src/terminal/xserver/manager.rs`               | **New** — `XServerManager`: spawn/supervise/reuse/idle-shutdown             |
+| `src-tauri/src/terminal/xserver/auth.rs`                  | **New (Windows)** — generate `MIT-MAGIC-COOKIE-1`, write `.Xauthority`      |
+| `src-tauri/src/terminal/xserver/orchestrator.rs`          | **New** — `ensure_x_server()` per-platform dispatch                         |
+| `core/src/backends/ssh/x11.rs`                            | **Modify** — managed-server-aware detection; Windows TCP:6000 probe         |
+| `core/src/backends/ssh/connector.rs`                      | **Modify** — call `ensure_x_server()` in X11 startup (~lines 160–189)       |
+| `core/src/backends/ssh/mod.rs`                            | **Modify** — new settings fields in the SSH schema                          |
+| `src-tauri/src/commands/xserver.rs`                       | **New** — `x_server_status` / `_ensure` / `_stop` / `_install_dependency`   |
+| `src-tauri/src/utils/portable.rs`                         | **Reuse** — `resolve_portable_path` / `AppMode` for storage location        |
+| `src/components/OpenConnections/OpenConnectionsModal.tsx` | **Modify** — add "X Servers" `Section`                                      |
+| `src/components/Settings/*`                               | **Modify** — surface `provideXServerAutomatically` (schema-driven)          |
+| `THIRD_PARTY_LICENSES` / installer                        | **Modify** — GPL-3.0 text + source offer for VcXsrv                         |
+
+### Windows: VcXsrv acquisition (decision)
+
+Deliver VcXsrv as a **pinned, pre-extracted minimal tree** (`vcxsrv.exe` + required DLLs +
+`fonts/`) hosted as a **versioned `.zip` on termiHub's own GitHub releases** (same host as agent
+binaries). Rationale: avoids running an NSIS installer that writes to `Program Files`, keeps the
+install self-contained/portable, and gives a stable pinned URL + checksum we control.
+
+Resolution order mirrors `agent_setup.rs` (`cache → bundled → download`):
+
+1. Already extracted for the pinned version → use it.
+2. Bundled alongside the app → copy/use.
+3. Download `.zip` → verify SHA-256 → extract → atomic rename into place.
+
+Storage via `resolve_portable_path` / `AppMode`:
+
+- Portable mode → `<data>/xserver/vcxsrv-<version>/`
+- Installed mode → `dirs::data_local_dir()/termiHub/xserver/vcxsrv-<version>/`
+
+Pinned table compiled into the app: `{ version, zip_url, sha256 }`. Version-keyed dirs give safe
+upgrade + rollback + prune of stale versions. New deps: `zip` (extraction), `sha2` (hashing);
+`reqwest` (blocking) and `dirs` already exist.
+
+### Windows: launch, auth, DISPLAY
+
+- Launch a single shared server: `vcxsrv.exe :0 -multiwindow -clipboard -auth <xauthfile>`
+  (`-multiwindow` → each remote app is its own native window; `-nowgl` as a GL fallback).
+- Generate a per-start `MIT-MAGIC-COOKIE-1` (16 random bytes → 32 hex), write a standard-format
+  `.Xauthority` for `localhost:0`, pass via `-auth`, and hand the cookie to the transport half
+  directly (bypassing `read_local_xauth_cookie()`, which shells to `xauth` — absent on Windows).
+  MVP fallback: `-ac` (loopback-only, documented security tradeoff).
+
+### Detection fix (`x11.rs`)
+
+`detect_local_x_server()` scans `/tmp/.X11-unix` and `read_local_xauth_cookie()` shells to
+`xauth` — both no-ops on Windows. Make detection **managed-server-aware**: consult
+`XServerManager` first (return `LocalXServerInfo { Tcp("127.0.0.1", 6000+n) }` + known cookie), and
+add a Windows TCP `127.0.0.1:6000` probe fallback for user-installed servers. `LocalXConnection`
+already has a `Tcp` variant, so no new transport type is needed. Unix behavior stays unchanged.
+
+### macOS & Linux
+
+- **macOS:** detect `/opt/X11` + `XQuartz.app`; if absent, offer `brew install --cask xquartz`,
+  a downloaded notarized `.pkg` via `installer -pkg … -target /` (admin prompt), or a deep link.
+  If present, `open -a XQuartz` and let `ssh -X/-Y` set `DISPLAY` (`:0` fallback). Cannot bundle.
+- **Linux:** the existing `/tmp/.X11-unix` detection covers the normal case. Classify gaps
+  (Wayland-only without XWayland, headless, Flatpak/Snap X-socket sandbox) and show a targeted
+  hint; never bundle or auto-install.
+
+### Orchestrator & IPC
+
+`ensure_x_server()` dispatches per platform and is called from `connector.rs` X11 startup. Tauri
+commands (`x_server_status`, `x_server_ensure`, `x_server_stop`, `x_server_install_dependency`)
+and progress events reuse the agent-deploy event shape (`download` / `verifying` / status).
+
+### Licensing (GPL-3.0)
+
+Hosting/redistributing VcXsrv (GPL-3.0) obliges shipping the GPL-3.0 text + a source offer/link
+for the exact pinned version (`github.com/marchaesen/vcxsrv`). VcXsrv runs strictly as a **separate
+process** (no linking), so termiHub's own license is unaffected — document this boundary; confirm
+with counsel before release. XQuartz (MIT + APSL2) needs attribution on the macOS path.
+
+### Implementation Order
+
+1. Windows acquisition (`acquire.rs`) — pinned zip resolve/download/verify/extract, portable-aware.
+2. Lifecycle manager (`manager.rs`) — spawn/supervise/reuse/idle-shutdown.
+3. Auth + DISPLAY (`auth.rs`) — cookie + `.Xauthority`, wire into transport.
+4. Detection fix (`x11.rs`) — managed-aware + Windows TCP probe.
+5. Orchestrator + Tauri commands/events; hook into `connector.rs`.
+6. UI — settings toggle, first-run/progress prompt, Open Connections "X Servers" section.
+7. macOS guided install; Linux detect-and-guide.
+8. GPL-3.0 compliance; integration/manual tests + docs.
+
+---
+
+## Implementation Status
+
+Not started — this is a `backlog/` concept authored for issue
+[#1044](https://github.com/armaxri/termiHub/issues/1044). Once implementation begins, run
+`/sync-concept x-server-provisioning` after each change to keep [`sync.md`](sync.md) current.

--- a/docs/concepts/backlog/x-server-provisioning/mockups/open-connections.html
+++ b/docs/concepts/backlog/x-server-provisioning/mockups/open-connections.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<!-- X Server Provisioning — "X Servers" section in the Open Connections panel. Layout altitude, real class names + lucide icons. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>X Server Provisioning — Open Connections (mockup)</title>
+    <link rel="stylesheet" href="../../../_assets/mockup.css" />
+  </head>
+  <body class="mockup-doc">
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="i-monitor" viewBox="0 0 24 24">
+        <rect width="20" height="14" x="2" y="3" rx="2" />
+        <path d="M8 21h8" />
+        <path d="M12 17v4" />
+      </symbol>
+      <symbol id="i-network" viewBox="0 0 24 24">
+        <rect x="16" y="16" width="6" height="6" rx="1" />
+        <rect x="2" y="16" width="6" height="6" rx="1" />
+        <rect x="9" y="2" width="6" height="6" rx="1" />
+        <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3" />
+        <path d="M12 12V8" />
+      </symbol>
+      <symbol id="i-power" viewBox="0 0 24 24">
+        <path d="M12 2v10" />
+        <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
+      </symbol>
+      <symbol id="i-x" viewBox="0 0 24 24">
+        <path d="M18 6 6 18" />
+        <path d="m6 6 12 12" />
+      </symbol>
+    </svg>
+
+    <h1>X Server Provisioning — Open Connections Panel</h1>
+    <p class="mockup-meta">
+      Layout-altitude mockup ·
+      <code>backlog/x-server-provisioning/mockups/open-connections.html</code>
+    </p>
+
+    <section class="mockup-section">
+      <h2>"X Servers" section among the other connection groups</h2>
+      <div class="mockup-note">
+        The managed (or adopted) X server appears as a new <strong>X Servers</strong> section in the
+        Open Connections modal <span class="callout">A</span>, alongside the existing groups. Each
+        row has a <strong>Stop</strong> control <span class="callout">B</span>; the section header
+        carries a count and a <strong>Kill all</strong> action <span class="callout">C</span> —
+        matching how every other section in this panel behaves.
+      </div>
+
+      <!-- Dialog surface (reuses .menu chrome, widened) -->
+      <div class="menu" style="width: 460px">
+        <div class="menu__title" style="display: flex; align-items: center; justify-content: space-between">
+          <span>Open Connections</span>
+          <button class="tab__close" style="opacity: 1">
+            <svg class="li"><use href="#i-x" /></svg>
+          </button>
+        </div>
+
+        <!-- sibling sections, collapsed for context -->
+        <div class="state-label" style="padding: 8px 14px 0; margin: 0">Local Sessions <span class="count">1</span></div>
+        <div class="menu__row">
+          <span class="state-dot state-dot--running"></span> zsh — /Users/arne
+        </div>
+
+        <div class="state-label" style="padding: 8px 14px 0; margin: 0">SSH Tunnels <span class="count">1</span></div>
+        <div class="menu__row">
+          <span class="state-dot state-dot--connected"></span> server-1 · 5432 → localhost:5432
+        </div>
+
+        <!-- NEW: X Servers section -->
+        <div
+          class="state-label"
+          style="padding: 10px 14px 2px; margin: 0; display: flex; align-items: center; gap: 8px; border-top: 1px solid var(--border-secondary)"
+        >
+          <svg class="li" style="width: 13px; height: 13px"><use href="#i-monitor" /></svg>
+          X Servers <span class="count" style="margin-left: 0">1</span>
+          <button class="btn btn--link" style="margin-left: auto">Kill all</button>
+        </div>
+
+        <div class="menu__row menu__row--selected">
+          <span class="state-dot state-dot--running"></span>
+          VcXsrv <span class="count" style="margin-left: 4px; color: var(--text-primary)">managed</span>
+          <span style="color: var(--text-secondary)">· display :0 · 2 sessions</span>
+          <button class="btn" style="margin-left: auto; display: inline-flex; align-items: center; gap: 5px">
+            <svg class="li"><use href="#i-power" /></svg> Stop
+          </button>
+        </div>
+      </div>
+
+      <div class="legend">
+        <ul>
+          <li>
+            <span class="callout">A</span> New <strong>X Servers</strong> section in
+            <code>OpenConnectionsModal.tsx</code>, following the existing <code>Section</code> pattern
+            (title + count + kill-all).
+          </li>
+          <li>
+            <span class="callout">B</span> Per-server <strong>Stop</strong> (lucide
+            <code>Power</code>) terminates the managed <code>vcxsrv.exe</code>.
+          </li>
+          <li>
+            <span class="callout">C</span> <strong>Kill all</strong> stops every managed server —
+            consistent with the panel being the single place to kill any connection.
+          </li>
+          <li>
+            An <em>adopted external</em> server shows as <code>External X server · display :0</code>
+            with no Stop control (termiHub did not start it, so it does not stop it).
+          </li>
+        </ul>
+      </div>
+    </section>
+  </body>
+</html>

--- a/docs/concepts/backlog/x-server-provisioning/mockups/provisioning.html
+++ b/docs/concepts/backlog/x-server-provisioning/mockups/provisioning.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<!-- X Server Provisioning — settings toggle + first-run consent/progress/running. Layout altitude, real class names + lucide icons. -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>X Server Provisioning — Settings &amp; First-Run (mockup)</title>
+    <link rel="stylesheet" href="../../../_assets/mockup.css" />
+  </head>
+  <body class="mockup-doc">
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="i-monitor" viewBox="0 0 24 24">
+        <rect width="20" height="14" x="2" y="3" rx="2" />
+        <path d="M8 21h8" />
+        <path d="M12 17v4" />
+      </symbol>
+      <symbol id="i-download" viewBox="0 0 24 24">
+        <path d="M12 15V3" />
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <path d="m7 10 5 5 5-5" />
+      </symbol>
+      <symbol id="i-circle-check" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" />
+        <path d="m9 12 2 2 4-4" />
+      </symbol>
+      <symbol id="i-app-window" viewBox="0 0 24 24">
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="M10 4v4" />
+        <path d="M2 8h20" />
+        <path d="M6 4v4" />
+      </symbol>
+    </svg>
+
+    <h1>X Server Provisioning — Settings &amp; First-Run Flow</h1>
+    <p class="mockup-meta">
+      Layout-altitude mockup · <code>backlog/x-server-provisioning/mockups/provisioning.html</code>
+    </p>
+
+    <!-- ── Settings ──────────────────────────────────────────────────── -->
+    <section class="mockup-section">
+      <h2>1 · Settings — schema-driven toggles</h2>
+      <div class="mockup-note">
+        Rendered by <code>DynamicForm</code>. <span class="callout">A</span> controls whether
+        termiHub may provision a local X server; <span class="callout">B</span> stops the managed
+        server once the last X11 session closes. The per-connection <em>X11 Forwarding</em> toggle
+        is unchanged — it lives on the SSH connection form.
+      </div>
+      <div class="menu" style="width: 340px">
+        <div class="menu__title">
+          <svg class="li"><use href="#i-monitor" /></svg> X Server
+        </div>
+        <div class="menu__row menu__row--selected">
+          <span class="check">✓</span> Provide an X server automatically
+          <span class="count">Windows</span>
+        </div>
+        <div class="menu__row menu__row--selected">
+          <span class="check">✓</span> Stop X server when idle
+        </div>
+        <div class="menu__row">
+          <span class="check"></span> Always allow network X clients
+          <span class="count">off</span>
+        </div>
+      </div>
+      <div class="legend">
+        <ul>
+          <li><span class="callout">A</span> <code>provideXServerAutomatically</code> (default on, Windows).</li>
+          <li><span class="callout">B</span> <code>stopXServerWhenIdle</code> (default on).</li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- ── First-run flow ────────────────────────────────────────────── -->
+    <section class="mockup-section">
+      <h2>2 · First-run flow (Windows) — consent → progress → running</h2>
+      <div class="mockup-note">
+        Shown the first time an X11-forwarding connection is opened with no reachable X server.
+        <strong>Nothing is downloaded before consent</strong> <span class="callout">C</span>.
+      </div>
+      <div class="states">
+        <!-- Consent -->
+        <div>
+          <p class="state-label">Step 1 — consent prompt</p>
+          <div class="menu">
+            <div class="menu__title">
+              <svg class="li"><use href="#i-app-window" /></svg> Set up X server
+            </div>
+            <div class="menu__row" style="display: block; color: var(--text-secondary)">
+              Remote GUI apps need a local X server to open as native windows. termiHub can
+              download and set up <strong>VcXsrv</strong> (~7&nbsp;MB, one time).
+            </div>
+            <div class="menu__footer">
+              <button class="btn btn--primary">
+                <svg class="li"><use href="#i-download" /></svg> Download &amp; Enable
+              </button>
+              <button class="btn">Not now</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Progress -->
+        <div>
+          <p class="state-label">Step 2 — provisioning</p>
+          <div class="menu">
+            <div class="menu__title">
+              <svg class="li"><use href="#i-download" /></svg> Setting up X server
+            </div>
+            <div class="menu__row menu__row--selected"><span class="check">✓</span> Download VcXsrv</div>
+            <div class="menu__row menu__row--selected"><span class="check">✓</span> Verify checksum</div>
+            <div class="menu__row">
+              <span class="state-dot state-dot--connecting"></span> Extract &amp; start
+              <span class="count">62%</span>
+            </div>
+            <div style="padding: 0 14px 12px">
+              <div style="height: 4px; border-radius: 2px; background: var(--bg-active)">
+                <div style="width: 62%; height: 100%; border-radius: 2px; background: var(--accent-color)"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Running -->
+        <div>
+          <p class="state-label">Step 3 — running</p>
+          <div class="menu">
+            <div class="menu__title" style="color: var(--color-success)">
+              <svg class="li"><use href="#i-circle-check" /></svg> X server running
+            </div>
+            <div class="menu__row">
+              <span class="state-dot state-dot--running"></span> VcXsrv on display
+              <code>:0</code> <span class="count">managed</span>
+            </div>
+            <div class="menu__row" style="display: block; color: var(--text-secondary)">
+              Remote GUI apps now open as native windows. Manage it any time from
+              <em>Open Connections → X Servers</em>.
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="legend">
+        <ul>
+          <li>
+            <span class="callout">C</span> No network request happens until the user picks
+            <strong>Download &amp; Enable</strong>. Progress is driven by backend events
+            (<code>download</code> / <code>verifying</code> / <code>status</code>).
+          </li>
+          <li>
+            On subsequent runs (VcXsrv already cached) Steps&nbsp;1–2 are skipped — the server just
+            starts.
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- ── macOS variant ─────────────────────────────────────────────── -->
+    <section class="mockup-section">
+      <h2>3 · macOS variant — guided XQuartz install (cannot bundle)</h2>
+      <div class="mockup-note">
+        macOS cannot embed an X server, so the prompt offers a guided, consent-based install of
+        XQuartz instead of an in-app download.
+      </div>
+      <div class="menu" style="width: 340px">
+        <div class="menu__title">
+          <svg class="li"><use href="#i-app-window" /></svg> XQuartz required
+        </div>
+        <div class="menu__row" style="display: block; color: var(--text-secondary)">
+          Remote GUI forwarding on macOS needs <strong>XQuartz</strong>. Install it?
+        </div>
+        <div class="menu__footer">
+          <button class="btn btn--primary">Install XQuartz</button>
+          <button class="btn btn--link">Open xquartz.org</button>
+          <button class="btn">Not now</button>
+        </div>
+      </div>
+    </section>
+  </body>
+</html>

--- a/docs/concepts/backlog/x-server-provisioning/sync.md
+++ b/docs/concepts/backlog/x-server-provisioning/sync.md
@@ -1,0 +1,22 @@
+# Sync Ledger — X Server Provisioning
+
+**Last synced:** never (concept not yet implemented)
+**Status:** diverged (entirely missing — backlog feature)
+
+This ledger is maintained by the `/sync-concept x-server-provisioning` skill. It records the last
+commit at which the concept artifacts and the code were reconciled, plus any open divergences.
+
+## Open divergences
+
+| #   | Artifact claim                                                 | Code reality                                             | Type     | Recommendation                                     |
+| --- | -------------------------------------------------------------- | -------------------------------------------------------- | -------- | -------------------------------------------------- |
+| 1   | X server provisioning subsystem (`src-tauri/.../xserver/`)     | Not implemented — backlog feature                        | Missing  | Implement per `concept.md` order, then re-sync     |
+| 2   | Managed-server-aware detection + Windows TCP:6000 probe        | `x11.rs` scans `/tmp/.X11-unix` + shells to `xauth` only | Diverged | Extend `detect_local_x_server` / cookie lookup     |
+| 3   | Settings `provideXServerAutomatically` / `stopXServerWhenIdle` | Not present in SSH schema                                | Missing  | Add schema fields once orchestrator lands          |
+| 4   | "X Servers" section in Open Connections panel                  | Not present in `OpenConnectionsModal.tsx`                | Missing  | Add `Section` after backend command surface exists |
+
+## Resolved
+
+| Date | #   | Resolution |
+| ---- | --- | ---------- |
+| —    | —   | —          |

--- a/docs/concepts/mockups-index.html
+++ b/docs/concepts/mockups-index.html
@@ -64,6 +64,11 @@
         <li><a href="backlog/ssh-jump-host/mockups/ssh-jump-host-indicators.html">ssh-jump-host-indicators.html</a></li>
       </ul></div>
       <div class="idx-group">
+        <h2><code>backlog/x-server-provisioning</code></h2><ul>
+        <li><a href="backlog/x-server-provisioning/mockups/open-connections.html">open-connections.html</a></li>
+        <li><a href="backlog/x-server-provisioning/mockups/provisioning.html">provisioning.html</a></li>
+      </ul></div>
+      <div class="idx-group">
         <h2><code>future/package-manager</code></h2><ul>
         <li><a href="future/package-manager/mockups/package-detail-and-install.html">package-detail-and-install.html</a></li>
         <li><a href="future/package-manager/mockups/package-manager-browse.html">package-manager-browse.html</a></li>


### PR DESCRIPTION
## Summary

Adds a **folder-form Concept** (design-only, no implementation) for ensuring a **local X server** is available when a user opens an SSH connection with X11 forwarding, so remote GUI apps open as **independent native windows** with zero manual setup — the MobaXterm model.

Closes #1044.

### Why

termiHub already implements the **transport half** of SSH X11 forwarding (`core/src/backends/ssh/x11.rs`, reverse port-forwarding, tested via `tests/docker/ssh-x11/`). It works only where a local X server already exists — which on Windows is almost never, and on macOS needs a manual XQuartz install. This concept specifies the **provisioning half**.

### Design of record

- **No embeddable X-server library exists** → ship/spawn an external server (as MobaXterm does).
- **Windows** — bundle/auto-download **VcXsrv** (GPL-3.0). Decision: host a pinned, pre-extracted minimal tree as a **versioned zip on our own GitHub releases**, download + SHA-256 verify + unzip into the portable-aware data dir (reusing the agent-binary resolve/download pattern).
- **macOS** — cannot embed; detect + guided/opt-in **XQuartz** install.
- **Linux** — Xorg/XWayland essentially always present; **detect-and-guide** only.
- Fix `x11.rs` detection (currently `/tmp/.X11-unix` + `xauth` only) to be managed-server-aware with a Windows TCP:6000 probe.

## What's in this PR

- `docs/concepts/backlog/x-server-provisioning/concept.md` — the four required sections, real file references, VcXsrv delivery decision.
- `behavior.md` — Mermaid state machines + sequence diagrams (ensure-server, per-platform, lifecycle, detection, install, idle shutdown) + edge-case table.
- `mockups/provisioning.html` + `mockups/open-connections.html` — hand-written, layout-altitude, **screenshot-verified** (real `mockup.css` classes + lucide icons).
- `sync.md` — seeded ledger (diverged / not implemented) with the concrete code gaps.
- `mockups-index.html` regenerated.

## Follow-up (separate issues, linked to #1044)

Implementation Epic + sub-issues (Windows acquire/lifecycle/auth/detection, cross-platform orchestrator, UI, macOS guided install, Linux detect-and-guide, GPL-3.0 compliance, integration/docs) — to be picked up after the concept stabilizes.

## Test plan

Design-only / docs change — no code. Verification performed:

- [x] `markdownlint-cli2` clean on all three markdown files
- [x] Both mockups rendered via `scripts/internal/screenshot-mockup.sh` and visually confirmed to look like termiHub
- [x] `scripts/internal/build-mockups-index.sh` regenerates the index and references the concept

🤖 Generated with [Claude Code](https://claude.com/claude-code)
