### PR TITLE
docs(ui): Phase 5 — lock in design-system guardrails

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -414,7 +414,7 @@ pnpm tauri dev
 1. Implement the backend in `core/src/backends/` (follow existing patterns like `local_shell.rs`, `telnet.rs`)
 2. Add config types in `core/src/config/` (Rust) and `src/types/terminal.ts` (TypeScript)
 3. Wire up in `src-tauri/src/terminal/` and add Tauri commands in `src-tauri/src/commands/` if needed
-4. Create settings UI in `src/components/Settings/`
+4. Create settings UI in `src/components/Settings/` — compose from the shared `src/components/ui/` primitives (Button, Input, Field, Select, Modal, Toggle); never hand-roll button/input/dialog CSS
 5. Add to connection type selector in `src/components/ConnectionEditor/ConnectionEditor.tsx`
 6. Test on target platform, run `./scripts/check.sh`
 

--- a/.claude/agents/ui-design.md
+++ b/.claude/agents/ui-design.md
@@ -19,7 +19,7 @@ reactive, modern** — and to keep it that way.
 ## Source of truth
 
 The design system is defined in
-`docs/concepts/backlog/ui-modernization/concept.html`. **When the concept and the
+`docs/concepts/backlog/ui-modernization.html`. **When the concept and the
 code disagree, the concept is authoritative — fix the code by default.** Only when
 a real platform/library/performance constraint makes the design wrong do you change
 the concept instead (and say so explicitly). Read that concept before substantial
@@ -58,8 +58,8 @@ The primitives are thin, token'd **skins over libraries already in
   agent deploy, tunnel start, import). Radix Toast is the zero-new-vendor fallback.
 - long lists → **`react-virtuoso`**; color → **`react-colorful`**; charts →
   **`uplot`**; icons → **`lucide-react`**.
-Per the repo's "Prefer Libraries Over Custom Code" standard, propose a dependency
-before a custom implementation; "I could write it in 50 lines" is not a reason.
+  Per the repo's "Prefer Libraries Over Custom Code" standard, propose a dependency
+  before a custom implementation; "I could write it in 50 lines" is not a reason.
 
 ### 3. Tokens only — no magic values
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,9 +324,20 @@ graph LR
 | **DynamicForm**       | `src/components/DynamicForm/`      | Generic schema-driven form renderer — renders `SettingsField` definitions as UI widgets (text, password, select, file picker, key-value list, etc.)                                                                                                                                |
 | **Settings Panel**    | `src/components/Settings/`         | Two-panel settings with categories: General, Appearance, Terminal, External Files, Security, plus Customize Layout dialog                                                                                                                                                          |
 | **Theme Engine**      | `src/themes/`                      | Dark/Light/System theme management, CSS variable application, xterm.js live re-theming                                                                                                                                                                                             |
+| **Design System**     | `src/components/ui/`               | Shared UI primitives (Button, Input, Field, Select, Modal, Toggle) + Toast feedback hub — token-driven skins over Radix / react-hook-form / sonner. All dialogs and forms compose from these.                                                                                      |
 | **App Store**         | `src/store/appStore.ts`            | Zustand store managing all frontend state (panels, tabs, connections, tunnels, agents, themes, layout, credentials)                                                                                                                                                                |
 | **API Service**       | `src/services/api.ts`              | Tauri command wrappers                                                                                                                                                                                                                                                             |
 | **Event Service**     | `src/services/events.ts`           | Tauri event listeners and dispatcher                                                                                                                                                                                                                                               |
+
+### Design System
+
+The frontend is built on a shared **design system** (`src/components/ui/`) that keeps every screen visually and behaviorally consistent:
+
+- **Primitives** — `Button`, `Input`, `Field`, `Select`, `Modal`, `Toggle`: thin, token-driven skins over installed libraries (Radix for `Modal`/`Select`, `@radix-ui/react-switch` for `Toggle`, `react-hook-form` + `zod` for forms). Dialogs and forms compose from these instead of hand-rolling CSS.
+- **Feedback** — a `Toast` hub (`src/components/ui/Toast/`, over `sonner`) plus an async `Button` lifecycle (idle → pending → success/error). Every mutating/async action gives immediate feedback; nothing resolves silently.
+- **Tokens** — all visual values come from `src/styles/variables.css` (colors, spacing, radii, shadows, control heights, z-index, transitions). No raw hex, per-component overlays, or ad-hoc scrollbars.
+
+The system is authoritative: its concept lives at [`docs/concepts/backlog/ui-modernization.html`](concepts/backlog/ui-modernization.html), the rules are in `.claude/CLAUDE.md` (UI / Design System), and the `ui-design` subagent (`.claude/agents/ui-design.md`) enforces them. New UI must compose from the primitives and use tokens only.
 
 ### Level 2: Backend Modules
 


### PR DESCRIPTION
Implements **Phase 5** of UI Modernization (Closes #1063).

## What
- **architecture.md** — adds a *Design System* row + subsection documenting `src/components/ui/` (primitives, Toast feedback, tokens) and pointing at the concept, CLAUDE.md rules, and the `ui-design` agent.
- **`.claude/agents/ui-design.md`** — fixes the stale concept path (retired folder form → single-file `ui-modernization.html`).
- **CLAUDE.md** — the "Adding a New Terminal Backend" checklist now tells contributors to compose settings UI from the `ui/` primitives.

The CLAUDE.md "UI / Design System" section and the `ui-design` subagent already landed with the concept, so those checklist items are complete.

## Deferred
The optional raw-hex / bespoke-`__btn` ESLint rule is intentionally deferred to after **Phase 4 (#1062)** — unmigrated dialogs still define `__btn` classes, so the rule would fail until migration completes.

## Test plan
Docs/tooling only. `markdownlint` clean on `docs/architecture.md`. No app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)