### PR TITLE
feat(ui): Phase 2 — shared primitive layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-switch": "^1.3.2",
     "@radix-ui/react-tabs": "^1.1.13",
     "@shikijs/monaco": "^4.1.0",
     "@tauri-apps/api": "^2.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-switch':
+        specifier: ^1.3.2
+        version: 1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -871,6 +874,9 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -906,6 +912,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context-menu@2.2.16':
     resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
     peerDependencies:
@@ -921,6 +936,15 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1072,6 +1096,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -1107,6 +1144,28 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.3.2':
+    resolution: {integrity: sha512-tgRBI3DdNwAJYE4BBZyZcz/HRRCvAsPkRvG1wvKc+41tBGMxPn/a87T/wikXAvyDypNQ9kaZwHbeZe+veHCGpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
     peerDependencies:
@@ -1138,8 +1197,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1165,8 +1242,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-previous@1.1.1':
     resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1185,6 +1280,15 @@ packages:
 
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3676,6 +3780,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.4': {}
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3703,6 +3809,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@radix-ui/react-context-menu@2.2.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3718,6 +3830,12 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
   '@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-context@1.1.4(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -3876,6 +3994,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3929,6 +4056,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@radix-ui/react-slot@1.3.0(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-switch@1.3.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3959,9 +4108,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
@@ -3979,7 +4143,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -3995,6 +4171,13 @@ snapshots:
   '@radix-ui/react-use-size@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28

--- a/src/components/ui/Button.test.tsx
+++ b/src/components/ui/Button.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Button } from "./Button";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+describe("Button", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders with the base class and default primary/md variant", () => {
+    render(<Button data-testid="btn">Click</Button>);
+    const btn = document.querySelector('[data-testid="btn"]') as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    expect(btn.classList.contains("ui-btn")).toBe(true);
+    expect(btn.classList.contains("ui-btn--primary")).toBe(true);
+    expect(btn.textContent).toContain("Click");
+    expect(btn.type).toBe("button");
+  });
+
+  it.each([
+    ["primary", "ui-btn--primary"],
+    ["secondary", "ui-btn--secondary"],
+    ["ghost", "ui-btn--ghost"],
+    ["danger", "ui-btn--danger"],
+  ] as const)("applies the %s variant class", (variant, expectedClass) => {
+    render(
+      <Button data-testid="btn" variant={variant}>
+        X
+      </Button>
+    );
+    const btn = document.querySelector('[data-testid="btn"]') as HTMLButtonElement;
+    expect(btn.classList.contains(expectedClass)).toBe(true);
+  });
+
+  it("applies the sm size modifier and omits it for md", () => {
+    render(
+      <Button data-testid="sm" size="sm">
+        S
+      </Button>
+    );
+    expect(document.querySelector('[data-testid="sm"]')!.classList.contains("ui-btn--sm")).toBe(
+      true
+    );
+
+    render(
+      <Button data-testid="md" size="md">
+        M
+      </Button>
+    );
+    expect(document.querySelector('[data-testid="md"]')!.classList.contains("ui-btn--sm")).toBe(
+      false
+    );
+  });
+
+  it("applies the full-width modifier when fullWidth is set", () => {
+    render(
+      <Button data-testid="btn" fullWidth>
+        Wide
+      </Button>
+    );
+    expect(document.querySelector('[data-testid="btn"]')!.classList.contains("ui-btn--full")).toBe(
+      true
+    );
+  });
+
+  it("is disabled and does not fire onClick when disabled", () => {
+    const onClick = vi.fn();
+    render(
+      <Button data-testid="btn" disabled onClick={onClick}>
+        No
+      </Button>
+    );
+    const btn = document.querySelector('[data-testid="btn"]') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    act(() => btn.click());
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("fires onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <Button data-testid="btn" onClick={onClick}>
+        Go
+      </Button>
+    );
+    act(() => (document.querySelector('[data-testid="btn"]') as HTMLElement).click());
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards a ref to the underlying button element", () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(
+      <Button data-testid="btn" ref={ref}>
+        Ref
+      </Button>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBe(document.querySelector('[data-testid="btn"]'));
+  });
+
+  it("spreads native button props such as type and aria-label", () => {
+    render(
+      <Button data-testid="btn" type="submit" aria-label="Submit form">
+        S
+      </Button>
+    );
+    const btn = document.querySelector('[data-testid="btn"]') as HTMLButtonElement;
+    expect(btn.type).toBe("submit");
+    expect(btn.getAttribute("aria-label")).toBe("Submit form");
+  });
+});

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,65 @@
+import React, { forwardRef } from "react";
+import "./ui.css";
+
+/** Visual variant of the button. */
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+
+/** Control size. `md` (default) is 32px tall; `sm` is 28px. */
+export type ButtonSize = "sm" | "md";
+
+const VARIANT_CLASS: Record<ButtonVariant, string> = {
+  primary: "ui-btn--primary",
+  secondary: "ui-btn--secondary",
+  ghost: "ui-btn--ghost",
+  danger: "ui-btn--danger",
+};
+
+/**
+ * Props for the shared {@link Button} primitive. Extends the native button
+ * attributes, so any standard prop (`type`, `aria-*`, `form`, …) works.
+ *
+ * Phase 3 will extend `onClick` to optionally return a `Promise<void>` and drive
+ * an internal idle → pending → success/error lifecycle. The click path here is
+ * intentionally left as the plain native handler so that seam stays clean.
+ */
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Visual style. Defaults to `primary`. */
+  variant?: ButtonVariant;
+  /** Control height. Defaults to `md` (32px). */
+  size?: ButtonSize;
+  /** Stretch the button to fill the width of its container. */
+  fullWidth?: boolean;
+  /** Optional leading icon rendered before the label (typically a lucide icon). */
+  icon?: React.ReactNode;
+  /** Test hook forwarded to the DOM node. */
+  "data-testid"?: string;
+}
+
+/**
+ * The single shared button primitive. Every action button in the app should
+ * compose from this rather than hand-rolling a `__btn` class. All colors,
+ * radii, spacing, and focus rings come from design tokens, so a theme swap
+ * recolors it automatically. Primary text uses `--text-on-accent` (never a
+ * hardcoded white, which breaks the light theme).
+ */
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = "primary", size = "md", fullWidth = false, icon, type, className, children, ...rest },
+  ref
+) {
+  const classes = [
+    "ui-btn",
+    VARIANT_CLASS[variant],
+    size === "sm" ? "ui-btn--sm" : "",
+    fullWidth ? "ui-btn--full" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button ref={ref} type={type ?? "button"} className={classes} {...rest}>
+      {icon ? <span className="ui-btn__icon">{icon}</span> : null}
+      {children}
+    </button>
+  );
+});

--- a/src/components/ui/Field.test.tsx
+++ b/src/components/ui/Field.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Field } from "./Field";
+import { Input } from "./Input";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+describe("Field", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a label wired to the control via htmlFor/id", () => {
+    render(
+      <Field data-testid="field" label="Host" htmlFor="host">
+        <Input id="host" />
+      </Field>
+    );
+    const label = document.querySelector('[data-testid="field"] label') as HTMLLabelElement;
+    expect(label).toBeTruthy();
+    expect(label.textContent).toContain("Host");
+    expect(label.getAttribute("for")).toBe("host");
+  });
+
+  it("does not render an error message when error is absent", () => {
+    render(
+      <Field data-testid="field" label="Host" htmlFor="host">
+        <Input id="host" />
+      </Field>
+    );
+    expect(document.querySelector('[data-testid="field-error"]')).toBeNull();
+  });
+
+  it("renders an inline error message when error is set", () => {
+    render(
+      <Field data-testid="field" label="Port" htmlFor="port" error="Must be 1–65535">
+        <Input id="port" />
+      </Field>
+    );
+    const msg = document.querySelector('[data-testid="field-error"]');
+    expect(msg).toBeTruthy();
+    expect(msg!.textContent).toContain("Must be 1–65535");
+    // The error message carries an id that ties back to the control via aria-describedby.
+    const describedById = msg!.getAttribute("id");
+    expect(describedById).toBe("port-error");
+  });
+});

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { AlertCircle } from "lucide-react";
+import "./ui.css";
+
+/**
+ * Props for the presentational {@link Field} wrapper: a label, a control slot,
+ * and an optional inline error message.
+ *
+ * It is react-hook-form-friendly but not coupled to it — pass a resolved
+ * `error?: string` (e.g. `formState.errors.host?.message`) and wire the control
+ * at the call site. The error node carries `id="{htmlFor}-error"` so the control
+ * can reference it via `aria-describedby`.
+ */
+export interface FieldProps {
+  /** Label text shown above the control. */
+  label: string;
+  /** `id` of the control this label points at (label `htmlFor`). */
+  htmlFor: string;
+  /** Resolved validation message. When set, the error state renders. */
+  error?: string;
+  /** The control element (e.g. an {@link Input} or {@link Select}). */
+  children: React.ReactNode;
+  /** Extra class names for the wrapper. */
+  className?: string;
+  /** Test hook forwarded to the wrapper node. */
+  "data-testid"?: string;
+}
+
+/**
+ * The single shared field wrapper — one consistent label + inline error
+ * affordance across every form in the app. Purely presentational: it renders
+ * structure and wires accessibility ids, leaving form state to the caller.
+ */
+export function Field({
+  label,
+  htmlFor,
+  error,
+  children,
+  className,
+  ...rest
+}: FieldProps): React.ReactElement {
+  const errorId = `${htmlFor}-error`;
+  const classes = ["ui-field", className ?? ""].filter(Boolean).join(" ");
+
+  return (
+    <div className={classes} {...rest}>
+      <label className="ui-field__label" htmlFor={htmlFor}>
+        {label}
+      </label>
+      {children}
+      {error ? (
+        <span className="ui-field__msg" id={errorId} role="alert" data-testid="field-error">
+          <AlertCircle className="ui-field__msg-icon" aria-hidden="true" />
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ui/Input.test.tsx
+++ b/src/components/ui/Input.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Input } from "./Input";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+describe("Input", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a text input with the base class", () => {
+    render(<Input data-testid="in" />);
+    const input = document.querySelector('[data-testid="in"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.tagName).toBe("INPUT");
+    expect(input.classList.contains("ui-input")).toBe(true);
+    expect(input.classList.contains("ui-input--error")).toBe(false);
+  });
+
+  it("applies the error modifier and aria-invalid when error is set", () => {
+    render(<Input data-testid="in" error />);
+    const input = document.querySelector('[data-testid="in"]') as HTMLInputElement;
+    expect(input.classList.contains("ui-input--error")).toBe(true);
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("forwards a ref to the underlying input element", () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<Input data-testid="in" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+    expect(ref.current).toBe(document.querySelector('[data-testid="in"]'));
+  });
+
+  it("spreads native input props (value, placeholder, onChange)", () => {
+    const onChange = vi.fn();
+    render(<Input data-testid="in" defaultValue="hello" placeholder="host" onChange={onChange} />);
+    const input = document.querySelector('[data-testid="in"]') as HTMLInputElement;
+    expect(input.value).toBe("hello");
+    expect(input.placeholder).toBe("host");
+  });
+});

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,39 @@
+import React, { forwardRef } from "react";
+import "./ui.css";
+
+/**
+ * Props for the shared {@link Input} primitive. Extends the native input
+ * attributes, so any standard prop (`value`, `placeholder`, `onChange`, `type`,
+ * …) works.
+ */
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** Render the error state (red border) and set `aria-invalid`. */
+  error?: boolean;
+  /** Test hook forwarded to the DOM node. */
+  "data-testid"?: string;
+}
+
+/**
+ * The single shared text-input primitive. Token-styled (`--bg-input`,
+ * `--border-primary`, focus ring via `--shadow-focus`); the `error` prop flips
+ * the border to `--color-error`. Compose it inside a {@link Field} to get a
+ * label and inline validation message.
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { error = false, type, className, ...rest },
+  ref
+) {
+  const classes = ["ui-input", error ? "ui-input--error" : "", className ?? ""]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <input
+      ref={ref}
+      type={type ?? "text"}
+      className={classes}
+      aria-invalid={error || undefined}
+      {...rest}
+    />
+  );
+});

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Modal } from "./Modal";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+describe("Modal", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("does not render content when closed", () => {
+    render(
+      <Modal data-testid="modal" open={false} onOpenChange={() => {}} title="Delete connection">
+        <p>Body</p>
+      </Modal>
+    );
+    expect(document.querySelector('[data-testid="modal"]')).toBeNull();
+  });
+
+  it("renders content, title, and body into a portal when open", () => {
+    render(
+      <Modal data-testid="modal" open onOpenChange={() => {}} title="Delete connection">
+        <p>Are you sure?</p>
+      </Modal>
+    );
+    const content = document.querySelector('[data-testid="modal"]');
+    expect(content).toBeTruthy();
+    expect(content!.classList.contains("ui-modal")).toBe(true);
+    expect(content!.textContent).toContain("Delete connection");
+    expect(content!.textContent).toContain("Are you sure?");
+  });
+
+  it("renders a footer when provided", () => {
+    render(
+      <Modal
+        data-testid="modal"
+        open
+        onOpenChange={() => {}}
+        title="Delete"
+        footer={<button data-testid="modal-confirm">Delete</button>}
+      >
+        <p>Body</p>
+      </Modal>
+    );
+    expect(document.querySelector('[data-testid="modal-confirm"]')).toBeTruthy();
+  });
+
+  it("calls onOpenChange(false) when the built-in close button is clicked", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Modal data-testid="modal" open onOpenChange={onOpenChange} title="Delete">
+        <p>Body</p>
+      </Modal>
+    );
+    act(() => (document.querySelector('[data-testid="modal-close"]') as HTMLElement).click());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import "./ui.css";
+
+/**
+ * Props for the shared {@link Modal} primitive — a token-styled skin over
+ * `@radix-ui/react-dialog`. Focus trap, ESC-to-close, scroll lock, and
+ * portalling all come from Radix. The overlay uses `--overlay-bg` +
+ * `--overlay-blur`; the content uses `--shadow-overlay` and the shared
+ * enter/exit motion (fade + 8px rise, disabled under reduced-motion).
+ */
+export interface ModalProps {
+  /** Whether the modal is open (controlled). */
+  open: boolean;
+  /** Called with the next open state (Radix fires `false` on ESC / close / scrim click). */
+  onOpenChange: (open: boolean) => void;
+  /** Heading text shown in the modal head. */
+  title: React.ReactNode;
+  /** Optional description for screen readers (rendered visually hidden). */
+  description?: string;
+  /** Body content. */
+  children: React.ReactNode;
+  /** Optional footer content — typically {@link Button} actions. */
+  footer?: React.ReactNode;
+  /** Hide the built-in close (X) button in the head. */
+  hideClose?: boolean;
+  /** Test hook forwarded to the content node. */
+  "data-testid"?: string;
+}
+
+/**
+ * The single shared modal shell. Compose dialogs from this + {@link Button}
+ * instead of hand-rolling an overlay, close button, and spacing per dialog.
+ */
+export function Modal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  footer,
+  hideClose = false,
+  ...rest
+}: ModalProps): React.ReactElement {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="ui-modal__overlay" />
+        <Dialog.Content className="ui-modal" data-testid={rest["data-testid"]}>
+          <div className="ui-modal__head">
+            <Dialog.Title className="ui-modal__title">{title}</Dialog.Title>
+            {!hideClose ? (
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="ui-modal__close"
+                  aria-label="Close"
+                  data-testid="modal-close"
+                >
+                  <X className="ui-modal__close-icon" aria-hidden="true" />
+                </button>
+              </Dialog.Close>
+            ) : null}
+          </div>
+          {description ? (
+            <Dialog.Description
+              style={{
+                position: "absolute",
+                width: 1,
+                height: 1,
+                overflow: "hidden",
+                clip: "rect(0 0 0 0)",
+                clipPath: "inset(50%)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {description}
+            </Dialog.Description>
+          ) : null}
+          <div className="ui-modal__body">{children}</div>
+          {footer ? <div className="ui-modal__foot">{footer}</div> : null}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/ui/Select.test.tsx
+++ b/src/components/ui/Select.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Select } from "./Select";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+const OPTIONS = [
+  { value: "ssh", label: "SSH" },
+  { value: "serial", label: "Serial" },
+  { value: "telnet", label: "Telnet" },
+];
+
+describe("Select", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a trigger with the base class and the selected label", () => {
+    render(<Select data-testid="sel" value="serial" onChange={() => {}} options={OPTIONS} />);
+    const trigger = document.querySelector('[data-testid="sel"]') as HTMLButtonElement;
+    expect(trigger).toBeTruthy();
+    expect(trigger.classList.contains("ui-select__trigger")).toBe(true);
+    // Radix renders the selected option's label into the trigger value slot.
+    expect(trigger.textContent).toContain("Serial");
+  });
+
+  it("shows the placeholder when no value is selected", () => {
+    render(
+      <Select
+        data-testid="sel"
+        value={undefined}
+        onChange={() => {}}
+        options={OPTIONS}
+        placeholder="Pick one"
+      />
+    );
+    const trigger = document.querySelector('[data-testid="sel"]') as HTMLButtonElement;
+    expect(trigger.textContent).toContain("Pick one");
+  });
+
+  it("reflects the disabled state on the trigger", () => {
+    render(<Select data-testid="sel" value="ssh" onChange={() => {}} options={OPTIONS} disabled />);
+    const trigger = document.querySelector('[data-testid="sel"]') as HTMLButtonElement;
+    expect(trigger.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("opens the listbox and lists all options when the trigger is activated", () => {
+    render(<Select data-testid="sel" value="ssh" onChange={() => {}} options={OPTIONS} />);
+    const trigger = document.querySelector('[data-testid="sel"]') as HTMLButtonElement;
+    // Radix opens on keyboard activation; dispatch the pointer + keyboard path.
+    act(() => {
+      trigger.focus();
+      trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    const items = document.querySelectorAll('[role="option"]');
+    expect(items.length).toBe(OPTIONS.length);
+    const labels = Array.from(items).map((i) => i.textContent);
+    expect(labels.join(" ")).toContain("Telnet");
+  });
+});

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import * as RadixSelect from "@radix-ui/react-select";
+import { Check, ChevronDown } from "lucide-react";
+import "./ui.css";
+
+/** A single option for the simple {@link Select} API. */
+export interface SelectOption {
+  /** The value submitted when this option is chosen. */
+  value: string;
+  /** The human-readable label shown in the trigger and list. */
+  label: string;
+  /** Disable this individual option. */
+  disabled?: boolean;
+}
+
+/**
+ * Props for the shared {@link Select} primitive — a token-styled skin over
+ * `@radix-ui/react-select`. Keyboard navigation, typeahead, and portalling come
+ * from Radix.
+ *
+ * The common case is the declarative `options` API. For richer items (icons,
+ * groups) pass `children` instead, using the exported {@link SelectItem} and the
+ * raw `RadixSelect.*` parts as an escape hatch.
+ */
+export interface SelectProps {
+  /** Controlled selected value. */
+  value: string | undefined;
+  /** Called with the newly selected value. */
+  onChange: (value: string) => void;
+  /** Declarative option list. Ignored when `children` is provided. */
+  options?: SelectOption[];
+  /** Custom item tree; overrides `options` for full control. */
+  children?: React.ReactNode;
+  /** Placeholder shown when no value is selected. */
+  placeholder?: string;
+  /** Disable the whole control. */
+  disabled?: boolean;
+  /** Accessible label for the trigger. */
+  "aria-label"?: string;
+  /** Test hook forwarded to the trigger. */
+  "data-testid"?: string;
+}
+
+/**
+ * A token-styled Radix Select item. Exposed so callers using the `children`
+ * escape hatch can render options that match the primitive's styling.
+ */
+export function SelectItem({
+  value,
+  disabled,
+  children,
+}: {
+  value: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <RadixSelect.Item className="ui-select__item" value={value} disabled={disabled}>
+      <RadixSelect.ItemText>{children}</RadixSelect.ItemText>
+      <RadixSelect.ItemIndicator className="ui-select__item-indicator">
+        <Check width={14} height={14} aria-hidden="true" />
+      </RadixSelect.ItemIndicator>
+    </RadixSelect.Item>
+  );
+}
+
+/**
+ * The single shared select primitive. Compose from this instead of a native
+ * `<select>` or a bespoke dropdown so styling and keyboard behavior stay
+ * consistent app-wide.
+ */
+export function Select({
+  value,
+  onChange,
+  options,
+  children,
+  placeholder,
+  disabled,
+  ...rest
+}: SelectProps): React.ReactElement {
+  const testid = rest["data-testid"];
+
+  return (
+    <RadixSelect.Root value={value} onValueChange={onChange} disabled={disabled}>
+      <RadixSelect.Trigger
+        className="ui-select__trigger"
+        aria-label={rest["aria-label"]}
+        data-testid={testid}
+      >
+        <RadixSelect.Value placeholder={placeholder} />
+        <RadixSelect.Icon className="ui-select__icon">
+          <ChevronDown width={14} height={14} aria-hidden="true" />
+        </RadixSelect.Icon>
+      </RadixSelect.Trigger>
+      <RadixSelect.Portal>
+        <RadixSelect.Content className="ui-select__content" position="popper" sideOffset={4}>
+          <RadixSelect.Viewport>
+            {children ??
+              options?.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value} disabled={opt.disabled}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+          </RadixSelect.Viewport>
+        </RadixSelect.Content>
+      </RadixSelect.Portal>
+    </RadixSelect.Root>
+  );
+}

--- a/src/components/ui/Toggle.test.tsx
+++ b/src/components/ui/Toggle.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Toggle } from "./Toggle";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+describe("Toggle", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a switch with the base class and reflects checked state", () => {
+    render(<Toggle data-testid="tg" checked onCheckedChange={() => {}} />);
+    const tg = document.querySelector('[data-testid="tg"]') as HTMLButtonElement;
+    expect(tg).toBeTruthy();
+    expect(tg.classList.contains("ui-toggle")).toBe(true);
+    // Radix Switch exposes role="switch" + aria-checked for accessibility.
+    expect(tg.getAttribute("role")).toBe("switch");
+    expect(tg.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("reflects the unchecked state", () => {
+    render(<Toggle data-testid="tg" checked={false} onCheckedChange={() => {}} />);
+    const tg = document.querySelector('[data-testid="tg"]') as HTMLButtonElement;
+    expect(tg.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("calls onCheckedChange with the new value when clicked", () => {
+    const onCheckedChange = vi.fn();
+    render(<Toggle data-testid="tg" checked={false} onCheckedChange={onCheckedChange} />);
+    act(() => (document.querySelector('[data-testid="tg"]') as HTMLElement).click());
+    expect(onCheckedChange).toHaveBeenCalledTimes(1);
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("is disabled and does not fire onCheckedChange when disabled", () => {
+    const onCheckedChange = vi.fn();
+    render(<Toggle data-testid="tg" checked={false} disabled onCheckedChange={onCheckedChange} />);
+    const tg = document.querySelector('[data-testid="tg"]') as HTMLButtonElement;
+    expect(tg.hasAttribute("disabled")).toBe(true);
+    act(() => tg.click());
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/Toggle.tsx
+++ b/src/components/ui/Toggle.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import * as Switch from "@radix-ui/react-switch";
+import "./ui.css";
+
+/**
+ * Props for the shared {@link Toggle} primitive — a token-styled skin over
+ * `@radix-ui/react-switch`, so real `role="switch"`, `aria-checked`, and
+ * keyboard toggling come from Radix rather than a hand-rolled control.
+ */
+export interface ToggleProps {
+  /** Controlled on/off state. */
+  checked: boolean;
+  /** Called with the next boolean value when the user flips the switch. */
+  onCheckedChange: (checked: boolean) => void;
+  /** Disable interaction. */
+  disabled?: boolean;
+  /** Accessible label (use when there is no associated visible `<label>`). */
+  "aria-label"?: string;
+  /** Associates the switch with a `<label htmlFor>`. */
+  id?: string;
+  /** Test hook forwarded to the switch root. */
+  "data-testid"?: string;
+}
+
+/**
+ * The single shared toggle primitive. On = `--accent-color`; the thumb slides
+ * via `--transition-fast` (disabled under reduced-motion). Prefer this over any
+ * bespoke checkbox-styled control.
+ */
+export function Toggle({
+  checked,
+  onCheckedChange,
+  disabled,
+  id,
+  ...rest
+}: ToggleProps): React.ReactElement {
+  return (
+    <Switch.Root
+      id={id}
+      className="ui-toggle"
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      disabled={disabled}
+      {...rest}
+    >
+      <Switch.Thumb className="ui-toggle__thumb" />
+    </Switch.Root>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared UI primitive layer (UI Modernization, Phase 2).
+ *
+ * Compose app UI from these token-driven primitives rather than hand-rolling
+ * buttons, inputs, dialogs, or toggles. Later phases add the async Button
+ * lifecycle (Phase 3) and migrate existing call sites (Phase 4).
+ */
+export { Button } from "./Button";
+export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button";
+
+export { Input } from "./Input";
+export type { InputProps } from "./Input";
+
+export { Field } from "./Field";
+export type { FieldProps } from "./Field";
+
+export { Select, SelectItem } from "./Select";
+export type { SelectProps, SelectOption } from "./Select";
+
+export { Modal } from "./Modal";
+export type { ModalProps } from "./Modal";
+
+export { Toggle } from "./Toggle";
+export type { ToggleProps } from "./Toggle";

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -1,0 +1,449 @@
+/*
+ * Shared primitive styles for the UI Modernization design system (Phase 2).
+ *
+ * Every value references a token from src/styles/variables.css — no raw hex,
+ * no rgba() overlays, no pixel radii. Class names mirror the concept's proposed
+ * `.ui-*` naming (docs/concepts/backlog/ui-modernization.html) so later phases
+ * can migrate mechanically.
+ *
+ * Scrollbars are styled globally (global.css); nothing here re-styles them.
+ * All motion uses --transition-* tokens and is disabled under reduced-motion.
+ */
+
+/* ── Button ─────────────────────────────────────────────────────────── */
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  height: var(--control-height-lg);
+  padding: 0 var(--spacing-md);
+  font-family: var(--font-family);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--letter-spacing-ui);
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background var(--transition-fast),
+    box-shadow var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.ui-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.ui-btn__icon {
+  display: inline-flex;
+  width: 15px;
+  height: 15px;
+}
+
+.ui-btn--sm {
+  height: var(--control-height-md);
+  padding: 0 var(--spacing-sm);
+  font-size: var(--font-size-sm);
+}
+
+.ui-btn--full {
+  width: 100%;
+}
+
+.ui-btn--primary {
+  background: var(--accent-color);
+  color: var(--text-on-accent);
+}
+.ui-btn--primary:hover {
+  background: var(--accent-hover);
+}
+
+.ui-btn--secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--border-primary);
+}
+.ui-btn--secondary:hover {
+  background: var(--bg-hover);
+}
+
+.ui-btn--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+}
+.ui-btn--ghost:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.ui-btn--danger {
+  background: var(--bg-tertiary);
+  color: var(--color-error);
+  border-color: var(--color-error);
+}
+.ui-btn--danger:hover {
+  background: var(--bg-hover);
+}
+
+.ui-btn[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ── Input ──────────────────────────────────────────────────────────── */
+.ui-input {
+  height: var(--control-height-lg);
+  width: 100%;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  padding: 0 var(--spacing-sm);
+  font-family: var(--font-family);
+  font-size: var(--font-size-md);
+  letter-spacing: var(--letter-spacing-ui);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.ui-input::placeholder {
+  color: var(--text-secondary);
+}
+
+.ui-input:focus {
+  outline: none;
+  border-color: var(--focus-border);
+  box-shadow: var(--shadow-focus);
+}
+
+.ui-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ui-input--error {
+  border-color: var(--color-error);
+}
+.ui-input--error:focus {
+  border-color: var(--color-error);
+  box-shadow: var(--shadow-focus);
+}
+
+/* ── Field ──────────────────────────────────────────────────────────── */
+.ui-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.ui-field__label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-medium);
+}
+
+.ui-field__msg {
+  font-size: var(--font-size-xs);
+  color: var(--color-error);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.ui-field__msg-icon {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
+/* ── Select (Radix skin) ────────────────────────────────────────────── */
+.ui-select__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  height: var(--control-height-lg);
+  width: 100%;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  padding: 0 var(--spacing-sm);
+  font-family: var(--font-family);
+  font-size: var(--font-size-md);
+  letter-spacing: var(--letter-spacing-ui);
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.ui-select__trigger:focus-visible {
+  outline: none;
+  border-color: var(--focus-border);
+  box-shadow: var(--shadow-focus);
+}
+
+.ui-select__trigger[data-placeholder] {
+  color: var(--text-secondary);
+}
+
+.ui-select__trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ui-select__icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  color: var(--text-secondary);
+}
+
+.ui-select__content {
+  background: var(--bg-dropdown);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-dropdown);
+  padding: var(--spacing-xs);
+  z-index: var(--z-toast);
+  overflow: hidden;
+}
+
+.ui-select__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  height: var(--control-height-md);
+  padding: 0 var(--spacing-sm);
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.ui-select__item[data-highlighted] {
+  background: var(--bg-hover);
+}
+
+.ui-select__item[data-state="checked"] {
+  color: var(--text-accent);
+}
+
+.ui-select__item-indicator {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  margin-left: auto;
+}
+
+/* ── Toggle (Radix Switch skin) ─────────────────────────────────────── */
+.ui-toggle {
+  width: 34px;
+  height: 20px;
+  flex-shrink: 0;
+  border-radius: var(--radius-xl);
+  background: var(--bg-active);
+  border: 1px solid var(--border-primary);
+  position: relative;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.ui-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.ui-toggle[data-state="checked"] {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+}
+
+.ui-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ui-toggle__thumb {
+  display: block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  transform: translateX(2px);
+  transition:
+    transform var(--transition-fast),
+    background var(--transition-fast);
+  will-change: transform;
+}
+
+.ui-toggle[data-state="checked"] .ui-toggle__thumb {
+  transform: translateX(16px);
+  background: var(--text-on-accent);
+}
+
+/* ── Modal (Radix Dialog skin) ──────────────────────────────────────── */
+.ui-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-bg);
+  backdrop-filter: var(--overlay-blur);
+  z-index: var(--z-toast);
+}
+
+.ui-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 420px;
+  max-width: calc(100vw - var(--spacing-xl) * 2);
+  max-height: calc(100vh - var(--spacing-xl) * 2);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-overlay);
+  z-index: var(--z-toast);
+  overflow: hidden;
+}
+
+.ui-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.ui-modal__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-heading);
+  color: var(--text-primary);
+}
+
+.ui-modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+.ui-modal__close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.ui-modal__close:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+.ui-modal__close-icon {
+  display: inline-flex;
+  width: 15px;
+  height: 15px;
+}
+
+.ui-modal__body {
+  padding: var(--spacing-lg);
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+  overflow: auto;
+}
+
+.ui-modal__foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  border-top: 1px solid var(--border-secondary);
+}
+
+/* Shared enter/exit motion: fade + 8px rise, driven by tokens. */
+.ui-modal__overlay[data-state="open"] {
+  animation: ui-fade-in var(--transition-normal);
+}
+.ui-modal__overlay[data-state="closed"] {
+  animation: ui-fade-out var(--transition-fast);
+}
+.ui-modal[data-state="open"] {
+  animation: ui-modal-in var(--transition-normal);
+}
+.ui-modal[data-state="closed"] {
+  animation: ui-modal-out var(--transition-fast);
+}
+
+@keyframes ui-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes ui-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@keyframes ui-modal-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 8px));
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
+@keyframes ui-modal-out {
+  from {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 8px));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ui-modal__overlay[data-state],
+  .ui-modal[data-state] {
+    animation: none;
+  }
+  .ui-btn,
+  .ui-input,
+  .ui-select__trigger,
+  .ui-toggle,
+  .ui-toggle__thumb,
+  .ui-modal__close {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Implements **Phase 2** of UI Modernization (Closes #1060). Stacked on **#1066 (Phase 1)** — base is the Phase 1 branch for a clean per-phase diff; will auto-retarget to `develop` when Phase 1 merges.

## What
New `src/components/ui/` primitive layer — thin, token-driven skins over installed libraries:
- **Button** — variants (primary/secondary/ghost/danger) + sizes (sm/md), icon slot, `--text-on-accent`, focus ring. Click path left as a clean seam for Phase 3's async lifecycle.
- **Input** / **Field** — styled input + presentational label/error wrapper (react-hook-form-friendly, not coupled).
- **Select** / **Modal** — wrap `@radix-ui/react-dialog` + `@radix-ui/react-select` (a11y, focus trap, ESC, portal come free). Modal overlay uses `--overlay-bg`/`--overlay-blur` + shared reduced-motion-aware enter/exit.
- **Toggle** — wraps `@radix-ui/react-switch` (new dep) for real switch semantics.
- `index.ts` barrel; shared `ui.css` (tokens only).

No call sites migrated (Phase 4) and no async Button lifecycle (Phase 3) — by design.

## Tests
30 unit tests (house `createRoot`+`act` pattern, no @testing-library) covering variants, disabled/error states, and interactions. Full suite 2024 passing; lint, format, and `pnpm build` (tsc) clean.

## Test plan
- [x] `pnpm test` green (30 new + no regressions)
- [x] `pnpm run lint` / `format:check` / `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)