### PR TITLE
fix(backend): priming indicator for first monitoring CPU sample (#1148)

### DIFF
--- a/docs/changes/dev2/feature/1148-monitoring-cpu-priming.md
+++ b/docs/changes/dev2/feature/1148-monitoring-cpu-priming.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Remote system monitoring (status bar): the CPU stat now shows a muted
+  "CPU —" priming indicator until the second sample arrives, instead of a
+  solid "CPU 0%". The remote collectors report 0% on the very first sample
+  because there is no prior delta to compute a rate from, and the old display
+  made that placeholder look like a real reading. Memory and disk are correct
+  on the first sample and keep rendering numerically (#1148).

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -201,6 +201,11 @@
   color: var(--color-error);
 }
 
+/* First-sample CPU placeholder: muted so it reads as "not a real value yet". */
+.monitoring-status__stat--priming {
+  color: var(--text-secondary);
+}
+
 .monitoring-status__loading {
   display: flex;
   align-items: center;

--- a/src/components/StatusBar/StatusBar.monitoring-priming.test.tsx
+++ b/src/components/StatusBar/StatusBar.monitoring-priming.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for the CPU first-sample priming indicator (audit gap G10, issue #1148).
+ *
+ * The remote collectors return CPU 0% on the very first sample because there is
+ * no prior delta to compute a rate from (documented in `session.rs` /
+ * `agent/collector.rs`). Rendering a solid "CPU 0%" makes that placeholder look
+ * like a real reading. Until the second sample has arrived, the status-bar CPU
+ * stat shows a priming indicator ("—") instead of the fake "0%".
+ *
+ * These tests drive the store's `monitoringSampleCount` signal directly to
+ * assert the render branch: sample #1 → priming; sample #2 onward → real value.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui";
+import { useAppStore } from "@/store/appStore";
+import { StatusBar } from "./StatusBar";
+import type { SystemStats } from "@/types/monitoring";
+import type { ConnectionTypeInfo } from "@/types/connection";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
+
+vi.mock("@/components/CredentialStoreIndicator", () => ({ CredentialStoreIndicator: () => null }));
+vi.mock("./PortableBadge", () => ({ PortableBadge: () => null }));
+vi.mock("./UpdateIndicator", () => ({ UpdateIndicator: () => null }));
+
+function makeStats(overrides: Partial<SystemStats> = {}): SystemStats {
+  return {
+    hostname: "host",
+    uptimeSeconds: 100,
+    loadAverage: [0, 0, 0],
+    cpuUsagePercent: 0,
+    memoryTotalKb: 1000,
+    memoryAvailableKb: 500,
+    memoryUsedPercent: 50,
+    diskTotalKb: 2000,
+    diskUsedKb: 1000,
+    diskUsedPercent: 50,
+    osInfo: "Linux",
+    ...overrides,
+  };
+}
+
+/** Registers a monitoring-capable SSH type and makes an SSH tab the active tab. */
+function primeMonitoringTab() {
+  const sshType: ConnectionTypeInfo = {
+    typeId: "ssh",
+    displayName: "SSH",
+    icon: "server",
+    schema: { groups: [] } as unknown as ConnectionTypeInfo["schema"],
+    capabilities: { monitoring: true, fileBrowser: true, resize: true, persistent: false },
+  };
+
+  const tab: TerminalTab = {
+    id: "tab-1",
+    sessionId: "sess-1",
+    title: "ssh-host",
+    connectionType: "ssh",
+    contentType: "terminal",
+    config: { type: "ssh", config: {} },
+    panelId: "leaf-1",
+    isActive: true,
+  };
+
+  const leaf: LeafPanel = {
+    type: "leaf",
+    id: "leaf-1",
+    tabs: [tab],
+    activeTabId: "tab-1",
+  };
+
+  useAppStore.setState((state) => ({
+    connectionTypes: [sshType],
+    settings: { ...state.settings, powerMonitoringEnabled: true },
+    rootPanel: leaf,
+    activePanelId: "leaf-1",
+  }));
+}
+
+describe("StatusBar — CPU first-sample priming (#1148, G10)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    primeMonitoringTab();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderStatusBar() {
+    act(() =>
+      root.render(React.createElement(TooltipProvider, null, React.createElement(StatusBar)))
+    );
+  }
+
+  it("shows a priming indicator (not '0%') for CPU on the first sample", () => {
+    useAppStore.setState({
+      monitoringSessionId: "sess-1",
+      monitoringHost: "user@host:22",
+      monitoringStats: makeStats({ cpuUsagePercent: 0 }),
+      monitoringSampleCount: 1,
+    });
+    renderStatusBar();
+
+    const cpu = container.querySelector('[data-testid="monitoring-cpu"]');
+    expect(cpu).not.toBeNull();
+    expect(cpu!.textContent).not.toContain("0%");
+    expect(cpu!.textContent).toContain("—");
+    // Memory and disk are correct on the first sample and stay numeric.
+    const mem = container.querySelector('[data-testid="monitoring-mem"]');
+    expect(mem!.textContent).toContain("50%");
+  });
+
+  it("shows the real CPU value from the second sample onward", () => {
+    useAppStore.setState({
+      monitoringSessionId: "sess-1",
+      monitoringHost: "user@host:22",
+      monitoringStats: makeStats({ cpuUsagePercent: 42 }),
+      monitoringSampleCount: 2,
+    });
+    renderStatusBar();
+
+    const cpu = container.querySelector('[data-testid="monitoring-cpu"]');
+    expect(cpu).not.toBeNull();
+    expect(cpu!.textContent).toContain("42%");
+    expect(cpu!.textContent).not.toContain("—");
+  });
+});

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -237,6 +237,7 @@ function MonitoringStatus() {
   const monitoringSessionId = useAppStore((s) => s.monitoringSessionId);
   const monitoringHost = useAppStore((s) => s.monitoringHost);
   const monitoringStats = useAppStore((s) => s.monitoringStats);
+  const monitoringSampleCount = useAppStore((s) => s.monitoringSampleCount);
   const monitoringLoading = useAppStore((s) => s.monitoringLoading);
   const monitoringError = useAppStore((s) => s.monitoringError);
   const connectMonitoring = useAppStore((s) => s.connectMonitoring);
@@ -487,13 +488,30 @@ function MonitoringStatus() {
       />
       {monitoringStats && (
         <>
-          <span
-            className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.cpuUsagePercent)}`}
-            title={`CPU: ${monitoringStats.cpuUsagePercent.toFixed(1)}%`}
-            data-testid="monitoring-cpu"
-          >
-            CPU {monitoringStats.cpuUsagePercent.toFixed(0)}%
-          </span>
+          {/*
+            The remote collectors report CPU 0% on the first sample because there
+            is no prior delta to compute a rate from (audit gap G10). Until the
+            second sample arrives, show a priming indicator so the placeholder is
+            not mistaken for a real 0% reading. Memory and disk are correct on
+            the first sample and always render numerically.
+          */}
+          {monitoringSampleCount < 2 ? (
+            <span
+              className="status-bar__item monitoring-status__stat monitoring-status__stat--priming"
+              title="CPU: priming (waiting for second sample)"
+              data-testid="monitoring-cpu"
+            >
+              CPU —
+            </span>
+          ) : (
+            <span
+              className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.cpuUsagePercent)}`}
+              title={`CPU: ${monitoringStats.cpuUsagePercent.toFixed(1)}%`}
+              data-testid="monitoring-cpu"
+            >
+              CPU {monitoringStats.cpuUsagePercent.toFixed(0)}%
+            </span>
+          )}
           <span
             className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.memoryUsedPercent)}`}
             title={`Memory: ${formatKb(monitoringStats.memoryTotalKb - monitoringStats.memoryAvailableKb)} / ${formatKb(monitoringStats.memoryTotalKb)}`}

--- a/src/store/appStore.monitoring.test.ts
+++ b/src/store/appStore.monitoring.test.ts
@@ -298,6 +298,57 @@ describe("appStore — monitoring", () => {
     });
   });
 
+  // Audit gap G10: the first sample reports CPU 0% (no prior delta), so the
+  // status bar shows a priming indicator until the second sample. The store
+  // tracks progress via monitoringSampleCount.
+  describe("monitoringSampleCount (CPU priming)", () => {
+    it("is 1 after the first SSH connect fetch", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+
+      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+
+      expect(useAppStore.getState().monitoringSampleCount).toBe(1);
+    });
+
+    it("increments to 2 after a subsequent refresh", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+
+      mockMonitoringFetchStats.mockResolvedValue({ ...TEST_STATS, cpuUsagePercent: 40 });
+      await useAppStore.getState().refreshMonitoring();
+
+      expect(useAppStore.getState().monitoringSampleCount).toBe(2);
+    });
+
+    it("resets to 0 on disconnect", async () => {
+      mockMonitoringClose.mockResolvedValue(undefined);
+      useAppStore.setState({
+        monitoringSessionId: "session-123",
+        monitoringHost: "pi@pi.local:22",
+        monitoringStats: TEST_STATS,
+        monitoringSampleCount: 5,
+      });
+
+      await useAppStore.getState().disconnectMonitoring();
+
+      expect(useAppStore.getState().monitoringSampleCount).toBe(0);
+    });
+
+    it("resets to 0 at the start of a fresh connect", async () => {
+      // Simulate a stale counter from a previous session.
+      useAppStore.setState({ monitoringSampleCount: 7 });
+      mockMonitoringOpen.mockResolvedValue("session-456");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+
+      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+
+      // Reset to 0, then +1 for the initial fetch = 1.
+      expect(useAppStore.getState().monitoringSampleCount).toBe(1);
+    });
+  });
+
   describe("stats cache", () => {
     it("disconnectMonitoring saves stats to cache keyed by host", async () => {
       mockMonitoringClose.mockResolvedValue(undefined);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -645,6 +645,14 @@ interface AppState {
   monitoringStats: SystemStats | null;
   monitoringLoading: boolean;
   monitoringError: string | null;
+  /**
+   * Number of stats samples received on the current monitoring connection.
+   * The remote collectors report CPU 0% on the first sample (no prior delta),
+   * so the UI treats sample #1 as "priming" for the CPU field. Reset to 0 on
+   * connect/disconnect and incremented on every real stats update. See audit
+   * gap G10.
+   */
+  monitoringSampleCount: number;
   /** Last-known stats per host key, persisted across tab switches for instant display on reconnect. */
   monitoringStatsCache: Record<string, SystemStats>;
   connectMonitoring: (config: Record<string, unknown>) => Promise<void>;
@@ -3461,6 +3469,7 @@ export const useAppStore = create<AppState>((set, get) => {
     monitoringStats: null,
     monitoringLoading: false,
     monitoringError: null,
+    monitoringSampleCount: 0,
     monitoringStatsCache: {},
     sessionCapabilities: {},
 
@@ -3482,6 +3491,9 @@ export const useAppStore = create<AppState>((set, get) => {
             monitoringError: null,
             monitoringStats: cachedStats,
             monitoringHost: cachedStats ? sessionId : null,
+            // Fresh connection: reset the sample counter so CPU shows the
+            // priming indicator until the second push arrives (audit gap G10).
+            monitoringSampleCount: 0,
           });
 
           const unlisten = await onSessionMonitoringStats((sid, stats) => {
@@ -3489,6 +3501,7 @@ export const useAppStore = create<AppState>((set, get) => {
               useAppStore.setState((state) => ({
                 monitoringStats: stats,
                 monitoringError: null,
+                monitoringSampleCount: state.monitoringSampleCount + 1,
                 monitoringStatsCache: { ...state.monitoringStatsCache, [sessionId]: stats },
               }));
             }
@@ -3513,6 +3526,9 @@ export const useAppStore = create<AppState>((set, get) => {
           monitoringError: null,
           monitoringStats: cachedStats,
           monitoringHost: cachedStats ? hostKey : null,
+          // Fresh connection: reset the sample counter so CPU shows the priming
+          // indicator until the second fetch arrives (audit gap G10).
+          monitoringSampleCount: 0,
         });
 
         const sessionId = await monitoringOpen(config);
@@ -3522,6 +3538,7 @@ export const useAppStore = create<AppState>((set, get) => {
           monitoringHost: hostKey,
           monitoringStats: stats,
           monitoringLoading: false,
+          monitoringSampleCount: state.monitoringSampleCount + 1,
           monitoringStatsCache: { ...state.monitoringStatsCache, [hostKey]: stats },
         }));
       } catch (err) {
@@ -3565,6 +3582,7 @@ export const useAppStore = create<AppState>((set, get) => {
         monitoringHost: null,
         monitoringStats: null,
         monitoringError: null,
+        monitoringSampleCount: 0,
         // Preserve last-known stats so the UI can show them instantly on reconnect.
         monitoringStatsCache:
           monitoringHost && monitoringStats
@@ -3583,6 +3601,7 @@ export const useAppStore = create<AppState>((set, get) => {
         set((state) => ({
           monitoringStats: stats,
           monitoringError: null,
+          monitoringSampleCount: state.monitoringSampleCount + 1,
           monitoringStatsCache: monitoringHost
             ? { ...state.monitoringStatsCache, [monitoringHost]: stats }
             : state.monitoringStatsCache,


### PR DESCRIPTION
## Summary

Addresses **audit gap G10** from the remote system monitoring audit: the first monitoring sample reports **CPU 0%** because the remote collectors have no prior delta to compute a rate from (documented in `session.rs` / `agent/collector.rs`). The status bar rendered a solid `CPU 0%` that looked like a real reading.

This is a **frontend/store-only** fix — the Rust collectors are unchanged.

## Changes

- **Store (`appStore.ts`)**: added `monitoringSampleCount`. Reset to `0` on connect start and disconnect; incremented on every real stats update (SSH initial fetch, refresh poll, and session push).
- **Status bar (`StatusBar.tsx` / `StatusBar.css`)**: while only the first sample has arrived (`monitoringSampleCount < 2`), the CPU stat renders a muted `CPU —` priming indicator (new `--priming` modifier, `--text-secondary` token) instead of the placeholder `0%`. Memory and disk are correct on the first sample and keep rendering numerically.

## Test plan

- `StatusBar.monitoring-priming.test.tsx` (new): CPU shows the priming indicator (`—`, not `0%`) on sample #1, and the real value from sample #2 onward.
- `appStore.monitoring.test.ts`: new `monitoringSampleCount` cases — `1` after first connect fetch, `2` after a refresh, reset to `0` on disconnect and at the start of a fresh connect.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` all pass.

Partially addresses #1148 (G10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)