### PR TITLE
feat(xserver): macOS XQuartz detect + guided/opt-in install (Closes #1054)

### DIFF
--- a/docs/changes/dev2/feature/1054-macos-xquartz-guided-install.md
+++ b/docs/changes/dev2/feature/1054-macos-xquartz-guided-install.md
@@ -1,0 +1,9 @@
+### Added
+
+- macOS SSH X11 forwarding: termiHub now detects XQuartz and, when it is
+  missing, offers an explicit, consent-based install instead of silently doing
+  nothing — `brew install --cask xquartz` when Homebrew is present (admin auth
+  prompted by Homebrew itself), otherwise actionable guidance to download it
+  from xquartz.org. When XQuartz is present, termiHub launches it if idle so a
+  forwarded remote window renders locally. No install ever runs silently
+  (#1054, epic #1047).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -894,6 +894,35 @@ Optional additional cases:
   granted; confirm the hint names the `--socket=x11` / `--socket=fallback-x11`
   grant.
 
+#### macOS XQuartz detect + guided install (#1054)
+
+macOS can't embed an X server, so termiHub detects XQuartz and offers an
+explicit, consent-based install (`src-tauri/src/terminal/xserver/macos.rs`).
+Detection is unit-tested (mock FS), but the guided install and forwarded
+rendering are macOS-only and manual (per ADR-5). **No install may ever run
+silently** — it happens only on the explicit install action.
+
+On a clean macOS **without** XQuartz (`/opt/X11` and
+`/Applications/Utilities/XQuartz.app` both absent):
+
+1. Open an SSH connection with **X11 forwarding** enabled. Confirm it surfaces
+   the **XQuartz missing** guidance (with a link to xquartz.org) — no silent
+   install, no generic failure.
+2. Trigger the install action (the `x_server_install_dependency` command, via
+   the #1053 UI once present):
+   - **With Homebrew installed:** confirm `brew install --cask xquartz` runs
+     (admin auth prompted by brew/macOS), progress is shown, and it reports
+     success.
+   - **Without Homebrew:** confirm it returns the actionable xquartz.org
+     download guidance rather than doing nothing or failing opaquely.
+
+With XQuartz **present**:
+
+1. Connect with X11 forwarding to a host running a GUI app (e.g. `xclock`).
+   Confirm termiHub launches XQuartz if it isn't running (`open -a XQuartz`) and
+   the remote window renders locally. (XQuartz's "Allow connections from network
+   clients" preference may be required.)
+
 #### VcXsrv provisioning: first-run download + offline re-run (Windows, #1076)
 
 termiHub downloads a pinned, minimal VcXsrv `.zip` from its GitHub releases on

--- a/src-tauri/src/commands/xserver.rs
+++ b/src-tauri/src/commands/xserver.rs
@@ -90,17 +90,36 @@ pub fn x_server_stop(
 
 /// Install (or guide the install of) the platform's X dependency.
 ///
-/// The real installers are their own issues (#1048 VcXsrv, #1054 XQuartz); until
-/// they land this returns the same typed guidance the orchestrator produces, so
-/// the UI (#1053) has something concrete to show rather than a silent no-op.
+/// macOS runs a guided, consent-based XQuartz install (#1054): Homebrew when
+/// present, otherwise actionable download guidance. Windows VcXsrv acquisition
+/// (#1048) and Linux (never installs) still return their typed guidance so the
+/// UI (#1053) has something concrete to show.
 #[tauri::command]
 pub async fn x_server_install_dependency(app: AppHandle) -> Result<(), XServerError> {
     emit_progress(&app, "install", "Preparing X dependency install…", -1.0);
-    let err = match XServerPlatform::current() {
-        XServerPlatform::Windows => XServerError::windows_provisioning_unavailable(),
-        XServerPlatform::MacOs => XServerError::xquartz_missing(),
-        XServerPlatform::Linux => XServerError::linux_install_unsupported(),
-    };
-    emit_progress(&app, "failed", &err.to_string(), 1.0);
-    Err(err)
+    match XServerPlatform::current() {
+        XServerPlatform::MacOs => {
+            emit_progress(&app, "install", "Installing XQuartz…", -1.0);
+            match xserver::macos::install_xquartz().await {
+                Ok(()) => {
+                    emit_progress(&app, "ready", "XQuartz is ready.", 1.0);
+                    Ok(())
+                }
+                Err(err) => {
+                    emit_progress(&app, "failed", &err.to_string(), 1.0);
+                    Err(err)
+                }
+            }
+        }
+        XServerPlatform::Windows => {
+            let err = XServerError::windows_provisioning_unavailable();
+            emit_progress(&app, "failed", &err.to_string(), 1.0);
+            Err(err)
+        }
+        XServerPlatform::Linux => {
+            let err = XServerError::linux_install_unsupported();
+            emit_progress(&app, "failed", &err.to_string(), 1.0);
+            Err(err)
+        }
+    }
 }

--- a/src-tauri/src/commands/xserver.rs
+++ b/src-tauri/src/commands/xserver.rs
@@ -108,9 +108,7 @@ pub async fn x_server_install_dependency(app: AppHandle) -> Result<(), XServerEr
             Err(XServerError::windows_provisioning_unavailable()),
             "",
         ),
-        XServerPlatform::Linux => {
-            finish(&app, Err(XServerError::linux_install_unsupported()), "")
-        }
+        XServerPlatform::Linux => finish(&app, Err(XServerError::linux_install_unsupported()), ""),
     }
 }
 

--- a/src-tauri/src/commands/xserver.rs
+++ b/src-tauri/src/commands/xserver.rs
@@ -98,28 +98,33 @@ pub fn x_server_stop(
 pub async fn x_server_install_dependency(app: AppHandle) -> Result<(), XServerError> {
     emit_progress(&app, "install", "Preparing X dependency install…", -1.0);
     match XServerPlatform::current() {
-        XServerPlatform::MacOs => {
-            emit_progress(&app, "install", "Installing XQuartz…", -1.0);
-            match xserver::macos::install_xquartz().await {
-                Ok(()) => {
-                    emit_progress(&app, "ready", "XQuartz is ready.", 1.0);
-                    Ok(())
-                }
-                Err(err) => {
-                    emit_progress(&app, "failed", &err.to_string(), 1.0);
-                    Err(err)
-                }
-            }
-        }
-        XServerPlatform::Windows => {
-            let err = XServerError::windows_provisioning_unavailable();
-            emit_progress(&app, "failed", &err.to_string(), 1.0);
-            Err(err)
-        }
+        XServerPlatform::MacOs => finish(
+            &app,
+            xserver::macos::install_xquartz().await,
+            "XQuartz is ready.",
+        ),
+        XServerPlatform::Windows => finish(
+            &app,
+            Err(XServerError::windows_provisioning_unavailable()),
+            "",
+        ),
         XServerPlatform::Linux => {
-            let err = XServerError::linux_install_unsupported();
-            emit_progress(&app, "failed", &err.to_string(), 1.0);
-            Err(err)
+            finish(&app, Err(XServerError::linux_install_unsupported()), "")
         }
     }
+}
+
+/// Emit the terminal progress event for an install `result` and return it, so the
+/// success/failure tail is written once. Mirrors the `Ok/Err => emit` shape
+/// [`x_server_ensure`] already uses.
+fn finish(
+    app: &AppHandle,
+    result: Result<(), XServerError>,
+    ok_message: &str,
+) -> Result<(), XServerError> {
+    match &result {
+        Ok(()) => emit_progress(app, "ready", ok_message, 1.0),
+        Err(err) => emit_progress(app, "failed", &err.to_string(), 1.0),
+    }
+    result
 }

--- a/src-tauri/src/terminal/xserver/macos.rs
+++ b/src-tauri/src/terminal/xserver/macos.rs
@@ -1,0 +1,54 @@
+//! macOS XQuartz detection and guided, consent-based install (#1054).
+//!
+//! macOS can't embed an X server, so termiHub detects XQuartz and — only on an
+//! explicit user action, never silently — guides its install. Detection is a
+//! pure check over injectable paths so it is unit-testable on any CI host.
+
+use std::path::Path;
+
+/// Canonical XQuartz install locations on macOS.
+///
+/// `/opt/X11` is the runtime/framework tree; the `.app` is the launcher. Either
+/// present means XQuartz is installed.
+const XQUARTZ_PATHS: [&str; 2] = ["/opt/X11", "/Applications/Utilities/XQuartz.app"];
+
+/// Whether XQuartz is installed at the canonical macOS locations.
+pub(super) fn xquartz_installed() -> bool {
+    any_path_exists(&XQUARTZ_PATHS.map(Path::new))
+}
+
+/// Whether any of `paths` exists. Pure over injected paths so detection is
+/// unit-testable against temp directories (mock FS).
+fn any_path_exists<P: AsRef<Path>>(_paths: &[P]) -> bool {
+    // Stubbed until the detection is implemented (see #1054).
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_when_a_canonical_path_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let present = tmp.path().join("opt-x11");
+        std::fs::create_dir(&present).unwrap();
+        let absent = tmp.path().join("nope");
+        assert!(any_path_exists(&[present.as_path(), absent.as_path()]));
+        assert!(any_path_exists(&[absent.as_path(), present.as_path()]));
+    }
+
+    #[test]
+    fn not_detected_when_no_path_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = tmp.path().join("nope-a");
+        let b = tmp.path().join("nope-b");
+        assert!(!any_path_exists(&[a.as_path(), b.as_path()]));
+    }
+
+    #[test]
+    fn xquartz_paths_are_the_documented_locations() {
+        assert!(XQUARTZ_PATHS.contains(&"/opt/X11"));
+        assert!(XQUARTZ_PATHS.contains(&"/Applications/Utilities/XQuartz.app"));
+    }
+}

--- a/src-tauri/src/terminal/xserver/macos.rs
+++ b/src-tauri/src/terminal/xserver/macos.rs
@@ -34,6 +34,10 @@ fn any_path_exists<P: AsRef<Path>>(paths: &[P]) -> bool {
 
 /// Best-effort launch of XQuartz when it is installed but idle. Errors are
 /// ignored — detection afterwards decides whether a server actually came up.
+///
+/// Only this fn is macOS-gated (`open -a` is nonsensical elsewhere and its caller
+/// is `#[cfg(target_os = "macos")]`); the rest of the module stays ungated so the
+/// cross-platform `dependency_available` / install-command match arms compile.
 #[cfg(target_os = "macos")]
 pub(super) fn launch_xquartz() {
     let _ = std::process::Command::new("open")
@@ -54,8 +58,10 @@ pub(crate) async fn install_xquartz() -> Result<(), XServerError> {
     }
     if !super::binary_on_path("brew") {
         // No automated path available (the hosted `.pkg` installer is a follow-up)
-        // → hand back the download guidance rather than doing anything silently.
-        return Err(XServerError::xquartz_missing());
+        // → hand back post-click download guidance rather than doing anything
+        // silently. Distinct from the detect-path `xquartz_missing` (no brew
+        // command, since brew is what's missing here).
+        return Err(XServerError::xquartz_manual_install_required());
     }
     run_brew_install().await
 }

--- a/src-tauri/src/terminal/xserver/macos.rs
+++ b/src-tauri/src/terminal/xserver/macos.rs
@@ -1,16 +1,25 @@
 //! macOS XQuartz detection and guided, consent-based install (#1054).
 //!
 //! macOS can't embed an X server, so termiHub detects XQuartz and — only on an
-//! explicit user action, never silently — guides its install. Detection is a
-//! pure check over injectable paths so it is unit-testable on any CI host.
+//! explicit user action, never silently — guides its install: `brew install
+//! --cask xquartz` when Homebrew is present, otherwise actionable guidance to
+//! download it from xquartz.org (the hosted notarized `.pkg` path is a
+//! follow-up). Detection is a pure check over injectable paths so it is
+//! unit-testable on any CI host; the install runs off the async reactor.
 
 use std::path::Path;
+
+use super::types::XServerError;
 
 /// Canonical XQuartz install locations on macOS.
 ///
 /// `/opt/X11` is the runtime/framework tree; the `.app` is the launcher. Either
 /// present means XQuartz is installed.
 const XQUARTZ_PATHS: [&str; 2] = ["/opt/X11", "/Applications/Utilities/XQuartz.app"];
+
+/// The Homebrew invocation that installs XQuartz. `brew` prompts for admin auth
+/// itself, so the install stays consent-based.
+const BREW_INSTALL_ARGS: [&str; 3] = ["install", "--cask", "xquartz"];
 
 /// Whether XQuartz is installed at the canonical macOS locations.
 pub(super) fn xquartz_installed() -> bool {
@@ -19,9 +28,67 @@ pub(super) fn xquartz_installed() -> bool {
 
 /// Whether any of `paths` exists. Pure over injected paths so detection is
 /// unit-testable against temp directories (mock FS).
-fn any_path_exists<P: AsRef<Path>>(_paths: &[P]) -> bool {
-    // Stubbed until the detection is implemented (see #1054).
-    false
+fn any_path_exists<P: AsRef<Path>>(paths: &[P]) -> bool {
+    paths.iter().any(|p| p.as_ref().exists())
+}
+
+/// Best-effort launch of XQuartz when it is installed but idle. Errors are
+/// ignored — detection afterwards decides whether a server actually came up.
+#[cfg(target_os = "macos")]
+pub(super) fn launch_xquartz() {
+    let _ = std::process::Command::new("open")
+        .args(["-a", "XQuartz"])
+        .spawn();
+}
+
+/// Guided, consent-based XQuartz install.
+///
+/// Only ever called from the `x_server_install_dependency` command — i.e. after
+/// an explicit user action, never on the silent connect path. Uses Homebrew when
+/// available (`brew install --cask xquartz`, which prompts for admin auth
+/// itself); otherwise returns the actionable download guidance the UI surfaces as
+/// an "Open xquartz.org" action. Never installs anything silently.
+pub(crate) async fn install_xquartz() -> Result<(), XServerError> {
+    if xquartz_installed() {
+        return Ok(());
+    }
+    if !super::binary_on_path("brew") {
+        // No automated path available (the hosted `.pkg` installer is a follow-up)
+        // → hand back the download guidance rather than doing anything silently.
+        return Err(XServerError::xquartz_missing());
+    }
+    run_brew_install().await
+}
+
+/// Run `brew install --cask xquartz` off the async reactor, mapping a spawn
+/// failure or non-zero exit to a typed, display-ready error.
+async fn run_brew_install() -> Result<(), XServerError> {
+    tokio::task::spawn_blocking(|| {
+        let output = std::process::Command::new("brew")
+            .args(BREW_INSTALL_ARGS)
+            .output()
+            .map_err(|e| XServerError::LaunchFailed {
+                message: format!("Failed to run Homebrew: {e}"),
+            })?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let detail = stderr
+                .trim()
+                .lines()
+                .last()
+                .unwrap_or("unknown error")
+                .to_string();
+            Err(XServerError::LaunchFailed {
+                message: format!("Homebrew failed to install XQuartz: {detail}"),
+            })
+        }
+    })
+    .await
+    .map_err(|e| XServerError::LaunchFailed {
+        message: format!("XQuartz install task failed: {e}"),
+    })?
 }
 
 #[cfg(test)]
@@ -50,5 +117,10 @@ mod tests {
     fn xquartz_paths_are_the_documented_locations() {
         assert!(XQUARTZ_PATHS.contains(&"/opt/X11"));
         assert!(XQUARTZ_PATHS.contains(&"/Applications/Utilities/XQuartz.app"));
+    }
+
+    #[test]
+    fn brew_install_args_target_the_xquartz_cask() {
+        assert_eq!(BREW_INSTALL_ARGS, ["install", "--cask", "xquartz"]);
     }
 }

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -17,6 +17,7 @@
 pub mod acquire;
 pub mod auth;
 mod linux_gap;
+mod macos;
 pub mod manager;
 mod orchestrator;
 mod types;

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -17,7 +17,7 @@
 pub mod acquire;
 pub mod auth;
 mod linux_gap;
-mod macos;
+pub(crate) mod macos;
 pub mod manager;
 mod orchestrator;
 mod types;

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -212,10 +212,7 @@ fn report(
 ///   running-server TCP probe, and managed acquisition is #1048.
 fn dependency_available(platform: XServerPlatform) -> bool {
     match platform {
-        XServerPlatform::MacOs => {
-            std::path::Path::new("/opt/X11").exists()
-                || std::path::Path::new("/Applications/Utilities/XQuartz.app").exists()
-        }
+        XServerPlatform::MacOs => super::macos::xquartz_installed(),
         XServerPlatform::Linux => {
             std::path::Path::new("/tmp/.X11-unix").is_dir()
                 || super::binary_on_path("Xwayland")

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -46,7 +46,7 @@ pub fn ensure_x_server(
     // SSH `DISPLAY` handshake can succeed.
     #[cfg(target_os = "macos")]
     if dependency && detect_local_x_server().is_none() {
-        macos::launch_xquartz();
+        super::macos::launch_xquartz();
     }
 
     // 1. Let the manager adopt/reuse/spawn (TCP-based; covers Windows + managed).
@@ -219,17 +219,6 @@ fn dependency_available(platform: XServerPlatform) -> bool {
                 || super::binary_on_path("Xorg")
         }
         XServerPlatform::Windows => false,
-    }
-}
-
-#[cfg(target_os = "macos")]
-mod macos {
-    /// Best-effort launch of XQuartz. Errors are ignored — detection afterwards
-    /// decides whether a server actually came up.
-    pub(super) fn launch_xquartz() {
-        let _ = std::process::Command::new("open")
-            .args(["-a", "XQuartz"])
-            .spawn();
     }
 }
 

--- a/src-tauri/src/terminal/xserver/types.rs
+++ b/src-tauri/src/terminal/xserver/types.rs
@@ -157,6 +157,29 @@ impl XServerError {
         }
     }
 
+    /// macOS: the user asked to install XQuartz but no automated installer is
+    /// available (Homebrew absent, and the hosted `.pkg` path is a follow-up).
+    ///
+    /// Distinct from the detect-path [`xquartz_missing`](Self::xquartz_missing):
+    /// this is a *post-click* response, so its message is phrased accordingly and
+    /// it carries **no** `install_command` (there is no working one without
+    /// Homebrew) — only the download guidance the UI turns into "Open xquartz.org".
+    pub fn xquartz_manual_install_required() -> Self {
+        XServerError::DependencyMissing {
+            message: "XQuartz can't be installed automatically because Homebrew was not found. \
+                Download XQuartz from https://www.xquartz.org, then log out and back in so \
+                DISPLAY is set."
+                .to_string(),
+            dependency: "XQuartz".to_string(),
+            install_hint: Some(
+                "Download XQuartz from https://www.xquartz.org, or install Homebrew first and \
+                retry the automatic install."
+                    .to_string(),
+            ),
+            install_command: None,
+        }
+    }
+
     /// macOS: XQuartz is installed but no server is running.
     pub fn macos_server_unreachable() -> Self {
         XServerError::ServerUnreachable {
@@ -283,6 +306,26 @@ mod tests {
         assert!(json.contains("\"displayNumber\":0"));
         assert!(json.contains("\"dependencyAvailable\":true"));
         assert!(!json.contains("message"));
+    }
+
+    #[test]
+    fn manual_install_required_has_download_guidance_but_no_brew_command() {
+        // Post-click "no automated installer" response must not hand back a brew
+        // command (Homebrew is absent in this branch) yet must still guide the
+        // download.
+        match XServerError::xquartz_manual_install_required() {
+            XServerError::DependencyMissing {
+                dependency,
+                install_hint,
+                install_command,
+                ..
+            } => {
+                assert_eq!(dependency, "XQuartz");
+                assert_eq!(install_command, None);
+                assert!(install_hint.unwrap_or_default().contains("xquartz.org"));
+            }
+            other => panic!("expected DependencyMissing, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements the macOS half of X server provisioning (epic #1047, concept #1044): macOS can't embed an X server, so termiHub detects XQuartz and offers an **explicit, consent-based** install — never a silent system install.

New `terminal/xserver/macos.rs` consolidates all macOS X concerns:
- **Detection** — `xquartz_installed()` checks `/opt/X11` + `/Applications/Utilities/XQuartz.app`, factored as a pure function over injectable paths so it's unit-testable (mock FS) on any CI host. `orchestrator::dependency_available` now routes through it.
- **Launch** — the best-effort `open -a XQuartz` nudge (moved out of `orchestrator.rs`).
- **Guided install** — `install_xquartz()`, wired into the `x_server_install_dependency` command with progress events:
  - Homebrew present → `brew install --cask xquartz` (brew prompts for admin auth itself → consent), run off the async reactor.
  - Homebrew absent → a distinct `xquartz_manual_install_required()` outcome with xquartz.org download guidance and **no** brew command (the UI's "Open xquartz.org" action).
  - Already installed → `Ok(())`.

**Scope:** brew + deep-link. The hosted, notarized `.pkg` install path (for macOS users without Homebrew) is deferred to follow-up **#1117**.

The dialog UI itself is #1053's scope; this is the macOS backend + detection.

## Test plan

TDD (test commit precedes implementation):
- **Unit** (all CI): XQuartz detection true/false from path presence (mock FS via tempdirs); `xquartz_manual_install_required()` carries download guidance and no brew command; brew args target the xquartz cask.
- `./scripts/check.sh` (fmt + clippy + ESLint + markdownlint) — green.
- `./scripts/test.sh` (frontend + backend + agent) — green.
- `pnpm build` (tsc) — green.
- **Manual** (macOS, per ADR-5 — X11 rendering can't be automated): guided install with/without Homebrew, and forwarded `xclock` rendering. Steps added to `docs/testing.md`.

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)