### PR TITLE
refactor(backend): extract shared download_to_file helper (Closes #1077)

### DIFF
--- a/src-tauri/src/terminal/agent_binary.rs
+++ b/src-tauri/src/terminal/agent_binary.rs
@@ -8,11 +8,13 @@
 //! 3. **GitHub Releases download** — fetched on demand and cached locally
 
 use std::fs;
-use std::io::Write;
 use std::path::PathBuf;
 
-use anyhow::{bail, Context, Result};
+use anyhow::Result;
 use tracing::{debug, info, warn};
+
+use crate::utils::download::download_to_file;
+use crate::utils::fs::is_nonempty_file;
 
 /// GitHub repository for release downloads.
 const GITHUB_REPO: &str = "armaxri/termiHub";
@@ -85,16 +87,12 @@ pub fn cached_binary_path(version: &str, arch_suffix: &str) -> PathBuf {
 /// Look for a cached binary. Returns `Some(path)` if it exists and is non-empty.
 pub fn find_cached_binary(version: &str, arch_suffix: &str) -> Option<PathBuf> {
     let path = cached_binary_path(version, arch_suffix);
-    if path.is_file() {
-        // Sanity check: non-empty
-        if let Ok(meta) = fs::metadata(&path) {
-            if meta.len() > 0 {
-                debug!("Found cached agent binary: {}", path.display());
-                return Some(path);
-            }
-        }
+    if is_nonempty_file(&path) {
+        debug!("Found cached agent binary: {}", path.display());
+        Some(path)
+    } else {
+        None
     }
-    None
 }
 
 /// Look for a bundled binary in the Tauri resource directory.
@@ -161,37 +159,10 @@ pub fn download_agent_binary_from_url<F>(
 where
     F: Fn(u64, u64),
 {
-    info!("Downloading agent binary from {}", url);
-
-    let response = reqwest::blocking::Client::new()
-        .get(url)
-        .send()
-        .context("Failed to start download")?;
-
-    if !response.status().is_success() {
-        bail!("Download failed: HTTP {} for {}", response.status(), url);
-    }
-
-    let total_size = response.content_length().unwrap_or(0);
-    let bytes = response.bytes().context("Failed to read response body")?;
-    progress_cb(bytes.len() as u64, total_size);
-
     let dest = cache_dir()
         .join(cache_key)
         .join(format!("termihub-agent-{arch_suffix}"));
-    if let Some(parent) = dest.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create cache dir: {}", parent.display()))?;
-    }
-    let mut file = fs::File::create(&dest)
-        .with_context(|| format!("Failed to create cache file: {}", dest.display()))?;
-    file.write_all(&bytes)?;
-
-    info!(
-        "Agent binary cached at {} ({} bytes)",
-        dest.display(),
-        bytes.len()
-    );
+    download_to_file(url, &dest, progress_cb)?;
     Ok(dest)
 }
 
@@ -212,13 +183,9 @@ where
         .join(&cache_key)
         .join(format!("termihub-agent-{arch_suffix}"));
 
-    if cached.is_file() {
-        if let Ok(meta) = fs::metadata(&cached) {
-            if meta.len() > 0 {
-                debug!("Using cached branch build binary: {}", cached.display());
-                return Ok(cached);
-            }
-        }
+    if is_nonempty_file(&cached) {
+        debug!("Using cached branch build binary: {}", cached.display());
+        return Ok(cached);
     }
 
     let url = compute_branch_build_url(branch, arch_suffix);
@@ -296,39 +263,8 @@ where
     F: Fn(u64, u64),
 {
     let url = compute_download_url(version, arch_suffix);
-    info!("Downloading agent binary from {}", url);
-
-    let response = reqwest::blocking::Client::new()
-        .get(&url)
-        .send()
-        .context("Failed to start download")?;
-
-    if !response.status().is_success() {
-        bail!("Download failed: HTTP {} for {}", response.status(), url);
-    }
-
-    let total_size = response.content_length().unwrap_or(0);
-    let bytes = response.bytes().context("Failed to read response body")?;
-
-    progress_cb(bytes.len() as u64, total_size);
-
-    // Write to cache
     let dest = cached_binary_path(version, arch_suffix);
-    if let Some(parent) = dest.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create cache dir: {}", parent.display()))?;
-    }
-
-    let mut file = fs::File::create(&dest)
-        .with_context(|| format!("Failed to create cache file: {}", dest.display()))?;
-    file.write_all(&bytes)?;
-
-    info!(
-        "Agent binary cached at {} ({} bytes)",
-        dest.display(),
-        bytes.len()
-    );
-
+    download_to_file(&url, &dest, progress_cb)?;
     Ok(dest)
 }
 

--- a/src-tauri/src/terminal/xserver/acquire.rs
+++ b/src-tauri/src/terminal/xserver/acquire.rs
@@ -27,6 +27,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 use tracing::{debug, info};
 
+use crate::utils::download::download_to_file;
+use crate::utils::fs::is_nonempty_file;
 use crate::utils::portable::AppMode;
 
 /// The executable name inside the extracted VcXsrv tree.
@@ -203,39 +205,9 @@ fn download_zip<F>(url: &str, dest: &Path, progress_cb: &F) -> Result<()>
 where
     F: Fn(AcquireProgress),
 {
-    info!("Downloading VcXsrv from {url}");
-    let response = reqwest::blocking::Client::new()
-        .get(url)
-        .send()
-        .context("Failed to start VcXsrv download")?;
-    if !response.status().is_success() {
-        bail!(
-            "VcXsrv download failed: HTTP {} for {url}",
-            response.status()
-        );
-    }
-
-    let total = response.content_length().unwrap_or(0);
-    let bytes = response
-        .bytes()
-        .context("Failed to read VcXsrv download body")?;
-    progress_cb(AcquireProgress::Downloading {
-        received: bytes.len() as u64,
-        total,
-    });
-
-    if let Some(parent) = dest.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create {}", parent.display()))?;
-    }
-    fs::write(dest, &bytes)
-        .with_context(|| format!("Failed to write VcXsrv download to {}", dest.display()))?;
-    info!(
-        "VcXsrv downloaded to {} ({} bytes)",
-        dest.display(),
-        bytes.len()
-    );
-    Ok(())
+    download_to_file(url, dest, |received, total| {
+        progress_cb(AcquireProgress::Downloading { received, total })
+    })
 }
 
 /// Verify a `.zip` against `expected_sha256`, then extract it into `install_dir`
@@ -336,13 +308,6 @@ where
     let result = install_from_zip(&tmp_zip, pinned.sha256, &dir, &progress_cb);
     let _ = fs::remove_file(&tmp_zip);
     result
-}
-
-/// Returns `true` if `path` is a regular file with a non-zero length.
-fn is_nonempty_file(path: &Path) -> bool {
-    fs::metadata(path)
-        .map(|m| m.is_file() && m.len() > 0)
-        .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/utils/download.rs
+++ b/src-tauri/src/utils/download.rs
@@ -1,0 +1,167 @@
+//! Shared HTTP download helper.
+//!
+//! [`download_to_file`] centralizes the `reqwest::blocking` "GET a URL, report
+//! progress, write the body to a destination path" boilerplate that agent-binary
+//! resolution ([`crate::terminal::agent_binary`]) and VcXsrv acquisition
+//! ([`crate::terminal::xserver::acquire`]) both need (consolidated per #1077).
+
+use std::path::Path;
+
+use anyhow::{bail, Result};
+
+/// Download `url` and write the full response body to `dest`, creating parent
+/// directories as needed.
+///
+/// `on_progress` is invoked once, after the body has been read, with
+/// `(bytes_downloaded, total_bytes)`. `total_bytes` is 0 when the server does not
+/// send a `Content-Length` header.
+///
+/// Uses `reqwest::blocking`, so it must be called off the async reactor (e.g.
+/// inside `spawn_blocking`). A non-success status is an error and nothing is
+/// written to `dest`.
+pub fn download_to_file<F>(_url: &str, _dest: &Path, _on_progress: F) -> Result<()>
+where
+    F: Fn(u64, u64),
+{
+    bail!("download_to_file not implemented yet")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::fs;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+
+    /// Spawn a one-shot HTTP/1.1 responder on an ephemeral loopback port.
+    ///
+    /// It accepts a single connection, drains the request, and replies with the
+    /// given status line, an optional `Content-Length`, and `body`. Returns the
+    /// bound `http://127.0.0.1:PORT` base URL and the server thread's join handle.
+    fn serve_once(
+        status_line: &'static str,
+        send_content_length: bool,
+        body: &'static [u8],
+    ) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Non-blocking accept with a bounded deadline so the server thread always
+        // terminates — `join()` can never deadlock even if the client never
+        // connects (e.g. a regression that stops `download_to_file` sending a
+        // request).
+        listener.set_nonblocking(true).unwrap();
+        let handle = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        if std::time::Instant::now() >= deadline {
+                            return; // give up — no client connected
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    Err(e) => panic!("accept failed: {e}"),
+                }
+            };
+            stream.set_nonblocking(false).unwrap();
+            drain_request(&mut stream);
+            let mut header = format!("HTTP/1.1 {status_line}\r\nConnection: close\r\n");
+            if send_content_length {
+                header.push_str(&format!("Content-Length: {}\r\n", body.len()));
+            }
+            header.push_str("\r\n");
+            stream.write_all(header.as_bytes()).unwrap();
+            stream.write_all(body).unwrap();
+            stream.flush().unwrap();
+        });
+        (format!("http://{addr}/file"), handle)
+    }
+
+    /// Read the request headers (up to the blank line) so the client's write side
+    /// completes before we respond.
+    fn drain_request(stream: &mut TcpStream) {
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut buf).unwrap_or(0);
+            if n == 0 {
+                break;
+            }
+            if buf[..n].windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn writes_body_creates_parent_and_reports_progress() {
+        const BODY: &[u8] = b"hello download helper payload";
+        let (url, server) = serve_once("200 OK", true, BODY);
+
+        let tmp = tempfile::tempdir().unwrap();
+        // `nested/` does not exist yet — the helper must create it.
+        let dest = tmp.path().join("nested").join("out.bin");
+        let progress: RefCell<Vec<(u64, u64)>> = RefCell::new(Vec::new());
+
+        download_to_file(&url, &dest, |received, total| {
+            progress.borrow_mut().push((received, total))
+        })
+        .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(fs::read(&dest).unwrap(), BODY);
+        let seen = progress.borrow();
+        assert!(
+            seen.iter()
+                .any(|(r, t)| *r == BODY.len() as u64 && *t == BODY.len() as u64),
+            "expected a progress report of ({}, {}), got {seen:?}",
+            BODY.len(),
+            BODY.len()
+        );
+    }
+
+    #[test]
+    fn reports_zero_total_when_content_length_absent() {
+        const BODY: &[u8] = b"no content-length here";
+        let (url, server) = serve_once("200 OK", false, BODY);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("out.bin");
+        let progress: RefCell<Vec<(u64, u64)>> = RefCell::new(Vec::new());
+
+        download_to_file(&url, &dest, |received, total| {
+            progress.borrow_mut().push((received, total))
+        })
+        .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(fs::read(&dest).unwrap(), BODY);
+        let seen = progress.borrow();
+        assert!(
+            seen.iter().any(|(r, t)| *r == BODY.len() as u64 && *t == 0),
+            "expected total=0 when Content-Length is omitted, got {seen:?}"
+        );
+    }
+
+    #[test]
+    fn errors_on_non_success_status_and_writes_nothing() {
+        const BODY: &[u8] = b"not found body";
+        let (url, server) = serve_once("404 Not Found", true, BODY);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("out.bin");
+
+        let err = download_to_file(&url, &dest, |_, _| {}).unwrap_err();
+        server.join().unwrap();
+
+        assert!(
+            err.to_string().contains("404"),
+            "error should mention the HTTP status, got: {err}"
+        );
+        assert!(
+            !dest.exists(),
+            "nothing must be written to dest on a failed download"
+        );
+    }
+}

--- a/src-tauri/src/utils/download.rs
+++ b/src-tauri/src/utils/download.rs
@@ -75,26 +75,11 @@ mod tests {
     ) -> (String, std::thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
-        // Non-blocking accept with a bounded deadline so the server thread always
-        // terminates — `join()` can never deadlock even if the client never
-        // connects (e.g. a regression that stops `download_to_file` sending a
-        // request).
-        listener.set_nonblocking(true).unwrap();
         let handle = std::thread::spawn(move || {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-            let mut stream = loop {
-                match listener.accept() {
-                    Ok((stream, _)) => break stream,
-                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        if std::time::Instant::now() >= deadline {
-                            return; // give up — no client connected
-                        }
-                        std::thread::sleep(std::time::Duration::from_millis(10));
-                    }
-                    Err(e) => panic!("accept failed: {e}"),
-                }
-            };
-            stream.set_nonblocking(false).unwrap();
+            // Every test connects immediately (the client is `download_to_file`,
+            // invoked right after), so a blocking accept is safe; a hung test is
+            // caught by the test-runner timeout.
+            let (mut stream, _) = listener.accept().unwrap();
             drain_request(&mut stream);
             let mut header = format!("HTTP/1.1 {status_line}\r\nConnection: close\r\n");
             if send_content_length {
@@ -108,19 +93,11 @@ mod tests {
         (format!("http://{addr}/file"), handle)
     }
 
-    /// Read the request headers (up to the blank line) so the client's write side
-    /// completes before we respond.
+    /// Read the pending request so the client's write side completes before we
+    /// respond (avoids a connection reset on close). One read is enough for a
+    /// small GET over loopback.
     fn drain_request(stream: &mut TcpStream) {
-        let mut buf = [0u8; 1024];
-        loop {
-            let n = stream.read(&mut buf).unwrap_or(0);
-            if n == 0 {
-                break;
-            }
-            if buf[..n].windows(4).any(|w| w == b"\r\n\r\n") {
-                break;
-            }
-        }
+        let _ = stream.read(&mut [0u8; 1024]);
     }
 
     #[test]

--- a/src-tauri/src/utils/download.rs
+++ b/src-tauri/src/utils/download.rs
@@ -5,9 +5,11 @@
 //! resolution ([`crate::terminal::agent_binary`]) and VcXsrv acquisition
 //! ([`crate::terminal::xserver::acquire`]) both need (consolidated per #1077).
 
+use std::fs;
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use tracing::info;
 
 /// Download `url` and write the full response body to `dest`, creating parent
 /// directories as needed.
@@ -19,11 +21,38 @@ use anyhow::{bail, Result};
 /// Uses `reqwest::blocking`, so it must be called off the async reactor (e.g.
 /// inside `spawn_blocking`). A non-success status is an error and nothing is
 /// written to `dest`.
-pub fn download_to_file<F>(_url: &str, _dest: &Path, _on_progress: F) -> Result<()>
+pub fn download_to_file<F>(url: &str, dest: &Path, on_progress: F) -> Result<()>
 where
     F: Fn(u64, u64),
 {
-    bail!("download_to_file not implemented yet")
+    let response = reqwest::blocking::Client::new()
+        .get(url)
+        .send()
+        .with_context(|| format!("Failed to start download from {url}"))?;
+
+    if !response.status().is_success() {
+        bail!("Download failed: HTTP {} for {url}", response.status());
+    }
+
+    let total = response.content_length().unwrap_or(0);
+    let bytes = response
+        .bytes()
+        .with_context(|| format!("Failed to read response body from {url}"))?;
+    on_progress(bytes.len() as u64, total);
+
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    fs::write(dest, &bytes)
+        .with_context(|| format!("Failed to write download to {}", dest.display()))?;
+
+    info!(
+        "Downloaded {url} to {} ({} bytes)",
+        dest.display(),
+        bytes.len()
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -1,0 +1,46 @@
+//! Small filesystem predicates shared across modules.
+
+use std::path::Path;
+
+/// Returns `true` if `path` is a regular file with a non-zero length.
+///
+/// Used to decide whether a cached or extracted artifact on disk is usable — a
+/// zero-byte file (e.g. a truncated download) is treated as absent.
+pub fn is_nonempty_file(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|m| m.is_file() && m.len() > 0)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn true_for_nonempty_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("blob.bin");
+        std::fs::write(&path, b"content").unwrap();
+        assert!(is_nonempty_file(&path));
+    }
+
+    #[test]
+    fn false_for_empty_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("empty.bin");
+        std::fs::write(&path, b"").unwrap();
+        assert!(!is_nonempty_file(&path));
+    }
+
+    #[test]
+    fn false_for_missing_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!is_nonempty_file(&tmp.path().join("nope.bin")));
+    }
+
+    #[test]
+    fn false_for_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!is_nonempty_file(tmp.path()));
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod docker_detect;
 pub mod download;
 pub mod errors;
 pub mod expand;
+pub mod fs;
 pub mod log_capture;
 pub mod portable;
 pub mod remote_exec;

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod docker_detect;
+pub mod download;
 pub mod errors;
 pub mod expand;
 pub mod log_capture;


### PR DESCRIPTION
## Summary

Extracts the duplicated `reqwest::blocking` "GET a URL, report progress, write the body to a path" boilerplate into a single shared helper, per #1077.

- **New `crate::utils::download::download_to_file(url, dest, on_progress: Fn(u64, u64))`** — the single home for the download-with-progress pattern. Behavior identical to the two originals (reqwest timeout/redirect handling, one progress call after the body is read, parent-dir creation, non-2xx → error with nothing written).
- **New `crate::utils::fs::is_nonempty_file`** — factors out the repeated "regular file with non-zero length" predicate.
- **Rewired call sites:**
  - `terminal/agent_binary.rs` — both `download_agent_binary` / `download_agent_binary_from_url` delegate to the helper; `find_cached_binary` / `resolve_branch_build_binary` use `is_nonempty_file`.
  - `terminal/xserver/acquire.rs::download_zip` — now a thin adapter mapping `(received, total)` → `AcquireProgress::Downloading`; its private `is_nonempty_file` removed.

Net **−69 lines**, no behavior change.

Follow-up **#1103** (streaming to disk + incremental progress + client timeout) was filed for the deferred hardening — kept out of this refactor so it stays behavior-preserving.

## Test plan

TDD (test commit precedes implementation):
- New `download_to_file` unit tests (body write + parent-dir creation + progress; zero-total without `Content-Length`; non-2xx → error + nothing written) driven by a one-shot in-test `TcpListener` responder.
- New `is_nonempty_file` unit tests (non-empty / empty / missing / directory).
- `./scripts/check.sh` (fmt + clippy + ESLint + markdownlint) — green.
- `./scripts/test.sh` (frontend + backend + agent) — green.
- `pnpm build` (tsc) — green.
- `acquire.rs` is `#[cfg(windows)]`-gated; validated by temporarily un-gating on macOS (only the Windows-only `zip`/`sha2` crates fail to resolve — no errors from this change). Windows CI compiles it fully.

Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)