### PR TITLE
fix(workspace): feedback on workspace import/export (#1146)

### DIFF
--- a/docs/changes/dev2/feature/1146-workspace-import-export-feedback.md
+++ b/docs/changes/dev2/feature/1146-workspace-import-export-feedback.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Importing and exporting workspaces now report their result instead of
+  swallowing every outcome silently. Import shows a success toast with the
+  number of workspaces actually imported (so a duplicate-skipping or
+  partial import is no longer indistinguishable from importing nothing) and an
+  error toast if the file cannot be parsed; export shows a success toast or a
+  recoverable error toast if the file cannot be written. Cancelling the file
+  dialog stays a no-op with no toast. Part of the workspace save/restore audit
+  (#1146, gap G8).

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
@@ -26,6 +26,28 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(vi.fn()),
 }));
 
+// Stub the native file dialogs and fs so import/export can be driven from tests.
+const dialogSave = vi.fn();
+const dialogOpen = vi.fn();
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  save: (...args: unknown[]) => dialogSave(...args),
+  open: (...args: unknown[]) => dialogOpen(...args),
+}));
+
+const fsWriteTextFile = vi.fn();
+const fsReadTextFile = vi.fn();
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  writeTextFile: (...args: unknown[]) => fsWriteTextFile(...args),
+  readTextFile: (...args: unknown[]) => fsReadTextFile(...args),
+}));
+
+const apiExportWorkspaces = vi.fn();
+const apiImportWorkspaces = vi.fn();
+vi.mock("@/services/workspaceApi", () => ({
+  exportWorkspaces: (...args: unknown[]) => apiExportWorkspaces(...args),
+  importWorkspaces: (...args: unknown[]) => apiImportWorkspaces(...args),
+}));
+
 vi.mock("@/themes", () => ({
   applyTheme: vi.fn(),
   onThemeChange: vi.fn(),
@@ -239,5 +261,131 @@ describe("WorkspaceSidebar", () => {
     expect(query("workspace-item-ws-1")).not.toBeNull();
     expect(toastError).toHaveBeenCalledTimes(1);
     expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a success toast with the imported count when import succeeds", async () => {
+    const loadWorkspaces = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ workspaces: [], loadWorkspaces });
+    dialogOpen.mockResolvedValue("/tmp/workspaces.json");
+    fsReadTextFile.mockResolvedValue("{}");
+    apiImportWorkspaces.mockResolvedValue(3);
+
+    act(() => {
+      root.render(withTooltip(<WorkspaceSidebar />));
+    });
+
+    act(() => (query("workspace-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(apiImportWorkspaces).toHaveBeenCalledWith("{}");
+    expect(loadWorkspaces).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledWith("Imported 3 workspaces");
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("uses singular wording when a single workspace is imported", async () => {
+    const loadWorkspaces = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ workspaces: [], loadWorkspaces });
+    dialogOpen.mockResolvedValue("/tmp/workspaces.json");
+    fsReadTextFile.mockResolvedValue("{}");
+    apiImportWorkspaces.mockResolvedValue(1);
+
+    act(() => {
+      root.render(withTooltip(<WorkspaceSidebar />));
+    });
+
+    act(() => (query("workspace-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(toastSuccess).toHaveBeenCalledWith("Imported 1 workspace");
+  });
+
+  it("surfaces an error toast when import fails", async () => {
+    const loadWorkspaces = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ workspaces: [], loadWorkspaces });
+    dialogOpen.mockResolvedValue("/tmp/workspaces.json");
+    fsReadTextFile.mockResolvedValue("not json");
+    apiImportWorkspaces.mockRejectedValue(new Error("invalid JSON"));
+
+    act(() => {
+      root.render(withTooltip(<WorkspaceSidebar />));
+    });
+
+    act(() => (query("workspace-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("shows no toast when the import file dialog is cancelled", async () => {
+    const loadWorkspaces = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ workspaces: [], loadWorkspaces });
+    dialogOpen.mockResolvedValue(null);
+
+    act(() => {
+      root.render(withTooltip(<WorkspaceSidebar />));
+    });
+
+    act(() => (query("workspace-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(apiImportWorkspaces).not.toHaveBeenCalled();
+    expect(loadWorkspaces).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a success toast when export succeeds", async () => {
+    useAppStore.setState({ workspaces: [] });
+    apiExportWorkspaces.mockResolvedValue("{}");
+    dialogSave.mockResolvedValue("/tmp/out.json");
+    fsWriteTextFile.mockResolvedValue(undefined);
+
+    act(() => {
+      root.render(withTooltip(<WorkspaceSidebar />));
+    });
+
+    act(() => (query("workspace-export-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(fsWriteTextFile).toHaveBeenCalledWith("/tmp/out.json", "{}");
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast when export fails", async () => {
+    useAppStore.setState({ workspaces: [] });
+    apiExportWorkspaces.mockResolvedValue("{}");
+    dialogSave.mockResolvedValue("/tmp/out.json");
+    fsWriteTextFile.mockRejectedValue(new Error("permission denied"));
+
+    act(() => {
+      root.render(withTooltip(<WorkspaceSidebar />));
+    });
+
+    act(() => (query("workspace-export-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("shows no toast when the export file dialog is cancelled", async () => {
+    useAppStore.setState({ workspaces: [] });
+    apiExportWorkspaces.mockResolvedValue("{}");
+    dialogSave.mockResolvedValue(null);
+
+    act(() => {
+      root.render(withTooltip(<WorkspaceSidebar />));
+    });
+
+    act(() => (query("workspace-export-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(fsWriteTextFile).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
   });
 });

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
@@ -213,7 +213,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     // No confirm dialog before the delete button is pressed.
@@ -231,7 +231,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     act(() => (query("workspace-delete-ws-1") as HTMLButtonElement).click());
@@ -249,7 +249,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     act(() => (query("workspace-delete-ws-1") as HTMLButtonElement).click());

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -97,6 +97,8 @@ export function WorkspaceSidebar() {
   const loadWorkspaces = useAppStore((s) => s.loadWorkspaces);
 
   const handleExport = useCallback(async () => {
+    // A cancelled file dialog returns null before any write happens — treat it
+    // as a no-op (no toast). Only a genuine failure surfaces an error (GAP G8).
     try {
       const json = await exportWorkspaces();
       const filePath = await save({
@@ -105,23 +107,30 @@ export function WorkspaceSidebar() {
       });
       if (!filePath) return;
       await writeTextFile(filePath, json);
-    } catch {
-      // Export cancelled or failed
+      toast.success("Exported workspaces");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to export workspaces: ${message}`);
     }
   }, []);
 
   const handleImport = useCallback(async () => {
+    // A cancelled file dialog returns null before any work happens — treat it as
+    // a no-op (no toast). A parse failure or duplicate-skip must be reported so
+    // the user can tell if 0, some, or all workspaces imported (GAP G8).
+    const filePath = await open({
+      multiple: false,
+      filters: [{ name: "JSON", extensions: ["json"] }],
+    });
+    if (!filePath) return;
     try {
-      const filePath = await open({
-        multiple: false,
-        filters: [{ name: "JSON", extensions: ["json"] }],
-      });
-      if (!filePath) return;
       const json = await readTextFile(filePath);
-      await importWorkspaces(json);
+      const count = await importWorkspaces(json);
       await loadWorkspaces();
-    } catch {
-      // Import cancelled or failed
+      toast.success(`Imported ${count} workspace${count === 1 ? "" : "s"}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to import workspaces: ${message}`);
     }
   }, [loadWorkspaces]);
 


### PR DESCRIPTION
## Summary

Workspace import and export previously swallowed every outcome in empty `catch` blocks (`WorkspaceSidebar.tsx`), so a duplicate-skipping or parse-failing import gave the user zero feedback and a failed export vanished silently. This surfaces the results as toasts. Addresses gap G8 of the workspace save/restore audit.

## Changes

- `handleImport` now reports the count returned by the backend `import_json` as `toast.success("Imported N workspace(s)")` (singular/plural aware) and reports parse/duplicate failures as `toast.error(...)`.
- `handleExport` now reports success or a write failure with a toast.
- A cancelled file dialog (open/save returns null) stays a no-op with **no** toast, distinct from a real failure.
- Fixed three pre-existing delete-flow tests that rendered `WorkspaceSidebar` without a `TooltipProvider` (they only passed by accident via leaked context in full-suite runs).

## Test plan

- New Vitest cases in `WorkspaceSidebar.test.tsx`: successful import shows a success toast with the count (and singular wording for 1); failed import shows an error toast; failed export shows an error toast; successful export shows a success toast; cancelled import and cancelled export dialogs show no toast. TDD — tests committed RED before the fix.
- `pnpm test` (full suite): 2260 passed.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check`: all clean.

Partially addresses #1146 (G8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)