### PR TITLE
fix(terminal): unique per-attempt connect id to prevent wrong-attempt cancellation (#1125)

### DIFF
--- a/docs/changes/dev1/bugfix/1125-unique-connect-id.md
+++ b/docs/changes/dev1/bugfix/1125-unique-connect-id.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Rapidly cancelling and retrying (or a reconnect firing while the previous
+  connect was still slow) no longer aborts the fresh connection attempt and
+  lands the tab in a confusing Failed state. Each connect attempt now uses a
+  unique per-attempt id, so a stale attempt's cancellation can only cancel
+  itself and never the newer, in-flight attempt for the same tab (#1125).

--- a/src/components/Terminal/Terminal.overlapping-connect.test.tsx
+++ b/src/components/Terminal/Terminal.overlapping-connect.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Regression test for #1125 — overlapping connects must not cancel each other.
+ *
+ * The mid-connect cancellation map is keyed by a connect id. Historically that
+ * id was the bare `tabId`, so a retry/reconnect that fired while the previous
+ * `createTerminal` was still in flight reused the SAME id. The old effect's
+ * cleanup then ran `cancelConnecting(tabId)` and aborted the NEW attempt's
+ * handshake — landing the tab in a spurious Failed state.
+ *
+ * The fix threads a UNIQUE per-attempt connect id (`${tabId}:${retryCount}`)
+ * through `createTerminal`, and the effect cleanup cancels only ITS OWN id. So
+ * a stale cleanup can never touch the fresh attempt's token.
+ *
+ * This test drives a direct (non-agent) connection whose first `createTerminal`
+ * never resolves, triggers a reconnect while it is in flight, and asserts that
+ * the fresh attempt's connect id is never passed to `cancelConnecting`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+import { useAppStore } from "@/store/appStore";
+
+// --- Mocks ---
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    onCursorMove = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    write = vi.fn((_data: unknown, cb?: () => void) => cb?.());
+    writeln = vi.fn();
+    reset = vi.fn();
+    scrollToBottom = vi.fn();
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn();
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = { active: { viewportY: 0, baseY: 0, length: 0, getLine: vi.fn() } };
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class MockFitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-unicode11", () => {
+  class MockUnicode11Addon {
+    dispose = vi.fn();
+  }
+  return { Unicode11Addon: MockUnicode11Addon };
+});
+
+vi.mock("@xterm/addon-search", () => {
+  class MockSearchAddon {
+    dispose = vi.fn();
+  }
+  return { SearchAddon: MockSearchAddon };
+});
+
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+/**
+ * `createTerminal` returns a promise that never resolves, so each attempt stays
+ * "in flight" and the cleanup path (which cancels the connect) is exercised.
+ * The connect id passed by the caller is recorded for assertions.
+ */
+const createTerminalConnectIds: (string | undefined)[] = [];
+const mockCreateTerminal = vi.fn((_config: unknown, connectId?: string) => {
+  createTerminalConnectIds.push(connectId);
+  return new Promise<string>(() => {
+    /* never resolves — connect stays in flight */
+  });
+});
+const mockCancelConnecting = vi.fn((_connectId: string) => Promise.resolve(true));
+
+vi.mock("@/services/api", () => ({
+  createTerminal: (...args: unknown[]) =>
+    mockCreateTerminal(args[0], args[1] as string | undefined),
+  cancelConnecting: (connectId: string) => mockCancelConnecting(connectId),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+  detachPersistentTab: vi.fn().mockResolvedValue(0),
+  getAgentSessionBuffer: vi.fn().mockResolvedValue(new Uint8Array()),
+}));
+
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: vi.fn(() => vi.fn()),
+    subscribeExit: vi.fn(() => vi.fn()),
+    clearPendingExit: vi.fn(),
+    clearPendingOutput: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  createTerminalConnectIds.length = 0;
+  mockCreateTerminal.mockClear();
+  mockCancelConnecting.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+// Direct (non-agent) local shell connection so setupTerminal takes the
+// createTerminal path rather than reattaching to an existing session.
+const DIRECT_CONFIG = {
+  type: "local" as const,
+  config: {},
+};
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Terminal — overlapping connect cancellation race (#1125)", () => {
+  it("uses a unique connect id per attempt so a reconnect-in-flight does not cancel the fresh attempt", async () => {
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal tabId="tab-1" config={DIRECT_CONFIG} isVisible={true} />
+        </TerminalPortalProvider>
+      );
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    // First attempt is in flight (createTerminal never resolves).
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    const firstConnectId = createTerminalConnectIds[0];
+    expect(firstConnectId).toBeTruthy();
+
+    // Reconnect while the first connect is still in flight → the effect re-runs
+    // (retryCount dep), tearing down the old attempt and starting a new one.
+    act(() => {
+      useAppStore.getState().reconnectTerminal("tab-1");
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    // The reconnect started a second connect with a DISTINCT connect id.
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(2);
+    const secondConnectId = createTerminalConnectIds[1];
+    expect(secondConnectId).toBeTruthy();
+    expect(secondConnectId).not.toBe(firstConnectId);
+
+    // The old effect's cleanup must cancel only its OWN attempt's id, never the
+    // fresh attempt's id. This is the core of the fix: with the bare-tabId id
+    // both attempts shared one id and the stale cleanup aborted the new connect.
+    const cancelledIds = mockCancelConnecting.mock.calls.map((c) => c[0]);
+    expect(cancelledIds).not.toContain(secondConnectId);
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -264,7 +264,7 @@ export function Terminal({
   }, [tabId]);
 
   const setupTerminal = useCallback(
-    async (xterm: XTerm, fitAddon: FitAddon, isCanceled: () => boolean) => {
+    async (xterm: XTerm, fitAddon: FitAddon, isCanceled: () => boolean, connectId: string) => {
       // Cancel any pending session close from a StrictMode unmount cycle
       if (pendingCloseTimerRef.current !== null) {
         clearTimeout(pendingCloseTimerRef.current);
@@ -422,11 +422,14 @@ export function Terminal({
               // createTerminal is awaiting if a container resize fires).
               ptyCols = xterm.cols;
               ptyRows = xterm.rows;
-              // Pass the tab id as the connect id so closing the tab while
-              // connecting can abort the in-flight handshake (#952).
+              // Pass a UNIQUE per-attempt connect id so closing the tab while
+              // connecting can abort the in-flight handshake (#952) — and so an
+              // overlapping retry/reconnect never shares the previous attempt's
+              // id. If it did, the old effect's cleanup would cancel the fresh
+              // attempt's token instead of its own (#1125).
               connectInFlightRef.current = true;
               try {
-                resolved = await createTerminal(sessionConfig, tabId);
+                resolved = await createTerminal(sessionConfig, connectId);
               } finally {
                 connectInFlightRef.current = false;
               }
@@ -739,6 +742,13 @@ export function Terminal({
     // second mount, which would send input to the wrong backend session.
     let canceled = false;
 
+    // Unique connect id for THIS effect run's connect attempt. Keyed by the
+    // retry generation so an overlapping retry/reconnect (which re-runs the
+    // effect via the retryCount dep) gets a distinct id. The cleanup below
+    // cancels only this id, so a stale cleanup can never abort a newer
+    // attempt's in-flight handshake (#1125).
+    const connectId = `${tabId}:${retryCount}`;
+
     // Create an imperative DOM element for xterm (not managed by React rendering)
     const el = document.createElement("div");
     el.style.position = "absolute";
@@ -912,7 +922,7 @@ export function Terminal({
     fitAddonRef.current = fitAddon;
 
     // Wire to backend
-    setupTerminal(xterm, fitAddon, () => canceled);
+    setupTerminal(xterm, fitAddon, () => canceled, connectId);
 
     // Re-fit once web fonts finish loading. The terminal font (Nerd Font
     // Mono) ships via @font-face with `font-display: swap`, so xterm's
@@ -1010,9 +1020,11 @@ export function Terminal({
       canceled = true;
       // If the tab is torn down while a connect is in flight (e.g. the user hit
       // Cancel on the connecting overlay), abort the backend's handshake instead
-      // of leaving it to run to completion (#952).
+      // of leaving it to run to completion (#952). Cancel only THIS effect run's
+      // connect id — never the bare tabId — so an overlapping newer attempt is
+      // not aborted by this stale cleanup (#1125).
       if (connectInFlightRef.current) {
-        void cancelConnecting(tabId).catch(() => {});
+        void cancelConnecting(connectId).catch(() => {});
       }
       resizeObserver.disconnect();
       el.removeEventListener("wheel", handleGapWheel);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -98,7 +98,10 @@ export async function cancelConnectionPathProbe(probeId: string): Promise<boolea
  * and forwards the rest as settings. For other types: passes config directly.
  *
  * `connectId` (when provided) lets the caller cancel a still-connecting session
- * via {@link cancelConnecting} — pass a stable per-attempt id such as the tab id.
+ * via {@link cancelConnecting}. Pass a UNIQUE per-attempt id (e.g.
+ * `${tabId}:${retryCount}`), not the bare tab id: overlapping retry/reconnect
+ * attempts for the same tab must not share an id, or a stale attempt's cancel
+ * would abort a newer in-flight connect (#1125).
  */
 export async function createTerminal(
   config: ConnectionConfig,


### PR DESCRIPTION
## Summary

Overlapping connect attempts for the same tab used to share a single cancellation-map key (`connect_id = tabId`). A retry/reconnect re-runs the whole connect effect (`retryCount` dependency). If the previous `createTerminal` was still in flight when the new attempt registered its cancellation token, the old effect's cleanup ran `cancelConnecting(tabId)` and aborted the **new** attempt's handshake — landing the tab in a spurious Failed state (rapid Cancel→Retry, or a reconnect firing while the prior connect was slow).

## Fix

Thread a **unique per-attempt connect id** (`${tabId}:${retryCount}`) through the connect path:

- `Terminal.tsx`: each connect effect run computes its own `connectId`, passes it to `setupTerminal` → `createTerminal`, and the effect cleanup cancels **only that id** (never the bare `tabId`). Because the id is captured in each effect run's closure, a stale cleanup can no longer cancel a newer attempt's token.
- `api.ts`: `createTerminal` JSDoc updated to require a unique per-attempt id.

No Rust change was needed: the backend cancellation map (`SessionManager::connecting`) already keys by an arbitrary `connect_id` string and clears the exact id via its RAII `ConnectingGuard`, so unique ids Just Work — the collision was purely on the frontend caller side.

Cancel/abort of the **current** attempt still works: the cleanup cancels the same id the current attempt registered.

Closes #1125

## Test plan

- Added a frontend regression test `Terminal.overlapping-connect.test.tsx`:
  - Mounts a direct (non-agent) Terminal whose `createTerminal` never resolves (stays in flight).
  - Triggers a reconnect while the first connect is in flight (effect re-runs via `retryCount`).
  - Asserts the two attempts use **distinct** connect ids and that the fresh attempt's id is **never** passed to `cancelConnecting`.
  - Verified **red** before the fix (both attempts used `tab-1`), **green** after.
- `pnpm` frontend suites for Terminal, api, OpenConnections: 236 passing.
- `tsc --noEmit`, `eslint`, `vite build`, `prettier --check`, `markdownlint-cli2`: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
