### PR TITLE
feat(terminal): Windows X server DISPLAY + MIT-MAGIC-COOKIE-1 provisioning (#1050)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 serde = { workspace = true }
+hex = "0.4"
 serde_json = { workspace = true }
 portable-pty = "0.8"
 russh = { workspace = true }
@@ -79,7 +80,6 @@ keyring = { version = "3", default-features = false, features = ["windows-native
 # on other platforms.
 zip = "2"
 sha2 = "0.10"
-hex = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Linux Secret Service backend. The `async-secret-service` backend talks to the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,8 +42,15 @@ use utils::log_capture::{create_log_buffer, default_env_filter, LogCaptureLayer}
 /// exists, but resolving it downloads VcXsrv, which the concept gates behind a
 /// user consent prompt — so the real resolver is wired by the provisioning
 /// orchestrator (#1052) once the consent flow exists, not here.
+///
+/// The cookie provider (#1050) writes `.Xauthority` files under a temp
+/// subdirectory; the files are ephemeral, regenerated per server start and
+/// removed on stop.
 fn build_xserver_manager() -> terminal::xserver::XServerManager {
+    use terminal::xserver::auth::FileXAuthProvider;
     use terminal::xserver::manager::{CommandLauncher, TcpPortProbe};
+
+    let auth_dir = std::env::temp_dir().join("termihub-xserver");
 
     terminal::xserver::XServerManager::new(
         Box::new(TcpPortProbe),
@@ -53,6 +60,7 @@ fn build_xserver_manager() -> terminal::xserver::XServerManager {
                 "managed X server provisioning is not wired yet (awaiting consent flow, #1052)"
             )
         }),
+        Box::new(FileXAuthProvider::new(auth_dir)),
         cfg!(windows),
         true,
     )

--- a/src-tauri/src/terminal/xserver/auth.rs
+++ b/src-tauri/src/terminal/xserver/auth.rs
@@ -14,6 +14,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use rand::RngCore;
 
 /// MIT-MAGIC-COOKIE-1 length in bytes (→ 32 hex chars).
 pub const COOKIE_LEN: usize = 16;
@@ -27,13 +28,18 @@ const FAMILY_WILD: u16 = 0xFFFF;
 
 /// Generate a fresh random 16-byte MIT-MAGIC-COOKIE-1.
 pub fn generate_cookie() -> [u8; COOKIE_LEN] {
-    unimplemented!("generate_cookie")
+    let mut cookie = [0u8; COOKIE_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut cookie);
+    cookie
 }
 
 /// Lowercase-hex encoding of a cookie (32 chars for a 16-byte cookie).
 pub fn cookie_to_hex(cookie: &[u8]) -> String {
-    let _ = cookie;
-    unimplemented!("cookie_to_hex")
+    use std::fmt::Write;
+    cookie.iter().fold(String::with_capacity(cookie.len() * 2), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    })
 }
 
 /// Build the binary `.Xauthority` record for `display` and `cookie`.
@@ -41,8 +47,19 @@ pub fn cookie_to_hex(cookie: &[u8]) -> String {
 /// Layout (all lengths big-endian `u16`): family, address, number (display as
 /// ASCII), name (`MIT-MAGIC-COOKIE-1`), data (the raw cookie bytes).
 pub fn xauthority_record(display: u32, cookie: &[u8]) -> Vec<u8> {
-    let _ = (display, cookie);
-    unimplemented!("xauthority_record")
+    fn push_sized(out: &mut Vec<u8>, bytes: &[u8]) {
+        out.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+        out.extend_from_slice(bytes);
+    }
+
+    let number = display.to_string();
+    let mut record = Vec::new();
+    record.extend_from_slice(&FAMILY_WILD.to_be_bytes());
+    push_sized(&mut record, &[]); // address (empty for FamilyWild)
+    push_sized(&mut record, number.as_bytes());
+    push_sized(&mut record, AUTH_PROTOCOL_NAME.as_bytes());
+    push_sized(&mut record, cookie);
+    record
 }
 
 /// A provisioned cookie plus the `.Xauthority` file that carries it.
@@ -77,8 +94,21 @@ impl FileXAuthProvider {
 
 impl XAuthProvider for FileXAuthProvider {
     fn provision(&self, display: u32) -> Result<XAuth> {
-        let _ = display;
-        unimplemented!("FileXAuthProvider::provision")
+        use anyhow::Context;
+
+        let cookie = generate_cookie();
+        let record = xauthority_record(display, &cookie);
+
+        std::fs::create_dir_all(&self.dir)
+            .with_context(|| format!("failed to create auth dir: {}", self.dir.display()))?;
+        let auth_file = self.dir.join(format!(".Xauthority-termihub-{display}"));
+        std::fs::write(&auth_file, &record)
+            .with_context(|| format!("failed to write .Xauthority: {}", auth_file.display()))?;
+
+        Ok(XAuth {
+            auth_file,
+            cookie_hex: cookie_to_hex(&cookie),
+        })
     }
 }
 

--- a/src-tauri/src/terminal/xserver/auth.rs
+++ b/src-tauri/src/terminal/xserver/auth.rs
@@ -1,0 +1,181 @@
+//! MIT-MAGIC-COOKIE-1 provisioning for the managed local X server (issue #1050).
+//!
+//! When termiHub starts VcXsrv it generates a per-start cookie, writes a
+//! standard-format `.Xauthority` file, and launches the server with
+//! `-auth <file>`. The same cookie (hex) is reported by
+//! [`XServerManager`](super::manager::XServerManager) so the SSH X11 forwarder
+//! injects it on the remote host (`xauth add … MIT-MAGIC-COOKIE-1 <cookie>`) —
+//! replacing the Unix-only `xauth`-shelling path, which is absent on Windows.
+//!
+//! The `.Xauthority` entry uses `FamilyWild` so the X server loads it regardless
+//! of how the (loopback TCP) client reaches it; MIT-MAGIC-COOKIE-1 then
+//! authenticates purely on the cookie value.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+/// MIT-MAGIC-COOKIE-1 length in bytes (→ 32 hex chars).
+pub const COOKIE_LEN: usize = 16;
+
+/// X11 authorization protocol name written into the `.Xauthority` record.
+pub const AUTH_PROTOCOL_NAME: &str = "MIT-MAGIC-COOKIE-1";
+
+/// `FamilyWild` — an `.Xauthority` entry that matches any host/transport, so the
+/// X server always loads it. See X11 `Xauth`/`family` semantics.
+const FAMILY_WILD: u16 = 0xFFFF;
+
+/// Generate a fresh random 16-byte MIT-MAGIC-COOKIE-1.
+pub fn generate_cookie() -> [u8; COOKIE_LEN] {
+    unimplemented!("generate_cookie")
+}
+
+/// Lowercase-hex encoding of a cookie (32 chars for a 16-byte cookie).
+pub fn cookie_to_hex(cookie: &[u8]) -> String {
+    let _ = cookie;
+    unimplemented!("cookie_to_hex")
+}
+
+/// Build the binary `.Xauthority` record for `display` and `cookie`.
+///
+/// Layout (all lengths big-endian `u16`): family, address, number (display as
+/// ASCII), name (`MIT-MAGIC-COOKIE-1`), data (the raw cookie bytes).
+pub fn xauthority_record(display: u32, cookie: &[u8]) -> Vec<u8> {
+    let _ = (display, cookie);
+    unimplemented!("xauthority_record")
+}
+
+/// A provisioned cookie plus the `.Xauthority` file that carries it.
+#[derive(Debug, Clone)]
+pub struct XAuth {
+    /// Path to the written `.Xauthority` file (passed to `vcxsrv.exe -auth`).
+    pub auth_file: PathBuf,
+    /// Lowercase-hex cookie the remote host must present.
+    pub cookie_hex: String,
+}
+
+/// Provisions cookie auth for a managed X server start.
+///
+/// Injected into the manager so the lifecycle logic stays filesystem-free in
+/// unit tests (a fake returns a fixed cookie without touching disk).
+pub trait XAuthProvider: Send + Sync {
+    /// Generate a cookie and write an `.Xauthority` for `display`.
+    fn provision(&self, display: u32) -> Result<XAuth>;
+}
+
+/// Real provider: writes a `.Xauthority` under a configured directory.
+pub struct FileXAuthProvider {
+    dir: PathBuf,
+}
+
+impl FileXAuthProvider {
+    /// Create a provider that writes `.Xauthority` files under `dir`.
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+}
+
+impl XAuthProvider for FileXAuthProvider {
+    fn provision(&self, display: u32) -> Result<XAuth> {
+        let _ = display;
+        unimplemented!("FileXAuthProvider::provision")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal `.Xauthority` record parser for round-trip assertions.
+    struct ParsedRecord {
+        family: u16,
+        address: Vec<u8>,
+        number: String,
+        name: String,
+        data: Vec<u8>,
+    }
+
+    fn parse_record(bytes: &[u8]) -> ParsedRecord {
+        let mut pos = 0;
+        let mut read_u16 = |bytes: &[u8], pos: &mut usize| {
+            let v = u16::from_be_bytes([bytes[*pos], bytes[*pos + 1]]);
+            *pos += 2;
+            v
+        };
+        let family = read_u16(bytes, &mut pos);
+        let addr_len = read_u16(bytes, &mut pos) as usize;
+        let address = bytes[pos..pos + addr_len].to_vec();
+        pos += addr_len;
+        let number_len = read_u16(bytes, &mut pos) as usize;
+        let number = String::from_utf8(bytes[pos..pos + number_len].to_vec()).unwrap();
+        pos += number_len;
+        let name_len = read_u16(bytes, &mut pos) as usize;
+        let name = String::from_utf8(bytes[pos..pos + name_len].to_vec()).unwrap();
+        pos += name_len;
+        let data_len = read_u16(bytes, &mut pos) as usize;
+        let data = bytes[pos..pos + data_len].to_vec();
+        pos += data_len;
+        assert_eq!(pos, bytes.len(), "record has trailing bytes");
+        ParsedRecord {
+            family,
+            address,
+            number,
+            name,
+            data,
+        }
+    }
+
+    #[test]
+    fn generate_cookie_is_16_bytes_and_non_constant() {
+        let a = generate_cookie();
+        let b = generate_cookie();
+        assert_eq!(a.len(), COOKIE_LEN);
+        assert_ne!(a, b, "cookies must be random, not constant");
+    }
+
+    #[test]
+    fn cookie_to_hex_is_32_lowercase_hex() {
+        let cookie = [0x00u8, 0xff, 0x1a, 0x2b, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let hex = cookie_to_hex(&cookie);
+        assert_eq!(hex.len(), 32);
+        assert!(hex.starts_with("00ff1a2b"));
+        assert!(hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn xauthority_record_has_expected_layout() {
+        let cookie: [u8; COOKIE_LEN] = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        ];
+        let record = xauthority_record(0, &cookie);
+        let parsed = parse_record(&record);
+        assert_eq!(parsed.family, FAMILY_WILD);
+        assert!(parsed.address.is_empty());
+        assert_eq!(parsed.number, "0");
+        assert_eq!(parsed.name, AUTH_PROTOCOL_NAME);
+        assert_eq!(parsed.data, cookie);
+    }
+
+    #[test]
+    fn xauthority_record_encodes_display_number_as_ascii() {
+        let cookie = [0u8; COOKIE_LEN];
+        let parsed = parse_record(&xauthority_record(7, &cookie));
+        assert_eq!(parsed.number, "7");
+    }
+
+    #[test]
+    fn file_provider_writes_matching_xauthority() {
+        let dir = tempfile::tempdir().unwrap();
+        let provider = FileXAuthProvider::new(dir.path().to_path_buf());
+
+        let auth = provider.provision(0).unwrap();
+        assert!(auth.auth_file.exists(), "auth file must be written");
+        assert_eq!(auth.cookie_hex.len(), 32);
+
+        let bytes = std::fs::read(&auth.auth_file).unwrap();
+        let parsed = parse_record(&bytes);
+        assert_eq!(parsed.name, AUTH_PROTOCOL_NAME);
+        // The file's cookie bytes match the reported hex.
+        assert_eq!(cookie_to_hex(&parsed.data), auth.cookie_hex);
+    }
+}

--- a/src-tauri/src/terminal/xserver/auth.rs
+++ b/src-tauri/src/terminal/xserver/auth.rs
@@ -14,6 +14,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use rand::rngs::OsRng;
 use rand::RngCore;
 
 /// MIT-MAGIC-COOKIE-1 length in bytes (→ 32 hex chars).
@@ -29,17 +30,13 @@ const FAMILY_WILD: u16 = 0xFFFF;
 /// Generate a fresh random 16-byte MIT-MAGIC-COOKIE-1.
 pub fn generate_cookie() -> [u8; COOKIE_LEN] {
     let mut cookie = [0u8; COOKIE_LEN];
-    rand::rngs::OsRng.fill_bytes(&mut cookie);
+    OsRng.fill_bytes(&mut cookie);
     cookie
 }
 
 /// Lowercase-hex encoding of a cookie (32 chars for a 16-byte cookie).
 pub fn cookie_to_hex(cookie: &[u8]) -> String {
-    use std::fmt::Write;
-    cookie.iter().fold(String::with_capacity(cookie.len() * 2), |mut s, b| {
-        let _ = write!(s, "{b:02x}");
-        s
-    })
+    hex::encode(cookie)
 }
 
 /// Build the binary `.Xauthority` record for `display` and `cookie`.
@@ -101,7 +98,12 @@ impl XAuthProvider for FileXAuthProvider {
 
         std::fs::create_dir_all(&self.dir)
             .with_context(|| format!("failed to create auth dir: {}", self.dir.display()))?;
-        let auth_file = self.dir.join(format!(".Xauthority-termihub-{display}"));
+        // Key the file on PID as well as display so concurrent termiHub
+        // instances (e.g. parallel dev checkouts) don't clobber each other.
+        let auth_file = self.dir.join(format!(
+            ".Xauthority-termihub-{}-{display}",
+            std::process::id()
+        ));
         std::fs::write(&auth_file, &record)
             .with_context(|| format!("failed to write .Xauthority: {}", auth_file.display()))?;
 
@@ -127,7 +129,7 @@ mod tests {
 
     fn parse_record(bytes: &[u8]) -> ParsedRecord {
         let mut pos = 0;
-        let mut read_u16 = |bytes: &[u8], pos: &mut usize| {
+        let read_u16 = |bytes: &[u8], pos: &mut usize| {
             let v = u16::from_be_bytes([bytes[*pos], bytes[*pos + 1]]);
             *pos += 2;
             v
@@ -169,14 +171,14 @@ mod tests {
         let hex = cookie_to_hex(&cookie);
         assert_eq!(hex.len(), 32);
         assert!(hex.starts_with("00ff1a2b"));
-        assert!(hex.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert!(hex
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
     }
 
     #[test]
     fn xauthority_record_has_expected_layout() {
-        let cookie: [u8; COOKIE_LEN] = [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-        ];
+        let cookie: [u8; COOKIE_LEN] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
         let record = xauthority_record(0, &cookie);
         let parsed = parse_record(&record);
         assert_eq!(parsed.family, FAMILY_WILD);

--- a/src-tauri/src/terminal/xserver/manager.rs
+++ b/src-tauri/src/terminal/xserver/manager.rs
@@ -22,6 +22,9 @@ use std::sync::Mutex;
 
 use anyhow::Result;
 use termihub_core::backends::ssh::x11::{ManagedXServer, ManagedXServerSource};
+use tracing::warn;
+
+use super::auth::XAuthProvider;
 
 /// TCP base port for X11: display `:N` listens on `6000 + N`.
 pub const X11_BASE_PORT: u16 = 6000;
@@ -145,6 +148,11 @@ impl DisplayInfo {
 struct Inner {
     status: XServerStatus,
     child: Option<Box<dyn ManagedProcess>>,
+    /// Hex MIT-MAGIC-COOKIE-1 the running managed server was launched with, or
+    /// `None` when it runs in `-ac` mode.
+    cookie: Option<String>,
+    /// `.Xauthority` file backing the current managed server, removed on stop.
+    auth_file: Option<PathBuf>,
     /// Number of live X11 sessions using the server.
     refcount: usize,
     /// Stop the managed server when the last session closes.
@@ -157,11 +165,10 @@ pub struct XServerManager {
     probe: Box<dyn PortProbe>,
     launcher: Box<dyn XServerLauncher>,
     resolver: Box<dyn Fn() -> Result<PathBuf> + Send + Sync>,
+    auth: Box<dyn XAuthProvider>,
     /// `true` on platforms that provide a managed server (Windows); `false`
     /// elsewhere, where the manager only adopts/report an existing server.
     provides_managed: bool,
-    /// Optional `-auth` cookie file (wired by #1050); `None` uses `-ac`.
-    auth_file: Mutex<Option<PathBuf>>,
 }
 
 impl XServerManager {
@@ -171,6 +178,7 @@ impl XServerManager {
         probe: Box<dyn PortProbe>,
         launcher: Box<dyn XServerLauncher>,
         resolver: Box<dyn Fn() -> Result<PathBuf> + Send + Sync>,
+        auth: Box<dyn XAuthProvider>,
         provides_managed: bool,
         stop_when_idle: bool,
     ) -> Self {
@@ -178,21 +186,16 @@ impl XServerManager {
             inner: Mutex::new(Inner {
                 status: XServerStatus::Stopped,
                 child: None,
+                cookie: None,
+                auth_file: None,
                 refcount: 0,
                 stop_when_idle,
             }),
             probe,
             launcher,
             resolver,
+            auth,
             provides_managed,
-            auth_file: Mutex::new(None),
-        }
-    }
-
-    /// Set the `-auth` cookie file used for future launches (issue #1050).
-    pub fn set_auth_file(&self, path: Option<PathBuf>) {
-        if let Ok(mut guard) = self.auth_file.lock() {
-            *guard = path;
         }
     }
 
@@ -285,14 +288,28 @@ impl XServerManager {
             anyhow::anyhow!(msg)
         })?;
 
-        let auth = self.auth_file.lock().expect("auth lock").clone();
-        match self.launcher.launch(&exe, display, auth.as_deref()) {
+        // Provision MIT-MAGIC-COOKIE-1 auth. On failure, fall back to `-ac`
+        // (loopback-only, no auth) so forwarding still works, with a warning.
+        let auth = match self.auth.provision(display) {
+            Ok(auth) => Some(auth),
+            Err(e) => {
+                warn!("X server: cookie provisioning failed, launching with -ac: {e}");
+                None
+            }
+        };
+        let auth_path = auth.as_ref().map(|a| a.auth_file.clone());
+
+        match self.launcher.launch(&exe, display, auth_path.as_deref()) {
             Ok(child) => {
                 inner.child = Some(child);
+                inner.cookie = auth.as_ref().map(|a| a.cookie_hex.clone());
+                inner.auth_file = auth_path;
                 inner.status = XServerStatus::Running { display };
                 Ok(DisplayInfo::managed(display))
             }
             Err(e) => {
+                // Do not leak the cookie file if the process never started.
+                remove_auth_file(&auth_path);
                 let msg = format!("failed to spawn X server: {e}");
                 inner.status = XServerStatus::Failed {
                     message: msg.clone(),
@@ -307,9 +324,19 @@ impl XServerManager {
         if let Some(child) = inner.child.as_mut() {
             child.terminate();
         }
+        remove_auth_file(&inner.auth_file);
         inner.child = None;
+        inner.cookie = None;
+        inner.auth_file = None;
         inner.refcount = 0;
         inner.status = XServerStatus::Stopped;
+    }
+}
+
+/// Best-effort removal of a written `.Xauthority` file.
+fn remove_auth_file(path: &Option<PathBuf>) {
+    if let Some(path) = path {
+        let _ = std::fs::remove_file(path);
     }
 }
 
@@ -319,15 +346,14 @@ impl ManagedXServerSource for XServerManager {
     /// #1052). Adopted external servers are intentionally excluded — they are
     /// discovered by the normal TCP probe and are not termiHub-managed.
     ///
-    /// The cookie is always `None` for now: managed servers currently launch in
-    /// `-ac` (loopback-only, no auth) mode until MIT-MAGIC-COOKIE-1 provisioning
-    /// lands in #1050.
+    /// The cookie is the MIT-MAGIC-COOKIE-1 the managed server was launched with
+    /// (#1050), or `None` when it fell back to `-ac` mode.
     fn managed_server(&self) -> Option<ManagedXServer> {
         let inner = self.inner.lock().expect("xserver lock");
         match inner.status {
             XServerStatus::Running { display } => Some(ManagedXServer {
                 display_number: display,
-                cookie: None,
+                cookie: inner.cookie.clone(),
             }),
             _ => None,
         }
@@ -499,9 +525,48 @@ mod tests {
         Box::new(|| Ok(PathBuf::from("vcxsrv.exe")))
     }
 
+    /// Fixed cookie the success-path fake provider hands out.
+    const FAKE_COOKIE: &str = "0011223344556677889900aabbccddee";
+
+    /// Auth provider fake: `Some(cookie)` → success (no disk I/O); `None` →
+    /// provisioning failure, exercising the `-ac` fallback.
+    struct FakeAuth {
+        cookie: Option<String>,
+    }
+
+    impl XAuthProvider for FakeAuth {
+        fn provision(&self, _display: u32) -> Result<super::super::auth::XAuth> {
+            match &self.cookie {
+                Some(cookie) => Ok(super::super::auth::XAuth {
+                    auth_file: PathBuf::from("C:/tmp/.Xauthority-fake"),
+                    cookie_hex: cookie.clone(),
+                }),
+                None => anyhow::bail!("fake provisioning failure"),
+            }
+        }
+    }
+
     fn manager_with(
         open_ports: &[u16],
         launcher: Arc<FakeLauncher>,
+        provides_managed: bool,
+        stop_when_idle: bool,
+    ) -> XServerManager {
+        manager_with_auth(
+            open_ports,
+            launcher,
+            Box::new(FakeAuth {
+                cookie: Some(FAKE_COOKIE.to_string()),
+            }),
+            provides_managed,
+            stop_when_idle,
+        )
+    }
+
+    fn manager_with_auth(
+        open_ports: &[u16],
+        launcher: Arc<FakeLauncher>,
+        auth: Box<dyn XAuthProvider>,
         provides_managed: bool,
         stop_when_idle: bool,
     ) -> XServerManager {
@@ -509,6 +574,7 @@ mod tests {
             Box::new(FakeProbe::with_open(open_ports)),
             Box::new(launcher),
             resolver_ok(),
+            auth,
             provides_managed,
             stop_when_idle,
         )
@@ -578,7 +644,7 @@ mod tests {
     }
 
     #[test]
-    fn spawns_managed_server_when_none_present() {
+    fn spawns_managed_server_with_cookie_auth() {
         let launcher = FakeLauncher::new();
         let mgr = manager_with(&[], launcher.clone(), true, true);
 
@@ -588,13 +654,31 @@ mod tests {
         assert_eq!(info.port, 6000);
         assert_eq!(launcher.count(), 1);
         assert_eq!(mgr.status(), XServerStatus::Running { display: 0 });
-        // launched with -ac (no auth file configured yet)
-        assert!(launcher
-            .last_args
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|a| a == "-ac"));
+        // Default is cookie auth: launched with -auth, not -ac.
+        let args = launcher.last_args.lock().unwrap();
+        assert!(args.iter().any(|a| a == "-auth"));
+        assert!(!args.iter().any(|a| a == "-ac"));
+    }
+
+    #[test]
+    fn falls_back_to_ac_when_cookie_provisioning_fails() {
+        let launcher = FakeLauncher::new();
+        let mgr = manager_with_auth(
+            &[],
+            launcher.clone(),
+            Box::new(FakeAuth { cookie: None }),
+            true,
+            true,
+        );
+
+        mgr.ensure_running().unwrap();
+        let args = launcher.last_args.lock().unwrap();
+        assert!(args.iter().any(|a| a == "-ac"), "must fall back to -ac");
+        assert!(!args.iter().any(|a| a == "-auth"));
+        assert!(
+            mgr.managed_server().unwrap().cookie.is_none(),
+            "-ac mode reports no cookie"
+        );
     }
 
     // -- reuse across sessions ---------------------------------------------
@@ -738,13 +822,13 @@ mod tests {
         // Nothing running yet.
         assert!(mgr.managed_server().is_none());
 
-        // A server we spawned is reported (cookie deferred to #1050).
+        // A server we spawned is reported with its MIT-MAGIC-COOKIE-1.
         mgr.ensure_running().unwrap();
         let managed = mgr
             .managed_server()
             .expect("managed server should be reported");
         assert_eq!(managed.display_number, 0);
-        assert!(managed.cookie.is_none());
+        assert_eq!(managed.cookie.as_deref(), Some(FAKE_COOKIE));
 
         // After stopping, nothing is reported.
         mgr.stop();

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -18,6 +18,7 @@
 
 #[cfg(windows)]
 pub mod acquire;
+pub mod auth;
 pub mod manager;
 
 pub use manager::XServerManager;


### PR DESCRIPTION
## Summary

Gives the managed Windows X server (VcXsrv) real cookie authentication instead of the insecure `-ac` fallback, and feeds the `(display, cookie)` into the existing SSH X11 forwarder — issue #1050, part of the X-server provisioning epic (#1047).

Builds directly on the #1049 seam: `ManagedXServerSource::managed_server()` already flows a cookie to the forwarder via core's `read_local_xauth_cookie()`, and `build_launch_args` already emits `-auth <file>` when given one. This PR fills in both.

### New — `xserver::auth` (cross-platform, unit-tested everywhere)
- Generate a per-start `MIT-MAGIC-COOKIE-1` (16 random bytes via `OsRng` → 32 lowercase hex).
- Write a standard-format `.Xauthority` record. Uses `FamilyWild` so the X server loads the entry regardless of the loopback-TCP transport; MIT-MAGIC-COOKIE-1 then authenticates purely on the cookie value.
- `FileXAuthProvider` writes the file (PID + display keyed, so concurrent instances don't clobber) and returns `(auth_file, cookie_hex)`.

### Wiring — `XServerManager`
- On a managed spawn: provision the cookie, launch `vcxsrv.exe -auth <file>`, store the cookie, and report it via `managed_server()`. The forwarder then injects it on the remote (`xauth add … MIT-MAGIC-COOKIE-1 <cookie>`) — replacing the Unix-only `xauth`-shelling path that doesn't exist on Windows.
- `.Xauthority` is removed on stop and on a failed spawn (no leak).
- **MVP fallback:** if provisioning fails, fall back to `-ac` (loopback-only) with a warning and report no cookie — the documented tradeoff; cookie auth is the default.
- Replaces the `set_auth_file` placeholder from #1049. The provider is injected (same DI pattern as probe/launcher/resolver), so the lifecycle tests stay filesystem-free.

No forwarder changes needed — `read_local_xauth_cookie(display, managed)` already returns `server.cookie`.

## Scope boundary
The manager still isn't invoked end-to-end: the provisioning orchestrator (#1052) is what starts the managed server on connect (behind the consent prompt) and passes it to the forwarder as the `managed` source. So the cookie path is complete and unit-tested here but becomes reachable — and manually verifiable against real VcXsrv — with #1052.

## Test plan (TDD — tests committed before implementation)

`xserver::auth` (5 tests): cookie generator (16 bytes, non-constant), hex (32 lowercase), `.Xauthority` byte-layout round-trip (FamilyWild, ASCII display number, protocol name, cookie data), `FileXAuthProvider` writes a file whose cookie bytes match the reported hex.

`xserver::manager` (updated + new): managed spawn launches with `-auth` (not `-ac`) and reports the cookie; provisioning failure falls back to `-ac` and reports no cookie.

`./scripts/check.sh` and the full Rust workspace test suite pass.

**Deferred to #1052:** the live `xeyes`/`xclock`-renders-with-cookie-auth manual step (needs the orchestrator to make the flow reachable), since `FamilyWild` cookie loading can only be fully validated against real VcXsrv on Windows.

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)