### PR TITLE
fix(sftp): resolve SFTP home via realpath (#1143)

### DIFF
--- a/docs/changes/dev2/feature/1143-sftp-realpath-home.md
+++ b/docs/changes/dev2/feature/1143-sftp-realpath-home.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- When opening the SFTP file browser, termiHub now lands in your actual remote
+  home directory. It resolves the real home from the server (via SFTP realpath)
+  instead of guessing `/home/<username>`, which was wrong for macOS, BSD, and
+  custom home layouts and silently dropped you at `/`. If the server can't
+  resolve the home, the browser still opens at root as before (audit gap C2,
+  #1143).

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -58,6 +58,23 @@ pub async fn sftp_list_dir(
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
 
+/// Resolve a remote path to its canonical absolute form via SFTP realpath.
+///
+/// Passing `"."` yields the session's home directory so the file browser can
+/// land there without guessing `/home/<user>` (audit GAP C2, issue #1143).
+#[tauri::command]
+pub async fn sftp_realpath(
+    session_id: String,
+    path: String,
+    manager: State<'_, SftpManager>,
+) -> Result<String, TerminalError> {
+    debug!(session_id, path, "SFTP realpath");
+    let session = manager.get_session(&session_id)?;
+    tokio::task::spawn_blocking(move || lock_session(&session)?.realpath(&path))
+        .await
+        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+}
+
 /// Download a remote file to a local path. Returns bytes transferred.
 #[tauri::command]
 pub async fn sftp_download(

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -272,6 +272,23 @@ impl SftpSession {
         })
     }
 
+    /// Resolve a remote path to its canonical absolute form via SFTP realpath.
+    ///
+    /// Passing `"."` yields the session's home directory, avoiding the fragile
+    /// `/home/<user>` guess that breaks on non-Linux layouts (audit GAP C2,
+    /// issue #1143).
+    pub fn realpath(&self, path: &str) -> Result<String, TerminalError> {
+        let path = path.to_string();
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                self.sftp
+                    .canonicalize(&path)
+                    .await
+                    .map_err(|e| TerminalError::SshError(format!("realpath failed: {e}")))
+            })
+        })
+    }
+
     /// Read a remote file's contents as raw bytes.
     #[allow(dead_code)]
     pub fn read_bytes(&self, remote_path: &str) -> Result<Vec<u8>, TerminalError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,6 +496,7 @@ pub fn run() {
             commands::files::sftp_open,
             commands::files::sftp_close,
             commands::files::sftp_list_dir,
+            commands::files::sftp_realpath,
             commands::files::sftp_download,
             commands::files::sftp_upload,
             commands::files::sftp_mkdir,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -502,6 +502,16 @@ export async function sftpListDir(sessionId: string, path: string): Promise<File
   return await invoke<FileEntry[]>("sftp_list_dir", { sessionId, path });
 }
 
+/**
+ * Resolve a remote path to its canonical absolute form via SFTP realpath.
+ *
+ * Pass `"."` to resolve the session's home directory instead of guessing
+ * `/home/<user>` (audit GAP C2).
+ */
+export async function sftpRealpath(sessionId: string, path: string): Promise<string> {
+  return await invoke<string>("sftp_realpath", { sessionId, path });
+}
+
 /** Download a remote file to a local path. Returns bytes transferred. */
 export async function sftpDownload(
   sessionId: string,

--- a/src/store/appStore.sftpRealpath.test.ts
+++ b/src/store/appStore.sftpRealpath.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve("persisted-id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  sftpRealpath: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore, _resetSftpListSeq } from "./appStore";
+import { sftpOpen, sftpListDir, sftpRealpath } from "@/services/api";
+import type { FileEntry } from "@/types/connection";
+
+function makeEntry(name: string): FileEntry {
+  return {
+    name,
+    path: `/${name}`,
+    isDirectory: true,
+    size: 0,
+    modified: "",
+    permissions: null,
+  };
+}
+
+const SAMPLE_CONFIG = { host: "example.com", port: 22, username: "alice", password: "pw" };
+
+describe("appStore — SFTP home resolved via realpath (C2)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    _resetSftpListSeq();
+    vi.clearAllMocks();
+  });
+
+  it("connectSftp uses the realpath-resolved home as the initial directory", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-1");
+    // Real home is NOT the /home/<user> guess — e.g. a non-Linux layout.
+    vi.mocked(sftpRealpath).mockResolvedValue("/Users/alice");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("Documents")]);
+
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    // The remote home must be resolved via realpath(".") rather than string-built.
+    expect(sftpRealpath).toHaveBeenCalledWith("session-1", ".");
+    // The listing must target the resolved path, not "/home/alice".
+    expect(sftpListDir).toHaveBeenCalledWith("session-1", "/Users/alice");
+
+    const state = useAppStore.getState();
+    expect(state.sftpSessionId).toBe("session-1");
+    expect(state.currentPath).toBe("/Users/alice");
+    expect(state.fileEntries).toEqual([makeEntry("Documents")]);
+    expect(state.sftpError).toBeNull();
+  });
+
+  it("connectSftp falls back to root when realpath resolution fails", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-2");
+    vi.mocked(sftpRealpath).mockRejectedValue(new Error("realpath unsupported"));
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("etc")]);
+
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    // Graceful fallback: still connect, listing root.
+    expect(sftpListDir).toHaveBeenCalledWith("session-2", "/");
+
+    const state = useAppStore.getState();
+    expect(state.sftpSessionId).toBe("session-2");
+    expect(state.currentPath).toBe("/");
+    expect(state.fileEntries).toEqual([makeEntry("etc")]);
+    // Fallback is graceful — the connect itself must not surface as an error.
+    expect(state.sftpError).toBeNull();
+  });
+
+  it("connectSftp falls back to root when listing the resolved home fails", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-3");
+    vi.mocked(sftpRealpath).mockResolvedValue("/home/alice");
+    vi.mocked(sftpListDir).mockImplementation(async (_id: string, path: string) => {
+      if (path === "/home/alice") throw new Error("permission denied");
+      return [makeEntry("root")];
+    });
+
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    const state = useAppStore.getState();
+    expect(state.sftpSessionId).toBe("session-3");
+    expect(state.currentPath).toBe("/");
+    expect(state.fileEntries).toEqual([makeEntry("root")]);
+    expect(state.sftpError).toBeNull();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -55,6 +55,7 @@ import {
   sftpOpen,
   sftpClose,
   sftpListDir,
+  sftpRealpath,
   sessionListFiles,
   localListDir,
   vscodeAvailable as checkVscode,
@@ -2774,14 +2775,23 @@ export const useAppStore = create<AppState>((set, get) => {
       set({ sftpLoading: true, sftpError: null, sftpLastConfig: config });
       try {
         const sessionId = await sftpOpen(config);
-        const homePath = `/home/${config.username as string}`;
+        // Resolve the real remote home via SFTP realpath(".") instead of the
+        // fragile /home/<user> guess, which is wrong for non-Linux layouts and
+        // custom home paths (audit GAP C2, issue #1143). Fall back to root if
+        // realpath is unsupported or the resolved home cannot be listed.
         let entries: FileEntry[];
-        let activePath = homePath;
+        let activePath = "/";
         try {
+          const homePath = await sftpRealpath(sessionId, ".");
           entries = await sftpListDir(sessionId, homePath);
-        } catch {
-          // Fall back to root if home dir doesn't exist
-          activePath = "/";
+          activePath = homePath;
+        } catch (homeErr) {
+          frontendLog(
+            "sftp",
+            `connectSftp: home resolution failed, falling back to root: ${
+              homeErr instanceof Error ? homeErr.message : String(homeErr)
+            }`
+          );
           entries = await sftpListDir(sessionId, "/");
         }
         set({


### PR DESCRIPTION
## Summary

Fixes audit GAP **C2** from the SFTP file-browser state-machine audit
(`docs/audits/sftp-file-browser-state-machine.md`).

`connectSftp` previously string-built the initial SFTP directory as
`/home/<username>` and silently fell back to `/` on any error. That guess is
wrong for macOS/BSD and custom home layouts, so users frequently landed at `/`
with no explanation. This resolves the **real** remote home from the server via
the SFTP session's `realpath(".")` instead.

## Changes

- **Backend:** new `sftp_realpath` Tauri command, backed by a `SftpSession::realpath`
  method that calls russh-sftp's `canonicalize` (`"."` → home). Registered in `lib.rs`.
- **API:** `sftpRealpath(sessionId, path)` wrapper in `src/services/api.ts`.
- **Store:** `connectSftp` now resolves the home via `sftpRealpath(sessionId, ".")`,
  lists it, and lands there. If realpath is unsupported or the resolved home can't
  be listed, it falls back to root gracefully and logs the reason via `frontendLog`
  (never `console.*`).

No `.unwrap()` added; the command reuses the existing `lock_session` poison-safe guard.

## Test plan

- Added `src/store/appStore.sftpRealpath.test.ts` (TDD, RED before fix):
  - home resolved via realpath is used as the initial dir
  - graceful fallback to root when realpath rejects
  - graceful fallback to root when listing the resolved home fails
- `pnpm test` — 214 files / 2333 tests pass
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — clean
- `cargo test -p termihub --lib files` — 19 pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Partially addresses #1143 (C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)