### PR TITLE
chore(test): drop testid-catalog count summary (stops recurring merge conflicts)

### DIFF
--- a/scripts/build-testid-catalog.py
+++ b/scripts/build-testid-catalog.py
@@ -262,9 +262,6 @@ def render(buckets: "dict[str, dict]") -> str:
         "",
         "- **Regenerate:** `python scripts/build-testid-catalog.py`",
         "- **Verify freshness (CI):** `python scripts/build-testid-catalog.py --check`",
-        "",
-        f"**{len(literal)}** literal · **{len(dynamic)}** dynamic · "
-        f"**{len(indirect)}** indirect.",
     ]
 
     lines += _section(

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -9,8 +9,6 @@ source — the #1 authoring error when porting system tests (#899).
 - **Regenerate:** `python scripts/build-testid-catalog.py`
 - **Verify freshness (CI):** `python scripts/build-testid-catalog.py --check`
 
-**456** literal · **123** dynamic · **18** indirect.
-
 ## Literal test IDs
 
 Fixed strings — match exactly.


### PR DESCRIPTION
## Problem

The generated `tests/system/testid-catalog.md` carried a summary line near the top:

```
**456** literal · **123** dynamic · **18** indirect.
```

Because it's an **aggregate of the whole catalog**, every branch that adds or removes *any* `data-testid` rewrites those three numbers on that **one shared line**. Parallel branches therefore conflict there on merge — even when their real testid additions land on different (alphabetically sorted) table rows and auto-merge cleanly. This is what caused the merge conflicts across the #1053 X-server UI PRs (#1110 / #1111): the only colliding line was the count.

## Fix

The line was purely informational — nothing reads it. Remove its emission from `scripts/build-testid-catalog.py` and regenerate the catalog. With no shared aggregate line left, this whole class of conflict goes away; the sorted per-testid rows continue to auto-merge.

- `--check` passes (`tests/system/testid-catalog.md is up to date.`).
- No test referenced the summary line (verified).
- No user-facing change → no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)