### PR TITLE
fix(sftp): recovery controls for failed connect / dropped session (#1143)

### DIFF
--- a/docs/changes/dev2/feature/1143-sftp-recovery.md
+++ b/docs/changes/dev2/feature/1143-sftp-recovery.md
@@ -1,0 +1,14 @@
+### Added
+
+- The SFTP file browser now offers **Retry** and **Dismiss** controls when a
+  connection fails, instead of leaving you stuck on the error message. Retry
+  re-attempts the connection with the same settings; Dismiss clears the error
+  (audit gap S1, #1143).
+
+### Fixed
+
+- When an SFTP session drops mid-browse (for example after a network blip, so
+  the server reports "session not found"), the file browser no longer keeps
+  looking connected with no way to recover. It now treats the session as gone,
+  automatically attempts to reconnect, and shows the Retry control if it cannot
+  (audit gap S2, #1143).

--- a/src/components/Sidebar/FileBrowser.css
+++ b/src/components/Sidebar/FileBrowser.css
@@ -262,3 +262,10 @@
   font-size: var(--font-size-sm);
   text-align: center;
 }
+
+/* Recovery controls (Retry / Dismiss) shown under a failed-connect message. */
+.file-browser__error-actions {
+  display: flex;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
+}

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -1446,3 +1446,144 @@ describe("FileBrowser – Go to Terminal CWD button", () => {
     expect(useAppStore.getState().sftpSessionId).toBe("session-xyz");
   });
 });
+
+describe("FileBrowser – failed-connect recovery UI (S1)", () => {
+  /** An SSH connection type that supports the file browser (→ sftp mode). */
+  function seedSshCapability() {
+    useAppStore.setState({
+      sidebarView: "files",
+      connectionTypes: [
+        {
+          typeId: "ssh",
+          displayName: "SSH",
+          icon: "terminal",
+          schema: { groups: [] },
+          capabilities: {
+            monitoring: false,
+            fileBrowser: true,
+            resize: true,
+            persistent: false,
+          },
+        },
+      ],
+    });
+  }
+
+  function makeSshTab() {
+    return makeTab({
+      connectionType: "ssh",
+      config: {
+        type: "ssh",
+        config: {
+          host: "example.com",
+          port: 22,
+          username: "alice",
+          authMethod: "password",
+          password: "pw",
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows Retry + Dismiss controls when the SFTP connect fails", async () => {
+    mockedInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "sftp_open") return Promise.reject(new Error("auth failed"));
+      return Promise.resolve(undefined);
+    });
+    seedSshCapability();
+    setActiveTab(makeSshTab());
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+    await flushAsync();
+
+    expect(useAppStore.getState().sftpError).toBe("auth failed");
+    const retryBtn = container.querySelector('[data-testid="file-browser-sftp-retry"]');
+    const dismissBtn = container.querySelector('[data-testid="file-browser-sftp-dismiss"]');
+    expect(retryBtn).toBeTruthy();
+    expect(dismissBtn).toBeTruthy();
+  });
+
+  it("Retry re-invokes the SFTP connect", async () => {
+    let openCalls = 0;
+    mockedInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "sftp_open") {
+        openCalls += 1;
+        return Promise.reject(new Error("auth failed"));
+      }
+      return Promise.resolve(undefined);
+    });
+    seedSshCapability();
+    setActiveTab(makeSshTab());
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+    await flushAsync();
+
+    const callsAfterAutoConnect = openCalls;
+    expect(callsAfterAutoConnect).toBeGreaterThanOrEqual(1);
+
+    const retryBtn = container.querySelector(
+      '[data-testid="file-browser-sftp-retry"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      retryBtn.click();
+    });
+    await flushAsync();
+
+    expect(openCalls).toBeGreaterThan(callsAfterAutoConnect);
+  });
+
+  it("Dismiss clears the error", async () => {
+    mockedInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "sftp_open") return Promise.reject(new Error("auth failed"));
+      return Promise.resolve(undefined);
+    });
+    seedSshCapability();
+    setActiveTab(makeSshTab());
+
+    await act(async () => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+    await flushAsync();
+
+    const dismissBtn = container.querySelector(
+      '[data-testid="file-browser-sftp-dismiss"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      dismissBtn.click();
+    });
+    await flushAsync();
+
+    expect(useAppStore.getState().sftpError).toBeNull();
+  });
+});

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -27,6 +27,7 @@ import {
   FolderSync,
   Globe,
   Terminal,
+  X,
 } from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
 import { Button, Tooltip } from "@/components/ui";
@@ -699,6 +700,8 @@ export function FileBrowser() {
   const { isDragOver } = useOsFileDrop(containerRef, handleOsDrop);
 
   const disconnectSftp = useAppStore((s) => s.disconnectSftp);
+  const retrySftp = useAppStore((s) => s.retrySftp);
+  const dismissSftpError = useAppStore((s) => s.dismissSftpError);
   const vscodeAvailable = useAppStore((s) => s.vscodeAvailable);
   const fileClipboard = useAppStore((s) => s.fileClipboard);
   const quickShareServer = useAppStore((s) => s.quickShareServer);
@@ -948,6 +951,27 @@ export function FileBrowser() {
             <>
               <AlertCircle size={20} />
               <span>{error}</span>
+              {/* Recovery controls for a failed connect (audit gap S1). */}
+              <div className="file-browser__error-actions">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  icon={<RefreshCw size={14} />}
+                  onClick={() => retrySftp()}
+                  data-testid="file-browser-sftp-retry"
+                >
+                  Retry
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={<X size={14} />}
+                  onClick={dismissSftpError}
+                  data-testid="file-browser-sftp-dismiss"
+                >
+                  Dismiss
+                </Button>
+              </div>
             </>
           ) : (
             <span>Waiting for SFTP connection...</span>

--- a/src/store/appStore.sftpRecovery.test.ts
+++ b/src/store/appStore.sftpRecovery.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve("persisted-id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore, _resetSftpListSeq } from "./appStore";
+import { sftpOpen, sftpListDir } from "@/services/api";
+import type { FileEntry } from "@/types/connection";
+
+function makeEntry(name: string): FileEntry {
+  return {
+    name,
+    path: `/${name}`,
+    isDirectory: true,
+    size: 0,
+    modified: "",
+    permissions: null,
+  };
+}
+
+const SAMPLE_CONFIG = { host: "example.com", port: 22, username: "alice", password: "pw" };
+
+describe("appStore — SFTP failed-connect recovery (S1)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    _resetSftpListSeq();
+    vi.clearAllMocks();
+  });
+
+  it("connectSftp persists the config used so Retry has something to call", async () => {
+    vi.mocked(sftpOpen).mockRejectedValue(new Error("auth failed"));
+
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    const state = useAppStore.getState();
+    expect(state.sftpError).toBe("auth failed");
+    expect(state.sftpSessionId).toBeNull();
+    // The last config must be retained so a Retry control can re-invoke connect.
+    expect(state.sftpLastConfig).toEqual(SAMPLE_CONFIG);
+  });
+
+  it("retrySftp re-invokes connectSftp with the last config and can succeed", async () => {
+    // First attempt fails.
+    vi.mocked(sftpOpen).mockRejectedValueOnce(new Error("host down"));
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+    expect(useAppStore.getState().sftpError).toBe("host down");
+
+    // Second attempt (via retry) succeeds.
+    vi.mocked(sftpOpen).mockResolvedValueOnce("session-xyz");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+
+    await useAppStore.getState().retrySftp();
+
+    const state = useAppStore.getState();
+    expect(sftpOpen).toHaveBeenCalledTimes(2);
+    expect(sftpOpen).toHaveBeenLastCalledWith(SAMPLE_CONFIG);
+    expect(state.sftpSessionId).toBe("session-xyz");
+    expect(state.sftpError).toBeNull();
+  });
+
+  it("retrySftp is a no-op when there is no persisted config", async () => {
+    await useAppStore.getState().retrySftp();
+    expect(sftpOpen).not.toHaveBeenCalled();
+  });
+
+  it("dismissSftpError clears the error so the failed-connect placeholder resets", async () => {
+    vi.mocked(sftpOpen).mockRejectedValue(new Error("nope"));
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+    expect(useAppStore.getState().sftpError).toBe("nope");
+
+    useAppStore.getState().dismissSftpError();
+
+    expect(useAppStore.getState().sftpError).toBeNull();
+  });
+
+  it("disconnectSftp clears the persisted last config", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-1");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+    expect(useAppStore.getState().sftpLastConfig).toEqual(SAMPLE_CONFIG);
+
+    await useAppStore.getState().disconnectSftp();
+
+    expect(useAppStore.getState().sftpLastConfig).toBeNull();
+  });
+});
+
+describe("appStore — SFTP dropped-session recovery (S2)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({
+      sftpSessionId: "session-1",
+      sftpConnectedHost: "alice@example.com:22",
+    });
+    _resetSftpListSeq();
+    vi.clearAllMocks();
+  });
+
+  it("navigateSftp clears sftpSessionId on a session-not-found error", async () => {
+    vi.mocked(sftpListDir).mockRejectedValue(new Error("SFTP session not found: session-1"));
+
+    await useAppStore.getState().navigateSftp("/tmp");
+
+    const state = useAppStore.getState();
+    // The dead session must no longer look "connected" — clearing the id lets
+    // the auto-connect effect re-establish and exposes a Reconnect control.
+    expect(state.sftpSessionId).toBeNull();
+    expect(state.sftpConnectedHost).toBeNull();
+    expect(state.sftpError).toContain("session not found");
+    expect(state.sftpLoading).toBe(false);
+  });
+
+  it("refreshSftp clears sftpSessionId on a transport/channel error", async () => {
+    vi.mocked(sftpListDir).mockRejectedValue(new Error("channel closed by peer"));
+
+    await useAppStore.getState().refreshSftp();
+
+    const state = useAppStore.getState();
+    expect(state.sftpSessionId).toBeNull();
+    expect(state.sftpConnectedHost).toBeNull();
+    expect(state.sftpLoading).toBe(false);
+  });
+
+  it("navigateSftp keeps sftpSessionId on an ordinary listing error (e.g. permission denied)", async () => {
+    vi.mocked(sftpListDir).mockRejectedValue(new Error("permission denied"));
+
+    await useAppStore.getState().navigateSftp("/root");
+
+    const state = useAppStore.getState();
+    // A recoverable per-directory error must NOT drop the whole session.
+    expect(state.sftpSessionId).toBe("session-1");
+    expect(state.sftpError).toContain("permission denied");
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -479,12 +479,21 @@ interface AppState {
   sftpLoading: boolean;
   sftpError: string | null;
   sftpConnectedHost: string | null;
+  /**
+   * The last config passed to `connectSftp`, retained so a failed connect can be
+   * retried (audit gap S1). Cleared on `disconnectSftp`.
+   */
+  sftpLastConfig: Record<string, unknown> | null;
   setCurrentPath: (path: string) => void;
   setFileEntries: (entries: FileEntry[]) => void;
   connectSftp: (config: Record<string, unknown>) => Promise<void>;
   disconnectSftp: () => Promise<void>;
   navigateSftp: (path: string) => Promise<void>;
   refreshSftp: () => Promise<void>;
+  /** Re-invoke `connectSftp` with the persisted last config (audit gap S1). */
+  retrySftp: () => Promise<void>;
+  /** Clear the SFTP error so the failed-connect placeholder resets (audit gap S1). */
+  dismissSftpError: () => void;
 
   // Per-tab CWD tracking
   tabCwds: Record<string, string>;
@@ -854,6 +863,26 @@ let _sftpListSeq = 0;
 /** @internal Reset the SFTP list sequencer — for tests only. */
 export function _resetSftpListSeq(): void {
   _sftpListSeq = 0;
+}
+
+// Detects a mid-browse failure that means the underlying SFTP session is dead
+// (audit gap S2): the Rust side raises "SFTP session not found" when the slot is
+// gone, and russh reports channel/transport drops with these phrasings. On such
+// an error the front end must stop pretending it is connected (clear
+// sftpSessionId) so the auto-connect effect can re-establish and a Reconnect
+// control is offered — as opposed to a recoverable per-directory error (e.g.
+// "permission denied") which must leave the session intact.
+function isSftpSessionDeadError(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    m.includes("session not found") ||
+    m.includes("channel") ||
+    m.includes("disconnected") ||
+    m.includes("connection reset") ||
+    m.includes("broken pipe") ||
+    m.includes("not connected") ||
+    m.includes("transport")
+  );
 }
 
 // In-flight guards for tunnel start/stop (GAP 4, #1141). A rapid double-click on
@@ -2735,12 +2764,14 @@ export const useAppStore = create<AppState>((set, get) => {
     sftpLoading: false,
     sftpError: null,
     sftpConnectedHost: null,
+    sftpLastConfig: null,
 
     setCurrentPath: (path) => set({ currentPath: path }),
     setFileEntries: (entries) => set({ fileEntries: entries }),
 
     connectSftp: async (config: Record<string, unknown>) => {
-      set({ sftpLoading: true, sftpError: null });
+      // Retain the config so a failed connect can be retried (audit gap S1).
+      set({ sftpLoading: true, sftpError: null, sftpLastConfig: config });
       try {
         const sessionId = await sftpOpen(config);
         const homePath = `/home/${config.username as string}`;
@@ -2783,8 +2814,21 @@ export const useAppStore = create<AppState>((set, get) => {
         currentPath: "/",
         sftpError: null,
         sftpConnectedHost: null,
+        sftpLastConfig: null,
       });
     },
+
+    retrySftp: async () => {
+      const config = useAppStore.getState().sftpLastConfig;
+      if (!config) {
+        frontendLog("sftp", "retrySftp: no persisted config to retry with");
+        return;
+      }
+      frontendLog("sftp", "retrySftp: re-attempting SFTP connect");
+      await useAppStore.getState().connectSftp(config);
+    },
+
+    dismissSftpError: () => set({ sftpError: null }),
 
     navigateSftp: async (path: string) => {
       const sessionId = useAppStore.getState().sftpSessionId;
@@ -2801,9 +2845,17 @@ export const useAppStore = create<AppState>((set, get) => {
         set({ fileEntries: entries, currentPath: path, sftpLoading: false });
       } catch (err) {
         if (seq !== _sftpListSeq) return;
+        const message = err instanceof Error ? err.message : String(err);
+        // A dead session (audit gap S2) must drop sftpSessionId so the UI stops
+        // looking connected and the auto-connect effect / Reconnect can recover.
+        const sessionDead = isSftpSessionDeadError(message);
+        if (sessionDead) {
+          frontendLog("sftp", `navigateSftp: session appears dead — clearing session (${message})`);
+        }
         set({
           sftpLoading: false,
-          sftpError: err instanceof Error ? err.message : String(err),
+          sftpError: message,
+          ...(sessionDead ? { sftpSessionId: null, sftpConnectedHost: null } : {}),
         });
       }
     },
@@ -2823,9 +2875,15 @@ export const useAppStore = create<AppState>((set, get) => {
         set({ fileEntries: entries, sftpLoading: false });
       } catch (err) {
         if (seq !== _sftpListSeq) return;
+        const message = err instanceof Error ? err.message : String(err);
+        const sessionDead = isSftpSessionDeadError(message);
+        if (sessionDead) {
+          frontendLog("sftp", `refreshSftp: session appears dead — clearing session (${message})`);
+        }
         set({
           sftpLoading: false,
-          sftpError: err instanceof Error ? err.message : String(err),
+          sftpError: message,
+          ...(sessionDead ? { sftpSessionId: null, sftpConnectedHost: null } : {}),
         });
       }
     },

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -168,6 +168,8 @@ Fixed strings — match exactly.
 | `file-browser-refresh` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-session-connecting` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-sftp-connecting` | `src/components/Sidebar/FileBrowser.tsx` |
+| `file-browser-sftp-dismiss` | `src/components/Sidebar/FileBrowser.tsx` |
+| `file-browser-sftp-retry` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-up` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-upload` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-editor-error` | `src/components/FileEditor/FileEditor.tsx` |


### PR DESCRIPTION
## Summary

Addresses gaps **S1** and **S2** from the SFTP file-browser state-machine audit
(`docs/audits/sftp-file-browser-state-machine.md`), both of which left the SFTP
file browser in an unrecoverable dead-end.

- **S1 — failed-connect was a dead-end.** A wrong password / host-down connect
  showed only the error text with no controls; the only "retry" was to switch
  tabs to make the auto-connect effect re-fire. The failed-connect placeholder
  now offers **Retry** and **Dismiss**. `connectSftp` persists the config it
  used (`sftpLastConfig`) so Retry (new `retrySftp` action) can re-invoke the
  connect; Dismiss clears the error (new `dismissSftpError` action).
- **S2 — session-not-found mid-browse was unrecoverable.** On a dead-session
  error the UI still looked "connected" (red strip, `sftpSessionId` non-null)
  with no recovery path. `navigateSftp`/`refreshSftp` now detect a dead-session
  error (session-not-found / transport / channel drop) and clear
  `sftpSessionId` + `sftpConnectedHost`, so the auto-connect effect can
  re-establish and the Retry control is shown. A recoverable per-directory
  error (e.g. permission denied) leaves the session intact.

## Changes

- `src/store/appStore.ts`: add `sftpLastConfig` state, `retrySftp` /
  `dismissSftpError` actions, persist config on connect, clear it on
  disconnect, and add dead-session detection in `navigateSftp`/`refreshSftp`.
- `src/components/Sidebar/FileBrowser.tsx` + `.css`: Retry + Dismiss controls in
  the failed-connect placeholder (composed from the shared `Button` primitive).

## Test plan

- `pnpm test` — full suite, 2311 passing (210 files).
- New tests: `src/store/appStore.sftpRecovery.test.ts` (S1/S2 store behavior)
  and a `FileBrowser.test.tsx` describe block (Retry/Dismiss UI). Written
  test-first (red) before the fix (green).
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all clean.

Partially addresses #1143 (S1, S2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)