### PR TITLE
fix(tunnel): confirm + feedback on tunnel delete (#1141)

### DIFF
--- a/docs/changes/dev2/feature/1141-tunnel-delete-feedback.md
+++ b/docs/changes/dev2/feature/1141-tunnel-delete-feedback.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Deleting an SSH tunnel now gives clear feedback: a loading toast while the
+  delete runs, then a success toast, or a recoverable error toast if the backend
+  delete fails (previously failures were swallowed silently and could leave the
+  tunnel list out of sync with the backend). Deleting a tunnel that is currently
+  active (connecting, connected, or reconnecting) now asks for confirmation
+  first, since it tears down a live connection. Addresses GAP 7 of the SSH tunnel
+  audit (#1141).

--- a/src/components/TunnelSidebar/TunnelSidebar.delete-confirm.test.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.delete-confirm.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Regression tests for GAP 7 from the SSH tunnel audit (#1141).
+ *
+ * Deleting an ACTIVE (connecting / connected / reconnecting) tunnel silently
+ * killed it with no chance to reconsider. These tests pin that the sidebar
+ * prompts for confirmation before deleting an active tunnel, and deletes an
+ * inactive tunnel directly (no prompt).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { TunnelConfig, TunnelState } from "@/types/tunnel";
+import { TooltipProvider } from "@/components/ui";
+import { TunnelSidebar } from "./TunnelSidebar";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+const mockDeleteTunnel = vi.fn(() => Promise.resolve());
+
+vi.mock("@/store/appStore", () => {
+  const state: Record<string, unknown> = {};
+  const useAppStore = (selector: (s: Record<string, unknown>) => unknown) => selector(state);
+  useAppStore.setState = (patch: Record<string, unknown>) => Object.assign(state, patch);
+  return { useAppStore };
+});
+
+function makeTunnel(id: string, name: string): TunnelConfig {
+  return {
+    id,
+    name,
+    sshConnectionId: "conn-1",
+    tunnelType: {
+      type: "local",
+      config: { localHost: "127.0.0.1", localPort: 8080, remoteHost: "127.0.0.1", remotePort: 80 },
+    },
+    autoStart: false,
+    reconnectOnDisconnect: false,
+  };
+}
+
+function makeState(id: string, status: TunnelState["status"]): TunnelState {
+  return {
+    tunnelId: id,
+    status,
+    stats: { bytesSent: 0, bytesReceived: 0, activeConnections: 0, totalConnections: 0 },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function seedStore(tunnel: TunnelConfig, state?: TunnelState) {
+  (useAppStore as unknown as { setState: (p: Record<string, unknown>) => void }).setState({
+    tunnels: [tunnel],
+    tunnelStates: state ? { [tunnel.id]: state } : {},
+    connections: [],
+    startTunnel: vi.fn(),
+    stopTunnel: vi.fn(),
+    saveTunnel: vi.fn(),
+    deleteTunnel: mockDeleteTunnel,
+    openTunnelEditorTab: vi.fn(),
+  });
+}
+
+describe("TunnelSidebar — delete confirmation (GAP 7, #1141)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("prompts for confirmation before deleting an active tunnel", async () => {
+    seedStore(makeTunnel("tun-1", "Active Tunnel"), makeState("tun-1", "connected"));
+    await act(async () => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <TunnelSidebar />
+        </TooltipProvider>
+      );
+    });
+    await flush();
+
+    const deleteBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="tunnel-delete-tun-1"]'
+    );
+    expect(deleteBtn).not.toBeNull();
+    await act(async () => {
+      deleteBtn!.click();
+    });
+    await flush();
+
+    // The confirm dialog must appear, and delete must NOT have fired yet.
+    const dialog = document.querySelector('[data-testid="confirm-delete-dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(mockDeleteTunnel).not.toHaveBeenCalled();
+
+    // Confirming the dialog performs the delete.
+    const confirm = document.querySelector<HTMLButtonElement>(
+      '[data-testid="confirm-delete-confirm"]'
+    );
+    expect(confirm).not.toBeNull();
+    await act(async () => {
+      confirm!.click();
+    });
+    await flush();
+    expect(mockDeleteTunnel).toHaveBeenCalledWith("tun-1");
+  });
+
+  it("deletes an inactive tunnel without prompting", async () => {
+    seedStore(makeTunnel("tun-2", "Idle Tunnel"), makeState("tun-2", "disconnected"));
+    await act(async () => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <TunnelSidebar />
+        </TooltipProvider>
+      );
+    });
+    await flush();
+
+    const deleteBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="tunnel-delete-tun-2"]'
+    );
+    await act(async () => {
+      deleteBtn!.click();
+    });
+    await flush();
+
+    expect(document.querySelector('[data-testid="confirm-delete-dialog"]')).toBeNull();
+    expect(mockDeleteTunnel).toHaveBeenCalledWith("tun-2");
+  });
+});

--- a/src/components/TunnelSidebar/TunnelSidebar.delete-confirm.test.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.delete-confirm.test.tsx
@@ -7,7 +7,7 @@
  * inactive tunnel directly (no prompt).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import React, { act } from "react";
+import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import type { TunnelConfig, TunnelState } from "@/types/tunnel";

--- a/src/components/TunnelSidebar/TunnelSidebar.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.tsx
@@ -1,8 +1,13 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { Plus } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { ConfirmDeleteDialog } from "@/components/Sidebar/ConfirmDeleteDialog";
+import type { TunnelStatus } from "@/types/tunnel";
 import { TunnelListItem } from "./TunnelListItem";
 import "./TunnelSidebar.css";
+
+/** Tunnel statuses that count as "active" — deleting one tears down a live connection. */
+const ACTIVE_STATUSES: readonly TunnelStatus[] = ["connecting", "connected", "reconnecting"];
 
 export function TunnelSidebar() {
   const tunnels = useAppStore((s) => s.tunnels);
@@ -13,6 +18,9 @@ export function TunnelSidebar() {
   const saveTunnel = useAppStore((s) => s.saveTunnel);
   const deleteTunnel = useAppStore((s) => s.deleteTunnel);
   const openTunnelEditorTab = useAppStore((s) => s.openTunnelEditorTab);
+
+  // Tunnel pending confirmation before an active-tunnel delete, or null when idle.
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null);
 
   const handleNew = useCallback(() => {
     openTunnelEditorTab(null);
@@ -42,10 +50,26 @@ export function TunnelSidebar() {
 
   const handleDelete = useCallback(
     (tunnelId: string) => {
-      deleteTunnel(tunnelId);
+      const status = tunnelStates[tunnelId]?.status;
+      // Deleting an active tunnel silently tears down a live connection — confirm first.
+      if (status && ACTIVE_STATUSES.includes(status)) {
+        const name = tunnels.find((t) => t.id === tunnelId)?.name ?? "this tunnel";
+        setPendingDelete({ id: tunnelId, name });
+        return;
+      }
+      void deleteTunnel(tunnelId);
     },
-    [deleteTunnel]
+    [tunnelStates, tunnels, deleteTunnel]
   );
+
+  const confirmDelete = useCallback(() => {
+    if (pendingDelete) {
+      void deleteTunnel(pendingDelete.id);
+      setPendingDelete(null);
+    }
+  }, [pendingDelete, deleteTunnel]);
+
+  const cancelDelete = useCallback(() => setPendingDelete(null), []);
 
   return (
     <div className="tunnel-sidebar" data-testid="tunnel-sidebar">
@@ -82,6 +106,16 @@ export function TunnelSidebar() {
           ))}
         </div>
       )}
+      <ConfirmDeleteDialog
+        open={pendingDelete !== null}
+        message={
+          pendingDelete
+            ? `"${pendingDelete.name}" is currently active. Deleting it will stop the tunnel. Continue?`
+            : ""
+        }
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
+      />
     </div>
   );
 }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3629,6 +3629,8 @@ export const useAppStore = create<AppState>((set, get) => {
     },
 
     deleteTunnel: async (tunnelId) => {
+      const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
+      const toastId = toast.loading(`Deleting ${name}…`);
       try {
         await apiDeleteTunnel(tunnelId);
         set((state) => ({
@@ -3637,8 +3639,13 @@ export const useAppStore = create<AppState>((set, get) => {
             Object.entries(state.tunnelStates).filter(([k]) => k !== tunnelId)
           ),
         }));
+        toast.success(`Deleted ${name}`, { id: toastId });
       } catch (err) {
-        console.error("Failed to delete tunnel:", err);
+        toast.error(
+          `Failed to delete ${name}: ${err instanceof Error ? err.message : String(err)}`,
+          { id: toastId }
+        );
+        throw err;
       }
     },
 

--- a/src/store/appStore.tunnel-delete.test.ts
+++ b/src/store/appStore.tunnel-delete.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression tests for GAP 7 from the SSH tunnel audit (#1141).
+ *
+ * The store's `deleteTunnel` previously swallowed errors with a bare
+ * `console.error` and gave no user feedback on success or failure (violating
+ * design-system rule 4: every action gives feedback). These tests pin that
+ * deleting a tunnel emits a loading→success toast on success and a
+ * loading→error toast on failure, mirroring the existing start/stop pattern.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock the service modules the store imports at module load. We only care about
+// tunnelApi + the toast primitive here, but the store pulls in the full graph.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/tunnelApi", () => ({
+  getTunnels: vi.fn(() => Promise.resolve([])),
+  saveTunnel: vi.fn(),
+  deleteTunnel: vi.fn(() => Promise.resolve()),
+  startTunnel: vi.fn(),
+  stopTunnel: vi.fn(),
+  getTunnelStatuses: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      loading: vi.fn(() => "toast-id"),
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+import { useAppStore } from "./appStore";
+import { deleteTunnel as apiDeleteTunnel } from "@/services/tunnelApi";
+import { toast } from "@/components/ui";
+import type { TunnelConfig } from "@/types/tunnel";
+
+function makeTunnel(id: string, name: string): TunnelConfig {
+  return {
+    id,
+    name,
+    sshConnectionId: "conn-1",
+    tunnelType: {
+      type: "local",
+      config: { localHost: "127.0.0.1", localPort: 8080, remoteHost: "127.0.0.1", remotePort: 80 },
+    },
+    autoStart: false,
+    reconnectOnDisconnect: false,
+  };
+}
+
+describe("appStore — deleteTunnel feedback (GAP 7, #1141)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ tunnels: [makeTunnel("tun-1", "My Tunnel")] });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a loading then success toast when a tunnel is deleted", async () => {
+    await useAppStore.getState().deleteTunnel("tun-1");
+
+    expect(toast.loading).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining("My Tunnel"),
+      expect.objectContaining({ id: "toast-id" })
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    // The tunnel is removed from the store on success.
+    expect(useAppStore.getState().tunnels).toHaveLength(0);
+  });
+
+  it("shows an error toast and keeps the tunnel when deletion fails", async () => {
+    vi.mocked(apiDeleteTunnel).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(useAppStore.getState().deleteTunnel("tun-1")).rejects.toThrow("boom");
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+    // On failure the row must NOT be optimistically removed (no desync).
+    expect(useAppStore.getState().tunnels).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes GAP 7 from the SSH tunnel audit (`docs/audits/ssh-tunnel-state-machine.md`): `deleteTunnel` swallowed errors and gave no user feedback, and the sidebar had no confirmation before deleting an active tunnel.

## Changes

- **`src/store/appStore.ts` — `deleteTunnel`**: now emits a `toast.loading` → `toast.success`/`toast.error` sequence (mirroring the existing `startTunnel`/`stopTunnel` pattern) and rethrows on failure instead of only `console.error`-ing. The optimistic list removal only happens on success, so a failed backend delete no longer desyncs the list.
- **`src/components/TunnelSidebar/TunnelSidebar.tsx` — `handleDelete`**: when the tunnel is active (`connecting` / `connected` / `reconnecting`), it now prompts via the shared `ConfirmDeleteDialog` primitive before deleting, since deleting tears down a live connection. Inactive tunnels delete directly as before.

Design-system: reuses the shared `ConfirmDeleteDialog` (Modal + Button primitives) and the `toast` primitive — no new dialog/CSS. Every delete now gives feedback (rule 4).

## Test plan

TDD — tests committed before the fix (confirmed RED first):

- `src/store/appStore.tunnel-delete.test.ts` — delete success shows loading+success toast and removes the row; delete failure shows an error toast, rethrows, and keeps the row.
- `src/components/TunnelSidebar/TunnelSidebar.delete-confirm.test.tsx` — deleting an active tunnel prompts for confirmation and only deletes on confirm; deleting an inactive tunnel deletes without prompting.

Verification (all green):
- `pnpm test` — 2232 passed (196 files)
- `pnpm build` — type-check + build clean
- `pnpm run lint` — clean
- `pnpm run format:check` — clean

Partially addresses #1141 (GAP 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
