### PR TITLE
fix(workspace): feedback on restore/launch failure (#1146)

### DIFF
--- a/docs/changes/dev2/feature/1146-restore-failure-feedback.md
+++ b/docs/changes/dev2/feature/1146-restore-failure-feedback.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Workspace restore/launch failures are no longer silent. Restoring the last
+  session or launching a saved workspace previously failed quietly (a blank or
+  unchanged window with no explanation) when the stored data could not be read
+  or when every referenced connection had been deleted. Both paths now surface
+  feedback: an error toast ("Could not restore last session" / "Could not launch
+  workspace") when the load fails, and a notice ("Previous session had no
+  launchable tabs" / `Workspace "X" had no launchable tabs`) when a load
+  succeeds but produces no launchable tabs.

--- a/src/store/appStore.lastSession.test.ts
+++ b/src/store/appStore.lastSession.test.ts
@@ -37,14 +37,28 @@ vi.mock("@/services/lastSessionApi", () => ({
   clearLastSession: vi.fn(() => Promise.resolve()),
 }));
 
+// Spy on the shared toast hub so restore-failure feedback (G3, #1146) is observable.
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
 import { useAppStore } from "./appStore";
 import { saveLastSession, loadLastSession, clearLastSession } from "@/services/lastSessionApi";
+import { toast } from "@/components/ui";
 import type { LastSession } from "@/types/lastSession";
 import { getAllLeaves } from "@/utils/panelTree";
 
 const mockSave = vi.mocked(saveLastSession);
 const mockLoad = vi.mocked(loadLastSession);
 const mockClear = vi.mocked(clearLastSession);
+const mockToast = vi.mocked(toast);
 
 describe("last session persistence", () => {
   beforeEach(() => {
@@ -110,6 +124,39 @@ describe("last session persistence", () => {
 
       expect(restored).toBe(false);
       expect(useAppStore.getState().tabGroups).toBe(before);
+      // A genuinely empty/absent session is not a failure — stay silent (G3, #1146).
+      expect(mockToast.error).not.toHaveBeenCalled();
+      expect(mockToast.info).not.toHaveBeenCalled();
+    });
+
+    // G3 (#1146): a corrupt/failed load must not leave the user at a blank
+    // window with no explanation — surface an error toast.
+    it("surfaces an error toast when the load fails", async () => {
+      mockLoad.mockRejectedValue(new Error("corrupt last-session.json"));
+
+      const restored = await useAppStore.getState().restoreLastSession();
+
+      expect(restored).toBe(false);
+      expect(mockToast.error).toHaveBeenCalledTimes(1);
+      expect(mockToast.error.mock.calls[0][0]).toMatch(/restore/i);
+    });
+
+    // G3 (#1146): a stored session whose tabs all fail to build (e.g. every
+    // referenced connection was deleted) must be surfaced, not silently dropped.
+    it("surfaces a notice when a stored session builds no launchable tabs", async () => {
+      mockLoad.mockResolvedValue({
+        version: "1",
+        activeGroupIndex: 0,
+        tabGroups: [{ name: "Gone", layout: { type: "leaf", tabs: [] } }],
+      });
+
+      const restored = await useAppStore.getState().restoreLastSession();
+
+      expect(restored).toBe(false);
+      expect(mockToast.info).toHaveBeenCalledTimes(1);
+      expect(mockToast.info.mock.calls[0][0]).toMatch(/no launchable tabs/i);
+      // Not an error — this is a soft notice.
+      expect(mockToast.error).not.toHaveBeenCalled();
     });
 
     it("rebuilds the live layout from a stored session", async () => {
@@ -140,6 +187,9 @@ describe("last session persistence", () => {
       expect(tabs.map((t) => t.title).sort()).toEqual(["Shell A", "Shell B"]);
       // Active group/panel point at the restored group.
       expect(state.activeTabGroupId).toBe(state.tabGroups[0].id);
+      // A successful restore must stay silent — no failure/notice toast (G3, #1146).
+      expect(mockToast.error).not.toHaveBeenCalled();
+      expect(mockToast.info).not.toHaveBeenCalled();
     });
   });
 

--- a/src/store/appStore.launchWorkspace-feedback.test.ts
+++ b/src/store/appStore.launchWorkspace-feedback.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for GAP G3 from the workspace save/restore audit (#1146) —
+ * the launch side.
+ *
+ * `launchWorkspace` treated a failed load (catch → console.error) and an
+ * empty build (`builtGroups.length === 0` → silent `return`) as no-ops. A user
+ * who launches a workspace whose connections were deleted got nothing and no
+ * explanation, indistinguishable from "nothing happened". These tests pin that
+ * both paths now surface user feedback via the shared toast hub.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/workspaceApi", () => ({
+  getWorkspaces: vi.fn(() => Promise.resolve([])),
+  loadWorkspace: vi.fn(),
+  saveWorkspace: vi.fn(() => Promise.resolve()),
+  deleteWorkspace: vi.fn(() => Promise.resolve()),
+  duplicateWorkspace: vi.fn(() => Promise.resolve("")),
+}));
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+import { useAppStore } from "./appStore";
+import { loadWorkspace as apiLoadWorkspace } from "@/services/workspaceApi";
+import { toast } from "@/components/ui";
+import type { WorkspaceDefinition } from "@/types/workspace";
+
+const mockLoad = vi.mocked(apiLoadWorkspace);
+const mockToast = vi.mocked(toast);
+
+describe("appStore — launchWorkspace failure feedback (GAP G3, #1146)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  it("surfaces an error toast when the workspace fails to load", async () => {
+    mockLoad.mockRejectedValueOnce(new Error("boom"));
+
+    await useAppStore.getState().launchWorkspace("ws-1");
+
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+    expect(mockToast.error.mock.calls[0][0]).toMatch(/launch/i);
+  });
+
+  it("surfaces a notice when the workspace has no launchable tabs", async () => {
+    // A workspace whose only tab group has no tabs builds zero groups.
+    const definition: WorkspaceDefinition = {
+      id: "ws-empty",
+      name: "Deleted Everything",
+      tabGroups: [{ name: "Group 1", layout: { type: "leaf", tabs: [] } }],
+    };
+    mockLoad.mockResolvedValueOnce(definition);
+
+    await useAppStore.getState().launchWorkspace("ws-empty");
+
+    expect(mockToast.info).toHaveBeenCalledTimes(1);
+    // Names the workspace so the user knows which launch produced nothing.
+    expect(mockToast.info.mock.calls[0][0]).toMatch(/Deleted Everything/);
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("stays silent on a successful launch that opens tabs", async () => {
+    const definition: WorkspaceDefinition = {
+      id: "ws-ok",
+      name: "Good",
+      tabGroups: [
+        {
+          name: "Group 1",
+          layout: { type: "leaf", tabs: [{ inlineConfig: { type: "shell", config: {} } }] },
+        },
+      ],
+    };
+    mockLoad.mockResolvedValueOnce(definition);
+
+    await useAppStore.getState().launchWorkspace("ws-ok");
+
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(mockToast.info).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -4127,7 +4127,23 @@ export const useAppStore = create<AppState>((set, get) => {
           state.defaultShell,
           agentContext
         );
-        if (builtGroups.length === 0) return;
+        // GAP G3 (#1146): a workspace that builds no launchable tabs (e.g. its
+        // referenced connections were all deleted, or it was saved empty) used
+        // to return silently, leaving the user with an unchanged window and no
+        // explanation. `buildTabGroupsFromWorkspace` maps one group per def, so
+        // "empty" means either zero groups or zero tabs across every group.
+        const builtTabCount = builtGroups.reduce(
+          (n, g) => n + getAllLeaves(g.rootPanel).reduce((m, leaf) => m + leaf.tabs.length, 0),
+          0
+        );
+        if (builtGroups.length === 0 || builtTabCount === 0) {
+          frontendLog(
+            "workspace",
+            `launchWorkspace(${workspaceId}): "${definition.name}" produced no launchable tabs`
+          );
+          toast.info(`Workspace "${definition.name}" had no launchable tabs`);
+          return;
+        }
         const firstGroup = builtGroups[0];
         set({
           tabGroups: builtGroups,
@@ -4137,7 +4153,10 @@ export const useAppStore = create<AppState>((set, get) => {
           activeWorkspaceName: definition.name,
         });
       } catch (err) {
+        // GAP G3 (#1146): a failed load used to be a silent console.error, so a
+        // launch that could not open anything looked like nothing happened.
         frontendLog("workspace", `Failed to launch workspace ${workspaceId}: ${String(err)}`);
+        toast.error("Could not launch workspace");
       } finally {
         set({ launchingWorkspaceId: null });
       }
@@ -4231,7 +4250,23 @@ export const useAppStore = create<AppState>((set, get) => {
           state.defaultShell,
           agentContext
         );
-        if (builtGroups.length === 0) return false;
+        // GAP G3 (#1146): a stored session whose tabs all fail to build (e.g.
+        // every referenced connection was deleted) used to return silently,
+        // leaving the user at an empty window indistinguishable from "nothing
+        // was saved". `buildTabGroupsFromWorkspace` maps one group per def, so
+        // "empty" means either zero groups or zero tabs across every group.
+        const builtTabCount = builtGroups.reduce(
+          (n, g) => n + getAllLeaves(g.rootPanel).reduce((m, leaf) => m + leaf.tabs.length, 0),
+          0
+        );
+        if (builtGroups.length === 0 || builtTabCount === 0) {
+          frontendLog(
+            "workspace",
+            "restoreLastSession: stored session produced no launchable tabs"
+          );
+          toast.info("Previous session had no launchable tabs");
+          return false;
+        }
         const idx = Math.min(Math.max(session.activeGroupIndex, 0), builtGroups.length - 1);
         const activeGroup = builtGroups[idx];
         set({
@@ -4242,7 +4277,11 @@ export const useAppStore = create<AppState>((set, get) => {
         });
         return true;
       } catch (err) {
-        console.error("Failed to restore last session:", err);
+        // GAP G3 (#1146): a corrupt/failed last-session load used to be a silent
+        // console.error, so a user who had a populated session opened to a blank
+        // window with no explanation. Surface a recoverable error toast.
+        frontendLog("workspace", `Failed to restore last session: ${String(err)}`);
+        toast.error("Could not restore last session");
         return false;
       }
     },


### PR DESCRIPTION
## Summary

Closes GAP **G3** of the workspace save/restore audit (`docs/audits/workspace-save-restore-state-machine.md`): silent restore failures that left the user at a blank/unchanged window with no explanation.

`restoreLastSession` and `launchWorkspace` (in `src/store/appStore.ts`) previously treated both a failed load and a build that produced no launchable tabs as silent `console.error` / early `return`. A user who had a populated last session opened to an empty window — indistinguishable from "nothing was saved" — and launching a workspace whose connections were all deleted did nothing with no feedback.

## Changes

- **`restoreLastSession`**: on load failure, `toast.error("Could not restore last session")`; when a stored session builds zero launchable tabs, `toast.info("Previous session had no launchable tabs")`. A genuinely empty/absent session stays silent (not a failure).
- **`launchWorkspace`**: on load failure, `toast.error("Could not launch workspace")`; when a workspace builds zero launchable tabs, `toast.info('Workspace "X" had no launchable tabs')` (names the workspace).
- Debug logging moved from `console.error` to `frontendLog` (LogViewer).
- Note: the termiHub toast hub has no `.warning` primitive, so the soft "no launchable tabs" notice uses `toast.info` (the neutral-notice primitive). `buildTabGroupsFromWorkspace` maps one group per def, so "empty" is detected as zero groups **or** zero tabs across all groups, not just zero groups.

## Test plan

- `pnpm test` (full suite) — 210 files / 2305 tests pass.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all clean.
- New/extended unit tests (TDD, test commit precedes fix):
  - `src/store/appStore.lastSession.test.ts` — rejected load → error toast; empty-build → info notice; successful restore & absent session stay silent.
  - `src/store/appStore.launchWorkspace-feedback.test.ts` — failed load → error toast; empty-build → info notice naming the workspace; successful launch stays silent.

## Scope

Scoped to surfacing the failures only. Building a full recovery-dialog channel for corrupt `last-session.json` (the way `workspaces.json` corruption uses `RecoveryWarning` + `RecoveryDialog`) is left as follow-up (audit **M5**).

Partially addresses #1146 (G3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)