### PR TITLE
fix(ssh): managed-server-aware local X detection + Windows TCP probe (#1051)

### DIFF
--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -180,7 +180,8 @@ impl SshConnector for RusshSshConnector {
             // (issue #1049) will supply one here; until then detection falls
             // back to a user-run server.
             let managed = None;
-            match X11Forwarder::start(config, &mut session, registry, alive.clone(), managed).await {
+            match X11Forwarder::start(config, &mut session, registry, alive.clone(), managed).await
+            {
                 Ok((forwarder, display_num, cookie)) => {
                     x11_display = Some(display_num);
                     x11_cookie = cookie;

--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -176,7 +176,11 @@ impl SshConnector for RusshSshConnector {
         let mut x11_display: Option<u32> = None;
         let mut x11_cookie: Option<String> = None;
         if config.enable_x11_forwarding {
-            match X11Forwarder::start(config, &mut session, registry, alive.clone()).await {
+            // No managed X server source yet — the Windows XServerManager
+            // (issue #1049) will supply one here; until then detection falls
+            // back to a user-run server.
+            let managed = None;
+            match X11Forwarder::start(config, &mut session, registry, alive.clone(), managed).await {
                 Ok((forwarder, display_num, cookie)) => {
                     x11_display = Some(display_num);
                     x11_cookie = cookie;

--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -30,6 +30,33 @@ pub struct LocalXServerInfo {
     pub connection: LocalXConnection,
 }
 
+/// A termiHub-managed local X server (one that termiHub itself started).
+///
+/// See epic #1047 / concept #1044 (X server provisioning). When present, this
+/// carries everything the forwarder needs, so detection can skip all
+/// filesystem/`xauth` probing — which are no-ops on Windows anyway.
+#[derive(Debug, Clone)]
+pub struct ManagedXServer {
+    /// Display number the managed server listens on (TCP `127.0.0.1:6000+n`).
+    pub display_number: u32,
+    /// The MIT-MAGIC-COOKIE-1 (32 hex chars) generated when the server was
+    /// started, or `None` when it runs in `-ac` (loopback-only, no auth) mode.
+    pub cookie: Option<String>,
+}
+
+/// A source of termiHub-managed X server information.
+///
+/// This is a thin seam so detection can be managed-server-aware without a
+/// global: the Windows [`XServerManager`] (issue #1049) will implement it, and
+/// [`detect_local_x_server`] / [`read_local_xauth_cookie`] consult it first.
+/// Until the manager lands, callers pass `None` and behavior is unchanged.
+///
+/// [`XServerManager`]: https://github.com/armaxri/termiHub/issues/1049
+pub trait ManagedXServerSource: Send + Sync {
+    /// Returns the currently managed local X server, if termiHub started one.
+    fn managed_server(&self) -> Option<ManagedXServer>;
+}
+
 /// Manages X11 forwarding over an SSH tunnel.
 pub struct X11Forwarder {
     alive: Arc<AtomicBool>,
@@ -39,14 +66,20 @@ pub struct X11Forwarder {
 impl X11Forwarder {
     /// Start X11 forwarding using an existing SSH session.
     ///
+    /// `managed` is an optional source of termiHub-managed X server info (a
+    /// server termiHub started itself). When present it is consulted before any
+    /// filesystem/`xauth` probing; pass `None` to rely purely on detection of a
+    /// user-run server.
+    ///
     /// Returns `(forwarder, remote_display_number, xauth_cookie)`.
     pub async fn start(
         _config: &SshConfig,
         session: &mut SshSession,
         registry: ForwardedChannelRegistry,
         alive: Arc<AtomicBool>,
+        managed: Option<&dyn ManagedXServerSource>,
     ) -> Result<(Self, u32, Option<String>), SessionError> {
-        let local_x = detect_local_x_server().ok_or_else(|| {
+        let local_x = detect_local_x_server(managed).ok_or_else(|| {
             SessionError::SpawnFailed(
                 "No local X server detected. Start an X server (XQuartz on macOS).".to_string(),
             )
@@ -57,7 +90,7 @@ impl X11Forwarder {
             local_x.display_number
         );
 
-        let xauth_cookie = read_local_xauth_cookie(local_x.display_number);
+        let xauth_cookie = read_local_xauth_cookie(local_x.display_number, managed);
         if xauth_cookie.is_some() {
             info!("X11 forwarding: read local xauth cookie");
         } else {
@@ -265,19 +298,53 @@ fn info_from_parsed(host: Option<String>, display_number: u32) -> LocalXServerIn
 
 /// Detect the local X server.
 ///
-/// Checks the DISPLAY environment variable first, then falls back to
-/// scanning `/tmp/.X11-unix/` for live sockets.
-pub fn detect_local_x_server() -> Option<LocalXServerInfo> {
+/// Resolution order (see the "Detection decision flow" diagram in concept
+/// #1044):
+/// 1. A termiHub-**managed** server (via `managed`) wins — returned as
+///    `Tcp("127.0.0.1", 6000+n)` with no filesystem/`xauth` probing.
+/// 2. The `DISPLAY` environment variable, when set.
+/// 3. Platform fallback for user-run servers: on Unix, scan `/tmp/.X11-unix/`
+///    for live sockets; on Windows, probe `127.0.0.1:6000`.
+pub fn detect_local_x_server(
+    managed: Option<&dyn ManagedXServerSource>,
+) -> Option<LocalXServerInfo> {
+    // 1. A termiHub-managed server takes precedence over everything.
+    if let Some(server) = managed.and_then(|src| src.managed_server()) {
+        return Some(managed_server_info(&server));
+    }
+
+    // 2. Honor an explicit DISPLAY.
     if let Ok(display) = std::env::var("DISPLAY") {
         if !display.is_empty() {
             let (host, display_number, _screen) = parse_display(&display)?;
             return Some(info_from_parsed(host, display_number));
         }
     }
-    detect_from_sockets()
+
+    // 3. Platform fallback for user-installed servers.
+    #[cfg(unix)]
+    {
+        detect_from_sockets()
+    }
+    #[cfg(not(unix))]
+    {
+        detect_from_tcp_probe()
+    }
 }
 
-/// Scan `/tmp/.X11-unix/` for X server sockets.
+/// Map a managed server to a `LocalXServerInfo` (always TCP loopback).
+fn managed_server_info(server: &ManagedXServer) -> LocalXServerInfo {
+    LocalXServerInfo {
+        display_number: server.display_number,
+        connection: LocalXConnection::Tcp(
+            "127.0.0.1".to_string(),
+            6000 + server.display_number as u16,
+        ),
+    }
+}
+
+/// Scan `/tmp/.X11-unix/` for X server sockets (Unix only).
+#[cfg(unix)]
 fn detect_from_sockets() -> Option<LocalXServerInfo> {
     let x11_dir = std::path::Path::new("/tmp/.X11-unix");
     if !x11_dir.is_dir() {
@@ -292,15 +359,9 @@ fn detect_from_sockets() -> Option<LocalXServerInfo> {
             if let Ok(display_num) = num_str.parse::<u32>() {
                 return Some(LocalXServerInfo {
                     display_number: display_num,
-                    #[cfg(unix)]
                     connection: LocalXConnection::UnixSocket(format!(
                         "/tmp/.X11-unix/X{display_num}"
                     )),
-                    #[cfg(not(unix))]
-                    connection: LocalXConnection::Tcp(
-                        "localhost".to_string(),
-                        6000 + display_num as u16,
-                    ),
                 });
             }
         }
@@ -308,11 +369,50 @@ fn detect_from_sockets() -> Option<LocalXServerInfo> {
     None
 }
 
+/// TCP fallback for platforms without `/tmp/.X11-unix` (Windows): probe whether
+/// a user-installed X server (e.g. VcXsrv) is listening on `127.0.0.1:6000`
+/// (display `:0`).
+#[cfg(not(unix))]
+fn detect_from_tcp_probe() -> Option<LocalXServerInfo> {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 6000));
+    if probe_tcp_x_server_at(addr, std::time::Duration::from_millis(300)) {
+        Some(LocalXServerInfo {
+            display_number: 0,
+            connection: LocalXConnection::Tcp("127.0.0.1".to_string(), 6000),
+        })
+    } else {
+        None
+    }
+}
+
+/// Probe whether a TCP X server accepts a connection at `addr` within `timeout`.
+///
+/// Extracted from [`detect_from_tcp_probe`] so it is unit-testable on every
+/// platform (the fallback itself is Windows-only).
+#[cfg(any(not(unix), test))]
+fn probe_tcp_x_server_at(addr: std::net::SocketAddr, timeout: std::time::Duration) -> bool {
+    std::net::TcpStream::connect_timeout(&addr, timeout).is_ok()
+}
+
 /// Read the MIT-MAGIC-COOKIE-1 for the given local display number.
 ///
-/// Runs `xauth list :N` and parses the hex cookie from the output.
-/// Returns `None` if xauth is not installed or no cookie is found.
-pub fn read_local_xauth_cookie(display_number: u32) -> Option<String> {
+/// Resolution order:
+/// 1. If `managed` reports a server on this display, return its known cookie
+///    directly — no `xauth` shell-out (which is a no-op on Windows). A `None`
+///    cookie means the managed server runs in `-ac` mode.
+/// 2. Otherwise run `xauth list :N` and parse the hex cookie. Returns `None` if
+///    `xauth` is not installed (e.g. Windows without a managed server, where a
+///    `-ac` server still works) or no cookie is found.
+pub fn read_local_xauth_cookie(
+    display_number: u32,
+    managed: Option<&dyn ManagedXServerSource>,
+) -> Option<String> {
+    if let Some(server) = managed.and_then(|src| src.managed_server()) {
+        if server.display_number == display_number {
+            return server.cookie;
+        }
+    }
+
     let output = std::process::Command::new("xauth")
         .args(["list", &format!(":{display_number}")])
         .output()

--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -402,4 +402,95 @@ mod tests {
     fn parse_display_invalid_number() {
         assert!(parse_display(":abc").is_none());
     }
+
+    // ── Managed-server-aware detection (issue #1051) ─────────────────────
+
+    /// A test double for a termiHub-managed X server source.
+    struct FakeManaged(Option<ManagedXServer>);
+
+    impl ManagedXServerSource for FakeManaged {
+        fn managed_server(&self) -> Option<ManagedXServer> {
+            self.0.clone()
+        }
+    }
+
+    /// Assert a connection is TCP to the expected host/port (cross-platform).
+    fn assert_tcp(conn: &LocalXConnection, host: &str, port: u16) {
+        match conn {
+            LocalXConnection::Tcp(h, p) => {
+                assert_eq!(h, host);
+                assert_eq!(*p, port);
+            }
+            #[cfg(unix)]
+            LocalXConnection::UnixSocket(_) => panic!("expected a TCP connection, got a Unix socket"),
+        }
+    }
+
+    #[test]
+    fn detect_prefers_managed_server_over_everything() {
+        // A managed server on display :0 must be returned as TCP 127.0.0.1:6000
+        // with no filesystem/xauth probing — even if DISPLAY happens to be set
+        // in the environment (managed is consulted first).
+        let src = FakeManaged(Some(ManagedXServer {
+            display_number: 0,
+            cookie: Some("deadbeef".to_string()),
+        }));
+        let info = detect_local_x_server(Some(&src)).expect("managed server should be detected");
+        assert_eq!(info.display_number, 0);
+        assert_tcp(&info.connection, "127.0.0.1", 6000);
+
+        // The managed cookie is returned directly, without shelling to `xauth`.
+        assert_eq!(
+            read_local_xauth_cookie(0, Some(&src)),
+            Some("deadbeef".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_managed_server_maps_display_to_port() {
+        // Display :3 → TCP port 6003.
+        let src = FakeManaged(Some(ManagedXServer {
+            display_number: 3,
+            cookie: None,
+        }));
+        let info = detect_local_x_server(Some(&src)).expect("managed server should be detected");
+        assert_eq!(info.display_number, 3);
+        assert_tcp(&info.connection, "127.0.0.1", 6003);
+    }
+
+    #[test]
+    fn managed_server_without_cookie_is_ac_mode() {
+        // A managed server started with `-ac` has no cookie; read must return
+        // None (and must not shell to `xauth`).
+        let src = FakeManaged(Some(ManagedXServer {
+            display_number: 0,
+            cookie: None,
+        }));
+        assert_eq!(read_local_xauth_cookie(0, Some(&src)), None);
+    }
+
+    #[test]
+    fn no_managed_server_does_not_short_circuit() {
+        // An empty managed source must behave exactly like `None`: detection
+        // falls through to the platform path (no panic, returns an Option).
+        let src = FakeManaged(None);
+        let _ = detect_local_x_server(Some(&src));
+    }
+
+    #[test]
+    fn tcp_probe_detects_open_and_refused_ports() {
+        use std::net::TcpListener;
+        use std::time::Duration;
+
+        // An open listener is detected.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let open_addr = listener.local_addr().expect("local addr");
+        assert!(probe_tcp_x_server_at(open_addr, Duration::from_millis(500)));
+
+        // A refused (closed) port is not detected.
+        let probe = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let closed_addr = probe.local_addr().expect("local addr");
+        drop(probe);
+        assert!(!probe_tcp_x_server_at(closed_addr, Duration::from_millis(200)));
+    }
 }

--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -522,7 +522,9 @@ mod tests {
                 assert_eq!(*p, port);
             }
             #[cfg(unix)]
-            LocalXConnection::UnixSocket(_) => panic!("expected a TCP connection, got a Unix socket"),
+            LocalXConnection::UnixSocket(_) => {
+                panic!("expected a TCP connection, got a Unix socket")
+            }
         }
     }
 
@@ -591,6 +593,9 @@ mod tests {
         let probe = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let closed_addr = probe.local_addr().expect("local addr");
         drop(probe);
-        assert!(!probe_tcp_x_server_at(closed_addr, Duration::from_millis(200)));
+        assert!(!probe_tcp_x_server_at(
+            closed_addr,
+            Duration::from_millis(200)
+        ));
     }
 }

--- a/docs/changes/feature/1051-managed-x-detection.md
+++ b/docs/changes/feature/1051-managed-x-detection.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- SSH X11 forwarding (Windows): a user-run X server (e.g. VcXsrv) listening on
+  `127.0.0.1:6000` is now discovered even when `DISPLAY` is unset. Local X-server
+  detection previously only scanned `/tmp/.X11-unix` and shelled out to `xauth` —
+  both no-ops on Windows — so a running X server was never found. Detection now
+  falls back to a TCP probe of display `:0` on Windows (#1051).
+
+### Changed
+
+- SSH X11 forwarding: local X-server detection is now managed-server-aware. When
+  termiHub itself provisions an X server (upcoming, epic #1047), detection returns
+  it directly as a loopback TCP connection with its known MIT-MAGIC-COOKIE-1,
+  bypassing all filesystem and `xauth` probing. Unix behavior is unchanged (#1051).

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -9,7 +9,7 @@ source — the #1 authoring error when porting system tests (#899).
 - **Regenerate:** `python scripts/build-testid-catalog.py`
 - **Verify freshness (CI):** `python scripts/build-testid-catalog.py --check`
 
-**452** literal · **123** dynamic · **14** indirect.
+**454** literal · **123** dynamic · **16** indirect.
 
 ## Literal test IDs
 
@@ -153,6 +153,7 @@ Fixed strings — match exactly.
 | `export-submit` | `src/components/ExportImport/ExportDialog.tsx` |
 | `export-warning` | `src/components/ExportImport/ExportDialog.tsx` |
 | `external-files-add` | `src/components/Settings/ExternalFilesSettings.tsx` |
+| `field-error` | `src/components/ui/Field.tsx` |
 | `file-browser-cd-here` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-current-path` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-disconnect` | `src/components/Sidebar/FileBrowser.tsx` |
@@ -249,6 +250,7 @@ Fixed strings — match exactly.
 | `migration-confirm` | `src/components/Settings/PortableModeSettings.tsx` |
 | `migration-dialog` | `src/components/Settings/PortableModeSettings.tsx` |
 | `migration-result` | `src/components/Settings/PortableModeSettings.tsx`, `src/components/Settings/SecuritySettings.tsx` |
+| `modal-close` | `src/components/ui/Modal.tsx` |
 | `monitoring-connect-btn` | `src/components/StatusBar/StatusBar.tsx` |
 | `monitoring-cpu` | `src/components/StatusBar/StatusBar.tsx` |
 | `monitoring-disconnect` | `src/components/StatusBar/StatusBar.tsx` |
@@ -612,7 +614,9 @@ where the component is used, not at the `data-testid` site.
 | `{dataTestId}` | `src/components/PasswordInput/PasswordInput.tsx` |
 | `{footerTestId}` | `src/components/NetworkTools/DiagnosticResultsTable.tsx` |
 | `{option.testId}` | `src/components/Settings/SecuritySettings.tsx` |
+| `{rest["data-testid"]}` | `src/components/ui/Modal.tsx` |
 | `{rowTestIdPrefix ? `${rowTestIdPrefix}-${i}` : undefined}` | `src/components/NetworkTools/DiagnosticResultsTable.tsx` |
+| `{testid}` | `src/components/ui/Select.tsx` |
 | `{tid("auth-method")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |
 | `{tid("connect-timeout")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |
 | `{tid("connection")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |


### PR DESCRIPTION
## Summary

Implements **#1051** (part of epic #1047 · concept #1044): makes local X-server detection managed-server-aware and adds a Windows TCP fallback, closing the `x11.rs` gap where a running VcXsrv was never discovered on Windows.

Previously `detect_local_x_server()` only scanned `/tmp/.X11-unix` and `read_local_xauth_cookie()` shelled to `xauth` — both no-ops on Windows — so even a running X server was invisible.

## Changes

- **New seam** `ManagedXServerSource` trait + `ManagedXServer` struct — the thin abstraction the issue calls for (no global). The Windows `XServerManager` (#1049) will implement it; the connector passes `None` until then.
- **`detect_local_x_server(managed)`** resolves in the concept's documented order: managed server → `DISPLAY` → platform fallback. A managed server returns `Tcp("127.0.0.1", 6000+n)` with **zero** filesystem/`xauth` calls.
- **Windows fallback** (`detect_from_tcp_probe`, `#[cfg(not(unix))]`): after `DISPLAY`, probes `127.0.0.1:6000` with a short timeout so a user-run VcXsrv is found.
- **`read_local_xauth_cookie(display, managed)`** returns the managed cookie directly (`None` = `-ac` mode), else shells to `xauth` as before.
- **Unix path unchanged** — `detect_from_sockets` is now `#[cfg(unix)]`-gated (dead not-unix branch removed); behavior is byte-for-byte identical.

## Acceptance criteria

- ✅ Windows + managed server → correct display + cookie, zero `xauth`/FS calls
- ✅ Windows + user-run server on 6000 without `DISPLAY` → found via TCP probe
- ✅ Unix behavior unchanged (existing tests green)

## Test plan (TDD — tests committed before implementation)

- ✅ Unit: managed source present → managed info + cookie (regression that failed on the pre-fix Windows path)
- ✅ Unit: display → port mapping (`:3` → 6003)
- ✅ Unit: `-ac` mode → no cookie
- ✅ Unit: TCP-probe fallback against a live/refused listener (cross-platform via extracted `probe_tcp_x_server_at`)
- ✅ Unix path unchanged (existing `parse_display` tests)

All 475 core + 7 agent tests pass; `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --check` clean.

> **Note:** the `#[cfg(not(unix))]` branch is verified by reasoning + portable-`std`-only APIs + the cross-platform probe test; a full Windows build couldn't run locally (the `aws-lc-sys` C dep needs the MSVC toolchain). CI builds it on Windows.

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)