### PR TITLE
fix(credential): unify + harden unlock gating (#1144)

### DIFF
--- a/docs/changes/dev2/feature/1144-unlock-gating.md
+++ b/docs/changes/dev2/feature/1144-unlock-gating.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Credential store unlock gating is now unified and hardened across all connect
+  paths (#1144). Connecting from the connection editor's "Save & Connect" now
+  prompts to unlock a locked master-password store before using a saved
+  credential, instead of silently falling back to an interactive password prompt
+  (G3). All four connect paths (sidebar connection, agent, agent reconnect,
+  connection editor) now share a single unlock gate that runs before credential
+  resolution, so the unlock dialog is the primary trigger rather than an
+  after-the-fact event (G2). Two connect actions hitting a locked store at the
+  same time no longer wedge one of them forever — every unlock request now
+  settles exactly once on any dialog exit, including wrong-password-then-dismiss
+  (G1).

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -328,6 +328,46 @@ describe("ConnectionEditor — Save & Connect credential handling", () => {
     expect(useAppStore.getState().passwordPromptOpen).toBe(true);
   });
 
+  it("prompts to unlock the credential store before resolving when locked (G3, #1144)", async () => {
+    // Regression: Save & Connect was the only connect path missing the
+    // mode===master_password && status===locked unlock gate. With the store
+    // locked it silently fell back to an interactive password prompt instead
+    // of first offering to unlock and use the saved credential. It must now
+    // call requestUnlock() before resolveCredential, matching the sidebar path.
+    const mockRequestUnlock = vi.fn().mockResolvedValue(false); // user dismisses
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+      requestUnlock: mockRequestUnlock,
+    });
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "resolve_credential") return Promise.resolve("vault-secret");
+      if (cmd === "save_connection") return Promise.resolve();
+      if (cmd === "load_connections_and_folders")
+        return Promise.resolve({ connections: [SSH_CONN_PASSWORD, SSH_CONN_KEY], folders: [] });
+      return Promise.resolve(null);
+    });
+
+    renderFor(SSH_CONN_PASSWORD.id);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const btn = container.querySelector(
+      '[data-testid="connection-editor-save-connect"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The unlock gate must fire on the locked store.
+    expect(mockRequestUnlock).toHaveBeenCalledTimes(1);
+    // Dismissed unlock aborts the connect — no interactive password prompt.
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+
   it("prompts for the key passphrase on key auth when the key is encrypted (#879/#885)", async () => {
     // SSH_CONN_KEY uses key auth. The password field is hidden for key auth, so
     // findPasswordPromptInfo returns null — but a passphrase-protected key still

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/services/api";
 import { frontendLog } from "@/utils/frontendLog";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
+import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
 import type { ConnectionTypeInfo } from "@/services/api";
 import {
   SavedConnection,
@@ -809,6 +810,17 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         let resolvedPassword: string | null = null;
         if (authMethod) {
           const savePasswordFlag = connSettings.savePassword as boolean | undefined;
+          // Unlock gate (G3, #1144): if the store is a locked master-password
+          // store, prompt for unlock first so the saved credential can be read —
+          // otherwise resolveCredential returns null and Save & Connect silently
+          // falls back to an interactive prompt, ignoring the stored secret. This
+          // matches the sidebar/agent/workspace connect paths.
+          const proceed = await ensureCredentialStoreUnlocked({
+            authMethod,
+            savePassword: savePasswordFlag,
+          });
+          if (!proceed) return;
+
           const resolution = await resolveConnectionCredential(
             saved.id,
             authMethod,

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/services/api";
 import { classifyAgentError, ClassifiedAgentError } from "@/utils/classifyAgentError";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
+import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
 import { computeFlatVisibleIds } from "@/utils/computeFlatVisibleIds";
 import { AgentSetupDialog } from "./AgentSetupDialog";
@@ -606,16 +607,11 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
     // If the credential store is locked and this agent uses a stored credential,
     // prompt for unlock first and wait — on success the code continues and the
     // credential resolves automatically.
-    const needsStoredCredential =
-      agent.config.authMethod === "password" ||
-      (agent.config.authMethod === "key" && agent.config.savePassword);
-    if (needsStoredCredential) {
-      const credStatus = useAppStore.getState().credentialStoreStatus;
-      if (credStatus?.mode === "master_password" && credStatus?.status === "locked") {
-        const unlocked = await useAppStore.getState().requestUnlock();
-        if (!unlocked) return;
-      }
-    }
+    const proceed = await ensureCredentialStoreUnlocked({
+      authMethod: agent.config.authMethod,
+      savePassword: agent.config.savePassword,
+    });
+    if (!proceed) return;
 
     setConnecting(true);
     try {

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -44,6 +44,7 @@ import { frontendLog } from "@/utils/frontendLog";
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { Tooltip } from "@/components/ui";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
+import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
 import { useSectionResize } from "@/hooks/useSectionResize";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
 import { computeFlatVisibleIds } from "@/utils/computeFlatVisibleIds";
@@ -478,15 +479,8 @@ export function ConnectionList() {
         // is locked. If it is, we can't read the stored credential and SSH would fall
         // back to interactive password prompts. Prompt for unlock first and wait —
         // on success the code continues and the credential resolves automatically.
-        const needsStoredCredential =
-          authMethod === "password" || (authMethod === "key" && savePassword);
-        if (needsStoredCredential) {
-          const credStatus = useAppStore.getState().credentialStoreStatus;
-          if (credStatus?.mode === "master_password" && credStatus?.status === "locked") {
-            const unlocked = await useAppStore.getState().requestUnlock();
-            if (!unlocked) return;
-          }
-        }
+        const proceed = await ensureCredentialStoreUnlocked({ authMethod, savePassword });
+        if (!proceed) return;
 
         // Try to resolve credential from the store first
         const resolution = await resolveConnectionCredential(

--- a/src/components/Terminal/AgentErrorTab.tsx
+++ b/src/components/Terminal/AgentErrorTab.tsx
@@ -3,6 +3,7 @@ import { WifiOff, RefreshCw } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { AgentErrorMeta } from "@/types/terminal";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
+import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
 import "./AgentErrorTab.css";
 
 interface AgentErrorTabProps {
@@ -33,26 +34,23 @@ export function AgentErrorTab({ tabId: _tabId, meta, isVisible }: AgentErrorTabP
       let password: string | undefined;
 
       if (agent) {
-        const needsStoredCredential =
-          agent.config.authMethod === "password" ||
-          (agent.config.authMethod === "key" && agent.config.savePassword);
-        if (needsStoredCredential) {
-          const credStatus = storeState.credentialStoreStatus;
-          if (credStatus?.mode === "master_password" && credStatus?.status === "locked") {
-            const unlocked = await useAppStore.getState().requestUnlock();
-            if (!unlocked) {
-              setIsReconnecting(false);
-              return;
-            }
-          }
-          const resolution = await resolveConnectionCredential(
-            meta.agentId,
-            agent.config.authMethod,
-            agent.config.savePassword
-          );
-          if (resolution.usedStoredCredential && resolution.password) {
-            password = resolution.password;
-          }
+        // Unlock the credential store first if it's a locked master-password
+        // store and this agent uses a stored credential (no-op otherwise).
+        const proceed = await ensureCredentialStoreUnlocked({
+          authMethod: agent.config.authMethod,
+          savePassword: agent.config.savePassword,
+        });
+        if (!proceed) {
+          setIsReconnecting(false);
+          return;
+        }
+        const resolution = await resolveConnectionCredential(
+          meta.agentId,
+          agent.config.authMethod,
+          agent.config.savePassword
+        );
+        if (resolution.usedStoredCredential && resolution.password) {
+          password = resolution.password;
         }
       }
 

--- a/src/hooks/useCredentialStoreEvents.test.ts
+++ b/src/hooks/useCredentialStoreEvents.test.ts
@@ -176,7 +176,7 @@ describe("useCredentialStoreEvents", () => {
     const result = await unlockPromise;
     expect(result).toBe(true);
     expect(useAppStore.getState().unlockDialogOpen).toBe(false);
-    expect(useAppStore.getState().unlockResolve).toBeNull();
+    expect(useAppStore.getState().unlockResolvers).toHaveLength(0);
   });
 
   it("resolves requestUnlock() with false when dialog is closed without unlock", async () => {
@@ -194,7 +194,7 @@ describe("useCredentialStoreEvents", () => {
 
     const result = await unlockPromise;
     expect(result).toBe(false);
-    expect(useAppStore.getState().unlockResolve).toBeNull();
+    expect(useAppStore.getState().unlockResolvers).toHaveLength(0);
   });
 
   it("updates credential store status when status-changed event fires", async () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -736,15 +736,20 @@ interface AppState {
   loadCredentialStoreStatus: () => Promise<void>;
   unlockDialogOpen: boolean;
   setUnlockDialogOpen: (open: boolean) => void;
-  /** Pending resolver for requestUnlock(). Internal — resolved by resolveUnlock(). */
-  unlockResolve: ((unlocked: boolean) => void) | null;
+  /**
+   * Pending resolvers for in-flight requestUnlock() calls. Internal — settled by
+   * resolveUnlock(). Held as a list so that concurrent connect flows each awaiting
+   * requestUnlock() all settle on a single dialog exit; a single resolver would
+   * be overwritten by the second caller, wedging the first connect forever (G1).
+   */
+  unlockResolvers: ((unlocked: boolean) => void)[];
   /**
    * Opens the unlock dialog and returns a Promise that resolves to `true` when the
    * store is successfully unlocked, or `false` when the user cancels/skips.
    * Callers can `await` this before proceeding with a credential-dependent action.
    */
   requestUnlock: () => Promise<boolean>;
-  /** Resolves (and clears) any pending requestUnlock() promise. */
+  /** Settles (and clears) every pending requestUnlock() promise. Idempotent. */
   resolveUnlock: (unlocked: boolean) => void;
   masterPasswordSetupOpen: boolean;
   masterPasswordSetupMode: "setup" | "change";
@@ -4280,16 +4285,26 @@ export const useAppStore = create<AppState>((set, get) => {
         get().resolveUnlock(false);
       }
     },
-    unlockResolve: null,
+    unlockResolvers: [],
     requestUnlock: () =>
       new Promise<boolean>((resolve) => {
-        set({ unlockDialogOpen: true, unlockResolve: resolve });
+        // Append rather than replace: two concurrent connect flows may both await
+        // requestUnlock() before the dialog resolves. Every awaiting caller must
+        // settle on the single dialog exit (G1) — overwriting a single resolver
+        // would leave the earlier connect wedged forever.
+        set((state) => ({
+          unlockDialogOpen: true,
+          unlockResolvers: [...state.unlockResolvers, resolve],
+        }));
       }),
     resolveUnlock: (unlocked) => {
-      const { unlockResolve } = get();
-      if (unlockResolve) {
-        unlockResolve(unlocked);
-        set({ unlockResolve: null });
+      const { unlockResolvers } = get();
+      if (unlockResolvers.length === 0) return;
+      // Clear first so a re-entrant resolveUnlock() (e.g. the unlocked event and a
+      // dialog-close both firing) is a harmless no-op — every promise settles once.
+      set({ unlockResolvers: [] });
+      for (const resolve of unlockResolvers) {
+        resolve(unlocked);
       }
     },
     masterPasswordSetupOpen: false,

--- a/src/store/appStore.unlockGating.test.ts
+++ b/src/store/appStore.unlockGating.test.ts
@@ -24,7 +24,7 @@ describe("appStore unlock gating — requestUnlock() settlement (G1)", () => {
   beforeEach(() => {
     useAppStore.setState({
       unlockDialogOpen: false,
-      unlockResolve: null,
+      unlockResolvers: [],
     });
   });
 
@@ -52,7 +52,7 @@ describe("appStore unlock gating — requestUnlock() settlement (G1)", () => {
     const promise = useAppStore.getState().requestUnlock();
     useAppStore.getState().resolveUnlock(true);
     await expect(promise).resolves.toBe(true);
-    expect(useAppStore.getState().unlockResolve).toBeNull();
+    expect(useAppStore.getState().unlockResolvers).toHaveLength(0);
 
     // A second resolveUnlock() must be a harmless no-op.
     expect(() => useAppStore.getState().resolveUnlock(false)).not.toThrow();
@@ -68,7 +68,7 @@ describe("appStore unlock gating — requestUnlock() settlement (G1)", () => {
     useAppStore.getState().resolveUnlock(true);
 
     await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
-    expect(useAppStore.getState().unlockResolve).toBeNull();
+    expect(useAppStore.getState().unlockResolvers).toHaveLength(0);
   });
 
   it("settles both concurrent promises when the dialog is dismissed", async () => {

--- a/src/store/appStore.unlockGating.test.ts
+++ b/src/store/appStore.unlockGating.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+import { useAppStore } from "./appStore";
+
+/**
+ * G1 — every requestUnlock() promise must settle exactly once on any dialog exit,
+ * including the fragile paths: wrong-password-then-dismiss and two concurrent
+ * unlock requests. A promise that never resolves wedges the awaiting connect forever.
+ */
+describe("appStore unlock gating — requestUnlock() settlement (G1)", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      unlockDialogOpen: false,
+      unlockResolve: null,
+    });
+  });
+
+  it("resolves the pending promise as false when the dialog is dismissed (wrong password → close)", async () => {
+    const promise = useAppStore.getState().requestUnlock();
+    expect(useAppStore.getState().unlockDialogOpen).toBe(true);
+
+    // User typed a wrong password (inline error, dialog stays open), then closed
+    // it via the X / overlay / Esc — all route through setUnlockDialogOpen(false).
+    useAppStore.getState().setUnlockDialogOpen(false);
+
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("resolves the pending promise as true when the backend reports unlocked", async () => {
+    const promise = useAppStore.getState().requestUnlock();
+
+    // The credential-store-unlocked event handler calls resolveUnlock(true).
+    useAppStore.getState().resolveUnlock(true);
+
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("does not leave a stale resolver after settlement (idempotent resolveUnlock)", async () => {
+    const promise = useAppStore.getState().requestUnlock();
+    useAppStore.getState().resolveUnlock(true);
+    await expect(promise).resolves.toBe(true);
+    expect(useAppStore.getState().unlockResolve).toBeNull();
+
+    // A second resolveUnlock() must be a harmless no-op.
+    expect(() => useAppStore.getState().resolveUnlock(false)).not.toThrow();
+  });
+
+  it("settles BOTH promises when two connect flows request unlock concurrently", async () => {
+    // Two connects both see a locked store and both await requestUnlock().
+    const first = useAppStore.getState().requestUnlock();
+    const second = useAppStore.getState().requestUnlock();
+
+    // A single unlock (or a single dismissal) must settle every awaiting caller —
+    // otherwise the first connect wedges forever (the G1 hang).
+    useAppStore.getState().resolveUnlock(true);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(useAppStore.getState().unlockResolve).toBeNull();
+  });
+
+  it("settles both concurrent promises when the dialog is dismissed", async () => {
+    const first = useAppStore.getState().requestUnlock();
+    const second = useAppStore.getState().requestUnlock();
+
+    useAppStore.getState().setUnlockDialogOpen(false);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([false, false]);
+  });
+});

--- a/src/utils/ensureCredentialStoreUnlocked.test.ts
+++ b/src/utils/ensureCredentialStoreUnlocked.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+import { useAppStore } from "@/store/appStore";
+import { ensureCredentialStoreUnlocked } from "./ensureCredentialStoreUnlocked";
+
+/**
+ * The shared unlock gate that every connect path calls before resolving a stored
+ * credential. Collapses the duplicated `needsStoredCredential + locked + requestUnlock`
+ * pattern (G1/G2/G3) into one helper.
+ */
+describe("ensureCredentialStoreUnlocked", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      credentialStoreStatus: null,
+      unlockDialogOpen: false,
+    });
+  });
+
+  it("prompts for unlock and returns true when a password auth hits a locked master-password store", async () => {
+    const requestUnlock = vi.fn().mockResolvedValue(true);
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+      requestUnlock,
+    });
+
+    const proceed = await ensureCredentialStoreUnlocked({ authMethod: "password" });
+
+    expect(requestUnlock).toHaveBeenCalledTimes(1);
+    expect(proceed).toBe(true);
+  });
+
+  it("returns false (abort) when the user dismisses the unlock dialog", async () => {
+    const requestUnlock = vi.fn().mockResolvedValue(false);
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+      requestUnlock,
+    });
+
+    const proceed = await ensureCredentialStoreUnlocked({ authMethod: "password" });
+
+    expect(requestUnlock).toHaveBeenCalledTimes(1);
+    expect(proceed).toBe(false);
+  });
+
+  it("does not prompt when the store is already unlocked", async () => {
+    const requestUnlock = vi.fn().mockResolvedValue(true);
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+      requestUnlock,
+    });
+
+    const proceed = await ensureCredentialStoreUnlocked({ authMethod: "password" });
+
+    expect(requestUnlock).not.toHaveBeenCalled();
+    expect(proceed).toBe(true);
+  });
+
+  it("does not prompt when the mode is not master_password (os_keychain / none)", async () => {
+    const requestUnlock = vi.fn().mockResolvedValue(true);
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "os_keychain", status: "unlocked" },
+      requestUnlock,
+    });
+
+    const proceed = await ensureCredentialStoreUnlocked({ authMethod: "password" });
+
+    expect(requestUnlock).not.toHaveBeenCalled();
+    expect(proceed).toBe(true);
+  });
+
+  it("does not prompt when the auth method does not need a stored credential", async () => {
+    const requestUnlock = vi.fn().mockResolvedValue(true);
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+      requestUnlock,
+    });
+
+    // agent auth needs no stored secret.
+    const proceedAgent = await ensureCredentialStoreUnlocked({ authMethod: "agent" });
+    expect(proceedAgent).toBe(true);
+
+    // key auth without savePassword needs no stored secret.
+    const proceedKey = await ensureCredentialStoreUnlocked({
+      authMethod: "key",
+      savePassword: false,
+    });
+    expect(proceedKey).toBe(true);
+
+    expect(requestUnlock).not.toHaveBeenCalled();
+  });
+
+  it("prompts for key auth WITH savePassword when the store is locked", async () => {
+    const requestUnlock = vi.fn().mockResolvedValue(true);
+    useAppStore.setState({
+      credentialStoreStatus: { mode: "master_password", status: "locked" },
+      requestUnlock,
+    });
+
+    const proceed = await ensureCredentialStoreUnlocked({
+      authMethod: "key",
+      savePassword: true,
+    });
+
+    expect(requestUnlock).toHaveBeenCalledTimes(1);
+    expect(proceed).toBe(true);
+  });
+});

--- a/src/utils/ensureCredentialStoreUnlocked.ts
+++ b/src/utils/ensureCredentialStoreUnlocked.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared credential-store unlock gate.
+ *
+ * Every connect path that may resolve a stored credential must first ensure the
+ * credential store is unlocked. Before this helper the same check was duplicated
+ * across four call sites (sidebar `ConnectionList`, `AgentNode`, `AgentErrorTab`,
+ * workspace launch) and was missing entirely on `ConnectionEditor`'s
+ * "Save & Connect" path — see the credential-store audit gaps G1/G2/G3 (#1144).
+ *
+ * Centralising the gate guarantees the check runs *before* `resolveCredential`,
+ * so the unlock dialog is the primary trigger rather than the after-the-fact
+ * `credential-store-unlock-needed` event (G2).
+ */
+
+import { useAppStore } from "@/store/appStore";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** Inputs the gate needs to decide whether a stored credential is involved. */
+export interface UnlockGateOptions {
+  /** The connection's auth method (`"password"`, `"key"`, `"agent"`, …). */
+  authMethod: string;
+  /** Whether the connection persists its secret (only meaningful for key auth). */
+  savePassword?: boolean;
+}
+
+/**
+ * Whether the given auth method resolves a secret from the credential store.
+ *
+ * - `password` auth always reads a stored password.
+ * - `key` auth only reads a stored passphrase when `savePassword` is set.
+ * - Everything else (agent auth, key without savePassword) needs no stored secret.
+ */
+function needsStoredCredential({ authMethod, savePassword }: UnlockGateOptions): boolean {
+  return authMethod === "password" || (authMethod === "key" && Boolean(savePassword));
+}
+
+/**
+ * Ensure the credential store is unlocked before a connect resolves its stored
+ * credential.
+ *
+ * When the store is in `master_password` mode and `locked`, and the auth method
+ * needs a stored secret, this opens the unlock dialog via `requestUnlock()` and
+ * awaits the outcome. In every other case it is a no-op that returns `true`.
+ *
+ * @returns `true` when the caller should proceed (store not locked, no stored
+ *   credential involved, or the user successfully unlocked); `false` when the
+ *   user dismissed the unlock dialog and the connect should abort.
+ */
+export async function ensureCredentialStoreUnlocked(opts: UnlockGateOptions): Promise<boolean> {
+  if (!needsStoredCredential(opts)) {
+    return true;
+  }
+
+  const { credentialStoreStatus, requestUnlock } = useAppStore.getState();
+  if (
+    credentialStoreStatus?.mode === "master_password" &&
+    credentialStoreStatus?.status === "locked"
+  ) {
+    frontendLog("credential", "connect gate: store locked, requesting unlock before resolve");
+    const unlocked = await requestUnlock();
+    if (!unlocked) {
+      frontendLog("credential", "connect gate: unlock dismissed, aborting connect");
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

Collapses three credential-store audit gaps (G1, G2, G3 from `docs/audits/credential-store-state-machine.md`) into one shared unlock gate that every connect path calls before resolving a stored credential.

- **G3** — the connection editor's **"Save & Connect"** was the only connect path missing the `mode === "master_password" && status === "locked"` unlock gate. With the store locked it silently fell back to an interactive password prompt, ignoring the saved credential. It now prompts to unlock first, matching the sidebar/agent/workspace paths.
- **G2** — the gate now runs **before** `resolveCredential` at every call site, so the unlock dialog is the primary trigger and the demand-driven `credential-store-unlock-needed` event becomes a redundant safety net rather than an after-the-fact race.
- **G1** — `requestUnlock()` promises now **all settle exactly once** on any dialog exit. The store tracks a *list* of pending resolvers instead of a single one: two concurrent connect flows both awaiting unlock previously overwrote each other's resolver, wedging one connect forever. `resolveUnlock` clears the list before settling, staying idempotent (covers wrong-password-then-dismiss and overlay/Esc/X/Skip).

## Changes

- New `src/utils/ensureCredentialStoreUnlocked.ts` — the single shared gate (`{ authMethod, savePassword } -> Promise<boolean>`), used by `ConnectionList`, `AgentNode`, `AgentErrorTab`, and now `ConnectionEditor`. Replaces the duplicated `needsStoredCredential + locked-status + requestUnlock` block at each site.
- `appStore`: `unlockResolve` (single) -> `unlockResolvers` (list); `requestUnlock` appends, `resolveUnlock` drains-and-clears.
- Uses `frontendLog`, no `console.*`; no `any`.

Note: `launchWorkspace`'s upfront multi-tab unlock check is intentionally left as-is — it gates once across many tabs (a different shape than the per-connection helper) and already gates before resolving.

## Test plan

- `test(credential)` commit lands first (RED): G1 concurrent-unlock hang, G3 ConnectionEditor locked-store gate, and the shared helper's behavior.
- `pnpm test` — 2312 passed (211 files); `pnpm build` (tsc) clean; `pnpm run lint` and `pnpm run format:check` clean.

Partially addresses #1144 (G1, G2, G3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)