### PR TITLE
fix(build): make build-mockups-index.sh run under macOS bash 3.2

### DIFF
--- a/scripts/internal/build-mockups-index.sh
+++ b/scripts/internal/build-mockups-index.sh
@@ -27,10 +27,13 @@ mockups=$(find . -type f -name '*.html' \
   ! -path './_assets/*' ! -name 'mockups-index.html' \
   | sed 's|^\./||' \
   | while IFS= read -r f; do
-      case "$f" in
-        */mockups/*) g="${f%%/mockups/*}" ;;
-        *) g="$(dirname "$f")" ;;
-      esac
+      # NB: avoid `case ... ;;` here — macOS bash 3.2 has a parser bug where a
+      # `case` inside $(...) command substitution fails ("syntax error near `;;'").
+      if [ "$f" != "${f%/mockups/*}" ]; then
+        g="${f%%/mockups/*}"   # legacy folder mockup
+      else
+        g="$(dirname "$f")"    # single-file concept
+      fi
       printf '%s\t%s\n' "$g" "$f"
     done | sort)
 


### PR DESCRIPTION
## Summary

`scripts/internal/build-mockups-index.sh` has `#!/bin/bash` and claims "no deps beyond a POSIX shell", but failed when invoked via its shebang on stock macOS:

```
./scripts/internal/build-mockups-index.sh: line 31: syntax error near unexpected token `;;'
```

macOS ships **bash 3.2** at `/bin/bash`, which has a long-standing parser bug: a `case` statement placed **inside a `$(...)` command substitution** fails to parse (`syntax error near ';;'`). The `mockups=$(... | while ...; do case ... esac ...)` block used exactly that pattern, so the script only worked under `bash <script>` with a modern Homebrew bash 5.x.

## Root cause + fix

Replaced the offending in-substitution `case` with an equivalent `if` + parameter-expansion test (`[ "$f" != "${f%/mockups/*}" ]`). No `case`/`;;` inside command substitution → bash 3.2 parses it fine. The second `case` (line ~72) lives inside a `{ }` group, not a command substitution, so it was never affected and is left unchanged.

Output is **byte-identical** under bash 3.2 and 5.x, so `docs/concepts/mockups-index.html` is unchanged and this PR is script-only.

The Windows `.cmd` variant is a separate batch implementation, unaffected by the bash bug — no change needed.

## Test plan

- [x] `./scripts/internal/build-mockups-index.sh` (via shebang, `/bin/bash` = bash 3.2.57 on macOS) → exits 0, writes the index (19 mockups).
- [x] `bash scripts/internal/build-mockups-index.sh` (Homebrew bash 5.3) → exits 0, identical output.
- [x] Regenerated `docs/concepts/mockups-index.html` is byte-identical to the committed version (`git diff` empty).
- [x] Confirmed the pre-fix failure reproduced (`syntax error near unexpected token ';;'`) and no longer occurs.

Not user-facing (internal build script) → no `docs/changes` fragment.

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)