### PR TITLE
feat(network): HTTP monitor pause/resume + Stop-vs-Remove (#1147)

### DIFF
--- a/docs/changes/dev2/feature/1147-pause-remove.md
+++ b/docs/changes/dev2/feature/1147-pause-remove.md
@@ -1,0 +1,16 @@
+### Added
+
+- HTTP monitors can now be **paused and resumed**. Pausing suspends polling
+  while keeping the monitor listed (and its poll loop alive) so it can be
+  resumed instantly with the same configuration and history; a paused monitor
+  shows a "paused" state in the Network Tools panel, the sidebar, and the Open
+  Connections panel (audit gap #5, #1147).
+
+### Changed
+
+- **Stop and Remove are now separate actions for HTTP monitors.** _Stop_ cancels
+  the poll loop but keeps the monitor listed (as stopped) and preserves its
+  saved configuration so it can be resumed or auto-restarts on the next launch.
+  _Remove_ deletes the monitor and its persisted config entirely. Previously
+  "Stop" silently destroyed the monitor and its configuration (audit gap #6,
+  #1147).

--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -333,13 +333,42 @@ pub fn network_http_monitor_start(
     manager.start_http_monitor(config)
 }
 
-/// Stop a running HTTP monitor.
+/// Stop a running HTTP monitor, keeping it listed (as not running) so it can be
+/// resumed. Use [`network_http_monitor_remove`] to delete it.
 #[tauri::command]
 pub fn network_http_monitor_stop(
     monitor_id: String,
     manager: State<'_, NetworkManager>,
 ) -> Result<(), TerminalError> {
     manager.stop_http_monitor(&monitor_id)
+}
+
+/// Remove an HTTP monitor entirely (cancel + drop handle + delete persisted
+/// config).
+#[tauri::command]
+pub fn network_http_monitor_remove(
+    monitor_id: String,
+    manager: State<'_, NetworkManager>,
+) -> Result<(), TerminalError> {
+    manager.remove_http_monitor(&monitor_id)
+}
+
+/// Pause a running HTTP monitor (suspend polling, keep the loop alive).
+#[tauri::command]
+pub fn network_http_monitor_pause(
+    monitor_id: String,
+    manager: State<'_, NetworkManager>,
+) -> Result<(), TerminalError> {
+    manager.pause_http_monitor(&monitor_id)
+}
+
+/// Resume a paused or stopped HTTP monitor with the same config.
+#[tauri::command]
+pub fn network_http_monitor_resume(
+    monitor_id: String,
+    manager: State<'_, NetworkManager>,
+) -> Result<(), TerminalError> {
+    manager.resume_http_monitor(&monitor_id)
 }
 
 /// Stop every running HTTP monitor at once.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -579,6 +579,9 @@ pub fn run() {
             commands::network::network_wol_device_delete,
             commands::network::network_http_monitor_start,
             commands::network::network_http_monitor_stop,
+            commands::network::network_http_monitor_remove,
+            commands::network::network_http_monitor_pause,
+            commands::network::network_http_monitor_resume,
             commands::network::network_http_monitor_stop_all,
             commands::network::network_http_monitor_list,
             // Embedded servers

--- a/src-tauri/src/network/http_monitor.rs
+++ b/src-tauri/src/network/http_monitor.rs
@@ -2,6 +2,8 @@
 //!
 //! This is desktop-only (uses `reqwest`) and is not part of `termihub-core`.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use reqwest::Client;
@@ -44,12 +46,19 @@ pub struct HttpCheckResult {
     pub timestamp_ms: u64,
 }
 
-/// Current state of a running HTTP monitor (for listing).
+/// Current state of a monitor (for listing).
+///
+/// The lifecycle is derived from two booleans:
+/// - `running`  — the poll loop is alive (`false` == stopped-but-listed).
+/// - `paused`   — the loop is alive but its poll body is suspended.
+///
+/// (`running: false` implies `paused: false`.)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HttpMonitorState {
     pub config: HttpMonitorConfig,
     pub running: bool,
+    pub paused: bool,
     pub last_result: Option<HttpCheckResult>,
 }
 
@@ -57,6 +66,8 @@ pub struct HttpMonitorState {
 pub struct HttpMonitorHandle {
     pub config: HttpMonitorConfig,
     pub cancel: CancellationToken,
+    /// When set, the poll loop stays alive but skips the HTTP check (Pause).
+    pub paused: Arc<AtomicBool>,
     pub last_result: std::sync::Arc<std::sync::Mutex<Option<HttpCheckResult>>>,
 }
 
@@ -89,9 +100,11 @@ impl HttpMonitorConfig {
 /// Returns a [`HttpMonitorHandle`] that can be used to stop the task.
 pub fn start_monitor(config: HttpMonitorConfig, app: AppHandle) -> HttpMonitorHandle {
     let cancel = CancellationToken::new();
+    let paused = Arc::new(AtomicBool::new(false));
     let last_result = std::sync::Arc::new(std::sync::Mutex::new(None::<HttpCheckResult>));
 
     let cancel_clone = cancel.clone();
+    let paused_clone = Arc::clone(&paused);
     let config_clone = config.clone();
     let last_result_clone = std::sync::Arc::clone(&last_result);
 
@@ -100,12 +113,20 @@ pub fn start_monitor(config: HttpMonitorConfig, app: AppHandle) -> HttpMonitorHa
     // with no Tokio reactor — `tokio::spawn` there panics ("no reactor running").
     // `tauri::async_runtime::spawn` works from any thread (see #828, #982).
     tauri::async_runtime::spawn(async move {
-        run_monitor(config_clone, app, cancel_clone, last_result_clone).await;
+        run_monitor(
+            config_clone,
+            app,
+            cancel_clone,
+            paused_clone,
+            last_result_clone,
+        )
+        .await;
     });
 
     HttpMonitorHandle {
         config,
         cancel,
+        paused,
         last_result,
     }
 }
@@ -114,6 +135,7 @@ async fn run_monitor(
     config: HttpMonitorConfig,
     app: AppHandle,
     cancel: CancellationToken,
+    paused: Arc<AtomicBool>,
     last_result: std::sync::Arc<std::sync::Mutex<Option<HttpCheckResult>>>,
 ) {
     let client = match Client::builder()
@@ -132,18 +154,25 @@ async fn run_monitor(
             break;
         }
 
-        let result = check_once(&config, &client).await;
-        debug!(
-            monitor_id = %config.id,
-            ok = result.ok,
-            latency_ms = ?result.latency_ms,
-            "HTTP monitor check complete"
-        );
+        // Pause suspends the poll body but keeps the loop alive so Resume is
+        // instant. The interval sleep still runs so the loop stays responsive to
+        // cancellation and re-checks the flag each tick.
+        if paused.load(Ordering::SeqCst) {
+            debug!(monitor_id = %config.id, "HTTP monitor paused — skipping check");
+        } else {
+            let result = check_once(&config, &client).await;
+            debug!(
+                monitor_id = %config.id,
+                ok = result.ok,
+                latency_ms = ?result.latency_ms,
+                "HTTP monitor check complete"
+            );
 
-        let _ = app.emit("network-http-monitor-check", &result);
+            let _ = app.emit("network-http-monitor-check", &result);
 
-        if let Ok(mut guard) = last_result.lock() {
-            *guard = Some(result);
+            if let Ok(mut guard) = last_result.lock() {
+                *guard = Some(result);
+            }
         }
 
         tokio::select! {

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -297,9 +297,14 @@ mod tests {
     use super::*;
     use http_monitor::HttpCheckResult;
 
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     /// Insert a bare monitor handle (no spawned task) so `stop_all_http_monitors`
-    /// can be exercised without a live Tauri `AppHandle`.
-    fn insert_dummy_monitor(mgr: &NetworkManager) -> (String, CancellationToken) {
+    /// can be exercised without a live Tauri `AppHandle`. Returns the id plus the
+    /// handle's cancellation token and `paused` flag so tests can assert on them.
+    fn insert_dummy_monitor(
+        mgr: &NetworkManager,
+    ) -> (String, CancellationToken, Arc<AtomicBool>) {
         let config = HttpMonitorConfig::new(
             "https://example.com".into(),
             30_000,
@@ -307,25 +312,36 @@ mod tests {
             200,
             5_000,
         );
+        insert_dummy_monitor_config(mgr, config)
+    }
+
+    /// Insert a dummy handle for a specific config (so persistence + map stay in
+    /// sync in tests that also persist the config).
+    fn insert_dummy_monitor_config(
+        mgr: &NetworkManager,
+        config: HttpMonitorConfig,
+    ) -> (String, CancellationToken, Arc<AtomicBool>) {
         let id = config.id.clone();
         let cancel = CancellationToken::new();
+        let paused = Arc::new(AtomicBool::new(false));
         let handle = HttpMonitorHandle {
             config,
             cancel: cancel.clone(),
+            paused: Arc::clone(&paused),
             last_result: Arc::new(Mutex::new(None::<HttpCheckResult>)),
         };
         mgr.http_monitors
             .lock()
             .expect("http monitor lock")
             .insert(id.clone(), handle);
-        (id, cancel)
+        (id, cancel, paused)
     }
 
     #[test]
     fn stop_all_http_monitors_cancels_and_clears() {
         let mgr = NetworkManager::new();
-        let (_id1, token1) = insert_dummy_monitor(&mgr);
-        let (_id2, token2) = insert_dummy_monitor(&mgr);
+        let (_id1, token1, _p1) = insert_dummy_monitor(&mgr);
+        let (_id2, token2, _p2) = insert_dummy_monitor(&mgr);
 
         assert_eq!(mgr.list_http_monitors().len(), 2);
         assert!(!token1.is_cancelled());
@@ -421,5 +437,140 @@ mod tests {
         let loaded = mgr.load_persisted_monitor_configs();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].url, "https://new.example.com");
+    }
+
+    // ── Stop vs. Remove (audit Gap #6) ────────────────────────────────────────
+
+    #[test]
+    fn stop_keeps_monitor_listed_as_not_running() {
+        // Gap #6: "Stop" must cancel the poll loop but KEEP the monitor listed
+        // (as running:false) so the user can resume it — it must NOT delete it.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mgr = manager_with_config_dir(dir.path());
+
+        let cfg = HttpMonitorConfig::new(
+            "https://example.com".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        let (id, token, _paused) = insert_dummy_monitor_config(&mgr, cfg.clone());
+        mgr.persist_monitor_config(cfg).expect("persist");
+
+        mgr.stop_http_monitor(&id).expect("stop");
+
+        // The poll loop is cancelled...
+        assert!(token.is_cancelled());
+        // ...but the monitor stays listed as not running...
+        let listed = mgr.list_http_monitors();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].config.id, id);
+        assert!(!listed[0].running);
+        // ...and its persisted config survives so it resumes on restart.
+        assert_eq!(mgr.load_persisted_monitor_configs().len(), 1);
+    }
+
+    #[test]
+    fn remove_deletes_monitor_and_config() {
+        // Gap #6: "Remove" is the destructive action — it cancels, drops the
+        // handle from the map, and deletes the persisted config.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mgr = manager_with_config_dir(dir.path());
+
+        let cfg = HttpMonitorConfig::new(
+            "https://example.com".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        let (id, token, _paused) = insert_dummy_monitor_config(&mgr, cfg.clone());
+        mgr.persist_monitor_config(cfg).expect("persist");
+
+        mgr.remove_http_monitor(&id).expect("remove");
+
+        assert!(token.is_cancelled());
+        assert!(mgr.list_http_monitors().is_empty());
+        assert!(mgr.load_persisted_monitor_configs().is_empty());
+    }
+
+    #[test]
+    fn remove_unknown_monitor_errors() {
+        let mgr = NetworkManager::new();
+        assert!(mgr.remove_http_monitor("does-not-exist").is_err());
+    }
+
+    // ── Pause / Resume (audit Gap #5) ─────────────────────────────────────────
+
+    #[test]
+    fn pause_suspends_and_keeps_monitor_running() {
+        // Gap #5: pausing suspends the poll body via the handle's `paused` flag
+        // while keeping the loop alive (running stays true) and the config intact.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mgr = manager_with_config_dir(dir.path());
+
+        let cfg = HttpMonitorConfig::new(
+            "https://example.com".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        let (id, token, paused) = insert_dummy_monitor_config(&mgr, cfg.clone());
+        mgr.persist_monitor_config(cfg).expect("persist");
+
+        assert!(!paused.load(Ordering::SeqCst));
+
+        mgr.pause_http_monitor(&id).expect("pause");
+
+        // The poll body is suspended...
+        assert!(paused.load(Ordering::SeqCst));
+        // ...but the loop is not cancelled and the monitor is still listed as
+        // running and paused, with its config kept.
+        assert!(!token.is_cancelled());
+        let listed = mgr.list_http_monitors();
+        assert_eq!(listed.len(), 1);
+        assert!(listed[0].running);
+        assert!(listed[0].paused);
+        assert_eq!(mgr.load_persisted_monitor_configs().len(), 1);
+    }
+
+    #[test]
+    fn resume_restarts_a_paused_monitor_with_same_config() {
+        // Resuming a paused monitor clears the flag and keeps the same config —
+        // no new id, no lost history binding.
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let mgr = manager_with_config_dir(dir.path());
+
+        let cfg = HttpMonitorConfig::new(
+            "https://example.com".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        );
+        let cfg_id = cfg.id.clone();
+        let (id, _token, paused) = insert_dummy_monitor_config(&mgr, cfg.clone());
+        mgr.persist_monitor_config(cfg).expect("persist");
+
+        mgr.pause_http_monitor(&id).expect("pause");
+        assert!(paused.load(Ordering::SeqCst));
+
+        mgr.resume_http_monitor(&id).expect("resume");
+
+        assert!(!paused.load(Ordering::SeqCst));
+        let listed = mgr.list_http_monitors();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].config.id, cfg_id);
+        assert!(listed[0].running);
+        assert!(!listed[0].paused);
+    }
+
+    #[test]
+    fn pause_unknown_monitor_errors() {
+        let mgr = NetworkManager::new();
+        assert!(mgr.pause_http_monitor("does-not-exist").is_err());
+        assert!(mgr.resume_http_monitor("does-not-exist").is_err());
     }
 }

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -10,6 +10,7 @@ pub mod wol_storage;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use tauri::AppHandle;
@@ -148,8 +149,36 @@ impl NetworkManager {
         Ok(id)
     }
 
-    /// Stop a running HTTP monitor and drop its persisted config.
+    /// Stop a running HTTP monitor, keeping it **listed** (as `running: false`).
+    ///
+    /// Audit Gap #6: Stop must suspend polling without destroying the monitor —
+    /// its handle stays in the map (with a cancelled token, so it lists as not
+    /// running) and its persisted config is kept, so [`resume_http_monitor`]
+    /// (or the next launch) can bring it back. Use [`remove_http_monitor`] to
+    /// truly delete it.
     pub fn stop_http_monitor(&self, monitor_id: &str) -> Result<(), TerminalError> {
+        let monitors = self
+            .http_monitors
+            .lock()
+            .map_err(|_| TerminalError::InternalError("http monitor lock poisoned".into()))?;
+        match monitors.get(monitor_id) {
+            Some(handle) => {
+                // Cancel the poll loop but leave the handle in the map so the
+                // monitor stays listed as `running: false`. `paused` is cleared
+                // so a later Resume starts clean.
+                handle.cancel.cancel();
+                handle.paused.store(false, Ordering::SeqCst);
+                Ok(())
+            }
+            None => Err(TerminalError::NotFound(format!("monitor '{monitor_id}'"))),
+        }
+    }
+
+    /// Remove an HTTP monitor entirely: cancel its poll loop, drop its handle
+    /// from the map, and delete its persisted config.
+    ///
+    /// Audit Gap #6: this is the destructive counterpart to [`stop_http_monitor`].
+    pub fn remove_http_monitor(&self, monitor_id: &str) -> Result<(), TerminalError> {
         let mut monitors = self
             .http_monitors
             .lock()
@@ -157,10 +186,9 @@ impl NetworkManager {
         match monitors.remove(monitor_id) {
             Some(handle) => {
                 handle.cancel.cancel();
-                // Drop the config from disk too — stopping a monitor removes it
-                // (see audit Gap #6: Stop currently means delete). A best-effort
-                // remove; a persistence error must not leave the loop running.
                 drop(monitors);
+                // Best-effort disk cleanup; a persistence error must not leave
+                // the handle re-inserted.
                 if let Err(e) = self.remove_persisted_monitor_config(monitor_id) {
                     error!(monitor_id, "Failed to remove persisted HTTP monitor: {e}");
                 }
@@ -168,6 +196,59 @@ impl NetworkManager {
             }
             None => Err(TerminalError::NotFound(format!("monitor '{monitor_id}'"))),
         }
+    }
+
+    /// Pause a running HTTP monitor: the poll loop stays alive but its poll body
+    /// is suspended (audit Gap #5). Lists as `running: true, paused: true`.
+    pub fn pause_http_monitor(&self, monitor_id: &str) -> Result<(), TerminalError> {
+        let monitors = self
+            .http_monitors
+            .lock()
+            .map_err(|_| TerminalError::InternalError("http monitor lock poisoned".into()))?;
+        match monitors.get(monitor_id) {
+            Some(handle) => {
+                handle.paused.store(true, Ordering::SeqCst);
+                debug!(monitor_id, "Paused HTTP monitor");
+                Ok(())
+            }
+            None => Err(TerminalError::NotFound(format!("monitor '{monitor_id}'"))),
+        }
+    }
+
+    /// Resume a paused or stopped HTTP monitor with the same config.
+    ///
+    /// - A **paused** monitor (loop still alive) simply clears its `paused` flag.
+    /// - A **stopped** monitor (loop cancelled, but still listed) is re-spawned
+    ///   with a fresh cancellation token, reusing the same config/id.
+    pub fn resume_http_monitor(&self, monitor_id: &str) -> Result<(), TerminalError> {
+        // Take the current handle so we can decide whether to un-pause in place
+        // or re-spawn a stopped loop. Clone the config first; drop the lock
+        // before re-spawning (spawn re-locks the map).
+        let stopped_config = {
+            let mut monitors = self
+                .http_monitors
+                .lock()
+                .map_err(|_| TerminalError::InternalError("http monitor lock poisoned".into()))?;
+            match monitors.get(monitor_id) {
+                Some(handle) if !handle.cancel.is_cancelled() => {
+                    // Alive (running or paused): clear the pause flag in place.
+                    handle.paused.store(false, Ordering::SeqCst);
+                    debug!(monitor_id, "Resumed paused HTTP monitor");
+                    None
+                }
+                Some(_) => {
+                    // Stopped: remove the dead handle and re-spawn below.
+                    monitors.remove(monitor_id).map(|h| h.config)
+                }
+                None => return Err(TerminalError::NotFound(format!("monitor '{monitor_id}'"))),
+            }
+        };
+
+        if let Some(config) = stopped_config {
+            self.spawn_http_monitor(config)?;
+            debug!(monitor_id, "Restarted stopped HTTP monitor");
+        }
+        Ok(())
     }
 
     // ── HTTP Monitor persistence ────────────────────────────────────────────
@@ -238,9 +319,12 @@ impl NetworkManager {
             .values()
             .map(|h| {
                 let last_result = h.last_result.lock().ok().and_then(|g| g.clone());
+                let running = !h.cancel.is_cancelled();
                 HttpMonitorState {
                     config: h.config.clone(),
-                    running: !h.cancel.is_cancelled(),
+                    running,
+                    // A stopped loop can't be paused; only report paused while alive.
+                    paused: running && h.paused.load(Ordering::SeqCst),
                     last_result,
                 }
             })
@@ -297,14 +381,12 @@ mod tests {
     use super::*;
     use http_monitor::HttpCheckResult;
 
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::AtomicBool;
 
     /// Insert a bare monitor handle (no spawned task) so `stop_all_http_monitors`
     /// can be exercised without a live Tauri `AppHandle`. Returns the id plus the
     /// handle's cancellation token and `paused` flag so tests can assert on them.
-    fn insert_dummy_monitor(
-        mgr: &NetworkManager,
-    ) -> (String, CancellationToken, Arc<AtomicBool>) {
+    fn insert_dummy_monitor(mgr: &NetworkManager) -> (String, CancellationToken, Arc<AtomicBool>) {
         let config = HttpMonitorConfig::new(
             "https://example.com".into(),
             30_000,

--- a/src/components/NetworkTools/HttpMonitorPanel.pause-remove.test.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.pause-remove.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for HTTP monitor Pause/Resume and Stop-vs-Remove (#1147 gaps #5, #6).
+ *
+ * Gap #6: "Stop" must cancel the poll loop but keep the monitor listed
+ * (running:false) so it can be resumed; a separate "Remove" deletes it.
+ * Gap #5: "Pause" suspends polling (running stays true, paused:true) and
+ * "Resume" restarts it with the same config.
+ *
+ * These pin the panel's per-monitor controls to the correct backend calls and
+ * feedback.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import {
+  networkHttpMonitorPause,
+  networkHttpMonitorResume,
+  networkHttpMonitorRemove,
+  networkHttpMonitorList,
+} from "@/services/networkApi";
+import type { HttpMonitorState } from "@/types/network";
+import { toast } from "@/components/ui";
+import { HttpMonitorPanel } from "./HttpMonitorPanel";
+import { withTooltip } from "@/test/tooltip";
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStart: vi.fn(() => Promise.resolve("mon-1")),
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorPause: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorResume: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorRemove: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+  onHttpMonitorCheck: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+vi.mock("./LatencyChart", () => ({ LatencyChart: () => null }));
+
+function makeMonitor(id: string, overrides: Partial<HttpMonitorState> = {}): HttpMonitorState {
+  return {
+    config: {
+      id,
+      url: "https://example.com",
+      intervalMs: 30_000,
+      method: "GET",
+      expectedStatus: 200,
+      timeoutMs: 10_000,
+    },
+    running: true,
+    paused: false,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function renderPanel() {
+  await act(async () => {
+    root.render(withTooltip(<HttpMonitorPanel />));
+  });
+  await flush();
+}
+
+describe("HttpMonitorPanel — pause/resume + stop vs remove (#1147 gaps #5, #6)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("a running monitor exposes Pause and Remove controls", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-1")]);
+    await renderPanel();
+
+    expect(
+      container.querySelector('[aria-label="Pause monitoring https://example.com"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[aria-label="Remove monitor https://example.com"]')
+    ).not.toBeNull();
+  });
+
+  it("Pause calls the pause API and toasts", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-1")]);
+    await renderPanel();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Pause monitoring https://example.com"]')!
+        .click();
+    });
+    await flush();
+
+    expect(networkHttpMonitorPause).toHaveBeenCalledWith("mon-1");
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("a paused monitor exposes a Resume control that calls the resume API", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-1", { paused: true })]);
+    await renderPanel();
+
+    const resumeBtn = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Resume monitoring https://example.com"]'
+    );
+    expect(resumeBtn).not.toBeNull();
+
+    await act(async () => {
+      resumeBtn!.click();
+    });
+    await flush();
+
+    expect(networkHttpMonitorResume).toHaveBeenCalledWith("mon-1");
+  });
+
+  it("a stopped monitor stays listed and exposes a Resume control", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-1", { running: false })]);
+    await renderPanel();
+
+    expect(container.querySelector('[data-testid="monitor-row-mon-1"]')).not.toBeNull();
+    expect(
+      container.querySelector('[aria-label="Resume monitoring https://example.com"]')
+    ).not.toBeNull();
+  });
+
+  it("Remove calls the remove API (not stop) and toasts", async () => {
+    vi.mocked(networkHttpMonitorList).mockResolvedValue([makeMonitor("mon-1")]);
+    await renderPanel();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Remove monitor https://example.com"]')!
+        .click();
+    });
+    await flush();
+
+    expect(networkHttpMonitorRemove).toHaveBeenCalledWith("mon-1");
+    expect(toast.success).toHaveBeenCalled();
+  });
+});

--- a/src/components/NetworkTools/HttpMonitorPanel.stop-feedback.test.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.stop-feedback.test.tsx
@@ -47,6 +47,7 @@ function makeMonitor(id: string): HttpMonitorState {
       timeoutMs: 10_000,
     },
     running: true,
+    paused: false,
   };
 }
 

--- a/src/components/NetworkTools/HttpMonitorPanel.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.tsx
@@ -388,18 +388,7 @@ export function HttpMonitorPanel() {
                   />
                 </Tooltip>
               )}
-              {m.running && m.paused && (
-                <Tooltip content="Resume" side="left">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    icon={<Play size={13} />}
-                    onClick={() => handleResumeMonitor(m.config.id)}
-                    aria-label={`Resume monitoring ${m.config.url}`}
-                  />
-                </Tooltip>
-              )}
-              {!m.running && (
+              {(m.paused || !m.running) && (
                 <Tooltip content="Resume" side="left">
                   <Button
                     variant="ghost"

--- a/src/components/NetworkTools/HttpMonitorPanel.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.tsx
@@ -1,9 +1,12 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { Play, StopCircle, RefreshCw } from "lucide-react";
+import { Play, Pause, StopCircle, Trash2, RefreshCw } from "lucide-react";
 import { Button, Tooltip, toast } from "@/components/ui";
 import {
   networkHttpMonitorStart,
   networkHttpMonitorStop,
+  networkHttpMonitorRemove,
+  networkHttpMonitorPause,
+  networkHttpMonitorResume,
   networkHttpMonitorList,
   onHttpMonitorCheck,
 } from "@/services/networkApi";
@@ -133,12 +136,54 @@ export function HttpMonitorPanel() {
     async (id: string) => {
       try {
         await networkHttpMonitorStop(id);
-        if (id === activeMonitorIdRef.current) clearActiveMonitor();
         await loadMonitors();
         toast.success("Monitor stopped");
       } catch (err) {
         setError(String(err));
         toast.error(`Failed to stop monitor: ${err}`);
+      }
+    },
+    [loadMonitors]
+  );
+
+  const handlePauseMonitor = useCallback(
+    async (id: string) => {
+      try {
+        await networkHttpMonitorPause(id);
+        await loadMonitors();
+        toast.success("Monitor paused");
+      } catch (err) {
+        setError(String(err));
+        toast.error(`Failed to pause monitor: ${err}`);
+      }
+    },
+    [loadMonitors]
+  );
+
+  const handleResumeMonitor = useCallback(
+    async (id: string) => {
+      try {
+        await networkHttpMonitorResume(id);
+        await loadMonitors();
+        toast.success("Monitor resumed");
+      } catch (err) {
+        setError(String(err));
+        toast.error(`Failed to resume monitor: ${err}`);
+      }
+    },
+    [loadMonitors]
+  );
+
+  const handleRemoveMonitor = useCallback(
+    async (id: string) => {
+      try {
+        await networkHttpMonitorRemove(id);
+        if (id === activeMonitorIdRef.current) clearActiveMonitor();
+        await loadMonitors();
+        toast.success("Monitor removed");
+      } catch (err) {
+        setError(String(err));
+        toast.error(`Failed to remove monitor: ${err}`);
       }
     },
     [loadMonitors, clearActiveMonitor]
@@ -315,25 +360,74 @@ export function HttpMonitorPanel() {
         </>
       )}
 
-      {/* All running monitors */}
+      {/* All monitors (running, paused, and stopped-but-listed) */}
       {monitors.length > 0 && (
         <>
-          <div className="network-panel__section-title">Running Monitors</div>
+          <div className="network-panel__section-title">Monitors</div>
           {monitors.map((m) => (
-            <div key={m.config.id} className="http-monitor-row">
+            <div
+              key={m.config.id}
+              className="http-monitor-row"
+              data-testid={`monitor-row-${m.config.id}`}
+            >
               <span className="http-monitor-row__url" title={m.config.url}>
                 {m.config.url}
               </span>
               <span className="http-monitor-row__meta">
                 {m.config.method} · every {m.config.intervalMs / 1000}s
+                {!m.running ? " · stopped" : m.paused ? " · paused" : ""}
               </span>
-              <Tooltip content="Stop" side="left">
+              {m.running && !m.paused && (
+                <Tooltip content="Pause" side="left">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<Pause size={13} />}
+                    onClick={() => handlePauseMonitor(m.config.id)}
+                    aria-label={`Pause monitoring ${m.config.url}`}
+                  />
+                </Tooltip>
+              )}
+              {m.running && m.paused && (
+                <Tooltip content="Resume" side="left">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<Play size={13} />}
+                    onClick={() => handleResumeMonitor(m.config.id)}
+                    aria-label={`Resume monitoring ${m.config.url}`}
+                  />
+                </Tooltip>
+              )}
+              {!m.running && (
+                <Tooltip content="Resume" side="left">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<Play size={13} />}
+                    onClick={() => handleResumeMonitor(m.config.id)}
+                    aria-label={`Resume monitoring ${m.config.url}`}
+                  />
+                </Tooltip>
+              )}
+              {m.running && (
+                <Tooltip content="Stop" side="left">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<StopCircle size={13} />}
+                    onClick={() => handleStopMonitor(m.config.id)}
+                    aria-label={`Stop monitoring ${m.config.url}`}
+                  />
+                </Tooltip>
+              )}
+              <Tooltip content="Remove" side="left">
                 <Button
                   variant="ghost"
                   size="sm"
-                  icon={<StopCircle size={13} />}
-                  onClick={() => handleStopMonitor(m.config.id)}
-                  aria-label={`Stop monitoring ${m.config.url}`}
+                  icon={<Trash2 size={13} />}
+                  onClick={() => handleRemoveMonitor(m.config.id)}
+                  aria-label={`Remove monitor ${m.config.url}`}
                 />
               </Tooltip>
             </div>

--- a/src/components/NetworkTools/NetworkToolsSidebar.button.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.button.test.tsx
@@ -37,6 +37,7 @@ function makeMonitor(id: string): HttpMonitorState {
       timeoutMs: 10_000,
     },
     running: true,
+    paused: false,
   };
 }
 

--- a/src/components/NetworkTools/NetworkToolsSidebar.live.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.live.test.tsx
@@ -38,6 +38,7 @@ function makeMonitor(id: string): HttpMonitorState {
       timeoutMs: 10_000,
     },
     running: true,
+    paused: false,
   };
 }
 

--- a/src/components/NetworkTools/NetworkToolsSidebar.staleness.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.staleness.test.tsx
@@ -37,6 +37,7 @@ function makeMonitor(id: string, timestampMs: number, intervalMs: number): HttpM
       timeoutMs: 10_000,
     },
     running: true,
+    paused: false,
     lastResult: {
       monitorId: id,
       statusCode: 200,

--- a/src/components/NetworkTools/NetworkToolsSidebar.stop-feedback.test.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.stop-feedback.test.tsx
@@ -43,6 +43,7 @@ function makeMonitor(id: string): HttpMonitorState {
       timeoutMs: 10_000,
     },
     running: true,
+    paused: false,
   };
 }
 

--- a/src/components/NetworkTools/NetworkToolsSidebar.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.tsx
@@ -1,10 +1,22 @@
 import { useCallback, useEffect, useState } from "react";
 import "./NetworkTools.css";
-import { Play, RefreshCw, Plus, Circle, StopCircle, AlertTriangle } from "lucide-react";
+import {
+  Play,
+  Pause,
+  RefreshCw,
+  Plus,
+  Circle,
+  StopCircle,
+  Trash2,
+  AlertTriangle,
+} from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import {
   networkHttpMonitorList,
   networkHttpMonitorStop,
+  networkHttpMonitorRemove,
+  networkHttpMonitorPause,
+  networkHttpMonitorResume,
   onHttpMonitorCheck,
 } from "@/services/networkApi";
 import type { NetworkTool } from "@/types/terminal";
@@ -47,11 +59,22 @@ interface MonitorRowProps {
   monitor: HttpMonitorState;
   now: number;
   onStop: (id: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
+  onRemove: (id: string) => void;
   onOpen: (id: string) => void;
 }
 
-function MonitorRow({ monitor, now, onStop, onOpen }: MonitorRowProps) {
-  const { config, running, lastResult } = monitor;
+function MonitorRow({
+  monitor,
+  now,
+  onStop,
+  onPause,
+  onResume,
+  onRemove,
+  onOpen,
+}: MonitorRowProps) {
+  const { config, running, paused, lastResult } = monitor;
   const shortUrl = config.url.replace(/^https?:\/\//, "").slice(0, 24);
   const stale = isMonitorStale(lastResult?.timestampMs, config.intervalMs, now);
 
@@ -77,9 +100,11 @@ function MonitorRow({ monitor, now, onStop, onOpen }: MonitorRowProps) {
             {lastResult.ok ? `${lastResult.statusCode} · ${lastResult.latencyMs}ms` : "✗ down"}
           </span>
         )}
-        {!lastResult && running && (
+        {!lastResult && running && !paused && (
           <span className="network-sidebar__monitor-status">checking…</span>
         )}
+        {running && paused && <span className="network-sidebar__monitor-status">paused</span>}
+        {!running && <span className="network-sidebar__monitor-status">stopped</span>}
         {lastResult && (
           <span
             className={`network-sidebar__monitor-age${
@@ -106,6 +131,28 @@ function MonitorRow({ monitor, now, onStop, onOpen }: MonitorRowProps) {
           </span>
         )}
       </div>
+      {running && !paused && (
+        <Tooltip content="Pause monitor" side="left">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Pause monitor"
+            icon={<Pause size={12} />}
+            onClick={() => onPause(config.id)}
+          />
+        </Tooltip>
+      )}
+      {(paused || !running) && (
+        <Tooltip content="Resume monitor" side="left">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Resume monitor"
+            icon={<Play size={12} />}
+            onClick={() => onResume(config.id)}
+          />
+        </Tooltip>
+      )}
       {running && (
         <Tooltip content="Stop monitor" side="left">
           <Button
@@ -117,6 +164,15 @@ function MonitorRow({ monitor, now, onStop, onOpen }: MonitorRowProps) {
           />
         </Tooltip>
       )}
+      <Tooltip content="Remove monitor" side="left">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Remove monitor"
+          icon={<Trash2 size={12} />}
+          onClick={() => onRemove(config.id)}
+        />
+      </Tooltip>
     </div>
   );
 }
@@ -197,6 +253,48 @@ export function NetworkToolsSidebar() {
     [refreshMonitors]
   );
 
+  const handlePauseMonitor = useCallback(
+    async (id: string) => {
+      try {
+        await networkHttpMonitorPause(id);
+        await refreshMonitors();
+        toast.success("Monitor paused");
+      } catch (err) {
+        frontendLog("network_sidebar", `Failed to pause monitor: ${err}`);
+        toast.error(`Failed to pause monitor: ${err}`);
+      }
+    },
+    [refreshMonitors]
+  );
+
+  const handleResumeMonitor = useCallback(
+    async (id: string) => {
+      try {
+        await networkHttpMonitorResume(id);
+        await refreshMonitors();
+        toast.success("Monitor resumed");
+      } catch (err) {
+        frontendLog("network_sidebar", `Failed to resume monitor: ${err}`);
+        toast.error(`Failed to resume monitor: ${err}`);
+      }
+    },
+    [refreshMonitors]
+  );
+
+  const handleRemoveMonitor = useCallback(
+    async (id: string) => {
+      try {
+        await networkHttpMonitorRemove(id);
+        await refreshMonitors();
+        toast.success("Monitor removed");
+      } catch (err) {
+        frontendLog("network_sidebar", `Failed to remove monitor: ${err}`);
+        toast.error(`Failed to remove monitor: ${err}`);
+      }
+    },
+    [refreshMonitors]
+  );
+
   const handleOpenMonitor = useCallback(
     (_id: string) => {
       openNetworkDiagnosticTab("http-monitor");
@@ -238,6 +336,9 @@ export function NetworkToolsSidebar() {
             monitor={m}
             now={now}
             onStop={handleStopMonitor}
+            onPause={handlePauseMonitor}
+            onResume={handleResumeMonitor}
+            onRemove={handleRemoveMonitor}
             onOpen={handleOpenMonitor}
           />
         ))}

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -110,9 +110,15 @@
   color: var(--color-error);
 }
 
-.oc-row__badge--connecting {
+.oc-row__badge--connecting,
+.oc-row__badge--paused {
   background: color-mix(in srgb, var(--color-warning) 18%, transparent);
   color: var(--color-warning);
+}
+
+.oc-row__badge--stopped {
+  background: color-mix(in srgb, var(--text-secondary) 18%, transparent);
+  color: var(--text-secondary);
 }
 
 /* termiHub-managed X server: accent to signal termiHub ownership. */

--- a/src/components/OpenConnections/OpenConnectionsModal.httpMonitors.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.httpMonitors.test.tsx
@@ -64,6 +64,7 @@ function monitorState(id: string, url: string, ok: boolean): HttpMonitorState {
       timeoutMs: 10000,
     },
     running: true,
+    paused: false,
     lastResult: {
       monitorId: id,
       ok,

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -477,7 +477,17 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                 key={m.config.id}
                 icon={<Globe size={14} />}
                 title={m.config.url}
-                badge={m.lastResult ? (m.lastResult.ok ? "up" : "down") : "connecting"}
+                badge={
+                  !m.running
+                    ? "stopped"
+                    : m.paused
+                      ? "paused"
+                      : m.lastResult
+                        ? m.lastResult.ok
+                          ? "up"
+                          : "down"
+                        : "connecting"
+                }
                 onKill={() => handleStopHttpMonitor(m.config.id)}
                 killLabel="Stop"
               />
@@ -589,7 +599,9 @@ type BadgeVariant =
   | "managed"
   | "external"
   | "up"
-  | "down";
+  | "down"
+  | "paused"
+  | "stopped";
 
 interface ConnectionRowProps {
   icon: React.ReactNode;

--- a/src/services/networkApi.ts
+++ b/src/services/networkApi.ts
@@ -158,9 +158,24 @@ export async function networkHttpMonitorStart(
   });
 }
 
-/** Stop a running HTTP monitor. */
+/** Stop a running HTTP monitor, keeping it listed so it can be resumed. */
 export async function networkHttpMonitorStop(monitorId: string): Promise<void> {
   await invoke("network_http_monitor_stop", { monitorId });
+}
+
+/** Remove an HTTP monitor entirely (cancel + delete its persisted config). */
+export async function networkHttpMonitorRemove(monitorId: string): Promise<void> {
+  await invoke("network_http_monitor_remove", { monitorId });
+}
+
+/** Pause a running HTTP monitor (suspend polling, keep the loop alive). */
+export async function networkHttpMonitorPause(monitorId: string): Promise<void> {
+  await invoke("network_http_monitor_pause", { monitorId });
+}
+
+/** Resume a paused or stopped HTTP monitor with the same config. */
+export async function networkHttpMonitorResume(monitorId: string): Promise<void> {
+  await invoke("network_http_monitor_resume", { monitorId });
 }
 
 /** Stop every running HTTP monitor at once (Kill All). */

--- a/src/types/network.ts
+++ b/src/types/network.ts
@@ -120,7 +120,10 @@ export interface HttpCheckResult {
 
 export interface HttpMonitorState {
   config: HttpMonitorConfig;
+  /** The poll loop is alive (`false` = stopped-but-listed). */
   running: boolean;
+  /** The loop is alive but its poll body is suspended (implies `running`). */
+  paused: boolean;
   lastResult?: HttpCheckResult;
 }
 

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -580,7 +580,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `layout-remove-tab-*-*` | `layout-remove-tab-${idx}-${tabIdx}` | `src/components/WorkspaceEditor/LayoutDesigner.tsx` |
 | `layout-sidebar-*` | `layout-sidebar-${pos}` | `src/components/Settings/CustomizeLayoutDialog.tsx` |
 | `layout-split-*` | `layout-split-${node.direction}` | `src/components/WorkspaceEditor/LayoutDesigner.tsx` |
-| `monitor-row-*` | `monitor-row-${config.id}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
+| `monitor-row-*` | `monitor-row-${config.id}` | `src/components/NetworkTools/HttpMonitorPanel.tsx`, `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `monitor-stale-*` | `monitor-stale-${config.id}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `monitoring-connect-*` | `monitoring-connect-${conn.id}` | `src/components/StatusBar/StatusBar.tsx` |
 | `network-quick-action-*` | `network-quick-action-${tool}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |


### PR DESCRIPTION
## Summary

Implements audit gaps **#5** (no pause/resume) and **#6** (Stop overloaded pause+delete) from the HTTP monitor state-machine audit. These interlock: the fix makes the already-typed `running: false` state and the sidebar grey-dot branch reachable.

- **Stop vs. Remove split.** *Stop* now cancels the poll loop but keeps the monitor **listed** (as `running: false`) and preserves its persisted config, so it survives restarts and can be resumed. *Remove* is the destructive action (cancel + drop from the map + delete the persisted config). Previously "Stop" silently destroyed the monitor and its config.
- **Pause / Resume.** A paused monitor stays listed with its poll loop alive but suspended via a `paused: AtomicBool` on the handle (guarding the poll body); resume clears it. Resume also re-spawns a *stopped* monitor with the same config/id.

## Changes

**Backend**
- `HttpMonitorHandle` gains `paused: Arc<AtomicBool>`; `run_monitor` skips the poll body while set (loop stays alive and cancel-responsive).
- `HttpMonitorState` gains a `paused` field.
- `stop_http_monitor` keeps the handle listed; new `remove_http_monitor`, `pause_http_monitor`, `resume_http_monitor`.
- New commands `network_http_monitor_remove` / `_pause` / `_resume`, registered in `lib.rs`.

**Frontend**
- `networkApi` remove/pause/resume wrappers; `HttpMonitorState.paused` typed.
- `HttpMonitorPanel` and `NetworkToolsSidebar` expose Pause / Resume / Stop / Remove per monitor with running/paused/stopped states and toast feedback.
- Open Connections HTTP-monitor rows badge paused/stopped states.

## Test plan

- `test(network)` commit first (RED): backend unit tests that Stop keeps the monitor listed as not-running (Remove deletes it + config), Pause suspends the loop while keeping it running, Resume restarts with the same config; frontend panel tests pinning the pause/resume/remove controls and feedback.
- Full suites green: `pnpm test` (2387 passed), `pnpm build`, `pnpm run lint`, `pnpm run format:check`, `cargo test -p termihub --lib network` (23 passed), `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo fmt --all --check`.

Partially addresses #1147 (#5, #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)