### PR TITLE
fix(workspace): confirm + feedback on workspace delete (#1146)

### DIFF
--- a/docs/changes/dev2/feature/1146-workspace-delete-feedback.md
+++ b/docs/changes/dev2/feature/1146-workspace-delete-feedback.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Deleting a saved workspace now asks for confirmation first and reports the
+  result. Previously delete was a one-click destructive action with no confirm
+  and no feedback: a failed delete was swallowed silently and the workspace
+  reappeared on the next refresh with no explanation. The delete now opens a
+  confirmation dialog, only removes the workspace after the backend confirms,
+  and shows a success or error toast. Part of the workspace save/restore audit
+  (#1146, gap G7).

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
@@ -171,4 +171,59 @@ describe("WorkspaceSidebar", () => {
     expect(toastSuccess).toHaveBeenCalledTimes(1);
     expect(toastError).not.toHaveBeenCalled();
   });
+
+  it("asks for confirmation before deleting and does not delete on click alone", () => {
+    const deleteWorkspaceFromBackend = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
+
+    act(() => {
+      root.render(<WorkspaceSidebar />);
+    });
+
+    // No confirm dialog before the delete button is pressed.
+    expect(query("confirm-delete-dialog")).toBeNull();
+
+    act(() => (query("workspace-delete-ws-1") as HTMLButtonElement).click());
+
+    // Confirm dialog appears; the backend delete has NOT been called yet.
+    expect(query("confirm-delete-dialog")).not.toBeNull();
+    expect(deleteWorkspaceFromBackend).not.toHaveBeenCalled();
+  });
+
+  it("deletes and surfaces success when the user confirms and the backend resolves", async () => {
+    const deleteWorkspaceFromBackend = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
+
+    act(() => {
+      root.render(<WorkspaceSidebar />);
+    });
+
+    act(() => (query("workspace-delete-ws-1") as HTMLButtonElement).click());
+    act(() => (query("confirm-delete-confirm") as HTMLButtonElement).click());
+    await flush();
+
+    expect(deleteWorkspaceFromBackend).toHaveBeenCalledWith("ws-1");
+    expect(query("confirm-delete-dialog")).toBeNull();
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("does not remove the workspace and surfaces an error when the backend delete rejects", async () => {
+    const deleteWorkspaceFromBackend = vi.fn().mockRejectedValue(new Error("lock poisoned"));
+    useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
+
+    act(() => {
+      root.render(<WorkspaceSidebar />);
+    });
+
+    act(() => (query("workspace-delete-ws-1") as HTMLButtonElement).click());
+    act(() => (query("confirm-delete-confirm") as HTMLButtonElement).click());
+    await flush();
+
+    expect(deleteWorkspaceFromBackend).toHaveBeenCalledWith("ws-1");
+    // The item must remain visible — a failed delete must not silently vanish.
+    expect(query("workspace-item-ws-1")).not.toBeNull();
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -8,6 +8,7 @@ import { frontendLog } from "@/utils/frontendLog";
 import { exportWorkspaces, importWorkspaces } from "@/services/workspaceApi";
 import { WorkspaceListItem } from "./WorkspaceListItem";
 import { SaveWorkspaceDialog, SaveWorkspaceScope } from "./SaveWorkspaceDialog";
+import { ConfirmDeleteDialog } from "@/components/Sidebar/ConfirmDeleteDialog";
 import "./WorkspaceSidebar.css";
 
 export function WorkspaceSidebar() {
@@ -21,6 +22,8 @@ export function WorkspaceSidebar() {
   const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
 
   const [showSaveDialog, setShowSaveDialog] = useState(false);
+  // The workspace pending deletion once the user confirms the destructive action.
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null);
 
   const handleNew = useCallback(() => {
     openWorkspaceEditorTab(null);
@@ -47,12 +50,31 @@ export function WorkspaceSidebar() {
     [duplicateWorkspace]
   );
 
+  // Open the confirmation dialog rather than deleting immediately — delete is a
+  // destructive one-click action on a named workspace (GAP G7).
   const handleDelete = useCallback(
     (workspaceId: string) => {
-      deleteWorkspace(workspaceId);
+      const workspace = workspaces.find((ws) => ws.id === workspaceId);
+      if (!workspace) return;
+      setPendingDelete({ id: workspace.id, name: workspace.name });
     },
-    [deleteWorkspace]
+    [workspaces]
   );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    const { id, name } = pendingDelete;
+    setPendingDelete(null);
+    try {
+      // The store only removes the item from local state after the backend
+      // resolves, so a failed delete leaves the workspace visible.
+      await deleteWorkspace(id);
+      toast.success(`Deleted workspace ${name}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to delete workspace: ${message}`);
+    }
+  }, [pendingDelete, deleteWorkspace]);
 
   const handleSaveCurrent = useCallback(
     async (name: string, scope: SaveWorkspaceScope, description?: string) => {
@@ -171,6 +193,14 @@ export function WorkspaceSidebar() {
           onCancel={() => setShowSaveDialog(false)}
         />
       )}
+      <ConfirmDeleteDialog
+        open={pendingDelete !== null}
+        message={
+          pendingDelete ? `Delete workspace "${pendingDelete.name}"? This cannot be undone.` : ""
+        }
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3837,14 +3837,14 @@ export const useAppStore = create<AppState>((set, get) => {
     },
 
     deleteWorkspaceFromBackend: async (workspaceId) => {
-      try {
-        await apiDeleteWorkspace(workspaceId);
-        set((state) => ({
-          workspaces: state.workspaces.filter((ws) => ws.id !== workspaceId),
-        }));
-      } catch (err) {
-        console.error("Failed to delete workspace:", err);
-      }
+      // Only mutate local state after the backend delete resolves, and rethrow
+      // on failure so the caller can surface the error (GAP G7). A swallowed
+      // failure would optimistically remove the item, then silently "un-delete"
+      // it on the next loadWorkspaces with no explanation.
+      await apiDeleteWorkspace(workspaceId);
+      set((state) => ({
+        workspaces: state.workspaces.filter((ws) => ws.id !== workspaceId),
+      }));
     },
 
     duplicateWorkspaceInBackend: async (workspaceId) => {


### PR DESCRIPTION
## Summary

Fixes GAP G7 from the workspace save/restore audit (umbrella #1146): deleting a
saved workspace was a destructive one-click action with no confirmation and no
feedback. The store swallowed backend failures with `console.error` and (before
resolving) offered no way for the UI to react, so a failed delete silently
"un-deleted" the workspace on the next `loadWorkspaces` with no explanation.

## Changes

- **Confirm before delete** — `WorkspaceSidebar` now opens the shared
  `ConfirmDeleteDialog` (Modal + Button primitives) before deleting, naming the
  workspace and warning the action cannot be undone.
- **Feedback on completion** — on confirm, the delete awaits the backend and
  shows `toast.success` or `toast.error`.
- **State only mutated after backend resolves** — `deleteWorkspaceFromBackend`
  now rethrows on failure (still removing the local item only after the backend
  resolves) so the sidebar can surface the error; a failed delete leaves the
  workspace visible instead of silently vanishing.

## Test plan

- `pnpm test` — full suite, 2231 passed (194 files). New `WorkspaceSidebar`
  tests cover: confirm dialog appears and no backend delete on click alone;
  confirm + backend success removes the item and shows a success toast; backend
  failure keeps the item and shows an error toast.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all pass.

Partially addresses #1146 (G7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)