### PR TITLE
fix(backend): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Problem

`cargo audit` began failing on **every** branch as of **2026-07-06**, breaking the **Security Audit** and **Rust Code Quality** CI jobs (both run `cargo audit`). This is a `develop`-wide breakage, not caused by any feature PR — it surfaced on whichever PRs happened to re-run CI after the advisory was published (e.g. #1157, #1164), while PRs whose CI ran earlier are stale-green.

## Root cause

**RUSTSEC-2026-0204** — invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` in **`crossbeam-epoch` 0.9.18**, published 2026-07-06. It's a transitive dependency:

```
crossbeam-epoch 0.9.18
└── moka 0.12.15
    ├── libunftp 0.20.3 → unftp-sbe-fs → termihub
    └── hickory-resolver 0.26.1 → termihub-core → {termihub, termihub-agent}
```

## Fix

Bump the locked version to the patched **0.9.20** (`cargo update -p crossbeam-epoch --precise 0.9.20`). Semver-compatible, **lockfile-only** — no source changes.

## Verification

- `cargo audit` now exits `0` locally (previously `error: 1 vulnerability found!`). Remaining output is the 19 pre-existing allowed warnings (unmaintained gtk-rs bindings, yanked `crypto-bigint`), unchanged by this PR.
- Full compilation is verified by the Build + Run Tests jobs across macOS/Linux/Windows.

## Follow-up for the other open PRs

Once this merges to `develop`, the other open PRs (#1157, #1164, and any re-run) just need to merge `develop` to pick up the patched lockfile and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)