### PR TITLE
refactor(ui): Phase 4 batch 3 — migrate Sidebar dialogs

### DIFF
--- a/docs/changes/feature/1062-migrate-sidebar-dialogs.md
+++ b/docs/changes/feature/1062-migrate-sidebar-dialogs.md
@@ -1,0 +1,3 @@
+## Changed
+
+- The connection-error, confirm-delete, agent-setup, and jump-host-path dialogs now use the shared modal and button components — consistent styling, motion, and focus. The confirm-delete dialog's button text also renders correctly in the light theme (was hardcoded white).

--- a/src/components/Sidebar/AgentSetupDialog.css
+++ b/src/components/Sidebar/AgentSetupDialog.css
@@ -1,42 +1,11 @@
-.agent-setup-dialog__overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--overlay-bg);
-  backdrop-filter: var(--overlay-blur);
-  -webkit-backdrop-filter: var(--overlay-blur);
-  z-index: 1000;
-}
+/* Content-specific styles for the multi-phase agent-setup flow. The shell,
+   overlay, close button, action buttons, and text inputs come from the shared
+   Modal + Button + Input primitives. */
 
-.agent-setup-dialog__overlay[data-state="open"] {
-  animation: dialog-overlay-show 200ms ease;
-}
-
-.agent-setup-dialog__content {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 1001;
-  width: 420px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-xl);
-  padding: var(--spacing-lg);
-  box-shadow: var(--shadow-overlay);
+.agent-setup-dialog__body {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
-}
-
-.agent-setup-dialog__content[data-state="open"] {
-  animation: dialog-content-show 280ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.agent-setup-dialog__title {
-  font-size: var(--font-size-lg);
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0;
 }
 
 .agent-setup-dialog__description {
@@ -63,46 +32,6 @@
   gap: var(--spacing-sm);
 }
 
-.agent-setup-dialog__input {
-  flex: 1;
-  height: 32px;
-  font-size: var(--font-size-sm);
-  background: var(--bg-input);
-  color: var(--text-primary);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-md);
-  padding: 0 var(--spacing-sm);
-  outline: none;
-  box-sizing: border-box;
-  transition:
-    border-color var(--transition-fast),
-    box-shadow var(--transition-fast);
-}
-
-.agent-setup-dialog__input:focus {
-  border-color: var(--focus-border);
-  box-shadow: var(--shadow-focus);
-}
-
-.agent-setup-dialog__browse-btn {
-  padding: var(--spacing-xs) var(--spacing-sm);
-  font-size: var(--font-size-sm);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-primary);
-  background: var(--bg-input);
-  color: var(--text-primary);
-  cursor: pointer;
-  white-space: nowrap;
-  transition:
-    background-color var(--transition-fast),
-    border-color var(--transition-fast);
-}
-
-.agent-setup-dialog__browse-btn:hover {
-  background-color: var(--bg-hover);
-  border-color: var(--border-primary);
-}
-
 .agent-setup-dialog__checkbox-row {
   display: flex;
   align-items: center;
@@ -119,58 +48,6 @@
   font-size: var(--font-size-sm);
   color: var(--color-error);
   margin: 0;
-}
-
-.agent-setup-dialog__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-sm);
-}
-
-.agent-setup-dialog__btn {
-  padding: var(--spacing-xs) var(--spacing-md);
-  font-size: var(--font-size-sm);
-  border-radius: var(--radius-md);
-  border: none;
-  cursor: pointer;
-  transition:
-    background-color var(--transition-fast),
-    transform var(--transition-fast),
-    box-shadow var(--transition-fast);
-}
-
-.agent-setup-dialog__btn--primary {
-  background-color: var(--accent-color);
-  color: var(--text-on-accent);
-}
-
-.agent-setup-dialog__btn--primary:hover {
-  background-color: var(--accent-hover);
-  box-shadow: 0 2px 12px rgba(61, 125, 232, 0.35);
-}
-
-.agent-setup-dialog__btn--primary:active {
-  transform: translateY(1px) scale(0.98);
-  box-shadow: none;
-}
-
-.agent-setup-dialog__btn--primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.agent-setup-dialog__btn--secondary {
-  background-color: transparent;
-  color: var(--text-secondary);
-}
-
-.agent-setup-dialog__btn--secondary:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.agent-setup-dialog__btn--secondary:active {
-  transform: translateY(1px) scale(0.98);
 }
 
 /* Detecting phase */
@@ -209,10 +86,27 @@
   gap: var(--spacing-sm);
 }
 
-/* Arch select */
+/* Arch select — a native select styled to match the Input primitive. */
 .agent-setup-dialog__select {
+  height: 32px;
+  font-size: var(--font-size-sm);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  padding: 0 var(--spacing-sm);
+  outline: none;
+  box-sizing: border-box;
   cursor: pointer;
   appearance: auto;
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.agent-setup-dialog__select:focus {
+  border-color: var(--focus-border);
+  box-shadow: var(--shadow-focus);
 }
 
 .agent-setup-dialog__arch-hint {

--- a/src/components/Sidebar/AgentSetupDialog.migration.test.tsx
+++ b/src/components/Sidebar/AgentSetupDialog.migration.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Migration regression guard for AgentSetupDialog (UI Modernization, Phase 4).
+ *
+ * Asserts the dialog renders through the shared `Modal` primitive (`.ui-modal`)
+ * and that its primary "Start Setup" action fires the deploy path once the
+ * architecture-detection phase has resolved to `ready`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { AgentSetupDialog } from "./AgentSetupDialog";
+import type { RemoteArchInfo } from "@/services/api";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+const detectAgentArch = vi.fn(async (_config: unknown): Promise<RemoteArchInfo> => makeArchInfo());
+const setupRemoteAgent = vi.fn();
+
+vi.mock("@/services/api", () => ({
+  detectAgentArch: (config: unknown) => detectAgentArch(config),
+  setupRemoteAgent: (...args: unknown[]) => setupRemoteAgent(...args),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
+const addTab = vi.fn();
+vi.mock("@/store/appStore", () => ({
+  useAppStore: (selector: (s: unknown) => unknown) =>
+    selector({ addTab, requestPassword: vi.fn() }),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      loading: vi.fn(() => "toast-1"),
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+let container: HTMLDivElement;
+let root: Root;
+
+const baseUrl = "https://github.com/armaxri/termiHub/releases/download/dev-latest/termihub-agent-";
+
+function makeArchInfo(overrides: Partial<RemoteArchInfo> = {}): RemoteArchInfo {
+  return {
+    arch: "x86_64",
+    os: "Linux",
+    archSuffix: "linux-x64",
+    downloadBaseUrl: baseUrl,
+    downloadUrl: `${baseUrl}linux-x64`,
+    buildBranch: null,
+    ...overrides,
+  };
+}
+
+function makeAgent(): RemoteAgentDefinition {
+  return {
+    id: "agent-1",
+    name: "Test Host",
+    config: {
+      host: "host.local",
+      port: 22,
+      username: "user",
+      authMethod: "key",
+      keyPath: "/home/user/.ssh/id_ed25519",
+    },
+    agentSettings: {
+      enableMonitoring: true,
+      enableFileBrowser: true,
+      enableDocker: false,
+      defaultShell: null,
+      startingDirectory: "",
+      logLevel: "info",
+      verboseTracing: false,
+      persistentScrollbackBufferSizeMb: 4,
+    },
+    isExpanded: false,
+    connectionState: "disconnected",
+  };
+}
+
+/** Render the dialog and let the async architecture detection settle. */
+async function renderAndDetect(agent: RemoteAgentDefinition, onOpenChange = vi.fn()) {
+  await act(async () => {
+    root.render(<AgentSetupDialog open={true} onOpenChange={onOpenChange} agent={agent} />);
+  });
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+describe("AgentSetupDialog — primitive migration", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    detectAgentArch.mockReset();
+    detectAgentArch.mockResolvedValue(makeArchInfo());
+    setupRemoteAgent.mockReset();
+    setupRemoteAgent.mockResolvedValue({ sessionId: "sess-1" });
+    addTab.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders through the shared Modal primitive", async () => {
+    await renderAndDetect(makeAgent());
+    expect(document.querySelector(".ui-modal")).not.toBeNull();
+    expect(document.querySelector('[data-testid="agent-setup-submit"]')).not.toBeNull();
+  });
+
+  it("shows the detecting phase while architecture detection is in flight", async () => {
+    // A detection that never resolves keeps the dialog in the detecting phase.
+    detectAgentArch.mockImplementation(() => new Promise<RemoteArchInfo>(() => {}));
+    await act(async () => {
+      root.render(<AgentSetupDialog open={true} onOpenChange={vi.fn()} agent={makeAgent()} />);
+    });
+    expect(document.querySelector(".agent-setup-dialog__detecting")).not.toBeNull();
+    // No form fields until detection completes.
+    expect(document.querySelector('[data-testid="agent-setup-arch-select"]')).toBeNull();
+  });
+
+  it("fires the deploy path when the primary Start Setup action is clicked", async () => {
+    await renderAndDetect(makeAgent());
+
+    const submit = document.querySelector(
+      '[data-testid="agent-setup-submit"]'
+    ) as HTMLButtonElement;
+    expect(submit).not.toBeNull();
+    expect(submit.disabled).toBe(false);
+
+    await act(async () => {
+      submit.click();
+    });
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(setupRemoteAgent).toHaveBeenCalledTimes(1);
+    expect(addTab).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Sidebar/AgentSetupDialog.tsx
+++ b/src/components/Sidebar/AgentSetupDialog.tsx
@@ -8,13 +8,12 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from "react";
-import * as Dialog from "@radix-ui/react-dialog";
 import { open } from "@tauri-apps/plugin-dialog";
 import { RemoteAgentDefinition } from "@/types/connection";
 import { RemoteAgentConfig } from "@/types/terminal";
 import { detectAgentArch, setupRemoteAgent, RemoteArchInfo } from "@/services/api";
 import { useAppStore } from "@/store/appStore";
-import { toast } from "@/components/ui";
+import { Modal, Button, Input, toast } from "@/components/ui";
 import "./AgentSetupDialog.css";
 
 interface AgentSetupDialogProps {
@@ -234,218 +233,206 @@ export function AgentSetupDialog({ open: isOpen, onOpenChange, agent }: AgentSet
     (binarySource === "branch" && !branchName.trim());
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="agent-setup-dialog__overlay" />
-        <Dialog.Content className="agent-setup-dialog__content">
-          <Dialog.Title className="agent-setup-dialog__title">
-            Setup Agent: {agent.name}
-          </Dialog.Title>
-          <Dialog.Description className="agent-setup-dialog__description">
-            Upload and install the termihub-agent binary on {agent.config.host}. The setup process
-            will be visible in an SSH terminal.
-          </Dialog.Description>
+    <Modal
+      open={isOpen}
+      onOpenChange={onOpenChange}
+      title={`Setup Agent: ${agent.name}`}
+      footer={
+        <>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            data-testid="agent-setup-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSetup}
+            disabled={isSubmitDisabled}
+            data-testid="agent-setup-submit"
+          >
+            {loading ? "Setting up…" : "Start Setup"}
+          </Button>
+        </>
+      }
+    >
+      <div className="agent-setup-dialog__body">
+        <p className="agent-setup-dialog__description">
+          Upload and install the termihub-agent binary on {agent.config.host}. The setup process
+          will be visible in an SSH terminal.
+        </p>
 
-          {phase.kind === "detecting" && (
-            <div className="agent-setup-dialog__detecting">
-              <div className="agent-setup-dialog__spinner" />
-              <span className="agent-setup-dialog__detecting-label">
-                Connecting and detecting architecture…
-              </span>
-            </div>
-          )}
+        {phase.kind === "detecting" && (
+          <div className="agent-setup-dialog__detecting">
+            <div className="agent-setup-dialog__spinner" />
+            <span className="agent-setup-dialog__detecting-label">
+              Connecting and detecting architecture…
+            </span>
+          </div>
+        )}
 
-          {phase.kind === "error" && (
-            <div className="agent-setup-dialog__detection-error">
-              <p className="agent-setup-dialog__error">{phase.message}</p>
-              <button
-                className="agent-setup-dialog__btn agent-setup-dialog__btn--secondary"
-                onClick={runDetection}
-                type="button"
+        {phase.kind === "error" && (
+          <div className="agent-setup-dialog__detection-error">
+            <p className="agent-setup-dialog__error">{phase.message}</p>
+            <Button variant="secondary" onClick={runDetection}>
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {phase.kind === "ready" && (
+          <>
+            <div className="agent-setup-dialog__field">
+              <label className="agent-setup-dialog__label" htmlFor="arch-select">
+                Target Architecture
+              </label>
+              <select
+                id="arch-select"
+                className="agent-setup-dialog__select"
+                value={selectedArch}
+                onChange={(e) => setSelectedArch(e.target.value as ArchSuffix)}
+                data-testid="agent-setup-arch-select"
               >
-                Retry
-              </button>
-            </div>
-          )}
-
-          {phase.kind === "ready" && (
-            <>
-              <div className="agent-setup-dialog__field">
-                <label className="agent-setup-dialog__label" htmlFor="arch-select">
-                  Target Architecture
-                </label>
-                <select
-                  id="arch-select"
-                  className="agent-setup-dialog__input agent-setup-dialog__select"
-                  value={selectedArch}
-                  onChange={(e) => setSelectedArch(e.target.value as ArchSuffix)}
-                  data-testid="agent-setup-arch-select"
-                >
-                  {ARCH_OPTIONS.map((o) => (
-                    <option key={o.suffix} value={o.suffix}>
-                      {o.label}
-                    </option>
-                  ))}
-                </select>
-                <span className="agent-setup-dialog__arch-hint">
-                  Detected: {phase.archInfo.os} / {phase.archInfo.arch}
-                  {!isKnownSuffix(phase.archInfo.archSuffix) && (
-                    <span className="agent-setup-dialog__unsupported">
-                      {" "}
-                      (unsupported — please verify the selection above)
-                    </span>
-                  )}
-                </span>
-              </div>
-
-              <div className="agent-setup-dialog__field">
-                <label className="agent-setup-dialog__label">Binary Source</label>
-                <div className="agent-setup-dialog__source-selector">
-                  <label
-                    className={`agent-setup-dialog__source-option${binarySource === "github" ? " agent-setup-dialog__source-option--selected" : ""}`}
-                  >
-                    <div className="agent-setup-dialog__source-option-header">
-                      <input
-                        type="radio"
-                        name="binarySource"
-                        value="github"
-                        checked={binarySource === "github"}
-                        onChange={() => setBinarySource("github")}
-                        data-testid="agent-setup-source-github"
-                      />
-                      <span>Download from GitHub</span>
-                    </div>
-                    {effectiveDownloadUrl && (
-                      <div className="agent-setup-dialog__url">{effectiveDownloadUrl}</div>
-                    )}
-                  </label>
-
-                  <label
-                    className={`agent-setup-dialog__source-option${binarySource === "branch" ? " agent-setup-dialog__source-option--selected" : ""}`}
-                  >
-                    <div className="agent-setup-dialog__source-option-header">
-                      <input
-                        type="radio"
-                        name="binarySource"
-                        value="branch"
-                        checked={binarySource === "branch"}
-                        onChange={() => setBinarySource("branch")}
-                        data-testid="agent-setup-source-branch"
-                      />
-                      <span>Branch build</span>
-                    </div>
-                    {binarySource === "branch" && (
-                      <>
-                        <input
-                          className="agent-setup-dialog__input"
-                          type="text"
-                          value={branchName}
-                          onChange={(e) => setBranchName(e.target.value)}
-                          placeholder="e.g. feature/666-my-branch"
-                          data-testid="agent-setup-branch-name"
-                        />
-                        {branchBuildUrl && (
-                          <div className="agent-setup-dialog__url">{branchBuildUrl}</div>
-                        )}
-                      </>
-                    )}
-                  </label>
-
-                  <label
-                    className={`agent-setup-dialog__source-option${binarySource === "local" ? " agent-setup-dialog__source-option--selected" : ""}`}
-                  >
-                    <div className="agent-setup-dialog__source-option-header">
-                      <input
-                        type="radio"
-                        name="binarySource"
-                        value="local"
-                        checked={binarySource === "local"}
-                        onChange={() => setBinarySource("local")}
-                        data-testid="agent-setup-source-local"
-                      />
-                      <span>Use local file</span>
-                    </div>
-                    {binarySource === "local" && (
-                      <div className="agent-setup-dialog__file-row">
-                        <input
-                          className="agent-setup-dialog__input"
-                          type="text"
-                          value={localBinaryPath}
-                          onChange={(e) => setLocalBinaryPath(e.target.value)}
-                          placeholder="Path to termihub-agent binary"
-                          data-testid="agent-setup-binary-path"
-                        />
-                        <button
-                          className="agent-setup-dialog__browse-btn"
-                          onClick={handleBrowse}
-                          type="button"
-                          data-testid="agent-setup-browse"
-                        >
-                          Browse
-                        </button>
-                      </div>
-                    )}
-                  </label>
-                </div>
-              </div>
-
-              <div className="agent-setup-dialog__field">
-                <label className="agent-setup-dialog__label">Remote Install Path</label>
-                <input
-                  className="agent-setup-dialog__input"
-                  type="text"
-                  value={remotePath}
-                  onChange={(e) => setRemotePath(e.target.value)}
-                  readOnly={isWindows}
-                  data-testid="agent-setup-remote-path"
-                />
-                {isWindows && (
-                  <span className="agent-setup-dialog__arch-hint">
-                    On Windows the agent is always installed under %LOCALAPPDATA%\termiHub\agent.
+                {ARCH_OPTIONS.map((o) => (
+                  <option key={o.suffix} value={o.suffix}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <span className="agent-setup-dialog__arch-hint">
+                Detected: {phase.archInfo.os} / {phase.archInfo.arch}
+                {!isKnownSuffix(phase.archInfo.archSuffix) && (
+                  <span className="agent-setup-dialog__unsupported">
+                    {" "}
+                    (unsupported — please verify the selection above)
                   </span>
                 )}
+              </span>
+            </div>
+
+            <div className="agent-setup-dialog__field">
+              <label className="agent-setup-dialog__label">Binary Source</label>
+              <div className="agent-setup-dialog__source-selector">
+                <label
+                  className={`agent-setup-dialog__source-option${binarySource === "github" ? " agent-setup-dialog__source-option--selected" : ""}`}
+                >
+                  <div className="agent-setup-dialog__source-option-header">
+                    <input
+                      type="radio"
+                      name="binarySource"
+                      value="github"
+                      checked={binarySource === "github"}
+                      onChange={() => setBinarySource("github")}
+                      data-testid="agent-setup-source-github"
+                    />
+                    <span>Download from GitHub</span>
+                  </div>
+                  {effectiveDownloadUrl && (
+                    <div className="agent-setup-dialog__url">{effectiveDownloadUrl}</div>
+                  )}
+                </label>
+
+                <label
+                  className={`agent-setup-dialog__source-option${binarySource === "branch" ? " agent-setup-dialog__source-option--selected" : ""}`}
+                >
+                  <div className="agent-setup-dialog__source-option-header">
+                    <input
+                      type="radio"
+                      name="binarySource"
+                      value="branch"
+                      checked={binarySource === "branch"}
+                      onChange={() => setBinarySource("branch")}
+                      data-testid="agent-setup-source-branch"
+                    />
+                    <span>Branch build</span>
+                  </div>
+                  {binarySource === "branch" && (
+                    <>
+                      <Input
+                        value={branchName}
+                        onChange={(e) => setBranchName(e.target.value)}
+                        placeholder="e.g. feature/666-my-branch"
+                        data-testid="agent-setup-branch-name"
+                      />
+                      {branchBuildUrl && (
+                        <div className="agent-setup-dialog__url">{branchBuildUrl}</div>
+                      )}
+                    </>
+                  )}
+                </label>
+
+                <label
+                  className={`agent-setup-dialog__source-option${binarySource === "local" ? " agent-setup-dialog__source-option--selected" : ""}`}
+                >
+                  <div className="agent-setup-dialog__source-option-header">
+                    <input
+                      type="radio"
+                      name="binarySource"
+                      value="local"
+                      checked={binarySource === "local"}
+                      onChange={() => setBinarySource("local")}
+                      data-testid="agent-setup-source-local"
+                    />
+                    <span>Use local file</span>
+                  </div>
+                  {binarySource === "local" && (
+                    <div className="agent-setup-dialog__file-row">
+                      <Input
+                        value={localBinaryPath}
+                        onChange={(e) => setLocalBinaryPath(e.target.value)}
+                        placeholder="Path to termihub-agent binary"
+                        data-testid="agent-setup-binary-path"
+                      />
+                      <Button
+                        variant="secondary"
+                        onClick={handleBrowse}
+                        data-testid="agent-setup-browse"
+                      >
+                        Browse
+                      </Button>
+                    </div>
+                  )}
+                </label>
               </div>
+            </div>
 
-              {!isWindows && (
-                <div className="agent-setup-dialog__checkbox-row">
-                  <input
-                    type="checkbox"
-                    id="install-service"
-                    checked={installService}
-                    onChange={(e) => setInstallService(e.target.checked)}
-                    data-testid="agent-setup-install-service"
-                  />
-                  <label htmlFor="install-service">Install systemd service</label>
-                </div>
+            <div className="agent-setup-dialog__field">
+              <label className="agent-setup-dialog__label">Remote Install Path</label>
+              <Input
+                value={remotePath}
+                onChange={(e) => setRemotePath(e.target.value)}
+                readOnly={isWindows}
+                data-testid="agent-setup-remote-path"
+              />
+              {isWindows && (
+                <span className="agent-setup-dialog__arch-hint">
+                  On Windows the agent is always installed under %LOCALAPPDATA%\termiHub\agent.
+                </span>
               )}
-            </>
-          )}
+            </div>
 
-          {submitError && (
-            <p className="agent-setup-dialog__error" data-testid="agent-setup-error">
-              {submitError}
-            </p>
-          )}
+            {!isWindows && (
+              <div className="agent-setup-dialog__checkbox-row">
+                <input
+                  type="checkbox"
+                  id="install-service"
+                  checked={installService}
+                  onChange={(e) => setInstallService(e.target.checked)}
+                  data-testid="agent-setup-install-service"
+                />
+                <label htmlFor="install-service">Install systemd service</label>
+              </div>
+            )}
+          </>
+        )}
 
-          <div className="agent-setup-dialog__actions">
-            <button
-              className="agent-setup-dialog__btn agent-setup-dialog__btn--secondary"
-              onClick={() => onOpenChange(false)}
-              data-testid="agent-setup-cancel"
-            >
-              Cancel
-            </button>
-            <button
-              className="agent-setup-dialog__btn agent-setup-dialog__btn--primary"
-              onClick={handleSetup}
-              disabled={isSubmitDisabled}
-              data-testid="agent-setup-submit"
-            >
-              {loading ? "Setting up…" : "Start Setup"}
-            </button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        {submitError && (
+          <p className="agent-setup-dialog__error" data-testid="agent-setup-error">
+            {submitError}
+          </p>
+        )}
+      </div>
+    </Modal>
   );
 }

--- a/src/components/Sidebar/ConfirmDeleteDialog.tsx
+++ b/src/components/Sidebar/ConfirmDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import * as Dialog from "@radix-ui/react-dialog";
+import { Modal, Button } from "@/components/ui";
 
 interface ConfirmDeleteDialogProps {
   open: boolean;
@@ -15,66 +15,23 @@ export function ConfirmDeleteDialog({
   onCancel,
 }: ConfirmDeleteDialogProps) {
   return (
-    <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="shortcuts-overlay__backdrop" />
-        <Dialog.Content
-          className="confirm-delete-dialog"
-          data-testid="confirm-delete-dialog"
-          style={{
-            position: "fixed",
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-            width: "380px",
-            padding: "var(--spacing-lg, 16px)",
-            backgroundColor: "var(--bg-secondary)",
-            border: "1px solid var(--border-primary)",
-            borderRadius: "var(--radius-lg, 8px)",
-            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)",
-            zIndex: 1001,
-          }}
-        >
-          <Dialog.Title
-            style={{ margin: "0 0 var(--spacing-md, 12px) 0", color: "var(--text-primary)" }}
-          >
-            Confirm Delete
-          </Dialog.Title>
-          <Dialog.Description style={{ color: "var(--text-secondary)", marginBottom: "16px" }}>
-            {message}
-          </Dialog.Description>
-          <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end" }}>
-            <button
-              onClick={onCancel}
-              data-testid="confirm-delete-cancel"
-              style={{
-                padding: "4px 16px",
-                border: "1px solid var(--border-primary)",
-                borderRadius: "var(--radius-md, 4px)",
-                background: "transparent",
-                color: "var(--text-primary)",
-                cursor: "pointer",
-              }}
-            >
-              Cancel
-            </button>
-            <button
-              onClick={onConfirm}
-              data-testid="confirm-delete-confirm"
-              style={{
-                padding: "4px 16px",
-                border: "none",
-                borderRadius: "var(--radius-md, 4px)",
-                background: "var(--color-error)",
-                color: "#fff",
-                cursor: "pointer",
-              }}
-            >
-              Delete
-            </button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    <Modal
+      open={open}
+      onOpenChange={(isOpen) => !isOpen && onCancel()}
+      title="Confirm Delete"
+      data-testid="confirm-delete-dialog"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onCancel} data-testid="confirm-delete-cancel">
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirm} data-testid="confirm-delete-confirm">
+            Delete
+          </Button>
+        </>
+      }
+    >
+      {message}
+    </Modal>
   );
 }

--- a/src/components/Sidebar/ConnectionErrorDialog.css
+++ b/src/components/Sidebar/ConnectionErrorDialog.css
@@ -1,38 +1,7 @@
-.connection-error-dialog__overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--overlay-bg);
-  backdrop-filter: var(--overlay-blur);
-  -webkit-backdrop-filter: var(--overlay-blur);
-  z-index: 1000;
-}
+/* Content-specific styles. The shell, overlay, close button, and action
+   buttons come from the shared Modal + Button primitives. */
 
-.connection-error-dialog__overlay[data-state="open"] {
-  animation: dialog-overlay-show 200ms ease;
-}
-
-.connection-error-dialog__content {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 1001;
-  width: 400px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-xl);
-  padding: var(--spacing-lg);
-  box-shadow: var(--shadow-overlay);
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-md);
-}
-
-.connection-error-dialog__content[data-state="open"] {
-  animation: dialog-content-show 280ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.connection-error-dialog__icon-row {
+.connection-error-dialog__title-row {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
@@ -43,13 +12,6 @@
   flex-shrink: 0;
 }
 
-.connection-error-dialog__title {
-  font-size: var(--font-size-lg);
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0;
-}
-
 .connection-error-dialog__message {
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
@@ -58,6 +20,7 @@
 }
 
 .connection-error-dialog__details {
+  margin-top: var(--spacing-md);
   font-size: var(--font-size-xs, 11px);
   color: var(--text-secondary);
 }
@@ -77,51 +40,4 @@
   font-size: var(--font-size-xs, 11px);
   word-break: break-all;
   white-space: pre-wrap;
-}
-
-.connection-error-dialog__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--spacing-sm);
-}
-
-.connection-error-dialog__btn {
-  padding: var(--spacing-xs) var(--spacing-md);
-  font-size: var(--font-size-sm);
-  border-radius: var(--radius-md);
-  border: none;
-  cursor: pointer;
-  transition:
-    background-color var(--transition-fast),
-    transform var(--transition-fast),
-    box-shadow var(--transition-fast);
-}
-
-.connection-error-dialog__btn--primary {
-  background-color: var(--accent-color);
-  color: var(--text-on-accent);
-}
-
-.connection-error-dialog__btn--primary:hover {
-  background-color: var(--accent-hover);
-  box-shadow: 0 2px 12px rgba(61, 125, 232, 0.35);
-}
-
-.connection-error-dialog__btn--primary:active {
-  transform: translateY(1px) scale(0.98);
-  box-shadow: none;
-}
-
-.connection-error-dialog__btn--secondary {
-  background-color: transparent;
-  color: var(--text-secondary);
-}
-
-.connection-error-dialog__btn--secondary:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.connection-error-dialog__btn--secondary:active {
-  transform: translateY(1px) scale(0.98);
 }

--- a/src/components/Sidebar/ConnectionErrorDialog.tsx
+++ b/src/components/Sidebar/ConnectionErrorDialog.tsx
@@ -6,8 +6,8 @@
  * AgentSetupDialog.
  */
 
-import * as Dialog from "@radix-ui/react-dialog";
 import { AlertTriangle } from "lucide-react";
+import { Modal, Button } from "@/components/ui";
 import { ClassifiedAgentError } from "@/utils/classifyAgentError";
 import "./ConnectionErrorDialog.css";
 
@@ -28,71 +28,69 @@ export function ConnectionErrorDialog({
 }: ConnectionErrorDialogProps) {
   if (!error) return null;
 
+  const showSetupAgent =
+    (error.category === "agent-missing" || error.category === "agent-outdated") &&
+    Boolean(onSetupAgent);
+  const showForceReconnect = error.category === "already-connected" && Boolean(onForceReconnect);
+
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="connection-error-dialog__overlay" />
-        <Dialog.Content className="connection-error-dialog__content">
-          <div className="connection-error-dialog__icon-row">
-            <AlertTriangle size={20} className="connection-error-dialog__icon" />
-            <Dialog.Title
-              className="connection-error-dialog__title"
-              data-testid="connection-error-title"
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={
+        <span className="connection-error-dialog__title-row">
+          <AlertTriangle size={20} className="connection-error-dialog__icon" aria-hidden="true" />
+          <span data-testid="connection-error-title">{error.title}</span>
+        </span>
+      }
+      footer={
+        <>
+          {showSetupAgent && (
+            <Button
+              variant="primary"
+              onClick={() => {
+                onOpenChange(false);
+                onSetupAgent?.();
+              }}
+              data-testid="connection-error-setup-agent"
             >
-              {error.title}
-            </Dialog.Title>
-          </div>
-          <Dialog.Description
-            className="connection-error-dialog__message"
-            data-testid="connection-error-message"
-          >
-            {error.message}
-          </Dialog.Description>
-          {error.rawError !== error.message && (
-            <details
-              className="connection-error-dialog__details"
-              data-testid="connection-error-details"
-            >
-              <summary>Technical details</summary>
-              <code className="connection-error-dialog__raw">{error.rawError}</code>
-            </details>
+              Setup Agent
+            </Button>
           )}
-          <div className="connection-error-dialog__actions">
-            {(error.category === "agent-missing" || error.category === "agent-outdated") &&
-              onSetupAgent && (
-                <button
-                  className="connection-error-dialog__btn connection-error-dialog__btn--primary"
-                  onClick={() => {
-                    onOpenChange(false);
-                    onSetupAgent();
-                  }}
-                  data-testid="connection-error-setup-agent"
-                >
-                  Setup Agent
-                </button>
-              )}
-            {error.category === "already-connected" && onForceReconnect && (
-              <button
-                className="connection-error-dialog__btn connection-error-dialog__btn--primary"
-                onClick={() => {
-                  onOpenChange(false);
-                  onForceReconnect();
-                }}
-                data-testid="connection-error-force-reconnect"
-              >
-                Force Reconnect
-              </button>
-            )}
-            <button
-              className="connection-error-dialog__btn connection-error-dialog__btn--secondary"
-              onClick={() => onOpenChange(false)}
-              data-testid="connection-error-close"
+          {showForceReconnect && (
+            <Button
+              variant="primary"
+              onClick={() => {
+                onOpenChange(false);
+                onForceReconnect?.();
+              }}
+              data-testid="connection-error-force-reconnect"
             >
-              Close
-            </button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+              Force Reconnect
+            </Button>
+          )}
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            data-testid="connection-error-close"
+          >
+            Close
+          </Button>
+        </>
+      }
+    >
+      <p className="connection-error-dialog__message" data-testid="connection-error-message">
+        {error.message}
+      </p>
+      {error.rawError !== error.message && (
+        <details
+          className="connection-error-dialog__details"
+          data-testid="connection-error-details"
+        >
+          <summary>Technical details</summary>
+          <code className="connection-error-dialog__raw">{error.rawError}</code>
+        </details>
+      )}
+    </Modal>
   );
 }

--- a/src/components/Sidebar/ConnectionPathDialog.css
+++ b/src/components/Sidebar/ConnectionPathDialog.css
@@ -1,25 +1,11 @@
-.connection-path-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 360px;
-  max-width: calc(100vw - 32px);
-  padding: var(--spacing-lg, 16px);
-  background-color: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-lg, 8px);
-  box-shadow: var(--shadow-overlay, 0 8px 32px rgba(0, 0, 0, 0.3));
-  z-index: 1001;
-}
+/* Content-specific styles for the jump-host path visualization. The shell,
+   overlay, close button, and Close action come from the shared Modal + Button
+   primitives. */
 
-.connection-path-dialog__title {
+.connection-path-dialog__title-row {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin: 0 0 4px 0;
-  color: var(--text-primary);
-  font-size: 14px;
 }
 
 .connection-path-dialog__subtitle {
@@ -111,23 +97,4 @@
 .connection-path-dialog__arrow {
   color: var(--text-secondary);
   margin: 2px 0 2px 14px;
-}
-
-.connection-path-dialog__actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 16px;
-}
-
-.connection-path-dialog__button {
-  padding: 4px 16px;
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-md, 4px);
-  background: transparent;
-  color: var(--text-primary);
-  cursor: pointer;
-}
-
-.connection-path-dialog__button:hover {
-  background: var(--bg-hover, var(--bg-tertiary));
 }

--- a/src/components/Sidebar/ConnectionPathDialog.tsx
+++ b/src/components/Sidebar/ConnectionPathDialog.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import * as Dialog from "@radix-ui/react-dialog";
 import {
   Route,
   ChevronDown,
@@ -11,6 +10,7 @@ import {
   XCircle,
   Circle,
 } from "lucide-react";
+import { Modal, Button } from "@/components/ui";
 import { SavedConnection } from "@/types/connection";
 import { getJumpHosts } from "@/utils/jumpHost";
 import { probeConnectionPath, cancelConnectionPathProbe } from "@/services/api";
@@ -143,70 +143,65 @@ export function ConnectionPathDialog({ open, connection, onClose }: ConnectionPa
   ];
 
   return (
-    <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="shortcuts-overlay__backdrop" />
-        <Dialog.Content className="connection-path-dialog" data-testid="connection-path-dialog">
-          <Dialog.Title className="connection-path-dialog__title">
-            <Route size={16} /> Connection Path
-          </Dialog.Title>
-          <Dialog.Description className="connection-path-dialog__subtitle">
-            {connection.name} reaches its target through{" "}
-            {hops.length === 1 ? "1 jump host" : `${hops.length} jump hosts`}.
-          </Dialog.Description>
-          <ol className="connection-path-dialog__chain">
-            {nodes.map((node, index) => {
-              const Icon = node.icon;
-              const isLast = index === nodes.length - 1;
-              // The "You" origin (index 0) is always reachable; probed nodes map
-              // to statuses[index - 1].
-              const status: NodeStatus =
-                index === 0 ? "connected" : (statuses[index - 1] ?? "pending");
-              const message = index === 0 ? undefined : messages[index - 1];
-              const { Icon: StatusIcon, spin } = statusIcon(status);
-              return (
-                <li
-                  key={index}
-                  className="connection-path-dialog__node"
-                  data-status={status}
-                  data-testid="connection-path-node"
-                >
-                  <div className="connection-path-dialog__row">
-                    <Icon size={15} className="connection-path-dialog__icon" />
-                    <span className="connection-path-dialog__label">{node.label}</span>
-                    <span className="connection-path-dialog__detail">{node.detail}</span>
-                    <StatusIcon
-                      size={15}
-                      className={`connection-path-dialog__status connection-path-dialog__status--${status}${
-                        spin ? " connection-path-dialog__status--spin" : ""
-                      }`}
-                      aria-label={`status: ${status}`}
-                    />
-                  </div>
-                  {message && (
-                    <span className="connection-path-dialog__error" role="alert">
-                      {message}
-                    </span>
-                  )}
-                  {!isLast && (
-                    <ChevronDown size={14} className="connection-path-dialog__arrow" aria-hidden />
-                  )}
-                </li>
-              );
-            })}
-          </ol>
-          <div className="connection-path-dialog__actions">
-            <button
-              type="button"
-              className="connection-path-dialog__button"
-              onClick={onClose}
-              data-testid="connection-path-close"
+    <Modal
+      open={open}
+      onOpenChange={(isOpen) => !isOpen && onClose()}
+      data-testid="connection-path-dialog"
+      title={
+        <span className="connection-path-dialog__title-row">
+          <Route size={16} /> Connection Path
+        </span>
+      }
+      footer={
+        <Button variant="secondary" onClick={onClose} data-testid="connection-path-close">
+          Close
+        </Button>
+      }
+    >
+      <p className="connection-path-dialog__subtitle">
+        {connection.name} reaches its target through{" "}
+        {hops.length === 1 ? "1 jump host" : `${hops.length} jump hosts`}.
+      </p>
+      <ol className="connection-path-dialog__chain">
+        {nodes.map((node, index) => {
+          const Icon = node.icon;
+          const isLast = index === nodes.length - 1;
+          // The "You" origin (index 0) is always reachable; probed nodes map
+          // to statuses[index - 1].
+          const status: NodeStatus = index === 0 ? "connected" : (statuses[index - 1] ?? "pending");
+          const message = index === 0 ? undefined : messages[index - 1];
+          const { Icon: StatusIcon, spin } = statusIcon(status);
+          return (
+            <li
+              key={index}
+              className="connection-path-dialog__node"
+              data-status={status}
+              data-testid="connection-path-node"
             >
-              Close
-            </button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+              <div className="connection-path-dialog__row">
+                <Icon size={15} className="connection-path-dialog__icon" />
+                <span className="connection-path-dialog__label">{node.label}</span>
+                <span className="connection-path-dialog__detail">{node.detail}</span>
+                <StatusIcon
+                  size={15}
+                  className={`connection-path-dialog__status connection-path-dialog__status--${status}${
+                    spin ? " connection-path-dialog__status--spin" : ""
+                  }`}
+                  aria-label={`status: ${status}`}
+                />
+              </div>
+              {message && (
+                <span className="connection-path-dialog__error" role="alert">
+                  {message}
+                </span>
+              )}
+              {!isLast && (
+                <ChevronDown size={14} className="connection-path-dialog__arrow" aria-hidden />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </Modal>
   );
 }


### PR DESCRIPTION
**Phase 4 (#1062), batch 3.** Migrates the `Sidebar/` dialogs onto the shared primitives.

## What
Migrated onto `Modal` + `Button` (+ `Input`): **ConnectionErrorDialog, ConfirmDeleteDialog, AgentSetupDialog, ConnectionPathDialog**. Removed bespoke overlay/`__btn` CSS across all four; fixed the confirm-delete button's hardcoded `#fff` (light-theme).

## Preserved verbatim
- ConnectionError **classification** gating (agent-missing/outdated → Setup Agent; already-connected → Force Reconnect)
- AgentSetup **phase flow** (detecting → error → ready), arch `<select>`, path/service sync — kept its own `toast.loading`→resolve (sync Button, no double-report)
- ConnectionPath **hop visualization** + probe lifecycle

## Tests
Added an AgentSetupDialog migration test; existing ConnectionError/ConfirmDelete/ConnectionPath/AgentSetup-windows tests pass unchanged. Full suite **2056 passing**; lint/format/build clean.

## Test plan
- [x] `pnpm test` green (no regressions), lint/format/build clean
- [ ] Manual: trigger a connection error (setup-agent + force-reconnect variants), delete a connection, run agent setup, view a jump-host path → behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)