### PR TITLE
fix(credential): feedback on credential-store actions (#1144)

### DIFF
--- a/docs/changes/dev2/feature/1144-credential-feedback-toasts.md
+++ b/docs/changes/dev2/feature/1144-credential-feedback-toasts.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Credential store actions now confirm success or failure with a toast instead
+  of resolving silently. Locking the store from the status-bar indicator shows a
+  success toast (and a recoverable error toast on failure, replacing a silent
+  console error); switching credential storage modes and changing the master
+  password show success toasts, and a failed store switch surfaces an error
+  toast. Wrong-current-password errors on the change dialog remain inline as
+  before (#1144).

--- a/src/components/CredentialStoreIndicator/CredentialStoreIndicator.test.tsx
+++ b/src/components/CredentialStoreIndicator/CredentialStoreIndicator.test.tsx
@@ -21,10 +21,20 @@ vi.mock("@/services/api", () => ({
   lockCredentialStore: vi.fn(),
 }));
 
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
 import { lockCredentialStore } from "@/services/api";
 import { useAppStore } from "@/store/appStore";
+import { toast } from "@/components/ui";
 
 const mockedLock = vi.mocked(lockCredentialStore);
+const mockedToast = vi.mocked(toast);
 
 let container: HTMLDivElement;
 let root: Root;
@@ -175,5 +185,46 @@ describe("CredentialStoreIndicator", () => {
     });
 
     expect(mockedLock).toHaveBeenCalled();
+  });
+
+  it("shows a success toast after locking the store", async () => {
+    mockedLock.mockResolvedValueOnce(undefined);
+    const status: CredentialStoreStatusInfo = {
+      mode: "master_password",
+      status: "unlocked",
+    };
+    useAppStore.setState({ credentialStoreStatus: status });
+
+    act(() => {
+      root.render(<CredentialStoreIndicator />);
+    });
+
+    const indicator = query("credential-store-indicator") as HTMLButtonElement;
+    await act(async () => {
+      indicator.click();
+    });
+
+    expect(mockedToast.success).toHaveBeenCalledWith(expect.stringContaining("locked"));
+  });
+
+  it("shows an error toast when locking fails", async () => {
+    mockedLock.mockRejectedValueOnce(new Error("boom"));
+    const status: CredentialStoreStatusInfo = {
+      mode: "master_password",
+      status: "unlocked",
+    };
+    useAppStore.setState({ credentialStoreStatus: status });
+
+    act(() => {
+      root.render(<CredentialStoreIndicator />);
+    });
+
+    const indicator = query("credential-store-indicator") as HTMLButtonElement;
+    await act(async () => {
+      indicator.click();
+    });
+
+    expect(mockedToast.error).toHaveBeenCalledWith(expect.stringContaining("lock"));
+    expect(mockedToast.success).not.toHaveBeenCalled();
   });
 });

--- a/src/components/CredentialStoreIndicator/CredentialStoreIndicator.tsx
+++ b/src/components/CredentialStoreIndicator/CredentialStoreIndicator.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { KeyRound, Lock, LockOpen } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { lockCredentialStore } from "@/services/api";
+import { toast } from "@/components/ui";
 import "./CredentialStoreIndicator.css";
 
 /**
@@ -24,8 +25,11 @@ export function CredentialStoreIndicator() {
     } else {
       try {
         await lockCredentialStore();
+        toast.success("Credential store locked");
       } catch (err) {
-        console.error("Failed to lock credential store:", err);
+        toast.error(
+          `Failed to lock credential store: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     }
   }, [status, setUnlockDialogOpen]);

--- a/src/components/Settings/SecuritySettings.test.tsx
+++ b/src/components/Settings/SecuritySettings.test.tsx
@@ -10,7 +10,28 @@ vi.mock("@/themes", () => ({
   onThemeChange: vi.fn(() => vi.fn()),
 }));
 
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+import { toast } from "@/components/ui";
+
 const mockedInvoke = vi.mocked(invoke);
+const mockedToast = vi.mocked(toast);
+
+/** Sets a controlled input's value the way the harness does (React-friendly). */
+function setInputValue(input: HTMLInputElement, value: string) {
+  input.focus();
+  Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!.call(
+    input,
+    value
+  );
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
 
 let container: HTMLDivElement;
 let root: Root;
@@ -216,5 +237,130 @@ describe("SecuritySettings", () => {
     // switch_credential_store must have been called with the password
     const switchCalls = mockedInvoke.mock.calls.filter((c) => c[0] === "switch_credential_store");
     expect(switchCalls.length).toBeGreaterThan(0);
+  });
+
+  it("shows a success toast after a successful store switch", async () => {
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+    });
+
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "switch_credential_store") {
+        return Promise.resolve({ migratedCount: 2, warnings: [] });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render();
+
+    const noneOption = query("storage-mode-none") as HTMLElement;
+    await act(async () => {
+      noneOption.click();
+    });
+
+    const confirmBtn = query("confirm-switch-confirm-btn") as HTMLElement;
+    await act(async () => {
+      confirmBtn.click();
+    });
+
+    expect(mockedToast.success).toHaveBeenCalled();
+  });
+
+  it("shows an error toast when the store switch fails", async () => {
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+    });
+
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "switch_credential_store") {
+        return Promise.reject(new Error("switch boom"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render();
+
+    const noneOption = query("storage-mode-none") as HTMLElement;
+    await act(async () => {
+      noneOption.click();
+    });
+
+    const confirmBtn = query("confirm-switch-confirm-btn") as HTMLElement;
+    await act(async () => {
+      confirmBtn.click();
+    });
+
+    expect(mockedToast.error).toHaveBeenCalled();
+    expect(mockedToast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows a success toast after changing the master password", async () => {
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+    });
+
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "change_master_password") {
+        return Promise.resolve(undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render();
+
+    const btn = query("change-master-password-btn") as HTMLElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    await act(async () => {
+      setInputValue(query("change-master-password-current") as HTMLInputElement, "oldpass12");
+      setInputValue(query("change-master-password-new") as HTMLInputElement, "newpass123");
+      setInputValue(query("change-master-password-confirm") as HTMLInputElement, "newpass123");
+    });
+
+    const confirmBtn = query("change-master-password-confirm-btn") as HTMLElement;
+    await act(async () => {
+      confirmBtn.click();
+    });
+
+    expect(mockedToast.success).toHaveBeenCalled();
+  });
+
+  it("keeps the wrong-password change failure inline (no success toast, dialog stays open)", async () => {
+    // Per the audit, the wrong-current-password case stays an inline field error
+    // (not a toast); only the success path is promoted to a toast.
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+    });
+
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "change_master_password") {
+        return Promise.reject(new Error("Current password is incorrect"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render();
+
+    const btn = query("change-master-password-btn") as HTMLElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    await act(async () => {
+      setInputValue(query("change-master-password-current") as HTMLInputElement, "wrongpass1");
+      setInputValue(query("change-master-password-new") as HTMLInputElement, "newpass123");
+      setInputValue(query("change-master-password-confirm") as HTMLInputElement, "newpass123");
+    });
+
+    const confirmBtn = query("change-master-password-confirm-btn") as HTMLElement;
+    await act(async () => {
+      confirmBtn.click();
+    });
+
+    expect(mockedToast.success).not.toHaveBeenCalled();
+    // The inline error still surfaces the wrong-password feedback; dialog stays open.
+    expect(query("change-password-dialog")).not.toBeNull();
   });
 });

--- a/src/components/Settings/SecuritySettings.tsx
+++ b/src/components/Settings/SecuritySettings.tsx
@@ -4,7 +4,7 @@ import { useAppStore } from "@/store/appStore";
 import { CredentialStorageMode } from "@/types/credential";
 import { switchCredentialStore, changeMasterPassword, setAutoLockTimeout } from "@/services/api";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
-import { Button } from "@/components/ui";
+import { Button, toast } from "@/components/ui";
 
 interface SecuritySettingsProps {
   visibleFields?: Set<string>;
@@ -122,6 +122,7 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
 
   const handleConfirmSwitch = useCallback(async () => {
     if (!confirmSwitch) return;
+    const targetMode = confirmSwitch;
 
     if (confirmSwitch === "master_password") {
       if (!newPassword) {
@@ -151,8 +152,17 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
       setNewPassword("");
       setConfirmPassword("");
       await loadCredentialStoreStatus();
+      toast.success(
+        result.migratedCount > 0
+          ? `Switched to ${modeLabel(targetMode)} — ${result.migratedCount} credential${
+              result.migratedCount !== 1 ? "s" : ""
+            } migrated`
+          : `Switched to ${modeLabel(targetMode)}`
+      );
     } catch (err) {
-      setPasswordError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      setPasswordError(message);
+      toast.error(`Failed to switch credential store: ${message}`);
     } finally {
       setSwitching(false);
     }
@@ -179,6 +189,7 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
     try {
       await changeMasterPassword(currentPasswordInput, changeNewPassword);
       resetChangePasswordDialog();
+      toast.success("Master password changed");
     } catch (err) {
       setChangePasswordError(err instanceof Error ? err.message : String(err));
     }


### PR DESCRIPTION
## Summary

Implements GAP **G5** from the credential-store audit (`docs/audits/credential-store-state-machine.md`): mutating credential-store actions previously resolved with no user feedback (or a silent `console.error`), violating the design-system rule "every action gives feedback."

## Changes

- **`CredentialStoreIndicator.tsx`** — clicking the status-bar indicator to lock the store now shows `toast.success("Credential store locked")`, and a lock failure shows a recoverable `toast.error(...)` (replacing the previous `console.error`).
- **`SecuritySettings.tsx`**
  - Successful store switch now shows `toast.success(...)` (including the migrated-credential count when > 0); failed switch shows `toast.error(...)` (the inline error is retained).
  - Successful master-password change shows `toast.success("Master password changed")`.
  - The wrong-current-password change failure stays an inline field error (unchanged), and the existing `UnlockDialog` toast is untouched.

## Test plan

- New Vitest cases (TDD, committed before the fix):
  - `CredentialStoreIndicator.test.tsx` — success toast on lock; error toast on lock failure.
  - `SecuritySettings.test.tsx` — success toast on store switch; error toast on failed switch; success toast on master-password change; wrong-password change stays inline with no success toast.
- `pnpm test` — full suite green (2210 tests).
- `pnpm build` (tsc typecheck), `pnpm run lint`, `pnpm run format:check` — all clean.

Partially addresses #1144 (G5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)