### PR TITLE
fix(workspace): feedback on workspace save failure (#1146)

### DIFF
--- a/docs/changes/dev2/feature/1146-workspace-save-feedback.md
+++ b/docs/changes/dev2/feature/1146-workspace-save-feedback.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Workspace: saving the current layout as a workspace now reports failures instead
+  of silently pretending to succeed. Previously the Save Current dialog closed the
+  moment you clicked Save, even if the underlying save failed (disk full, permission
+  denied, or a poisoned lock), leaving you believing the workspace was stored — silent
+  data loss. The dialog now stays open with an error toast when the save fails, and
+  only closes with a success toast once the workspace is actually written (#1146).

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
@@ -17,6 +17,23 @@ vi.mock("@/themes", () => ({
   onThemeChange: vi.fn(),
 }));
 
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+// Keep the real UI primitives (Modal/Button/Input) so the SaveWorkspaceDialog
+// still renders, but spy on the toast helper to assert save feedback.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return {
+    ...actual,
+    toast: {
+      ...actual.toast,
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+    },
+  };
+});
+
 import { useAppStore } from "@/store/appStore";
 
 let container: HTMLDivElement;
@@ -24,6 +41,25 @@ let root: Root;
 
 function query(testId: string): HTMLElement | null {
   return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+/** Flush a microtask queue turn so awaited promises settle inside act(). */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Open the Save dialog, enter a name, and click the confirm button. */
+function openDialogAndConfirm(name: string) {
+  act(() => query("workspace-save-current-btn")!.click());
+  const nameInput = query("save-workspace-name") as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(nameInput, name);
+    nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  act(() => (query("save-workspace-confirm") as HTMLButtonElement).click());
 }
 
 const sampleWorkspaces: WorkspaceSummary[] = [
@@ -99,5 +135,40 @@ describe("WorkspaceSidebar", () => {
     expect(query("workspace-edit-ws-1")).not.toBeNull();
     expect(query("workspace-duplicate-ws-1")).not.toBeNull();
     expect(query("workspace-delete-ws-1")).not.toBeNull();
+  });
+
+  it("keeps the save dialog open and surfaces an error when the save rejects", async () => {
+    const saveCurrentAsWorkspace = vi.fn().mockRejectedValue(new Error("disk full"));
+    useAppStore.setState({ workspaces: [], saveCurrentAsWorkspace });
+
+    act(() => {
+      root.render(<WorkspaceSidebar />);
+    });
+
+    openDialogAndConfirm("My Layout");
+    await flush();
+
+    expect(saveCurrentAsWorkspace).toHaveBeenCalledWith("My Layout", "all", undefined);
+    // Dialog must stay open so the user does not falsely believe the save succeeded.
+    expect(query("save-workspace-dialog")).not.toBeNull();
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("closes the save dialog and surfaces success when the save resolves", async () => {
+    const saveCurrentAsWorkspace = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ workspaces: [], saveCurrentAsWorkspace });
+
+    act(() => {
+      root.render(<WorkspaceSidebar />);
+    });
+
+    openDialogAndConfirm("My Layout");
+    await flush();
+
+    expect(saveCurrentAsWorkspace).toHaveBeenCalledWith("My Layout", "all", undefined);
+    expect(query("save-workspace-dialog")).toBeNull();
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
   });
 });

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -3,6 +3,8 @@ import { Plus, Save, Download, Upload } from "lucide-react";
 import { save, open } from "@tauri-apps/plugin-dialog";
 import { writeTextFile, readTextFile } from "@tauri-apps/plugin-fs";
 import { useAppStore } from "@/store/appStore";
+import { toast } from "@/components/ui";
+import { frontendLog } from "@/utils/frontendLog";
 import { exportWorkspaces, importWorkspaces } from "@/services/workspaceApi";
 import { WorkspaceListItem } from "./WorkspaceListItem";
 import { SaveWorkspaceDialog, SaveWorkspaceScope } from "./SaveWorkspaceDialog";
@@ -53,9 +55,19 @@ export function WorkspaceSidebar() {
   );
 
   const handleSaveCurrent = useCallback(
-    (name: string, scope: SaveWorkspaceScope, description?: string) => {
-      saveCurrentAsWorkspace(name, scope, description);
-      setShowSaveDialog(false);
+    async (name: string, scope: SaveWorkspaceScope, description?: string) => {
+      try {
+        await saveCurrentAsWorkspace(name, scope, description);
+        setShowSaveDialog(false);
+        toast.success(`Saved workspace ${name}`);
+      } catch (err) {
+        // Keep the dialog open so the user does not falsely believe the save
+        // succeeded (disk full / permission / lock poisoned would otherwise
+        // vanish silently — GAP G2).
+        const message = err instanceof Error ? err.message : String(err);
+        frontendLog("workspace", `Failed to save workspace "${name}": ${message}`);
+        toast.error(`Failed to save workspace: ${message}`);
+      }
     },
     [saveCurrentAsWorkspace]
   );


### PR DESCRIPTION
## Summary

Fixes GAP **G2** (silent save failure with false success — data loss) from the workspace save/restore state-machine audit (`docs/audits/workspace-save-restore-state-machine.md`).

Previously `handleSaveCurrent` in `WorkspaceSidebar.tsx` fired `saveCurrentAsWorkspace(...)` **without awaiting** and synchronously closed the Save dialog. A rejected save (disk full, permission denied, poisoned lock — all surface `WorkspaceError` from the backend) closed the dialog anyway, leaving the user believing the workspace was saved when it wasn't — silent data loss.

## Changes

- `handleSaveCurrent` is now `async` and `await`s the save inside `try/catch`.
- On failure: the dialog stays open, a `toast.error(...)` is shown, and the error is logged via `frontendLog`.
- On success: the dialog closes and `toast.success(...)` fires — mirroring the existing connection-save feedback pattern in `appStore.ts`.

## Test plan

- New Vitest cases in `WorkspaceSidebar.test.tsx`:
  - When the save rejects, the Save dialog stays open, `toast.error` fires, and `toast.success` does not.
  - When the save resolves, the dialog closes, `toast.success` fires, and `toast.error` does not.
- Confirmed RED before the fix, GREEN after.
- `pnpm test`: 2180 passed (185 files).
- `pnpm build` (tsc typecheck + Vite): passed.

Partially addresses #1146 (G2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)