### PR TITLE
refactor(ui): migrate editor panels & schema forms onto ui/ primitives (#1085)

### DIFF
--- a/docs/changes/dev1/feature/1085-migrate-editor-panels-forms.md
+++ b/docs/changes/dev1/feature/1085-migrate-editor-panels-forms.md
@@ -1,0 +1,3 @@
+## Changed
+
+- The connection editor, tunnel editor, and workspace editor, plus the schema-driven connection forms, sidebar folder input, and the embedded-server bind-address picker, now use the shared input/select/toggle/button components — consistent styling, motion, focus, and accessible switches app-wide. Save and connect actions in these editors now surface errors as toasts instead of failing silently. The save-workspace name field also renders correctly in the light theme (was hardcoded white).

--- a/src/components/ConnectionEditor/ConnectionAppearanceSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionAppearanceSettings.tsx
@@ -1,6 +1,7 @@
 import { ColorPickerDialog } from "@/components/Terminal/ColorPickerDialog";
 import { IconPickerDialog } from "./IconPickerDialog";
 import { IconByName } from "@/utils/connectionIcons";
+import { Button } from "@/components/ui";
 import { useState } from "react";
 
 interface ConnectionAppearanceSettingsProps {
@@ -29,23 +30,23 @@ export function ConnectionAppearanceSettings({
           {color && (
             <div className="connection-editor__color-preview" style={{ backgroundColor: color }} />
           )}
-          <button
-            className="connection-editor__btn connection-editor__btn--secondary"
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => setColorPickerOpen(true)}
             data-testid="connection-editor-color-picker"
           >
             {color ? "Change" : "Set Color"}
-          </button>
+          </Button>
           {color && (
-            <button
-              className="connection-editor__btn connection-editor__btn--secondary"
-              type="button"
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => onColorChange(undefined)}
               data-testid="connection-editor-clear-color"
             >
               Clear
-            </button>
+            </Button>
           )}
         </div>
         <span className="settings-form__hint">
@@ -57,23 +58,23 @@ export function ConnectionAppearanceSettings({
         <span className="settings-form__label">Icon</span>
         <div className="connection-editor__color-row">
           {icon && <IconByName name={icon} size={18} />}
-          <button
-            className="connection-editor__btn connection-editor__btn--secondary"
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => setIconPickerOpen(true)}
             data-testid="connection-editor-icon-picker"
           >
             {icon ? "Change" : "Set Icon"}
-          </button>
+          </Button>
           {icon && (
-            <button
-              className="connection-editor__btn connection-editor__btn--secondary"
-              type="button"
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => onIconChange(undefined)}
               data-testid="connection-editor-clear-icon"
             >
               Clear
-            </button>
+            </Button>
           )}
         </div>
         <span className="settings-form__hint">

--- a/src/components/ConnectionEditor/ConnectionEditor.css
+++ b/src/components/ConnectionEditor/ConnectionEditor.css
@@ -47,50 +47,8 @@
   flex-shrink: 0;
 }
 
-.connection-editor__btn {
-  padding: var(--spacing-xs) var(--spacing-md);
-  font-size: var(--font-size-sm);
-  border-radius: var(--radius-md);
-  transition:
-    background-color var(--transition-fast),
-    transform var(--transition-fast),
-    box-shadow var(--transition-fast);
-}
-
-.connection-editor__btn--primary {
-  background-color: var(--accent-color);
-  color: var(--text-on-accent);
-}
-
-.connection-editor__btn--primary:hover {
-  background-color: var(--accent-hover);
-  box-shadow: 0 2px 12px rgba(61, 125, 232, 0.35);
-}
-
-.connection-editor__btn--primary:active {
-  transform: translateY(1px) scale(0.98);
-  box-shadow: none;
-}
-
-.connection-editor__btn--secondary {
-  color: var(--text-secondary);
-}
-
-.connection-editor__btn--secondary:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.connection-editor__btn--secondary:active {
-  transform: translateY(1px) scale(0.98);
-}
-
 .connection-editor__setup-agent-btn {
   align-self: flex-start;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  border: 1px solid var(--border-color);
 }
 
 .connection-editor__color-row {
@@ -126,13 +84,6 @@
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.3px;
-}
-
-.settings-form__field input,
-.settings-form__field select {
-  width: 100%;
-  height: 28px;
-  font-size: var(--font-size-sm);
 }
 
 .settings-form__field--checkbox {

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -749,22 +749,23 @@ describe("ConnectionEditor — unsaved-changes dirty state", () => {
     renderEditor(CONN_WITHOUT_EXPLICIT_DEFAULTS.id);
     await flushEffects();
 
-    // Checkbox shows as checked because the schema default is true
-    const checkbox = container.querySelector(
+    // Toggle shows as on because the schema default is true (Radix Switch:
+    // read `aria-checked` rather than a native checkbox `.checked`).
+    const toggle = container.querySelector(
       '[data-testid="field-shellIntegration"]'
-    ) as HTMLInputElement;
-    expect(checkbox).not.toBeNull();
-    expect(checkbox.checked).toBe(true);
+    ) as HTMLButtonElement;
+    expect(toggle).not.toBeNull();
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
 
-    // Uncheck → dirty
+    // Toggle off → dirty
     await act(async () => {
-      checkbox.click();
+      toggle.click();
     });
     expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
 
-    // Re-check (back to schema default) → clean
+    // Toggle back on (schema default) → clean
     await act(async () => {
-      checkbox.click();
+      toggle.click();
     });
     expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(false);
   });

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -27,6 +27,7 @@ import {
   JumpHostConfig,
 } from "@/types/connection";
 import { SettingsNav } from "@/components/Settings";
+import { Button, Input, Select, Toggle } from "@/components/ui";
 import { ConnectionSettingsForm, AGENT_SCHEMA } from "@/components/DynamicForm";
 import {
   buildDefaults,
@@ -911,13 +912,13 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         <h3 className="settings-panel__category-title">General</h3>
         <label className="settings-form__field">
           <span className="settings-form__label">Name</span>
-          <input
+          <Input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Connection name"
             autoFocus
-            className={nameError ? "settings-form__input--error" : ""}
+            error={!!nameError}
             data-testid="connection-editor-name-input"
           />
           {nameError && (
@@ -932,18 +933,14 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         {!isAgentTransportMode && (
           <label className="settings-form__field">
             <span className="settings-form__label">Type</span>
-            <select
+            <Select
               value={selectedType}
-              onChange={(e) => handleTypeChange(e.target.value)}
+              onChange={handleTypeChange}
+              options={typeOptions}
               disabled={isAgentDefinitionMode ? !!existingAgentDef : false}
+              aria-label="Type"
               data-testid="connection-editor-type-select"
-            >
-              {typeOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+            />
           </label>
         )}
         {!isAgentTransportMode && (
@@ -955,18 +952,16 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         {!isAnyAgentMode && enabledExternalFiles.length > 0 && (
           <label className="settings-form__field">
             <span className="settings-form__label">Storage File</span>
-            <select
+            <Select
               value={sourceFile ?? ""}
-              onChange={(e) => setSourceFile(e.target.value || null)}
+              onChange={(v) => setSourceFile(v || null)}
+              options={[
+                { value: "", label: "Default (connections.json)" },
+                ...enabledExternalFiles.map((f) => ({ value: f.path, label: f.path })),
+              ]}
+              aria-label="Storage File"
               data-testid="connection-editor-source-file"
-            >
-              <option value="">Default (connections.json)</option>
-              {enabledExternalFiles.map((f) => (
-                <option key={f.path} value={f.path}>
-                  {f.path}
-                </option>
-              ))}
-            </select>
+            />
           </label>
         )}
       </div>
@@ -999,15 +994,16 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
       {showSshAgentSetup && (
         <div className="settings-panel__category" data-testid="ssh-agent-setup-section">
           <h3 className="settings-panel__category-title">SSH Agent</h3>
-          <button
-            type="button"
-            className="connection-editor__btn connection-editor__btn--secondary connection-editor__setup-agent-btn"
+          <Button
+            variant="secondary"
+            size="sm"
+            className="connection-editor__setup-agent-btn"
+            icon={<KeyRound size={13} aria-hidden />}
             onClick={handleSetupSshAgent}
             data-testid="ssh-setup-agent"
           >
-            <KeyRound size={13} aria-hidden />
             Setup SSH Agent
-          </button>
+          </Button>
           <p className="settings-form__hint">
             Opens a terminal that starts your SSH agent and adds your keys (<code>ssh-add</code>),
             so agent authentication can find them.
@@ -1020,15 +1016,12 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           <h3 className="settings-panel__category-title">Session</h3>
           <div className="settings-form__field">
             <span className="settings-form__label">Persistent session</span>
-            <label className="settings-panel__toggle">
-              <input
-                type="checkbox"
-                checked={persistent}
-                onChange={(e) => setPersistent(e.target.checked)}
-                data-testid="connection-editor-persistent"
-              />
-              <span className="settings-panel__toggle-slider" />
-            </label>
+            <Toggle
+              checked={persistent}
+              onCheckedChange={setPersistent}
+              aria-label="Persistent session"
+              data-testid="connection-editor-persistent"
+            />
             <span className="settings-form__hint">
               Keep the session alive when the tab is closed
             </span>
@@ -1113,29 +1106,21 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         <div className="connection-editor__content">{renderContent()}</div>
       </div>
       <div className="connection-editor__actions">
-        <button
-          className="connection-editor__btn connection-editor__btn--secondary"
-          onClick={handleCancel}
-          data-testid="connection-editor-cancel"
-        >
+        <Button variant="secondary" onClick={handleCancel} data-testid="connection-editor-cancel">
           Cancel
-        </button>
+        </Button>
         {!isAgentTransportMode && (
-          <button
-            className="connection-editor__btn connection-editor__btn--primary"
+          <Button
+            variant="primary"
             onClick={handleSaveAndConnect}
             data-testid="connection-editor-save-connect"
           >
             Save &amp; Connect
-          </button>
+          </Button>
         )}
-        <button
-          className="connection-editor__btn connection-editor__btn--primary"
-          onClick={handleSave}
-          data-testid="connection-editor-save"
-        >
+        <Button variant="primary" onClick={handleSave} data-testid="connection-editor-save">
           Save
-        </button>
+        </Button>
       </div>
       <UnsavedChangesDialog
         open={pendingCloseRequest?.tabId === tabId}

--- a/src/components/DynamicForm/ConnectionSettingsForm.test.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.test.tsx
@@ -106,6 +106,16 @@ describe("ConnectionSettingsForm", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    // Radix Select (the migrated auth-method dropdown) probes pointer-capture
+    // and scroll APIs that jsdom omits.
+    if (!Element.prototype.hasPointerCapture) {
+      Element.prototype.hasPointerCapture = () => false;
+      Element.prototype.setPointerCapture = () => {};
+      Element.prototype.releasePointerCapture = () => {};
+    }
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = () => {};
+    }
   });
 
   afterEach(() => {
@@ -136,10 +146,12 @@ describe("ConnectionSettingsForm", () => {
   });
 
   it("updates conditional fields when the test bridge selects an option", async () => {
-    // Regression: the auth-method <select> is a react-hook-form Controller, whose
+    // Regression: the auth-method dropdown is a react-hook-form Controller, whose
     // watched value drives `visibleWhen`. A bridge `select` must actually update
-    // that value so dependent fields (keyPath) appear — i.e. it must fire the
-    // event RHF listens to, exactly like the `type` command does for inputs.
+    // that value so dependent fields (keyPath) appear — i.e. it must drive the
+    // migrated Radix Select the way a real user does. The live harness wraps
+    // `select` in a retry (`wait`), so mirror that here; in a WebView one call
+    // suffices, but Radix binds its portalled option handlers a tick after open.
     renderForm(SSH_SCHEMA, { authMethod: "password", port: 22 }, vi.fn());
     expect(query("dynamic-field-keyPath")).toBeNull();
 
@@ -154,9 +166,11 @@ describe("ConnectionSettingsForm", () => {
       resizeWindow: async () => {},
       screenshot: async () => "data:image/png;base64,AAAA",
     };
-    await act(async () => {
-      await dispatchCommand({ action: "select", testId: "field-authMethod", value: "key" }, deps);
-    });
+    for (let i = 0; i < 3 && query("dynamic-field-keyPath") === null; i++) {
+      await act(async () => {
+        await dispatchCommand({ action: "select", testId: "field-authMethod", value: "key" }, deps);
+      });
+    }
 
     expect(query("dynamic-field-keyPath")).toBeTruthy();
     expect(query("dynamic-field-password")).toBeNull();

--- a/src/components/DynamicForm/DynamicField.test.tsx
+++ b/src/components/DynamicForm/DynamicField.test.tsx
@@ -166,10 +166,10 @@ describe("DynamicField", () => {
         required: false,
       };
       renderField(field, true, vi.fn());
-      const input = query("field-removeOnExit") as HTMLInputElement;
-      expect(input).toBeTruthy();
-      expect(input.type).toBe("checkbox");
-      expect(input.checked).toBe(true);
+      const toggle = query("field-removeOnExit") as HTMLButtonElement;
+      expect(toggle).toBeTruthy();
+      expect(toggle.getAttribute("role")).toBe("switch");
+      expect(toggle.getAttribute("aria-checked")).toBe("true");
     });
 
     it("renders label text", () => {
@@ -192,8 +192,8 @@ describe("DynamicField", () => {
         default: true,
       };
       renderField(field, undefined, vi.fn());
-      const input = query("field-shellIntegration") as HTMLInputElement;
-      expect(input.checked).toBe(true);
+      const toggle = query("field-shellIntegration") as HTMLButtonElement;
+      expect(toggle.getAttribute("aria-checked")).toBe("true");
     });
 
     it("falls back to false when value is undefined and no schema default", () => {
@@ -204,8 +204,8 @@ describe("DynamicField", () => {
         required: false,
       };
       renderField(field, undefined, vi.fn());
-      const input = query("field-flag") as HTMLInputElement;
-      expect(input.checked).toBe(false);
+      const toggle = query("field-flag") as HTMLButtonElement;
+      expect(toggle.getAttribute("aria-checked")).toBe("false");
     });
   });
 
@@ -224,12 +224,12 @@ describe("DynamicField", () => {
         required: true,
       };
       renderField(field, "key", vi.fn());
-      const select = query("field-authMethod") as HTMLSelectElement;
-      expect(select.value).toBe("key");
-      expect(select.options.length).toBe(2);
-      expect(select.options[0].text).toBe("SSH Key");
-      expect(select.options[1].text).toBe("Password");
-      expect(select.disabled).toBe(false);
+      // The Select primitive (Radix skin) exposes its value via `data-value` on
+      // the trigger button and shows the selected option's label as its text.
+      const trigger = query("field-authMethod") as HTMLButtonElement;
+      expect(trigger.getAttribute("data-value")).toBe("key");
+      expect(trigger.textContent).toContain("SSH Key");
+      expect(trigger.hasAttribute("disabled")).toBe(false);
     });
 
     it("disables select when only one option exists", () => {
@@ -243,9 +243,9 @@ describe("DynamicField", () => {
         required: true,
       };
       renderField(field, "docker", vi.fn());
-      const select = query("field-runtime") as HTMLSelectElement;
-      expect(select.disabled).toBe(true);
-      expect(select.options.length).toBe(1);
+      const trigger = query("field-runtime") as HTMLButtonElement;
+      expect(trigger.hasAttribute("disabled")).toBe(true);
+      expect(trigger.getAttribute("data-value")).toBe("docker");
     });
   });
 
@@ -499,7 +499,8 @@ describe("DynamicField", () => {
       renderField(volumeField, items, vi.fn());
       expect((query("field-volumes-hostPath-0") as HTMLInputElement).value).toBe("/data");
       expect((query("field-volumes-containerPath-0") as HTMLInputElement).value).toBe("/mnt");
-      expect((query("field-volumes-readOnly-0") as HTMLInputElement).checked).toBe(true);
+      // The per-row boolean is a Toggle (Radix Switch) — read `aria-checked`.
+      expect(query("field-volumes-readOnly-0")?.getAttribute("aria-checked")).toBe("true");
     });
 
     it("adds new item with defaults", () => {

--- a/src/components/DynamicForm/DynamicField.tsx
+++ b/src/components/DynamicForm/DynamicField.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { HelpCircle, X } from "lucide-react";
+import { HelpCircle, Plus, X } from "lucide-react";
 import type { SettingsField, FieldType } from "@/types/schema";
 import { KeyPathInput } from "@/components/Settings/KeyPathInput";
 import { listSerialPorts } from "@/services/api";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
+import { Button, Input, Select, Toggle } from "@/components/ui";
 
 interface DynamicFieldProps {
   field: SettingsField;
@@ -123,7 +124,7 @@ function TextField({ field, value, onChange, onBlur }: FieldProps & { onBlur?: (
   return (
     <>
       <span className="settings-form__label">{field.label}</span>
-      <input
+      <Input
         type="text"
         value={(value as string) ?? ""}
         onChange={(e) => onChange(e.target.value || undefined)}
@@ -158,7 +159,7 @@ function NumberField({
   return (
     <>
       <span className="settings-form__label">{field.label}</span>
-      <input
+      <Input
         type="number"
         value={value != null ? Number(value) : ""}
         onChange={(e) => {
@@ -196,15 +197,12 @@ function BooleanField({ field, value, onChange }: FieldProps) {
           </button>
         )}
       </span>
-      <label className="settings-panel__toggle">
-        <input
-          type="checkbox"
-          checked={(value as boolean) ?? (field.default as boolean) ?? false}
-          onChange={(e) => onChange(e.target.checked)}
-          data-testid={`field-${field.key}`}
-        />
-        <span className="settings-panel__toggle-slider" />
-      </label>
+      <Toggle
+        checked={(value as boolean) ?? (field.default as boolean) ?? false}
+        onCheckedChange={(checked) => onChange(checked)}
+        aria-label={field.label}
+        data-testid={`field-${field.key}`}
+      />
       {dialogOpen && field.helpText && (
         <FieldHelpDialog
           title={field.label}
@@ -258,18 +256,15 @@ function SelectField({
   return (
     <>
       <span className="settings-form__label">{field.label}</span>
-      <select
-        value={(value as string) ?? ""}
-        onChange={(e) => onChange(e.target.value)}
+      <Select
+        value={(value as string) || undefined}
+        onChange={(v) => onChange(v)}
+        options={fieldType.options}
         disabled={isLocked}
+        aria-label={field.label}
+        placeholder={field.placeholder}
         data-testid={`field-${field.key}`}
-      >
-        {fieldType.options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
-        ))}
-      </select>
+      />
     </>
   );
 }
@@ -278,7 +273,7 @@ function PortField({ field, value, onChange }: FieldProps) {
   return (
     <>
       <span className="settings-form__label">{field.label}</span>
-      <input
+      <Input
         type="number"
         value={value != null ? Number(value) : ""}
         onChange={(e) => {
@@ -321,7 +316,7 @@ function SerialPortField({
   return (
     <>
       <span className="settings-form__label">{field.label}</span>
-      <input
+      <Input
         type="text"
         value={currentValue}
         onChange={(e) => onChange(e.target.value || undefined)}
@@ -380,22 +375,22 @@ function FilePathField({
     <>
       <span className="settings-form__label">{field.label}</span>
       <div className="settings-form__file-row">
-        <input
+        <Input
           type="text"
           value={(value as string) ?? ""}
           onChange={(e) => onChange(e.target.value || undefined)}
           placeholder={field.placeholder}
           data-testid={`field-${field.key}`}
         />
-        <button
-          type="button"
-          className="settings-form__list-browse"
+        <Button
+          variant="secondary"
+          size="sm"
           onClick={handleBrowse}
           title="Browse"
           data-testid={`field-${field.key}-browse`}
         >
           ...
-        </button>
+        </Button>
       </div>
     </>
   );
@@ -428,7 +423,7 @@ function KeyValueListField({ field, value, onChange }: FieldProps) {
       <span className="settings-form__label">{field.label}</span>
       {items.map((item, index) => (
         <div key={index} className="settings-form__list-row">
-          <input
+          <Input
             type="text"
             value={item.key}
             onChange={(e) => handleUpdate(index, "key", e.target.value)}
@@ -436,7 +431,7 @@ function KeyValueListField({ field, value, onChange }: FieldProps) {
             className="settings-form__list-input"
             data-testid={`field-${field.key}-key-${index}`}
           />
-          <input
+          <Input
             type="text"
             value={item.value}
             onChange={(e) => handleUpdate(index, "value", e.target.value)}
@@ -444,25 +439,28 @@ function KeyValueListField({ field, value, onChange }: FieldProps) {
             className="settings-form__list-input"
             data-testid={`field-${field.key}-value-${index}`}
           />
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             className="settings-form__list-remove"
             onClick={() => handleRemove(index)}
             title="Remove"
+            aria-label="Remove"
             data-testid={`field-${field.key}-remove-${index}`}
           >
-            &times;
-          </button>
+            <X size={14} />
+          </Button>
         </div>
       ))}
-      <button
-        type="button"
-        className="settings-form__list-add"
+      <Button
+        variant="ghost"
+        size="sm"
+        icon={<Plus size={14} />}
         onClick={handleAdd}
         data-testid={`field-${field.key}-add`}
       >
-        + Add
-      </button>
+        Add
+      </Button>
     </>
   );
 }
@@ -519,10 +517,10 @@ function ObjectListField({
                   className="settings-form__list-checkbox"
                   title={subField.label}
                 >
-                  <input
-                    type="checkbox"
+                  <Toggle
                     checked={(item[subField.key] as boolean) ?? false}
-                    onChange={(e) => handleUpdate(index, subField.key, e.target.checked)}
+                    onCheckedChange={(checked) => handleUpdate(index, subField.key, checked)}
+                    aria-label={subField.label}
                     data-testid={`field-${field.key}-${subField.key}-${index}`}
                   />
                   {subField.label.length <= 3 ? subField.label : subField.label.slice(0, 2)}
@@ -532,7 +530,7 @@ function ObjectListField({
             if (subField.fieldType.type === "filePath" && subField.fieldType.kind === "directory") {
               return (
                 <span key={subField.key} style={{ display: "contents" }}>
-                  <input
+                  <Input
                     type="text"
                     value={(item[subField.key] as string) ?? ""}
                     onChange={(e) => handleUpdate(index, subField.key, e.target.value)}
@@ -540,20 +538,20 @@ function ObjectListField({
                     className="settings-form__list-input"
                     data-testid={`field-${field.key}-${subField.key}-${index}`}
                   />
-                  <button
-                    type="button"
-                    className="settings-form__list-browse"
+                  <Button
+                    variant="secondary"
+                    size="sm"
                     onClick={() => handleBrowseDir(index, subField.key)}
                     title="Browse"
                     data-testid={`field-${field.key}-${subField.key}-browse-${index}`}
                   >
                     ...
-                  </button>
+                  </Button>
                 </span>
               );
             }
             return (
-              <input
+              <Input
                 key={subField.key}
                 type="text"
                 value={(item[subField.key] as string) ?? ""}
@@ -564,25 +562,28 @@ function ObjectListField({
               />
             );
           })}
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             className="settings-form__list-remove"
             onClick={() => handleRemove(index)}
             title="Remove"
+            aria-label="Remove"
             data-testid={`field-${field.key}-remove-${index}`}
           >
-            &times;
-          </button>
+            <X size={14} />
+          </Button>
         </div>
       ))}
-      <button
-        type="button"
-        className="settings-form__list-add"
+      <Button
+        variant="ghost"
+        size="sm"
+        icon={<Plus size={14} />}
         onClick={handleAdd}
         data-testid={`field-${field.key}-add`}
       >
-        + Add
-      </button>
+        Add
+      </Button>
     </>
   );
 }

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.test.tsx
@@ -42,6 +42,16 @@ describe("EmbeddedServerDialog", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    // Radix Select (the migrated bind-address dropdown) probes pointer-capture
+    // and scroll APIs that jsdom omits.
+    if (!Element.prototype.hasPointerCapture) {
+      Element.prototype.hasPointerCapture = () => false;
+      Element.prototype.setPointerCapture = () => {};
+      Element.prototype.releasePointerCapture = () => {};
+    }
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = () => {};
+    }
   });
 
   afterEach(() => {
@@ -55,14 +65,16 @@ describe("EmbeddedServerDialog", () => {
     expect(document.querySelector('[data-testid="server-dialog-name"]')).toBeNull();
   });
 
-  it("renders through the Modal primitive with a token'd name Input and native bind-host select", () => {
+  it("renders through the Modal primitive with a token'd name Input and Select bind-host", () => {
     render(<EmbeddedServerDialog {...baseProps} />);
     expect(document.querySelector(".ui-modal")).toBeTruthy();
     const name = document.querySelector('[data-testid="server-dialog-name"]') as HTMLInputElement;
     expect(name.classList.contains("ui-input")).toBe(true);
-    // Bind host remains a native <select> so its .value stays readable.
+    // Bind host is the Select primitive (Radix skin): a trigger button carrying
+    // the base class, with its value mirrored to `data-value`.
     const bind = document.querySelector('[data-testid="server-dialog-bind-host"]');
-    expect(bind?.tagName).toBe("SELECT");
+    expect(bind?.classList.contains("ui-select__trigger")).toBe(true);
+    expect(bind?.getAttribute("data-value")).toBe("127.0.0.1");
   });
 
   it("Save is disabled until name + root are set, then fires onSave with the config", () => {
@@ -100,11 +112,32 @@ describe("EmbeddedServerDialog", () => {
     render(<EmbeddedServerDialog {...baseProps} />);
     const bind = document.querySelector(
       '[data-testid="server-dialog-bind-host"]'
-    ) as HTMLSelectElement;
-    act(() => {
-      bind.value = "0.0.0.0";
-      bind.dispatchEvent(new Event("change", { bubbles: true }));
-    });
+    ) as HTMLButtonElement;
+
+    // Open the Radix Select and pick the 0.0.0.0 option — the migrated
+    // `onChange` must still route through `handleBindHostChange` and intercept
+    // the all-interfaces address to raise the LAN warning (regression for #1074).
+    for (let i = 0; i < 3 && !document.querySelector('[data-testid="lan-warning-confirm"]'); i++) {
+      act(() => {
+        bind.focus();
+        bind.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Enter", code: "Enter", keyCode: 13, bubbles: true })
+        );
+      });
+      const option = document.querySelector(
+        '.ui-select__item[data-value="0.0.0.0"]'
+      ) as HTMLElement | null;
+      if (option) {
+        act(() => {
+          option.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
+          option.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, button: 0 }));
+          option.click();
+        });
+      }
+    }
+
     expect(document.querySelector('[data-testid="lan-warning-confirm"]')).toBeTruthy();
+    // And the bind host must NOT have committed to 0.0.0.0 until confirmed.
+    expect(bind.getAttribute("data-value")).toBe("127.0.0.1");
   });
 });

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import "./EmbeddedServerSidebar.css";
 import { AlertTriangle } from "lucide-react";
-import { Modal, Button, Input } from "@/components/ui";
+import { Modal, Button, Input, Select } from "@/components/ui";
 import {
   EmbeddedServerConfig,
   NetworkInterface,
@@ -204,20 +204,19 @@ export function EmbeddedServerDialog({ open, onOpenChange, config, onSave }: Pro
             <div className="server-dialog__row">
               <label className="server-dialog__label server-dialog__label--inline">
                 Bind Address
-                <select
-                  className="server-dialog__input"
+                <Select
                   value={form.bindHost}
-                  onChange={(e) => handleBindHostChange(e.target.value)}
-                  data-testid="server-dialog-bind-host"
-                >
-                  {interfaces.map((iface) => (
-                    <option key={`${iface.name}-${iface.addr}`} value={iface.addr}>
-                      {iface.addr === "0.0.0.0" || iface.addr === "127.0.0.1"
+                  onChange={handleBindHostChange}
+                  options={interfaces.map((iface) => ({
+                    value: iface.addr,
+                    label:
+                      iface.addr === "0.0.0.0" || iface.addr === "127.0.0.1"
                         ? `${iface.addr} — ${iface.name}`
-                        : `${iface.addr} (${iface.name})`}
-                    </option>
-                  ))}
-                </select>
+                        : `${iface.addr} (${iface.name})`,
+                  }))}
+                  aria-label="Bind Address"
+                  data-testid="server-dialog-bind-host"
+                />
               </label>
               <label className="server-dialog__label server-dialog__label--inline">
                 Port

--- a/src/components/Sidebar/InlineFolderInput.tsx
+++ b/src/components/Sidebar/InlineFolderInput.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Folder, Check, X } from "lucide-react";
+import { Input } from "@/components/ui";
 
 interface InlineFolderInputProps {
   depth: number;
@@ -24,7 +25,7 @@ export function InlineFolderInput({ depth, onConfirm, onCancel }: InlineFolderIn
       style={{ paddingLeft: `${depth * 16 + 8}px` }}
     >
       <Folder size={16} />
-      <input
+      <Input
         className="connection-tree__inline-input"
         type="text"
         value={name}

--- a/src/components/TunnelEditor/TunnelEditor.css
+++ b/src/components/TunnelEditor/TunnelEditor.css
@@ -43,37 +43,6 @@
   color: var(--text-secondary);
 }
 
-.tunnel-editor__input {
-  padding: 6px 10px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: 13px;
-  font-family: inherit;
-  outline: none;
-}
-
-.tunnel-editor__input:focus {
-  border-color: var(--accent-color);
-}
-
-.tunnel-editor__select {
-  padding: 6px 10px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: 13px;
-  font-family: inherit;
-  outline: none;
-  cursor: pointer;
-}
-
-.tunnel-editor__select:focus {
-  border-color: var(--accent-color);
-}
-
 .tunnel-editor__row {
   display: flex;
   gap: 12px;
@@ -91,10 +60,6 @@
   display: flex;
   align-items: center;
   gap: 8px;
-}
-
-.tunnel-editor__checkbox {
-  accent-color: var(--accent-color);
 }
 
 .tunnel-editor__checkbox-label {
@@ -148,30 +113,6 @@
   display: flex;
   gap: 8px;
   padding-top: 8px;
-}
-
-.tunnel-editor__btn {
-  padding: 8px 16px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.tunnel-editor__btn:hover {
-  background: var(--bg-hover);
-}
-
-.tunnel-editor__btn--primary {
-  background: var(--accent-color);
-  color: var(--text-on-accent);
-  border-color: var(--accent-color);
-}
-
-.tunnel-editor__btn--primary:hover {
-  opacity: 0.9;
 }
 
 .tunnel-editor__section-title {

--- a/src/components/TunnelEditor/TunnelEditor.tsx
+++ b/src/components/TunnelEditor/TunnelEditor.tsx
@@ -8,6 +8,8 @@ import {
   DynamicForwardConfig,
 } from "@/types/tunnel";
 import { TunnelEditorMeta } from "@/types/terminal";
+import { Button, Input, Select, Field, Toggle, toast } from "@/components/ui";
+import { frontendLog } from "@/utils/frontendLog";
 import { TunnelDiagram } from "./TunnelDiagram";
 import "./TunnelEditor.css";
 
@@ -118,9 +120,10 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
       try {
         await saveTunnel(config);
         if (andStart) {
-          startTunnel(config.id).catch((err) =>
-            console.error("Failed to start tunnel after save:", err)
-          );
+          startTunnel(config.id).catch((err) => {
+            frontendLog("tunnel_editor", `Failed to start tunnel after save: ${err}`);
+            toast.error("Failed to start tunnel");
+          });
         }
         // Find panelId for this tab and close it
         const { findLeafByTab } = await import("@/utils/panelTree");
@@ -129,7 +132,8 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           closeTab(tabId, leaf.id);
         }
       } catch (err) {
-        console.error("Failed to save tunnel:", err);
+        frontendLog("tunnel_editor", `Failed to save tunnel: ${err}`);
+        throw err instanceof Error ? err : new Error("Failed to save tunnel");
       }
     },
     [
@@ -155,6 +159,8 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
     }
   }, [rootPanel, tabId, closeTab]);
 
+  const sshOptions = sshConnections.map((c) => ({ value: c.id, label: c.name }));
+
   return (
     <div
       className={`tunnel-editor ${isVisible ? "" : "tunnel-editor--hidden"}`}
@@ -167,34 +173,27 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
       </div>
 
       <div className="tunnel-editor__form" data-testid="tunnel-editor-form">
-        <div className="tunnel-editor__field">
-          <label className="tunnel-editor__label">Name</label>
-          <input
-            className="tunnel-editor__input"
+        <Field label="Name" htmlFor={`tunnel-name-${tabId}`}>
+          <Input
+            id={`tunnel-name-${tabId}`}
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g. Dev Database"
             data-testid="tunnel-editor-name"
           />
-        </div>
+        </Field>
 
-        <div className="tunnel-editor__field">
-          <label className="tunnel-editor__label">SSH Connection</label>
-          <select
-            className="tunnel-editor__select"
-            value={sshConnectionId}
-            onChange={(e) => setSshConnectionId(e.target.value)}
+        <Field label="SSH Connection" htmlFor={`tunnel-ssh-${tabId}`}>
+          <Select
+            value={sshConnectionId || undefined}
+            onChange={setSshConnectionId}
+            options={sshOptions}
+            placeholder="No SSH connections available"
+            aria-label="SSH Connection"
             data-testid="tunnel-editor-ssh-connection"
-          >
-            {sshConnections.length === 0 && <option value="">No SSH connections available</option>}
-            {sshConnections.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name}
-              </option>
-            ))}
-          </select>
-        </div>
+          />
+        </Field>
 
         <div className="tunnel-editor__field">
           <label className="tunnel-editor__label">Tunnel Type</label>
@@ -232,48 +231,52 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           <>
             <span className="tunnel-editor__section-title">Local Bind</span>
             <div className="tunnel-editor__row">
-              <div className="tunnel-editor__field">
-                <label className="tunnel-editor__label">Local Host</label>
-                <input
-                  className="tunnel-editor__input"
+              <Field label="Local Host" htmlFor={`tunnel-local-host-${tabId}`}>
+                <Input
+                  id={`tunnel-local-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.localHost}
                   onChange={(e) => updateConfig("localHost", e.target.value)}
                 />
-              </div>
-              <div className="tunnel-editor__field tunnel-editor__port-field">
-                <label className="tunnel-editor__label">Local Port</label>
-                <input
-                  className="tunnel-editor__input"
+              </Field>
+              <Field
+                label="Local Port"
+                htmlFor={`tunnel-local-port-${tabId}`}
+                className="tunnel-editor__port-field"
+              >
+                <Input
+                  id={`tunnel-local-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.localPort}
                   onChange={(e) => updateConfig("localPort", parseInt(e.target.value) || 0)}
                   data-testid="tunnel-editor-local-port"
                 />
-              </div>
+              </Field>
             </div>
             <span className="tunnel-editor__section-title">Remote Target</span>
             <div className="tunnel-editor__row">
-              <div className="tunnel-editor__field">
-                <label className="tunnel-editor__label">Remote Host</label>
-                <input
-                  className="tunnel-editor__input"
+              <Field label="Remote Host" htmlFor={`tunnel-remote-host-${tabId}`}>
+                <Input
+                  id={`tunnel-remote-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.remoteHost}
                   onChange={(e) => updateConfig("remoteHost", e.target.value)}
                   data-testid="tunnel-editor-remote-host"
                 />
-              </div>
-              <div className="tunnel-editor__field tunnel-editor__port-field">
-                <label className="tunnel-editor__label">Remote Port</label>
-                <input
-                  className="tunnel-editor__input"
+              </Field>
+              <Field
+                label="Remote Port"
+                htmlFor={`tunnel-remote-port-${tabId}`}
+                className="tunnel-editor__port-field"
+              >
+                <Input
+                  id={`tunnel-remote-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.remotePort}
                   onChange={(e) => updateConfig("remotePort", parseInt(e.target.value) || 0)}
                   data-testid="tunnel-editor-remote-port"
                 />
-              </div>
+              </Field>
             </div>
           </>
         )}
@@ -282,45 +285,49 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           <>
             <span className="tunnel-editor__section-title">Remote Bind (on SSH Server)</span>
             <div className="tunnel-editor__row">
-              <div className="tunnel-editor__field">
-                <label className="tunnel-editor__label">Remote Host</label>
-                <input
-                  className="tunnel-editor__input"
+              <Field label="Remote Host" htmlFor={`tunnel-r-remote-host-${tabId}`}>
+                <Input
+                  id={`tunnel-r-remote-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.remoteHost}
                   onChange={(e) => updateConfig("remoteHost", e.target.value)}
                 />
-              </div>
-              <div className="tunnel-editor__field tunnel-editor__port-field">
-                <label className="tunnel-editor__label">Remote Port</label>
-                <input
-                  className="tunnel-editor__input"
+              </Field>
+              <Field
+                label="Remote Port"
+                htmlFor={`tunnel-r-remote-port-${tabId}`}
+                className="tunnel-editor__port-field"
+              >
+                <Input
+                  id={`tunnel-r-remote-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.remotePort}
                   onChange={(e) => updateConfig("remotePort", parseInt(e.target.value) || 0)}
                 />
-              </div>
+              </Field>
             </div>
             <span className="tunnel-editor__section-title">Local Target</span>
             <div className="tunnel-editor__row">
-              <div className="tunnel-editor__field">
-                <label className="tunnel-editor__label">Local Host</label>
-                <input
-                  className="tunnel-editor__input"
+              <Field label="Local Host" htmlFor={`tunnel-r-local-host-${tabId}`}>
+                <Input
+                  id={`tunnel-r-local-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.localHost}
                   onChange={(e) => updateConfig("localHost", e.target.value)}
                 />
-              </div>
-              <div className="tunnel-editor__field tunnel-editor__port-field">
-                <label className="tunnel-editor__label">Local Port</label>
-                <input
-                  className="tunnel-editor__input"
+              </Field>
+              <Field
+                label="Local Port"
+                htmlFor={`tunnel-r-local-port-${tabId}`}
+                className="tunnel-editor__port-field"
+              >
+                <Input
+                  id={`tunnel-r-local-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.localPort}
                   onChange={(e) => updateConfig("localPort", parseInt(e.target.value) || 0)}
                 />
-              </div>
+              </Field>
             </div>
           </>
         )}
@@ -329,78 +336,64 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           <>
             <span className="tunnel-editor__section-title">SOCKS5 Proxy Bind</span>
             <div className="tunnel-editor__row">
-              <div className="tunnel-editor__field">
-                <label className="tunnel-editor__label">Local Host</label>
-                <input
-                  className="tunnel-editor__input"
+              <Field label="Local Host" htmlFor={`tunnel-d-local-host-${tabId}`}>
+                <Input
+                  id={`tunnel-d-local-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.localHost}
                   onChange={(e) => updateConfig("localHost", e.target.value)}
                 />
-              </div>
-              <div className="tunnel-editor__field tunnel-editor__port-field">
-                <label className="tunnel-editor__label">Local Port</label>
-                <input
-                  className="tunnel-editor__input"
+              </Field>
+              <Field
+                label="Local Port"
+                htmlFor={`tunnel-d-local-port-${tabId}`}
+                className="tunnel-editor__port-field"
+              >
+                <Input
+                  id={`tunnel-d-local-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.localPort}
                   onChange={(e) => updateConfig("localPort", parseInt(e.target.value) || 0)}
                 />
-              </div>
+              </Field>
             </div>
           </>
         )}
 
         <div className="tunnel-editor__checkbox-row">
-          <input
-            className="tunnel-editor__checkbox"
-            type="checkbox"
-            id={`auto-start-${tabId}`}
-            checked={autoStart}
-            onChange={(e) => setAutoStart(e.target.checked)}
-          />
+          <Toggle id={`auto-start-${tabId}`} checked={autoStart} onCheckedChange={setAutoStart} />
           <label className="tunnel-editor__checkbox-label" htmlFor={`auto-start-${tabId}`}>
             Auto-start when app launches
           </label>
         </div>
 
         <div className="tunnel-editor__checkbox-row">
-          <input
-            className="tunnel-editor__checkbox"
-            type="checkbox"
-            id={`reconnect-${tabId}`}
-            checked={reconnect}
-            onChange={(e) => setReconnect(e.target.checked)}
-          />
+          <Toggle id={`reconnect-${tabId}`} checked={reconnect} onCheckedChange={setReconnect} />
           <label className="tunnel-editor__checkbox-label" htmlFor={`reconnect-${tabId}`}>
             Reconnect automatically on disconnect
           </label>
         </div>
 
         <div className="tunnel-editor__actions">
-          <button
-            className="tunnel-editor__btn tunnel-editor__btn--primary"
+          <Button
+            variant="primary"
             onClick={() => handleSave(false)}
             disabled={!sshConnectionId}
             data-testid="tunnel-editor-save"
           >
             Save
-          </button>
-          <button
-            className="tunnel-editor__btn tunnel-editor__btn--primary"
+          </Button>
+          <Button
+            variant="primary"
             onClick={() => handleSave(true)}
             disabled={!sshConnectionId}
             data-testid="tunnel-editor-save-start"
           >
             Save &amp; Start
-          </button>
-          <button
-            className="tunnel-editor__btn"
-            onClick={handleCancel}
-            data-testid="tunnel-editor-cancel"
-          >
+          </Button>
+          <Button variant="secondary" onClick={handleCancel} data-testid="tunnel-editor-cancel">
             Cancel
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/WorkspaceEditor/WorkspaceEditor.css
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.css
@@ -47,20 +47,6 @@
   color: var(--text-secondary);
 }
 
-.workspace-editor__input {
-  padding: 6px 8px;
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: 13px;
-  outline: none;
-}
-
-.workspace-editor__input:focus {
-  border-color: var(--accent-color);
-}
-
 .workspace-editor__layout-section {
   display: flex;
   flex-direction: column;
@@ -84,30 +70,6 @@
   gap: 8px;
   padding-top: 8px;
   border-top: 1px solid var(--border-primary);
-}
-
-.workspace-editor__btn {
-  padding: 6px 16px;
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.workspace-editor__btn:hover {
-  background: var(--bg-hover);
-}
-
-.workspace-editor__btn--primary {
-  background: var(--accent-color);
-  color: white;
-  border-color: var(--accent-color);
-}
-
-.workspace-editor__btn--primary:hover {
-  opacity: 0.9;
 }
 
 /* Group Strip */

--- a/src/components/WorkspaceEditor/WorkspaceEditor.tsx
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.tsx
@@ -5,6 +5,8 @@ import { WorkspaceEditorMeta } from "@/types/terminal";
 import { WorkspaceDefinition, WorkspaceLayoutNode, WorkspaceTabGroupDef } from "@/types/workspace";
 import { loadWorkspace } from "@/services/workspaceApi";
 import { getWorkspaceLeaves, countWorkspaceTabs } from "@/utils/workspaceLayout";
+import { Button, Input, Field } from "@/components/ui";
+import { frontendLog } from "@/utils/frontendLog";
 import { LayoutDesigner } from "./LayoutDesigner";
 import "./WorkspaceEditor.css";
 
@@ -121,8 +123,10 @@ export function WorkspaceEditor({ tabId, meta, isVisible }: WorkspaceEditorProps
       if (leaf) {
         closeTab(tabId, leaf.id);
       }
-    } catch {
-      // Save failed — stay open
+    } catch (err) {
+      // Save failed — surface it via the async Button's error toast and stay open.
+      frontendLog("workspace_editor", `Failed to save workspace: ${err}`);
+      throw err instanceof Error ? err : new Error("Failed to save workspace");
     }
   }, [
     meta.workspaceId,
@@ -172,35 +176,27 @@ export function WorkspaceEditor({ tabId, meta, isVisible }: WorkspaceEditorProps
       </div>
 
       <div className="workspace-editor__form">
-        <div className="workspace-editor__field">
-          <label className="workspace-editor__label" htmlFor="ws-name">
-            Name
-          </label>
-          <input
+        <Field label="Name" htmlFor="ws-name" className="workspace-editor__field">
+          <Input
             id="ws-name"
-            className="workspace-editor__input"
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Workspace name"
             data-testid="workspace-name-input"
           />
-        </div>
+        </Field>
 
-        <div className="workspace-editor__field">
-          <label className="workspace-editor__label" htmlFor="ws-description">
-            Description
-          </label>
-          <input
+        <Field label="Description" htmlFor="ws-description" className="workspace-editor__field">
+          <Input
             id="ws-description"
-            className="workspace-editor__input"
             type="text"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Optional description"
             data-testid="workspace-description-input"
           />
-        </div>
+        </Field>
 
         <div className="workspace-editor__layout-section">
           <div className="workspace-editor__layout-header">
@@ -287,20 +283,12 @@ export function WorkspaceEditor({ tabId, meta, isVisible }: WorkspaceEditorProps
       </div>
 
       <div className="workspace-editor__actions">
-        <button
-          className="workspace-editor__btn workspace-editor__btn--primary"
-          onClick={handleSave}
-          data-testid="workspace-save-btn"
-        >
+        <Button variant="primary" onClick={handleSave} data-testid="workspace-save-btn">
           Save
-        </button>
-        <button
-          className="workspace-editor__btn"
-          onClick={handleCancel}
-          data-testid="workspace-cancel-btn"
-        >
+        </Button>
+        <Button variant="secondary" onClick={handleCancel} data-testid="workspace-cancel-btn">
           Cancel
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -55,7 +55,12 @@ export function SelectItem({
   children: React.ReactNode;
 }): React.ReactElement {
   return (
-    <RadixSelect.Item className="ui-select__item" value={value} disabled={disabled}>
+    <RadixSelect.Item
+      className="ui-select__item"
+      value={value}
+      disabled={disabled}
+      data-value={value}
+    >
       <RadixSelect.ItemText>{children}</RadixSelect.ItemText>
       <RadixSelect.ItemIndicator className="ui-select__item-indicator">
         <Check width={14} height={14} aria-hidden="true" />
@@ -86,6 +91,7 @@ export function Select({
         className="ui-select__trigger"
         aria-label={rest["aria-label"]}
         data-testid={testid}
+        data-value={value ?? ""}
       >
         <RadixSelect.Value placeholder={placeholder} />
         <RadixSelect.Icon className="ui-select__icon">

--- a/src/testbridge/dispatcher.select.test.tsx
+++ b/src/testbridge/dispatcher.select.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Select } from "@/components/ui";
+import { dispatchCommand, type BridgeDeps } from "./dispatcher";
+
+/**
+ * The bridge `select` verb must drive the design-system {@link Select} (a Radix
+ * Select skin) as well as native `<select>`: its testid lands on the button
+ * trigger, so the dispatcher opens the listbox and clicks the option whose
+ * `data-value` matches, and `getValue` reads the trigger's mirrored `data-value`.
+ */
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // Radix Select probes pointer-capture APIs that jsdom omits.
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.setPointerCapture = () => {};
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+function deps(): BridgeDeps {
+  return {
+    root: document.body, // Radix renders its content in a portal under <body>
+    readTerminal: () => undefined,
+    scrollTerminal: () => false,
+    getTerminalViewport: () => undefined,
+    getActiveTabId: () => undefined,
+    getState: () => ({}),
+    sendTerminalInput: async () => false,
+    resizeWindow: async () => {},
+    screenshot: async () => "data:image/png;base64,AAAA",
+  };
+}
+
+const OPTIONS = [
+  { value: "local", label: "Local Shell" },
+  { value: "ssh", label: "SSH" },
+  { value: "serial", label: "Serial" },
+];
+
+describe("dispatchCommand getValue against the Select primitive", () => {
+  it("reads the mirrored data-value from the trigger", async () => {
+    act(() => {
+      root.render(<Select data-testid="sel" value="ssh" onChange={() => {}} options={OPTIONS} />);
+    });
+
+    const res = await dispatchCommand({ action: "getValue", testId: "sel" }, deps());
+    expect(res).toEqual({ ok: true, action: "getValue", value: "ssh" });
+  });
+});
+
+describe("dispatchCommand select against the Select primitive", () => {
+  it("opens the listbox and picks the matching option", async () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(<Select data-testid="sel" value="local" onChange={onChange} options={OPTIONS} />);
+    });
+
+    // Radix mounts the listbox in a layout effect that flushes at the end of
+    // `act`, so a single synchronous dispatch opens + locates the option but the
+    // option's handlers may bind a tick later — retrying (as the live harness's
+    // `wait(select)` does) converges. In a real WebView one call suffices.
+    for (let i = 0; i < 3 && onChange.mock.calls.length === 0; i++) {
+      await act(async () => {
+        await dispatchCommand({ action: "select", testId: "sel", value: "serial" }, deps());
+      });
+    }
+
+    expect(onChange).toHaveBeenCalledWith("serial");
+  });
+
+  it("reports an error when the requested option is absent", async () => {
+    act(() => {
+      root.render(<Select data-testid="sel" value="local" onChange={() => {}} options={OPTIONS} />);
+    });
+
+    const res = await dispatchCommand({ action: "select", testId: "sel", value: "telnet" }, deps());
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/testbridge/dispatcher.ts
+++ b/src/testbridge/dispatcher.ts
@@ -115,6 +115,46 @@ function clickSequence(el: Element, x: number, y: number): void {
   (el as HTMLElement).click();
 }
 
+/**
+ * Drive the design-system {@link Select} (a Radix `Select` skin) from the bridge.
+ *
+ * The visible testid sits on the button trigger, so a native `.value` set is not
+ * available. Instead reproduce a real interaction: open the listbox via the
+ * realistic pointer sequence, then click the option whose `data-value` matches.
+ * Radix portals its content, so options are searched in both the bridge root and
+ * the owning document (where the portal lands under `<body>`).
+ */
+function selectRadixOption(root: ParentNode, trigger: Element, value: string): string | null {
+  const escaped =
+    typeof CSS !== "undefined" && typeof CSS.escape === "function"
+      ? CSS.escape(value)
+      : value.replace(/["\\]/g, "\\$&");
+  // Scope to `.ui-select__item` so the trigger's own `data-value` mirror never
+  // matches — only the mounted listbox options do.
+  const optionSelector = `.ui-select__item[data-value="${escaped}"]`;
+
+  const findOption = (): Element | null =>
+    root.querySelector(optionSelector) ?? ownerDocument(root).querySelector(optionSelector);
+
+  // Open the listbox. Radix Select opens reliably on keyboard activation across
+  // both a real WebView and jsdom (its pointerdown-to-open path depends on
+  // pointer-capture APIs that behave inconsistently), so focus + Enter.
+  (trigger as HTMLElement).focus();
+  trigger.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Enter", code: "Enter", keyCode: 13, bubbles: true })
+  );
+
+  // When the option has mounted, click it — otherwise return an error message so
+  // the harness (which wraps `select` in a retry) can try again on the next poll.
+  const option = findOption();
+  if (!option) {
+    return `option "${value}" not found in the open Radix listbox`;
+  }
+  const optAnchor = centerOf(option);
+  clickSequence(option, optAnchor.x, optAnchor.y);
+  return null;
+}
+
 /** Named DOM keys whose `code` / legacy `keyCode` aren't derivable from the char. */
 const NAMED_KEYS: Record<string, { code: string; keyCode: number }> = {
   Enter: { code: "Enter", keyCode: 13 },
@@ -239,6 +279,11 @@ export async function dispatchCommand(
     case "getValue": {
       const el = findByTestId(deps.root, command.testId);
       if (!el) return fail("getValue", `no element with data-testid="${command.testId}"`);
+      // Radix `Select` primitive: the value lives in the trigger's `data-value`
+      // (there is no native `.value`), mirrored by the `Select` component.
+      if (el.classList.contains("ui-select__trigger")) {
+        return ok("getValue", el.getAttribute("data-value") ?? "");
+      }
       if (
         !(el instanceof HTMLInputElement) &&
         !(el instanceof HTMLTextAreaElement) &&
@@ -423,6 +468,15 @@ export async function dispatchCommand(
     case "select": {
       const el = findByTestId(deps.root, command.testId);
       if (!el) return fail("select", `no element with data-testid="${command.testId}"`);
+
+      // Radix `Select` primitive (the `ui/` design-system control): its testid
+      // lands on the button trigger, not a native <select>. Drive it like a real
+      // user — open the listbox, then click the option whose `data-value` matches.
+      if (el.classList.contains("ui-select__trigger")) {
+        const err = selectRadixOption(deps.root, el, command.value);
+        return err ? fail("select", err) : ok("select");
+      }
+
       if (!(el instanceof HTMLSelectElement)) {
         return fail("select", `element data-testid="${command.testId}" is not a select`);
       }


### PR DESCRIPTION
## Summary

Migrates the remaining **non-dialog** UI surface onto the shared `src/components/ui/` primitives (Phase 4 covered modal dialogs; this covers editor panels and form controls). Closes the bulk of #1085.

Migrated groups:
- **Editor panels** — `ConnectionEditor/`, `TunnelEditor/`, `WorkspaceEditor/`: action buttons → `Button`, inputs → `Input`/`Field`, native `<select>` → `Select`, checkboxes → `Toggle`. Dead bespoke button/input/select CSS removed (including a light-theme white-text bug and a hardcoded `rgba(...)` shadow).
- **Schema-driven forms** — `DynamicForm/` (`DynamicField`): text/number/port/serial → `Input`, `<select>` → `Select`, booleans → `Toggle`, list/file-path buttons → `Button`.
- **Sidebar inline input** — `InlineFolderInput` → `Input`.
- **EmbeddedServerDialog bind-address** — native `<select>` → `Select` (deferred in #1074); the `0.0.0.0` LAN-warning interception was re-tested against the Radix control.

### Enabling infra
The Radix-based `Select` has no native `.value`, so the system-test bridge couldn't drive it (the reason #1074 deferred selects). Added `data-value` mirroring on the `Select` trigger/items and taught the bridge dispatcher to open the listbox + click the matching option — native `<select>` handling is unchanged. Covered by a new `dispatcher.select.test.tsx`.

## Behavior changes
- Save/connect actions in these editors now surface errors as toasts instead of failing silently.
- Booleans are accessible Radix switches (`aria-checked`) rather than native checkboxes.

## Test plan
- `pnpm build` (tsc + vite) — green.
- Full frontend suite: **2090 tests / 170 files** pass.
- `testid-catalog.md` regenerated — **zero changes** (all testid values preserved).
- ESLint + Prettier clean.
- Worth a targeted system-test run against a built app: `test_connection_forms.py`, `test_embedded_services.py`, `test_ssh_tunnels.py` (the Radix Select bridge path only fully exercises in a real WebView).

## Follow-up
A few ConnectionEditor subcomponents and the WorkspaceEditor rename-chip input remain bespoke — tracked in a follow-up issue.

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)