### PR TITLE
chore(config): auto-regenerate testid catalog from the autoformat hook (#1084)

### DIFF
--- a/.claude/agents/ui-design.md
+++ b/.claude/agents/ui-design.md
@@ -99,10 +99,12 @@ wrap motion in `@media (prefers-reduced-motion: reduce)`; use the shared enter/e
   A design change ships with at least a unit test or documented manual test.
 - **`data-testid` catalog**: if you add, remove, or rename ANY `data-testid`
   (migrating a dialog to `Modal` adds `modal-close`; primitives forward the
-  hook), regenerate `tests/system/testid-catalog.md` with
-  `python scripts/build-testid-catalog.py` and commit it in the same change.
-  CI fails on a stale catalog (both the "Frontend Code Quality" catalog check
-  and the "System-Test machinery" job).
+  hook), `tests/system/testid-catalog.md` must stay in sync — CI fails on a
+  stale catalog (both the "Frontend Code Quality" catalog check and the
+  "System-Test machinery" job). The PostToolUse autoformat hook now regenerates
+  it automatically whenever you edit a `src/**` `.tsx` (#1084), so in a normal
+  Claude Code session it stays current on its own — just commit the resulting
+  change. If you edit outside the hook, run `python scripts/build-testid-catalog.py`.
 - Run `./scripts/check.sh` (lint/format/clippy mirror of CI) and `./scripts/test.sh`
   before declaring done. Formatting is auto-applied by the PostToolUse hook.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -868,6 +868,19 @@ To verify SSH tunnels actually work on macOS, do this manually against the tunne
 4. Confirm the tunnel reaches a running state (sidebar shows Stop control) and `curl http://127.0.0.1:18083` returns `TUNNEL_TEST_OK`.
 5. Click **Stop** and confirm the tunnel returns to disconnected and the Start control reappears.
 
+### Development Tooling — testid-catalog auto-regeneration (#1084)
+
+The `tests/system/testid-catalog.md` catalog is regenerated automatically by the
+PostToolUse autoformat hook (`scripts/internal/autoformat.sh`) whenever a `src/**`
+`.tsx` is edited in a Claude Code session, so a stale catalog can't reach CI. The
+hook fires only inside Claude Code, so verify it manually after changing the hook
+or the generator:
+
+1. Edit any `src/**` component to **add** a new `data-testid` (e.g. `data-testid="tmp-probe"`).
+2. Confirm `git status` shows `tests/system/testid-catalog.md` modified **without** running the generator by hand, and that the new id appears in the catalog.
+3. **Remove** the `data-testid` again and edit the same `.tsx`; confirm the catalog drops the id automatically.
+4. Run `python scripts/build-testid-catalog.py --check` — it should report the catalog is up to date (exit 0), proving the hook kept CI's guard satisfied.
+
 ### Legacy Guided Manual Test Runner (YAML)
 
 The remaining manual test items are still defined as machine-readable YAML in [`tests/manual/*.yaml`](../tests/manual/). The standalone runner presents applicable tests one at a time, manages infrastructure, and generates a JSON report. It is being subsumed by the harness flow above:

--- a/scripts/internal/autoformat.sh
+++ b/scripts/internal/autoformat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Auto-format a single file based on its extension.
-# Designed to be called by a Claude Code PostToolUse hook.
+# Auto-format a single file based on its extension, and keep the data-testid
+# catalog in sync. Designed to be called by a Claude Code PostToolUse hook.
 # Reads JSON from stdin to extract the file path.
 
 INPUT=$(cat)
@@ -19,6 +19,45 @@ case "$FILE_PATH" in
         ;;
     *.rs)
         rustfmt "$FILE_PATH" &>/dev/null
+        ;;
+esac
+
+# Keep tests/system/testid-catalog.md in sync (#1084). A stale catalog breaks two
+# CI jobs ("Frontend Code Quality" catalog check and "System-Test machinery") and
+# is easy to forget to regenerate by hand. Regenerate automatically whenever a
+# frontend source file that could carry a data-testid changes, so the normal dev
+# flow can never leave the catalog stale. The generator is fast (~0.2s, stdlib
+# only) and idempotent — it rewrites the file only when the scan actually differs.
+#
+# Trigger on any edited `src/**` `.tsx` (JSX components — where every data-testid
+# lives, so add/change/remove are all caught), plus any other frontend source
+# that currently references data-testid. This must never block the hook, so all
+# failures are swallowed and we always exit 0.
+regenerate_testid_catalog() {
+    local script_dir catalog_script python_bin
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    catalog_script="$script_dir/../build-testid-catalog.py"
+    [ -f "$catalog_script" ] || return 0
+
+    if command -v python3 &>/dev/null; then
+        python_bin=python3
+    elif command -v python &>/dev/null; then
+        python_bin=python
+    else
+        return 0
+    fi
+
+    "$python_bin" "$catalog_script" &>/dev/null || true
+}
+
+case "$FILE_PATH" in
+    */src/*.tsx)
+        regenerate_testid_catalog
+        ;;
+    */src/*.ts|*/src/*.jsx|*/src/*.js)
+        if grep -q "data-testid" "$FILE_PATH" 2>/dev/null; then
+            regenerate_testid_catalog
+        fi
         ;;
 esac
 


### PR DESCRIPTION
## Summary

During the UI Modernization migration every batch that touched a `data-testid` broke CI twice (the "Frontend Code Quality" catalog check and the "System-Test machinery" job) because `tests/system/testid-catalog.md` was stale and had to be regenerated by hand — easy to forget.

This wires catalog regeneration into the **PostToolUse autoformat hook** (`scripts/internal/autoformat.sh`): whenever a `src/**` `.tsx` is edited (where every `data-testid` lives — so add/change/remove are all caught), or any other frontend source that references `data-testid`, the hook re-runs `python scripts/build-testid-catalog.py`. The generator is fast (~0.2s, stdlib-only) and idempotent — it rewrites the catalog only when the scan actually differs.

The hook is **non-blocking**: it swallows all failures and tolerates a missing Python, so it can never break the edit flow. CI's existing `--check` guard is unchanged as the safety net for edits made outside Claude Code.

Also:
- Updates the `ui-design` agent checklist to note the automation (still commit the resulting change).
- Adds a documented manual verification to `docs/testing.md`.

## Test plan
- Verified in-session by making the catalog deliberately stale, simulating the hook payload for a real `src/*.tsx` (`src/App.tsx`), and confirming the catalog **self-healed** with no manual step; confirmed a non-`src` edit (`README.md`) does **not** trigger regeneration.
- `bash -n` clean; `python scripts/build-testid-catalog.py --check` passes.
- Documented manual test added under Manual Testing → "Development Tooling — testid-catalog auto-regeneration (#1084)".

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)