### PR TITLE
refactor(ssh): collapse X server managed-source seam, remove double detection (#1087)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,6 +1913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7149,6 +7155,7 @@ dependencies = [
  "tracing-subscriber",
  "unftp-sbe-fs",
  "uuid",
+ "which",
  "windows 0.58.0",
  "zeroize",
  "zip",
@@ -8298,6 +8305,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8905,6 +8924,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winx"

--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -177,14 +177,16 @@ impl SshConnector for RusshSshConnector {
         let mut x11_cookie: Option<String> = None;
         if config.enable_x11_forwarding {
             // Ensure a usable local X server via the app-registered provisioner
-            // (epic #1047). When none is registered (core standalone / tests),
-            // fall back to detecting a user-run server. A provisioning failure is
-            // logged with its actionable message and the session continues without
-            // display forwarding rather than aborting the whole connect.
-            use super::x11::{x_server_provisioner, ManagedXServerSource, SingleManagedServer};
-            let managed_server = match x_server_provisioner() {
+            // (epic #1047). It resolves the concrete server (managed or adopted)
+            // so the forwarder does not re-probe. When none is registered (core
+            // standalone / tests) `resolved` is `None` and the forwarder falls
+            // back to detecting a user-run server. A provisioning failure is
+            // logged with its actionable message and the session continues
+            // without display forwarding rather than aborting the whole connect.
+            use super::x11::x_server_provisioner;
+            let resolved = match x_server_provisioner() {
                 Some(provisioner) => match provisioner.ensure().await {
-                    Ok(server) => server,
+                    Ok(resolved) => resolved,
                     Err(message) => {
                         tracing::warn!("X server provisioning failed: {message}");
                         None
@@ -192,11 +194,7 @@ impl SshConnector for RusshSshConnector {
                 },
                 None => None,
             };
-            let managed_source = managed_server.map(SingleManagedServer::new);
-            let managed = managed_source
-                .as_ref()
-                .map(|source| source as &dyn ManagedXServerSource);
-            match X11Forwarder::start(config, &mut session, registry, alive.clone(), managed).await
+            match X11Forwarder::start(config, &mut session, registry, alive.clone(), resolved).await
             {
                 Ok((forwarder, display_num, cookie)) => {
                     x11_display = Some(display_num);

--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -31,10 +31,25 @@ pub struct LocalXServerInfo {
     pub connection: LocalXConnection,
 }
 
+impl LocalXServerInfo {
+    /// Build info for a TCP-loopback X server on `display_number`
+    /// (`127.0.0.1:6000+n`) — how every termiHub-managed server, and an adopted
+    /// server on a reachable local TCP port, is reached.
+    pub fn tcp_loopback(display_number: u32) -> Self {
+        Self {
+            display_number,
+            connection: LocalXConnection::Tcp(
+                "127.0.0.1".to_string(),
+                6000 + display_number as u16,
+            ),
+        }
+    }
+}
+
 /// A termiHub-managed local X server (one that termiHub itself started).
 ///
-/// See epic #1047 / concept #1044 (X server provisioning). When present, this
-/// carries everything the forwarder needs, so detection can skip all
+/// See epic #1047 / concept #1044 (X server provisioning). It carries everything
+/// the forwarder needs, so the connect path can forward to it without any
 /// filesystem/`xauth` probing — which are no-ops on Windows anyway.
 #[derive(Debug, Clone)]
 pub struct ManagedXServer {
@@ -45,36 +60,31 @@ pub struct ManagedXServer {
     pub cookie: Option<String>,
 }
 
-/// A source of termiHub-managed X server information.
-///
-/// This is a thin seam so detection can be managed-server-aware without a
-/// global: the Windows [`XServerManager`] (issue #1049) will implement it, and
-/// [`detect_local_x_server`] / [`read_local_xauth_cookie`] consult it first.
-/// Until the manager lands, callers pass `None` and behavior is unchanged.
-///
-/// [`XServerManager`]: https://github.com/armaxri/termiHub/issues/1049
-pub trait ManagedXServerSource: Send + Sync {
-    /// Returns the currently managed local X server, if termiHub started one.
-    fn managed_server(&self) -> Option<ManagedXServer>;
-}
-
-/// A [`ManagedXServerSource`] that always reports a single, fixed managed server.
-///
-/// Lets the SSH connect path hand a just-ensured [`ManagedXServer`] to
-/// [`X11Forwarder::start`] without reaching for a global.
-pub struct SingleManagedServer(ManagedXServer);
-
-impl SingleManagedServer {
-    /// Wrap a managed server so it can be passed as a [`ManagedXServerSource`].
-    pub fn new(server: ManagedXServer) -> Self {
-        Self(server)
+impl ManagedXServer {
+    /// Resolve this managed server to a concrete [`ResolvedXServer`] (TCP
+    /// loopback with the known cookie) ready to hand to [`X11Forwarder::start`].
+    pub fn resolved(&self) -> ResolvedXServer {
+        ResolvedXServer {
+            info: LocalXServerInfo::tcp_loopback(self.display_number),
+            cookie: self.cookie.clone(),
+        }
     }
 }
 
-impl ManagedXServerSource for SingleManagedServer {
-    fn managed_server(&self) -> Option<ManagedXServer> {
-        Some(self.0.clone())
-    }
+/// A fully-resolved local X server for the connect path to forward to, plus its
+/// auth cookie.
+///
+/// Produced once by the desktop X server provisioner (for a managed *or* an
+/// adopted server) and handed to [`X11Forwarder::start`], which then performs no
+/// second socket/DISPLAY/TCP probe. When no provisioner is registered (core used
+/// standalone, or in tests) the forwarder falls back to [`detect_local_x_server`].
+#[derive(Debug, Clone)]
+pub struct ResolvedXServer {
+    /// Where to reach the server.
+    pub info: LocalXServerInfo,
+    /// MIT-MAGIC-COOKIE-1 (hex) to authorize the forwarded display, or `None`
+    /// for a cookieless (`-ac`) server.
+    pub cookie: Option<String>,
 }
 
 /// A hook the desktop app installs so the SSH connect path can ensure a usable
@@ -90,14 +100,15 @@ impl ManagedXServerSource for SingleManagedServer {
 /// user-run server.
 #[async_trait]
 pub trait XServerProvisioner: Send + Sync {
-    /// Ensure a usable local X server exists.
+    /// Ensure a usable local X server exists and resolve where to reach it.
     ///
-    /// - `Ok(Some(server))` — a termiHub-managed server is ready; forward to it.
-    /// - `Ok(None)` — no managed server is needed (a user-run server was adopted,
-    ///   or provisioning is disabled); fall back to detection.
+    /// - `Ok(Some(resolved))` — a server (managed or adopted) is ready; forward
+    ///   to `resolved.info` with `resolved.cookie`, no further detection.
+    /// - `Ok(None)` — provisioning is disabled or resolved nothing; fall back to
+    ///   [`detect_local_x_server`] for a user-run server.
     /// - `Err(message)` — provisioning failed; `message` is an actionable,
     ///   user-facing explanation surfaced to the UI (never a silent no-op).
-    async fn ensure(&self) -> Result<Option<ManagedXServer>, String>;
+    async fn ensure(&self) -> Result<Option<ResolvedXServer>, String>;
 }
 
 static PROVISIONER: OnceLock<Arc<dyn XServerProvisioner>> = OnceLock::new();
@@ -123,10 +134,10 @@ pub struct X11Forwarder {
 impl X11Forwarder {
     /// Start X11 forwarding using an existing SSH session.
     ///
-    /// `managed` is an optional source of termiHub-managed X server info (a
-    /// server termiHub started itself). When present it is consulted before any
-    /// filesystem/`xauth` probing; pass `None` to rely purely on detection of a
-    /// user-run server.
+    /// `resolved` is the server the desktop provisioner already resolved (managed
+    /// or adopted); when present it is used as-is with **no** second
+    /// socket/DISPLAY/TCP probe. Pass `None` (core standalone / tests) to detect
+    /// a user-run server here via [`detect_local_x_server`].
     ///
     /// Returns `(forwarder, remote_display_number, xauth_cookie)`.
     pub async fn start(
@@ -134,20 +145,29 @@ impl X11Forwarder {
         session: &mut SshSession,
         registry: ForwardedChannelRegistry,
         alive: Arc<AtomicBool>,
-        managed: Option<&dyn ManagedXServerSource>,
+        resolved: Option<ResolvedXServer>,
     ) -> Result<(Self, u32, Option<String>), SessionError> {
-        let local_x = detect_local_x_server(managed).ok_or_else(|| {
-            SessionError::SpawnFailed(
-                "No local X server detected. Start an X server (XQuartz on macOS).".to_string(),
-            )
-        })?;
+        let (local_x, xauth_cookie) = match resolved {
+            // Provisioner already resolved the server — forward to it directly.
+            Some(resolved) => (resolved.info, resolved.cookie),
+            // No provisioner: detect a user-run server and read its cookie.
+            None => {
+                let info = detect_local_x_server().ok_or_else(|| {
+                    SessionError::SpawnFailed(
+                        "No local X server detected. Start an X server (XQuartz on macOS)."
+                            .to_string(),
+                    )
+                })?;
+                let cookie = read_local_xauth_cookie(info.display_number);
+                (info, cookie)
+            }
+        };
 
         info!(
-            "X11 forwarding: detected local X server at display :{}",
+            "X11 forwarding: using local X server at display :{}",
             local_x.display_number
         );
 
-        let xauth_cookie = read_local_xauth_cookie(local_x.display_number, managed);
         if xauth_cookie.is_some() {
             info!("X11 forwarding: read local xauth cookie");
         } else {
@@ -353,24 +373,17 @@ fn info_from_parsed(host: Option<String>, display_number: u32) -> LocalXServerIn
     }
 }
 
-/// Detect the local X server.
+/// Detect a user-run local X server.
 ///
-/// Resolution order (see the "Detection decision flow" diagram in concept
-/// #1044):
-/// 1. A termiHub-**managed** server (via `managed`) wins — returned as
-///    `Tcp("127.0.0.1", 6000+n)` with no filesystem/`xauth` probing.
-/// 2. The `DISPLAY` environment variable, when set.
-/// 3. Platform fallback for user-run servers: on Unix, scan `/tmp/.X11-unix/`
-///    for live sockets; on Windows, probe `127.0.0.1:6000`.
-pub fn detect_local_x_server(
-    managed: Option<&dyn ManagedXServerSource>,
-) -> Option<LocalXServerInfo> {
-    // 1. A termiHub-managed server takes precedence over everything.
-    if let Some(server) = managed.and_then(|src| src.managed_server()) {
-        return Some(managed_server_info(&server));
-    }
-
-    // 2. Honor an explicit DISPLAY.
+/// A termiHub-**managed** server is resolved upstream by the desktop provisioner
+/// (which hands the forwarder a [`ResolvedXServer`]); this covers only the
+/// no-provisioner fallback. Resolution order (see the "Detection decision flow"
+/// diagram in concept #1044):
+/// 1. The `DISPLAY` environment variable, when set.
+/// 2. Platform fallback: on Unix, scan `/tmp/.X11-unix/` for live sockets; on
+///    Windows, probe `127.0.0.1:6000`.
+pub fn detect_local_x_server() -> Option<LocalXServerInfo> {
+    // 1. Honor an explicit DISPLAY.
     if let Ok(display) = std::env::var("DISPLAY") {
         if !display.is_empty() {
             let (host, display_number, _screen) = parse_display(&display)?;
@@ -378,7 +391,7 @@ pub fn detect_local_x_server(
         }
     }
 
-    // 3. Platform fallback for user-installed servers.
+    // 2. Platform fallback for user-installed servers.
     #[cfg(unix)]
     {
         detect_from_sockets()
@@ -386,17 +399,6 @@ pub fn detect_local_x_server(
     #[cfg(not(unix))]
     {
         detect_from_tcp_probe()
-    }
-}
-
-/// Map a managed server to a `LocalXServerInfo` (always TCP loopback).
-fn managed_server_info(server: &ManagedXServer) -> LocalXServerInfo {
-    LocalXServerInfo {
-        display_number: server.display_number,
-        connection: LocalXConnection::Tcp(
-            "127.0.0.1".to_string(),
-            6000 + server.display_number as u16,
-        ),
     }
 }
 
@@ -456,23 +458,11 @@ pub fn probe_tcp_x_server_at(addr: std::net::SocketAddr, timeout: std::time::Dur
 
 /// Read the MIT-MAGIC-COOKIE-1 for the given local display number.
 ///
-/// Resolution order:
-/// 1. If `managed` reports a server on this display, return its known cookie
-///    directly — no `xauth` shell-out (which is a no-op on Windows). A `None`
-///    cookie means the managed server runs in `-ac` mode.
-/// 2. Otherwise run `xauth list :N` and parse the hex cookie. Returns `None` if
-///    `xauth` is not installed (e.g. Windows without a managed server, where a
-///    `-ac` server still works) or no cookie is found.
-pub fn read_local_xauth_cookie(
-    display_number: u32,
-    managed: Option<&dyn ManagedXServerSource>,
-) -> Option<String> {
-    if let Some(server) = managed.and_then(|src| src.managed_server()) {
-        if server.display_number == display_number {
-            return server.cookie;
-        }
-    }
-
+/// Runs `xauth list :N` and parses the hex cookie. Returns `None` if `xauth` is
+/// not installed (e.g. Windows, where a `-ac` server still works) or no cookie
+/// is found. A termiHub-managed server's cookie is known up front and threaded
+/// through [`ResolvedXServer`] instead, so this is only the user-run path.
+pub fn read_local_xauth_cookie(display_number: u32) -> Option<String> {
     let output = std::process::Command::new("xauth")
         .args(["list", &format!(":{display_number}")])
         .output()
@@ -563,16 +553,7 @@ mod tests {
         assert!(parse_display(":abc").is_none());
     }
 
-    // ── Managed-server-aware detection (issue #1051) ─────────────────────
-
-    /// A test double for a termiHub-managed X server source.
-    struct FakeManaged(Option<ManagedXServer>);
-
-    impl ManagedXServerSource for FakeManaged {
-        fn managed_server(&self) -> Option<ManagedXServer> {
-            self.0.clone()
-        }
-    }
+    // ── Resolved / managed server mapping (issue #1087) ──────────────────
 
     /// Assert a connection is TCP to the expected host/port (cross-platform).
     fn assert_tcp(conn: &LocalXConnection, host: &str, port: u16) {
@@ -589,75 +570,42 @@ mod tests {
     }
 
     #[test]
-    fn detect_prefers_managed_server_over_everything() {
-        // A managed server on display :0 must be returned as TCP 127.0.0.1:6000
-        // with no filesystem/xauth probing — even if DISPLAY happens to be set
-        // in the environment (managed is consulted first).
-        let src = FakeManaged(Some(ManagedXServer {
-            display_number: 0,
-            cookie: Some("deadbeef".to_string()),
-        }));
-        let info = detect_local_x_server(Some(&src)).expect("managed server should be detected");
-        assert_eq!(info.display_number, 0);
-        assert_tcp(&info.connection, "127.0.0.1", 6000);
+    fn tcp_loopback_maps_display_to_port() {
+        // Display :0 → 127.0.0.1:6000; display :3 → 127.0.0.1:6003.
+        let zero = LocalXServerInfo::tcp_loopback(0);
+        assert_eq!(zero.display_number, 0);
+        assert_tcp(&zero.connection, "127.0.0.1", 6000);
 
-        // The managed cookie is returned directly, without shelling to `xauth`.
-        assert_eq!(
-            read_local_xauth_cookie(0, Some(&src)),
-            Some("deadbeef".to_string())
-        );
+        let three = LocalXServerInfo::tcp_loopback(3);
+        assert_eq!(three.display_number, 3);
+        assert_tcp(&three.connection, "127.0.0.1", 6003);
     }
 
     #[test]
-    fn detect_managed_server_maps_display_to_port() {
-        // Display :3 → TCP port 6003.
-        let src = FakeManaged(Some(ManagedXServer {
-            display_number: 3,
-            cookie: None,
-        }));
-        let info = detect_local_x_server(Some(&src)).expect("managed server should be detected");
-        assert_eq!(info.display_number, 3);
-        assert_tcp(&info.connection, "127.0.0.1", 6003);
-    }
-
-    #[test]
-    fn managed_server_without_cookie_is_ac_mode() {
-        // A managed server started with `-ac` has no cookie; read must return
-        // None (and must not shell to `xauth`).
-        let src = FakeManaged(Some(ManagedXServer {
-            display_number: 0,
-            cookie: None,
-        }));
-        assert_eq!(read_local_xauth_cookie(0, Some(&src)), None);
-    }
-
-    #[test]
-    fn single_managed_server_adapter_reports_its_server() {
-        // The adapter used by the connect path to hand a just-ensured server to
-        // the forwarder must report exactly that server, and drive detection to
-        // the managed TCP loopback path.
-        let adapter = SingleManagedServer::new(ManagedXServer {
+    fn managed_server_resolves_to_tcp_loopback_with_cookie() {
+        // A managed server on :2 resolves to TCP 127.0.0.1:6002 carrying its
+        // known cookie — no filesystem/xauth probing needed at the forwarder.
+        let resolved = ManagedXServer {
             display_number: 2,
             cookie: Some("cafebabe".to_string()),
-        });
-        let server = adapter.managed_server().expect("adapter reports a server");
-        assert_eq!(server.display_number, 2);
-
-        let info = detect_local_x_server(Some(&adapter)).expect("managed server detected");
-        assert_eq!(info.display_number, 2);
-        assert_tcp(&info.connection, "127.0.0.1", 6002);
-        assert_eq!(
-            read_local_xauth_cookie(2, Some(&adapter)),
-            Some("cafebabe".to_string())
-        );
+        }
+        .resolved();
+        assert_eq!(resolved.info.display_number, 2);
+        assert_tcp(&resolved.info.connection, "127.0.0.1", 6002);
+        assert_eq!(resolved.cookie.as_deref(), Some("cafebabe"));
     }
 
     #[test]
-    fn no_managed_server_does_not_short_circuit() {
-        // An empty managed source must behave exactly like `None`: detection
-        // falls through to the platform path (no panic, returns an Option).
-        let src = FakeManaged(None);
-        let _ = detect_local_x_server(Some(&src));
+    fn managed_server_without_cookie_resolves_ac_mode() {
+        // A managed server started with `-ac` has no cookie; the resolved
+        // server carries `None` so no `xauth` add is emitted.
+        let resolved = ManagedXServer {
+            display_number: 0,
+            cookie: None,
+        }
+        .resolved();
+        assert_tcp(&resolved.info.connection, "127.0.0.1", 6000);
+        assert!(resolved.cookie.is_none());
     }
 
     #[test]

--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -87,6 +87,19 @@ pub struct ResolvedXServer {
     pub cookie: Option<String>,
 }
 
+impl ResolvedXServer {
+    /// Resolve a user-run X server (no termiHub provisioner) into a forwarding
+    /// target: [`detect_local_x_server`] for the connection, then
+    /// [`read_local_xauth_cookie`] for its cookie. `None` when no local server is
+    /// found. Shared by [`X11Forwarder::start`]'s no-provisioner fallback and the
+    /// desktop orchestrator so user-run resolution lives in one place.
+    pub fn detect_user_run() -> Option<Self> {
+        let info = detect_local_x_server()?;
+        let cookie = read_local_xauth_cookie(info.display_number);
+        Some(Self { info, cookie })
+    }
+}
+
 /// A hook the desktop app installs so the SSH connect path can ensure a usable
 /// local X server *before* X11 forwarding starts.
 ///
@@ -147,21 +160,18 @@ impl X11Forwarder {
         alive: Arc<AtomicBool>,
         resolved: Option<ResolvedXServer>,
     ) -> Result<(Self, u32, Option<String>), SessionError> {
-        let (local_x, xauth_cookie) = match resolved {
-            // Provisioner already resolved the server — forward to it directly.
-            Some(resolved) => (resolved.info, resolved.cookie),
-            // No provisioner: detect a user-run server and read its cookie.
-            None => {
-                let info = detect_local_x_server().ok_or_else(|| {
-                    SessionError::SpawnFailed(
-                        "No local X server detected. Start an X server (XQuartz on macOS)."
-                            .to_string(),
-                    )
-                })?;
-                let cookie = read_local_xauth_cookie(info.display_number);
-                (info, cookie)
-            }
-        };
+        // Use the provisioner-resolved server as-is; without one, detect a
+        // user-run server here (the sole fallback probe on the connect path).
+        let ResolvedXServer {
+            info: local_x,
+            cookie: xauth_cookie,
+        } = resolved
+            .or_else(ResolvedXServer::detect_user_run)
+            .ok_or_else(|| {
+                SessionError::SpawnFailed(
+                    "No local X server detected. Start an X server (XQuartz on macOS).".to_string(),
+                )
+            })?;
 
         info!(
             "X11 forwarding: using local X server at display :{}",
@@ -435,10 +445,7 @@ fn detect_from_sockets() -> Option<LocalXServerInfo> {
 fn detect_from_tcp_probe() -> Option<LocalXServerInfo> {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 6000));
     if probe_tcp_x_server_at(addr, std::time::Duration::from_millis(300)) {
-        Some(LocalXServerInfo {
-            display_number: 0,
-            connection: LocalXConnection::Tcp("127.0.0.1".to_string(), 6000),
-        })
+        Some(LocalXServerInfo::tcp_loopback(0))
     } else {
         None
     }

--- a/docs/concepts/backlog/x-server-provisioning.html
+++ b/docs/concepts/backlog/x-server-provisioning.html
@@ -953,8 +953,12 @@ flowchart TB
           </p>
         </blockquote>
         <p>
-          <strong>Last synced:</strong> never (concept not yet implemented) ·
-          <strong>Status:</strong> diverged (entirely missing — backlog feature)
+          <strong>Last synced:</strong> 2026-07-05 at commit <code>17a7bba2</code> ·
+          <strong>Status:</strong> diverged — <strong>backend implemented</strong> (acquire #1048,
+          manager #1049, auth #1050, detection #1051, orchestrator + Tauri commands #1052, seam
+          refactor #1087); <strong>frontend UI pending</strong> (#1053). Three artifacts describe
+          the pre-#1087 detection design and need updating to the current layering (tracked in
+          #1100).
         </p>
 
         <h3>Open divergences</h3>
@@ -972,37 +976,74 @@ flowchart TB
             <tbody>
               <tr>
                 <td>1</td>
-                <td>X server provisioning subsystem (<code>src-tauri/.../xserver/</code>)</td>
-                <td>Not implemented — backlog feature</td>
-                <td>Missing</td>
-                <td>Implement per order above, then re-sync</td>
+                <td>
+                  "Detection decision flow" diagram + "Detection fix (x11.rs)" prose:
+                  <code>detect_local_x_server</code> consults a registered managed server first and
+                  returns TCP loopback + known cookie
+                </td>
+                <td>
+                  Post-#1087, core detection is <strong>not</strong> managed-aware. The desktop
+                  orchestrator/provisioner resolves the managed server into a
+                  <code>ResolvedXServer</code> and threads it to <code>X11Forwarder::start</code>;
+                  <code>detect_local_x_server()</code> handles only the user-run fallback (DISPLAY /
+                  socket / Windows TCP:6000). Observable behavior is unchanged — the seam moved up a
+                  layer.
+                </td>
+                <td>Design reality (approved #1087 refactor)</td>
+                <td>Edit concept — redraw the detection diagram + reword the prose (#1100)</td>
               </tr>
               <tr>
                 <td>2</td>
-                <td>Managed-server-aware detection + Windows TCP:6000 probe</td>
                 <td>
-                  <code>x11.rs</code> scans <code>/tmp/.X11-unix</code> + shells to
-                  <code>xauth</code> only
+                  Session-open sequence diagram: <code>Orch-->>Conn: LocalXServerInfo(:0, cookie)</code>
                 </td>
-                <td>Diverged</td>
-                <td>Extend <code>detect_local_x_server</code> / cookie lookup</td>
+                <td>
+                  Provisioner returns <code>Option&lt;ResolvedXServer&gt;</code>;
+                  <code>ensure_x_server</code> returns
+                  <code>EnsureOutcome { report, resolved }</code>
+                </td>
+                <td>Design reality (#1087)</td>
+                <td>Edit concept — relabel to <code>ResolvedXServer</code> (#1100)</td>
               </tr>
               <tr>
                 <td>3</td>
                 <td>
-                  Settings <code>provideXServerAutomatically</code> /
-                  <code>stopXServerWhenIdle</code>
+                  Impl-details table row <code>core/src/backends/ssh/x11.rs</code> →
+                  "managed-server-aware detection; Windows TCP:6000 probe"
                 </td>
-                <td>Not present in SSH schema</td>
-                <td>Missing</td>
-                <td>Add schema fields once orchestrator lands</td>
+                <td>
+                  Windows TCP:6000 probe present; managed-awareness removed from detection in #1087
+                </td>
+                <td>Design reality (#1087)</td>
+                <td>Edit concept — reword row (#1100)</td>
               </tr>
               <tr>
                 <td>4</td>
-                <td>"X Servers" section in Open Connections panel</td>
+                <td>
+                  Settings <code>provideXServerAutomatically</code> /
+                  <code>stopXServerWhenIdle</code> rendered by <code>DynamicForm</code>
+                </td>
+                <td>
+                  Backend fields exist (<code>settings.rs</code>:
+                  <code>provide_x_server_automatically</code>,
+                  <code>stop_x_server_when_idle</code>); no settings UI yet
+                </td>
+                <td>Missing (partial)</td>
+                <td>Implement settings UI in #1053</td>
+              </tr>
+              <tr>
+                <td>5</td>
+                <td>First-run consent + provisioning-progress UI (Mockup 1)</td>
+                <td>No frontend consent/progress surface; backend emits progress events</td>
+                <td>Missing</td>
+                <td>Implement in #1053</td>
+              </tr>
+              <tr>
+                <td>6</td>
+                <td>"X Servers" section in Open Connections panel (Mockup 2)</td>
                 <td>Not present in <code>OpenConnectionsModal.tsx</code></td>
                 <td>Missing</td>
-                <td>Add <code>Section</code> after backend command surface exists</td>
+                <td>Implement in #1053</td>
               </tr>
             </tbody>
           </table>
@@ -1020,9 +1061,16 @@ flowchart TB
             </thead>
             <tbody>
               <tr>
+                <td>2026-07-05</td>
                 <td>—</td>
-                <td>—</td>
-                <td>—</td>
+                <td>
+                  Backend subsystem implemented across the epic: <code>acquire.rs</code> (#1048),
+                  <code>manager.rs</code> (#1049), <code>auth.rs</code> (#1050), managed detection +
+                  Windows TCP:6000 probe (#1051), <code>orchestrator.rs</code> + four Tauri commands
+                  (#1052), and the managed-source seam collapse (#1087). Settings fields
+                  <code>provideXServerAutomatically</code> / <code>stopXServerWhenIdle</code> exist
+                  in <code>settings.rs</code>. Remaining work is the frontend UI (#1053).
+                </td>
               </tr>
             </tbody>
           </table>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ async-trait = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking", "json"] }
 semver = "1"
 dirs = "6"
+which = "7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "fmt", "env-filter"] }
 chrono = "0.4"

--- a/src-tauri/src/commands/xserver.rs
+++ b/src-tauri/src/commands/xserver.rs
@@ -56,15 +56,19 @@ pub async fn x_server_ensure(
     let result = xserver::ensure_off_reactor(&app, manager.inner().clone()).await;
 
     match &result {
-        Ok(status) => emit_progress(
+        Ok(outcome) => emit_progress(
             &app,
             "ready",
-            status.message.as_deref().unwrap_or("X server ready."),
+            outcome
+                .report
+                .message
+                .as_deref()
+                .unwrap_or("X server ready."),
             1.0,
         ),
         Err(err) => emit_progress(&app, "failed", &err.to_string(), 1.0),
     }
-    result
+    result.map(|outcome| outcome.report)
 }
 
 /// Stop the termiHub-managed X server, if one is running.

--- a/src-tauri/src/terminal/xserver/manager.rs
+++ b/src-tauri/src/terminal/xserver/manager.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use anyhow::Result;
-use termihub_core::backends::ssh::x11::{ManagedXServer, ManagedXServerSource};
+use termihub_core::backends::ssh::x11::ManagedXServer;
 use tracing::warn;
 
 use super::auth::XAuthProvider;
@@ -340,15 +340,15 @@ fn remove_auth_file(path: &Option<PathBuf>) {
     }
 }
 
-impl ManagedXServerSource for XServerManager {
-    /// Report the server termiHub itself started so core X11 detection can skip
-    /// its filesystem/`xauth` probing (issue #1049 seam; consumers wired in
-    /// #1052). Adopted external servers are intentionally excluded — they are
-    /// discovered by the normal TCP probe and are not termiHub-managed.
+impl XServerManager {
+    /// Report the server termiHub itself started, so the orchestrator can resolve
+    /// it (display + cookie) for the connect path without any filesystem/`xauth`
+    /// probing (#1050). Adopted external servers are intentionally excluded — they
+    /// are discovered by the normal TCP probe and are not termiHub-managed.
     ///
-    /// The cookie is the MIT-MAGIC-COOKIE-1 the managed server was launched with
-    /// (#1050), or `None` when it fell back to `-ac` mode.
-    fn managed_server(&self) -> Option<ManagedXServer> {
+    /// The cookie is the MIT-MAGIC-COOKIE-1 the managed server was launched with,
+    /// or `None` when it fell back to `-ac` mode.
+    pub fn managed_server(&self) -> Option<ManagedXServer> {
         let inner = self.inner.lock().expect("xserver lock");
         match inner.status {
             XServerStatus::Running { display } => Some(ManagedXServer {
@@ -812,7 +812,7 @@ mod tests {
         assert_eq!(launcher.count(), 0);
     }
 
-    // -- core detection seam (ManagedXServerSource) -------------------------
+    // -- managed-server reporting (orchestrator resolution seam) ------------
 
     #[test]
     fn managed_server_reports_only_our_spawned_server() {

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -74,12 +74,12 @@ impl XServerProvisioner for XServerProvisionerImpl {
     async fn ensure(&self) -> Result<Option<ResolvedXServer>, String> {
         // Run the orchestrator (adopt / spawn / launch XQuartz / typed error) and
         // hand the connect path the server it resolved — managed or adopted —
-        // together with its cookie, so the forwarder performs no second probe. A
-        // `None` resolved server (no reachable server) lets core fall back to
-        // detection.
+        // together with its cookie, so the forwarder performs no second probe.
+        // `Ok` always carries a resolved server; the "nothing usable" case is an
+        // `Err`, and the "no provisioner registered" case is handled in core.
         ensure_off_reactor(&self.app, self.manager.clone())
             .await
-            .map(|outcome| outcome.resolved)
+            .map(|outcome| Some(outcome.resolved))
             .map_err(|e| e.to_string())
     }
 }

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -24,12 +24,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use tauri::{AppHandle, Manager};
-use termihub_core::backends::ssh::x11::{ManagedXServer, ManagedXServerSource, XServerProvisioner};
+use termihub_core::backends::ssh::x11::{ResolvedXServer, XServerProvisioner};
 
 use crate::connection::manager::ConnectionManager;
 
 pub use manager::XServerManager;
-pub use orchestrator::{current_status, ensure_x_server};
+pub use orchestrator::{current_status, ensure_x_server, EnsureOutcome};
 pub use types::{
     XServerError, XServerPlatform, XServerProgress, XServerStatusReport, X_SERVER_PROGRESS_EVENT,
 };
@@ -71,14 +71,15 @@ impl XServerProvisionerImpl {
 
 #[async_trait]
 impl XServerProvisioner for XServerProvisionerImpl {
-    async fn ensure(&self) -> Result<Option<ManagedXServer>, String> {
-        // Run the orchestrator for its side effects (adopt / spawn / launch
-        // XQuartz / typed error). A termiHub-managed server is then handed to the
-        // forwarder directly; an adopted external server yields `None`, so core
-        // detection finds it (covering Unix-socket servers on macOS/Linux).
+    async fn ensure(&self) -> Result<Option<ResolvedXServer>, String> {
+        // Run the orchestrator (adopt / spawn / launch XQuartz / typed error) and
+        // hand the connect path the server it resolved — managed or adopted —
+        // together with its cookie, so the forwarder performs no second probe. A
+        // `None` resolved server (no reachable server) lets core fall back to
+        // detection.
         ensure_off_reactor(&self.app, self.manager.clone())
             .await
-            .map(|_report| self.manager.managed_server())
+            .map(|outcome| outcome.resolved)
             .map_err(|e| e.to_string())
     }
 }
@@ -90,7 +91,7 @@ impl XServerProvisioner for XServerProvisionerImpl {
 pub(crate) async fn ensure_off_reactor(
     app: &AppHandle,
     manager: Arc<XServerManager>,
-) -> Result<XServerStatusReport, XServerError> {
+) -> Result<EnsureOutcome, XServerError> {
     let provide = resolve_provide_automatically(app);
     tokio::task::spawn_blocking(move || ensure_x_server(&manager, provide))
         .await

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -8,10 +8,26 @@
 //! status. The per-platform install internals (VcXsrv download #1047 remainder,
 //! XQuartz install #1054, Linux gap classification #1055) are their own issues.
 
-use termihub_core::backends::ssh::x11::detect_local_x_server;
+use termihub_core::backends::ssh::x11::{
+    detect_local_x_server, read_local_xauth_cookie, LocalXServerInfo, ResolvedXServer,
+};
 
 use super::manager::{XServerManager, XServerStatus as ManagedStatus};
 use super::types::{XServerError, XServerPlatform, XServerState, XServerStatusReport};
+
+/// Outcome of [`ensure_x_server`]: the UI-facing status report plus, on success,
+/// the fully-resolved server the SSH connect path should forward to.
+///
+/// Threading the resolved server here (rather than re-detecting it in
+/// [`X11Forwarder::start`](termihub_core::backends::ssh::x11::X11Forwarder::start))
+/// removes the second socket/DISPLAY/TCP probe on the connect hot path (#1087).
+pub struct EnsureOutcome {
+    /// Frontend-friendly status (state, platform, message).
+    pub report: XServerStatusReport,
+    /// Where to forward to, when a usable server was resolved; `None` when the
+    /// call returned a report without a reachable server.
+    pub resolved: Option<ResolvedXServer>,
+}
 
 /// Ensure a usable local X server for the current platform.
 ///
@@ -21,43 +37,67 @@ use super::types::{XServerError, XServerPlatform, XServerState, XServerStatusRep
 pub fn ensure_x_server(
     manager: &XServerManager,
     provide_automatically: bool,
-) -> Result<XServerStatusReport, XServerError> {
+) -> Result<EnsureOutcome, XServerError> {
     let platform = XServerPlatform::current();
     let dependency = dependency_available(platform);
 
     // macOS: if XQuartz is installed but idle, nudge it up so detection and the
     // SSH `DISPLAY` handshake can succeed.
     #[cfg(target_os = "macos")]
-    if dependency && detect_local_x_server(None).is_none() {
+    if dependency && detect_local_x_server().is_none() {
         macos::launch_xquartz();
     }
 
     // 1. Let the manager adopt/reuse/spawn (TCP-based; covers Windows + managed).
     if let Ok(info) = manager.ensure_running() {
-        let state = if info.managed {
-            XServerState::Running
+        // Both managed and TCP-adopted servers are reached at 127.0.0.1:6000+n;
+        // resolve here so the forwarder need not probe again. A managed server's
+        // cookie is known up front; an adopted one's is read via `xauth` (a
+        // no-op on Windows, where an `-ac` server needs no cookie).
+        let (state, cookie) = if info.managed {
+            (
+                XServerState::Running,
+                manager.managed_server().and_then(|m| m.cookie),
+            )
         } else {
-            XServerState::Adopted
+            (XServerState::Adopted, read_local_xauth_cookie(info.display))
         };
-        return Ok(report(
+        let resolved = ResolvedXServer {
+            info: LocalXServerInfo::tcp_loopback(info.display),
+            cookie,
+        };
+        let report = report(
             platform,
             state,
             Some(info.display),
             info.managed,
             dependency,
-        ));
+        );
+        return Ok(EnsureOutcome {
+            report,
+            resolved: Some(resolved),
+        });
     }
 
     // 2. Fall back to cross-platform detection for a user-run server the TCP
-    //    probe cannot see (DISPLAY / Unix socket on macOS & Linux).
-    if let Some(local) = detect_local_x_server(None) {
-        return Ok(report(
+    //    probe cannot see (DISPLAY / Unix socket on macOS & Linux). Thread the
+    //    resolved info (and its cookie) straight through to the forwarder.
+    if let Some(local) = detect_local_x_server() {
+        let cookie = read_local_xauth_cookie(local.display_number);
+        let report = report(
             platform,
             XServerState::Adopted,
             Some(local.display_number),
             false,
             dependency,
-        ));
+        );
+        return Ok(EnsureOutcome {
+            report,
+            resolved: Some(ResolvedXServer {
+                info: local,
+                cookie,
+            }),
+        });
     }
 
     // 3. Nothing usable — return actionable, typed guidance.
@@ -97,7 +137,7 @@ pub fn current_status(manager: &XServerManager) -> XServerStatusReport {
         ManagedStatus::Stopped => {
             // The manager only tracks TCP servers; consult cross-platform
             // detection for an adopted Unix-socket server it can't see.
-            match detect_local_x_server(None) {
+            match detect_local_x_server() {
                 Some(local) => report(
                     platform,
                     XServerState::Adopted,
@@ -185,17 +225,12 @@ fn dependency_available(platform: XServerPlatform) -> bool {
 }
 
 /// Whether `name` resolves to an executable on `PATH` (best-effort).
-#[cfg(not(target_os = "windows"))]
+///
+/// Uses the `which` crate so `PATH` parsing and platform executable rules
+/// (Windows `PATHEXT`, etc.) are handled by a maintained library rather than a
+/// hand-rolled split.
 fn binary_on_path(name: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path).any(|dir| dir.join(name).exists())
-}
-
-#[cfg(target_os = "windows")]
-fn binary_on_path(_name: &str) -> bool {
-    false
+    which::which(name).is_ok()
 }
 
 #[cfg(target_os = "macos")]
@@ -280,5 +315,114 @@ mod tests {
         assert_eq!(r.display_number, Some(7));
         assert!(!r.managed);
         assert!(r.message.unwrap().contains(":7"));
+    }
+
+    // ── Resolved-server threading (#1087) ────────────────────────────────
+    //
+    // These exercise `ensure_x_server` end-to-end with an injected manager to
+    // prove the resolved server (the thing that removes the forwarder's second
+    // probe) is threaded through. Skipped on macOS, where `ensure_x_server`
+    // best-effort launches XQuartz when idle — an unwanted side effect in a unit
+    // test. The resolution logic is platform-independent, so Windows + Linux
+    // coverage is sufficient.
+    #[cfg(not(target_os = "macos"))]
+    mod resolved {
+        use super::*;
+        use crate::terminal::xserver::auth::{XAuth, XAuthProvider};
+        use crate::terminal::xserver::manager::{ManagedProcess, PortProbe, XServerLauncher};
+        use std::path::{Path, PathBuf};
+        use termihub_core::backends::ssh::x11::LocalXConnection;
+
+        const FAKE_COOKIE: &str = "0011223344556677889900aabbccddee";
+
+        struct FakeProbe {
+            open: Vec<u16>,
+        }
+        impl PortProbe for FakeProbe {
+            fn is_open(&self, port: u16) -> bool {
+                self.open.contains(&port)
+            }
+        }
+
+        struct FakeProc;
+        impl ManagedProcess for FakeProc {
+            fn is_alive(&mut self) -> bool {
+                true
+            }
+            fn terminate(&mut self) {}
+        }
+
+        struct FakeLauncher;
+        impl XServerLauncher for FakeLauncher {
+            fn launch(
+                &self,
+                _exe: &Path,
+                _display: u32,
+                _auth_file: Option<&Path>,
+            ) -> anyhow::Result<Box<dyn ManagedProcess>> {
+                Ok(Box::new(FakeProc))
+            }
+        }
+
+        struct FakeAuth;
+        impl XAuthProvider for FakeAuth {
+            fn provision(&self, _display: u32) -> anyhow::Result<XAuth> {
+                Ok(XAuth {
+                    auth_file: PathBuf::from("fake/.Xauthority"),
+                    cookie_hex: FAKE_COOKIE.to_string(),
+                })
+            }
+        }
+
+        fn manager(open: Vec<u16>, provides_managed: bool) -> XServerManager {
+            XServerManager::new(
+                Box::new(FakeProbe { open }),
+                Box::new(FakeLauncher),
+                Box::new(|| Ok(PathBuf::from("vcxsrv.exe"))),
+                Box::new(FakeAuth),
+                provides_managed,
+                false,
+            )
+        }
+
+        fn assert_tcp_loopback(conn: &LocalXConnection, port: u16) {
+            match conn {
+                LocalXConnection::Tcp(host, p) => {
+                    assert_eq!(host, "127.0.0.1");
+                    assert_eq!(*p, port);
+                }
+                #[cfg(unix)]
+                LocalXConnection::UnixSocket(_) => panic!("expected TCP loopback, got a socket"),
+            }
+        }
+
+        #[test]
+        fn spawned_managed_server_is_resolved_with_cookie() {
+            // No port open → the manager spawns a managed server on :0. The
+            // outcome carries the resolved TCP-loopback target and the known
+            // cookie, so the forwarder needs no second probe or `xauth` call.
+            let mgr = manager(vec![], true);
+            let outcome = ensure_x_server(&mgr, true).expect("managed server ensured");
+
+            assert_eq!(outcome.report.state, XServerState::Running);
+            let resolved = outcome.resolved.expect("resolved server threaded through");
+            assert_eq!(resolved.info.display_number, 0);
+            assert_tcp_loopback(&resolved.info.connection, 6000);
+            assert_eq!(resolved.cookie.as_deref(), Some(FAKE_COOKIE));
+        }
+
+        #[test]
+        fn adopted_tcp_server_is_resolved_as_loopback() {
+            // A reachable server on :0 is adopted and resolved to TCP loopback
+            // (its cookie, if any, is read via `xauth` and is environment
+            // dependent, so it is not asserted here).
+            let mgr = manager(vec![6000], false);
+            let outcome = ensure_x_server(&mgr, true).expect("adopted server ensured");
+
+            assert_eq!(outcome.report.state, XServerState::Adopted);
+            let resolved = outcome.resolved.expect("resolved adopted server threaded");
+            assert_eq!(resolved.info.display_number, 0);
+            assert_tcp_loopback(&resolved.info.connection, 6000);
+        }
     }
 }

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -24,9 +24,9 @@ use super::types::{XServerError, XServerPlatform, XServerState, XServerStatusRep
 pub struct EnsureOutcome {
     /// Frontend-friendly status (state, platform, message).
     pub report: XServerStatusReport,
-    /// Where to forward to, when a usable server was resolved; `None` when the
-    /// call returned a report without a reachable server.
-    pub resolved: Option<ResolvedXServer>,
+    /// The server the SSH connect path should forward to (managed or adopted).
+    /// Present on every `Ok`; the "no server at all" case is an `Err` instead.
+    pub resolved: ResolvedXServer,
 }
 
 /// Ensure a usable local X server for the current platform.
@@ -51,53 +51,43 @@ pub fn ensure_x_server(
     // 1. Let the manager adopt/reuse/spawn (TCP-based; covers Windows + managed).
     if let Ok(info) = manager.ensure_running() {
         // Both managed and TCP-adopted servers are reached at 127.0.0.1:6000+n;
-        // resolve here so the forwarder need not probe again. A managed server's
-        // cookie is known up front; an adopted one's is read via `xauth` (a
-        // no-op on Windows, where an `-ac` server needs no cookie).
-        let (state, cookie) = if info.managed {
-            (
-                XServerState::Running,
-                manager.managed_server().and_then(|m| m.cookie),
-            )
-        } else {
-            (XServerState::Adopted, read_local_xauth_cookie(info.display))
-        };
-        let resolved = ResolvedXServer {
-            info: LocalXServerInfo::tcp_loopback(info.display),
-            cookie,
+        // resolve here so the forwarder need not probe again. A server termiHub
+        // spawned reports its cookie up front (`managed_server()`); an adopted
+        // one's is read via `xauth` (a no-op on Windows, where an `-ac` server
+        // needs none).
+        let (state, managed, resolved) = match manager.managed_server() {
+            Some(server) => (XServerState::Running, true, server.resolved()),
+            None => (
+                XServerState::Adopted,
+                false,
+                ResolvedXServer {
+                    info: LocalXServerInfo::tcp_loopback(info.display),
+                    cookie: read_local_xauth_cookie(info.display),
+                },
+            ),
         };
         let report = report(
             platform,
             state,
-            Some(info.display),
-            info.managed,
+            Some(resolved.info.display_number),
+            managed,
             dependency,
         );
-        return Ok(EnsureOutcome {
-            report,
-            resolved: Some(resolved),
-        });
+        return Ok(EnsureOutcome { report, resolved });
     }
 
     // 2. Fall back to cross-platform detection for a user-run server the TCP
     //    probe cannot see (DISPLAY / Unix socket on macOS & Linux). Thread the
     //    resolved info (and its cookie) straight through to the forwarder.
-    if let Some(local) = detect_local_x_server() {
-        let cookie = read_local_xauth_cookie(local.display_number);
+    if let Some(resolved) = ResolvedXServer::detect_user_run() {
         let report = report(
             platform,
             XServerState::Adopted,
-            Some(local.display_number),
+            Some(resolved.info.display_number),
             false,
             dependency,
         );
-        return Ok(EnsureOutcome {
-            report,
-            resolved: Some(ResolvedXServer {
-                info: local,
-                cookie,
-            }),
-        });
+        return Ok(EnsureOutcome { report, resolved });
     }
 
     // 3. Nothing usable — return actionable, typed guidance.
@@ -405,7 +395,7 @@ mod tests {
             let outcome = ensure_x_server(&mgr, true).expect("managed server ensured");
 
             assert_eq!(outcome.report.state, XServerState::Running);
-            let resolved = outcome.resolved.expect("resolved server threaded through");
+            let resolved = outcome.resolved;
             assert_eq!(resolved.info.display_number, 0);
             assert_tcp_loopback(&resolved.info.connection, 6000);
             assert_eq!(resolved.cookie.as_deref(), Some(FAKE_COOKIE));
@@ -420,7 +410,7 @@ mod tests {
             let outcome = ensure_x_server(&mgr, true).expect("adopted server ensured");
 
             assert_eq!(outcome.report.state, XServerState::Adopted);
-            let resolved = outcome.resolved.expect("resolved adopted server threaded");
+            let resolved = outcome.resolved;
             assert_eq!(resolved.info.display_number, 0);
             assert_tcp_loopback(&resolved.info.connection, 6000);
         }


### PR DESCRIPTION
## Summary

Collapses the X server provisioning seam introduced by #1051/#1052 and removes the duplicate detection on the SSH X11 connect path. Closes #1087.

Before: `provisioner.ensure()` returned `Option<ManagedXServer>`, the connect path re-wrapped it in a `SingleManagedServer` adapter just to satisfy the `ManagedXServerSource` trait, and `X11Forwarder::start` then ran `detect_local_x_server()` a **second** time — after `ensure_x_server` had already resolved (and discarded) the server. Two overlapping "where does the managed server come from" traits + an adapter, and the socket/DISPLAY/TCP probe ran twice per connect in the adopt case.

After: the orchestrator resolves the server **once** into a plain `ResolvedXServer { info, cookie }` and threads it straight to the forwarder, which forwards to it with no second probe and no second `xauth` shell-out.

## Changes

- **Retire `ManagedXServerSource` + `SingleManagedServer`.** `X11Forwarder::start` takes an owned `Option<ResolvedXServer>`; `detect_local_x_server` / `read_local_xauth_cookie` drop their managed-source parameter and cover only the no-provisioner fallback.
- **Thread the resolved server through the orchestrator.** `ensure_x_server` returns `EnsureOutcome { report, resolved }`; the provisioner hands `resolved` to the connect path. Net work on connect drops by one TCP probe + one `xauth` call.
- **`which` crate** replaces the hand-rolled `binary_on_path` PATH split (+ its `#[cfg(windows)]` stub) — handles Windows `PATHEXT` (per the "prefer libraries" rule).
- Post-`/simplify` tightening: shared `ResolvedXServer::detect_user_run()` helper (one home for user-run resolution), managed branch wired through `ManagedXServer::resolved()`, `EnsureOutcome.resolved` made non-optional, `LocalXServerInfo::tcp_loopback` used at the TCP-probe fallback.

## Behaviour note

In the rare case where a TCP X server is reachable on `:0` **and** `DISPLAY` points elsewhere, the adopt path now consistently forwards to what the manager adopted (TCP loopback) rather than following `DISPLAY`. On Windows (the target) `DISPLAY` is typically unset — no practical change; Unix socket-only servers still route through the detection fallback unchanged.

## Testing

- Rewrote the core `x11` unit tests for the new API (13 pass) and added two orchestrator tests proving the resolved server is threaded through (`spawned_managed_server_is_resolved_with_cookie`, `adopted_tcp_server_is_resolved_as_loopback`); full `xserver` suite 54/54.
- `cargo test` (core + src-tauri), `cargo clippy --workspace --all-targets --all-features -D warnings`, and `cargo fmt --all --check` all green.

No user-facing change (internal refactor) → no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)