### PR TITLE
fix(embedded-servers): live stats + uptime (#1145)

### DIFF
--- a/docs/changes/dev2/feature/1145-embedded-live-stats.md
+++ b/docs/changes/dev2/feature/1145-embedded-live-stats.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The embedded server sidebar now shows live traffic and uptime. Previously the
+  status broadcast on every server transition carried zeroed stats and no start
+  time, so the traffic line always read `0 conn · ↑0 B ↓0 B` and uptime never
+  appeared, even under load. The backend now snapshots the running server's real
+  stats and start time into the status payload, and while any server is running
+  the frontend polls the live states (every 1.5s) so the traffic line and uptime
+  update continuously instead of only on start/stop transitions. Addresses GAP G6
+  of the embedded servers state-machine audit (#1145).

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -581,6 +581,67 @@ mod tests {
         );
     }
 
+    /// GAP G6, #1145: the status payload broadcast on
+    /// `embedded-server-status-changed` must carry the *real* live stats and
+    /// `started_at` snapshotted from the active entry, not zeroed defaults —
+    /// otherwise the sidebar traffic line and uptime always read zero.
+    #[test]
+    fn status_state_carries_real_stats_and_started_at() {
+        let stats = ServerStats {
+            active_connections: 2,
+            total_connections: 7,
+            bytes_sent: 4096,
+            bytes_received: 512,
+        };
+        let started_at = "2024-01-01T00:00:00+00:00".to_string();
+
+        let state = build_status_state(
+            "srv-1",
+            ServerStatus::Running,
+            None,
+            stats.clone(),
+            Some(started_at.clone()),
+        );
+
+        assert_eq!(state.server_id, "srv-1");
+        assert_eq!(state.status, ServerStatus::Running);
+        assert_eq!(
+            state.stats.total_connections, 7,
+            "live total_connections must be preserved, not reset to 0"
+        );
+        assert_eq!(
+            state.stats.active_connections, 2,
+            "live active_connections must be preserved"
+        );
+        assert_eq!(state.stats.bytes_sent, 4096, "bytes_sent must be preserved");
+        assert_eq!(
+            state.stats.bytes_received, 512,
+            "bytes_received must be preserved"
+        );
+        assert_eq!(
+            state.started_at,
+            Some(started_at),
+            "started_at must be carried through so uptime can render (GAP G6)"
+        );
+    }
+
+    /// When no active entry exists (e.g. a `Stopped` transition after the entry
+    /// was removed), the status payload falls back to zeroed stats / no start
+    /// time — which is correct, since a stopped server has no live traffic.
+    #[test]
+    fn status_state_defaults_when_no_active_entry() {
+        let state = build_status_state(
+            "srv-1",
+            ServerStatus::Stopped,
+            None,
+            ServerStats::default(),
+            None,
+        );
+        assert_eq!(state.status, ServerStatus::Stopped);
+        assert_eq!(state.stats.total_connections, 0);
+        assert!(state.started_at.is_none());
+    }
+
     /// A port bound at boot must not cause a silent no-op: the auto-start
     /// failure has to surface as an `Error` state carrying the reason so the
     /// sidebar can show the server red at launch (GAP G7, #1145).

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -433,16 +433,47 @@ impl EmbeddedServerManager {
     }
 
     fn emit_status(&self, server_id: &str, status: ServerStatus, error: Option<String>) {
-        let state = ServerState {
-            server_id: server_id.to_string(),
-            status,
-            error,
-            stats: ServerStats::default(),
-            started_at: None,
-        };
+        // Snapshot the *real* live stats and start time from the active entry (as
+        // `get_states` does) instead of shipping zeroed defaults, so the sidebar
+        // traffic line and uptime reflect reality (GAP G6, #1145). If the server
+        // is no longer active (e.g. a `Stopped` transition), fall back to the
+        // zeroed defaults, which is correct for a server with no live traffic.
+        let (stats, started_at) = self
+            .active
+            .lock()
+            .ok()
+            .and_then(|active| {
+                active
+                    .get(server_id)
+                    .map(|srv| (srv.stats.snapshot(), Some(srv.started_at.clone())))
+            })
+            .unwrap_or_default();
+
+        let state = build_status_state(server_id, status, error, stats, started_at);
         let _ = self
             .app_handle
             .emit("embedded-server-status-changed", &state);
+    }
+}
+
+/// Assemble the [`ServerState`] broadcast on `embedded-server-status-changed`.
+///
+/// Kept as a free function so the payload contract (real stats + `started_at`
+/// carried through, not zeroed — GAP G6, #1145) can be unit-tested without a
+/// live [`AppHandle`].
+fn build_status_state(
+    server_id: &str,
+    status: ServerStatus,
+    error: Option<String>,
+    stats: ServerStats,
+    started_at: Option<String>,
+) -> ServerState {
+    ServerState {
+        server_id: server_id.to_string(),
+        status,
+        error,
+        stats,
+        started_at,
     }
 }
 

--- a/src/hooks/useEmbeddedServerEvents.test.ts
+++ b/src/hooks/useEmbeddedServerEvents.test.ts
@@ -36,11 +36,23 @@ vi.mock("@/services/api", () => ({
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
 }));
 
+vi.mock("@/services/embeddedServerApi", () => ({
+  listEmbeddedServers: vi.fn(() => Promise.resolve([])),
+  saveEmbeddedServer: vi.fn(() => Promise.resolve()),
+  deleteEmbeddedServer: vi.fn(() => Promise.resolve()),
+  startEmbeddedServer: vi.fn(() => Promise.resolve()),
+  stopEmbeddedServer: vi.fn(() => Promise.resolve()),
+  getEmbeddedServerStates: vi.fn(() => Promise.resolve([])),
+  createAndStartServer: vi.fn(() => Promise.resolve("")),
+}));
+
 import { onEmbeddedServerStatusChanged } from "@/services/events";
+import { getEmbeddedServerStates } from "@/services/embeddedServerApi";
 import { useAppStore } from "@/store/appStore";
 import { useEmbeddedServerEvents } from "./useEmbeddedServerEvents";
 
 const mockOnStatusChanged = vi.mocked(onEmbeddedServerStatusChanged);
+const mockGetStates = vi.mocked(getEmbeddedServerStates);
 
 function HookConsumer() {
   useEmbeddedServerEvents();
@@ -121,5 +133,90 @@ describe("useEmbeddedServerEvents", () => {
     root = createRoot(container);
 
     expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+
+  // The status-changed event only fires on transitions, so live traffic/uptime
+  // would stay frozen while a server runs. The hook must poll the real states
+  // while any server is running so the sidebar updates continuously (#1145, G6).
+  it("polls live server states on an interval while a server is running", async () => {
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        root.render(createElement(HookConsumer));
+      });
+
+      // No server running yet: no polling should occur.
+      mockGetStates.mockClear();
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(mockGetStates).not.toHaveBeenCalled();
+
+      // A running server arrives via the status event -> polling should begin.
+      await act(async () => {
+        statusChangedHandler?.({
+          serverId: "srv-1",
+          status: "running",
+          stats: {
+            activeConnections: 0,
+            totalConnections: 0,
+            bytesSent: 0,
+            bytesReceived: 0,
+          },
+        });
+      });
+
+      mockGetStates.mockClear();
+      await act(async () => {
+        vi.advanceTimersByTime(3200);
+      });
+      expect(mockGetStates.mock.calls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops polling once no server is running", async () => {
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        root.render(createElement(HookConsumer));
+      });
+
+      await act(async () => {
+        statusChangedHandler?.({
+          serverId: "srv-1",
+          status: "running",
+          stats: {
+            activeConnections: 0,
+            totalConnections: 0,
+            bytesSent: 0,
+            bytesReceived: 0,
+          },
+        });
+      });
+
+      // Server stops -> the running flag flips false and the interval clears.
+      await act(async () => {
+        statusChangedHandler?.({
+          serverId: "srv-1",
+          status: "stopped",
+          stats: {
+            activeConnections: 0,
+            totalConnections: 0,
+            bytesSent: 0,
+            bytesReceived: 0,
+          },
+        });
+      });
+
+      mockGetStates.mockClear();
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(mockGetStates).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/hooks/useEmbeddedServerEvents.ts
+++ b/src/hooks/useEmbeddedServerEvents.ts
@@ -2,12 +2,23 @@ import { useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
 import { onEmbeddedServerStatusChanged } from "@/services/events";
 
+/** How often to poll live server stats while at least one server is running (#1145, GAP G6). */
+const STATS_POLL_INTERVAL_MS = 1500;
+
 /**
- * Hook that listens for embedded server status events from the backend
- * and keeps the store's `embeddedServerStates` map up to date.
+ * Hook that keeps the store's `embeddedServerStates` map up to date:
+ *
+ * 1. Subscribes to backend status-changed events (fired on transitions).
+ * 2. While any server is running, polls the real runtime states on an interval
+ *    so the sidebar's live traffic line and uptime keep updating — status
+ *    events only fire on transitions, not on continuous traffic (#1145, G6).
  */
 export function useEmbeddedServerEvents(): void {
   const updateEmbeddedServerState = useAppStore((s) => s.updateEmbeddedServerState);
+  const refreshEmbeddedServerStates = useAppStore((s) => s.refreshEmbeddedServerStates);
+  const hasRunningServer = useAppStore((s) =>
+    Object.values(s.embeddedServerStates).some((state) => state.status === "running")
+  );
 
   useEffect(() => {
     let unlisten: (() => void) | null = null;
@@ -24,4 +35,12 @@ export function useEmbeddedServerEvents(): void {
       unlisten?.();
     };
   }, [updateEmbeddedServerState]);
+
+  useEffect(() => {
+    if (!hasRunningServer) return;
+    const interval = window.setInterval(() => {
+      void refreshEmbeddedServerStates();
+    }, STATS_POLL_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [hasRunningServer, refreshEmbeddedServerStates]);
 }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -700,6 +700,8 @@ interface AppState {
   embeddedServers: EmbeddedServerConfig[];
   embeddedServerStates: Record<string, EmbeddedServerState>;
   loadEmbeddedServers: () => Promise<void>;
+  /** Refresh only the live runtime states (stats/uptime) without reloading the config list. */
+  refreshEmbeddedServerStates: () => Promise<void>;
   saveEmbeddedServer: (config: EmbeddedServerConfig) => Promise<void>;
   deleteEmbeddedServer: (serverId: string) => Promise<void>;
   startEmbeddedServer: (serverId: string) => Promise<void>;
@@ -3896,6 +3898,19 @@ export const useAppStore = create<AppState>((set, get) => {
         set({ embeddedServers: servers, embeddedServerStates });
       } catch (err) {
         console.error("Failed to load embedded servers:", err);
+      }
+    },
+
+    refreshEmbeddedServerStates: async () => {
+      try {
+        const stateList = await getEmbeddedServerStates();
+        const embeddedServerStates: Record<string, EmbeddedServerState> = {};
+        for (const s of stateList) {
+          embeddedServerStates[s.serverId] = s;
+        }
+        set({ embeddedServerStates });
+      } catch (err) {
+        frontendLog("embedded_server", `Failed to refresh embedded server states: ${err}`);
       }
     },
 


### PR DESCRIPTION
## Summary

Fixes GAP G6 of the embedded servers state-machine audit: the sidebar's live traffic line (`0 conn · ↑0 B ↓0 B`) and uptime were always zero.

`emit_status` in `server_manager.rs` hard-coded `stats: ServerStats::default()` and `started_at: None`, so every `embedded-server-status-changed` broadcast shipped zeroed traffic and no uptime. `get_states` (called once at startup) was the only path returning real values, and nothing re-polled it, so the live values were captured once and never updated.

## Changes

- **Backend** (`server_manager.rs`): `emit_status` now snapshots the running server's real stats + `started_at` from the `active` entry (mirroring `get_states`), falling back to zeroed defaults only when the server is no longer active. Extracted `build_status_state` as a testable, `AppHandle`-free free function.
- **Frontend**: status-changed events only fire on transitions, so live traffic/uptime would otherwise stay frozen while a server runs. Added a light `getEmbeddedServerStates` poll (every 1.5s) in the always-mounted `useEmbeddedServerEvents` hook, active only while a server is running, backed by a new `refreshEmbeddedServerStates` store action that refreshes states without reloading the config list.

## Test plan

- `cargo test -p termihub --lib embedded_servers` — 34 passed (incl. new `status_state_carries_real_stats_and_started_at`, `status_state_defaults_when_no_active_entry`).
- `pnpm test src/hooks/useEmbeddedServerEvents.test.ts` — 6 passed (incl. new poll-starts / poll-stops tests); verified RED before the fix.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all clean.

Partially addresses #1145 (G6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)