### PR TITLE
test(settings): fix order-dependent SettingsPanel test flake

### DIFF
--- a/src/components/Settings/SettingsPanel.test.tsx
+++ b/src/components/Settings/SettingsPanel.test.tsx
@@ -81,6 +81,15 @@ async function clickCheckbox(checkbox: HTMLInputElement) {
 
 describe("SettingsPanel — dirty state on revert to default", () => {
   beforeEach(() => {
+    // Use fake timers so the panel's 300ms debounced save (SAVE_DEBOUNCE_MS)
+    // never fires on its own during a test. With real timers, a starved parallel
+    // worker can let the debounce elapse between the two clicks of a
+    // toggle-then-revert flow: the save would rewrite `savedSettings` to the
+    // intermediate value, shifting the dirty baseline, so the revert click would
+    // wrongly leave the tab dirty. Fake timers make the flow order-independent —
+    // the debounce only advances when a test explicitly asks it to.
+    vi.useFakeTimers();
+
     globalThis.ResizeObserver = class {
       observe() {}
       unobserve() {}
@@ -108,6 +117,7 @@ describe("SettingsPanel — dirty state on revert to default", () => {
     });
     container.remove();
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it("clears dirty flag when setting is reverted to its last-saved value", async () => {


### PR DESCRIPTION
## Problem

`src/components/Settings/SettingsPanel.test.tsx` **passes in isolation** but **intermittently fails under the full parallel `pnpm test` run**, breaking CI's "Run Tests". An order/load-dependent flake.

## Root cause

The toggle-then-revert tests ran on **real timers**, while `SettingsPanel` debounces its save by `SAVE_DEBOUNCE_MS = 300`. The flow is: click a checkbox (→ dirty, schedules a 300ms save), then click again to revert to the saved value (→ expected clean). This only holds if the 300ms debounce does **not** fire between the two clicks.

Under a starved parallel worker (many test files in flight), 300ms of wall-clock can elapse mid-test. The debounced save then fires, rewriting `savedSettings` to the *intermediate* (unchecked) value. That shifts the dirty baseline, so the revert click no longer matches the baseline → `editorDirtyTabs[TAB_ID]` stays `true` → `expect(...).toBe(false)` fails.

Reproduced deterministically by inserting a >300ms gap between the two clicks with real timers (fails); the gap is harmless with fake timers.

This is a test-level race, not a product bug — the debounce behaves correctly; the test just raced it.

## Fix

Install `vi.useFakeTimers()` in `beforeEach` and restore `vi.useRealTimers()` in `afterEach` (mirroring `KeyPathInput.test.tsx`). With fake timers, the debounce only advances when a test explicitly asks it to, so the toggle-then-revert flow is deterministic regardless of scheduling order. The dirty-flag assertions are unaffected because `setEditorDirty` runs synchronously. No production code changed.

## Verification

- Affected test in isolation: `pnpm exec vitest run src/components/Settings/SettingsPanel.test.tsx` → 5 passed.
- Full suite `pnpm test` run twice → **205 files / 2280 tests passed** each time.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` all clean.

Test-only change; no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)