### PR TITLE
fix(workspace): guard re-entrant workspace launch (#1146)

### DIFF
--- a/docs/changes/dev2/feature/1146-launch-guard.md
+++ b/docs/changes/dev2/feature/1146-launch-guard.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Workspace: launching a workspace is now guarded against re-entry. Previously a
+  second double-click or Play press during the multi-second credential-unlock /
+  agent-connect phase started a second concurrent launch, racing the two layout
+  updates and orphaning terminal sessions. The Launch control now shows a spinner
+  and is disabled while a launch is in flight, and repeated presses are ignored
+  until the launch settles (#1146).

--- a/src/components/WorkspaceSidebar/WorkspaceListItem.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceListItem.tsx
@@ -1,4 +1,4 @@
-import { Play, Pencil, Copy, Trash2 } from "lucide-react";
+import { Play, Loader2, Pencil, Copy, Trash2 } from "lucide-react";
 import { Tooltip } from "@/components/ui";
 import { WorkspaceSummary } from "@/types/workspace";
 
@@ -8,6 +8,12 @@ interface WorkspaceListItemProps {
   onEdit: (workspaceId: string) => void;
   onDuplicate: (workspaceId: string) => void;
   onDelete: (workspaceId: string) => void;
+  /**
+   * True while any workspace launch is in flight. The Launch control is disabled
+   * and double-click is suppressed so a second press cannot start a concurrent
+   * launch (GAP G6, #1146).
+   */
+  launchDisabled?: boolean;
 }
 
 export function WorkspaceListItem({
@@ -16,29 +22,37 @@ export function WorkspaceListItem({
   onEdit,
   onDuplicate,
   onDelete,
+  launchDisabled = false,
 }: WorkspaceListItemProps) {
   return (
     <div
       className="workspace-item"
       data-testid={`workspace-item-${workspace.id}`}
-      onDoubleClick={() => onLaunch(workspace.id)}
+      onDoubleClick={() => {
+        if (!launchDisabled) onLaunch(workspace.id);
+      }}
     >
       <div className="workspace-item__header">
         <span className="workspace-item__name" data-testid={`workspace-name-${workspace.id}`}>
           {workspace.name}
         </span>
         <div className="workspace-item__actions">
-          <Tooltip content="Launch" side="top">
+          <Tooltip content={launchDisabled ? "Launching…" : "Launch"} side="top">
             <button
               className="workspace-item__action"
               aria-label="Launch"
               data-testid={`workspace-launch-${workspace.id}`}
+              disabled={launchDisabled}
               onClick={(e) => {
                 e.stopPropagation();
                 onLaunch(workspace.id);
               }}
             >
-              <Play size={12} />
+              {launchDisabled ? (
+                <Loader2 size={12} className="workspace-item__spinner" />
+              ) : (
+                <Play size={12} />
+              )}
             </button>
           </Tooltip>
           <Tooltip content="Edit" side="top">

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.css
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.css
@@ -105,6 +105,36 @@
   color: var(--text-primary);
 }
 
+.workspace-item__action:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.workspace-item__action:disabled:hover {
+  background: none;
+  color: var(--text-secondary);
+}
+
+/* Launch-in-flight indicator (GAP G6, issue 1146). */
+.workspace-item__spinner {
+  animation: workspace-item-spin 1s linear infinite;
+}
+
+@keyframes workspace-item-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-item__spinner {
+    animation: none;
+  }
+}
+
 .workspace-item__description {
   padding: 2px 0 0 0;
   font-size: 11px;

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -17,6 +17,7 @@ export function WorkspaceSidebar() {
   const duplicateWorkspace = useAppStore((s) => s.duplicateWorkspaceInBackend);
   const openWorkspaceEditorTab = useAppStore((s) => s.openWorkspaceEditorTab);
   const launchWorkspace = useAppStore((s) => s.launchWorkspace);
+  const launchingWorkspaceId = useAppStore((s) => s.launchingWorkspaceId);
   const saveCurrentAsWorkspace = useAppStore((s) => s.saveCurrentAsWorkspace);
   const tabGroups = useAppStore((s) => s.tabGroups);
   const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
@@ -198,6 +199,7 @@ export function WorkspaceSidebar() {
               onEdit={handleEdit}
               onDuplicate={handleDuplicate}
               onDelete={handleDelete}
+              launchDisabled={launchingWorkspaceId !== null}
             />
           ))}
         </div>

--- a/src/store/appStore.launchWorkspace-reentrancy.test.ts
+++ b/src/store/appStore.launchWorkspace-reentrancy.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression test for GAP G6 from the workspace save/restore audit (#1146).
+ *
+ * `launchWorkspace` had no in-flight guard. Because it awaits several
+ * multi-second phases (credential unlock, agent connects), a second
+ * double-click / Play press issued before the first launch resolved started
+ * a second concurrent launch — two overlapping `set(...)` calls that tore over
+ * each other and multiplied orphaned sessions.
+ *
+ * This test pins that a second `launchWorkspace` for the same (or any) id,
+ * issued before the first call resolves, is a no-op (only ONE launch runs).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/workspaceApi", () => ({
+  getWorkspaces: vi.fn(() => Promise.resolve([])),
+  loadWorkspace: vi.fn(),
+  saveWorkspace: vi.fn(() => Promise.resolve()),
+  deleteWorkspace: vi.fn(() => Promise.resolve()),
+  duplicateWorkspace: vi.fn(() => Promise.resolve("")),
+}));
+
+import { useAppStore } from "./appStore";
+import { loadWorkspace as apiLoadWorkspace } from "@/services/workspaceApi";
+import type { WorkspaceDefinition } from "@/types/workspace";
+
+function makeDefinition(id: string): WorkspaceDefinition {
+  return {
+    id,
+    name: `Workspace ${id}`,
+    tabGroups: [
+      {
+        name: "Group 1",
+        layout: { type: "leaf", tabs: [{ inlineConfig: { type: "shell", config: {} } }] },
+      },
+    ],
+  };
+}
+
+/** A promise that never resolves on its own — keeps the load "in flight". */
+function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("appStore — launchWorkspace re-entrancy guard (GAP G6, #1146)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ignores a second launchWorkspace while the first is still in flight", async () => {
+    const deferred = makeDeferred<WorkspaceDefinition>();
+    vi.mocked(apiLoadWorkspace).mockReturnValueOnce(deferred.promise);
+
+    // First launch — kicks off the load (still pending).
+    const first = useAppStore.getState().launchWorkspace("ws-1");
+    // Second launch before the first resolves — must be a no-op.
+    await useAppStore.getState().launchWorkspace("ws-1");
+
+    expect(apiLoadWorkspace).toHaveBeenCalledTimes(1);
+
+    // Let the first launch finish so the in-flight guard clears.
+    deferred.resolve(makeDefinition("ws-1"));
+    await first;
+
+    // A later launch (after the first resolved) is allowed again.
+    vi.mocked(apiLoadWorkspace).mockResolvedValueOnce(makeDefinition("ws-1"));
+    await useAppStore.getState().launchWorkspace("ws-1");
+    expect(apiLoadWorkspace).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a launch of a different workspace while one is already in flight", async () => {
+    const deferred = makeDeferred<WorkspaceDefinition>();
+    vi.mocked(apiLoadWorkspace).mockReturnValueOnce(deferred.promise);
+
+    const first = useAppStore.getState().launchWorkspace("ws-1");
+    // A different id, but a launch is already in flight — must still be ignored.
+    await useAppStore.getState().launchWorkspace("ws-2");
+
+    expect(apiLoadWorkspace).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(makeDefinition("ws-1"));
+    await first;
+  });
+
+  it("exposes the launching workspace id while a launch is in flight and clears it after", async () => {
+    const deferred = makeDeferred<WorkspaceDefinition>();
+    vi.mocked(apiLoadWorkspace).mockReturnValueOnce(deferred.promise);
+
+    expect(useAppStore.getState().launchingWorkspaceId).toBeNull();
+
+    const first = useAppStore.getState().launchWorkspace("ws-1");
+    expect(useAppStore.getState().launchingWorkspaceId).toBe("ws-1");
+
+    deferred.resolve(makeDefinition("ws-1"));
+    await first;
+    expect(useAppStore.getState().launchingWorkspaceId).toBeNull();
+  });
+
+  it("clears the launching id even when the launch throws", async () => {
+    vi.mocked(apiLoadWorkspace).mockRejectedValueOnce(new Error("boom"));
+
+    await useAppStore.getState().launchWorkspace("ws-1");
+    expect(useAppStore.getState().launchingWorkspaceId).toBeNull();
+
+    // A subsequent launch is not blocked by the failed one.
+    vi.mocked(apiLoadWorkspace).mockResolvedValueOnce(makeDefinition("ws-1"));
+    await useAppStore.getState().launchWorkspace("ws-1");
+    expect(apiLoadWorkspace).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -695,6 +695,12 @@ interface AppState {
   deleteWorkspaceFromBackend: (workspaceId: string) => Promise<void>;
   duplicateWorkspaceInBackend: (workspaceId: string) => Promise<void>;
   openWorkspaceEditorTab: (workspaceId: string | null) => void;
+  /**
+   * The id of the workspace whose launch is currently in flight, or `null` when
+   * none is launching. Used to guard against re-entrant `launchWorkspace` calls
+   * (double-click / repeated Play) and to disable the Launch controls in the UI.
+   */
+  launchingWorkspaceId: string | null;
   launchWorkspace: (workspaceId: string) => Promise<void>;
   /** scope "all" captures all tab groups; "active" captures only the active group. */
   saveCurrentAsWorkspace: (
@@ -3863,6 +3869,7 @@ export const useAppStore = create<AppState>((set, get) => {
     // Workspaces
     workspaces: [],
     activeWorkspaceName: null,
+    launchingWorkspaceId: null,
 
     loadWorkspaces: async () => {
       try {
@@ -3950,6 +3957,19 @@ export const useAppStore = create<AppState>((set, get) => {
       }),
 
     launchWorkspace: async (workspaceId) => {
+      // In-flight guard (GAP G6, #1146): launching a workspace awaits several
+      // multi-second phases (credential unlock, agent connects). Without this
+      // guard a second double-click / Play press starts a concurrent launch,
+      // racing the two `set(...)` calls and orphaning sessions. Ignore any
+      // re-entrant launch (of this or any other workspace) while one is running.
+      if (get().launchingWorkspaceId !== null) {
+        frontendLog(
+          "workspace",
+          `launchWorkspace(${workspaceId}) ignored: a launch is already in flight`
+        );
+        return;
+      }
+      set({ launchingWorkspaceId: workspaceId });
       try {
         const definition = await apiLoadWorkspace(workspaceId);
         const state = get();
@@ -4070,7 +4090,9 @@ export const useAppStore = create<AppState>((set, get) => {
           activeWorkspaceName: definition.name,
         });
       } catch (err) {
-        console.error("Failed to launch workspace:", err);
+        frontendLog("workspace", `Failed to launch workspace ${workspaceId}: ${String(err)}`);
+      } finally {
+        set({ launchingWorkspaceId: null });
       }
     },
 


### PR DESCRIPTION
## Summary

Fixes GAP G6 from the workspace save/restore state-machine audit (umbrella #1146): `launchWorkspace` had no in-flight guard. Because it awaits several multi-second phases — credential-store unlock and disconnected-agent connects — a second double-click or Play press during that window started a *second concurrent launch*. The two overlapping `set(...)` calls raced and tore over each other, orphaning terminal sessions.

## Changes

- **Store (`src/store/appStore.ts`)**: added a `launchingWorkspaceId: string | null` field. `launchWorkspace` now sets it synchronously before the first `await`, ignores any re-entrant call (of this or any other workspace) while a launch is in flight, and clears it in a `finally` block so a failed launch does not wedge the guard. Re-entry and failures are logged via `frontendLog` (replacing the prior `console.error`).
- **UI (`WorkspaceListItem.tsx` / `WorkspaceSidebar.tsx` / `WorkspaceSidebar.css`)**: the Launch control shows a spinner and is `disabled` while a launch is in flight, its tooltip reads "Launching…", and double-click is suppressed — so a second press cannot start a concurrent launch. Spinner honors `prefers-reduced-motion`.

## Test plan

- `src/store/appStore.launchWorkspace-reentrancy.test.ts` (TDD, added first, red before the fix): a second `launchWorkspace` while the first is in flight is a no-op (only ONE `loadWorkspace` call); a launch of a *different* workspace while one is in flight is likewise ignored; `launchingWorkspaceId` is exposed while in flight and cleared afterward; it is cleared even when the launch throws.
- `pnpm test` (full): 2284 passed.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check`: all clean.

Partially addresses #1146 (G6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)