### PR TITLE
refactor(ui): migrate editor subcomponents & workspace rename-chip onto ui/ primitives (#1094)

### DIFF
--- a/docs/changes/dev1/feature/1094-migrate-editor-subcomponents.md
+++ b/docs/changes/dev1/feature/1094-migrate-editor-subcomponents.md
@@ -1,0 +1,3 @@
+## Changed
+
+- The jump-host, agent-settings, terminal-settings, and agent-external-files sections of the connection editor, plus the workspace group rename field, now use the shared input/select/toggle/button components — consistent styling, focus, and accessible switches, matching the rest of the editor.

--- a/src/components/ConnectionEditor/AgentExternalFilesSettings.tsx
+++ b/src/components/ConnectionEditor/AgentExternalFilesSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { ExternalAgentFile } from "@/types/terminal";
+import { Button, Input, Toggle } from "@/components/ui";
 
 interface AgentExternalFilesSettingsProps {
   files: ExternalAgentFile[];
@@ -58,36 +59,35 @@ export function AgentExternalFilesSettings({ files, onChange }: AgentExternalFil
               className="settings-panel__file-item"
               data-testid="agent-external-file-row"
             >
-              <label className="settings-panel__toggle">
-                <input
-                  type="checkbox"
-                  checked={file.enabled}
-                  onChange={() => handleToggle(file.path)}
-                  data-testid="agent-external-file-toggle"
-                />
-                <span className="settings-panel__toggle-slider" />
-              </label>
+              <Toggle
+                checked={file.enabled}
+                onCheckedChange={() => handleToggle(file.path)}
+                aria-label={`Toggle ${file.path}`}
+                data-testid="agent-external-file-toggle"
+              />
               <span
                 className={`settings-panel__file-path settings-panel__file-path--rtl${!file.enabled ? " settings-panel__file-path--disabled" : ""}`}
                 title={file.path}
               >
                 {file.path}
               </span>
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 className="settings-panel__file-remove"
+                icon={<Trash2 size={14} />}
                 onClick={() => handleRemove(file.path)}
                 title="Remove file"
+                aria-label="Remove file"
                 data-testid="agent-external-file-remove"
-              >
-                <Trash2 size={14} />
-              </button>
+              />
             </li>
           ))}
         </ul>
       )}
 
       <div className="settings-form__list-row" style={{ marginTop: "var(--spacing-sm)" }}>
-        <input
+        <Input
           type="text"
           className="settings-form__list-input"
           value={newPath}
@@ -98,15 +98,16 @@ export function AgentExternalFilesSettings({ files, onChange }: AgentExternalFil
           placeholder="/home/user/team-connections.json"
           data-testid="agent-external-file-input"
         />
-        <button
-          className="settings-form__list-browse"
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={<Plus size={12} />}
           onClick={handleAdd}
           disabled={!newPath.trim()}
           data-testid="agent-external-file-add"
           title="Add external connection file path"
-        >
-          <Plus size={12} />
-        </button>
+          aria-label="Add external connection file path"
+        />
       </div>
     </div>
   );

--- a/src/components/ConnectionEditor/AgentSettingsForm.tsx
+++ b/src/components/ConnectionEditor/AgentSettingsForm.tsx
@@ -8,8 +8,16 @@
  */
 
 import { AgentCapabilities, AgentSettings } from "@/types/connection";
+import { Input, Select, Toggle } from "@/components/ui";
 
 const LOG_LEVELS = ["error", "warn", "info", "debug", "trace"] as const;
+
+/**
+ * Sentinel for the "auto-detect" shell option. Radix Select reserves the empty
+ * string to clear the selection, so an explicit non-empty value is required and
+ * mapped back to `null` (auto-detect) at the call site.
+ */
+const AUTO_DETECT_SHELL = "__auto__";
 
 interface AgentSettingsFormProps {
   settings: AgentSettings;
@@ -33,14 +41,11 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
         <div className="settings-form__field">
           <span className="settings-form__label">System Monitoring</span>
-          <label className="settings-panel__toggle">
-            <input
-              type="checkbox"
-              checked={settings.enableMonitoring}
-              onChange={(e) => update("enableMonitoring", e.target.checked)}
-            />
-            <span className="settings-panel__toggle-slider" />
-          </label>
+          <Toggle
+            checked={settings.enableMonitoring}
+            onCheckedChange={(v) => update("enableMonitoring", v)}
+            aria-label="System Monitoring"
+          />
           <span className="settings-form__hint">
             Collect CPU, memory, and disk usage from the remote host.
           </span>
@@ -48,14 +53,11 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
         <div className="settings-form__field">
           <span className="settings-form__label">File Browser (SFTP)</span>
-          <label className="settings-panel__toggle">
-            <input
-              type="checkbox"
-              checked={settings.enableFileBrowser}
-              onChange={(e) => update("enableFileBrowser", e.target.checked)}
-            />
-            <span className="settings-panel__toggle-slider" />
-          </label>
+          <Toggle
+            checked={settings.enableFileBrowser}
+            onCheckedChange={(v) => update("enableFileBrowser", v)}
+            aria-label="File Browser (SFTP)"
+          />
           <span className="settings-form__hint">
             Browse and transfer files on the remote host via SFTP.
           </span>
@@ -63,14 +65,11 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
         <div className="settings-form__field">
           <span className="settings-form__label">Docker Sessions</span>
-          <label className="settings-panel__toggle">
-            <input
-              type="checkbox"
-              checked={settings.enableDocker}
-              onChange={(e) => update("enableDocker", e.target.checked)}
-            />
-            <span className="settings-panel__toggle-slider" />
-          </label>
+          <Toggle
+            checked={settings.enableDocker}
+            onCheckedChange={(v) => update("enableDocker", v)}
+            aria-label="Docker Sessions"
+          />
           <span className="settings-form__hint">
             Open terminal sessions directly inside Docker containers on the remote host.
           </span>
@@ -94,19 +93,17 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
             )}
           </span>
           {isConnected ? (
-            <select
-              value={settings.defaultShell ?? ""}
-              onChange={(e) => update("defaultShell", e.target.value || null)}
-            >
-              <option value="">Auto-detect</option>
-              {availableShells.map((shell) => (
-                <option key={shell} value={shell}>
-                  {shell}
-                </option>
-              ))}
-            </select>
+            <Select
+              value={settings.defaultShell ?? AUTO_DETECT_SHELL}
+              onChange={(v) => update("defaultShell", v === AUTO_DETECT_SHELL ? null : v)}
+              options={[
+                { value: AUTO_DETECT_SHELL, label: "Auto-detect" },
+                ...availableShells.map((shell) => ({ value: shell, label: shell })),
+              ]}
+              aria-label="Default Shell"
+            />
           ) : (
-            <input
+            <Input
               type="text"
               placeholder="Auto-detect"
               value={settings.defaultShell ?? ""}
@@ -120,7 +117,7 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
         <label className="settings-form__field">
           <span className="settings-form__label">Starting Directory</span>
-          <input
+          <Input
             type="text"
             value={settings.startingDirectory}
             onChange={(e) => update("startingDirectory", e.target.value)}
@@ -137,7 +134,7 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
         <label className="settings-form__field">
           <span className="settings-form__label">Persistent Scrollback Buffer</span>
-          <input
+          <Input
             type="number"
             min={1}
             max={64}
@@ -162,16 +159,15 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
         <label className="settings-form__field">
           <span className="settings-form__label">Log Level</span>
-          <select
+          <Select
             value={settings.logLevel}
-            onChange={(e) => update("logLevel", e.target.value as AgentSettings["logLevel"])}
-          >
-            {LOG_LEVELS.map((level) => (
-              <option key={level} value={level}>
-                {level.charAt(0).toUpperCase() + level.slice(1)}
-              </option>
-            ))}
-          </select>
+            onChange={(v) => update("logLevel", v as AgentSettings["logLevel"])}
+            options={LOG_LEVELS.map((level) => ({
+              value: level,
+              label: level.charAt(0).toUpperCase() + level.slice(1),
+            }))}
+            aria-label="Log Level"
+          />
           <span className="settings-form__hint">
             Controls the verbosity of agent-side log output.
           </span>
@@ -179,14 +175,11 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
         <div className="settings-form__field">
           <span className="settings-form__label">Verbose Protocol Tracing</span>
-          <label className="settings-panel__toggle">
-            <input
-              type="checkbox"
-              checked={settings.verboseTracing}
-              onChange={(e) => update("verboseTracing", e.target.checked)}
-            />
-            <span className="settings-panel__toggle-slider" />
-          </label>
+          <Toggle
+            checked={settings.verboseTracing}
+            onCheckedChange={(v) => update("verboseTracing", v)}
+            aria-label="Verbose Protocol Tracing"
+          />
           <span className="settings-form__hint">
             Log every JSON-RPC message. Useful for debugging connection issues.
           </span>

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
@@ -1,11 +1,19 @@
 import { useAppStore } from "@/store/appStore";
 import { TerminalOptions, LineEnding } from "@/types/terminal";
 import { DEFAULT_LINE_ENDING, LINE_ENDING_OPTIONS, lineEndingLabel } from "@/utils/lineEndings";
+import { Input, Select, Toggle } from "@/components/ui";
 
 interface ConnectionTerminalSettingsProps {
   options: TerminalOptions;
   onChange: (options: TerminalOptions) => void;
 }
+
+/**
+ * Sentinel for the "use global default" option. Radix Select reserves the empty
+ * string to clear the selection, so an explicit non-empty value is required and
+ * mapped back to `undefined` (inherit the global setting) at the call site.
+ */
+const GLOBAL_DEFAULT = "__global__";
 
 export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerminalSettingsProps) {
   const globalSettings = useAppStore((s) => s.settings);
@@ -25,7 +33,7 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
 
       <label className="settings-form__field">
         <span className="settings-form__label">Font Family</span>
-        <input
+        <Input
           type="text"
           value={options.fontFamily ?? ""}
           onChange={(e) => onChange({ ...options, fontFamily: e.target.value || undefined })}
@@ -36,7 +44,7 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
 
       <label className="settings-form__field">
         <span className="settings-form__label">Font Size</span>
-        <input
+        <Input
           type="number"
           min={8}
           max={72}
@@ -52,7 +60,7 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
 
       <label className="settings-form__field">
         <span className="settings-form__label">Scrollback Buffer</span>
-        <input
+        <Input
           type="number"
           min={100}
           max={1000000}
@@ -74,40 +82,43 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
 
       <label className="settings-form__field">
         <span className="settings-form__label">Cursor Style</span>
-        <select
-          value={options.cursorStyle ?? ""}
-          onChange={(e) =>
+        <Select
+          value={options.cursorStyle ?? GLOBAL_DEFAULT}
+          onChange={(v) =>
             onChange({
               ...options,
-              cursorStyle: (e.target.value as "block" | "underline" | "bar") || undefined,
+              cursorStyle: v === GLOBAL_DEFAULT ? undefined : (v as "block" | "underline" | "bar"),
             })
           }
-        >
-          <option value="">Use global default ({globalCursorStyle})</option>
-          <option value="block">Block</option>
-          <option value="underline">Underline</option>
-          <option value="bar">Bar</option>
-        </select>
+          options={[
+            { value: GLOBAL_DEFAULT, label: `Use global default (${globalCursorStyle})` },
+            { value: "block", label: "Block" },
+            { value: "underline", label: "Underline" },
+            { value: "bar", label: "Bar" },
+          ]}
+          aria-label="Cursor Style"
+        />
       </label>
 
       <label className="settings-form__field">
         <span className="settings-form__label">Line Ending (Enter &amp; Paste)</span>
-        <select
-          value={options.lineEnding ?? ""}
-          onChange={(e) =>
+        <Select
+          value={options.lineEnding ?? GLOBAL_DEFAULT}
+          onChange={(v) =>
             onChange({
               ...options,
-              lineEnding: (e.target.value as LineEnding) || undefined,
+              lineEnding: v === GLOBAL_DEFAULT ? undefined : (v as LineEnding),
             })
           }
-        >
-          <option value="">Use global default ({lineEndingLabel(globalLineEnding)})</option>
-          {LINE_ENDING_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
+          options={[
+            {
+              value: GLOBAL_DEFAULT,
+              label: `Use global default (${lineEndingLabel(globalLineEnding)})`,
+            },
+            ...LINE_ENDING_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label })),
+          ]}
+          aria-label="Line Ending (Enter & Paste)"
+        />
         <span className="settings-form__hint">
           Sequence sent on Enter and used to normalize pasted text for this connection.
         </span>
@@ -115,14 +126,11 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
 
       <div className="settings-form__field">
         <span className="settings-form__label">Cursor Blink</span>
-        <label className="settings-panel__toggle">
-          <input
-            type="checkbox"
-            checked={options.cursorBlink ?? globalCursorBlink}
-            onChange={(e) => onChange({ ...options, cursorBlink: e.target.checked })}
-          />
-          <span className="settings-panel__toggle-slider" />
-        </label>
+        <Toggle
+          checked={options.cursorBlink ?? globalCursorBlink}
+          onCheckedChange={(v) => onChange({ ...options, cursorBlink: v })}
+          aria-label="Cursor Blink"
+        />
         <span className="settings-form__hint">
           Whether the terminal cursor blinks.
           {options.cursorBlink != null && (
@@ -139,14 +147,11 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
 
       <div className="settings-form__field">
         <span className="settings-form__label">Horizontal Scrolling</span>
-        <label className="settings-panel__toggle">
-          <input
-            type="checkbox"
-            checked={options.horizontalScrolling ?? globalHorizontalScrolling}
-            onChange={(e) => onChange({ ...options, horizontalScrolling: e.target.checked })}
-          />
-          <span className="settings-panel__toggle-slider" />
-        </label>
+        <Toggle
+          checked={options.horizontalScrolling ?? globalHorizontalScrolling}
+          onCheckedChange={(v) => onChange({ ...options, horizontalScrolling: v })}
+          aria-label="Horizontal Scrolling"
+        />
         <span className="settings-form__hint">
           Enable horizontal scrolling for this connection.
           {options.horizontalScrolling != null && (

--- a/src/components/ConnectionEditor/JumpHostEntry.tsx
+++ b/src/components/ConnectionEditor/JumpHostEntry.tsx
@@ -2,6 +2,7 @@ import type { JumpHostConfig } from "@/types/connection";
 import type { SavedConnectionOption } from "@/utils/jumpHost";
 import { KeyPathInput } from "@/components/Settings/KeyPathInput";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
+import { Input, Select, SelectItem } from "@/components/ui";
 
 interface JumpHostEntryProps {
   /** The hop being edited. */
@@ -80,24 +81,27 @@ export function JumpHostEntry({ hop, index, onChange, savedConnections }: JumpHo
       {mode === "saved" ? (
         <div className="settings-form__field">
           <span className="settings-form__label">Connection</span>
-          <select
+          <Select
             value={hop.connectionId ?? ""}
-            onChange={(e) => onChange({ connectionId: e.target.value })}
+            onChange={(v) => onChange({ connectionId: v })}
+            aria-label="Connection"
             data-testid={tid("connection")}
           >
-            {refMissing && <option value={hop.connectionId}>{hop.connectionId} (not found)</option>}
+            {refMissing && (
+              <SelectItem value={hop.connectionId ?? ""}>{hop.connectionId} (not found)</SelectItem>
+            )}
             {savedConnections.map((opt) => (
-              <option key={opt.id} value={opt.id}>
+              <SelectItem key={opt.id} value={opt.id}>
                 {opt.label}
-              </option>
+              </SelectItem>
             ))}
-          </select>
+          </Select>
         </div>
       ) : (
         <>
           <div className="settings-form__field">
             <span className="settings-form__label">Host</span>
-            <input
+            <Input
               type="text"
               value={hop.host}
               onChange={(e) => onChange({ host: e.target.value })}
@@ -108,7 +112,7 @@ export function JumpHostEntry({ hop, index, onChange, savedConnections }: JumpHo
 
           <div className="settings-form__field">
             <span className="settings-form__label">Port</span>
-            <input
+            <Input
               type="number"
               value={hop.port}
               min={1}
@@ -122,7 +126,7 @@ export function JumpHostEntry({ hop, index, onChange, savedConnections }: JumpHo
 
           <div className="settings-form__field">
             <span className="settings-form__label">Username</span>
-            <input
+            <Input
               type="text"
               value={hop.username}
               onChange={(e) => onChange({ username: e.target.value })}
@@ -133,17 +137,13 @@ export function JumpHostEntry({ hop, index, onChange, savedConnections }: JumpHo
 
           <div className="settings-form__field">
             <span className="settings-form__label">Auth Method</span>
-            <select
+            <Select
               value={hop.authMethod}
-              onChange={(e) => onChange({ authMethod: e.target.value })}
+              onChange={(v) => onChange({ authMethod: v })}
+              options={AUTH_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label }))}
+              aria-label="Auth Method"
               data-testid={tid("auth-method")}
-            >
-              {AUTH_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+            />
           </div>
 
           {hop.authMethod === "key" && (
@@ -174,7 +174,7 @@ export function JumpHostEntry({ hop, index, onChange, savedConnections }: JumpHo
 
       <div className="settings-form__field">
         <span className="settings-form__label">Connect Timeout (s)</span>
-        <input
+        <Input
           type="number"
           value={hop.connectTimeoutSecs ?? ""}
           min={1}

--- a/src/components/ConnectionEditor/JumpHostSection.test.tsx
+++ b/src/components/ConnectionEditor/JumpHostSection.test.tsx
@@ -80,14 +80,32 @@ function render(
   });
 }
 
-/** Set a value on a React-controlled <input>/<select> and fire the native event. */
-function setValue(el: HTMLInputElement | HTMLSelectElement, value: string, event = "input") {
-  const proto =
-    el instanceof HTMLSelectElement ? HTMLSelectElement.prototype : HTMLInputElement.prototype;
-  const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+/** Set a value on a React-controlled <input> and fire the native input event. */
+function setValue(el: HTMLInputElement, value: string, event = "input") {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
   act(() => {
     setter?.call(el, value);
     el.dispatchEvent(new Event(event, { bubbles: true }));
+  });
+}
+
+/**
+ * Select an option in a shared {@link Select} (Radix) primitive addressed by
+ * its trigger test id. Opens via the keyboard path (mirrors ui/Select.test.tsx,
+ * which avoids the pointer-capture jsdom gap), then clicks the option whose text
+ * matches `label`.
+ */
+function selectOption(triggerTestId: string, label: string) {
+  const trigger = query(triggerTestId) as HTMLButtonElement;
+  act(() => {
+    trigger.focus();
+    trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+  });
+  const option = Array.from(document.querySelectorAll('[role="option"]')).find((o) =>
+    o.textContent?.includes(label)
+  ) as HTMLElement | undefined;
+  act(() => {
+    option?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
 }
 
@@ -141,7 +159,7 @@ describe("JumpHostSection", () => {
     expect((query("jump-host-host-0") as HTMLInputElement).value).toBe("bastion.example.com");
     expect((query("jump-host-port-0") as HTMLInputElement).value).toBe("2222");
     expect((query("jump-host-username-0") as HTMLInputElement).value).toBe("admin");
-    expect((query("jump-host-auth-method-0") as HTMLSelectElement).value).toBe("key");
+    expect(query("jump-host-auth-method-0")?.getAttribute("data-value")).toBe("key");
     expect(query("jump-host-key-path-0")).toBeTruthy();
     expect(query("jump-host-password-0")).toBeNull();
     // A single hop is not wrapped in a numbered card.
@@ -170,7 +188,7 @@ describe("JumpHostSection", () => {
   it("switching auth method merges into the hop", () => {
     const onChange = vi.fn();
     render([HOP], onChange);
-    setValue(query("jump-host-auth-method-0") as HTMLSelectElement, "password", "change");
+    selectOption("jump-host-auth-method-0", "Password");
     expect(onChange).toHaveBeenCalledWith([{ ...HOP, authMethod: "password" }]);
   });
 
@@ -313,16 +331,16 @@ describe("JumpHostSection", () => {
 
   it("renders the dropdown (not inline fields) for a saved-connection hop", () => {
     render([{ ...HOP, connectionId: "Work/bastion" }], vi.fn(), { savedConnections: OPTIONS });
-    const select = query("jump-host-connection-0") as HTMLSelectElement;
+    const select = query("jump-host-connection-0");
     expect(select).toBeTruthy();
-    expect(select.value).toBe("Work/bastion");
+    expect(select?.getAttribute("data-value")).toBe("Work/bastion");
     expect(query("jump-host-host-0")).toBeNull();
   });
 
   it("picking a different connection updates connectionId", () => {
     const onChange = vi.fn();
     render([{ ...HOP, connectionId: "Work/bastion" }], onChange, { savedConnections: OPTIONS });
-    setValue(query("jump-host-connection-0") as HTMLSelectElement, "Work/edge", "change");
+    selectOption("jump-host-connection-0", "Work / edge");
     expect(onChange).toHaveBeenCalledWith([{ ...HOP, connectionId: "Work/edge" }]);
   });
 
@@ -337,7 +355,9 @@ describe("JumpHostSection", () => {
 
   it("shows a 'not found' option for a reference whose connection is gone", () => {
     render([{ ...HOP, connectionId: "deleted-id" }], vi.fn(), { savedConnections: OPTIONS });
-    const select = query("jump-host-connection-0") as HTMLSelectElement;
-    expect(select.textContent).toContain("not found");
+    // The Select trigger renders the selected item's label, which for a missing
+    // reference is the synthesized "<id> (not found)" entry.
+    const select = query("jump-host-connection-0");
+    expect(select?.textContent).toContain("not found");
   });
 });

--- a/src/components/WorkspaceEditor/WorkspaceEditor.css
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.css
@@ -116,14 +116,13 @@
   user-select: none;
 }
 
+/*
+ * Sizing-only override for the inline rename input; the borderless/transparent
+ * skin (no border/background, inherited font/color) comes from the `inline`
+ * variant of the shared Input primitive (.ui-input--inline).
+ */
 .workspace-group-chip__rename-input {
   width: 80px;
-  border: none;
-  background: transparent;
-  color: var(--text-primary);
-  font-size: 12px;
-  outline: none;
-  padding: 0;
 }
 
 .workspace-group-chip__close {

--- a/src/components/WorkspaceEditor/WorkspaceEditor.tsx
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.tsx
@@ -214,7 +214,8 @@ export function WorkspaceEditor({ tabId, meta, isVisible }: WorkspaceEditorProps
                   data-testid={`workspace-group-chip-${index}`}
                 >
                   {renamingGroupIndex === index ? (
-                    <input
+                    <Input
+                      inline
                       autoFocus
                       className="workspace-group-chip__rename-input"
                       value={renameValue}

--- a/src/components/ui/Input.test.tsx
+++ b/src/components/ui/Input.test.tsx
@@ -55,4 +55,24 @@ describe("Input", () => {
     expect(input.value).toBe("hello");
     expect(input.placeholder).toBe("host");
   });
+
+  it("does not apply the inline modifier by default", () => {
+    render(<Input data-testid="in" />);
+    const input = document.querySelector('[data-testid="in"]') as HTMLInputElement;
+    expect(input.classList.contains("ui-input--inline")).toBe(false);
+  });
+
+  it("applies the inline modifier when inline is set", () => {
+    render(<Input data-testid="in" inline />);
+    const input = document.querySelector('[data-testid="in"]') as HTMLInputElement;
+    expect(input.classList.contains("ui-input")).toBe(true);
+    expect(input.classList.contains("ui-input--inline")).toBe(true);
+  });
+
+  it("keeps the error modifier alongside the inline modifier", () => {
+    render(<Input data-testid="in" inline error />);
+    const input = document.querySelector('[data-testid="in"]') as HTMLInputElement;
+    expect(input.classList.contains("ui-input--inline")).toBe(true);
+    expect(input.classList.contains("ui-input--error")).toBe(true);
+  });
 });

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -9,6 +9,13 @@ import "./ui.css";
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   /** Render the error state (red border) and set `aria-invalid`. */
   error?: boolean;
+  /**
+   * Drop the border, background, and fixed height so the input inherits the
+   * surrounding container's styling. Use for borderless inline editing (e.g. a
+   * rename input inside a pill chip) where the standard bordered skin would
+   * break the layout. Focus/keyboard behavior is unchanged.
+   */
+  inline?: boolean;
   /** Test hook forwarded to the DOM node. */
   "data-testid"?: string;
 }
@@ -18,12 +25,21 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
  * `--border-primary`, focus ring via `--shadow-focus`); the `error` prop flips
  * the border to `--color-error`. Compose it inside a {@link Field} to get a
  * label and inline validation message.
+ *
+ * The `inline` variant drops the border/background/height so the input blends
+ * into a surrounding element (e.g. an inline rename affordance), inheriting its
+ * font and color while keeping the primitive's focus/keyboard behavior.
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { error = false, type, className, ...rest },
+  { error = false, inline = false, type, className, ...rest },
   ref
 ) {
-  const classes = ["ui-input", error ? "ui-input--error" : "", className ?? ""]
+  const classes = [
+    "ui-input",
+    inline ? "ui-input--inline" : "",
+    error ? "ui-input--error" : "",
+    className ?? "",
+  ]
     .filter(Boolean)
     .join(" ");
 

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -161,6 +161,30 @@
   box-shadow: var(--shadow-focus);
 }
 
+/*
+ * Borderless inline variant: blends into a surrounding element (e.g. a rename
+ * input inside a pill chip). Drops the border, background, fixed height, and
+ * horizontal padding so it inherits the container's font/color; keeps the
+ * primitive's focus behavior but suppresses the ring/border since the ambient
+ * container already communicates focus context.
+ */
+.ui-input--inline {
+  height: auto;
+  width: auto;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+}
+
+.ui-input--inline:focus {
+  border: none;
+  box-shadow: none;
+}
+
 /* ── Field ──────────────────────────────────────────────────────────── */
 .ui-field {
   display: flex;

--- a/src/styles/tokenDiscipline.test.ts
+++ b/src/styles/tokenDiscipline.test.ts
@@ -74,17 +74,14 @@ const WHITE_ALLOWLIST: string[] = [];
  * primitive (tracked by follow-up issues), its entry is removed here. The guard's
  * value is the ratchet — a currently-clean file that reintroduces `__btn` FAILS.
  *
- * ConnectionEditor / TunnelEditor / WorkspaceEditor are being migrated in a
- * parallel PR (#1085); leaving them allowlisted here is harmless (over-permissive)
- * until that lands. Do NOT assert this list has no stale entries — that would
+ * ConnectionEditor / TunnelEditor / WorkspaceEditor were migrated onto the
+ * `Button` primitive in #1085 and #1094; their now-clean entries were removed
+ * from this list. Do NOT assert this list has no stale entries — that would
  * cause cross-PR breakage.
  *
  * Paths are repo-relative suffixes (POSIX separators), matched with `endsWith`.
  */
 const BESPOKE_BTN_ALLOWLIST: string[] = [
-  "ConnectionEditor/ConnectionAppearanceSettings.tsx",
-  "ConnectionEditor/ConnectionEditor.css",
-  "ConnectionEditor/ConnectionEditor.tsx",
   "NetworkTools/DnsLookupPanel.tsx",
   "NetworkTools/HttpMonitorPanel.tsx",
   "NetworkTools/NetworkTools.css",
@@ -106,12 +103,8 @@ const BESPOKE_BTN_ALLOWLIST: string[] = [
   "Sidebar/FileBrowser.tsx",
   "Terminal/TerminalSearchBar.css",
   "Terminal/TerminalSearchBar.tsx",
-  "TunnelEditor/TunnelEditor.css",
-  "TunnelEditor/TunnelEditor.tsx",
   "UpdateNotification/UpdateNotification.css",
   "UpdateNotification/UpdateNotification.tsx",
-  "WorkspaceEditor/WorkspaceEditor.css",
-  "WorkspaceEditor/WorkspaceEditor.tsx",
 ];
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #1085 — migrates the last bespoke native controls in the editor area onto the shared `src/components/ui/` primitives.

- **ConnectionEditor subcomponents** — `JumpHostEntry`, `AgentSettingsForm`, `ConnectionTerminalSettings`, `AgentExternalFilesSettings`: native `<select>`/`<input>`/checkbox/`<button>` → `Select`/`Input`/`Field`/`Toggle`/`Button`.
- **New `Input` variant** — added a borderless `inline` prop to the `Input` primitive (drops border/background/height, inherits host styling, keeps focus/keyboard behavior) for inline-edit affordances.
- **WorkspaceEditor group-chip rename input** → the new `inline` Input (was a bespoke `workspace-group-chip__rename-input`); Enter/Escape/blur behavior and the `workspace-group-rename-input-${index}` testid preserved.
- **Radix empty-value fix** — "use global default"/"auto-detect" `<select>` sentinels used empty-string values, which Radix `Select` forbids; replaced with non-empty tokens (`__global__`/`__auto__`) mapped back to `undefined`/`null` at the call site.
- **Tightened the #1083 `__btn` ratchet** — removed the ConnectionEditor/TunnelEditor/WorkspaceEditor allowlist entries that became clean when #1085 merged.

## Behavior notes
- Toggles are now accessible Radix switches; selects are the Radix-based `Select` (system-test bridge already supports them via `data-value`).
- Left intentionally native (token-clean, not Button-primitive concerns): the `jump-host__source-opt` `role="radio"` segmented control and the "Reset to global default" inline text-link affordances.

## Test plan
- Full suite: **2112 tests / 172 files** pass; `pnpm build`, lint, format:check clean.
- New inline-variant tests in `Input.test.tsx`; `JumpHostSection.test.tsx` updated for the Radix `Select`.
- No `data-testid` values changed (catalog unchanged).

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)