### PR TITLE
refactor(network): migrate NetworkToolsSidebar buttons onto Button primitive

### DIFF
--- a/src/components/NetworkTools/NetworkTools.css
+++ b/src/components/NetworkTools/NetworkTools.css
@@ -303,90 +303,19 @@
   padding: var(--spacing-sm) var(--spacing-md) 4px;
 }
 
-.network-sidebar__btn {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  width: 100%;
-  padding: 5px var(--spacing-md);
-  border: none;
-  background: transparent;
-  color: var(--text-primary);
-  font-size: var(--font-size-sm);
-  text-align: left;
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: background-color var(--transition-fast);
-}
-
-.network-sidebar__btn:hover {
-  background-color: var(--bg-hover);
-}
-
-.network-sidebar__monitor-item {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  padding: 3px var(--spacing-md);
-}
-
-.network-sidebar__monitor-url {
-  font-size: var(--font-size-sm);
-  font-family: var(--font-mono);
-  color: var(--text-primary);
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.network-sidebar__monitor-actions {
-  display: flex;
-  gap: var(--spacing-xs);
-}
-
-.network-sidebar__icon-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-}
-
-.network-sidebar__icon-btn:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
-}
-
 .network-sidebar__empty {
   padding: var(--spacing-xs) var(--spacing-md);
   font-size: var(--font-size-sm);
   color: var(--text-disabled);
 }
 
-/* Quick-action launcher buttons in sidebar */
-.network-sidebar__action {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  width: 100%;
-  padding: 5px var(--spacing-md);
-  border: none;
-  background: transparent;
+/* Layout-only modifier composed onto the ghost `Button` primitive so the
+   sidebar quick-action and New Monitor rows read as full-width, left-aligned
+   list rows (the primitive centers content and ghost text is secondary). Shape,
+   radius, focus ring, sizing, and hover background all come from the primitive. */
+.network-sidebar__list-btn {
+  justify-content: flex-start;
   color: var(--text-primary);
-  font-size: var(--font-size-sm);
-  text-align: left;
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: background-color var(--transition-fast);
-}
-
-.network-sidebar__action:hover {
-  background-color: var(--bg-hover);
 }
 
 /* Monitor rows in sidebar */
@@ -426,61 +355,10 @@
   white-space: nowrap;
 }
 
-.network-sidebar__monitor-stop {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-}
-
-.network-sidebar__monitor-stop:hover {
-  background-color: var(--bg-hover);
-  color: var(--color-error);
-}
-
-/* Sidebar header action buttons */
-.network-sidebar__refresh {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
+/* The Monitors-header refresh button needs a little breathing room from the
+   section title (the ghost icon `Button` primitive supplies the rest). */
+.network-sidebar__section-title .ui-btn {
   margin-left: var(--spacing-xs);
-}
-
-.network-sidebar__refresh:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.network-sidebar__add {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  width: 100%;
-  padding: 4px var(--spacing-md);
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: var(--font-size-sm);
-  text-align: left;
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: background-color var(--transition-fast);
-}
-
-.network-sidebar__add:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
 }
 
 /* Port scan warning */

--- a/src/components/NetworkTools/NetworkToolsSidebar.button.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.button.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Verifies the Network Tools sidebar buttons compose from the shared `Button`
+ * primitive (issue #1109), replacing the bespoke `network-sidebar__*` buttons.
+ *
+ * Pins:
+ *  - Quick-action / New-monitor rows render the `Button` primitive (ghost, full
+ *    width) plus the thin `network-sidebar__list-btn` layout modifier, keep their
+ *    `data-testid`, and still trigger their action.
+ *  - The Refresh and Stop icon-only controls render as ghost `Button`s wrapped in
+ *    a `Tooltip`, keeping their `aria-label` with no bare `title` leak.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import {
+  networkHttpMonitorList,
+  networkHttpMonitorStop,
+  onHttpMonitorCheck,
+} from "@/services/networkApi";
+import type { HttpMonitorState } from "@/types/network";
+import { useAppStore } from "@/store/appStore";
+import { NetworkToolsSidebar } from "./NetworkToolsSidebar";
+import { TooltipProvider } from "@/components/ui";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts the tooltip-wrapped icon buttons; shim them so the sidebar renders.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  onHttpMonitorCheck: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+function makeMonitor(id: string): HttpMonitorState {
+  return {
+    config: {
+      id,
+      url: "https://example.com",
+      intervalMs: 30_000,
+      method: "GET",
+      expectedStatus: 200,
+      timeoutMs: 10_000,
+    },
+    running: true,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+const openTab = vi.fn();
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Wrap so the shared Tooltip primitive finds its provider (zero delay). */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
+
+describe("NetworkToolsSidebar — Button primitive migration (#1109)", () => {
+  beforeEach(() => {
+    openTab.mockReset();
+    useAppStore.setState({ httpMonitors: [], openNetworkDiagnosticTab: openTab });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    useAppStore.setState({ httpMonitors: [] });
+  });
+
+  it("renders quick-action rows as the ghost Button primitive with the list modifier", async () => {
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const ping = container.querySelector<HTMLButtonElement>(
+      '[data-testid="network-quick-action-ping"]'
+    );
+    expect(ping).not.toBeNull();
+    expect(ping?.classList.contains("ui-btn")).toBe(true);
+    expect(ping?.classList.contains("ui-btn--ghost")).toBe(true);
+    expect(ping?.classList.contains("ui-btn--full")).toBe(true);
+    expect(ping?.classList.contains("network-sidebar__list-btn")).toBe(true);
+    // No leftover bespoke button class.
+    expect(ping?.classList.contains("network-sidebar__action")).toBe(false);
+  });
+
+  it("fires the quick-action handler on click", async () => {
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const ping = container.querySelector<HTMLButtonElement>(
+      '[data-testid="network-quick-action-ping"]'
+    )!;
+    act(() => ping.click());
+    expect(openTab).toHaveBeenCalledWith("ping");
+  });
+
+  it("renders the New Monitor row as the ghost Button primitive with the list modifier", async () => {
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const add = container.querySelector<HTMLButtonElement>('[data-testid="network-new-monitor"]');
+    expect(add).not.toBeNull();
+    expect(add?.classList.contains("ui-btn--ghost")).toBe(true);
+    expect(add?.classList.contains("ui-btn--full")).toBe(true);
+    expect(add?.classList.contains("network-sidebar__list-btn")).toBe(true);
+    act(() => add!.click());
+    expect(openTab).toHaveBeenCalledWith("http-monitor");
+  });
+
+  it("renders the Refresh control as a ghost icon Button keeping its aria-label", async () => {
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const refresh = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Refresh monitors"]'
+    );
+    expect(refresh).not.toBeNull();
+    expect(refresh?.classList.contains("ui-btn--ghost")).toBe(true);
+    // The tooltip must not leak into the accessible name as a bare title.
+    expect(refresh?.getAttribute("title")).toBeNull();
+  });
+
+  it("renders the monitor Stop control as a ghost icon Button that stops the monitor", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-1")]);
+    useAppStore.setState({ httpMonitors: [makeMonitor("mon-1")] });
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const stop = container.querySelector<HTMLButtonElement>('button[aria-label="Stop monitor"]');
+    expect(stop).not.toBeNull();
+    expect(stop?.classList.contains("ui-btn--ghost")).toBe(true);
+    expect(stop?.getAttribute("title")).toBeNull();
+
+    await act(async () => {
+      stop!.click();
+    });
+    await flush();
+    expect(networkHttpMonitorStop).toHaveBeenCalledWith("mon-1");
+  });
+});

--- a/src/components/NetworkTools/NetworkToolsSidebar.button.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.button.test.tsx
@@ -12,11 +12,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
-import {
-  networkHttpMonitorList,
-  networkHttpMonitorStop,
-  onHttpMonitorCheck,
-} from "@/services/networkApi";
+import { networkHttpMonitorList, networkHttpMonitorStop } from "@/services/networkApi";
 import type { HttpMonitorState } from "@/types/network";
 import { useAppStore } from "@/store/appStore";
 import { NetworkToolsSidebar } from "./NetworkToolsSidebar";

--- a/src/components/NetworkTools/NetworkToolsSidebar.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.tsx
@@ -10,7 +10,7 @@ import {
 import type { NetworkTool } from "@/types/terminal";
 import type { HttpMonitorState } from "@/types/network";
 import { frontendLog } from "@/utils/frontendLog";
-import { Tooltip } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 
 interface QuickActionProps {
   label: string;
@@ -20,14 +20,17 @@ interface QuickActionProps {
 function QuickAction({ label, tool }: QuickActionProps) {
   const openNetworkDiagnosticTab = useAppStore((s) => s.openNetworkDiagnosticTab);
   return (
-    <button
-      className="network-sidebar__action"
+    <Button
+      variant="ghost"
+      size="sm"
+      fullWidth
+      className="network-sidebar__list-btn"
+      icon={<Play size={12} />}
       onClick={() => openNetworkDiagnosticTab(tool)}
       data-testid={`network-quick-action-${tool}`}
     >
-      <Play size={12} />
       {label}
-    </button>
+    </Button>
   );
 }
 
@@ -67,13 +70,13 @@ function MonitorRow({ monitor, onStop, onOpen }: MonitorRowProps) {
       </div>
       {running && (
         <Tooltip content="Stop monitor" side="left">
-          <button
-            className="network-sidebar__monitor-stop"
+          <Button
+            variant="ghost"
+            size="sm"
             aria-label="Stop monitor"
+            icon={<StopCircle size={12} />}
             onClick={() => onStop(config.id)}
-          >
-            <StopCircle size={12} />
-          </button>
+          />
         </Tooltip>
       )}
     </div>
@@ -165,13 +168,13 @@ export function NetworkToolsSidebar() {
         <div className="network-sidebar__section-title">
           Monitors
           <Tooltip content="Refresh monitors" side="bottom">
-            <button
-              className="network-sidebar__refresh"
+            <Button
+              variant="ghost"
+              size="sm"
               aria-label="Refresh monitors"
+              icon={<RefreshCw size={11} />}
               onClick={refreshMonitors}
-            >
-              <RefreshCw size={11} />
-            </button>
+            />
           </Tooltip>
         </div>
         {httpMonitors.length === 0 && (
@@ -185,14 +188,17 @@ export function NetworkToolsSidebar() {
             onOpen={handleOpenMonitor}
           />
         ))}
-        <button
-          className="network-sidebar__add"
+        <Button
+          variant="ghost"
+          size="sm"
+          fullWidth
+          className="network-sidebar__list-btn"
+          icon={<Plus size={12} />}
           onClick={() => openNetworkDiagnosticTab("http-monitor")}
           data-testid="network-new-monitor"
         >
-          <Plus size={12} />
           New Monitor
-        </button>
+        </Button>
       </div>
 
       {/* Local Utilities */}

--- a/src/styles/tokenDiscipline.test.ts
+++ b/src/styles/tokenDiscipline.test.ts
@@ -74,18 +74,16 @@ const WHITE_ALLOWLIST: string[] = [];
  * primitive (tracked by follow-up issues), its entry is removed here. The guard's
  * value is the ratchet — a currently-clean file that reintroduces `__btn` FAILS.
  *
- * ConnectionEditor / TunnelEditor / WorkspaceEditor (migrated in #1085/#1094)
- * and the Settings / NetworkTools panels / FileBrowser / TerminalSearchBar /
- * UpdateNotification buttons (migrated in #1096) were all moved onto the `Button`
- * primitive and removed from this list. The only remaining entry is
- * NetworkTools/NetworkTools.css, which still carries `network-sidebar__btn` for
- * the NetworkToolsSidebar (out of #1096's panel scope — tracked as a follow-up).
- * Do NOT assert this list has no stale entries — that would cause cross-PR
- * breakage.
+ * ConnectionEditor / TunnelEditor / WorkspaceEditor (migrated in #1085/#1094),
+ * the Settings / NetworkTools panels / FileBrowser / TerminalSearchBar /
+ * UpdateNotification buttons (migrated in #1096), and the NetworkToolsSidebar
+ * (migrated in #1109) were all moved onto the `Button` primitive and removed
+ * from this list, which is now empty. Do NOT assert this list has no stale
+ * entries — that would cause cross-PR breakage.
  *
  * Paths are repo-relative suffixes (POSIX separators), matched with `endsWith`.
  */
-const BESPOKE_BTN_ALLOWLIST: string[] = ["NetworkTools/NetworkTools.css"];
+const BESPOKE_BTN_ALLOWLIST: string[] = [];
 
 /**
  * Documented allowlist of component CSS files permitted to carry a standalone


### PR DESCRIPTION
Closes #1109

## Summary

Migrates the four bespoke buttons in the Network Tools sidebar
(`NetworkToolsSidebar.tsx`) onto the shared `Button` primitive, mirroring the
approach in #1096 (PR #1108) which migrated the Network Tools panels:

- **Quick-action rows** (Ping/Scan/DNS/WoL/Open Ports/Traceroute) and the
  **New Monitor** row → `<Button variant="ghost" size="sm" fullWidth>` with a
  leading icon. A thin, token-only layout modifier
  `.network-sidebar__list-btn` (`justify-content: flex-start; color: var(--text-primary)`)
  is composed onto the primitive so they still read as full-width, left-aligned
  list rows (the primitive centers content and ghost text is `--text-secondary`).
- **Refresh** and **Stop monitor** icon-only controls → ghost icon `Button`s,
  still wrapped in the `Tooltip` primitive, keeping their `aria-label`s (and
  `data-testid`s where present).

CSS cleanup in `NetworkTools.css`:
- Removed the dead `network-sidebar__btn` / `__icon-btn` / `__monitor-item` /
  `__monitor-actions` rules (the ratchet's last `__btn` offender).
- Removed the now-migrated `__action` / `__add` / `__refresh` / `__monitor-stop`
  rules.
- Added the single `.network-sidebar__list-btn` layout modifier and a small
  `.network-sidebar__section-title .ui-btn { margin-left }` rule for the header
  refresh button spacing.

Ratchet: emptied `BESPOKE_BTN_ALLOWLIST` in `tokenDiscipline.test.ts` — the
`NetworkTools/NetworkTools.css` entry is removed, and the file now contains no
`__btn` class, so the guard stays green while blocking any future reintroduction.

Design-system compliance: all values are tokens; the primitive owns shape,
radius, focus ring, sizing, and hover background; the only override is the
alignment/color layout modifier (the primitive has no alignment prop), which the
`ui-design` agent confirmed is the sanctioned composition pattern.

Minor visual note: the Stop-monitor icon previously turned `--color-error` red
on hover via bespoke CSS; it now uses the standard ghost hover (matching the
`HttpMonitorPanel` stop-monitor icon migrated in #1096) — a deliberate parity
convergence, not a behavior change.

## Test plan

- `test(network)`: new `NetworkToolsSidebar.button.test.tsx` pins the migration —
  quick-action and New Monitor rows render `ui-btn ui-btn--ghost ui-btn--full
  network-sidebar__list-btn`, keep their `data-testid`, and fire their handler;
  Refresh/Stop render as ghost `Button`s keeping their `aria-label` with no bare
  `title` leak; Stop still calls `networkHttpMonitorStop`.
- Existing `NetworkToolsSidebar.live.test.tsx` (#986) still passes.
- `tokenDiscipline.test.ts` passes with the allowlist entry removed.
- Full suite: `vitest run` → 2160 passed. `eslint` clean, `tsc --noEmit` clean,
  `vite build` succeeds, `prettier --check` clean.

## Change fragment

None — this is an internal styling/refactor with no user-visible behavior change
(same controls, same labels, same actions; only the underlying button
implementation changed). Per the workflow, change fragments are skipped for
refactors with no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)