### PR TITLE
feat(ui): adopt Tooltip on EmbeddedServerSidebar icon buttons

### DIFF
--- a/docs/changes/dev1/feature/1161-tooltip-embedded-server-sidebar.md
+++ b/docs/changes/dev1/feature/1161-tooltip-embedded-server-sidebar.md
@@ -1,0 +1,8 @@
+## Changed
+
+- The Services sidebar server actions (Start, Stop, Edit, Duplicate, Delete)
+  now use the shared accessible Tooltip for hover help — consistent, themed,
+  and reachable on keyboard focus instead of mouse-only. Each icon-only button
+  exposes its label as a proper accessible name (`aria-label`) instead of the
+  browser `title`. Truncation/full-text hovers on server names, paths, and
+  status text are unchanged (#1161).

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.test.tsx
@@ -4,15 +4,19 @@ import { createRoot, Root } from "react-dom/client";
 
 const toastError = vi.fn();
 
-vi.mock("@/components/ui", () => ({
-  toast: {
-    error: (...args: unknown[]) => toastError(...args),
-    success: vi.fn(),
-    info: vi.fn(),
-    loading: vi.fn(),
-    dismiss: vi.fn(),
-  },
-}));
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      error: (...args: unknown[]) => toastError(...args),
+      success: vi.fn(),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
 
 vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
   writeText: vi.fn(() => Promise.resolve()),
@@ -23,7 +27,25 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 }));
 
 import { EmbeddedServerItem } from "./EmbeddedServerItem";
+import { TooltipProvider } from "@/components/ui";
 import { EmbeddedServerConfig, ServerState } from "@/types/embeddedServer";
+
+// jsdom lacks the observers/pointer-capture APIs Radix Tooltip touches when it
+// measures its content; shim them so the item's tooltip triggers can mount.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
 
 let container: HTMLDivElement;
 let root: Root;
@@ -63,7 +85,7 @@ function baseProps(overrides: Partial<React.ComponentProps<typeof EmbeddedServer
 
 function render(ui: React.ReactElement) {
   act(() => {
-    root.render(ui);
+    root.render(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
   });
 }
 

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tooltip.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tooltip.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      error: vi.fn(),
+      success: vi.fn(),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(() => Promise.resolve()),
+}));
+
+import { EmbeddedServerItem } from "./EmbeddedServerItem";
+import { TooltipProvider } from "@/components/ui";
+import { EmbeddedServerConfig, ServerState } from "@/types/embeddedServer";
+
+// jsdom lacks the observers/pointer-capture APIs Radix Tooltip touches when it
+// measures and portals its content; shim them so the primitive can mount.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+const config: EmbeddedServerConfig = {
+  id: "srv-1",
+  name: "My HTTP",
+  serverType: "http",
+  rootDirectory: "/tmp",
+  bindHost: "127.0.0.1",
+  port: 8080,
+  autoStart: false,
+  readOnly: false,
+  directoryListing: true,
+};
+
+const runningState: ServerState = {
+  serverId: "srv-1",
+  status: "running",
+  stats: { activeConnections: 0, totalConnections: 0, bytesSent: 0, bytesReceived: 0 },
+};
+
+const noop = () => {};
+
+function baseProps(overrides: Partial<React.ComponentProps<typeof EmbeddedServerItem>> = {}) {
+  return {
+    config,
+    state: undefined as ServerState | undefined,
+    onStart: vi.fn(() => Promise.resolve()),
+    onStop: vi.fn(() => Promise.resolve()),
+    onEdit: noop,
+    onDuplicate: noop,
+    onDelete: noop,
+    ...overrides,
+  };
+}
+
+function renderItem(overrides: Partial<React.ComponentProps<typeof EmbeddedServerItem>> = {}) {
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <EmbeddedServerItem {...baseProps(overrides)} />
+      </TooltipProvider>
+    );
+  });
+}
+
+// The icon-only action buttons whose bare title= should now be a Tooltip +
+// aria-label. testid → expected accessible name / render state.
+const CONVERTED_ACTIONS: Array<{ testid: string; label: string; running: boolean }> = [
+  { testid: "server-start-srv-1", label: "Start", running: false },
+  { testid: "server-stop-srv-1", label: "Stop", running: true },
+  { testid: "server-edit-srv-1", label: "Edit", running: false },
+  { testid: "server-duplicate-srv-1", label: "Duplicate", running: false },
+  { testid: "server-delete-srv-1", label: "Delete", running: false },
+];
+
+describe("EmbeddedServerItem tooltip adoption", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  for (const { testid, label, running } of CONVERTED_ACTIONS) {
+    it(`gives the ${label} button an aria-label and no bare title`, () => {
+      renderItem({ state: running ? runningState : undefined });
+      const btn = container.querySelector<HTMLButtonElement>(`[data-testid="${testid}"]`);
+      expect(btn, `${testid} should render`).toBeTruthy();
+      expect(btn?.getAttribute("aria-label")).toBe(label);
+      // The bare title= has been replaced by the Tooltip primitive.
+      expect(btn?.hasAttribute("title")).toBe(false);
+    });
+  }
+
+  it("wires aria-describedby on focus of an action button", () => {
+    renderItem();
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="server-start-srv-1"]'
+    ) as HTMLButtonElement;
+    act(() => {
+      btn.focus();
+      btn.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    });
+    // Radix associates the visible tooltip with its trigger for screen readers.
+    expect(btn.getAttribute("aria-describedby")).toBeTruthy();
+  });
+
+  it("preserves the data-testid on every converted control", () => {
+    renderItem({ state: runningState });
+    for (const { testid } of CONVERTED_ACTIONS.filter((a) => a.running)) {
+      expect(container.querySelector(`[data-testid="${testid}"]`)).toBeTruthy();
+    }
+  });
+});

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
@@ -3,7 +3,7 @@ import { Play, Square, Pencil, Copy, Trash2, ExternalLink, Clipboard } from "luc
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manager";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { toast } from "@/components/ui";
+import { toast, Tooltip } from "@/components/ui";
 import {
   EmbeddedServerConfig,
   ServerState,
@@ -133,65 +133,75 @@ export function EmbeddedServerItem({
             </span>
             <div className="server-item__actions">
               {active ? (
-                <button
-                  className="server-item__action"
-                  title="Stop"
-                  data-testid={`server-stop-${config.id}`}
-                  disabled={busy}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void handleStop();
-                  }}
-                >
-                  <Square size={12} />
-                </button>
+                <Tooltip content="Stop" side="top">
+                  <button
+                    className="server-item__action"
+                    aria-label="Stop"
+                    data-testid={`server-stop-${config.id}`}
+                    disabled={busy}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void handleStop();
+                    }}
+                  >
+                    <Square size={12} />
+                  </button>
+                </Tooltip>
               ) : (
+                <Tooltip content="Start" side="top">
+                  <button
+                    className="server-item__action"
+                    aria-label="Start"
+                    data-testid={`server-start-${config.id}`}
+                    disabled={busy}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void handleStart();
+                    }}
+                  >
+                    <Play size={12} />
+                  </button>
+                </Tooltip>
+              )}
+              <Tooltip content="Edit" side="top">
                 <button
                   className="server-item__action"
-                  title="Start"
-                  data-testid={`server-start-${config.id}`}
-                  disabled={busy}
+                  aria-label="Edit"
+                  data-testid={`server-edit-${config.id}`}
                   onClick={(e) => {
                     e.stopPropagation();
-                    void handleStart();
+                    onEdit(config.id);
                   }}
                 >
-                  <Play size={12} />
+                  <Pencil size={12} />
                 </button>
-              )}
-              <button
-                className="server-item__action"
-                title="Edit"
-                data-testid={`server-edit-${config.id}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEdit(config.id);
-                }}
-              >
-                <Pencil size={12} />
-              </button>
-              <button
-                className="server-item__action"
-                title="Duplicate"
-                data-testid={`server-duplicate-${config.id}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDuplicate(config.id);
-                }}
-              >
-                <Copy size={12} />
-              </button>
-              <button
-                className="server-item__action server-item__action--danger"
-                title="Delete"
-                data-testid={`server-delete-${config.id}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete(config.id);
-                }}
-              >
-                <Trash2 size={12} />
-              </button>
+              </Tooltip>
+              <Tooltip content="Duplicate" side="top">
+                <button
+                  className="server-item__action"
+                  aria-label="Duplicate"
+                  data-testid={`server-duplicate-${config.id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDuplicate(config.id);
+                  }}
+                >
+                  <Copy size={12} />
+                </button>
+              </Tooltip>
+              <Tooltip content="Delete" side="top">
+                <button
+                  className="server-item__action server-item__action--danger"
+                  aria-label="Delete"
+                  data-testid={`server-delete-${config.id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(config.id);
+                  }}
+                >
+                  <Trash2 size={12} />
+                </button>
+              </Tooltip>
             </div>
           </div>
           <div className="server-item__details">

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx
@@ -80,7 +80,6 @@ export function EmbeddedServerSidebar() {
         <button
           className="server-sidebar__add-btn"
           onClick={handleNew}
-          title="New Service"
           data-testid="server-new-btn"
         >
           <Plus size={14} />


### PR DESCRIPTION
## Summary

Continues the Tooltip primitive adoption (#1102/#1114) in the embedded servers UI. Migrates the interactive icon buttons in `EmbeddedServerSidebar/` from bare `title=` to the shared accessible `Tooltip` primitive.

- `EmbeddedServerItem`: the **Start / Stop / Edit / Duplicate / Delete** icon-only action buttons now use `Tooltip` (`side="top"` for the compact action row) with an `aria-label` on each button instead of a mouse-only browser `title`. Radix wires `aria-describedby` on hover/focus, so the hover help is themed and keyboard/focus accessible.
- `EmbeddedServerSidebar`: dropped the redundant `title="New Service"` on the New Service button — its visible text label already provides the accessible name.
- All `data-testid`s are preserved. Non-interactive truncation/full-text hovers (server name, `:port → path`, status/error strings) keep their bare `title=` as intended.
- `EmbeddedServerDialog`'s `title={...}` props are Modal component props (not HTML title attributes), so they are untouched.

## Test plan

- New `EmbeddedServerItem.tooltip.test.tsx` pins, for each converted control: an `aria-label` is present, no bare `title=` remains, `data-testid` is preserved, and `aria-describedby` is wired on focus (written first, verified red before the change, green after).
- Existing `EmbeddedServerItem.test.tsx` renders are wrapped in `TooltipProvider` (with Radix jsdom shims) and remain green.
- `pnpm test src/components/EmbeddedServerSidebar/` → 14 passed.
- `pnpm run lint`, `pnpm build` → clean.

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
