### PR TITLE
fix(embedded-servers): recoverable Error state (#1145)

### DIFF
--- a/docs/changes/dev2/feature/1145-embedded-error-recover.md
+++ b/docs/changes/dev2/feature/1145-embedded-error-recover.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- An embedded HTTP/FTP/TFTP server that failed at runtime is no longer stuck in a
+  dead-end Error state. Previously the failed server kept its internal "running"
+  bookkeeping, so the sidebar showed it red while clicking Start silently did
+  nothing (the only escape was Delete or Edit). Start now acts as a real
+  Retry — it clears the failed entry and starts the server again — so
+  `Error → Stopped → Running` works. Addresses GAP G2/G9 of the embedded servers
+  state-machine audit (#1145).

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -166,14 +166,28 @@ impl EmbeddedServerManager {
         };
 
         {
-            let active = self
+            let mut active = self
                 .active
                 .lock()
                 .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
-            if active.contains_key(server_id) {
-                return Err(TerminalError::EmbeddedServerError(format!(
-                    "Server {server_id} is already running"
-                )));
+            match active.get(server_id) {
+                // A live server (no runtime error recorded) genuinely blocks a
+                // second start.
+                Some(srv) if active_entry_is_live(&srv.error) => {
+                    return Err(TerminalError::EmbeddedServerError(format!(
+                        "Server {server_id} is already running"
+                    )));
+                }
+                // GAP G2/G9: a server that failed at runtime leaves a dead husk
+                // in `active`. Drop it so `Error → Stopped` is real and this
+                // start acts as a Retry instead of being rejected as "already
+                // running". Its thread has already exited (it emitted `Error`).
+                Some(_) => {
+                    if let Some(dead) = active.remove(server_id) {
+                        dead.shutdown.store(true, Ordering::Relaxed);
+                    }
+                }
+                None => {}
             }
         }
 
@@ -351,6 +365,22 @@ impl EmbeddedServerManager {
             .app_handle
             .emit("embedded-server-status-changed", &state);
     }
+}
+
+/// Decide whether an `active` map entry represents a *live* server (as opposed
+/// to a dead husk left behind by a runtime failure).
+///
+/// The server thread records the failure reason into its shared `error` slot and
+/// then exits, but the manager keeps the map entry so `get_states` can keep
+/// surfacing the error. A live entry (empty error slot) must block a second
+/// concurrent start; a failed entry (error slot set) must NOT, so a subsequent
+/// `start_server` acts as a Retry rather than being rejected as "already
+/// running" — making `Error → Stopped` a real, escapable transition
+/// (GAP G2/G9, #1145).
+fn active_entry_is_live(error: &Arc<Mutex<Option<String>>>) -> bool {
+    // If the lock is poisoned we cannot prove the server is healthy, so treat it
+    // as not-live and allow a fresh start to recover.
+    error.lock().map(|slot| slot.is_none()).unwrap_or(false)
 }
 
 /// Build the `Error` [`ServerState`] surfaced when a server marked `auto_start`

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -372,6 +372,33 @@ fn auto_start_error_state(server_id: &str, error: &str) -> ServerState {
 mod tests {
     use super::*;
 
+    /// A freshly-spawned server whose error slot is still empty is live and must
+    /// block a second, concurrent start with "already running".
+    #[test]
+    fn active_entry_without_error_is_live() {
+        let error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        assert!(
+            active_entry_is_live(&error),
+            "a running server (no error recorded) must count as live"
+        );
+    }
+
+    /// GAP G2/G9: once a server thread has failed at runtime its `active` entry is
+    /// a dead husk — `active_entry_is_live` must report `false` so `start_server`
+    /// no longer rejects a retry with "already running". This makes `Error →
+    /// Stopped` real and Start/Retry work again, while `get_states` still surfaces
+    /// the recorded error until the retry happens.
+    #[test]
+    fn errored_active_entry_is_not_live_so_start_is_allowed() {
+        let error: Arc<Mutex<Option<String>>> =
+            Arc::new(Mutex::new(Some("Port 8080 is already in use".to_string())));
+        assert!(
+            !active_entry_is_live(&error),
+            "a server whose error slot is set must NOT count as live, so a retry \
+             (start_server) is allowed instead of being blocked as 'already running'"
+        );
+    }
+
     /// A port bound at boot must not cause a silent no-op: the auto-start
     /// failure has to surface as an `Error` state carrying the reason so the
     /// sidebar can show the server red at launch (GAP G7, #1145).


### PR DESCRIPTION
## Summary

Fixes the embedded-servers **G2 + G9** gaps from the state-machine audit
(`docs/audits/embedded-servers-state-machine.md`): the `Error` state was a
dead-end. A server that failed at runtime kept its entry in the manager's
`active` map, so `get_states` reported `Error` while `start_server` refused to
run (`active.contains_key ⇒ "already running"`). The only escape was Delete or
Edit, and clicking Start silently failed.

## Changes

- New pure helper `active_entry_is_live(&Arc<Mutex<Option<String>>>) -> bool`:
  an `active` entry whose shared error slot is set is a **dead husk**, not a
  live server (G9 disambiguation). Testable without an `AppHandle`, mirroring
  the existing `check_port_config` / `auto_start_error_state` pattern.
- `start_server` now only rejects a *live* entry as "already running"; a failed
  entry is dropped (its `shutdown` flag set) and the call proceeds as a **Retry**
  — making `Error → Stopped → Running` a real, escapable transition (G2). The
  recorded error keeps surfacing via `get_states` until the retry happens.

## Test plan

- `cargo test -p termihub --lib embedded_servers` — 27 passed (incl. two new
  regression tests: `active_entry_without_error_is_live`,
  `errored_active_entry_is_not_live_so_start_is_allowed`).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

Partially addresses #1145 (G2, G9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)