### PR TITLE
feat(ui): adopt Tooltip on interactive icon controls (Terminal, StatusBar, NetworkTools) (#1102)

### DIFF
--- a/docs/changes/dev1/feature/1102-tooltip-adoption.md
+++ b/docs/changes/dev1/feature/1102-tooltip-adoption.md
@@ -1,0 +1,3 @@
+## Changed
+
+- Interactive icon buttons in the terminal view toolbar and tab strip, the terminal search bar, the status bar (line-ending and services controls), and the Network Tools panels now use the shared accessible Tooltip for hover help — consistent, themed, and reachable on keyboard focus instead of mouse-only. Icon-only buttons that previously conveyed their label only through the browser `title` now expose it as a proper accessible name (`aria-label`). Full-text/truncation hovers on labels and status text are unchanged.

--- a/src/components/NetworkTools/HttpMonitorPanel.race.test.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.race.test.tsx
@@ -13,11 +13,34 @@
  * resolves). These tests pin that ordering and that the first check renders.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act } from "react";
+import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { networkHttpMonitorStart, onHttpMonitorCheck } from "@/services/networkApi";
 import type { HttpCheckResult } from "@/types/network";
 import { HttpMonitorPanel } from "./HttpMonitorPanel";
+import { TooltipProvider } from "@/components/ui";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts the tooltip-wrapped icon buttons; shim them so the panel renders.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+/** Wrap a subtree so the shared Tooltip primitive finds its provider. */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
 
 vi.mock("@/services/networkApi", () => ({
   networkHttpMonitorStart: vi.fn(() => Promise.resolve("mon-1")),
@@ -86,7 +109,7 @@ describe("HttpMonitorPanel — first-check race", () => {
 
   it("registers the check listener before starting the monitor", async () => {
     await act(async () => {
-      root.render(<HttpMonitorPanel />);
+      root.render(withTooltip(<HttpMonitorPanel />));
     });
     await flush();
 
@@ -102,7 +125,7 @@ describe("HttpMonitorPanel — first-check race", () => {
 
   it("shows the immediate first check for the started monitor", async () => {
     await act(async () => {
-      root.render(<HttpMonitorPanel />);
+      root.render(withTooltip(<HttpMonitorPanel />));
     });
     await flush();
 
@@ -123,7 +146,7 @@ describe("HttpMonitorPanel — first-check race", () => {
 
   it("ignores checks for a different monitor id", async () => {
     await act(async () => {
-      root.render(<HttpMonitorPanel />);
+      root.render(withTooltip(<HttpMonitorPanel />));
     });
     await flush();
 

--- a/src/components/NetworkTools/HttpMonitorPanel.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.tsx
@@ -9,6 +9,7 @@ import {
 import type { HttpMonitorState, HttpCheckResult } from "@/types/network";
 import { LatencyChart } from "./LatencyChart";
 import { frontendLog } from "@/utils/frontendLog";
+import { Tooltip } from "@/components/ui";
 
 const MAX_HISTORY = 120;
 
@@ -147,13 +148,15 @@ export function HttpMonitorPanel() {
       <div className="network-panel__header">
         <span className="network-panel__title">HTTP Monitor</span>
         <div className="network-panel__actions">
-          <button
-            className="network-panel__btn network-panel__btn--run"
-            onClick={loadMonitors}
-            title="Refresh monitor list"
-          >
-            <RefreshCw size={14} />
-          </button>
+          <Tooltip content="Refresh monitor list" side="bottom">
+            <button
+              className="network-panel__btn network-panel__btn--run"
+              onClick={loadMonitors}
+              aria-label="Refresh monitor list"
+            >
+              <RefreshCw size={14} />
+            </button>
+          </Tooltip>
           {activeMonitorId ? (
             <button
               className="network-panel__btn network-panel__btn--stop"
@@ -306,13 +309,15 @@ export function HttpMonitorPanel() {
               <span className="http-monitor-row__meta">
                 {m.config.method} · every {m.config.intervalMs / 1000}s
               </span>
-              <button
-                className="network-panel__icon-btn network-panel__icon-btn--danger"
-                onClick={() => handleStopMonitor(m.config.id)}
-                title="Stop"
-              >
-                <StopCircle size={13} />
-              </button>
+              <Tooltip content="Stop" side="left">
+                <button
+                  className="network-panel__icon-btn network-panel__icon-btn--danger"
+                  onClick={() => handleStopMonitor(m.config.id)}
+                  aria-label={`Stop monitoring ${m.config.url}`}
+                >
+                  <StopCircle size={13} />
+                </button>
+              </Tooltip>
             </div>
           ))}
         </>

--- a/src/components/NetworkTools/NetworkToolsSidebar.live.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.live.test.tsx
@@ -11,12 +11,35 @@
  * up reactively (its first check fires immediately on start).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act } from "react";
+import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { networkHttpMonitorList, onHttpMonitorCheck } from "@/services/networkApi";
 import type { HttpMonitorState, HttpCheckResult } from "@/types/network";
 import { useAppStore } from "@/store/appStore";
 import { NetworkToolsSidebar } from "./NetworkToolsSidebar";
+import { TooltipProvider } from "@/components/ui";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts the tooltip-wrapped icon buttons; shim them so the sidebar renders.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+/** Wrap a subtree so the shared Tooltip primitive finds its provider. */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
 
 vi.mock("@/services/networkApi", () => ({
   networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
@@ -66,7 +89,7 @@ describe("NetworkToolsSidebar — live monitor updates (#986)", () => {
 
   it("subscribes to the http-monitor-check event on mount", async () => {
     await act(async () => {
-      root.render(<NetworkToolsSidebar />);
+      root.render(withTooltip(<NetworkToolsSidebar />));
     });
     await flush();
 
@@ -77,7 +100,7 @@ describe("NetworkToolsSidebar — live monitor updates (#986)", () => {
     // Sidebar mounts with no monitors running.
     vi.mocked(networkHttpMonitorList).mockResolvedValueOnce([]);
     await act(async () => {
-      root.render(<NetworkToolsSidebar />);
+      root.render(withTooltip(<NetworkToolsSidebar />));
     });
     await flush();
 
@@ -108,7 +131,7 @@ describe("NetworkToolsSidebar — live monitor updates (#986)", () => {
     const unlisten = vi.fn();
     vi.mocked(onHttpMonitorCheck).mockResolvedValueOnce(unlisten);
     await act(async () => {
-      root.render(<NetworkToolsSidebar />);
+      root.render(withTooltip(<NetworkToolsSidebar />));
     });
     await flush();
 

--- a/src/components/NetworkTools/NetworkToolsSidebar.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.tsx
@@ -10,6 +10,7 @@ import {
 import type { NetworkTool } from "@/types/terminal";
 import type { HttpMonitorState } from "@/types/network";
 import { frontendLog } from "@/utils/frontendLog";
+import { Tooltip } from "@/components/ui";
 
 interface QuickActionProps {
   label: string;
@@ -65,13 +66,15 @@ function MonitorRow({ monitor, onStop, onOpen }: MonitorRowProps) {
         )}
       </div>
       {running && (
-        <button
-          className="network-sidebar__monitor-stop"
-          title="Stop monitor"
-          onClick={() => onStop(config.id)}
-        >
-          <StopCircle size={12} />
-        </button>
+        <Tooltip content="Stop monitor" side="left">
+          <button
+            className="network-sidebar__monitor-stop"
+            aria-label="Stop monitor"
+            onClick={() => onStop(config.id)}
+          >
+            <StopCircle size={12} />
+          </button>
+        </Tooltip>
       )}
     </div>
   );
@@ -161,13 +164,15 @@ export function NetworkToolsSidebar() {
       <div className="network-sidebar__section" data-testid="network-monitors-section">
         <div className="network-sidebar__section-title">
           Monitors
-          <button
-            className="network-sidebar__refresh"
-            title="Refresh monitors"
-            onClick={refreshMonitors}
-          >
-            <RefreshCw size={11} />
-          </button>
+          <Tooltip content="Refresh monitors" side="bottom">
+            <button
+              className="network-sidebar__refresh"
+              aria-label="Refresh monitors"
+              onClick={refreshMonitors}
+            >
+              <RefreshCw size={11} />
+            </button>
+          </Tooltip>
         </div>
         {httpMonitors.length === 0 && (
           <span className="network-sidebar__empty">No monitors running</span>

--- a/src/components/NetworkTools/WolPanel.tooltip.test.tsx
+++ b/src/components/NetworkTools/WolPanel.tooltip.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Verifies the Wake-on-LAN saved-device row adopts the shared `Tooltip`
+ * primitive for its icon-only Wake/Delete controls (issue #1102).
+ *
+ * A tooltip is not an accessible name, so each converted icon button must keep
+ * an `aria-label`, and the Radix tooltip trigger must wire `aria-describedby`
+ * when focused. These assertions pin both.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { networkWolDevicesList } from "@/services/networkApi";
+import type { WolDevice } from "@/types/network";
+import { WolPanel } from "./WolPanel";
+import { TooltipProvider } from "@/components/ui";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so the tooltip-wrapped buttons render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+vi.mock("@/services/networkApi", () => ({
+  networkWolSend: vi.fn(() => Promise.resolve()),
+  networkWolDevicesList: vi.fn(() => Promise.resolve([])),
+  networkWolDeviceSave: vi.fn(() => Promise.resolve()),
+  networkWolDeviceDelete: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+const DEVICE: WolDevice = {
+  id: "dev-1",
+  name: "Office NAS",
+  mac: "AA:BB:CC:DD:EE:FF",
+  broadcast: "255.255.255.255",
+  port: 9,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Wrap so the shared Tooltip primitive finds its provider (zero delay). */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
+
+describe("WolPanel — tooltip adoption (#1102)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.mocked(networkWolDevicesList).mockResolvedValue([DEVICE]);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("exposes accessible names via aria-label on the Wake and Delete icon buttons", async () => {
+    await act(async () => {
+      root.render(withTooltip(<WolPanel />));
+    });
+    await flush();
+
+    const wake = container.querySelector<HTMLButtonElement>('button[aria-label="Wake Office NAS"]');
+    const del = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete Office NAS"]'
+    );
+    expect(wake).not.toBeNull();
+    expect(del).not.toBeNull();
+    // The tooltip must not leak into the accessible name as a bare title.
+    expect(wake?.getAttribute("title")).toBeNull();
+    expect(del?.getAttribute("title")).toBeNull();
+  });
+
+  it("wires the Wake button to its tooltip via aria-describedby on focus", async () => {
+    await act(async () => {
+      root.render(withTooltip(<WolPanel />));
+    });
+    await flush();
+
+    const wake = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Wake Office NAS"]'
+    )!;
+    act(() => {
+      wake.focus();
+      wake.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    });
+
+    // Radix associates the open tooltip with its trigger for screen readers.
+    expect(wake.getAttribute("aria-describedby")).toBeTruthy();
+  });
+});

--- a/src/components/NetworkTools/WolPanel.tsx
+++ b/src/components/NetworkTools/WolPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/services/networkApi";
 import type { WolDevice } from "@/types/network";
 import { frontendLog } from "@/utils/frontendLog";
+import { Tooltip } from "@/components/ui";
 
 interface WolHistoryEntry {
   mac: string;
@@ -152,20 +153,24 @@ export function WolPanel() {
         <div key={device.id} className="wol-device-row">
           <span className="wol-device-row__name">{device.name}</span>
           <span className="wol-device-row__mac">{device.mac}</span>
-          <button
-            className="network-panel__icon-btn"
-            onClick={() => handleWakeDevice(device)}
-            title="Wake"
-          >
-            <Zap size={13} />
-          </button>
-          <button
-            className="network-panel__icon-btn network-panel__icon-btn--danger"
-            onClick={() => handleDeleteDevice(device.id)}
-            title="Delete"
-          >
-            <Trash2 size={13} />
-          </button>
+          <Tooltip content="Wake" side="top">
+            <button
+              className="network-panel__icon-btn"
+              onClick={() => handleWakeDevice(device)}
+              aria-label={`Wake ${device.name}`}
+            >
+              <Zap size={13} />
+            </button>
+          </Tooltip>
+          <Tooltip content="Delete" side="top">
+            <button
+              className="network-panel__icon-btn network-panel__icon-btn--danger"
+              onClick={() => handleDeleteDevice(device.id)}
+              aria-label={`Delete ${device.name}`}
+            >
+              <Trash2 size={13} />
+            </button>
+          </Tooltip>
         </div>
       ))}
 

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -9,6 +9,7 @@ import type { ConnectionTypeInfo } from "@/services/api";
 import { SystemStats } from "@/types/monitoring";
 import { resolveFeatureEnabled } from "@/utils/featureFlags";
 import { CredentialStoreIndicator } from "@/components/CredentialStoreIndicator";
+import { Tooltip } from "@/components/ui";
 import { PortableBadge } from "./PortableBadge";
 import { UpdateIndicator } from "./UpdateIndicator";
 import "./StatusBar.css";
@@ -151,14 +152,16 @@ export function StatusBar() {
               </DropdownMenu.Portal>
             </DropdownMenu.Root>
             <span className="status-bar__item">{editorStatus.encoding}</span>
-            <button
-              className="status-bar__item status-bar__item--interactive"
-              onClick={() => editorActions?.toggleEol()}
-              title="Toggle line endings"
-              data-testid="status-bar-eol"
-            >
-              {editorStatus.eol}
-            </button>
+            <Tooltip content="Toggle line endings" side="top">
+              <button
+                className="status-bar__item status-bar__item--interactive"
+                onClick={() => editorActions?.toggleEol()}
+                aria-label="Toggle line endings"
+                data-testid="status-bar-eol"
+              >
+                {editorStatus.eol}
+              </button>
+            </Tooltip>
             <LanguageSelector
               currentLanguage={editorStatus.language}
               languages={editorStatus.availableLanguages}
@@ -206,16 +209,20 @@ function ServicesIndicator() {
 
   if (runningCount === 0) return null;
 
+  const servicesLabel = `${runningCount} service${runningCount !== 1 ? "s" : ""} running — click to open Services`;
+
   return (
-    <button
-      className="status-bar__item status-bar__item--interactive"
-      title={`${runningCount} service${runningCount !== 1 ? "s" : ""} running — click to open Services`}
-      data-testid="services-indicator"
-      onClick={() => setSidebarView("services")}
-    >
-      <Server size={12} />
-      {runningCount}
-    </button>
+    <Tooltip content={servicesLabel} side="top">
+      <button
+        className="status-bar__item status-bar__item--interactive"
+        aria-label={servicesLabel}
+        data-testid="services-indicator"
+        onClick={() => setSidebarView("services")}
+      >
+        <Server size={12} />
+        {runningCount}
+      </button>
+    </Tooltip>
   );
 }
 

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { ConnectionIcon } from "@/utils/connectionIcons";
+import { Tooltip } from "@/components/ui";
 
 interface TabProps {
   tab: TerminalTab;
@@ -103,17 +104,19 @@ export function Tab({
         {tab.title}
       </span>
       {tab.persistentConnectionId && <span className="tab__persistent-badge">∞</span>}
-      <button
-        className="tab__close"
-        onClick={(e) => {
-          e.stopPropagation();
-          onClose();
-        }}
-        title="Close"
-        data-testid={`tab-close-${tab.id}`}
-      >
-        <X size={14} />
-      </button>
+      <Tooltip content="Close" side="bottom">
+        <button
+          className="tab__close"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          aria-label="Close"
+          data-testid={`tab-close-${tab.id}`}
+        >
+          <X size={14} />
+        </button>
+      </Tooltip>
     </div>
   );
 

--- a/src/components/Terminal/TabGroupChips.tsx
+++ b/src/components/Terminal/TabGroupChips.tsx
@@ -7,6 +7,7 @@ import * as ContextMenu from "@radix-ui/react-context-menu";
 import { useAppStore } from "@/store/appStore";
 import { TabGroup } from "@/types/terminal";
 import { RenameDialog } from "./RenameDialog";
+import { Tooltip } from "@/components/ui";
 import "./TabGroupChips.css";
 
 /**
@@ -72,15 +73,17 @@ export function TabGroupChips() {
           ))}
         </SortableContext>
       </DndContext>
-      <button
-        className={`tab-group-chips__add${draggingTabId ? " tab-group-chips__add--drop-target" : ""}`}
-        onClick={() => addTabGroup()}
-        title="New Tab Group (Ctrl+Shift+T)"
-        data-testid="tab-group-add"
-        data-new-group-btn="true"
-      >
-        <Plus size={14} />
-      </button>
+      <Tooltip content="New Tab Group (Ctrl+Shift+T)" side="bottom">
+        <button
+          className={`tab-group-chips__add${draggingTabId ? " tab-group-chips__add--drop-target" : ""}`}
+          onClick={() => addTabGroup()}
+          aria-label="New Tab Group (Ctrl+Shift+T)"
+          data-testid="tab-group-add"
+          data-new-group-btn="true"
+        >
+          <Plus size={14} />
+        </button>
+      </Tooltip>
       <RenameDialog
         open={renameGroupId !== null}
         onOpenChange={(open) => {

--- a/src/components/Terminal/TerminalDisconnectOverlay.test.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.test.tsx
@@ -1,8 +1,31 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act } from "react";
+import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { TerminalDisconnectOverlay } from "./TerminalDisconnectOverlay";
+import { TooltipProvider } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so the tooltip-wrapped dismiss button renders.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+/** Wrap a subtree so the shared Tooltip primitive finds its provider. */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
 
 // Stub lucide-react icons used in the overlay
 vi.mock("lucide-react", () => ({
@@ -39,7 +62,7 @@ describe("TerminalDisconnectOverlay — default (disconnected) state", () => {
 
   it("renders the overlay with the disconnected heading", () => {
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     expect(container.querySelector("[data-testid='terminal-disconnect-overlay']")).not.toBeNull();
@@ -48,7 +71,7 @@ describe("TerminalDisconnectOverlay — default (disconnected) state", () => {
 
   it("renders reconnect and view-scrollback buttons", () => {
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     expect(
@@ -64,7 +87,7 @@ describe("TerminalDisconnectOverlay — default (disconnected) state", () => {
     useAppStore.setState({ terminalExitedTabs: { "tab-1": true } });
 
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     const btn = container.querySelector(
@@ -83,7 +106,7 @@ describe("TerminalDisconnectOverlay — default (disconnected) state", () => {
     useAppStore.setState({ terminalExitedTabs: { "tab-1": true }, terminalRetryCounters: {} });
 
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     const btn = container.querySelector(
@@ -106,7 +129,7 @@ describe("TerminalDisconnectOverlay — default (disconnected) state", () => {
     useAppStore.setState({ terminalExitedTabs: { "tab-1": true } });
 
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     const btn = container.querySelector(
@@ -149,7 +172,7 @@ describe("TerminalDisconnectOverlay — reconnecting state", () => {
 
   it("shows reconnecting heading and a stop button", () => {
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     expect(container.textContent).toContain("Reconnecting");
@@ -160,7 +183,7 @@ describe("TerminalDisconnectOverlay — reconnecting state", () => {
 
   it("stop button transitions tab from reconnecting to exited", () => {
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     const btn = container.querySelector(
@@ -182,7 +205,7 @@ describe("TerminalDisconnectOverlay — reconnecting state", () => {
     });
 
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     expect(
@@ -193,7 +216,7 @@ describe("TerminalDisconnectOverlay — reconnecting state", () => {
 
   it("does not show trigger error box when no error is set", () => {
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     expect(
@@ -228,7 +251,7 @@ describe("TerminalDisconnectOverlay — error (reconnect failed) state", () => {
 
   it("shows error heading and the error message", () => {
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     expect(container.textContent).toContain("Reconnect failed");
@@ -238,7 +261,7 @@ describe("TerminalDisconnectOverlay — error (reconnect failed) state", () => {
 
   it("try-again button clears error and increments retry counter", () => {
     act(() => {
-      root.render(<TerminalDisconnectOverlay tabId="tab-1" />);
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
     });
 
     const btn = container.querySelector(

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { WifiOff, RefreshCw, X, AlertTriangle, Loader2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { Tooltip } from "@/components/ui";
 import "./TerminalDisconnectOverlay.css";
 
 interface TerminalDisconnectOverlayProps {
@@ -83,15 +84,16 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
         className="terminal-disconnect-overlay terminal-disconnect-overlay--error"
         data-testid="terminal-disconnect-overlay"
       >
-        <button
-          className="terminal-disconnect-overlay__dismiss"
-          onClick={handleDismiss}
-          title="View scrollback"
-          aria-label="Dismiss and view scrollback"
-          data-testid="terminal-disconnect-dismiss-btn"
-        >
-          <X size={14} />
-        </button>
+        <Tooltip content="View scrollback" side="bottom">
+          <button
+            className="terminal-disconnect-overlay__dismiss"
+            onClick={handleDismiss}
+            aria-label="Dismiss and view scrollback"
+            data-testid="terminal-disconnect-dismiss-btn"
+          >
+            <X size={14} />
+          </button>
+        </Tooltip>
 
         <div className="terminal-disconnect-overlay__body">
           <AlertTriangle
@@ -135,15 +137,16 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
 
   return (
     <div className="terminal-disconnect-overlay" data-testid="terminal-disconnect-overlay">
-      <button
-        className="terminal-disconnect-overlay__dismiss"
-        onClick={handleDismiss}
-        title="View scrollback"
-        aria-label="Dismiss disconnect overlay and view scrollback"
-        data-testid="terminal-disconnect-dismiss-btn"
-      >
-        <X size={14} />
-      </button>
+      <Tooltip content="View scrollback" side="bottom">
+        <button
+          className="terminal-disconnect-overlay__dismiss"
+          onClick={handleDismiss}
+          aria-label="Dismiss disconnect overlay and view scrollback"
+          data-testid="terminal-disconnect-dismiss-btn"
+        >
+          <X size={14} />
+        </button>
+      </Tooltip>
 
       <div className="terminal-disconnect-overlay__body">
         <WifiOff size={32} className="terminal-disconnect-overlay__icon" />

--- a/src/components/Terminal/TerminalSearchBar.tsx
+++ b/src/components/Terminal/TerminalSearchBar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { X, ChevronUp, ChevronDown, CaseSensitive, Regex } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { useTerminalRegistry } from "./TerminalRegistry";
+import { Tooltip } from "@/components/ui";
 import "./TerminalSearchBar.css";
 
 interface TerminalSearchBarProps {
@@ -86,29 +87,43 @@ export function TerminalSearchBar({ tabId }: TerminalSearchBarProps) {
         placeholder="Find..."
         spellCheck={false}
       />
-      <button
-        className={`terminal-search-bar__btn${caseSensitive ? " terminal-search-bar__btn--active" : ""}`}
-        onClick={() => setCaseSensitive(!caseSensitive)}
-        title="Match Case"
-      >
-        <CaseSensitive size={14} />
-      </button>
-      <button
-        className={`terminal-search-bar__btn${useRegex ? " terminal-search-bar__btn--active" : ""}`}
-        onClick={() => setUseRegex(!useRegex)}
-        title="Use Regular Expression"
-      >
-        <Regex size={14} />
-      </button>
-      <button className="terminal-search-bar__btn" onClick={handleFindPrevious} title="Previous">
-        <ChevronUp size={14} />
-      </button>
-      <button className="terminal-search-bar__btn" onClick={handleFindNext} title="Next">
-        <ChevronDown size={14} />
-      </button>
-      <button className="terminal-search-bar__btn" onClick={handleClose} title="Close">
-        <X size={14} />
-      </button>
+      <Tooltip content="Match Case" side="bottom">
+        <button
+          className={`terminal-search-bar__btn${caseSensitive ? " terminal-search-bar__btn--active" : ""}`}
+          onClick={() => setCaseSensitive(!caseSensitive)}
+          aria-label="Match Case"
+        >
+          <CaseSensitive size={14} />
+        </button>
+      </Tooltip>
+      <Tooltip content="Use Regular Expression" side="bottom">
+        <button
+          className={`terminal-search-bar__btn${useRegex ? " terminal-search-bar__btn--active" : ""}`}
+          onClick={() => setUseRegex(!useRegex)}
+          aria-label="Use Regular Expression"
+        >
+          <Regex size={14} />
+        </button>
+      </Tooltip>
+      <Tooltip content="Previous" side="bottom">
+        <button
+          className="terminal-search-bar__btn"
+          onClick={handleFindPrevious}
+          aria-label="Previous"
+        >
+          <ChevronUp size={14} />
+        </button>
+      </Tooltip>
+      <Tooltip content="Next" side="bottom">
+        <button className="terminal-search-bar__btn" onClick={handleFindNext} aria-label="Next">
+          <ChevronDown size={14} />
+        </button>
+      </Tooltip>
+      <Tooltip content="Close" side="bottom">
+        <button className="terminal-search-bar__btn" onClick={handleClose} aria-label="Close">
+          <X size={14} />
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -4,6 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
 import { getAllLeaves } from "@/utils/panelTree";
+import { Tooltip } from "@/components/ui";
 import { TerminalPortalProvider } from "./TerminalRegistry";
 import { TerminalCommandBridge } from "./TerminalCommandBridge";
 import { TestBridge } from "@/testbridge/TestBridge";
@@ -253,48 +254,58 @@ export function TerminalView() {
         <div className="terminal-view__toolbar">
           <TabGroupChips />
           <div className="terminal-view__toolbar-actions">
-            <button
-              className="terminal-view__toolbar-btn"
-              onClick={handleNewTerminal}
-              title="New Terminal"
-              data-testid="terminal-view-new-terminal"
-            >
-              <Plus size={16} />
-            </button>
-            <button
-              className="terminal-view__toolbar-btn"
-              onClick={handleSplitHorizontal}
-              title="Split Terminal Right"
-              data-testid="terminal-view-split-horizontal"
-            >
-              <Columns2 size={16} />
-            </button>
-            <button
-              className="terminal-view__toolbar-btn"
-              onClick={handleSplitVertical}
-              title="Split Terminal Down"
-              data-testid="terminal-view-split-vertical"
-            >
-              <Rows2 size={16} />
-            </button>
-            {allLeaves.length > 1 && (
+            <Tooltip content="New Terminal" side="bottom">
               <button
                 className="terminal-view__toolbar-btn"
-                onClick={handleClosePanel}
-                title="Close Panel"
-                data-testid="terminal-view-close-panel"
+                onClick={handleNewTerminal}
+                aria-label="New Terminal"
+                data-testid="terminal-view-new-terminal"
               >
-                <X size={16} />
+                <Plus size={16} />
               </button>
+            </Tooltip>
+            <Tooltip content="Split Terminal Right" side="bottom">
+              <button
+                className="terminal-view__toolbar-btn"
+                onClick={handleSplitHorizontal}
+                aria-label="Split Terminal Right"
+                data-testid="terminal-view-split-horizontal"
+              >
+                <Columns2 size={16} />
+              </button>
+            </Tooltip>
+            <Tooltip content="Split Terminal Down" side="bottom">
+              <button
+                className="terminal-view__toolbar-btn"
+                onClick={handleSplitVertical}
+                aria-label="Split Terminal Down"
+                data-testid="terminal-view-split-vertical"
+              >
+                <Rows2 size={16} />
+              </button>
+            </Tooltip>
+            {allLeaves.length > 1 && (
+              <Tooltip content="Close Panel" side="bottom">
+                <button
+                  className="terminal-view__toolbar-btn"
+                  onClick={handleClosePanel}
+                  aria-label="Close Panel"
+                  data-testid="terminal-view-close-panel"
+                >
+                  <X size={16} />
+                </button>
+              </Tooltip>
             )}
-            <button
-              className={`terminal-view__toolbar-btn${!sidebarCollapsed ? " terminal-view__toolbar-btn--active" : ""}`}
-              onClick={toggleSidebar}
-              title={sidebarToggleTitle}
-              data-testid="terminal-view-toggle-sidebar"
-            >
-              <PanelLeft size={16} />
-            </button>
+            <Tooltip content={sidebarToggleTitle} side="bottom">
+              <button
+                className={`terminal-view__toolbar-btn${!sidebarCollapsed ? " terminal-view__toolbar-btn--active" : ""}`}
+                onClick={toggleSidebar}
+                aria-label={sidebarToggleTitle}
+                data-testid="terminal-view-toggle-sidebar"
+              >
+                <PanelLeft size={16} />
+              </button>
+            </Tooltip>
           </div>
         </div>
         <div className="terminal-view__content">


### PR DESCRIPTION
## Summary

Continues the `Tooltip` adoption started in #1086 (Activity Bar first pass). Replaces bare `title=` with the shared accessible `Tooltip` primitive on **interactive icon controls** in three of the issue's named areas — **22 controls**:

- **Terminal** (14) — view-toolbar buttons (new/split/close/sidebar-toggle), tab close, new-tab-group add, search-bar buttons (case/regex/prev/next/close), disconnect-overlay dismiss.
- **StatusBar** (2) — line-ending toggle, services indicator.
- **NetworkTools** (6) — WoL wake/delete, HTTP-monitor refresh/stop, sidebar stop/refresh.

Icon-only buttons that conveyed their label only via `title` now carry an `aria-label` (a tooltip is not an accessible name).

## Deliberately left as bare `title=` (per the issue's judgment rule)
Truncation / full-text hovers on **non-interactive** elements (tab label text, tab-group names, connection/host/URL/path strings, CPU/mem/disk stat reveals, status messages) — a tooltip primitive is for interactive-control hover help, not text-overflow reveal. Also left: `ContextMenu.Trigger asChild` elements (would nest `asChild` triggers) and `DropdownMenu.Trigger` text-buttons that already have accessible names.

## Test plan
- `pnpm test -- src/components/Terminal src/components/StatusBar src/components/NetworkTools` → **2111 pass**; `pnpm build`, ESLint, Prettier clean.
- Added `WolPanel.tooltip.test.tsx` (accessible-name via `aria-label` + `aria-describedby` on focus); wrapped affected component tests in `TooltipProvider` with the jsdom shims.
- No `data-testid` changes.

## Follow-up
The remaining areas (Sidebar/connection tree, WorkspaceSidebar/Editor, EmbeddedServerSidebar, TunnelSidebar, OpenConnections, Settings, StatusBar dropdown triggers) are tracked in a follow-up issue.

Closes #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)