### PR TITLE
feat(backend): detect-and-guide Linux X server edge cases (Closes #1055)

### DIFF
--- a/docs/changes/feature/1055-linux-x-detect-guide.md
+++ b/docs/changes/feature/1055-linux-x-detect-guide.md
@@ -1,0 +1,8 @@
+### Added
+
+- Linux SSH X11 forwarding: when no local X server can be reached, termiHub now
+  surfaces a targeted, actionable hint instead of a generic failure — install
+  `xwayland` on a Wayland session that lacks it, guidance for a headless system
+  (graphical session / Xvfb), or the `--socket=x11` / `--socket=fallback-x11`
+  grant when a Flatpak/Snap sandbox is hiding the host X socket. A normal
+  graphical desktop is unaffected (#1055, epic #1047).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -868,6 +868,31 @@ To verify SSH tunnels actually work on macOS, do this manually against the tunne
 4. Confirm the tunnel reaches a running state (sidebar shows Stop control) and `curl http://127.0.0.1:18083` returns `TUNNEL_TEST_OK`.
 5. Click **Stop** and confirm the tunnel returns to disconnected and the Start control reappears.
 
+#### Linux X server detect-and-guide edge cases (#1055)
+
+The Linux X-server gap classifier (`src-tauri/src/terminal/xserver/linux_gap.rs`)
+turns an unreachable-server failure into a targeted hint. The classification is
+covered exhaustively by unit tests (fixtures → gap → error), but confirming the
+hint actually surfaces in a real edge-case environment is manual. A normal
+graphical desktop must be unaffected (server adopted, no prompt).
+
+To verify the **Wayland-without-XWayland** hint (the headline case):
+
+1. On a Wayland-only VM/session, ensure XWayland is not installed and no X
+   socket exists: `ls /tmp/.X11-unix` is empty and `echo $DISPLAY` is unset.
+2. In termiHub, open an SSH connection with **X11 forwarding** enabled.
+3. Confirm the connect surfaces the **XWayland** dependency hint (install
+   `xwayland`, then reconnect) — not a generic "no display" error.
+
+Optional additional cases:
+
+- **Headless:** on a box with no local display (no `DISPLAY`, no
+  `/tmp/.X11-unix`, no `Xorg`/`Xwayland`), connect with X11 forwarding and
+  confirm the headless hint (graphical session / Xvfb) appears.
+- **Sandboxed socket:** run termiHub as a Flatpak/Snap without the X socket
+  granted; confirm the hint names the `--socket=x11` / `--socket=fallback-x11`
+  grant.
+
 ### Legacy Guided Manual Test Runner (YAML)
 
 The remaining manual test items are still defined as machine-readable YAML in [`tests/manual/*.yaml`](../tests/manual/). The standalone runner presents applicable tests one at a time, manages infrastructure, and generates a JSON report. It is being subsumed by the harness flow above:

--- a/src-tauri/src/terminal/xserver/linux_gap.rs
+++ b/src-tauri/src/terminal/xserver/linux_gap.rs
@@ -67,6 +67,59 @@ impl LinuxXEnv {
     fn has_x_server_binary(&self) -> bool {
         self.xorg_on_path || self.xwayland_on_path
     }
+
+    /// Snapshot the real Linux environment. The only side-effecting entry point;
+    /// classification itself stays pure over the returned value.
+    pub fn detect() -> Self {
+        LinuxXEnv {
+            display: env_nonempty("DISPLAY"),
+            wayland_display: env_nonempty("WAYLAND_DISPLAY"),
+            xdg_session_type: env_nonempty("XDG_SESSION_TYPE"),
+            x11_socket_present: x11_socket_present(),
+            xwayland_on_path: binary_on_path("Xwayland"),
+            xorg_on_path: binary_on_path("Xorg"),
+            sandbox: detect_sandbox(),
+        }
+    }
+}
+
+/// Read an environment variable, treating empty as unset.
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+/// Whether `/tmp/.X11-unix` holds at least one `X<N>` server socket.
+fn x11_socket_present() -> bool {
+    let dir = std::path::Path::new("/tmp/.X11-unix");
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_string_lossy()
+            .strip_prefix('X')
+            .is_some_and(|rest| rest.parse::<u32>().is_ok())
+    })
+}
+
+/// Whether `name` resolves to a file on `PATH` (best-effort).
+fn binary_on_path(name: &str) -> bool {
+    let Ok(path) = std::env::var("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(name).exists())
+}
+
+/// Detect the sandbox termiHub is confined by, if any.
+fn detect_sandbox() -> SandboxKind {
+    if std::env::var_os("FLATPAK_ID").is_some() || std::path::Path::new("/.flatpak-info").exists() {
+        SandboxKind::Flatpak
+    } else if std::env::var_os("SNAP").is_some() {
+        SandboxKind::Snap
+    } else {
+        SandboxKind::None
+    }
 }
 
 /// A specific, actionable reason SSH X11 forwarding can't reach a local X server.
@@ -90,14 +143,58 @@ pub enum LinuxXGap {
 /// orchestrator's adopt/reuse/spawn and cross-platform detection have all come
 /// up empty — so a "normal desktop" never reaches here.
 pub fn classify(env: &LinuxXEnv) -> LinuxXGap {
-    let _ = env;
-    todo!("gap classification implemented in the follow-up commit (#1055)")
+    // 1. A sandbox is hiding the host socket: we're confined, no socket is
+    //    visible, yet a compositor/server clearly exists (graphical session or
+    //    an installed binary). Checked first — the real fix is a socket grant,
+    //    not installing anything.
+    if env.sandbox != SandboxKind::None
+        && !env.x11_socket_present
+        && (env.is_wayland() || env.is_x11_session() || env.has_x_server_binary())
+    {
+        return LinuxXGap::SandboxSocketHidden;
+    }
+
+    // 2. Wayland session with no XWayland and no X socket → the one case where
+    //    Linux genuinely needs a package installed to forward X11.
+    if env.is_wayland() && !env.xwayland_on_path && !env.x11_socket_present {
+        return LinuxXGap::WaylandWithoutXwayland;
+    }
+
+    // 3. A socket exists but earlier probes couldn't connect → present but
+    //    unreachable (misconfigured/permission), not missing.
+    if env.x11_socket_present {
+        return LinuxXGap::ServerUnreachable;
+    }
+
+    // 4. No display, no graphical session, and no server binary → headless box.
+    if env.display.is_none()
+        && !env.is_wayland()
+        && !env.is_x11_session()
+        && !env.has_x_server_binary()
+    {
+        return LinuxXGap::Headless;
+    }
+
+    // 5. A server binary (or a live graphical session) exists but nothing was
+    //    reachable → unreachable rather than missing.
+    if env.has_x_server_binary() || env.is_wayland() {
+        return LinuxXGap::ServerUnreachable;
+    }
+
+    // 6. A session/display is claimed but no server binary and no socket back it.
+    LinuxXGap::MissingXServer
 }
 
 impl LinuxXGap {
     /// Map the gap to a typed, actionable [`XServerError`] for the UI.
     pub fn to_error(self) -> XServerError {
-        todo!("gap-to-error mapping implemented in the follow-up commit (#1055)")
+        match self {
+            LinuxXGap::SandboxSocketHidden => XServerError::linux_sandbox_socket_hidden(),
+            LinuxXGap::WaylandWithoutXwayland => XServerError::linux_xwayland_missing(),
+            LinuxXGap::Headless => XServerError::linux_headless(),
+            LinuxXGap::MissingXServer => XServerError::linux_x_missing(),
+            LinuxXGap::ServerUnreachable => XServerError::linux_server_unreachable(),
+        }
     }
 }
 

--- a/src-tauri/src/terminal/xserver/linux_gap.rs
+++ b/src-tauri/src/terminal/xserver/linux_gap.rs
@@ -76,9 +76,24 @@ impl LinuxXEnv {
             wayland_display: env_nonempty("WAYLAND_DISPLAY"),
             xdg_session_type: env_nonempty("XDG_SESSION_TYPE"),
             x11_socket_present: x11_socket_present(),
-            xwayland_on_path: binary_on_path("Xwayland"),
-            xorg_on_path: binary_on_path("Xorg"),
+            xwayland_on_path: super::binary_on_path("Xwayland"),
+            xorg_on_path: super::binary_on_path("Xorg"),
             sandbox: detect_sandbox(),
+        }
+    }
+
+    /// A neutral snapshot with nothing present, for non-Linux callers that must
+    /// pass a [`LinuxXEnv`] the Linux-specific classification never consumes.
+    /// Avoids the filesystem/PATH scans of [`detect`](Self::detect) off Linux.
+    pub fn unknown() -> Self {
+        LinuxXEnv {
+            display: None,
+            wayland_display: None,
+            xdg_session_type: None,
+            x11_socket_present: false,
+            xwayland_on_path: false,
+            xorg_on_path: false,
+            sandbox: SandboxKind::None,
         }
     }
 }
@@ -101,14 +116,6 @@ fn x11_socket_present() -> bool {
             .strip_prefix('X')
             .is_some_and(|rest| rest.parse::<u32>().is_ok())
     })
-}
-
-/// Whether `name` resolves to a file on `PATH` (best-effort).
-fn binary_on_path(name: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path).any(|dir| dir.join(name).exists())
 }
 
 /// Detect the sandbox termiHub is confined by, if any.
@@ -143,27 +150,26 @@ pub enum LinuxXGap {
 /// orchestrator's adopt/reuse/spawn and cross-platform detection have all come
 /// up empty — so a "normal desktop" never reaches here.
 pub fn classify(env: &LinuxXEnv) -> LinuxXGap {
-    // 1. A sandbox is hiding the host socket: we're confined, no socket is
+    // 1. A live socket exists but earlier probes couldn't connect → present but
+    //    unreachable (misconfigured/permission), not missing. Checked first so
+    //    the remaining guards all operate on the known socket-absent world.
+    if env.x11_socket_present {
+        return LinuxXGap::ServerUnreachable;
+    }
+
+    // 2. A sandbox is hiding the host socket: we're confined and no socket is
     //    visible, yet a compositor/server clearly exists (graphical session or
-    //    an installed binary). Checked first — the real fix is a socket grant,
-    //    not installing anything.
+    //    an installed binary). The real fix is a socket grant, not an install.
     if env.sandbox != SandboxKind::None
-        && !env.x11_socket_present
         && (env.is_wayland() || env.is_x11_session() || env.has_x_server_binary())
     {
         return LinuxXGap::SandboxSocketHidden;
     }
 
-    // 2. Wayland session with no XWayland and no X socket → the one case where
-    //    Linux genuinely needs a package installed to forward X11.
-    if env.is_wayland() && !env.xwayland_on_path && !env.x11_socket_present {
+    // 3. Wayland session with no XWayland → the one case where Linux genuinely
+    //    needs a package installed to forward X11.
+    if env.is_wayland() && !env.xwayland_on_path {
         return LinuxXGap::WaylandWithoutXwayland;
-    }
-
-    // 3. A socket exists but earlier probes couldn't connect → present but
-    //    unreachable (misconfigured/permission), not missing.
-    if env.x11_socket_present {
-        return LinuxXGap::ServerUnreachable;
     }
 
     // 4. No display, no graphical session, and no server binary → headless box.
@@ -175,9 +181,9 @@ pub fn classify(env: &LinuxXEnv) -> LinuxXGap {
         return LinuxXGap::Headless;
     }
 
-    // 5. A server binary (or a live graphical session) exists but nothing was
-    //    reachable → unreachable rather than missing.
-    if env.has_x_server_binary() || env.is_wayland() {
+    // 5. A server binary exists (incl. a Wayland session that got past guard 3
+    //    because XWayland is installed) but nothing was reachable → unreachable.
+    if env.has_x_server_binary() {
         return LinuxXGap::ServerUnreachable;
     }
 

--- a/src-tauri/src/terminal/xserver/linux_gap.rs
+++ b/src-tauri/src/terminal/xserver/linux_gap.rs
@@ -1,0 +1,297 @@
+//! Linux X-server gap classification (#1055).
+//!
+//! On Linux termiHub never bundles or installs an X server: Xorg/XWayland is
+//! essentially always present and the orchestrator adopts it. This module
+//! handles only the *edge cases* where forwarding can't reach a local server,
+//! turning a generic "no display" failure into a targeted, actionable hint:
+//!
+//! - **Wayland-only without XWayland** — a Wayland session with no XWayland and
+//!   no X socket: forwarding needs an X server, so guide the `xwayland` install.
+//! - **Headless** — no local display at all: X11 forwarding has nowhere to
+//!   render; suggest a graphical session or a virtual framebuffer.
+//! - **Sandboxed socket** — running inside Flatpak/Snap that isn't exposing the
+//!   host X socket: guide the `--socket=x11` / `--socket=fallback-x11` grant.
+//!
+//! Classification is a pure function over an injected [`LinuxXEnv`] snapshot, so
+//! every case is unit-testable from fixtures on any CI host; only
+//! [`LinuxXEnv::detect`] touches the real environment.
+
+use super::types::XServerError;
+
+/// Sandbox runtime termiHub might be executing inside, which can hide the host
+/// X socket from the process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxKind {
+    /// Not sandboxed (normal host process).
+    None,
+    /// Flatpak sandbox (`FLATPAK_ID` / `/.flatpak-info`).
+    Flatpak,
+    /// Snap confinement (`SNAP` environment).
+    Snap,
+}
+
+/// An injected snapshot of the Linux X situation, so classification stays pure.
+///
+/// Built from the real environment by [`LinuxXEnv::detect`]; constructed
+/// directly in tests to exercise each gap.
+#[derive(Debug, Clone)]
+pub struct LinuxXEnv {
+    /// `DISPLAY` value, if set and non-empty.
+    pub display: Option<String>,
+    /// `WAYLAND_DISPLAY` value, if set and non-empty.
+    pub wayland_display: Option<String>,
+    /// `XDG_SESSION_TYPE` (`wayland` / `x11` / `tty`), if set and non-empty.
+    pub xdg_session_type: Option<String>,
+    /// Whether `/tmp/.X11-unix` holds at least one `X<N>` server socket.
+    pub x11_socket_present: bool,
+    /// Whether an `Xwayland` binary is on `PATH`.
+    pub xwayland_on_path: bool,
+    /// Whether an `Xorg` binary is on `PATH`.
+    pub xorg_on_path: bool,
+    /// The sandbox termiHub is running under, if any.
+    pub sandbox: SandboxKind,
+}
+
+impl LinuxXEnv {
+    /// True if this looks like a Wayland session.
+    fn is_wayland(&self) -> bool {
+        self.wayland_display.is_some() || self.xdg_session_type.as_deref() == Some("wayland")
+    }
+
+    /// True if `XDG_SESSION_TYPE` explicitly claims an X11 session.
+    fn is_x11_session(&self) -> bool {
+        self.xdg_session_type.as_deref() == Some("x11")
+    }
+
+    /// True if any local X-server binary is installed.
+    fn has_x_server_binary(&self) -> bool {
+        self.xorg_on_path || self.xwayland_on_path
+    }
+}
+
+/// A specific, actionable reason SSH X11 forwarding can't reach a local X server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinuxXGap {
+    /// A sandbox (Flatpak/Snap) is hiding the host X socket.
+    SandboxSocketHidden,
+    /// A Wayland session with no XWayland and no X socket.
+    WaylandWithoutXwayland,
+    /// No local display at all (headless box).
+    Headless,
+    /// No X server (Xorg/XWayland) is installed.
+    MissingXServer,
+    /// A server appears present but no display was reachable.
+    ServerUnreachable,
+}
+
+/// Classify why no local X server was reachable, given an environment snapshot.
+///
+/// Pure and side-effect-free. Only called on the failure path, after the
+/// orchestrator's adopt/reuse/spawn and cross-platform detection have all come
+/// up empty — so a "normal desktop" never reaches here.
+pub fn classify(env: &LinuxXEnv) -> LinuxXGap {
+    let _ = env;
+    todo!("gap classification implemented in the follow-up commit (#1055)")
+}
+
+impl LinuxXGap {
+    /// Map the gap to a typed, actionable [`XServerError`] for the UI.
+    pub fn to_error(self) -> XServerError {
+        todo!("gap-to-error mapping implemented in the follow-up commit (#1055)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A base snapshot representing an unremarkable, fully-present desktop; each
+    /// test overrides only the fields that define its gap.
+    fn base() -> LinuxXEnv {
+        LinuxXEnv {
+            display: Some(":0".to_string()),
+            wayland_display: None,
+            xdg_session_type: Some("x11".to_string()),
+            x11_socket_present: true,
+            xwayland_on_path: true,
+            xorg_on_path: true,
+            sandbox: SandboxKind::None,
+        }
+    }
+
+    // ----- classify: one fixture per gap ------------------------------------
+
+    #[test]
+    fn wayland_session_without_xwayland_or_socket_is_wayland_gap() {
+        let env = LinuxXEnv {
+            display: None,
+            wayland_display: Some("wayland-0".to_string()),
+            xdg_session_type: Some("wayland".to_string()),
+            x11_socket_present: false,
+            xwayland_on_path: false,
+            xorg_on_path: false,
+            ..base()
+        };
+        assert_eq!(classify(&env), LinuxXGap::WaylandWithoutXwayland);
+    }
+
+    #[test]
+    fn flatpak_hiding_socket_in_wayland_session_is_sandbox_gap() {
+        // Sandbox takes precedence: a compositor is clearly up (Wayland) but the
+        // X socket isn't visible to the confined process.
+        let env = LinuxXEnv {
+            display: None,
+            wayland_display: Some("wayland-0".to_string()),
+            xdg_session_type: Some("wayland".to_string()),
+            x11_socket_present: false,
+            xwayland_on_path: true,
+            xorg_on_path: false,
+            sandbox: SandboxKind::Flatpak,
+        };
+        assert_eq!(classify(&env), LinuxXGap::SandboxSocketHidden);
+    }
+
+    #[test]
+    fn snap_hiding_socket_in_x11_session_is_sandbox_gap() {
+        let env = LinuxXEnv {
+            display: Some(":0".to_string()),
+            wayland_display: None,
+            xdg_session_type: Some("x11".to_string()),
+            x11_socket_present: false,
+            xwayland_on_path: false,
+            xorg_on_path: true,
+            sandbox: SandboxKind::Snap,
+        };
+        assert_eq!(classify(&env), LinuxXGap::SandboxSocketHidden);
+    }
+
+    #[test]
+    fn no_display_no_session_no_binaries_is_headless() {
+        let env = LinuxXEnv {
+            display: None,
+            wayland_display: None,
+            xdg_session_type: Some("tty".to_string()),
+            x11_socket_present: false,
+            xwayland_on_path: false,
+            xorg_on_path: false,
+            sandbox: SandboxKind::None,
+        };
+        assert_eq!(classify(&env), LinuxXGap::Headless);
+    }
+
+    #[test]
+    fn unset_session_with_nothing_present_is_headless() {
+        let env = LinuxXEnv {
+            display: None,
+            wayland_display: None,
+            xdg_session_type: None,
+            x11_socket_present: false,
+            xwayland_on_path: false,
+            xorg_on_path: false,
+            sandbox: SandboxKind::None,
+        };
+        assert_eq!(classify(&env), LinuxXGap::Headless);
+    }
+
+    #[test]
+    fn x11_session_without_any_server_binary_or_socket_is_missing() {
+        let env = LinuxXEnv {
+            display: Some(":0".to_string()),
+            wayland_display: None,
+            xdg_session_type: Some("x11".to_string()),
+            x11_socket_present: false,
+            xwayland_on_path: false,
+            xorg_on_path: false,
+            sandbox: SandboxKind::None,
+        };
+        assert_eq!(classify(&env), LinuxXGap::MissingXServer);
+    }
+
+    #[test]
+    fn live_socket_present_is_unreachable() {
+        // A socket exists but earlier probes failed to connect → unreachable.
+        let env = LinuxXEnv {
+            x11_socket_present: true,
+            ..base()
+        };
+        assert_eq!(classify(&env), LinuxXGap::ServerUnreachable);
+    }
+
+    #[test]
+    fn xwayland_installed_but_no_socket_is_unreachable_not_wayland_gap() {
+        // XWayland is present, so the gap is "not started/reachable", not "missing".
+        let env = LinuxXEnv {
+            display: Some(":0".to_string()),
+            wayland_display: Some("wayland-0".to_string()),
+            xdg_session_type: Some("wayland".to_string()),
+            x11_socket_present: false,
+            xwayland_on_path: true,
+            xorg_on_path: false,
+            sandbox: SandboxKind::None,
+        };
+        assert_eq!(classify(&env), LinuxXGap::ServerUnreachable);
+    }
+
+    #[test]
+    fn normal_desktop_never_misclassifies_as_a_missing_dependency() {
+        // Defensive: the fully-present base must not surface as missing/headless.
+        let gap = classify(&base());
+        assert!(matches!(gap, LinuxXGap::ServerUnreachable));
+    }
+
+    // ----- to_error: targeted, actionable mapping ---------------------------
+
+    #[test]
+    fn wayland_gap_maps_to_xwayland_dependency_missing() {
+        match LinuxXGap::WaylandWithoutXwayland.to_error() {
+            XServerError::DependencyMissing {
+                dependency,
+                install_hint,
+                ..
+            } => {
+                assert_eq!(dependency, "XWayland");
+                assert!(install_hint
+                    .unwrap_or_default()
+                    .to_lowercase()
+                    .contains("xwayland"));
+            }
+            other => panic!("expected DependencyMissing(XWayland), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sandbox_gap_hint_mentions_the_socket_grant() {
+        let msg = LinuxXGap::SandboxSocketHidden.to_error().to_string();
+        assert!(
+            msg.contains("--socket=x11") || msg.contains("fallback-x11"),
+            "sandbox hint must name the socket grant, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn headless_gap_hint_mentions_headless_or_virtual_framebuffer() {
+        let msg = LinuxXGap::Headless.to_error().to_string().to_lowercase();
+        assert!(
+            msg.contains("headless") || msg.contains("xvfb") || msg.contains("virtual"),
+            "headless hint must explain the no-display case, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn missing_gap_maps_to_xorg_dependency_missing() {
+        match LinuxXGap::MissingXServer.to_error() {
+            XServerError::DependencyMissing { dependency, .. } => {
+                assert_eq!(dependency, "Xorg/XWayland");
+            }
+            other => panic!("expected DependencyMissing(Xorg/XWayland), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unreachable_gap_maps_to_server_unreachable() {
+        assert!(matches!(
+            LinuxXGap::ServerUnreachable.to_error(),
+            XServerError::ServerUnreachable { .. }
+        ));
+    }
+}

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -35,6 +35,24 @@ pub use types::{
     XServerError, XServerPlatform, XServerProgress, XServerStatusReport, X_SERVER_PROGRESS_EVENT,
 };
 
+/// Whether `name` resolves to an executable on `PATH` (best-effort).
+///
+/// Shared by the orchestrator's dependency probe and the Linux gap detector.
+/// Always `false` on Windows, where X-server discovery goes through the running
+/// server's TCP probe rather than a `PATH` lookup.
+#[cfg(not(target_os = "windows"))]
+pub(super) fn binary_on_path(name: &str) -> bool {
+    let Ok(path) = std::env::var("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(name).exists())
+}
+
+#[cfg(target_os = "windows")]
+pub(super) fn binary_on_path(_name: &str) -> bool {
+    false
+}
+
 /// Resolve whether automatic X server provisioning is enabled.
 ///
 /// Reads the global `provideXServerAutomatically` setting; when unset it

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -16,6 +16,7 @@
 #[cfg(windows)]
 pub mod acquire;
 pub mod auth;
+mod linux_gap;
 pub mod manager;
 mod orchestrator;
 mod types;

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -63,12 +63,18 @@ pub fn ensure_x_server(
 
     // 3. Nothing usable — return actionable, typed guidance. On Linux the
     //    specific gap (Wayland-without-XWayland / headless / sandboxed socket)
-    //    is classified from an environment snapshot.
+    //    is classified from an environment snapshot; other platforms ignore it,
+    //    so only pay for the snapshot's filesystem/PATH scans on Linux.
+    let linux_env = if platform == XServerPlatform::Linux {
+        LinuxXEnv::detect()
+    } else {
+        LinuxXEnv::unknown()
+    };
     Err(classify_failure(
         platform,
         provide_automatically,
         dependency,
-        &LinuxXEnv::detect(),
+        &linux_env,
     ))
 }
 
@@ -182,25 +188,11 @@ fn dependency_available(platform: XServerPlatform) -> bool {
         }
         XServerPlatform::Linux => {
             std::path::Path::new("/tmp/.X11-unix").is_dir()
-                || binary_on_path("Xwayland")
-                || binary_on_path("Xorg")
+                || super::binary_on_path("Xwayland")
+                || super::binary_on_path("Xorg")
         }
         XServerPlatform::Windows => false,
     }
-}
-
-/// Whether `name` resolves to an executable on `PATH` (best-effort).
-#[cfg(not(target_os = "windows"))]
-fn binary_on_path(name: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path).any(|dir| dir.join(name).exists())
-}
-
-#[cfg(target_os = "windows")]
-fn binary_on_path(_name: &str) -> bool {
-    false
 }
 
 #[cfg(target_os = "macos")]
@@ -216,38 +208,32 @@ mod macos {
 
 #[cfg(test)]
 mod tests {
-    use super::super::linux_gap::SandboxKind;
     use super::*;
 
-    /// A neutral env for the Windows/macOS cases, which ignore it. The Linux
-    /// arm's own gap logic is covered exhaustively in `linux_gap`'s tests.
-    fn no_linux_env() -> LinuxXEnv {
-        LinuxXEnv {
-            display: None,
-            wayland_display: None,
-            xdg_session_type: None,
-            x11_socket_present: false,
-            xwayland_on_path: false,
-            xorg_on_path: false,
-            sandbox: SandboxKind::None,
-        }
-    }
+    // Windows/macOS cases ignore the Linux env; pass the neutral `unknown()`
+    // snapshot. The Linux gap logic itself is covered exhaustively in
+    // `linux_gap`'s own tests.
 
     #[test]
     fn windows_with_auto_provisioning_returns_provisioning_unavailable() {
-        let err = classify_failure(XServerPlatform::Windows, true, false, &no_linux_env());
+        let err = classify_failure(XServerPlatform::Windows, true, false, &LinuxXEnv::unknown());
         assert!(matches!(err, XServerError::ProvisioningUnavailable { .. }));
     }
 
     #[test]
     fn windows_without_auto_provisioning_returns_no_local_server() {
-        let err = classify_failure(XServerPlatform::Windows, false, false, &no_linux_env());
+        let err = classify_failure(
+            XServerPlatform::Windows,
+            false,
+            false,
+            &LinuxXEnv::unknown(),
+        );
         assert!(matches!(err, XServerError::NoLocalServer { .. }));
     }
 
     #[test]
     fn macos_without_xquartz_returns_dependency_missing() {
-        let err = classify_failure(XServerPlatform::MacOs, false, false, &no_linux_env());
+        let err = classify_failure(XServerPlatform::MacOs, false, false, &LinuxXEnv::unknown());
         match err {
             XServerError::DependencyMissing {
                 dependency,
@@ -266,7 +252,7 @@ mod tests {
 
     #[test]
     fn macos_with_xquartz_but_no_server_returns_unreachable() {
-        let err = classify_failure(XServerPlatform::MacOs, false, true, &no_linux_env());
+        let err = classify_failure(XServerPlatform::MacOs, false, true, &LinuxXEnv::unknown());
         assert!(matches!(err, XServerError::ServerUnreachable { .. }));
     }
 
@@ -276,7 +262,7 @@ mod tests {
         let env = LinuxXEnv {
             display: Some(":0".to_string()),
             xdg_session_type: Some("x11".to_string()),
-            ..no_linux_env()
+            ..LinuxXEnv::unknown()
         };
         match classify_failure(XServerPlatform::Linux, false, false, &env) {
             XServerError::DependencyMissing { dependency, .. } => {
@@ -293,7 +279,7 @@ mod tests {
             display: Some(":0".to_string()),
             xdg_session_type: Some("x11".to_string()),
             xorg_on_path: true,
-            ..no_linux_env()
+            ..LinuxXEnv::unknown()
         };
         let err = classify_failure(XServerPlatform::Linux, false, true, &env);
         assert!(matches!(err, XServerError::ServerUnreachable { .. }));
@@ -305,7 +291,7 @@ mod tests {
         let env = LinuxXEnv {
             wayland_display: Some("wayland-0".to_string()),
             xdg_session_type: Some("wayland".to_string()),
-            ..no_linux_env()
+            ..LinuxXEnv::unknown()
         };
         match classify_failure(XServerPlatform::Linux, false, false, &env) {
             XServerError::DependencyMissing { dependency, .. } => {

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -10,6 +10,7 @@
 
 use termihub_core::backends::ssh::x11::detect_local_x_server;
 
+use super::linux_gap::{self, LinuxXEnv};
 use super::manager::{XServerManager, XServerStatus as ManagedStatus};
 use super::types::{XServerError, XServerPlatform, XServerState, XServerStatusReport};
 
@@ -60,11 +61,14 @@ pub fn ensure_x_server(
         ));
     }
 
-    // 3. Nothing usable — return actionable, typed guidance.
+    // 3. Nothing usable — return actionable, typed guidance. On Linux the
+    //    specific gap (Wayland-without-XWayland / headless / sandboxed socket)
+    //    is classified from an environment snapshot.
     Err(classify_failure(
         platform,
         provide_automatically,
         dependency,
+        &LinuxXEnv::detect(),
     ))
 }
 
@@ -123,6 +127,7 @@ pub fn classify_failure(
     platform: XServerPlatform,
     provide_automatically: bool,
     dependency_available: bool,
+    linux_env: &LinuxXEnv,
 ) -> XServerError {
     match platform {
         XServerPlatform::Windows if provide_automatically => {
@@ -131,8 +136,8 @@ pub fn classify_failure(
         XServerPlatform::Windows => XServerError::windows_no_local_server(),
         XServerPlatform::MacOs if dependency_available => XServerError::macos_server_unreachable(),
         XServerPlatform::MacOs => XServerError::xquartz_missing(),
-        XServerPlatform::Linux if dependency_available => XServerError::linux_server_unreachable(),
-        XServerPlatform::Linux => XServerError::linux_x_missing(),
+        // Linux never installs a server; the specific gap decides the hint.
+        XServerPlatform::Linux => linux_gap::classify(linux_env).to_error(),
     }
 }
 
@@ -211,23 +216,38 @@ mod macos {
 
 #[cfg(test)]
 mod tests {
+    use super::super::linux_gap::SandboxKind;
     use super::*;
+
+    /// A neutral env for the Windows/macOS cases, which ignore it. The Linux
+    /// arm's own gap logic is covered exhaustively in `linux_gap`'s tests.
+    fn no_linux_env() -> LinuxXEnv {
+        LinuxXEnv {
+            display: None,
+            wayland_display: None,
+            xdg_session_type: None,
+            x11_socket_present: false,
+            xwayland_on_path: false,
+            xorg_on_path: false,
+            sandbox: SandboxKind::None,
+        }
+    }
 
     #[test]
     fn windows_with_auto_provisioning_returns_provisioning_unavailable() {
-        let err = classify_failure(XServerPlatform::Windows, true, false);
+        let err = classify_failure(XServerPlatform::Windows, true, false, &no_linux_env());
         assert!(matches!(err, XServerError::ProvisioningUnavailable { .. }));
     }
 
     #[test]
     fn windows_without_auto_provisioning_returns_no_local_server() {
-        let err = classify_failure(XServerPlatform::Windows, false, false);
+        let err = classify_failure(XServerPlatform::Windows, false, false, &no_linux_env());
         assert!(matches!(err, XServerError::NoLocalServer { .. }));
     }
 
     #[test]
     fn macos_without_xquartz_returns_dependency_missing() {
-        let err = classify_failure(XServerPlatform::MacOs, false, false);
+        let err = classify_failure(XServerPlatform::MacOs, false, false, &no_linux_env());
         match err {
             XServerError::DependencyMissing {
                 dependency,
@@ -246,14 +266,19 @@ mod tests {
 
     #[test]
     fn macos_with_xquartz_but_no_server_returns_unreachable() {
-        let err = classify_failure(XServerPlatform::MacOs, false, true);
+        let err = classify_failure(XServerPlatform::MacOs, false, true, &no_linux_env());
         assert!(matches!(err, XServerError::ServerUnreachable { .. }));
     }
 
     #[test]
     fn linux_without_x_server_returns_dependency_missing() {
-        let err = classify_failure(XServerPlatform::Linux, false, false);
-        match err {
+        // No display, an x11 session claimed, but no server binary or socket.
+        let env = LinuxXEnv {
+            display: Some(":0".to_string()),
+            xdg_session_type: Some("x11".to_string()),
+            ..no_linux_env()
+        };
+        match classify_failure(XServerPlatform::Linux, false, false, &env) {
             XServerError::DependencyMissing { dependency, .. } => {
                 assert_eq!(dependency, "Xorg/XWayland");
             }
@@ -263,8 +288,31 @@ mod tests {
 
     #[test]
     fn linux_with_dependency_but_no_display_returns_unreachable() {
-        let err = classify_failure(XServerPlatform::Linux, false, true);
+        // Xorg installed but no reachable display → unreachable, not missing.
+        let env = LinuxXEnv {
+            display: Some(":0".to_string()),
+            xdg_session_type: Some("x11".to_string()),
+            xorg_on_path: true,
+            ..no_linux_env()
+        };
+        let err = classify_failure(XServerPlatform::Linux, false, true, &env);
         assert!(matches!(err, XServerError::ServerUnreachable { .. }));
+    }
+
+    #[test]
+    fn linux_wayland_without_xwayland_returns_xwayland_dependency() {
+        // The headline edge case: Wayland session, no XWayland, no socket.
+        let env = LinuxXEnv {
+            wayland_display: Some("wayland-0".to_string()),
+            xdg_session_type: Some("wayland".to_string()),
+            ..no_linux_env()
+        };
+        match classify_failure(XServerPlatform::Linux, false, false, &env) {
+            XServerError::DependencyMissing { dependency, .. } => {
+                assert_eq!(dependency, "XWayland");
+            }
+            other => panic!("expected DependencyMissing(XWayland), got {other:?}"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/terminal/xserver/types.rs
+++ b/src-tauri/src/terminal/xserver/types.rs
@@ -189,6 +189,44 @@ impl XServerError {
         }
     }
 
+    /// Linux: a Wayland session without XWayland, so X11 forwarding has no X
+    /// server to render into. The one Linux case that needs a package install.
+    pub fn linux_xwayland_missing() -> Self {
+        XServerError::DependencyMissing {
+            message: "This is a Wayland session without XWayland, so there is no X server for \
+                X11 forwarding to use."
+                .to_string(),
+            dependency: "XWayland".to_string(),
+            install_hint: Some(
+                "Install your distribution's XWayland package (e.g. `xwayland`, `xorg-xwayland`, \
+                or `xwayland` via your package manager), then reconnect."
+                    .to_string(),
+            ),
+            install_command: None,
+        }
+    }
+
+    /// Linux: termiHub is confined by a Flatpak/Snap sandbox that is not exposing
+    /// the host X socket.
+    pub fn linux_sandbox_socket_hidden() -> Self {
+        XServerError::ServerUnreachable {
+            message: "termiHub is running in a Flatpak/Snap sandbox that is not exposing the host \
+                X socket. Grant X access to the sandbox (e.g. `--socket=x11`, or \
+                `--socket=fallback-x11` on Wayland) and reconnect."
+                .to_string(),
+        }
+    }
+
+    /// Linux: no local display at all (headless system).
+    pub fn linux_headless() -> Self {
+        XServerError::NoLocalServer {
+            message: "No local display was found — this looks like a headless system. X11 \
+                forwarding renders remote apps on a local X server, so run termiHub in a graphical \
+                session, or start a virtual framebuffer (e.g. Xvfb) and set DISPLAY."
+                .to_string(),
+        }
+    }
+
     /// Linux: termiHub never installs an X server here.
     pub fn linux_install_unsupported() -> Self {
         XServerError::Unsupported {


### PR DESCRIPTION
## Summary

Part of Epic #1047 · Concept #1044. On Linux termiHub never bundles or installs an X server — Xorg/XWayland is essentially always present and the orchestrator adopts it. This adds targeted, non-intrusive guidance for the *edge cases* where SSH X11 forwarding can't reach a local server, turning a generic "no display" failure into a specific, actionable hint.

### What changed

- New `src-tauri/src/terminal/xserver/linux_gap.rs` — a **pure** `classify(&LinuxXEnv) -> LinuxXGap` over an injected environment snapshot (`DISPLAY`, `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `/tmp/.X11-unix` presence, `Xwayland`/`Xorg` on PATH, Flatpak/Snap markers). Only `LinuxXEnv::detect()` touches the real environment, so every case is unit-testable from fixtures on any host.
- The orchestrator's Linux failure path routes through the classifier:
  - **Wayland session without XWayland** → `DependencyMissing(XWayland)` + install hint (the one Linux case that needs a package installed).
  - **Headless** (no local display) → `NoLocalServer` + graphical-session / Xvfb guidance.
  - **Flatpak/Snap hiding the host socket** → `ServerUnreachable` + `--socket=x11` / `--socket=fallback-x11` grant hint.
  - No server binaries → `DependencyMissing(Xorg/XWayland)`; a live-but-unreachable socket → `ServerUnreachable`.
- A **normal desktop is unaffected** — the server is adopted before this path runs.

### Notes

- Merged latest `develop`, which independently switched `binary_on_path` to the maintained **`which`** crate (#1087). Resolved by keeping that improvement in the new shared `xserver::binary_on_path` helper (deduped from the orchestrator + the Linux detector).
- Post-implementation `/simplify` pass: hoisted the socket-present check to the top of `classify()` (dropping redundant negations and a dead branch), deduped the PATH lookup, and gated the env snapshot to Linux at the call site so Windows/macOS don't pay for its scans while `classify_failure` stays pure and fixture-testable.

## Test plan

- `cargo test -p termihub -- terminal::xserver` → all pass (adds exhaustive per-gap fixture tests in `linux_gap` + orchestrator wiring tests).
- `./scripts/check.sh` → all checks pass (prettier, markdownlint, eslint, cargo fmt, clippy `-D warnings`, version drift).
- Manual (deferred to a Linux env): Wayland-only-without-XWayland / headless / sandboxed-socket hints — steps added to `docs/testing.md`.

Closes #1055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)