### PR TITLE
feat(backend): VcXsrv minimal-zip packaging tooling for SSH X11 (#1076)

### DIFF
--- a/docs/changes/feature/1076-vcxsrv-minimal-zip.md
+++ b/docs/changes/feature/1076-vcxsrv-minimal-zip.md
@@ -1,0 +1,12 @@
+### Added
+
+- Windows SSH X11 forwarding: tooling to build and publish the pinned, minimal
+  VcXsrv `.zip` that termiHub downloads and SHA-256-verifies on first use.
+  `scripts/internal/package-vcxsrv.ps1` repackages an installed VcXsrv into the
+  redistributable artifact, prints its SHA-256, and can patch
+  `PINNED_VCXSRV.sha256` directly. A networked release-verification test
+  (`pinned_artifact_downloads_verifies_and_contains_exe`, `#[ignore]`) confirms
+  the published artifact resolves and contains a runnable `vcxsrv.exe`. Once the
+  artifact is published, first-run VcXsrv provisioning downloads, verifies, and
+  extracts it automatically; offline re-runs reuse the cached tree (#1076,
+  epic #1047).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -868,6 +868,42 @@ To verify SSH tunnels actually work on macOS, do this manually against the tunne
 4. Confirm the tunnel reaches a running state (sidebar shows Stop control) and `curl http://127.0.0.1:18083` returns `TUNNEL_TEST_OK`.
 5. Click **Stop** and confirm the tunnel returns to disconnected and the Start control reappears.
 
+#### VcXsrv provisioning: first-run download + offline re-run (Windows, #1076)
+
+termiHub downloads a pinned, minimal VcXsrv `.zip` from its GitHub releases on
+first use of SSH X11 forwarding, SHA-256-verifies it, and extracts a runnable
+`vcxsrv.exe` (`src-tauri/src/terminal/xserver/acquire.rs`). Building and
+publishing that artifact is a release step; the acquisition path is then
+verified on a **clean Windows box** (no VcXsrv installed).
+
+Build & publish the artifact (once per pinned version):
+
+1. Install the pinned VcXsrv (currently **21.1.13**) from
+   <https://github.com/marchaesen/vcxsrv/releases> on a build machine.
+2. Run `scripts/internal/package-vcxsrv.ps1 -UpdateAcquire`. It stages a minimal
+   tree, writes `target/vcxsrv-package/vcxsrv-<version>-minimal.zip`, prints the
+   SHA-256, and patches `PINNED_VCXSRV.sha256` in `acquire.rs`.
+3. Publish the printed artifact: `gh release create vcxsrv-<version> <zip>
+--title "VcXsrv <version> (minimal, for termiHub X11)"
+--notes "GPL-3.0. See THIRD_PARTY_LICENSES.md and licenses/GPL-3.0.txt."`.
+4. Confirm the automated check passes against the live asset:
+   `cargo test -p termihub -- --ignored pinned_artifact_downloads_verifies_and_contains_exe`.
+
+Verify acquisition end-to-end on a **clean Windows box** (no VcXsrv installed):
+
+1. First run — download + verify + extract: trigger X server provisioning (open
+   an SSH connection with X11 forwarding, or use the Settings/Open Connections X
+   server control once #1053 lands). Confirm the pinned `.zip` downloads,
+   verifies, and yields a runnable `vcxsrv.exe` under the app data dir
+   (`<data>/xserver/vcxsrv-<version>/vcxsrv.exe`; portable mode uses the
+   `data/` folder). An X client from the forwarded session should display.
+2. Offline re-run — cache reuse: disconnect the network and repeat. Provisioning
+   must **not** attempt a download; it reuses the already-extracted tree and the
+   X client displays again.
+3. Tamper check (optional): corrupt the cached `vcxsrv.exe` to zero bytes and
+   confirm the next provisioning re-resolves (download when online, or a clear
+   error offline) rather than launching a broken server.
+
 ### Legacy Guided Manual Test Runner (YAML)
 
 The remaining manual test items are still defined as machine-readable YAML in [`tests/manual/*.yaml`](../tests/manual/). The standalone runner presents applicable tests one at a time, manages infrastructure, and generates a JSON report. It is being subsumed by the harness flow above:

--- a/scripts/internal/README.md
+++ b/scripts/internal/README.md
@@ -7,3 +7,5 @@ Internal helper scripts used by other scripts or tooling. These are **not** inte
 | `autoformat.sh`            | `.claude/settings.json` PostToolUse hook | Auto-format a single edited file (Prettier / rustfmt) and refresh the `data-testid` catalog when a source `.tsx` changes     |
 | `regen-testid-catalog.mjs` | `autoformat.sh`                          | Regenerate `tests/system/testid-catalog.md` when the edited file is a source `.ts`/`.tsx` containing a `data-testid` (#1084) |
 | `kill-port.cjs`            | `dev.sh` / `dev.cmd`                     | Kill any process occupying the Vite dev server port                                                                          |
+| `package-vcxsrv.ps1`       | release process (operator, Windows)      | Build the pinned minimal VcXsrv `.zip` for SSH X11 forwarding from an installed VcXsrv, print/patch its SHA-256 (#1076)      |
+| `package-vcxsrv.sh`        | `package-vcxsrv.ps1`                     | Git-Bash wrapper that forwards long flags to `package-vcxsrv.ps1`                                                            |

--- a/scripts/internal/package-vcxsrv.ps1
+++ b/scripts/internal/package-vcxsrv.ps1
@@ -1,0 +1,177 @@
+﻿<#
+.SYNOPSIS
+    Build the pinned, minimal VcXsrv .zip that termiHub downloads for SSH X11
+    forwarding, compute its SHA-256, and (optionally) patch it into the source.
+
+.DESCRIPTION
+    termiHub redistributes a pinned, pre-extracted minimal VcXsrv tree
+    (vcxsrv.exe + required DLLs + fonts/) as a versioned .zip hosted on its own
+    GitHub releases. `src-tauri/src/terminal/xserver/acquire.rs` downloads that
+    .zip, verifies it against a compiled-in SHA-256, and extracts it. This script
+    produces that artifact reproducibly from an installed VcXsrv and prints the
+    SHA-256 to paste into `PINNED_VCXSRV.sha256` (see issue #1076).
+
+    VcXsrv is GPL-3.0; termiHub runs it as a separate process (mere aggregation)
+    - see docs/licensing.md. Install upstream VcXsrv once from
+    https://github.com/marchaesen/vcxsrv/releases (pin: 21.1.13) and point -Src
+    at its install directory. This script never installs or downloads anything;
+    it only repackages a tree you already have, so the bytes are auditable.
+
+    The zip stores files at its ROOT (vcxsrv.exe at top level, not under a
+    version subdir) so that acquire.rs's extract-into-install-dir logic yields
+    <install_dir>/vcxsrv.exe directly.
+
+.PARAMETER Version
+    Upstream VcXsrv version to stamp into the artifact name and (with
+    -UpdateAcquire) validate against acquire.rs. Default: 21.1.13.
+
+.PARAMETER Src
+    Path to an installed VcXsrv directory (must contain vcxsrv.exe). Defaults to
+    the standard install location, falling back to the x86 Program Files dir.
+
+.PARAMETER OutDir
+    Directory to write the staging tree and the .zip into. Default:
+    <repo>/target/vcxsrv-package (gitignored).
+
+.PARAMETER Full
+    Package the entire install tree unchanged (correctness over size). By default
+    a small denylist of clearly-unneeded files (the XLaunch wizard, its PuTTY
+    helper, the uninstaller, logs) is pruned - everything the running server
+    needs is kept.
+
+.PARAMETER UpdateAcquire
+    After building, rewrite PINNED_VCXSRV.sha256 in acquire.rs with the computed
+    hash. Fails if the file's PINNED_VCXSRV.version does not match -Version.
+
+.EXAMPLE
+    powershell -File scripts/internal/package-vcxsrv.ps1 -UpdateAcquire
+    # then publish the printed artifact:
+    gh release create vcxsrv-21.1.13 target/vcxsrv-package/vcxsrv-21.1.13-minimal.zip `
+      --title "VcXsrv 21.1.13 (minimal, for termiHub X11)" --notes "GPL-3.0. See THIRD_PARTY_LICENSES.md."
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = "21.1.13",
+    [string]$Src,
+    [string]$OutDir,
+    [switch]$Full,
+    [switch]$UpdateAcquire
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Resolve repo root (scripts/internal/ -> repo root) ---------------------
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$AcquireRs = Join-Path $RepoRoot "src-tauri\src\terminal\xserver\acquire.rs"
+
+# --- Resolve the VcXsrv source install dir ----------------------------------
+if (-not $Src) {
+    $candidates = @(
+        (Join-Path $env:ProgramFiles "VcXsrv"),
+        (Join-Path ${env:ProgramFiles(x86)} "VcXsrv")
+    )
+    $Src = $candidates | Where-Object { $_ -and (Test-Path (Join-Path $_ "vcxsrv.exe")) } | Select-Object -First 1
+    if (-not $Src) {
+        throw "No VcXsrv install found. Install VcXsrv $Version from https://github.com/marchaesen/vcxsrv/releases, or pass -Src <dir>."
+    }
+}
+$Src = (Resolve-Path $Src).Path
+$srcExe = Join-Path $Src "vcxsrv.exe"
+if (-not (Test-Path $srcExe)) {
+    throw "vcxsrv.exe not found under -Src '$Src'."
+}
+
+# Sanity-check the installed version against -Version so the artifact name and
+# the pinned table cannot silently drift from what is actually packaged.
+$fileVersion = (Get-Item $srcExe).VersionInfo.FileVersion
+if ($fileVersion -and -not $fileVersion.StartsWith($Version)) {
+    Write-Warning "Installed vcxsrv.exe reports version '$fileVersion' but -Version is '$Version'. Confirm you installed the pinned build before publishing."
+}
+
+if (-not $OutDir) { $OutDir = Join-Path $RepoRoot "target\vcxsrv-package" }
+$staging = Join-Path $OutDir "vcxsrv-$Version"
+$zipPath = Join-Path $OutDir "vcxsrv-$Version-minimal.zip"
+
+Write-Host "Packaging VcXsrv $Version"
+Write-Host "  source : $Src"
+Write-Host "  staging: $staging"
+Write-Host "  zip    : $zipPath"
+
+# --- Stage a copy, then prune (never touch the real install) ----------------
+if (Test-Path $staging) { Remove-Item -Recurse -Force $staging }
+New-Item -ItemType Directory -Force -Path $staging | Out-Null
+Copy-Item -Recurse -Force (Join-Path $Src "*") $staging
+
+if (-not $Full) {
+    # Clearly-unneeded for a headless `vcxsrv.exe :0 -multiwindow -clipboard
+    # -auth <file>` launch. Best-effort: missing entries are fine across builds.
+    $deny = @("xlaunch.exe", "plink.exe", "uninstall.exe", "vcxsrv.exe.log", "XLaunch.log")
+    foreach ($name in $deny) {
+        $p = Join-Path $staging $name
+        if (Test-Path $p) {
+            Remove-Item -Force -Recurse $p
+            Write-Host "  pruned : $name"
+        }
+    }
+}
+
+# --- Guard: the running server must still have what it needs -----------------
+if (-not (Test-Path (Join-Path $staging "vcxsrv.exe"))) {
+    throw "Staged tree is missing vcxsrv.exe - refusing to package."
+}
+if (-not (Test-Path (Join-Path $staging "fonts"))) {
+    Write-Warning "Staged tree has no fonts/ directory - the server may fail to start core fonts."
+}
+
+# --- Zip the CONTENTS of the staging dir (files at the zip root) -------------
+# Build entries by hand with forward-slash names. `Compress-Archive` (and .NET
+# Framework's ZipFile) on Windows PowerShell 5.1 stores backslash separators,
+# which is non-conformant ZIP; the extractor in acquire.rs and other tools
+# expect `/`. Emitting `/` keeps the artifact portable and matches the
+# forward-slash archives the Rust extraction tests exercise.
+Add-Type -AssemblyName System.IO.Compression | Out-Null
+Add-Type -AssemblyName System.IO.Compression.FileSystem | Out-Null
+if (Test-Path $zipPath) { Remove-Item -Force $zipPath }
+$stagingFull = (Resolve-Path $staging).Path.TrimEnd('\')
+$zipStream = [System.IO.File]::Open($zipPath, [System.IO.FileMode]::CreateNew)
+try {
+    $archive = New-Object System.IO.Compression.ZipArchive($zipStream, [System.IO.Compression.ZipArchiveMode]::Create)
+    try {
+        Get-ChildItem -Path $staging -Recurse -File | ForEach-Object {
+            $rel = $_.FullName.Substring($stagingFull.Length + 1) -replace '\\', '/'
+            [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+                $archive, $_.FullName, $rel, [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
+        }
+    } finally { $archive.Dispose() }
+} finally { $zipStream.Dispose() }
+$zipPath = (Resolve-Path $zipPath).Path
+
+# --- Compute the SHA-256 (lowercase hex, as acquire.rs expects) --------------
+$sha = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLower()
+$sizeMB = "{0:N1}" -f ((Get-Item $zipPath).Length / 1MB)
+
+Write-Host ""
+Write-Host "Artifact : $zipPath ($sizeMB MB)"
+Write-Host "SHA-256  : $sha"
+Write-Host ""
+
+# --- Optionally patch PINNED_VCXSRV.sha256 in acquire.rs ---------------------
+if ($UpdateAcquire) {
+    $text = Get-Content -Raw -Path $AcquireRs
+    if ($text -notmatch "version:\s*""$([regex]::Escape($Version))""") {
+        throw "acquire.rs PINNED_VCXSRV.version does not match -Version '$Version'. Update the pinned version (and THIRD_PARTY_LICENSES.md) first."
+    }
+    $updated = [regex]::Replace($text, 'sha256:\s*"[0-9a-fA-F]{64}"', "sha256: `"$sha`"")
+    if ($updated -eq $text) {
+        Write-Warning "No sha256 field replaced in acquire.rs (already up to date?)."
+    } else {
+        Set-Content -Path $AcquireRs -Value $updated -NoNewline
+        Write-Host "Patched PINNED_VCXSRV.sha256 in $AcquireRs"
+    }
+}
+
+Write-Host "Next: publish the artifact, then verify the pinned URL resolves:"
+Write-Host "  gh release create vcxsrv-$Version `"$zipPath`" \"
+Write-Host "    --title `"VcXsrv $Version (minimal, for termiHub X11)`" \"
+Write-Host "    --notes `"GPL-3.0. See THIRD_PARTY_LICENSES.md and licenses/GPL-3.0.txt.`""
+Write-Host "  cargo test -p termihub -- --ignored pinned_artifact_downloads_verifies_and_contains_exe"

--- a/scripts/internal/package-vcxsrv.sh
+++ b/scripts/internal/package-vcxsrv.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Git-Bash wrapper for scripts/internal/package-vcxsrv.ps1.
+#
+# Packaging the pinned minimal VcXsrv .zip is inherently Windows-only (VcXsrv is
+# a Windows program), so the real work lives in the PowerShell script and this
+# wrapper simply forwards long flags to it. Run it from Git Bash on Windows;
+# on other platforms it exits with a clear message.
+#
+# Usage:
+#   ./scripts/internal/package-vcxsrv.sh [--version <v>] [--src <dir>]
+#                                        [--out <dir>] [--full] [--update-acquire]
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v powershell.exe >/dev/null 2>&1; then
+    echo "package-vcxsrv is Windows-only (needs powershell.exe and an installed VcXsrv)." >&2
+    exit 1
+fi
+
+ps_args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --version) ps_args+=("-Version" "$2"); shift 2 ;;
+    --src) ps_args+=("-Src" "$2"); shift 2 ;;
+    --out) ps_args+=("-OutDir" "$2"); shift 2 ;;
+    --full) ps_args+=("-Full"); shift ;;
+    --update-acquire) ps_args+=("-UpdateAcquire"); shift ;;
+    -h | --help)
+        echo "See scripts/internal/package-vcxsrv.ps1 for full documentation."
+        exit 0
+        ;;
+    *)
+        echo "Unknown option: $1" >&2
+        exit 1
+        ;;
+    esac
+done
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass \
+    -File "scripts/internal/package-vcxsrv.ps1" "${ps_args[@]}"

--- a/src-tauri/src/terminal/xserver/acquire.rs
+++ b/src-tauri/src/terminal/xserver/acquire.rs
@@ -50,12 +50,16 @@ pub struct PinnedVcxsrv {
 
 /// The VcXsrv build termiHub provisions.
 ///
-/// NOTE: `sha256` is a placeholder until the minimal `.zip` artifact is
-/// published to termiHub's GitHub releases (tracked with the GPL-3.0 licensing
-/// work, #1056). Until then a real download is *rejected* by verification and
-/// never executed — which is the safe failure mode. The offline unit tests
-/// exercise verification and extraction against synthetic archives, so they do
-/// not depend on this value.
+/// NOTE: `sha256` is a placeholder until the minimal `.zip` artifact is built
+/// and published to termiHub's GitHub releases (#1076). Build it reproducibly
+/// from an installed VcXsrv with `scripts/internal/package-vcxsrv.ps1`, which
+/// prints the SHA-256 to paste here (or run it with `-UpdateAcquire` to patch
+/// this field), then publish the printed artifact. Until then a real download
+/// is *rejected* by verification and never executed — the safe failure mode.
+/// The offline unit tests exercise verification and extraction against synthetic
+/// archives, so they do not depend on this value; the networked
+/// `pinned_artifact_downloads_verifies_and_contains_exe` test (`#[ignore]`)
+/// confirms the real artifact once it is published.
 pub const PINNED_VCXSRV: PinnedVcxsrv = PinnedVcxsrv {
     version: "21.1.13",
     zip_url: "https://github.com/armaxri/termiHub/releases/download/vcxsrv-21.1.13/vcxsrv-21.1.13-minimal.zip",

--- a/src-tauri/src/terminal/xserver/acquire.rs
+++ b/src-tauri/src/terminal/xserver/acquire.rs
@@ -602,6 +602,43 @@ mod tests {
             .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
     }
 
+    /// Release-verification (networked, `#[ignore]` by default): fetch the
+    /// published pinned `.zip`, confirm it matches `PINNED_VCXSRV.sha256`, and
+    /// that it extracts a runnable `vcxsrv.exe`. This is the automated half of
+    /// issue #1076's acceptance criteria — run it once the artifact is published
+    /// and the SHA-256 filled in:
+    ///
+    /// ```text
+    /// cargo test -p termihub -- --ignored pinned_artifact_downloads_verifies_and_contains_exe
+    /// ```
+    ///
+    /// It stays ignored so the normal offline test run never reaches the network
+    /// and never fails on the placeholder SHA before the artifact exists.
+    #[test]
+    #[ignore = "networked release-verification: requires the published VcXsrv artifact (#1076)"]
+    fn pinned_artifact_downloads_verifies_and_contains_exe() {
+        let tmp = tempfile::tempdir().unwrap();
+        let zip = tmp.path().join("vcxsrv-pinned.zip");
+
+        let bytes = reqwest::blocking::get(PINNED_VCXSRV.zip_url)
+            .expect("request pinned VcXsrv zip")
+            .error_for_status()
+            .expect("pinned VcXsrv URL must resolve to a published asset")
+            .bytes()
+            .expect("read pinned VcXsrv zip body");
+        fs::write(&zip, &bytes).unwrap();
+
+        verify_sha256(&zip, PINNED_VCXSRV.sha256)
+            .expect("published artifact must match PINNED_VCXSRV.sha256");
+
+        let out = tmp.path().join("tree");
+        extract_zip(&zip, &out).unwrap();
+        assert!(
+            is_nonempty_file(&out.join(VCXSRV_EXE)),
+            "published artifact must contain a non-empty {VCXSRV_EXE} at its root"
+        );
+    }
+
     // ----- licensing / compliance (GPL-3.0, #1056) --------------------------
 
     /// Path to a file at the repository root (parent of this crate's manifest


### PR DESCRIPTION
## Summary

Part of Epic #1047 · follow-up to #1048. Adds the tooling and verification to build and publish the pinned, minimal **VcXsrv** `.zip` that termiHub downloads + SHA-256-verifies on first use of SSH X11 forwarding (`src-tauri/src/terminal/xserver/acquire.rs`). The blocking licensing dependency (#1056) is closed.

The actual artifact upload + clean-box verification are release steps (they need release-publish rights and a clean Windows box); everything reproducible is automated here.

### What's included

- **`scripts/internal/package-vcxsrv.ps1`** (+ Git-Bash wrapper `.sh`) — repackages an installed VcXsrv into the redistributable `.zip`:
  - stages a copy, prunes clearly-unneeded files (XLaunch wizard, `plink.exe`, uninstaller, logs) — kept everything the running server needs;
  - writes a **conformant forward-slash zip with `vcxsrv.exe` at the root** (avoids the PS 5.1 `Compress-Archive` backslash bug, so it matches what `acquire.rs` extracts);
  - prints the SHA-256 and can patch `PINNED_VCXSRV.sha256` directly (`-UpdateAcquire`, guarded by a version match).
- **Release-verification test** `pinned_artifact_downloads_verifies_and_contains_exe` (`#[ignore]`, networked) — downloads the pinned URL, verifies it against `PINNED_VCXSRV.sha256`, and asserts a runnable `vcxsrv.exe`. Encodes acceptance criterion 2; stays ignored so offline runs never hit the network or the placeholder SHA.
- Docs: build-and-publish steps + clean-box first-run/offline-re-run manual procedure in `docs/testing.md`; change fragment.

### Remaining (operator, release step)

On a Windows box with VcXsrv 21.1.13 installed:
1. `powershell -File scripts/internal/package-vcxsrv.ps1 -UpdateAcquire`
2. `gh release create vcxsrv-21.1.13 <printed zip> --title "…" --notes "GPL-3.0. See THIRD_PARTY_LICENSES.md…"`
3. `cargo test -p termihub -- --ignored pinned_artifact_downloads_verifies_and_contains_exe`
4. Clean-box verify per `docs/testing.md`.

## Test plan

- `cargo test -p termihub -- terminal::xserver::acquire` → 17 pass, 1 ignored (the networked verifier).
- `./scripts/check.sh` → all checks pass (prettier, markdownlint, eslint, cargo fmt, clippy `-D warnings`, version drift).
- Packaging script smoke-tested end-to-end against a synthetic install: staging, pruning, forward-slash zip with exe at root, SHA-256, and the `-UpdateAcquire` regex/version-guard all verified.
- Manual (deferred to release): first-run download+verify+extract and offline re-run on a clean Windows box — steps added to `docs/testing.md`.

Relates to #1076, epic #1047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)