### PR TITLE
fix(config): use non-empty sentinel for storage-file Select default option (#1105)

### DIFF
--- a/docs/changes/dev1/bugfix/1105-radix-select-empty-string.md
+++ b/docs/changes/dev1/bugfix/1105-radix-select-empty-string.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Connection editor: the **Storage File** picker no longer crashes when it is
+  shown. Its "Default (connections.json)" option used an empty-string value,
+  which Radix Select forbids (the empty string is reserved for clearing the
+  selection). The default option now uses a non-empty sentinel that maps back to
+  the default storage file, so the picker renders correctly whenever external
+  connection files are enabled (#1105).

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -1297,3 +1297,69 @@ describe("ConnectionEditor — Setup SSH Agent button", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Storage-file picker — Radix Select forbids empty-string item values (#1105).
+// The "Default (connections.json)" option must use a non-empty sentinel value
+// that maps back to `null` (the default storage file) at the call site.
+// ---------------------------------------------------------------------------
+
+describe("ConnectionEditor — storage-file picker (#1105)", () => {
+  function renderFor(connId: string) {
+    act(() => {
+      root.render(
+        <ConnectionEditor
+          tabId="tab-sf-1"
+          meta={{ connectionId: connId, folderId: null }}
+          isVisible={true}
+        />
+      );
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetRuntimeCache();
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      connections: [EXISTING_CONN],
+      connectionTypes: [SSH_TYPE],
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+      // At least one enabled external file makes the storage-file picker render.
+      settings: {
+        ...useAppStore.getInitialState().settings,
+        externalConnectionFiles: [{ path: "/tmp/team.json", enabled: true }],
+      },
+    });
+    mockedInvoke.mockImplementation(() => Promise.resolve(false));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the storage-file picker when an external file is enabled", () => {
+    renderFor(CONN_ID);
+    const select = container.querySelector('[data-testid="connection-editor-source-file"]');
+    expect(select).not.toBeNull();
+  });
+
+  it("uses a non-empty sentinel value for the default option (Radix rejects empty string)", () => {
+    // Regression: the default option previously used value="" and the select's
+    // value fell back to "" when no source file was chosen. Radix Select forbids
+    // empty-string item values, so the default must resolve to a non-empty
+    // sentinel. EXISTING_CONN has no sourceFile, so this is the default case.
+    renderFor(CONN_ID);
+    const trigger = container.querySelector(
+      '[data-testid="connection-editor-source-file"]'
+    ) as HTMLElement | null;
+    expect(trigger).not.toBeNull();
+    // The trigger mirrors the controlled Select value via data-value.
+    expect(trigger?.getAttribute("data-value")).not.toBe("");
+    expect(trigger?.getAttribute("data-value")).toBeTruthy();
+  });
+});

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -150,6 +150,14 @@ function buildTypeDefaults(
   return defaults;
 }
 
+/**
+ * Sentinel for the "Default (connections.json)" storage-file option. Radix
+ * Select reserves the empty string to clear the selection, so an explicit
+ * non-empty value is required and mapped back to `null` (the default storage
+ * file) at the call site.
+ */
+const DEFAULT_STORAGE_FILE = "__default__";
+
 interface ConnectionEditorProps {
   tabId: string;
   meta: ConnectionEditorMeta;
@@ -953,10 +961,10 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           <label className="settings-form__field">
             <span className="settings-form__label">Storage File</span>
             <Select
-              value={sourceFile ?? ""}
-              onChange={(v) => setSourceFile(v || null)}
+              value={sourceFile ?? DEFAULT_STORAGE_FILE}
+              onChange={(v) => setSourceFile(v === DEFAULT_STORAGE_FILE ? null : v)}
               options={[
-                { value: "", label: "Default (connections.json)" },
+                { value: DEFAULT_STORAGE_FILE, label: "Default (connections.json)" },
                 ...enabledExternalFiles.map((f) => ({ value: f.path, label: f.path })),
               ]}
               aria-label="Storage File"


### PR DESCRIPTION
Closes #1105

## Summary

The storage-file **Storage File** picker in `ConnectionEditor` used an
empty-string value (`value=""`) for its "Default (connections.json)" option.
Radix Select reserves the empty string to clear the selection and throws
`A <Select.Item /> must have a value prop that is not an empty string.` — so
the picker crashed whenever it was rendered (i.e. whenever at least one external
connection file is enabled).

This mirrors the fix applied in #1094 / PR #1104 to the migrated ConnectionEditor
subcomponents (`__global__` / `__auto__` sentinels): the default option now uses a
non-empty `__default__` sentinel, mapped back to `null` (the default storage file)
at the `onChange` call site.

### Changes

- `src/components/ConnectionEditor/ConnectionEditor.tsx`: added a
  `DEFAULT_STORAGE_FILE = "__default__"` sentinel; the storage-file `Select`
  binds `value={sourceFile ?? DEFAULT_STORAGE_FILE}` and maps the sentinel back
  to `null` on change.
- `src/components/ConnectionEditor/ConnectionEditor.test.tsx`: regression tests
  for the storage-file picker.

## Test plan

- `pnpm exec vitest run src/components/ConnectionEditor/ConnectionEditor.test.tsx` — 33 passed.
  - New tests fail (red) on the pre-fix code: rendering throws the Radix
    empty-string error; pass (green) after the fix.
- `pnpm run lint` — clean.
- `pnpm run format:check` — clean.
- `pnpm build` — TypeScript check + Vite build succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
