### PR TITLE
fix(sftp): guard overlapping SFTP list responses (#1143)

### DIFF
--- a/docs/changes/dev2/feature/1143-sftp-list-race-guard.md
+++ b/docs/changes/dev2/feature/1143-sftp-list-race-guard.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Rapid SFTP folder navigation no longer desyncs the path from the shown files.
+  `navigateSftp`/`refreshSftp` awaited the directory listing with no ordering
+  guard, so when two navigations overlapped, whichever list resolved last won —
+  leaving the current path and the displayed file list out of sync. A monotonic
+  request sequencer now drops superseded (stale) list responses, so only the
+  latest navigation updates the view (audit gap R1, #1143).

--- a/src/store/appStore.sftpRace.test.ts
+++ b/src/store/appStore.sftpRace.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve("persisted-id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore } from "./appStore";
+import { sftpListDir } from "@/services/api";
+import type { FileEntry } from "@/types/connection";
+
+function makeEntry(name: string): FileEntry {
+  return {
+    name,
+    path: `/${name}`,
+    isDirectory: true,
+    size: 0,
+    modified: "",
+    permissions: null,
+  };
+}
+
+/** A promise plus its resolve fn, so a test can control settle order. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("appStore — SFTP overlapping-list race guard (R1)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ sftpSessionId: "session-1" });
+    vi.clearAllMocks();
+  });
+
+  it("navigateSftp: a stale (superseded) response does not overwrite the newer one", async () => {
+    const firstEntries = [makeEntry("stale-dir")];
+    const secondEntries = [makeEntry("fresh-dir")];
+
+    const firstList = deferred<FileEntry[]>();
+    const secondList = deferred<FileEntry[]>();
+
+    // First call (to /old) gets the first deferred; second call (to /new) the second.
+    vi.mocked(sftpListDir)
+      .mockImplementationOnce(() => firstList.promise)
+      .mockImplementationOnce(() => secondList.promise);
+
+    const store = useAppStore.getState();
+
+    // Fire two navigations back-to-back. The SECOND is the user's latest intent.
+    const p1 = store.navigateSftp("/old");
+    const p2 = store.navigateSftp("/new");
+
+    // Resolve out of order: the newer (second) request settles FIRST...
+    secondList.resolve(secondEntries);
+    await p2;
+
+    // ...then the stale (first) request settles LAST. Without a guard, this
+    // would clobber currentPath/fileEntries back to the superseded values.
+    firstList.resolve(firstEntries);
+    await p1;
+
+    const state = useAppStore.getState();
+    expect(state.currentPath).toBe("/new");
+    expect(state.fileEntries).toEqual(secondEntries);
+  });
+
+  it("refreshSftp: a stale navigate response does not clobber a newer refresh", async () => {
+    const navEntries = [makeEntry("nav-dir")];
+    const refreshEntries = [makeEntry("refresh-dir")];
+
+    const navList = deferred<FileEntry[]>();
+    const refreshList = deferred<FileEntry[]>();
+
+    vi.mocked(sftpListDir)
+      .mockImplementationOnce(() => navList.promise)
+      .mockImplementationOnce(() => refreshList.promise);
+
+    const store = useAppStore.getState();
+
+    const pNav = store.navigateSftp("/somewhere");
+    const pRefresh = store.refreshSftp();
+
+    // The later refresh settles first and should win.
+    refreshList.resolve(refreshEntries);
+    await pRefresh;
+
+    // The earlier, now-stale navigate settles last and must be ignored.
+    navList.resolve(navEntries);
+    await pNav;
+
+    const state = useAppStore.getState();
+    expect(state.fileEntries).toEqual(refreshEntries);
+  });
+});

--- a/src/store/appStore.sftpRace.test.ts
+++ b/src/store/appStore.sftpRace.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/services/api", () => ({
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
 }));
 
-import { useAppStore } from "./appStore";
+import { useAppStore, _resetSftpListSeq } from "./appStore";
 import { sftpListDir } from "@/services/api";
 import type { FileEntry } from "@/types/connection";
 
@@ -58,6 +58,7 @@ describe("appStore — SFTP overlapping-list race guard (R1)", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
     useAppStore.setState({ sftpSessionId: "session-1" });
+    _resetSftpListSeq();
     vi.clearAllMocks();
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -826,6 +826,19 @@ export function _resetConnectionReloadSeq(): void {
   _connAppliedSeq = 0;
 }
 
+// Monotonic sequencer for SFTP directory-list requests (GAP R1, #1143).
+// navigateSftp/refreshSftp await sftpListDir with no ordering guarantee, so when
+// two navigations overlap the response that resolves LAST wins currentPath/
+// fileEntries — leaving the path and displayed list desynced. Each list request
+// captures the next seq; a response only commits state if it is still the latest
+// request, so a stale (superseded) response is ignored.
+let _sftpListSeq = 0;
+
+/** @internal Reset the SFTP list sequencer — for tests only. */
+export function _resetSftpListSeq(): void {
+  _sftpListSeq = 0;
+}
+
 // In-flight guards for tunnel start/stop (GAP 4, #1141). A rapid double-click on
 // Start/Stop for a tunnel that is already `connecting` must not fire a second
 // backend call — that produces spurious "already active/connecting" error toasts
@@ -2759,11 +2772,18 @@ export const useAppStore = create<AppState>((set, get) => {
     navigateSftp: async (path: string) => {
       const sessionId = useAppStore.getState().sftpSessionId;
       if (!sessionId) return;
+      const seq = ++_sftpListSeq;
       set({ sftpLoading: true, sftpError: null });
       try {
         const entries = await sftpListDir(sessionId, path);
+        // Ignore a stale response: a newer navigate/refresh superseded this one.
+        if (seq !== _sftpListSeq) {
+          frontendLog("sftp", `navigateSftp: dropping stale list for ${path} (seq ${seq})`);
+          return;
+        }
         set({ fileEntries: entries, currentPath: path, sftpLoading: false });
       } catch (err) {
+        if (seq !== _sftpListSeq) return;
         set({
           sftpLoading: false,
           sftpError: err instanceof Error ? err.message : String(err),
@@ -2774,11 +2794,18 @@ export const useAppStore = create<AppState>((set, get) => {
     refreshSftp: async () => {
       const { sftpSessionId, currentPath } = useAppStore.getState();
       if (!sftpSessionId) return;
+      const seq = ++_sftpListSeq;
       set({ sftpLoading: true, sftpError: null });
       try {
         const entries = await sftpListDir(sftpSessionId, currentPath);
+        // Ignore a stale response: a newer navigate/refresh superseded this one.
+        if (seq !== _sftpListSeq) {
+          frontendLog("sftp", `refreshSftp: dropping stale list for ${currentPath} (seq ${seq})`);
+          return;
+        }
         set({ fileEntries: entries, sftpLoading: false });
       } catch (err) {
+        if (seq !== _sftpListSeq) return;
         set({
           sftpLoading: false,
           sftpError: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary

Fixes SFTP audit gap **R1** (umbrella #1143): `navigateSftp` and `refreshSftp` in `src/store/appStore.ts` awaited `sftpListDir` with no ordering guard. When two navigations overlapped, whichever directory listing resolved **last** won `currentPath`/`fileEntries` — so a rapid folder click could land the path from click #2 with the list from click #1 (or vice-versa), desyncing the shown path from the shown files.

## Changes

- Add a module-level monotonic request sequencer `_sftpListSeq`. Each `navigateSftp`/`refreshSftp` call captures the next seq before awaiting the listing; after it resolves (success or error), it only commits state if its seq is still the latest — otherwise it drops the superseded response and logs a note via `frontendLog`. Mirrors the existing connection-reload sequencer (`_connReloadSeq`) pattern.
- Add `_resetSftpListSeq()` test helper.
- Change fragment: `docs/changes/dev2/feature/1143-sftp-list-race-guard.md`.

## Test plan

- New unit test `src/store/appStore.sftpRace.test.ts` drives two overlapping `navigateSftp` calls (and a navigate/refresh pair) that settle **out of order**, asserting the newer request's result wins and the stale one is ignored. Verified RED before the fix, GREEN after.
- `pnpm test` — full suite passes except one pre-existing flake (`SettingsPanel.test.tsx`, editor-dirty-tab tracking, unrelated to SFTP) that passes in isolation.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all pass.

Partially addresses #1143 (R1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)