### PR TITLE
fix(network): tear down HTTP monitors on app exit (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-http-monitor-teardown.md
+++ b/docs/changes/dev2/feature/1147-http-monitor-teardown.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- HTTP monitor (Network Tools): running monitors are now torn down cleanly when
+  the app exits. On quit, every monitor's poll loop is cancelled and any
+  in-flight HTTP request is aborted, matching how SSH tunnels, embedded servers,
+  and the managed X server already shut down. Previously the poll tasks were only
+  cancelled on an explicit Stop and otherwise just died with the process,
+  abandoning in-flight requests. Addresses gap #3 of the HTTP monitor audit
+  (#1147).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -647,6 +647,11 @@ pub fn run() {
                     if let Some(mgr) = handle.try_state::<Arc<terminal::xserver::XServerManager>>() {
                         mgr.stop();
                     }
+                    // Cancel all HTTP monitor poll loops so in-flight reqwest
+                    // requests are aborted rather than abandoned on exit (#1147).
+                    if let Some(mgr) = handle.try_state::<NetworkManager>() {
+                        mgr.stop_all_http_monitors();
+                    }
                 });
             }
         });

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -200,3 +200,60 @@ impl Default for NetworkManager {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_monitor::HttpCheckResult;
+
+    /// Insert a bare monitor handle (no spawned task) so `stop_all_http_monitors`
+    /// can be exercised without a live Tauri `AppHandle`.
+    fn insert_dummy_monitor(mgr: &NetworkManager) -> (String, CancellationToken) {
+        let config = HttpMonitorConfig::new(
+            "https://example.com".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        let id = config.id.clone();
+        let cancel = CancellationToken::new();
+        let handle = HttpMonitorHandle {
+            config,
+            cancel: cancel.clone(),
+            last_result: Arc::new(Mutex::new(None::<HttpCheckResult>)),
+        };
+        mgr.http_monitors
+            .lock()
+            .expect("http monitor lock")
+            .insert(id.clone(), handle);
+        (id, cancel)
+    }
+
+    #[test]
+    fn stop_all_http_monitors_cancels_and_clears() {
+        let mgr = NetworkManager::new();
+        let (_id1, token1) = insert_dummy_monitor(&mgr);
+        let (_id2, token2) = insert_dummy_monitor(&mgr);
+
+        assert_eq!(mgr.list_http_monitors().len(), 2);
+        assert!(!token1.is_cancelled());
+        assert!(!token2.is_cancelled());
+
+        mgr.stop_all_http_monitors();
+
+        // Every monitor's cancellation token is fired...
+        assert!(token1.is_cancelled());
+        assert!(token2.is_cancelled());
+        // ...and the map is emptied so nothing lingers.
+        assert!(mgr.list_http_monitors().is_empty());
+    }
+
+    #[test]
+    fn stop_all_http_monitors_is_noop_when_empty() {
+        let mgr = NetworkManager::new();
+        assert!(mgr.list_http_monitors().is_empty());
+        mgr.stop_all_http_monitors();
+        assert!(mgr.list_http_monitors().is_empty());
+    }
+}

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -138,6 +138,26 @@ impl NetworkManager {
         }
     }
 
+    /// Stop and remove **all** running HTTP monitors.
+    ///
+    /// Used during app shutdown (mirrors [`TunnelManager::stop_all`] /
+    /// [`EmbeddedServerManager::stop_all`]): cancels every monitor's
+    /// [`CancellationToken`] so its poll loop breaks and any in-flight `reqwest`
+    /// request is aborted, then clears the map so nothing lingers. Without this,
+    /// the poll tasks would only die when the process exits, abandoning
+    /// in-flight requests — inconsistent with every sibling subsystem's clean
+    /// teardown.
+    pub fn stop_all_http_monitors(&self) {
+        let Ok(mut monitors) = self.http_monitors.lock() else {
+            error!("http monitor lock poisoned during stop_all");
+            return;
+        };
+        for (id, handle) in monitors.drain() {
+            handle.cancel.cancel();
+            debug!(monitor_id = %id, "Stopped HTTP monitor during teardown");
+        }
+    }
+
     /// List all HTTP monitors (running and stopped).
     pub fn list_http_monitors(&self) -> Vec<HttpMonitorState> {
         let Ok(monitors) = self.http_monitors.lock() else {


### PR DESCRIPTION
## Summary

Fixes gap #3 from the HTTP monitor audit (`docs/audits/http-monitor-state-machine.md`): the app-exit / window `Destroyed` handler in `src-tauri/src/lib.rs` stopped tunnels, embedded servers, and the managed X server, but **not** the `NetworkManager` HTTP monitors. The background poll tasks were only cancelled on an explicit `stop_http_monitor`; on exit they just died with the process, abandoning in-flight `reqwest` requests — inconsistent with every sibling subsystem's clean teardown.

## Changes

- Add `NetworkManager::stop_all_http_monitors()` (mirrors `TunnelManager::stop_all` / `EmbeddedServerManager::stop_all`): cancels every monitor's `CancellationToken` and drains the monitor map.
- Call it from the `WindowEvent::Destroyed` block in `lib.rs`, alongside the existing tunnel / embedded-server / X-server teardown.

## Test plan

- New unit tests in `src-tauri/src/network/mod.rs`:
  - `stop_all_http_monitors_cancels_and_clears` — after inserting two monitors, `stop_all_http_monitors()` cancels both tokens and empties the map.
  - `stop_all_http_monitors_is_noop_when_empty` — safe no-op with no monitors.
- Verified RED before the fix (method absent → compile error), GREEN after.
- `cargo test -p termihub stop_all_http_monitors` → 2 passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.

Partially addresses #1147 (#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)