### PR TITLE
feat(ui): X server Set up consent + provisioning progress (#1053, PR 3/3)

### DIFF
--- a/docs/changes/feature/1053-x-server-consent-progress.md
+++ b/docs/changes/feature/1053-x-server-consent-progress.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Set up X server** flow for SSH X11 forwarding. The Open Connections panel's
+  **X Servers** section now offers a **Set up** action when no local X server is
+  running. It opens a consent dialog (nothing is downloaded or launched before
+  you confirm), then streams live provisioning progress; on success the new
+  server appears in the panel. If a platform dependency is missing (e.g. XQuartz
+  on macOS), the dialog surfaces the guidance and an **Install** action. Part of
+  the X server provisioning epic (#1047, #1053).

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -79,6 +79,10 @@
   white-space: nowrap;
 }
 
+.oc-row__title--muted {
+  color: var(--text-muted);
+}
+
 .oc-row__detail {
   margin-left: var(--spacing-sm);
   color: var(--text-muted);

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/services/api";
 import { TunnelState } from "@/types/tunnel";
 import { XServerStatusReport } from "@/types/xserver";
+import { XServerSetupDialog } from "./XServerSetupDialog";
 import "./OpenConnectionsModal.css";
 
 interface OpenConnectionsModalProps {
@@ -68,6 +69,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const [agentSessions, setAgentSessions] = useState<AgentSessionsState>({});
   const [tunnelStates, setTunnelStates] = useState<TunnelState[]>([]);
   const [xServer, setXServer] = useState<XServerStatusReport | null>(null);
+  const [xServerSetupOpen, setXServerSetupOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const connectedAgents = remoteAgents.filter((a) => a.connectionState === "connected");
@@ -124,6 +126,11 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const showXServer =
     xServer !== null && (xServer.state === "running" || xServer.state === "adopted");
   const xServerManaged = xServer?.state === "running" && xServer.managed === true;
+
+  // When no live server exists (absent/failed/unknown), offer a Set up affordance
+  // instead. Suppressed while loading so the row doesn't flash before status
+  // arrives. This affordance is not counted as an active connection.
+  const showXServerSetup = !loading && !showXServer;
 
   const totalCount =
     connectingTabs.length +
@@ -227,7 +234,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     >
       <div className="open-connections__body">
         {loading && totalCount === 0 && <div className="open-connections__empty">Loading…</div>}
-        {!loading && totalCount === 0 && (
+        {!loading && totalCount === 0 && !showXServerSetup && (
           <div className="open-connections__empty">No open connections.</div>
         )}
 
@@ -398,33 +405,56 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           </Section>
         )}
 
-        {/* X Servers (the single shared X server, when live) */}
-        {showXServer && xServer && (
+        {/* X Servers (the single shared X server, or a Set up affordance) */}
+        {(showXServer || showXServerSetup) && (
           <Section
             title="X Servers"
             icon={<MonitorCog size={14} />}
-            count={1}
-            onKillAll={xServerManaged ? handleStopXServer : undefined}
+            count={showXServer ? 1 : 0}
+            onKillAll={showXServer && xServerManaged ? handleStopXServer : undefined}
             killAllLabel="Stop"
             data-testid="open-connections-x-servers-section"
           >
-            <ConnectionRow
-              icon={<MonitorCog size={14} />}
-              title={xServerManaged ? "VcXsrv" : "External X server"}
-              detail={
-                xServer.displayNumber !== undefined
-                  ? `display :${xServer.displayNumber}`
-                  : undefined
-              }
-              badge={xServerManaged ? "managed" : "external"}
-              onKill={xServerManaged ? handleStopXServer : undefined}
-              killLabel="Stop"
-              data-testid="open-connections-x-server-row"
-              killTestId="open-connections-x-server-stop"
-            />
+            {showXServer && xServer ? (
+              <ConnectionRow
+                icon={<MonitorCog size={14} />}
+                title={xServerManaged ? "VcXsrv" : "External X server"}
+                detail={
+                  xServer.displayNumber !== undefined
+                    ? `display :${xServer.displayNumber}`
+                    : undefined
+                }
+                badge={xServerManaged ? "managed" : "external"}
+                onKill={xServerManaged ? handleStopXServer : undefined}
+                killLabel="Stop"
+                data-testid="open-connections-x-server-row"
+                killTestId="open-connections-x-server-stop"
+              />
+            ) : (
+              <div className="oc-row" data-testid="open-connections-x-server-empty">
+                <span className="oc-row__icon">
+                  <MonitorCog size={14} />
+                </span>
+                <span className="oc-row__title oc-row__title--muted">No X server</span>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setXServerSetupOpen(true)}
+                  data-testid="open-connections-x-server-setup"
+                >
+                  Set up
+                </Button>
+              </div>
+            )}
           </Section>
         )}
       </div>
+
+      <XServerSetupDialog
+        open={xServerSetupOpen}
+        onOpenChange={setXServerSetupOpen}
+        onProvisioned={(report) => setXServer(report)}
+      />
     </Modal>
   );
 }
@@ -455,7 +485,7 @@ function Section({
     <div data-testid={testId}>
       <div className="oc-section__header">
         <span className="oc-section__title">{title}</span>
-        <span className="oc-section__count">{count}</span>
+        {count > 0 && <span className="oc-section__count">{count}</span>}
         {onKillAll && (
           <Button
             variant="danger"

--- a/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
@@ -20,6 +20,12 @@ vi.mock("@/services/api", () => ({
   cancelConnecting: vi.fn(() => Promise.resolve(true)),
   xServerStatus: () => xServerStatus(),
   xServerStop: () => xServerStop(),
+  xServerEnsure: vi.fn(() => Promise.resolve()),
+  xServerInstallDependency: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/events", () => ({
+  onXServerProgress: vi.fn(() => Promise.resolve(() => {})),
 }));
 
 import { OpenConnectionsModal } from "./OpenConnectionsModal";
@@ -114,7 +120,7 @@ describe("OpenConnectionsModal — X Servers section", () => {
     expect(section?.querySelector(".oc-section__kill-all")).toBeNull();
   });
 
-  it("renders no X Servers section when the server is absent", async () => {
+  it("offers a Set up affordance when the server is absent and opens the setup dialog", async () => {
     xServerStatus.mockResolvedValue({
       state: "absent",
       platform: "windows",
@@ -122,6 +128,27 @@ describe("OpenConnectionsModal — X Servers section", () => {
     });
     await renderModal();
 
-    expect(document.querySelector('[data-testid="open-connections-x-servers-section"]')).toBeNull();
+    // The section still renders, now with a Set up affordance instead of a row.
+    const section = document.querySelector('[data-testid="open-connections-x-servers-section"]');
+    expect(section).not.toBeNull();
+    expect(document.querySelector('[data-testid="open-connections-x-server-row"]')).toBeNull();
+
+    const setupBtn = document.querySelector(
+      '[data-testid="open-connections-x-server-setup"]'
+    ) as HTMLButtonElement;
+    expect(setupBtn).not.toBeNull();
+
+    // The dialog is not open yet.
+    expect(document.querySelector('[data-testid="x-server-setup-dialog"]')).toBeNull();
+
+    await act(async () => {
+      setupBtn.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    // Clicking Set up opens the consent dialog.
+    expect(document.querySelector('[data-testid="x-server-setup-dialog"]')).not.toBeNull();
+    expect(document.querySelector('[data-testid="x-server-setup-consent"]')).not.toBeNull();
   });
 });

--- a/src/components/OpenConnections/XServerSetupDialog.css
+++ b/src/components/OpenConnections/XServerSetupDialog.css
@@ -1,0 +1,107 @@
+/*
+ * Styles for the X server setup / provisioning dialog (issue 1053). The overlay,
+ * head, body padding, and footer all come from the shared Modal primitive; only
+ * the consent copy, progress bar, and error guidance layout live here. All
+ * values reference design tokens.
+ */
+
+.x-server-setup__consent,
+.x-server-setup__provisioning,
+.x-server-setup__error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.x-server-setup__lead {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  margin: 0;
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+}
+
+.x-server-setup__lead-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--accent-color);
+}
+
+.x-server-setup__body-text,
+.x-server-setup__step,
+.x-server-setup__hint,
+.x-server-setup__error-message {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.x-server-setup__step {
+  color: var(--text-primary);
+}
+
+.x-server-setup__error-message {
+  color: var(--text-primary);
+}
+
+/* Progress bar */
+.x-server-setup__progress {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  overflow: hidden;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-full);
+}
+
+.x-server-setup__progress-fill {
+  height: 100%;
+  background: var(--accent-color);
+  border-radius: var(--radius-full);
+  transition: width var(--transition-normal);
+}
+
+.x-server-setup__progress-fill--indeterminate {
+  width: 40%;
+  animation: x-server-setup-indeterminate 1.2s ease-in-out infinite;
+}
+
+@keyframes x-server-setup-indeterminate {
+  0% {
+    margin-left: -40%;
+  }
+  100% {
+    margin-left: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .x-server-setup__progress-fill {
+    transition: none;
+  }
+  .x-server-setup__progress-fill--indeterminate {
+    /* Show a static partial bar instead of a looping animation. */
+    animation: none;
+    margin-left: 0;
+    width: 100%;
+    opacity: 0.6;
+  }
+}
+
+/* Dependency install command block */
+.x-server-setup__command {
+  margin: 0;
+  padding: var(--spacing-sm) var(--spacing-md);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+}
+
+.x-server-setup__command code {
+  font-family: inherit;
+}

--- a/src/components/OpenConnections/XServerSetupDialog.test.tsx
+++ b/src/components/OpenConnections/XServerSetupDialog.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Tests for the X server setup / provisioning dialog (#1053): consent → Enable
+ * runs x_server_ensure and shows progress → resolve calls onProvisioned and
+ * closes; a dependencyMissing rejection surfaces an Install action; a plain
+ * rejection surfaces the message with a Retry action.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { XServerError, XServerStatusReport } from "@/types/xserver";
+
+const xServerEnsure = vi.fn<() => Promise<XServerStatusReport>>();
+const xServerInstallDependency = vi.fn<() => Promise<void>>();
+const onXServerProgress = vi.fn(() => Promise.resolve(() => {}));
+
+vi.mock("@/services/api", () => ({
+  xServerEnsure: () => xServerEnsure(),
+  xServerInstallDependency: () => xServerInstallDependency(),
+}));
+
+vi.mock("@/services/events", () => ({
+  onXServerProgress: () => onXServerProgress(),
+}));
+
+import { XServerSetupDialog } from "./XServerSetupDialog";
+
+/** Flush pending microtasks (the async subscribe + ensure chain) inside act. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** A deferred promise whose resolve/reject can be triggered by the test. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("XServerSetupDialog", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    xServerEnsure.mockReset();
+    xServerInstallDependency.mockReset();
+    onXServerProgress.mockClear();
+    onXServerProgress.mockImplementation(() => Promise.resolve(() => {}));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderDialog(props: {
+    onOpenChange?: (open: boolean) => void;
+    onProvisioned?: (report: XServerStatusReport) => void;
+  }) {
+    act(() => {
+      root.render(
+        React.createElement(XServerSetupDialog, {
+          open: true,
+          onOpenChange: props.onOpenChange ?? (() => {}),
+          onProvisioned: props.onProvisioned,
+        })
+      );
+    });
+  }
+
+  function click(testId: string) {
+    const el = document.querySelector(`[data-testid="${testId}"]`) as HTMLButtonElement | null;
+    if (!el) throw new Error(`missing element: ${testId}`);
+    el.click();
+  }
+
+  it("shows consent, runs ensure on Enable, then provisions and closes", async () => {
+    const ensure = deferred<XServerStatusReport>();
+    xServerEnsure.mockReturnValue(ensure.promise);
+    const onOpenChange = vi.fn();
+    const onProvisioned = vi.fn();
+
+    renderDialog({ onOpenChange, onProvisioned });
+
+    // Consent screen is visible; nothing provisioned yet.
+    expect(document.querySelector('[data-testid="x-server-setup-consent"]')).not.toBeNull();
+    expect(xServerEnsure).not.toHaveBeenCalled();
+
+    await act(async () => {
+      click("x-server-setup-enable");
+      await Promise.resolve();
+    });
+    await flush();
+
+    // Provisioning: ensure was called and the progress bar is shown.
+    expect(xServerEnsure).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('[data-testid="x-server-setup-progress"]')).not.toBeNull();
+
+    const report: XServerStatusReport = {
+      state: "running",
+      platform: "windows",
+      displayNumber: 0,
+      managed: true,
+    };
+    await act(async () => {
+      ensure.resolve(report);
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(onProvisioned).toHaveBeenCalledWith(report);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("surfaces an Install action on a dependencyMissing failure", async () => {
+    const ensure = deferred<XServerStatusReport>();
+    xServerEnsure.mockReturnValue(ensure.promise);
+    xServerInstallDependency.mockResolvedValue(undefined);
+
+    renderDialog({});
+
+    await act(async () => {
+      click("x-server-setup-enable");
+      await Promise.resolve();
+    });
+    await flush();
+
+    const err: XServerError = {
+      kind: "dependencyMissing",
+      message: "VcXsrv is not installed",
+      dependency: "VcXsrv",
+      installHint: "Download VcXsrv from SourceForge",
+      installCommand: "choco install vcxsrv",
+    };
+    await act(async () => {
+      ensure.reject(err);
+      await Promise.resolve();
+    });
+    await flush();
+
+    const errEl = document.querySelector('[data-testid="x-server-setup-error"]');
+    expect(errEl?.textContent).toContain("VcXsrv is not installed");
+    expect(document.querySelector('[data-testid="x-server-setup-install-dep"]')).not.toBeNull();
+    // The install command is rendered for copy/paste.
+    expect(document.body.textContent).toContain("choco install vcxsrv");
+
+    await act(async () => {
+      click("x-server-setup-install-dep");
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(xServerInstallDependency).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the message and a Retry action on a generic failure", async () => {
+    const ensure = deferred<XServerStatusReport>();
+    xServerEnsure.mockReturnValue(ensure.promise);
+
+    renderDialog({});
+
+    await act(async () => {
+      click("x-server-setup-enable");
+      await Promise.resolve();
+    });
+    await flush();
+
+    const err: XServerError = {
+      kind: "provisioningUnavailable",
+      message: "Provisioning is not available on this platform",
+    };
+    await act(async () => {
+      ensure.reject(err);
+      await Promise.resolve();
+    });
+    await flush();
+
+    const errEl = document.querySelector('[data-testid="x-server-setup-error"]');
+    expect(errEl?.textContent).toContain("Provisioning is not available on this platform");
+    // No install action for a non-dependency failure, but Retry is offered.
+    expect(document.querySelector('[data-testid="x-server-setup-install-dep"]')).toBeNull();
+    expect(document.querySelector('[data-testid="x-server-setup-retry"]')).not.toBeNull();
+  });
+});

--- a/src/components/OpenConnections/XServerSetupDialog.tsx
+++ b/src/components/OpenConnections/XServerSetupDialog.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useState } from "react";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { AppWindow } from "lucide-react";
+import { Modal, Button, toast } from "@/components/ui";
+import { xServerEnsure, xServerInstallDependency } from "@/services/api";
+import { onXServerProgress } from "@/services/events";
+import { frontendLog } from "@/utils/frontendLog";
+import {
+  isXServerError,
+  type XServerError,
+  type XServerProgress,
+  type XServerStatusReport,
+} from "@/types/xserver";
+import "./XServerSetupDialog.css";
+
+/** Which screen of the setup flow is showing. */
+type Phase = "consent" | "provisioning" | "error";
+
+interface XServerSetupDialogProps {
+  /** Whether the dialog is open (controlled). */
+  open: boolean;
+  /** Called with the next open state (Modal fires `false` on ESC / close / cancel). */
+  onOpenChange: (open: boolean) => void;
+  /** Invoked with the final report once provisioning succeeds. */
+  onProvisioned?: (report: XServerStatusReport) => void;
+}
+
+/**
+ * Consent-gated setup and live provisioning-progress flow for the shared X
+ * server (#1053). Nothing is downloaded or launched before the user hits
+ * "Enable". Once consented, it subscribes to `x-server-progress` events, calls
+ * `x_server_ensure`, and resolves in place — a failure drops into a recoverable
+ * error screen (with an install action when a dependency is missing).
+ */
+export function XServerSetupDialog({ open, onOpenChange, onProvisioned }: XServerSetupDialogProps) {
+  const [phase, setPhase] = useState<Phase>("consent");
+  const [progress, setProgress] = useState<XServerProgress | null>(null);
+  const [error, setError] = useState<XServerError | null>(null);
+  const [rawError, setRawError] = useState<unknown>(null);
+
+  // Reset to the consent screen whenever the dialog is (re)opened.
+  useEffect(() => {
+    if (open) {
+      setPhase("consent");
+      setProgress(null);
+      setError(null);
+      setRawError(null);
+    }
+  }, [open]);
+
+  // Drive provisioning: subscribe to progress events, then run x_server_ensure.
+  useEffect(() => {
+    if (phase !== "provisioning") return;
+
+    let cancelled = false;
+    let unlisten: UnlistenFn | undefined;
+    setProgress(null);
+
+    void (async () => {
+      unlisten = await onXServerProgress((p) => {
+        if (!cancelled) setProgress(p);
+      });
+      try {
+        const report = await xServerEnsure();
+        if (cancelled) return;
+        frontendLog("x_server_setup", `provisioning succeeded (state=${report.state})`);
+        toast.success("X server ready");
+        onProvisioned?.(report);
+        onOpenChange(false);
+      } catch (e) {
+        if (cancelled) return;
+        frontendLog(
+          "x_server_setup",
+          `provisioning failed: ${isXServerError(e) ? e.message : String(e)}`
+        );
+        setRawError(e);
+        setError(isXServerError(e) ? e : null);
+        setPhase("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+    // Callbacks are stable per open cycle; re-running would restart provisioning.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
+
+  const handleEnable = () => setPhase("provisioning");
+  const handleClose = () => onOpenChange(false);
+  const handleRetry = () => setPhase("provisioning");
+
+  const handleInstallDependency = async () => {
+    const dep = error?.dependency ?? "dependency";
+    try {
+      await xServerInstallDependency();
+      frontendLog("x_server_setup", `installed dependency ${dep}`);
+      toast.success(`${dep} installed`);
+      setPhase("provisioning");
+    } catch (e) {
+      const msg = isXServerError(e) ? e.message : String(e);
+      frontendLog("x_server_setup", `dependency install failed: ${msg}`);
+      toast.error(msg);
+      throw e; // return the Button to idle without a success flash
+    }
+  };
+
+  const title = phase === "error" ? "X server setup failed" : "Set up X server";
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      data-testid="x-server-setup-dialog"
+      footer={renderFooter()}
+    >
+      {phase === "consent" && renderConsent()}
+      {phase === "provisioning" && renderProvisioning()}
+      {phase === "error" && renderError()}
+    </Modal>
+  );
+
+  function renderConsent() {
+    return (
+      <div className="x-server-setup__consent" data-testid="x-server-setup-consent">
+        <p className="x-server-setup__lead">
+          <AppWindow className="x-server-setup__lead-icon" size={16} aria-hidden />
+          Remote GUI apps forwarded over SSH (X11) need a local X server to open as native windows.
+        </p>
+        <p className="x-server-setup__body-text">
+          On Windows, termiHub downloads and manages <strong>VcXsrv</strong> (~7&nbsp;MB, a one-time
+          download). On macOS and Linux it uses your detected X server, guiding you through setup
+          when one is not yet available.
+        </p>
+      </div>
+    );
+  }
+
+  function renderProvisioning() {
+    const indeterminate = progress === null || progress.progress < 0;
+    const pct = indeterminate ? 0 : Math.round(Math.min(1, Math.max(0, progress.progress)) * 100);
+    return (
+      <div className="x-server-setup__provisioning">
+        <p className="x-server-setup__step">{progress?.message ?? "Starting…"}</p>
+        <div
+          className="x-server-setup__progress"
+          data-testid="x-server-setup-progress"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={indeterminate ? undefined : pct}
+        >
+          <div
+            className={
+              indeterminate
+                ? "x-server-setup__progress-fill x-server-setup__progress-fill--indeterminate"
+                : "x-server-setup__progress-fill"
+            }
+            style={indeterminate ? undefined : { width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  function renderError() {
+    const message =
+      error?.message ?? (rawError instanceof Error ? rawError.message : String(rawError));
+    const isDependencyMissing = error?.kind === "dependencyMissing";
+    return (
+      <div className="x-server-setup__error">
+        <p className="x-server-setup__error-message" data-testid="x-server-setup-error">
+          {message}
+        </p>
+        {isDependencyMissing && error?.installHint && (
+          <p className="x-server-setup__hint">{error.installHint}</p>
+        )}
+        {isDependencyMissing && error?.installCommand && (
+          <pre className="x-server-setup__command">
+            <code>{error.installCommand}</code>
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  function renderFooter() {
+    if (phase === "consent") {
+      return (
+        <>
+          <Button variant="secondary" onClick={handleClose} data-testid="x-server-setup-cancel">
+            Not now
+          </Button>
+          <Button variant="primary" onClick={handleEnable} data-testid="x-server-setup-enable">
+            Enable
+          </Button>
+        </>
+      );
+    }
+    if (phase === "error") {
+      return (
+        <>
+          <Button variant="secondary" onClick={handleClose} data-testid="x-server-setup-close">
+            Close
+          </Button>
+          {error?.kind === "dependencyMissing" && (
+            <Button
+              variant="secondary"
+              onClick={handleInstallDependency}
+              errorToast={false}
+              data-testid="x-server-setup-install-dep"
+            >
+              Install {error.dependency ?? "dependency"}
+            </Button>
+          )}
+          <Button variant="primary" onClick={handleRetry} data-testid="x-server-setup-retry">
+            Retry
+          </Button>
+        </>
+      );
+    }
+    // provisioning — no footer actions (work is in flight).
+    return null;
+  }
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -273,6 +273,25 @@ export async function xServerStop(): Promise<void> {
   return await invoke<void>("x_server_stop");
 }
 
+/**
+ * Resolve or provision the shared X server (adopt an external one, or download
+ * and launch the managed one). Emits `x-server-progress` events while running
+ * and resolves with the final status. Rejects with a typed `XServerError` on
+ * failure.
+ */
+export async function xServerEnsure(): Promise<XServerStatusReport> {
+  return await invoke<XServerStatusReport>("x_server_ensure");
+}
+
+/**
+ * Install the platform X server dependency (e.g. VcXsrv) when provisioning
+ * reported it missing. Rejects with a typed `XServerError` carrying guidance
+ * when the install cannot proceed automatically.
+ */
+export async function xServerInstallDependency(): Promise<void> {
+  await invoke("x_server_install_dependency");
+}
+
 /** Check whether the SSH agent is running, stopped, or not installed. */
 export async function checkSshAgentStatus(): Promise<string> {
   return await invoke<string>("check_ssh_agent_status");

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -7,6 +7,7 @@ import { LogEntry } from "@/types/terminal";
 import { TunnelState, TunnelStats } from "@/types/tunnel";
 import { CredentialStoreStatusInfo } from "@/types/credential";
 import { ServerState } from "@/types/embeddedServer";
+import { XServerProgress } from "@/types/xserver";
 
 interface TerminalOutputPayload {
   session_id: string;
@@ -504,6 +505,19 @@ export async function onJumpHostProbeComplete(
   callback: (payload: ProbeCompletePayload) => void
 ): Promise<UnlistenFn> {
   return await listen<ProbeCompletePayload>("jump-host-probe-complete", (event) => {
+    callback(event.payload);
+  });
+}
+
+/**
+ * Subscribe to X server provisioning progress emitted during `x_server_ensure`
+ * (download / launch / verify steps). `progress = -1` marks an indeterminate
+ * step. Returns the unlisten handle (#1053).
+ */
+export async function onXServerProgress(
+  callback: (progress: XServerProgress) => void
+): Promise<UnlistenFn> {
+  return await listen<XServerProgress>("x-server-progress", (event) => {
     callback(event.payload);
   });
 }

--- a/src/types/xserver.ts
+++ b/src/types/xserver.ts
@@ -39,13 +39,62 @@ export interface XServerStatusReport {
 
 /**
  * Progress update emitted while the managed X server is being provisioned or
- * started. Reserved for later PRs (deploy/start flows).
+ * started (the `x-server-progress` event, fired during `x_server_ensure`).
  */
 export interface XServerProgress {
   /** Machine-readable identifier for the current step. */
   step: string;
   /** Human-readable description of the current step. */
   message: string;
-  /** Completion fraction in the range `0`–`1`. */
+  /**
+   * Completion fraction in the range `0`–`1`, or `-1` for an indeterminate
+   * step (render a looping/indeterminate progress bar).
+   */
   progress: number;
+}
+
+/**
+ * Machine-readable classification of an X server provisioning failure. Drives
+ * how the setup dialog recovers: `dependencyMissing` offers an install action;
+ * the rest offer a plain retry with the human-readable `message`.
+ */
+export type XServerErrorKind =
+  | "provisioningUnavailable"
+  | "noLocalServer"
+  | "dependencyMissing"
+  | "serverUnreachable"
+  | "launchFailed"
+  | "unsupported";
+
+/**
+ * Typed error rejected by `x_server_ensure` / `x_server_install_dependency`.
+ * Serialized from the tagged Rust `XServerError`; optional fields are omitted
+ * when the backend has no value. `dependencyMissing` carries the missing
+ * `dependency` plus optional install guidance.
+ */
+export interface XServerError {
+  /** Failure classification. */
+  kind: XServerErrorKind;
+  /** Human-readable failure detail. */
+  message: string;
+  /** Name of the missing dependency (only for `dependencyMissing`). */
+  dependency?: string;
+  /** Human-readable hint on how to install the dependency. */
+  installHint?: string;
+  /** A concrete shell command that installs the dependency, if available. */
+  installCommand?: string;
+}
+
+/**
+ * Type guard for {@link XServerError}: an object carrying a string `kind` and a
+ * string `message`. Use to narrow the `unknown` a rejected Tauri command
+ * surfaces before reading typed guidance.
+ */
+export function isXServerError(e: unknown): e is XServerError {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    typeof (e as { kind?: unknown }).kind === "string" &&
+    typeof (e as { message?: unknown }).message === "string"
+  );
 }

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -266,7 +266,9 @@ Fixed strings — match exactly.
 | `network-monitors-section` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-new-monitor` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-tools-sidebar` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
+| `open-connections-x-server-empty` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-row` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `open-connections-x-server-setup` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-servers-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-ports-panel` | `src/components/NetworkTools/OpenPortsPanel.tsx` |
 | `open-ports-refresh` | `src/components/NetworkTools/OpenPortsPanel.tsx` |
@@ -465,6 +467,15 @@ Fixed strings — match exactly.
 | `workspace-save-btn` | `src/components/WorkspaceEditor/WorkspaceEditor.tsx` |
 | `workspace-save-current-btn` | `src/components/WorkspaceSidebar/WorkspaceSidebar.tsx` |
 | `workspace-sidebar` | `src/components/WorkspaceSidebar/WorkspaceSidebar.tsx` |
+| `x-server-setup-cancel` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
+| `x-server-setup-close` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
+| `x-server-setup-consent` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
+| `x-server-setup-dialog` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
+| `x-server-setup-enable` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
+| `x-server-setup-error` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
+| `x-server-setup-install-dep` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
+| `x-server-setup-progress` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
+| `x-server-setup-retry` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
 | `zoom-context-clear` | `src/components/SplitView/SplitView.tsx` |
 | `zoom-context-copy` | `src/components/SplitView/SplitView.tsx` |
 | `zoom-context-horizontal-scroll` | `src/components/SplitView/SplitView.tsx` |


### PR DESCRIPTION
**Part of #1053 (X server UI) · epic #1047 · PR 3 of 3.** Builds on merged #1110.

The final X-server UI slice: a manual **Set up X server** consent + provisioning-progress flow.

## Why manual (not connect-triggered)
The concept's "first-use consent on connect" isn't buildable frontend-only: the SSH connect path provisions synchronously in Rust (`connector.rs`), emits no `x-server-progress`, and never pauses for the UI. Upgrading to the on-connect experience needs backend support and is tracked in **#1116**.

## What this adds
- **`XServerSetupDialog`** — a `consent | provisioning | error` phase machine in a `Modal`:
  - **consent**: explains remote GUI apps need a local X server (Windows → downloads VcXsrv ~7 MB; macOS/Linux → detected/guided). Nothing runs before **Enable**.
  - **provisioning**: subscribes to `x-server-progress`, calls `x_server_ensure`, shows a live progress bar (indeterminate when `progress < 0`, ARIA `role="progressbar"`).
  - **error**: shows the typed `XServerError` message; on `dependencyMissing`, surfaces `installHint`/`installCommand` and an **Install {dependency}** action (`x_server_install_dependency`); **Retry**/**Close**.
- **Open Connections "X Servers" section** now renders a **Set up X server** affordance when no server is live; on success the provisioned server replaces it.
- Wiring: `xServerEnsure` / `xServerInstallDependency` api wrappers, `onXServerProgress` event hook, `XServerError` + `isXServerError` guard.

## Two UX decisions to review
1. **Always-visible affordance** — the "X Servers" section shows a "Set up" row whenever no server is live (so it appears even for users not using X11). It's excluded from the panel's connection count, and the "No open connections" empty text is suppressed when it shows. Alternative: gate it on `provideXServerAutomatically` once PR #1111 (settings) merges — happy to follow up.
2. **Platform-generic consent copy** — the dialog gets no platform prop, so the consent text mentions Windows + macOS/Linux together (the concept describes per-platform variants). Can add a `platform` prop if you want per-platform copy.

## Design
- Composes `Modal`/`Button`/`toast` primitives; tokens only (progress bar: `--bg-tertiary` track, `--accent-color` fill; indeterminate animation gated by `prefers-reduced-motion`). Install action uses the async `Button` lifecycle with its own typed-error toast.

## Testing (TDD)
- `XServerSetupDialog.test.tsx` (consent→ensure→progress→resolve/close; `dependencyMissing`→Install; generic failure→Retry) and updated `OpenConnectionsModal.xservers.test.tsx` (absent → Set up affordance opens dialog). Commit order: failing tests → implementation.
- `vitest` (9/9 OpenConnections), `eslint`, `tsc --noEmit`, `prettier` green; `data-testid` catalog regenerated (count-less generator).

## Note
On Windows the VcXsrv download isn't wired yet (#1048/#1076), so `x_server_ensure` currently returns "provisioning unavailable" guidance rather than downloading — this flow is the front door that activates when those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)