### PR TITLE
fix(embedded-servers): abort in-flight TFTP transfers on shutdown (#1145)

### DIFF
--- a/docs/changes/dev2/feature/1145-tftp-shutdown.md
+++ b/docs/changes/dev2/feature/1145-tftp-shutdown.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Embedded TFTP server: an in-flight file transfer now aborts promptly when the
+  server is stopped (or the app quits). Previously each transfer ran in a
+  detached thread that ignored the server shutdown flag, so it could keep a UDP
+  socket and file handle open for up to ~25 seconds after stop (5 retries ×
+  5 s ACK timeout), leaving the port busy with nothing shown in the UI. The
+  shutdown flag is now checked in the transfer send/receive loops (#1145).

--- a/src-tauri/src/embedded_servers/tftp_server.rs
+++ b/src-tauri/src/embedded_servers/tftp_server.rs
@@ -22,6 +22,9 @@ const OP_ERROR: u16 = 5;
 
 const BLOCK_SIZE: usize = 512;
 
+/// Maximum number of DATA (re)transmissions before an RRQ block is abandoned.
+const MAX_RETRIES: u32 = 5;
+
 // TFTP error codes (RFC 1350 §5).
 const ERR_ACCESS: u16 = 2;
 const ERR_ILLEGAL_OP: u16 = 4;
@@ -78,6 +81,7 @@ pub fn start_tftp_server(
         let root = root.clone();
         let stats = Arc::clone(&stats);
         let bind_host = bind_host.clone();
+        let shutdown = Arc::clone(&shutdown);
 
         match opcode {
             OP_RRQ => {
@@ -85,7 +89,9 @@ pub fn start_tftp_server(
                     std::thread::spawn(move || {
                         stats.active_connections.fetch_add(1, Ordering::Relaxed);
                         stats.total_connections.fetch_add(1, Ordering::Relaxed);
-                        if let Err(e) = handle_rrq(&root, &filename, peer, &bind_host, &stats) {
+                        if let Err(e) =
+                            handle_rrq(&root, &filename, peer, &bind_host, &stats, &shutdown)
+                        {
                             tracing::debug!(%peer, "TFTP RRQ error: {e}");
                         }
                         stats.active_connections.fetch_sub(1, Ordering::Relaxed);
@@ -99,7 +105,9 @@ pub fn start_tftp_server(
                     std::thread::spawn(move || {
                         stats.active_connections.fetch_add(1, Ordering::Relaxed);
                         stats.total_connections.fetch_add(1, Ordering::Relaxed);
-                        if let Err(e) = handle_wrq(&root, &filename, peer, &bind_host, &stats) {
+                        if let Err(e) =
+                            handle_wrq(&root, &filename, peer, &bind_host, &stats, &shutdown)
+                        {
                             tracing::debug!(%peer, "TFTP WRQ error: {e}");
                         }
                         stats.active_connections.fetch_sub(1, Ordering::Relaxed);
@@ -123,6 +131,7 @@ fn handle_rrq(
     peer: SocketAddr,
     bind_host: &str,
     stats: &AtomicServerStats,
+    shutdown: &Arc<AtomicBool>,
 ) -> Result<()> {
     let path = safe_path(root, filename).ok_or_else(|| anyhow::anyhow!("Access denied"))?;
 
@@ -152,41 +161,74 @@ fn handle_rrq(
         packet.extend_from_slice(&block_num.to_be_bytes());
         packet.extend_from_slice(block_data);
 
-        // Retry up to 5 times on timeout.
-        let mut attempts = 0;
-        loop {
-            socket.send_to(&packet, peer).context("Send DATA failed")?;
-            stats
-                .bytes_sent
-                .fetch_add(block_data.len() as u64, Ordering::Relaxed);
+        stats
+            .bytes_sent
+            .fetch_add(block_data.len() as u64, Ordering::Relaxed);
 
-            // Wait for ACK.
-            let mut ack_buf = [0u8; 4];
-            match socket.recv_from(&mut ack_buf) {
-                Ok((4, _)) => {
-                    let ack_op = u16::from_be_bytes([ack_buf[0], ack_buf[1]]);
-                    let ack_block = u16::from_be_bytes([ack_buf[2], ack_buf[3]]);
-                    if ack_op == OP_ACK && ack_block == block_num {
-                        break;
-                    }
-                }
-                Err(e)
-                    if e.kind() == std::io::ErrorKind::WouldBlock
-                        || e.kind() == std::io::ErrorKind::TimedOut =>
-                {
-                    attempts += 1;
-                    if attempts >= 5 {
-                        return Err(anyhow::anyhow!("ACK timeout after {attempts} retries"));
-                    }
-                    continue;
-                }
-                Err(e) => return Err(e.into()),
-                _ => {}
-            }
+        match wait_for_ack(&socket, peer, &packet, block_num, MAX_RETRIES, shutdown)? {
+            AckOutcome::Acked => {}
+            // Server was stopped mid-transfer: abort promptly instead of
+            // burning the remaining retry budget (up to ~25s). (#1145 / G1)
+            AckOutcome::Aborted => return Ok(()),
         }
     }
 
     Ok(())
+}
+
+/// Result of waiting for the ACK to a single RRQ DATA block.
+#[derive(Debug)]
+enum AckOutcome {
+    /// The expected ACK arrived.
+    Acked,
+    /// The server shutdown flag was set; the transfer should stop.
+    Aborted,
+}
+
+/// (Re)send `packet` to `peer` and wait for the ACK for `block_num`, retrying on
+/// read timeout up to `max_retries` times.
+///
+/// Before each (re)transmit the `shutdown` flag is checked, so a stopped server
+/// aborts an in-flight transfer promptly instead of running its full retry
+/// budget. Returns [`AckOutcome::Aborted`] on shutdown, [`AckOutcome::Acked`] on
+/// success, or an error if the retry budget is exhausted.
+fn wait_for_ack(
+    socket: &UdpSocket,
+    peer: SocketAddr,
+    packet: &[u8],
+    block_num: u16,
+    max_retries: u32,
+    shutdown: &Arc<AtomicBool>,
+) -> Result<AckOutcome> {
+    let _ = shutdown; // RED placeholder: shutdown not yet honored
+    let mut attempts = 0;
+    loop {
+        socket.send_to(packet, peer).context("Send DATA failed")?;
+
+        // Wait for ACK.
+        let mut ack_buf = [0u8; 4];
+        match socket.recv_from(&mut ack_buf) {
+            Ok((4, _)) => {
+                let ack_op = u16::from_be_bytes([ack_buf[0], ack_buf[1]]);
+                let ack_block = u16::from_be_bytes([ack_buf[2], ack_buf[3]]);
+                if ack_op == OP_ACK && ack_block == block_num {
+                    return Ok(AckOutcome::Acked);
+                }
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                attempts += 1;
+                if attempts >= max_retries {
+                    return Err(anyhow::anyhow!("ACK timeout after {attempts} retries"));
+                }
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+            _ => {}
+        }
+    }
 }
 
 // ─── WRQ handler (client → server) ───────────────────────────────────────────
@@ -197,6 +239,7 @@ fn handle_wrq(
     peer: SocketAddr,
     bind_host: &str,
     stats: &AtomicServerStats,
+    shutdown: &Arc<AtomicBool>,
 ) -> Result<()> {
     let path = safe_path(root, filename).ok_or_else(|| anyhow::anyhow!("Access denied"))?;
 
@@ -216,8 +259,20 @@ fn handle_wrq(
     let mut buf = [0u8; 516];
     let mut expected_block: u16 = 1;
 
+    let _ = shutdown; // RED placeholder: shutdown not yet honored
     loop {
-        let (len, _) = socket.recv_from(&mut buf).context("Receive DATA failed")?;
+        let (len, _) = match socket.recv_from(&mut buf) {
+            Ok(r) => r,
+            // The read timeout lets us re-check the shutdown flag instead of
+            // blocking indefinitely on a stalled client.
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                continue;
+            }
+            Err(e) => return Err(anyhow::Error::new(e).context("Receive DATA failed")),
+        };
         if len < 4 {
             continue;
         }
@@ -341,5 +396,55 @@ mod tests {
     fn make_ack_correct_bytes() {
         let ack = make_ack(3);
         assert_eq!(ack, [0, 4, 0, 3]);
+    }
+
+    /// Bind a UDP socket to an ephemeral loopback port with the same short read
+    /// timeout the transfer helpers use, so the ACK-wait loop hits a timeout on
+    /// every attempt (no peer ever replies).
+    fn test_socket() -> UdpSocket {
+        let socket = UdpSocket::bind("127.0.0.1:0").expect("bind test socket");
+        socket
+            .set_read_timeout(Some(std::time::Duration::from_millis(50)))
+            .expect("set timeout");
+        socket
+    }
+
+    #[test]
+    fn wait_for_ack_aborts_immediately_when_shutdown_set() {
+        // Regression for #1145 (G1): an in-flight transfer must abort promptly
+        // when the server is stopped, instead of burning its full retry budget.
+        let socket = test_socket();
+        let peer: SocketAddr = "127.0.0.1:9".parse().expect("parse peer");
+        let shutdown = Arc::new(AtomicBool::new(true));
+
+        let start = std::time::Instant::now();
+        let outcome = wait_for_ack(&socket, peer, &[0, 3, 0, 1], 1, MAX_RETRIES, &shutdown);
+        let elapsed = start.elapsed();
+
+        assert!(
+            matches!(outcome, Ok(AckOutcome::Aborted)),
+            "expected Aborted, got {outcome:?}"
+        );
+        // Must not have waited even a single full 50ms read timeout, let alone
+        // the 5 × 5s budget of the real server.
+        assert!(
+            elapsed < std::time::Duration::from_millis(40),
+            "aborted too slowly: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn wait_for_ack_times_out_after_retry_budget_without_shutdown() {
+        // Without shutdown, the loop must exhaust its retry budget (no peer ever
+        // ACKs), proving the shutdown check is what changes the outcome above.
+        let socket = test_socket();
+        let peer: SocketAddr = "127.0.0.1:9".parse().expect("parse peer");
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let outcome = wait_for_ack(&socket, peer, &[0, 3, 0, 1], 1, 2, &shutdown);
+        assert!(
+            matches!(outcome, Err(_)),
+            "expected timeout error, got {outcome:?}"
+        );
     }
 }

--- a/src-tauri/src/embedded_servers/tftp_server.rs
+++ b/src-tauri/src/embedded_servers/tftp_server.rs
@@ -449,9 +449,6 @@ mod tests {
         let shutdown = Arc::new(AtomicBool::new(false));
 
         let outcome = wait_for_ack(&socket, peer, &[0, 3, 0, 1], 1, 2, &shutdown);
-        assert!(
-            matches!(outcome, Err(_)),
-            "expected timeout error, got {outcome:?}"
-        );
+        assert!(outcome.is_err(), "expected timeout error, got {outcome:?}");
     }
 }

--- a/src-tauri/src/embedded_servers/tftp_server.rs
+++ b/src-tauri/src/embedded_servers/tftp_server.rs
@@ -200,9 +200,12 @@ fn wait_for_ack(
     max_retries: u32,
     shutdown: &Arc<AtomicBool>,
 ) -> Result<AckOutcome> {
-    let _ = shutdown; // RED placeholder: shutdown not yet honored
     let mut attempts = 0;
     loop {
+        if shutdown.load(Ordering::Relaxed) {
+            return Ok(AckOutcome::Aborted);
+        }
+
         socket.send_to(packet, peer).context("Send DATA failed")?;
 
         // Wait for ACK.
@@ -259,8 +262,12 @@ fn handle_wrq(
     let mut buf = [0u8; 516];
     let mut expected_block: u16 = 1;
 
-    let _ = shutdown; // RED placeholder: shutdown not yet honored
     loop {
+        // Abort promptly if the server was stopped mid-transfer. (#1145 / G1)
+        if shutdown.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
         let (len, _) = match socket.recv_from(&mut buf) {
             Ok(r) => r,
             // The read timeout lets us re-check the shutdown flag instead of


### PR DESCRIPTION
## Summary

Fixes GAP G1 of the embedded-servers state-machine audit (`docs/audits/embedded-servers-state-machine.md`): TFTP transfer threads leaked past server shutdown.

Each TFTP RRQ/WRQ was handled in a detached `std::thread::spawn` that bound its own ephemeral UDP socket and never checked the server `shutdown` flag. After the user stopped a TFTP server (or quit the app) mid-transfer, an in-flight transfer kept a UDP socket and file handle open for up to ~25s (5 retries × 5s ACK timeout), holding the port busy with nothing surfaced in the UI or Open Connections panel.

## Changes

- Extract the RRQ ACK-wait/retry loop into a testable `wait_for_ack` helper returning an `AckOutcome` (`Acked` / `Aborted`).
- Thread the `shutdown` `Arc<AtomicBool>` into `handle_rrq` / `handle_wrq`.
- Check the flag before each (re)transmit in the RRQ loop and before each receive in the WRQ loop, so a stopped server aborts an in-flight transfer promptly instead of running its full retry budget.

## Test plan

- `cargo test -p termihub --lib embedded_servers` — 34 passed (2 new TFTP regression tests):
  - `wait_for_ack_aborts_immediately_when_shutdown_set` — verifies a transfer aborts in <40ms when `shutdown` is set (fails without the fix: `expected Aborted, got Err(ACK timeout after 5 retries)`).
  - `wait_for_ack_times_out_after_retry_budget_without_shutdown` — control: without shutdown the loop still exhausts its retry budget.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

Partially addresses #1145 (G1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)