### PR TITLE
fix(embedded-servers): surface auto-start failures (#1145)

### DIFF
--- a/docs/changes/dev2/feature/1145-embedded-autostart-error.md
+++ b/docs/changes/dev2/feature/1145-embedded-autostart-error.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Embedded servers: auto-start failures at launch (e.g. a port already in use at boot) are no longer silent. A server marked "auto-start" that fails to start now shows as an error in the Embedded Servers sidebar with the reason, instead of silently staying stopped with no explanation (#1145, G7).

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -289,7 +289,15 @@ impl EmbeddedServerManager {
         for cfg in configs {
             if cfg.auto_start {
                 if let Err(e) = self.start_server(&cfg.id) {
-                    tracing::warn!(id = %cfg.id, "Failed to auto-start embedded server: {e}");
+                    // Surface the failure (e.g. port busy at boot) as an Error
+                    // state so the sidebar shows the server red with a reason,
+                    // instead of silently leaving it stopped (GAP G7, #1145).
+                    let msg = e.to_string();
+                    tracing::warn!(id = %cfg.id, "Failed to auto-start embedded server: {msg}");
+                    let state = auto_start_error_state(&cfg.id, &msg);
+                    let _ = self
+                        .app_handle
+                        .emit("embedded-server-status-changed", &state);
                 }
             }
         }
@@ -299,6 +307,14 @@ impl EmbeddedServerManager {
 
     /// Attempt a quick bind to check whether the port is available.
     fn check_port(&self, config: &EmbeddedServerConfig) -> Result<(), TerminalError> {
+        Self::check_port_config(config)
+    }
+
+    /// Attempt a quick bind to check whether a config's port is available.
+    ///
+    /// Static so the pre-flight check can be exercised without a live manager
+    /// (and its [`AppHandle`]).
+    fn check_port_config(config: &EmbeddedServerConfig) -> Result<(), TerminalError> {
         let addr = format!("{}:{}", config.bind_host, config.port);
         match config.server_type {
             ServerType::Tftp => {
@@ -334,6 +350,21 @@ impl EmbeddedServerManager {
         let _ = self
             .app_handle
             .emit("embedded-server-status-changed", &state);
+    }
+}
+
+/// Build the `Error` [`ServerState`] surfaced when a server marked `auto_start`
+/// fails to start at launch (e.g. its port is already in use).
+///
+/// Keeps the failure visible in the sidebar (red, with a reason) instead of
+/// silently leaving the server stopped (GAP G7, #1145).
+fn auto_start_error_state(server_id: &str, error: &str) -> ServerState {
+    ServerState {
+        server_id: server_id.to_string(),
+        status: ServerStatus::Error,
+        error: Some(error.to_string()),
+        stats: ServerStats::default(),
+        started_at: None,
     }
 }
 

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -336,3 +336,56 @@ impl EmbeddedServerManager {
             .emit("embedded-server-status-changed", &state);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A port bound at boot must not cause a silent no-op: the auto-start
+    /// failure has to surface as an `Error` state carrying the reason so the
+    /// sidebar can show the server red at launch (GAP G7, #1145).
+    #[test]
+    fn auto_start_failure_surfaces_error_state_with_message() {
+        // Bind a TCP port so the pre-flight bind check fails deterministically.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("should bind an ephemeral port for the test");
+        let busy_port = listener
+            .local_addr()
+            .expect("bound listener should expose its address")
+            .port();
+
+        let config = EmbeddedServerConfig {
+            id: "auto-http".to_string(),
+            name: "Auto HTTP".to_string(),
+            server_type: ServerType::Http,
+            root_directory: ".".to_string(),
+            bind_host: "127.0.0.1".to_string(),
+            port: busy_port,
+            auto_start: true,
+            read_only: true,
+            directory_listing: None,
+            ftp_auth: None,
+        };
+
+        // Reproduce the auto-start pre-flight failure: the port is taken.
+        let err = EmbeddedServerManager::check_port_config(&config)
+            .expect_err("binding an already-bound port must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already in use"),
+            "error should explain the port is busy, got: {msg}"
+        );
+
+        // The failure must be turned into a visible Error state, not swallowed.
+        let state = auto_start_error_state(&config.id, &msg);
+        assert_eq!(state.server_id, "auto-http");
+        assert_eq!(state.status, ServerStatus::Error);
+        assert_eq!(state.error.as_deref(), Some(msg.as_str()));
+        assert!(
+            state.error.is_some_and(|e| e.contains("already in use")),
+            "surfaced error must carry the reason"
+        );
+
+        drop(listener);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes GAP **G7** from the embedded-servers state-machine audit (`docs/audits/embedded-servers-state-machine.md`): auto-start failures at launch were completely invisible.

Previously, `EmbeddedServerManager::start_auto_servers` only logged a `warn!` when a server marked `auto_start` failed to start (e.g. its port was already in use at boot) and emitted no event. The result: the server silently stayed stopped with no explanation, and the sidebar showed no error.

Now, on an auto-start failure, the manager emits an `Error` `ServerState` carrying the failure reason via the existing `embedded-server-status-changed` event, so the Embedded Servers sidebar shows the server red with the reason at launch.

## Changes

- `src-tauri/src/embedded_servers/server_manager.rs`:
  - `start_auto_servers` now emits an `Error` state (with message) on a failed auto-start, matching the existing status-emission mechanism.
  - Added `auto_start_error_state(server_id, error)` helper that builds the `Error` `ServerState`.
  - Extracted the pre-flight port check into a static `check_port_config` (the instance `check_port` delegates to it) so the failure path is unit-testable without a live `AppHandle`.
- `docs/changes/dev2/feature/1145-embedded-autostart-error.md`: change fragment.

Happy-path start/stop and the other audit gaps are untouched.

## Test plan

- New regression test `auto_start_failure_surfaces_error_state_with_message`: binds an ephemeral TCP port, points a config at it, confirms the pre-flight bind check fails with an "already in use" reason, and asserts that reason is turned into an `Error` `ServerState` (not swallowed).
- `cargo test -p termihub --lib embedded_servers::server_manager` → `1 passed`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

Partially addresses #1145 (G7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)