### PR TITLE
fix(network): HTTP monitors in Open Connections panel (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-open-connections-monitors.md
+++ b/docs/changes/dev2/feature/1147-open-connections-monitors.md
@@ -1,0 +1,3 @@
+## Added
+
+- The Open Connections panel now includes an "HTTP Monitors" group listing every running HTTP monitor (URL plus an up/down badge) with a per-row Stop and a Stop All button, so the panel that inspects and kills all live connections can now also see and stop the HTTP monitor poll loops.

--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -347,7 +347,9 @@ pub fn network_http_monitor_stop(
 /// Backs the "Kill All" action of the Open Connections panel's HTTP Monitors
 /// group (#1147). Reuses the same teardown as app shutdown.
 #[tauri::command]
-pub fn network_http_monitor_stop_all(manager: State<'_, NetworkManager>) -> Result<(), TerminalError> {
+pub fn network_http_monitor_stop_all(
+    manager: State<'_, NetworkManager>,
+) -> Result<(), TerminalError> {
     manager.stop_all_http_monitors();
     Ok(())
 }

--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -342,6 +342,16 @@ pub fn network_http_monitor_stop(
     manager.stop_http_monitor(&monitor_id)
 }
 
+/// Stop every running HTTP monitor at once.
+///
+/// Backs the "Kill All" action of the Open Connections panel's HTTP Monitors
+/// group (#1147). Reuses the same teardown as app shutdown.
+#[tauri::command]
+pub fn network_http_monitor_stop_all(manager: State<'_, NetworkManager>) -> Result<(), TerminalError> {
+    manager.stop_all_http_monitors();
+    Ok(())
+}
+
 /// List all HTTP monitors and their current state.
 #[tauri::command]
 pub fn network_http_monitor_list(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -578,6 +578,7 @@ pub fn run() {
             commands::network::network_wol_device_delete,
             commands::network::network_http_monitor_start,
             commands::network::network_http_monitor_stop,
+            commands::network::network_http_monitor_stop_all,
             commands::network::network_http_monitor_list,
             // Embedded servers
             commands::embedded_servers::list_embedded_servers,

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -98,12 +98,14 @@
 }
 
 .oc-row__badge--alive,
-.oc-row__badge--connected {
+.oc-row__badge--connected,
+.oc-row__badge--up {
   background: color-mix(in srgb, var(--color-success) 18%, transparent);
   color: var(--color-success);
 }
 
-.oc-row__badge--dead {
+.oc-row__badge--dead,
+.oc-row__badge--down {
   background: color-mix(in srgb, var(--color-error) 18%, transparent);
   color: var(--color-error);
 }

--- a/src/components/OpenConnections/OpenConnectionsModal.httpMonitors.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.httpMonitors.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Tests for the "HTTP Monitors" section of the Open Connections panel (#1147,
+ * GAP 9): running HTTP monitors were absent from the panel, contradicting its
+ * "every live subsystem" mandate. The section is driven by the store's live
+ * `httpMonitors` array (the single source of truth kept in sync by the Network
+ * Tools sidebar / check events), listing each monitor with a per-row Stop and a
+ * Kill-All wired to the stop actions.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { HttpMonitorState } from "@/types/network";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches when it
+// mounts its trigger; shim them so tooltip-wrapped controls render.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() => Promise.resolve([])),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+const networkHttpMonitorStop = vi.fn((_id: string) => Promise.resolve());
+const networkHttpMonitorStopAll = vi.fn(() => Promise.resolve());
+const networkHttpMonitorList = vi.fn(() => Promise.resolve([] as HttpMonitorState[]));
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStop: (id: string) => networkHttpMonitorStop(id),
+  networkHttpMonitorStopAll: () => networkHttpMonitorStopAll(),
+  networkHttpMonitorList: () => networkHttpMonitorList(),
+}));
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+function monitorState(id: string, url: string, ok: boolean): HttpMonitorState {
+  return {
+    config: {
+      id,
+      url,
+      intervalMs: 5000,
+      method: "GET",
+      expectedStatus: 200,
+      timeoutMs: 10000,
+    },
+    running: true,
+    lastResult: {
+      monitorId: id,
+      ok,
+      statusCode: ok ? 200 : 503,
+      latencyMs: 12,
+      timestampMs: Date.now(),
+    },
+  };
+}
+
+function monitorSection(): HTMLElement | null {
+  const title = Array.from(document.querySelectorAll(".oc-section__title")).find(
+    (t) => t.textContent === "HTTP Monitors"
+  );
+  return (title?.closest("div")?.parentElement as HTMLElement) ?? null;
+}
+
+function monitorRows(): Element[] {
+  return Array.from(monitorSection()?.querySelectorAll(".oc-row") ?? []);
+}
+
+describe("OpenConnectionsModal — HTTP Monitors section", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    networkHttpMonitorStop.mockClear();
+    networkHttpMonitorStopAll.mockClear();
+    networkHttpMonitorList.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderModal() {
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
+      );
+    });
+  }
+
+  it("renders a row per running monitor from the store's httpMonitors", () => {
+    useAppStore.setState({
+      httpMonitors: [
+        monitorState("m1", "https://up.example.com", true),
+        monitorState("m2", "https://down.example.com", false),
+      ],
+    });
+
+    renderModal();
+
+    const titles = monitorRows().map((r) => r.querySelector(".oc-row__title")?.textContent);
+    expect(titles.some((t) => t?.includes("https://up.example.com"))).toBe(true);
+    expect(titles.some((t) => t?.includes("https://down.example.com"))).toBe(true);
+  });
+
+  it("shows an up/down badge derived from the last result", () => {
+    useAppStore.setState({
+      httpMonitors: [
+        monitorState("m1", "https://up.example.com", true),
+        monitorState("m2", "https://down.example.com", false),
+      ],
+    });
+
+    renderModal();
+
+    const badges = monitorRows().map((r) => r.querySelector(".oc-row__badge")?.textContent);
+    expect(badges).toContain("up");
+    expect(badges).toContain("down");
+  });
+
+  it("stops a single monitor via networkHttpMonitorStop", async () => {
+    useAppStore.setState({
+      httpMonitors: [monitorState("m1", "https://up.example.com", true)],
+    });
+
+    renderModal();
+
+    const killBtn = monitorRows()[0]?.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      killBtn.click();
+    });
+
+    expect(networkHttpMonitorStop).toHaveBeenCalledWith("m1");
+  });
+
+  it("Kill-All stops every monitor via networkHttpMonitorStopAll", async () => {
+    useAppStore.setState({
+      httpMonitors: [
+        monitorState("m1", "https://up.example.com", true),
+        monitorState("m2", "https://down.example.com", false),
+      ],
+    });
+
+    renderModal();
+
+    const killAll = monitorSection()?.querySelector(".oc-section__kill-all") as HTMLButtonElement;
+    await act(async () => {
+      killAll.click();
+    });
+
+    expect(networkHttpMonitorStopAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no HTTP Monitors section when there are no monitors", () => {
+    renderModal();
+    expect(monitorSection()).toBeNull();
+  });
+});

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -7,9 +7,10 @@ import {
   Activity,
   MonitorStop,
   MonitorCog,
+  Globe,
   Loader2,
 } from "lucide-react";
-import { Modal, Button, Tooltip } from "@/components/ui";
+import { Modal, Button, Tooltip, toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
 import {
@@ -23,6 +24,12 @@ import {
   LocalSessionInfo,
   AgentSessionInfo,
 } from "@/services/api";
+import {
+  networkHttpMonitorStop,
+  networkHttpMonitorStopAll,
+  networkHttpMonitorList,
+} from "@/services/networkApi";
+import { frontendLog } from "@/utils/frontendLog";
 import { XServerStatusReport } from "@/types/xserver";
 import { XServerSetupDialog } from "./XServerSetupDialog";
 import "./OpenConnectionsModal.css";
@@ -56,6 +63,11 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const disconnectSftp = useAppStore((s) => s.disconnectSftp);
   const monitoringHost = useAppStore((s) => s.monitoringHost);
   const disconnectMonitoring = useAppStore((s) => s.disconnectMonitoring);
+  // Live source of truth for HTTP monitors (kept current by the Network Tools
+  // sidebar / check events); the panel reads it directly so it stays in sync
+  // and this "kill everything" surface can see and stop the poll loops (#1147).
+  const httpMonitors = useAppStore((s) => s.httpMonitors);
+  const setHttpMonitors = useAppStore((s) => s.setHttpMonitors);
   const rootPanel = useAppStore((s) => s.rootPanel);
   const terminalConnecting = useAppStore((s) => s.terminalConnecting);
   const closeTab = useAppStore((s) => s.closeTab);
@@ -137,6 +149,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     activeTunnels.length +
     (sftpConnectedHost ? 1 : 0) +
     (monitoringHost ? 1 : 0) +
+    httpMonitors.length +
     (showXServer ? 1 : 0);
 
   const handleCancelConnecting = async (tabId: string, panelId: string) => {
@@ -219,6 +232,38 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const handleStopXServer = async () => {
     await xServerStop().catch(() => {});
     setXServer(null);
+  };
+
+  // Refresh the store's live monitor list after a stop so the section reflects
+  // the change immediately (the sidebar keeps it current the rest of the time).
+  const refreshHttpMonitors = async () => {
+    try {
+      setHttpMonitors(await networkHttpMonitorList());
+    } catch (err) {
+      frontendLog("open_connections", `Failed to refresh HTTP monitors: ${err}`);
+    }
+  };
+
+  const handleStopHttpMonitor = async (monitorId: string) => {
+    try {
+      await networkHttpMonitorStop(monitorId);
+      await refreshHttpMonitors();
+      toast.success("Monitor stopped");
+    } catch (err) {
+      frontendLog("open_connections", `Failed to stop HTTP monitor: ${err}`);
+      toast.error(`Failed to stop monitor: ${err}`);
+    }
+  };
+
+  const handleStopAllHttpMonitors = async () => {
+    try {
+      await networkHttpMonitorStopAll();
+      await refreshHttpMonitors();
+      toast.success("All monitors stopped");
+    } catch (err) {
+      frontendLog("open_connections", `Failed to stop all HTTP monitors: ${err}`);
+      toast.error(`Failed to stop monitors: ${err}`);
+    }
   };
 
   return (
@@ -406,6 +451,29 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           </Section>
         )}
 
+        {/* HTTP Monitors (backend-owned polling loops) */}
+        {httpMonitors.length > 0 && (
+          <Section
+            title="HTTP Monitors"
+            icon={<Globe size={14} />}
+            count={httpMonitors.length}
+            onKillAll={handleStopAllHttpMonitors}
+            killAllLabel="Stop All"
+            data-testid="open-connections-http-monitors-section"
+          >
+            {httpMonitors.map((m) => (
+              <ConnectionRow
+                key={m.config.id}
+                icon={<Globe size={14} />}
+                title={m.config.url}
+                badge={m.lastResult ? (m.lastResult.ok ? "up" : "down") : "connecting"}
+                onKill={() => handleStopHttpMonitor(m.config.id)}
+                killLabel="Stop"
+              />
+            ))}
+          </Section>
+        )}
+
         {/* X Servers (the single shared X server, or a Set up affordance) */}
         {(showXServer || showXServerSetup) && (
           <Section
@@ -506,7 +574,15 @@ function Section({
   );
 }
 
-type BadgeVariant = "alive" | "dead" | "connected" | "connecting" | "managed" | "external";
+type BadgeVariant =
+  | "alive"
+  | "dead"
+  | "connected"
+  | "connecting"
+  | "managed"
+  | "external"
+  | "up"
+  | "down";
 
 interface ConnectionRowProps {
   icon: React.ReactNode;

--- a/src/services/networkApi.test.ts
+++ b/src/services/networkApi.test.ts
@@ -28,6 +28,7 @@ import {
   networkWolDeviceDelete,
   networkHttpMonitorStart,
   networkHttpMonitorStop,
+  networkHttpMonitorStopAll,
   networkHttpMonitorList,
   onScanResult,
   onScanComplete,
@@ -281,6 +282,14 @@ describe("networkApi", () => {
       expect(mockedInvoke).toHaveBeenCalledWith("network_http_monitor_stop", {
         monitorId: "monitor-1",
       });
+    });
+
+    it("networkHttpMonitorStopAll invokes stop-all command", async () => {
+      mockedInvoke.mockResolvedValue(undefined);
+
+      await networkHttpMonitorStopAll();
+
+      expect(mockedInvoke).toHaveBeenCalledWith("network_http_monitor_stop_all");
     });
 
     it("networkHttpMonitorList returns all monitors", async () => {

--- a/src/services/networkApi.ts
+++ b/src/services/networkApi.ts
@@ -163,6 +163,11 @@ export async function networkHttpMonitorStop(monitorId: string): Promise<void> {
   await invoke("network_http_monitor_stop", { monitorId });
 }
 
+/** Stop every running HTTP monitor at once (Kill All). */
+export async function networkHttpMonitorStopAll(): Promise<void> {
+  await invoke("network_http_monitor_stop_all");
+}
+
 /** List all HTTP monitors and their current state. */
 export async function networkHttpMonitorList(): Promise<HttpMonitorState[]> {
   return await invoke<HttpMonitorState[]>("network_http_monitor_list");

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -268,6 +268,7 @@ Fixed strings — match exactly.
 | `network-monitors-section` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-new-monitor` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-tools-sidebar` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
+| `open-connections-http-monitors-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-empty` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-row` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-setup` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |


### PR DESCRIPTION
## Summary

The Open Connections panel is termiHub's canonical "inspect and kill every live subsystem" surface, but running HTTP monitors (network tools) were absent from it — contradicting that mandate (audit gap #9, `docs/audits/http-monitor-state-machine.md`).

This adds an **HTTP Monitors** group to the panel listing each running monitor (URL + an up/down badge) with a per-row **Stop** and a **Stop All** button, so a user hunting a leak can finally see and stop the backend poll loops from the same place they stop tunnels, SFTP, and monitoring.

## Changes

- **UI:** New "HTTP Monitors" section in `OpenConnectionsModal`, driven by the store's live `httpMonitors` array (the same source of truth the Network Tools sidebar keeps current via check events) — no one-shot fetch, so it stays in sync while the panel is open. Per-row **Stop** + section **Stop All**, each with `toast` success/error feedback and `frontendLog` diagnostics. New `up`/`down` badge tokens.
- **Backend:** New `network_http_monitor_stop_all` Tauri command wrapping the existing `NetworkManager::stop_all_http_monitors` (registered in `lib.rs`).
- **API:** New `networkHttpMonitorStopAll` wrapper in `networkApi.ts`.

## Test plan

- `pnpm test` (full suite)
- New `OpenConnectionsModal.httpMonitors.test.tsx`: renders a row per monitor from the store, up/down badges, per-row Stop → `networkHttpMonitorStop`, Stop All → `networkHttpMonitorStopAll`, and no section when empty.
- New `networkApi.test.ts` case covering the stop-all wrapper.
- Existing manager unit tests already cover `stop_all_http_monitors` teardown.

Partially addresses #1147 (#9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
