### PR TITLE
feat(backend): harden download_to_file — stream to disk with incremental progress + client timeout

### DIFF
--- a/docs/changes/dev1/feature/1103-harden-download-to-file.md
+++ b/docs/changes/dev1/feature/1103-harden-download-to-file.md
@@ -1,0 +1,14 @@
+### Changed
+
+- Downloads that termiHub performs in the background (remote agent binaries and,
+  on Windows, the bundled X server) now stream to disk with real, incremental
+  progress instead of jumping from 0% to 100% only once the whole file has been
+  fetched — progress reflects bytes actually received. The full artifact is no
+  longer held in memory while downloading (#1103).
+
+### Fixed
+
+- A download from a server that connects but then stalls (sends no further
+  bytes) now fails after a bounded timeout instead of hanging indefinitely. The
+  destination file is never left holding a partial download: the body is written
+  to a temporary file and atomically moved into place only once complete (#1103).

--- a/src-tauri/src/utils/download.rs
+++ b/src-tauri/src/utils/download.rs
@@ -150,6 +150,76 @@ mod tests {
         );
     }
 
+    /// Spawn a responder that streams `body` in several small TCP writes with a
+    /// short pause between them, so the client's read loop observes the body
+    /// arriving in multiple chunks rather than as one buffer.
+    fn serve_chunked(body: Vec<u8>) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            drain_request(&mut stream);
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: {}\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(header.as_bytes()).unwrap();
+            stream.flush().unwrap();
+            // Emit the body in fixed-size slices with a small delay so the
+            // download loop wakes up repeatedly and reports incremental progress.
+            for slice in body.chunks(16 * 1024) {
+                stream.write_all(slice).unwrap();
+                stream.flush().unwrap();
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+        });
+        (format!("http://{addr}/file"), handle)
+    }
+
+    #[test]
+    fn streams_to_disk_with_incremental_monotonic_progress() {
+        // A payload larger than the read buffer, delivered over multiple TCP
+        // writes, must surface several progress reports (not one 0->100% jump).
+        let body: Vec<u8> = (0..256 * 1024).map(|i| (i % 251) as u8).collect();
+        let total = body.len() as u64;
+        let (url, server) = serve_chunked(body.clone());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("big.bin");
+        let progress: RefCell<Vec<(u64, u64)>> = RefCell::new(Vec::new());
+
+        download_to_file(&url, &dest, |received, t| {
+            progress.borrow_mut().push((received, t))
+        })
+        .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(fs::read(&dest).unwrap(), body, "streamed bytes must match");
+
+        let seen = progress.borrow();
+        assert!(
+            seen.len() >= 2,
+            "expected multiple incremental progress reports, got {}: {seen:?}",
+            seen.len()
+        );
+        // `received` must be strictly increasing and `total` constant.
+        for pair in seen.windows(2) {
+            assert!(
+                pair[1].0 > pair[0].0,
+                "received must increase monotonically, got {seen:?}"
+            );
+        }
+        assert!(
+            seen.iter().all(|(_, t)| *t == total),
+            "total must be the Content-Length for every report, got {seen:?}"
+        );
+        assert_eq!(
+            seen.last().map(|(r, _)| *r),
+            Some(total),
+            "final report must cover the whole body"
+        );
+    }
+
     #[test]
     fn errors_on_non_success_status_and_writes_nothing() {
         const BODY: &[u8] = b"not found body";

--- a/src-tauri/src/utils/download.rs
+++ b/src-tauri/src/utils/download.rs
@@ -6,26 +6,74 @@
 //! ([`crate::terminal::xserver::acquire`]) both need (consolidated per #1077).
 
 use std::fs;
+use std::io::{Read, Write};
 use std::path::Path;
+use std::sync::OnceLock;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use tracing::info;
 
-/// Download `url` and write the full response body to `dest`, creating parent
+/// Bound the initial connect so an unreachable host fails fast instead of
+/// blocking the `spawn_blocking` worker on the OS connect timeout.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Bound each streaming read so a server that accepts the connection but then
+/// stalls (sends no further bytes) fails rather than hanging the worker forever.
+///
+/// For `reqwest`'s *blocking* client, the request `timeout` is applied to each
+/// individual `Read::read` on the response body — it resets whenever a read
+/// makes progress — so this caps stalls without capping a large-but-steady
+/// download by wall-clock time.
+const READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Size of the streaming read buffer; the body is copied to disk in chunks of
+/// this size, with a progress report emitted per chunk.
+const CHUNK_SIZE: usize = 64 * 1024;
+
+/// Shared blocking HTTP client with bounded connect/read timeouts.
+///
+/// Built once and reused across downloads (the client owns a connection pool),
+/// so timeouts are configured centrally rather than per call. For the blocking
+/// client, `timeout` bounds each individual body read (see [`READ_TIMEOUT`]),
+/// so a large-but-steady download is not capped by it while a stalled server
+/// is.
+fn client() -> &'static reqwest::blocking::Client {
+    static CLIENT: OnceLock<reqwest::blocking::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::blocking::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(READ_TIMEOUT)
+            .build()
+            // A misconfigured builder is a programming error, not a runtime
+            // condition; fall back to a default client rather than panicking.
+            .unwrap_or_default()
+    })
+}
+
+/// Download `url`, streaming the response body to `dest` and creating parent
 /// directories as needed.
 ///
-/// `on_progress` is invoked once, after the body has been read, with
-/// `(bytes_downloaded, total_bytes)`. `total_bytes` is 0 when the server does not
-/// send a `Content-Length` header.
+/// The body is read in chunks straight to disk (never fully buffered in
+/// memory). `on_progress` is invoked repeatedly as bytes arrive with
+/// `(bytes_downloaded_so_far, total_bytes)`, where `bytes_downloaded_so_far`
+/// increases monotonically and a final call reports the complete size.
+/// `total_bytes` is 0 when the server does not send a `Content-Length` header.
 ///
-/// Uses `reqwest::blocking`, so it must be called off the async reactor (e.g.
-/// inside `spawn_blocking`). A non-success status is an error and nothing is
-/// written to `dest`.
+/// The download is written to a sibling temporary file and atomically renamed
+/// onto `dest` only after it completes, so `dest` is never left holding a
+/// partial body: on any failure (connect, timeout, non-success status, I/O
+/// error) `dest` is untouched.
+///
+/// Uses a shared `reqwest::blocking` client with bounded connect/read timeouts,
+/// so it must be called off the async reactor (e.g. inside `spawn_blocking`)
+/// and a non-responding server fails rather than hangs. A non-success status is
+/// an error.
 pub fn download_to_file<F>(url: &str, dest: &Path, on_progress: F) -> Result<()>
 where
     F: Fn(u64, u64),
 {
-    let response = reqwest::blocking::Client::new()
+    let mut response = client()
         .get(url)
         .send()
         .with_context(|| format!("Failed to start download from {url}"))?;
@@ -35,23 +83,42 @@ where
     }
 
     let total = response.content_length().unwrap_or(0);
-    let bytes = response
-        .bytes()
-        .with_context(|| format!("Failed to read response body from {url}"))?;
-    on_progress(bytes.len() as u64, total);
 
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create {}", parent.display()))?;
     }
-    fs::write(dest, &bytes)
-        .with_context(|| format!("Failed to write download to {}", dest.display()))?;
 
-    info!(
-        "Downloaded {url} to {} ({} bytes)",
-        dest.display(),
-        bytes.len()
-    );
+    // Stream into a sibling temp file, then atomically rename onto `dest`. This
+    // keeps the whole artifact off the heap and guarantees `dest` never holds a
+    // partial download if the stream fails partway through.
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".download-")
+        .tempfile_in(dest.parent().unwrap_or_else(|| Path::new(".")))
+        .with_context(|| format!("Failed to create temp file for {}", dest.display()))?;
+
+    let mut received: u64 = 0;
+    let mut buf = vec![0u8; CHUNK_SIZE];
+    loop {
+        let n = response
+            .read(&mut buf)
+            .with_context(|| format!("Failed to read response body from {url}"))?;
+        if n == 0 {
+            break;
+        }
+        tmp.write_all(&buf[..n])
+            .with_context(|| format!("Failed to write download to {}", dest.display()))?;
+        received += n as u64;
+        on_progress(received, total);
+    }
+
+    tmp.as_file()
+        .sync_all()
+        .with_context(|| format!("Failed to flush download to {}", dest.display()))?;
+    tmp.persist(dest)
+        .with_context(|| format!("Failed to move download into place at {}", dest.display()))?;
+
+    info!("Downloaded {url} to {} ({received} bytes)", dest.display());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Hardens the centralized `download_to_file` helper (`src-tauri/src/utils/download.rs`, extracted in #1077) that agent-binary resolution and Windows VcXsrv acquisition both use. Fixes all three findings from #1103:

1. **Incremental progress** — the body is now streamed to disk in 64 KiB chunks via a blocking `Read` loop over the `reqwest::blocking::Response`, invoking the progress callback per chunk with cumulative `received` and the `Content-Length` `total`. Previously the whole body was buffered and the callback fired once (0→100% jump).
2. **No longer held in RAM** — the artifact streams straight to a file; it is never fully buffered on the heap.
3. **Bounded client timeouts** — a shared, lazily-built `reqwest::blocking::Client` (`OnceLock`, reused across calls) sets a 30 s connect timeout and a 60 s read timeout. For reqwest's blocking client the request `timeout` is applied to each individual body read (it resets whenever a read makes progress), so a stalled server fails within the bound while a large-but-steady download is not capped by wall-clock time.

Atomic/partial-file semantics are preserved and strengthened: the body streams to a sibling temp file (`tempfile::Builder`) and is `sync_all`'d then atomically `persist`ed onto the destination only on success. On any failure (non-success status, connect/read timeout, I/O error) the destination is left untouched — the existing "writes nothing on failure" guarantee still holds, and there is now no partial-file window.

Call sites (`download_agent_binary_from_url` / `resolve_branch_build_binary`, `download_zip` for VcXsrv) are unchanged — the signature and progress-callback shapes (`Fn(u64, u64)` / `AcquireProgress::Downloading { received, total }`) are identical.

## Test plan

- New unit test `streams_to_disk_with_incremental_monotonic_progress` spins up a loopback HTTP server that emits a 256 KiB body in multiple delayed TCP writes and asserts: multiple progress reports, strictly increasing `received`, constant `total` == Content-Length, and a final report covering the whole body. Verified red before the fix (`got 1: [(262144, 262144)]`), green after.
- Existing tests still pass: `writes_body_creates_parent_and_reports_progress`, `reports_zero_total_when_content_length_absent`, `errors_on_non_success_status_and_writes_nothing` (confirms nothing is written to `dest` on a 404).
- `cargo test -p termihub --lib utils::download` → 4 passed.
- `cargo clippy -p termihub --all-targets --all-features -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.

Closes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
