### PR TITLE
fix(credential): gate Change Master Password on unlock (#1144)

### DIFF
--- a/docs/changes/dev2/feature/1144-change-pw-unlock-gate.md
+++ b/docs/changes/dev2/feature/1144-change-pw-unlock-gate.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Changing the master password while the credential store is locked no longer
+  dead-ends. Clicking **Change Master Password** in Settings → Security while the
+  store is locked now opens the unlock flow first and proceeds to the change
+  dialog only after a successful unlock, instead of surfacing a raw "Store is
+  locked — cannot change password" error with no way to unlock. Cancelling the
+  unlock aborts without opening the dialog, and a tooltip explains the gate
+  (#1144).

--- a/src/components/Settings/SecuritySettings.test.tsx
+++ b/src/components/Settings/SecuritySettings.test.tsx
@@ -327,6 +327,70 @@ describe("SecuritySettings", () => {
     expect(mockedToast.success).toHaveBeenCalled();
   });
 
+  it("triggers the unlock flow when Change Master Password is clicked while locked", async () => {
+    // GAP G4: change_master_password requires an unlocked store. When locked, the
+    // change-password button must route through the unlock flow instead of opening a
+    // dialog that dead-ends on a raw "Store is locked" error.
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+    });
+
+    // requestUnlock never resolves here so we can assert it was invoked and that the
+    // change dialog does NOT open before the store is unlocked.
+    const requestUnlock = vi.fn(() => new Promise<boolean>(() => {}));
+    useAppStore.setState({ requestUnlock });
+
+    render();
+
+    const btn = query("change-master-password-btn") as HTMLElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    expect(requestUnlock).toHaveBeenCalledTimes(1);
+    // The change-password dialog stays closed until the store is unlocked.
+    expect(query("change-password-dialog")).toBeNull();
+  });
+
+  it("opens the change-password dialog after a successful unlock while locked", async () => {
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+    });
+
+    const requestUnlock = vi.fn(() => Promise.resolve(true));
+    useAppStore.setState({ requestUnlock });
+
+    render();
+
+    const btn = query("change-master-password-btn") as HTMLElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    expect(requestUnlock).toHaveBeenCalledTimes(1);
+    // Unlock succeeded, so the change-password dialog is now available.
+    expect(query("change-password-dialog")).not.toBeNull();
+  });
+
+  it("does not open the change-password dialog if the unlock is cancelled while locked", async () => {
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+    });
+
+    const requestUnlock = vi.fn(() => Promise.resolve(false));
+    useAppStore.setState({ requestUnlock });
+
+    render();
+
+    const btn = query("change-master-password-btn") as HTMLElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    expect(requestUnlock).toHaveBeenCalledTimes(1);
+    expect(query("change-password-dialog")).toBeNull();
+  });
+
   it("keeps the wrong-password change failure inline (no success toast, dialog stays open)", async () => {
     // Per the audit, the wrong-current-password case stays an inline field error
     // (not a toast); only the success path is promoted to a toast.

--- a/src/components/Settings/SecuritySettings.tsx
+++ b/src/components/Settings/SecuritySettings.tsx
@@ -65,6 +65,7 @@ const AUTO_LOCK_OPTIONS: AutoLockOption[] = [
 export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
   const credentialStoreStatus = useAppStore((s) => s.credentialStoreStatus);
   const loadCredentialStoreStatus = useAppStore((s) => s.loadCredentialStoreStatus);
+  const requestUnlock = useAppStore((s) => s.requestUnlock);
   const settings = useAppStore((s) => s.settings);
   const updateSettings = useAppStore((s) => s.updateSettings);
 
@@ -194,6 +195,21 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
       setChangePasswordError(err instanceof Error ? err.message : String(err));
     }
   }, [currentPasswordInput, changeNewPassword, changeConfirmPassword, resetChangePasswordDialog]);
+
+  /**
+   * Opens the change-master-password dialog. changeMasterPassword requires an unlocked
+   * store, so when the store is locked this routes through the shared unlock flow first
+   * (matching the connect-flow gate) and only opens the dialog once the unlock succeeds —
+   * avoiding the dead-end where submitting yields a raw "Store is locked" error with no
+   * unlock affordance (audit GAP G4).
+   */
+  const handleOpenChangePassword = useCallback(async () => {
+    if (credentialStoreStatus?.status === "locked") {
+      const unlocked = await requestUnlock();
+      if (!unlocked) return;
+    }
+    setChangingPassword(true);
+  }, [credentialStoreStatus?.status, requestUnlock]);
 
   const handleAutoLockChange = useCallback(
     (value: number) => {
@@ -355,7 +371,12 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
                   variant="secondary"
                   size="sm"
                   data-testid="change-master-password-btn"
-                  onClick={() => setChangingPassword(true)}
+                  onClick={handleOpenChangePassword}
+                  title={
+                    credentialStoreStatus?.status === "locked"
+                      ? "The credential store is locked — you'll be asked to unlock it first."
+                      : undefined
+                  }
                 >
                   Change Master Password
                 </Button>


### PR DESCRIPTION
## Summary

Fixes GAP **G4** from the credential-store state-machine audit: **Change Master Password is a dead-end when the store is locked.**

`change_master_password` requires an unlocked store. Previously, opening Settings → Security → **Change Master Password** while the master-password store was locked (e.g. after auto-lock) and submitting produced a raw `Store is locked — cannot change password` error inline, with **no unlock affordance** — the user had to close the dialog, unlock via the status-bar indicator, and reopen Settings.

## Changes

- `src/components/Settings/SecuritySettings.tsx`: the **Change Master Password** button now routes through the shared unlock flow (`requestUnlock()` — the same gate the connect paths use) when `credentialStoreStatus.status === "locked"`. The change dialog opens only after a successful unlock; a cancelled unlock aborts without opening it. A tooltip on the button explains the gate while locked.
- Added a `docs/changes` fragment.

This reuses the existing `requestUnlock()` promise-based unlock pattern rather than introducing a new dialog, keeping the credential-store gating consistent across the app.

## Test plan

- Added three Vitest regression cases in `SecuritySettings.test.tsx`:
  - locked store → clicking Change Master Password invokes `requestUnlock()` and does **not** open the change dialog while unlock is pending;
  - locked store + successful unlock → the change dialog opens;
  - locked store + cancelled unlock → the change dialog stays closed.
- Confirmed the tests fail without the fix (RED) before implementing.
- `pnpm test` — full suite passes (2269 tests).
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all pass.

Partially addresses #1144 (G4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
