### PR TITLE
fix(network): notify on HTTP monitor up/down transitions (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-monitor-updown-notify.md
+++ b/docs/changes/dev2/feature/1147-monitor-updown-notify.md
@@ -1,0 +1,9 @@
+### Added
+
+- HTTP monitors now surface up/down transitions as toast notifications
+  app-wide, regardless of which view is on-screen. When a monitored endpoint
+  goes down you get an error toast; when it recovers you get a success toast.
+  Only the transition edge fires (not every poll), so a persistently-down
+  endpoint is reported once, and a monitor's first check establishes a silent
+  baseline. Previously an up/down change was silent unless the Network Tools
+  sidebar or HTTP Monitor panel happened to be open (#1147).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useTunnelEvents } from "@/hooks/useTunnelEvents";
 import { useEmbeddedServerEvents } from "@/hooks/useEmbeddedServerEvents";
 import { useCredentialStoreEvents } from "@/hooks/useCredentialStoreEvents";
+import { useHttpMonitorNotifications } from "@/hooks/useHttpMonitorNotifications";
 import { useWebviewZoom } from "@/hooks/useWebviewZoom";
 import { useSidebarResize } from "@/hooks/useSidebarResize";
 import { useAppStore } from "@/store/appStore";
@@ -99,6 +100,7 @@ function App() {
   useTunnelEvents();
   useEmbeddedServerEvents();
   useCredentialStoreEvents();
+  useHttpMonitorNotifications();
   useWebviewZoom();
   const loadFromBackend = useAppStore((s) => s.loadFromBackend);
   const checkForUpdates = useAppStore((s) => s.checkForUpdates);

--- a/src/hooks/useHttpMonitorNotifications.test.ts
+++ b/src/hooks/useHttpMonitorNotifications.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+vi.mock("@/services/networkApi", () => ({
+  onHttpMonitorCheck: vi.fn(),
+}));
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { onHttpMonitorCheck } from "@/services/networkApi";
+import { toast } from "@/components/ui";
+import type { HttpCheckResult } from "@/types/network";
+import { useHttpMonitorNotifications } from "./useHttpMonitorNotifications";
+
+const mockOnCheck = vi.mocked(onHttpMonitorCheck);
+const mockToast = vi.mocked(toast);
+
+function HookConsumer() {
+  useHttpMonitorNotifications();
+  return null;
+}
+
+function makeResult(overrides: Partial<HttpCheckResult> = {}): HttpCheckResult {
+  return {
+    monitorId: "mon-1",
+    statusCode: 200,
+    latencyMs: 12,
+    ok: true,
+    timestampMs: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("useHttpMonitorNotifications", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let checkHandler: ((result: HttpCheckResult) => void) | undefined;
+  const unlisten = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnCheck.mockImplementation((cb) => {
+      checkHandler = cb;
+      return Promise.resolve(unlisten);
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function mount() {
+    await act(async () => {
+      root.render(createElement(HookConsumer));
+    });
+  }
+
+  function emit(result: HttpCheckResult) {
+    act(() => {
+      checkHandler?.(result);
+    });
+  }
+
+  it("registers the check listener on mount", async () => {
+    await mount();
+    expect(mockOnCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not toast on the very first result (no previous state to diff)", async () => {
+    await mount();
+    emit(makeResult({ ok: false, error: "boom" }));
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
+
+  it("fires a down toast exactly once on an ok -> !ok edge", async () => {
+    await mount();
+    emit(makeResult({ ok: true }));
+    emit(makeResult({ ok: false, error: "500 Internal Server Error" }));
+
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
+
+  it("does not re-fire the down toast while steady-state down", async () => {
+    await mount();
+    emit(makeResult({ ok: true }));
+    emit(makeResult({ ok: false, error: "down" }));
+    emit(makeResult({ ok: false, error: "down" }));
+    emit(makeResult({ ok: false, error: "down" }));
+
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires a recovery toast exactly once on a !ok -> ok edge", async () => {
+    await mount();
+    emit(makeResult({ ok: true }));
+    emit(makeResult({ ok: false, error: "down" }));
+    mockToast.success.mockClear();
+    emit(makeResult({ ok: true, statusCode: 200 }));
+
+    expect(mockToast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-fire on steady-state up", async () => {
+    await mount();
+    emit(makeResult({ ok: true }));
+    emit(makeResult({ ok: true }));
+    emit(makeResult({ ok: true }));
+
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("tracks previous ok independently per monitor id", async () => {
+    await mount();
+    // mon-1 establishes up, then goes down.
+    emit(makeResult({ monitorId: "mon-1", ok: true }));
+    // mon-2 establishes down as its first result (no toast), then recovers.
+    emit(makeResult({ monitorId: "mon-2", ok: false, error: "down" }));
+    expect(mockToast.error).not.toHaveBeenCalled();
+
+    emit(makeResult({ monitorId: "mon-1", ok: false, error: "down" }));
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+
+    emit(makeResult({ monitorId: "mon-2", ok: true }));
+    expect(mockToast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes the listener on unmount", async () => {
+    await mount();
+    act(() => root.unmount());
+    root = createRoot(container);
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useHttpMonitorNotifications.ts
+++ b/src/hooks/useHttpMonitorNotifications.ts
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+import { onHttpMonitorCheck } from "@/services/networkApi";
+import { toast } from "@/components/ui";
+import type { HttpCheckResult } from "@/types/network";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * Global hook that surfaces HTTP monitor up/down transitions as toasts.
+ *
+ * The `network-http-monitor-check` event is broadcast on every poll, but nothing
+ * previously diffed the previous vs. current `ok` state — so an endpoint going
+ * down (or recovering) was silent unless the Network Tools sidebar/panel happened
+ * to be on-screen. This hook is mounted once at the app root, tracks the last
+ * known `ok` per monitor id, and fires a toast only on the *edge*:
+ *
+ * - up → down: `toast.error`
+ * - down → up: `toast.success`
+ *
+ * The very first result for a monitor establishes a baseline and never toasts
+ * (there is no previous state to diff against). Steady-state polls (up→up,
+ * down→down) are silent, so a persistently-down endpoint is reported once, not
+ * on every interval.
+ */
+export function useHttpMonitorNotifications(): void {
+  useEffect(() => {
+    // Previous `ok` per monitor id. Not React state: the value is only read
+    // inside the event callback and must never trigger a re-render.
+    const previousOk = new Map<string, boolean>();
+    let unlisten: (() => void) | null = null;
+    let disposed = false;
+
+    onHttpMonitorCheck((result: HttpCheckResult) => {
+      const prev = previousOk.get(result.monitorId);
+      previousOk.set(result.monitorId, result.ok);
+
+      // No baseline yet — record it and stay silent.
+      if (prev === undefined || prev === result.ok) return;
+
+      if (!result.ok) {
+        const detail =
+          result.error ?? (result.statusCode ? `HTTP ${result.statusCode}` : "no response");
+        frontendLog("http_monitor_notify", `monitor ${result.monitorId} went DOWN: ${detail}`);
+        toast.error(`Monitor down: ${detail}`);
+      } else {
+        const detail = result.statusCode ? `HTTP ${result.statusCode}` : "OK";
+        frontendLog("http_monitor_notify", `monitor ${result.monitorId} recovered: ${detail}`);
+        toast.success(`Monitor recovered: ${detail}`);
+      }
+    })
+      .then((fn) => {
+        if (disposed) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((err) => frontendLog("http_monitor_notify", `Failed to subscribe to checks: ${err}`));
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

Fixes GAP #2 from the HTTP monitor state-machine audit (`docs/audits/http-monitor-state-machine.md`): an HTTP monitor going up→down (or recovering down→up) was **silent** unless the Network Tools sidebar or HTTP Monitor panel happened to be on-screen — nothing anywhere diffed the previous vs. current check result, so no edge alert could fire. For a "monitor," that's the single biggest UX gap.

## Changes

- New global `useHttpMonitorNotifications` hook (`src/hooks/useHttpMonitorNotifications.ts`), mounted once at the app root in `App.tsx` alongside the other event hooks (`useTunnelEvents`, `useEmbeddedServerEvents`, …). It subscribes to the existing `network-http-monitor-check` broadcast, tracks the last `ok` per monitor id, and fires a toast **only on the edge**:
  - up → down → `toast.error("Monitor down: …")`
  - down → up → `toast.success("Monitor recovered: …")`
- Being global, it works whether or not any network view is mounted.
- The first result for a monitor establishes a silent baseline (nothing to diff); steady-state polls (up→up, down→down) are silent, so a persistently-down endpoint is reported **once**, not every interval.
- Uses `frontendLog` (never `console.*`); toasts come from the shared `ui` primitive; no new tokens/magic values. No OS notifications or persistence (those are separate audit gaps #2's out-of-scope siblings).

## Test plan

- New unit test `src/hooks/useHttpMonitorNotifications.test.ts` (TDD, committed before the fix) covers: no toast on first result; down toast fires exactly once on ok→!ok; no re-fire in steady-state down; recovery toast fires exactly once on !ok→ok; no toast on steady-state up; per-monitor-id independence; listener unsubscribed on unmount.
- `pnpm test` — full suite green (214 files, 2338 tests).
- `pnpm build` (tsc + vite), `pnpm run lint`, `pnpm run format:check` — all pass.

Partially addresses #1147 (#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)