### PR TITLE
fix(network): persist HTTP monitor configs across restart (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-monitor-persistence.md
+++ b/docs/changes/dev2/feature/1147-monitor-persistence.md
@@ -1,0 +1,9 @@
+# Changes
+
+## Fixed
+
+- HTTP monitors now persist across app restarts. A monitor's configuration (URL,
+  interval, method, expected status, timeout) is saved to disk when started and
+  removed when stopped, and every saved monitor is automatically restarted when
+  the app launches — previously all configured monitors silently disappeared on
+  restart. (#1147)

--- a/src-tauri/src/network/http_monitor_storage.rs
+++ b/src-tauri/src/network/http_monitor_storage.rs
@@ -1,0 +1,129 @@
+//! Persistent storage for HTTP monitor configurations.
+//!
+//! Only the monitor **configs** (url, interval, method, expected status,
+//! timeout, id) are persisted — never runtime state (last result, running
+//! flag). On the next launch [`NetworkManager::init`](super::NetworkManager)
+//! reloads these configs and auto-starts a poll loop for each, so a configured
+//! monitor survives an app restart instead of silently disappearing.
+//!
+//! Mirrors the Wake-on-LAN persistence in [`super::wol_storage`].
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::http_monitor::HttpMonitorConfig;
+
+const HTTP_MONITORS_FILE: &str = "http-monitors.json";
+
+#[derive(Serialize, Deserialize, Default)]
+struct HttpMonitorsFile {
+    monitors: Vec<HttpMonitorConfig>,
+}
+
+/// Resolve the path to the HTTP monitors file.
+fn monitors_path(config_dir: &std::path::Path) -> PathBuf {
+    config_dir.join(HTTP_MONITORS_FILE)
+}
+
+/// Load saved HTTP monitor configs from disk. Returns an empty list if the file
+/// doesn't exist yet.
+pub fn load_http_monitors(config_dir: &std::path::Path) -> Result<Vec<HttpMonitorConfig>> {
+    let path = monitors_path(config_dir);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let file: HttpMonitorsFile =
+        serde_json::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(file.monitors)
+}
+
+/// Persist the current HTTP monitor config list to disk.
+pub fn save_http_monitors(
+    config_dir: &std::path::Path,
+    monitors: &[HttpMonitorConfig],
+) -> Result<()> {
+    let path = monitors_path(config_dir);
+    let file = HttpMonitorsFile {
+        monitors: monitors.to_vec(),
+    };
+    let content = serde_json::to_string_pretty(&file).context("serialising HTTP monitors")?;
+    std::fs::write(&path, content).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_config(url: &str) -> HttpMonitorConfig {
+        HttpMonitorConfig::new(url.to_string(), 30_000, "GET".into(), 200, 5_000)
+    }
+
+    #[test]
+    fn roundtrip_empty() {
+        let dir = TempDir::new().unwrap();
+        let monitors = load_http_monitors(dir.path()).unwrap();
+        assert!(monitors.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_with_monitors() {
+        let dir = TempDir::new().unwrap();
+        let original = vec![
+            make_config("https://a.example.com"),
+            make_config("https://b.example.com"),
+        ];
+        save_http_monitors(dir.path(), &original).unwrap();
+        let loaded = load_http_monitors(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].url, "https://a.example.com");
+        assert_eq!(loaded[1].url, "https://b.example.com");
+        // IDs must survive the round-trip so reloaded monitors keep identity.
+        assert_eq!(loaded[0].id, original[0].id);
+        assert_eq!(loaded[1].id, original[1].id);
+    }
+
+    #[test]
+    fn roundtrip_preserves_all_config_fields() {
+        let dir = TempDir::new().unwrap();
+        let cfg = HttpMonitorConfig::new(
+            "https://api.example.com/health".into(),
+            15_000,
+            "HEAD".into(),
+            204,
+            8_000,
+        );
+        save_http_monitors(dir.path(), std::slice::from_ref(&cfg)).unwrap();
+        let loaded = load_http_monitors(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+        let got = &loaded[0];
+        assert_eq!(got.id, cfg.id);
+        assert_eq!(got.url, "https://api.example.com/health");
+        assert_eq!(got.interval_ms, 15_000);
+        assert_eq!(got.method, "HEAD");
+        assert_eq!(got.expected_status, 204);
+        assert_eq!(got.timeout_ms, 8_000);
+    }
+
+    #[test]
+    fn overwrite_updates_list() {
+        let dir = TempDir::new().unwrap();
+        save_http_monitors(dir.path(), &[make_config("https://old.example.com")]).unwrap();
+        save_http_monitors(
+            dir.path(),
+            &[
+                make_config("https://new.example.com"),
+                make_config("https://extra.example.com"),
+            ],
+        )
+        .unwrap();
+        let loaded = load_http_monitors(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].url, "https://new.example.com");
+    }
+}

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -67,6 +67,15 @@ impl NetworkManager {
                 error!("Failed to load WoL devices: {e}");
             }
         }
+        // Reload persisted HTTP monitor configs and auto-start a poll loop for
+        // each, so a monitor configured before the last shutdown resumes on
+        // launch instead of silently vanishing.
+        for config in self.load_persisted_monitor_configs() {
+            let id = config.id.clone();
+            if let Err(e) = self.spawn_http_monitor(config) {
+                error!(monitor_id = %id, "Failed to auto-start persisted HTTP monitor: {e}");
+            }
+        }
     }
 
     // ── Task lifecycle ──────────────────────────────────────────────────────
@@ -111,8 +120,23 @@ impl NetworkManager {
 
     // ── HTTP Monitors ───────────────────────────────────────────────────────
 
-    /// Start a new HTTP monitor. Returns its ID.
+    /// Start a new HTTP monitor and persist its config. Returns its ID.
+    ///
+    /// The config is written to disk (see [`http_monitor_storage`]) so the
+    /// monitor is auto-restarted on the next launch. Runtime state (last
+    /// result, running flag) is never persisted.
     pub fn start_http_monitor(&self, config: HttpMonitorConfig) -> Result<String, TerminalError> {
+        // Persist first so a monitor the user just created survives a restart
+        // even if it is stopped before the next save.
+        self.persist_monitor_config(config.clone())?;
+        self.spawn_http_monitor(config)
+    }
+
+    /// Spawn the poll loop for a config and track its handle, **without**
+    /// touching disk. Used both by [`start_http_monitor`](Self::start_http_monitor)
+    /// (after persisting) and by [`init`](Self::init) when auto-starting the
+    /// persisted monitors on launch.
+    fn spawn_http_monitor(&self, config: HttpMonitorConfig) -> Result<String, TerminalError> {
         let app = self
             .app_handle()
             .ok_or_else(|| TerminalError::InternalError("app handle not available".into()))?;
@@ -124,7 +148,7 @@ impl NetworkManager {
         Ok(id)
     }
 
-    /// Stop a running HTTP monitor.
+    /// Stop a running HTTP monitor and drop its persisted config.
     pub fn stop_http_monitor(&self, monitor_id: &str) -> Result<(), TerminalError> {
         let mut monitors = self
             .http_monitors
@@ -133,10 +157,56 @@ impl NetworkManager {
         match monitors.remove(monitor_id) {
             Some(handle) => {
                 handle.cancel.cancel();
+                // Drop the config from disk too — stopping a monitor removes it
+                // (see audit Gap #6: Stop currently means delete). A best-effort
+                // remove; a persistence error must not leave the loop running.
+                drop(monitors);
+                if let Err(e) = self.remove_persisted_monitor_config(monitor_id) {
+                    error!(monitor_id, "Failed to remove persisted HTTP monitor: {e}");
+                }
                 Ok(())
             }
             None => Err(TerminalError::NotFound(format!("monitor '{monitor_id}'"))),
         }
+    }
+
+    // ── HTTP Monitor persistence ────────────────────────────────────────────
+
+    /// Load the persisted HTTP monitor configs from disk (empty on any error).
+    fn load_persisted_monitor_configs(&self) -> Vec<HttpMonitorConfig> {
+        match http_monitor_storage::load_http_monitors(&self.config_dir) {
+            Ok(configs) => configs,
+            Err(e) => {
+                error!("Failed to load persisted HTTP monitors: {e}");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Persist a single monitor config, replacing any existing entry with the
+    /// same ID.
+    fn persist_monitor_config(&self, config: HttpMonitorConfig) -> Result<(), TerminalError> {
+        let mut configs = self.load_persisted_monitor_configs();
+        if let Some(existing) = configs.iter_mut().find(|c| c.id == config.id) {
+            *existing = config;
+        } else {
+            configs.push(config);
+        }
+        http_monitor_storage::save_http_monitors(&self.config_dir, &configs)
+            .map_err(|e| TerminalError::InternalError(e.to_string()))
+    }
+
+    /// Remove the persisted config for a monitor. No-op if the file has no such
+    /// entry (the map removal already happened).
+    fn remove_persisted_monitor_config(&self, monitor_id: &str) -> Result<(), TerminalError> {
+        let mut configs = self.load_persisted_monitor_configs();
+        let before = configs.len();
+        configs.retain(|c| c.id != monitor_id);
+        if configs.len() == before {
+            return Ok(());
+        }
+        http_monitor_storage::save_http_monitors(&self.config_dir, &configs)
+            .map_err(|e| TerminalError::InternalError(e.to_string()))
     }
 
     /// Stop and remove **all** running HTTP monitors.
@@ -276,5 +346,80 @@ mod tests {
         assert!(mgr.list_http_monitors().is_empty());
         mgr.stop_all_http_monitors();
         assert!(mgr.list_http_monitors().is_empty());
+    }
+
+    /// A manager pointed at a temp config dir, so persistence can be exercised
+    /// without a live Tauri app.
+    fn manager_with_config_dir(dir: &std::path::Path) -> NetworkManager {
+        let mut mgr = NetworkManager::new();
+        mgr.config_dir = dir.to_path_buf();
+        mgr
+    }
+
+    #[test]
+    fn persist_and_reload_monitor_configs() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mgr = manager_with_config_dir(dir.path());
+
+        let cfg = HttpMonitorConfig::new(
+            "https://example.com/health".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        let id = cfg.id.clone();
+        mgr.persist_monitor_config(cfg).expect("persist config");
+
+        // A fresh manager over the same dir reloads the saved config.
+        let reloaded = manager_with_config_dir(dir.path());
+        let loaded = reloaded.load_persisted_monitor_configs();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, id);
+        assert_eq!(loaded[0].url, "https://example.com/health");
+    }
+
+    #[test]
+    fn removing_persisted_config_deletes_it_from_disk() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mgr = manager_with_config_dir(dir.path());
+
+        let cfg = HttpMonitorConfig::new(
+            "https://example.com".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        let id = cfg.id.clone();
+        mgr.persist_monitor_config(cfg).expect("persist config");
+        assert_eq!(mgr.load_persisted_monitor_configs().len(), 1);
+
+        mgr.remove_persisted_monitor_config(&id)
+            .expect("remove config");
+        assert!(mgr.load_persisted_monitor_configs().is_empty());
+    }
+
+    #[test]
+    fn persist_overwrites_config_with_same_id() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mgr = manager_with_config_dir(dir.path());
+
+        let mut cfg = HttpMonitorConfig::new(
+            "https://old.example.com".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        mgr.persist_monitor_config(cfg.clone()).expect("persist");
+        // Same id, different url.
+        cfg.url = "https://new.example.com".into();
+        mgr.persist_monitor_config(cfg.clone())
+            .expect("persist again");
+
+        let loaded = mgr.load_persisted_monitor_configs();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].url, "https://new.example.com");
     }
 }

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -5,6 +5,7 @@
 //! the persistent HTTP monitors.
 
 pub mod http_monitor;
+pub mod http_monitor_storage;
 pub mod wol_storage;
 
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary

HTTP monitor configurations previously lived only in the in-memory `NetworkManager` map (and Zustand), so every configured monitor silently disappeared on app restart — the user had to re-enter URL/interval/method each session. This persists monitor **configs** to disk following the existing Wake-on-LAN pattern and auto-restarts each saved monitor on launch.

This addresses **Gap #1** of the HTTP monitor state-machine audit (`docs/audits/http-monitor-state-machine.md`).

## Changes

- New `src-tauri/src/network/http_monitor_storage.rs` — load/save `Vec<HttpMonitorConfig>` to `http-monitors.json`, mirroring `wol_storage.rs`.
- `NetworkManager::start_http_monitor` now persists the config (via a new `persist_monitor_config`) before spawning the poll loop; the spawn logic is factored into a private `spawn_http_monitor` reused by auto-start.
- `NetworkManager::stop_http_monitor` drops the persisted config (Stop = delete, matching current behavior).
- `NetworkManager::init` reloads persisted configs and auto-starts a poll loop for each on launch.
- Only configs (url, interval, method, expected status, timeout, id) are persisted — never runtime state (last result, running flag).
- Poll/backoff/teardown behavior is unchanged (other audit gaps); shutdown teardown (`stop_all_http_monitors`) intentionally does **not** delete the config files, so monitors survive across restart.

## Test plan

- `cargo test -p termihub --lib network` — 17 passed, 0 failed. New tests:
  - `http_monitor_storage`: `roundtrip_empty`, `roundtrip_with_monitors`, `roundtrip_preserves_all_config_fields`, `overwrite_updates_list`
  - `network::tests`: `persist_and_reload_monitor_configs`, `removing_persisted_config_deletes_it_from_disk`, `persist_overwrites_config_with_same_id`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

Manual: start an HTTP monitor, restart the app, confirm the monitor resumes polling automatically; stop a monitor, restart, confirm it stays gone.

Partially addresses #1147 (#1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)