### PR TITLE
feat(ui): X Server settings toggles (#1053, PR 2/3)

### DIFF
--- a/docs/changes/feature/1053-x-server-settings-toggles.md
+++ b/docs/changes/feature/1053-x-server-settings-toggles.md
@@ -1,0 +1,8 @@
+### Added
+
+- Settings → General now has an **X Server** section with two toggles for SSH
+  X11 forwarding: **Provide X Server Automatically** (start a local X server —
+  VcXsrv on Windows — automatically; defaults on for Windows) and **Stop X
+  Server When Idle** (shut the managed server down once no connection uses it;
+  defaults on). Both are searchable in settings. Part of the X server
+  provisioning epic (#1047, #1053).

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -4,6 +4,7 @@ import { ShellType } from "@/types/terminal";
 import { detectAvailableShells } from "@/utils/shell-detection";
 import { getWslDistroName } from "@/utils/shell-detection";
 import { useAppStore } from "@/store/appStore";
+import { isWindows } from "@/utils/platform";
 import { KeyPathInput } from "./KeyPathInput";
 
 const SHELL_LABELS: Record<string, string> = {
@@ -211,6 +212,51 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
               </label>
               <span className="settings-form__hint">
                 Pre-enable X11 Forwarding for new SSH connections.
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {(show("provideXServerAutomatically") || show("stopXServerWhenIdle")) && (
+        <div className="settings-panel__category">
+          <h3 className="settings-panel__category-title">X Server</h3>
+
+          {show("provideXServerAutomatically") && (
+            <div className="settings-form__field">
+              <span className="settings-form__label">Provide X Server Automatically</span>
+              <label className="settings-panel__toggle">
+                <input
+                  type="checkbox"
+                  checked={settings.provideXServerAutomatically ?? isWindows()}
+                  onChange={(e) =>
+                    onChange({ ...settings, provideXServerAutomatically: e.target.checked })
+                  }
+                  data-testid="settings-provide-x-server"
+                />
+                <span className="settings-panel__toggle-slider" />
+              </label>
+              <span className="settings-form__hint">
+                Windows: download &amp; run VcXsrv automatically. macOS/Linux: use the
+                detected/guided server.
+              </span>
+            </div>
+          )}
+
+          {show("stopXServerWhenIdle") && (
+            <div className="settings-form__field">
+              <span className="settings-form__label">Stop X Server When Idle</span>
+              <label className="settings-panel__toggle">
+                <input
+                  type="checkbox"
+                  checked={settings.stopXServerWhenIdle ?? true}
+                  onChange={(e) => onChange({ ...settings, stopXServerWhenIdle: e.target.checked })}
+                  data-testid="settings-stop-x-server-idle"
+                />
+                <span className="settings-panel__toggle-slider" />
+              </label>
+              <span className="settings-form__hint">
+                Shut the managed X server down once no connection is using it.
               </span>
             </div>
           )}

--- a/src/components/Settings/SettingsPanel.test.tsx
+++ b/src/components/Settings/SettingsPanel.test.tsx
@@ -33,6 +33,8 @@ const FULL_SETTINGS: AppSettings = {
   ...SPARSE_SETTINGS,
   defaultShellIntegration: true,
   defaultX11Forwarding: true,
+  provideXServerAutomatically: true,
+  stopXServerWhenIdle: true,
   updates: { autoCheck: true },
 };
 
@@ -50,6 +52,18 @@ function render() {
 function findShellIntegrationCheckbox(): HTMLInputElement | null {
   return container.querySelector(
     "[data-testid='settings-default-shell-integration']"
+  ) as HTMLInputElement | null;
+}
+
+function findProvideXServerCheckbox(): HTMLInputElement | null {
+  return container.querySelector(
+    "[data-testid='settings-provide-x-server']"
+  ) as HTMLInputElement | null;
+}
+
+function findStopXServerIdleCheckbox(): HTMLInputElement | null {
+  return container.querySelector(
+    "[data-testid='settings-stop-x-server-idle']"
   ) as HTMLInputElement | null;
 }
 
@@ -158,5 +172,47 @@ describe("SettingsPanel — dirty state on revert to default", () => {
 
     // Dirty flag must still be true — the external update must not have reset the baseline
     expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
+  });
+
+  it("marks settings dirty when toggling Provide X Server Automatically", async () => {
+    useAppStore.setState({ settings: FULL_SETTINGS, savedSettings: FULL_SETTINGS });
+    render();
+
+    const checkbox = findProvideXServerCheckbox();
+    expect(checkbox).not.toBeNull();
+    expect(checkbox!.checked).toBe(true);
+
+    // User disables auto-provisioning → dirty
+    await clickCheckbox(checkbox!);
+    expect(checkbox!.checked).toBe(false);
+    expect(useAppStore.getState().settings.provideXServerAutomatically).toBe(false);
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
+
+    // User reverts to original (enabled) value → clean
+    await clickCheckbox(checkbox!);
+    expect(checkbox!.checked).toBe(true);
+    expect(useAppStore.getState().settings.provideXServerAutomatically).toBe(true);
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(false);
+  });
+
+  it("marks settings dirty when toggling Stop X Server When Idle", async () => {
+    useAppStore.setState({ settings: FULL_SETTINGS, savedSettings: FULL_SETTINGS });
+    render();
+
+    const checkbox = findStopXServerIdleCheckbox();
+    expect(checkbox).not.toBeNull();
+    expect(checkbox!.checked).toBe(true);
+
+    // User disables idle shutdown → dirty
+    await clickCheckbox(checkbox!);
+    expect(checkbox!.checked).toBe(false);
+    expect(useAppStore.getState().settings.stopXServerWhenIdle).toBe(false);
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
+
+    // User reverts to original (enabled) value → clean
+    await clickCheckbox(checkbox!);
+    expect(checkbox!.checked).toBe(true);
+    expect(useAppStore.getState().settings.stopXServerWhenIdle).toBe(true);
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(false);
   });
 });

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -268,6 +268,20 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     ],
   },
   {
+    id: "provideXServerAutomatically",
+    label: "Provide X Server Automatically",
+    description: "Start a local X server automatically for X11 forwarding",
+    category: "general",
+    keywords: ["x server", "x11", "xserver", "display", "vcxsrv", "forwarding", "gui"],
+  },
+  {
+    id: "stopXServerWhenIdle",
+    label: "Stop X Server When Idle",
+    description: "Shut down the auto-provided X server when no connection uses it",
+    category: "general",
+    keywords: ["x server", "x11", "idle", "stop", "shutdown", "display"],
+  },
+  {
     id: "portableMode",
     label: "Portable Mode",
     description: "Run termiHub from a USB drive or any directory without system installation",

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -233,6 +233,10 @@ export interface AppSettings {
   askOpenSavedFileInTab?: boolean;
   defaultShellIntegration?: boolean;
   defaultX11Forwarding?: boolean;
+  /** Start/provide a local X server automatically for SSH X11 forwarding. Unset → platform default (on for Windows). */
+  provideXServerAutomatically?: boolean;
+  /** Stop the auto-provided X server once no connection is using it. */
+  stopXServerWhenIdle?: boolean;
   /**
    * When true (default), the open tab groups and layout are auto-saved on every
    * change and restored on the next startup. When false, the app always starts

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -9,7 +9,7 @@ source — the #1 authoring error when porting system tests (#899).
 - **Regenerate:** `python scripts/build-testid-catalog.py`
 - **Verify freshness (CI):** `python scripts/build-testid-catalog.py --check`
 
-**454** literal · **123** dynamic · **16** indirect.
+**456** literal · **123** dynamic · **16** indirect.
 
 ## Literal test IDs
 
@@ -346,8 +346,10 @@ Fixed strings — match exactly.
 | `settings-menu-open` | `src/components/ActivityBar/ActivityBar.tsx` |
 | `settings-menu-open-connections` | `src/components/ActivityBar/ActivityBar.tsx` |
 | `settings-menu-updates` | `src/components/ActivityBar/ActivityBar.tsx` |
+| `settings-provide-x-server` | `src/components/Settings/GeneralSettings.tsx` |
 | `settings-restore-last-session` | `src/components/Settings/GeneralSettings.tsx` |
 | `settings-serial-port-prefixes` | `src/components/Settings/SerialPortSettings.tsx` |
+| `settings-stop-x-server-idle` | `src/components/Settings/GeneralSettings.tsx` |
 | `shortcuts-overlay` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |
 | `shortcuts-overlay-search` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |
 | `sidebar` | `src/components/Sidebar/Sidebar.tsx` |


### PR DESCRIPTION
**Part of #1053 (X server UI) · epic #1047 · PR 2 of 3.** Independent of PR #1110.

Adds the two global settings toggles for the X server feature.

## What this adds
- **`AppSettings`** (`src/types/connection.ts`): `provideXServerAutomatically?` and `stopXServerWhenIdle?` (round-trip through `get_settings`/`save_settings` automatically; backend fields already exist in `settings.rs`).
- **Settings → General → "X Server"** section (`GeneralSettings.tsx`), after "SSH Defaults":
  - **Provide X Server Automatically** — defaults **on for Windows** via the existing `isWindows()` util, matching the backend's `resolve_provide_automatically` (Windows→true, else→false).
  - **Stop X Server When Idle** — defaults **on**.
- **Search discoverability**: two `settingsRegistry.ts` entries.

## Design notes
- Uses the existing hand-authored `settings-panel__toggle` checkbox pattern for consistency with every sibling setting on this screen (a deliberate, scoped deviation from "compose from primitives" — migrating the whole Settings surface to the `Toggle` primitive is a separate concern).
- No `updateSettings`/store side-effects: `provideXServerAutomatically` is read live at connect time by the backend. (`stopXServerWhenIdle` is read by the manager at construction — applying it live is a backend concern, not this UI PR.)

## Testing (TDD)
- `SettingsPanel.test.tsx`: dirty-tracking tests for both toggles (commit order: failing test → implementation).
- `data-testid`s (`settings-provide-x-server`, `settings-stop-x-server-idle`) added; `testid-catalog.md` regenerated.
- `vitest` (169/169 Settings tests), `eslint`, `tsc --noEmit`, `prettier` all green.

## Test plan (manual)
- On Windows, open Settings → General → X Server: "Provide automatically" is on by default; toggle both and reopen settings → values persist.
- On macOS/Linux, "Provide automatically" defaults off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)