### PR TITLE
fix(sftp): map poisoned SFTP session lock to a recoverable error (#1143)

### DIFF
--- a/docs/changes/dev2/feature/1143-sftp-mutex-no-unwrap.md
+++ b/docs/changes/dev2/feature/1143-sftp-mutex-no-unwrap.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- A crashing SFTP operation no longer takes down every subsequent SFTP command.
+  The SFTP command layer previously locked the session mutex with `.unwrap()`, so
+  if any transfer or file op panicked while holding the lock, the poisoned mutex
+  made every later SFTP command abort the whole process. Locks now map a poisoned
+  session to a recoverable error, so the app reports a normal failure and keeps
+  running (audit gap C1, #1143).

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -68,8 +68,10 @@ pub async fn sftp_download(
 ) -> Result<u64, TerminalError> {
     debug!(session_id, remote_path, local_path, "SFTP download");
     let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.read_file(&remote_path, &local_path))
-        .await
+    tokio::task::spawn_blocking(move || {
+        lock_session(&session)?.read_file(&remote_path, &local_path)
+    })
+    .await
     .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
 
@@ -83,8 +85,10 @@ pub async fn sftp_upload(
 ) -> Result<u64, TerminalError> {
     debug!(session_id, local_path, remote_path, "SFTP upload");
     let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.write_file(&local_path, &remote_path))
-        .await
+    tokio::task::spawn_blocking(move || {
+        lock_session(&session)?.write_file(&local_path, &remote_path)
+    })
+    .await
     .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
 

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -4,7 +4,7 @@ use termihub_core::backends::ssh::parse_ssh_settings;
 use tracing::{debug, info};
 
 use crate::connection::manager::ConnectionManager;
-use crate::files::sftp::SftpManager;
+use crate::files::sftp::{lock_session, SftpManager};
 use crate::files::FileEntry;
 use crate::utils::errors::TerminalError;
 use crate::utils::vscode;
@@ -53,7 +53,7 @@ pub async fn sftp_list_dir(
 ) -> Result<Vec<FileEntry>, TerminalError> {
     debug!(session_id, path, "SFTP list directory");
     let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || session.lock().unwrap().list_dir(&path))
+    tokio::task::spawn_blocking(move || lock_session(&session)?.list_dir(&path))
         .await
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
@@ -68,10 +68,8 @@ pub async fn sftp_download(
 ) -> Result<u64, TerminalError> {
     debug!(session_id, remote_path, local_path, "SFTP download");
     let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || {
-        session.lock().unwrap().read_file(&remote_path, &local_path)
-    })
-    .await
+    tokio::task::spawn_blocking(move || lock_session(&session)?.read_file(&remote_path, &local_path))
+        .await
     .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
 
@@ -85,13 +83,8 @@ pub async fn sftp_upload(
 ) -> Result<u64, TerminalError> {
     debug!(session_id, local_path, remote_path, "SFTP upload");
     let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || {
-        session
-            .lock()
-            .unwrap()
-            .write_file(&local_path, &remote_path)
-    })
-    .await
+    tokio::task::spawn_blocking(move || lock_session(&session)?.write_file(&local_path, &remote_path))
+        .await
     .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
 
@@ -103,7 +96,7 @@ pub async fn sftp_mkdir(
     manager: State<'_, SftpManager>,
 ) -> Result<(), TerminalError> {
     let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || session.lock().unwrap().mkdir(&path))
+    tokio::task::spawn_blocking(move || lock_session(&session)?.mkdir(&path))
         .await
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
@@ -118,7 +111,7 @@ pub async fn sftp_delete(
 ) -> Result<(), TerminalError> {
     let session = manager.get_session(&session_id)?;
     tokio::task::spawn_blocking(move || {
-        let session = session.lock().unwrap();
+        let session = lock_session(&session)?;
         if is_directory {
             session.remove_dir(&path)
         } else {
@@ -138,7 +131,7 @@ pub async fn sftp_rename(
     manager: State<'_, SftpManager>,
 ) -> Result<(), TerminalError> {
     let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || session.lock().unwrap().rename(&old_path, &new_path))
+    tokio::task::spawn_blocking(move || lock_session(&session)?.rename(&old_path, &new_path))
         .await
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
@@ -205,7 +198,7 @@ pub async fn sftp_read_file_content(
     manager: State<'_, SftpManager>,
 ) -> Result<String, TerminalError> {
     let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || session.lock().unwrap().read_file_content(&remote_path))
+    tokio::task::spawn_blocking(move || lock_session(&session)?.read_file_content(&remote_path))
         .await
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
@@ -220,10 +213,7 @@ pub async fn sftp_write_file_content(
 ) -> Result<(), TerminalError> {
     let session = manager.get_session(&session_id)?;
     tokio::task::spawn_blocking(move || {
-        session
-            .lock()
-            .unwrap()
-            .write_file_content(&remote_path, &content)
+        lock_session(&session)?.write_file_content(&remote_path, &content)
     })
     .await
     .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
@@ -289,10 +279,7 @@ pub async fn vscode_open_remote(
         let remote_path = remote_path.clone();
         let temp_path_str = temp_path_str.clone();
         tokio::task::spawn_blocking(move || {
-            session
-                .lock()
-                .unwrap()
-                .read_file(&remote_path, &temp_path_str)
+            lock_session(&session)?.read_file(&remote_path, &temp_path_str)
         })
         .await
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))??;
@@ -307,10 +294,8 @@ pub async fn vscode_open_remote(
         let event = match result {
             Ok(()) => {
                 // Re-upload the edited file
-                let upload_result = {
-                    let session = session_arc.lock().unwrap();
-                    session.write_file(&temp_path_str, &remote_path)
-                };
+                let upload_result = lock_session(&session_arc)
+                    .and_then(|session| session.write_file(&temp_path_str, &remote_path));
                 match upload_result {
                     Ok(_) => VscodeEditCompleteEvent {
                         remote_path,

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -468,3 +468,40 @@ impl SftpManager {
             .ok_or_else(|| TerminalError::SftpSessionNotFound(id.to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    /// The lock helper must map a poisoned mutex to a recoverable
+    /// `TerminalError` instead of panicking (audit GAP C1, #1143).
+    #[test]
+    fn lock_session_maps_poisoned_mutex_to_error() {
+        let mutex = Arc::new(Mutex::new(0i32));
+
+        // Poison the mutex by panicking while holding the lock.
+        let poisoner = Arc::clone(&mutex);
+        let handle = thread::spawn(move || {
+            let _guard = poisoner.lock().expect("first lock should succeed");
+            panic!("intentional panic to poison the mutex");
+        });
+        assert!(handle.join().is_err(), "poisoning thread should panic");
+
+        // A raw `.lock().unwrap()` would panic here; the helper must not.
+        let result = lock_session(&mutex);
+        assert!(
+            matches!(result, Err(TerminalError::SshError(_))),
+            "poisoned lock should return a recoverable SshError, got {result:?}"
+        );
+    }
+
+    /// On a healthy mutex the helper returns a usable guard.
+    #[test]
+    fn lock_session_returns_guard_when_healthy() {
+        let mutex = Mutex::new(41i32);
+        let mut guard = lock_session(&mutex).expect("healthy lock should succeed");
+        *guard += 1;
+        assert_eq!(*guard, 42);
+    }
+}

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use russh_sftp::client::SftpSession as RusshSftp;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -13,6 +13,20 @@ use termihub_core::files::{FileBackend, FileEntry};
 use crate::terminal::backend::SshConfig;
 use crate::utils::errors::TerminalError;
 use crate::utils::ssh_auth::connect_and_authenticate;
+
+/// Lock a mutex, mapping a poisoned lock to a recoverable [`TerminalError`]
+/// instead of panicking.
+///
+/// A prior SFTP op that panicked while holding the lock poisons the `Mutex`;
+/// a raw `.lock().unwrap()` would then abort the whole process on every
+/// subsequent command. Mapping the error keeps the session recoverable
+/// (audit GAP C1, issue #1143). Mirrors the error mapping already used by the
+/// [`SftpFileBackend`] impl.
+pub fn lock_session<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, TerminalError> {
+    mutex
+        .lock()
+        .map_err(|_| TerminalError::SshError("SFTP session lock poisoned".to_string()))
+}
 
 /// SFTP session backed by a dedicated SSH connection.
 ///
@@ -447,7 +461,7 @@ impl SftpManager {
     pub fn open_session(&self, config: &SshConfig) -> Result<String, TerminalError> {
         let session = SftpSession::new(config)?;
         let id = uuid::Uuid::new_v4().to_string();
-        let mut sessions = self.sessions.lock().unwrap();
+        let mut sessions = lock_session(&self.sessions)?;
         sessions.insert(id.clone(), Arc::new(Mutex::new(session)));
         Ok(id)
     }
@@ -455,13 +469,18 @@ impl SftpManager {
     /// Close and drop an SFTP session.
     pub fn close_session(&self, id: &str) {
         info!(session_id = id, "Closing SFTP session");
-        let mut sessions = self.sessions.lock().unwrap();
+        // Recover the guard even if the map mutex is poisoned — removing a
+        // session is cleanup and must not itself panic (audit GAP C1, #1143).
+        let mut sessions = self
+            .sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         sessions.remove(id);
     }
 
     /// Get a session Arc for use outside the manager lock.
     pub fn get_session(&self, id: &str) -> Result<Arc<Mutex<SftpSession>>, TerminalError> {
-        let sessions = self.sessions.lock().unwrap();
+        let sessions = lock_session(&self.sessions)?;
         sessions
             .get(id)
             .cloned()


### PR DESCRIPTION
## Summary

Production `.unwrap()` calls on the SFTP session/manager mutexes could poison the whole session: if any transfer or file op panicked while holding the lock, the `Mutex` became poisoned and **every subsequent SFTP command panicked** — a process-level abort rather than a recoverable error. This fixes audit GAP C1 from the SFTP / file-browser state-machine audit.

## Changes

- Added a `lock_session` helper in `src-tauri/src/files/sftp.rs` that maps a poisoned lock to a recoverable `TerminalError::SshError` instead of panicking (mirrors the mapping the `SftpFileBackend` impl already uses).
- Replaced every `session.lock().unwrap()` / `sessions.lock().unwrap()` in `src-tauri/src/commands/files.rs` and the `SftpManager` methods with the helper (via `?`).
- `SftpManager::close_session` recovers the poisoned guard (`into_inner`) so cleanup never panics.

## Test plan

- `test(sftp)`: new regression tests in `files::sftp::tests` poison a `Mutex` from a panicking thread and assert `lock_session` returns `Err(TerminalError::SshError)` instead of panicking, plus a healthy-path guard test. Confirmed RED (helper absent → compile error) before implementing, GREEN after.
- `cargo test -p termihub --lib files::sftp` → 2 passed, 0 failed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.

Partially addresses #1143 (C1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
