### PR TITLE
fix(network): clamp HTTP monitor poll interval (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-http-monitor-interval-floor.md
+++ b/docs/changes/dev2/feature/1147-http-monitor-interval-floor.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- HTTP monitor (Network Tools): the poll interval is now clamped to a safe
+  minimum (1 s) in the backend. Previously an empty or invalid interval field
+  could send `0` to the backend, which forwarded it verbatim and turned the
+  monitor into a tight busy-loop of HTTP requests. The interval floor is now
+  enforced server-side regardless of what the UI sends (#1147).

--- a/src-tauri/src/network/http_monitor.rs
+++ b/src-tauri/src/network/http_monitor.rs
@@ -236,8 +236,13 @@ mod tests {
 
     #[test]
     fn interval_above_floor_is_preserved() {
-        let cfg =
-            HttpMonitorConfig::new("https://example.com".into(), 5_000, "GET".into(), 200, 5_000);
+        let cfg = HttpMonitorConfig::new(
+            "https://example.com".into(),
+            5_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
         assert_eq!(cfg.interval_ms, 5_000);
     }
 }

--- a/src-tauri/src/network/http_monitor.rs
+++ b/src-tauri/src/network/http_monitor.rs
@@ -193,4 +193,39 @@ mod tests {
         assert_eq!(cfg.expected_status, 200);
         assert_eq!(cfg.interval_ms, 30_000);
     }
+
+    #[test]
+    fn zero_interval_clamps_to_floor() {
+        // A `0` interval from the UI (e.g. `Number("")` → NaN → 0 in JS) must not
+        // be honored verbatim, or the poll loop busy-loops requests.
+        let cfg = HttpMonitorConfig::new("https://example.com".into(), 0, "GET".into(), 200, 5_000);
+        assert_eq!(cfg.interval_ms, MIN_INTERVAL_MS);
+    }
+
+    #[test]
+    fn tiny_interval_clamps_to_floor() {
+        // Any value below the floor is raised to the floor.
+        let cfg =
+            HttpMonitorConfig::new("https://example.com".into(), 50, "GET".into(), 200, 5_000);
+        assert_eq!(cfg.interval_ms, MIN_INTERVAL_MS);
+    }
+
+    #[test]
+    fn interval_at_floor_is_preserved() {
+        let cfg = HttpMonitorConfig::new(
+            "https://example.com".into(),
+            MIN_INTERVAL_MS,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        assert_eq!(cfg.interval_ms, MIN_INTERVAL_MS);
+    }
+
+    #[test]
+    fn interval_above_floor_is_preserved() {
+        let cfg =
+            HttpMonitorConfig::new("https://example.com".into(), 5_000, "GET".into(), 200, 5_000);
+        assert_eq!(cfg.interval_ms, 5_000);
+    }
 }

--- a/src-tauri/src/network/http_monitor.rs
+++ b/src-tauri/src/network/http_monitor.rs
@@ -11,6 +11,15 @@ use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use uuid::Uuid;
 
+/// Minimum poll interval, in milliseconds.
+///
+/// The frontend's `min={5}` on the interval field is only a soft HTML hint —
+/// an empty field yields `Number("")` → `NaN` → `0`, which would otherwise be
+/// forwarded verbatim and turn the poll loop into a tight busy-loop of
+/// requests. Clamping to this floor server-side guarantees a sane cadence
+/// regardless of what the UI (or any future caller) sends.
+pub const MIN_INTERVAL_MS: u64 = 1_000;
+
 /// Configuration for a single HTTP monitor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -53,6 +62,9 @@ pub struct HttpMonitorHandle {
 
 impl HttpMonitorConfig {
     /// Create a new config with a generated ID.
+    ///
+    /// `interval_ms` is clamped to at least [`MIN_INTERVAL_MS`] so a `0` or
+    /// tiny value can never turn the poll loop into a request busy-loop.
     pub fn new(
         url: String,
         interval_ms: u64,
@@ -63,7 +75,7 @@ impl HttpMonitorConfig {
         Self {
             id: Uuid::new_v4().to_string(),
             url,
-            interval_ms,
+            interval_ms: interval_ms.max(MIN_INTERVAL_MS),
             method,
             expected_status,
             timeout_ms,


### PR DESCRIPTION
## Summary

The HTTP monitor's `network_http_monitor_start` command forwarded any `interval_ms` straight into the poll loop, including `0`/NaN values the UI can send when the interval field is empty (`Number("")` → NaN → 0 in JS). That turned the poll loop into a tight busy-loop of HTTP requests. The UI's `min={5}` is only a soft HTML hint.

This clamps `interval_ms` to a `>= 1000 ms` floor server-side, in `HttpMonitorConfig::new` — the single constructor used by the command — so no caller can trigger a request busy-loop regardless of what the UI sends.

## Changes

- Add `MIN_INTERVAL_MS` (1000 ms) constant in `src-tauri/src/network/http_monitor.rs`.
- Clamp `interval_ms` with `.max(MIN_INTERVAL_MS)` inside `HttpMonitorConfig::new`.
- Add regression unit tests covering `0`, sub-floor, at-floor, and above-floor intervals.
- Change fragment `docs/changes/dev2/feature/1147-http-monitor-interval-floor.md`.

## Test plan

- `cargo test -p termihub --lib http_monitor` — 5 passed, 0 failed.
- `cargo clippy -p termihub --all-targets --all-features -- -D warnings` — clean (exit 0).

Partially addresses #1147 (#8, interval floor). The fixed-rate `tokio::time::interval` rewrite and exponential backoff (the rest of #8) remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)