### PR TITLE
feat(terminal): connect elapsed-time overlay and success confirmation (Closes #1127)

### DIFF
--- a/docs/changes/dev1/feature/1127-connect-feedback-elapsed.md
+++ b/docs/changes/dev1/feature/1127-connect-feedback-elapsed.md
@@ -1,0 +1,7 @@
+## Added
+
+- The "Connecting…" terminal overlay now shows an elapsed-time readout that ticks up while the connection is being established, plus a "Taking longer than usual" hint once a connect drags past 20 seconds — so a slow or stuck connect is no longer an indefinite, silent spinner.
+
+## Changed
+
+- A successful terminal connection now surfaces a brief, non-intrusive "Connected" toast (naming the connection) instead of silently clearing the overlay, giving positive confirmation that the session is live.

--- a/src/components/Terminal/Terminal.connect-toast.test.tsx
+++ b/src/components/Terminal/Terminal.connect-toast.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Regression tests for the connect success confirmation (#1127).
+ *
+ * A successful connect must not resolve silently: once createTerminal resolves,
+ * the Terminal fires a non-intrusive `toast.success` so the user gets positive
+ * feedback that the session is live.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+import { useAppStore } from "@/store/appStore";
+
+// --- Mocks ---
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    onCursorMove = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    write = vi.fn((_data: unknown, cb?: () => void) => cb?.());
+    writeln = vi.fn();
+    reset = vi.fn();
+    scrollToBottom = vi.fn();
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn();
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = { active: { viewportY: 0, baseY: 0, length: 0, getLine: vi.fn() } };
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class MockFitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-unicode11", () => {
+  class MockUnicode11Addon {
+    dispose = vi.fn();
+  }
+  return { Unicode11Addon: MockUnicode11Addon };
+});
+
+vi.mock("@xterm/addon-search", () => {
+  class MockSearchAddon {
+    dispose = vi.fn();
+  }
+  return { SearchAddon: MockSearchAddon };
+});
+
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+const mockCreateTerminal = vi.fn().mockResolvedValue("live-session");
+
+vi.mock("@/services/api", () => ({
+  createTerminal: (...args: unknown[]) => mockCreateTerminal(...args),
+  cancelConnecting: vi.fn().mockResolvedValue(undefined),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  setSessionLineEnding: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+  detachPersistentTab: vi.fn().mockResolvedValue(0),
+  getAgentSessionBuffer: vi.fn().mockResolvedValue(new Uint8Array()),
+}));
+
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: vi.fn(() => vi.fn()),
+    subscribeExit: vi.fn(() => vi.fn()),
+    clearPendingExit: vi.fn(),
+    clearPendingOutput: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+  isShellReservedKey: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+const mockToastSuccess = vi.fn();
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  mockCreateTerminal.mockClear();
+  mockCreateTerminal.mockResolvedValue("live-session");
+  mockToastSuccess.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const LOCAL_CONFIG = {
+  type: "local" as const,
+  config: { shell: "/bin/bash" },
+};
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Terminal — connect success confirmation", () => {
+  it("fires a success toast once a fresh connect resolves", async () => {
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal tabId="tab-1" config={LOCAL_CONFIG} isVisible={true} />
+        </TerminalPortalProvider>
+      );
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire a success toast when the connect fails", async () => {
+    mockCreateTerminal.mockRejectedValueOnce(new Error("boom"));
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal tabId="tab-2" config={LOCAL_CONFIG} isVisible={true} />
+        </TerminalPortalProvider>
+      );
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/services/keybindings";
 import { frontendLog } from "@/utils/frontendLog";
 import { resolveLineEnding } from "@/utils/lineEndings";
+import { getAllLeaves } from "@/utils/panelTree";
+import { toast } from "@/components/ui";
 import { createTerminalScrollbar, type TerminalScrollbarController } from "./terminalScrollbar";
 
 const HORIZONTAL_SCROLL_COLS = 500;
@@ -48,6 +50,20 @@ const DEFAULT_CURSOR_BLINK = true;
  * remote command is gone) does not retry forever.
  */
 const MAX_AGENT_SPAWN_ATTEMPTS = 5;
+
+/**
+ * Resolves a tab's display title from the current store so the connect success
+ * toast can name the connection. Falls back to a generic label if the tab has
+ * been removed by the time the connect resolves.
+ */
+function resolveTabTitle(tabId: string): string {
+  const state = useAppStore.getState();
+  const tab = [
+    ...getAllLeaves(state.rootPanel).flatMap((l) => l.tabs),
+    ...state.tabGroups.flatMap((g) => getAllLeaves(g.rootPanel).flatMap((l) => l.tabs)),
+  ].find((t) => t.id === tabId);
+  return tab?.title?.trim() || "Session";
+}
 
 /**
  * Wait until the xterm element is sitting in a real slot (large parent
@@ -438,10 +454,13 @@ export function Terminal({
                 closeTerminal(resolved);
                 return;
               }
-              // Success — clear all pre-connect overlay state.
+              // Success — clear all pre-connect overlay state and give the user
+              // a brief, non-intrusive confirmation that the session is live so
+              // the connect does not resolve silently (#1127).
               useAppStore.getState().setTerminalConnecting(tabId, false);
               useAppStore.getState().setTerminalAutoRetrying(tabId, 0);
               useAppStore.getState().setTerminalSpawnError(tabId, null);
+              toast.success("Connected", { description: resolveTabTitle(tabId) });
               break;
             } catch (err) {
               if (isCanceled()) return;

--- a/src/components/Terminal/TerminalConnectionOverlay.css
+++ b/src/components/Terminal/TerminalConnectionOverlay.css
@@ -58,6 +58,15 @@
   margin: 0;
 }
 
+.terminal-connection-overlay__elapsed {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs, var(--font-size-sm));
+  color: var(--text-secondary);
+  letter-spacing: var(--letter-spacing-ui, normal);
+  opacity: 0.85;
+  margin: 0;
+}
+
 .terminal-connection-overlay__error-box {
   max-width: 520px;
   width: 100%;

--- a/src/components/Terminal/TerminalConnectionOverlay.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.test.tsx
@@ -409,3 +409,63 @@ describe("TerminalConnectionOverlay — failed state", () => {
     expect(closeFn).toHaveBeenCalledWith(TAB_ID, PANEL_ID);
   });
 });
+
+describe("TerminalConnectionOverlay — elapsed time", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetStore();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("shows an elapsed-time readout while connecting", () => {
+    useAppStore.setState({ terminalConnecting: { [TAB_ID]: true } });
+    act(() => {
+      root.render(
+        <TerminalConnectionOverlay
+          tabId={TAB_ID}
+          panelId={PANEL_ID}
+          tabTitle="my-server"
+          isVisible={true}
+        />
+      );
+    });
+    // Starts at 0s.
+    expect(container.textContent).toContain("0s");
+    // Advances one second at a time.
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(container.textContent).toContain("3s");
+  });
+
+  it("surfaces a slow-connection hint once the connect drags on", () => {
+    useAppStore.setState({ terminalConnecting: { [TAB_ID]: true } });
+    act(() => {
+      root.render(
+        <TerminalConnectionOverlay
+          tabId={TAB_ID}
+          panelId={PANEL_ID}
+          tabTitle="my-server"
+          isVisible={true}
+        />
+      );
+    });
+    // No hint early on.
+    expect(container.textContent).not.toContain("Taking longer than usual");
+    act(() => {
+      vi.advanceTimersByTime(20000);
+    });
+    expect(container.textContent).toContain("Taking longer than usual");
+  });
+});

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { ServerCrash, RefreshCw, Loader2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useElapsed } from "@/hooks/useElapsed";
 import "./TerminalConnectionOverlay.css";
 
 interface TerminalConnectionOverlayProps {
@@ -22,6 +23,17 @@ const TIMEOUT_PATTERN = "timed out";
 const SERIAL_NOT_FOUND_PATTERNS = ["No such file", "cannot find", "not found"];
 const SERIAL_PERMISSION_PATTERN = "Permission denied";
 const SERIAL_BUSY_PATTERNS = ["busy", "in use", "Access is denied"];
+
+/** Seconds after which a still-pending connect is flagged as unusually slow. */
+const SLOW_CONNECT_THRESHOLD_SECONDS = 20;
+
+/** Formats whole seconds as a compact `mm:ss`-ish readout: `5s`, `1m 05s`. */
+function formatElapsed(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}m ${String(secs).padStart(2, "0")}s`;
+}
 
 /**
  * Shown over a terminal slot while the backend session is being established.
@@ -49,6 +61,13 @@ export function TerminalConnectionOverlay({
   const waitingForAgent = useAppStore((s) => s.terminalWaitingForAgent[tabId]);
   const isReattaching = useAppStore((s) => s.terminalReattaching[tabId] ?? false);
   const error = useAppStore((s) => s.terminalSpawnErrors[tabId] ?? "");
+
+  // Tick a wall-clock timer while any active connect attempt is in flight so the
+  // overlay can show elapsed time and flag an unusually slow connect (#1127).
+  const isActivelyConnecting = isConnecting || autoRetryCount > 0 || !!waitingForAgent;
+  const elapsedSeconds = useElapsed(isActivelyConnecting);
+  const elapsedLabel = formatElapsed(elapsedSeconds);
+  const isSlowConnect = elapsedSeconds >= SLOW_CONNECT_THRESHOLD_SECONDS;
 
   const handleCancel = useCallback(() => {
     closeTab(tabId, panelId);
@@ -123,6 +142,17 @@ export function TerminalConnectionOverlay({
             Connecting… (attempt {autoRetryCount + 1})
           </p>
           <p className="terminal-connection-overlay__subheading">{tabTitle}</p>
+          <p
+            className="terminal-connection-overlay__elapsed"
+            data-testid="terminal-connection-elapsed"
+          >
+            Elapsed {elapsedLabel}
+          </p>
+          {isSlowConnect && (
+            <p className="terminal-connection-overlay__hint-text">
+              Taking longer than usual — the host may be slow to respond or unreachable.
+            </p>
+          )}
           <div className="terminal-connection-overlay__actions">
             <button
               className="terminal-connection-overlay__cancel-btn"
@@ -147,6 +177,17 @@ export function TerminalConnectionOverlay({
           />
           <p className="terminal-connection-overlay__heading">Connecting…</p>
           <p className="terminal-connection-overlay__subheading">{tabTitle}</p>
+          <p
+            className="terminal-connection-overlay__elapsed"
+            data-testid="terminal-connection-elapsed"
+          >
+            Elapsed {elapsedLabel}
+          </p>
+          {isSlowConnect && (
+            <p className="terminal-connection-overlay__hint-text">
+              Taking longer than usual — the host may be slow to respond or unreachable.
+            </p>
+          )}
           <div className="terminal-connection-overlay__actions">
             <button
               className="terminal-connection-overlay__cancel-btn"

--- a/src/hooks/useElapsed.test.tsx
+++ b/src/hooks/useElapsed.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useElapsed } from "./useElapsed";
+
+/**
+ * Renders the hook into a throwaway component and mirrors its return value onto
+ * a closure so assertions can read the latest elapsed value without JSX/testids.
+ */
+function renderHook(active: boolean): { get: () => number; setActive: (a: boolean) => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest = 0;
+  let current = active;
+
+  function Probe({ active: a }: { active: boolean }) {
+    latest = useElapsed(a);
+    return null;
+  }
+
+  act(() => root.render(<Probe active={current} />));
+
+  return {
+    get: () => latest,
+    setActive: (a: boolean) => {
+      current = a;
+      act(() => root.render(<Probe active={current} />));
+    },
+  };
+}
+
+describe("useElapsed", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts at 0 seconds when active", () => {
+    const hook = renderHook(true);
+    expect(hook.get()).toBe(0);
+  });
+
+  it("ticks up one second at a time while active", () => {
+    const hook = renderHook(true);
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(hook.get()).toBe(3);
+  });
+
+  it("returns 0 and stops ticking when inactive", () => {
+    const hook = renderHook(false);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(hook.get()).toBe(0);
+  });
+
+  it("resets to 0 when reactivated", () => {
+    const hook = renderHook(true);
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(hook.get()).toBe(4);
+    hook.setActive(false);
+    expect(hook.get()).toBe(0);
+    hook.setActive(true);
+    expect(hook.get()).toBe(0);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(hook.get()).toBe(2);
+  });
+});

--- a/src/hooks/useElapsed.ts
+++ b/src/hooks/useElapsed.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Tracks the whole seconds elapsed since `active` last became `true`.
+ *
+ * While `active` is true the value ticks up once per second (starting at 0);
+ * when `active` is false it resets to 0 and stops ticking. Each fresh activation
+ * restarts the count from 0, so it is suitable for driving a "Connecting… (Ns)"
+ * readout that must reset per connect attempt.
+ *
+ * @param active Whether the timer should be running.
+ * @returns Whole seconds elapsed since activation (0 when inactive).
+ */
+export function useElapsed(active: boolean): number {
+  const [elapsed, setElapsed] = useState(0);
+  const startRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!active) {
+      setElapsed(0);
+      return;
+    }
+
+    startRef.current = Date.now();
+    setElapsed(0);
+
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startRef.current) / 1000));
+    }, 1000);
+
+    return () => clearInterval(id);
+  }, [active]);
+
+  return elapsed;
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -379,6 +379,7 @@ Fixed strings — match exactly.
 | `tab-group-ctx-close` | `src/components/Terminal/TabGroupChips.tsx` |
 | `tab-group-ctx-rename` | `src/components/Terminal/TabGroupChips.tsx` |
 | `terminal-connection-cancel-btn` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
+| `terminal-connection-elapsed` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-connection-overlay` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-connection-retry-btn` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-context-copy-all` | `src/components/SplitView/SplitView.tsx` |


### PR DESCRIPTION
Closes #1127

## Summary

Removes the two silent gaps in the terminal connect flow (P7 cosmetic UX):

- **Elapsed time in the connecting overlay** — the "Connecting…" overlay now shows a live elapsed-time readout (`Elapsed 3s`, `Elapsed 1m 05s`) that ticks up once per second while a connect attempt is in flight, so the spinner is no longer indefinite. It also surfaces a subtle "Taking longer than usual — the host may be slow to respond or unreachable." hint once a connect drags past 20 seconds. The readout is shown for both the `Connecting…` and the auto-retry (`Connecting… (attempt N)`) states.
- **Success confirmation on connect** — a successful connect now fires a brief, non-intrusive `toast.success("Connected")` (naming the connection) via the existing `sonner`-based toast primitive, instead of silently clearing the overlay. This satisfies the design-system feedback-on-every-action rule.

### Implementation notes

- New reusable `useElapsed(active)` hook (`src/hooks/useElapsed.ts`) drives the timer from the active-connect state and resets to 0 on each fresh attempt.
- Overlay styling uses tokens only (`--font-mono`, `--font-size-xs`, `--text-secondary`, `--letter-spacing-ui`); no magic values.
- Toast fired at the single fresh-create success point in `Terminal.tsx`; failed connects do not toast.
- New `data-testid="terminal-connection-elapsed"` added to the testid catalog.

## Test plan

TDD — tests committed before implementation:

- `src/hooks/useElapsed.test.tsx` — hook starts at 0, ticks per second, resets when inactive/reactivated (fake timers).
- `src/components/Terminal/TerminalConnectionOverlay.test.tsx` — overlay shows the elapsed readout while connecting and surfaces the slow-connect hint after 20s.
- `src/components/Terminal/Terminal.connect-toast.test.tsx` — a success toast fires when a fresh connect resolves, and does **not** fire when the connect fails.

Verification:

- `pnpm test` — full suite: 2258 passed. The only failures (3, in `WorkspaceSidebar.test.tsx`, a pre-existing `TooltipProvider` test-harness issue) reproduce unchanged on `origin/develop` and are unrelated to this change.
- `pnpm run lint` — clean.
- `pnpm build` — passes (TypeScript check + Vite).
- `pnpm run format:check` — clean.

### Manual test steps

1. Open a connection (SSH/serial/local). While the "Connecting…" overlay is shown, confirm an `Elapsed Ns` readout ticks up.
2. Point at an unreachable host so the connect hangs; after ~20s confirm the "Taking longer than usual" hint appears.
3. On a successful connect, confirm a brief "Connected" toast appears and auto-dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
