### PR TITLE
fix(backend): fix monitoring event-listener leak on failed open (#1148)

### DIFF
--- a/src/store/appStore.monitoring.test.ts
+++ b/src/store/appStore.monitoring.test.ts
@@ -26,6 +26,8 @@ vi.mock("@/services/storage", () => ({
 const mockMonitoringOpen = vi.fn();
 const mockMonitoringClose = vi.fn();
 const mockMonitoringFetchStats = vi.fn();
+const mockSessionMonitoringOpen = vi.fn();
+const mockSessionMonitoringClose = vi.fn();
 
 vi.mock("@/services/api", () => ({
   sftpOpen: vi.fn(),
@@ -36,6 +38,18 @@ vi.mock("@/services/api", () => ({
   monitoringOpen: (...args: unknown[]) => mockMonitoringOpen(...args),
   monitoringClose: (...args: unknown[]) => mockMonitoringClose(...args),
   monitoringFetchStats: (...args: unknown[]) => mockMonitoringFetchStats(...args),
+  sessionMonitoringOpen: (...args: unknown[]) => mockSessionMonitoringOpen(...args),
+  sessionMonitoringClose: (...args: unknown[]) => mockSessionMonitoringClose(...args),
+}));
+
+// Session-based monitoring subscribes to a Tauri event and stores the returned
+// unlisten fn; the tests below assert that listener is not leaked on a failed open.
+const mockUnlisten = vi.fn();
+const mockOnSessionMonitoringStats = vi.fn((..._args: unknown[]) => Promise.resolve(mockUnlisten));
+
+vi.mock("@/services/events", () => ({
+  onSessionMonitoringStats: (...args: unknown[]) => mockOnSessionMonitoringStats(...args),
+  onPersistentSessionStateChanged: vi.fn(() => Promise.resolve(() => {})),
 }));
 
 import { useAppStore } from "./appStore";
@@ -122,6 +136,51 @@ describe("appStore — monitoring", () => {
       resolveOpen!("session-123");
       await promise;
       expect(useAppStore.getState().monitoringLoading).toBe(false);
+    });
+  });
+
+  describe("connectMonitoring — session-based (push)", () => {
+    const SESSION_CONFIG = { _sessionBased: true, _sessionId: "sess-abc" };
+
+    it("sets session and clears loading on successful open", async () => {
+      mockSessionMonitoringOpen.mockResolvedValue(undefined);
+
+      await useAppStore.getState().connectMonitoring(SESSION_CONFIG);
+
+      const state = useAppStore.getState();
+      expect(state.monitoringSessionId).toBe("sess-abc");
+      expect(state.monitoringHost).toBe("sess-abc");
+      expect(state.monitoringLoading).toBe(false);
+      expect(mockOnSessionMonitoringStats).toHaveBeenCalledTimes(1);
+    });
+
+    it("unlistens the stats listener when session_monitoring_open fails (no leak)", async () => {
+      mockSessionMonitoringOpen.mockRejectedValue(new Error("open refused"));
+
+      await useAppStore.getState().connectMonitoring(SESSION_CONFIG);
+
+      // The event listener was attached before the failing open, so it must be
+      // detached in the catch — otherwise a dangling listener could later update
+      // the wrong host (audit G5).
+      expect(mockOnSessionMonitoringStats).toHaveBeenCalledTimes(1);
+      expect(mockUnlisten).toHaveBeenCalledTimes(1);
+
+      const state = useAppStore.getState();
+      expect(state.monitoringSessionId).toBeNull();
+      expect(state.monitoringLoading).toBe(false);
+      expect(state.monitoringError).toBe("open refused");
+    });
+
+    it("does not re-invoke the leaked listener on a later disconnect", async () => {
+      mockSessionMonitoringOpen.mockRejectedValue(new Error("open refused"));
+
+      await useAppStore.getState().connectMonitoring(SESSION_CONFIG);
+      expect(mockUnlisten).toHaveBeenCalledTimes(1);
+
+      // A subsequent disconnect must not call the (already-detached) listener again,
+      // proving _monitoringUnlisten was nulled in the catch.
+      await useAppStore.getState().disconnectMonitoring();
+      expect(mockUnlisten).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3474,6 +3474,15 @@ export const useAppStore = create<AppState>((set, get) => {
           monitoringStatsCache: { ...state.monitoringStatsCache, [hostKey]: stats },
         }));
       } catch (err) {
+        // The session-based branch attaches the stats listener before the open
+        // that may throw here. Detach it so a failed open never leaks a dangling
+        // Tauri listener (monitoringSessionId stays null, so disconnectMonitoring
+        // would not clean it up either). See audit gap G5.
+        if (_monitoringUnlisten) {
+          frontendLog("monitoring", "detaching stats listener after failed monitoring open");
+          _monitoringUnlisten();
+          _monitoringUnlisten = null;
+        }
         set({
           monitoringLoading: false,
           monitoringError: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary

Fixes audit gap **G5** from the remote-system-monitoring state-machine audit (umbrella issue #1148): the session/push branch of `connectMonitoring` leaked a Tauri event listener when the session monitoring open failed.

In `src/store/appStore.ts`, the session-based branch of `connectMonitoring` attaches the `onSessionMonitoringStats` listener and stores its unlisten fn in `_monitoringUnlisten` **before** awaiting `sessionMonitoringOpen`. If the open rejected, control jumped to the `catch`, which only set `monitoringError` — the listener was never detached, and `monitoringSessionId` stayed `null`, so `disconnectMonitoring` skipped cleanup too. The result was a dangling listener that could later update the wrong host after a subsequent successful subscribe.

## What changed

- **`src/store/appStore.ts`** — the `catch` in `connectMonitoring` now calls `_monitoringUnlisten?.()` and nulls it (with a `frontendLog` debug line) so a failed open leaves no dangling listener. This covers both branches, but only the session branch attaches a listener before the throwing call.
- **`src/store/appStore.monitoring.test.ts`** — added a `connectMonitoring — session-based (push)` describe block:
  - success path sets session/host and clears loading,
  - **regression:** on a rejected `sessionMonitoringOpen`, the stored unlisten fn is invoked exactly once and state is left clean (`monitoringSessionId: null`, `monitoringLoading: false`, `monitoringError` set),
  - a follow-up `disconnectMonitoring` does not re-invoke the (already-detached, nulled) listener.

## Test plan

- `pnpm test` (vitest, full suite): **183 files, 2158 tests passed**.
- `pnpm build` (tsc typecheck + vite build): **passed**.
- Verified TDD red→green: the two new leak assertions fail before the `appStore.ts` change and pass after (test commit precedes fix commit).

This is an internal robustness fix with no user-visible behavior change, so no changelog fragment was added.

Partially addresses #1148 (G5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)