### PR TITLE
fix(network): guard HTTP monitor start against double-fire (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-http-monitor-start-guard.md
+++ b/docs/changes/dev2/feature/1147-http-monitor-start-guard.md
@@ -1,0 +1,8 @@
+# HTTP monitor start double-fire guard
+
+## Fixed
+
+- HTTP Monitor: rapidly double-clicking **Start** (or clicking again while a
+  start was still in flight) no longer spawns two independent backend monitors
+  for the same URL. Only one monitor starts per Start action; the previously
+  untracked duplicate poller can no longer be created. (#1147, GAP #7)

--- a/src/components/NetworkTools/HttpMonitorPanel.start-guard.test.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.start-guard.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Regression test for the HTTP monitor Start double-fire guard (GAP #7, #1147).
+ *
+ * The Start button had no pending guard — it was only disabled when the URL was
+ * empty. A rapid double-click (or a second click while a previous start promise
+ * was still in flight) fired `handleStart` twice, spawning two independent
+ * backend monitors for the same URL. The panel attaches to the *last* returned
+ * id; the first monitor becomes an untracked background poller only killable via
+ * the sidebar.
+ *
+ * The fix relies on the shared Button's async lifecycle: because `handleStart`
+ * returns a promise, the Button enters its `pending` state on the first click,
+ * disables itself, and ignores further clicks until the promise resolves. This
+ * test pins that a second click while the first start is in flight results in
+ * exactly ONE start call.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { networkHttpMonitorStart } from "@/services/networkApi";
+import { HttpMonitorPanel } from "./HttpMonitorPanel";
+import { TooltipProvider } from "@/components/ui";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts the tooltip-wrapped icon buttons; shim them so the panel renders.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+/** Wrap a subtree so the shared Tooltip primitive finds its provider. */
+function withTooltip(ui: React.ReactElement): React.ReactElement {
+  return <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>;
+}
+
+// A deferred start: the promise stays pending until we resolve it, letting us
+// fire a second click while the first start is genuinely in flight.
+let resolveStart: ((id: string) => void) | null = null;
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStart: vi.fn(
+    () =>
+      new Promise<string>((resolve) => {
+        resolveStart = resolve;
+      })
+  ),
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+  onHttpMonitorCheck: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+// LatencyChart draws to a canvas jsdom can't back; stub it.
+vi.mock("./LatencyChart", () => ({ LatencyChart: () => null }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Set a React-controlled input's value via the native setter so onChange fires. */
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function startButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="http-monitor-start"]')!;
+}
+
+describe("HttpMonitorPanel — Start double-fire guard", () => {
+  beforeEach(() => {
+    resolveStart = null;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("fires only one start when Start is double-clicked with the first start in flight", async () => {
+    await act(async () => {
+      root.render(withTooltip(<HttpMonitorPanel />));
+    });
+    await flush();
+
+    await act(async () => {
+      setInputValue(
+        container.querySelector<HTMLInputElement>('[data-testid="http-monitor-url"]')!,
+        "https://example.com"
+      );
+    });
+
+    // Two clicks in the SAME tick, before React can re-render the disabled
+    // state — the worst case of a rapid double-click. Without an in-handler
+    // guard this fires two duplicate starts.
+    await act(async () => {
+      startButton().click();
+      startButton().click();
+    });
+    await flush();
+
+    expect(vi.mocked(networkHttpMonitorStart)).toHaveBeenCalledTimes(1);
+
+    // A further click while the first start is still in flight is also rejected
+    // by the in-flight guard — still exactly one start.
+    await act(async () => {
+      startButton().click();
+    });
+    await flush();
+    expect(vi.mocked(networkHttpMonitorStart)).toHaveBeenCalledTimes(1);
+
+    // Resolve the first start so the pending state can settle cleanly.
+    await act(async () => {
+      resolveStart?.("mon-1");
+    });
+    await flush();
+  });
+});

--- a/src/components/NetworkTools/HttpMonitorPanel.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.tsx
@@ -41,6 +41,12 @@ export function HttpMonitorPanel() {
   // stop/unmount/restart.
   const activeMonitorIdRef = useRef<string | null>(null);
   const unlistenCheckRef = useRef<(() => void) | null>(null);
+  // Guards against a Start double-fire (#1147, GAP #7). The Button's async
+  // lifecycle only disables on the *next* click; two clicks in the same tick
+  // both reach handleStart before React re-renders the pending state, spawning
+  // two backend monitors for one URL. This synchronous ref rejects the second
+  // call immediately, so only one start is ever in flight.
+  const startInFlightRef = useRef(false);
 
   const loadMonitors = useCallback(async () => {
     try {
@@ -69,6 +75,9 @@ export function HttpMonitorPanel() {
 
   const handleStart = useCallback(async () => {
     if (!url.trim()) return;
+    // Reject a re-entrant start while one is already in flight (#1147, GAP #7).
+    if (startInFlightRef.current) return;
+    startInFlightRef.current = true;
     setError(null);
     setHistory([]);
     stopListening();
@@ -102,6 +111,8 @@ export function HttpMonitorPanel() {
       stopListening();
       setError(String(err));
       frontendLog("http_monitor", `Start failed: ${err}`);
+    } finally {
+      startInFlightRef.current = false;
     }
   }, [url, intervalSecs, method, expectedStatus, timeoutSecs, loadMonitors, stopListening]);
 


### PR DESCRIPTION
## Summary

Fixes GAP #7 from the HTTP monitor state-machine audit
(`docs/audits/http-monitor-state-machine.md`): the **Start** button in the
HTTP Monitor panel had no pending guard (it was only disabled when the URL was
empty). A rapid double-click — or a second click while a previous start was
still in flight — fired `handleStart` twice and spawned two independent backend
monitors for the same URL. The panel attached to the *last* returned id, leaving
the first as an untracked background poller only killable via the sidebar.

The shared `Button`'s async lifecycle alone was insufficient: it only disables on
the *next* click, so two clicks in the same tick both reach `handleStart` before
React re-renders the pending/disabled state. The fix adds a synchronous
`startInFlightRef` guard that rejects a re-entrant start immediately, so exactly
one monitor starts per Start action.

## Changes

- `src/components/NetworkTools/HttpMonitorPanel.tsx` — add a `startInFlightRef`
  in-flight guard around `handleStart`, reset in a `finally` block.
- `src/components/NetworkTools/HttpMonitorPanel.start-guard.test.tsx` — new
  regression test: two same-tick Start clicks (and a further in-flight click)
  result in exactly one `networkHttpMonitorStart` call.
- `docs/changes/dev2/feature/1147-http-monitor-start-guard.md` — change fragment.

Scope is limited to the Start double-fire guard only; pause/remove/persistence
and the other audit gaps are out of scope.

## Test plan

- `pnpm test` — full suite, 2229/2229 passing.
- New test is red without the fix (2 starts), green with it (1 start); verified
  by stashing the source change.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` all pass.

Partially addresses #1147 (#7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
