### PR TITLE
docs(audits): state-machine audits for 8 stateful subsystems (#1130–#1137)

### DIFF
--- a/docs/audits/credential-store-state-machine.md
+++ b/docs/audits/credential-store-state-machine.md
@@ -1,0 +1,305 @@
+# Credential Store State Machine — Audit
+
+> **Issue:** #1133 — Audit + fix the credential store state machine (locked / unlocked / master-password)
+> **Scope:** Credential store lifecycle (no-store → initialized → locked → unlocked) + connect-flow unlock gating
+> **Deliverable:** Audit findings only — analysis, diagrams, and prioritized gaps. No production code changes.
+
+## 1. Where the state lives
+
+The credential store is a three-mode machine. The **mode** (`master_password` / `os_keychain` / `none`) is orthogonal to the **status** (`unlocked` / `locked` / `unavailable`); only `master_password` mode has a meaningful lock/unlock lifecycle.
+
+| Concept                       | Rust type                                                                            | file:line                                             |
+| ----------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| Store status enum             | `CredentialStoreStatus::{Unlocked, Locked, Unavailable}`                             | `src-tauri/src/credential/types.rs:60-68`             |
+| Storage mode enum             | `StorageMode::{MasterPassword, OsKeychain, None}`                                    | `src-tauri/src/credential/types.rs:71-80`             |
+| Status derivation (master pw) | `status()` — unlocked if key in memory, else Locked if file exists, else Unavailable | `src-tauri/src/credential/master_password.rs:349-357` |
+| In-memory secret state        | `derived_key` / `credentials` / `salt` (all `RwLock<Option<…>>`)                     | `src-tauri/src/credential/master_password.rs:29-34`   |
+| Frontend mirror               | `credentialStoreStatus: CredentialStoreStatusInfo \| null` (Zustand)                 | `src/store/appStore.ts:691, 4087`                     |
+| Demand-unlock promise         | `unlockResolve` + `requestUnlock()` / `resolveUnlock()`                              | `src/store/appStore.ts:696-705, 4107-4118`            |
+
+**Transitions** (each `set` of the master-password store's in-memory state):
+
+- `setup()` — creates file + loads empty map into memory → **Unlocked** (`master_password.rs:55-80`)
+- `unlock()` — decrypts file into memory → **Unlocked** (`master_password.rs:84-134`)
+- `lock()` — zeroizes + clears memory → **Locked** (`master_password.rs:137-155`), also fired by `Drop` (`:360-364`), auto-lock timer (`auto_lock.rs:174`), and `switch_store` (`manager.rs:73-75`)
+- `change_password()` — re-derives key, re-encrypts (stays **Unlocked**) (`master_password.rs:167-205`)
+
+**Guards / reads** (gate other transitions or rendering):
+
+- `resolveConnectionCredential` connect gate: `credStatus?.mode === "master_password" && credStatus?.status === "locked"` (`ConnectionList.tsx:484`, `AgentNode.tsx:607`, `AgentErrorTab.tsx:41`, `appStore.ts:3873`)
+- Indicator render branch: `status.status === "locked"` (`CredentialStoreIndicator.tsx:22, 50`)
+
+---
+
+## 2. Lifecycle diagrams
+
+### 2.1 Master-password mode lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unavailable : mode = master_password, no credentials.enc
+
+    Unavailable --> Unlocked : setup(pw) [no file exists]\n(setup_master_password cmd)
+    Unavailable --> Unavailable : setup fails [file already exists]\n(master_password.rs:56 bail)
+
+    Unlocked --> Locked : lock()\n(indicator click / auto-lock / mode switch / app drop)
+    Locked --> Unlocked : unlock(pw) [correct pw]\n(unlock_credential_store cmd)
+    Locked --> Locked : unlock(pw) [wrong pw → error]\n(master_password.rs:114)
+
+    Unlocked --> Unlocked : change_password(cur,new) [cur correct]
+    Unlocked --> Unlocked : change_password fails [cur wrong → error]\n(master_password.rs:182)
+
+    Unlocked --> [*] : switch_store(none/os_keychain)
+    Locked --> [*] : switch_store(none/os_keychain)
+
+    note right of Locked
+      status() reports Locked
+      because file exists but
+      derived_key is None
+    end note
+```
+
+### 2.2 Mode machine (top-level, orthogonal to lock state)
+
+```mermaid
+stateDiagram-v2
+    [*] --> None : default (StorageMode::None)
+
+    None --> MasterPassword : switch_credential_store("master_password", pw)\n[setup or unlock existing file]
+    None --> OsKeychain : switch_credential_store("os_keychain")
+    MasterPassword --> None : switch(none) [creds removed]
+    MasterPassword --> OsKeychain : switch(os_keychain) [creds migrated]
+    OsKeychain --> None : switch(none)
+    OsKeychain --> MasterPassword : switch(master_password, pw)
+
+    state None {
+        [*] --> Unavailable_None : status always Unavailable
+    }
+    state OsKeychain {
+        [*] --> Unlocked_OS : status always Unlocked (OS-gated)
+    }
+    state MasterPassword {
+        [*] --> mp : see lifecycle diagram 2.1
+    }
+```
+
+Note: `NullStore.status()` is always `Unavailable` (`null.rs:33-35`); `OsKeychainStore.status()` is always `Unlocked` (`os_keychain.rs:119-121`) — neither has an in-app lock state.
+
+---
+
+## 3. Sequence diagrams
+
+### 3.1 Unlock-gated connect (sidebar happy path)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CL as ConnectionList.tsx
+    participant St as appStore (Zustand)
+    participant UD as UnlockDialog
+    participant API as api.ts
+    participant Cmd as credential.rs (Tauri)
+    participant MP as MasterPasswordStore
+
+    U->>CL: click Connect (SSH, savePassword)
+    CL->>St: getState().credentialStoreStatus
+    alt mode=master_password AND status=locked
+        CL->>St: requestUnlock()  (returns Promise<boolean>)
+        St->>UD: unlockDialogOpen = true
+        U->>UD: enter master password → Unlock
+        UD->>API: unlockCredentialStore(pw)
+        API->>Cmd: unlock_credential_store
+        Cmd->>MP: unlock(pw)
+        alt correct pw
+            MP-->>Cmd: Ok
+            Cmd-->>API: emit "credential-store-unlocked"
+            API-->>St: onCredentialStoreUnlocked → resolveUnlock(true)
+            St-->>CL: Promise resolves true
+        else wrong pw
+            MP-->>Cmd: Err
+            Cmd-->>UD: reject → "Incorrect master password" (dialog stays open)
+            Note over CL: requestUnlock() Promise is NOT resolved — CL awaits forever
+        end
+    end
+    CL->>API: resolveConnectionCredential → resolve_credential
+    Cmd->>MP: get(key) → password
+    CL->>API: createTerminal(config + password)
+```
+
+### 3.2 Demand-driven unlock (locked store hit during resolve)
+
+```mermaid
+sequenceDiagram
+    participant Caller as connect flow / ConnectionEditor
+    participant API as api.ts
+    participant Mgr as CredentialManager
+    participant MP as MasterPasswordStore
+    participant Ev as events.ts
+    participant St as appStore
+
+    Caller->>API: resolveCredential(connId, "password")
+    API->>Mgr: get(key)
+    Mgr->>MP: get(key)
+    MP-->>Mgr: Err("Store is locked")
+    Mgr->>Mgr: emit "credential-store-unlock-needed" (manager.rs:181-184)
+    Mgr-->>API: resolve_credential swallows Err → Ok(None) (credential.rs:330-336)
+    API-->>Caller: null  (usedStoredCredential=false)
+    Ev-->>St: onCredentialStoreUnlockNeeded → setUnlockDialogOpen(true)
+    Note over Caller,St: Caller already treated null as "no stored credential"\nand moved on to an interactive prompt — dialog opens too late / in parallel
+```
+
+### 3.3 Master-password set / change
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant SS as SecuritySettings.tsx
+    participant API as api.ts
+    participant Cmd as credential.rs
+    participant Mgr as CredentialManager
+    participant MP as MasterPasswordStore
+
+    rect rgb(40,50,60)
+    Note over U,MP: SET (via mode switch to master_password)
+    U->>SS: select "Master Password" + enter pw twice
+    SS->>API: switchCredentialStore("master_password", pw)
+    API->>Cmd: switch_credential_store
+    Cmd->>Mgr: switch_store(MasterPassword)
+    Cmd->>MP: has_file ? unlock(pw) : setup(pw)
+    Cmd->>Mgr: migrate old creds → set(key,val)
+    Cmd-->>SS: emit status-changed → Unlocked
+    end
+
+    rect rgb(50,40,50)
+    Note over U,MP: CHANGE
+    U->>SS: Change Master Password (cur,new)
+    SS->>API: changeMasterPassword(cur,new)
+    API->>Cmd: change_master_password
+    Cmd->>MP: change_password(cur,new)
+    alt cur correct
+        MP-->>SS: Ok → resetChangePasswordDialog()
+        Note over SS: NO success toast — silent
+    else cur wrong
+        MP-->>SS: Err "Current password is incorrect" (inline error)
+    end
+    end
+```
+
+---
+
+## 4. Credential-unlock gating decision (flowchart)
+
+```mermaid
+flowchart TD
+    A[User triggers connect] --> B{authMethod needs stored cred?\npassword OR key+savePassword}
+    B -- no --> Z[proceed / interactive prompt]
+    B -- yes --> C{mode == master_password\nAND status == locked?}
+    C -- no --> R[resolveConnectionCredential]
+    C -- yes --> D[requestUnlock -> open UnlockDialog]
+    D --> E{unlocked?}
+    E -- true --> R
+    E -- false / Skip --> X[return — abort connect silently]
+    R --> F{usedStoredCredential && password?}
+    F -- yes --> G[createTerminal with stored pw]
+    F -- no --> H[interactive password prompt]
+    G --> I{auth failed?}
+    I -- yes --> J[removeCredential + fall through to prompt]
+    I -- no --> K[tab opens]
+
+    style C fill:#5a3
+    style X fill:#a33
+```
+
+The green node is the gate that **three of four** connect call sites implement (`ConnectionList`, `AgentNode`, `AgentErrorTab`, `openWorkspace`) but **ConnectionEditor "Save & Connect" does not** (Gap G3).
+
+---
+
+## 5. Prioritized gap list
+
+Ranked stuck/leak/data-loss first.
+
+### G1 — `requestUnlock()` promise hangs forever on wrong password (STUCK) 🔴
+
+- **State/transition:** `Locked --unlock[wrong pw]--> Locked`; the connect caller is awaiting `requestUnlock()`.
+- **file:line:** `UnlockDialog.tsx:38-40` (on error only sets inline error, never resolves the promise), `useCredentialStoreEvents.ts:34-40` (only `onCredentialStoreUnlocked` → `resolveUnlock(true)`), `appStore.ts:4108-4111`.
+- **Symptom:** User clicks Connect on a locked store, the unlock dialog opens, they type the wrong password, get "Incorrect master password", then close the dialog with the **X / overlay click** (not the Skip button). If that dismissal doesn't route through `setUnlockDialogOpen(false)`'s cancel path, the awaiting connect promise never settles — the connect action is wedged with no feedback. Even via Skip it works, but the "retry wrong password then give up" path is fragile: the only thing that resolves `true` is the backend `unlocked` event; the only thing that resolves `false` is `setUnlockDialogOpen(prevOpen && !open)`.
+- **Smallest fix:** Guarantee every dialog exit resolves the pending promise exactly once. Have `UnlockDialog.handleUnlock` success/`handleSkip` both funnel through `onOpenChange`, and make `resolveUnlock` idempotent (it already clears `unlockResolve`, so a double-call is safe). Confirm Modal's overlay/Esc close also calls `onOpenChange(false)`.
+
+### G2 — Demand-driven unlock fires too late and is swallowed (STUCK / silent) 🔴
+
+- **State/transition:** `Locked` hit inside `resolve_credential`; `get()` emits `credential-store-unlock-needed` **after** returning `Ok(None)`.
+- **file:line:** `manager.rs:181-184` (emit on error), `credential.rs:330-336` (`resolve_credential` maps the locked-store `Err` to `Ok(None)`), `resolveConnectionCredential.ts:36-47` (catches / treats null as "not found").
+- **Symptom:** In any path that calls `resolveCredential` **without** the pre-check gate (notably ConnectionEditor, G3), a locked store returns "no credential", so the caller proceeds to an interactive password prompt — **while** the unlock-needed event asynchronously opens the UnlockDialog on top. The user sees two overlapping prompts, or unlocks the store but the connect already fell back to manual entry. The store status field and the actual store state momentarily disagree (the `get` proved it's locked, but nothing updated `credentialStoreStatus` to Locked).
+- **Smallest fix:** Make the emit path drive the gate: either (a) have `resolve_credential` surface a distinct "locked" result the frontend can await on, or (b) always run the `mode===master_password && status===locked` pre-check gate before `resolveCredential` at every call site (see G3), so the demand-driven emit becomes a redundant safety net rather than the primary trigger.
+
+### G3 — ConnectionEditor "Save & Connect" has no unlock gate (silent fallback) 🔴
+
+- **State/transition:** Missing `Locked --> requestUnlock` edge on the editor's connect path.
+- **file:line:** `ConnectionEditor.tsx:797-816` resolves the credential and, if null, jumps straight to `requestPassword`. No `credentialStoreStatus?.status === "locked"` check exists on this path (grep at `ConnectionEditor.tsx` shows `credentialStoreStatus` only used for `.mode`, never `.status`).
+- **Symptom:** With master-password mode **locked**, "Save & Connect" silently ignores the saved credential and prompts for a password every time — the user's stored secret appears "lost" until they manually lock/unlock via the indicator. Inconsistent with the sidebar path.
+- **Smallest fix:** Add the same gate the other three sites use before `resolveConnectionCredential` (`ConnectionList.tsx:480-488` is the template): if locked, `await requestUnlock()` and abort on `false`.
+
+### G4 — `change_master_password` requires unlocked but no unlock prompt; dead-end when locked 🟠
+
+- **State/transition:** `change_password` guarded by `Store is locked — cannot change password` but nothing transitions Locked→Unlocked first.
+- **file:line:** `master_password.rs:172-183` (both `salt`/`derived_key` reads `.context("Store is locked …")`), `SecuritySettings.tsx:161-185` and `MasterPasswordSetup.tsx:71` (surface the raw error inline).
+- **Symptom:** If the store auto-locked (or user locked it) and they open Settings → Change Master Password, submitting yields "Store is locked — cannot change password" with **no unlock affordance in the dialog**. Dead-end: user must know to close, click the status-bar indicator to unlock, reopen Settings.
+- **Smallest fix:** Disable / gate the "Change Master Password" button when `status === "locked"` and show "Unlock first" (or auto-open the unlock dialog on submit-while-locked).
+
+### G5 — No success feedback on unlock-gated actions / change-password (feedback gap) 🟠
+
+- **file:line:** `SecuritySettings.tsx:180-181` (change password success just closes the dialog — no toast), `switch_credential_store` migration result shows inline text but no toast (`SecuritySettings.tsx:300-314`), `CredentialStoreIndicator.tsx:24-30` (lock action has no success feedback; error only `console.error`, violating the "use LogViewer/toast, never console" rule).
+- **Symptom:** User changes the master password or clicks the indicator to lock and gets no confirmation the mutating action succeeded. Violates design-system rule 4 ("every action gives feedback"). `UnlockDialog` does `toast.success` (`:36`) — the rest are inconsistent.
+- **Smallest fix:** Add `toast.success()` on change-password, lock, and switch; replace the `console.error` at `CredentialStoreIndicator.tsx:28` with a recoverable `toast.error()`.
+
+### G6 — `unlock` "already unlocked" is an error string, not a benign no-op (race) 🟠
+
+- **file:line:** `credential.rs:59-61` returns `Err("Store is already unlocked")`.
+- **Symptom:** Two connect flows race: both see `status === locked`, both open/await unlock (or one unlocks via the auto-lock-cleared event while the other's dialog submits). The second `unlock_credential_store` returns an error, surfacing "Store is already unlocked" as an "Incorrect master password" style failure in `UnlockDialog.tsx:38` (its catch is generic). The store is actually fine.
+- **Smallest fix:** Treat already-unlocked as `Ok(())` (idempotent) and still emit `credential-store-unlocked` so any awaiting `requestUnlock()` resolves.
+
+### G7 — Auto-lock while a session is mid-connect / holding secrets (ambiguous timing) 🟡
+
+- **file:line:** `auto_lock.rs:166-186` locks purely on inactivity; `record_activity()` is only called on store `get/set/remove/list` (`manager.rs:186, 199, 211, 223, 235`), **not** on live terminal I/O.
+- **Symptom:** During a long interactive SSH session that used a stored credential once at connect, no further credential reads occur, so the auto-lock timer expires and locks the store underneath the user. The next reconnect/new-tab then hits a locked store. Not a leak, but the "unlocked" indicator flips to "Locked" with only a silent status refresh (`useCredentialStoreEvents.ts:30-32`) — no toast telling the user why their next connect will re-prompt.
+- **Smallest fix:** Emit a low-key toast on auto-lock ("Credential store auto-locked after inactivity"), and consider treating an active session as activity, or document that auto-lock is credential-access-based by design.
+
+### G8 — Wrong-password attempt count / lockout absent; no distinction corrupt-vs-wrong (ambiguous state) 🟡
+
+- **file:line:** `master_password.rs:114` collapses "wrong password" and "corrupted file" into one message; `UnlockDialog.tsx:38-39` further flattens all errors to "Incorrect master password."
+- **Symptom:** A genuinely corrupted `credentials.enc` reports "Incorrect master password", sending the user down an infinite wrong-password loop with no path to recovery/reset. There's a `RecoveryDialog` in `App.tsx:281` but it's wired to switch-store migration warnings, not to unlock corruption.
+- **Smallest fix:** Distinguish decrypt-failure (auth) from parse/version failure (corruption) and surface a "reset store" affordance for the latter.
+
+---
+
+## 6. Missing controls
+
+Controls the correct machine needs but the UI doesn't expose, each tied to the transition it would fire:
+
+| Missing control                                                    | Where it belongs                                                                                                                                                                                                | Transition it fires                                                                                                                                  |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Unlock affordance inside Change-Password dialog**                | `SecuritySettings.tsx` change-password inline dialog                                                                                                                                                            | `Locked --> Unlocked` before `change_password` (fixes G4 dead-end)                                                                                   |
+| **"Retry" vs "Reset store" on unlock failure**                     | `UnlockDialog.tsx` error state                                                                                                                                                                                  | `Locked --unlock--> Unlocked` (retry) / `Locked --> Unavailable` (reset corrupt file, G8)                                                            |
+| **Success toast on lock / change-password / switch**               | `CredentialStoreIndicator.tsx`, `SecuritySettings.tsx`                                                                                                                                                          | Observable feedback for `Unlocked-->Locked` and `change_password` (G5)                                                                               |
+| **Explicit "Set up master password" entry point when Unavailable** | Currently only reachable via mode-switch radio (`SecuritySettings.tsx:113`); `openMasterPasswordSetup`/`MasterPasswordSetup` modal exists (`appStore.ts:4119-4123`, `App.tsx:274`) but has **no trigger** wired | `Unavailable --setup--> Unlocked` (the `MasterPasswordSetup` modal is effectively orphaned UI — no `openMasterPasswordSetup("setup")` caller exists) |
+| **Auto-lock notification**                                         | status-bar / toast on `credential-store-locked`                                                                                                                                                                 | Make `Unlocked --auto-lock--> Locked` observable (G7)                                                                                                |
+| **Idempotent unlock guard**                                        | `credential.rs:59`                                                                                                                                                                                              | Removes the spurious `Unlocked --> error` self-edge on races (G6)                                                                                    |
+
+### Orphan-UI finding
+
+`MasterPasswordSetup` modal + its store actions `openMasterPasswordSetup` / `masterPasswordSetupOpen` (`appStore.ts:706-708, 4119-4123`) are mounted in `App.tsx:274` but **no code calls `openMasterPasswordSetup`** — it is an unreachable state / dead control. Master-password setup happens instead through `SecuritySettings`'s inline dialog + `switchCredentialStore`. Either wire a trigger to it or remove it; today it is duplicate, unreachable setup UI.
+
+---
+
+## 7. Summary
+
+The core Rust state machine (`MasterPasswordStore` status derivation, zeroize-on-lock, atomic file writes, auto-lock timer) is sound and well-tested. The defects are concentrated at the **UI↔state seams**:
+
+1. **Promise-based unlock gating is fragile** — `requestUnlock()` can hang (G1) and the demand-driven `unlock-needed` event fires after the credential has already been reported missing (G2).
+2. **Inconsistent gating across the four connect entry points** — ConnectionEditor lacks the lock pre-check the other three have (G3).
+3. **Dead-ends** — change-password while locked (G4), corrupt-file unlock loop (G8).
+4. **Feedback gaps** — silent lock/change/switch, `console.error` instead of toast (G5, G7).
+5. **Race edge** — "already unlocked" surfaces as an error (G6).
+6. **Orphan setup UI** — `MasterPasswordSetup` modal has no trigger.
+
+Highest-leverage fix: unify all four connect paths behind one gating helper that (a) checks `mode===master_password && status===locked`, (b) `await requestUnlock()` with a promise guaranteed to settle on every dialog exit, and (c) makes `unlock`/`resolve_credential` idempotent and lock-aware — which collapses G1, G2, G3, and G6 into a single corrected transition.

--- a/docs/audits/embedded-servers-state-machine.md
+++ b/docs/audits/embedded-servers-state-machine.md
@@ -1,0 +1,239 @@
+# Embedded Servers State Machine — Audit
+
+> **Issue:** #1134 — Audit + fix the embedded servers state machine (HTTP / FTP / TFTP start / stop / error)
+> **Scope:** Embedded server lifecycle (stopped → starting → running → stopping → error) per server type
+> **Deliverable:** Audit findings only — analysis, diagrams, and prioritized gaps. No production code changes.
+
+## 1. Where the state lives
+
+| Layer                  | Location                                                                                                          | Role                                                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Status enum            | `src-tauri/src/embedded_servers/config.rs:56-62` — `ServerStatus { Stopped, Starting, Running, Stopping, Error }` | Canonical state vocabulary                                                                                         |
+| Runtime state struct   | `config.rs:75-85` — `ServerState { server_id, status, error, stats, started_at }`                                 | What the frontend receives                                                                                         |
+| Active-server registry | `server_manager.rs:37` — `active: Mutex<HashMap<String, ActiveServer>>`                                           | The _real_ source of truth: a config is "running" iff it has an entry here (`get_states`, `server_manager.rs:122`) |
+| Per-server error slot  | `server_manager.rs:28` — `error: Arc<Mutex<Option<String>>>`                                                      | Error text set by the server thread on failure                                                                     |
+| Frontend cache         | `src/store/appStore.ts:655,3668` — `embeddedServerStates: Record<string, ServerState>`                            | Zustand mirror driving the sidebar                                                                                 |
+| Event push             | `server_manager.rs:326-337` `emit_status` + `216` (thread error) → `"embedded-server-status-changed"`             | Backend → UI notification                                                                                          |
+| Event receiver         | `src/hooks/useEmbeddedServerEvents.ts:16` → `updateEmbeddedServerState` (`appStore.ts:3732`)                      | Applies pushed state, mounted in `App.tsx:100`                                                                     |
+
+**Key structural fact:** the `ServerStatus` enum has **5 variants but only 3 are ever produced at runtime**. `Starting` is emitted then immediately overwritten by `Running` in the same synchronous call (`start_server`, `server_manager.rs:183` then `:239`), and `Stopping` is **never emitted anywhere** (grep confirms `Stopping` appears only at its definition, `config.rs:60`). So the true runtime machine is `Stopped ⇄ Running`, plus a transient `Error`.
+
+## 2. Lifecycle state diagram (as-built)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Stopped : config saved / loaded from disk
+    Stopped --> Running : start_server() ok\n[check_port passes, not already active]
+    Stopped --> Stopped : start_server() Err\n[check_port fails — port in use]\n(command rejects; no state change, no event)
+    Running --> Error : server thread returns Err\n(thread emits Error asynchronously)
+    Running --> Stopped : stop_server()\n(shutdown flag set, entry removed)
+    Error --> Stopped : stop_server()\n[entry still in active map]
+    Error --> Running : start_server()?\n[BLOCKED — active.contains_key ⇒ "already running"]
+    Stopped --> [*] : delete_config()
+
+    note right of Running
+      Emitted transiently but never
+      observed: Starting (overwritten
+      by Running same call), Stopping
+      (never emitted at all)
+    end note
+```
+
+### Per-type differences
+
+The lifecycle is identical across HTTP/FTP/TFTP at the manager level — the only branch is which `start_*_server` runs (`server_manager.rs:197-201`). The **teardown semantics differ per type**, which is where correctness diverges:
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    state "Running (thread)" as R
+    state HTTP {
+        [*] --> httpServe : axum::serve + graceful_shutdown
+        httpServe --> httpGone : polls shutdown flag every 100ms\n(http_server.rs:203-210) ✅ exits
+    }
+    state FTP {
+        [*] --> ftpServe : libunftp listen + tokio::select! poll_shutdown
+        ftpServe --> ftpGone : poll_shutdown every 50ms\n(ftp_server.rs:76,84-91) ✅ select! cancels listen
+    }
+    state TFTP {
+        [*] --> tftpListen : recv_from loop, 100ms read timeout
+        tftpListen --> tftpGone : checks shutdown each loop\n(tftp_server.rs:52-55) ✅ main loop exits
+        tftpListen --> tftpLeak : per-transfer threads spawned\n(tftp_server.rs:85,99) ⚠️ NOT tracked, NOT signalled
+    }
+```
+
+- **HTTP** — graceful; `with_graceful_shutdown` drains then returns (`http_server.rs:202-212`).
+- **FTP** — graceful; `tokio::select!` cancels `server.listen` when `poll_shutdown` wins (`ftp_server.rs:72-79`). Note libunftp's own client connections are dropped when the runtime is dropped at thread exit.
+- **TFTP** — the **listen loop** exits, but each RRQ/WRQ is handled in a **detached `std::thread::spawn`** (`tftp_server.rs:85,99`) that binds its own ephemeral socket and never sees the shutdown flag. An in-flight transfer keeps running (up to its 5×5s ACK timeout, `tftp_server.rs:135,178`) after the server reports `Stopped`.
+
+## 3. Start-flow sequence (UI → store → command → manager → thread)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant I as EmbeddedServerItem.tsx
+    participant S as appStore.startEmbeddedServer
+    participant C as start_embedded_server (cmd)
+    participant M as EmbeddedServerManager.start_server
+    participant T as server thread (http/ftp/tftp)
+    participant EV as useEmbeddedServerEvents
+
+    U->>I: click Play (line 118)
+    I->>S: onStart(id)  %% NO await, NO .catch (Item 106-121)
+    S->>C: apiStartEmbeddedServer(id)
+    C->>M: start_server(id)
+    M->>M: check_port() bind probe (mgr 181,301)
+    alt port free
+        M-->>EV: emit Starting (mgr 183)
+        M->>T: thread::spawn(start_*_server) (mgr 196)
+        M->>M: active.insert(...) (mgr 227)
+        M-->>EV: emit Running (mgr 239)
+        EV->>S: updateEmbeddedServerState(Running)
+        Note over T: thread runs until shutdown or error
+    else port in use
+        M-->>C: Err "Port N already in use" (mgr 314-319)
+        C-->>S: reject
+        S-->>S: console.error + throw (store 3717-3720)
+        Note over I: rejected promise is UNHANDLED — no toast, no UI change
+    end
+```
+
+**Two critical race/feedback problems visible here:**
+
+1. **TOCTOU port race** — `check_port` binds a probe socket and immediately drops it (`server_manager.rs:305-320`), _then_ the server thread binds again later (`http_server.rs:194`, `tftp_server.rs:38`, libunftp `listen`). Between the probe and the real bind the port can be taken. If the real bind then fails, HTTP/TFTP surface it via the async `Error` event (`server_manager.rs:203-217`), but the manager has **already emitted `Running`** (`:239`) and inserted into `active`. Result: the item shows Running, then flips to Error, but is stuck-"active" (see Gap G2).
+
+2. **Silent start failure** — the store re-throws (`appStore.ts:3719`) but `EmbeddedServerItem` calls `onStart(config.id)` with no `.catch` (`EmbeddedServerItem.tsx:106-121`) and the sidebar passes the raw action (`EmbeddedServerSidebar.tsx:105`). A port-in-use rejection becomes an unhandled promise rejection with **zero user feedback** — the button just does nothing.
+
+## 4. Stop-flow sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant I as EmbeddedServerItem.tsx
+    participant S as appStore.stopEmbeddedServer
+    participant M as EmbeddedServerManager.stop_server
+    participant T as server thread
+
+    U->>I: click Stop (line 106)
+    I->>S: onStop(id)  %% no await/catch
+    S->>M: stop_server(id)
+    M->>M: active.remove(id) (mgr 251)
+    alt entry existed
+        M->>T: shutdown.store(true) (mgr 255)
+        Note over M,T: thread NOT joined (mgr 256-257) — exits on next poll
+        M-->>I: emit Stopped (mgr 258) → store updates
+    else already gone
+        Note over M: returns Ok, emits nothing (silent no-op)
+    end
+```
+
+**No `Stopping` state is ever shown.** The manager jumps `Running → Stopped` synchronously (`server_manager.rs:258`) while the thread is still winding down. For TFTP with in-flight transfers, and briefly for HTTP/FTP, the OS resource is still held after the UI says "Stopped" — the port may not be immediately re-bindable, so an immediate restart can hit the check_port probe and fail (see Gap G3).
+
+## 5. Stats-refresh gap (dead data)
+
+```mermaid
+sequenceDiagram
+    participant M as manager (atomic stats)
+    participant EV as embedded-server-status-changed event
+    participant Store as embeddedServerStates
+    participant UI as EmbeddedServerItem stats line
+
+    Note over M: bytes/conns tick continuously in AtomicServerStats
+    M-->>EV: emit_status(...) always sends ServerStats::default() (mgr 331)
+    EV->>Store: updateEmbeddedServerState overwrites stats with ZEROS
+    Note over Store,UI: getEmbeddedServerStates() (real stats) only called on\nloadEmbeddedServers at startup (store 3673, App 2365)
+    Note over UI: stats line (Item 78-79,165) shows stale/zero — never polled
+```
+
+`emit_status` hard-codes `stats: ServerStats::default()` (`server_manager.rs:331`) and `started_at: None` (`:332`), and the thread-error path also sends `ServerStats::default()` (`:213`). The only path that returns _real_ stats is `get_states` (`server_manager.rs:133`), reachable solely via `getEmbeddedServerStates` → `loadEmbeddedServers`, which runs **once at startup** (`appStore.ts:2365`). There is **no polling timer**, so the live "conn · ↑ ↓" line (`EmbeddedServerItem.tsx:78-79,165`) and `started_at` are effectively always zero/stale, and every status event _overwrites_ whatever was loaded with zeros.
+
+---
+
+## 6. Prioritized gap list
+
+Ranked stuck/leak/data-loss first.
+
+### G1 — TFTP transfer threads leak past shutdown _(leak)_
+
+- **State/transition:** `Running → Stopped`, TFTP per-transfer threads.
+- **file:line:** `tftp_server.rs:85` and `:99` (`std::thread::spawn`), no shutdown propagation; `server_manager.rs:256-257` deliberately does not join.
+- **Symptom:** After the user stops (or quits the app) a TFTP server mid-transfer, detached threads keep a UDP socket + file handle open, spinning up to ~25s (5 retries × 5s, `tftp_server.rs:135,178`). Nothing in the UI or Open Connections shows them; the port can stay busy.
+- **Smallest fix:** Pass the `shutdown` `Arc<AtomicBool>` into `handle_rrq`/`handle_wrq` and check it in the ACK-wait loops so transfers abort promptly; optionally track child handles and join on stop.
+
+### G2 — Error state is a dead-end (no Retry, Start is blocked) _(stuck)_
+
+- **State/transition:** `Error → Running` missing / blocked.
+- **file:line:** `server_manager.rs:173-177` (`active.contains_key ⇒ "already running"`) — a failed server still has its `active` entry (it's only removed on `stop_server`), so `get_states` reports `Error` (`:124`) while `start_server` refuses to run. UI shows the Stop button for `error` status (`EmbeddedServerItem.tsx:48-49` treats `error`… actually `isActive` returns false for `error`, so it shows **Start**, which then rejects with "already running").
+- **Symptom:** A server that failed at runtime (e.g. late bind failure) shows red with an error message and a Start button that silently fails; the only escape is Delete or Edit. No Retry.
+- **Smallest fix:** On the async error path, remove the entry from `active` (or add a distinct `Failed` bookkeeping) so `Error → Stopped` is real, then Start works again; add a Retry control that fires `stop_server` then `start_server`.
+
+### G3 — `Running` emitted before the bind actually succeeds; late failure desyncs _(stuck / wrong state)_
+
+- **State/transition:** `Starting → Running` premature.
+- **file:line:** `server_manager.rs:239` emits `Running` unconditionally right after `thread::spawn`, while the real bind happens later inside the thread (`http_server.rs:194`, `ftp_server.rs:73`, `tftp_server.rs:38`). `check_port` (`:181`) is a separate socket, so it does not guarantee the thread's bind succeeds (TOCTOU).
+- **Symptom:** Item briefly shows green "Running", then flips to red "Error" (or, if the error event is missed, stays green while nothing is listening). User can't tell whether the server is up.
+- **Smallest fix:** Have the server thread signal successful bind back (a `oneshot`/channel) and only emit `Running` on that signal; emit `Error` and drop the `active` entry on bind failure.
+
+### G4 — Port-in-use start failure is completely silent in the UI _(feedback / data-loss-of-intent)_
+
+- **State/transition:** `Stopped → Stopped` on `check_port` failure.
+- **file:line:** `server_manager.rs:314-319` returns the error; `appStore.ts:3717-3720` re-throws; **but** `EmbeddedServerItem.tsx:106-121` and `EmbeddedServerSidebar.tsx:105` call `onStart`/`onStop` with no `.catch` and no toast.
+- **Symptom:** User clicks Play on a server whose port is taken → nothing happens, no error, no toast. Violates the "every action gives feedback" design rule.
+- **Smallest fix:** Wrap the start/stop handlers to `toast.error(err)` (mirror the port message from `server_manager.rs:307`) and reflect a transient pending state on the button.
+
+### G5 — Manual Start has no port-fallback that the code already implements _(inconsistency)_
+
+- **State/transition:** `Stopped → Running` via sidebar Play vs. `quickShareServer`.
+- **file:line:** Sidebar Start → `apiStartEmbeddedServer` (plain, no fallback). The 10-port-fallback logic exists only in `create_and_start_server` (`commands/embedded_servers.rs:106-142`) used by `quickShareServer` (`appStore.ts:3750`).
+- **Symptom:** Quick-share auto-avoids busy ports; the normal Start button does not — same operation, two behaviors. Confusing and makes G4 more likely to bite.
+- **Smallest fix:** Either surface a clear "port busy" error (G4) or offer a "start on next free port" affordance; unify the two start paths.
+
+### G6 — Stats and `started_at` are overwritten with zeros; never polled _(data-loss / stale UI)_
+
+- **State/transition:** `Running` render.
+- **file:line:** `server_manager.rs:331-332` (`emit_status` sends default stats + `None` started_at) and `:213` (error path); no polling in the frontend (only `loadEmbeddedServers` at `appStore.ts:2365`).
+- **Symptom:** The live traffic line (`EmbeddedServerItem.tsx:165`) shows `0 conn · ↑0 B ↓0 B` even under load; `started_at`/uptime is lost.
+- **Smallest fix:** In `emit_status`, snapshot real stats from the `active` entry (as `get_states` does at `:133`); add a lightweight periodic `getEmbeddedServerStates` poll (e.g. every 1–2s while any server is active) in the store.
+
+### G7 — Auto-start failures are invisible _(feedback)_
+
+- **State/transition:** `Stopped → Running` at launch.
+- **file:line:** `server_manager.rs:281-296` (`start_auto_servers`) logs a `warn!` on failure but emits no event; called from `lib.rs:346`.
+- **Symptom:** A server marked auto-start whose port is busy at boot silently stays stopped; user sees a stopped server with no explanation.
+- **Smallest fix:** Emit an `Error` state (with message) for auto-start failures so the sidebar shows red on launch.
+
+### G8 — `stop_all` never resets frontend state on shutdown _(cosmetic / cross-session)_
+
+- **State/transition:** app-quit teardown.
+- **file:line:** `lib.rs:640-644` calls `mgr.stop_all()`; `stop_all` (`server_manager.rs:266-278`) stops threads but the window is already being destroyed so emitted `Stopped` events (`:258`) may not reach the (gone) UI. Not a leak (threads are signalled), but combined with G1 the TFTP transfer threads still linger.
+- **Symptom:** None visible normally; relevant only alongside G1.
+- **Smallest fix:** Covered by G1's shutdown propagation.
+
+### G9 — Overloaded `Error` state can't distinguish start-failure vs. runtime-crash _(ambiguity)_
+
+- **file:line:** `server_manager.rs:124` (any non-empty `error` slot ⇒ `Error`) — same status whether bind failed at start or the server died later, and whether the `active` entry should be considered live.
+- **Symptom:** UI can't decide whether to offer Retry vs. Restart; contributes to G2.
+- **Smallest fix:** Separate `Failed(reason)` from `Error(runtime)`, or clear the `active` entry on failure so `Error` always means "was running, now not".
+
+---
+
+## 7. Missing controls
+
+| Control                                                                                       | Where it belongs                                                                                                                              | Transition it should fire                    | Currently                                                                                                                                                     |
+| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Restart**                                                                                   | `EmbeddedServerItem` action row + context menu (`EmbeddedServerItem.tsx:100-159`, `:175-223`)                                                 | `Running → Stopped → Running`                | Absent — user must Stop then Start manually                                                                                                                   |
+| **Retry** (after error)                                                                       | Item, shown when `status === "error"`                                                                                                         | `Error → Running`                            | Absent; the shown Start button silently fails (G2)                                                                                                            |
+| **Cancel** (during start)                                                                     | Item, while `Starting`                                                                                                                        | abort pending `start_server`                 | N/A — `Starting` is never actually shown (G3); no cancel path                                                                                                 |
+| **Error feedback / toast**                                                                    | store or item handlers                                                                                                                        | surface `start`/`stop` rejection             | Absent (G4) — rejections unhandled                                                                                                                            |
+| **"Open in Browser"** for non-HTTP is correctly hidden (`EmbeddedServerItem.tsx:215`); no gap | —                                                                                                                                             | —                                            | OK                                                                                                                                                            |
+| **Presence in Open Connections panel**                                                        | `OpenConnections/OpenConnectionsModal.tsx` (has locals, agents, SSH, SFTP, monitoring, X server — **no embedded servers**, confirmed by grep) | central "kill all" for running HTTP/FTP/TFTP | Absent — running servers cannot be inspected or force-stopped from the canonical panel, contradicting the CLAUDE.md contract that it covers "every subsystem" |
+| **Uptime display**                                                                            | Item details                                                                                                                                  | render `started_at`                          | Data exists (`config.rs:84`) but is nulled by `emit_status` (G6) and never rendered                                                                           |
+
+### Highest-leverage fixes
+
+1. **G1** (TFTP thread leak) and **G2/G9** (Error dead-end) — these are true stuck/leak defects.
+2. **G3** (premature `Running`) — makes the whole machine's `Running` state untrustworthy.
+3. **G4 + G7** (silent failures) — cheapest wins; add toasts + surface auto-start errors.
+4. Add embedded servers to the **Open Connections panel** and add **Restart/Retry** controls — closes the UX loop and satisfies the panel's documented "every subsystem" mandate.

--- a/docs/audits/http-monitor-state-machine.md
+++ b/docs/audits/http-monitor-state-machine.md
@@ -1,0 +1,211 @@
+# HTTP Monitor State Machine — Audit
+
+> **Issue:** #1136 — Audit + fix the HTTP monitor state machine (network tools)
+> **Scope:** HTTP monitor lifecycle (stopped → polling → up/down → paused → error)
+> **Deliverable:** Audit findings only — analysis, diagrams, and prioritized gaps. No production code changes.
+
+## 1. What the machine actually is
+
+The HTTP monitor is a **backend-owned polling loop with a thin, derived frontend view**. There is no explicit `status` enum anywhere — the "state" is reconstructed from a handful of booleans and `Option`s spread across the backend handle and the last check result.
+
+**State is encoded by, and only by:**
+
+- `HttpMonitorHandle.cancel: CancellationToken` — whether the loop is alive (`src-tauri/src/network/http_monitor.rs:48-52`). `cancel.is_cancelled()` is the sole `running` signal (`mod.rs:152`).
+- Presence in the `http_monitors: Mutex<HashMap<String, HttpMonitorHandle>>` map (`mod.rs:31`). Insert = exists; `remove` = gone (`mod.rs:121`, `mod.rs:132`).
+- `HttpCheckResult.ok: bool` + `error: Option<String>` (`http_monitor.rs:29-36`) — the up/down/error signal, recomputed each poll (`http_monitor.rs:158`, `http_monitor.rs:168-175`).
+- Frontend `activeMonitorId: string | null` (`HttpMonitorPanel.tsx:35`) — which monitor _this panel instance_ is "attached" to for the chart/history. This is **panel-local UI state, not monitor state**.
+
+**Critical structural facts that shape every finding below:**
+
+- `stop_http_monitor` does `monitors.remove(monitor_id)` **then** `cancel()` (`mod.rs:132-134`). A stopped monitor is _deleted from the map entirely_, so `list_http_monitors` (`mod.rs:142-157`) can never return a `running: false` entry. The `running` field, the `HttpMonitorState.running: bool` type (`network.ts:123`), and the disabled-grey dot branch in the sidebar (`NetworkToolsSidebar.tsx:53-54`) are **dead code** — the "stopped-but-listed" state is unreachable.
+- There is **no persistence**. No monitor config is written to disk (contrast WoL: `wol_storage::save_wol_devices`, `mod.rs:179`). Nothing in `src-tauri/src/workspace/` references monitors. The store field `httpMonitors` (`appStore.ts:338`, `appStore.ts:858`) is plain in-memory Zustand, not persisted. → **All monitors vanish on app restart.**
+- There is **no pause**. No `paused` field, no pause command, no pause UI. The lifecycle the issue names (`paused`) does not exist in code.
+- There is **no backoff**. `run_monitor` sleeps a fixed `config.interval_ms` regardless of success/failure/error (`http_monitor.rs:137-140`). "up" and "down" poll at the identical cadence.
+
+## 2. Lifecycle — the machine the code has
+
+```mermaid
+stateDiagram-v2
+    [*] --> Stopped : monitor does not exist
+
+    Stopped --> Polling : network_http_monitor_start\n(insert handle + spawn loop)\n[url non-empty in UI guard]
+
+    state Polling {
+        [*] --> Checking
+        Checking --> Emitting : check_once returns\nHttpCheckResult
+        Emitting --> Sleeping : emit event +\nstore last_result
+        Sleeping --> Checking : sleep(interval_ms) elapsed
+
+        state up_down <<choice>>
+        Emitting --> up_down
+        up_down --> Up : [status == expected_status]
+        up_down --> Down : [status != expected]\nor transport error
+        Up --> Sleeping
+        Down --> Sleeping
+    }
+
+    Polling --> Stopped : network_http_monitor_stop\n(remove from map + cancel token)
+    Polling --> Stopped : app window Destroyed\n(process dies; NOT cancelled cleanly)
+
+    note right of Stopped
+        No persistence: on restart the
+        machine is always [*] Stopped.
+        Removed-from-map == gone; there is
+        NO listed "Stopped" state.
+    end note
+```
+
+Note there is **no `Paused` state** and **no `Error` terminal state**. A client-build failure (`http_monitor.rs:112-115`) is the only true dead-end: the loop `return`s before it ever polls, the handle stays in the map with `running: true`, and no check is ever emitted — an invisible zombie (see Gap #4).
+
+### Up / Down as sub-states of Polling (the derived view)
+
+```mermaid
+stateDiagram-v2
+    [*] --> NoResult : monitor just started\n(last_result == None)
+
+    NoResult --> Up : first check\n[ok == true]
+    NoResult --> Down : first check\n[ok == false]
+
+    Up --> Up : check ok
+    Up --> Down : check !ok\n(status mismatch OR transport error)
+    Down --> Up : check ok
+    Down --> Down : check !ok
+
+    note right of NoResult
+        Sidebar renders "checking…"
+        (NetworkToolsSidebar.tsx:64-66)
+    end note
+    note right of Down
+        Up<->Down flips are SILENT:
+        no toast, no OS notification,
+        only a dot colour change
+        (NetworkToolsSidebar.tsx:49-56).
+        Panel must be open to see it.
+    end note
+```
+
+## 3. Poll cycle sequence
+
+```mermaid
+sequenceDiagram
+    participant UI as HttpMonitorPanel
+    participant Api as networkApi.ts
+    participant Cmd as commands/network.rs
+    participant Mgr as NetworkManager
+    participant Task as run_monitor loop
+    participant Win as All windows
+
+    UI->>UI: onHttpMonitorCheck(listener) FIRST (#1002)
+    UI->>Api: networkHttpMonitorStart(url,...)
+    Api->>Cmd: invoke network_http_monitor_start
+    Cmd->>Mgr: start_http_monitor(config)
+    Mgr->>Task: tauri::async_runtime::spawn(run_monitor)
+    Mgr-->>UI: monitorId
+    UI->>UI: activeMonitorIdRef = monitorId
+
+    loop until cancel
+        Task->>Task: check_once() (bounded by timeout_ms)
+        Task->>Win: emit "network-http-monitor-check" (broadcast)
+        Task->>Mgr: last_result.lock() = result
+        Note over UI: listener filters result.monitorId == activeMonitorIdRef\n(HttpMonitorPanel.tsx:85)
+        Win-->>UI: check event → append to history
+        Note over UI: sidebar's SEPARATE listener re-lists on every check (#986)
+        Task->>Task: sleep(interval_ms) OR cancel
+    end
+```
+
+**Ordering note (a real gap):** the panel's history listener filters `result.monitorId !== activeMonitorIdRef.current` (`HttpMonitorPanel.tsx:85`). The event is **broadcast to every window/listener** (`app.emit`, `http_monitor.rs:131` — not `emit_to`). Every running monitor's checks hit every panel's listener; correctness relies entirely on the id filter. Fine today, but there is no per-window scoping, so any future multi-window use will cross-talk.
+
+## 4. Up→Down notification path (the missing edge)
+
+```mermaid
+sequenceDiagram
+    participant Task as run_monitor
+    participant Win as Window(s)
+    participant Sidebar as NetworkToolsSidebar
+    participant Panel as HttpMonitorPanel
+    participant User
+
+    Task->>Task: check_once → ok=false (was ok=true)
+    Task->>Win: emit "network-http-monitor-check"
+    Win-->>Sidebar: re-list → dot turns red (#986)
+    Win-->>Panel: append row; "Last: ✗ error"
+    Note over User: NO toast, NO OS notification,\nNO status-bar badge.
+    Note over User: If Network Tools sidebar is not the\nactive activity-bar view AND the panel\ntab is not focused, the down transition\nis completely invisible.
+    User--xUser: learns of outage only by\nmanually opening the panel
+```
+
+There is **no comparison of previous vs current `ok`** anywhere (backend or frontend). The transition Up→Down is computed fresh each poll and never diffed, so nothing can fire an alert on the _edge_. For a "monitor," missing the up→down edge notification is the single biggest UX gap.
+
+## 5. Interval / backoff policy (as-is vs. as-should-be)
+
+```mermaid
+flowchart TD
+    A[Poll complete] --> B{cancelled?}
+    B -- yes --> Z[break loop → Stopped]
+    B -- no --> C[sleep interval_ms]
+    C --> A
+
+    subgraph asis[AS-IS http_monitor.rs:118-141]
+      A
+      B
+      C
+    end
+
+    D[Poll complete] --> E{ok?}
+    E -- yes --> F[sleep interval_ms]
+    E -- no --> G[sleep min interval*2^failures, cap]
+    F --> H[reset failure count]
+    G --> I[failures++]
+
+    subgraph ideal[AS-SHOULD-BE: backoff on failure]
+      D
+      E
+      F
+      G
+      H
+      I
+    end
+```
+
+**Interval correctness issues found:**
+
+- **No backoff.** Down hosts are hammered at the same `interval_ms` as healthy ones (`http_monitor.rs:137-140`). A dead endpoint at a 5 s interval gets 12 doomed requests/min forever.
+- **Interval is measured _after_ the request returns, not from a fixed schedule.** The loop is `check → emit → sleep(interval)` (`http_monitor.rs:123-140`), so the _effective_ period is `interval_ms + latency` (up to `+timeout_ms` when the endpoint hangs). At a 5 s interval with a 10 s timeout, a hanging host polls every ~15 s, silently drifting the chart's x-axis (which assumes a fixed `intervalMs`, `HttpMonitorPanel.tsx:137`, `LatencyChart.tsx`). Use `tokio::time::interval` (fixed-rate) instead of `sleep` after work.
+- **No minimum-interval guard in the backend.** The UI `min={5}` (`HttpMonitorPanel.tsx:216`) is a soft HTML hint only; `network_http_monitor_start` accepts any `interval_ms` (`network.rs:318-333`), including `0` → a tight busy-loop of requests. A `Number(e.target.value)` of `0`/`NaN` from the field is passed straight through (`HttpMonitorPanel.tsx:93`, `215`).
+
+## 6. Prioritized gap list
+
+Ranked stuck/leak/data-loss first.
+
+| #   | Severity                                       | State / transition                                            | file:line                                                                                                         | User-visible symptom                                                                                                                                                                                                                                                          | Smallest fix                                                                                                                                                                                            |
+| --- | ---------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Data-loss**                                  | No `Stopped→Polling` restore on launch; no persistence at all | `mod.rs:31` (in-mem map only), `lib.rs:93` (fresh `NetworkManager::new()`), no `workspace/` ref                   | Every configured monitor silently disappears on app restart. User must re-enter URL/interval/method every session. A "monitor" that forgets what it monitors.                                                                                                                 | Persist monitor **configs** (not runtime) to disk like WoL (`wol_storage.rs` pattern); reload + auto-`start_http_monitor` in `NetworkManager::init` (`mod.rs:54`).                                      |
+| 2   | **Silent transition**                          | Polling `Up → Down` (and recovery `Down → Up`)                | `http_monitor.rs:158`/`168` set `ok`; nothing diffs prev vs curr; `app.emit` only (`:131`)                        | An endpoint goes down and the user is never told unless the Network Tools sidebar/panel happens to be on-screen. Defeats the purpose of a monitor.                                                                                                                            | Track previous `ok` per monitor; on edge, `toast` (via a dedicated `network-http-monitor-transition` event) and/or fire an OS notification. Add a status-bar badge for any monitor currently Down.      |
+| 3   | **Leak / no cleanup**                          | `Polling → Stopped` on app exit                               | `lib.rs:623-652` cleans tunnels/embedded-servers/xserver but **not** `NetworkManager` monitors                    | On a normal quit the poll loops are never cancelled cleanly; they die only because the process dies. In-flight `reqwest` requests are abandoned mid-flight rather than cancelled. No orphan survives, but teardown is inconsistent with every sibling subsystem.              | Add `handle.try_state::<NetworkManager>() → stop_all_http_monitors()` to the `WindowEvent::Destroyed` block (`lib.rs:634-650`); add a `stop_all` method mirroring `TunnelManager::stop_all`.            |
+| 4   | **Stuck / zombie**                             | `Stopped → Polling` when `Client::builder().build()` fails    | `http_monitor.rs:107-116` — loop `return`s before first poll, but handle already inserted (`mod.rs:120-122`)      | Monitor shows `running: true`, "checking…" forever (`NetworkToolsSidebar.tsx:64`), never emits a check, never recovers. No error surfaced to the user. Dead-end state with no exit but manual Stop.                                                                           | Emit a failure `HttpCheckResult`/error event before `return`; or surface the build error to the caller so `start` rejects and the row never appears.                                                    |
+| 5   | **Missing control (no way out except delete)** | No `Polling → Paused → Polling`                               | No `paused` field anywhere; `HttpMonitorHandle` (`http_monitor.rs:48`) has only `cancel`                          | User can only Stop (which **deletes** the monitor, Gap #6) — there is no way to temporarily suspend polling (e.g. during maintenance) and resume with the same config/history.                                                                                                | Add a `paused: AtomicBool` to the handle; guard the poll body; add pause/resume commands + a Pause button.                                                                                              |
+| 6   | **Ambiguous / data-loss**                      | `Stop` overloads "pause" and "delete"                         | `mod.rs:132` `remove` + `cancel`; panel history reset on next start (`HttpMonitorPanel.tsx:73`)                   | "Stop" doesn't stop-and-keep — it destroys the monitor and its config; the `running:false` listed state is unreachable. Chart/history are lost. User expecting to resume finds nothing.                                                                                       | Split into Stop (cancel, keep in map as `running:false`) and Remove (delete). Fixes the dead `running` field + `Disabled` dot branch at once.                                                           |
+| 7   | **Race / double-fire**                         | `Stopped → Polling` fired twice                               | Start button has no pending guard (`HttpMonitorPanel.tsx:172-181`); only disabled by URL emptiness                | Rapid double-click of Start (or Start while a previous start is in-flight) spawns two independent monitors for the same URL, each its own UUID and loop. The panel attaches to the _last_ id; the first becomes an untracked background poller only killable via the sidebar. | Disable Start while a start promise is pending (async `Button` state); or dedupe by URL in `start_http_monitor`.                                                                                        |
+| 8   | **Interval correctness**                       | `Sleeping` uses post-work fixed sleep, no backoff, no floor   | `http_monitor.rs:137-140`; unguarded `interval_ms` (`network.rs:328`)                                             | Effective period drifts to `interval+latency` (chart x-axis wrong, `HttpMonitorPanel.tsx:137`); down hosts hammered every interval; `interval_ms=0`/NaN → request busy-loop.                                                                                                  | Use `tokio::time::interval` (fixed-rate MissedTickBehavior::Delay); apply exponential backoff on consecutive failures; clamp `interval_ms >= 1000` server-side in `HttpMonitorConfig::new`/the command. |
+| 9   | **Silent / observability**                     | HTTP monitors absent from Open Connections panel              | `OpenConnectionsModal.tsx` "Monitoring" section is SSH system-monitoring only (`:384-396`); no HTTP-monitor group | The canonical "kill everything" panel cannot see or stop HTTP monitors, contradicting CLAUDE.md's rule that it covers every live subsystem. A user hunting a leak won't find the poll loops.                                                                                  | Add an "HTTP Monitors" group to Open Connections listing each monitor with a per-row Stop and a Kill-All wired to a new `stop_all` command.                                                             |
+| 10  | **Silent transition**                          | `Polling → Stopped` via Stop                                  | `handleStop`/`handleStopMonitor` (`HttpMonitorPanel.tsx:108-130`) update state but no toast                       | Stopping a monitor gives no success feedback (violates design-system rule 4); errors only set an inline `error` string, no toast on the sidebar path (`NetworkToolsSidebar.tsx:139` logs only).                                                                               | `toast.success("Monitor stopped")` / `toast.error` on both stop paths.                                                                                                                                  |
+| 11  | **Cosmetic / stale view**                      | `Polling` sub-state staleness                                 | Sidebar refreshes only on check events (`NetworkToolsSidebar.tsx:112-131`)                                        | If a monitor's interval is long (e.g. 5 min), the sidebar dot can show a stale "up" for minutes after the endpoint died, until the next poll. No "last checked N ago / overdue" indicator.                                                                                    | Show relative "last checked" time; mark a monitor "stale/overdue" when `now - timestampMs > 2×interval`.                                                                                                |
+
+## 7. Missing controls list
+
+Buttons/menu items the correct machine needs but the UI doesn't expose, each tied to the transition it fires:
+
+- **Pause / Resume** — fires `Polling → Paused` / `Paused → Polling`. Neither the state nor the control exists (Gap #5). Today Stop is the only suspend, and it destroys the monitor.
+- **Stop vs. Remove (two distinct controls)** — currently one button both cancels and deletes (Gap #6). Need `Stop` (→ listed `running:false`) and `Remove` (→ truly gone). This also makes the already-typed `running:false` state and the grey-dot render branch (`NetworkToolsSidebar.tsx:53`) reachable.
+- **Edit monitor** — no way to change URL/interval/method of an existing monitor; user must Stop (destroy) and recreate, losing history. Fires `Polling → (reconfigure) → Polling`.
+- **Retry / Clear-error** — when the client build fails (Gap #4) the monitor is a stuck zombie with no Retry and no auto-error surfaced; only manual Stop escapes. Need a `Retry` that re-enters `Stopped → Polling`.
+- **Kill-All in Open Connections** — the panel that is supposed to force-kill every subsystem has no HTTP-monitor entry at all (Gap #9). Needs a group + per-row Stop + Kill-All → `stop_all`.
+- **Clear history** — the panel accumulates up to `MAX_HISTORY=120` in-memory points (`HttpMonitorPanel.tsx:14`, `:86-88`) with no way to reset without restarting the monitor (which currently means destroying it).
+- **Acknowledge / mute a down alert** — precondition once Gap #2 adds notifications: a way to silence a known-down endpoint without stopping monitoring.
+
+## 8. Concept cross-check
+
+No `docs/concepts/**` file describes the HTTP monitor's intended lifecycle (searched — the network-tools surface has no concept doc). Per the repo's concept-drives-code rule, the intended machine is unspecified; this audit's Section 2 machine plus the Section 6/7 gaps should be treated as the behavior spec to build against, and ideally captured as a concept before implementation of the fixes in #1136.
+
+**Bottom line:** the monitor is really a _fire-and-forget poller_, not a stateful monitor. The four highest-impact fixes are: **persist configs across restart (#1)**, **notify on up/down edges (#2)**, **clean teardown at exit + Open-Connections visibility (#3, #9)**, and **separate Stop from Delete + add Pause (#5, #6)** — after which the currently-dead `running:false` state and grey-dot branch become reachable and the diagram in Section 2 gains its missing `Paused` and listed-`Stopped` states.

--- a/docs/audits/remote-agent-lifecycle-state-machine.md
+++ b/docs/audits/remote-agent-lifecycle-state-machine.md
@@ -1,0 +1,284 @@
+# Remote Agent Lifecycle State Machine — Audit
+
+> **Issue:** #1131 — Audit + fix the remote agent lifecycle state machine (deploy / setup / connect / reconnect / sessions-on-agent)
+> **Scope:** Remote agent transport lifecycle + sessions-hosted-on-agent
+> **Deliverable:** Audit findings only — analysis, diagrams, and prioritized gaps. No production code changes.
+
+## 1. Where the state lives
+
+The remote-agent transport machine is encoded in two loosely-coupled places that are **not kept in sync by a single authority**:
+
+| Layer                                            | State variable                                                                                           | File:line                                     |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Frontend (authoritative for UI)                  | `RemoteAgentDefinition.connectionState: "disconnected" \| "connecting" \| "connected" \| "reconnecting"` | `src/types/connection.ts:124`                 |
+| Backend liveness (authoritative for RPC routing) | `AgentConnection.alive: Arc<AtomicBool>`                                                                 | `src-tauri/src/terminal/agent_manager.rs:191` |
+| Backend map presence                             | `AgentConnectionManager.agents: HashMap<String, AgentConnection>`                                        | `src-tauri/src/terminal/agent_manager.rs:369` |
+
+The backend never stores the four-variant enum; it stores only `alive` + map presence and **emits** the enum as strings via the `agent-state-change` event (`emit_agent_state`, `agent_manager.rs:1319`). The frontend enum is then written from **two independent writers**:
+
+- **Optimistic writer** — the store action `connectRemoteAgent` sets `"connecting"` → `"connected"`/`"disconnected"` directly (`appStore.ts:3002`, `:3018`, `:3032`).
+- **Event writer** — `TerminalView`'s `agent-state-change` listener calls `setAgentConnectionState` (`TerminalView.tsx:68`, store `appStore.ts:3054`).
+
+These two writers race (see Gap #4).
+
+---
+
+## 2. Lifecycle state diagram — agent transport
+
+```mermaid
+stateDiagram-v2
+    [*] --> disconnected : loadFromBackend hydrate<br/>(appStore.ts:2299)
+
+    disconnected --> connecting : connectRemoteAgent()<br/>[!connecting local guard]<br/>(appStore.ts:3002)
+    note right of connecting
+        Backend also emits "connecting"
+        (agent_manager.rs:409) — redundant
+        with the optimistic store write.
+        NO Cancel control exists.
+    end note
+
+    connecting --> connected : apiConnectAgent resolves<br/>(appStore.ts:3018) + emit "connected" (agent_manager.rs:583)
+    connecting --> disconnected : SSH/handshake error<br/>(agent_manager.rs:432-538, appStore.ts:3032)
+
+    connected --> reconnecting : channel EOF/Exit in io_task<br/>emit "reconnecting" (agent_manager.rs:1511)
+    connected --> disconnected : user Disconnect<br/>(appStore.ts:3047) / Kill (OpenConnections)
+
+    reconnecting --> connected : reconnect_agent Ok<br/>emit "connected" (agent_manager.rs:1528)
+    reconnecting --> disconnected : reconnect exhausted (10 tries)<br/>emit "disconnected"+error (agent_manager.rs:1538)
+    reconnecting --> disconnected : user Disconnect sets alive=false<br/>(agent_manager.rs:1616) — see Gap #6
+
+    connected --> [*] : deleteRemoteAgent (appStore.ts:2965)
+    disconnected --> [*] : deleteRemoteAgent
+```
+
+### Backend-only "shadow" states not represented in the enum
+
+```mermaid
+stateDiagram-v2
+    state "map present + alive=true" as Alive
+    state "map present + alive=false" as Zombie
+    state "map absent" as Gone
+
+    [*] --> Alive : connect_agent inserts (agent_manager.rs:591)
+    Alive --> Gone : disconnect_agent removes (agent_manager.rs:612)
+    Alive --> Zombie : io_task reconnect FAILED, sets alive=false, returns<br/>WITHOUT removing itself from map (agent_manager.rs:1539-1544)
+    Zombie --> Gone : next connect_agent evicts dead entry (agent_manager.rs:398-405)
+    note right of Zombie
+        The frontend shows "disconnected" (event fired),
+        but the HashMap entry lingers with a dead I/O task.
+        is_connected() returns false, so it's harmless for
+        routing — but it is never proactively reaped.
+    end note
+```
+
+---
+
+## 3. Sessions-hosted-on-agent (composite sub-machine)
+
+A connected agent multiplexes N sessions over one SSH channel. Each terminal **tab** bound to the agent (`tab.config.config.agentId === agentId`, matched in `TerminalView.tsx:83`) has its own overlay sub-state driven by the _agent's_ transitions, plus the agent-reported session list (`agentSessions[agentId]`, `appStore.ts` / `OpenConnectionsModal.tsx`).
+
+```mermaid
+stateDiagram-v2
+    [*] --> Live : session created / attached
+
+    state "Agent connected" as AgentUp {
+        Live --> Live : output flows (handle_notification, agent_manager.rs:1562)
+    }
+
+    Live --> TabReconnecting : agent-state-change "reconnecting"<br/>setTerminalReconnecting(true) (TerminalView.tsx:183)
+    note right of TabReconnecting
+        Overlay spinner shown ONLY for tabs
+        where tab.sessionId is set (TerminalView.tsx:181).
+        A tab still spawning (no sessionId yet) gets no feedback.
+    end note
+
+    TabReconnecting --> Live : agent "connected" AND session id in<br/>listAgentSessions() (TerminalView.tsx:115-122)
+    TabReconnecting --> TabExited : agent "connected" AND session NOT recovered<br/>setTerminalExited (TerminalView.tsx:129)
+    TabReconnecting --> TabExited : agent "disconnected"<br/>setTerminalExited / WithError (TerminalView.tsx:199-201)
+
+    Live --> TabExited : agent "disconnected"<br/>(TerminalView.tsx:194-204)
+
+    state "Orphaned on remote" as Orphan
+    Live --> Orphan : agent drops but daemon-backed<br/>persistent session survives on host
+    Orphan --> Live : agent reconnects, session re-listed & re-attached
+    note right of Orphan
+        The remote daemon keeps running (agent survives
+        SSH drop for persistent sessions). On the desktop
+        side agentSessions is cleared on "disconnected"
+        (clearAgentSessions, TerminalView.tsx:208), so the
+        session is invisible until reconnect re-lists it.
+    end note
+
+    TabExited --> [*] : user closes tab
+```
+
+Key routing detail: on agent drop the I/O task's `session_outputs`/`monitoring_outputs` maps **survive** in `agent_io_task` (they are local `HashMap`s, `agent_manager.rs:1345-1346`) and are **reused after reconnect** without re-registration. This is correct for surviving sessions but means stale senders for dead sessions linger until the tab explicitly unregisters (Gap #7).
+
+---
+
+## 4. Sequence — connect (SSH/IPC boundary)
+
+```mermaid
+sequenceDiagram
+    participant UI as AgentNode (UI)
+    participant Store as Zustand store
+    participant Cmd as connect_agent cmd
+    participant Mgr as AgentConnectionManager
+    participant SSH as russh channel
+    participant Agent as remote agent
+
+    UI->>Store: connectRemoteAgent(id) [guard: local `connecting` flag, AgentNode.tsx:597]
+    Store->>Store: set connectionState="connecting" (appStore.ts:3002)
+    Store->>Cmd: apiConnectAgent (spawn_blocking, agent.rs:32)
+    Cmd->>Mgr: connect_agent (agent_manager.rs:385)
+    Mgr-->>Store: emit "connecting" (agent_manager.rs:409)  %% redundant, races optimistic write
+    Mgr->>SSH: connect_and_authenticate (BLOCKING, no cancel)
+    Mgr->>Agent: exec agent, send initialize (agent_manager.rs:462)
+    Agent-->>Mgr: capabilities (skip pre-init notifications, :477-547)
+    Mgr->>Mgr: spawn agent_io_task (:559)
+    Mgr-->>Store: emit "connected" (:583)
+    Mgr-->>Cmd: AgentConnectResult
+    Cmd-->>Store: resolve
+    Store->>Store: set "connected" + capabilities (appStore.ts:3018)
+    Store->>Store: refreshAgentSessions (appStore.ts:3027)
+    Note over Store: "connected" written TWICE (event + optimistic)<br/>and refreshAgentSessions can fire twice (here + TerminalView.tsx:175)
+```
+
+## 5. Sequence — reconnect after drop
+
+```mermaid
+sequenceDiagram
+    participant Agent as remote agent
+    participant IO as agent_io_task
+    participant App as AppHandle (events)
+    participant TV as TerminalView listener
+    participant Tabs as agent tabs
+
+    Agent--xIO: channel EOF / ExitStatus (agent_manager.rs:1488-1499)
+    IO->>App: emit "reconnecting" (+error) (:1511)
+    App->>TV: agent-state-change "reconnecting"
+    TV->>Tabs: setTerminalReconnecting(true) for tabs WITH sessionId (:180-188)
+    loop up to 10 attempts, backoff 2^n capped 30s (:1610-1611)
+        IO->>IO: check alive flag between/within sleep (:1616,:1628)
+        IO->>Agent: SSH connect + exec + initialize (:1635-1685)
+        alt success
+            IO->>App: emit "connected" (:1528)
+            App->>TV: agent-state-change "connected"
+            TV->>TV: listAgentSessions() (:95)
+            TV->>Tabs: recovered? clear spinner (:121) : setTerminalExited (:129)
+            IO->>IO: drain pending_responses -> "Connection lost" (:1531)
+        else exhausted
+            IO->>App: emit "disconnected" (+error) (:1538)
+            App->>TV: setTerminalExited/WithError (:199)
+            IO->>IO: alive=false, RETURN (leaves map entry -> zombie) (:1539-1544)
+        end
+    end
+```
+
+---
+
+## 6. Prioritized gap list
+
+Ranked stuck / leak / data-loss first, cosmetic feedback last.
+
+### G1 — [STUCK, no Cancel] In-flight `connecting` cannot be aborted
+
+- **State/transition:** `connecting → (stuck)`.
+- **file:line:** `agent_manager.rs:385-581` (single blocking `connect_and_authenticate` + handshake with no cancellation token); command `agent.rs:24-39`; UI `AgentNode.tsx:596-672` (no cancel path).
+- **Symptom:** User clicks Connect to an unreachable/slow host. SSH auth or the initialize handshake blocks (russh has no client timeout applied here; the handshake loop caps _message count_ at 1000, `agent_manager.rs:474`, but has **no wall-clock timeout**). The sidebar dot sits on `connecting` (`AgentNode.tsx:858`) with **no Cancel button** and no way back to `disconnected` except waiting for the OS/TCP to error out. Compare with `cancel_connecting` for local sessions (`commands/session.rs:60`) and `cancel_connection_path_probe` (`commands/connection_path.rs:206`) which both exist — the agent connect path is the odd one out.
+- **Smallest fix:** Add a `CancellationToken` per agent-connect (mirroring `connection_path.rs`'s registry), a `cancel_connect_agent` command, and a Cancel control in the connecting state. On cancel, drop the channel and emit `"disconnected"`.
+
+### G2 — [LEAK / INVISIBLE] Reconnecting & connecting agents are absent from Open Connections
+
+- **State/transition:** `reconnecting` (and `connecting`) hold a live SSH connection + spawned `agent_io_task` + possibly surviving remote sessions, yet are filtered out of the panel.
+- **file:line:** `OpenConnectionsModal.tsx:73` — `connectedAgents = remoteAgents.filter(a => a.connectionState === "connected")`. Every agent section, proxy-session section, and "Sessions on <agent>" section (`:274-338`) iterates only `connectedAgents`.
+- **Symptom:** An agent stuck in `reconnecting` (looping up to ~1–5 min through 10 backoff attempts, `agent_manager.rs:1610`) owns a russh session and a tokio task, but the canonical kill panel shows nothing for it. The user "thinks it's gone" but the resource lingers — exactly the leak signature the panel exists to catch. The only kill route is the sidebar Disconnect.
+- **Smallest fix:** Include `reconnecting` (and ideally `connecting`) agents in the panel with a state badge and a Kill/Cancel button wired to `disconnectRemoteAgent`.
+
+### G3 — [STUCK] No user-driven Retry from `disconnected`-with-error after reconnect exhaustion
+
+- **State/transition:** `reconnecting → disconnected` after 10 failed attempts (`agent_manager.rs:1751`).
+- **file:line:** `agent_manager.rs:1538` emits `"disconnected"` with the error; `TerminalView.tsx:199` shows `setTerminalDisconnectWithError` on tabs. The agent node offers plain "Connect" again, but there is **no automatic resumption and no Retry affordance on the agent header** — only the per-tab overlay and the context-menu Connect.
+- **Symptom:** After a long dropout the agent silently gives up; the sidebar dot goes grey. The reason (`error`) is delivered to tabs (`TerminalView.tsx:184`) but the **agent-level** `connectionState="disconnected"` carries no stored error, so the sidebar has no "reconnect failed: <reason>" surface — the user must guess whether the network is still down.
+- **Smallest fix:** Store the last error on the `RemoteAgentDefinition` and render a "Reconnect" button + tooltip in the disconnected state; optionally offer manual "keep retrying".
+
+### G4 — [RACE / AMBIGUOUS] Two writers for `connectionState`, order-dependent
+
+- **State/transition:** every transition into `connecting`/`connected`/`disconnected`.
+- **file:line:** optimistic writes `appStore.ts:3002,3018,3032,3047`; event writes via `TerminalView.tsx:68` → `appStore.ts:3054`. Backend emits `"connecting"` (`agent_manager.rs:409`) and `"connected"` (`:583`) that duplicate the optimistic writes.
+- **Symptom:** The `agent-state-change` "connected" event and the awaited `apiConnectAgent` promise resolution both set `"connected"` and both trigger `refreshAgentSessions` (`appStore.ts:3027` and `TerminalView.tsx:175`) — a double refresh on every connect. Worse: if a fast drop→`"reconnecting"` event arrives _before_ the optimistic `"connected"` write lands (promise still settling), the optimistic write can clobber `reconnecting` back to `connected`, hiding an active reconnect. The two paths also disagree about who owns capabilities.
+- **Smallest fix:** Make the backend `agent-state-change` event the **single** writer of `connectionState`; have `connectRemoteAgent` only kick off the request and consume `capabilities`, not set terminal states. De-dupe `refreshAgentSessions`.
+
+### G5 — [SILENT / STALE] Tab-strip state dot does not reflect agent-level reconnect/disconnect
+
+- **State/transition:** `connected → reconnecting → disconnected` at the agent level.
+- **file:line:** the tab dot reads `remoteStates[tab.id]` (`TabBar.tsx:78`, `Tab.tsx:99`), which is written only by the per-session `remote-state-change` event (`setRemoteState`, `appStore.ts:2921`; subscribed in `events.ts:140`). The `agent-state-change` path (`TerminalView.tsx`) updates `terminalReconnecting`/`terminalExited` overlays but **never calls `setRemoteState`**, and `agent_io_task` never emits a per-session `remote-state-change` on drop.
+- **Symptom:** When an agent drops, the terminal body shows a reconnecting overlay, but the **tab strip dot** for that session stays whatever it last was (often "connected"/green). Two different truth sources for "is this session live," and the compact tab indicator lies.
+- **Smallest fix:** In the `agent-state-change` handler, also `setRemoteState(tab.sessionId, state)` for each agent tab so the tab dot and the overlay agree.
+
+### G6 — [ZOMBIE / LEAK] Failed-reconnect I/O task leaves its HashMap entry behind
+
+- **State/transition:** `reconnecting → disconnected` (exhausted).
+- **file:line:** `agent_manager.rs:1539-1544` — on exhausted reconnect the task sets `alive=false` and `return`s **without** removing itself from `AgentConnectionManager.agents`. The stale entry is only reaped lazily on the _next_ `connect_agent` (eviction check `:398-405`).
+- **Symptom:** A dead `AgentConnection` (with a closed `command_tx`) lingers in the map indefinitely if the user never reconnects. `is_connected` correctly returns false (guards routing), so it is not a _correctness_ bug, but it is an untracked resource that the Open Connections panel cannot see or clear (compounds G2). If the user tries to reconnect, it is silently evicted — fine — but until then it is invisible dead state.
+- **Smallest fix:** Have `disconnect_agent`/a reaper (or the task itself via a shared weak handle) remove the entry on terminal failure; or expose a "prune dead agents" action.
+
+### G7 — [LEAK, minor] Output/monitoring senders for non-recovered sessions persist across reconnect
+
+- **State/transition:** `reconnecting → connected` where some sessions did not survive.
+- **file:line:** `agent_io_task` keeps `session_outputs`/`monitoring_outputs` across the reconnect (`agent_manager.rs:1345-1346`, maps not cleared at `:1526`). Cleanup relies on the tab calling `unregister_session_output` (`agent_manager.rs:913`), which only happens when the frontend marks the tab exited and tears down.
+- **Symptom:** For a session that did **not** recover (`TerminalView.tsx:129` marks the tab exited), the sender entry stays in the I/O task's map until the tab-side unregister fires. Low impact (bounded by tab count) but it is untracked state keyed by a now-dead session id.
+- **Smallest fix:** On successful reconnect, reconcile `session_outputs` keys against the freshly-listed session ids and drop the missing ones.
+
+### G8 — [DATA-LOSS window] `reconnecting` overlay skipped for tabs still spawning
+
+- **State/transition:** `connected → reconnecting`.
+- **file:line:** `TerminalView.tsx:181` — `if (!tab.sessionId) continue;` skips reconnecting feedback for any agent tab that has not yet been assigned a `sessionId` (mid-`connection.create`). Such a tab's in-flight create RPC is answered with `"Connection lost during request"` (`agent_manager.rs:1532`) but the tab shows neither the reconnecting spinner nor a clear error tied to the drop.
+- **Symptom:** Open a new shell on an agent exactly as the link drops → the tab can land in an ambiguous state (spawn error unrelated-looking) with no reconnect overlay.
+- **Smallest fix:** For agent tabs without a sessionId, route to the waiting/retry path (`terminalWaitingForAgent`) on `reconnecting` rather than skipping.
+
+### G9 — [SILENT teardown mismatch] `disconnect_agent` doesn't proactively close remote sessions
+
+- **State/transition:** `connected → disconnected` (user-initiated).
+- **file:line:** `agent_manager.rs:606-623` sends only `AgentIoCommand::Disconnect` (drops the channel). Non-persistent remote sessions are left to die with the channel; persistent daemon-backed ones keep running on the host. The desktop clears `agentSessions` (`TerminalView.tsx:208` / `appStore.ts:3049`).
+- **Symptom:** Ambiguity between "closed the transport" and "killed the remote sessions." After a Disconnect, remote persistent daemons keep running but the panel shows nothing, and there is no "Disconnect (keep sessions running)" vs "Shutdown agent" distinction surfaced next to the plain Disconnect (the `shutdown_agent` path exists at `agent_manager.rs:644` and reports `detached_sessions`, but the sidebar Disconnect uses the plain path). This overloads one control with two intents.
+- **Smallest fix:** Surface both intents in the UI (Disconnect = detach, Shutdown = stop remote), and show the `detached_sessions` count as feedback.
+
+### G10 — [SILENT, deploy/setup] No cancellation of deploy/setup; agent state not modeled during it
+
+- **State/transition:** deploy/setup runs orthogonally to `connectionState` (agent stays `disconnected` throughout).
+- **file:line:** `deploy_agent` (`agent_deploy.rs:148`) and `setup_remote_agent` (`agent_setup.rs:145`) take **no cancellation token** (contrast `connection_path.rs`). Deploy emits `agent-deploy-progress` (`agent_deploy.rs:377`); setup spawns a background thread (`agent_setup.rs:219`) that cannot be stopped once running. Setup dialog has a Cancel button (`AgentSetupDialog.tsx:245`) but it only closes the dialog — the background SFTP upload/script injection keeps going.
+- **Symptom:** A long download/upload (`resolve_agent_binary`, `agent_deploy.rs:199`) cannot be aborted; "Cancel" is a lie during setup. If the SFTP connection stalls, the setup thread hangs with only terminal echo as feedback.
+- **Smallest fix:** Thread a `CancellationToken` through `deploy_agent`/`run_setup_background`, checked before each network step, and wire the dialog's Cancel to fire it.
+
+### G11 — [COSMETIC] `connecting` backend emit is redundant and unobserved distinctly
+
+- **file:line:** `agent_manager.rs:409` emits `"connecting"` but the store already set it optimistically (`appStore.ts:3002`); harmless duplicate. Listed for completeness under G4.
+
+---
+
+## 7. Missing-controls list
+
+Buttons/menu items the correct machine needs, tied to the transition each would fire:
+
+| Missing control                                                                   | State it belongs in               | Transition it fires                                                               | Why (gap)                                                                                 |
+| --------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Cancel connect** (sidebar + connect overlay)                                    | `connecting`                      | `connecting → disconnected` via new `cancel_connect_agent`                        | G1 — connecting is currently a dead-end while blocked                                     |
+| **Kill / Cancel reconnect** in Open Connections                                   | `reconnecting` (and `connecting`) | `reconnecting → disconnected` (`disconnect_agent`, sets `alive=false`)            | G2 — reconnecting agents are invisible & unkillable in the canonical panel                |
+| **Reconnect** on the agent header                                                 | `disconnected` (post-exhaustion)  | `disconnected → connecting` (`connectRemoteAgent`) with stored last-error tooltip | G3 — no first-class retry after auto-reconnect gives up                                   |
+| **"Shutdown agent (stop remote sessions)"** distinct from **Disconnect (detach)** | `connected`                       | `connected → disconnected` via `shutdown_agent` vs `disconnect_agent`             | G9 — one control overloads two intents; `shutdown_agent` already exists but is unsurfaced |
+| **Cancel setup / deploy** that actually aborts                                    | during deploy/setup progress      | fire a `CancellationToken`                                                        | G10 — current Cancel only closes the dialog                                               |
+| **"Prune dead agents"** (or automatic reap)                                       | zombie backend entries            | remove stale `AgentConnection`                                                    | G6 — failed-reconnect entries linger untracked                                            |
+
+---
+
+## 8. Summary of the delta (real vs. ideal)
+
+The machine's happy path (connect → connected → reconnect → connected) is well-built: backoff respects the `alive` flag (regression-tested, `agent_manager.rs:2189`), the handshake tolerates pre-init notifications, and surviving sessions are correctly re-linked by id on reconnect (`TerminalView.tsx:113-136`). The defects cluster at the **edges and the cross-writer seam**:
+
+1. **No cancellation anywhere in the agent path** (connect G1, deploy/setup G10) while sibling subsystems have it — the biggest UX hole.
+2. **`reconnecting` is a first-class transport state the kill panel refuses to acknowledge** (G2), so its resources leak from the user's view.
+3. **Two writers for `connectionState`** (G4) create a race and duplicate work, and the tab dot reads a _third_ source that no agent transition updates (G5).
+4. **Terminal failure leaves a zombie map entry** (G6) reaped only lazily.
+
+Fixing G1, G2, and G4 first collapses most of the "stuck/leak/invisible" symptoms; G5/G3/G9 then make the remaining transitions observable and reversible.

--- a/docs/audits/remote-system-monitoring-state-machine.md
+++ b/docs/audits/remote-system-monitoring-state-machine.md
@@ -1,0 +1,301 @@
+# Remote System Monitoring State Machine — Audit
+
+> **Issue:** #1137 — Audit + fix the remote system monitoring state machine
+> **Scope:** SSH remote system monitoring lifecycle (idle → collecting → streaming → paused → error/disconnected)
+> **Deliverable:** Audit findings only — analysis, diagrams, and prioritized gaps. No production code changes.
+
+## Executive summary
+
+There are **two independent monitoring machines** that share one frontend surface (the status-bar `MonitoringStatus` widget and a single global slice in `appStore`):
+
+1. **Legacy desktop-SSH path** ("standard" monitoring) — `monitoring_open` / `monitoring_fetch_stats` / `monitoring_close` (`src-tauri/src/commands/monitoring.rs`), backed by `MonitoringSession` (`src-tauri/src/monitoring/session.rs`). **Pull-based**: the UI polls every 5 s via a `setInterval` in `StatusBar.tsx:279`.
+2. **Session-based / agent path** ("remote-session" tabs) — `session_monitoring_open` / `session_monitoring_close` (`src-tauri/src/commands/session.rs:324`), backed by `SessionManager::start_session_monitoring` (`src-tauri/src/session/manager.rs:630`), which subscribes to a `MonitoringProvider` (`core/src/backends/ssh/monitoring.rs` = `SshMonitoringProvider`, or the agent's `MonitoringManager` in `agent/src/monitoring/mod.rs`). **Push-based**: stats arrive as `session-monitoring-stats` Tauri events.
+
+The two machines are **overloaded onto the same five store fields** (`monitoringSessionId`, `monitoringHost`, `monitoringStats`, `monitoringLoading`, `monitoringError` — `src/store/appStore.ts:3408-3412`), which are **global/singleton** (only one host can be monitored app-wide). The most serious defects are: **no error state on a mid-stream SSH drop** (both paths go silent instead of surfacing an error), **no reconnect for either machine after the transport dies**, and a **collect-hang risk** because neither exec loop has a timeout. There is also **no user-facing Pause/Resume/Retry control** — the state machine has states the user cannot drive.
+
+---
+
+## Diagram 1 — Legacy desktop-SSH monitoring lifecycle (pull-based)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Connecting : connectMonitoring(config) [monitoringEnabled && tab supports]
+    note right of Idle
+        monitoringSessionId == null
+        appStore.ts:3408
+    end note
+
+    Connecting --> Streaming : monitoring_open OK then first monitoring_fetch_stats OK
+    Connecting --> Error : open/fetch throws (auth, TCP timeout ~75s)
+    note right of Connecting
+        connectMonitoring, appStore.ts:3467-3468
+        set monitoringLoading=true
+    end note
+
+    Streaming --> Streaming : setInterval 5s -> refreshMonitoring -> monitoring_fetch_stats OK
+    note right of Streaming
+        StatusBar.tsx:279 poll
+        refreshMonitoring appStore.ts:3516
+    end note
+
+    Streaming --> StreamingButStale : monitoring_fetch_stats throws mid-stream (SSH dropped)
+    note right of StreamingButStale
+        BUG: monitoringSessionId stays set,
+        stale monitoringStats keeps rendering,
+        only monitoringError updates (no visible
+        error while connected). appStore.ts:3531
+    end note
+    StreamingButStale --> StreamingButStale : next poll throws again (no reconnect)
+    StreamingButStale --> Streaming : remote recovers on its own AND session still alive
+
+    Streaming --> Disconnected : disconnectMonitoring (user Kill / tab switch / session exit)
+    StreamingButStale --> Disconnected : disconnectMonitoring
+    Error --> Idle : user picks another host from picker
+    Disconnected --> [*]
+
+    Error --> Error : autoConnectFailedRef blocks retry (StatusBar.tsx:340)
+```
+
+### Where each transition lives
+
+- `Idle → Connecting`: auto-connect effect `StatusBar.tsx:343-375`, or manual `handleConnect` `StatusBar.tsx:385-393` → `connectMonitoring` `appStore.ts:3457-3475`.
+- `Connecting → Streaming`: `appStore.ts:3467-3475` (both `monitoring_open` and the first `monitoring_fetch_stats` must succeed before `monitoringSessionId` is set).
+- `Streaming → Streaming`: `setInterval(refreshMonitoring, 5000)` `StatusBar.tsx:279-281`; `refreshMonitoring` `appStore.ts:3516-3535`.
+- `Streaming → StreamingButStale`: `refreshMonitoring` catch `appStore.ts:3530-3534` sets **only** `monitoringError` and leaves `monitoringSessionId`/`monitoringStats` intact.
+- `* → Disconnected`: `disconnectMonitoring` `appStore.ts:3484-3514`.
+
+---
+
+## Diagram 2 — Session-based / agent monitoring lifecycle (push-based)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Subscribing : connectMonitoring({_sessionBased,_sessionId})
+    note right of Idle
+        remote-session tab, StatusBar.tsx:305
+    end note
+
+    Subscribing --> Streaming : onSessionMonitoringStats listener attached + session_monitoring_open OK
+    note right of Subscribing
+        appStore.ts:3436-3453
+        listener BEFORE open (good)
+    end note
+    Subscribing --> ErrorNoRecover : session_monitoring_open throws
+    note right of ErrorNoRecover
+        BUG: listener already attached but
+        never detached in this path;
+        monitoringSessionId never set ->
+        Open Connections shows nothing
+    end note
+
+    Streaming --> Streaming : session-monitoring-stats event (agent push 2s)
+    note right of Streaming
+        core/backends/ssh/monitoring.rs:116 loop
+        or agent/monitoring/mod.rs:214 loop
+    end note
+
+    Streaming --> SilentStall : provider SSH exec fails repeatedly
+    note right of SilentStall
+        BUG: provider loop swallows errors
+        (debug! only, monitoring.rs:127-133),
+        no notification, UI shows last stats
+        forever, no error, no reconnect
+    end note
+    SilentStall --> Streaming : remote recovers (same open SSH session)
+
+    Streaming --> Disconnected : disconnectMonitoring / stop_session_monitoring
+    SilentStall --> Disconnected : disconnectMonitoring
+    Disconnected --> [*]
+```
+
+### Where each transition lives
+
+- `Idle → Subscribing → Streaming`: `connectMonitoring` session branch `appStore.ts:3426-3454`; backend `SessionManager::start_session_monitoring` `manager.rs:630-670`.
+- push loop desktop-direct: `SshMonitoringProvider::subscribe` `core/src/backends/ssh/monitoring.rs:89-152`.
+- push loop on agent: `MonitoringManager::monitoring_task` `agent/src/monitoring/mod.rs:204-264`.
+- `* → Disconnected`: `stop_session_monitoring` `manager.rs:672-687` (aborts push task, unsubscribes); frontend `disconnectMonitoring` `appStore.ts:3484-3514`.
+
+---
+
+## Sequence 1 — Legacy pull-based collection crossing the IPC/SSH boundary
+
+```mermaid
+sequenceDiagram
+    participant UI as StatusBar (React)
+    participant Store as appStore (Zustand)
+    participant Cmd as monitoring.rs (Tauri cmd)
+    participant Mgr as MonitoringManager
+    participant Sess as MonitoringSession
+    participant SSH as Remote host
+
+    UI->>Store: connectMonitoring(config)
+    Store->>Cmd: invoke monitoring_open
+    Cmd->>Mgr: spawn_blocking open_session
+    Mgr->>Sess: connect_and_authenticate (session.rs:31)
+    Sess->>SSH: TCP+auth (up to ~75s on dead host)
+    SSH-->>Sess: authenticated
+    Sess-->>Store: sessionId
+    Store->>Cmd: invoke monitoring_fetch_stats
+    Cmd->>Sess: run_remote_command(MONITORING_COMMAND)
+    Note over Sess,SSH: remote_exec.rs:31 channel.wait() loop\nNO TIMEOUT — hangs if peer silently drops
+    SSH-->>Store: SystemStats (cpu=0 on first sample)
+    Store-->>UI: monitoringStats render
+
+    loop every 5s (StatusBar.tsx:279)
+        UI->>Store: refreshMonitoring
+        Store->>Cmd: monitoring_fetch_stats
+        alt SSH dropped mid-stream
+            Cmd-->>Store: Err (or HANGS with no timeout)
+            Store->>Store: set monitoringError ONLY (appStore.ts:3531)
+            Note over UI: keeps rendering STALE stats,\nno visible error while connected
+        else OK
+            SSH-->>Store: fresh SystemStats
+        end
+    end
+```
+
+### Boundary gaps this exposes
+
+- `run_remote_command` (`src-tauri/src/utils/remote_exec.rs:31-46`) has **no timeout** on `channel.wait()`. If the TCP peer half-drops, the `spawn_blocking` task hangs indefinitely; the 5 s poll then stacks a _new_ `spawn_blocking` each tick (`StatusBar.tsx:279` fires regardless of whether the prior `refreshMonitoring` resolved) → thread/blocking-pool leak under a dead remote.
+- On a fetch error while `monitoringSessionId` is still set, the render branch `StatusBar.tsx:474-508` stays in the "connected" arm, so the **`monitoringError` is never shown** (the error UI only renders in the _disconnected_ arm, `StatusBar.tsx:424-432`).
+
+---
+
+## Sequence 2 — Session/agent push collection crossing the IPC/SSH boundary
+
+```mermaid
+sequenceDiagram
+    participant UI as StatusBar (React)
+    participant Store as appStore
+    participant Cmd as session.rs (Tauri cmd)
+    participant SM as SessionManager
+    participant Prov as MonitoringProvider (SSH)
+    participant SSH as Remote host
+
+    UI->>Store: connectMonitoring({_sessionBased})
+    Store->>Store: onSessionMonitoringStats listener (appStore.ts:3436)
+    Store->>Cmd: session_monitoring_open
+    Cmd->>SM: start_session_monitoring (manager.rs:630)
+    SM->>Prov: subscribe() -> Receiver (manager.rs:643)
+    Prov->>Prov: tokio::spawn connect_target (monitoring.rs:102)
+    alt provider connect fails
+        Prov-->>Prov: warn! + task returns (monitoring.rs:109-111)
+        Note over SM,UI: subscribe() STILL returned Ok(rx);\nsession_monitoring_open reports success;\nUI enters Streaming but NO stats ever arrive
+    end
+    loop every 2s (monitoring.rs:116)
+        Prov->>SSH: ssh_exec(MONITORING_COMMAND)
+        alt exec/parse error
+            Prov-->>Prov: debug! only, continue (monitoring.rs:127-133)
+            Note over UI: silent stall — last stats linger,\nno error event, no reconnect
+        else OK
+            Prov->>SM: tx.send(stats)
+            SM->>UI: emit session-monitoring-stats (manager.rs:657)
+            UI->>Store: update monitoringStats
+        end
+    end
+    UI->>Store: disconnectMonitoring
+    Store->>Cmd: session_monitoring_close
+    Cmd->>SM: stop_session_monitoring -> abort + unsubscribe (manager.rs:673-687)
+```
+
+### Boundary gaps this exposes
+
+- `SshMonitoringProvider::subscribe` returns `Ok(rx)` **before** the SSH connection is even attempted (the connect happens inside the spawned task, `monitoring.rs:102-112`). A connect failure only logs `warn!` and drops the task — the UI is told monitoring started and waits forever for a first stat with no error and no timeout.
+- The agent's `monitoring_task` (`agent/src/monitoring/mod.rs:253-255`) and the provider loop (`monitoring.rs:127-133`) both **swallow collection errors** (`warn!`/`debug!` only). The remote going away mid-stream produces a **silent stall**, never a state change the UI can see.
+
+---
+
+## Prioritized gap list (stuck / leak / data-loss first)
+
+### G1 — Mid-stream SSH drop shows stale data as if live (data-integrity, both paths) 🔴
+
+- **State/transition:** `Streaming → StreamingButStale` / `Streaming → SilentStall` — no state change reaches the UI.
+- **file:line:** legacy: `appStore.ts:3530-3534` (fetch error sets only `monitoringError`, keeps `monitoringSessionId`+`monitoringStats`); render never surfaces it because the connected arm has no error branch (`StatusBar.tsx:474-508`). Push: provider swallows errors `core/src/backends/ssh/monitoring.rs:127-133`; agent `agent/src/monitoring/mod.rs:253-255`.
+- **User-visible symptom:** CPU/Mem/Disk numbers freeze at last-good values but keep looking "connected" (green/normal severity). User trusts stale metrics of a host that may be down.
+- **Smallest fix:** Introduce an explicit `Stale`/`Error-while-connected` sub-state. Legacy: after N consecutive `refreshMonitoring` failures, flip a `monitoringStale=true` flag and render a warning badge in the connected arm. Push: emit a `session-monitoring-error` event (or a status field on the stats event) when the provider loop's exec fails K times in a row, and have the store surface it.
+
+### G2 — No reconnect after transport dies (stuck, both paths) 🔴
+
+- **State/transition:** missing `Stale → Reconnecting → Streaming`.
+- **file:line:** legacy `MonitoringSession` holds one `SshSession` (`session.rs:23`) with no re-dial on `fetch_stats` error. Push loop reuses one `session` for the task lifetime (`monitoring.rs:106`); it never re-runs `connect_target` after a drop.
+- **User-visible symptom:** once the SSH session drops, monitoring is dead until the user manually Kills and re-picks the host (legacy) or switches the tab away and back (session). For remote-session it may never recover.
+- **Smallest fix:** add a bounded backoff reconnect in each collector loop (re-establish the SSH session on `Err`, cap attempts) and, for the legacy path, have `fetch_stats` transparently re-open on a broken channel. Surface `Reconnecting` in the UI.
+
+### G3 — Collect can hang forever (leak / runtime starvation, legacy) 🔴
+
+- **State/transition:** `Streaming` self-loop that never completes.
+- **file:line:** `run_remote_command` `src-tauri/src/utils/remote_exec.rs:31-46` — `channel.wait()` loop has no timeout; `monitoring_fetch_stats` `src-tauri/src/commands/monitoring.rs:56-59` wraps it in `spawn_blocking` but never bounds it.
+- **User-visible symptom:** against a half-dead remote, each 5 s poll (`StatusBar.tsx:279`) launches another blocking task that never returns; blocking pool fills, and the stale-data problem (G1) becomes permanent because `refreshMonitoring` never resolves to update `monitoringError`.
+- **Smallest fix:** wrap the exec in `tokio::time::timeout` (e.g. 10 s) and, in `StatusBar.tsx`, skip a poll tick while the previous `refreshMonitoring` is still in flight (in-flight guard).
+
+### G4 — Provider `subscribe()` returns Ok before the SSH connect (false "connected", push) 🟠
+
+- **State/transition:** `Subscribing → Streaming` fires on a connection that hasn't happened.
+- **file:line:** `core/src/backends/ssh/monitoring.rs:89-152` — `Ok(rx)` returned at line 151; the actual `connect_target` runs later inside the spawned task (line 102) and a failure only `warn!`s (line 109).
+- **User-visible symptom:** UI shows "connected"/Connecting-cleared with no stats forever when the remote is unreachable; no error.
+- **Smallest fix:** perform (or await a one-shot result of) the initial connect inside `subscribe()` and return `Err(CoreError)` on failure so `start_session_monitoring` → `session_monitoring_open` → `connectMonitoring` lands in the error branch.
+
+### G5 — Session-open failure leaks the event listener (leak, push) 🟠
+
+- **State/transition:** `Subscribing → ErrorNoRecover`.
+- **file:line:** `appStore.ts:3436-3453` — `onSessionMonitoringStats` listener is attached and stored in `_monitoringUnlisten` _before_ `sessionMonitoringOpen`; if `sessionMonitoringOpen` throws, control jumps to the `catch` (`appStore.ts:3476`) which sets `monitoringError` but **never calls `_monitoringUnlisten()`**. `monitoringSessionId` stays null, so `disconnectMonitoring` (`appStore.ts:3487` guard) won't clean it up either.
+- **User-visible symptom:** a dangling Tauri event listener survives; on a later successful subscribe of another session, stray events can update the wrong host.
+- **Smallest fix:** in the `catch` of `connectMonitoring`, call `_monitoringUnlisten?.()` and null it.
+
+### G6 — Only one host can be monitored app-wide; second connect silently evicts first (data-loss, both) 🟠
+
+- **State/transition:** singleton store slice overloaded across all tabs.
+- **file:line:** single global fields `appStore.ts:3408-3413`; auto-connect disconnects the previous host on tab switch (`StatusBar.tsx:317-319`, `351-353`).
+- **User-visible symptom:** with two SSH tabs open, switching tabs tears down the first tab's monitoring and its live stream; the Open Connections panel only ever shows one Monitoring row (`OpenConnectionsModal.tsx:385` gates on the single `monitoringHost`).
+- **Smallest fix (spec-level):** key monitoring state by session/host (`Record<hostKey, MonitoringState>`) instead of a singleton, so each tab keeps its own machine and Open Connections lists all of them. (Larger change — flag for design.)
+
+### G7 — Auto-connect failure is a hard dead-end (stuck, both) 🟠
+
+- **State/transition:** `Error → Error` (no path back to `Connecting`).
+- **file:line:** `autoConnectFailedRef` `StatusBar.tsx:340-341` (SSH) and `311-312` (session) latch the failed host key and block any further auto-connect attempt; it's only cleared on success (`371`) or tab-exit reset (`297`).
+- **User-visible symptom:** if the first auto-connect fails (host briefly down, password cancelled), monitoring for that tab never retries even after the host recovers — no Retry button exists, so the user must switch tabs away and back.
+- **Smallest fix:** add a visible **Retry** control in the error state that clears `autoConnectFailedRef` and re-invokes connect; optionally auto-retry with backoff.
+
+### G8 — Password cancel during auto-connect leaves it "failed" with no feedback (silent, legacy) 🟡
+
+- **State/transition:** `Connecting → Idle` with no user signal.
+- **file:line:** `StatusBar.tsx:363-364` — `requestPassword` returning `null` just `return`s; `autoConnectFailedRef` remains latched, `monitoringLoading` is never set, no toast.
+- **User-visible symptom:** nothing appears; user doesn't know monitoring didn't start and (per G7) can't retry.
+- **Smallest fix:** on cancel, surface a subtle "Monitoring not connected" affordance and leave the picker/Retry reachable.
+
+### G9 — `monitoringError` never auto-clears between hosts (cosmetic/stale, both) 🟡
+
+- **State/transition:** `Error` persists into the next `Idle`.
+- **file:line:** `refreshMonitoring` catch sets `monitoringError` (`appStore.ts:3531`) but leaves it set; only `connectMonitoring` start (`appStore.ts:3431`,`3462`) or `disconnectMonitoring` (`appStore.ts:3507`) clears it.
+- **User-visible symptom:** a stale "Monitor error" tooltip can linger from a previous host.
+- **Smallest fix:** clear `monitoringError` on every successful stat update (session push branch `appStore.ts:3438-3442` already does; make the legacy poll-success path do the same — it does at `appStore.ts:3525`, so this is mainly the disconnected-arm error render timing).
+
+### G10 — CPU% is 0 on the first sample with no indication (minor data-quality) 🟡
+
+- **file:line:** `session.rs:48-51` and `agent/collector.rs:220-223` — first `collect` returns 0 % because there's no prior CPU delta; documented but the UI renders a solid "CPU 0%" that looks real.
+- **User-visible symptom:** first status-bar reading always says CPU 0 %.
+- **Smallest fix:** render a "—"/priming indicator until the second sample (or prime the counters on connect, as `LocalCollector::new` already does at `agent/collector.rs:43`).
+
+---
+
+## Missing-controls list
+
+| Control                                        | Where it belongs                                                                 | Transition it should fire                                                                                                                                    | Today                                                                                                                                                          |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Retry / Reconnect**                          | status-bar error state & Open Connections monitoring row                         | `Error/Stale → Connecting` (clears `autoConnectFailedRef`)                                                                                                   | Absent — failure is a dead-end (G7). Open Connections only offers Kill (`OpenConnectionsModal.tsx:390,396`).                                                   |
+| **Pause / Resume**                             | status-bar monitoring dropdown (`MonitoringDetailDropdown`, `StatusBar.tsx:516`) | `Streaming ↔ Paused` (stop polling / stop push without tearing down the SSH session)                                                                         | Absent — there is no `Paused` state at all; the "paused" leg of the issue's scope is unimplemented. Only Refresh + Disconnect exist (`StatusBar.tsx:481-482`). |
+| **Cancel (during Connecting)**                 | status-bar "Connecting…" indicator (`StatusBar.tsx:414-421`)                     | `Connecting → Idle` (abort the up-to-75 s SSH handshake)                                                                                                     | Absent — the "Connecting…" state is uninterruptible; the blocking open runs to timeout.                                                                        |
+| **Explicit "Monitor stale/offline" indicator** | connected stats arm (`StatusBar.tsx:484-508`)                                    | render branch for `Stale`                                                                                                                                    | Absent — G1; stale data is indistinguishable from live.                                                                                                        |
+| **Per-host Kill in Open Connections**          | monitoring section (`OpenConnectionsModal.tsx:384-399`)                          | `Streaming → Disconnected` per host                                                                                                                          | Only a single global row exists (G6); multi-host monitoring can't be inspected or individually killed.                                                         |
+| **Interval / refresh-rate control**            | monitoring settings or dropdown                                                  | reconfigure poll/push interval (`REFRESH_INTERVAL_MS` `StatusBar.tsx:18`, `MONITORING_INTERVAL` `monitoring.rs:24`, agent `DEFAULT_INTERVAL_MS` `mod.rs:27`) | Absent — hardcoded; three different intervals across the three loops with no user control.                                                                     |
+
+---
+
+## Cross-cutting observations
+
+- **Two intervals disagree:** legacy UI polls at **5 s** (`StatusBar.tsx:18`) while the push provider ticks at **2 s** (`core/src/backends/ssh/monitoring.rs:24`) and the agent at **2 s** (`agent/src/monitoring/mod.rs:27`). Same widget, inconsistent refresh cadence depending on path.
+- **Teardown correctness (the good part):** the push machine tears down cleanly — `stop_session_monitoring` both aborts the task and calls `provider.unsubscribe()` (`manager.rs:673-687`), and `MonitoringTask`/`Subscription` use `Drop`/`CancellationToken` to stop the loop (`monitoring.rs:34-38`, `mod.rs:62-65`). The legacy path drops the `SshSession` on `close_session` (`session.rs:87-90`). The **leak risk is not in teardown** but in G3 (unbounded in-flight collects) and G5 (listener leak on open failure).
+- **Terminal-exit coupling works:** when the underlying terminal session dies, the store calls `disconnectMonitoring` (`appStore.ts:2848-2851`, `2860-2861`) and the auto-connect effect is gated on `activeTabExited` (`StatusBar.tsx:296-298`) — so an _expected_ session death does tear monitoring down. The gap is the _unexpected_ mid-stream SSH drop that doesn't kill the terminal session (G1/G2).
+- **Legacy path is explicitly marked for removal** (`session.rs:16-21` doc comment) in favor of the unified `MonitoringProvider`; several gaps (G1–G3, G6) would be resolved by completing that migration and giving the provider loop real error/reconnect semantics.

--- a/docs/audits/sftp-file-browser-state-machine.md
+++ b/docs/audits/sftp-file-browser-state-machine.md
@@ -1,0 +1,293 @@
+# SFTP / File Browser Session State Machine — Audit
+
+> **Issue:** #1132 — Audit + fix the SFTP / file browser session state machine
+> **Scope:** SFTP / file browser lifecycle (connect → browse → transfer → cancel → error → disconnect)
+> **Deliverable:** Audit findings only — analysis, diagrams, and prioritized gaps. No production code changes.
+
+## 1. Where the state actually lives
+
+The "SFTP session" is encoded across three layers, and the front-end state is deliberately **single-slot** — there is one connection tracked at a time even though the Rust manager can hold many.
+
+| Layer          | State carrier                                                                                                                                        | File:line                                                                     |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Rust manager   | `SftpManager.sessions: Arc<Mutex<HashMap<String, Arc<Mutex<SftpSession>>>>>` — N sessions keyed by UUID                                              | `src-tauri/src/files/sftp.rs:435-470`                                         |
+| Tauri commands | Stateless per-call; each command does `get_session(id)` → `spawn_blocking(lock().unwrap())`                                                          | `src-tauri/src/commands/files.rs:49-144`                                      |
+| Zustand store  | `sftpSessionId: string \| null`, `sftpLoading: bool`, `sftpError: string \| null`, `sftpConnectedHost: string \| null`, `currentPath`, `fileEntries` | `src/store/appStore.ts:477-480, 2664-2670`                                    |
+| Browser mode   | `fileBrowserMode: "local" \| "sftp" \| "session" \| "none"` (derived from the active tab)                                                            | `src/store/appStore.ts:607`, `src/components/Sidebar/FileBrowser.tsx:432-490` |
+
+The **desktop SFTP session state** is therefore the 3-tuple `(sftpSessionId, sftpLoading, sftpError)`. There is **no explicit `status` enum** — the state is inferred:
+
+- `sftpSessionId === null && sftpLoading` → _Connecting_
+- `sftpSessionId === null && sftpError` → _Failed_
+- `sftpSessionId !== null && !sftpLoading` → _Connected/Idle_
+- `sftpSessionId !== null && sftpLoading` → _Busy_ (listing/refresh — **shared with connect**)
+
+That overload (one `sftpLoading` boolean for connect, navigate, refresh, and every mutating op) is the root of several gaps below.
+
+There is **no transfer state at all** — `sftp_download` / `sftp_upload` (`src-tauri/src/commands/files.rs:63-96`) are one-shot request/response; `read_file`/`write_file` read the whole file into a `Vec<u8>` in memory (`src-tauri/src/files/sftp.rs:93-143`) with no chunking, no progress event, and no cancel token.
+
+---
+
+## 2. Session lifecycle — desktop SFTP
+
+```mermaid
+stateDiagram-v2
+    [*] --> None : active tab has no fileBrowser capability
+
+    None --> Connecting : useFileBrowserSync auto-connect effect\n[mode==sftp && host!=connectedHost]\nconnectSftp() sets sftpLoading=true
+
+    Connecting --> Connected : sftpOpen resolves\n+ home/root listDir ok\nset sftpSessionId, currentPath
+    Connecting --> Failed : sftpOpen throws\nset sftpError, sftpLoading=false
+
+    Failed --> Connecting : effect re-fires on dep change\n[no explicit Retry button]
+    Failed --> None : user switches tab / disables browser
+
+    Connected --> Busy : navigateSftp/refreshSftp\nsftpLoading=true
+    Busy --> Connected : listDir ok
+    Busy --> BusyError : listDir throws\nsftpError set, sftpLoading=false
+    BusyError --> Busy : any navigate/refresh
+    BusyError --> Connected : successful navigate
+
+    Connected --> Transferring : downloadFile/uploadFile/paste\n(no state flag — see transfer sub-machine)
+    Transferring --> Connected : op resolves (refresh)
+    Transferring --> TransferError : op throws (caught by .catch console.error)
+
+    Connected --> None : disconnectSftp()\nsftp_close, clear slot
+    Connected --> Connecting : host change → disconnectSftp then connectSftp
+    Connected --> [*] : tab closed (LEAK — see Gap L1)
+
+    note right of Failed
+        Dead-ends: no Retry/Close control.
+        Recovery only via unrelated dep change.
+    end note
+    note right of Transferring
+        Not represented in store state.
+        No progress, no cancel, no busy lock.
+    end note
+```
+
+**Key observations bound to code:**
+
+- `Connecting → Connected` is gated by the home-dir probe: `connectSftp` lists `/home/<username>`, falling back to `/` on error (`src/store/appStore.ts:2679-2688`). The fallback is silent.
+- `Failed` has **no user-driven outgoing edge**. `connectSftp`'s error path only sets `sftpError`/`sftpLoading=false` (`appStore.ts:2696-2701`); the render shows an `AlertCircle` + message with **no Retry/Close button** (`FileBrowser.tsx:944-953`). Re-entry into `Connecting` happens only if the auto-connect effect's deps change (`FileBrowser.tsx:606-617`).
+- `Connected → None` is the disconnect edge, driven by the toolbar Unplug button (`FileBrowser.tsx:1070-1080`) or the Open Connections panel kill (`OpenConnectionsModal.tsx:373-379`), both calling `disconnectSftp` (`appStore.ts:2704-2720`).
+
+---
+
+## 3. Transfer sub-machine (download / upload / paste)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+
+    Idle --> PickingTarget : download → save() dialog\nupload → open() dialog
+    PickingTarget --> Idle : dialog cancelled (localPath null)
+    PickingTarget --> InFlight : path chosen\nsftpDownload/sftpUpload invoked
+
+    InFlight --> Done : promise resolves\n(upload/paste → refreshSftp)
+    InFlight --> Errored : promise rejects
+
+    Done --> Idle
+    Errored --> Idle : silent — .catch(console.error) only\n[no toast, no inline error, no state]
+
+    note right of InFlight
+        BLOCKING & INVISIBLE:
+        - whole file buffered in RAM (read_to_end / fs::read)
+        - session Mutex held for the entire transfer
+        - no progress event
+        - no cancel token
+        - UI shows NO pending indicator
+    end note
+```
+
+Grounding:
+
+- Download: `useFileSystem.downloadFile` → `save()` dialog → `sftpDownload(id, remote, local)` (`src/hooks/useFileSystem.ts:44-52`). **No `refresh`, no progress, no try/catch** — errors bubble to `FileBrowser.handleContextAction`'s `.catch(console.error)` (`FileBrowser.tsx:759-762`), which is a DevTools-only console call (violates the "LogViewer, never console" rule and gives the user nothing).
+- Upload: `uploadFile` / `uploadFileFromPath` → `sftpUpload` → `refreshSftp()` (`useFileSystem.ts:54-74`). Same absence of progress/pending/cancel.
+- Rust side buffers the entire file: download does `remote.read_to_end(&mut data)` then `tokio::fs::write` (`sftp.rs:104-113`); upload does `tokio::fs::read` then `remote.write_all` (`sftp.rs:125-138`). A multi-GB transfer will consume RAM equal to file size and **hold the per-session `Mutex`** (`files.rs:71-73, 88-93`) so **every other browse/list on that session is blocked** for the whole transfer — the shared `sftpLoading` never even flips, so the browser looks frozen with no spinner.
+
+---
+
+## 4. Browse sequence (list dir across the IPC/SSH boundary)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FB as FileBrowser.tsx
+    participant St as appStore (navigateSftp)
+    participant API as api.ts (sftpListDir)
+    participant Cmd as sftp_list_dir (Rust)
+    participant Mgr as SftpManager
+    participant S as SftpSession (russh-sftp)
+    participant SSH as Remote sshd
+
+    U->>FB: double-click folder / Up / Refresh
+    FB->>St: navigateSftp(path)
+    St->>St: set sftpLoading=true, sftpError=null
+    St->>API: sftpListDir(id, path)
+    API->>Cmd: invoke("sftp_list_dir")
+    Cmd->>Mgr: get_session(id)
+    alt session missing
+        Mgr-->>Cmd: Err SftpSessionNotFound
+        Cmd-->>St: reject
+        St->>St: sftpError set, sftpLoading=false
+        Note over FB: dead-end — no reconnect offered
+    else session present
+        Cmd->>S: spawn_blocking(lock().unwrap().list_dir)
+        S->>SSH: SSH_FXP_READDIR
+        SSH-->>S: entries
+        S-->>Cmd: Vec<FileEntry>
+        Cmd-->>St: entries
+        St->>St: fileEntries=entries, currentPath=path, sftpLoading=false
+        St->>FB: re-render
+    end
+```
+
+Race note: the store `set` in `navigateSftp` (`appStore.ts:2725-2728`) is not guarded against overlapping calls — two fast navigations both set `sftpLoading=true` and whichever `listDir` resolves **last** wins `currentPath`/`fileEntries`, which can leave `currentPath` and the displayed list out of sync (out-of-order responses). The buttons that fire it (`Up`, `Refresh`, row double-click) are **not disabled during a pending list** (`FileBrowser.tsx:986-1024`).
+
+---
+
+## 5. Transfer sequence (upload) — shows the missing feedback/cancel gaps
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FB as FileBrowser.tsx
+    participant H as useFileSystem.uploadFile
+    participant API as api.ts
+    participant Cmd as sftp_upload (Rust)
+    participant S as SftpSession
+    participant SSH as Remote sshd
+
+    U->>FB: click Upload
+    FB->>H: uploadFile()
+    H->>H: open() file dialog
+    Note over H: no pending UI yet
+    H->>API: sftpUpload(id, local, remote)
+    API->>Cmd: invoke("sftp_upload")
+    Cmd->>S: spawn_blocking(lock().unwrap().write_file)
+    Note over Cmd,S: Mutex LOCKED for entire transfer\nno progress events\nno cancel token
+    S->>S: fs::read(local) → full buffer in RAM
+    S->>SSH: create + write_all(all bytes)
+    SSH-->>S: ok / err
+    S-->>Cmd: bytes | Err
+    Cmd-->>H: resolve | reject
+    alt resolve
+        H->>H: refreshSftp()
+        Note over FB: only signal — list quietly updates
+    else reject
+        H-->>FB: throws → (no local .catch in uploadFile)
+    end
+```
+
+Note: `uploadFile` / `uploadFileFromPath` have **no `try/catch`** at all (`useFileSystem.ts:54-74`). For the toolbar button (`onClick={uploadFile}`, `FileBrowser.tsx:1030`) and OS drop (`handleOsDrop`, `FileBrowser.tsx:689-696`), a rejected upload becomes an **unhandled promise rejection** — no toast, no inline error, nothing. Contrast with `pasteEntry`, which the caller wraps in `.catch(console.error)` (`FileBrowser.tsx:815`) — still console-only.
+
+---
+
+## 6. Prioritized gap list
+
+Ranked stuck / leak / data-loss first.
+
+### L1 — SFTP session leaks on tab close (LEAK, high)
+
+- **State/transition:** `Connected → [*]` when the SSH tab that spawned the browser is closed.
+- **file:line:** `closeTab` (`src/store/appStore.ts:1870-1920`) cleans ~18 per-tab maps but never reads/clears `sftpSessionId` and never calls `sftpClose`; `SftpManager` keeps the entry (`sftp.rs:435-470`).
+- **Symptom:** User closes the SSH terminal tab; the underlying dedicated SSH+SFTP connection stays open on the server indefinitely. Because the store only tracks the _current_ `sftpSessionId`, if the user had browsed host A then switched to a tab for host B, host A's UUID is overwritten (`connectSftp` at `appStore.ts:2690`) with **no `sftp_close`** for A — a fully orphaned session with no UUID anywhere in the front end.
+- **Also invisible in Open Connections:** the panel lists SFTP purely from `sftpConnectedHost` (single string, `OpenConnectionsModal.tsx:135, 368-381`). Orphaned/previous-host sessions in the Rust `HashMap` **never appear** and **cannot be killed** — directly contradicting the "canonical kill surface" mandate.
+- **Smallest fix:** In `closeTab`, if the closing tab is the SFTP-owning tab, call `disconnectSftp()`. Track sessions as a `Record<hostKey, sessionId>` (or list) instead of a single slot so host-switch closes the old UUID, and drive the Open Connections list from that map so every live `HashMap` entry is shown and killable. Add a Rust-side `close_all` invoked on window `CloseRequested`.
+
+### L2 — No app-shutdown cleanup of SFTP sessions (LEAK, high)
+
+- **State/transition:** `Connected → [*]` on window close / app quit.
+- **file:line:** No `on_window_event(CloseRequested)` or `beforeunload` handler touches SFTP (grep for `CloseRequested`/`beforeunload` finds only `TestBridge.tsx:106`). `SftpManager` has `close_session` but no `close_all` and no Drop-based teardown wired to app exit.
+- **Symptom:** Quitting termiHub with an open SFTP browser leaves the SSH connection dangling until the server times it out.
+- **Smallest fix:** Wire `SftpManager::close_all()` to the Tauri window `CloseRequested`/exit event.
+
+### S1 — Failed-connect is a dead-end (STUCK, high)
+
+- **State/transition:** `Connecting → Failed`, no user edge back to `Connecting`.
+- **file:line:** `connectSftp` catch sets only `sftpError`/`sftpLoading` (`appStore.ts:2696-2701`); render shows message with no controls (`FileBrowser.tsx:944-953`).
+- **Symptom:** Wrong password / host down → the panel shows the error text and the user is stuck; the only "retry" is to switch tabs and back, or toggle a setting, to make the auto-connect effect re-fire (`FileBrowser.tsx:606-617`). Non-obvious.
+- **Smallest fix:** Add a **Retry** button (fires `connectSftp(lastConfig)`) and a **Dismiss/Close** button to the `sftp-connecting` error state. Persist the last config used so Retry has something to call.
+
+### S2 — Session-not-found mid-browse is unrecoverable (STUCK, high)
+
+- **State/transition:** `Busy → BusyError` when `get_session` fails (session was closed/expired underneath).
+- **file:line:** `get_session` → `SftpSessionNotFound` (`sftp.rs:463-469`); surfaces as `sftpError` via `navigateSftp`/`refreshSftp` catch (`appStore.ts:2729-2733`) but `sftpSessionId` stays non-null, so the UI still renders "Connected" with a red error strip and no reconnect path.
+- **Symptom:** After the peer drops the SSH channel (network blip), every navigate throws "session not found" with no way to re-establish except manual disconnect+tab-switch. The state is **ambiguous**: `sftpSessionId !== null` but the session is dead.
+- **Smallest fix:** On a `SftpSessionNotFound`/transport error, clear `sftpSessionId` (transition to a real `Disconnected`/`Failed` state) so the auto-connect effect can re-establish, and/or expose a Reconnect button.
+
+### D1 — Transfers have no cancel (DATA-LOSS / STUCK, high)
+
+- **State/transition:** `Transferring` (InFlight) has no cancel edge.
+- **file:line:** `sftp_download`/`sftp_upload` are single blocking calls with no cancel token (`files.rs:63-96`); Rust reads/writes the whole file under the session `Mutex` (`sftp.rs:93-143`).
+- **Symptom:** A user who starts a large/wrong transfer cannot stop it. Worse, because the transfer holds the session `Mutex`, **the entire browser is frozen** for that session until it finishes — every list/navigate on that session blocks (`files.rs:71-73, 88-93`), with no spinner because `sftpLoading` is never set for transfers.
+- **Smallest fix (machine-level):** Introduce a transfer registry with per-transfer IDs + a cancel command, chunk the copy (loop with a `CancellationToken` check), emit progress, and — critically — do transfers on a **cloned/dedicated channel** rather than under the single session `Mutex` so browsing stays live. Minimum viable: at least set a busy flag and disable browse controls during a transfer.
+
+### D2 — Transfer errors are silent (FEEDBACK, high)
+
+- **State/transition:** `Transferring → TransferError`.
+- **file:line:** download error → `.catch(console.error)` (`FileBrowser.tsx:759-762`); upload has **no catch** (`useFileSystem.ts:54-74`) → unhandled rejection; paste → `.catch(console.error)` (`FileBrowser.tsx:815`).
+- **Symptom:** A failed download/upload gives the user **zero feedback** — the file silently isn't there. Violates CLAUDE.md rule "every action gives feedback" and "never console.log for debug."
+- **Smallest fix:** Wrap each transfer in the async Button/`toast` pattern — `toast.loading()` on start, `toast.success()`/`toast.error()` on settle; replace `console.error` with a `toast.error` + `frontendLog`.
+
+### D3 — No transfer progress / pending indicator (FEEDBACK, medium)
+
+- **State/transition:** entry into `Transferring`.
+- **file:line:** no progress event exists anywhere (grep for `progress` in the file stack returns nothing); UI toolbar upload/download buttons show no pending state (`FileBrowser.tsx:1026-1035`, row download in menu `FileBrowser.tsx:127-135`).
+- **Symptom:** For any non-trivial file the app appears to hang; user cannot tell whether it's working.
+- **Smallest fix:** Emit a Tauri progress event from a chunked transfer loop and render a progress bar / toast.loading percentage (depends on D1's chunking).
+
+### R1 — Overlapping list responses can desync path & list (RACE, medium)
+
+- **State/transition:** `Busy → Connected` when two navigations overlap.
+- **file:line:** `navigateSftp` sets `sftpLoading` then awaits, with no request-sequence guard or abort (`appStore.ts:2722-2735`); nav buttons not disabled while loading (`FileBrowser.tsx:986-1024`).
+- **Symptom:** Rapid folder clicks can land `currentPath` from click #2 with `fileEntries` from click #1 (or vice-versa).
+- **Smallest fix:** Guard with a monotonically increasing request id (ignore stale responses) or disable navigation while `sftpLoading`.
+
+### A1 — `sftpLoading` overloaded across connect/list/refresh (AMBIGUOUS, medium)
+
+- **State/transition:** all of `Connecting`, `Busy`, refresh share one flag.
+- **file:line:** `connectSftp`, `navigateSftp`, `refreshSftp` all write `sftpLoading` (`appStore.ts:2676, 2725, 2740`); render decides "Connecting SFTP…" vs "Loading…" purely from `isConnected` (`FileBrowser.tsx:937-957, 1145-1149`).
+- **Symptom:** UI cannot distinguish "connecting" from "listing" from "refreshing"; a refresh after connect can flash the wrong spinner label.
+- **Smallest fix:** Replace the three booleans + implicit inference with an explicit `sftpStatus: 'idle'|'connecting'|'connected'|'listing'|'error'` enum.
+
+### C1 — `.unwrap()` on the session Mutex in every command (ROBUSTNESS, medium)
+
+- **file:line:** every command does `session.lock().unwrap()` (`files.rs:56, 72, 89, 106, 121, 141, 208, 222`) and manager methods `sessions.lock().unwrap()` (`sftp.rs:450, 458, 464`).
+- **Symptom:** If any prior transfer/op panicked while holding the lock, the `Mutex` is poisoned and **every subsequent SFTP command panics** — the whole session becomes unusable with a process-level abort rather than a recoverable error. Violates the "no `.unwrap()` in production" rule.
+- **Smallest fix:** Map lock errors to `TerminalError`/`FileError` (the `SftpFileBackend` impl already does this correctly at `sftp.rs:331-333`) instead of `.unwrap()`.
+
+### C2 — Silent home→root fallback on connect (FEEDBACK, low)
+
+- **file:line:** `connectSftp` guesses `/home/<username>`, falls back to `/` on any error with no notice (`appStore.ts:2679-2688`).
+- **Symptom:** User connects and lands at `/` with no explanation when the home guess is wrong (non-Linux layouts, different home path). The guess is also fragile (assumes `/home/<user>`).
+- **Smallest fix:** Resolve the real home via the session (SFTP `realpath(".")`) instead of string-building; if falling back, note it.
+
+---
+
+## 7. Missing controls list
+
+Controls the correct machine needs but the UI does not expose today.
+
+| Control                                  | Fires transition                        | Where it belongs                                                       | Currently                                                                               |
+| ---------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Retry** (connect)                      | `Failed → Connecting`                   | `file-browser-sftp-connecting` error state (`FileBrowser.tsx:944-953`) | Absent — only implicit via effect re-fire                                               |
+| **Dismiss / Close error**                | `Failed → None`                         | same error placeholder                                                 | Absent                                                                                  |
+| **Reconnect** (live)                     | `BusyError/dead-session → Connecting`   | toolbar next to Disconnect (`FileBrowser.tsx:1070-1080`)               | Absent                                                                                  |
+| **Cancel transfer**                      | `Transferring → Idle`                   | a transfer/progress affordance (toast or toolbar)                      | Absent — no cancel path exists at all (D1)                                              |
+| **Transfer progress indicator**          | visualizes `Transferring`               | toast.loading / progress bar                                           | Absent (D3)                                                                             |
+| **Per-session kill in Open Connections** | `Connected → None` for _each_ live UUID | `OpenConnectionsModal.tsx:368-381`                                     | Only the single current host shown/killable; orphaned `HashMap` sessions invisible (L1) |
+| **Force-kill / close-all on quit**       | `Connected → [*]`                       | Rust window `CloseRequested`                                           | Absent (L2)                                                                             |
+
+---
+
+## 8. Summary of the delta (ideal vs. real)
+
+- The real machine has **no transfer sub-state** — transfers are fire-and-forget blocking calls that freeze the session and give no progress, cancel, or error feedback (D1–D3). This is the largest correctness gap.
+- The session slot is **single-valued** while the backend holds **N sessions**, so host-switch and tab-close **leak** SSH connections that are invisible and unkillable in the canonical Open Connections panel (L1, L2).
+- `Failed` and dead-session states are **dead-ends** with no Retry/Reconnect (S1, S2), and the `sftpSessionId !== null` flag is **ambiguous** once the transport drops.
+- `sftpLoading` is **overloaded** across connect/list/refresh/transfer, and navigation is **unguarded** against overlapping responses (A1, R1).
+- Production `.unwrap()` on the session mutex can **poison the whole session** on any panic (C1).
+
+The smallest coherent fix set: (1) add an explicit `sftpStatus` enum + last-config for Retry; (2) close the SFTP session on owning-tab close and on app quit, and track sessions as a keyed map surfaced to Open Connections; (3) build a cancellable, chunked, progress-emitting transfer path off the shared session mutex; (4) route all transfer/connect outcomes through toasts instead of `console.error`.

--- a/docs/audits/ssh-tunnel-state-machine.md
+++ b/docs/audits/ssh-tunnel-state-machine.md
@@ -1,0 +1,215 @@
+# SSH Tunnel State Machine — Audit
+
+> **Issue:** #1130 — Audit + fix the SSH tunnel state machine
+> **Scope:** SSH tunnel lifecycle (start → active → stopped → error → retry)
+> **Deliverable:** Audit findings only — analysis, diagrams, and prioritized gaps. No production code changes.
+
+## 1. Where the state lives
+
+The tunnel machine is split across two authorities that are **only loosely reconciled**:
+
+| Layer                             | State carrier                                                               | File:line                                               |
+| --------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Rust — declared status enum       | `TunnelStatus { Disconnected, Connecting, Connected, Reconnecting, Error }` | `src-tauri/src/tunnel/config.rs:76-82`                  |
+| Rust — runtime truth (active set) | `active_tunnels: Mutex<HashMap<String, ActiveTunnel>>`                      | `src-tauri/src/tunnel/tunnel_manager.rs:95`             |
+| Rust — connecting truth           | `ConnectingTracker` (map of `CancellationToken`)                            | `src-tauri/src/tunnel/connecting.rs:29-31`              |
+| Frontend — mirror                 | `tunnelStates: Record<string, TunnelState>`                                 | `src/store/appStore.ts:644, 3616-3620`                  |
+| Frontend — derived render flag    | `status`, `isActive`                                                        | `src/components/TunnelSidebar/TunnelListItem.tsx:39-40` |
+
+**Key observation:** the Rust status is _not_ stored anywhere. `get_statuses()` (`tunnel_manager.rs:183-226`) **recomputes** status on every call purely from set membership: in `active_tunnels` → `Connected`; in `ConnectingTracker` → `Connecting`; otherwise → `Disconnected`. There is **no field that can ever hold `Error` or `Reconnecting`**. Those two variants are reachable _only_ through the transient `emit_status` event, never through a queried status. This is the root of several gaps below.
+
+## 2. Real lifecycle state machine (as coded)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Disconnected
+
+    Disconnected --> Connecting : start_tunnel()<br/>[connecting.begin() ok]<br/>tunnel_manager.rs:264-269
+    Disconnected --> Disconnected : start_tunnel()<br/>[already in active map → Err]<br/>tunnel_manager.rs:247-258
+
+    Connecting --> Connected : build_forwarder ok<br/>+ finish()==Commit<br/>tunnel_manager.rs:293-310
+    Connecting --> Error : build_forwarder Err<br/>+ finish()==Commit<br/>tunnel_manager.rs:282-284
+    Connecting --> Disconnected : build_forwarder Err<br/>+ finish()==Cancel<br/>tunnel_manager.rs:279-281
+    Connecting --> Disconnected : Stop during connect<br/>(teardown just-built)<br/>tunnel_manager.rs:293-298
+
+    Connected --> Disconnected : stop_tunnel()<br/>teardown_forwarder<br/>tunnel_manager.rs:461-466
+    Connected --> Connected : SSH session dies<br/>(NO transition — see Gap 1)
+
+    Error --> Connecting : start_tunnel() again<br/>(user re-clicks Play)
+    Error --> Disconnected : loadTunnels()/get_statuses<br/>(Error silently reset — Gap 3)
+
+    note right of Error
+        Error is EVENT-ONLY.
+        get_statuses() can never
+        return Error; a reload maps it
+        back to Disconnected.
+    end note
+
+    note right of Connected
+        Reconnecting is declared
+        but never entered anywhere.
+    end note
+```
+
+### Orphan / unreachable states
+
+- **`TunnelStatus::Reconnecting`** (`config.rs:80`) — never constructed in any production path. Grep of `src-tauri/`/`core/` finds it only in the enum definition and serde tests. `reconnect_on_disconnect` (`config.rs:70`, surfaced as a Toggle at `TunnelEditor.tsx:370-375`) is **persisted but never read** by any runtime code. The whole "Reconnecting" branch of the machine is dead.
+- **`TunnelStatus::Error`** — reachable _only_ as a fire-and-forget event (`tunnel_manager.rs:283`), never as a queryable state (§1). It is a transient, not a resting state.
+
+## 3. Cross-actor sequence — Start (happy path)
+
+```mermaid
+sequenceDiagram
+    participant U as User (TunnelListItem)
+    participant S as appStore.startTunnel
+    participant API as tunnelApi / invoke
+    participant CMD as commands/tunnel.rs
+    participant M as TunnelManager
+    participant Ev as tunnel-status-changed
+    participant Hook as useTunnelEvents
+
+    U->>S: onStart(id) (Play btn, TunnelListItem.tsx:80-84)
+    S->>S: toast.loading("Starting…") (appStore.ts:3587)
+    S->>API: apiStartTunnel(id)
+    API->>CMD: invoke("start_tunnel")
+    CMD->>M: spawn_blocking(start_tunnel) (tunnel.rs:56)
+    M->>M: connecting.begin() (tm.rs:264)
+    M-->>Ev: emit Connecting (tm.rs:269)
+    Ev-->>Hook: updateTunnelState(Connecting)
+    Note over M: BLOCKING SSH handshake (build_forwarder)
+    M->>M: finish()==Commit → insert active (tm.rs:300-307)
+    M-->>Ev: emit Connected (tm.rs:310)
+    Ev-->>Hook: updateTunnelState(Connected)
+    M-->>CMD: Ok
+    CMD-->>S: resolve
+    S->>S: toast.success("Started") (appStore.ts:3590)
+```
+
+## 4. Cross-actor sequence — Start fails (silent-error gap)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as appStore.startTunnel
+    participant M as TunnelManager
+    participant Ev as tunnel-status-changed
+    participant Hook as useTunnelEvents
+    participant List as TunnelListItem
+
+    U->>S: onStart(id) via Play
+    S->>M: start_tunnel (spawn_blocking)
+    M-->>Ev: emit Connecting
+    Note over M: build_forwarder → Err (bind fail / auth fail)
+    M->>M: finish()==Commit
+    M-->>Ev: emit Error(msg) (tm.rs:283)
+    Ev-->>Hook: updateTunnelState(Error, msg)
+    Hook-->>List: status="error" → red text (TunnelListItem.tsx:134-136)
+    M-->>S: return Err(e) (tm.rs:286)
+    S->>S: toast.error (appStore.ts:3593)
+    Note over List: Play btn shown again (isActive=false), so re-click == retry.
+```
+
+This path (Play button → failure) _does_ give feedback (toast + red error text). The **silent** failures are the ones that do **not** flow through `start_tunnel`'s return — see Gaps 1 & 2.
+
+## 5. Prioritized gap list
+
+Ranked **stuck / leak / silent-death first**, cosmetic last. Each cites the state/transition, `file:line`, the user-visible symptom, and the smallest fix.
+
+---
+
+### GAP 1 — `Connected → (dead)` : a tunnel whose SSH session dies stays "Connected" forever (silent death + leak) — **CRITICAL**
+
+- **Transition:** the missing edge `Connected --> Error/Disconnected` on peer/session loss.
+- **Evidence:** `LocalForwarder`/`DynamicForwarder` accept loops `break` on listener error and log only (`local_forward.rs:124-127`, `dynamic_forward.rs:81-85`); per-connection relays swallow channel-open failures (`local_forward.rs:143-147`, `dynamic_forward.rs:172-181`). Nothing observes `SshSession` liveness. `get_statuses()` reports `Connected` purely from `active_tunnels` membership (`tunnel_manager.rs:197-208`) — the entry is never removed when the underlying session dies. No task ever calls `stop_tunnel` or `emit_status` on transport loss.
+- **Symptom:** the bastion drops / laptop sleeps / server reboots → the tunnel is functionally dead, every `localhost:port` connection fails, but the sidebar dot stays green "connected" and the only control is **Stop**. The `ActiveTunnel` (and its pooled endpoint/gateway `PooledRef`, `tunnel_manager.rs:81-86`) linger in the active map and in Open Connections. User has no signal and no Retry.
+- **Smallest fix:** give each forwarder a "dead" signal (accept-loop exit / a watch channel from the SSH session), and in the manager spawn a supervisor that, on that signal, removes the entry from `active_tunnels`, drops guards, and `emit_status(Error, "connection lost")` — i.e. actually enter the declared `Error` state. This is also the natural hook point for the unimplemented `reconnect_on_disconnect` (Gap 5).
+
+---
+
+### GAP 2 — `Connecting → Connected` reported even when the accept loop instantly dies (false-positive Connected) — **HIGH**
+
+- **Transition:** `build_forwarder → Connected` (`tunnel_manager.rs:293-310`).
+- **Evidence:** `LocalForwarder::start`/`DynamicForwarder::start` bind the listener synchronously (good — a port-in-use bind error _is_ surfaced, `local_forward.rs:72-75`), but then `tokio::spawn(accept_loop)` and immediately return `Ok` (`local_forward.rs:82-90`). For **Remote** forwarding the server-side `tcpip_forward` is awaited (`remote_forward.rs:36-40`) so a rejected remote bind _is_ caught — but the local relay target is never validated. Any post-bind failure (accept loop `break`, remote target `connect` refused at `remote_forward.rs:110-119`) happens after `Ok` was already returned → status is `Connected`.
+- **Symptom:** tunnel shows green "connected" but no traffic can pass (e.g. remote-forward's local target port isn't listening). No error, no toast.
+- **Smallest fix:** same supervisor as Gap 1 — treat an early accept-loop exit as a transition to `Error`. Additionally surface per-connection relay failures as a transient status/toast rather than `tracing::error!` only.
+
+---
+
+### GAP 3 — `Error` is not a resting state; a reload silently launders it back to `Disconnected` (ambiguous/overloaded state) — **HIGH**
+
+- **Transition:** `Error --> Disconnected` via `loadTunnels()` / `get_statuses()`.
+- **Evidence:** `get_statuses()` has no branch that can emit `Error` (`tunnel_manager.rs:203-221`); it only knows `Connected`/`Connecting`/`Disconnected`. The frontend `Error` status lives _only_ in `tunnelStates` from the one-shot event (`useTunnelEvents.ts:17-19`). `loadTunnels` overwrites the whole map from `get_statuses` (`appStore.ts:3541-3549`), so any window reload / re-open replaces `Error` with `Disconnected`. Open Connections' `activeTunnels` filter only counts `connected`/`connecting` (`OpenConnectionsModal.tsx:117-120`), so an errored tunnel never appears there.
+- **Symptom:** a tunnel that failed shows a red error until the next status refresh, then reverts to a normal "disconnected/Play" row as if nothing happened — the failure cause is lost. Two very different situations ("never started" and "died with an error") share one visible state.
+- **Smallest fix:** persist last-error per tunnel in the manager (a `Mutex<HashMap<String, String>>` set on the `Error` branch, cleared on successful `start`/`stop`) and have `get_statuses` return `Error{error}` for those ids so the state survives reloads and shows in Open Connections.
+
+---
+
+### GAP 4 — Start/Stop can double-fire during `Connecting` (button not gated to the pending state) — **HIGH (race)**
+
+- **Transition:** UI-triggered `start_tunnel` / `stop_tunnel` while `status == "connecting"`.
+- **Evidence:** `TunnelListItem` treats `connecting` and `reconnecting` as `isActive` and therefore shows the **Stop** button (`TunnelListItem.tsx:40, 64-75`) — good, Stop during connect is wanted (and handled via `ConnectingTracker`, `tunnel_manager.rs:469-476`). But neither `startTunnel` nor `stopTunnel` in the store guards against being fired again while a prior call is in flight (`appStore.ts:3585-3614`) — the toast id is regenerated each click and both calls hit the backend. The backend _does_ defend the start side (`connecting.begin()` returns `None` on a second start → Err, `connecting.rs:46-54`; active-map check, `tunnel_manager.rs:247-258`), so a true double-PTY is prevented. However rapid **Stop then Start** while connecting: the first Stop cancels the token (`request_cancel`, `connecting.rs:64-72`); a second Start before `finish()` runs sees the id still in the tracker and is rejected with a confusing "already connecting" error toast.
+- **Symptom:** fast double-clicking Start/Stop on a connecting tunnel yields spurious "already active"/"already connecting" error toasts even though nothing is wrong; the visible state can briefly flip Stop→Play→Stop.
+- **Smallest fix:** in the store, ignore re-entrant `startTunnel`/`stopTunnel` for an id whose status is already `connecting` (or disable the button while a call is pending); optionally map the backend "already connecting/active" errors to a no-op instead of an error toast.
+
+---
+
+### GAP 5 — `reconnect_on_disconnect` toggle is a no-op (dead control feeding a dead state) — **MEDIUM**
+
+- **State:** the intended `Connected --> Reconnecting --> Connecting` sub-machine.
+- **Evidence:** the Toggle is rendered and persisted (`TunnelEditor.tsx:370-375`, `config.rs:70`) but `reconnect_on_disconnect` is never read in `tunnel_manager.rs` (grep: only definition + tests). No code ever sets `TunnelStatus::Reconnecting` (`config.rs:80`).
+- **Symptom:** user enables "Reconnect automatically on disconnect", the tunnel drops, nothing reconnects — a promised feature silently does nothing. (Compounded by Gap 1: a drop isn't even detected.)
+- **Smallest fix:** once Gap 1's supervisor exists, branch on `reconnect_on_disconnect`: emit `Reconnecting`, back off, and re-run the start path; otherwise emit `Error`. Until implemented, the honest interim is to hide/disable the toggle so it doesn't imply behavior that doesn't exist.
+
+---
+
+### GAP 6 — Live stats never update after start; the `tunnel-stats-updated` event has no emitter (stale UI) — **MEDIUM**
+
+- **Evidence:** `emit_status` always ships `TunnelStats::default()` (all zeros) (`tunnel_manager.rs:564-571`), so the `Connected` event carries no traffic. Real stats exist only behind the pull API `get_statuses` (`tunnel_manager.rs:198-208`), which the sidebar calls once in `loadTunnels` and never again. The push channel `tunnel-stats-updated` is defined on both sides (`events.ts:362-369`, `useTunnelEvents.ts:21-26`) but **nothing in Rust ever emits it** (grep: zero `emit("tunnel-stats-updated")`).
+- **Symptom:** the sidebar's `↑/↓ bytes` and `N conn` (`TunnelListItem.tsx:127-132`) freeze at 0 for the tunnel's whole lifetime; Open Connections shows no throughput either.
+- **Smallest fix:** either spawn a periodic emitter of `tunnel-stats-updated` per active tunnel, or have the sidebar poll `get_tunnel_statuses` on an interval while any tunnel is active. (The push route is cheaper and matches the already-wired hook.)
+
+---
+
+### GAP 7 — `deleteTunnel` swallows errors and doesn't stop a running tunnel from the store's view (potential leak/desync) — **LOW/MEDIUM**
+
+- **Evidence:** backend `delete_tunnel` _does_ call `stop_tunnel` first (`tunnel_manager.rs:164-166`) — correct. But the store `deleteTunnel` catches and only `console.error`s (`appStore.ts:3571-3583`), giving no user feedback (violates the "every action gives feedback" rule) and, on failure, leaves the row visually removed while the backend may still hold it. `handleDelete` has no confirmation for an _active_ tunnel (`TunnelSidebar.tsx:43-48`).
+- **Symptom:** deleting a running tunnel silently kills it with no toast; a delete that fails backend-side desyncs the list.
+- **Smallest fix:** add a loading/success/error toast to `deleteTunnel` (like start/stop already have), and confirm-before-delete when the tunnel is active.
+
+---
+
+### GAP 8 — `stop_tunnel` during `Connecting` returns `Ok` but the forwarder is torn down only _after_ the full blocking handshake (delayed teardown) — **LOW**
+
+- **Evidence:** the cancel token is threaded into the SSH connect (`tunnel_manager.rs:264, 275`, `connect_through_gateway` selects on `cancel.cancelled()`, `tunnel_manager.rs:425-435`) so cancellation is prompt for the _jumped_ path, and the direct path passes the token to `core_connect_cancellable`/`connect_with_registry_cancellable`. The UI is told "Disconnected" immediately (`tunnel_manager.rs:473-475`). Good design overall (#829/#841). The residual risk: if `build_forwarder` _succeeds_ in the race window before the cancel is observed, teardown happens at `tunnel_manager.rs:293-298` — correct, but the pooled endpoint session may already have been created and is only drained when guards drop.
+- **Symptom:** minor — brief lifetime of a pooled SSH session that's immediately dropped; no user-visible leak. Listed for completeness.
+- **Smallest fix:** none required; behavior is correct. Worth a regression test asserting `active_tunnels`/pool counts return to zero after Stop-during-connect.
+
+---
+
+### GAP 9 — Open Connections "Kill" optimistically prunes local state, masking a failed stop — **LOW**
+
+- **Evidence:** `handleKillTunnel`/`handleKillAllTunnels` `await stopTunnel` then unconditionally strip the row from local `tunnelStates` (`OpenConnectionsModal.tsx:201-209`). If `stopTunnel` throws (it re-throws, `appStore.ts:3612`), the `await` rejects and the row-prune is skipped — acceptable — but there's no error surfaced beyond the store's toast, and the panel's `tunnelStates` are a **separate copy** fetched once on open (`OpenConnectionsModal.tsx:108-114`), not the store's live map, so it can drift from the sidebar.
+- **Symptom:** the Open Connections tunnel list can show stale membership vs. the sidebar; a genuinely-stuck tunnel (Gap 1) never appears here to be killed.
+- **Smallest fix:** drive the panel's tunnel list from the store's `tunnelStates` (single source) rather than a one-shot `getTunnelStatuses`, and include `error` tunnels once Gap 3 makes `Error` queryable.
+
+## 6. Missing controls list
+
+Buttons/menu items the correct machine needs but the UI does not expose, each tied to the transition it would fire:
+
+| Control                                                     | Where it belongs                                                                                                              | Transition it fires                                           | Why it's missing today                                                                                                                                                                  |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Retry**                                                   | `TunnelListItem` when `status === "error"`                                                                                    | `Error --> Connecting`                                        | Today the Play button _is_ the only retry, but it disappears the instant `Error` is laundered to `Disconnected` (Gap 3); an explicit Retry that also clears the stored error is needed. |
+| **Reconnect / force-reconnect**                             | `TunnelListItem` when `status === "connected"` but session is dead                                                            | `Connected --> Connecting`                                    | No liveness detection exists (Gap 1), so the UI can't even offer it.                                                                                                                    |
+| **Cancel (connecting)**                                     | already covered by the Stop button during `connecting` (`TunnelListItem.tsx:64-75`) → `stop_tunnel` cancel path. **Present.** | `Connecting --> Disconnected`                                 | — (works; keep).                                                                                                                                                                        |
+| **View last error**                                         | `TunnelListItem` / Open Connections on an errored tunnel                                                                      | (no transition; diagnostic)                                   | Error text shows only transiently (`TunnelListItem.tsx:134-136`) and is lost on reload (Gap 3).                                                                                         |
+| **Confirm-delete for active tunnel**                        | `handleDelete` in `TunnelSidebar`                                                                                             | `Connected/Connecting --> Disconnected --> (removed)`         | Delete silently stops+removes with no confirmation or feedback (Gap 7).                                                                                                                 |
+| **Stop from Open Connections for a _stuck/errored_ tunnel** | `OpenConnectionsModal` tunnel section                                                                                         | force `Connected(stale)/Error --> Disconnected` + drop guards | The filter only lists `connected`/`connecting` (`OpenConnectionsModal.tsx:117-120`), so a leaked/errored tunnel (Gaps 1, 3) can't be force-killed from the canonical kill panel.        |
+
+## 7. Summary of the delta (ideal vs. coded)
+
+- The machine has **two terminal-ish states declared but not real**: `Error` is event-only (not queryable, lost on reload) and `Reconnecting` is entirely dead.
+- The single biggest defect is the **missing `Connected → Error` edge on session death** (Gap 1): the active map is treated as ground truth for "connected" but is never invalidated when the transport dies, producing a silent-death + resource-leak state that also disappears from the Open Connections kill panel.
+- Feedback is good on the _user-initiated_ start/stop paths (toasts, red error text) but **absent for backend-initiated transitions** (session loss, post-bind failures, stats) because those never reach the UI.
+- The `reconnect_on_disconnect` toggle and the `tunnel-stats-updated` push channel are **wired end-to-end on the frontend but have no Rust producer** — promised behavior that silently does nothing.
+
+Recommended fix order: **Gap 1 → 2 → 3** (make session death observable and `Error` a real persisted, queryable state, surfaced in the sidebar + Open Connections), then **Gap 4** (re-entrancy guard), then **Gap 5/6** (reconnect + live stats on top of the new supervisor), then the LOW cosmetic/feedback items.

--- a/docs/audits/workspace-save-restore-state-machine.md
+++ b/docs/audits/workspace-save-restore-state-machine.md
@@ -1,0 +1,227 @@
+# Workspace Save/Restore State Machine — Audit
+
+> **Issue:** #1135 — Audit + fix the workspace save/restore state machine
+> **Scope:** Workspace save (idle → saving → saved) and restore (loading → restoring → restored / partial-failure)
+> **Deliverable:** Audit findings only — analysis, diagrams, and prioritized gaps. No production code changes.
+
+## 1. What the machine actually is
+
+There are **two distinct save/restore subsystems**, and neither has an explicit status enum — both are one-shot `async` functions wrapped in `try/catch` that resolve silently or log to `console.error`:
+
+| Subsystem               | Save trigger                                                                             | Restore trigger                                                      | Persistence                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Named workspaces**    | `saveCurrentAsWorkspace` (`appStore.ts:3970`), `saveWorkspaceToBackend` (`:3769`)        | `launchWorkspace` (`appStore.ts:3845`) — double-click / Play button  | `workspaces.json` via `WorkspaceStorage::save` (`storage.rs:86`)           |
+| **Last session (auto)** | `saveLastSession` (`appStore.ts:3998`), debounced by `scheduleLastSessionSave` (`:4029`) | `restoreLastSession` (`appStore.ts:4037`) on startup (`App.tsx:169`) | `last-session.json` via `LastSessionManager::save` (`last_session.rs:123`) |
+
+**The critical architectural fact:** neither restore path connects any terminals. `buildTabGroupsFromWorkspace` (`workspaceLayout.ts:668`) → `buildPanelTreeFromWorkspace` (`:432`) produces `TerminalTab` structs with **`sessionId: null`** (`:441-469`). The actual per-session reconnect fan-out happens **later and independently** inside each mounted `Terminal.tsx` (connect logic around `Terminal.tsx:310-535`, overlay/retry state in `appStore.ts` via `terminalRetryCounters` `:508`, `terminalDisconnectErrors` `:524`, `setTerminalDisconnectWithError` `:2854`). So "restore" as a state machine **ends the moment the tab structs are placed in the store** — there is no aggregate notion of "restoring sessions" or "restored / partial-failure" anywhere in the workspace layer. That absence is the root of most gaps below.
+
+`agentRef` tabs are the one exception that is pre-resolved: at build time a disconnected/missing agent resolves to an **`agent-error`** tab (`workspaceLayout.ts:496-564`) rather than a live terminal — that is the only place partial-failure is modeled as a first-class visible state, and only for agent tabs.
+
+---
+
+## 2. Save lifecycle — state diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+
+    state "Named workspace save" as NW {
+        Idle --> Capturing : user clicks Save (SaveWorkspaceDialog handleSave)
+        Capturing --> Persisting : captureAllTabGroups() ok [name.trim() non-empty]
+        Persisting --> Saved : apiSaveWorkspace resolves
+        Persisting --> SaveFailed : apiSaveWorkspace rejects
+        Saved --> Idle : loadWorkspaces() + set activeWorkspaceName
+        SaveFailed --> Idle : console.error only — NO user feedback, dialog already closed
+    }
+
+    state "Last-session auto-save" as LS {
+        IdleLS --> Debouncing : any layout change (App.tsx subscribe -> scheduleLastSessionSave)
+        Debouncing --> Debouncing : another change within 1 debounce window (timer reset)
+        Debouncing --> WritingLS : timer fires -> saveLastSession
+        WritingLS --> SavedLS : apiSaveLastSession resolves
+        WritingLS --> WriteFailedLS : apiSaveLastSession rejects
+        WritingLS --> SkippedLS : restoreLastSessionOnStartup == false [guard, appStore.ts:4001]
+        SavedLS --> IdleLS
+        SkippedLS --> IdleLS
+        WriteFailedLS --> IdleLS : console.error only — silent
+    }
+```
+
+**Key save observations (grounded):**
+
+- `SaveFailed` is a **silent terminal transition**. `saveCurrentAsWorkspace` re-throws (`appStore.ts:3994`) but the caller `handleSaveCurrent` (`WorkspaceSidebar.tsx:55-61`) does **not** await and does **not** catch — it fires `saveCurrentAsWorkspace(...)` then synchronously `setShowSaveDialog(false)` (`WorkspaceSidebar.tsx:57-58`). The dialog closes optimistically; a rejected save leaves the user believing it succeeded. No toast, unlike connection saves which do toast (`appStore.ts:2498`, `:2503`).
+- Auto-save write failure is fully silent (`appStore.ts:4024-4026`) — acceptable for a background bookkeeping write, but there is no "last session may be stale" signal anywhere.
+- The last-session debounce timer is a **module-global** (`lastSessionPersistTimer`, `appStore.ts:729`), not per-store — fine for a singleton app but a latent hazard for tests/multi-store.
+
+---
+
+## 3. Restore lifecycle — state diagram (partial-failure modeled explicitly)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading : App.tsx:169 restoreLastSession (or launchWorkspace :3845)
+
+    Loading --> NothingToRestore : session null or tabGroups empty (appStore.ts:4040)
+    Loading --> LoadFailed : apiLoadLastSession / apiLoadWorkspace rejects (:4068)
+    Loading --> Building : payload ok
+
+    Building --> EmptyBuild : builtGroups.length == 0 (:4058 / :3956)
+    Building --> Placed : set{tabGroups,rootPanel,...} (:4061 / :3958)
+
+    NothingToRestore --> [*] : return false
+    LoadFailed --> [*] : console.error only — SILENT
+    EmptyBuild --> [*] : return false — SILENT
+
+    Placed --> MountingTerminals : React mounts Terminal.tsx per tab (sessionId=null)
+
+    state MountingTerminals {
+        [*] --> PerTabConnect
+        PerTabConnect --> TabConnected : spawn/reattach ok
+        PerTabConnect --> TabDisconnectedError : spawn fails (setTerminalDisconnectWithError :2854)
+        PerTabConnect --> TabAgentError : agentRef unresolved at build time (workspaceLayout.ts:509-563)
+        TabDisconnectedError --> PerTabConnect : user clicks Reconnect (retryTerminalSpawn)
+        TabAgentError --> PerTabConnect : agent later emits "connected" (auto-wake)
+    }
+
+    MountingTerminals --> AllConnected : every tab TabConnected
+    MountingTerminals --> PartialFailure : some TabConnected, some Tab*Error
+    MountingTerminals --> AllFailed : every tab Tab*Error
+
+    note right of PartialFailure
+        NO aggregate state exists in code.
+        "Placed" is the machine's real terminal state;
+        AllConnected / PartialFailure / AllFailed are
+        emergent from independent per-tab Terminal.tsx
+        machines and are never summarized to the user.
+    end note
+```
+
+**Key restore observations (grounded):**
+
+- `LoadFailed` (`appStore.ts:4068`, `:3965`) and `EmptyBuild` (`:4058`, `:3956`) are both **silent** — a corrupt/unreadable session or a workspace whose every connection ref went missing yields an empty window with zero explanation.
+- **`launchWorkspace` and `restoreLastSession` both blindly `set(...)` the new `tabGroups`/`rootPanel` (`appStore.ts:3958-3964`, `:4061-4066`) without closing the currently-open live sessions.** No `closeTab`/`closeTabGroup`/session-kill is called first (verified: only `closeTabGroup`/`closeTab` exist at `:954`/`:1870`, neither is invoked from either path). Any live PTY/SSH/agent session that was open is dropped from the store — its backend resource is orphaned (see leak analysis §5).
+- The corrupt last-session file is swallowed to `Ok(None)` (`last_session.rs:76-82`) — correct for not blocking startup, but it means a user who had a session silently gets a blank window with no "we couldn't restore your last session" notice.
+
+---
+
+## 4. Restore fan-out — sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant App as App.tsx
+    participant Store as appStore
+    participant API as lastSessionApi / workspaceApi
+    participant Rust as WorkspaceManager / LastSessionManager
+    participant Build as workspaceLayout.buildTabGroupsFromWorkspace
+    participant TA as Terminal.tsx (tab A)
+    participant TB as Terminal.tsx (tab B)
+    participant Be as Session backend / agent
+
+    App->>Store: restoreLastSession() (App.tsx:169)
+    Store->>API: apiLoadLastSession()
+    API->>Rust: load() (last_session.rs:68)
+    Rust-->>API: Some(session) | None (corrupt -> None)
+    API-->>Store: session | null
+    alt null / empty / load error
+        Store-->>App: return false (SILENT — no toast)
+    else payload ok
+        Store->>Build: buildTabGroupsFromWorkspace(session.tabGroups, connections, agentContext)
+        Note over Build: agentRef -> agent-error tab if agent disconnected (workspaceLayout.ts:509-563)
+        Build-->>Store: TabGroup[] (all tabs sessionId=null)
+        Store->>Store: set{tabGroups,rootPanel,...} (:4061) — NO teardown of prior sessions
+        Store-->>App: return true
+    end
+
+    Note over TA,TB: React mounts one Terminal per restored tab — independent, un-coordinated
+    par tab A connects
+        TA->>Be: spawn/attach (Terminal.tsx:427)
+        Be-->>TA: ready -> TabConnected
+    and tab B connects
+        TB->>Be: spawn/attach
+        Be-->>TB: error -> setTerminalDisconnectWithError (appStore.ts:2854)
+    end
+    Note over App: Result: 1 connected, 1 errored. No component ever learns "restore was partial".
+```
+
+The fan-out is **not orchestrated by the restore action** — it is the emergent sum of N independent `Terminal.tsx` mounts. There is no `Promise.all`, no counter, no completion event for "all restored tabs settled," and therefore no place to raise a summary toast such as _"Restored 5 tabs — 2 could not reconnect."_
+
+---
+
+## 5. Prioritized gap list (stuck / leak / data-loss first)
+
+### G1 — Restore/launch orphans live sessions (resource leak) — **HIGH**
+
+- **State/transition:** `Placed` transition in both restore machines.
+- **file:line:** `appStore.ts:3958-3964` (`launchWorkspace`) and `appStore.ts:4061-4066` (`restoreLastSession`) — `set(...)` replaces `tabGroups`/`rootPanel` with **no** preceding teardown.
+- **Symptom:** Double-clicking a workspace (or a startup restore that runs after tabs already exist, e.g. CLI workspace at `App.tsx:158` then restore) discards the current live tabs from the store. Their backend PTY/SSH/agent sessions are never closed — they linger in the **Open Connections panel** (`OpenConnectionsModal.tsx`) with no tab to reach them, exactly the "leaked" signature the mandate flags.
+- **Smallest fix:** Before the `set(...)`, enumerate the existing `tabGroups` leaves and call the existing `closeTab`/session-kill for each (or add a `teardownAllSessions()` helper), then place the new groups. Guard `launchWorkspace` with a confirm-if-dirty prompt (see missing controls M1).
+
+### G2 — Silent save failure with false success (data-loss) — **HIGH**
+
+- **State/transition:** `Persisting → SaveFailed`.
+- **file:line:** `WorkspaceSidebar.tsx:55-61` (dialog closes without awaiting), `appStore.ts:3992-3995` (throws into the void).
+- **Symptom:** If `apiSaveWorkspace` rejects (disk full, permission, lock poisoned — `manager.rs:87-89` / `storage.rs:86-90` all surface `WorkspaceError`), the dialog closes and the user believes the workspace was saved. It wasn't — silent data loss.
+- **Smallest fix:** Make `handleSaveCurrent` `async` and `await` the save inside `try/catch`; keep the dialog open on error and `toast.error(...)`; only `setShowSaveDialog(false)` and `toast.success(...)` on resolve — mirroring the connection-save feedback at `appStore.ts:2498/2503`.
+
+### G3 — Silent restore failure = blank window (stuck / no-feedback) — **HIGH**
+
+- **State/transition:** `Loading → LoadFailed`, `Building → EmptyBuild`, corrupt-file → `None`.
+- **file:line:** `appStore.ts:4068-4070` and `:3965-3967` (console.error only); `last_session.rs:76-82` (corrupt → `Ok(None)`); `appStore.ts:4058`, `:3956` (empty build → silent `return false`).
+- **Symptom:** User who had a populated session/workspace opens the app to an empty window with no explanation; or launches a workspace whose connections were deleted and gets nothing. Indistinguishable from "nothing was saved."
+- **Smallest fix:** On `LoadFailed`/`EmptyBuild`, `toast.error("Could not restore last session")` / `toast.warning("Workspace \"X\" had no launchable tabs")`. For the corrupt-file case, surface a recovery warning the way `workspaces.json` corruption already does via `RecoveryWarning` + `RecoveryDialog` (`storage.rs:64-72`, `App.tsx:281`) — `last_session.rs` currently has no equivalent warning channel.
+
+### G4 — No aggregate partial-restore feedback (no-feedback) — **MEDIUM**
+
+- **State/transition:** the missing `PartialFailure` / `AllFailed` aggregate states.
+- **file:line:** absent by construction — fan-out is per-tab in `Terminal.tsx` (`:310-535`); the workspace layer stops at `set(...)` (`appStore.ts:4061`). Per-tab errors live isolated in `terminalDisconnectErrors` (`appStore.ts:524`).
+- **Symptom:** Restore 6 tabs, 2 fail to reconnect. The 2 failures are only visible if the user manually clicks into each tab (per-tab overlay). No "Restored 4 of 6 tabs (2 failed)" summary anywhere.
+- **Smallest fix:** After `set(...)`, register the set of restored tab ids as a pending cohort; when each Terminal settles (connected or `setTerminalDisconnectWithError`), decrement; on cohort completion raise one summary toast. Alternatively a lighter first step: a badge on the Workspace sidebar / status bar reading `activeWorkspaceName` (`appStore.ts:666`) plus failed count.
+
+### G5 — Race: auto-save can capture a mid-restore layout (data corruption of session file) — **MEDIUM**
+
+- **State/transition:** `Debouncing` overlapping `Placed → MountingTerminals`.
+- **file:line:** auto-save subscription attached _after_ restore (`App.tsx:178` `enableAutoSave()` runs post-restore) — good — **but** any manual tab action during the debounce window, or a `set(...)` from an in-flight per-tab connect that mutates `rootPanel`, fires `scheduleLastSessionSave` (`App.tsx:132-142`). Because `saveLastSession` recaptures the _whole_ live tree (`appStore.ts:4002-4007`), a save landing while some tabs are still `agent-error`/unconnected persists that degraded snapshot over the good one.
+- **Symptom:** Restart during/right after a partial restore → the previously-good last session gets overwritten with the partially-failed layout; agent-error tabs get re-persisted as agent-error (`captureTab` preserves `agentRef`, `workspaceLayout.ts:626-632`), which is intended, but transient failures become sticky.
+- **Smallest fix:** Gate `scheduleLastSessionSave` behind a `restoreInProgress` flag until the restored cohort settles (ties to G4's cohort tracking); or debounce longer than the expected connect settle time. At minimum, add a `restoreInProgress` boolean to the store and skip auto-save while true.
+
+### G6 — Race / double-fire: launch button not disabled during launch — **LOW/MEDIUM**
+
+- **State/transition:** `Loading` re-entry.
+- **file:line:** `WorkspaceListItem.tsx:32-40` (Launch button + `onDoubleClick` at `:23`) → `launchWorkspace` (`appStore.ts:3845`), which has no in-flight guard and awaits credential unlock (`:3885`) and agent connects (`:3893`).
+- **Symptom:** During the (possibly multi-second) credential-unlock / agent-connect phase, a second double-click starts a second `launchWorkspace`; two concurrent `set(...)` calls race, and both tear over each other — combined with G1 this multiplies orphaned sessions.
+- **Smallest fix:** Track a `launchingWorkspaceId` in the store; disable the Launch/Play controls and ignore re-entry while a launch is in flight (the Button primitive already supports async pending state).
+
+### G7 — Delete/duplicate have no confirmation and no feedback — **LOW**
+
+- **State/transition:** delete transition.
+- **file:line:** `WorkspaceListItem.tsx:63-72` → `deleteWorkspaceFromBackend` (`appStore.ts:3779-3788`), which on failure only `console.error`s (`:3786`) and optimistically removes from state (`:3782`) — if the backend delete failed, the item reappears on next `loadWorkspaces` with no explanation.
+- **Symptom:** One-click destructive delete of a saved workspace, no confirm, no toast on success or failure; a failed delete silently "un-deletes" on refresh.
+- **Smallest fix:** Add a confirm step (or undo toast) before delete; `toast.success/error` on completion; only mutate local state after the backend resolves.
+
+### G8 — Import/Export fully swallow errors — **LOW**
+
+- **file:line:** `WorkspaceSidebar.tsx:65-92` — both `handleExport` (`:74` empty catch) and `handleImport` (`:89` empty catch) discard all errors; import success count from `import_json` (`manager.rs:239`) is never shown.
+- **Symptom:** Import that skips duplicates (`manager.rs:206`) or fails parse (`manager.rs:195`) gives zero feedback; user can't tell if 0, some, or all workspaces imported.
+- **Smallest fix:** Surface the returned count as `toast.success("Imported N workspaces")` and `toast.error(...)` on failure; distinguish user-cancel (no toast) from real failure.
+
+---
+
+## 6. Missing controls list
+
+| Control                                                                 | Where it belongs                                           | Transition it would fire                                 | Rationale                                                                                                                               |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **M1 — "Launch will close current tabs" confirm**                       | `launchWorkspace` entry / `WorkspaceListItem` Play         | guards `Idle → Loading`, forces teardown before `Placed` | Prevents G1 session orphaning + accidental loss of the current live layout.                                                             |
+| **M2 — Retry-all / "Reconnect failed tabs"**                            | Workspace sidebar or status bar after a partial restore    | drives every `Tab*Error → PerTabConnect` at once         | Today reconnect is per-tab only (`Terminal.tsx` retry); no bulk recovery from a partial restore (G4).                                   |
+| **M3 — "Restore last session now" manual action**                       | Command palette / File menu                                | `Idle → Loading` (last-session) on demand                | Restore only runs at startup (`App.tsx:169`); no way to re-trigger after an accidental close.                                           |
+| **M4 — Save success/error feedback (toast)**                            | `saveCurrentAsWorkspace` / dialog                          | makes `Persisting → Saved/SaveFailed` observable         | Closes G2; matches existing connection-save toasts.                                                                                     |
+| **M5 — Restore-failed notice / recovery entry for `last-session.json`** | startup, RecoveryDialog channel                            | makes `LoadFailed`/corrupt-`None` observable             | Closes G3; `workspaces.json` already has this via `RecoveryWarning` — `last-session.json` does not (`last_session.rs:76-82`).           |
+| **M6 — Cancel during launch**                                           | Launch in-flight (credential unlock / agent connect phase) | `Loading → Idle`                                         | `launchWorkspace` can block on `requestUnlock` (`appStore.ts:3885`) and agent connects (`:3893`) with no abort; user is stuck watching. |
+| **M7 — Delete confirmation / undo**                                     | `WorkspaceListItem` delete                                 | gates the delete transition                              | Closes G7; destructive one-click action on named workspaces.                                                                            |
+
+---
+
+## 7. Notes for the implementer
+
+- The cleanest structural fix for G1/G4/G5/G6 is to introduce an explicit **restore-status field** in the store (e.g. `workspaceRestore: { status: "idle" | "loading" | "restoring" | "settled"; total: number; failed: number; launchingId: string | null }`). This gives the machine the aggregate `restoring → restored / partial-failure` states the issue title assumes exist but which the code currently only has emergently. Every gap above except G7/G8 collapses into "read/write this one field."
+- **Concept check:** I found no `docs/concepts/**` HTML/MD concept describing the workspace save/restore behavior, so there is no source-of-truth spec to diff against — this audit is reconstructed purely from code. If #1135 proceeds, consider authoring the concept alongside so the fixed machine has an authoritative reference.
+- Existing tests cover only the Rust CRUD/round-trip (`manager.rs:403-735`) and the store's happy-path last-session (`appStore.lastSession.test.ts`). There is **no** test for partial-restore, teardown-on-launch, or save-failure feedback — any fix for G1–G4 should ship with regression tests per the TDD workflow.


### PR DESCRIPTION
## Summary

State-machine **audits** for the eight stateful subsystems flagged by the "Audit + fix …" issues. Each audit was produced by the `state-machine` specialist (`.claude/agents/state-machine.md`): it reconstructs the real machine from the code, binds UI actions to transitions, and reports what's missing for a correct UX. Every claim is grounded in `file:line`.

**This PR delivers the audit portion only — analysis, diagrams, and prioritized gaps. No production code changes.** Implementation is deferred to follow-up issues split out from each gap list (per each issue's note: *"Follow-up implementation issues may be split out from the audit findings"*).

One deliverable file per issue under `docs/audits/`, one commit each:

| Issue | Subsystem | File |
|---|---|---|
| #1130 | SSH tunnel | `docs/audits/ssh-tunnel-state-machine.md` |
| #1131 | Remote agent lifecycle | `docs/audits/remote-agent-lifecycle-state-machine.md` |
| #1132 | SFTP / file browser | `docs/audits/sftp-file-browser-state-machine.md` |
| #1133 | Credential store | `docs/audits/credential-store-state-machine.md` |
| #1134 | Embedded servers | `docs/audits/embedded-servers-state-machine.md` |
| #1135 | Workspace save/restore | `docs/audits/workspace-save-restore-state-machine.md` |
| #1136 | HTTP monitor (network tools) | `docs/audits/http-monitor-state-machine.md` |
| #1137 | Remote system monitoring | `docs/audits/remote-system-monitoring-state-machine.md` |

Each file contains: `stateDiagram-v2` lifecycle diagram(s), `sequenceDiagram`(s) for the cross-actor / IPC-SSH flows, a **prioritized gap list** (ranked stuck/leak/data-loss first, each with state·transition·`file:line`·symptom·smallest-fix), and a **missing-controls list**.

## Recurring cross-subsystem themes
- **Silent death on transport drop** — tunnels, monitoring, and agents all keep showing "connected" after the underlying SSH session dies (no `Connected → Error` edge), leaving leaked resources invisible in the Open Connections panel.
- **Open Connections coverage gaps** — embedded servers and HTTP monitors don't appear at all; reconnecting agents and orphaned SFTP sessions are filtered out — contradicting the panel's "every subsystem" mandate.
- **No cancel / retry** — blocking connects (agent, monitoring) can't be aborted; failed states (tunnel error, credential wrong-password, embedded-server error) are dead-ends with no Retry.
- **Silent failures** — many mutating actions resolve with `console.error`-only or unhandled rejections instead of a toast (design-system rule 4).

## Test plan
Documentation-only deliverable — no code paths changed. Diagrams are Mermaid; findings are grounded in `file:line` references and are meant to seed follow-up implementation issues.

Relates to #1130, #1131, #1132, #1133, #1134, #1135, #1136, #1137 (audit deliverable; fixes tracked as follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)