### PR TITLE
feat(ui): adopt Tooltip on OpenConnections and TunnelSidebar icon controls (#1114)

### DIFF
--- a/docs/changes/dev1/feature/1114-tooltip-adoption-openconnections-tunnel.md
+++ b/docs/changes/dev1/feature/1114-tooltip-adoption-openconnections-tunnel.md
@@ -1,0 +1,3 @@
+## Changed
+
+- The SSH tunnel list action icons (Start/Stop/Edit/Duplicate/Delete) and the Open Connections panel's per-section "Kill All" control now use the shared accessible Tooltip for hover help — themed, consistent, and reachable on keyboard focus instead of mouse-only. The tunnel action icons that previously conveyed their label only through the browser `title` now expose it as a proper accessible name (`aria-label`). Full-text/truncation hovers on connection names are unchanged.

--- a/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
@@ -7,7 +7,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
 import type { TerminalTab } from "@/types/terminal";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so tooltip-wrapped controls render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
 
 const cancelConnecting = vi.fn((_id: string) => Promise.resolve(true));
 vi.mock("@/services/api", () => ({
@@ -64,7 +82,11 @@ describe("OpenConnectionsModal — Connecting section", () => {
     });
     act(() => {
       root.render(
-        React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
+        React.createElement(
+          TooltipProvider,
+          { delayDuration: 0 },
+          React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
+        )
       );
     });
   }
@@ -97,7 +119,11 @@ describe("OpenConnectionsModal — Connecting section", () => {
   it("shows no Connecting section when nothing is connecting", () => {
     act(() => {
       root.render(
-        React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
+        React.createElement(
+          TooltipProvider,
+          { delayDuration: 0 },
+          React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
+        )
       );
     });
     const titles = Array.from(document.querySelectorAll(".oc-section__title")).map(

--- a/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
@@ -4,7 +4,7 @@
  * which aborts the in-flight connect via cancel_connecting.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import React, { act } from "react";
+import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { TooltipProvider } from "@/components/ui";
@@ -82,11 +82,9 @@ describe("OpenConnectionsModal — Connecting section", () => {
     });
     act(() => {
       root.render(
-        React.createElement(
-          TooltipProvider,
-          { delayDuration: 0 },
-          React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
-        )
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
       );
     });
   }
@@ -119,11 +117,9 @@ describe("OpenConnectionsModal — Connecting section", () => {
   it("shows no Connecting section when nothing is connecting", () => {
     act(() => {
       root.render(
-        React.createElement(
-          TooltipProvider,
-          { delayDuration: 0 },
-          React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
-        )
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
       );
     });
     const titles = Array.from(document.querySelectorAll(".oc-section__title")).map(

--- a/src/components/OpenConnections/OpenConnectionsModal.tooltip.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tooltip.test.tsx
@@ -10,7 +10,7 @@
  * left in place and is not asserted against here.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import React, { act } from "react";
+import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { TooltipProvider } from "@/components/ui";

--- a/src/components/OpenConnections/OpenConnectionsModal.tooltip.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tooltip.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Verifies the Open Connections panel adopts the shared `Tooltip` primitive for
+ * its section bulk-action control (issue #1114, follow-up to #1102).
+ *
+ * The per-section "Kill All" button previously carried a bare `title=` giving
+ * the section-specific action ("Kill All Local Sessions"). That help must now
+ * come from the shared Tooltip: the button must no longer expose a bare title,
+ * and focusing it must wire `aria-describedby` to the Radix tooltip. The
+ * truncation `title=` on non-interactive connection-name spans is intentionally
+ * left in place and is not asserted against here.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { TerminalTab } from "@/types/terminal";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so the tooltip-wrapped buttons render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() => Promise.resolve([])),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+function connectingTab(id: string, title: string, panelId: string): TerminalTab {
+  return {
+    id,
+    sessionId: null,
+    title,
+    connectionType: "ssh",
+    contentType: "terminal",
+    config: { type: "ssh", config: {} },
+    panelId,
+    isActive: true,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderWithSection() {
+  const leafId = useAppStore.getState().rootPanel.id;
+  const tab = connectingTab("tab-1", "app-server", leafId);
+  useAppStore.setState({
+    rootPanel: { type: "leaf", id: leafId, tabs: [tab], activeTabId: tab.id },
+    activePanelId: leafId,
+    terminalConnecting: { "tab-1": true },
+  });
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+      </TooltipProvider>
+    );
+  });
+}
+
+describe("OpenConnectionsModal — tooltip adoption (#1114)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("does not leave a bare title on the section Kill All control", () => {
+    renderWithSection();
+    const killAll = document.querySelector<HTMLButtonElement>(".oc-section__kill-all");
+    expect(killAll).not.toBeNull();
+    expect(killAll?.getAttribute("title")).toBeNull();
+  });
+
+  it("wires the section Kill All control to its tooltip via aria-describedby on focus", () => {
+    renderWithSection();
+    const killAll = document.querySelector<HTMLButtonElement>(".oc-section__kill-all")!;
+    act(() => {
+      killAll.focus();
+      killAll.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    });
+    expect(killAll.getAttribute("aria-describedby")).toBeTruthy();
+  });
+});

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -9,7 +9,7 @@ import {
   MonitorCog,
   Loader2,
 } from "lucide-react";
-import { Modal, Button } from "@/components/ui";
+import { Modal, Button, Tooltip } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
 import {
@@ -493,15 +493,17 @@ function Section({
         <span className="oc-section__title">{title}</span>
         {count > 0 && <span className="oc-section__count">{count}</span>}
         {onKillAll && (
-          <Button
-            variant="danger"
-            size="sm"
-            className="oc-section__kill-all"
-            onClick={() => onKillAll()}
-            title={`${killAllLabel} ${title}`}
-          >
-            {killAllLabel}
-          </Button>
+          <Tooltip content={`${killAllLabel} ${title}`} side="top">
+            <Button
+              variant="danger"
+              size="sm"
+              className="oc-section__kill-all"
+              onClick={() => onKillAll()}
+              aria-label={`${killAllLabel} ${title}`}
+            >
+              {killAllLabel}
+            </Button>
+          </Tooltip>
         )}
       </div>
       {children}

--- a/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
@@ -5,7 +5,7 @@
  * adopted external server exposes no Stop control.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import React, { act } from "react";
+import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { TooltipProvider } from "@/components/ui";
@@ -77,11 +77,9 @@ describe("OpenConnectionsModal — X Servers section", () => {
   async function renderModal() {
     await act(async () => {
       root.render(
-        React.createElement(
-          TooltipProvider,
-          { delayDuration: 0 },
-          React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
-        )
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
       );
     });
     await flush();

--- a/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
@@ -8,7 +8,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
 import type { XServerStatusReport } from "@/types/xserver";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so tooltip-wrapped controls render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
 
 const xServerStatus = vi.fn<() => Promise<XServerStatusReport>>();
 const xServerStop = vi.fn(() => Promise.resolve());
@@ -59,7 +77,11 @@ describe("OpenConnectionsModal — X Servers section", () => {
   async function renderModal() {
     await act(async () => {
       root.render(
-        React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
+        React.createElement(
+          TooltipProvider,
+          { delayDuration: 0 },
+          React.createElement(OpenConnectionsModal, { open: true, onOpenChange: () => {} })
+        )
       );
     });
     await flush();

--- a/src/components/TunnelSidebar/TunnelListItem.tooltip.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tooltip.test.tsx
@@ -38,6 +38,7 @@ const TUNNEL: TunnelConfig = {
   name: "My Tunnel",
   sshConnectionId: "ssh-1",
   autoStart: false,
+  reconnectOnDisconnect: false,
   tunnelType: {
     type: "local",
     config: {

--- a/src/components/TunnelSidebar/TunnelListItem.tooltip.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tooltip.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Verifies the tunnel list-item row adopts the shared `Tooltip` primitive for
+ * its icon-only Start/Stop/Edit/Duplicate/Delete controls (issue #1114,
+ * follow-up to #1102).
+ *
+ * A tooltip is not an accessible name, so each converted icon button must keep
+ * an `aria-label`, must no longer carry a bare `title`, and the Radix tooltip
+ * trigger must wire `aria-describedby` when focused. These assertions pin all
+ * three. The stable `data-testid`s must survive the migration.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TunnelListItem } from "./TunnelListItem";
+import { TooltipProvider } from "@/components/ui";
+import type { TunnelConfig, TunnelState } from "@/types/tunnel";
+import type { SavedConnection } from "@/types/connection";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so the tooltip-wrapped buttons render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+const TUNNEL: TunnelConfig = {
+  id: "tun-1",
+  name: "My Tunnel",
+  sshConnectionId: "ssh-1",
+  autoStart: false,
+  tunnelType: {
+    type: "local",
+    config: {
+      localHost: "127.0.0.1",
+      localPort: 8080,
+      remoteHost: "example.com",
+      remotePort: 80,
+    },
+  },
+};
+
+const noop = () => {};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Wrap so the shared Tooltip primitive finds its provider (zero delay). */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
+
+function renderItem(state: TunnelState | undefined): void {
+  act(() => {
+    root.render(
+      withTooltip(
+        <TunnelListItem
+          tunnel={TUNNEL}
+          state={state}
+          connections={[] as SavedConnection[]}
+          onStart={noop}
+          onStop={noop}
+          onEdit={noop}
+          onDuplicate={noop}
+          onDelete={noop}
+        />
+      )
+    );
+  });
+}
+
+describe("TunnelListItem — tooltip adoption (#1114)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("exposes accessible names via aria-label without a bare title on the action icons", async () => {
+    renderItem(undefined);
+    await flush();
+
+    // Disconnected → Start is shown (not Stop).
+    const start = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-start-tun-1"]');
+    const edit = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-edit-tun-1"]');
+    const dup = container.querySelector<HTMLButtonElement>(
+      '[data-testid="tunnel-duplicate-tun-1"]'
+    );
+    const del = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-delete-tun-1"]');
+
+    for (const btn of [start, edit, dup, del]) {
+      expect(btn).not.toBeNull();
+      expect(btn?.getAttribute("aria-label")).toBeTruthy();
+      // The tooltip must not leak into the accessible name as a bare title.
+      expect(btn?.getAttribute("title")).toBeNull();
+    }
+  });
+
+  it("shows the Stop icon with an accessible name when the tunnel is active", async () => {
+    renderItem({
+      tunnelId: "tun-1",
+      status: "connected",
+    } as TunnelState);
+    await flush();
+
+    const stop = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-stop-tun-1"]');
+    expect(stop).not.toBeNull();
+    expect(stop?.getAttribute("aria-label")).toBeTruthy();
+    expect(stop?.getAttribute("title")).toBeNull();
+  });
+
+  it("wires the Edit button to its tooltip via aria-describedby on focus", async () => {
+    renderItem(undefined);
+    await flush();
+
+    const edit = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-edit-tun-1"]')!;
+    act(() => {
+      edit.focus();
+      edit.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    });
+
+    // Radix associates the open tooltip with its trigger for screen readers.
+    expect(edit.getAttribute("aria-describedby")).toBeTruthy();
+  });
+});

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -1,4 +1,5 @@
 import { Play, Square, Pencil, Copy, Trash2 } from "lucide-react";
+import { Tooltip } from "@/components/ui";
 import { TunnelConfig, TunnelState } from "@/types/tunnel";
 import { SavedConnection } from "@/types/connection";
 import { formatBytes } from "@/utils/formatters";
@@ -62,63 +63,73 @@ export function TunnelListItem({
         </span>
         <div className="tunnel-item__actions">
           {isActive ? (
-            <button
-              className="tunnel-item__action"
-              title="Stop"
-              data-testid={`tunnel-stop-${tunnel.id}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                onStop(tunnel.id);
-              }}
-            >
-              <Square size={12} />
-            </button>
+            <Tooltip content="Stop" side="top">
+              <button
+                className="tunnel-item__action"
+                aria-label="Stop"
+                data-testid={`tunnel-stop-${tunnel.id}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onStop(tunnel.id);
+                }}
+              >
+                <Square size={12} />
+              </button>
+            </Tooltip>
           ) : (
+            <Tooltip content="Start" side="top">
+              <button
+                className="tunnel-item__action"
+                aria-label="Start"
+                data-testid={`tunnel-start-${tunnel.id}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onStart(tunnel.id);
+                }}
+              >
+                <Play size={12} />
+              </button>
+            </Tooltip>
+          )}
+          <Tooltip content="Edit" side="top">
             <button
               className="tunnel-item__action"
-              title="Start"
-              data-testid={`tunnel-start-${tunnel.id}`}
+              aria-label="Edit"
+              data-testid={`tunnel-edit-${tunnel.id}`}
               onClick={(e) => {
                 e.stopPropagation();
-                onStart(tunnel.id);
+                onEdit(tunnel.id);
               }}
             >
-              <Play size={12} />
+              <Pencil size={12} />
             </button>
-          )}
-          <button
-            className="tunnel-item__action"
-            title="Edit"
-            data-testid={`tunnel-edit-${tunnel.id}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onEdit(tunnel.id);
-            }}
-          >
-            <Pencil size={12} />
-          </button>
-          <button
-            className="tunnel-item__action"
-            title="Duplicate"
-            data-testid={`tunnel-duplicate-${tunnel.id}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onDuplicate(tunnel.id);
-            }}
-          >
-            <Copy size={12} />
-          </button>
-          <button
-            className="tunnel-item__action"
-            title="Delete"
-            data-testid={`tunnel-delete-${tunnel.id}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete(tunnel.id);
-            }}
-          >
-            <Trash2 size={12} />
-          </button>
+          </Tooltip>
+          <Tooltip content="Duplicate" side="top">
+            <button
+              className="tunnel-item__action"
+              aria-label="Duplicate"
+              data-testid={`tunnel-duplicate-${tunnel.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDuplicate(tunnel.id);
+              }}
+            >
+              <Copy size={12} />
+            </button>
+          </Tooltip>
+          <Tooltip content="Delete" side="top">
+            <button
+              className="tunnel-item__action"
+              aria-label="Delete"
+              data-testid={`tunnel-delete-${tunnel.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(tunnel.id);
+              }}
+            >
+              <Trash2 size={12} />
+            </button>
+          </Tooltip>
         </div>
       </div>
       <div className="tunnel-item__details">


### PR DESCRIPTION
Partially addresses #1114 (does **not** close it — the remaining groups continue in the follow-up issues below).

Follow-up to #1102 (PR #1113), which adopted the shared `Tooltip` primitive on interactive icon controls in Terminal, StatusBar, and NetworkTools. Per #1114's "one group per PR" guidance, this PR migrates the **two most self-contained groups**.

## Groups migrated
- **TunnelSidebar** (`TunnelListItem`) — the tunnel row action icons (Start/Stop/Edit/Duplicate/Delete) now wrap their `<button>`s in the shared `Tooltip` (`asChild`, `side="top"`) and gain an explicit `aria-label` (previously the only accessible name was the browser `title`).
- **OpenConnections** (`OpenConnectionsModal`) — the per-section **Kill All** bulk-action button moves its section-specific `title` help ("Kill All Local Sessions", etc.) into a `Tooltip` and keeps an `aria-label`.

Rule from #1102 preserved: only genuinely **interactive icon controls** are converted. The truncation `title=` on non-interactive connection-name spans (e.g. `.oc-row__title`) is intentionally left in place. All `data-testid`s are preserved.

## Tests
- New `TunnelListItem.tooltip.test.tsx` and `OpenConnectionsModal.tooltip.test.tsx` pin: `aria-label` present, no bare `title`, and `aria-describedby` wired on focus (Radix tooltip association).
- Existing OpenConnections tests are wrapped in `TooltipProvider` (Radix Tooltip requires a provider in scope).
- `pnpm test` (2183 passed), `pnpm run lint`, `pnpm build`, and `prettier --check` all green.

## Follow-up issues (remaining #1114 groups)
- #1159 — Sidebar connection-tree row action icons
- #1160 — WorkspaceSidebar / WorkspaceEditor icon buttons
- #1161 — EmbeddedServerSidebar icon buttons
- #1162 — remaining Settings interactive icon controls
- #1163 — StatusBar `DropdownMenu.Trigger` text-buttons (decision + composition)

Each is labeled `Ready2Implement`, left unassigned, and carries a Scope checklist + Done-when.

🤖 Generated with [Claude Code](https://claude.com/claude-code)