### PR TITLE
fix(embedded-servers): emit Running only after confirmed bind (#1145)

### DIFF
--- a/docs/changes/dev2/feature/1145-embedded-bind-signal.md
+++ b/docs/changes/dev2/feature/1145-embedded-bind-signal.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Embedded HTTP/FTP/TFTP servers now report **Running** only after their
+  listening socket is actually bound. Previously the sidebar item turned green
+  the moment the server thread was spawned, so a late bind failure left it
+  briefly green before flipping to red — or stuck green while nothing was
+  listening. Each server thread now confirms (or rejects) its bind back to the
+  manager, which emits **Running** on confirmation and **Error** (with the
+  reason) on failure, leaving no stale "running" entry behind. Addresses GAP G3
+  of the embedded servers state-machine audit (#1145).

--- a/src-tauri/src/embedded_servers/ftp_server.rs
+++ b/src-tauri/src/embedded_servers/ftp_server.rs
@@ -20,6 +20,7 @@ use libunftp::ServerBuilder;
 use unftp_sbe_fs::Filesystem;
 
 use super::config::{AtomicServerStats, EmbeddedServerConfig, FtpAuth};
+use super::server_manager::BindSignal;
 
 // ─── Public entry point ───────────────────────────────────────────────────────
 
@@ -27,31 +28,42 @@ use super::config::{AtomicServerStats, EmbeddedServerConfig, FtpAuth};
 ///
 /// Internally this creates a single-threaded tokio runtime so that the async
 /// libunftp server can run inside the OS thread that the `EmbeddedServerManager`
-/// already spawned.
+/// already spawned. `ready` is signalled exactly once once the control port is
+/// confirmed bindable (or if binding fails), so the manager only reports
+/// `Running` after the bind is confirmed (GAP G3, #1145).
 pub fn start_ftp_server(
     config: &EmbeddedServerConfig,
     shutdown: Arc<AtomicBool>,
     stats: Arc<AtomicServerStats>,
+    ready: BindSignal,
 ) -> Result<()> {
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .context("Failed to build tokio runtime for FTP server")?;
+        .context("Failed to build tokio runtime for FTP server")
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            ready.fail(&e.to_string());
+            return Err(e);
+        }
+    };
 
-    rt.block_on(run_ftp_server(config, shutdown, stats))
+    rt.block_on(run_ftp_server(config, shutdown, stats, ready))
 }
 
 async fn run_ftp_server(
     config: &EmbeddedServerConfig,
     shutdown: Arc<AtomicBool>,
     stats: Arc<AtomicServerStats>,
+    ready: BindSignal,
 ) -> Result<()> {
     let root: PathBuf = config.root_directory.clone().into();
     let addr = format!("{}:{}", config.bind_host, config.port);
     let read_only = config.read_only;
 
     let root_for_factory = root.clone();
-    let server = ServerBuilder::new(Box::new(move || MaybeReadOnlyFilesystem {
+    let server = match ServerBuilder::new(Box::new(move || MaybeReadOnlyFilesystem {
         inner: Filesystem::new(root_for_factory.clone()),
         read_only,
     }))
@@ -65,7 +77,30 @@ async fn run_ftp_server(
         stats: Arc::clone(&stats),
     })
     .build()
-    .context("Failed to build libunftp server")?;
+    .context("Failed to build libunftp server")
+    {
+        Ok(server) => server,
+        Err(e) => {
+            ready.fail(&e.to_string());
+            return Err(e);
+        }
+    };
+
+    // libunftp binds the control port inside `listen`, with no bound-callback.
+    // Probe-bind the control port ourselves so we can confirm (or fail) the
+    // bind before reporting Running; drop the probe immediately so libunftp can
+    // take the port (GAP G3, #1145).
+    match tokio::net::TcpListener::bind(&addr).await {
+        Ok(probe) => {
+            drop(probe);
+            ready.confirm();
+        }
+        Err(e) => {
+            let msg = format!("Failed to bind FTP server to {addr}: {e}");
+            ready.fail(&msg);
+            return Err(anyhow::anyhow!(msg));
+        }
+    }
 
     tracing::info!(addr, "FTP server listening (libunftp)");
 

--- a/src-tauri/src/embedded_servers/http_server.rs
+++ b/src-tauri/src/embedded_servers/http_server.rs
@@ -14,6 +14,7 @@ use axum::{middleware, Router};
 use tower_http::services::ServeDir;
 
 use super::config::{AtomicServerStats, EmbeddedServerConfig};
+use super::server_manager::BindSignal;
 
 /// State shared with middleware for connection tracking.
 #[derive(Clone)]
@@ -168,15 +169,25 @@ fn build_router(root: PathBuf, directory_listing: bool, tracking_state: Tracking
 /// Start and run the HTTP server, blocking until the shutdown flag is set.
 ///
 /// The function must be called from within a dedicated std thread that builds
-/// its own tokio runtime.
+/// its own tokio runtime. `ready` is signalled exactly once as soon as the
+/// listening socket is bound (or if binding fails), so the manager only reports
+/// `Running` after the bind is confirmed (GAP G3, #1145).
 pub fn start_http_server(
     config: &EmbeddedServerConfig,
     shutdown: Arc<AtomicBool>,
     stats: Arc<AtomicServerStats>,
+    ready: BindSignal,
 ) -> Result<()> {
-    let addr: SocketAddr = format!("{}:{}", config.bind_host, config.port)
+    let addr: SocketAddr = match format!("{}:{}", config.bind_host, config.port)
         .parse()
-        .context("Invalid bind address")?;
+        .context("Invalid bind address")
+    {
+        Ok(addr) => addr,
+        Err(e) => {
+            ready.fail(&e.to_string());
+            return Err(e);
+        }
+    };
 
     let root = PathBuf::from(&config.root_directory);
     let directory_listing = config.directory_listing.unwrap_or(false);
@@ -185,15 +196,32 @@ pub fn start_http_server(
     };
 
     // Build a tokio current-thread runtime in this thread.
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .context("Failed to build async runtime")?;
+        .context("Failed to build async runtime")
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            ready.fail(&e.to_string());
+            return Err(e);
+        }
+    };
 
     rt.block_on(async move {
-        let listener = tokio::net::TcpListener::bind(addr)
+        let listener = match tokio::net::TcpListener::bind(addr)
             .await
-            .context("Failed to bind HTTP server")?;
+            .context("Failed to bind HTTP server")
+        {
+            Ok(listener) => listener,
+            Err(e) => {
+                ready.fail(&e.to_string());
+                return Err(e);
+            }
+        };
+
+        // Bind confirmed — tell the manager it is safe to report Running.
+        ready.confirm();
 
         let router = build_router(root, directory_listing, tracking_state);
 

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tauri::{AppHandle, Emitter};
@@ -16,6 +18,40 @@ use super::storage::EmbeddedServerStorage;
 use super::tftp_server::start_tftp_server;
 use crate::connection::recovery::RecoveryWarning;
 use crate::utils::errors::TerminalError;
+
+/// How long the manager waits for a server thread to confirm its bind before
+/// treating the start as failed. Binding a local socket is near-instant, so a
+/// generous timeout only guards against a wedged thread (GAP G3, #1145).
+const BIND_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Decision the manager makes from a server thread's bind signal.
+#[derive(Debug)]
+enum BindOutcome {
+    /// The socket bound — keep the `active` entry and emit `Running`.
+    Running,
+    /// The bind failed (explicit error, dropped sender, or timeout) — drop the
+    /// `active` entry and emit `Error` with this reason.
+    Failed(String),
+}
+
+/// Map a server thread's bind signal (received over the confirm channel) to the
+/// manager's next action, so `Running` is only ever produced after a *confirmed*
+/// bind (GAP G3, #1145).
+///
+/// Pure and `AppHandle`-free so the start-flow decision can be unit-tested.
+#[allow(dead_code)]
+fn decide_bind_outcome(signal: Result<Result<(), String>, RecvTimeoutError>) -> BindOutcome {
+    match signal {
+        Ok(Ok(())) => BindOutcome::Running,
+        Ok(Err(reason)) => BindOutcome::Failed(reason),
+        Err(RecvTimeoutError::Disconnected) => {
+            BindOutcome::Failed("server exited before confirming it was listening".to_string())
+        }
+        Err(RecvTimeoutError::Timeout) => {
+            BindOutcome::Failed("server did not confirm it was listening in time".to_string())
+        }
+    }
+}
 
 /// A running server instance.
 struct ActiveServer {
@@ -371,6 +407,79 @@ fn auto_start_error_state(server_id: &str, error: &str) -> ServerState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc;
+
+    /// A successful bind signal must produce a `Running` outcome so the manager
+    /// keeps the `active` entry and emits `Running` (GAP G3, #1145).
+    #[test]
+    fn bind_success_signal_yields_running() {
+        let outcome = decide_bind_outcome(Ok(Ok(())));
+        assert!(
+            matches!(outcome, BindOutcome::Running),
+            "Ok(Ok(())) should map to Running, got {outcome:?}"
+        );
+    }
+
+    /// A late bind failure reported by the server thread must yield `Failed`
+    /// carrying the reason, so the manager emits `Error` and drops the `active`
+    /// entry instead of leaving the item stuck green (GAP G3, #1145).
+    #[test]
+    fn bind_failure_signal_yields_failed_with_reason() {
+        let outcome = decide_bind_outcome(Ok(Err("Port 8080 is already in use".to_string())));
+        match outcome {
+            BindOutcome::Failed(reason) => assert!(
+                reason.contains("already in use"),
+                "failure reason must be preserved, got: {reason}"
+            ),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    /// If the thread dies (panics / returns) before signalling, the sender is
+    /// dropped and `recv` reports `Disconnected` — this is a start failure, so
+    /// it must be `Failed`, never `Running` (GAP G3, #1145).
+    #[test]
+    fn bind_disconnected_signal_yields_failed() {
+        let outcome = decide_bind_outcome(Err(mpsc::RecvTimeoutError::Disconnected));
+        assert!(
+            matches!(outcome, BindOutcome::Failed(_)),
+            "a disconnected channel means the bind never confirmed, got {outcome:?}"
+        );
+    }
+
+    /// A bind that never confirms within the timeout must also be `Failed`, so
+    /// `Running` is only ever emitted after a *confirmed* bind (GAP G3, #1145).
+    #[test]
+    fn bind_timeout_signal_yields_failed() {
+        let outcome = decide_bind_outcome(Err(mpsc::RecvTimeoutError::Timeout));
+        assert!(
+            matches!(outcome, BindOutcome::Failed(_)),
+            "a timed-out bind is not a confirmed bind, got {outcome:?}"
+        );
+    }
+
+    /// End-to-end over the real channel: a thread that binds then signals success
+    /// must result in `Running`, while a thread that reports a bind error must
+    /// not — so no live `active` entry lingers on failure (GAP G3, #1145).
+    #[test]
+    fn real_channel_success_and_failure_paths() {
+        // Success path: sender reports Ok before the (simulated) serve loop.
+        let (tx, rx) = mpsc::sync_channel::<Result<(), String>>(1);
+        std::thread::spawn(move || {
+            let _ = tx.send(Ok(()));
+        });
+        let outcome = decide_bind_outcome(rx.recv_timeout(BIND_CONFIRM_TIMEOUT));
+        assert!(matches!(outcome, BindOutcome::Running));
+
+        // Failure path: sender reports a bind error and the manager must not
+        // treat it as running.
+        let (tx, rx) = mpsc::sync_channel::<Result<(), String>>(1);
+        std::thread::spawn(move || {
+            let _ = tx.send(Err("bind failed".to_string()));
+        });
+        let outcome = decide_bind_outcome(rx.recv_timeout(BIND_CONFIRM_TIMEOUT));
+        assert!(matches!(outcome, BindOutcome::Failed(_)));
+    }
 
     /// A port bound at boot must not cause a silent no-op: the auto-start
     /// failure has to surface as an `Error` state carrying the reason so the

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::RecvTimeoutError;
+use std::sync::mpsc::{RecvTimeoutError, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -24,6 +24,31 @@ use crate::utils::errors::TerminalError;
 /// generous timeout only guards against a wedged thread (GAP G3, #1145).
 const BIND_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// One-shot handle a server thread uses to report whether its listening socket
+/// bound successfully.
+///
+/// The manager holds the receiving end and only emits `Running` once
+/// [`BindSignal::confirm`] arrives; a [`BindSignal::fail`] (or a dropped sender)
+/// keeps the server out of the `active` map so it never shows a stuck "Running"
+/// before flipping to `Error` (GAP G3, #1145).
+pub(super) struct BindSignal {
+    tx: SyncSender<Result<(), String>>,
+}
+
+impl BindSignal {
+    /// Report that the listening socket bound successfully.
+    pub(super) fn confirm(&self) {
+        // A full/closed channel means the manager already gave up waiting; the
+        // send failure is harmless because the thread will still shut down.
+        let _ = self.tx.send(Ok(()));
+    }
+
+    /// Report that binding failed, carrying the reason for the UI.
+    pub(super) fn fail(&self, reason: &str) {
+        let _ = self.tx.send(Err(reason.to_string()));
+    }
+}
+
 /// Decision the manager makes from a server thread's bind signal.
 #[derive(Debug)]
 enum BindOutcome {
@@ -39,7 +64,6 @@ enum BindOutcome {
 /// bind (GAP G3, #1145).
 ///
 /// Pure and `AppHandle`-free so the start-flow decision can be unit-tested.
-#[allow(dead_code)]
 fn decide_bind_outcome(signal: Result<Result<(), String>, RecvTimeoutError>) -> BindOutcome {
     match signal {
         Ok(Ok(())) => BindOutcome::Running,
@@ -213,7 +237,8 @@ impl EmbeddedServerManager {
             }
         }
 
-        // Pre-flight bind check so we can return an error immediately.
+        // Pre-flight bind check so we can return an error immediately for the
+        // common "port already in use" case.
         self.check_port(&config)?;
 
         self.emit_status(server_id, ServerStatus::Starting, None);
@@ -221,6 +246,11 @@ impl EmbeddedServerManager {
         let shutdown = Arc::new(AtomicBool::new(false));
         let stats = AtomicServerStats::new();
         let error_slot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+        // One-slot channel the server thread uses to confirm (or reject) its
+        // real bind. `Running` is only emitted after this confirmation, so a
+        // late bind failure never leaves the item stuck green (GAP G3, #1145).
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel::<Result<(), String>>(1);
 
         let cfg = config.clone();
         let shutdown_clone = Arc::clone(&shutdown);
@@ -230,10 +260,11 @@ impl EmbeddedServerManager {
         let id = server_id.to_string();
 
         let thread_handle = thread::spawn(move || {
+            let ready = BindSignal { tx: ready_tx };
             let result = match cfg.server_type {
-                ServerType::Http => start_http_server(&cfg, shutdown_clone, stats_clone),
-                ServerType::Ftp => start_ftp_server(&cfg, shutdown_clone, stats_clone),
-                ServerType::Tftp => start_tftp_server(&cfg, shutdown_clone, stats_clone),
+                ServerType::Http => start_http_server(&cfg, shutdown_clone, stats_clone, ready),
+                ServerType::Ftp => start_ftp_server(&cfg, shutdown_clone, stats_clone, ready),
+                ServerType::Tftp => start_tftp_server(&cfg, shutdown_clone, stats_clone, ready),
             };
 
             if let Err(e) = result {
@@ -253,28 +284,40 @@ impl EmbeddedServerManager {
             }
         });
 
-        let started_at = chrono::Utc::now().to_rfc3339();
+        // Wait for the thread to confirm its bind before declaring Running.
+        match decide_bind_outcome(ready_rx.recv_timeout(BIND_CONFIRM_TIMEOUT)) {
+            BindOutcome::Running => {
+                let started_at = chrono::Utc::now().to_rfc3339();
+                {
+                    let mut active = self.active.lock().map_err(|e| {
+                        TerminalError::EmbeddedServerError(format!("Lock error: {e}"))
+                    })?;
+                    active.insert(
+                        server_id.to_string(),
+                        ActiveServer {
+                            shutdown,
+                            thread_handle,
+                            stats,
+                            started_at,
+                            error: error_slot,
+                        },
+                    );
+                }
 
-        {
-            let mut active = self
-                .active
-                .lock()
-                .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
-            active.insert(
-                server_id.to_string(),
-                ActiveServer {
-                    shutdown,
-                    thread_handle,
-                    stats,
-                    started_at,
-                    error: error_slot,
-                },
-            );
+                self.emit_status(server_id, ServerStatus::Running, None);
+                tracing::info!(%server_id, "Embedded server started");
+                Ok(())
+            }
+            BindOutcome::Failed(reason) => {
+                // Bind never confirmed. Signal the thread to unwind (in case it
+                // did bind but timed out) and leave nothing in `active`, so the
+                // server is reported as Error rather than a stuck Running.
+                shutdown.store(true, Ordering::Relaxed);
+                tracing::warn!(%server_id, "Embedded server failed to start: {reason}");
+                self.emit_status(server_id, ServerStatus::Error, Some(reason.clone()));
+                Err(TerminalError::EmbeddedServerError(reason))
+            }
         }
-
-        self.emit_status(server_id, ServerStatus::Running, None);
-        tracing::info!(%server_id, "Embedded server started");
-        Ok(())
     }
 
     /// Stop a running server by ID.

--- a/src-tauri/src/embedded_servers/tftp_server.rs
+++ b/src-tauri/src/embedded_servers/tftp_server.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 
 use super::config::{AtomicServerStats, EmbeddedServerConfig};
+use super::server_manager::BindSignal;
 
 // ─── TFTP opcodes (RFC 1350 §5) ──────────────────────────────────────────────
 
@@ -29,17 +30,36 @@ const ERR_ILLEGAL_OP: u16 = 4;
 // ─── Public entry point ───────────────────────────────────────────────────────
 
 /// Start the TFTP server in the current thread, blocking until the shutdown flag is set.
+///
+/// `ready` is signalled exactly once as soon as the listening UDP socket is
+/// bound (or if binding fails), so the manager only reports `Running` after the
+/// bind is confirmed (GAP G3, #1145).
 pub fn start_tftp_server(
     config: &EmbeddedServerConfig,
     shutdown: Arc<AtomicBool>,
     stats: Arc<AtomicServerStats>,
+    ready: BindSignal,
 ) -> Result<()> {
     let addr = format!("{}:{}", config.bind_host, config.port);
-    let socket =
-        UdpSocket::bind(&addr).with_context(|| format!("Failed to bind TFTP server to {addr}"))?;
-    socket
+    let socket = match UdpSocket::bind(&addr)
+        .with_context(|| format!("Failed to bind TFTP server to {addr}"))
+    {
+        Ok(socket) => socket,
+        Err(e) => {
+            ready.fail(&e.to_string());
+            return Err(e);
+        }
+    };
+    if let Err(e) = socket
         .set_read_timeout(Some(std::time::Duration::from_millis(100)))
-        .context("Failed to set UDP read timeout")?;
+        .context("Failed to set UDP read timeout")
+    {
+        ready.fail(&e.to_string());
+        return Err(e);
+    }
+
+    // Bind confirmed — tell the manager it is safe to report Running.
+    ready.confirm();
 
     let root = PathBuf::from(&config.root_directory);
     let read_only = config.read_only;


### PR DESCRIPTION
## Summary

Closes **GAP G3** of the embedded servers state-machine audit
(`docs/audits/embedded-servers-state-machine.md`): embedded HTTP/FTP/TFTP
servers used to report **Running** the instant the server thread was spawned,
before the real socket bind happened inside that thread. A late bind failure
(TOCTOU against the pre-flight `check_port` probe) left the sidebar item briefly
green, then flipping to red — or stuck green while nothing was listening.

## Changes

- Added a `BindSignal` (one-slot channel handle) that each server thread uses to
  **confirm** or **fail** its bind, plus a pure `decide_bind_outcome` helper that
  maps the received signal to the manager's next action.
- `EmbeddedServerManager::start_server` now waits on the bind signal
  (`BIND_CONFIRM_TIMEOUT`) and only emits **Running** + registers the `active`
  entry on a confirmed bind. On failure (explicit error, dropped sender, or
  timeout) it signals the thread to unwind, emits **Error** with the reason, and
  leaves **nothing** in `active` — so the state never desyncs.
- Per backend:
  - **HTTP** / **TFTP** confirm right after their explicit `bind`.
  - **FTP** probe-binds the control port before handing off to libunftp (which
    binds inside `listen` with no bound-callback), matching the existing
    pre-flight semantics.

## Test plan

- New unit tests on the pure `decide_bind_outcome` seam (no live `AppHandle`),
  mirroring the existing `check_port_config` / `auto_start_error_state` test
  pattern:
  - bind success → `Running`
  - bind failure → `Failed(reason)` (reason preserved)
  - dropped sender (`Disconnected`) → `Failed`
  - `Timeout` → `Failed`
  - end-to-end over a real `sync_channel` for both success and failure paths
- `cargo test -p termihub --lib embedded_servers` → 32 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

Partially addresses #1145 (G3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)