### PR TITLE
feat(ui): adopt Tooltip on WorkspaceSidebar and WorkspaceEditor icon buttons

### DIFF
--- a/docs/changes/dev1/feature/1160-tooltip-workspace.md
+++ b/docs/changes/dev1/feature/1160-tooltip-workspace.md
@@ -1,0 +1,10 @@
+## Changed
+
+- The Workspace sidebar and Workspace editor icon buttons (New / Save Current /
+  Export / Import; per-workspace Launch / Edit / Duplicate / Delete; and the
+  layout designer's split, add-connection, add/remove group, remove-panel,
+  remove-tab, reset-sizes, and size-badge controls) now use the shared
+  accessible Tooltip for hover help — consistent, themed, and reachable on
+  keyboard focus instead of mouse-only. Each converted button exposes its label
+  as a proper accessible name (`aria-label`) instead of the browser `title`.
+  Truncation/full-text hovers on workspace names and paths are unchanged (#1160).

--- a/src/components/WorkspaceEditor/LayoutDesigner.test.tsx
+++ b/src/components/WorkspaceEditor/LayoutDesigner.test.tsx
@@ -221,7 +221,9 @@ describe("LayoutDesigner", () => {
     });
 
     act(() => {
-      root.render(withTooltip(<LayoutDesigner layout={leaf(tab("a"), tab("b"))} onChange={onChange} />));
+      root.render(
+        withTooltip(<LayoutDesigner layout={leaf(tab("a"), tab("b"))} onChange={onChange} />)
+      );
     });
 
     act(() => {

--- a/src/components/WorkspaceEditor/LayoutDesigner.test.tsx
+++ b/src/components/WorkspaceEditor/LayoutDesigner.test.tsx
@@ -1,9 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act } from "react";
+import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { LayoutDesigner } from "./LayoutDesigner";
+import { TooltipProvider } from "@/components/ui";
 import { WorkspaceLayoutNode, WorkspaceLeafNode, WorkspaceTabDef } from "@/types/workspace";
 import { getWorkspaceLeaves } from "@/utils/workspaceLayout";
+
+// jsdom lacks the pointer-capture APIs Radix Tooltip touches; shim them so the
+// tooltip-wrapped layout buttons render.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+/** Wrap so the shared Tooltip primitive finds its provider. */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -53,7 +67,7 @@ describe("LayoutDesigner", () => {
   it("renders with a single leaf", () => {
     const onChange = vi.fn();
     act(() => {
-      root.render(<LayoutDesigner layout={leaf(tab("a"))} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={leaf(tab("a"))} onChange={onChange} />));
     });
 
     expect(query("layout-designer")).not.toBeNull();
@@ -63,7 +77,7 @@ describe("LayoutDesigner", () => {
   it("does not show X button when only one leaf exists", () => {
     const onChange = vi.fn();
     act(() => {
-      root.render(<LayoutDesigner layout={leaf(tab("a"))} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={leaf(tab("a"))} onChange={onChange} />));
     });
 
     expect(query("layout-remove-leaf-0")).toBeNull();
@@ -73,7 +87,7 @@ describe("LayoutDesigner", () => {
     const onChange = vi.fn();
     const layout = hsplit(leaf(tab("a")), leaf(tab("b")));
     act(() => {
-      root.render(<LayoutDesigner layout={layout} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={layout} onChange={onChange} />));
     });
 
     expect(query("layout-remove-leaf-0")).not.toBeNull();
@@ -87,7 +101,7 @@ describe("LayoutDesigner", () => {
     });
 
     act(() => {
-      root.render(<LayoutDesigner layout={leaf(tab("a"))} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={leaf(tab("a"))} onChange={onChange} />));
     });
 
     act(() => {
@@ -107,7 +121,7 @@ describe("LayoutDesigner", () => {
     });
 
     act(() => {
-      root.render(<LayoutDesigner layout={leaf(tab("a"))} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={leaf(tab("a"))} onChange={onChange} />));
     });
 
     act(() => {
@@ -116,7 +130,7 @@ describe("LayoutDesigner", () => {
 
     // Re-render with new layout — new leaf (index 1) should be selected
     act(() => {
-      root.render(<LayoutDesigner layout={lastLayout!} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={lastLayout!} onChange={onChange} />));
     });
 
     const leaf1 = query("layout-leaf-1");
@@ -131,7 +145,7 @@ describe("LayoutDesigner", () => {
 
     const layout = hsplit(leaf(tab("a")), leaf(tab("b")));
     act(() => {
-      root.render(<LayoutDesigner layout={layout} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={layout} onChange={onChange} />));
     });
 
     // Split the second panel using its inline button
@@ -151,7 +165,7 @@ describe("LayoutDesigner", () => {
     const onChange = vi.fn();
     const layout = hsplit(leaf(tab("a")), leaf(tab("b")));
     act(() => {
-      root.render(<LayoutDesigner layout={layout} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={layout} onChange={onChange} />));
     });
 
     const allText = container.textContent ?? "";
@@ -162,7 +176,7 @@ describe("LayoutDesigner", () => {
   it("shows empty state prompt for empty leaf", () => {
     const onChange = vi.fn();
     act(() => {
-      root.render(<LayoutDesigner layout={leaf()} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={leaf()} onChange={onChange} />));
     });
 
     const emptyEl = container.querySelector(".layout-leaf__empty");
@@ -173,7 +187,7 @@ describe("LayoutDesigner", () => {
     const onChange = vi.fn();
     const layout = hsplit(leaf(tab("a")), leaf(tab("b")));
     act(() => {
-      root.render(<LayoutDesigner layout={layout} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={layout} onChange={onChange} />));
     });
 
     expect(query("layout-leaf-split-h-0")).not.toBeNull();
@@ -191,7 +205,7 @@ describe("LayoutDesigner", () => {
       { connectionRef: "other-conn" }
     );
     act(() => {
-      root.render(<LayoutDesigner layout={layout} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={layout} onChange={onChange} />));
     });
 
     const tabNames = container.querySelectorAll(".layout-tab__name");
@@ -207,7 +221,7 @@ describe("LayoutDesigner", () => {
     });
 
     act(() => {
-      root.render(<LayoutDesigner layout={leaf(tab("a"), tab("b"))} onChange={onChange} />);
+      root.render(withTooltip(<LayoutDesigner layout={leaf(tab("a"), tab("b"))} onChange={onChange} />));
     });
 
     act(() => {

--- a/src/components/WorkspaceEditor/LayoutDesigner.tsx
+++ b/src/components/WorkspaceEditor/LayoutDesigner.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { SplitSquareHorizontal, SplitSquareVertical, Plus, X, RotateCcw } from "lucide-react";
+import { Tooltip } from "@/components/ui";
 import { WorkspaceLayoutNode, WorkspaceSplitNode, WorkspaceTabDef } from "@/types/workspace";
 import {
   getWorkspaceLeaves,
@@ -184,29 +185,35 @@ function LayoutNodePreview({
         </span>
         <div className="layout-split-container__actions">
           {hasSizes && (
+            <Tooltip content="Reset to Equal" side="top">
+              <button
+                className="layout-split-container__action-btn"
+                onClick={() => onUpdateSizes(node, null)}
+                aria-label="Reset to Equal"
+                data-testid="layout-size-reset"
+              >
+                <RotateCcw size={10} />
+              </button>
+            </Tooltip>
+          )}
+          <Tooltip content="Split Horizontal" side="top">
             <button
               className="layout-split-container__action-btn"
-              onClick={() => onUpdateSizes(node, null)}
-              title="Reset to Equal"
-              data-testid="layout-size-reset"
+              onClick={() => onSplitContainer(node, "horizontal")}
+              aria-label="Split Horizontal"
             >
-              <RotateCcw size={10} />
+              <SplitSquareHorizontal size={10} />
             </button>
-          )}
-          <button
-            className="layout-split-container__action-btn"
-            onClick={() => onSplitContainer(node, "horizontal")}
-            title="Split Horizontal"
-          >
-            <SplitSquareHorizontal size={10} />
-          </button>
-          <button
-            className="layout-split-container__action-btn"
-            onClick={() => onSplitContainer(node, "vertical")}
-            title="Split Vertical"
-          >
-            <SplitSquareVertical size={10} />
-          </button>
+          </Tooltip>
+          <Tooltip content="Split Vertical" side="top">
+            <button
+              className="layout-split-container__action-btn"
+              onClick={() => onSplitContainer(node, "vertical")}
+              aria-label="Split Vertical"
+            >
+              <SplitSquareVertical size={10} />
+            </button>
+          </Tooltip>
         </div>
       </div>
       <div
@@ -311,14 +318,16 @@ function SizeBadge({ size, isCustom, splitNode, childIndex, onUpdateSizes }: Siz
   }
 
   return (
-    <button
-      className={`layout-size-badge ${isCustom ? "layout-size-badge--custom" : ""}`}
-      onClick={handleStartEdit}
-      title="Click to edit size"
-      data-testid="layout-size-badge"
-    >
-      {Math.round(size)}%
-    </button>
+    <Tooltip content="Click to edit size" side="top">
+      <button
+        className={`layout-size-badge ${isCustom ? "layout-size-badge--custom" : ""}`}
+        onClick={handleStartEdit}
+        aria-label="Click to edit size"
+        data-testid="layout-size-badge"
+      >
+        {Math.round(size)}%
+      </button>
+    </Tooltip>
   );
 }
 
@@ -355,52 +364,60 @@ function LeafPanel({
     <div className={className} onClick={onSelect} data-testid={`layout-leaf-${idx}`}>
       <div className="layout-leaf__header">
         <div className="layout-leaf__actions">
-          <button
-            className="layout-leaf__action-btn"
-            onClick={(e) => {
-              e.stopPropagation();
-              onSplitH();
-            }}
-            title="Split Horizontal"
-            data-testid={`layout-leaf-split-h-${idx}`}
-          >
-            <SplitSquareHorizontal size={10} />
-          </button>
-          <button
-            className="layout-leaf__action-btn"
-            onClick={(e) => {
-              e.stopPropagation();
-              onSplitV();
-            }}
-            title="Split Vertical"
-            data-testid={`layout-leaf-split-v-${idx}`}
-          >
-            <SplitSquareVertical size={10} />
-          </button>
-          <button
-            className="layout-leaf__action-btn"
-            onClick={(e) => {
-              e.stopPropagation();
-              onAddTab();
-            }}
-            title="Add Connection"
-            data-testid={`layout-leaf-add-tab-${idx}`}
-          >
-            <Plus size={10} />
-          </button>
+          <Tooltip content="Split Horizontal" side="top">
+            <button
+              className="layout-leaf__action-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSplitH();
+              }}
+              aria-label="Split Horizontal"
+              data-testid={`layout-leaf-split-h-${idx}`}
+            >
+              <SplitSquareHorizontal size={10} />
+            </button>
+          </Tooltip>
+          <Tooltip content="Split Vertical" side="top">
+            <button
+              className="layout-leaf__action-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSplitV();
+              }}
+              aria-label="Split Vertical"
+              data-testid={`layout-leaf-split-v-${idx}`}
+            >
+              <SplitSquareVertical size={10} />
+            </button>
+          </Tooltip>
+          <Tooltip content="Add Connection" side="top">
+            <button
+              className="layout-leaf__action-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddTab();
+              }}
+              aria-label="Add Connection"
+              data-testid={`layout-leaf-add-tab-${idx}`}
+            >
+              <Plus size={10} />
+            </button>
+          </Tooltip>
         </div>
         {leafCount > 1 && (
-          <button
-            className="layout-leaf__remove"
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove();
-            }}
-            title="Remove Panel"
-            data-testid={`layout-remove-leaf-${idx}`}
-          >
-            <X size={10} />
-          </button>
+          <Tooltip content="Remove Panel" side="top">
+            <button
+              className="layout-leaf__remove"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove();
+              }}
+              aria-label="Remove Panel"
+              data-testid={`layout-remove-leaf-${idx}`}
+            >
+              <X size={10} />
+            </button>
+          </Tooltip>
         )}
       </div>
       <div className="layout-leaf__tabs">
@@ -412,17 +429,19 @@ function LeafPanel({
               <span className="layout-tab__name">
                 {tab.title ?? tab.connectionRef ?? "Inline Connection"}
               </span>
-              <button
-                className="layout-tab__remove"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onRemoveTab(tabIdx);
-                }}
-                title="Remove Tab"
-                data-testid={`layout-remove-tab-${idx}-${tabIdx}`}
-              >
-                <X size={10} />
-              </button>
+              <Tooltip content="Remove Tab" side="top">
+                <button
+                  className="layout-tab__remove"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemoveTab(tabIdx);
+                  }}
+                  aria-label="Remove Tab"
+                  data-testid={`layout-remove-tab-${idx}-${tabIdx}`}
+                >
+                  <X size={10} />
+                </button>
+              </Tooltip>
             </div>
           ))
         )}

--- a/src/components/WorkspaceEditor/WorkspaceEditor.tooltip.test.tsx
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.tooltip.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Verifies the workspace layout designer icon buttons adopt the shared
+ * `Tooltip` primitive (issue #1160, follow-up to #1114).
+ *
+ * A tooltip is not an accessible name, so each converted icon button must keep
+ * an `aria-label`, must no longer carry a bare `title`, and the Radix tooltip
+ * trigger must wire `aria-describedby` when focused. The stable `data-testid`s
+ * must survive the migration.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { LayoutDesigner } from "./LayoutDesigner";
+import { TooltipProvider } from "@/components/ui";
+import type { WorkspaceLayoutNode, WorkspaceTabDef } from "@/types/workspace";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so the tooltip-wrapped buttons render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+function tab(ref?: string): WorkspaceTabDef {
+  return { connectionRef: ref };
+}
+
+function leaf(...tabs: WorkspaceTabDef[]): WorkspaceLayoutNode {
+  return { type: "leaf", tabs };
+}
+
+function hsplit(...children: WorkspaceLayoutNode[]): WorkspaceLayoutNode {
+  return { type: "split", direction: "horizontal", children };
+}
+
+const noop = () => {};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Wrap so the shared Tooltip primitive finds its provider (zero delay). */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
+
+function render(layout: WorkspaceLayoutNode): void {
+  act(() => {
+    root.render(withTooltip(<LayoutDesigner layout={layout} onChange={noop} />));
+  });
+}
+
+describe("LayoutDesigner — tooltip adoption (#1160)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("exposes accessible names via aria-label without a bare title on leaf icons", async () => {
+    render(hsplit(leaf(tab("a"), tab("b")), leaf(tab("c"))));
+    await flush();
+
+    const ids = [
+      "layout-leaf-split-h-0",
+      "layout-leaf-split-v-0",
+      "layout-leaf-add-tab-0",
+      "layout-remove-leaf-0",
+      "layout-remove-tab-0-0",
+    ];
+    for (const id of ids) {
+      const btn = container.querySelector<HTMLButtonElement>(`[data-testid="${id}"]`);
+      expect(btn).not.toBeNull();
+      expect(btn?.getAttribute("aria-label")).toBeTruthy();
+      expect(btn?.getAttribute("title")).toBeNull();
+    }
+  });
+
+  it("exposes an accessible name without a bare title on the size-reset control", async () => {
+    // A split with custom sizes surfaces the reset-to-equal button.
+    const layout: WorkspaceLayoutNode = {
+      type: "split",
+      direction: "horizontal",
+      sizes: [70, 30],
+      children: [leaf(tab("a")), leaf(tab("b"))],
+    };
+    render(layout);
+    await flush();
+
+    const reset = container.querySelector<HTMLButtonElement>('[data-testid="layout-size-reset"]');
+    expect(reset).not.toBeNull();
+    expect(reset?.getAttribute("aria-label")).toBeTruthy();
+    expect(reset?.getAttribute("title")).toBeNull();
+  });
+
+  it("wires an icon button to its tooltip via aria-describedby on focus", async () => {
+    render(leaf(tab("a")));
+    await flush();
+
+    const add = container.querySelector<HTMLButtonElement>(
+      '[data-testid="layout-leaf-add-tab-0"]'
+    )!;
+    act(() => {
+      add.focus();
+      add.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    });
+
+    expect(add.getAttribute("aria-describedby")).toBeTruthy();
+  });
+});

--- a/src/components/WorkspaceEditor/WorkspaceEditor.tsx
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.tsx
@@ -5,7 +5,7 @@ import { WorkspaceEditorMeta } from "@/types/terminal";
 import { WorkspaceDefinition, WorkspaceLayoutNode, WorkspaceTabGroupDef } from "@/types/workspace";
 import { loadWorkspace } from "@/services/workspaceApi";
 import { getWorkspaceLeaves, countWorkspaceTabs } from "@/utils/workspaceLayout";
-import { Button, Input, Field } from "@/components/ui";
+import { Button, Input, Field, Tooltip } from "@/components/ui";
 import { frontendLog } from "@/utils/frontendLog";
 import { LayoutDesigner } from "./LayoutDesigner";
 import "./WorkspaceEditor.css";
@@ -241,41 +241,47 @@ export function WorkspaceEditor({ tabId, meta, isVisible }: WorkspaceEditorProps
                       {group.name}
                     </span>
                   )}
-                  <button
-                    className="workspace-group-chip__close"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleCloseGroup(index);
-                    }}
-                    title="Remove group"
-                    data-testid={`workspace-group-close-${index}`}
-                  >
-                    <X size={10} />
-                  </button>
+                  <Tooltip content="Remove group" side="top">
+                    <button
+                      className="workspace-group-chip__close"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleCloseGroup(index);
+                      }}
+                      aria-label="Remove group"
+                      data-testid={`workspace-group-close-${index}`}
+                    >
+                      <X size={10} />
+                    </button>
+                  </Tooltip>
                 </div>
               ))}
-              <button
-                className="workspace-group-strip__add"
-                onClick={handleAddGroup}
-                title="Add group"
-                data-testid="workspace-group-add"
-              >
-                <Plus size={12} />
-              </button>
+              <Tooltip content="Add group" side="top">
+                <button
+                  className="workspace-group-strip__add"
+                  onClick={handleAddGroup}
+                  aria-label="Add group"
+                  data-testid="workspace-group-add"
+                >
+                  <Plus size={12} />
+                </button>
+              </Tooltip>
             </div>
           )}
 
           {!showGroupStrip && (
             <div className="workspace-group-strip workspace-group-strip--single">
-              <button
-                className="workspace-group-strip__add"
-                onClick={handleAddGroup}
-                title="Add group"
-                data-testid="workspace-group-add"
-              >
-                <Plus size={12} />
-                Add Group
-              </button>
+              <Tooltip content="Add group" side="top">
+                <button
+                  className="workspace-group-strip__add"
+                  onClick={handleAddGroup}
+                  aria-label="Add group"
+                  data-testid="workspace-group-add"
+                >
+                  <Plus size={12} />
+                  Add Group
+                </button>
+              </Tooltip>
             </div>
           )}
 

--- a/src/components/WorkspaceSidebar/WorkspaceListItem.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceListItem.tsx
@@ -1,4 +1,5 @@
 import { Play, Pencil, Copy, Trash2 } from "lucide-react";
+import { Tooltip } from "@/components/ui";
 import { WorkspaceSummary } from "@/types/workspace";
 
 interface WorkspaceListItemProps {
@@ -27,50 +28,58 @@ export function WorkspaceListItem({
           {workspace.name}
         </span>
         <div className="workspace-item__actions">
-          <button
-            className="workspace-item__action"
-            title="Launch"
-            data-testid={`workspace-launch-${workspace.id}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onLaunch(workspace.id);
-            }}
-          >
-            <Play size={12} />
-          </button>
-          <button
-            className="workspace-item__action"
-            title="Edit"
-            data-testid={`workspace-edit-${workspace.id}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onEdit(workspace.id);
-            }}
-          >
-            <Pencil size={12} />
-          </button>
-          <button
-            className="workspace-item__action"
-            title="Duplicate"
-            data-testid={`workspace-duplicate-${workspace.id}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onDuplicate(workspace.id);
-            }}
-          >
-            <Copy size={12} />
-          </button>
-          <button
-            className="workspace-item__action"
-            title="Delete"
-            data-testid={`workspace-delete-${workspace.id}`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete(workspace.id);
-            }}
-          >
-            <Trash2 size={12} />
-          </button>
+          <Tooltip content="Launch" side="top">
+            <button
+              className="workspace-item__action"
+              aria-label="Launch"
+              data-testid={`workspace-launch-${workspace.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onLaunch(workspace.id);
+              }}
+            >
+              <Play size={12} />
+            </button>
+          </Tooltip>
+          <Tooltip content="Edit" side="top">
+            <button
+              className="workspace-item__action"
+              aria-label="Edit"
+              data-testid={`workspace-edit-${workspace.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(workspace.id);
+              }}
+            >
+              <Pencil size={12} />
+            </button>
+          </Tooltip>
+          <Tooltip content="Duplicate" side="top">
+            <button
+              className="workspace-item__action"
+              aria-label="Duplicate"
+              data-testid={`workspace-duplicate-${workspace.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDuplicate(workspace.id);
+              }}
+            >
+              <Copy size={12} />
+            </button>
+          </Tooltip>
+          <Tooltip content="Delete" side="top">
+            <button
+              className="workspace-item__action"
+              aria-label="Delete"
+              data-testid={`workspace-delete-${workspace.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(workspace.id);
+              }}
+            >
+              <Trash2 size={12} />
+            </button>
+          </Tooltip>
         </div>
       </div>
       {workspace.description && (

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
@@ -1,8 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act } from "react";
+import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { WorkspaceSidebar } from "./WorkspaceSidebar";
+import { TooltipProvider } from "@/components/ui";
 import { WorkspaceSummary } from "@/types/workspace";
+
+// jsdom lacks the pointer-capture APIs Radix Tooltip touches; shim them so the
+// tooltip-wrapped sidebar buttons render.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+/** Wrap so the shared Tooltip primitive finds its provider. */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -84,7 +98,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [] });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     expect(query("workspace-empty-message")).not.toBeNull();
@@ -95,7 +109,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: sampleWorkspaces });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     expect(query("workspace-empty-message")).toBeNull();
@@ -108,7 +122,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: sampleWorkspaces });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     expect(query("workspace-name-ws-1")?.textContent).toBe("Dev Setup");
@@ -119,7 +133,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [] });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     expect(query("workspace-new-btn")).not.toBeNull();
@@ -129,7 +143,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [sampleWorkspaces[0]] });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     expect(query("workspace-edit-ws-1")).not.toBeNull();
@@ -142,7 +156,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [], saveCurrentAsWorkspace });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     openDialogAndConfirm("My Layout");
@@ -160,7 +174,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [], saveCurrentAsWorkspace });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     openDialogAndConfirm("My Layout");

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.tooltip.test.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.tooltip.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Verifies the workspace sidebar and its list-item rows adopt the shared
+ * `Tooltip` primitive for their icon buttons (issue #1160, follow-up to #1114).
+ *
+ * A tooltip is not an accessible name, so each converted icon button must keep
+ * an `aria-label`, must no longer carry a bare `title`, and the Radix tooltip
+ * trigger must wire `aria-describedby` when focused. These assertions pin all
+ * three. The stable `data-testid`s must survive the migration.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { WorkspaceListItem } from "./WorkspaceListItem";
+import { WorkspaceSidebar } from "./WorkspaceSidebar";
+import { TooltipProvider } from "@/components/ui";
+import type { WorkspaceSummary } from "@/types/workspace";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+import { useAppStore } from "@/store/appStore";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so the tooltip-wrapped buttons render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+const WORKSPACE: WorkspaceSummary = {
+  id: "ws-1",
+  name: "Dev Setup",
+  description: "Daily dev layout",
+  connectionCount: 3,
+};
+
+const noop = () => {};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Wrap so the shared Tooltip primitive finds its provider (zero delay). */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
+
+function renderItem(): void {
+  act(() => {
+    root.render(
+      withTooltip(
+        <WorkspaceListItem
+          workspace={WORKSPACE}
+          onLaunch={noop}
+          onEdit={noop}
+          onDuplicate={noop}
+          onDelete={noop}
+        />
+      )
+    );
+  });
+}
+
+describe("WorkspaceListItem — tooltip adoption (#1160)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("exposes accessible names via aria-label without a bare title on the action icons", async () => {
+    renderItem();
+    await flush();
+
+    const ids = [
+      "workspace-launch-ws-1",
+      "workspace-edit-ws-1",
+      "workspace-duplicate-ws-1",
+      "workspace-delete-ws-1",
+    ];
+    for (const id of ids) {
+      const btn = container.querySelector<HTMLButtonElement>(`[data-testid="${id}"]`);
+      expect(btn).not.toBeNull();
+      expect(btn?.getAttribute("aria-label")).toBeTruthy();
+      // The tooltip must not leak into the accessible name as a bare title.
+      expect(btn?.getAttribute("title")).toBeNull();
+    }
+  });
+
+  it("leaves the workspace name as a bare title-free text node (not a control)", async () => {
+    renderItem();
+    await flush();
+
+    const name = container.querySelector<HTMLElement>('[data-testid="workspace-name-ws-1"]');
+    expect(name).not.toBeNull();
+    // The name is a truncation-hover target, not an interactive control, so it
+    // must not gain an aria-label.
+    expect(name?.getAttribute("aria-label")).toBeNull();
+  });
+
+  it("wires the Edit button to its tooltip via aria-describedby on focus", async () => {
+    renderItem();
+    await flush();
+
+    const edit = container.querySelector<HTMLButtonElement>('[data-testid="workspace-edit-ws-1"]')!;
+    act(() => {
+      edit.focus();
+      edit.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    });
+
+    expect(edit.getAttribute("aria-describedby")).toBeTruthy();
+  });
+});
+
+describe("WorkspaceSidebar action buttons — tooltip adoption (#1160)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ workspaces: [] });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("exposes accessible names via aria-label without a bare title on the toolbar icons", async () => {
+    act(() => {
+      root.render(withTooltip(<WorkspaceSidebar />));
+    });
+    await flush();
+
+    const ids = [
+      "workspace-new-btn",
+      "workspace-save-current-btn",
+      "workspace-export-btn",
+      "workspace-import-btn",
+    ];
+    for (const id of ids) {
+      const btn = container.querySelector<HTMLButtonElement>(`[data-testid="${id}"]`);
+      expect(btn).not.toBeNull();
+      expect(btn?.getAttribute("aria-label")).toBeTruthy();
+      expect(btn?.getAttribute("title")).toBeNull();
+    }
+  });
+});

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -3,7 +3,7 @@ import { Plus, Save, Download, Upload } from "lucide-react";
 import { save, open } from "@tauri-apps/plugin-dialog";
 import { writeTextFile, readTextFile } from "@tauri-apps/plugin-fs";
 import { useAppStore } from "@/store/appStore";
-import { toast } from "@/components/ui";
+import { toast, Tooltip } from "@/components/ui";
 import { frontendLog } from "@/utils/frontendLog";
 import { exportWorkspaces, importWorkspaces } from "@/services/workspaceApi";
 import { WorkspaceListItem } from "./WorkspaceListItem";
@@ -109,40 +109,48 @@ export function WorkspaceSidebar() {
   return (
     <div className="workspace-sidebar" data-testid="workspace-sidebar">
       <div className="workspace-sidebar__actions">
-        <button
-          className="workspace-sidebar__add-btn"
-          onClick={handleNew}
-          title="New Workspace"
-          data-testid="workspace-new-btn"
-        >
-          <Plus size={14} />
-          New Workspace
-        </button>
-        <button
-          className="workspace-sidebar__add-btn"
-          onClick={() => setShowSaveDialog(true)}
-          title="Save Current Layout"
-          data-testid="workspace-save-current-btn"
-        >
-          <Save size={14} />
-          Save Current
-        </button>
-        <button
-          className="workspace-sidebar__add-btn"
-          onClick={handleExport}
-          title="Export Workspaces"
-          data-testid="workspace-export-btn"
-        >
-          <Download size={14} />
-        </button>
-        <button
-          className="workspace-sidebar__add-btn"
-          onClick={handleImport}
-          title="Import Workspaces"
-          data-testid="workspace-import-btn"
-        >
-          <Upload size={14} />
-        </button>
+        <Tooltip content="New Workspace" side="top">
+          <button
+            className="workspace-sidebar__add-btn"
+            onClick={handleNew}
+            aria-label="New Workspace"
+            data-testid="workspace-new-btn"
+          >
+            <Plus size={14} />
+            New Workspace
+          </button>
+        </Tooltip>
+        <Tooltip content="Save Current Layout" side="top">
+          <button
+            className="workspace-sidebar__add-btn"
+            onClick={() => setShowSaveDialog(true)}
+            aria-label="Save Current Layout"
+            data-testid="workspace-save-current-btn"
+          >
+            <Save size={14} />
+            Save Current
+          </button>
+        </Tooltip>
+        <Tooltip content="Export Workspaces" side="top">
+          <button
+            className="workspace-sidebar__add-btn"
+            onClick={handleExport}
+            aria-label="Export Workspaces"
+            data-testid="workspace-export-btn"
+          >
+            <Download size={14} />
+          </button>
+        </Tooltip>
+        <Tooltip content="Import Workspaces" side="top">
+          <button
+            className="workspace-sidebar__add-btn"
+            onClick={handleImport}
+            aria-label="Import Workspaces"
+            data-testid="workspace-import-btn"
+          >
+            <Upload size={14} />
+          </button>
+        </Tooltip>
       </div>
       {workspaces.length === 0 ? (
         <div className="workspace-sidebar__empty" data-testid="workspace-empty-message">


### PR DESCRIPTION
Closes #1160. Follow-up to #1114, continuing the shared `Tooltip` primitive adoption established in #1102/#1114/#1159/#1161.

## Summary

Migrated the interactive icon buttons in the Workspace UI from bare `title=` attributes to the shared accessible `Tooltip` primitive (`asChild`, `side="top"` for the compact rows), and gave each converted button a proper `aria-label` accessible name.

**`WorkspaceSidebar/`**
- `WorkspaceSidebar.tsx` — New Workspace, Save Current Layout, Export, Import toolbar buttons.
- `WorkspaceListItem.tsx` — per-workspace Launch, Edit, Duplicate, Delete row actions.

**`WorkspaceEditor/`**
- `LayoutDesigner.tsx` — split-container Reset-to-Equal / Split Horizontal / Split Vertical, per-leaf Split Horizontal / Split Vertical / Add Connection / Remove Panel, Remove Tab, and the size-badge (Click to edit size).
- `WorkspaceEditor.tsx` — Remove group and Add group (both grouped and single-strip variants).

Left untouched (not interactive icon buttons): the `SaveWorkspaceDialog` `Modal` `title` prop (dialog heading), and the plain workspace-name / tab-name / group-name text nodes (no bare title on them today). All `data-testid`s preserved.

## Test plan

- New `WorkspaceSidebar.tooltip.test.tsx` and `WorkspaceEditor.tooltip.test.tsx` pin: `aria-label` present on each converted icon button, no bare `title` remaining, `aria-describedby` wired on focus (Radix), and that the non-interactive workspace-name node gains no `aria-label`. Written test-first and confirmed red before implementation (6 failing), green after.
- Wrapped the pre-existing `WorkspaceSidebar.test.tsx` and `LayoutDesigner.test.tsx` renders in `TooltipProvider` (with jsdom pointer-capture shims) so the tooltip-wrapped buttons mount.
- `vitest run` on the 5 affected suites: 29 passed.
- `pnpm run build` (tsc typecheck + vite) clean; `eslint` on both directories clean; `prettier`/`markdownlint` clean.
- Verified no bare `title=` remains on interactive icon controls in either directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
