### PR TITLE
fix(network): feedback on HTTP monitor stop (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-http-monitor-stop-feedback.md
+++ b/docs/changes/dev2/feature/1147-http-monitor-stop-feedback.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- HTTP monitor (Network Tools): stopping a monitor now shows a confirmation
+  toast ("Monitor stopped") on success and an error toast on failure. Stopping
+  a monitor previously gave no feedback — a successful stop was silent and a
+  failed stop only set an inline error or a log entry. This applies to both the
+  HTTP Monitor panel (the active monitor and the listed running monitors) and
+  the Network Tools sidebar stop control. (#1147)

--- a/src/components/NetworkTools/HttpMonitorPanel.stop-feedback.test.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.stop-feedback.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Regression test for gap #10 from the HTTP monitor audit (#1147).
+ *
+ * Stopping a monitor previously updated component state but surfaced no
+ * feedback — a successful stop was silent and a failed stop only set an inline
+ * error string (violating design-system rule 4: every action gives feedback).
+ * These tests pin that the panel's stop paths emit a success toast on success
+ * and an error toast on failure.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { networkHttpMonitorStop, networkHttpMonitorList } from "@/services/networkApi";
+import type { HttpMonitorState } from "@/types/network";
+import { toast } from "@/components/ui";
+import { HttpMonitorPanel } from "./HttpMonitorPanel";
+import { TooltipProvider } from "@/components/ui";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts the tooltip-wrapped icon buttons; shim them so the panel renders.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+/** Wrap a subtree so the shared Tooltip primitive finds its provider. */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStart: vi.fn(() => Promise.resolve("mon-1")),
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+  onHttpMonitorCheck: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+// LatencyChart draws to a canvas jsdom can't back; stub it out.
+vi.mock("./LatencyChart", () => ({ LatencyChart: () => null }));
+
+function makeMonitor(id: string): HttpMonitorState {
+  return {
+    config: {
+      id,
+      url: "https://example.com",
+      intervalMs: 30_000,
+      method: "GET",
+      expectedStatus: 200,
+      timeoutMs: 10_000,
+    },
+    running: true,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Set a React-controlled input's value via the native setter so onChange fires. */
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function startActiveMonitor() {
+  await act(async () => {
+    setInputValue(
+      container.querySelector<HTMLInputElement>('[data-testid="http-monitor-url"]')!,
+      "https://example.com"
+    );
+  });
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('[data-testid="http-monitor-start"]')!.click();
+  });
+  await flush();
+}
+
+describe("HttpMonitorPanel — stop feedback (#1147 gap #10)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows a success toast when the active monitor stops", async () => {
+    await act(async () => {
+      root.render(withTooltip(<HttpMonitorPanel />));
+    });
+    await flush();
+    await startActiveMonitor();
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="http-monitor-stop"]')!.click();
+    });
+    await flush();
+
+    expect(toast.success).toHaveBeenCalledWith("Monitor stopped");
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast when stopping the active monitor fails", async () => {
+    vi.mocked(networkHttpMonitorStop).mockRejectedValueOnce(new Error("boom"));
+    await act(async () => {
+      root.render(withTooltip(<HttpMonitorPanel />));
+    });
+    await flush();
+    await startActiveMonitor();
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="http-monitor-stop"]')!.click();
+    });
+    await flush();
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows a success toast when stopping a listed running monitor", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-2")]);
+    await act(async () => {
+      root.render(withTooltip(<HttpMonitorPanel />));
+    });
+    await flush();
+
+    const stopBtn = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Stop monitoring https://example.com"]'
+    );
+    expect(stopBtn).not.toBeNull();
+    await act(async () => {
+      stopBtn!.click();
+    });
+    await flush();
+
+    expect(toast.success).toHaveBeenCalledWith("Monitor stopped");
+  });
+
+  it("shows an error toast when stopping a listed running monitor fails", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-2")]);
+    vi.mocked(networkHttpMonitorStop).mockRejectedValueOnce(new Error("boom"));
+    await act(async () => {
+      root.render(withTooltip(<HttpMonitorPanel />));
+    });
+    await flush();
+
+    const stopBtn = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Stop monitoring https://example.com"]'
+    );
+    await act(async () => {
+      stopBtn!.click();
+    });
+    await flush();
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/NetworkTools/HttpMonitorPanel.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.tsx
@@ -111,8 +111,10 @@ export function HttpMonitorPanel() {
       await networkHttpMonitorStop(activeMonitorIdRef.current);
       clearActiveMonitor();
       await loadMonitors();
+      toast.success("Monitor stopped");
     } catch (err) {
       setError(String(err));
+      toast.error(`Failed to stop monitor: ${err}`);
     }
   }, [loadMonitors, clearActiveMonitor]);
 
@@ -122,8 +124,10 @@ export function HttpMonitorPanel() {
         await networkHttpMonitorStop(id);
         if (id === activeMonitorIdRef.current) clearActiveMonitor();
         await loadMonitors();
+        toast.success("Monitor stopped");
       } catch (err) {
         setError(String(err));
+        toast.error(`Failed to stop monitor: ${err}`);
       }
     },
     [loadMonitors, clearActiveMonitor]

--- a/src/components/NetworkTools/NetworkToolsSidebar.stop-feedback.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.stop-feedback.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Regression test for gap #10 from the HTTP monitor audit (#1147).
+ *
+ * The sidebar's stop path previously only logged failures via frontendLog and
+ * gave no feedback at all on success. These tests pin that stopping a monitor
+ * from the sidebar emits a success toast on success and an error toast on
+ * failure (design-system rule 4: every action gives feedback).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { networkHttpMonitorList, networkHttpMonitorStop } from "@/services/networkApi";
+import type { HttpMonitorState } from "@/types/network";
+import { useAppStore } from "@/store/appStore";
+import { toast } from "@/components/ui";
+import { NetworkToolsSidebar } from "./NetworkToolsSidebar";
+import { TooltipProvider } from "@/components/ui";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts the tooltip-wrapped icon buttons; shim them so the sidebar renders.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+/** Wrap a subtree so the shared Tooltip primitive finds its provider. */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  onHttpMonitorCheck: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+function makeMonitor(id: string): HttpMonitorState {
+  return {
+    config: {
+      id,
+      url: "https://example.com",
+      intervalMs: 30_000,
+      method: "GET",
+      expectedStatus: 200,
+      timeoutMs: 10_000,
+    },
+    running: true,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("NetworkToolsSidebar — stop feedback (#1147 gap #10)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ httpMonitors: [makeMonitor("mon-1")] });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    useAppStore.setState({ httpMonitors: [] });
+  });
+
+  it("shows a success toast when a monitor is stopped from the sidebar", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-1")]);
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const stopBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="monitor-row-mon-1"] [aria-label="Stop monitor"]'
+    );
+    expect(stopBtn).not.toBeNull();
+    await act(async () => {
+      stopBtn!.click();
+    });
+    await flush();
+
+    expect(toast.success).toHaveBeenCalledWith("Monitor stopped");
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast when stopping a monitor from the sidebar fails", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-1")]);
+    vi.mocked(networkHttpMonitorStop).mockRejectedValueOnce(new Error("boom"));
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const stopBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="monitor-row-mon-1"] [aria-label="Stop monitor"]'
+    );
+    await act(async () => {
+      stopBtn!.click();
+    });
+    await flush();
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/NetworkTools/NetworkToolsSidebar.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.tsx
@@ -10,7 +10,7 @@ import {
 import type { NetworkTool } from "@/types/terminal";
 import type { HttpMonitorState } from "@/types/network";
 import { frontendLog } from "@/utils/frontendLog";
-import { Button, Tooltip } from "@/components/ui";
+import { Button, Tooltip, toast } from "@/components/ui";
 
 interface QuickActionProps {
   label: string;
@@ -138,8 +138,10 @@ export function NetworkToolsSidebar() {
       try {
         await networkHttpMonitorStop(id);
         await refreshMonitors();
+        toast.success("Monitor stopped");
       } catch (err) {
         frontendLog("network_sidebar", `Failed to stop monitor: ${err}`);
+        toast.error(`Failed to stop monitor: ${err}`);
       }
     },
     [refreshMonitors]


### PR DESCRIPTION
## Summary

Stopping an HTTP monitor previously gave no user feedback: a successful stop was silent and a failed stop only set an inline error string (panel) or wrote to the LogViewer (sidebar), violating design-system rule 4 ("every action gives feedback"). This adds success and error toasts to every stop path.

This is gap #10 of the HTTP monitor state-machine audit (`docs/audits/http-monitor-state-machine.md`).

## Changes

- `src/components/NetworkTools/HttpMonitorPanel.tsx`: both stop paths — `handleStop` (active monitor) and `handleStopMonitor` (a listed running monitor) — now call `toast.success("Monitor stopped")` on success and `toast.error(...)` on failure (in addition to the existing inline error).
- `src/components/NetworkTools/NetworkToolsSidebar.tsx`: the sidebar stop path (`handleStopMonitor`) now surfaces `toast.success(...)` / `toast.error(...)` instead of only logging failures to the LogViewer.

Scope is deliberately limited to stop feedback. Pause / remove / persistence (other audit gaps) are out of scope.

## Test plan

- Added `HttpMonitorPanel.stop-feedback.test.tsx` (4 tests) and `NetworkToolsSidebar.stop-feedback.test.tsx` (2 tests), each asserting a success toast on a successful stop and an error toast on a failed stop. Confirmed RED before the fix (6 failing) and GREEN after.
- `pnpm test`: 2198 passed / 189 files.
- `pnpm build` (tsc typecheck + Vite): success.
- `pnpm run lint`, `pnpm run format:check`: pass.

Partially addresses #1147 (#10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
