### PR TITLE
fix(terminal): track connect in-flight state per attempt (#1214)

### DIFF
--- a/docs/changes/dev2/bugfix/1214-connect-inflight-per-tab.md
+++ b/docs/changes/dev2/bugfix/1214-connect-inflight-per-tab.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Terminal: closing a tab while a connection is still being established no longer
+  leaves an orphaned backend handshake when an overlapping connect attempt (from a
+  retry/reconnect) had already settled. The connect in-flight guard is now tracked
+  per attempt instead of as a single shared flag, so tearing down the tab reliably
+  cancels the attempt that is actually still connecting (#1214).

--- a/src/components/Terminal/Terminal.inflight-per-attempt.test.tsx
+++ b/src/components/Terminal/Terminal.inflight-per-attempt.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * Regression test for #1214 — the connect in-flight guard must be tracked PER
+ * attempt, not as a single shared boolean.
+ *
+ * Each connect attempt already carries a unique connect id (`${tabId}:${retryCount}`)
+ * and the effect cleanup cancels only its own id (#1125). But the in-flight
+ * *guard* used to be a single shared `useRef(false)`: set true before
+ * `createTerminal`, reset to false in a `finally`. Because the boolean was
+ * shared across overlapping attempts, a stale attempt that settled late cleared
+ * the flag out from under the live attempt:
+ *
+ *   1. Attempt A (`tab:0`) starts and stays in flight.
+ *   2. A reconnect starts attempt B (`tab:1`); A's cleanup already ran.
+ *   3. A's `createTerminal` finally settles (late) → its `finally` sets the
+ *      shared flag to false.
+ *   4. The tab is torn down while B is STILL in flight → B's cleanup sees the
+ *      shared flag as false and SKIPS `cancelConnecting(tab:1)`, orphaning B's
+ *      backend handshake (the exact orphan-session class of #1122).
+ *
+ * The fix tracks in-flight state per connect id (a Set): the cleanup cancels iff
+ * its OWN connect id is still in flight, so a stale attempt's late settle can no
+ * longer suppress the live attempt's cancel.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+import { useAppStore } from "@/store/appStore";
+
+// --- Mocks ---
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    onCursorMove = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    write = vi.fn((_data: unknown, cb?: () => void) => cb?.());
+    writeln = vi.fn();
+    reset = vi.fn();
+    scrollToBottom = vi.fn();
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn();
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = { active: { viewportY: 0, baseY: 0, length: 0, getLine: vi.fn() } };
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class MockFitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-unicode11", () => {
+  class MockUnicode11Addon {
+    dispose = vi.fn();
+  }
+  return { Unicode11Addon: MockUnicode11Addon };
+});
+
+vi.mock("@xterm/addon-search", () => {
+  class MockSearchAddon {
+    dispose = vi.fn();
+  }
+  return { SearchAddon: MockSearchAddon };
+});
+
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+/**
+ * Each `createTerminal` call returns a promise whose resolve/reject is captured
+ * so the test can settle a specific attempt on demand while another stays in
+ * flight. The connect id passed by the caller is recorded for assertions.
+ */
+interface PendingConnect {
+  connectId?: string;
+  resolve: (sessionId: string) => void;
+  reject: (err: unknown) => void;
+}
+const pendingConnects: PendingConnect[] = [];
+const mockCreateTerminal = vi.fn((_config: unknown, connectId?: string) => {
+  return new Promise<string>((resolve, reject) => {
+    pendingConnects.push({ connectId, resolve, reject });
+  });
+});
+const mockCancelConnecting = vi.fn((_connectId: string) => Promise.resolve(true));
+
+vi.mock("@/services/api", () => ({
+  createTerminal: (...args: unknown[]) =>
+    mockCreateTerminal(args[0], args[1] as string | undefined),
+  cancelConnecting: (connectId: string) => mockCancelConnecting(connectId),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+  detachPersistentTab: vi.fn().mockResolvedValue(0),
+  getAgentSessionBuffer: vi.fn().mockResolvedValue(new Uint8Array()),
+}));
+
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: vi.fn(() => vi.fn()),
+    subscribeExit: vi.fn(() => vi.fn()),
+    clearPendingExit: vi.fn(),
+    clearPendingOutput: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  pendingConnects.length = 0;
+  mockCreateTerminal.mockClear();
+  mockCancelConnecting.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+// Direct (non-agent) local shell connection so setupTerminal takes the
+// createTerminal path rather than reattaching to an existing session.
+const DIRECT_CONFIG = {
+  type: "local" as const,
+  config: {},
+};
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Terminal — per-attempt connect in-flight tracking (#1214)", () => {
+  it("still cancels the live attempt on teardown after a stale attempt settled late", async () => {
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal tabId="tab-1" config={DIRECT_CONFIG} isVisible={true} />
+        </TerminalPortalProvider>
+      );
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    // Attempt A is in flight (its createTerminal promise is captured, unsettled).
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    const attemptA = pendingConnects[0];
+    expect(attemptA.connectId).toBeTruthy();
+
+    // Reconnect while A is still in flight → the effect re-runs (retryCount dep):
+    // A's cleanup runs (cancelling A) and attempt B starts.
+    act(() => {
+      useAppStore.getState().reconnectTerminal("tab-1");
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(2);
+    const attemptB = pendingConnects[1];
+    expect(attemptB.connectId).toBeTruthy();
+    expect(attemptB.connectId).not.toBe(attemptA.connectId);
+
+    // A settles LATE (after B has started). With a shared boolean this cleared
+    // the in-flight flag out from under B, which is still connecting.
+    await act(async () => {
+      attemptA.reject(new Error("stale attempt failed late"));
+      await wait(50);
+    });
+
+    // B is still in flight. Tear the tab down.
+    act(() => root.unmount());
+    await act(async () => {
+      await wait(20);
+    });
+
+    // The teardown MUST cancel B's still-in-flight handshake. With the shared
+    // boolean, A's late settle had cleared the flag, so B's cleanup skipped the
+    // cancel and orphaned the handshake.
+    const cancelledIds = mockCancelConnecting.mock.calls.map((c) => c[0]);
+    expect(cancelledIds).toContain(attemptB.connectId);
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -243,8 +243,12 @@ export function Terminal({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
-  // True only while a backend connect is in flight, so teardown can abort it (#952).
-  const connectInFlightRef = useRef(false);
+  // The set of connect ids (`${tabId}:${retryCount}`) whose backend handshake is
+  // currently in flight, so teardown can abort them (#952). Tracked PER attempt
+  // rather than as a single shared boolean: overlapping attempts each add/remove
+  // their own id, so a stale attempt that settles late can no longer clear the
+  // flag out from under a live attempt and skip its cancel on teardown (#1214).
+  const connectInFlightRef = useRef<Set<string>>(new Set());
   const horizontalScrollingRef = useRef(false);
   const userScrolledUpRef = useRef(false);
   const lastInputTimeRef = useRef(0);
@@ -443,11 +447,11 @@ export function Terminal({
               // overlapping retry/reconnect never shares the previous attempt's
               // id. If it did, the old effect's cleanup would cancel the fresh
               // attempt's token instead of its own (#1125).
-              connectInFlightRef.current = true;
+              connectInFlightRef.current.add(connectId);
               try {
                 resolved = await createTerminal(sessionConfig, connectId);
               } finally {
-                connectInFlightRef.current = false;
+                connectInFlightRef.current.delete(connectId);
               }
 
               if (isCanceled()) {
@@ -768,6 +772,13 @@ export function Terminal({
     // attempt's in-flight handshake (#1125).
     const connectId = `${tabId}:${retryCount}`;
 
+    // Capture the in-flight connect-id set for the cleanup below. The ref's
+    // `.current` identity is stable for the tab's lifetime (it is never
+    // reassigned, only mutated), so this local is the same Set the connect loop
+    // adds/removes ids on — and reading it in cleanup avoids the
+    // react-hooks/exhaustive-deps stale-ref warning.
+    const inFlightConnects = connectInFlightRef.current;
+
     // Create an imperative DOM element for xterm (not managed by React rendering)
     const el = document.createElement("div");
     el.style.position = "absolute";
@@ -1042,7 +1053,7 @@ export function Terminal({
       // of leaving it to run to completion (#952). Cancel only THIS effect run's
       // connect id — never the bare tabId — so an overlapping newer attempt is
       // not aborted by this stale cleanup (#1125).
-      if (connectInFlightRef.current) {
+      if (inFlightConnects.has(connectId)) {
         void cancelConnecting(connectId).catch(() => {});
       }
       resizeObserver.disconnect();


### PR DESCRIPTION
## Summary

Fixes an orphaned-handshake bug (follow-up to #1125/#1122). `connectInFlightRef` was a single shared boolean while each connect attempt has a unique `connectId` (`${tabId}:${retryCount}`). When attempt B settled first, its `finally` cleared the shared flag, so tearing down the tab while attempt A was still in flight skipped `cancelConnecting(A)` — leaving A's backend handshake to run to completion (an orphan session).

**Fix:** track in-flight state **per attempt** — a `Set<string>` of in-flight `connectId`s (added on start, removed in `finally`). The teardown cleanup now cancels iff *its own* `connectId` is still in the set. The existing per-attempt `cancelConnecting(connectId)` and the JS `isCanceled()` backstop are unchanged.

## Test plan
TDD (test commit precedes implementation). New regression test `Terminal.inflight-per-attempt.test.tsx`: overlapping attempts where the newer settles first still cancel the older on teardown. Verified red without the fix, green with it. `pnpm build` (type-check) clean.

Closes #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)