### PR TITLE
fix(workspace): partial-restore summary feedback (#1146)

### DIFF
--- a/docs/changes/dev2/feature/1146-partial-restore-summary.md
+++ b/docs/changes/dev2/feature/1146-partial-restore-summary.md
@@ -1,0 +1,9 @@
+### Added
+
+- After restoring the last session or launching a saved workspace, termiHub now
+  shows a single summary toast once every restored tab has finished connecting.
+  A fully successful restore reports "Restored N tabs"; a partial restore reports
+  "Restored N of M tabs — K could not reconnect". Previously each tab that failed
+  to reconnect was only visible by clicking into that individual tab, with no
+  overview of how many tabs came back. Addresses GAP G4 of the workspace
+  save/restore audit (#1146).

--- a/src/store/appStore.restoreSummary.test.ts
+++ b/src/store/appStore.restoreSummary.test.ts
@@ -45,6 +45,9 @@ vi.mock("@/services/api", () => ({
   sftpListDir: vi.fn(),
   localListDir: vi.fn(),
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  // Teardown-on-restore (GAP G1) closes/detaches prior live sessions best-effort.
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  detachPersistentTab: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("@/services/lastSessionApi", () => ({
@@ -96,6 +99,7 @@ describe("partial-restore summary", () => {
       remoteAgents: [],
       agentDefinitions: {},
       defaultShell: "bash",
+      restoreCohort: null,
       settings: { ...useAppStore.getState().settings, restoreLastSessionOnStartup: true },
     });
   });

--- a/src/store/appStore.restoreSummary.test.ts
+++ b/src/store/appStore.restoreSummary.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock the toast hub so we can assert the aggregate restore summary without real DOM toasts.
+const toastSuccess = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+const toastError = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+const toastInfo = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastSuccess(message) : toastSuccess(message, opts),
+    error: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastError(message) : toastError(message, opts),
+    info: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastInfo(message) : toastInfo(message, opts),
+    loading: vi.fn(() => "toast-id"),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@/services/lastSessionApi", () => ({
+  saveLastSession: vi.fn(() => Promise.resolve()),
+  loadLastSession: vi.fn(() => Promise.resolve(null)),
+  clearLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import { loadLastSession } from "@/services/lastSessionApi";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { LastSession } from "@/types/lastSession";
+
+const mockLoad = vi.mocked(loadLastSession);
+
+/** A three-tab session that all resolve to plain local terminals. */
+function threeLocalTabsSession(): LastSession {
+  return {
+    version: "1",
+    activeGroupIndex: 0,
+    tabGroups: [
+      {
+        name: "Restored",
+        layout: {
+          type: "leaf",
+          tabs: [
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell A" },
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell B" },
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell C" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function restoredTabIds(): string[] {
+  return getAllLeaves(useAppStore.getState().rootPanel)
+    .flatMap((l) => l.tabs)
+    .map((t) => t.id);
+}
+
+describe("partial-restore summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoad.mockResolvedValue(null);
+    useAppStore.setState({
+      connections: [],
+      remoteAgents: [],
+      agentDefinitions: {},
+      defaultShell: "bash",
+      settings: { ...useAppStore.getState().settings, restoreLastSessionOnStartup: true },
+    });
+  });
+
+  it("raises one info summary reflecting M/K when some restored tabs fail", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+
+    const restored = await useAppStore.getState().restoreLastSession();
+    expect(restored).toBe(true);
+
+    const ids = restoredTabIds();
+    expect(ids).toHaveLength(3);
+
+    // No summary until every tab in the cohort has settled.
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastInfo).not.toHaveBeenCalled();
+
+    // Two connect, one fails.
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+    expect(toastInfo).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+
+    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "connection refused");
+
+    // Exactly one aggregate summary, and it is the partial (info) variant.
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+    const msg = String(toastInfo.mock.calls[0][0]);
+    expect(msg).toContain("2"); // restored count (M - K)
+    expect(msg).toContain("3"); // total
+    expect(msg).toContain("1"); // failed count
+  });
+
+  it("raises one success summary when every restored tab connects", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+    expect(toastSuccess).not.toHaveBeenCalled();
+    useAppStore.getState().setTabSessionId(ids[2], "sess-c");
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastInfo).not.toHaveBeenCalled();
+    expect(String(toastSuccess.mock.calls[0][0])).toContain("3");
+  });
+
+  it("raises nothing further once the cohort has settled (steady state)", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+
+    ids.forEach((id, i) => useAppStore.getState().setTabSessionId(id, `sess-${i}`));
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+
+    // Later reconnect churn on the same tabs must not re-fire a summary.
+    useAppStore.getState().setTerminalDisconnectWithError(ids[0], "later drop");
+    useAppStore.getState().setTabSessionId(ids[0], "sess-0b");
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+
+  it("does not summarize session-id changes that are outside a restore cohort", () => {
+    // A plain manual tab, no restore cohort registered.
+    useAppStore.setState({
+      connections: [],
+      remoteAgents: [],
+      agentDefinitions: {},
+    });
+    useAppStore.getState().addTab("Shell", "local", { type: "local", config: { shell: "bash" } });
+    const id = restoredTabIds()[0];
+
+    useAppStore.getState().setTabSessionId(id, "sess-manual");
+    useAppStore.getState().setTerminalDisconnectWithError(id, "boom");
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -570,6 +570,29 @@ interface AppState {
   /** Return whether a session was intentionally killed, clearing the flag (#1121). */
   consumeSessionKilled: (sessionId: string) => boolean;
   setTerminalDisconnectWithError: (tabId: string, error: string) => void;
+
+  /**
+   * Aggregate feedback for a fan-out restore/launch (#1146, audit G4). When a
+   * restore or workspace launch places N tabs, each reconnects independently
+   * inside its own Terminal.tsx mount, so failures are otherwise only visible
+   * per-tab. This cohort tracks the set of tab ids placed by one restore/launch
+   * and settles them as each connects ({@link setTabSessionId}) or fails
+   * ({@link setTerminalDisconnectWithError}); when the last one settles a single
+   * summary toast is raised. `null` when no restore/launch is in flight.
+   */
+  restoreCohort: { pending: Set<string>; total: number; failed: number } | null;
+  /**
+   * Register the cohort of tabs placed by a restore/launch. `pendingTabIds` are
+   * the live terminal tabs that will attempt to connect; `preFailedCount` counts
+   * tabs already known to have failed at build time (e.g. agent-error tabs that
+   * never emit a connect/fail signal). If nothing is pending, the summary is
+   * raised immediately.
+   */
+  beginRestoreCohort: (pendingTabIds: string[], preFailedCount: number) => void;
+  /** Settle one tab of the active restore cohort; raises the summary once the cohort empties. */
+  settleRestoreTab: (tabId: string, outcome: "connected" | "failed") => void;
+  /** Raise the single aggregate summary toast for the settled cohort and clear it. Internal. */
+  settleRestoreCohort: () => void;
   setTerminalReconnecting: (tabId: string, reconnecting: boolean) => void;
   setTerminalReattaching: (tabId: string, reattaching: boolean) => void;
   setTerminalReconnectTriggerError: (tabId: string, error: string | null) => void;
@@ -868,6 +891,25 @@ function teardownAllSessions(state: {
   if (closed > 0) {
     frontendLog("workspace", `tore down ${closed} live session(s) before restore/launch`);
   }
+}
+
+/**
+ * Partition the tabs of freshly-built restore/launch groups into the cohort that
+ * feeds the aggregate partial-restore summary (GAP G4, #1146). Only `terminal`
+ * tabs will attempt a live connect (settling via {@link setTabSessionId} /
+ * {@link setTerminalDisconnectWithError}); `agent-error` tabs are resolved as
+ * failed at build time and never emit a settle signal, so they are pre-counted
+ * as failed. All other content types (editors, settings, …) are not connections
+ * and are ignored.
+ */
+function collectRestoreCohort(groups: TabGroup[]): {
+  pendingTabIds: string[];
+  preFailedCount: number;
+} {
+  const tabs = groups.flatMap((g) => getAllLeaves(g.rootPanel).flatMap((leaf) => leaf.tabs));
+  const pendingTabIds = tabs.filter((t) => t.contentType === "terminal").map((t) => t.id);
+  const preFailedCount = tabs.filter((t) => t.contentType === "agent-error").length;
+  return { pendingTabIds, preFailedCount };
 }
 
 /** Unlisten function for the active session-based monitoring event subscription. */
@@ -1708,6 +1750,9 @@ export const useAppStore = create<AppState>((set, get) => {
           })),
         };
       });
+      // A non-null session id means this tab has connected — settle it in any
+      // in-flight restore/launch cohort so the aggregate summary can fire (#1146).
+      if (sessionId) get().settleRestoreTab(tabId, "connected");
     },
 
     addTab: (
@@ -3133,8 +3178,53 @@ export const useAppStore = create<AppState>((set, get) => {
         terminalDisconnectErrors: { ...state.terminalDisconnectErrors, [tabId]: error },
         terminalReconnectingTabs: omitKey(state.terminalReconnectingTabs, tabId),
       }));
+      // A failed (re)connect settles this tab as failed in any in-flight
+      // restore/launch cohort so the aggregate summary reflects it (#1146).
+      get().settleRestoreTab(tabId, "failed");
       if (get().monitoringSessionId) {
         get().disconnectMonitoring();
+      }
+    },
+
+    // Aggregate partial-restore feedback (#1146, audit G4).
+    restoreCohort: null,
+    beginRestoreCohort: (pendingTabIds, preFailedCount) => {
+      const pending = new Set(pendingTabIds);
+      const total = pending.size + preFailedCount;
+      if (total === 0) return;
+      frontendLog(
+        "workspace_restore",
+        `restore cohort started: ${total} tab(s), ${pending.size} pending, ${preFailedCount} pre-failed`
+      );
+      set({ restoreCohort: { pending, total, failed: preFailedCount } });
+      // A cohort with no live tabs to wait on (e.g. all agent-error) settles now.
+      if (pending.size === 0) get().settleRestoreCohort();
+    },
+    settleRestoreTab: (tabId, outcome) => {
+      const cohort = get().restoreCohort;
+      if (!cohort || !cohort.pending.has(tabId)) return;
+      const pending = new Set(cohort.pending);
+      pending.delete(tabId);
+      const failed = cohort.failed + (outcome === "failed" ? 1 : 0);
+      set({ restoreCohort: { ...cohort, pending, failed } });
+      if (pending.size === 0) get().settleRestoreCohort();
+    },
+    settleRestoreCohort: () => {
+      const cohort = get().restoreCohort;
+      if (!cohort) return;
+      // Clear first so this fires exactly once even if a stray settle races in.
+      set({ restoreCohort: null });
+      const { total, failed } = cohort;
+      const restored = total - failed;
+      frontendLog(
+        "workspace_restore",
+        `restore cohort settled: ${restored}/${total} connected, ${failed} failed`
+      );
+      if (failed === 0) {
+        toast.success(`Restored ${total} ${total === 1 ? "tab" : "tabs"}`);
+      } else {
+        // No toast.warning primitive — use info for the partial-failure case.
+        toast.info(`Restored ${restored} of ${total} tabs — ${failed} could not reconnect`);
       }
     },
     setTerminalReconnecting: (tabId, reconnecting) =>
@@ -4340,6 +4430,10 @@ export const useAppStore = create<AppState>((set, get) => {
           activePanelId: firstGroup.activePanelId,
           activeWorkspaceName: definition.name,
         });
+        // GAP G4 (#1146): register the placed tabs as a cohort so a single
+        // summary toast fires once every tab has connected or failed.
+        const { pendingTabIds, preFailedCount } = collectRestoreCohort(builtGroups);
+        get().beginRestoreCohort(pendingTabIds, preFailedCount);
       } catch (err) {
         // GAP G3 (#1146): a failed load used to be a silent console.error, so a
         // launch that could not open anything looked like nothing happened.
@@ -4479,6 +4573,10 @@ export const useAppStore = create<AppState>((set, get) => {
           rootPanel: activeGroup.rootPanel,
           activePanelId: activeGroup.activePanelId,
         });
+        // GAP G4 (#1146): register the placed tabs as a cohort so a single
+        // summary toast fires once every tab has connected or failed.
+        const { pendingTabIds, preFailedCount } = collectRestoreCohort(builtGroups);
+        get().beginRestoreCohort(pendingTabIds, preFailedCount);
         return true;
       } catch (err) {
         // GAP G3 (#1146): a corrupt/failed last-session load used to be a silent


### PR DESCRIPTION
## Summary

Adds aggregate partial-restore feedback (audit GAP **G4**) for the workspace save/restore state machine. When restoring the last session or launching a saved workspace fans out to N tabs, each tab reconnects independently inside its own `Terminal.tsx` mount, so a failure was previously only visible by clicking into that individual tab — there was no overview of how many tabs came back.

This tracks the cohort of tabs placed by `restoreLastSession` / `launchWorkspace` and raises a single summary toast once every tab in the cohort has settled:

- All connected → `toast.success("Restored N tabs")`
- Some failed → `toast.info("Restored N of M tabs — K could not reconnect")` (there is no `toast.warning` primitive, so `toast.info` carries the partial case)

## Changes

- `appStore.ts`: new `restoreCohort` store state plus `beginRestoreCohort` / `settleRestoreTab` / `settleRestoreCohort` actions. A tab settles as **connected** via `setTabSessionId` (non-null session id) or **failed** via `setTerminalDisconnectWithError`. `agent-error` tabs never emit a settle signal, so they are pre-counted as failed at registration time. Both restore/launch paths register the cohort right after they place the new layout. Builds on the existing `restoreInProgress` guard / teardown work from earlier G1/G5 PRs.
- Cohort tracking is idempotent: the cohort is cleared the moment it settles, so later reconnect churn on the same tabs never re-fires a summary.

A bulk "reconnect failed tabs" control (audit M2) was left out to keep this PR focused on the summary feedback; it is a nice-to-have follow-up.

## Test plan

- `test(workspace): add test for partial-restore summary` — new `appStore.restoreSummary.test.ts` covering: a cohort of M tabs where K fail raises a single info summary reflecting M/K once all settle; an all-success cohort raises a single success summary; steady state after settle raises nothing further on later reconnect churn; and session-id changes outside any cohort raise nothing.
- Full frontend suite: `pnpm test` → 222 files / 2386 tests pass.
- `pnpm build` (type-check), `pnpm run lint`, `pnpm run format:check` all clean.

Partially addresses #1146 (G4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)