### PR TITLE
fix(sftp): feedback on SFTP transfer failure (#1143)

### DIFF
--- a/docs/changes/dev2/feature/1143-sftp-transfer-feedback.md
+++ b/docs/changes/dev2/feature/1143-sftp-transfer-feedback.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- SFTP file transfers no longer fail silently. Downloading, uploading (toolbar
+  button or dropping a file onto the browser), and pasting into an SFTP location
+  now show a pending toast that resolves into a success confirmation or a
+  persistent error carrying the backend's message. Previously a failed transfer
+  gave no feedback at all — the file simply was not there. A multi-item paste now
+  stops on the first failure instead of clearing a cut clipboard on a partial
+  paste (audit gap D2, #1143).

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -757,9 +757,8 @@ export function FileBrowser() {
           // session mode: file editing via editor not yet supported for agent sessions
           break;
         case "download":
-          downloadFile(entry.path, entry.name).catch((err: unknown) =>
-            console.error("Download failed:", err)
-          );
+          // downloadFile surfaces its own success/error toast (see useFileSystem).
+          void downloadFile(entry.path, entry.name);
           break;
         case "vscode":
           openInVscode(entry.path).catch((err: unknown) =>
@@ -812,7 +811,8 @@ export function FileBrowser() {
   );
 
   const handlePaste = useCallback(() => {
-    pasteEntry().catch((err: unknown) => console.error("Paste failed:", err));
+    // pasteEntry surfaces its own per-item success/error toast (see useFileSystem).
+    void pasteEntry();
   }, [pasteEntry]);
 
   const handleRowClick = useCallback(

--- a/src/hooks/useFileSystem.test.ts
+++ b/src/hooks/useFileSystem.test.ts
@@ -42,6 +42,17 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
   save: vi.fn(() => Promise.resolve(null)),
 }));
 
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
 // Test the SFTP navigateUp path logic — same algorithm as the local version,
 // but without Windows drive-root handling.
 function navigateUpSftp(currentPath: string): string | null {
@@ -207,5 +218,130 @@ describe("useFileSystem (SFTP) — store integration", () => {
   it("isConnected is false when sftpSessionId is null", () => {
     const { sftpSessionId } = useAppStore.getState();
     expect(sftpSessionId).toBeNull();
+  });
+});
+
+// D2 (#1143): a failed transfer must surface an error to the user via toast
+// rather than resolving silently or producing an unhandled rejection.
+import { sftpDownload } from "@/services/api";
+import { open, save } from "@tauri-apps/plugin-dialog";
+import { toast } from "@/components/ui";
+
+describe("useFileSystem (SFTP) — transfer-error feedback (D2, #1143)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderHook(): Promise<ReturnType<typeof useFileSystem>> {
+    let api: ReturnType<typeof useFileSystem> | undefined;
+    function Harness() {
+      api = useFileSystem();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    return api!;
+  }
+
+  it("surfaces a toast error (not an unhandled rejection) when an upload fails", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/uploads" });
+    vi.mocked(open).mockResolvedValueOnce("/local/file.txt");
+    vi.mocked(sftpUpload).mockRejectedValueOnce(new Error("permission denied"));
+
+    const api = await renderHook();
+
+    // Must resolve (swallow the rejection), not throw an unhandled rejection.
+    await act(async () => {
+      await expect(api.uploadFile()).resolves.toBeUndefined();
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalled();
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toContain("permission denied");
+  });
+
+  it("surfaces a toast error when uploadFileFromPath (OS drop) fails", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/uploads" });
+    vi.mocked(sftpUpload).mockRejectedValueOnce(new Error("disk full"));
+
+    const api = await renderHook();
+
+    await act(async () => {
+      await expect(api.uploadFileFromPath("/local/big.bin")).resolves.toBeUndefined();
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalled();
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toContain("disk full");
+  });
+
+  it("surfaces a toast error when a download fails", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/" });
+    vi.mocked(save).mockResolvedValueOnce("/local/save.txt");
+    vi.mocked(sftpDownload).mockRejectedValueOnce(new Error("no such file"));
+
+    const api = await renderHook();
+
+    await act(async () => {
+      await expect(api.downloadFile("/remote/save.txt", "save.txt")).resolves.toBeUndefined();
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalled();
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toContain("no such file");
+  });
+
+  it("surfaces a toast error when a paste (copy) transfer fails", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/dest" });
+    useAppStore.getState().setFileClipboard({
+      entries: [
+        {
+          name: "file.txt",
+          path: "/src/file.txt",
+          isDirectory: false,
+          size: 1,
+          modified: "",
+          permissions: null,
+        },
+      ],
+      operation: "copy",
+      sourceMode: "local",
+      sourcePath: "/src",
+      sftpSessionId: null,
+    });
+    vi.mocked(sftpUpload).mockRejectedValueOnce(new Error("connection reset"));
+
+    const api = await renderHook();
+
+    await act(async () => {
+      await expect(api.pasteEntry()).resolves.toBeUndefined();
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalled();
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toContain("connection reset");
+  });
+
+  it("does not toast an error on a successful upload", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/uploads" });
+    vi.mocked(open).mockResolvedValueOnce("/local/file.txt");
+    vi.mocked(sftpUpload).mockResolvedValueOnce(0);
+
+    const api = await renderHook();
+
+    await act(async () => {
+      await api.uploadFile();
+    });
+
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -11,6 +11,40 @@ import {
   vscodeOpenRemote,
 } from "@/services/api";
 import { FileEntry } from "@/types/connection";
+import { toast } from "@/components/ui";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** Extract a human-readable message from an unknown transfer error. */
+function transferErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return String(error);
+}
+
+/**
+ * Run an SFTP transfer with user feedback: a pending toast that resolves in
+ * place into success or a persistent error (audit gap D2 — transfers must
+ * never fail silently). The rejection is surfaced via `toast.error` and logged
+ * to the LogViewer, then swallowed so callers do not produce an unhandled
+ * rejection. Returns whether the transfer succeeded.
+ */
+async function runTransfer(
+  label: string,
+  action: () => Promise<unknown>,
+  messages: { loading: string; success: string }
+): Promise<boolean> {
+  const toastId = toast.loading(messages.loading);
+  try {
+    await action();
+    toast.success(messages.success, { id: toastId });
+    return true;
+  } catch (error) {
+    const message = transferErrorMessage(error);
+    frontendLog("sftp_transfer", `${label} failed: ${message}`);
+    toast.error(`${label} failed: ${message}`, { id: toastId });
+    return false;
+  }
+}
 
 /**
  * Hook for SFTP file system operations.
@@ -46,7 +80,10 @@ export function useFileSystem() {
       if (!sftpSessionId) return;
       const localPath = await save({ title: "Save file as...", defaultPath: fileName });
       if (!localPath) return;
-      await sftpDownload(sftpSessionId, remotePath, localPath);
+      await runTransfer("Download", () => sftpDownload(sftpSessionId, remotePath, localPath), {
+        loading: `Downloading ${fileName}…`,
+        success: `Downloaded ${fileName}`,
+      });
     },
     [sftpSessionId]
   );
@@ -57,8 +94,11 @@ export function useFileSystem() {
     if (!localPath) return;
     const fileName = localPath.split("/").pop() ?? localPath.split("\\").pop() ?? "upload";
     const remotePath = currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
-    await sftpUpload(sftpSessionId, localPath, remotePath);
-    refreshSftp();
+    const ok = await runTransfer("Upload", () => sftpUpload(sftpSessionId, localPath, remotePath), {
+      loading: `Uploading ${fileName}…`,
+      success: `Uploaded ${fileName}`,
+    });
+    if (ok) refreshSftp();
   }, [sftpSessionId, currentPath, refreshSftp]);
 
   const uploadFileFromPath = useCallback(
@@ -67,8 +107,12 @@ export function useFileSystem() {
       const parts = localPath.replace(/\\/g, "/").split("/");
       const fileName = parts[parts.length - 1] || "upload";
       const remotePath = currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
-      await sftpUpload(sftpSessionId, localPath, remotePath);
-      refreshSftp();
+      const ok = await runTransfer(
+        "Upload",
+        () => sftpUpload(sftpSessionId, localPath, remotePath),
+        { loading: `Uploading ${fileName}…`, success: `Uploaded ${fileName}` }
+      );
+      if (ok) refreshSftp();
     },
     [sftpSessionId, currentPath, refreshSftp]
   );
@@ -153,7 +197,7 @@ export function useFileSystem() {
 
     const destDir = currentPath;
 
-    for (const clipEntry of clipboard.entries) {
+    const pasteOne = async (clipEntry: FileEntry): Promise<void> => {
       const destPath = destDir === "/" ? `/${clipEntry.name}` : `${destDir}/${clipEntry.name}`;
 
       if (clipboard.sourceMode === "sftp") {
@@ -179,6 +223,16 @@ export function useFileSystem() {
         // local→sftp: upload local file to remote destination
         await sftpUpload(sftpSessionId, clipEntry.path, destPath);
       }
+    };
+
+    for (const clipEntry of clipboard.entries) {
+      const ok = await runTransfer("Paste", () => pasteOne(clipEntry), {
+        loading: `Pasting ${clipEntry.name}…`,
+        success: `Pasted ${clipEntry.name}`,
+      });
+      // Abort on first failure so a cut clipboard is not cleared and the user
+      // is not left with a partial, silently-incomplete paste.
+      if (!ok) return;
     }
 
     if (clipboard.operation === "cut") {


### PR DESCRIPTION
## Summary

SFTP file transfers previously failed **silently** — the "every action gives feedback" design rule was violated for the whole transfer surface (audit gap D2). Download errors went to `console.error`, upload (toolbar button + OS drop) had no error handling at all (unhandled rejection), and paste went to `console.error`. A failed transfer left the user with no indication that anything went wrong.

This routes every transfer through the shared toast: a pending toast that resolves in place into a success confirmation or a persistent error carrying the backend's message.

## Changes

- **`src/hooks/useFileSystem.ts`** — new module-level `runTransfer` helper wraps each transfer with `toast.loading()` → `toast.success()` / `toast.error()`, logs failures via `frontendLog`, and swallows the rejection so callers no longer produce unhandled rejections. Applied to `downloadFile`, `uploadFile` (toolbar), `uploadFileFromPath` (OS drop), and `pasteEntry`. A multi-item paste now **aborts on the first failure** so a cut clipboard is not cleared on a partial paste.
- **`src/components/Sidebar/FileBrowser.tsx`** — removed the `.catch(console.error)` call sites for download and paste (the hook now owns feedback), replacing them with `void`-ed calls.
- **`docs/changes/dev2/feature/1143-sftp-transfer-feedback.md`** — user-facing change fragment.

Scope is **D2 only** — transfer cancel (D1) and progress (D3) machinery are intentionally untouched.

## Test plan

- New Vitest cases in `src/hooks/useFileSystem.test.ts` assert that a rejected download, upload (button + OS drop), and paste each surface a `toast.error` (with the backend message) and **resolve** rather than throwing an unhandled rejection; a success case asserts no error toast fires. Verified RED before the fix, GREEN after.
- `pnpm test` → **185 files, 2183 tests passed**.
- `pnpm build` (tsc + vite) → **passes** (pre-existing chunk-size warning only).
- `pnpm run lint` and `pnpm run format:check` → clean.

Partially addresses #1143 (D2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)