### PR TITLE
feat(ui): X Servers section in Open Connections panel (#1053, PR 1/3)

### DIFF
--- a/docs/changes/feature/1053-open-connections-x-servers.md
+++ b/docs/changes/feature/1053-open-connections-x-servers.md
@@ -1,0 +1,8 @@
+### Added
+
+- Open Connections panel now has an **X Servers** section showing termiHub's
+  shared local X server (used for SSH X11 forwarding). A termiHub-managed server
+  appears as `VcXsrv · display :N` with a **Stop** control; an adopted external
+  server appears as `External X server · display :N` with no stop (termiHub did
+  not start it, so it does not stop it). The section is hidden when no server is
+  running. Part of the X server provisioning epic (#1047, #1053).

--- a/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
@@ -16,6 +16,10 @@ vi.mock("@/services/api", () => ({
   closeTerminal: vi.fn(() => Promise.resolve()),
   closeAgentSession: vi.fn(() => Promise.resolve()),
   cancelConnecting: (id: string) => cancelConnecting(id),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
 }));
 
 import { OpenConnectionsModal } from "./OpenConnectionsModal";

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -79,6 +79,12 @@
   white-space: nowrap;
 }
 
+.oc-row__detail {
+  margin-left: var(--spacing-sm);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
 .oc-row__badge {
   font-size: 10px;
   padding: 1px 6px;
@@ -101,4 +107,16 @@
 .oc-row__badge--connecting {
   background: color-mix(in srgb, var(--color-warning) 18%, transparent);
   color: var(--color-warning);
+}
+
+/* termiHub-managed X server: accent to signal termiHub ownership. */
+.oc-row__badge--managed {
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  color: var(--accent-color);
+}
+
+/* Adopted external X server: neutral, matches the section count chip. */
+.oc-row__badge--external {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
 }

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -6,6 +6,7 @@ import {
   FolderOpen,
   Activity,
   MonitorStop,
+  MonitorCog,
   Loader2,
 } from "lucide-react";
 import { Modal, Button } from "@/components/ui";
@@ -17,10 +18,13 @@ import {
   closeTerminal,
   closeAgentSession,
   cancelConnecting,
+  xServerStatus,
+  xServerStop,
   LocalSessionInfo,
   AgentSessionInfo,
 } from "@/services/api";
 import { TunnelState } from "@/types/tunnel";
+import { XServerStatusReport } from "@/types/xserver";
 import "./OpenConnectionsModal.css";
 
 interface OpenConnectionsModalProps {
@@ -63,6 +67,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const [proxySessions, setProxySessions] = useState<ProxySessionsState>({});
   const [agentSessions, setAgentSessions] = useState<AgentSessionsState>({});
   const [tunnelStates, setTunnelStates] = useState<TunnelState[]>([]);
+  const [xServer, setXServer] = useState<XServerStatusReport | null>(null);
   const [loading, setLoading] = useState(false);
 
   const connectedAgents = remoteAgents.filter((a) => a.connectionState === "connected");
@@ -70,12 +75,14 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const [locals, ...agentSessionArrays] = await Promise.all([
+      const [locals, xServerReport, ...agentSessionArrays] = await Promise.all([
         listLocalSessions(),
+        xServerStatus().catch(() => null),
         ...connectedAgents.map((a) => listAgentSessions(a.id).catch(() => [])),
       ]);
 
       setLocalSessions(locals.filter((s) => !s.agentId));
+      setXServer(xServerReport as XServerStatusReport | null);
 
       const byProxy: ProxySessionsState = {};
       for (const s of locals) {
@@ -112,6 +119,12 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     return state && (state.status === "connected" || state.status === "connecting");
   });
 
+  // Only surface a live X server: a managed one that is running, or an adopted
+  // external one. Absent/failed servers have nothing to list or stop.
+  const showXServer =
+    xServer !== null && (xServer.state === "running" || xServer.state === "adopted");
+  const xServerManaged = xServer?.state === "running" && xServer.managed === true;
+
   const totalCount =
     connectingTabs.length +
     localSessions.length +
@@ -120,7 +133,8 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     Object.values(agentSessions).reduce((s, arr) => s + arr.length, 0) +
     activeTunnels.length +
     (sftpConnectedHost ? 1 : 0) +
-    (monitoringHost ? 1 : 0);
+    (monitoringHost ? 1 : 0) +
+    (showXServer ? 1 : 0);
 
   const handleCancelConnecting = async (tabId: string, panelId: string) => {
     await cancelConnecting(tabId).catch(() => {});
@@ -192,6 +206,11 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const handleKillAllTunnels = async () => {
     await Promise.all(activeTunnels.map((t) => stopTunnel(t.id)));
     setTunnelStates([]);
+  };
+
+  const handleStopXServer = async () => {
+    await xServerStop().catch(() => {});
+    setXServer(null);
   };
 
   return (
@@ -378,6 +397,33 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
             />
           </Section>
         )}
+
+        {/* X Servers (the single shared X server, when live) */}
+        {showXServer && xServer && (
+          <Section
+            title="X Servers"
+            icon={<MonitorCog size={14} />}
+            count={1}
+            onKillAll={xServerManaged ? handleStopXServer : undefined}
+            killAllLabel="Stop"
+            data-testid="open-connections-x-servers-section"
+          >
+            <ConnectionRow
+              icon={<MonitorCog size={14} />}
+              title={xServerManaged ? "VcXsrv" : "External X server"}
+              detail={
+                xServer.displayNumber !== undefined
+                  ? `display :${xServer.displayNumber}`
+                  : undefined
+              }
+              badge={xServerManaged ? "managed" : "external"}
+              onKill={xServerManaged ? handleStopXServer : undefined}
+              killLabel="Stop"
+              data-testid="open-connections-x-server-row"
+              killTestId="open-connections-x-server-stop"
+            />
+          </Section>
+        )}
       </div>
     </Modal>
   );
@@ -389,51 +435,90 @@ interface SectionProps {
   title: string;
   icon: React.ReactNode;
   count: number;
-  onKillAll: () => void | Promise<void>;
+  /** When omitted, no bulk-action button is rendered (nothing to stop). */
+  onKillAll?: () => void | Promise<void>;
+  /** Label for the bulk-action button (defaults to "Kill All"). */
+  killAllLabel?: string;
+  "data-testid"?: string;
   children: React.ReactNode;
 }
 
-function Section({ title, count, onKillAll, children }: SectionProps) {
+function Section({
+  title,
+  count,
+  onKillAll,
+  killAllLabel = "Kill All",
+  "data-testid": testId,
+  children,
+}: SectionProps) {
   return (
-    <div>
+    <div data-testid={testId}>
       <div className="oc-section__header">
         <span className="oc-section__title">{title}</span>
         <span className="oc-section__count">{count}</span>
-        <Button
-          variant="danger"
-          size="sm"
-          className="oc-section__kill-all"
-          onClick={() => onKillAll()}
-          title={`Kill all ${title}`}
-        >
-          Kill All
-        </Button>
+        {onKillAll && (
+          <Button
+            variant="danger"
+            size="sm"
+            className="oc-section__kill-all"
+            onClick={() => onKillAll()}
+            title={`${killAllLabel} ${title}`}
+          >
+            {killAllLabel}
+          </Button>
+        )}
       </div>
       {children}
     </div>
   );
 }
 
-type BadgeVariant = "alive" | "dead" | "connected" | "connecting";
+type BadgeVariant = "alive" | "dead" | "connected" | "connecting" | "managed" | "external";
 
 interface ConnectionRowProps {
   icon: React.ReactNode;
   title: string;
+  /** Secondary line of context (e.g. the X display number). */
+  detail?: string;
   badge: BadgeVariant;
-  onKill: () => void | Promise<void>;
+  /** When omitted, no per-row kill button is rendered. */
+  onKill?: () => void | Promise<void>;
+  /** Label for the kill button (defaults to "Kill"). */
+  killLabel?: string;
+  "data-testid"?: string;
+  /** data-testid forwarded to the kill button. */
+  killTestId?: string;
 }
 
-function ConnectionRow({ icon, title, badge, onKill }: ConnectionRowProps) {
+function ConnectionRow({
+  icon,
+  title,
+  detail,
+  badge,
+  onKill,
+  killLabel = "Kill",
+  "data-testid": testId,
+  killTestId,
+}: ConnectionRowProps) {
   return (
-    <div className="oc-row">
+    <div className="oc-row" data-testid={testId}>
       <span className="oc-row__icon">{icon}</span>
       <span className="oc-row__title" title={title}>
         {title}
+        {detail && <span className="oc-row__detail">{detail}</span>}
       </span>
       <span className={`oc-row__badge oc-row__badge--${badge}`}>{badge}</span>
-      <Button variant="danger" size="sm" className="oc-row__kill" onClick={() => onKill()}>
-        Kill
-      </Button>
+      {onKill && (
+        <Button
+          variant="danger"
+          size="sm"
+          className="oc-row__kill"
+          onClick={() => onKill()}
+          data-testid={killTestId}
+        >
+          {killLabel}
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for the "X Servers" section of the Open Connections panel (#1053):
+ * the single shared X server is surfaced only when live (managed-running or
+ * adopted-external). A managed server can be stopped via x_server_stop; an
+ * adopted external server exposes no Stop control.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { XServerStatusReport } from "@/types/xserver";
+
+const xServerStatus = vi.fn<() => Promise<XServerStatusReport>>();
+const xServerStop = vi.fn(() => Promise.resolve());
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() => Promise.resolve([])),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  xServerStatus: () => xServerStatus(),
+  xServerStop: () => xServerStop(),
+}));
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+/** Flush the async loadData (Promise.all) and its resulting state update. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("OpenConnectionsModal — X Servers section", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    xServerStatus.mockReset();
+    xServerStop.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderModal() {
+    await act(async () => {
+      root.render(
+        React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
+      );
+    });
+    await flush();
+  }
+
+  it("lists a managed running X server and stops it via x_server_stop", async () => {
+    xServerStatus.mockResolvedValue({
+      state: "running",
+      platform: "windows",
+      displayNumber: 0,
+      managed: true,
+    });
+    await renderModal();
+
+    const section = document.querySelector('[data-testid="open-connections-x-servers-section"]');
+    expect(section).not.toBeNull();
+
+    const row = document.querySelector('[data-testid="open-connections-x-server-row"]');
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toContain("VcXsrv");
+    expect(row?.textContent).toContain("display :0");
+    expect(row?.querySelector(".oc-row__badge--managed")).not.toBeNull();
+
+    const stopBtn = document.querySelector(
+      '[data-testid="open-connections-x-server-stop"]'
+    ) as HTMLButtonElement;
+    expect(stopBtn).not.toBeNull();
+
+    await act(async () => {
+      stopBtn.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(xServerStop).toHaveBeenCalledTimes(1);
+    // Optimistically removed → row and section disappear.
+    expect(document.querySelector('[data-testid="open-connections-x-server-row"]')).toBeNull();
+  });
+
+  it("lists an adopted external X server with no Stop or Kill All control", async () => {
+    xServerStatus.mockResolvedValue({
+      state: "adopted",
+      platform: "linux",
+      displayNumber: 10,
+      managed: false,
+    });
+    await renderModal();
+
+    const section = document.querySelector('[data-testid="open-connections-x-servers-section"]');
+    expect(section).not.toBeNull();
+
+    const row = document.querySelector('[data-testid="open-connections-x-server-row"]');
+    expect(row?.textContent).toContain("External X server");
+    expect(row?.querySelector(".oc-row__badge--external")).not.toBeNull();
+
+    // No per-row Stop button and no bulk Kill All button in the header.
+    expect(document.querySelector('[data-testid="open-connections-x-server-stop"]')).toBeNull();
+    expect(section?.querySelector(".oc-section__kill-all")).toBeNull();
+  });
+
+  it("renders no X Servers section when the server is absent", async () => {
+    xServerStatus.mockResolvedValue({
+      state: "absent",
+      platform: "windows",
+      managed: false,
+    });
+    await renderModal();
+
+    expect(document.querySelector('[data-testid="open-connections-x-servers-section"]')).toBeNull();
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -12,6 +12,7 @@ import {
   LineEnding,
 } from "@/types/terminal";
 import { SystemStats } from "@/types/monitoring";
+import { XServerStatusReport } from "@/types/xserver";
 import { CredentialStoreStatusInfo, SwitchCredentialStoreResult } from "@/types/credential";
 import {
   SavedConnection,
@@ -260,6 +261,16 @@ export async function getDefaultShell(): Promise<string | null> {
 /** Check if a local X server is available for X11 forwarding */
 export async function checkX11Available(): Promise<boolean> {
   return await invoke<boolean>("check_x11_available");
+}
+
+/** Get the status of the shared X server that termiHub manages or has adopted. */
+export async function xServerStatus(): Promise<XServerStatusReport> {
+  return await invoke<XServerStatusReport>("x_server_status");
+}
+
+/** Stop the termiHub-managed X server. Rejects with an XServerError on failure. */
+export async function xServerStop(): Promise<void> {
+  return await invoke<void>("x_server_stop");
 }
 
 /** Check whether the SSH agent is running, stopped, or not installed. */

--- a/src/types/xserver.ts
+++ b/src/types/xserver.ts
@@ -1,0 +1,51 @@
+/**
+ * Types for the shared X server that termiHub manages (or adopts) for X11
+ * forwarding. The backend tracks exactly one server at a time, so the UI shows
+ * either zero or one server.
+ */
+
+/**
+ * Lifecycle state of the shared X server.
+ *
+ * - `absent` — no X server is running or known.
+ * - `adopted` — an external X server (not started by termiHub) is in use.
+ * - `running` — a termiHub-managed X server is running.
+ * - `failed` — the managed X server failed to start or crashed.
+ */
+export type XServerState = "absent" | "adopted" | "running" | "failed";
+
+/** Platform the X server report was produced on. */
+export type XServerPlatform = "windows" | "macOs" | "linux";
+
+/**
+ * Snapshot of the shared X server status as reported by the backend
+ * (`x_server_status`). Optional fields are omitted when the backend has no
+ * value (serialized from `Option::None`).
+ */
+export interface XServerStatusReport {
+  /** Current lifecycle state of the server. */
+  state: XServerState;
+  /** Platform the report was produced on. */
+  platform: XServerPlatform;
+  /** X display number the server listens on (e.g. `0` for `:0`). */
+  displayNumber?: number;
+  /** Whether termiHub started and manages this server. */
+  managed: boolean;
+  /** Whether the platform dependency (e.g. VcXsrv) is installed. */
+  dependencyAvailable?: boolean;
+  /** Human-readable status detail, if any. */
+  message?: string;
+}
+
+/**
+ * Progress update emitted while the managed X server is being provisioned or
+ * started. Reserved for later PRs (deploy/start flows).
+ */
+export interface XServerProgress {
+  /** Machine-readable identifier for the current step. */
+  step: string;
+  /** Human-readable description of the current step. */
+  message: string;
+  /** Completion fraction in the range `0`–`1`. */
+  progress: number;
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -9,7 +9,7 @@ source — the #1 authoring error when porting system tests (#899).
 - **Regenerate:** `python scripts/build-testid-catalog.py`
 - **Verify freshness (CI):** `python scripts/build-testid-catalog.py --check`
 
-**454** literal · **123** dynamic · **16** indirect.
+**456** literal · **123** dynamic · **18** indirect.
 
 ## Literal test IDs
 
@@ -268,6 +268,8 @@ Fixed strings — match exactly.
 | `network-monitors-section` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-new-monitor` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-tools-sidebar` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
+| `open-connections-x-server-row` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `open-connections-x-servers-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-ports-panel` | `src/components/NetworkTools/OpenPortsPanel.tsx` |
 | `open-ports-refresh` | `src/components/NetworkTools/OpenPortsPanel.tsx` |
 | `open-saved-file-ask-again` | `src/components/Terminal/OpenSavedFileDialog.tsx` |
@@ -613,9 +615,11 @@ where the component is used, not at the `data-testid` site.
 | `{confirmTestId}` | `src/components/Terminal/ConfirmCloseTabDialog.tsx` |
 | `{dataTestId}` | `src/components/PasswordInput/PasswordInput.tsx` |
 | `{footerTestId}` | `src/components/NetworkTools/DiagnosticResultsTable.tsx` |
+| `{killTestId}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `{option.testId}` | `src/components/Settings/SecuritySettings.tsx` |
 | `{rest["data-testid"]}` | `src/components/ui/Modal.tsx`, `src/components/ui/Tooltip.tsx` |
 | `{rowTestIdPrefix ? `${rowTestIdPrefix}-${i}` : undefined}` | `src/components/NetworkTools/DiagnosticResultsTable.tsx` |
+| `{testId}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `{testid}` | `src/components/ui/Select.tsx` |
 | `{tid("auth-method")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |
 | `{tid("connect-timeout")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |


### PR DESCRIPTION
**Part of #1053 (X server UI) · epic #1047 · PR 1 of 3.**

First slice of the X-server UI: surface the shared local X server in the Open Connections panel — the primary place to inspect and kill connections.

## What this adds
- **`src/types/xserver.ts`** (new) — TS mirrors of the backend camelCase serde shapes (`XServerState`, `XServerPlatform`, `XServerStatusReport`, `XServerProgress`).
- **`src/services/api.ts`** — `xServerStatus()` / `xServerStop()` invoke wrappers.
- **Open Connections "X Servers" section** — fetched via `x_server_status` on open:
  - **managed** (running): `VcXsrv · display :N`, `managed` badge, **Stop** control.
  - **adopted** (external): `External X server · display :N`, `external` badge, **no Stop** (termiHub didn't start it).
  - **absent/failed**: section hidden.
  - Stop calls `x_server_stop` with optimistic removal.
- Generalized the shared `Section`/`ConnectionRow` helpers: `onKillAll`/`onKill` are now optional (no button when omitted), with configurable labels, a detail line, and forwarded `data-testid`s. Existing call sites unchanged.

## Design
- Composed from the `ui/` `Button`/`Modal` primitives; tokens only. `managed` badge → `--accent-color` (termiHub ownership); `external` badge → neutral `--bg-tertiary`/`--text-muted`.

## Not in this PR
- **Session count** ("· N sessions" in the mockup) is deferred to **#1107** — the backend doesn't expose the refcount and session tracking isn't wired to the connect path yet.
- Settings toggles (PR 2) and the first-use consent/progress flow (PR 3) follow.

## Testing (TDD)
- New `OpenConnectionsModal.xservers.test.tsx` (managed/adopted/absent states + Stop calls the command). Commit order: failing test → implementation.
- `data-testid`s (`open-connections-x-servers-section`, `-x-server-row`, `-x-server-stop`) added; `testid-catalog.md` regenerated.
- `vitest` (6/6 pass), `eslint`, `tsc --noEmit`, `prettier` all green.

## Test plan (manual)
- Open the Open Connections panel with a managed VcXsrv running → "X Servers" shows VcXsrv + display + Stop; Stop terminates it and the row disappears.
- With an external X server adopted on :0 → shows "External X server" with no Stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)