### PR TITLE
fix(tunnel): Open Connections tunnel list from live store (#1141)

### DIFF
--- a/docs/changes/dev2/feature/1141-open-connections-live-tunnels.md
+++ b/docs/changes/dev2/feature/1141-open-connections-live-tunnels.md
@@ -1,0 +1,3 @@
+## Fixed
+
+- The Open Connections panel's SSH Tunnels list now reads the application's live tunnel state instead of a one-shot snapshot taken when the panel opens, so it always stays in sync with the tunnel sidebar (e.g. a tunnel that starts, stops, or changes status while the panel is open is reflected immediately).

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -23,7 +23,6 @@ import {
   LocalSessionInfo,
   AgentSessionInfo,
 } from "@/services/api";
-import { TunnelState } from "@/types/tunnel";
 import { XServerStatusReport } from "@/types/xserver";
 import { XServerSetupDialog } from "./XServerSetupDialog";
 import "./OpenConnectionsModal.css";
@@ -50,6 +49,9 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const disconnectRemoteAgent = useAppStore((s) => s.disconnectRemoteAgent);
   const stopTunnel = useAppStore((s) => s.stopTunnel);
   const tunnels = useAppStore((s) => s.tunnels);
+  // Live single source of truth for tunnel status (kept in sync by tunnel
+  // events); the panel reads it directly so it never drifts from the sidebar.
+  const tunnelStates = useAppStore((s) => s.tunnelStates);
   const sftpConnectedHost = useAppStore((s) => s.sftpConnectedHost);
   const disconnectSftp = useAppStore((s) => s.disconnectSftp);
   const monitoringHost = useAppStore((s) => s.monitoringHost);
@@ -68,7 +70,6 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const [localSessions, setLocalSessions] = useState<LocalSessionInfo[]>([]);
   const [proxySessions, setProxySessions] = useState<ProxySessionsState>({});
   const [agentSessions, setAgentSessions] = useState<AgentSessionsState>({});
-  const [tunnelStates, setTunnelStates] = useState<TunnelState[]>([]);
   const [xServer, setXServer] = useState<XServerStatusReport | null>(null);
   const [xServerSetupOpen, setXServerSetupOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -108,17 +109,11 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   useEffect(() => {
     if (open) {
       void loadData();
-      // Tunnel states are already in the store; grab them.
-      import("@/services/tunnelApi").then(({ getTunnelStatuses }) => {
-        getTunnelStatuses()
-          .then(setTunnelStates)
-          .catch(() => {});
-      });
     }
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const activeTunnels = tunnels.filter((t) => {
-    const state = tunnelStates.find((ts) => ts.tunnelId === t.id);
+    const state = tunnelStates[t.id];
     return state && (state.status === "connected" || state.status === "connecting");
   });
 
@@ -211,14 +206,14 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     setAgentSessions((prev) => ({ ...prev, [agentId]: [] }));
   };
 
+  // stopTunnel updates the store's live tunnelStates (via tunnel events), which
+  // this panel now reads directly — no separate local copy to prune.
   const handleKillTunnel = async (tunnelId: string) => {
     await stopTunnel(tunnelId);
-    setTunnelStates((prev) => prev.filter((ts) => ts.tunnelId !== tunnelId));
   };
 
   const handleKillAllTunnels = async () => {
     await Promise.all(activeTunnels.map((t) => stopTunnel(t.id)));
-    setTunnelStates([]);
   };
 
   const handleStopXServer = async () => {
@@ -363,7 +358,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
             onKillAll={handleKillAllTunnels}
           >
             {activeTunnels.map((t) => {
-              const state = tunnelStates.find((ts) => ts.tunnelId === t.id);
+              const state = tunnelStates[t.id];
               return (
                 <ConnectionRow
                   key={t.id}

--- a/src/components/OpenConnections/OpenConnectionsModal.tunnels.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tunnels.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for the "SSH Tunnels" section of the Open Connections panel (#1141,
+ * GAP 9): the tunnel list must be driven by the store's live `tunnelStates`
+ * (the single source of truth) rather than a one-shot `getTunnelStatuses`
+ * snapshot fetched only when the modal opens. This keeps the panel in sync with
+ * the sidebar and reflects store updates without re-opening the modal.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { TunnelConfig, TunnelState } from "@/types/tunnel";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so tooltip-wrapped controls render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() => Promise.resolve([])),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+// The one-shot fetch, if the component still used it, would return an EMPTY
+// list — so any tunnel rows that render must come from the store's live map.
+const getTunnelStatuses = vi.fn(() => Promise.resolve([] as TunnelState[]));
+const stopTunnel = vi.fn((_id: string) => Promise.resolve());
+vi.mock("@/services/tunnelApi", () => ({
+  getTunnelStatuses: () => getTunnelStatuses(),
+  stopTunnel: (id: string) => stopTunnel(id),
+}));
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+function tunnelConfig(id: string, name: string): TunnelConfig {
+  return {
+    id,
+    name,
+    sshConnectionId: "ssh-1",
+    tunnelType: {
+      type: "local",
+      config: {
+        localHost: "127.0.0.1",
+        localPort: 8080,
+        remoteHost: "example.com",
+        remotePort: 80,
+      },
+    },
+    autoStart: false,
+    reconnectOnDisconnect: false,
+  };
+}
+
+function tunnelState(id: string, status: TunnelState["status"]): TunnelState {
+  return {
+    tunnelId: id,
+    status,
+    stats: { bytesSent: 0, bytesReceived: 0, activeConnections: 0, totalConnections: 0 },
+  };
+}
+
+function tunnelRows(): Element[] {
+  const section = Array.from(document.querySelectorAll(".oc-section__title")).find(
+    (t) => t.textContent === "SSH Tunnels"
+  );
+  if (!section) return [];
+  const sectionEl = section.closest("div")?.parentElement;
+  return Array.from(sectionEl?.querySelectorAll(".oc-row") ?? []);
+}
+
+describe("OpenConnectionsModal — SSH Tunnels section (live store source)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    getTunnelStatuses.mockClear();
+    stopTunnel.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderModal() {
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
+      );
+    });
+  }
+
+  it("renders tunnels from the store's live tunnelStates, not the one-shot fetch", () => {
+    // Store holds a connected tunnel; the one-shot fetch returns nothing.
+    useAppStore.setState({
+      tunnels: [tunnelConfig("t1", "web-forward")],
+      tunnelStates: { t1: tunnelState("t1", "connected") },
+    });
+
+    renderModal();
+
+    const titles = Array.from(document.querySelectorAll(".oc-row__title")).map(
+      (t) => t.textContent
+    );
+    expect(titles.some((t) => t?.includes("web-forward"))).toBe(true);
+  });
+
+  it("reflects a store tunnelStates change without re-opening the modal", () => {
+    useAppStore.setState({
+      tunnels: [tunnelConfig("t1", "web-forward")],
+      tunnelStates: {},
+    });
+
+    renderModal();
+
+    // Nothing connected yet → no tunnel rows.
+    expect(tunnelRows()).toHaveLength(0);
+
+    // A live store update (as tunnel events would push) must appear.
+    act(() => {
+      useAppStore.setState({ tunnelStates: { t1: tunnelState("t1", "connecting") } });
+    });
+
+    const titles = Array.from(document.querySelectorAll(".oc-row__title")).map(
+      (t) => t.textContent
+    );
+    expect(titles.some((t) => t?.includes("web-forward"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The Open Connections panel fetched tunnel statuses **once** via a separate `getTunnelStatuses` copy when the modal opened, so its **SSH Tunnels** list could drift from the tunnel sidebar (the two read different sources). This switches the panel to read the store's live `tunnelStates` `Record` — the single source of truth, kept in sync by tunnel events — so the list always matches the sidebar and reflects status changes without re-opening the modal.

This is **GAP 9** from the SSH tunnel state-machine audit (`docs/audits/ssh-tunnel-state-machine.md`).

## Changes

- `OpenConnectionsModal.tsx`: subscribe to `useAppStore((s) => s.tunnelStates)` instead of holding a local `useState` copy filled by a one-shot `getTunnelStatuses()` on open.
  - `activeTunnels` filter and the per-row status lookup now index the live `Record<string, TunnelState>` directly.
  - Removed the one-shot fetch in the open effect and the local-state pruning in `handleKillTunnel` / `handleKillAllTunnels` (the store's `stopTunnel` → tunnel events already update `tunnelStates`).
  - Dropped the now-unused `TunnelState` type import.

Scoped to switching the data source only. The `error`-tunnel visibility (surfacing errored tunnels here) depends on the persisted-`Error` redesign tracked separately in #1191 and is intentionally **not** part of this PR.

## Test plan

- Added `OpenConnectionsModal.tunnels.test.tsx` (TDD, red before the fix):
  - Renders tunnel rows from the store's live `tunnelStates` even when the one-shot `getTunnelStatuses` mock returns an empty list (proves the store is the source).
  - Reflects a `tunnelStates` store update while the modal is open, without re-opening it.
- `pnpm test` — full suite: 2274 passed (204 files).
- `pnpm build` (tsc + vite) — passes.
- `pnpm run lint` — clean.
- `prettier --check` on changed files — clean.

Partially addresses #1141 (GAP 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)