### PR TITLE
docs(concept): regenerate mockups gallery for the four lifecycle concepts

### DIFF
--- a/docs/concepts/mockups-index.html
+++ b/docs/concepts/mockups-index.html
@@ -30,9 +30,13 @@
         <li><a href="backlog/embedded-unix-windows.html">embedded-unix-windows.html</a></li>
         <li><a href="backlog/ftp-client.html">ftp-client.html</a></li>
         <li><a href="backlog/macro-recording.html">macro-recording.html</a></li>
+        <li><a href="backlog/remote-agent-lifecycle-redesign.html">remote-agent-lifecycle-redesign.html</a></li>
         <li><a href="backlog/remote-agent-update-strategy.html">remote-agent-update-strategy.html</a></li>
+        <li><a href="backlog/remote-monitoring-lifecycle-redesign.html">remote-monitoring-lifecycle-redesign.html</a></li>
+        <li><a href="backlog/sftp-session-and-transfers.html">sftp-session-and-transfers.html</a></li>
         <li><a href="backlog/shell-context-menu-integration.html">shell-context-menu-integration.html</a></li>
         <li><a href="backlog/ssh-jump-host.html">ssh-jump-host.html</a></li>
+        <li><a href="backlog/ssh-tunnel-lifecycle-redesign.html">ssh-tunnel-lifecycle-redesign.html</a></li>
         <li><a href="backlog/ui-modernization.html">ui-modernization.html</a></li>
         <li><a href="backlog/x-server-provisioning.html">x-server-provisioning.html</a></li>
       </ul></div>


### PR DESCRIPTION
Regenerates `docs/concepts/mockups-index.html` to include the four lifecycle-redesign concepts merged in #1220, #1219, #1218, #1221:

- `remote-agent-lifecycle-redesign.html` (#1142)
- `ssh-tunnel-lifecycle-redesign.html` (#1191)
- `sftp-session-and-transfers.html` (#1192)
- `remote-monitoring-lifecycle-redesign.html` (#1193)

The four concept PRs deliberately did not each regenerate the gallery (to avoid 4-way conflicts on the generated index); this single regen picks them all up. Output: 19 mockups.

Docs-only; no change fragment.

Note: `scripts/internal/build-mockups-index.sh` fails under macOS's `/bin/bash` (3.2) via its shebang but runs cleanly under bash 5.x — worth a small portability follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)