### PR TITLE
feat(ui): adopt Tooltip on remaining Settings interactive icon controls (Closes #1162)

### DIFF
--- a/docs/changes/dev1/feature/1162-tooltip-settings.md
+++ b/docs/changes/dev1/feature/1162-tooltip-settings.md
@@ -1,0 +1,11 @@
+## Changed
+
+- The remaining interactive icon-only controls in Settings — the file-type mapping
+  Remove and copy-into-add-form buttons, the SSH key-path Browse button, the settings
+  search Clear button, the per-shortcut Reset button, the external-file Remove button,
+  the language-package Install / Uninstall buttons, the custom-grammar Remove button,
+  and the serial-port custom-prefix Remove button — now use the shared accessible
+  Tooltip for hover help: consistent, themed, and reachable on keyboard focus instead
+  of mouse-only. Each converted control exposes its label as a proper accessible name
+  (`aria-label`) rather than only through the browser `title`. Non-interactive
+  full-text/truncation hovers (git commit hash, file paths) are unchanged.

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -6,6 +6,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
 import { resetRuntimeCache } from "@/hooks/useAvailableRuntimes";
 import { ConnectionEditor } from "./ConnectionEditor";
+import { TooltipProvider } from "@/components/ui";
 import type { ConnectionTypeInfo } from "@/types/connection";
 import type { SavedConnection, RemoteAgentDefinition } from "@/types/connection";
 import { DEFAULT_AGENT_SETTINGS } from "@/types/connection";
@@ -1098,11 +1099,13 @@ describe("ConnectionEditor — SSH Jump Host section", () => {
   function renderFor(connId: string) {
     act(() => {
       root.render(
-        <ConnectionEditor
-          tabId="tab-jh-1"
-          meta={{ connectionId: connId, folderId: null }}
-          isVisible={true}
-        />
+        <TooltipProvider>
+          <ConnectionEditor
+            tabId="tab-jh-1"
+            meta={{ connectionId: connId, folderId: null }}
+            isVisible={true}
+          />
+        </TooltipProvider>
       );
     });
   }

--- a/src/components/Settings/CustomGrammarsSettings.test.tsx
+++ b/src/components/Settings/CustomGrammarsSettings.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, Root } from "react-dom/client";
 import { open } from "@tauri-apps/plugin-dialog";
 import { readTextFile } from "@tauri-apps/plugin-fs";
 import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
 import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
 
 vi.mock("@/themes", () => ({
@@ -30,7 +31,11 @@ let root: Root;
 
 function render(props: { visibleFields?: Set<string> } = {}) {
   act(() => {
-    root.render(<CustomGrammarsSettings {...props} />);
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <CustomGrammarsSettings {...props} />
+      </TooltipProvider>
+    );
   });
 }
 

--- a/src/components/Settings/CustomGrammarsSettings.tsx
+++ b/src/components/Settings/CustomGrammarsSettings.tsx
@@ -5,7 +5,7 @@ import { readTextFile } from "@tauri-apps/plugin-fs";
 import { useAppStore } from "@/store/appStore";
 import { registerCustomGrammars } from "@/utils/monacoCustomLanguages";
 import type { CustomLanguageGrammar } from "@/types/connection";
-import { Button } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 
 interface CustomGrammarsSettingsProps {
   visibleFields?: Set<string>;
@@ -273,14 +273,16 @@ export function CustomGrammarsSettings({ visibleFields }: CustomGrammarsSettings
                     >
                       {g.name}
                     </span>
-                    <button
-                      className="settings-panel__file-remove"
-                      onClick={() => handleRemove(g.id)}
-                      title={`Remove grammar "${g.name}"`}
-                      data-testid={`custom-grammar-remove-${g.id}`}
-                    >
-                      <Trash2 size={14} />
-                    </button>
+                    <Tooltip content={`Remove grammar "${g.name}"`}>
+                      <button
+                        className="settings-panel__file-remove"
+                        onClick={() => handleRemove(g.id)}
+                        aria-label={`Remove grammar "${g.name}"`}
+                        data-testid={`custom-grammar-remove-${g.id}`}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </Tooltip>
                   </li>
                 ))}
               </ul>

--- a/src/components/Settings/ExternalFilesSettings.test.tsx
+++ b/src/components/Settings/ExternalFilesSettings.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
 import { ExternalFilesSettings } from "./ExternalFilesSettings";
 
 vi.mock("@/themes", () => ({
@@ -21,7 +22,11 @@ let root: Root;
 
 function render() {
   act(() => {
-    root.render(<ExternalFilesSettings />);
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <ExternalFilesSettings />
+      </TooltipProvider>
+    );
   });
 }
 

--- a/src/components/Settings/ExternalFilesSettings.tsx
+++ b/src/components/Settings/ExternalFilesSettings.tsx
@@ -4,7 +4,7 @@ import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { FilePlus2, Plus, Trash2, RefreshCw } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { ExternalFileConfig } from "@/types/connection";
-import { Button } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 import { frontendLog } from "@/utils/frontendLog";
 
 /**
@@ -187,13 +187,15 @@ export function ExternalFilesSettings() {
                 >
                   {file.path}
                 </span>
-                <button
-                  className="settings-panel__file-remove"
-                  onClick={() => handleRemoveFile(file.path)}
-                  title="Remove file"
-                >
-                  <Trash2 size={14} />
-                </button>
+                <Tooltip content="Remove file">
+                  <button
+                    className="settings-panel__file-remove"
+                    onClick={() => handleRemoveFile(file.path)}
+                    aria-label="Remove file"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </Tooltip>
               </li>
             ))}
           </ul>

--- a/src/components/Settings/FileTypeSettings.test.tsx
+++ b/src/components/Settings/FileTypeSettings.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
 import { FileTypeSettings } from "./FileTypeSettings";
 
 vi.mock("@/themes", () => ({
@@ -17,7 +18,11 @@ let root: Root;
 
 function render(props: { visibleFields?: Set<string> } = {}) {
   act(() => {
-    root.render(<FileTypeSettings {...props} />);
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <FileTypeSettings {...props} />
+      </TooltipProvider>
+    );
   });
 }
 

--- a/src/components/Settings/FileTypeSettings.tsx
+++ b/src/components/Settings/FileTypeSettings.tsx
@@ -3,7 +3,7 @@ import { Plus, Trash2, RotateCcw, Copy } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { BUILT_IN_FILENAME_MAPPINGS, BUILT_IN_EXTENSION_MAPPINGS } from "@/utils/languageMapping";
 import { getAvailableLanguages } from "@/utils/monacoLanguages";
-import { Button } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 
 /** Combined view of a built-in mapping row (shown in the reference table). */
 interface BuiltInRow {
@@ -210,14 +210,16 @@ export function FileTypeSettings({ visibleFields }: FileTypeSettingsProps) {
                     >
                       → {language}
                     </span>
-                    <button
-                      className="settings-panel__file-remove"
-                      onClick={() => handleRemove(pattern)}
-                      title={`Remove mapping for ${pattern}`}
-                      data-testid={`file-type-remove-${pattern}`}
-                    >
-                      <Trash2 size={14} />
-                    </button>
+                    <Tooltip content={`Remove mapping for ${pattern}`}>
+                      <button
+                        className="settings-panel__file-remove"
+                        onClick={() => handleRemove(pattern)}
+                        aria-label={`Remove mapping for ${pattern}`}
+                        data-testid={`file-type-remove-${pattern}`}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </Tooltip>
                   </li>
                 ))}
               </ul>
@@ -259,14 +261,16 @@ export function FileTypeSettings({ visibleFields }: FileTypeSettingsProps) {
                         overridden
                       </span>
                     )}
-                    <button
-                      className="settings-panel__file-remove"
-                      onClick={() => handlePrefillOverride(pattern, language)}
-                      title={`Copy "${pattern}" into the add form`}
-                      data-testid={`file-type-copy-${pattern}`}
-                    >
-                      <Copy size={14} />
-                    </button>
+                    <Tooltip content={`Copy "${pattern}" into the add form`}>
+                      <button
+                        className="settings-panel__file-remove"
+                        onClick={() => handlePrefillOverride(pattern, language)}
+                        aria-label={`Copy "${pattern}" into the add form`}
+                        data-testid={`file-type-copy-${pattern}`}
+                      >
+                        <Copy size={14} />
+                      </button>
+                    </Tooltip>
                   </li>
                 );
               })}

--- a/src/components/Settings/KeyPathInput.test.tsx
+++ b/src/components/Settings/KeyPathInput.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui";
 import { KeyPathInput } from "./KeyPathInput";
 
 // Mock Tauri dialog (Browse button)
@@ -29,7 +30,11 @@ const HINT = "field-keyPath-key-path-validation";
 
 function renderInput(value: string) {
   act(() => {
-    root.render(<KeyPathInput value={value} onChange={() => {}} testIdPrefix="field-keyPath" />);
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <KeyPathInput value={value} onChange={() => {}} testIdPrefix="field-keyPath" />
+      </TooltipProvider>
+    );
   });
 }
 

--- a/src/components/Settings/KeyPathInput.tsx
+++ b/src/components/Settings/KeyPathInput.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useSshKeyFiles, SshKeyFile } from "@/hooks/useSshKeyFiles";
 import { validateSshKey, SshKeyValidation } from "@/services/api";
+import { Tooltip } from "@/components/ui";
 import "./KeyPathInput.css";
 
 /** Debounce (ms) before validating a typed key path against the backend. */
@@ -158,15 +159,17 @@ export function KeyPathInput({ value, onChange, placeholder, testIdPrefix }: Key
           aria-autocomplete="list"
           data-testid={`${prefix}key-path-input`}
         />
-        <button
-          type="button"
-          className="settings-form__list-browse"
-          onClick={handleBrowse}
-          title="Browse"
-          data-testid={`${prefix}key-path-browse`}
-        >
-          ...
-        </button>
+        <Tooltip content="Browse">
+          <button
+            type="button"
+            className="settings-form__list-browse"
+            onClick={handleBrowse}
+            aria-label="Browse"
+            data-testid={`${prefix}key-path-browse`}
+          >
+            ...
+          </button>
+        </Tooltip>
         {isOpen && filtered.length > 0 && (
           <ul
             className="key-path-input__dropdown"

--- a/src/components/Settings/KeyboardSettings.test.tsx
+++ b/src/components/Settings/KeyboardSettings.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui";
 import { KeyboardSettings } from "./KeyboardSettings";
 import { clearOverrides } from "@/services/keybindings";
 import { useAppStore } from "@/store/appStore";
@@ -19,7 +20,11 @@ let root: Root;
 
 function renderComponent(visibleFields?: Set<string>) {
   act(() => {
-    root.render(<KeyboardSettings visibleFields={visibleFields} />);
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <KeyboardSettings visibleFields={visibleFields} />
+      </TooltipProvider>
+    );
   });
 }
 

--- a/src/components/Settings/KeyboardSettings.tsx
+++ b/src/components/Settings/KeyboardSettings.tsx
@@ -12,6 +12,7 @@ import {
   getOverrides,
 } from "@/services/keybindings";
 import { exportCheatSheet } from "@/utils/cheatSheetPdf";
+import { Tooltip } from "@/components/ui";
 import "./KeyboardSettings.css";
 
 const CATEGORY_LABELS: Record<ShortcutCategory, string> = {
@@ -319,14 +320,16 @@ function KeybindingRow({
         {isRecording ? "Press a key combination..." : displayStr}
       </td>
       <td className="keyboard-settings__reset-cell">
-        <button
-          className="keyboard-settings__reset-btn"
-          onClick={onReset}
-          title="Reset to default"
-          data-testid={`keybinding-reset-${binding.action}`}
-        >
-          <RotateCcw size={12} />
-        </button>
+        <Tooltip content="Reset to default">
+          <button
+            className="keyboard-settings__reset-btn"
+            onClick={onReset}
+            aria-label="Reset to default"
+            data-testid={`keybinding-reset-${binding.action}`}
+          >
+            <RotateCcw size={12} />
+          </button>
+        </Tooltip>
       </td>
     </tr>
   );

--- a/src/components/Settings/LanguagePackagesSettings.test.tsx
+++ b/src/components/Settings/LanguagePackagesSettings.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
 import { LanguagePackagesSettings } from "./LanguagePackagesSettings";
 
 vi.mock("@/themes", () => ({
@@ -20,7 +21,11 @@ let root: Root;
 
 function render(props: { visibleFields?: Set<string> } = {}) {
   act(() => {
-    root.render(<LanguagePackagesSettings {...props} />);
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <LanguagePackagesSettings {...props} />
+      </TooltipProvider>
+    );
   });
 }
 

--- a/src/components/Settings/LanguagePackagesSettings.tsx
+++ b/src/components/Settings/LanguagePackagesSettings.tsx
@@ -3,6 +3,7 @@ import { PackagePlus, PackageMinus, Search } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { ALL_LANGUAGE_PACKAGES, BUILTIN_PACKAGE_IDS } from "@/utils/monacoLanguagePackages";
 import { registerAdditionalLanguagePackages } from "@/utils/monacoCustomLanguages";
+import { Tooltip } from "@/components/ui";
 
 interface LanguagePackagesSettingsProps {
   visibleFields?: Set<string>;
@@ -112,14 +113,16 @@ export function LanguagePackagesSettings({ visibleFields }: LanguagePackagesSett
                   {pendingUninstall.has(pkg.id) && (
                     <span className="settings-panel__badge">restart required</span>
                   )}
-                  <button
-                    className="settings-panel__file-remove"
-                    onClick={() => handleUninstall(pkg.id)}
-                    title={`Uninstall ${pkg.name}`}
-                    data-testid={`lang-pkg-uninstall-${pkg.id}`}
-                  >
-                    <PackageMinus size={14} />
-                  </button>
+                  <Tooltip content={`Uninstall ${pkg.name}`}>
+                    <button
+                      className="settings-panel__file-remove"
+                      onClick={() => handleUninstall(pkg.id)}
+                      aria-label={`Uninstall ${pkg.name}`}
+                      data-testid={`lang-pkg-uninstall-${pkg.id}`}
+                    >
+                      <PackageMinus size={14} />
+                    </button>
+                  </Tooltip>
                 </li>
               ))}
 
@@ -188,14 +191,16 @@ export function LanguagePackagesSettings({ visibleFields }: LanguagePackagesSett
                     ) : isInstalled ? (
                       <span className="settings-panel__badge">installed</span>
                     ) : (
-                      <button
-                        className="settings-panel__file-remove"
-                        onClick={() => handleInstall(pkg.id)}
-                        title={`Install ${pkg.name}`}
-                        data-testid={`lang-pkg-install-${pkg.id}`}
-                      >
-                        <PackagePlus size={14} />
-                      </button>
+                      <Tooltip content={`Install ${pkg.name}`}>
+                        <button
+                          className="settings-panel__file-remove"
+                          onClick={() => handleInstall(pkg.id)}
+                          aria-label={`Install ${pkg.name}`}
+                          data-testid={`lang-pkg-install-${pkg.id}`}
+                        >
+                          <PackagePlus size={14} />
+                        </button>
+                      </Tooltip>
                     )}
                   </li>
                 );

--- a/src/components/Settings/SerialPortSettings.test.tsx
+++ b/src/components/Settings/SerialPortSettings.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
 import { SerialPortSettings } from "./SerialPortSettings";
 
 vi.mock("@/themes", () => ({
@@ -17,7 +18,11 @@ let root: Root;
 
 function render() {
   act(() => {
-    root.render(<SerialPortSettings />);
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <SerialPortSettings />
+      </TooltipProvider>
+    );
   });
 }
 

--- a/src/components/Settings/SerialPortSettings.tsx
+++ b/src/components/Settings/SerialPortSettings.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { SerialPortScanPrefix } from "@/types/connection";
-import { Button } from "@/components/ui";
+import { Button, Tooltip } from "@/components/ui";
 
 interface SerialPortSettingsProps {
   visibleFields?: Set<string>;
@@ -126,13 +126,15 @@ export function SerialPortSettings({ visibleFields }: SerialPortSettingsProps) {
                 >
                   {p.prefix}
                 </code>
-                <button
-                  className="settings-panel__file-remove"
-                  onClick={() => handleDelete(p.prefix)}
-                  title="Remove custom prefix"
-                >
-                  <Trash2 size={14} />
-                </button>
+                <Tooltip content="Remove custom prefix">
+                  <button
+                    className="settings-panel__file-remove"
+                    onClick={() => handleDelete(p.prefix)}
+                    aria-label="Remove custom prefix"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </Tooltip>
               </li>
             ))}
           </ul>

--- a/src/components/Settings/Settings.tooltip.test.tsx
+++ b/src/components/Settings/Settings.tooltip.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui";
+import { useAppStore } from "@/store/appStore";
+import { FileTypeSettings } from "./FileTypeSettings";
+import { KeyPathInput } from "./KeyPathInput";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(() => Promise.resolve(null)),
+}));
+
+// jsdom lacks the observers/pointer-capture APIs Radix Tooltip touches when it
+// measures and portals its content; shim them so the primitive can mount.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderNode(node: React.ReactNode) {
+  act(() => {
+    root.render(<TooltipProvider delayDuration={0}>{node}</TooltipProvider>);
+  });
+}
+
+function btn(testId: string): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`);
+}
+
+/**
+ * Pins the Tooltip-primitive adoption on the interactive icon-only controls in
+ * `src/components/Settings/`: each converted control keeps its `data-testid`,
+ * exposes an `aria-label` (a tooltip is not an accessible name), no longer sets a
+ * bare `title=`, and gets `aria-describedby` wired by Radix on focus.
+ */
+describe("Settings icon controls tooltip adoption", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  describe("FileTypeSettings remove/copy icon buttons", () => {
+    function renderWithMapping() {
+      act(() => {
+        useAppStore.setState({
+          settings: {
+            ...useAppStore.getState().settings,
+            fileLanguageMappings: { Jenkinsfile: "groovy" },
+          },
+        });
+      });
+      renderNode(<FileTypeSettings />);
+    }
+
+    it("gives the remove-mapping button an aria-label and no bare title", () => {
+      renderWithMapping();
+      const remove = btn("file-type-remove-Jenkinsfile");
+      expect(remove, "remove button should render").toBeTruthy();
+      expect(remove?.getAttribute("aria-label")).toBe("Remove mapping for Jenkinsfile");
+      expect(remove?.hasAttribute("title")).toBe(false);
+    });
+
+    it("gives the copy-override button an aria-label and no bare title", () => {
+      renderWithMapping();
+      // Built-in reference rows expose the copy-into-add-form icon control.
+      const copy = container.querySelector<HTMLButtonElement>('[data-testid^="file-type-copy-"]');
+      expect(copy, "a copy button should render").toBeTruthy();
+      expect(copy?.getAttribute("aria-label")).toMatch(/^Copy /);
+      expect(copy?.hasAttribute("title")).toBe(false);
+    });
+
+    it("wires aria-describedby on focus of the remove button", () => {
+      renderWithMapping();
+      const remove = btn("file-type-remove-Jenkinsfile") as HTMLButtonElement;
+      act(() => {
+        remove.focus();
+        remove.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+      });
+      expect(remove.getAttribute("aria-describedby")).toBeTruthy();
+    });
+  });
+
+  describe("KeyPathInput browse icon button", () => {
+    function renderInput() {
+      renderNode(<KeyPathInput value="" onChange={() => {}} testIdPrefix="field-keyPath" />);
+    }
+
+    it("gives the browse button an aria-label and no bare title", () => {
+      renderInput();
+      const browse = btn("field-keyPath-key-path-browse");
+      expect(browse, "browse button should render").toBeTruthy();
+      expect(browse?.getAttribute("aria-label")).toBe("Browse");
+      expect(browse?.hasAttribute("title")).toBe(false);
+    });
+
+    it("wires aria-describedby on focus of the browse button", () => {
+      renderInput();
+      const browse = btn("field-keyPath-key-path-browse") as HTMLButtonElement;
+      act(() => {
+        browse.focus();
+        browse.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+      });
+      expect(browse.getAttribute("aria-describedby")).toBeTruthy();
+    });
+  });
+});

--- a/src/components/Settings/Settings.tooltip.test.tsx
+++ b/src/components/Settings/Settings.tooltip.test.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { FileTypeSettings } from "./FileTypeSettings";
 import { KeyPathInput } from "./KeyPathInput";
+import { SerialPortSettings } from "./SerialPortSettings";
 
 vi.mock("@/themes", () => ({
   applyTheme: vi.fn(),
@@ -127,6 +128,42 @@ describe("Settings icon controls tooltip adoption", () => {
         browse.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
       });
       expect(browse.getAttribute("aria-describedby")).toBeTruthy();
+    });
+  });
+
+  describe("SerialPortSettings remove-custom-prefix icon button", () => {
+    function renderWithCustomPrefix() {
+      act(() => {
+        useAppStore.setState({
+          settings: {
+            ...useAppStore.getState().settings,
+            serialPortScanPrefixes: [{ prefix: "ttyXYZ", enabled: true, builtIn: false }],
+          },
+        });
+      });
+      renderNode(<SerialPortSettings />);
+    }
+
+    function removeButton(): HTMLButtonElement | null {
+      return container.querySelector<HTMLButtonElement>(".settings-panel__file-remove");
+    }
+
+    it("gives the remove-prefix button an aria-label and no bare title", () => {
+      renderWithCustomPrefix();
+      const remove = removeButton();
+      expect(remove, "remove-prefix button should render").toBeTruthy();
+      expect(remove?.getAttribute("aria-label")).toBe("Remove custom prefix");
+      expect(remove?.hasAttribute("title")).toBe(false);
+    });
+
+    it("wires aria-describedby on focus of the remove-prefix button", () => {
+      renderWithCustomPrefix();
+      const remove = removeButton() as HTMLButtonElement;
+      act(() => {
+        remove.focus();
+        remove.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+      });
+      expect(remove.getAttribute("aria-describedby")).toBeTruthy();
     });
   });
 });

--- a/src/components/Settings/SettingsPanel.test.tsx
+++ b/src/components/Settings/SettingsPanel.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { AppSettings } from "@/types/connection";
+import { TooltipProvider } from "@/components/ui";
 import { SettingsPanel } from "./SettingsPanel";
 
 vi.mock("@/themes", () => ({
@@ -45,7 +46,11 @@ let root: Root;
 
 function render() {
   act(() => {
-    root.render(<SettingsPanel tabId={TAB_ID} isVisible={true} />);
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <SettingsPanel tabId={TAB_ID} isVisible={true} />
+      </TooltipProvider>
+    );
   });
 }
 

--- a/src/components/Settings/SettingsSearch.tsx
+++ b/src/components/Settings/SettingsSearch.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { Search, X } from "lucide-react";
+import { Tooltip } from "@/components/ui";
 
 interface SettingsSearchProps {
   query: string;
@@ -37,14 +38,16 @@ export function SettingsSearch({ query, onQueryChange }: SettingsSearchProps) {
         placeholder="Search settings..."
       />
       {query && (
-        <button
-          className="settings-search__clear"
-          onClick={handleClear}
-          title="Clear search"
-          type="button"
-        >
-          <X size={14} />
-        </button>
+        <Tooltip content="Clear search">
+          <button
+            className="settings-search__clear"
+            onClick={handleClear}
+            aria-label="Clear search"
+            type="button"
+          >
+            <X size={14} />
+          </button>
+        </Tooltip>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Follow-up to #1114. Migrates the remaining **interactive icon-only controls** in `src/components/Settings/` from a bare `title=` to the shared `Tooltip` primitive (`asChild`), matching the pattern established in #1102/#1114/#1159/#1161. Each converted control keeps its `data-testid` and gains an `aria-label` (a tooltip is not an accessible name), so hover help is themed, consistent, and reachable on keyboard focus with correct `aria-describedby` wiring from Radix.

Converted controls:

- `FileTypeSettings` — remove-mapping and copy-into-add-form buttons
- `KeyPathInput` — Browse button
- `SettingsSearch` — Clear search button
- `KeyboardSettings` — per-shortcut Reset button
- `ExternalFilesSettings` — Remove file button
- `LanguagePackagesSettings` — Install / Uninstall buttons
- `CustomGrammarsSettings` — Remove grammar button
- `SerialPortSettings` — Remove custom prefix button

Left as bare `title=` (out of scope, per the issue):

- Non-interactive truncation/label hovers on `<span>`/`<code>`: git commit hash (`UpdateSettings`, `AboutSettings`, `SettingsPanel`), external file paths (`ExternalFilesSettings`).
- `Modal` / `MigrationDialog` `title=` **component props** (`RecoveryDialog`, `OverlayViewPanel`, `CustomizeLayoutDialog`, `PortableModeSettings`).
- Text buttons whose visible label already names them and whose `title` carries supplementary help (`FileTypeSettings` Reset All, `KeyboardSettings` Reset to Safer Defaults / Save HTML Cheat Sheet, `ExternalFilesSettings` Reload / Create File / Add File) — these are labeled buttons, not icon controls.

Pre-existing tests that render the affected components are wrapped in `TooltipProvider` (Radix throws without one). A new `Settings.tooltip.test.tsx` pins the behavior: `aria-label` present, no bare `title`, and `aria-describedby` wired on focus.

## Test plan

- `pnpm test` on the affected suites — `src/components/Settings/` (20 files, 193 tests) all green, including the new `Settings.tooltip.test.tsx` (7 cases across FileTypeSettings, KeyPathInput, SerialPortSettings).
- `pnpm run lint` — clean.
- `pnpm build` — TypeScript check + Vite build pass.
- testid catalog regenerated — unchanged (all `data-testid`s preserved, none added).

Closes #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
