### PR TITLE
fix(tunnel): guard re-entrant tunnel start/stop (#1141)

### DIFF
--- a/docs/changes/dev2/feature/1141-tunnel-start-stop-guard.md
+++ b/docs/changes/dev2/feature/1141-tunnel-start-stop-guard.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Rapidly double-clicking Start or Stop on an SSH tunnel that is still
+  connecting no longer fires a second backend call — the store now ignores a
+  re-entrant start/stop for a tunnel whose previous call is still in flight.
+  This removes the spurious "already active/connecting" error toasts and the
+  brief Stop→Play→Stop state flicker. Addresses GAP 4 of the SSH tunnel audit
+  (#1141).

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -826,6 +826,14 @@ export function _resetConnectionReloadSeq(): void {
   _connAppliedSeq = 0;
 }
 
+// In-flight guards for tunnel start/stop (GAP 4, #1141). A rapid double-click on
+// Start/Stop for a tunnel that is already `connecting` must not fire a second
+// backend call — that produces spurious "already active/connecting" error toasts
+// and can flip the visible state. We track the id of each tunnel whose start/stop
+// call has not yet resolved and no-op any re-entrant call for the same id.
+const _tunnelStartInFlight = new Set<string>();
+const _tunnelStopInFlight = new Set<string>();
+
 export const useAppStore = create<AppState>((set, get) => {
   // Reload connections from the backend, applying the result only if this
   // reload was initiated more recently than the last applied one.
@@ -3669,6 +3677,11 @@ export const useAppStore = create<AppState>((set, get) => {
     },
 
     startTunnel: async (tunnelId) => {
+      // GAP 4 (#1141): ignore a re-entrant start while a prior start for the
+      // same tunnel is still in flight, so a rapid double-click can't fire a
+      // second backend call (spurious "already connecting/active" toast).
+      if (_tunnelStartInFlight.has(tunnelId)) return;
+      _tunnelStartInFlight.add(tunnelId);
       const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
       const toastId = toast.loading(`Starting ${name}…`);
       try {
@@ -3681,10 +3694,16 @@ export const useAppStore = create<AppState>((set, get) => {
           { id: toastId }
         );
         throw err;
+      } finally {
+        _tunnelStartInFlight.delete(tunnelId);
       }
     },
 
     stopTunnel: async (tunnelId) => {
+      // GAP 4 (#1141): ignore a re-entrant stop while a prior stop for the same
+      // tunnel is still in flight (see startTunnel).
+      if (_tunnelStopInFlight.has(tunnelId)) return;
+      _tunnelStopInFlight.add(tunnelId);
       const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
       const toastId = toast.loading(`Stopping ${name}…`);
       try {
@@ -3696,6 +3715,8 @@ export const useAppStore = create<AppState>((set, get) => {
           id: toastId,
         });
         throw err;
+      } finally {
+        _tunnelStopInFlight.delete(tunnelId);
       }
     },
 

--- a/src/store/appStore.tunnel-reentrancy.test.ts
+++ b/src/store/appStore.tunnel-reentrancy.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for GAP 4 from the SSH tunnel audit (#1141).
+ *
+ * Neither `startTunnel` nor `stopTunnel` in the store guarded against being
+ * fired again while a prior call for the same tunnel was still in flight.
+ * Rapid double-clicks therefore produced two backend calls and spurious
+ * "already active/connecting" error toasts, and could flip the visible state.
+ *
+ * These tests pin that a second `startTunnel`/`stopTunnel` for the same id,
+ * issued before the first call resolves, is a no-op (only ONE backend call).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock the service modules the store imports at module load. We only care about
+// tunnelApi + the toast primitive here, but the store pulls in the full graph.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/tunnelApi", () => ({
+  getTunnels: vi.fn(() => Promise.resolve([])),
+  saveTunnel: vi.fn(),
+  deleteTunnel: vi.fn(() => Promise.resolve()),
+  startTunnel: vi.fn(),
+  stopTunnel: vi.fn(),
+  getTunnelStatuses: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      loading: vi.fn(() => "toast-id"),
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+import { useAppStore } from "./appStore";
+import { startTunnel as apiStartTunnel, stopTunnel as apiStopTunnel } from "@/services/tunnelApi";
+import type { TunnelConfig } from "@/types/tunnel";
+
+function makeTunnel(id: string, name: string): TunnelConfig {
+  return {
+    id,
+    name,
+    sshConnectionId: "conn-1",
+    tunnelType: {
+      type: "local",
+      config: { localHost: "127.0.0.1", localPort: 8080, remoteHost: "127.0.0.1", remotePort: 80 },
+    },
+    autoStart: false,
+    reconnectOnDisconnect: false,
+  };
+}
+
+/** A promise that never resolves on its own — keeps the backend call "in flight". */
+function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("appStore — tunnel start/stop re-entrancy guard (GAP 4, #1141)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ tunnels: [makeTunnel("tun-1", "My Tunnel")] });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ignores a second startTunnel while the first is still in flight", async () => {
+    const deferred = makeDeferred<void>();
+    vi.mocked(apiStartTunnel).mockReturnValueOnce(deferred.promise);
+
+    // First click — kicks off the backend call (still pending).
+    const first = useAppStore.getState().startTunnel("tun-1");
+    // Second click before the first resolves — must be a no-op.
+    await useAppStore.getState().startTunnel("tun-1");
+
+    expect(apiStartTunnel).toHaveBeenCalledTimes(1);
+
+    // Let the first call finish so the in-flight guard clears.
+    deferred.resolve();
+    await first;
+
+    // A later start (after the first resolved) is allowed again.
+    vi.mocked(apiStartTunnel).mockResolvedValueOnce(undefined);
+    await useAppStore.getState().startTunnel("tun-1");
+    expect(apiStartTunnel).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a second stopTunnel while the first is still in flight", async () => {
+    const deferred = makeDeferred<void>();
+    vi.mocked(apiStopTunnel).mockReturnValueOnce(deferred.promise);
+
+    const first = useAppStore.getState().stopTunnel("tun-1");
+    await useAppStore.getState().stopTunnel("tun-1");
+
+    expect(apiStopTunnel).toHaveBeenCalledTimes(1);
+
+    deferred.resolve();
+    await first;
+
+    vi.mocked(apiStopTunnel).mockResolvedValueOnce(undefined);
+    await useAppStore.getState().stopTunnel("tun-1");
+    expect(apiStopTunnel).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks start and stop in-flight independently per tunnel id", async () => {
+    const startDeferred = makeDeferred<void>();
+    vi.mocked(apiStartTunnel).mockReturnValueOnce(startDeferred.promise);
+    vi.mocked(apiStopTunnel).mockResolvedValue(undefined);
+
+    // Start tun-1 is in flight; stopping a *different* tunnel is unaffected.
+    const startFirst = useAppStore.getState().startTunnel("tun-1");
+    await useAppStore.getState().stopTunnel("tun-2");
+
+    expect(apiStartTunnel).toHaveBeenCalledTimes(1);
+    expect(apiStopTunnel).toHaveBeenCalledTimes(1);
+
+    startDeferred.resolve();
+    await startFirst;
+  });
+});


### PR DESCRIPTION
## Summary

Addresses **GAP 4** of the SSH tunnel state-machine audit: `startTunnel` and `stopTunnel` in the store did not guard against being fired again while a prior call for the same tunnel was still in flight. Rapid double-clicking Start/Stop on a connecting tunnel produced two backend calls, spurious "already active/connecting" error toasts, and a brief Stop→Play→Stop state flicker.

## Changes

- **`src/store/appStore.ts`** — added module-level in-flight sets (`_tunnelStartInFlight`, `_tunnelStopInFlight`) tracked per tunnel id. `startTunnel`/`stopTunnel` now no-op a re-entrant call for an id whose previous call has not yet resolved, and clear the guard in a `finally` block. Start and stop are tracked independently per id.
- No backend changes.

## Test plan

- New Vitest store test `src/store/appStore.tunnel-reentrancy.test.ts` (TDD, committed before the fix — confirmed RED first):
  - A second `startTunnel(id)` issued while the first is still in flight results in only ONE `apiStartTunnel` call; a later start (after the first resolves) is allowed again.
  - Same for `stopTunnel`.
  - Start/stop in-flight tracking is independent per tunnel id.
- Full suite: `pnpm test` → 203 files, 2269 tests passing.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` all clean.

Partially addresses #1141 (GAP 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)