### PR TITLE
docs(ui): teach ui-design agent to regenerate the testid catalog

### DIFF
--- a/.claude/agents/ui-design.md
+++ b/.claude/agents/ui-design.md
@@ -97,6 +97,12 @@ wrap motion in `@media (prefers-reduced-motion: reduce)`; use the shared enter/e
 - Debug logging goes through `frontendLog` (LogViewer), never `console.*`.
 - **TDD**: write/adjust the Vitest test first, watch it fail, then implement.
   A design change ships with at least a unit test or documented manual test.
+- **`data-testid` catalog**: if you add, remove, or rename ANY `data-testid`
+  (migrating a dialog to `Modal` adds `modal-close`; primitives forward the
+  hook), regenerate `tests/system/testid-catalog.md` with
+  `python scripts/build-testid-catalog.py` and commit it in the same change.
+  CI fails on a stale catalog (both the "Frontend Code Quality" catalog check
+  and the "System-Test machinery" job).
 - Run `./scripts/check.sh` (lint/format/clippy mirror of CI) and `./scripts/test.sh`
   before declaring done. Formatting is auto-applied by the PostToolUse hook.
 


### PR DESCRIPTION
Adds a coding-standards rule to `.claude/agents/ui-design.md`: whenever it adds/removes/renames a `data-testid`, the `ui-design` agent must regenerate `tests/system/testid-catalog.md` (`python scripts/build-testid-catalog.py`) and commit it in the same change.

## Why
A stale catalog fails two CI jobs ("Frontend Code Quality" catalog check #899 + "System-Test machinery"). This repeatedly broke the Phase 4 dialog-migration PRs (#1074/#1078) and had to be fixed by hand each time. This is the durable one-line guardrail; the broader automation (autoformat hook / pre-commit) is tracked in #1084.

## Test plan
Docs/tooling only — no code change. `.claude/` is outside markdownlint scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)