### PR TITLE
fix(backend): monitoring retry + cancel affordance + error clearing (#1148)

### DIFF
--- a/docs/changes/dev2/feature/1148-monitoring-feedback-gaps.md
+++ b/docs/changes/dev2/feature/1148-monitoring-feedback-gaps.md
@@ -1,0 +1,15 @@
+### Added
+
+- Remote system monitoring now offers a **Retry** control in the status bar
+  whenever an auto-connect attempt fails, so a failed monitoring connection is
+  no longer a dead-end. Retry clears the failed-host latch and re-attempts the
+  connection (audit gap G7, #1148).
+- Cancelling the SSH password prompt during monitoring auto-connect now shows a
+  subtle "Monitoring not connected" affordance in the status bar (with a
+  reachable Retry) instead of silently doing nothing (audit gap G8, #1148).
+
+### Fixed
+
+- A stale monitoring error tooltip no longer lingers in the status bar when
+  switching between hosts; the error is cleared as soon as a fresh connection is
+  attempted or a successful stat update arrives (audit gap G9, #1148).

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -229,6 +229,11 @@
   color: var(--color-error);
 }
 
+/* Subtle "not connected" affordance after a cancelled password prompt (G8). */
+.monitoring-status__cancelled {
+  color: var(--text-secondary);
+}
+
 /* Monitoring connection picker dropdown */
 .monitoring-picker__content {
   min-width: 180px;

--- a/src/components/StatusBar/StatusBar.monitoring-feedback.test.tsx
+++ b/src/components/StatusBar/StatusBar.monitoring-feedback.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for the monitoring auto-connect feedback gaps (issue #1148, G7 + G8 + G9).
+ *
+ * G7 — auto-connect failure is a dead-end: the error state must expose a visible
+ *      Retry control that clears the failed-host latch and re-invokes connect.
+ * G8 — cancelling the password prompt during auto-connect leaves no feedback: a
+ *      subtle "Monitoring not connected" affordance with a reachable Retry must
+ *      appear when `monitoringCancelled` is set.
+ * G9 — a stale `monitoringError` must not linger; the Retry control clears it.
+ *
+ * These tests drive the store's monitoring signals directly and assert the
+ * disconnected-state render branch and the Retry interaction.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui";
+import { useAppStore } from "@/store/appStore";
+import { StatusBar } from "./StatusBar";
+import type { ConnectionTypeInfo, SavedConnection } from "@/types/connection";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
+
+vi.mock("@/components/CredentialStoreIndicator", () => ({ CredentialStoreIndicator: () => null }));
+vi.mock("./PortableBadge", () => ({ PortableBadge: () => null }));
+vi.mock("./UpdateIndicator", () => ({ UpdateIndicator: () => null }));
+
+const SSH_TYPE: ConnectionTypeInfo = {
+  typeId: "ssh",
+  displayName: "SSH",
+  icon: "server",
+  schema: { groups: [] } as unknown as ConnectionTypeInfo["schema"],
+  capabilities: { monitoring: true, fileBrowser: true, resize: true, persistent: false },
+};
+
+const SAVED_CONNECTION: SavedConnection = {
+  id: "conn-1",
+  name: "pi",
+  folderId: null,
+  config: {
+    type: "ssh",
+    config: { host: "pi.local", port: 22, username: "pi", authMethod: "key" },
+  },
+};
+
+/** Registers a monitoring-capable SSH type + saved connection and makes an SSH tab active. */
+function primeMonitoringTab() {
+  const tab: TerminalTab = {
+    id: "tab-1",
+    sessionId: "sess-1",
+    title: "ssh-host",
+    connectionType: "ssh",
+    contentType: "terminal",
+    config: { type: "ssh", config: { host: "pi.local", port: 22, username: "pi" } },
+    panelId: "leaf-1",
+    isActive: true,
+  };
+
+  const leaf: LeafPanel = {
+    type: "leaf",
+    id: "leaf-1",
+    tabs: [tab],
+    activeTabId: "tab-1",
+  };
+
+  useAppStore.setState((state) => ({
+    connectionTypes: [SSH_TYPE],
+    connections: [SAVED_CONNECTION],
+    settings: { ...state.settings, powerMonitoringEnabled: true },
+    rootPanel: leaf,
+    activePanelId: "leaf-1",
+  }));
+}
+
+describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    primeMonitoringTab();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderStatusBar() {
+    act(() =>
+      root.render(React.createElement(TooltipProvider, null, React.createElement(StatusBar)))
+    );
+  }
+
+  it("(G7) shows a Retry control when monitoring is in the error state", () => {
+    useAppStore.setState({ monitoringError: "Connection refused" });
+    renderStatusBar();
+
+    const err = container.querySelector('[data-testid="monitoring-error"]');
+    expect(err).not.toBeNull();
+
+    const retry = container.querySelector('[data-testid="monitoring-retry-btn"]');
+    expect(retry).not.toBeNull();
+  });
+
+  it("(G7 + G9) Retry clears the lingering error and re-invokes connect", () => {
+    const connectSpy = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ monitoringError: "Connection refused", connectMonitoring: connectSpy });
+    renderStatusBar();
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="monitoring-retry-btn"]'
+    );
+    expect(retry).not.toBeNull();
+
+    act(() => retry!.click());
+
+    // The stale error must be cleared so it does not linger (G9)…
+    expect(useAppStore.getState().monitoringError).toBeNull();
+    // …and a fresh connect attempt must be made (G7).
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("(G8) shows a 'not connected' affordance with Retry when the password prompt was cancelled", () => {
+    useAppStore.setState({ monitoringCancelled: true });
+    renderStatusBar();
+
+    const notConnected = container.querySelector('[data-testid="monitoring-not-connected"]');
+    expect(notConnected).not.toBeNull();
+    expect(notConnected!.textContent).toContain("not connected");
+
+    const retry = container.querySelector('[data-testid="monitoring-retry-btn"]');
+    expect(retry).not.toBeNull();
+  });
+
+  it("(G8) Retry from the cancelled affordance clears the flag and re-invokes connect", () => {
+    const connectSpy = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ monitoringCancelled: true, connectMonitoring: connectSpy });
+    renderStatusBar();
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="monitoring-retry-btn"]'
+    );
+    act(() => retry!.click());
+
+    expect(useAppStore.getState().monitoringCancelled).toBe(false);
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/StatusBar/StatusBar.monitoring-feedback.test.tsx
+++ b/src/components/StatusBar/StatusBar.monitoring-feedback.test.tsx
@@ -95,7 +95,12 @@ describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () 
   }
 
   it("(G7) shows a Retry control when monitoring is in the error state", () => {
-    useAppStore.setState({ monitoringError: "Connection refused" });
+    // A no-op connect prevents the mount auto-connect effect from mutating the
+    // error/cancelled state we set up for the render assertions.
+    useAppStore.setState({
+      monitoringError: "Connection refused",
+      connectMonitoring: vi.fn(() => Promise.resolve()),
+    });
     renderStatusBar();
 
     const err = container.querySelector('[data-testid="monitoring-error"]');
@@ -105,26 +110,39 @@ describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () 
     expect(retry).not.toBeNull();
   });
 
-  it("(G7 + G9) Retry clears the lingering error and re-invokes connect", () => {
+  it("(G7 + G9) Retry clears the lingering error and re-invokes connect", async () => {
     const connectSpy = vi.fn(() => Promise.resolve());
     useAppStore.setState({ monitoringError: "Connection refused", connectMonitoring: connectSpy });
     renderStatusBar();
+    // Let any mount auto-connect microtasks settle before counting.
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const retry = container.querySelector<HTMLButtonElement>(
       '[data-testid="monitoring-retry-btn"]'
     );
     expect(retry).not.toBeNull();
 
-    act(() => retry!.click());
+    // Count connect calls after mount settles (the auto-connect effect may have
+    // fired once on mount); Retry must add exactly one fresh attempt.
+    const before = connectSpy.mock.calls.length;
+    await act(async () => {
+      retry!.click();
+      await Promise.resolve();
+    });
 
     // The stale error must be cleared so it does not linger (G9)…
     expect(useAppStore.getState().monitoringError).toBeNull();
     // …and a fresh connect attempt must be made (G7).
-    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(connectSpy.mock.calls.length).toBe(before + 1);
   });
 
   it("(G8) shows a 'not connected' affordance with Retry when the password prompt was cancelled", () => {
-    useAppStore.setState({ monitoringCancelled: true });
+    useAppStore.setState({
+      monitoringCancelled: true,
+      connectMonitoring: vi.fn(() => Promise.resolve()),
+    });
     renderStatusBar();
 
     const notConnected = container.querySelector('[data-testid="monitoring-not-connected"]');
@@ -135,17 +153,24 @@ describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () 
     expect(retry).not.toBeNull();
   });
 
-  it("(G8) Retry from the cancelled affordance clears the flag and re-invokes connect", () => {
+  it("(G8) Retry from the cancelled affordance clears the flag and re-invokes connect", async () => {
     const connectSpy = vi.fn(() => Promise.resolve());
     useAppStore.setState({ monitoringCancelled: true, connectMonitoring: connectSpy });
     renderStatusBar();
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     const retry = container.querySelector<HTMLButtonElement>(
       '[data-testid="monitoring-retry-btn"]'
     );
-    act(() => retry!.click());
+    const before = connectSpy.mock.calls.length;
+    await act(async () => {
+      retry!.click();
+      await Promise.resolve();
+    });
 
     expect(useAppStore.getState().monitoringCancelled).toBe(false);
-    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(connectSpy.mock.calls.length).toBe(before + 1);
   });
 });

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Activity, RefreshCw, Unplug, Loader2, Server, Route } from "lucide-react";
+import { Activity, RefreshCw, Unplug, Loader2, Server, Route, RotateCw } from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
+import { frontendLog } from "@/utils/frontendLog";
 import { jumpHostStatusLabel } from "@/utils/jumpHost";
 import { ConnectionConfig } from "@/types/terminal";
 import { SavedConnection } from "@/types/connection";
@@ -240,6 +241,7 @@ function MonitoringStatus() {
   const monitoringSampleCount = useAppStore((s) => s.monitoringSampleCount);
   const monitoringLoading = useAppStore((s) => s.monitoringLoading);
   const monitoringError = useAppStore((s) => s.monitoringError);
+  const monitoringCancelled = useAppStore((s) => s.monitoringCancelled);
   const connectMonitoring = useAppStore((s) => s.connectMonitoring);
   const disconnectMonitoring = useAppStore((s) => s.disconnectMonitoring);
   const refreshMonitoring = useAppStore((s) => s.refreshMonitoring);
@@ -267,6 +269,13 @@ function MonitoringStatus() {
 
   /** Tracks which host key already failed auto-connect to prevent retry loops. */
   const autoConnectFailedRef = useRef<string | null>(null);
+
+  /**
+   * Bumped by the Retry control to re-run the auto-connect effect after clearing
+   * the failed-host latch, so a failed/cancelled auto-connect is not a dead-end
+   * (audit gaps G7 + G8).
+   */
+  const [retryNonce, setRetryNonce] = useState(0);
 
   const monitorableConnections = useMemo(() => {
     return connections.filter((c) =>
@@ -364,7 +373,14 @@ function MonitoringStatus() {
         });
         const baseConfig = savedConn ? savedConn.config.config : cfg;
         const password = await requestPassword(host, username);
-        if (password === null) return;
+        if (password === null) {
+          // The user cancelled the password prompt. Surface a subtle
+          // "Monitoring not connected" affordance instead of returning silently,
+          // and keep the Retry/picker reachable (audit gap G8).
+          frontendLog("monitoring", "auto-connect cancelled at password prompt");
+          useAppStore.getState().setMonitoringCancelled(true);
+          return;
+        }
         configToUse = { ...baseConfig, password };
       }
 
@@ -383,6 +399,8 @@ function MonitoringStatus() {
     monitoringHost,
     monitoringEnabled,
     activeTabExited,
+    // Re-run auto-connect when the user hits Retry (audit gaps G7 + G8).
+    retryNonce,
   ]);
 
   const handleConnect = useCallback(
@@ -395,6 +413,21 @@ function MonitoringStatus() {
     [connectMonitoring]
   );
 
+  /**
+   * Retry auto-connect after a failure or a cancelled password prompt. Clears
+   * the failed-host latch, the stale error, and the cancel affordance, then
+   * bumps the nonce so the auto-connect effect fires again (audit gaps G7 + G8;
+   * G9 — the lingering error is cleared here too).
+   */
+  const handleRetry = useCallback(() => {
+    frontendLog("monitoring", "user retrying monitoring auto-connect");
+    autoConnectFailedRef.current = null;
+    const { clearMonitoringError, setMonitoringCancelled } = useAppStore.getState();
+    clearMonitoringError();
+    setMonitoringCancelled(false);
+    setRetryNonce((n) => n + 1);
+  }, []);
+
   // Hide monitoring UI when disabled or when active tab doesn't support monitoring
   if (!monitoringEnabled) return null;
 
@@ -403,14 +436,20 @@ function MonitoringStatus() {
   const isReconnectingWithCache =
     !monitoringSessionId && monitoringLoading && monitoringStats !== null;
 
-  // Not connected: show connect button (or loading/error state)
+  // Not connected: show connect button (or loading/error/cancelled state)
   if (!monitoringSessionId && !isReconnectingWithCache) {
-    // Remote-session tabs auto-connect; show loading indicator while connecting.
+    // Remote-session tabs auto-connect; show loading/error/cancelled feedback.
     if (isRemoteSession) {
-      if (!monitoringLoading && !monitoringError) return null;
-    } else if (monitorableConnections.length === 0) {
+      if (!monitoringLoading && !monitoringError && !monitoringCancelled) return null;
+    } else if (monitorableConnections.length === 0 && !monitoringError && !monitoringCancelled) {
+      // No saved monitorable connections to offer — but a failed/cancelled
+      // auto-connect must still surface its feedback + Retry (audit gaps G7/G8).
       return null;
     }
+
+    // Retry is reachable whenever auto-connect failed or was cancelled, so the
+    // failure is never a dead-end (audit gaps G7 + G8).
+    const showRetry = !monitoringLoading && (monitoringError !== null || monitoringCancelled);
 
     return (
       <>
@@ -434,7 +473,31 @@ function MonitoringStatus() {
           </span>
         )}
 
-        {!monitoringLoading && (
+        {monitoringCancelled && !monitoringError && (
+          <span
+            className="status-bar__item monitoring-status__cancelled"
+            title="Monitoring not connected — the password prompt was cancelled"
+            data-testid="monitoring-not-connected"
+          >
+            Monitoring not connected
+          </span>
+        )}
+
+        {showRetry && (
+          <Tooltip content="Retry monitoring connection" side="top">
+            <button
+              className="status-bar__item status-bar__item--interactive"
+              aria-label="Retry monitoring connection"
+              data-testid="monitoring-retry-btn"
+              onClick={handleRetry}
+            >
+              <RotateCw size={12} />
+              Retry
+            </button>
+          </Tooltip>
+        )}
+
+        {!monitoringLoading && monitorableConnections.length > 0 && (
           <DropdownMenu.Root>
             <Tooltip content="Connect monitoring" side="top">
               <DropdownMenu.Trigger asChild>

--- a/src/store/appStore.monitoring.test.ts
+++ b/src/store/appStore.monitoring.test.ts
@@ -430,4 +430,102 @@ describe("appStore — monitoring", () => {
       expect(useAppStore.getState().monitoringStatsCache["pi@pi.local:22"]).toEqual(TEST_STATS);
     });
   });
+
+  // Audit gap G9: a stale monitoringError must not linger across hosts. The
+  // store clears it on every successful stat update and exposes an explicit
+  // clearMonitoringError() so the status bar can reset it when switching hosts.
+  describe("clearMonitoringError (G9)", () => {
+    it("clears a lingering monitoringError", () => {
+      useAppStore.setState({ monitoringError: "stale error from previous host" });
+
+      useAppStore.getState().clearMonitoringError();
+
+      expect(useAppStore.getState().monitoringError).toBeNull();
+    });
+
+    it("is a no-op when there is no error", () => {
+      useAppStore.setState({ monitoringError: null });
+
+      useAppStore.getState().clearMonitoringError();
+
+      expect(useAppStore.getState().monitoringError).toBeNull();
+    });
+
+    it("refreshMonitoring success clears a pre-existing error (does not linger)", async () => {
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+
+      useAppStore.setState({
+        monitoringSessionId: "session-123",
+        monitoringHost: "pi@pi.local:22",
+        monitoringStats: TEST_STATS,
+        monitoringError: "old timeout error",
+      });
+
+      await useAppStore.getState().refreshMonitoring();
+
+      expect(useAppStore.getState().monitoringError).toBeNull();
+    });
+
+    it("connectMonitoring start clears a stale error before connecting", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+
+      useAppStore.setState({ monitoringError: "error from a previous host" });
+
+      let errorWhileLoading: string | null | undefined = undefined;
+      const unsub = useAppStore.subscribe((state) => {
+        if (state.monitoringLoading && errorWhileLoading === undefined) {
+          errorWhileLoading = state.monitoringError;
+        }
+      });
+
+      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+      unsub();
+
+      expect(errorWhileLoading).toBeNull();
+    });
+  });
+
+  // Audit gap G8: cancelling the password prompt during auto-connect must leave
+  // a visible "not connected" affordance instead of silently returning. The
+  // store tracks this via monitoringCancelled.
+  describe("monitoringCancelled (G8)", () => {
+    it("defaults to false", () => {
+      expect(useAppStore.getState().monitoringCancelled).toBe(false);
+    });
+
+    it("setMonitoringCancelled toggles the flag", () => {
+      useAppStore.getState().setMonitoringCancelled(true);
+      expect(useAppStore.getState().monitoringCancelled).toBe(true);
+
+      useAppStore.getState().setMonitoringCancelled(false);
+      expect(useAppStore.getState().monitoringCancelled).toBe(false);
+    });
+
+    it("connectMonitoring start clears a stale cancelled flag", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+
+      useAppStore.setState({ monitoringCancelled: true });
+
+      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+
+      expect(useAppStore.getState().monitoringCancelled).toBe(false);
+    });
+
+    it("disconnectMonitoring clears the cancelled flag", async () => {
+      mockMonitoringClose.mockResolvedValue(undefined);
+
+      useAppStore.setState({
+        monitoringSessionId: "session-123",
+        monitoringHost: "pi@pi.local:22",
+        monitoringStats: TEST_STATS,
+        monitoringCancelled: true,
+      });
+
+      await useAppStore.getState().disconnectMonitoring();
+
+      expect(useAppStore.getState().monitoringCancelled).toBe(false);
+    });
+  });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -653,11 +653,22 @@ interface AppState {
    * gap G10.
    */
   monitoringSampleCount: number;
+  /**
+   * True when auto-connect was aborted because the user cancelled the password
+   * prompt. The status bar renders a subtle "Monitoring not connected"
+   * affordance (with a reachable Retry) instead of failing silently. Reset on
+   * connect start, disconnect, and retry. See audit gap G8.
+   */
+  monitoringCancelled: boolean;
   /** Last-known stats per host key, persisted across tab switches for instant display on reconnect. */
   monitoringStatsCache: Record<string, SystemStats>;
   connectMonitoring: (config: Record<string, unknown>) => Promise<void>;
   disconnectMonitoring: () => Promise<void>;
   refreshMonitoring: () => Promise<void>;
+  /** Clear a lingering monitoringError so a stale tooltip cannot persist across hosts (audit gap G9). */
+  clearMonitoringError: () => void;
+  /** Set/reset the "connect was cancelled" affordance flag (audit gap G8). */
+  setMonitoringCancelled: (cancelled: boolean) => void;
   /** Per-session capabilities fetched after session creation (keyed by sessionId). */
   sessionCapabilities: Record<string, { monitoring: boolean; fileBrowser: boolean }>;
   setSessionCapabilities: (
@@ -3478,8 +3489,12 @@ export const useAppStore = create<AppState>((set, get) => {
     monitoringLoading: false,
     monitoringError: null,
     monitoringSampleCount: 0,
+    monitoringCancelled: false,
     monitoringStatsCache: {},
     sessionCapabilities: {},
+
+    clearMonitoringError: () => set({ monitoringError: null }),
+    setMonitoringCancelled: (cancelled) => set({ monitoringCancelled: cancelled }),
 
     setSessionCapabilities: (sessionId, caps) =>
       set((state) => ({
@@ -3502,6 +3517,8 @@ export const useAppStore = create<AppState>((set, get) => {
             // Fresh connection: reset the sample counter so CPU shows the
             // priming indicator until the second push arrives (audit gap G10).
             monitoringSampleCount: 0,
+            // Clear any stale cancel affordance from a previous attempt (G8).
+            monitoringCancelled: false,
           });
 
           const unlisten = await onSessionMonitoringStats((sid, stats) => {
@@ -3537,6 +3554,8 @@ export const useAppStore = create<AppState>((set, get) => {
           // Fresh connection: reset the sample counter so CPU shows the priming
           // indicator until the second fetch arrives (audit gap G10).
           monitoringSampleCount: 0,
+          // Clear any stale cancel affordance from a previous attempt (G8).
+          monitoringCancelled: false,
         });
 
         const sessionId = await monitoringOpen(config);
@@ -3591,6 +3610,7 @@ export const useAppStore = create<AppState>((set, get) => {
         monitoringStats: null,
         monitoringError: null,
         monitoringSampleCount: 0,
+        monitoringCancelled: false,
         // Preserve last-known stats so the UI can show them instantly on reconnect.
         monitoringStatsCache:
           monitoringHost && monitoringStats

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -258,7 +258,9 @@ Fixed strings — match exactly.
 | `monitoring-host` | `src/components/StatusBar/StatusBar.tsx` |
 | `monitoring-loading` | `src/components/StatusBar/StatusBar.tsx` |
 | `monitoring-mem` | `src/components/StatusBar/StatusBar.tsx` |
+| `monitoring-not-connected` | `src/components/StatusBar/StatusBar.tsx` |
 | `monitoring-refresh` | `src/components/StatusBar/StatusBar.tsx` |
+| `monitoring-retry-btn` | `src/components/StatusBar/StatusBar.tsx` |
 | `multi-select-copy` | `src/components/Sidebar/FileBrowser.tsx` |
 | `multi-select-cut` | `src/components/Sidebar/FileBrowser.tsx` |
 | `multi-select-delete` | `src/components/Sidebar/FileBrowser.tsx` |


### PR DESCRIPTION
## Summary

Fixes three related status-bar / monitoring feedback gaps from the remote system
monitoring audit (`docs/audits/remote-system-monitoring-state-machine.md`).

- **G7 — auto-connect failure was a dead-end.** `autoConnectFailedRef` latched the
  failed host key and blocked any further auto-connect (only cleared on success or
  tab-exit), so a monitoring connection that failed once never retried. A visible
  **Retry** control now appears in the status-bar monitoring error state; it clears
  the latch and re-invokes auto-connect.
- **G8 — cancelling the password prompt was silent.** When `requestPassword`
  returned `null` during auto-connect, the effect returned with the latch still set
  and no feedback. The store now tracks `monitoringCancelled` and the status bar
  surfaces a subtle "Monitoring not connected" affordance with a reachable Retry.
- **G9 — stale `monitoringError` lingered across hosts.** A new `clearMonitoringError()`
  action plus clearing the error on connect start ensures a stale "Monitor error"
  tooltip from a previous host cannot persist.

## Changes

- `src/store/appStore.ts`: add `monitoringCancelled` state, `clearMonitoringError()`
  and `setMonitoringCancelled()` actions; clear the cancel flag on connect start and
  disconnect.
- `src/components/StatusBar/StatusBar.tsx`: set `monitoringCancelled` on password
  cancel; add a `handleRetry` (clears latch + error + cancel flag, re-runs
  auto-connect via a retry nonce); render a Retry control and the "not connected"
  affordance in the disconnected state.
- `src/components/StatusBar/StatusBar.css`: token-based style for the cancelled affordance.
- Tests: `appStore.monitoring.test.ts` (G8/G9 store behavior) and new
  `StatusBar.monitoring-feedback.test.tsx` (G7/G8/G9 render + Retry interaction).

## Test plan

- `pnpm test` — 206 files / 2292 tests pass (includes the new store + render tests).
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all clean.
- Manual: with monitoring enabled on an SSH tab, force a connect failure or cancel
  the password prompt and confirm the status bar shows Retry / "Monitoring not
  connected", and that Retry re-attempts the connection.

Partially addresses #1148 (G7, G8, G9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
