### PR TITLE
fix(credential): idempotent credential-store unlock (#1144)

### DIFF
--- a/docs/changes/dev2/feature/1144-idempotent-credential-unlock.md
+++ b/docs/changes/dev2/feature/1144-idempotent-credential-unlock.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Credential store: unlocking an already-unlocked master-password store is now
+  a benign no-op instead of an error. Previously, when two connect flows raced
+  to unlock the store, the second unlock returned "Store is already unlocked",
+  which surfaced as a spurious "Incorrect master password"-style failure even
+  though the store was fine. Unlock is now idempotent and still emits the
+  unlock event so any awaiting connect flow resolves. Wrong-password behavior
+  on a locked store is unchanged (#1144, G6).

--- a/src-tauri/src/commands/credential.rs
+++ b/src-tauri/src/commands/credential.rs
@@ -43,6 +43,24 @@ pub fn get_credential_store_status(
     Ok(build_status_info(&manager))
 }
 
+/// Unlock a master-password store, treating an already-unlocked store as a
+/// benign no-op.
+///
+/// This makes unlock idempotent (G6, #1144): when two connect flows race to
+/// unlock the same store, the second call returns `Ok(())` instead of a
+/// spurious "already unlocked" error that would surface as an
+/// "Incorrect master password"-style failure. A wrong password on a locked
+/// store still errors, preserving the existing wrong-password behavior.
+fn unlock_store_idempotent(
+    store: &crate::credential::MasterPasswordStore,
+    password: &str,
+) -> Result<(), String> {
+    if store.is_unlocked() {
+        return Ok(());
+    }
+    store.unlock(password).map_err(|e| e.to_string())
+}
+
 /// Unlock the master password credential store.
 ///
 /// This is async because Argon2id key derivation is CPU-intensive.
@@ -55,12 +73,7 @@ pub async fn unlock_credential_store(
     info!("Unlocking credential store");
 
     let result = manager
-        .with_master_password_store(|store| {
-            if store.is_unlocked() {
-                return Err("Store is already unlocked".to_string());
-            }
-            store.unlock(&password).map_err(|e| e.to_string())
-        })
+        .with_master_password_store(|store| unlock_store_idempotent(store, &password))
         .ok_or_else(|| "Credential store is not in master password mode".to_string())?;
 
     result?;

--- a/src-tauri/src/commands/credential.rs
+++ b/src-tauri/src/commands/credential.rs
@@ -358,6 +358,7 @@ pub fn remove_credential(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::credential::MasterPasswordStore;
 
     #[test]
     fn parse_credential_type_password() {
@@ -379,5 +380,52 @@ mod tests {
     fn parse_credential_type_unknown() {
         let err = parse_credential_type("invalid").unwrap_err();
         assert!(err.contains("Unknown credential type"));
+    }
+
+    /// Regression test for #1144 (G6): unlocking an already-unlocked store
+    /// must be a benign no-op (`Ok`), not an error, so racing connect flows
+    /// don't surface a spurious "already unlocked" failure.
+    #[test]
+    fn unlock_store_idempotent_when_already_unlocked_returns_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MasterPasswordStore::new(dir.path().join("credentials.enc"));
+        store.setup("test-password").unwrap();
+        assert!(store.is_unlocked());
+
+        // Second unlock on the already-unlocked store must succeed idempotently.
+        let result = unlock_store_idempotent(&store, "test-password");
+        assert!(
+            result.is_ok(),
+            "unlocking an already-unlocked store should be Ok, got {result:?}"
+        );
+        assert!(store.is_unlocked());
+    }
+
+    /// A wrong password on a locked store must still fail (behavior unchanged).
+    #[test]
+    fn unlock_store_idempotent_wrong_password_still_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MasterPasswordStore::new(dir.path().join("credentials.enc"));
+        store.setup("correct").unwrap();
+        store.lock();
+        assert!(!store.is_unlocked());
+
+        let result = unlock_store_idempotent(&store, "wrong");
+        assert!(result.is_err());
+        assert!(!store.is_unlocked());
+    }
+
+    /// A locked store with the correct password unlocks (benign happy path).
+    #[test]
+    fn unlock_store_idempotent_correct_password_unlocks() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MasterPasswordStore::new(dir.path().join("credentials.enc"));
+        store.setup("correct").unwrap();
+        store.lock();
+        assert!(!store.is_unlocked());
+
+        let result = unlock_store_idempotent(&store, "correct");
+        assert!(result.is_ok());
+        assert!(store.is_unlocked());
     }
 }


### PR DESCRIPTION
## Summary

Fixes GAP **G6** from the credential-store state-machine audit (`docs/audits/credential-store-state-machine.md`): `unlock_credential_store` returned `Err("Store is already unlocked")` when the master-password store was already unlocked. When two connect flows race to unlock the same store, the second call surfaced this as an "Incorrect master password"-style failure in the unlock dialog, even though the store was perfectly fine.

## What changed

- `src-tauri/src/commands/credential.rs`: unlocking an already-unlocked store is now a **benign no-op** — the command returns `Ok(())` and still emits `credential-store-unlocked`, so any awaiting `requestUnlock()` promise on the frontend resolves. The closure body was extracted into a small, testable `unlock_store_idempotent` helper.
- **Wrong-password behavior is unchanged**: a wrong password against a locked store still returns an error.
- Added a per-branch changelog fragment (`docs/changes/dev2/feature/1144-idempotent-credential-unlock.md`).

## Test plan

TDD — test committed before the fix:

- `unlock_store_idempotent_when_already_unlocked_returns_ok` — the regression test: unlock on an already-unlocked store returns `Ok` (would fail without the fix).
- `unlock_store_idempotent_wrong_password_still_errors` — wrong password on a locked store still errors.
- `unlock_store_idempotent_correct_password_unlocks` — correct password on a locked store unlocks.

Verification:

- `cargo test -p termihub --lib commands::credential` → 6 passed, 0 failed.
- `cargo clippy -p termihub --all-targets --all-features -- -D warnings` → clean, no warnings.

Partially addresses #1144 (G6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)