### PR TITLE
refactor(ui): Phase 4 batch 6 (final) — migrate ShortcutsOverlay + OpenConnections

### DIFF
--- a/docs/changes/feature/1062-migrate-remaining-dialogs.md
+++ b/docs/changes/feature/1062-migrate-remaining-dialogs.md
@@ -1,0 +1,3 @@
+## Changed
+
+- The keyboard-shortcuts reference and the Open Connections panel now use the shared modal and button components — consistent styling, motion, and focus. The Kill / Kill All actions in Open Connections show a pending state while a connection is being stopped, and the status badges are now theme-aware.

--- a/src/components/KeyboardShortcuts/ShortcutsOverlay.css
+++ b/src/components/KeyboardShortcuts/ShortcutsOverlay.css
@@ -1,3 +1,8 @@
+/*
+ * Backdrop retained for other in-flight branches that still reference it;
+ * scheduled for a post-merge cleanup. The overlay shell (content, header,
+ * title, close, body) now comes from the shared Modal primitive.
+ */
 .shortcuts-overlay__backdrop {
   position: fixed;
   inset: 0;
@@ -11,97 +16,8 @@
   animation: dialog-overlay-show 200ms ease;
 }
 
-.shortcuts-overlay__content {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 90vw;
-  max-width: 700px;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  background-color: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-overlay);
-  z-index: 1001;
-  overflow: hidden;
-}
-
-.shortcuts-overlay__content[data-state="open"] {
-  animation: dialog-content-show 280ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.shortcuts-overlay__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-bottom: 1px solid var(--border-primary);
-  flex-shrink: 0;
-}
-
-.shortcuts-overlay__title {
-  font-size: var(--font-size-lg, 16px);
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0;
-}
-
-.shortcuts-overlay__close {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition:
-    background-color var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.shortcuts-overlay__close:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
-}
-
 .shortcuts-overlay__search {
-  padding: var(--spacing-sm) var(--spacing-lg);
-  border-bottom: 1px solid var(--border-primary);
-  flex-shrink: 0;
-}
-
-.shortcuts-overlay__search-input {
-  width: 100%;
-  height: 30px;
-  padding: 0 var(--spacing-sm);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-md);
-  background-color: var(--bg-input);
-  color: var(--text-primary);
-  font-size: var(--font-size-sm);
-  outline: none;
-  box-sizing: border-box;
-  transition:
-    border-color var(--transition-fast),
-    box-shadow var(--transition-fast);
-}
-
-.shortcuts-overlay__search-input:focus {
-  border-color: var(--accent-color);
-  box-shadow: var(--shadow-focus);
-}
-
-.shortcuts-overlay__body {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--spacing-md) var(--spacing-lg);
+  margin-bottom: var(--spacing-md);
 }
 
 .shortcuts-overlay__table {

--- a/src/components/KeyboardShortcuts/ShortcutsOverlay.test.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutsOverlay.test.tsx
@@ -40,13 +40,21 @@ describe("ShortcutsOverlay", () => {
     expect(overlay).not.toBeNull();
   });
 
+  it("renders through the shared Modal primitive", () => {
+    act(() => {
+      root.render(<ShortcutsOverlay open={true} onOpenChange={vi.fn()} />);
+    });
+    // The shell comes from the Modal primitive (.ui-modal), not a bespoke overlay.
+    const modal = document.querySelector('.ui-modal[data-testid="shortcuts-overlay"]');
+    expect(modal).not.toBeNull();
+    expect(modal?.querySelector(".ui-modal__title")?.textContent).toBe("Keyboard Shortcuts");
+  });
+
   it("shows the title", () => {
     act(() => {
       root.render(<ShortcutsOverlay open={true} onOpenChange={vi.fn()} />);
     });
-    expect(document.querySelector(".shortcuts-overlay__title")?.textContent).toBe(
-      "Keyboard Shortcuts"
-    );
+    expect(document.querySelector(".ui-modal__title")?.textContent).toBe("Keyboard Shortcuts");
   });
 
   it("renders the search input", () => {
@@ -114,9 +122,7 @@ describe("ShortcutsOverlay", () => {
     act(() => {
       root.render(<ShortcutsOverlay open={true} onOpenChange={onOpenChange} />);
     });
-    const closeBtn = document.querySelector(
-      '[data-testid="shortcuts-overlay-close"]'
-    ) as HTMLElement;
+    const closeBtn = document.querySelector('[data-testid="modal-close"]') as HTMLElement;
     act(() => {
       closeBtn.click();
     });

--- a/src/components/KeyboardShortcuts/ShortcutsOverlay.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutsOverlay.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from "react";
-import * as Dialog from "@radix-ui/react-dialog";
-import { X } from "lucide-react";
+import { Modal, Input } from "@/components/ui";
 import { ShortcutCategory, ShortcutScope } from "@/types/keybindings";
 import { getDefaultBindings, getEffectiveCombo, serializeBinding } from "@/services/keybindings";
 import { isMac } from "@/utils/platform";
@@ -58,92 +57,72 @@ export function ShortcutsOverlay({ open, onOpenChange }: ShortcutsOverlayProps) 
   })).filter((g) => g.bindings.length > 0);
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="shortcuts-overlay__backdrop" />
-        <Dialog.Content
-          className="shortcuts-overlay__content"
-          data-testid="shortcuts-overlay"
-          onOpenAutoFocus={(e) => e.preventDefault()}
-        >
-          <div className="shortcuts-overlay__header">
-            <Dialog.Title className="shortcuts-overlay__title">Keyboard Shortcuts</Dialog.Title>
-            <Dialog.Close asChild>
-              <button className="shortcuts-overlay__close" data-testid="shortcuts-overlay-close">
-                <X size={16} />
-              </button>
-            </Dialog.Close>
-          </div>
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Keyboard Shortcuts"
+      size="lg"
+      data-testid="shortcuts-overlay"
+    >
+      <div className="shortcuts-overlay__search">
+        <Input
+          placeholder="Search shortcuts..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          data-testid="shortcuts-overlay-search"
+          autoFocus
+        />
+      </div>
 
-          <div className="shortcuts-overlay__search">
-            <input
-              type="text"
-              placeholder="Search shortcuts..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="shortcuts-overlay__search-input"
-              data-testid="shortcuts-overlay-search"
-              autoFocus
-            />
-          </div>
+      <table className="shortcuts-overlay__table">
+        <thead>
+          <tr>
+            <th>Action</th>
+            <th className={!currentPlatformIsMac ? "shortcuts-overlay__highlight" : ""}>
+              Win / Linux
+            </th>
+            <th className={currentPlatformIsMac ? "shortcuts-overlay__highlight" : ""}>macOS</th>
+          </tr>
+        </thead>
+        <tbody>
+          {groupedBindings.map((group) => (
+            <>
+              <tr key={`header-${group.category}`} className="shortcuts-overlay__group-row">
+                <td colSpan={3} className="shortcuts-overlay__group-label">
+                  {group.label}
+                </td>
+              </tr>
+              {group.bindings.map((binding) => {
+                const winLinux = serializeBinding(binding.winLinuxDefault);
+                const mac = serializeBinding(binding.macDefault);
+                const effective = getEffectiveCombo(binding.action);
+                const effectiveStr = effective ? serializeBinding(effective) : "";
 
-          <div className="shortcuts-overlay__body">
-            <table className="shortcuts-overlay__table">
-              <thead>
-                <tr>
-                  <th>Action</th>
-                  <th className={!currentPlatformIsMac ? "shortcuts-overlay__highlight" : ""}>
-                    Win / Linux
-                  </th>
-                  <th className={currentPlatformIsMac ? "shortcuts-overlay__highlight" : ""}>
-                    macOS
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {groupedBindings.map((group) => (
-                  <>
-                    <tr key={`header-${group.category}`} className="shortcuts-overlay__group-row">
-                      <td colSpan={3} className="shortcuts-overlay__group-label">
-                        {group.label}
-                      </td>
-                    </tr>
-                    {group.bindings.map((binding) => {
-                      const winLinux = serializeBinding(binding.winLinuxDefault);
-                      const mac = serializeBinding(binding.macDefault);
-                      const effective = getEffectiveCombo(binding.action);
-                      const effectiveStr = effective ? serializeBinding(effective) : "";
-
-                      return (
-                        <tr key={binding.action} data-testid={`shortcut-row-${binding.action}`}>
-                          <td className="shortcuts-overlay__action">
-                            {binding.label}
-                            <span className="shortcuts-overlay__scope">
-                              {SCOPE_HINTS[binding.scope ?? "global"]}
-                            </span>
-                          </td>
-                          <td
-                            className={`shortcuts-overlay__binding ${!currentPlatformIsMac ? "shortcuts-overlay__highlight" : ""}`}
-                          >
-                            <kbd>
-                              {!currentPlatformIsMac && effective ? effectiveStr : winLinux}
-                            </kbd>
-                          </td>
-                          <td
-                            className={`shortcuts-overlay__binding ${currentPlatformIsMac ? "shortcuts-overlay__highlight" : ""}`}
-                          >
-                            <kbd>{currentPlatformIsMac && effective ? effectiveStr : mac}</kbd>
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+                return (
+                  <tr key={binding.action} data-testid={`shortcut-row-${binding.action}`}>
+                    <td className="shortcuts-overlay__action">
+                      {binding.label}
+                      <span className="shortcuts-overlay__scope">
+                        {SCOPE_HINTS[binding.scope ?? "global"]}
+                      </span>
+                    </td>
+                    <td
+                      className={`shortcuts-overlay__binding ${!currentPlatformIsMac ? "shortcuts-overlay__highlight" : ""}`}
+                    >
+                      <kbd>{!currentPlatformIsMac && effective ? effectiveStr : winLinux}</kbd>
+                    </td>
+                    <td
+                      className={`shortcuts-overlay__binding ${currentPlatformIsMac ? "shortcuts-overlay__highlight" : ""}`}
+                    >
+                      <kbd>{currentPlatformIsMac && effective ? effectiveStr : mac}</kbd>
+                    </td>
+                  </tr>
+                );
+              })}
+            </>
+          ))}
+        </tbody>
+      </table>
+    </Modal>
   );
 }

--- a/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
@@ -76,9 +76,18 @@ describe("OpenConnectionsModal — Connecting section", () => {
 
     const killBtn = rows[0].querySelector(".oc-row__kill") as HTMLButtonElement;
     expect(killBtn).not.toBeNull();
+    // Kill is now the shared Button primitive (retains .oc-row__kill as a hook).
+    expect(killBtn.classList.contains("ui-btn")).toBe(true);
     act(() => killBtn.click());
 
     expect(cancelConnecting).toHaveBeenCalledWith("tab-1");
+  });
+
+  it("renders through the shared Modal primitive", () => {
+    renderWithConnectingTab();
+    const modal = document.querySelector(".ui-modal");
+    expect(modal).not.toBeNull();
+    expect(modal?.querySelector(".ui-modal__title")?.textContent).toContain("Open Connections");
   });
 
   it("shows no Connecting section when nothing is connecting", () => {

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -1,79 +1,17 @@
-.open-connections__overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--overlay-bg);
-  backdrop-filter: var(--overlay-blur);
-  -webkit-backdrop-filter: var(--overlay-blur);
-  z-index: 1000;
-}
+/*
+ * Content styles for the Open Connections panel. The overlay shell (backdrop,
+ * container, header, title, close button) now comes from the shared Modal
+ * primitive; Kill / Kill All actions use the shared Button primitive. Only the
+ * section/row/badge layout specific to this panel lives here.
+ */
 
-.open-connections__overlay[data-state="open"] {
-  animation: dialog-overlay-show 200ms ease;
-}
-
-.open-connections__content {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 1001;
-  width: 580px;
-  max-width: 90vw;
-  max-height: 80vh;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-overlay);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.open-connections__content[data-state="open"] {
-  animation: dialog-content-show 280ms cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-.open-connections__header {
-  display: flex;
+.open-connections__title-row {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-bottom: 1px solid var(--border-primary);
-  flex-shrink: 0;
-}
-
-.open-connections__title {
-  font-size: var(--font-size-lg);
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0;
-}
-
-.open-connections__close {
-  background: transparent;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: var(--spacing-xs);
-  border-radius: var(--radius-sm);
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition:
-    background-color var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.open-connections__close:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
+  gap: var(--spacing-sm);
 }
 
 .open-connections__body {
-  overflow-y: auto;
-  flex: 1;
-  padding: var(--spacing-md) var(--spacing-lg);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-lg);
@@ -109,26 +47,6 @@
   background: var(--bg-tertiary);
   border-radius: var(--radius-full);
   padding: 1px 7px;
-}
-
-.oc-section__kill-all {
-  font-size: var(--font-size-xs);
-  padding: 2px var(--spacing-sm);
-  background: transparent;
-  color: var(--text-muted);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition:
-    background-color var(--transition-fast),
-    color var(--transition-fast),
-    border-color var(--transition-fast);
-}
-
-.oc-section__kill-all:hover {
-  background: var(--color-error-bg, rgba(255, 80, 80, 0.12));
-  border-color: var(--color-error, #e05252);
-  color: var(--color-error, #e05252);
 }
 
 /* Row */
@@ -169,43 +87,18 @@
   flex-shrink: 0;
 }
 
-.oc-row__badge--alive {
-  background: rgba(72, 186, 120, 0.18);
-  color: #48ba78;
+.oc-row__badge--alive,
+.oc-row__badge--connected {
+  background: color-mix(in srgb, var(--color-success) 18%, transparent);
+  color: var(--color-success);
 }
 
 .oc-row__badge--dead {
-  background: rgba(224, 82, 82, 0.18);
-  color: #e05252;
-}
-
-.oc-row__badge--connected {
-  background: rgba(72, 186, 120, 0.18);
-  color: #48ba78;
+  background: color-mix(in srgb, var(--color-error) 18%, transparent);
+  color: var(--color-error);
 }
 
 .oc-row__badge--connecting {
-  background: rgba(255, 170, 50, 0.18);
-  color: #ffaa32;
-}
-
-.oc-row__kill {
-  font-size: var(--font-size-xs);
-  padding: 2px var(--spacing-sm);
-  background: transparent;
-  color: var(--text-muted);
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition:
-    background-color var(--transition-fast),
-    color var(--transition-fast),
-    border-color var(--transition-fast);
-}
-
-.oc-row__kill:hover {
-  background: var(--color-error-bg, rgba(255, 80, 80, 0.12));
-  border-color: var(--color-error, #e05252);
-  color: var(--color-error, #e05252);
+  background: color-mix(in srgb, var(--color-warning) 18%, transparent);
+  color: var(--color-warning);
 }

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useState, useCallback } from "react";
-import * as Dialog from "@radix-ui/react-dialog";
 import {
   Terminal,
   Server,
   ArrowLeftRight,
   FolderOpen,
   Activity,
-  X,
   MonitorStop,
   Loader2,
 } from "lucide-react";
+import { Modal, Button } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
 import {
@@ -196,204 +195,191 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="open-connections__overlay" />
-        <Dialog.Content className="open-connections__content" aria-describedby={undefined}>
-          <div className="open-connections__header">
-            <Dialog.Title className="open-connections__title">
-              Open Connections
-              {totalCount > 0 && (
-                <span className="oc-section__count" style={{ marginLeft: "8px" }}>
-                  {totalCount}
-                </span>
-              )}
-            </Dialog.Title>
-            <Dialog.Close asChild>
-              <button className="open-connections__close" aria-label="Close">
-                <X size={16} />
-              </button>
-            </Dialog.Close>
-          </div>
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      size="lg"
+      title={
+        <span className="open-connections__title-row">
+          Open Connections
+          {totalCount > 0 && <span className="oc-section__count">{totalCount}</span>}
+        </span>
+      }
+    >
+      <div className="open-connections__body">
+        {loading && totalCount === 0 && <div className="open-connections__empty">Loading…</div>}
+        {!loading && totalCount === 0 && (
+          <div className="open-connections__empty">No open connections.</div>
+        )}
 
-          <div className="open-connections__body">
-            {loading && totalCount === 0 && <div className="open-connections__empty">Loading…</div>}
-            {!loading && totalCount === 0 && (
-              <div className="open-connections__empty">No open connections.</div>
-            )}
-
-            {/* Connecting (in-flight handshakes) */}
-            {connectingTabs.length > 0 && (
-              <Section
-                title="Connecting"
+        {/* Connecting (in-flight handshakes) */}
+        {connectingTabs.length > 0 && (
+          <Section
+            title="Connecting"
+            icon={<Loader2 size={14} />}
+            count={connectingTabs.length}
+            onKillAll={handleCancelAllConnecting}
+          >
+            {connectingTabs.map((tab) => (
+              <ConnectionRow
+                key={tab.id}
                 icon={<Loader2 size={14} />}
-                count={connectingTabs.length}
-                onKillAll={handleCancelAllConnecting}
-              >
-                {connectingTabs.map((tab) => (
-                  <ConnectionRow
-                    key={tab.id}
-                    icon={<Loader2 size={14} />}
-                    title={tab.title}
-                    badge="connecting"
-                    onKill={() => handleCancelConnecting(tab.id, tab.panelId)}
-                  />
-                ))}
-              </Section>
-            )}
+                title={tab.title}
+                badge="connecting"
+                onKill={() => handleCancelConnecting(tab.id, tab.panelId)}
+              />
+            ))}
+          </Section>
+        )}
 
-            {/* Local Sessions */}
-            {localSessions.length > 0 && (
-              <Section
-                title="Local Sessions"
+        {/* Local Sessions */}
+        {localSessions.length > 0 && (
+          <Section
+            title="Local Sessions"
+            icon={<Terminal size={14} />}
+            count={localSessions.length}
+            onKillAll={handleKillAllLocal}
+          >
+            {localSessions.map((s) => (
+              <ConnectionRow
+                key={s.id}
                 icon={<Terminal size={14} />}
-                count={localSessions.length}
-                onKillAll={handleKillAllLocal}
-              >
-                {localSessions.map((s) => (
-                  <ConnectionRow
-                    key={s.id}
-                    icon={<Terminal size={14} />}
-                    title={s.title}
-                    badge={s.alive ? "alive" : "dead"}
-                    onKill={() => handleKillLocal(s.id)}
-                  />
-                ))}
-              </Section>
-            )}
+                title={s.title}
+                badge={s.alive ? "alive" : "dead"}
+                onKill={() => handleKillLocal(s.id)}
+              />
+            ))}
+          </Section>
+        )}
 
-            {/* Agent Connections */}
-            {connectedAgents.length > 0 && (
-              <Section
-                title="Agent Connections"
+        {/* Agent Connections */}
+        {connectedAgents.length > 0 && (
+          <Section
+            title="Agent Connections"
+            icon={<Server size={14} />}
+            count={connectedAgents.length}
+            onKillAll={handleKillAllAgents}
+          >
+            {connectedAgents.map((a) => (
+              <ConnectionRow
+                key={a.id}
                 icon={<Server size={14} />}
-                count={connectedAgents.length}
-                onKillAll={handleKillAllAgents}
-              >
-                {connectedAgents.map((a) => (
-                  <ConnectionRow
-                    key={a.id}
-                    icon={<Server size={14} />}
-                    title={a.name}
-                    badge="connected"
-                    onKill={() => handleKillAgent(a.id)}
-                  />
-                ))}
-              </Section>
-            )}
+                title={a.name}
+                badge="connected"
+                onKill={() => handleKillAgent(a.id)}
+              />
+            ))}
+          </Section>
+        )}
 
-            {/* Connections via each agent (proxy sessions opened from the desktop) */}
-            {connectedAgents.map((a) => {
-              const sessions = proxySessions[a.id] ?? [];
-              if (sessions.length === 0) return null;
-              return (
-                <Section
-                  key={`proxy-sessions-${a.id}`}
-                  title={`Connections via ${a.name}`}
-                  icon={<Server size={14} />}
-                  count={sessions.length}
-                  onKillAll={() => handleKillAllProxy(a.id)}
-                >
-                  {sessions.map((s) => (
-                    <ConnectionRow
-                      key={s.id}
-                      icon={
-                        s.connectionType === "ssh" ? <Server size={14} /> : <Terminal size={14} />
-                      }
-                      title={s.title}
-                      badge={s.alive ? "alive" : "dead"}
-                      onKill={() => handleKillProxy(a.id, s.id)}
-                    />
-                  ))}
-                </Section>
-              );
-            })}
+        {/* Connections via each agent (proxy sessions opened from the desktop) */}
+        {connectedAgents.map((a) => {
+          const sessions = proxySessions[a.id] ?? [];
+          if (sessions.length === 0) return null;
+          return (
+            <Section
+              key={`proxy-sessions-${a.id}`}
+              title={`Connections via ${a.name}`}
+              icon={<Server size={14} />}
+              count={sessions.length}
+              onKillAll={() => handleKillAllProxy(a.id)}
+            >
+              {sessions.map((s) => (
+                <ConnectionRow
+                  key={s.id}
+                  icon={s.connectionType === "ssh" ? <Server size={14} /> : <Terminal size={14} />}
+                  title={s.title}
+                  badge={s.alive ? "alive" : "dead"}
+                  onKill={() => handleKillProxy(a.id, s.id)}
+                />
+              ))}
+            </Section>
+          );
+        })}
 
-            {/* Native sessions on each agent (reported by the agent itself) */}
-            {connectedAgents.map((a) => {
-              const sessions = agentSessions[a.id] ?? [];
-              if (sessions.length === 0) return null;
-              return (
-                <Section
-                  key={`agent-sessions-${a.id}`}
-                  title={`Sessions on ${a.name}`}
+        {/* Native sessions on each agent (reported by the agent itself) */}
+        {connectedAgents.map((a) => {
+          const sessions = agentSessions[a.id] ?? [];
+          if (sessions.length === 0) return null;
+          return (
+            <Section
+              key={`agent-sessions-${a.id}`}
+              title={`Sessions on ${a.name}`}
+              icon={<Terminal size={14} />}
+              count={sessions.length}
+              onKillAll={() => handleKillAllAgentSessions(a.id)}
+            >
+              {sessions.map((s) => (
+                <ConnectionRow
+                  key={s.sessionId}
                   icon={<Terminal size={14} />}
-                  count={sessions.length}
-                  onKillAll={() => handleKillAllAgentSessions(a.id)}
-                >
-                  {sessions.map((s) => (
-                    <ConnectionRow
-                      key={s.sessionId}
-                      icon={<Terminal size={14} />}
-                      title={s.title}
-                      badge={s.status === "attached" || s.status === "running" ? "alive" : "dead"}
-                      onKill={() => handleKillAgentSession(a.id, s.sessionId)}
-                    />
-                  ))}
-                </Section>
+                  title={s.title}
+                  badge={s.status === "attached" || s.status === "running" ? "alive" : "dead"}
+                  onKill={() => handleKillAgentSession(a.id, s.sessionId)}
+                />
+              ))}
+            </Section>
+          );
+        })}
+
+        {/* SSH Tunnels */}
+        {activeTunnels.length > 0 && (
+          <Section
+            title="SSH Tunnels"
+            icon={<ArrowLeftRight size={14} />}
+            count={activeTunnels.length}
+            onKillAll={handleKillAllTunnels}
+          >
+            {activeTunnels.map((t) => {
+              const state = tunnelStates.find((ts) => ts.tunnelId === t.id);
+              return (
+                <ConnectionRow
+                  key={t.id}
+                  icon={<ArrowLeftRight size={14} />}
+                  title={t.name}
+                  badge={state?.status === "connected" ? "connected" : "connecting"}
+                  onKill={() => handleKillTunnel(t.id)}
+                />
               );
             })}
+          </Section>
+        )}
 
-            {/* SSH Tunnels */}
-            {activeTunnels.length > 0 && (
-              <Section
-                title="SSH Tunnels"
-                icon={<ArrowLeftRight size={14} />}
-                count={activeTunnels.length}
-                onKillAll={handleKillAllTunnels}
-              >
-                {activeTunnels.map((t) => {
-                  const state = tunnelStates.find((ts) => ts.tunnelId === t.id);
-                  return (
-                    <ConnectionRow
-                      key={t.id}
-                      icon={<ArrowLeftRight size={14} />}
-                      title={t.name}
-                      badge={state?.status === "connected" ? "connected" : "connecting"}
-                      onKill={() => handleKillTunnel(t.id)}
-                    />
-                  );
-                })}
-              </Section>
-            )}
+        {/* SFTP */}
+        {sftpConnectedHost && (
+          <Section
+            title="SFTP"
+            icon={<FolderOpen size={14} />}
+            count={1}
+            onKillAll={disconnectSftp}
+          >
+            <ConnectionRow
+              icon={<FolderOpen size={14} />}
+              title={sftpConnectedHost}
+              badge="connected"
+              onKill={disconnectSftp}
+            />
+          </Section>
+        )}
 
-            {/* SFTP */}
-            {sftpConnectedHost && (
-              <Section
-                title="SFTP"
-                icon={<FolderOpen size={14} />}
-                count={1}
-                onKillAll={disconnectSftp}
-              >
-                <ConnectionRow
-                  icon={<FolderOpen size={14} />}
-                  title={sftpConnectedHost}
-                  badge="connected"
-                  onKill={disconnectSftp}
-                />
-              </Section>
-            )}
-
-            {/* Monitoring */}
-            {monitoringHost && (
-              <Section
-                title="Monitoring"
-                icon={<Activity size={14} />}
-                count={1}
-                onKillAll={disconnectMonitoring}
-              >
-                <ConnectionRow
-                  icon={<MonitorStop size={14} />}
-                  title={monitoringHost}
-                  badge="connected"
-                  onKill={disconnectMonitoring}
-                />
-              </Section>
-            )}
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        {/* Monitoring */}
+        {monitoringHost && (
+          <Section
+            title="Monitoring"
+            icon={<Activity size={14} />}
+            count={1}
+            onKillAll={disconnectMonitoring}
+          >
+            <ConnectionRow
+              icon={<MonitorStop size={14} />}
+              title={monitoringHost}
+              badge="connected"
+              onKill={disconnectMonitoring}
+            />
+          </Section>
+        )}
+      </div>
+    </Modal>
   );
 }
 
@@ -403,7 +389,7 @@ interface SectionProps {
   title: string;
   icon: React.ReactNode;
   count: number;
-  onKillAll: () => void;
+  onKillAll: () => void | Promise<void>;
   children: React.ReactNode;
 }
 
@@ -413,9 +399,15 @@ function Section({ title, count, onKillAll, children }: SectionProps) {
       <div className="oc-section__header">
         <span className="oc-section__title">{title}</span>
         <span className="oc-section__count">{count}</span>
-        <button className="oc-section__kill-all" onClick={onKillAll} title={`Kill all ${title}`}>
+        <Button
+          variant="danger"
+          size="sm"
+          className="oc-section__kill-all"
+          onClick={() => onKillAll()}
+          title={`Kill all ${title}`}
+        >
           Kill All
-        </button>
+        </Button>
       </div>
       {children}
     </div>
@@ -428,7 +420,7 @@ interface ConnectionRowProps {
   icon: React.ReactNode;
   title: string;
   badge: BadgeVariant;
-  onKill: () => void;
+  onKill: () => void | Promise<void>;
 }
 
 function ConnectionRow({ icon, title, badge, onKill }: ConnectionRowProps) {
@@ -439,9 +431,9 @@ function ConnectionRow({ icon, title, badge, onKill }: ConnectionRowProps) {
         {title}
       </span>
       <span className={`oc-row__badge oc-row__badge--${badge}`}>{badge}</span>
-      <button className="oc-row__kill" onClick={onKill}>
+      <Button variant="danger" size="sm" className="oc-row__kill" onClick={() => onKill()}>
         Kill
-      </button>
+      </Button>
     </div>
   );
 }

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -9,7 +9,7 @@ source — the #1 authoring error when porting system tests (#899).
 - **Regenerate:** `python scripts/build-testid-catalog.py`
 - **Verify freshness (CI):** `python scripts/build-testid-catalog.py --check`
 
-**455** literal · **123** dynamic · **16** indirect.
+**454** literal · **123** dynamic · **16** indirect.
 
 ## Literal test IDs
 
@@ -349,7 +349,6 @@ Fixed strings — match exactly.
 | `settings-restore-last-session` | `src/components/Settings/GeneralSettings.tsx` |
 | `settings-serial-port-prefixes` | `src/components/Settings/SerialPortSettings.tsx` |
 | `shortcuts-overlay` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |
-| `shortcuts-overlay-close` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |
 | `shortcuts-overlay-search` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |
 | `sidebar` | `src/components/Sidebar/Sidebar.tsx` |
 | `sidebar-group-header-connections` | `src/components/Sidebar/ConnectionList.tsx` |

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -9,6 +9,8 @@ source — the #1 authoring error when porting system tests (#899).
 - **Regenerate:** `python scripts/build-testid-catalog.py`
 - **Verify freshness (CI):** `python scripts/build-testid-catalog.py --check`
 
+**454** literal · **123** dynamic · **16** indirect.
+
 ## Literal test IDs
 
 Fixed strings — match exactly.


### PR DESCRIPTION
**Phase 4 (#1062), batch 6 — the final migration batch.** Stacked on **#1078 (batch 5)** because it uses `Modal size="lg"` (introduced there); base is the batch-5 branch for a clean per-batch diff, auto-retargets to `develop` once batch 5 merges. **Merge #1078 first.**

## What
Migrated the last two hand-rolled dialog surfaces onto `Modal` (`size="lg"`) + `Button`:
- **ShortcutsOverlay** — keyboard-shortcuts reference (wide table)
- **OpenConnectionsModal** — the primary connection-monitoring panel; Kill / Kill All → async `danger` Button; all session enumeration + kill logic preserved; status-badge hexes → `color-mix` over semantic tokens.

Left `shortcuts-overlay__backdrop` in place (final post-merge cleanup once all batches land).

## After this batch
**No dialog surfaces remain on hand-rolled shells** — every dialog in the app composes from the primitives.

## Tests
Updated ShortcutsOverlay + OpenConnections tests to the primitive structure (behavior assertions preserved); full suite green; lint/format/build clean.

## Test plan
- [x] `pnpm test` green (no regressions), lint/format/build clean
- [ ] Manual: open the shortcuts reference (search works), open Open Connections, Kill a session + Kill All a section → behavior unchanged, buttons show pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)