### PR TITLE
test(workspace): fix order-dependent WorkspaceSidebar TooltipProvider flake

### DIFF
--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx
@@ -191,7 +191,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     // No confirm dialog before the delete button is pressed.
@@ -209,7 +209,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     act(() => (query("workspace-delete-ws-1") as HTMLButtonElement).click());
@@ -227,7 +227,7 @@ describe("WorkspaceSidebar", () => {
     useAppStore.setState({ workspaces: [sampleWorkspaces[0]], deleteWorkspaceFromBackend });
 
     act(() => {
-      root.render(<WorkspaceSidebar />);
+      root.render(withTooltip(<WorkspaceSidebar />));
     });
 
     act(() => (query("workspace-delete-ws-1") as HTMLButtonElement).click());


### PR DESCRIPTION
## Problem

`Run Tests` is failing on develop and every new PR (e.g. #1181, #1182) with:

```
Error: Tooltip must be used within TooltipProvider (src/components/ui/Tooltip.tsx)
  at WorkspaceSidebar.test.tsx delete-flow tests
```

The three delete-flow tests added in #1179 render `<WorkspaceSidebar />` **without** a `TooltipProvider`. They passed only when an earlier suite leaked provider context in a full run, and **fail in isolation** or under different scheduling — an order-dependent flake.

## Fix

Wrap those three renders in the file's existing `withTooltip(...)` helper (as every other test in the file already does). Test-only change.

## Verification
- `pnpm exec vitest run src/components/WorkspaceSidebar/WorkspaceSidebar.test.tsx` (isolation) → **10 passed** (was 3 failing in isolation).

Unblocks Run Tests for #1181, #1182 and any future PR once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)