### PR TITLE
fix(network): HTTP monitor staleness/overdue indicator (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-http-monitor-staleness.md
+++ b/docs/changes/dev2/feature/1147-http-monitor-staleness.md
@@ -1,0 +1,8 @@
+### Added
+
+- HTTP monitors in the Network Tools sidebar now show a relative "checked N
+  ago" label and flag a monitor as **overdue** (amber dot + "overdue" chip)
+  when its last check is older than twice its poll interval. The label ticks on
+  its own every few seconds, so a long-interval monitor no longer shows a stale
+  "up" for minutes after its endpoint has actually died — the staleness surfaces
+  without waiting for the next poll. Addresses audit gap #11 (#1147).

--- a/src/components/NetworkTools/NetworkTools.css
+++ b/src/components/NetworkTools/NetworkTools.css
@@ -350,9 +350,32 @@
 }
 
 .network-sidebar__monitor-status {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--text-disabled);
   white-space: nowrap;
+}
+
+/* Relative "checked N ago" label; the freshest reading's age lives here so a
+   long-interval monitor no longer looks perpetually current (audit gap #11). */
+.network-sidebar__monitor-age {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  color: var(--text-disabled);
+  white-space: nowrap;
+}
+
+.network-sidebar__monitor-age--stale {
+  color: var(--color-warning);
+}
+
+/* Overdue chip: shown when the last check is older than 2× the interval. */
+.network-sidebar__monitor-stale {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: var(--color-warning);
 }
 
 /* The Monitors-header refresh button needs a little breathing room from the

--- a/src/components/NetworkTools/NetworkToolsSidebar.staleness.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.staleness.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Regression test for HTTP monitor audit gap #11.
+ *
+ * The sidebar dot only refreshes on check events, so for a long-interval
+ * monitor it can show a stale "up" for minutes after the endpoint died. The
+ * fix adds a relative "checked N ago" label and a stale/overdue indicator when
+ * `now - timestampMs > 2×intervalMs`. This test pins `Date.now()` so the age is
+ * deterministic and asserts the rendered indicator.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { networkHttpMonitorList } from "@/services/networkApi";
+import type { HttpMonitorState } from "@/types/network";
+import { useAppStore } from "@/store/appStore";
+import { NetworkToolsSidebar } from "./NetworkToolsSidebar";
+import { withTooltip } from "@/test/tooltip";
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  onHttpMonitorCheck: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+const NOW = 1_700_000_000_000;
+
+function makeMonitor(id: string, timestampMs: number, intervalMs: number): HttpMonitorState {
+  return {
+    config: {
+      id,
+      url: "https://example.com",
+      intervalMs,
+      method: "GET",
+      expectedStatus: 200,
+      timeoutMs: 10_000,
+    },
+    running: true,
+    lastResult: {
+      monitorId: id,
+      statusCode: 200,
+      latencyMs: 42,
+      ok: true,
+      timestampMs,
+    },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("NetworkToolsSidebar — staleness indicator (#1147, gap #11)", () => {
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+    useAppStore.setState({ httpMonitors: [] });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    useAppStore.setState({ httpMonitors: [] });
+  });
+
+  it("marks a monitor overdue when its last check is older than 2× interval", async () => {
+    const interval = 30_000;
+    // Last checked 5 minutes ago with a 30s interval → far past 2× interval.
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([
+      makeMonitor("stale-1", NOW - 5 * 60_000, interval),
+    ]);
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const row = container.querySelector('[data-testid="monitor-row-stale-1"]');
+    expect(row).not.toBeNull();
+    const stale = container.querySelector('[data-testid="monitor-stale-stale-1"]');
+    expect(stale).not.toBeNull();
+    expect(row?.textContent).toContain("overdue");
+    // The relative age is shown so the user knows how old the reading is.
+    expect(row?.textContent).toContain("5m ago");
+  });
+
+  it("does not mark a freshly checked monitor overdue", async () => {
+    const interval = 30_000;
+    // Last checked 10s ago with a 30s interval → fresh.
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([
+      makeMonitor("fresh-1", NOW - 10_000, interval),
+    ]);
+    await act(async () => {
+      root.render(withTooltip(<NetworkToolsSidebar />));
+    });
+    await flush();
+
+    const row = container.querySelector('[data-testid="monitor-row-fresh-1"]');
+    expect(row).not.toBeNull();
+    expect(container.querySelector('[data-testid="monitor-stale-fresh-1"]')).toBeNull();
+    expect(row?.textContent).not.toContain("overdue");
+    expect(row?.textContent).toContain("10s ago");
+  });
+});

--- a/src/components/NetworkTools/NetworkToolsSidebar.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import "./NetworkTools.css";
-import { Play, RefreshCw, Plus, Circle, StopCircle } from "lucide-react";
+import { Play, RefreshCw, Plus, Circle, StopCircle, AlertTriangle } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import {
   networkHttpMonitorList,
@@ -11,6 +11,15 @@ import type { NetworkTool } from "@/types/terminal";
 import type { HttpMonitorState } from "@/types/network";
 import { frontendLog } from "@/utils/frontendLog";
 import { Button, Tooltip, toast } from "@/components/ui";
+import { isMonitorStale, formatCheckedAgo } from "./monitorStaleness";
+
+/**
+ * How often the sidebar re-evaluates monitor ages/staleness. The backend poller
+ * only emits on each check, so without this tick a long-interval monitor's
+ * "checked N ago" label would freeze and it would never flip to overdue between
+ * polls (audit gap #11).
+ */
+const STALENESS_TICK_MS = 5_000;
 
 interface QuickActionProps {
   label: string;
@@ -36,13 +45,15 @@ function QuickAction({ label, tool }: QuickActionProps) {
 
 interface MonitorRowProps {
   monitor: HttpMonitorState;
+  now: number;
   onStop: (id: string) => void;
   onOpen: (id: string) => void;
 }
 
-function MonitorRow({ monitor, onStop, onOpen }: MonitorRowProps) {
+function MonitorRow({ monitor, now, onStop, onOpen }: MonitorRowProps) {
   const { config, running, lastResult } = monitor;
   const shortUrl = config.url.replace(/^https?:\/\//, "").slice(0, 24);
+  const stale = isMonitorStale(lastResult?.timestampMs, config.intervalMs, now);
 
   return (
     <div className="network-sidebar__monitor" data-testid={`monitor-row-${config.id}`}>
@@ -51,9 +62,11 @@ function MonitorRow({ monitor, onStop, onOpen }: MonitorRowProps) {
           size={8}
           fill={
             running
-              ? lastResult?.ok
-                ? "var(--vscode-charts-green)"
-                : "var(--vscode-charts-red)"
+              ? stale
+                ? "var(--color-warning)"
+                : lastResult?.ok
+                  ? "var(--vscode-charts-green)"
+                  : "var(--vscode-charts-red)"
               : "var(--vscode-disabledForeground)"
           }
           color="transparent"
@@ -66,6 +79,31 @@ function MonitorRow({ monitor, onStop, onOpen }: MonitorRowProps) {
         )}
         {!lastResult && running && (
           <span className="network-sidebar__monitor-status">checking…</span>
+        )}
+        {lastResult && (
+          <span
+            className={`network-sidebar__monitor-age${
+              stale ? " network-sidebar__monitor-age--stale" : ""
+            }`}
+          >
+            {stale && (
+              <Tooltip
+                content={`Overdue: last check was more than 2× the ${Math.round(
+                  config.intervalMs / 1000
+                )}s interval ago; this reading may be out of date`}
+                side="left"
+              >
+                <span
+                  className="network-sidebar__monitor-stale"
+                  data-testid={`monitor-stale-${config.id}`}
+                >
+                  <AlertTriangle size={10} aria-hidden="true" />
+                  overdue
+                </span>
+              </Tooltip>
+            )}
+            {formatCheckedAgo(lastResult.timestampMs, now)}
+          </span>
         )}
       </div>
       {running && (
@@ -92,6 +130,11 @@ export function NetworkToolsSidebar() {
   const httpMonitors = useAppStore((s) => s.httpMonitors);
   const setHttpMonitors = useAppStore((s) => s.setHttpMonitors);
   const openNetworkDiagnosticTab = useAppStore((s) => s.openNetworkDiagnosticTab);
+
+  // A ticking "now" so relative ages and the overdue flag refresh on their own
+  // between check events — otherwise a long-interval monitor's dot would stay a
+  // stale "up" until the next poll (audit gap #11).
+  const [now, setNow] = useState(() => Date.now());
 
   // Load monitors on mount.
   const refreshMonitors = useCallback(async () => {
@@ -132,6 +175,13 @@ export function NetworkToolsSidebar() {
       unlisten?.();
     };
   }, [refreshMonitors]);
+
+  // Advance "now" on a fixed cadence so ages age and overdue monitors surface
+  // without needing a check event to arrive.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), STALENESS_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
 
   const handleStopMonitor = useCallback(
     async (id: string) => {
@@ -186,6 +236,7 @@ export function NetworkToolsSidebar() {
           <MonitorRow
             key={m.config.id}
             monitor={m}
+            now={now}
             onStop={handleStopMonitor}
             onOpen={handleOpenMonitor}
           />

--- a/src/components/NetworkTools/monitorStaleness.test.ts
+++ b/src/components/NetworkTools/monitorStaleness.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { isMonitorStale, formatCheckedAgo } from "./monitorStaleness";
+
+describe("isMonitorStale (audit gap #11)", () => {
+  const NOW = 1_000_000_000_000;
+  const INTERVAL = 30_000; // 30s
+
+  it("is not stale when the last check is fresh (within one interval)", () => {
+    expect(isMonitorStale(NOW - 10_000, INTERVAL, NOW)).toBe(false);
+  });
+
+  it("is not stale exactly at 2× interval (boundary is exclusive)", () => {
+    expect(isMonitorStale(NOW - 2 * INTERVAL, INTERVAL, NOW)).toBe(false);
+  });
+
+  it("is stale once the last check is older than 2× interval", () => {
+    expect(isMonitorStale(NOW - (2 * INTERVAL + 1), INTERVAL, NOW)).toBe(true);
+  });
+
+  it("is stale for a long-interval monitor that died minutes ago", () => {
+    const fiveMin = 5 * 60_000;
+    // Last checked 11 minutes ago with a 5-minute interval → overdue.
+    expect(isMonitorStale(NOW - 11 * 60_000, fiveMin, NOW)).toBe(true);
+  });
+
+  it("is never stale when it has not been checked yet", () => {
+    expect(isMonitorStale(undefined, INTERVAL, NOW)).toBe(false);
+  });
+
+  it("is never stale for a non-positive interval", () => {
+    expect(isMonitorStale(NOW - 999_999, 0, NOW)).toBe(false);
+  });
+});
+
+describe("formatCheckedAgo (audit gap #11)", () => {
+  const NOW = 1_000_000_000_000;
+
+  it("reads 'just now' for sub-2s ages", () => {
+    expect(formatCheckedAgo(NOW - 500, NOW)).toBe("just now");
+  });
+
+  it("uses second granularity", () => {
+    expect(formatCheckedAgo(NOW - 5_000, NOW)).toBe("5s ago");
+  });
+
+  it("uses minute granularity", () => {
+    expect(formatCheckedAgo(NOW - 3 * 60_000, NOW)).toBe("3m ago");
+  });
+
+  it("uses hour granularity", () => {
+    expect(formatCheckedAgo(NOW - 2 * 3_600_000, NOW)).toBe("2h ago");
+  });
+
+  it("uses day granularity", () => {
+    expect(formatCheckedAgo(NOW - 25 * 3_600_000, NOW)).toBe("1d ago");
+  });
+
+  it("never returns a negative age for clock skew", () => {
+    expect(formatCheckedAgo(NOW + 5_000, NOW)).toBe("just now");
+  });
+});

--- a/src/components/NetworkTools/monitorStaleness.ts
+++ b/src/components/NetworkTools/monitorStaleness.ts
@@ -1,0 +1,52 @@
+/**
+ * Staleness helpers for HTTP monitors (audit gap #11).
+ *
+ * The backend poller emits a check result only once per `intervalMs`, so the
+ * sidebar dot can keep showing a stale "up" for the whole interval (minutes, if
+ * the interval is long) after an endpoint has actually died. These pure helpers
+ * let the UI show a relative "checked N ago" label and flag a monitor as
+ * overdue when it has missed more than one expected poll — without touching the
+ * Rust poller.
+ */
+
+/**
+ * A monitor is considered stale/overdue when the time since its last check
+ * exceeds twice its configured poll interval, i.e. it has missed more than one
+ * expected poll. `now` is injectable for deterministic tests.
+ *
+ * @param timestampMs - epoch millis of the last check (`undefined` = never checked yet)
+ * @param intervalMs - configured poll interval in millis
+ * @param now - current epoch millis (defaults to `Date.now()`)
+ */
+export function isMonitorStale(
+  timestampMs: number | undefined,
+  intervalMs: number,
+  now: number = Date.now()
+): boolean {
+  if (timestampMs === undefined) return false;
+  if (intervalMs <= 0) return false;
+  return now - timestampMs > 2 * intervalMs;
+}
+
+/**
+ * Format the age of a monitor's last check as a compact relative string
+ * ("just now", "5s ago", "3m ago", "2h ago", "1d ago"). Second-level
+ * granularity matters here: monitors often poll every few seconds, so the
+ * coarser minute-based `formatRelativeTime` would read "just now" for a monitor
+ * that is already overdue.
+ *
+ * @param timestampMs - epoch millis of the last check
+ * @param now - current epoch millis (defaults to `Date.now()`)
+ */
+export function formatCheckedAgo(timestampMs: number, now: number = Date.now()): string {
+  const diffMs = Math.max(0, now - timestampMs);
+  const diffSecs = Math.floor(diffMs / 1000);
+  if (diffSecs < 2) return "just now";
+  if (diffSecs < 60) return `${diffSecs}s ago`;
+  const diffMins = Math.floor(diffSecs / 60);
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -576,6 +576,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `layout-sidebar-*` | `layout-sidebar-${pos}` | `src/components/Settings/CustomizeLayoutDialog.tsx` |
 | `layout-split-*` | `layout-split-${node.direction}` | `src/components/WorkspaceEditor/LayoutDesigner.tsx` |
 | `monitor-row-*` | `monitor-row-${config.id}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
+| `monitor-stale-*` | `monitor-stale-${config.id}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `monitoring-connect-*` | `monitoring-connect-${conn.id}` | `src/components/StatusBar/StatusBar.tsx` |
 | `network-quick-action-*` | `network-quick-action-${tool}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `persistent-attach-*` | `persistent-attach-${definition.id}` | `src/components/Sidebar/AgentNode.tsx` |


### PR DESCRIPTION
## Summary

Addresses audit gap #11 from `docs/audits/http-monitor-state-machine.md`: a long-interval HTTP monitor's sidebar dot only refreshed on check events, so it could keep showing a stale "up" for minutes after the endpoint actually died. This adds a relative "checked N ago" label and an overdue indicator to the Network Tools monitor sidebar. Frontend only — the Rust poller is untouched.

## Changes

- New pure helper `src/components/NetworkTools/monitorStaleness.ts`:
  - `isMonitorStale(timestampMs, intervalMs, now)` — true when `now - timestampMs > 2×intervalMs`.
  - `formatCheckedAgo(timestampMs, now)` — compact relative age with second-level granularity ("just now", "5s ago", "3m ago", "2h ago", "1d ago"), since monitors often poll every few seconds.
- `NetworkToolsSidebar` monitor rows now render a "checked N ago" label plus an amber dot and an "overdue" chip (with tooltip) when the last check is older than 2× the interval. A 5s tick advances "now" so ages age and overdue status surfaces on its own, without waiting for the next poll.
- Token-only styling for the new label/chip in `NetworkTools.css` (`--color-warning`, `--font-size-xs`, `--spacing-xs`).
- Regenerated `tests/system/testid-catalog.md` for the new `monitor-stale-*` test id.

## Test plan

- `pnpm test` — 2294 passed (207 files); includes new `monitorStaleness.test.ts` (helper units) and `NetworkToolsSidebar.staleness.test.tsx` (renders overdue chip + "5m ago" for a monitor last checked past 2× interval; no chip for a fresh one). Tests were committed first and verified red before the fix.
- `pnpm build` — passes (type-check + Vite).
- `pnpm run lint` — clean.
- `pnpm run format:check` — clean.

Partially addresses #1147 (#11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)