### PR TITLE
refactor(sftp): explicit sftpStatus enum (#1143)

### DIFF
--- a/docs/changes/dev2/feature/1143-sftp-status-enum.md
+++ b/docs/changes/dev2/feature/1143-sftp-status-enum.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Internal refactor (no user-visible behavior change): the SFTP file browser's
+  overloaded `sftpLoading` flag was replaced with an explicit
+  `sftpStatus` lifecycle enum (`idle` / `connecting` / `connected` / `listing` /
+  `error`), so the UI can reliably tell "connecting" apart from
+  "listing"/"refreshing" and show the correct placeholder (audit gap A1, #1143).

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -702,6 +702,9 @@ export function FileBrowser() {
   const disconnectSftp = useAppStore((s) => s.disconnectSftp);
   const retrySftp = useAppStore((s) => s.retrySftp);
   const dismissSftpError = useAppStore((s) => s.dismissSftpError);
+  // Explicit SFTP lifecycle status (audit gap A1) — used to pick the SFTP
+  // placeholder label without inferring it from isConnected + isLoading.
+  const sftpStatus = useAppStore((s) => s.sftpStatus);
   const vscodeAvailable = useAppStore((s) => s.vscodeAvailable);
   const fileClipboard = useAppStore((s) => s.fileClipboard);
   const quickShareServer = useAppStore((s) => s.quickShareServer);
@@ -942,7 +945,7 @@ export function FileBrowser() {
     return (
       <div className="file-browser">
         <div className="file-browser__placeholder" data-testid="file-browser-sftp-connecting">
-          {isLoading ? (
+          {sftpStatus === "connecting" ? (
             <>
               <Loader2 size={20} className="file-browser__spinner" />
               <span>Connecting SFTP...</span>

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -53,7 +53,7 @@ export function useFileSystem() {
   const fileEntries = useAppStore((s) => s.fileEntries);
   const currentPath = useAppStore((s) => s.currentPath);
   const sftpSessionId = useAppStore((s) => s.sftpSessionId);
-  const sftpLoading = useAppStore((s) => s.sftpLoading);
+  const sftpStatus = useAppStore((s) => s.sftpStatus);
   const sftpError = useAppStore((s) => s.sftpError);
   const navigateSftp = useAppStore((s) => s.navigateSftp);
   const refreshSftp = useAppStore((s) => s.refreshSftp);
@@ -246,7 +246,10 @@ export function useFileSystem() {
     fileEntries,
     currentPath,
     isConnected: sftpSessionId !== null,
-    isLoading: sftpLoading,
+    // Derived from the explicit status enum (audit gap A1): either the initial
+    // connect or a directory list is in flight. Callers that need to tell
+    // "connecting" apart from "listing" read `sftpStatus` from the store.
+    isLoading: sftpStatus === "connecting" || sftpStatus === "listing",
     error: sftpError,
     navigateTo,
     navigateUp,

--- a/src/store/appStore.sftpRecovery.test.ts
+++ b/src/store/appStore.sftpRecovery.test.ts
@@ -134,7 +134,9 @@ describe("appStore — SFTP dropped-session recovery (S2)", () => {
     expect(state.sftpSessionId).toBeNull();
     expect(state.sftpConnectedHost).toBeNull();
     expect(state.sftpError).toContain("session not found");
-    expect(state.sftpLoading).toBe(false);
+    // The overloaded `sftpLoading` boolean was replaced by an explicit status
+    // enum (audit gap A1); a failed list settles on `error`, not a loading flag.
+    expect(state.sftpStatus).toBe("error");
   });
 
   it("refreshSftp clears sftpSessionId on a transport/channel error", async () => {
@@ -145,7 +147,7 @@ describe("appStore — SFTP dropped-session recovery (S2)", () => {
     const state = useAppStore.getState();
     expect(state.sftpSessionId).toBeNull();
     expect(state.sftpConnectedHost).toBeNull();
-    expect(state.sftpLoading).toBe(false);
+    expect(state.sftpStatus).toBe("error");
   });
 
   it("navigateSftp keeps sftpSessionId on an ordinary listing error (e.g. permission denied)", async () => {

--- a/src/store/appStore.sftpStatus.test.ts
+++ b/src/store/appStore.sftpStatus.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve("persisted-id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore, _resetSftpListSeq } from "./appStore";
+import { sftpOpen, sftpListDir } from "@/services/api";
+import type { FileEntry } from "@/types/connection";
+
+function makeEntry(name: string): FileEntry {
+  return {
+    name,
+    path: `/${name}`,
+    isDirectory: true,
+    size: 0,
+    modified: "",
+    permissions: null,
+  };
+}
+
+const SAMPLE_CONFIG = { host: "example.com", port: 22, username: "alice", password: "pw" };
+
+/**
+ * Deferred promise helper: lets a test observe the intermediate store state
+ * while an async store action is still in flight (before the mocked API call
+ * resolves). Used to assert the transient `connecting` / `listing` statuses.
+ */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("appStore — sftpStatus enum transitions (A1)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    _resetSftpListSeq();
+    vi.clearAllMocks();
+  });
+
+  it("starts in the 'idle' status", () => {
+    expect(useAppStore.getState().sftpStatus).toBe("idle");
+  });
+
+  it("connectSftp transitions idle → connecting → connected on success", async () => {
+    const open = deferred<string>();
+    vi.mocked(sftpOpen).mockReturnValue(open.promise);
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+
+    const connectPromise = useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    // While sftpOpen is pending the status must read 'connecting'.
+    expect(useAppStore.getState().sftpStatus).toBe("connecting");
+
+    open.resolve("session-1");
+    await connectPromise;
+
+    expect(useAppStore.getState().sftpStatus).toBe("connected");
+    expect(useAppStore.getState().sftpSessionId).toBe("session-1");
+  });
+
+  it("connectSftp transitions idle → connecting → error on failure", async () => {
+    vi.mocked(sftpOpen).mockRejectedValue(new Error("auth failed"));
+
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    const state = useAppStore.getState();
+    expect(state.sftpStatus).toBe("error");
+    expect(state.sftpError).toBe("auth failed");
+    expect(state.sftpSessionId).toBeNull();
+  });
+
+  it("navigateSftp transitions connected → listing → connected on success", async () => {
+    // Establish a connected session first.
+    vi.mocked(sftpOpen).mockResolvedValue("session-1");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+    expect(useAppStore.getState().sftpStatus).toBe("connected");
+
+    const list = deferred<FileEntry[]>();
+    vi.mocked(sftpListDir).mockReturnValue(list.promise);
+
+    const navPromise = useAppStore.getState().navigateSftp("/tmp");
+
+    // While the list request is pending the status must read 'listing'.
+    expect(useAppStore.getState().sftpStatus).toBe("listing");
+
+    list.resolve([makeEntry("tmpfile")]);
+    await navPromise;
+
+    expect(useAppStore.getState().sftpStatus).toBe("connected");
+    expect(useAppStore.getState().currentPath).toBe("/tmp");
+  });
+
+  it("refreshSftp transitions connected → listing → connected on success", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-1");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+    expect(useAppStore.getState().sftpStatus).toBe("connected");
+
+    const list = deferred<FileEntry[]>();
+    vi.mocked(sftpListDir).mockReturnValue(list.promise);
+
+    const refreshPromise = useAppStore.getState().refreshSftp();
+    expect(useAppStore.getState().sftpStatus).toBe("listing");
+
+    list.resolve([makeEntry("home")]);
+    await refreshPromise;
+
+    expect(useAppStore.getState().sftpStatus).toBe("connected");
+  });
+
+  it("navigateSftp transitions connected → listing → error but stays connected on a recoverable listing error", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-1");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    vi.mocked(sftpListDir).mockRejectedValue(new Error("permission denied"));
+    await useAppStore.getState().navigateSftp("/root");
+
+    const state = useAppStore.getState();
+    expect(state.sftpStatus).toBe("error");
+    expect(state.sftpError).toContain("permission denied");
+    // Recoverable error keeps the underlying session.
+    expect(state.sftpSessionId).toBe("session-1");
+  });
+
+  it("navigateSftp on a dead-session error transitions to error and clears the session", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-1");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    vi.mocked(sftpListDir).mockRejectedValue(new Error("SFTP session not found: session-1"));
+    await useAppStore.getState().navigateSftp("/tmp");
+
+    const state = useAppStore.getState();
+    expect(state.sftpStatus).toBe("error");
+    expect(state.sftpSessionId).toBeNull();
+    expect(state.sftpConnectedHost).toBeNull();
+  });
+
+  it("disconnectSftp returns the status to 'idle'", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-1");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+    expect(useAppStore.getState().sftpStatus).toBe("connected");
+
+    await useAppStore.getState().disconnectSftp();
+
+    expect(useAppStore.getState().sftpStatus).toBe("idle");
+    expect(useAppStore.getState().sftpSessionId).toBeNull();
+  });
+
+  it("dismissSftpError clears an error status back to idle when disconnected", async () => {
+    vi.mocked(sftpOpen).mockRejectedValue(new Error("nope"));
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+    expect(useAppStore.getState().sftpStatus).toBe("error");
+
+    useAppStore.getState().dismissSftpError();
+
+    const state = useAppStore.getState();
+    expect(state.sftpError).toBeNull();
+    // With no live session, dismissing the error returns to idle.
+    expect(state.sftpStatus).toBe("idle");
+  });
+
+  it("dismissSftpError returns to 'connected' when a live session survived the error", async () => {
+    vi.mocked(sftpOpen).mockResolvedValue("session-1");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+
+    // A recoverable listing error leaves the session intact but flips to error.
+    vi.mocked(sftpListDir).mockRejectedValue(new Error("permission denied"));
+    await useAppStore.getState().navigateSftp("/root");
+    expect(useAppStore.getState().sftpStatus).toBe("error");
+    expect(useAppStore.getState().sftpSessionId).toBe("session-1");
+
+    useAppStore.getState().dismissSftpError();
+
+    const state = useAppStore.getState();
+    expect(state.sftpError).toBeNull();
+    expect(state.sftpStatus).toBe("connected");
+  });
+
+  it("retrySftp goes back through connecting to connected on a successful retry", async () => {
+    vi.mocked(sftpOpen).mockRejectedValueOnce(new Error("host down"));
+    await useAppStore.getState().connectSftp(SAMPLE_CONFIG);
+    expect(useAppStore.getState().sftpStatus).toBe("error");
+
+    vi.mocked(sftpOpen).mockResolvedValueOnce("session-xyz");
+    vi.mocked(sftpListDir).mockResolvedValue([makeEntry("home")]);
+    await useAppStore.getState().retrySftp();
+
+    expect(useAppStore.getState().sftpStatus).toBe("connected");
+    expect(useAppStore.getState().sftpSessionId).toBe("session-xyz");
+  });
+});

--- a/src/store/appStore.sftpStatus.test.ts
+++ b/src/store/appStore.sftpStatus.test.ts
@@ -26,12 +26,13 @@ vi.mock("@/services/api", () => ({
   sftpOpen: vi.fn(),
   sftpClose: vi.fn(),
   sftpListDir: vi.fn(),
+  sftpRealpath: vi.fn(),
   localListDir: vi.fn(),
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
 }));
 
 import { useAppStore, _resetSftpListSeq } from "./appStore";
-import { sftpOpen, sftpListDir } from "@/services/api";
+import { sftpOpen, sftpListDir, sftpRealpath } from "@/services/api";
 import type { FileEntry } from "@/types/connection";
 
 function makeEntry(name: string): FileEntry {
@@ -67,6 +68,9 @@ describe("appStore — sftpStatus enum transitions (A1)", () => {
     useAppStore.setState(useAppStore.getInitialState());
     _resetSftpListSeq();
     vi.clearAllMocks();
+    // connectSftp resolves the remote home via realpath(".") (audit gap C2);
+    // default it so the connect path does not fall back to root.
+    vi.mocked(sftpRealpath).mockResolvedValue("/home/alice");
   });
 
   it("starts in the 'idle' status", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -24,6 +24,7 @@ import {
   SavedConnection,
   ConnectionFolder,
   FileEntry,
+  SftpStatus,
   AppSettings,
   RemoteAgentDefinition,
   AgentCapabilities,
@@ -476,7 +477,12 @@ interface AppState {
   fileEntries: FileEntry[];
   currentPath: string;
   sftpSessionId: string | null;
-  sftpLoading: boolean;
+  /**
+   * Explicit SFTP session lifecycle status (audit gap A1). Replaces the
+   * overloaded `sftpLoading` boolean so the UI can tell "connecting" apart from
+   * "listing"/"refreshing" and "idle".
+   */
+  sftpStatus: SftpStatus;
   sftpError: string | null;
   sftpConnectedHost: string | null;
   /**
@@ -2761,7 +2767,7 @@ export const useAppStore = create<AppState>((set, get) => {
     fileEntries: [],
     currentPath: "/",
     sftpSessionId: null,
-    sftpLoading: false,
+    sftpStatus: "idle",
     sftpError: null,
     sftpConnectedHost: null,
     sftpLastConfig: null,
@@ -2771,7 +2777,7 @@ export const useAppStore = create<AppState>((set, get) => {
 
     connectSftp: async (config: Record<string, unknown>) => {
       // Retain the config so a failed connect can be retried (audit gap S1).
-      set({ sftpLoading: true, sftpError: null, sftpLastConfig: config });
+      set({ sftpStatus: "connecting", sftpError: null, sftpLastConfig: config });
       try {
         const sessionId = await sftpOpen(config);
         const homePath = `/home/${config.username as string}`;
@@ -2786,14 +2792,14 @@ export const useAppStore = create<AppState>((set, get) => {
         }
         set({
           sftpSessionId: sessionId,
-          sftpLoading: false,
+          sftpStatus: "connected",
           currentPath: activePath,
           fileEntries: entries,
           sftpConnectedHost: `${config.username as string}@${config.host as string}:${config.port as number}`,
         });
       } catch (err) {
         set({
-          sftpLoading: false,
+          sftpStatus: "error",
           sftpError: err instanceof Error ? err.message : String(err),
         });
       }
@@ -2810,6 +2816,7 @@ export const useAppStore = create<AppState>((set, get) => {
       }
       set({
         sftpSessionId: null,
+        sftpStatus: "idle",
         fileEntries: [],
         currentPath: "/",
         sftpError: null,
@@ -2828,13 +2835,21 @@ export const useAppStore = create<AppState>((set, get) => {
       await useAppStore.getState().connectSftp(config);
     },
 
-    dismissSftpError: () => set({ sftpError: null }),
+    dismissSftpError: () =>
+      // Clearing the error must also leave a coherent status: fall back to
+      // `connected` when a live session survived the error (a recoverable
+      // listing error), otherwise `idle`. Leaving it on `error` would keep the
+      // failed-connect placeholder up even after the message is dismissed.
+      set((state) => ({
+        sftpError: null,
+        sftpStatus: state.sftpSessionId ? "connected" : "idle",
+      })),
 
     navigateSftp: async (path: string) => {
       const sessionId = useAppStore.getState().sftpSessionId;
       if (!sessionId) return;
       const seq = ++_sftpListSeq;
-      set({ sftpLoading: true, sftpError: null });
+      set({ sftpStatus: "listing", sftpError: null });
       try {
         const entries = await sftpListDir(sessionId, path);
         // Ignore a stale response: a newer navigate/refresh superseded this one.
@@ -2842,7 +2857,7 @@ export const useAppStore = create<AppState>((set, get) => {
           frontendLog("sftp", `navigateSftp: dropping stale list for ${path} (seq ${seq})`);
           return;
         }
-        set({ fileEntries: entries, currentPath: path, sftpLoading: false });
+        set({ fileEntries: entries, currentPath: path, sftpStatus: "connected" });
       } catch (err) {
         if (seq !== _sftpListSeq) return;
         const message = err instanceof Error ? err.message : String(err);
@@ -2853,7 +2868,7 @@ export const useAppStore = create<AppState>((set, get) => {
           frontendLog("sftp", `navigateSftp: session appears dead — clearing session (${message})`);
         }
         set({
-          sftpLoading: false,
+          sftpStatus: "error",
           sftpError: message,
           ...(sessionDead ? { sftpSessionId: null, sftpConnectedHost: null } : {}),
         });
@@ -2864,7 +2879,7 @@ export const useAppStore = create<AppState>((set, get) => {
       const { sftpSessionId, currentPath } = useAppStore.getState();
       if (!sftpSessionId) return;
       const seq = ++_sftpListSeq;
-      set({ sftpLoading: true, sftpError: null });
+      set({ sftpStatus: "listing", sftpError: null });
       try {
         const entries = await sftpListDir(sftpSessionId, currentPath);
         // Ignore a stale response: a newer navigate/refresh superseded this one.
@@ -2872,7 +2887,7 @@ export const useAppStore = create<AppState>((set, get) => {
           frontendLog("sftp", `refreshSftp: dropping stale list for ${currentPath} (seq ${seq})`);
           return;
         }
-        set({ fileEntries: entries, sftpLoading: false });
+        set({ fileEntries: entries, sftpStatus: "connected" });
       } catch (err) {
         if (seq !== _sftpListSeq) return;
         const message = err instanceof Error ? err.message : String(err);
@@ -2881,7 +2896,7 @@ export const useAppStore = create<AppState>((set, get) => {
           frontendLog("sftp", `refreshSftp: session appears dead — clearing session (${message})`);
         }
         set({
-          sftpLoading: false,
+          sftpStatus: "error",
           sftpError: message,
           ...(sessionDead ? { sftpSessionId: null, sftpConnectedHost: null } : {}),
         });

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -2,6 +2,21 @@ import { ConnectionConfig, RemoteAgentConfig, TerminalOptions, LineEnding } from
 import { SettingsSchema, Capabilities } from "./schema";
 import { KeybindingOverrideEntry } from "./keybindings";
 
+/**
+ * Explicit lifecycle status of the single desktop SFTP session (audit gap A1).
+ *
+ * Replaces the previously-overloaded `sftpLoading` boolean, which could not
+ * distinguish "connecting" from "listing"/"refreshing" from "idle". The UI reads
+ * this to pick the right placeholder (e.g. "Connecting SFTP…" vs "Loading…").
+ *
+ * - `idle`      — no session, no error (initial / after disconnect)
+ * - `connecting`— `connectSftp` in flight, no session yet
+ * - `connected` — session established, no operation in flight
+ * - `listing`   — a `navigateSftp` / `refreshSftp` list request is in flight
+ * - `error`     — the last connect or list operation failed (see `sftpError`)
+ */
+export type SftpStatus = "idle" | "connecting" | "connected" | "listing" | "error";
+
 export interface SavedConnection {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

GAP A1 from the SFTP / file browser state-machine audit (`docs/audits/sftp-file-browser-state-machine.md`, umbrella #1143). The single `sftpLoading` boolean was overloaded across connect, navigate, refresh, and every mutating op, so the UI could not distinguish "connecting" from "listing"/"refreshing" from "idle". This replaces it with an explicit `sftpStatus` lifecycle enum.

This is a pure refactor — no behavior change. `sftpError` and `sftpSessionId` are untouched, and it builds cleanly on top of the recently merged SFTP work on develop (S1/S2 recovery, C2 realpath home, R1 race guard).

## Changes

- **`src/types/connection.ts`** — new `SftpStatus = "idle" | "connecting" | "connected" | "listing" | "error"` type.
- **`src/store/appStore.ts`** — replace `sftpLoading: boolean` with `sftpStatus: SftpStatus`. Every writer updates the enum: `connectSftp` (`connecting` → `connected` / `error`), `navigateSftp` / `refreshSftp` (`listing` → `connected` / `error`), `disconnectSftp` (`idle`), `retrySftp` (via `connectSftp`), and `dismissSftpError` (falls back to `connected` when a live session survived the error, else `idle`).
- **`src/hooks/useFileSystem.ts`** — derive `isLoading` from the enum (`connecting || listing`) so all existing generic-loading UI (refresh spinner, "Loading…" list) keeps working unchanged.
- **`src/components/Sidebar/FileBrowser.tsx`** — the SFTP placeholder now branches on `sftpStatus === "connecting"` explicitly instead of inferring "Connecting SFTP…" from `isConnected` + `isLoading`.
- Updated the S2 recovery tests to assert the new status field (behavior unchanged).

## Test plan

- New `src/store/appStore.sftpStatus.test.ts` covers all transitions: `idle → connecting → connected`, `idle → connecting → error`, `connected → listing → connected` (navigate + refresh), listing errors (recoverable stays connected, dead-session clears + `error`), `disconnect → idle`, `dismissSftpError`, and `retrySftp`.
- `pnpm test` — 220 files / 2376 tests pass.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all clean.

Partially addresses #1143 (A1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)