### PR TITLE
fix(workspace): tear down live sessions before restore/launch (#1146)

### DIFF
--- a/docs/changes/dev2/feature/1146-teardown-before-restore.md
+++ b/docs/changes/dev2/feature/1146-teardown-before-restore.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Launching a saved workspace or restoring the last session now closes the
+  currently-open live sessions before placing the new layout. Previously the old
+  tabs were dropped from the store while their backend PTY/SSH/agent sessions
+  kept running, leaving them orphaned in the Open Connections panel with no tab
+  to reach them. Persistent sessions are detached (their background process
+  survives and can be re-adopted) rather than force-closed. Addresses GAP G1 of
+  the workspace save/restore audit (#1146).

--- a/src/store/appStore.teardownBeforeRestore.test.ts
+++ b/src/store/appStore.teardownBeforeRestore.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Regression tests for GAP G1 from the workspace save/restore audit (#1146).
+ *
+ * `launchWorkspace` and `restoreLastSession` placed the new `tabGroups` /
+ * `rootPanel` with a single `set(...)` WITHOUT first tearing down the currently
+ * open live sessions. Any live (non-persistent) PTY/SSH/agent session that was
+ * open before the launch/restore was dropped from the store and orphaned — it
+ * lingered in the Open Connections panel with no tab to reach it.
+ *
+ * The fix enumerates every leaf across the existing `tabGroups` (the active
+ * group's live tree lives in `rootPanel`, the others in `group.rootPanel`) and
+ * closes each tab's backend session BEFORE placing the new layout. Persistent
+ * sessions are left running on purpose — they are re-adoptable and not orphans.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PanelNode, TabGroup, TerminalTab } from "@/types/terminal";
+import type { WorkspaceDefinition } from "@/types/workspace";
+import type { LastSession } from "@/types/lastSession";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/workspaceApi", () => ({
+  getWorkspaces: vi.fn(() => Promise.resolve([])),
+  loadWorkspace: vi.fn(),
+  saveWorkspace: vi.fn(() => Promise.resolve()),
+  deleteWorkspace: vi.fn(() => Promise.resolve()),
+  duplicateWorkspace: vi.fn(() => Promise.resolve("")),
+}));
+
+vi.mock("@/services/lastSessionApi", () => ({
+  saveLastSession: vi.fn(() => Promise.resolve()),
+  loadLastSession: vi.fn(() => Promise.resolve(null)),
+  clearLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/api", () => ({
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  detachPersistentTab: vi.fn(() => Promise.resolve(0)),
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+import { useAppStore } from "./appStore";
+import { loadWorkspace as apiLoadWorkspace } from "@/services/workspaceApi";
+import { loadLastSession as apiLoadLastSession } from "@/services/lastSessionApi";
+import { closeTerminal, detachPersistentTab } from "@/services/api";
+
+const mockLoadWorkspace = vi.mocked(apiLoadWorkspace);
+const mockLoadLastSession = vi.mocked(apiLoadLastSession);
+const mockCloseTerminal = vi.mocked(closeTerminal);
+const mockDetachPersistentTab = vi.mocked(detachPersistentTab);
+
+/** Recursively collect session ids from a panel tree (test-local helper). */
+function collectSessionIds(node: PanelNode): string[] {
+  if (node.type === "leaf") {
+    return node.tabs.map((t) => t.sessionId).filter((s): s is string => s !== null);
+  }
+  return node.children.flatMap(collectSessionIds);
+}
+
+/** Build a leaf tab carrying a live session id. */
+function liveTab(id: string, sessionId: string, extra?: Partial<TerminalTab>): TerminalTab {
+  return {
+    id,
+    sessionId,
+    title: id,
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: { shell: "bash" } },
+    panelId: `panel-${id}`,
+    isActive: true,
+    ...extra,
+  };
+}
+
+/** Build a single-leaf panel tree containing the given tabs. */
+function leaf(panelId: string, tabs: TerminalTab[]): PanelNode {
+  return {
+    type: "leaf",
+    id: panelId,
+    tabs,
+    activeTabId: tabs[0]?.id ?? null,
+  };
+}
+
+/**
+ * Seed the store with two live tab groups. The active group's tree is held in
+ * the live `rootPanel`; the inactive group's tree is held in `group.rootPanel`,
+ * mirroring how the real store carries the active vs. inactive trees.
+ */
+function seedTwoLiveGroups(): void {
+  const activeLeaf = leaf("panel-tab-active", [liveTab("tab-active", "sess-active")]);
+  const inactiveLeaf = leaf("panel-tab-inactive", [liveTab("tab-inactive", "sess-inactive")]);
+
+  const groups: TabGroup[] = [
+    {
+      id: "grp-active",
+      name: "Active",
+      // The entry in tabGroups for the active group is stale on purpose; the
+      // live tree is rootPanel below (matches captureAllTabGroups semantics).
+      rootPanel: leaf("panel-stale", []),
+      activePanelId: "panel-stale",
+    },
+    {
+      id: "grp-inactive",
+      name: "Inactive",
+      rootPanel: inactiveLeaf,
+      activePanelId: "panel-tab-inactive",
+    },
+  ];
+
+  useAppStore.setState({
+    connections: [],
+    remoteAgents: [],
+    agentDefinitions: {},
+    defaultShell: "bash",
+    restoreInProgress: false,
+    launchingWorkspaceId: null,
+    tabGroups: groups,
+    activeTabGroupId: "grp-active",
+    rootPanel: activeLeaf,
+    activePanelId: "panel-tab-active",
+  });
+}
+
+describe("appStore — teardown live sessions before restore/launch (GAP G1, #1146)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+    mockLoadLastSession.mockResolvedValue(null);
+  });
+
+  it("closes every existing live session before launchWorkspace places new tabs", async () => {
+    seedTwoLiveGroups();
+
+    const definition: WorkspaceDefinition = {
+      id: "ws-new",
+      name: "Fresh",
+      tabGroups: [
+        {
+          name: "Group 1",
+          layout: { type: "leaf", tabs: [{ inlineConfig: { type: "shell", config: {} } }] },
+        },
+      ],
+    };
+    mockLoadWorkspace.mockResolvedValueOnce(definition);
+
+    await useAppStore.getState().launchWorkspace("ws-new");
+
+    // Both prior live sessions (active-group + inactive-group) were torn down.
+    const closed = mockCloseTerminal.mock.calls.map((c) => c[0]).sort();
+    expect(closed).toEqual(["sess-active", "sess-inactive"]);
+
+    // And the new layout actually replaced the old one afterwards.
+    const state = useAppStore.getState();
+    expect(state.activeWorkspaceName).toBe("Fresh");
+    const remainingSessions = state.tabGroups.flatMap((g) =>
+      collectSessionIds(g.id === state.activeTabGroupId ? state.rootPanel : g.rootPanel)
+    );
+    expect(remainingSessions).not.toContain("sess-active");
+    expect(remainingSessions).not.toContain("sess-inactive");
+  });
+
+  it("closes every existing live session before restoreLastSession places new tabs", async () => {
+    seedTwoLiveGroups();
+
+    const session: LastSession = {
+      version: "1",
+      activeGroupIndex: 0,
+      tabGroups: [
+        {
+          name: "Restored",
+          layout: {
+            type: "leaf",
+            tabs: [{ inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell" }],
+          },
+        },
+      ],
+    };
+    mockLoadLastSession.mockResolvedValueOnce(session);
+
+    const ok = await useAppStore.getState().restoreLastSession();
+    expect(ok).toBe(true);
+
+    const closed = mockCloseTerminal.mock.calls.map((c) => c[0]).sort();
+    expect(closed).toEqual(["sess-active", "sess-inactive"]);
+  });
+
+  it("detaches (does not kill) persistent sessions so they can be re-adopted", async () => {
+    const persistentTab = liveTab("tab-persist", "sess-persist", {
+      persistentConnectionId: "conn-persist",
+    });
+    useAppStore.setState({
+      connections: [],
+      remoteAgents: [],
+      agentDefinitions: {},
+      defaultShell: "bash",
+      restoreInProgress: false,
+      launchingWorkspaceId: null,
+      tabGroups: [
+        {
+          id: "grp-only",
+          name: "Only",
+          rootPanel: leaf("panel-stale", []),
+          activePanelId: "panel-stale",
+        },
+      ],
+      activeTabGroupId: "grp-only",
+      rootPanel: leaf("panel-tab-persist", [persistentTab]),
+      activePanelId: "panel-tab-persist",
+    });
+
+    const definition: WorkspaceDefinition = {
+      id: "ws-new",
+      name: "Fresh",
+      tabGroups: [
+        {
+          name: "Group 1",
+          layout: { type: "leaf", tabs: [{ inlineConfig: { type: "shell", config: {} } }] },
+        },
+      ],
+    };
+    mockLoadWorkspace.mockResolvedValueOnce(definition);
+
+    await useAppStore.getState().launchWorkspace("ws-new");
+
+    // Persistent session is detached (process kept alive), not force-closed.
+    expect(mockCloseTerminal).not.toHaveBeenCalledWith("sess-persist");
+    expect(mockDetachPersistentTab).toHaveBeenCalledWith("sess-persist", "tab-persist");
+  });
+
+  it("is a no-op teardown when there are no live sessions to close", async () => {
+    // Fresh initial state has an empty layout / no sessions.
+    const definition: WorkspaceDefinition = {
+      id: "ws-new",
+      name: "Fresh",
+      tabGroups: [
+        {
+          name: "Group 1",
+          layout: { type: "leaf", tabs: [{ inlineConfig: { type: "shell", config: {} } }] },
+        },
+      ],
+    };
+    mockLoadWorkspace.mockResolvedValueOnce(definition);
+
+    await useAppStore.getState().launchWorkspace("ws-new");
+
+    expect(mockCloseTerminal).not.toHaveBeenCalled();
+    expect(mockDetachPersistentTab).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -91,6 +91,8 @@ import {
   stopPersistentSession as apiStopPersistentSession,
   attachPersistentTab as apiAttachPersistentTab,
   adoptPersistentSession as apiAdoptPersistentSession,
+  closeTerminal as apiCloseTerminal,
+  detachPersistentTab as apiDetachPersistentTab,
 } from "@/services/api";
 import type { ConnectionTypeInfo } from "@/services/api";
 import { RemoteAgentConfig } from "@/types/terminal";
@@ -820,6 +822,46 @@ function beginRestoreGuard(setState: (partial: Partial<AppState>) => void): void
     frontendLog("workspace", "restore settle window elapsed; auto-save re-enabled");
   }, RESTORE_SETTLE_MS);
 }
+
+/**
+ * Tear down every live backend session currently held by the store (GAP G1,
+ * #1146). `launchWorkspace` / `restoreLastSession` replace the whole layout with
+ * a single `set(...)`; without this, the prior tabs' PTY/SSH/agent sessions are
+ * dropped from the store and orphaned into the Open Connections panel with no
+ * tab to reach them. Call this BEFORE placing the new groups.
+ *
+ * The active group's live tree lives in `rootPanel`; every other group's tree
+ * lives in `group.rootPanel` (mirrors {@link captureAllTabGroups}). Persistent
+ * sessions are detached rather than killed so their background process survives
+ * and can be re-adopted — the same distinction the Terminal unmount cleanup
+ * makes. Failures are swallowed: a best-effort close must never block the
+ * launch/restore that follows.
+ */
+function teardownAllSessions(state: {
+  tabGroups: TabGroup[];
+  activeTabGroupId: string;
+  rootPanel: PanelNode;
+}): void {
+  const trees = state.tabGroups.map((g) =>
+    g.id === state.activeTabGroupId ? state.rootPanel : g.rootPanel
+  );
+  const tabs = trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
+  let closed = 0;
+  for (const tab of tabs) {
+    if (!tab.sessionId) continue;
+    closed++;
+    if (tab.persistentConnectionId) {
+      // Persistent session — detach so the background process keeps running.
+      apiDetachPersistentTab(tab.sessionId, tab.id).catch(() => {});
+    } else {
+      apiCloseTerminal(tab.sessionId).catch(() => {});
+    }
+  }
+  if (closed > 0) {
+    frontendLog("workspace", `tore down ${closed} live session(s) before restore/launch`);
+  }
+}
+
 /** Unlisten function for the active session-based monitoring event subscription. */
 let _monitoringUnlisten: (() => void) | null = null;
 
@@ -4252,6 +4294,10 @@ export const useAppStore = create<AppState>((set, get) => {
           return;
         }
         const firstGroup = builtGroups[0];
+        // GAP G1 (#1146): tear down the currently-open live sessions BEFORE the
+        // `set` replaces the layout, otherwise their PTY/SSH/agent sessions are
+        // dropped from the store and orphaned into the Open Connections panel.
+        teardownAllSessions(get());
         // GAP G5 (#1146): raise the guard BEFORE placing the layout so the
         // auto-save subscription that fires from this `set` — and the per-tab
         // connects that follow — do not persist a mid-launch snapshot over the
@@ -4389,6 +4435,10 @@ export const useAppStore = create<AppState>((set, get) => {
         }
         const idx = Math.min(Math.max(session.activeGroupIndex, 0), builtGroups.length - 1);
         const activeGroup = builtGroups[idx];
+        // GAP G1 (#1146): tear down any currently-open live sessions BEFORE the
+        // `set` replaces the layout (e.g. a CLI-opened workspace at startup that
+        // runs before restore), otherwise those sessions are orphaned.
+        teardownAllSessions(get());
         // GAP G5 (#1146): raise the guard BEFORE placing the layout so the
         // auto-save subscription that fires from this very `set` — and the
         // per-tab connects that follow — are skipped until the cohort settles.


### PR DESCRIPTION
## Summary

Fixes **GAP G1** of the workspace save/restore state-machine audit
(`docs/audits/workspace-save-restore-state-machine.md`).

`launchWorkspace` and `restoreLastSession` replaced the whole layout with a
single `set(...)` **without first closing the currently-open live sessions**.
Any live (non-persistent) PTY/SSH/agent session that was open before the
launch/restore was dropped from the store and **orphaned** into the Open
Connections panel with no tab to reach it — the exact leak signature the audit
flags.

## Changes

- Add a `teardownAllSessions()` helper in `appStore.ts` that enumerates every
  leaf across the existing tab groups (the active group's live tree from
  `rootPanel`, every other group's tree from `group.rootPanel` — mirroring
  `captureAllTabGroups`) and closes each tab's backend session.
  - Non-persistent sessions → `closeTerminal(sessionId)` (killed).
  - Persistent sessions → `detachPersistentTab(sessionId, tabId)` (background
    process kept alive so it can be re-adopted), matching the Terminal unmount
    cleanup distinction.
  - Best-effort: close failures are swallowed so they never block the
    launch/restore.
- Call it in both `launchWorkspace` and `restoreLastSession` immediately before
  the layout-placing `set(...)` (just ahead of the existing `beginRestoreGuard`).
- The existing `restoreInProgress` guard (G5) and `launchingWorkspaceId`
  re-entrancy guard (G6) are unchanged and still in force.

## Test plan

- New regression suite `src/store/appStore.teardownBeforeRestore.test.ts`
  (added test-first; RED before the fix, GREEN after):
  - `launchWorkspace` closes every existing live session (across active and
    inactive groups) before placing new tabs.
  - `restoreLastSession` does the same.
  - Persistent sessions are **detached, not killed**.
  - No-op when there are no live sessions.
- `pnpm test` — 220 files / 2369 tests pass.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all clean.

Partially addresses #1146 (G1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)