### PR TITLE
docs(ui): UI modernization design-system concept + guardrails

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,9 +16,9 @@ gh issue list --label Concept
 ```
 
 - **Always confirm before implementing**: when picking up an issue, first show the user the issue title and description and ask for confirmation before starting any work
-- **Assign yourself to picked issues**: when picking up an issue, determine the current GitHub user via `gh api user -q .login` and assign them to the issue with `gh issue edit <N> --add-assignee <login>`. Before starting work, check if the issue already has an assignee — if so, warn the user that someone else may already be working on it (check for existing branches like `feature/*` or `bugfix/*` referencing the issue number)
+- **Assignment happens ONLY when _taking_ an issue to implement it — never at creation time**: when (and only when) picking up an existing issue to start work on it, determine the current GitHub user via `gh api user -q .login` and assign them with `gh issue edit <N> --add-assignee <login>`. Before starting work, check if the issue already has an assignee — if so, warn the user that someone else may already be working on it (check for existing branches like `feature/*` or `bugfix/*` referencing the issue number)
 - Reference issue numbers in commits and PRs (`Closes #N` / `Fixes #N`)
-- Create new issues for work discovered during development and label them appropriately
+- Create new issues for work discovered during development and label them appropriately. **Never add an assignee when _creating_ an issue** — not the user, not yourself. Newly created issues are always left unassigned so anyone can pick them up; assigning is exclusively the "taking an issue" action above.
 
 ### Concept Issues
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -207,6 +207,18 @@ Bundle/dep-size concerns belong in the "secondary" bucket — raise them in PR d
 - JSDoc for public functions
 - Naming: `PascalCase` components, `camelCase` functions/hooks, `UPPER_SNAKE_CASE` constants
 
+### UI / Design System
+
+termiHub has a shared design system (concept — the source of truth: [`docs/concepts/backlog/ui-modernization/concept.html`](../docs/concepts/backlog/ui-modernization/concept.html)). **For any non-trivial UI work — building or restyling components/dialogs/forms, adding user-facing feedback, reviewing a UI diff, or making a visual/interaction decision — delegate to the `ui-design` subagent** (`.claude/agents/ui-design.md`), which owns the full system. The concept is authoritative: when it and the code disagree, fix the code by default.
+
+These rules hold in every session (the `ui-design` agent enforces them in depth):
+
+1. **Compose from primitives.** Build UI from the shared primitives in `src/components/ui/` (Button, Input, Field, Select, Modal, Toggle, Toast) — never a new `__btn`, bespoke input, or one-off dialog shell. If a primitive is missing or doesn't exist yet, create/extend it there rather than adding another one-off.
+2. **Build on installed libraries.** Primitives are thin token'd skins over deps already in `package.json` — Modal/Select/Tabs → Radix, Field → `react-hook-form` + `zod`, toasts → `sonner`. Propose a dependency before a custom implementation (see [Prefer Libraries Over Custom Code](#dependencies--prefer-libraries-over-custom-code)).
+3. **Tokens only — no magic values.** Every color/spacing/radius/shadow/font-size/z-index/transition references a token from `src/styles/variables.css`. No raw hex, no `rgba(0,0,0,…)` overlays, no pixel radii. Add a token (with per-theme values) if one is missing; primary-button text uses `--text-on-accent`, never `#fff`.
+4. **Every action gives feedback.** No mutating/async action resolves silently — show a pending state, then success (`toast.success()`) or a recoverable error. Button actions use the async Button state; long-running work uses `toast.loading()`; field errors are inline; blocking connects use the connection-overlay pattern.
+5. **One scrollbar, one motion language.** Scrollbars are styled globally (`global.css`) — never re-style per component. Use `--transition-*` tokens and wrap motion in `@media (prefers-reduced-motion: reduce)`.
+
 ### Rust
 
 - No `.unwrap()` in production code — use `?` with `anyhow::Result`

--- a/.claude/agents/ui-design.md
+++ b/.claude/agents/ui-design.md
@@ -1,0 +1,115 @@
+---
+name: ui-design
+description: >-
+  termiHub UI / frontend design specialist. Use for any non-trivial frontend
+  work: building or restyling React components, dialogs, forms, panels, or
+  sidebars; adding user-facing feedback (loading/success/error); reviewing a
+  UI diff for design-system consistency; or making visual / interaction design
+  decisions. It owns and enforces the termiHub design system — shared token'd
+  primitives, feedback-on-every-action, and one scrollbar / one motion language.
+  The design-system concept is the source of truth; code is fixed to match it.
+tools: Read, Grep, Glob, Edit, Write, Bash
+---
+
+You are the **termiHub UI / design‑system specialist**. termiHub is a Tauri 2 +
+React 18 + TypeScript terminal hub with a VS Code–inspired aesthetic. Your job is
+to make every corner of the app look and behave like the same product: **clean,
+reactive, modern** — and to keep it that way.
+
+## Source of truth
+
+The design system is defined in
+`docs/concepts/backlog/ui-modernization/concept.html`. **When the concept and the
+code disagree, the concept is authoritative — fix the code by default.** Only when
+a real platform/library/performance constraint makes the design wrong do you change
+the concept instead (and say so explicitly). Read that concept before substantial
+UI work.
+
+## The three pillars
+
+1. **Clean** — one shared primitive layer + strict token discipline. No component
+   invents its own colors, radii, shadows, spacing, or scrollbars.
+2. **Reactive** — every mutating/async action gives immediate feedback: a pending
+   state, then success or a recoverable error. Nothing resolves silently.
+3. **Modern** — one motion language, one focus ring, one scrollbar; polish from
+   consistency, not decoration. Respect `prefers-reduced-motion`.
+
+## Non‑negotiable rules
+
+### 1. Compose from primitives — don't hand‑roll
+
+Build UI from the shared primitives in **`src/components/ui/`**: `Button`, `Input`,
+`Field`, `Select`, `Modal`, `Toggle`, `Toast`. Never write a new `__btn` class,
+bespoke input, or one‑off dialog shell. If a primitive is missing a variant,
+**extend the primitive** — don't fork its styles into a component's CSS. If a
+primitive doesn't exist yet (the layer is being introduced per the concept, Phase
+2), **create it in `src/components/ui/`** rather than adding another ad‑hoc control.
+
+### 2. Build on installed libraries
+
+The primitives are thin, token'd **skins over libraries already in
+`package.json`** — do not reinvent their machinery:
+
+- `Modal` / `Select` / `Tabs` / menus → **Radix** (`@radix-ui/react-dialog`,
+  `-select`, `-tabs`, `-dropdown-menu`, `-context-menu`)
+- `Field` + forms → **`react-hook-form` + `@hookform/resolvers` + `zod`**
+  (the schema-driven `DynamicForm` already uses zod — wire, don't rebuild)
+- `Toast` → **`sonner`** (its promise/loading toast resolves in place — ideal for
+  agent deploy, tunnel start, import). Radix Toast is the zero-new-vendor fallback.
+- long lists → **`react-virtuoso`**; color → **`react-colorful`**; charts →
+  **`uplot`**; icons → **`lucide-react`**.
+Per the repo's "Prefer Libraries Over Custom Code" standard, propose a dependency
+before a custom implementation; "I could write it in 50 lines" is not a reason.
+
+### 3. Tokens only — no magic values
+
+Every color, spacing, radius, shadow, font-size, z-index, and transition must
+reference a token from `src/styles/variables.css`. **No raw hex, no
+`rgba(0,0,0,…)` overlays, no pixel radii.** If a value is missing, add a token
+(and its per-theme value in all four theme files) rather than hardcoding.
+Primary-button text uses `--text-on-accent`, never `#fff` (hardcoded white breaks
+the light theme — this is an existing bug to fix, not copy).
+
+### 4. Every action gives feedback (the reactive rule)
+
+No mutating or async user action may resolve silently. Pick the mechanism:
+
+- **button-initiated** (Save/Delete/Apply) → async `Button` state
+  (`onClick: () => Promise<void>` → idle→pending→success/error) + error toast
+- **background / long-running** (agent deploy, tunnel start, import) →
+  `toast.loading()` that resolves in place
+- **field-level** (invalid port, bad key path) → inline `Field` error
+- **blocking connect** (SSH/serial) → the connection-overlay pattern
+  (`TerminalConnectionOverlay` is the reference — spinner, cancel, contextual hints)
+- **success confirmation** → `toast.success()` (auto-dismiss)
+
+### 5. One scrollbar, one motion language
+
+Scrollbars are styled globally (auto-hide, `src/styles/global.css`) — never
+re-style scrollbars in a component. Use `--transition-*` tokens for all motion;
+wrap motion in `@media (prefers-reduced-motion: reduce)`; use the shared enter/exit
+(fade + 8px rise) for overlays and toasts.
+
+## Coding standards (inherit the repo's)
+
+- No `any`; one component per file with a named export; props interface always
+  defined; hooks → handlers → render; JSDoc on public functions.
+- Debug logging goes through `frontendLog` (LogViewer), never `console.*`.
+- **TDD**: write/adjust the Vitest test first, watch it fail, then implement.
+  A design change ships with at least a unit test or documented manual test.
+- Run `./scripts/check.sh` (lint/format/clippy mirror of CI) and `./scripts/test.sh`
+  before declaring done. Formatting is auto-applied by the PostToolUse hook.
+
+## How to work
+
+- **Building UI**: locate the relevant component, reuse/extend a primitive, keep
+  all values on tokens, add the appropriate feedback mechanism, add a test.
+- **Reviewing a diff**: flag every violation of rules 1–5 with the file:line and a
+  concrete fix. Prioritize: light-theme-breaking hardcoded colors, silent actions,
+  and bespoke buttons/dialogs that should be primitives.
+- **Design decisions**: decide from the concept + tokens; if the concept is silent,
+  choose the option most consistent with existing primitives and say what you chose
+  and why. Surface genuine concept↔constraint conflicts instead of silently
+  diverging.
+- Report back concisely: what you changed/found, why, and what still needs a human
+  decision. Your final message is the whole result the main agent receives.

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ tests/reports/*.json
 !.claude/skills
 .claude/skills/*
 !.claude/skills/sync-concept
+# Project agents are shared; personal agents under .claude/agents/ stay local.
+!.claude/agents
+.claude/agents/*
+!.claude/agents/ui-design.md
 *.suo
 *.ntvs*
 *.njsproj

--- a/docs/concepts/backlog/ui-modernization.html
+++ b/docs/concepts/backlog/ui-modernization.html
@@ -1,0 +1,1331 @@
+<!doctype html>
+<!--
+  UI Modernization — single-file concept (design system: clean · reactive · modern).
+  Follows the single-file HTML concept convention: links the shared _assets/
+  (mockup.css chrome + tokens, concept.css document styling, mermaid.min.js).
+  The page-local <style id="proposed"> block holds ONLY the concept's proposed
+  primitive/feedback classes (Button/Input/Toast/…) that do not exist in the app
+  or the shared kit yet — they are the thing being proposed. Everything else
+  reuses real mockup.css class names.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>UI Modernization — Design System (concept)</title>
+    <link rel="stylesheet" href="../_assets/mockup.css" />
+    <link rel="stylesheet" href="../_assets/concept.css" />
+    <style id="proposed">
+      /* PROPOSED tokens (destined for src/styles/variables.css) */
+      :root {
+        --overlay-bg: rgba(6, 7, 10, 0.66);
+        --overlay-blur: blur(8px) saturate(120%);
+        --text-on-accent: #ffffff;
+        --control-height-md: 28px;
+        --control-height-lg: 32px;
+        --bg-input: #1a1e2c;
+        --bg-dropdown: #161b24;
+        --color-info: #6db0ff;
+        --shadow-focus: 0 0 0 3px rgba(61, 125, 232, 0.22);
+        --shadow-dropdown: 0 8px 28px rgba(0, 0, 0, 0.6), 0 2px 8px rgba(0, 0, 0, 0.4);
+        --transition-fast: 130ms cubic-bezier(0.16, 1, 0.3, 1);
+        --transition-normal: 220ms cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      /* app becomes the positioning context for overlays/toasts in mockups */
+      .concept .app {
+        position: relative;
+      }
+      .concept .state-dot--connecting {
+        animation: pulse 1.2s ease-in-out infinite;
+      }
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.35;
+        }
+      }
+
+      /* --- PROPOSED Button primitive --- */
+      .ui-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 7px;
+        height: var(--control-height-lg);
+        padding: 0 14px;
+        font-family: var(--font-family);
+        font-size: 13px;
+        font-weight: 500;
+        border-radius: var(--radius-md);
+        border: 1px solid transparent;
+        cursor: pointer;
+        white-space: nowrap;
+        transition:
+          background var(--transition-fast),
+          box-shadow var(--transition-fast);
+      }
+      .ui-btn .li {
+        width: 15px;
+        height: 15px;
+      }
+      .ui-btn--sm {
+        height: var(--control-height-md);
+        padding: 0 10px;
+        font-size: 12px;
+      }
+      .ui-btn--primary {
+        background: var(--accent-color);
+        color: var(--text-on-accent);
+      }
+      .ui-btn--primary:hover {
+        background: var(--accent-hover);
+        box-shadow: 0 2px 12px rgba(61, 125, 232, 0.35);
+      }
+      .ui-btn--secondary {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        border-color: var(--border-primary);
+      }
+      .ui-btn--ghost {
+        background: transparent;
+        color: var(--text-secondary);
+      }
+      .ui-btn--danger {
+        background: rgba(239, 107, 90, 0.14);
+        color: var(--color-error);
+        border-color: rgba(239, 107, 90, 0.45);
+      }
+      .ui-btn[disabled],
+      .ui-btn--pending {
+        opacity: 0.7;
+        pointer-events: none;
+      }
+      .ui-btn--success {
+        background: rgba(125, 207, 136, 0.16);
+        color: var(--color-success);
+        border-color: rgba(125, 207, 136, 0.4);
+      }
+      .spinner {
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        border: 2px solid currentColor;
+        border-right-color: transparent;
+        animation: spin 0.7s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      /* --- PROPOSED Input / Field / Toggle --- */
+      .ui-field {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+      .ui-field__label {
+        font-size: 12px;
+        color: var(--text-secondary);
+        font-weight: 500;
+      }
+      .ui-input {
+        height: var(--control-height-lg);
+        background: var(--bg-input);
+        color: var(--text-primary);
+        border: 1px solid var(--border-primary);
+        border-radius: var(--radius-md);
+        padding: 0 10px;
+        font: inherit;
+        font-size: 13px;
+        width: 100%;
+      }
+      .ui-input--error {
+        border-color: var(--color-error);
+      }
+      .ui-field__msg {
+        font-size: 11px;
+        color: var(--color-error);
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .ui-field__msg .li {
+        width: 12px;
+        height: 12px;
+      }
+      .ui-toggle {
+        width: 34px;
+        height: 20px;
+        border-radius: 999px;
+        background: var(--bg-active);
+        position: relative;
+        border: 1px solid var(--border-primary);
+      }
+      .ui-toggle::after {
+        content: "";
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: var(--text-secondary);
+      }
+      .ui-toggle--on {
+        background: var(--accent-color);
+        border-color: var(--accent-color);
+      }
+      .ui-toggle--on::after {
+        transform: translateX(14px);
+        background: #fff;
+      }
+
+      /* --- PROPOSED Modal shell --- */
+      .ui-modal-scrim {
+        border-radius: 8px;
+        overflow: hidden;
+        padding: 26px;
+        display: grid;
+        place-items: center;
+        background: var(--overlay-bg);
+        backdrop-filter: var(--overlay-blur);
+      }
+      .ui-modal {
+        width: 320px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-overlay);
+        overflow: hidden;
+      }
+      .ui-modal__head {
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border-secondary);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-weight: 600;
+      }
+      .ui-modal__body {
+        padding: 16px;
+        font-size: 13px;
+        color: var(--text-secondary);
+      }
+      .ui-modal__foot {
+        padding: 11px 16px;
+        border-top: 1px solid var(--border-secondary);
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+      }
+
+      /* --- PROPOSED Toast --- */
+      .toast-stack {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        align-items: stretch;
+      }
+      .toast-stack--float {
+        position: absolute;
+        right: 12px;
+        bottom: 30px;
+        z-index: 1000;
+      }
+      .toast {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        width: 300px;
+        padding: 11px 12px;
+        background: var(--bg-dropdown);
+        border: 1px solid var(--border-primary);
+        border-left-width: 3px;
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-dropdown);
+      }
+      .toast__icon {
+        margin-top: 1px;
+      }
+      .toast__icon .li {
+        width: 16px;
+        height: 16px;
+      }
+      .toast__body {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .toast__title {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-primary);
+      }
+      .toast__msg {
+        font-size: 12px;
+        color: var(--text-secondary);
+      }
+      .toast__close {
+        color: var(--text-secondary);
+        background: none;
+        border: none;
+        cursor: pointer;
+      }
+      .toast__close .li {
+        width: 14px;
+        height: 14px;
+      }
+      .toast--success {
+        border-left-color: var(--color-success);
+      }
+      .toast--success .toast__icon {
+        color: var(--color-success);
+      }
+      .toast--error {
+        border-left-color: var(--color-error);
+      }
+      .toast--error .toast__icon {
+        color: var(--color-error);
+      }
+      .toast--info {
+        border-left-color: var(--color-info);
+      }
+      .toast--info .toast__icon {
+        color: var(--color-info);
+      }
+      .toast--loading {
+        border-left-color: var(--accent-color);
+      }
+      .toast--loading .toast__icon {
+        color: var(--accent-color);
+      }
+      .toast__progress {
+        height: 2px;
+        background: rgba(125, 207, 136, 0.4);
+        margin: 8px -12px -11px;
+      }
+
+      /* --- PROPOSED connection overlay --- */
+      .conn-overlay {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        background: var(--overlay-bg);
+        backdrop-filter: var(--overlay-blur);
+      }
+      .conn-overlay__card {
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 10px;
+      }
+      .conn-overlay__spin {
+        width: 28px;
+        height: 28px;
+        border: 3px solid rgba(61, 125, 232, 0.3);
+        border-top-color: var(--accent-color);
+        border-radius: 50%;
+        animation: spin 0.9s linear infinite;
+      }
+      .conn-overlay h5 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+      }
+      .conn-overlay p {
+        margin: 0;
+        font-size: 12px;
+        color: var(--text-secondary);
+      }
+
+      /* --- mockup helpers (specimen sheets / before-after) --- */
+      .specimen {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        align-items: center;
+        padding: 16px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border-secondary);
+        border-radius: var(--radius-md);
+      }
+      .specimen__row {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .specimen__hint {
+        font-size: 11px;
+        color: var(--text-secondary);
+        font-family: var(--font-mono);
+      }
+      .compare {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+      @media (max-width: 760px) {
+        .compare {
+          grid-template-columns: 1fr;
+        }
+      }
+      .compare__pill {
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-weight: 600;
+      }
+      .compare__pill--before {
+        background: rgba(239, 107, 90, 0.15);
+        color: var(--color-error);
+      }
+      .compare__pill--after {
+        background: rgba(125, 207, 136, 0.15);
+        color: var(--color-success);
+      }
+    </style>
+  </head>
+  <body class="mockup-doc">
+    <!-- Inline lucide sprite (real lucide geometry). Only the symbols used below. -->
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="i-network" viewBox="0 0 24 24">
+        <rect x="16" y="16" width="6" height="6" rx="1" />
+        <rect x="2" y="16" width="6" height="6" rx="1" />
+        <rect x="9" y="2" width="6" height="6" rx="1" />
+        <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3" />
+        <path d="M12 12V8" />
+      </symbol>
+      <symbol id="i-folder-open" viewBox="0 0 24 24">
+        <path
+          d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"
+        />
+      </symbol>
+      <symbol id="i-settings" viewBox="0 0 24 24">
+        <path
+          d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"
+        />
+        <circle cx="12" cy="12" r="3" />
+      </symbol>
+      <symbol id="i-plus" viewBox="0 0 24 24">
+        <path d="M5 12h14" />
+        <path d="M12 5v14" />
+      </symbol>
+      <symbol id="i-panel-left" viewBox="0 0 24 24">
+        <rect width="18" height="18" x="3" y="3" rx="2" />
+        <path d="M9 3v18" />
+      </symbol>
+      <symbol id="i-x" viewBox="0 0 24 24">
+        <path d="M18 6 6 18" />
+        <path d="m6 6 12 12" />
+      </symbol>
+      <symbol id="i-terminal" viewBox="0 0 24 24">
+        <path d="m4 17 6-6-6-6" />
+        <path d="M12 19h8" />
+      </symbol>
+      <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5" /></symbol>
+      <symbol id="i-check-circle" viewBox="0 0 24 24">
+        <path d="M21.801 10A10 10 0 1 1 17 3.335" />
+        <path d="m9 11 3 3L22 4" />
+      </symbol>
+      <symbol id="i-alert-circle" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 8v4" />
+        <path d="M12 16h.01" />
+      </symbol>
+      <symbol id="i-alert-triangle" viewBox="0 0 24 24">
+        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+        <path d="M12 9v4" />
+        <path d="M12 17h.01" />
+      </symbol>
+      <symbol id="i-info" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 16v-4" />
+        <path d="M12 8h.01" />
+      </symbol>
+      <symbol id="i-save" viewBox="0 0 24 24">
+        <path
+          d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"
+        />
+        <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+        <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+      </symbol>
+      <symbol id="i-trash" viewBox="0 0 24 24">
+        <path d="M3 6h18" />
+        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      </symbol>
+      <symbol id="i-server" viewBox="0 0 24 24">
+        <rect width="20" height="8" x="2" y="2" rx="2" />
+        <rect width="20" height="8" x="2" y="14" rx="2" />
+        <path d="M6 6h.01" />
+        <path d="M6 18h.01" />
+      </symbol>
+    </svg>
+
+    <div class="concept">
+      <!-- ── Header ──────────────────────────────────────────────────── -->
+      <header class="concept-header">
+        <h1>UI Modernization — Design System</h1>
+        <div class="concept-meta">
+          <span class="concept-status">Backlog · not implemented</span>
+          <span
+            >Issues:
+            <a href="https://github.com/armaxri/termiHub/issues/1059">#1059</a>
+            <a href="https://github.com/armaxri/termiHub/issues/1060">#1060</a>
+            <a href="https://github.com/armaxri/termiHub/issues/1061">#1061</a>
+            <a href="https://github.com/armaxri/termiHub/issues/1062">#1062</a>
+            <a href="https://github.com/armaxri/termiHub/issues/1063">#1063</a>
+          </span>
+          <span><code>docs/concepts/backlog/ui-modernization.html</code></span>
+        </div>
+      </header>
+
+      <!-- ── TOC ─────────────────────────────────────────────────────── -->
+      <nav class="concept-toc">
+        <h2>Contents</h2>
+        <ol>
+          <li><a href="#overview">Overview &amp; the three pillars</a></li>
+          <li><a href="#ui">UI Interface (primitives, feedback, target state)</a></li>
+          <li><a href="#handling">General Handling</a></li>
+          <li><a href="#behavior">States &amp; Sequences</a></li>
+          <li><a href="#impl">Preliminary Implementation Details</a></li>
+          <li><a href="#sync">Sync Ledger</a></li>
+        </ol>
+      </nav>
+
+      <!-- ── Overview ────────────────────────────────────────────────── -->
+      <section>
+        <h2 id="overview">
+          Overview &amp; the three pillars <a class="anchor" href="#overview">#</a>
+        </h2>
+        <p>
+          termiHub already ships a real design-token system (<code>src/styles/variables.css</code>,
+          ~125 tokens: a 4-8-12-16-24 spacing scale, a radius scale, semantic status colors,
+          connection-state colors, spring transitions) and a clean theme engine with four themes.
+          Scrollbars were recently unified into one auto-hide style.
+          <strong>The foundation is strong — the problem is adoption, not architecture.</strong>
+        </p>
+        <p>
+          There is <strong>no shared component layer</strong>: every dialog re-implements its own
+          button, every form rolls its own input, and most non-terminal actions give the user
+          <strong>no feedback at all</strong>. This concept fixes the shared layer once — so the
+          whole app inherits the improvement — and encodes the rules into <code>CLAUDE.md</code> + a
+          <code>ui-design</code> subagent so future work can't quietly regress.
+        </p>
+
+        <h3>Evidence (current state)</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Count</th>
+                <th>Finding</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>14+</strong></td>
+                <td>dialogs that each re-define their own button CSS (copy-pasted, divergent)</td>
+              </tr>
+              <tr>
+                <td><strong>33</strong></td>
+                <td>
+                  distinct modal/dialog implementations; 14 with hardcoded
+                  <code>rgba(0,0,0,0.7)</code> overlays
+                </td>
+              </tr>
+              <tr>
+                <td><strong>32</strong></td>
+                <td>hardcoded <code>#ffffff</code> button-text uses that break the light theme</td>
+              </tr>
+              <tr>
+                <td><strong>0</strong></td>
+                <td>toast / notification systems — most actions resolve silently</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>The three pillars</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Pillar</th>
+                <th>Concept</th>
+                <th>Fixes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>Clean</strong></td>
+                <td>
+                  One shared primitive layer (Button, Input, Field, Select, Modal, Toggle, Toast) +
+                  strict token discipline. No component invents its own colors, radii, shadows, or
+                  scrollbars.
+                </td>
+                <td>14× button dup, 33 dialog one-offs, light-theme text bug</td>
+              </tr>
+              <tr>
+                <td><strong>Reactive</strong></td>
+                <td>
+                  A global feedback system: a Toast hub + an async-action lifecycle (idle → pending
+                  → success/error) baked into the button.
+                </td>
+                <td>silent CRUD (save/delete/folders/tunnels/unlock/deploy)</td>
+              </tr>
+              <tr>
+                <td><strong>Modern</strong></td>
+                <td>
+                  One motion language, one focus ring, one scrollbar, a tightened spacing rhythm —
+                  respecting <code>prefers-reduced-motion</code>.
+                </td>
+                <td>snap transitions, the last scrollbar straggler</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Goals</h3>
+        <ul>
+          <li>
+            A shared, token-driven primitive layer in <code>src/components/ui/</code> that every
+            screen composes from.
+          </li>
+          <li>Immediate, honest feedback for every mutating/async action.</li>
+          <li>
+            One motion language and one scrollbar; consistency enforced by tokens + a subagent +
+            CLAUDE.md.
+          </li>
+        </ul>
+        <h3>Non-Goals</h3>
+        <ul>
+          <li>
+            No screen-by-screen visual redesign — the layout is good. This is a
+            <strong>systemic</strong> change to the shared layer.
+          </li>
+          <li>
+            No new custom UI machinery where an installed library already fits (see Implementation
+            Details).
+          </li>
+        </ul>
+      </section>
+
+      <!-- ── UI Interface ────────────────────────────────────────────── -->
+      <section>
+        <h2 id="ui">UI Interface <a class="anchor" href="#ui">#</a></h2>
+        <p>
+          The mockups below are authoritative for layout. They reuse the real app class names
+          (<code>.app</code>, <code>.tab</code>, <code>.status-bar</code>, …); the
+          <code>.ui-*</code> and <code>.toast</code> classes are the <em>proposed</em> primitives.
+        </p>
+
+        <div class="mockup-section">
+          <h3>Button — every variant, size, and state in one component</h3>
+          <div class="mockup-note">
+            The <code>&lt;Button&gt;</code> primitive. All values come from tokens, so a theme swap
+            recolors it automatically.
+          </div>
+          <div class="specimen">
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--primary">
+                <svg class="li"><use href="#i-plus" /></svg> Primary</button
+              ><span class="specimen__hint">variant="primary"</span>
+            </div>
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--secondary">Secondary</button
+              ><span class="specimen__hint">variant="secondary"</span>
+            </div>
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--ghost">
+                <svg class="li"><use href="#i-settings" /></svg> Ghost</button
+              ><span class="specimen__hint">variant="ghost"</span>
+            </div>
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--danger">
+                <svg class="li"><use href="#i-trash" /></svg> Delete</button
+              ><span class="specimen__hint">variant="danger"</span>
+            </div>
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--primary" disabled>Disabled</button
+              ><span class="specimen__hint">disabled</span>
+            </div>
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--secondary ui-btn--sm">Small</button
+              ><span class="specimen__hint">size="sm"</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="mockup-section">
+          <h3>Input, Field, Toggle — one styled control set</h3>
+          <div class="mockup-note">
+            <code>&lt;Field&gt;</code> wraps label + control + inline validation — one consistent
+            error affordance everywhere.
+          </div>
+          <div class="specimen" style="align-items: flex-start">
+            <div class="ui-field" style="width: 210px">
+              <label class="ui-field__label">Host</label>
+              <input class="ui-input" value="prod-gateway.internal" />
+            </div>
+            <div class="ui-field" style="width: 210px">
+              <label class="ui-field__label">Port</label>
+              <input class="ui-input ui-input--error" value="22a" />
+              <span class="ui-field__msg"
+                ><svg class="li"><use href="#i-alert-circle" /></svg> Must be a number between
+                1–65535</span
+              >
+            </div>
+            <div class="specimen__row">
+              <span class="ui-field__label">Save credentials</span>
+              <div style="display: flex; gap: 14px; align-items: center">
+                <div class="ui-toggle ui-toggle--on"></div>
+                <span class="specimen__hint">on</span>
+                <div class="ui-toggle"></div>
+                <span class="specimen__hint">off</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mockup-section">
+          <h3>Async Button lifecycle — feedback where the click happens</h3>
+          <div class="mockup-note">
+            One button, four states, handled by the primitive: idle → pending (disabled + spinner) →
+            success (1.2s) / error. Opt-in via <code>onClick={async …}</code>.
+          </div>
+          <div class="specimen">
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--primary">
+                <svg class="li"><use href="#i-save" /></svg> Save</button
+              ><span class="specimen__hint">idle</span>
+            </div>
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--primary ui-btn--pending">
+                <span class="spinner"></span> Saving…</button
+              ><span class="specimen__hint">pending · disabled</span>
+            </div>
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--success">
+                <svg class="li"><use href="#i-check" /></svg> Saved</button
+              ><span class="specimen__hint">success</span>
+            </div>
+            <div class="specimen__row">
+              <button class="ui-btn ui-btn--danger">
+                <svg class="li"><use href="#i-alert-triangle" /></svg> Retry</button
+              ><span class="specimen__hint">error</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="mockup-section">
+          <h3>Toast hub — app-wide transient confirmations &amp; errors</h3>
+          <div class="mockup-note">
+            Four intents from one <code>toast.success/.error/.info/.loading</code> API. Loading
+            toasts resolve into success/error in place (ideal for agent deploy).
+          </div>
+          <div class="toast-stack">
+            <div class="toast toast--success">
+              <span class="toast__icon"
+                ><svg class="li"><use href="#i-check-circle" /></svg
+              ></span>
+              <div class="toast__body">
+                <div class="toast__title">Connection saved</div>
+                <div class="toast__msg">prod-gateway added to <strong>Production</strong>.</div>
+              </div>
+              <button class="toast__close">
+                <svg class="li"><use href="#i-x" /></svg>
+              </button>
+            </div>
+            <div class="toast toast--error">
+              <span class="toast__icon"
+                ><svg class="li"><use href="#i-alert-circle" /></svg
+              ></span>
+              <div class="toast__body">
+                <div class="toast__title">Couldn't reach host</div>
+                <div class="toast__msg">
+                  Connection timed out after 10s. <a href="#ui">Retry</a>
+                </div>
+              </div>
+              <button class="toast__close">
+                <svg class="li"><use href="#i-x" /></svg>
+              </button>
+            </div>
+            <div class="toast toast--loading">
+              <span class="toast__icon"><span class="spinner"></span></span>
+              <div class="toast__body">
+                <div class="toast__title">Deploying agent to build-02…</div>
+                <div class="toast__msg">Downloading binary (2.1 MB)</div>
+                <div class="toast__progress" style="width: 62%"></div>
+              </div>
+            </div>
+            <div class="toast toast--info">
+              <span class="toast__icon"
+                ><svg class="li"><use href="#i-info" /></svg
+              ></span>
+              <div class="toast__body">
+                <div class="toast__title">Copied to clipboard</div>
+                <div class="toast__msg">Terminal buffer (312 lines).</div>
+              </div>
+              <button class="toast__close">
+                <svg class="li"><use href="#i-x" /></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="mockup-section">
+          <h3>Before → after: a dialog composed from primitives</h3>
+          <div class="mockup-note">
+            Same dialog. Left: ~40 lines of bespoke CSS, multiplied by 33. Right:
+            <code>&lt;Modal&gt;</code> + <code>&lt;Button&gt;</code>, zero bespoke CSS, theme-aware.
+          </div>
+          <div class="compare">
+            <div>
+              <h4>
+                <span class="compare__pill compare__pill--before">Today</span> Bespoke per dialog
+              </h4>
+              <div class="ui-modal-scrim" style="background: #0a0c12">
+                <div class="ui-modal">
+                  <div class="ui-modal__head">Delete connection</div>
+                  <div class="ui-modal__body">
+                    Own overlay, own buttons, own spacing — repeated across 33 dialogs.
+                  </div>
+                  <div class="ui-modal__foot">
+                    <button
+                      class="ui-btn ui-btn--ghost"
+                      style="border: 1px solid var(--border-primary)"
+                    >
+                      Cancel
+                    </button>
+                    <button class="ui-btn" style="background: #b23b30; color: #fff">Delete</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <h4>
+                <span class="compare__pill compare__pill--after">Concept</span> Composed shell
+              </h4>
+              <div class="ui-modal-scrim">
+                <div class="ui-modal">
+                  <div class="ui-modal__head">
+                    Delete connection
+                    <button class="toast__close">
+                      <svg class="li"><use href="#i-x" /></svg>
+                    </button>
+                  </div>
+                  <div class="ui-modal__body">
+                    Delete <strong>prod-gateway</strong>? This can't be undone.
+                  </div>
+                  <div class="ui-modal__foot">
+                    <button class="ui-btn ui-btn--secondary">Cancel</button>
+                    <button class="ui-btn ui-btn--danger">
+                      <svg class="li"><use href="#i-trash" /></svg> Delete
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mockup-section">
+          <h3>Target state — the three pillars together</h3>
+          <div class="mockup-note">
+            Clean shared chrome, a blocking connection overlay <em>and</em> a non-blocking success
+            toast coexisting, one connecting dot mirrored in tree, tab, and status bar.
+          </div>
+          <div class="app" style="height: 420px">
+            <div class="app__body">
+              <nav class="activity-bar">
+                <div class="activity-bar__top">
+                  <button class="activity-bar__item activity-bar__item--active" title="Connections">
+                    <svg class="li"><use href="#i-network" /></svg
+                    ><span class="activity-bar__indicator"></span>
+                  </button>
+                  <button class="activity-bar__item" title="Files">
+                    <svg class="li"><use href="#i-folder-open" /></svg>
+                  </button>
+                  <button class="activity-bar__item" title="Servers">
+                    <svg class="li"><use href="#i-server" /></svg>
+                  </button>
+                </div>
+                <div class="activity-bar__bottom">
+                  <button class="activity-bar__item" title="Settings">
+                    <svg class="li"><use href="#i-settings" /></svg>
+                  </button>
+                </div>
+              </nav>
+              <aside class="sidebar">
+                <div class="sidebar__header"><span class="sidebar__title">Connections</span></div>
+                <div class="sidebar__content">
+                  <div class="connection-tree__item">
+                    <svg class="li"><use href="#i-folder-open" /></svg> Production
+                  </div>
+                  <div
+                    class="connection-tree__item connection-tree__item--selected"
+                    style="padding-left: 24px"
+                  >
+                    <span class="state-dot state-dot--connecting"></span> prod-gateway
+                  </div>
+                  <div class="connection-tree__item" style="padding-left: 24px">
+                    <span class="state-dot state-dot--connected"></span> build-02
+                  </div>
+                  <div class="connection-tree__item" style="padding-left: 24px">
+                    <span class="state-dot state-dot--disconnected"></span> db-primary
+                  </div>
+                </div>
+              </aside>
+              <div class="terminal-view">
+                <div class="terminal-view__toolbar">
+                  <div class="terminal-view__toolbar-actions">
+                    <button class="terminal-view__toolbar-btn" title="New Terminal">
+                      <svg class="li"><use href="#i-plus" /></svg>
+                    </button>
+                    <button
+                      class="terminal-view__toolbar-btn terminal-view__toolbar-btn--active"
+                      title="Toggle Sidebar"
+                    >
+                      <svg class="li"><use href="#i-panel-left" /></svg>
+                    </button>
+                  </div>
+                </div>
+                <div class="terminal-view__content">
+                  <div class="panel" style="position: relative">
+                    <div class="tab-bar">
+                      <div class="tab tab--active">
+                        <svg class="li"><use href="#i-network" /></svg
+                        ><span class="state-dot state-dot--connecting"></span
+                        ><span class="tab__title">prod-gateway</span
+                        ><button class="tab__close">
+                          <svg class="li"><use href="#i-x" /></svg>
+                        </button>
+                      </div>
+                      <div class="tab">
+                        <svg class="li"><use href="#i-terminal" /></svg
+                        ><span class="state-dot state-dot--connected"></span
+                        ><span class="tab__title">build-02</span
+                        ><button class="tab__close">
+                          <svg class="li"><use href="#i-x" /></svg>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="terminal"># establishing session…</div>
+                    <div class="conn-overlay">
+                      <div class="conn-overlay__card">
+                        <div class="conn-overlay__spin"></div>
+                        <h5>Connecting to prod-gateway…</h5>
+                        <p>via jump host bastion-1 · attempt 1</p>
+                        <button class="ui-btn ui-btn--secondary ui-btn--sm">Cancel</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="toast-stack toast-stack--float">
+              <div class="toast toast--success">
+                <span class="toast__icon"
+                  ><svg class="li"><use href="#i-check-circle" /></svg
+                ></span>
+                <div class="toast__body">
+                  <div class="toast__title">Tunnel started</div>
+                  <div class="toast__msg">local:5432 → db-primary:5432</div>
+                </div>
+                <button class="toast__close">
+                  <svg class="li"><use href="#i-x" /></svg>
+                </button>
+              </div>
+            </div>
+            <div class="status-bar">
+              <div class="status-bar__section status-bar__section--left">
+                <span class="status-bar__item"
+                  ><span class="state-dot state-dot--connecting"></span> connecting…</span
+                >
+              </div>
+              <div class="status-bar__section status-bar__section--right">
+                <span class="status-bar__item"
+                  ><svg class="li"><use href="#i-server" /></svg> 2 sessions</span
+                ><span class="status-bar__item">UTF-8</span>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li>
+                <span class="callout">A</span> Blocking connection overlay (generalized from today's
+                <code>TerminalConnectionOverlay</code>) — spinner, cancel, contextual hints.
+              </li>
+              <li>
+                <span class="callout">B</span> Non-blocking success toast for a background action —
+                the user keeps working.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── General Handling ────────────────────────────────────────── -->
+      <section>
+        <h2 id="handling">General Handling <a class="anchor" href="#handling">#</a></h2>
+        <p>
+          The core rule: <strong>no mutating or async user action may resolve silently.</strong> It
+          must (a) show an immediate pending state, and (b) confirm success or surface a recoverable
+          error. Which mechanism to use:
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Situation</th>
+                <th>Mechanism</th>
+                <th>Why</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Button-initiated mutation (Save, Delete, Apply)</td>
+                <td>Async Button state + error toast</td>
+                <td>Feedback at the point of action; no eye travel</td>
+              </tr>
+              <tr>
+                <td>Background / long-running (agent deploy, tunnel start, import)</td>
+                <td>Loading toast → resolves in place</td>
+                <td>User keeps working; progress stays visible</td>
+              </tr>
+              <tr>
+                <td>Field-level problem (invalid port, bad key path)</td>
+                <td>Inline <code>Field</code> error</td>
+                <td>Anchored to the offending input</td>
+              </tr>
+              <tr>
+                <td>Blocking connection lifecycle (SSH/serial connect)</td>
+                <td>Connection overlay</td>
+                <td>Full-surface state with cancel + contextual hints</td>
+              </tr>
+              <tr>
+                <td>Success confirmation (saved, copied, deleted)</td>
+                <td>Success toast (auto-dismiss)</td>
+                <td>Acknowledge without interrupting</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <h3>Consistency rules (always on)</h3>
+        <ul>
+          <li>
+            <strong>One scrollbar.</strong> Scrollbars are styled globally (auto-hide,
+            <code>global.css</code>); components never re-style them. Fixes the one straggler (<code
+              >TabGroupChips.css</code
+            >
+            forcing <code>scrollbar-width: none</code>).
+          </li>
+          <li>
+            <strong>One motion language.</strong> Dialogs and toasts share one enter (fade + 8px
+            rise) and exit, using the <code>--transition-*</code> tokens; all motion wrapped in
+            <code>@media (prefers-reduced-motion: reduce)</code>.
+          </li>
+          <li>
+            <strong>Tokens only.</strong> No raw hex, no <code>rgba(0,0,0,…)</code> overlays, no
+            pixel radii — add a token if one is missing.
+          </li>
+        </ul>
+      </section>
+
+      <!-- ── States & Sequences ──────────────────────────────────────── -->
+      <section>
+        <h2 id="behavior">States &amp; Sequences <a class="anchor" href="#behavior">#</a></h2>
+
+        <div class="diagram">
+          <span class="diagram__caption">Async-action (Button) state machine</span>
+          <pre class="mermaid">
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Pending: click (async onClick)
+    Pending --> Success: resolved
+    Pending --> Error: rejected
+    Success --> Idle: after 1.2s
+    Error --> Pending: Retry
+    note right of Success
+        toast.success()
+    end note
+    note right of Error
+        error toast + Retry
+    end note
+          </pre>
+        </div>
+
+        <div class="diagram">
+          <span class="diagram__caption">Toast lifecycle</span>
+          <pre class="mermaid">
+stateDiagram-v2
+    [*] --> Enqueued: toast.x()
+    Enqueued --> Visible: fade + rise · ARIA announce
+    Visible --> Dismissed: success/info timer (4s)
+    Visible --> Dismissed: user close / error acknowledged
+    Dismissed --> [*]: fade out · unmount
+          </pre>
+        </div>
+
+        <div class="diagram">
+          <span class="diagram__caption"
+            >Loading toast that resolves in place (e.g. agent deploy)</span
+          >
+          <pre class="mermaid">
+stateDiagram-v2
+    [*] --> Loading: id = toast.loading()
+    Loading --> Loading: update(id, msg, %)
+    Loading --> Success: toast.success(id)
+    Loading --> Error: toast.error(id)
+    Success --> [*]: auto-dismiss
+    Error --> [*]: sticky until dismissed
+          </pre>
+        </div>
+      </section>
+
+      <!-- ── Implementation Details ──────────────────────────────────── -->
+      <section>
+        <h2 id="impl">Preliminary Implementation Details <a class="anchor" href="#impl">#</a></h2>
+        <p>
+          Aligned to the current architecture (React 18 + TS, Zustand, component-local CSS, Radix
+          for overlays). The design-system work is largely
+          <strong>wrapping libraries already in <code>package.json</code></strong
+          >, not building new machinery — per the repo's "Prefer Libraries Over Custom Code"
+          standard.
+        </p>
+
+        <h3>Build on installed libraries</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Need</th>
+                <th>Already installed</th>
+                <th>Verdict</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Modal / Select / Tabs / menus</td>
+                <td>
+                  <code>@radix-ui/react-dialog</code>, <code>-select</code>, <code>-tabs</code>,
+                  <code>-dropdown-menu</code>, <code>-context-menu</code>
+                </td>
+                <td>wrap, don't build</td>
+              </tr>
+              <tr>
+                <td>Form state + validation</td>
+                <td>
+                  <code>react-hook-form</code> + <code>@hookform/resolvers</code> + <code>zod</code>
+                </td>
+                <td>wire <code>Field</code>/<code>DynamicForm</code>; don't reinvent</td>
+              </tr>
+              <tr>
+                <td>Long lists (tree, 2k-line LogViewer)</td>
+                <td><code>react-virtuoso</code></td>
+                <td>available perf lever</td>
+              </tr>
+              <tr>
+                <td>Color / charts / icons</td>
+                <td>
+                  <code>react-colorful</code> · <code>uplot</code> · <code>lucide-react</code>
+                </td>
+                <td>in use</td>
+              </tr>
+              <tr>
+                <td><strong>Toast / notifications</strong> (the one gap)</td>
+                <td><em>none</em></td>
+                <td>
+                  <strong>add <code>sonner</code></strong> (recommended) — or
+                  <code>@radix-ui/react-toast</code> as the zero-new-vendor fallback
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          <code>sonner</code> is recommended because its promise/loading toast that resolves in
+          place maps 1:1 onto the agent-deploy pattern, and its imperative
+          <code>toast.success()</code> API means no store to build. Two optional accessibility
+          add-ons: <code>@radix-ui/react-tooltip</code> (replace bare <code>title</code> attrs) and
+          <code>@radix-ui/react-switch</code> (the <code>Toggle</code>).
+          <strong>Net new dependencies: one required, at most two optional.</strong>
+        </p>
+
+        <h3>Where things live</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Area</th>
+                <th>Location</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Primitives</td>
+                <td>
+                  <code>src/components/ui/</code> — Button, Input, Field, Select, Modal, Toggle
+                </td>
+                <td>Thin token'd skins over Radix + react-hook-form; shared <code>ui.css</code></td>
+              </tr>
+              <tr>
+                <td>Toast hub</td>
+                <td>
+                  <code>src/components/ui/Toast/</code> + <code>ToastProvider</code> in
+                  <code>App.tsx</code>
+                </td>
+                <td>
+                  Wrapper over <code>sonner</code>; <code>toast.success/.error/.info/.loading</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Async button</td>
+                <td>
+                  <code>Button</code> prop <code>onClick?: () =&gt; Promise&lt;void&gt;</code>
+                </td>
+                <td>Internal idle/pending/success/error; auto-disable; toast on throw</td>
+              </tr>
+              <tr>
+                <td>Tokens</td>
+                <td><code>src/styles/variables.css</code> + 4 theme files</td>
+                <td>
+                  <code>--overlay-bg</code>, <code>--text-on-accent</code>,
+                  <code>--control-height-*</code>, <code>--z-toast</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Guardrails</td>
+                <td><code>.claude/CLAUDE.md</code> + <code>.claude/agents/ui-design.md</code></td>
+                <td><strong>Already landed</strong> on this branch</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Rollout roadmap</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Phase</th>
+                <th>Work</th>
+                <th>Issue</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>1 · Tokens</td>
+                <td>
+                  Add tokens; replace 14 overlays, 32 <code>#fff</code>, stray radii; fix the
+                  scrollbar straggler.
+                </td>
+                <td><a href="https://github.com/armaxri/termiHub/issues/1059">#1059</a></td>
+              </tr>
+              <tr>
+                <td>2 · Primitives</td>
+                <td>Ship <code>src/components/ui/</code> with tests; no call-site changes.</td>
+                <td><a href="https://github.com/armaxri/termiHub/issues/1060">#1060</a></td>
+              </tr>
+              <tr>
+                <td>3 · Feedback</td>
+                <td>Toast hub (sonner) + async Button; wire the silent CRUD paths.</td>
+                <td><a href="https://github.com/armaxri/termiHub/issues/1061">#1061</a></td>
+              </tr>
+              <tr>
+                <td>4 · Migrate</td>
+                <td>Convert the 33 dialogs/forms onto primitives; add motion; one group per PR.</td>
+                <td><a href="https://github.com/armaxri/termiHub/issues/1062">#1062</a></td>
+              </tr>
+              <tr>
+                <td>5 · Guardrails</td>
+                <td>CLAUDE.md + agent (done); architecture.md section; optional lint rule.</td>
+                <td><a href="https://github.com/armaxri/termiHub/issues/1063">#1063</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ── Sync ledger ─────────────────────────────────────────────── -->
+      <section>
+        <h2 id="sync">Sync Ledger <a class="anchor" href="#sync">#</a></h2>
+        <blockquote>
+          <p>
+            Maintained by <code>/sync-concept ui-modernization</code>. Records the last commit at
+            which the concept and code were reconciled, plus open divergences. The concept is the
+            source of truth.
+          </p>
+        </blockquote>
+        <p>
+          <strong>Last synced:</strong> never (not implemented) · <strong>Status:</strong> diverged
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Artifact claim</th>
+                <th>Code reality</th>
+                <th>Type</th>
+                <th>Recommendation</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>1</td>
+                <td><code>src/components/ui/</code> primitive layer</td>
+                <td>Does not exist</td>
+                <td>Missing</td>
+                <td>Implement (#1060), then re-sync</td>
+              </tr>
+              <tr>
+                <td>2</td>
+                <td>Toast hub via <code>sonner</code></td>
+                <td>No toast system; <code>sonner</code> not a dependency</td>
+                <td>Missing</td>
+                <td>Implement (#1061)</td>
+              </tr>
+              <tr>
+                <td>3</td>
+                <td>
+                  Tokens <code>--overlay-bg</code>, <code>--text-on-accent</code>,
+                  <code>--control-height-*</code>
+                </td>
+                <td>Not in <code>variables.css</code></td>
+                <td>Missing</td>
+                <td>Implement (#1059)</td>
+              </tr>
+              <tr>
+                <td>4</td>
+                <td>CLAUDE.md UI section + <code>ui-design</code> agent</td>
+                <td>Present on this branch</td>
+                <td>Aligned</td>
+                <td>—</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+
+    <!-- Mermaid: vendored, offline, renders <pre class="mermaid"> as text → SVG. -->
+    <script src="../_assets/mermaid.min.js"></script>
+    <script>
+      mermaid.initialize({
+        startOnLoad: true,
+        theme: "dark",
+        securityLevel: "loose",
+        fontFamily: "Geist, sans-serif",
+      });
+    </script>
+  </body>
+</html>

--- a/docs/concepts/mockups-index.html
+++ b/docs/concepts/mockups-index.html
@@ -25,6 +25,7 @@
     </p>
       <div class="idx-group">
         <h2><code>backlog</code></h2><ul>
+        <li><a href="backlog/ui-modernization.html">ui-modernization.html</a></li>
         <li><a href="backlog/x-server-provisioning.html">x-server-provisioning.html</a></li>
       </ul></div>
       <div class="idx-group">


### PR DESCRIPTION
## What & why

A **design-only** UI concept plus the durable guardrails to make it stick. termiHub's token/theme foundation is strong, but there's no shared component layer, so dialogs re-roll their own buttons (14+ copies), 33 distinct dialog implementations diverge, and most non-terminal actions give the user no feedback. This PR lands the concept that fixes the shared layer once, and the mechanisms so future work honors it.

No app/runtime code changes — docs, a concept, and Claude Code tooling only.

## Contents

- **Concept (single-file HTML):** `docs/concepts/backlog/ui-modernization.html` — follows the newly-adopted single-file convention (links `_assets/mockup.css` + `concept.css` + `mermaid.min.js`, Mermaid state diagrams, real mockup class names + lucide icons). Covers the three pillars — **clean** (shared primitives + token discipline), **reactive** (Toast hub + async-Button lifecycle), **modern** (one motion language / scrollbar) — a library audit favoring installed deps (`sonner` is the one recommended new dependency), and a 5-phase roadmap. Screenshot-verified.
- **`ui-design` subagent:** `.claude/agents/ui-design.md` — carries the deep design-system knowledge; delegated to for non-trivial UI work. Shared via a `.gitignore` exception mirroring the `sync-concept` skill pattern.
- **CLAUDE.md — "UI / Design System" section:** the always-on guardrail (compose from primitives, tokens-only, feedback-on-every-action, one scrollbar/motion) that delegates to the agent.
- **CLAUDE.md — issue-assignment policy:** newly-created issues are always left unassigned; assignment happens only when _taking_ an issue to implement it.

## Implementation tracking

Phases are filed as separate `Ready2Implement` issues (unassigned): #1059 (tokens) · #1060 (primitives) · #1061 (feedback) · #1062 (migration) · #1063 (guardrails). This PR does not close them — it establishes the concept + guardrails they build on.

## Test plan

Design/docs only — no automated tests apply.

- [x] Concept renders and reads as termiHub — verified via `scripts/internal/screenshot-mockup.sh` (Mermaid diagrams render to SVG; mockups match the app chrome).
- [x] Mockups index regenerated (`scripts/internal/build-mockups-index.sh`).
- [x] Prettier passes on the concept HTML; markdownlint scope (`docs/**/*.md`, `*.md`) does not include the changed files.
- [x] No user-facing app change → no `docs/changes/` fragment required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
