### PR TITLE
fix(workspace): guard auto-save during restore (#1146)

### DIFF
--- a/docs/changes/dev2/feature/1146-restore-inprogress-guard.md
+++ b/docs/changes/dev2/feature/1146-restore-inprogress-guard.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- A workspace restore or launch can no longer overwrite the previously-good
+  saved session with a mid-restore snapshot. While a restore/launch is settling,
+  a manual tab action or an in-flight per-tab connect fired the auto-save
+  subscription, and the auto-save recaptured the whole live tree — persisting
+  tabs that were still connecting or in an agent-error state over the good
+  `last-session.json`. A `restoreInProgress` guard now skips auto-save from when
+  a restored/launched layout is placed until the cohort settles, so only a
+  stable layout is captured (audit gap G5, #1146).

--- a/src/store/appStore.restoreGuard.test.ts
+++ b/src/store/appStore.restoreGuard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression test for GAP G5 from the workspace save/restore audit (#1146).
+ *
+ * During (and right after) a restore/launch, a manual tab action or an in-flight
+ * per-tab connect mutates `rootPanel`/`tabGroups` and fires the App auto-save
+ * subscription → `scheduleLastSessionSave`. Because `saveLastSession` recaptures
+ * the WHOLE live tree, a save landing while some tabs are still connecting /
+ * agent-error persists that degraded snapshot over the previously-good session.
+ *
+ * The fix adds a `restoreInProgress` flag: while it is true,
+ * `scheduleLastSessionSave` is a no-op, so a mid-restore snapshot cannot
+ * overwrite the good last-session file. Once the restore cohort settles (a short
+ * settle window), the flag clears and auto-saves resume.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@/services/lastSessionApi", () => ({
+  saveLastSession: vi.fn(() => Promise.resolve()),
+  loadLastSession: vi.fn(() => Promise.resolve(null)),
+  clearLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import { saveLastSession, loadLastSession } from "@/services/lastSessionApi";
+import type { LastSession } from "@/types/lastSession";
+
+const mockSave = vi.mocked(saveLastSession);
+const mockLoad = vi.mocked(loadLastSession);
+
+describe("appStore — auto-save mid-restore guard (GAP G5, #1146)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoad.mockResolvedValue(null);
+    useAppStore.setState({
+      connections: [],
+      remoteAgents: [],
+      agentDefinitions: {},
+      defaultShell: "bash",
+      restoreInProgress: false,
+      settings: { ...useAppStore.getState().settings, restoreLastSessionOnStartup: true },
+    });
+    // Open a fresh local terminal so there is real content to capture.
+    useAppStore.getState().addTab("Shell", "local", { type: "local", config: { shell: "bash" } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("skips scheduling an auto-save while restoreInProgress is true", async () => {
+    vi.useFakeTimers();
+    useAppStore.setState({ restoreInProgress: true });
+
+    // A layout change fires this while a restore is settling.
+    useAppStore.getState().scheduleLastSessionSave();
+
+    // Flush any debounce timer — nothing should have been scheduled.
+    await vi.runAllTimersAsync();
+
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it("resumes auto-save once restoreInProgress clears", async () => {
+    vi.useFakeTimers();
+    useAppStore.setState({ restoreInProgress: true });
+    useAppStore.getState().scheduleLastSessionSave();
+    await vi.runAllTimersAsync();
+    expect(mockSave).not.toHaveBeenCalled();
+
+    // The restore cohort settles and clears the flag.
+    useAppStore.setState({ restoreInProgress: false });
+    useAppStore.getState().scheduleLastSessionSave();
+    await vi.runAllTimersAsync();
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    const payload = mockSave.mock.calls[0][0] as LastSession;
+    expect(payload.tabGroups.length).toBeGreaterThan(0);
+  });
+
+  it("holds restoreInProgress during a restore and clears it after the settle window", async () => {
+    vi.useFakeTimers();
+    mockLoad.mockResolvedValue({
+      version: "1",
+      activeGroupIndex: 0,
+      tabGroups: [
+        {
+          name: "Restored",
+          layout: {
+            type: "leaf",
+            tabs: [
+              { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell A" },
+            ],
+          },
+        },
+      ],
+    });
+
+    const restore = useAppStore.getState().restoreLastSession();
+    await vi.advanceTimersByTimeAsync(0);
+    // The store mutation from the restore has landed; the guard must be up so
+    // the App auto-save subscription that just fired is a no-op.
+    expect(useAppStore.getState().restoreInProgress).toBe(true);
+
+    await restore;
+    // Still guarded immediately after restore resolves (tabs are still settling).
+    expect(useAppStore.getState().restoreInProgress).toBe(true);
+
+    // A save scheduled during the settle window is dropped.
+    useAppStore.getState().scheduleLastSessionSave();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockSave).not.toHaveBeenCalled();
+
+    // After the settle window elapses the guard clears and saves resume.
+    await vi.runAllTimersAsync();
+    expect(useAppStore.getState().restoreInProgress).toBe(false);
+
+    useAppStore.getState().scheduleLastSessionSave();
+    await vi.runAllTimersAsync();
+    expect(mockSave).toHaveBeenCalled();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -730,6 +730,14 @@ interface AppState {
   ) => Promise<void>;
 
   // Last session (auto-saved layout restored on startup)
+  /**
+   * True while a restore/launch is settling (GAP G5, #1146). While set,
+   * {@link scheduleLastSessionSave} is a no-op so a mid-restore snapshot — where
+   * some tabs are still connecting or in agent-error — cannot be captured and
+   * persisted over the previously-good last session. Cleared once the restored
+   * cohort settles (a short settle window after the layout is placed).
+   */
+  restoreInProgress: boolean;
   /** Capture the current tab groups/layout and persist them as the last session. */
   saveLastSession: () => Promise<void>;
   /** Debounced wrapper around {@link saveLastSession} for high-frequency layout changes. */
@@ -780,6 +788,32 @@ let layoutPersistTimer: ReturnType<typeof setTimeout> | null = null;
 /** Debounce timer for auto-saving the last session on layout changes. */
 let lastSessionPersistTimer: ReturnType<typeof setTimeout> | null = null;
 const LAST_SESSION_SAVE_DEBOUNCE_MS = 500;
+/**
+ * Settle timer for the restore-in-progress guard (GAP G5, #1146). After a
+ * restore/launch places its layout, per-tab connects keep mutating the tree for
+ * a moment; we hold {@link AppState.restoreInProgress} for this window so those
+ * transient (still-connecting / agent-error) states are not auto-saved over the
+ * good session. Comfortably larger than the auto-save debounce.
+ */
+let restoreSettleTimer: ReturnType<typeof setTimeout> | null = null;
+const RESTORE_SETTLE_MS = 2000;
+
+/**
+ * Raise the restore-in-progress guard (GAP G5, #1146) and (re)arm the settle
+ * timer that lowers it. Call immediately after a restore/launch has placed its
+ * layout so the auto-save subscription and any in-flight per-tab connects are
+ * skipped until the cohort settles. Safe to call repeatedly — the timer is
+ * reset each time so overlapping restores extend the window.
+ */
+function beginRestoreGuard(setState: (partial: Partial<AppState>) => void): void {
+  setState({ restoreInProgress: true });
+  if (restoreSettleTimer) clearTimeout(restoreSettleTimer);
+  restoreSettleTimer = setTimeout(() => {
+    restoreSettleTimer = null;
+    setState({ restoreInProgress: false });
+    frontendLog("workspace", "restore settle window elapsed; auto-save re-enabled");
+  }, RESTORE_SETTLE_MS);
+}
 /** Unlisten function for the active session-based monitoring event subscription. */
 let _monitoringUnlisten: (() => void) | null = null;
 
@@ -4203,6 +4237,11 @@ export const useAppStore = create<AppState>((set, get) => {
           return;
         }
         const firstGroup = builtGroups[0];
+        // GAP G5 (#1146): raise the guard BEFORE placing the layout so the
+        // auto-save subscription that fires from this `set` — and the per-tab
+        // connects that follow — do not persist a mid-launch snapshot over the
+        // previously-good session.
+        beginRestoreGuard(set);
         set({
           tabGroups: builtGroups,
           activeTabGroupId: firstGroup.id,
@@ -4248,6 +4287,8 @@ export const useAppStore = create<AppState>((set, get) => {
       }
     },
 
+    restoreInProgress: false,
+
     saveLastSession: async () => {
       const state = get();
       // Respect the setting at save time so toggling it takes effect immediately.
@@ -4280,6 +4321,12 @@ export const useAppStore = create<AppState>((set, get) => {
     },
 
     scheduleLastSessionSave: () => {
+      // GAP G5 (#1146): while a restore/launch is settling, a manual tab action
+      // or an in-flight per-tab connect fires this via the layout subscription.
+      // Saving now would recapture the whole live tree — including tabs still
+      // connecting or in agent-error — over the previously-good session. Skip it
+      // until the restored cohort settles (see beginRestoreGuard).
+      if (get().restoreInProgress) return;
       if (lastSessionPersistTimer) clearTimeout(lastSessionPersistTimer);
       lastSessionPersistTimer = setTimeout(() => {
         lastSessionPersistTimer = null;
@@ -4327,6 +4374,10 @@ export const useAppStore = create<AppState>((set, get) => {
         }
         const idx = Math.min(Math.max(session.activeGroupIndex, 0), builtGroups.length - 1);
         const activeGroup = builtGroups[idx];
+        // GAP G5 (#1146): raise the guard BEFORE placing the layout so the
+        // auto-save subscription that fires from this very `set` — and the
+        // per-tab connects that follow — are skipped until the cohort settles.
+        beginRestoreGuard(set);
         set({
           tabGroups: builtGroups,
           activeTabGroupId: activeGroup.id,


### PR DESCRIPTION
## Summary

Fixes audit gap **G5** from the workspace save/restore state-machine audit: an auto-save landing while a restore/launch is still settling could overwrite the previously-good session file with a degraded (mid-restore) snapshot.

During and right after a restore or launch, the layout is placed with a `set(...)` and per-tab connects keep mutating the tree. Every mutation fires the App auto-save subscription (`scheduleLastSessionSave`), and `saveLastSession` recaptures the **whole** live tree — so a save landing while some tabs are still connecting or in `agent-error` persisted that degraded snapshot over the good `last-session.json`, making transient failures sticky.

## Changes

- Add a `restoreInProgress` flag to `appStore`.
- `restoreLastSession` and `launchWorkspace` raise the guard **before** placing the layout (so the very `set` that triggers the subscription is skipped) and re-arm a settle timer (`RESTORE_SETTLE_MS = 2000`) that lowers it once the restored cohort stabilizes.
- `scheduleLastSessionSave` is a no-op while the flag is set, so only a stable layout is ever auto-saved. Uses `frontendLog` (not `console.*`).

## Test plan

- New `src/store/appStore.restoreGuard.test.ts` (TDD, committed red first):
  - auto-save is skipped while `restoreInProgress` is true;
  - auto-save resumes once the flag clears;
  - `restoreLastSession` holds the guard through the restore + settle window, then clears it and saves resume.
- Full suite green: `pnpm test` (214 files / 2333 tests), `pnpm build`, `pnpm run lint`, `pnpm run format:check` all pass.

Partially addresses #1146 (G5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)