### PR TITLE
feat(backend): expose X server dependent-session count and wire acquire/release into X11 connect lifecycle (#1107)

### DIFF
--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -186,7 +186,17 @@ impl SshConnector for RusshSshConnector {
             use super::x11::x_server_provisioner;
             let resolved = match x_server_provisioner() {
                 Some(provisioner) => match provisioner.ensure().await {
-                    Ok(resolved) => resolved,
+                    Ok(lease) => {
+                        // Hold the desktop session-lifetime guard (dependent-session
+                        // refcount lease, #1107) for the whole session. Pushing it
+                        // into `extensions` now — before the forwarder even starts —
+                        // means it is released on session end *or* if the connect
+                        // fails afterwards, so the refcount matches acquire exactly.
+                        if let Some(guard) = lease.guard {
+                            extensions.push(guard);
+                        }
+                        lease.resolved
+                    }
                     Err(message) => {
                         tracing::warn!("X server provisioning failed: {message}");
                         None

--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -4,6 +4,7 @@
 //! connections, then routes incoming channels through the [`ForwardedChannelRegistry`]
 //! to async proxy tasks that bridge to the local X server.
 
+use std::any::Any;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
@@ -100,6 +101,25 @@ impl ResolvedXServer {
     }
 }
 
+/// The outcome of [`XServerProvisioner::ensure`]: where to forward, plus an
+/// opaque session-lifetime guard.
+///
+/// The `guard` is a desktop-side RAII handle (a dependent-session refcount lease,
+/// #1107) that core keeps alive alongside the [`X11Forwarder`] for the session's
+/// lifetime and drops when the session ends — so the desktop side sees exactly
+/// one release per acquired session, whether the session closed cleanly or the
+/// connect failed after acquisition. Core treats it as an opaque `Any` and never
+/// inspects it.
+#[derive(Default)]
+pub struct XServerLease {
+    /// The resolved server to forward to, or `None` to fall back to
+    /// [`detect_local_x_server`] (provisioning disabled / nothing resolved).
+    pub resolved: Option<ResolvedXServer>,
+    /// Opaque guard held for the session lifetime; dropping it releases the
+    /// desktop-side session claim. `None` when nothing was claimed.
+    pub guard: Option<Box<dyn Any + Send>>,
+}
+
 /// A hook the desktop app installs so the SSH connect path can ensure a usable
 /// local X server *before* X11 forwarding starts.
 ///
@@ -113,15 +133,20 @@ impl ResolvedXServer {
 /// user-run server.
 #[async_trait]
 pub trait XServerProvisioner: Send + Sync {
-    /// Ensure a usable local X server exists and resolve where to reach it.
+    /// Ensure a usable local X server exists, resolve where to reach it, and
+    /// claim a dependent session against it.
     ///
-    /// - `Ok(Some(resolved))` — a server (managed or adopted) is ready; forward
-    ///   to `resolved.info` with `resolved.cookie`, no further detection.
-    /// - `Ok(None)` — provisioning is disabled or resolved nothing; fall back to
-    ///   [`detect_local_x_server`] for a user-run server.
-    /// - `Err(message)` — provisioning failed; `message` is an actionable,
-    ///   user-facing explanation surfaced to the UI (never a silent no-op).
-    async fn ensure(&self) -> Result<Option<ResolvedXServer>, String>;
+    /// On success returns an [`XServerLease`]:
+    /// - `lease.resolved = Some(resolved)` — a server (managed or adopted) is
+    ///   ready; forward to `resolved.info` with `resolved.cookie`.
+    /// - `lease.resolved = None` — provisioning is disabled or resolved nothing;
+    ///   fall back to [`detect_local_x_server`] for a user-run server.
+    /// - `lease.guard` — an opaque session-lifetime guard the connect path holds
+    ///   until the session ends (see [`XServerLease`]).
+    ///
+    /// `Err(message)` — provisioning failed; `message` is an actionable,
+    /// user-facing explanation surfaced to the UI (never a silent no-op).
+    async fn ensure(&self) -> Result<XServerLease, String>;
 }
 
 static PROVISIONER: OnceLock<Arc<dyn XServerProvisioner>> = OnceLock::new();

--- a/docs/changes/dev1/feature/1107-xserver-session-refcount.md
+++ b/docs/changes/dev1/feature/1107-xserver-session-refcount.md
@@ -1,0 +1,6 @@
+## Added
+
+- The Open Connections panel's "X Servers" row now shows how many live SSH X11-forwarding
+  sessions depend on the shared X server (e.g. `display :0 · 2 sessions`). The count is tracked
+  as sessions connect and disconnect, and returns to zero (with the row's detail dropping the
+  "sessions" suffix) once nothing is using the server.

--- a/src-tauri/src/terminal/xserver/manager.rs
+++ b/src-tauri/src/terminal/xserver/manager.rs
@@ -756,6 +756,53 @@ mod tests {
         assert_eq!(mgr.status(), XServerStatus::Adopted { display: 0 });
     }
 
+    // -- session count (refcount surfaced to the UI, #1107) ----------------
+
+    #[test]
+    fn session_count_tracks_acquire_and_release() {
+        let launcher = FakeLauncher::new();
+        // idle-stop off so releasing to zero does not tear the server down and
+        // reset the count out from under the assertions.
+        let mgr = manager_with(&[], launcher.clone(), true, false);
+
+        assert_eq!(mgr.session_count(), 0, "no sessions before acquire");
+
+        mgr.acquire_session().unwrap();
+        assert_eq!(mgr.session_count(), 1, "one acquired session");
+
+        mgr.acquire_session().unwrap();
+        assert_eq!(mgr.session_count(), 2, "two acquired sessions");
+
+        mgr.release_session();
+        assert_eq!(mgr.session_count(), 1, "one released, one remaining");
+
+        mgr.release_session();
+        assert_eq!(mgr.session_count(), 0, "all sessions released");
+    }
+
+    #[test]
+    fn session_count_is_zero_after_idle_shutdown() {
+        let launcher = FakeLauncher::new();
+        let mgr = manager_with(&[], launcher.clone(), true, true);
+
+        mgr.acquire_session().unwrap();
+        assert_eq!(mgr.session_count(), 1);
+        // Last release with idle-stop on tears the server down and resets state.
+        mgr.release_session();
+        assert_eq!(mgr.session_count(), 0);
+        assert_eq!(mgr.status(), XServerStatus::Stopped);
+    }
+
+    #[test]
+    fn release_without_acquire_does_not_underflow() {
+        let launcher = FakeLauncher::new();
+        let mgr = manager_with(&[6000], launcher.clone(), true, false);
+
+        // Defensive: an unpaired release must saturate at zero, never wrap.
+        mgr.release_session();
+        assert_eq!(mgr.session_count(), 0);
+    }
+
     // -- explicit stop / shutdown ------------------------------------------
 
     #[test]

--- a/src-tauri/src/terminal/xserver/manager.rs
+++ b/src-tauri/src/terminal/xserver/manager.rs
@@ -18,7 +18,7 @@
 #![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use termihub_core::backends::ssh::x11::ManagedXServer;
@@ -204,6 +204,16 @@ impl XServerManager {
         self.inner.lock().expect("xserver lock").status.clone()
     }
 
+    /// Number of live X11 sessions currently depending on the server.
+    ///
+    /// Surfaced to the UI (Open Connections "X Servers" row → "· N sessions",
+    /// #1107). Mirrors the internal refcount driven by
+    /// [`acquire_session`](Self::acquire_session) /
+    /// [`release_session`](Self::release_session).
+    pub fn session_count(&self) -> usize {
+        self.inner.lock().expect("xserver lock").refcount
+    }
+
     /// Ensure a usable X server exists, spawning or adopting one as needed.
     ///
     /// Order: reuse our live managed process → adopt an external server on `:0`
@@ -219,6 +229,21 @@ impl XServerManager {
         let info = self.ensure_running_locked(&mut inner)?;
         inner.refcount += 1;
         Ok(info)
+    }
+
+    /// Acquire a session and return a RAII [`SessionGuard`] that releases it
+    /// exactly once when dropped.
+    ///
+    /// This is the connect-lifecycle entry point (#1107): the SSH X11 connect
+    /// path holds the guard for the session's lifetime (alongside the
+    /// `X11Forwarder`), so [`release_session`](Self::release_session) — and thus
+    /// the existing idle-shutdown behavior — fires precisely when the session
+    /// ends, whether it closed cleanly or the connect failed.
+    pub fn acquire_session_lease(self: &Arc<Self>) -> Result<SessionGuard> {
+        self.acquire_session()?;
+        Ok(SessionGuard {
+            manager: self.clone(),
+        })
     }
 
     /// Release a previously acquired session (refcount - 1). When the count
@@ -333,6 +358,23 @@ impl XServerManager {
     }
 }
 
+/// RAII guard for one acquired X11 session (#1107).
+///
+/// Holds a session against the shared [`XServerManager`] for as long as it is
+/// alive; dropping it calls [`release_session`](XServerManager::release_session)
+/// exactly once, preserving idle-shutdown for a managed server. Threaded into
+/// core's SSH connect path as an opaque, session-lifetime resource so release is
+/// tied to the session ending (or its connect failing).
+pub struct SessionGuard {
+    manager: Arc<XServerManager>,
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        self.manager.release_session();
+    }
+}
+
 /// Best-effort removal of a written `.Xauthority` file.
 fn remove_auth_file(path: &Option<PathBuf>) {
     if let Some(path) = path {
@@ -438,7 +480,6 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
 
     /// Probe backed by a fixed set of "open" ports.
     struct FakeProbe {

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -26,12 +26,14 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use tauri::{AppHandle, Manager};
-use termihub_core::backends::ssh::x11::{ResolvedXServer, XServerProvisioner};
+use termihub_core::backends::ssh::x11::{XServerLease, XServerProvisioner};
 
 use crate::connection::manager::ConnectionManager;
 
 pub use manager::XServerManager;
-pub use orchestrator::{current_status, ensure_x_server, EnsureOutcome};
+pub use orchestrator::{
+    current_status, ensure_x_server, ensure_x_server_for_session, EnsureOutcome,
+};
 pub use types::{
     XServerError, XServerPlatform, XServerProgress, XServerStatusReport, X_SERVER_PROGRESS_EVENT,
 };
@@ -83,16 +85,22 @@ impl XServerProvisionerImpl {
 
 #[async_trait]
 impl XServerProvisioner for XServerProvisionerImpl {
-    async fn ensure(&self) -> Result<Option<ResolvedXServer>, String> {
-        // Run the orchestrator (adopt / spawn / launch XQuartz / typed error) and
-        // hand the connect path the server it resolved — managed or adopted —
-        // together with its cookie, so the forwarder performs no second probe.
-        // `Ok` always carries a resolved server; the "nothing usable" case is an
-        // `Err`, and the "no provisioner registered" case is handled in core.
-        ensure_off_reactor(&self.app, self.manager.clone())
+    async fn ensure(&self) -> Result<XServerLease, String> {
+        // Run the orchestrator (adopt / spawn / launch XQuartz / typed error),
+        // claiming a dependent session against the manager (#1107). The connect
+        // path gets the resolved server — managed or adopted, with its cookie, so
+        // the forwarder performs no second probe — plus an opaque
+        // [`SessionGuard`] it holds for the session lifetime; dropping the guard
+        // releases the session (respecting idle-shutdown). `Ok` always carries a
+        // resolved server; the "nothing usable" case is an `Err`, and the "no
+        // provisioner registered" case is handled in core.
+        let (outcome, guard) = ensure_session_off_reactor(&self.app, self.manager.clone())
             .await
-            .map(|outcome| Some(outcome.resolved))
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        Ok(XServerLease {
+            resolved: Some(outcome.resolved),
+            guard: Some(Box::new(guard)),
+        })
     }
 }
 
@@ -106,6 +114,22 @@ pub(crate) async fn ensure_off_reactor(
 ) -> Result<EnsureOutcome, XServerError> {
     let provide = resolve_provide_automatically(app);
     tokio::task::spawn_blocking(move || ensure_x_server(&manager, provide))
+        .await
+        .map_err(|e| XServerError::LaunchFailed {
+            message: format!("X server provisioning task failed: {e}"),
+        })?
+}
+
+/// Like [`ensure_off_reactor`] but claims a dependent session against the manager
+/// (#1107), returning the outcome plus a [`SessionGuard`](manager::SessionGuard)
+/// whose drop releases the session. Used by the SSH connect provisioner so the
+/// refcount tracks live X11-forwarding sessions.
+pub(crate) async fn ensure_session_off_reactor(
+    app: &AppHandle,
+    manager: Arc<XServerManager>,
+) -> Result<(EnsureOutcome, manager::SessionGuard), XServerError> {
+    let provide = resolve_provide_automatically(app);
+    tokio::task::spawn_blocking(move || ensure_x_server_for_session(&manager, provide))
         .await
         .map_err(|e| XServerError::LaunchFailed {
             message: format!("X server provisioning task failed: {e}"),

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -69,8 +69,9 @@ pub fn resolve_provide_automatically(app: &AppHandle) -> bool {
 ///
 /// Core's SSH connect path calls [`ensure`](XServerProvisioner::ensure) before
 /// starting X11 forwarding; this runs the orchestrator (off the async reactor,
-/// since detection briefly blocks) and returns the managed server to forward to
-/// — or `Ok(None)` to let core adopt a user-run server, or an actionable `Err`.
+/// since detection briefly blocks), claims a dependent session (#1107), and
+/// returns an [`XServerLease`] with the server to forward to plus a
+/// session-lifetime guard — or an actionable `Err`.
 pub struct XServerProvisionerImpl {
     app: AppHandle,
     manager: Arc<XServerManager>,

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -439,5 +439,57 @@ mod tests {
             assert_eq!(resolved.info.display_number, 0);
             assert_tcp_loopback(&resolved.info.connection, 6000);
         }
+
+        // ── Session refcount wiring (#1107) ──────────────────────────────
+
+        #[test]
+        fn acquire_flag_increments_refcount_and_populates_session_count() {
+            // The connect path acquires a session: the refcount rises and the
+            // status report surfaces it as `session_count`.
+            let mgr = manager(vec![], true);
+
+            let outcome = ensure_x_server_for_session(&mgr, true).expect("session acquired");
+            assert_eq!(outcome.report.session_count, 1, "first session counted");
+            assert_eq!(mgr.session_count(), 1);
+
+            let outcome = ensure_x_server_for_session(&mgr, true).expect("second session acquired");
+            assert_eq!(outcome.report.session_count, 2, "second session counted");
+            assert_eq!(mgr.session_count(), 2);
+        }
+
+        #[test]
+        fn probe_only_ensure_does_not_acquire_a_session() {
+            // The status/probe path (`x_server_ensure` command) must not leak a
+            // refcount: it ensures the server but acquires nothing.
+            let mgr = manager(vec![], true);
+
+            let outcome = ensure_x_server(&mgr, true).expect("server ensured");
+            assert_eq!(outcome.report.session_count, 0, "probe must not acquire");
+            assert_eq!(mgr.session_count(), 0);
+        }
+
+        #[test]
+        fn current_status_reflects_live_session_count() {
+            let mgr = manager(vec![], true);
+
+            ensure_x_server_for_session(&mgr, true).expect("session acquired");
+            ensure_x_server_for_session(&mgr, true).expect("session acquired");
+
+            let status = current_status(&mgr);
+            assert_eq!(status.state, XServerState::Running);
+            assert_eq!(status.session_count, 2, "live count surfaced in status");
+        }
+
+        #[test]
+        fn session_lease_releases_on_drop() {
+            // The lease returned by the connect path releases exactly one
+            // session when dropped, preserving the manager's refcount.
+            let mgr = std::sync::Arc::new(manager(vec![], true));
+
+            let lease = XServerManager::acquire_session_lease(&mgr).expect("session lease");
+            assert_eq!(mgr.session_count(), 1);
+            drop(lease);
+            assert_eq!(mgr.session_count(), 0, "lease drop releases the session");
+        }
     }
 }

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -507,11 +507,16 @@ mod tests {
             // status report surfaces it as `session_count`.
             let mgr = manager(vec![], true);
 
-            let outcome = ensure_x_server_for_session(&mgr, true).expect("session acquired");
+            // Hold each guard alive: dropping it would release the session and
+            // decrement the refcount, so the accumulation assertions below rely
+            // on both leases staying in scope.
+            let (outcome, _guard1) =
+                ensure_x_server_for_session(&mgr, true).expect("session acquired");
             assert_eq!(outcome.report.session_count, 1, "first session counted");
             assert_eq!(mgr.session_count(), 1);
 
-            let outcome = ensure_x_server_for_session(&mgr, true).expect("second session acquired");
+            let (outcome, _guard2) =
+                ensure_x_server_for_session(&mgr, true).expect("second session acquired");
             assert_eq!(outcome.report.session_count, 2, "second session counted");
             assert_eq!(mgr.session_count(), 2);
         }
@@ -531,8 +536,9 @@ mod tests {
         fn current_status_reflects_live_session_count() {
             let mgr = manager(vec![], true);
 
-            ensure_x_server_for_session(&mgr, true).expect("session acquired");
-            ensure_x_server_for_session(&mgr, true).expect("session acquired");
+            // Keep both leases alive so the live count stays at 2.
+            let (_o1, _guard1) = ensure_x_server_for_session(&mgr, true).expect("session acquired");
+            let (_o2, _guard2) = ensure_x_server_for_session(&mgr, true).expect("session acquired");
 
             let status = current_status(&mgr);
             assert_eq!(status.state, XServerState::Running);

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -8,6 +8,8 @@
 //! status. The per-platform install internals (VcXsrv download #1047 remainder,
 //! XQuartz install #1054, Linux gap classification #1055) are their own issues.
 
+use std::sync::Arc;
+
 use termihub_core::backends::ssh::x11::{
     detect_local_x_server, read_local_xauth_cookie, LocalXServerInfo, ResolvedXServer,
 };
@@ -30,12 +32,52 @@ pub struct EnsureOutcome {
     pub resolved: ResolvedXServer,
 }
 
-/// Ensure a usable local X server for the current platform.
+/// Ensure a usable local X server for the current platform, **without** claiming
+/// a session against it (the status/probe path behind the `x_server_ensure`
+/// command).
 ///
 /// Resolution order: the manager's own adopt/spawn (`ensure_running`) → a
 /// cross-platform detection fallback for a user-run server the TCP probe can't
 /// see (e.g. XQuartz on a Unix socket) → a typed, actionable error.
 pub fn ensure_x_server(
+    manager: &XServerManager,
+    provide_automatically: bool,
+) -> Result<EnsureOutcome, XServerError> {
+    ensure_x_server_impl(manager, provide_automatically)
+}
+
+/// Ensure a usable local X server **and** claim a session against it, returning
+/// an owned [`SessionGuard`] whose drop releases the session exactly once (the
+/// SSH X11 connect path, #1107).
+///
+/// The guard is threaded into core's connect path as a session-lifetime
+/// resource, so [`release_session`](XServerManager::release_session) — and thus
+/// the existing idle-shutdown behavior — fires when the session ends. The
+/// returned [`EnsureOutcome::report`] reflects the freshly-incremented count.
+pub fn ensure_x_server_for_session(
+    manager: &Arc<XServerManager>,
+    provide_automatically: bool,
+) -> Result<(EnsureOutcome, super::manager::SessionGuard), XServerError> {
+    // Acquire first: this drives the same adopt/reuse/spawn logic as
+    // `ensure_running` while bumping the refcount, and hands back a guard that
+    // releases on drop. If acquisition fails there is nothing to release.
+    let guard = manager
+        .acquire_session_lease()
+        .map_err(|e| XServerError::LaunchFailed {
+            message: format!("failed to acquire X server session: {e}"),
+        })?;
+    // Resolve the (now running) server for the report/forwarder. The lease
+    // already ensured it, so this reuses the live process without a second
+    // acquire. If resolution somehow fails, dropping `guard` releases the
+    // session we just claimed.
+    let outcome = ensure_x_server_impl(manager, provide_automatically)?;
+    Ok((outcome, guard))
+}
+
+/// Shared adopt/reuse/spawn + resolve body for the probe and connect paths. The
+/// session claim (if any) is made by the caller via `acquire_session_lease`;
+/// this reads the resulting count into the report.
+fn ensure_x_server_impl(
     manager: &XServerManager,
     provide_automatically: bool,
 ) -> Result<EnsureOutcome, XServerError> {
@@ -73,6 +115,7 @@ pub fn ensure_x_server(
             Some(resolved.info.display_number),
             managed,
             dependency,
+            manager.session_count(),
         );
         return Ok(EnsureOutcome { report, resolved });
     }
@@ -87,6 +130,7 @@ pub fn ensure_x_server(
             Some(resolved.info.display_number),
             false,
             dependency,
+            manager.session_count(),
         );
         return Ok(EnsureOutcome { report, resolved });
     }
@@ -114,6 +158,11 @@ pub fn current_status(manager: &XServerManager) -> XServerStatusReport {
     let platform = XServerPlatform::current();
     let dependency = dependency_available(platform);
 
+    // Live dependent-session count from the manager's refcount (#1107). Only the
+    // manager-tracked Running/Adopted states carry live sessions; the
+    // detection-fallback and Failed/Absent cases report zero.
+    let sessions = manager.session_count();
+
     match manager.status() {
         ManagedStatus::Running { display } => report(
             platform,
@@ -121,6 +170,7 @@ pub fn current_status(manager: &XServerManager) -> XServerStatusReport {
             Some(display),
             true,
             dependency,
+            sessions,
         ),
         ManagedStatus::Adopted { display } => report(
             platform,
@@ -128,9 +178,10 @@ pub fn current_status(manager: &XServerManager) -> XServerStatusReport {
             Some(display),
             false,
             dependency,
+            sessions,
         ),
         ManagedStatus::Failed { message } => {
-            let mut r = report(platform, XServerState::Failed, None, false, dependency);
+            let mut r = report(platform, XServerState::Failed, None, false, dependency, 0);
             r.message = Some(message);
             r
         }
@@ -144,9 +195,10 @@ pub fn current_status(manager: &XServerManager) -> XServerStatusReport {
                     Some(local.display_number),
                     false,
                     dependency,
+                    0,
                 ),
                 None => {
-                    let mut r = report(platform, XServerState::Absent, None, false, dependency);
+                    let mut r = report(platform, XServerState::Absent, None, false, dependency, 0);
                     r.message = Some("No local X server detected.".to_string());
                     r
                 }
@@ -178,12 +230,16 @@ pub fn classify_failure(
 }
 
 /// Build a status report with an adoption/managed message derived from the state.
+///
+/// `session_count` is the live dependent-session refcount (#1107), surfaced to
+/// the UI; it is `0` for states with no active server.
 fn report(
     platform: XServerPlatform,
     state: XServerState,
     display_number: Option<u32>,
     managed: bool,
     dependency_available: bool,
+    session_count: usize,
 ) -> XServerStatusReport {
     let message = match (state, display_number) {
         (XServerState::Running, Some(d)) => {
@@ -200,6 +256,7 @@ fn report(
         display_number,
         managed,
         dependency_available: Some(dependency_available),
+        session_count,
         message,
     }
 }
@@ -325,10 +382,12 @@ mod tests {
             Some(7),
             false,
             true,
+            3,
         );
         assert_eq!(r.state, XServerState::Adopted);
         assert_eq!(r.display_number, Some(7));
         assert!(!r.managed);
+        assert_eq!(r.session_count, 3);
         assert!(r.message.unwrap().contains(":7"));
     }
 

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -505,7 +505,7 @@ mod tests {
         fn acquire_flag_increments_refcount_and_populates_session_count() {
             // The connect path acquires a session: the refcount rises and the
             // status report surfaces it as `session_count`.
-            let mgr = manager(vec![], true);
+            let mgr = std::sync::Arc::new(manager(vec![], true));
 
             // Hold each guard alive: dropping it would release the session and
             // decrement the refcount, so the accumulation assertions below rely
@@ -534,7 +534,7 @@ mod tests {
 
         #[test]
         fn current_status_reflects_live_session_count() {
-            let mgr = manager(vec![], true);
+            let mgr = std::sync::Arc::new(manager(vec![], true));
 
             // Keep both leases alive so the live count stays at 2.
             let (_o1, _guard1) = ensure_x_server_for_session(&mgr, true).expect("session acquired");

--- a/src-tauri/src/terminal/xserver/types.rs
+++ b/src-tauri/src/terminal/xserver/types.rs
@@ -71,6 +71,11 @@ pub struct XServerStatusReport {
     /// Whether the platform's X dependency is installed (XQuartz / Xorg / VcXsrv).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dependency_available: Option<bool>,
+    /// Number of live X11 sessions currently depending on this server (#1107).
+    ///
+    /// Drives the Open Connections "X Servers" row's "· N sessions" detail. Zero
+    /// when the server is idle, adopted-but-unused, or absent.
+    pub session_count: usize,
     /// Human-readable detail (adoption source, or why the server is absent).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
@@ -299,12 +304,14 @@ mod tests {
             display_number: Some(0),
             managed: false,
             dependency_available: Some(true),
+            session_count: 2,
             message: None,
         };
         let json = serde_json::to_string(&status).unwrap();
         assert!(json.contains("\"state\":\"adopted\""));
         assert!(json.contains("\"displayNumber\":0"));
         assert!(json.contains("\"dependencyAvailable\":true"));
+        assert!(json.contains("\"sessionCount\":2"));
         assert!(!json.contains("message"));
     }
 

--- a/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/services/api", () => ({
   closeAgentSession: vi.fn(() => Promise.resolve()),
   cancelConnecting: (id: string) => cancelConnecting(id),
   xServerStatus: vi.fn(() =>
-    Promise.resolve({ state: "absent", platform: "linux", managed: false })
+    Promise.resolve({ state: "absent", platform: "linux", managed: false, sessionCount: 0 })
   ),
   xServerStop: vi.fn(() => Promise.resolve()),
 }));

--- a/src/components/OpenConnections/OpenConnectionsModal.tooltip.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tooltip.test.tsx
@@ -40,7 +40,7 @@ vi.mock("@/services/api", () => ({
   closeAgentSession: vi.fn(() => Promise.resolve()),
   cancelConnecting: vi.fn(() => Promise.resolve(true)),
   xServerStatus: vi.fn(() =>
-    Promise.resolve({ state: "absent", platform: "linux", managed: false })
+    Promise.resolve({ state: "absent", platform: "linux", managed: false, sessionCount: 0 })
   ),
   xServerStop: vi.fn(() => Promise.resolve()),
 }));

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -128,6 +128,17 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     xServer !== null && (xServer.state === "running" || xServer.state === "adopted");
   const xServerManaged = xServer?.state === "running" && xServer.managed === true;
 
+  // "display :N" plus, when any sessions depend on the server, "· N sessions"
+  // (singular for one). Omitted entirely when there is no display to show.
+  const xServerDetail = (() => {
+    if (!xServer || xServer.displayNumber === undefined) return undefined;
+    const base = `display :${xServer.displayNumber}`;
+    const count = xServer.sessionCount ?? 0;
+    if (count <= 0) return base;
+    const noun = count === 1 ? "session" : "sessions";
+    return `${base} · ${count} ${noun}`;
+  })();
+
   // When no live server exists (absent/failed/unknown), offer a Set up affordance
   // instead. Suppressed while loading so the row doesn't flash before status
   // arrives. This affordance is not counted as an active connection.
@@ -425,11 +436,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
               <ConnectionRow
                 icon={<MonitorCog size={14} />}
                 title={xServerManaged ? "VcXsrv" : "External X server"}
-                detail={
-                  xServer.displayNumber !== undefined
-                    ? `display :${xServer.displayNumber}`
-                    : undefined
-                }
+                detail={xServerDetail}
                 badge={xServerManaged ? "managed" : "external"}
                 onKill={xServerManaged ? handleStopXServer : undefined}
                 killLabel="Stop"

--- a/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
@@ -91,6 +91,7 @@ describe("OpenConnectionsModal — X Servers section", () => {
       platform: "windows",
       displayNumber: 0,
       managed: true,
+      sessionCount: 0,
     });
     await renderModal();
 
@@ -170,6 +171,7 @@ describe("OpenConnectionsModal — X Servers section", () => {
       platform: "linux",
       displayNumber: 10,
       managed: false,
+      sessionCount: 0,
     });
     await renderModal();
 
@@ -190,6 +192,7 @@ describe("OpenConnectionsModal — X Servers section", () => {
       state: "absent",
       platform: "windows",
       managed: false,
+      sessionCount: 0,
     });
     await renderModal();
 

--- a/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
@@ -119,6 +119,51 @@ describe("OpenConnectionsModal — X Servers section", () => {
     expect(document.querySelector('[data-testid="open-connections-x-server-row"]')).toBeNull();
   });
 
+  it("shows the dependent session count next to the display", async () => {
+    xServerStatus.mockResolvedValue({
+      state: "running",
+      platform: "windows",
+      displayNumber: 0,
+      managed: true,
+      sessionCount: 2,
+    });
+    await renderModal();
+
+    const row = document.querySelector('[data-testid="open-connections-x-server-row"]');
+    expect(row?.textContent).toContain("display :0");
+    expect(row?.textContent).toContain("2 sessions");
+  });
+
+  it("uses the singular form for a single dependent session", async () => {
+    xServerStatus.mockResolvedValue({
+      state: "adopted",
+      platform: "linux",
+      displayNumber: 0,
+      managed: false,
+      sessionCount: 1,
+    });
+    await renderModal();
+
+    const row = document.querySelector('[data-testid="open-connections-x-server-row"]');
+    expect(row?.textContent).toContain("1 session");
+    expect(row?.textContent).not.toContain("1 sessions");
+  });
+
+  it("omits the session count when zero sessions depend on the server", async () => {
+    xServerStatus.mockResolvedValue({
+      state: "running",
+      platform: "windows",
+      displayNumber: 0,
+      managed: true,
+      sessionCount: 0,
+    });
+    await renderModal();
+
+    const row = document.querySelector('[data-testid="open-connections-x-server-row"]');
+    expect(row?.textContent).toContain("display :0");
+    expect(row?.textContent).not.toContain("session");
+  });
+
   it("lists an adopted external X server with no Stop or Kill All control", async () => {
     xServerStatus.mockResolvedValue({
       state: "adopted",

--- a/src/components/OpenConnections/XServerSetupDialog.test.tsx
+++ b/src/components/OpenConnections/XServerSetupDialog.test.tsx
@@ -111,6 +111,7 @@ describe("XServerSetupDialog", () => {
       platform: "windows",
       displayNumber: 0,
       managed: true,
+      sessionCount: 0,
     };
     await act(async () => {
       ensure.resolve(report);

--- a/src/types/xserver.ts
+++ b/src/types/xserver.ts
@@ -33,6 +33,11 @@ export interface XServerStatusReport {
   managed: boolean;
   /** Whether the platform dependency (e.g. VcXsrv) is installed. */
   dependencyAvailable?: boolean;
+  /**
+   * Number of live X11-forwarding sessions currently depending on this server.
+   * Drives the Open Connections "· N sessions" detail; `0` when idle or absent.
+   */
+  sessionCount: number;
   /** Human-readable status detail, if any. */
   message?: string;
 }


### PR DESCRIPTION
## Summary

Wires the managed/adopted X server's **dependent-session count** through the whole stack so the Open Connections "X Servers" row can show "· N sessions" (split out from #1053). Before this, `XServerManager` tracked a `refcount` via `acquire_session()` / `release_session()`, but the post-#1087 SSH X11 connect path (`provisioner.ensure()` → `ensure_x_server()` → `manager.ensure_running()`) never incremented it, so the count was always 0.

Closes #1107.

## What changed

- **Refcount wired into the X11 connect lifecycle.** The desktop provisioner now claims a session on X11-forwarding connect and releases it on session close via a new RAII `SessionGuard` (holds an `Arc<XServerManager>`, calls `release_session()` on drop). The guard is threaded into core's SSH connect path as an opaque, session-lifetime resource (alongside `X11Forwarder` in `extensions`), so release fires **exactly once** per acquired session — whether the session closes cleanly or the connect fails after acquisition. The existing idle-shutdown semantics in `release_session` are preserved (adopted servers are never torn down; managed servers stop when the last session closes).
- **New provisioner seam.** `XServerProvisioner::ensure()` now returns an `XServerLease { resolved, guard }` instead of `Option<ResolvedXServer>`, so core can hold the desktop-side guard without knowing what it is.
- **`sessionCount` surfaced.** Added `session_count: usize` (serde `sessionCount`) to `XServerStatusReport`, populated from `inner.refcount` in `current_status` / `ensure_x_server`. The status/probe path (`x_server_ensure` command) does **not** acquire a session, so it never leaks a refcount.
- **Open Connections UI.** The "X Servers" row detail now reads e.g. `display :0 · 2 sessions` (singular for one, omitted at zero).

## Test plan

- **Rust unit tests (TDD, test commit precedes feat):**
  - `manager.rs`: `session_count` tracks acquire/release; is zero after idle shutdown; unpaired release saturates (no underflow).
  - `orchestrator.rs`: connect path increments refcount and populates `report.session_count`; probe path does not acquire; `current_status` reflects the live count; `SessionGuard` drop releases exactly one session.
  - `types.rs`: `sessionCount` serializes camelCase.
  - `cargo test -p termihub --all-features` → 706 passed. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean. `cargo fmt --all -- --check` clean.
- **Frontend:**
  - `OpenConnectionsModal.xservers.test.tsx`: shows "N sessions", singular "1 session", and omits the count at zero.
  - Full `pnpm test` → 2285 passed. `pnpm run lint` clean. `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
