### PR TITLE
feat(embedded-servers): feedback on start/stop failure (#1145)

### DIFF
--- a/docs/changes/dev2/feature/1145-embedded-server-start-feedback.md
+++ b/docs/changes/dev2/feature/1145-embedded-server-start-feedback.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Embedded servers (HTTP/FTP/TFTP): starting or stopping a server that fails
+  (for example a port already in use) now surfaces a clear error toast with the
+  backend message instead of silently doing nothing. The Start/Stop action
+  button is also disabled while the action is in flight so it cannot be
+  double-triggered. (#1145)

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(() => Promise.resolve()),
+}));
+
+import { EmbeddedServerItem } from "./EmbeddedServerItem";
+import { EmbeddedServerConfig, ServerState } from "@/types/embeddedServer";
+
+let container: HTMLDivElement;
+let root: Root;
+
+const config: EmbeddedServerConfig = {
+  id: "srv-1",
+  name: "My HTTP",
+  serverType: "http",
+  rootDirectory: "/tmp",
+  bindHost: "127.0.0.1",
+  port: 8080,
+  autoStart: false,
+  readOnly: false,
+  directoryListing: true,
+};
+
+const runningState: ServerState = {
+  serverId: "srv-1",
+  status: "running",
+  stats: { activeConnections: 0, totalConnections: 0, bytesSent: 0, bytesReceived: 0 },
+};
+
+const noop = () => {};
+
+function baseProps(overrides: Partial<React.ComponentProps<typeof EmbeddedServerItem>> = {}) {
+  return {
+    config,
+    state: undefined as ServerState | undefined,
+    onStart: vi.fn(() => Promise.resolve()),
+    onStop: vi.fn(() => Promise.resolve()),
+    onEdit: noop,
+    onDuplicate: noop,
+    onDelete: noop,
+    ...overrides,
+  };
+}
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function click(el: Element) {
+  act(() => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+/** Flush pending microtasks (rejected/resolved promise callbacks). */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("EmbeddedServerItem", () => {
+  beforeEach(() => {
+    toastError.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("surfaces a toast.error when starting fails", async () => {
+    const onStart = vi.fn(() => Promise.reject(new Error("Port 8080 already in use")));
+    render(<EmbeddedServerItem {...baseProps({ onStart })} />);
+
+    const startBtn = container.querySelector('[data-testid="server-start-srv-1"]')!;
+    click(startBtn);
+    await flush();
+
+    expect(onStart).toHaveBeenCalledWith("srv-1");
+    expect(toastError).toHaveBeenCalledTimes(1);
+    const [title, opts] = toastError.mock.calls[0] as [
+      string,
+      { description?: string } | undefined,
+    ];
+    expect(title).toContain("My HTTP");
+    expect(opts?.description).toContain("Port 8080 already in use");
+  });
+
+  it("disables the start button while the action is in flight", async () => {
+    let resolveStart!: () => void;
+    const onStart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        })
+    );
+    render(<EmbeddedServerItem {...baseProps({ onStart })} />);
+
+    const startBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="server-start-srv-1"]'
+    )!;
+    click(startBtn);
+
+    expect(startBtn.disabled).toBe(true);
+
+    await act(async () => {
+      resolveStart();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector<HTMLButtonElement>('[data-testid="server-start-srv-1"]')!.disabled
+    ).toBe(false);
+  });
+
+  it("surfaces a toast.error when stopping fails", async () => {
+    const onStop = vi.fn(() => Promise.reject("stop boom"));
+    render(<EmbeddedServerItem {...baseProps({ onStop, state: runningState })} />);
+
+    const stopBtn = container.querySelector('[data-testid="server-stop-srv-1"]')!;
+    click(stopBtn);
+    await flush();
+
+    expect(onStop).toHaveBeenCalledWith("srv-1");
+    expect(toastError).toHaveBeenCalledTimes(1);
+    const [title] = toastError.mock.calls[0] as [string, unknown];
+    expect(title).toContain("My HTTP");
+  });
+});

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useState } from "react";
 import { Play, Square, Pencil, Copy, Trash2, ExternalLink, Clipboard } from "lucide-react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manager";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "@/components/ui";
 import {
   EmbeddedServerConfig,
   ServerState,
@@ -13,11 +15,18 @@ import {
 interface Props {
   config: EmbeddedServerConfig;
   state: ServerState | undefined;
-  onStart: (id: string) => void;
-  onStop: (id: string) => void;
+  onStart: (id: string) => void | Promise<void>;
+  onStop: (id: string) => void | Promise<void>;
   onEdit: (id: string) => void;
   onDuplicate: (id: string) => void;
   onDelete: (id: string) => void;
+}
+
+/** Extract a human-readable message from an unknown rejection value. */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return String(err);
 }
 
 function formatBytes(n: number): string {
@@ -64,6 +73,31 @@ export function EmbeddedServerItem({
   const status = state?.status;
   const active = isActive(status);
   const url = serverUrl(config);
+  const [busy, setBusy] = useState(false);
+
+  const handleStart = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onStart(config.id);
+    } catch (err) {
+      toast.error(`Failed to start ${config.name}`, { description: errorMessage(err) });
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, onStart, config.id, config.name]);
+
+  const handleStop = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onStop(config.id);
+    } catch (err) {
+      toast.error(`Failed to stop ${config.name}`, { description: errorMessage(err) });
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, onStop, config.id, config.name]);
 
   const handleCopyUrl = () => {
     writeClipboard(url).catch(() => {});
@@ -103,9 +137,10 @@ export function EmbeddedServerItem({
                   className="server-item__action"
                   title="Stop"
                   data-testid={`server-stop-${config.id}`}
+                  disabled={busy}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onStop(config.id);
+                    void handleStop();
                   }}
                 >
                   <Square size={12} />
@@ -115,9 +150,10 @@ export function EmbeddedServerItem({
                   className="server-item__action"
                   title="Start"
                   data-testid={`server-start-${config.id}`}
+                  disabled={busy}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onStart(config.id);
+                    void handleStart();
                   }}
                 >
                   <Play size={12} />
@@ -175,7 +211,7 @@ export function EmbeddedServerItem({
           {active ? (
             <ContextMenu.Item
               className="context-menu__item"
-              onSelect={() => onStop(config.id)}
+              onSelect={() => void handleStop()}
               data-testid={`ctx-stop-${config.id}`}
             >
               <Square size={14} /> Stop
@@ -183,7 +219,7 @@ export function EmbeddedServerItem({
           ) : (
             <ContextMenu.Item
               className="context-menu__item"
-              onSelect={() => onStart(config.id)}
+              onSelect={() => void handleStart()}
               data-testid={`ctx-start-${config.id}`}
             >
               <Play size={14} /> Start

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.css
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.css
@@ -141,6 +141,17 @@
   color: var(--text-primary);
 }
 
+/* In-flight start/stop: mirror the shared button's disabled convention. */
+.server-item__action:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.server-item__action:disabled:hover {
+  background: none;
+  color: var(--text-secondary);
+}
+
 .server-item__action--danger:hover {
   color: var(--color-error);
 }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3715,7 +3715,7 @@ export const useAppStore = create<AppState>((set, get) => {
       try {
         await apiStartEmbeddedServer(serverId);
       } catch (err) {
-        console.error("Failed to start embedded server:", err);
+        frontendLog("embedded_server", `Failed to start embedded server ${serverId}: ${err}`);
         throw err;
       }
     },
@@ -3724,7 +3724,7 @@ export const useAppStore = create<AppState>((set, get) => {
       try {
         await apiStopEmbeddedServer(serverId);
       } catch (err) {
-        console.error("Failed to stop embedded server:", err);
+        frontendLog("embedded_server", `Failed to stop embedded server ${serverId}: ${err}`);
         throw err;
       }
     },


### PR DESCRIPTION
## Summary

Addresses **GAP G4** from the embedded-servers state-machine audit (`docs/audits/embedded-servers-state-machine.md`, umbrella issue #1145).

Previously, starting or stopping an embedded HTTP/FTP/TFTP server that failed (e.g. a port-in-use rejection — the backend already returns a clear "Port N already in use" message) became an **unhandled promise rejection with zero user feedback**: the store re-threw, but `EmbeddedServerItem` called `onStart`/`onStop` with no `.catch` and the sidebar passed the raw action. Clicking Play/Stop on a busy port just did nothing, violating the design system's "every action gives feedback" rule.

## What changed

- **`EmbeddedServerItem.tsx`** — start/stop are now wrapped in local `handleStart`/`handleStop` handlers that:
  - surface a persistent `toast.error("Failed to start <name>", { description: <backend message> })` on rejection (shared `toast` from `src/components/ui`, i.e. sonner), and
  - disable the action button while the action is in flight via a local `busy` state (prevents double-fire).
  - Both the toolbar buttons **and** the context-menu Start/Stop items are covered.
  - `onStart`/`onStop` prop types widened to `(id: string) => void | Promise<void>` so rejections can be caught.
- **`EmbeddedServerSidebar.css`** — added a tokenized `:disabled` affordance for `.server-item__action` mirroring the shared button's disabled convention (`opacity: 0.5; cursor: progress;`). No new button chrome, no magic colors.
- **`appStore.ts`** — the store's `startEmbeddedServer`/`stopEmbeddedServer` now log failures via `frontendLog` (LogViewer) instead of `console.error`, while still re-throwing so the UI can react.

The custom dense 12px icon buttons are intentionally kept (the shared `Button` primitive is a large labeled control, wrong for this hover-reveal action row) — reusing the existing `.server-item__action`, not adding a new one-off. Validated with the `ui-design` agent.

## Test plan

TDD — test committed before implementation:

- New `EmbeddedServerItem.test.tsx` (3 cases): failed start surfaces `toast.error` with the server name + backend message in the description; the start button is `disabled` while the action is pending and re-enabled after; failed stop surfaces `toast.error`. Confirmed red before the fix, green after.
- `pnpm build` (tsc typecheck + Vite): passes.
- Full `vitest` suite: 184 files / 2158 tests pass.
- ESLint on changed files: clean.

## Scope

Partially addresses #1145 (G4). Other audit gaps (G1–G3, G5–G9) are out of scope for this PR.

### Follow-up
- The **TunnelSidebar** (`TunnelListItem.tsx`) has the identical silent-rejection gap on its dense icon start/stop buttons. The design-system-correct end state is a shared dense `IconButton` primitive that both sidebars consume; worth a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)