### PR TITLE
feat(testing): automate testid-catalog regeneration (#1084)

### DIFF
--- a/.claude/agents/ui-design.md
+++ b/.claude/agents/ui-design.md
@@ -97,12 +97,14 @@ wrap motion in `@media (prefers-reduced-motion: reduce)`; use the shared enter/e
 - Debug logging goes through `frontendLog` (LogViewer), never `console.*`.
 - **TDD**: write/adjust the Vitest test first, watch it fail, then implement.
   A design change ships with at least a unit test or documented manual test.
-- **`data-testid` catalog**: if you add, remove, or rename ANY `data-testid`
+- **`data-testid` catalog**: adding, removing, or renaming ANY `data-testid`
   (migrating a dialog to `Modal` adds `modal-close`; primitives forward the
-  hook), regenerate `tests/system/testid-catalog.md` with
-  `python scripts/build-testid-catalog.py` and commit it in the same change.
-  CI fails on a stale catalog (both the "Frontend Code Quality" catalog check
-  and the "System-Test machinery" job).
+  hook) changes `tests/system/testid-catalog.md`. The autoformat PostToolUse
+  hook regenerates it automatically after each `.ts`/`.tsx` edit (#1084), so it
+  usually stays fresh on its own — just **commit the catalog change** alongside
+  your edit. If you edited outside the hook, regenerate manually with
+  `python scripts/build-testid-catalog.py`. CI fails on a stale catalog (both
+  the "Frontend Code Quality" catalog check and the "System-Test machinery" job).
 - Run `./scripts/check.sh` (lint/format/clippy mirror of CI) and `./scripts/test.sh`
   before declaring done. Formatting is auto-applied by the PostToolUse hook.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -83,6 +83,8 @@ python scripts/test-manual.py --keep-infra        # Keep Docker containers after
 python scripts/test-manual.py --resume tests/reports/manual-*.json  # Resume previous session
 
 # data-testid catalog (for system-test authors)
+# The autoformat PostToolUse hook regenerates this automatically after a source
+# .tsx edit (#1084); run it by hand only when editing outside that flow.
 python scripts/build-testid-catalog.py            # Regenerate tests/system/testid-catalog.md
 python scripts/build-testid-catalog.py --check    # Verify it is up to date (CI gate)
 python scripts/build-testid-catalog.py --stdout   # Print without writing
@@ -96,7 +98,8 @@ python scripts/build-testid-catalog.py --stdout   # Print without writing
 
 The `internal/` subdirectory contains scripts that are **not** intended for direct use. They are invoked by other scripts or by tooling. See [`internal/README.md`](internal/README.md) for details.
 
-| File                     | Used by                                  | Purpose                                             |
-| ------------------------ | ---------------------------------------- | --------------------------------------------------- |
-| `internal/autoformat.sh` | `.claude/settings.json` PostToolUse hook | Auto-format a single file (Prettier / rustfmt)      |
-| `internal/kill-port.cjs` | `dev.sh` / `dev.cmd`                     | Kill any process occupying the Vite dev server port |
+| File                                | Used by                                  | Purpose                                                                                        |
+| ----------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `internal/autoformat.sh`            | `.claude/settings.json` PostToolUse hook | Auto-format a single edited file (Prettier / rustfmt) and refresh the `data-testid` catalog    |
+| `internal/regen-testid-catalog.mjs` | `internal/autoformat.sh`                 | Regenerate the `data-testid` catalog when a source `.tsx` with a `data-testid` changes (#1084) |
+| `internal/kill-port.cjs`            | `dev.sh` / `dev.cmd`                     | Kill any process occupying the Vite dev server port                                            |

--- a/scripts/build-testid-catalog.py
+++ b/scripts/build-testid-catalog.py
@@ -341,7 +341,11 @@ def main(argv: "list[str] | None" = None) -> int:
         print(f"{CATALOG_PATH.relative_to(REPO_ROOT).as_posix()} is up to date.")
         return 0
 
-    CATALOG_PATH.write_text(content, encoding="utf-8")
+    # Force LF newlines so regenerating on Windows (e.g. from the autoformat
+    # hook, #1084) does not rewrite the file with CRLF and create a spurious
+    # diff — the repo normalizes the catalog to LF via .gitattributes anyway.
+    with open(CATALOG_PATH, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(content)
     print(f"Wrote {CATALOG_PATH.relative_to(REPO_ROOT).as_posix()}")
     return 0
 

--- a/scripts/internal/README.md
+++ b/scripts/internal/README.md
@@ -2,7 +2,8 @@
 
 Internal helper scripts used by other scripts or tooling. These are **not** intended for direct use by developers.
 
-| File            | Used by                                  | Purpose                                             |
-| --------------- | ---------------------------------------- | --------------------------------------------------- |
-| `autoformat.sh` | `.claude/settings.json` PostToolUse hook | Auto-format a single file (Prettier / rustfmt)      |
-| `kill-port.cjs` | `dev.sh` / `dev.cmd`                     | Kill any process occupying the Vite dev server port |
+| File                       | Used by                                  | Purpose                                                                                                                      |
+| -------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `autoformat.sh`            | `.claude/settings.json` PostToolUse hook | Auto-format a single edited file (Prettier / rustfmt) and refresh the `data-testid` catalog when a source `.tsx` changes     |
+| `regen-testid-catalog.mjs` | `autoformat.sh`                          | Regenerate `tests/system/testid-catalog.md` when the edited file is a source `.ts`/`.tsx` containing a `data-testid` (#1084) |
+| `kill-port.cjs`            | `dev.sh` / `dev.cmd`                     | Kill any process occupying the Vite dev server port                                                                          |

--- a/scripts/internal/autoformat.sh
+++ b/scripts/internal/autoformat.sh
@@ -4,7 +4,11 @@
 # Reads JSON from stdin to extract the file path.
 
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+# Parse the edited file path from the hook's JSON payload with Node rather than
+# jq: Node is already a hard dependency of this script (`npx` below) and of the
+# project, whereas jq is often absent (e.g. Git-Bash on Windows), which silently
+# turned the whole hook into a no-op. See #1084.
+FILE_PATH=$(printf '%s' "$INPUT" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).tool_input?.file_path??""))}catch{}})' 2>/dev/null)
 
 [ -z "$FILE_PATH" ] && exit 0
 [ ! -f "$FILE_PATH" ] && exit 0
@@ -19,6 +23,17 @@ case "$FILE_PATH" in
         ;;
     *.rs)
         rustfmt "$FILE_PATH" &>/dev/null
+        ;;
+esac
+
+# Keep tests/system/testid-catalog.md in sync when a component's data-testid set
+# may have changed, so a stale catalog never reaches CI (#1084, #899). The Node
+# helper self-gates on path + contents (no-op for non-source / testid-free
+# files) and locates a usable Python interpreter itself. Best-effort: never fail
+# the edit.
+case "$FILE_PATH" in
+    *.ts|*.tsx)
+        node "$(dirname "$0")/regen-testid-catalog.mjs" "$FILE_PATH" &>/dev/null || true
         ;;
 esac
 

--- a/scripts/internal/regen-testid-catalog.mjs
+++ b/scripts/internal/regen-testid-catalog.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Regenerate tests/system/testid-catalog.md when a source file's `data-testid`
+// set may have changed, so a stale catalog never reaches CI (#1084).
+//
+// Background: `scripts/build-testid-catalog.py` generates the catalog and the
+// "Frontend Code Quality" CI job verifies its freshness (`--check`, #899). A
+// stale catalog fails that job *and* the system-test machinery job, and used to
+// require a manual `python scripts/build-testid-catalog.py` per branch — easy to
+// forget, costing red CI runs (the whole of #1062 hit this repeatedly).
+//
+// This helper is invoked from the autoformat PostToolUse hook
+// (`autoformat.sh`) for every edited `.ts`/`.tsx`. It self-gates: it only runs
+// the (Python) generator when the edited file is an app source file that
+// actually contains a `data-testid`. The catalog stays the single source of
+// truth in Python; this is just the "when to regenerate" glue.
+//
+// The logic lives here (rather than inline in bash) so the two fragile parts —
+// the trigger predicate and locating a usable Python interpreter across
+// platforms (Windows ships a `python`/`python3` App-Execution-Alias stub that is
+// NOT a real interpreter) — can be unit-tested. See regen-testid-catalog.test.mjs.
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/** Filename suffixes that are tests/fixtures/decls, not app UI (mirrors the Python scanner). */
+const SKIP_SUFFIXES = [".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx", ".d.ts"];
+
+/** Path segments whose contents are tests/mocks/plumbing, not app UI. */
+const SKIP_DIR_PARTS = new Set(["__tests__", "test", "__mocks__", "testbridge"]);
+
+/** Interpreter candidates tried in order; the first that probes as real Python 3 wins. */
+export const PYTHON_CANDIDATES = [
+  ["python3"],
+  ["python"],
+  ["py", "-3"],
+  ["python3.12"],
+  // Last resort: uv provisions a managed CPython. On a box with no system
+  // Python (e.g. only the Windows Store alias), this makes the hook work; uv
+  // caches the interpreter after the first use.
+  ["uv", "run", "--python", "3.12", "python"],
+];
+
+/**
+ * Decide whether editing `filePath` (with the given `contents`) should trigger a
+ * catalog regeneration.
+ *
+ * True only for an app-source `.ts`/`.tsx` file under `src/` that is not a
+ * test/spec/decl/mock and actually contains a `data-testid`.
+ *
+ * @param {string} filePath - Absolute or relative path to the edited file.
+ * @param {string} contents - The file's text contents.
+ * @returns {boolean}
+ */
+export function shouldRegenerate(filePath, contents) {
+  if (typeof filePath !== "string" || typeof contents !== "string") {
+    return false;
+  }
+  const norm = filePath.replace(/\\/g, "/");
+  const match = norm.match(/(?:^|\/)src\/(.+\.(?:ts|tsx))$/);
+  if (!match) {
+    return false;
+  }
+  const relFromSrc = match[1];
+  if (SKIP_SUFFIXES.some((suffix) => relFromSrc.endsWith(suffix))) {
+    return false;
+  }
+  const dirParts = relFromSrc.split("/").slice(0, -1);
+  if (dirParts.some((part) => SKIP_DIR_PARTS.has(part))) {
+    return false;
+  }
+  return contents.includes("data-testid");
+}
+
+/**
+ * Resolve a usable Python 3 interpreter from `candidates`, using `probe` to test
+ * each. Returns the first candidate argv that probes successfully, or null.
+ *
+ * @param {string[][]} [candidates] - Ordered interpreter argv candidates.
+ * @param {(argv: string[]) => boolean} [probe] - Returns true if argv is real Python 3.
+ * @returns {string[] | null}
+ */
+export function resolvePython(candidates = PYTHON_CANDIDATES, probe = probePython) {
+  for (const argv of candidates) {
+    if (probe(argv)) {
+      return argv;
+    }
+  }
+  return null;
+}
+
+/**
+ * Probe whether `argv` launches a real Python 3 interpreter.
+ *
+ * Runs `argv --version` and requires a clean exit that reports "Python 3.x".
+ * This rejects the Windows App-Execution-Alias stub (`python`/`python3` with no
+ * real install), which prints "Python was not found…" and exits non-zero.
+ *
+ * Runs via the shell (a single command string, not an args array) so bare
+ * commands (`uv`, `python`, `py`) resolve via `PATHEXT` on Windows — Node does
+ * not do that resolution itself. `--version` is a single, space-free argument,
+ * so it needs no quoting. The candidate parts come from a fixed internal list,
+ * so there is no untrusted input in the command string.
+ *
+ * @param {string[]} argv
+ * @returns {boolean}
+ */
+export function probePython(argv) {
+  try {
+    const result = spawnSync(`${argv.join(" ")} --version`, {
+      encoding: "utf8",
+      timeout: 20000,
+      shell: true,
+    });
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    return result.status === 0 && /Python 3\./.test(output);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run the Python catalog generator with the resolved interpreter.
+ *
+ * Uses the shell for the same cross-platform command resolution as
+ * {@link probePython}; the script path is quoted so a path containing spaces
+ * survives the shell.
+ *
+ * @param {string[]} pythonArgv - Interpreter argv from {@link resolvePython}.
+ * @param {string} scriptPath - Path to build-testid-catalog.py.
+ * @returns {boolean} True if the generator ran and exited 0.
+ */
+export function runGenerator(pythonArgv, scriptPath) {
+  const result = spawnSync(`${pythonArgv.join(" ")} "${scriptPath}"`, {
+    encoding: "utf8",
+    timeout: 25000,
+    shell: true,
+  });
+  return result.status === 0;
+}
+
+// CLI mode: `node regen-testid-catalog.mjs <edited-file>`. Best-effort and
+// quiet — any failure (no Python, unreadable file) is swallowed so the hook
+// never blocks an edit; CI's freshness check remains the correctness backstop.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const filePath = process.argv[2];
+  if (filePath) {
+    try {
+      const contents = readFileSync(filePath, "utf8");
+      if (shouldRegenerate(filePath, contents)) {
+        const python = resolvePython();
+        if (python) {
+          const scriptPath = resolve(
+            dirname(fileURLToPath(import.meta.url)),
+            "..",
+            "build-testid-catalog.py"
+          );
+          runGenerator(python, scriptPath);
+        }
+      }
+    } catch {
+      // Best-effort: never fail the edit.
+    }
+  }
+}

--- a/scripts/internal/regen-testid-catalog.test.mjs
+++ b/scripts/internal/regen-testid-catalog.test.mjs
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { shouldRegenerate, resolvePython, PYTHON_CANDIDATES } from "./regen-testid-catalog.mjs";
+
+const WITH_ID = 'return <div data-testid="foo" />;';
+const WITHOUT_ID = "return <div className='foo' />;";
+
+describe("shouldRegenerate", () => {
+  it("triggers for an app source .tsx under src/ containing a data-testid", () => {
+    expect(shouldRegenerate("src/components/Settings/AboutSettings.tsx", WITH_ID)).toBe(true);
+    expect(shouldRegenerate("src/hooks/useThing.ts", WITH_ID)).toBe(true);
+  });
+
+  it("triggers regardless of absolute vs relative path or backslashes", () => {
+    expect(shouldRegenerate("/home/dev/repo/src/components/Foo.tsx", WITH_ID)).toBe(true);
+    expect(shouldRegenerate("C:\\dev\\repo\\src\\components\\Foo.tsx", WITH_ID)).toBe(true);
+  });
+
+  it("does not trigger when the file has no data-testid", () => {
+    expect(shouldRegenerate("src/components/Foo.tsx", WITHOUT_ID)).toBe(false);
+  });
+
+  it("does not trigger for files outside src/", () => {
+    expect(shouldRegenerate("scripts/internal/foo.ts", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("tests/system/thing.tsx", WITH_ID)).toBe(false);
+  });
+
+  it("does not trigger for non ts/tsx files", () => {
+    expect(shouldRegenerate("src/components/Foo.css", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/components/Foo.js", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/data/thing.json", WITH_ID)).toBe(false);
+  });
+
+  it("skips test / spec / declaration files (mirrors the Python scanner)", () => {
+    expect(shouldRegenerate("src/components/Foo.test.tsx", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/components/Foo.test.ts", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/components/Foo.spec.tsx", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/types/foo.d.ts", WITH_ID)).toBe(false);
+  });
+
+  it("skips test/mock/testbridge directories", () => {
+    expect(shouldRegenerate("src/components/__tests__/Foo.tsx", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/test/helpers.tsx", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/__mocks__/Foo.tsx", WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/testbridge/selectors.tsx", WITH_ID)).toBe(false);
+  });
+
+  it("returns false for non-string inputs", () => {
+    expect(shouldRegenerate(null, WITH_ID)).toBe(false);
+    expect(shouldRegenerate("src/components/Foo.tsx", null)).toBe(false);
+    expect(shouldRegenerate(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("resolvePython", () => {
+  it("returns the first candidate whose probe succeeds", () => {
+    const tried = [];
+    const probe = (argv) => {
+      tried.push(argv.join(" "));
+      return argv[0] === "python"; // first real interpreter
+    };
+    expect(resolvePython(PYTHON_CANDIDATES, probe)).toEqual(["python"]);
+    // python3 was tried first and rejected, then python matched — no further tries.
+    expect(tried).toEqual(["python3", "python"]);
+  });
+
+  it("skips a Windows-stub-like candidate (probe false) and falls through", () => {
+    // Simulate python3/python being the App-Execution-Alias stub (probe false),
+    // so resolution falls through to a working `py -3`.
+    const probe = (argv) => argv.join(" ") === "py -3";
+    expect(resolvePython(PYTHON_CANDIDATES, probe)).toEqual(["py", "-3"]);
+  });
+
+  it("returns null when no candidate is a usable interpreter", () => {
+    expect(resolvePython(PYTHON_CANDIDATES, () => false)).toBeNull();
+  });
+
+  it("preserves candidate order and stops at the first match", () => {
+    const order = [["a"], ["b"], ["c"]];
+    const seen = [];
+    resolvePython(order, (argv) => {
+      seen.push(argv[0]);
+      return argv[0] === "b";
+    });
+    expect(seen).toEqual(["a", "b"]);
+  });
+});

--- a/src/components/Terminal/LargePasteDialog.test.tsx
+++ b/src/components/Terminal/LargePasteDialog.test.tsx
@@ -42,7 +42,11 @@ describe("LargePasteDialog", () => {
     const dialog = document.querySelector('[data-testid="large-paste-dialog"]');
     expect(dialog).toBeTruthy();
     expect(dialog!.classList.contains("ui-modal")).toBe(true);
-    expect(dialog!.textContent).toContain("12,345");
+    // The component groups the count with `toLocaleString()`, so the separator
+    // is locale-dependent ("12,345" in en-US, "12.345" in en-DE). Assert against
+    // the same locale-formatted value rather than a hard-coded US separator so
+    // the test passes regardless of the runner's default locale.
+    expect(dialog!.textContent).toContain(baseProps.charCount.toLocaleString());
   });
 
   it("Paste button fires onConfirm", () => {

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -9,6 +9,8 @@ source — the #1 authoring error when porting system tests (#899).
 - **Regenerate:** `python scripts/build-testid-catalog.py`
 - **Verify freshness (CI):** `python scripts/build-testid-catalog.py --check`
 
+**455** literal · **123** dynamic · **16** indirect.
+
 ## Literal test IDs
 
 Fixed strings — match exactly.


### PR DESCRIPTION
## Summary

Implements **#1084**. A stale `tests/system/testid-catalog.md` fails CI — both the "Frontend Code Quality" catalog check (#899) and the "System-Test machinery" job — and previously had to be regenerated by hand (`python scripts/build-testid-catalog.py`) per branch. That's easy to forget and cost repeated red CI runs during the #1062 migration.

This wires catalog regeneration into the existing **autoformat PostToolUse hook** so a stale catalog can't reach CI, and puts the fragile logic in a unit-tested Node helper.

## What's included

- **`scripts/internal/regen-testid-catalog.mjs`** (+ `.test.mjs`, matching the `parse-issue-refs.mjs` pattern):
  - `shouldRegenerate(path, contents)` — self-gates: only app-source `.ts`/`.tsx` under `src/`, not test/spec/decl/mock, that actually contain a `data-testid`.
  - `resolvePython()` — locates a usable Python 3 across platforms, **rejecting the Windows App-Execution-Alias stub** and falling back to `uv run`. Both are unit-tested (12 tests).
- **`scripts/internal/autoformat.sh`** now calls the helper after each `.ts`/`.tsx` edit (best-effort; never blocks the edit). It also **parses the hook's JSON payload with Node instead of `jq`** — `jq` is frequently absent (e.g. Git-Bash on Windows), which silently turned the *entire* autoformat hook into a no-op.
- **`scripts/build-testid-catalog.py`** now writes the catalog with explicit **LF** newlines, so regenerating on Windows doesn't churn it to CRLF.
- **Regenerated the catalog** — it had drifted on develop (a prior generator change added a summary-counts line without a regeneration), so `--check` was already failing. This brings it back in sync; the automation prevents recurrence.
- Docs: `scripts/README.md`, `scripts/internal/README.md`, and the `ui-design` agent checklist.

## Bundled fix — flaky `LargePasteDialog` test (#1092)

While validating, I hit a **pre-existing, unrelated** develop failure: `LargePasteDialog.test.tsx` hard-coded the en-US-grouped count `12,345`, but the component formats with `toLocaleString()`, whose separator is locale-dependent (`12.345` under `en-DE`, incl. CI). It failed deterministically off en-US and turned develop's "Run Tests" red. Fixed by asserting against the locale-formatted value (component behavior unchanged). Included here at the reviewer's request so this PR's "Run Tests" job goes green.

## Test plan

- [x] New unit tests: `vitest run scripts/internal/regen-testid-catalog.test.mjs` → 12 pass.
- [x] End-to-end: staled the catalog, ran the full hook via stdin JSON → regenerated; a `data-testid`-free edit is a no-op.
- [x] `LargePasteDialog.test.tsx` → 4 pass (verified under a non-en-US locale, the previously-failing condition).
- [x] `build-testid-catalog.py --check` passes; commitlint + prettier clean; merged latest `origin/develop`.

Closes #1084. Closes #1092.

🤖 Generated with [Claude Code](https://claude.com/claude-code)