### PR TITLE
fix(terminal): render per-tab connection status dot from lifecycle maps

### DIFF
--- a/docs/changes/dev1/bugfix/1124-per-tab-status-dot.md
+++ b/docs/changes/dev1/bugfix/1124-per-tab-status-dot.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Terminal tabs now show a connection status dot that actually renders and
+  reflects the live session state — connecting, connected, failed, or
+  disconnected. Previously the dot never appeared (it was wired to a dead,
+  mismatched state source). The dot updates on background (inactive) tabs too,
+  so you can see a connection drop or fail without first focusing the tab.

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -18,8 +18,17 @@ import {
   FileSearch,
 } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
+import { TabStatus } from "@/utils/tabStatus";
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { Tooltip } from "@/components/ui";
+
+/** Human-readable label for each connection status, used as the dot's tooltip. */
+const STATUS_LABELS: Record<TabStatus, string> = {
+  connecting: "Connecting",
+  connected: "Connected",
+  failed: "Connection failed",
+  disconnected: "Disconnected",
+};
 
 interface TabProps {
   tab: TerminalTab;
@@ -35,7 +44,8 @@ interface TabProps {
   tabColor?: string;
   onRename?: () => void;
   onSetColor?: () => void;
-  remoteState?: string;
+  /** Per-tab connection status; drives the status dot. `undefined` hides the dot. */
+  status?: TabStatus;
 }
 
 export function Tab({
@@ -52,7 +62,7 @@ export function Tab({
   tabColor,
   onRename,
   onSetColor,
-  remoteState,
+  status,
 }: TabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: tab.id,
@@ -96,8 +106,12 @@ export function Tab({
       ) : (
         <ConnectionIcon config={tab.config} size={14} className="tab__icon" />
       )}
-      {remoteState && (
-        <span className={`tab__state-dot tab__state-dot--${remoteState}`} title={remoteState} />
+      {status && (
+        <span
+          className={`tab__state-dot tab__state-dot--${status}`}
+          title={STATUS_LABELS[status]}
+          data-testid={`tab-state-dot-${tab.id}`}
+        />
       )}
       <span className="tab__title">
         {isDirty && <span className="tab__dirty-dot" />}

--- a/src/components/Terminal/TabBar.css
+++ b/src/components/Terminal/TabBar.css
@@ -132,6 +132,13 @@
   background-color: var(--state-disconnected);
 }
 
+/* A failed connect/reconnect uses the same alert color as a plain disconnect,
+   but pulses to draw the eye to the actionable error state. */
+.tab__state-dot--failed {
+  background-color: var(--state-disconnected);
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
 @keyframes pulse-dot {
   0%,
   100% {

--- a/src/components/Terminal/TabBar.status-dot.test.tsx
+++ b/src/components/Terminal/TabBar.status-dot.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TabBar } from "./TabBar";
+import { TooltipProvider } from "@/components/ui";
+import { useAppStore } from "@/store/appStore";
+import { TerminalTab } from "@/types/terminal";
+
+// Render the *real* Tab so we exercise the actual state-dot markup, but stub out
+// the dnd-kit sortable wrapper and the terminal registry so the component mounts
+// cleanly in jsdom.
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  horizontalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("./TerminalRegistry", () => ({
+  useTerminalRegistry: () => ({
+    clearTerminal: vi.fn(),
+    saveTerminalToFile: vi.fn().mockResolvedValue(undefined),
+    copyTerminalToClipboard: vi.fn().mockResolvedValue(undefined),
+    openTerminalInEditor: vi.fn(),
+  }),
+}));
+
+vi.mock("./ColorPickerDialog", () => ({ ColorPickerDialog: () => null }));
+vi.mock("./RenameDialog", () => ({ RenameDialog: () => null }));
+
+const PANEL_ID = "panel-1";
+
+function makeTerminalTab(id: string, isActive: boolean): TerminalTab {
+  return {
+    id,
+    sessionId: `sess-${id}`,
+    title: `Tab ${id}`,
+    // Concrete connection type — NOT "remote" (the old dead-code path).
+    connectionType: "ssh",
+    contentType: "terminal",
+    config: { type: "ssh", config: {} },
+    panelId: PANEL_ID,
+    isActive,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(tabs: TerminalTab[]) {
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <TabBar panelId={PANEL_ID} tabs={tabs} />
+      </TooltipProvider>
+    );
+  });
+}
+
+/** Return the state-dot element for a given tab id, or null. */
+function dotFor(tabId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="tab-state-dot-${tabId}"]`);
+}
+
+function resetStore() {
+  useAppStore.setState({
+    terminalConnecting: {},
+    terminalReconnectingTabs: {},
+    terminalSpawnErrors: {},
+    terminalDisconnectErrors: {},
+    terminalExitedTabs: {},
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  resetStore();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("TabBar — per-tab connection status dot", () => {
+  it("renders a 'connected' dot for a terminal tab with no lifecycle flags", () => {
+    render([makeTerminalTab("t1", true)]);
+    const dot = dotFor("t1");
+    expect(dot).not.toBeNull();
+    expect(dot?.className).toContain("tab__state-dot--connected");
+  });
+
+  it("renders a 'connecting' dot while the terminal is connecting", () => {
+    render([makeTerminalTab("t1", true)]);
+    act(() => {
+      useAppStore.setState({ terminalConnecting: { t1: true } });
+    });
+    expect(dotFor("t1")?.className).toContain("tab__state-dot--connecting");
+  });
+
+  it("renders a 'failed' dot when the terminal has a spawn error", () => {
+    render([makeTerminalTab("t1", true)]);
+    act(() => {
+      useAppStore.setState({ terminalSpawnErrors: { t1: "boom" } });
+    });
+    expect(dotFor("t1")?.className).toContain("tab__state-dot--failed");
+  });
+
+  it("renders a 'disconnected' dot when the terminal session has exited", () => {
+    render([makeTerminalTab("t1", true)]);
+    act(() => {
+      useAppStore.setState({ terminalExitedTabs: { t1: true } });
+    });
+    expect(dotFor("t1")?.className).toContain("tab__state-dot--disconnected");
+  });
+
+  it("reflects state changes on a background (inactive) tab without focusing it", () => {
+    // t1 is active/focused, t2 is a background tab.
+    render([makeTerminalTab("t1", true), makeTerminalTab("t2", false)]);
+
+    // Background tab starts connected.
+    expect(dotFor("t2")?.className).toContain("tab__state-dot--connected");
+
+    // Its session drops while it stays in the background.
+    act(() => {
+      useAppStore.setState({ terminalExitedTabs: { t2: true } });
+    });
+
+    expect(dotFor("t2")?.className).toContain("tab__state-dot--disconnected");
+    // The focused tab is unaffected.
+    expect(dotFor("t1")?.className).toContain("tab__state-dot--connected");
+  });
+});

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
 import { useAppStore } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
+import { deriveTabStatus } from "@/utils/tabStatus";
 import { useTerminalRegistry } from "./TerminalRegistry";
 import { Tab } from "./Tab";
 import { ColorPickerDialog } from "./ColorPickerDialog";
@@ -24,7 +25,12 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   const renameTab = useAppStore((s) => s.renameTab);
   const editorDirtyTabs = useAppStore((s) => s.editorDirtyTabs);
   const setPendingCloseRequest = useAppStore((s) => s.setPendingCloseRequest);
-  const remoteStates = useAppStore((s) => s.remoteStates);
+  // Tab-id-keyed lifecycle maps that drive the per-tab connection status dot.
+  const terminalConnecting = useAppStore((s) => s.terminalConnecting);
+  const terminalReconnectingTabs = useAppStore((s) => s.terminalReconnectingTabs);
+  const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
+  const terminalDisconnectErrors = useAppStore((s) => s.terminalDisconnectErrors);
+  const terminalExitedTabs = useAppStore((s) => s.terminalExitedTabs);
   const { clearTerminal, saveTerminalToFile, copyTerminalToClipboard, openTerminalInEditor } =
     useTerminalRegistry();
 
@@ -75,7 +81,20 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               tabColor={tabColors[tab.id]}
               onRename={() => setRenameTabId(tab.id)}
               onSetColor={() => setColorPickerTabId(tab.id)}
-              remoteState={tab.connectionType === "remote" ? remoteStates[tab.id] : undefined}
+              status={
+                tab.contentType === "terminal"
+                  ? deriveTabStatus(
+                      {
+                        terminalConnecting,
+                        terminalReconnectingTabs,
+                        terminalSpawnErrors,
+                        terminalDisconnectErrors,
+                        terminalExitedTabs,
+                      },
+                      tab.id
+                    )
+                  : undefined
+              }
             />
           ))}
         </div>

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -26,7 +26,9 @@ export function TerminalView() {
     terminalDispatcher.init();
   }, []);
 
-  // Update global remote-connection state in the store (drives tab state dots).
+  // Handle backend-reported remote-connection state changes: a "disconnected"
+  // state marks the owning tab exited (which drives the per-tab status dot via
+  // the tab-id-keyed lifecycle maps — see deriveTabStatus).
   useEffect(() => {
     let unlisten: (() => void) | null = null;
     listen<{ session_id: string; state: string }>("remote-state-change", (event) => {

--- a/src/utils/tabStatus.test.ts
+++ b/src/utils/tabStatus.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { deriveTabStatus, type TabStatusMaps } from "./tabStatus";
+
+/** Build a maps object with all lifecycle records empty, then override selectively. */
+function makeMaps(overrides: Partial<TabStatusMaps> = {}): TabStatusMaps {
+  return {
+    terminalConnecting: {},
+    terminalReconnectingTabs: {},
+    terminalSpawnErrors: {},
+    terminalDisconnectErrors: {},
+    terminalExitedTabs: {},
+    ...overrides,
+  };
+}
+
+describe("deriveTabStatus", () => {
+  it("returns 'connecting' while a terminal is spawning", () => {
+    const maps = makeMaps({ terminalConnecting: { a: true } });
+    expect(deriveTabStatus(maps, "a")).toBe("connecting");
+  });
+
+  it("returns 'connecting' while a terminal is reconnecting", () => {
+    const maps = makeMaps({ terminalReconnectingTabs: { a: true } });
+    expect(deriveTabStatus(maps, "a")).toBe("connecting");
+  });
+
+  it("returns 'failed' when the terminal has a spawn error", () => {
+    const maps = makeMaps({ terminalSpawnErrors: { a: "boom" } });
+    expect(deriveTabStatus(maps, "a")).toBe("failed");
+  });
+
+  it("returns 'failed' when the terminal has a disconnect error", () => {
+    const maps = makeMaps({ terminalDisconnectErrors: { a: "dropped" } });
+    expect(deriveTabStatus(maps, "a")).toBe("failed");
+  });
+
+  it("returns 'disconnected' when the terminal session has exited without an error", () => {
+    const maps = makeMaps({ terminalExitedTabs: { a: true } });
+    expect(deriveTabStatus(maps, "a")).toBe("disconnected");
+  });
+
+  it("returns 'connected' when no lifecycle flags are set", () => {
+    const maps = makeMaps();
+    expect(deriveTabStatus(maps, "a")).toBe("connected");
+  });
+
+  it("prioritises 'connecting' over other flags (retry/reconnect in-flight)", () => {
+    const maps = makeMaps({
+      terminalConnecting: { a: true },
+      terminalExitedTabs: { a: true },
+      terminalSpawnErrors: { a: "boom" },
+    });
+    expect(deriveTabStatus(maps, "a")).toBe("connecting");
+  });
+
+  it("prioritises 'failed' over a bare 'disconnected' flag", () => {
+    const maps = makeMaps({
+      terminalExitedTabs: { a: true },
+      terminalDisconnectErrors: { a: "dropped" },
+    });
+    expect(deriveTabStatus(maps, "a")).toBe("failed");
+  });
+
+  it("keys strictly by tab id — an unrelated tab's flags do not leak", () => {
+    const maps = makeMaps({ terminalConnecting: { other: true } });
+    expect(deriveTabStatus(maps, "a")).toBe("connected");
+  });
+});

--- a/src/utils/tabStatus.ts
+++ b/src/utils/tabStatus.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-tab connection status derived from the real terminal-lifecycle maps.
+ *
+ * All of these maps are keyed by `tab.id` (unlike the legacy `remoteStates`
+ * map, which is keyed by `session_id` and fed by a never-firing event), so the
+ * derived status stays correct for every tab — including background/inactive
+ * ones — without needing the tab to be focused.
+ */
+export type TabStatus = "connecting" | "connected" | "failed" | "disconnected";
+
+/**
+ * The subset of the app store's tab-lifecycle maps needed to derive a tab's
+ * connection status. Each is a `Record<tabId, …>`; presence of a key is what
+ * matters (error maps also carry a message, but the status only needs the key).
+ */
+export interface TabStatusMaps {
+  /** True while a createTerminal call is in-flight. */
+  terminalConnecting: Record<string, boolean>;
+  /** True while the agent is actively trying to reconnect. */
+  terminalReconnectingTabs: Record<string, boolean>;
+  /** Spawn error message for a tab whose terminal failed to start. */
+  terminalSpawnErrors: Record<string, string>;
+  /** Error message from a failed reconnect (agent auto-reconnect exhausted). */
+  terminalDisconnectErrors: Record<string, string>;
+  /** True when a tab's terminal session has exited. */
+  terminalExitedTabs: Record<string, boolean>;
+}
+
+/**
+ * Derive the connection-status dot for a single tab from the tab-id-keyed
+ * lifecycle maps.
+ *
+ * Priority order (most transient / most severe first):
+ *  1. `connecting`   — a connect or reconnect attempt is in flight.
+ *  2. `failed`       — a spawn or reconnect attempt errored out.
+ *  3. `disconnected` — the session exited without a recorded error.
+ *  4. `connected`    — no lifecycle flags set (the live, healthy state).
+ *
+ * @param maps  The tab-lifecycle maps (typically a slice of the app store).
+ * @param tabId The tab whose status to derive.
+ */
+export function deriveTabStatus(maps: TabStatusMaps, tabId: string): TabStatus {
+  if (maps.terminalConnecting[tabId] || maps.terminalReconnectingTabs[tabId]) {
+    return "connecting";
+  }
+  if (maps.terminalSpawnErrors[tabId] || maps.terminalDisconnectErrors[tabId]) {
+    return "failed";
+  }
+  if (maps.terminalExitedTabs[tabId]) {
+    return "disconnected";
+  }
+  return "connected";
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -596,6 +596,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `tab-*` | `tab-${tab.id}` | `src/components/Terminal/Tab.tsx` |
 | `tab-close-*` | `tab-close-${tab.id}` | `src/components/Terminal/Tab.tsx` |
 | `tab-group-chip-*` | `tab-group-chip-${group.id}` | `src/components/Terminal/TabGroupChips.tsx` |
+| `tab-state-dot-*` | `tab-state-dot-${tab.id}` | `src/components/Terminal/Tab.tsx` |
 | `terminal-context-trigger-*` | `terminal-context-trigger-${tab.id}` | `src/components/SplitView/SplitView.tsx` |
 | `tunnel-delete-*` | `tunnel-delete-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-duplicate-*` | `tunnel-duplicate-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |


### PR DESCRIPTION
Closes #1124

## Summary

The per-tab connection status dot never rendered. It was gated on `connectionType === "remote"` (but terminal tabs use `"remote-session"` or a concrete type, never `"remote"`) and looked up `remoteStates[tab.id]` — a map keyed by `session_id`, not `tab.id`, and fed only by the `remote-state-change` writer that never fires. That's a double key mismatch plus a dead event source, so the dot was permanently absent.

This fix derives the dot from the real tab-id-keyed lifecycle maps that the rest of the terminal UI already uses:

- `terminalConnecting` / `terminalReconnectingTabs` → **connecting** (pulsing amber)
- `terminalSpawnErrors` / `terminalDisconnectErrors` → **failed** (pulsing red)
- `terminalExitedTabs` → **disconnected** (red)
- otherwise → **connected** (green)

The derivation lives in a small, unit-tested selector `deriveTabStatus` (`src/utils/tabStatus.ts`) rather than inline logic. `TabBar` subscribes to the five maps and passes a `status` prop to `Tab`, which renders the dot unconditionally for terminal tabs (with a `tab-state-dot-<id>` testid and a human-readable tooltip). Because the maps are global store state keyed by `tab.id`, background/inactive tabs update without needing focus.

The dead `remoteStates` store field was left in place (out of scope to remove); only the stale "drives tab state dots" comment on the `remote-state-change` listener was corrected.

## Test plan

- `pnpm test` on the affected suites — all green:
  - `src/utils/tabStatus.test.ts` — unit tests for `deriveTabStatus` (each status + priority ordering + strict tab-id keying)
  - `src/components/Terminal/TabBar.status-dot.test.tsx` — renders the real `Tab`, asserts the dot class for connecting/connected/failed/disconnected, including a **background (inactive) tab** reflecting a session drop without being focused
  - `src/components/Terminal/TabBar.close-editor.test.tsx` — unchanged, still passes
- `pnpm run lint` — clean
- `pnpm build` — typecheck + Vite build clean
- `src/styles/tokenDiscipline.test.ts` — the new `--failed` dot CSS uses only design tokens

### Manual verification (recommended)

1. Open an SSH/serial/telnet connection → dot pulses amber (connecting), then turns green (connected).
2. Open a connection that fails to spawn → dot pulses red (failed).
3. Kill a connection while its tab is in the **background** → the background tab's dot turns red (disconnected) without focusing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)