### PR TITLE
feat(workspace): bulk "reconnect failed tabs" control after partial restore (#1227)

### DIFF
--- a/docs/changes/dev2/feature/1227-bulk-reconnect-failed-tabs.md
+++ b/docs/changes/dev2/feature/1227-bulk-reconnect-failed-tabs.md
@@ -1,0 +1,10 @@
+### Added
+
+- The partial-restore summary toast ("Restored N of M tabs — K could not
+  reconnect") now carries a **Reconnect failed tabs** action button. One tap
+  re-drives every failed tab from that restore through the normal per-tab
+  reconnect at once, instead of clicking into each tab and reconnecting it
+  individually. The retry shows a pending toast that resolves into a fresh
+  summary — success if all failed tabs come back, or another partial summary
+  (with the retry button again) if some still fail. Addresses control M2 of the
+  workspace save/restore audit (#1227).

--- a/src/components/ui/Toast/toast.ts
+++ b/src/components/ui/Toast/toast.ts
@@ -1,5 +1,17 @@
 import { toast as sonnerToast } from "sonner";
 
+/**
+ * A single inline action button rendered on a toast (a token-styled skin over
+ * sonner's `action`). Use for one-tap recovery affordances such as
+ * "Reconnect failed tabs" on a partial-restore summary.
+ */
+export interface ToastAction {
+  /** Button label. */
+  label: string;
+  /** Invoked when the action button is pressed. */
+  onClick: () => void;
+}
+
 /** Options accepted by the toast helpers. A thin, intentional subset of sonner. */
 export interface ToastOptions {
   /** Secondary line rendered under the title. */
@@ -14,6 +26,8 @@ export interface ToastOptions {
    * auto-dismiss, errors persist until dismissed. Pass `Infinity` to persist.
    */
   duration?: number;
+  /** Optional inline action button (e.g. a retry affordance). */
+  action?: ToastAction;
 }
 
 /** The success/error messages a loading toast resolves into. */
@@ -74,6 +88,7 @@ export const toast: ToastApi = {
       id: opts?.id,
       description: opts?.description,
       duration: opts?.duration,
+      action: opts?.action,
     });
   },
 
@@ -82,6 +97,7 @@ export const toast: ToastApi = {
       id: opts?.id,
       description: opts?.description,
       duration: opts?.duration ?? PERSIST_DURATION,
+      action: opts?.action,
     });
   },
 
@@ -90,6 +106,7 @@ export const toast: ToastApi = {
       id: opts?.id,
       description: opts?.description,
       duration: opts?.duration,
+      action: opts?.action,
     });
   },
 

--- a/src/store/appStore.bulkReconnect.test.ts
+++ b/src/store/appStore.bulkReconnect.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock the toast hub so we can assert the aggregate restore/reconnect feedback
+// without real DOM toasts. Mirrors appStore.restoreSummary.test.ts.
+const toastSuccess = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+const toastError = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+const toastInfo = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+const toastLoading = vi.fn((_message: unknown, _opts?: unknown) => "toast-id");
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastSuccess(message) : toastSuccess(message, opts),
+    error: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastError(message) : toastError(message, opts),
+    info: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastInfo(message) : toastInfo(message, opts),
+    loading: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastLoading(message) : toastLoading(message, opts),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  detachPersistentTab: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/lastSessionApi", () => ({
+  saveLastSession: vi.fn(() => Promise.resolve()),
+  loadLastSession: vi.fn(() => Promise.resolve(null)),
+  clearLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import { loadLastSession } from "@/services/lastSessionApi";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { LastSession } from "@/types/lastSession";
+
+const mockLoad = vi.mocked(loadLastSession);
+
+/** A three-tab session that all resolve to plain local terminals. */
+function threeLocalTabsSession(): LastSession {
+  return {
+    version: "1",
+    activeGroupIndex: 0,
+    tabGroups: [
+      {
+        name: "Restored",
+        layout: {
+          type: "leaf",
+          tabs: [
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell A" },
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell B" },
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell C" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function restoredTabIds(): string[] {
+  return getAllLeaves(useAppStore.getState().rootPanel)
+    .flatMap((l) => l.tabs)
+    .map((t) => t.id);
+}
+
+function tabById(id: string) {
+  return getAllLeaves(useAppStore.getState().rootPanel)
+    .flatMap((l) => l.tabs)
+    .find((t) => t.id === id);
+}
+
+/**
+ * Restore three tabs and settle two connected + one failed, leaving one failed
+ * tab captured for the bulk-reconnect control. Returns the tab ids.
+ */
+async function restoreWithOneFailure(): Promise<string[]> {
+  mockLoad.mockResolvedValue(threeLocalTabsSession());
+  await useAppStore.getState().restoreLastSession();
+  const ids = restoredTabIds();
+  useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+  useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+  useAppStore.getState().setTerminalDisconnectWithError(ids[2], "connection refused");
+  return ids;
+}
+
+describe("bulk reconnect of failed restore tabs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoad.mockResolvedValue(null);
+    useAppStore.setState({
+      connections: [],
+      remoteAgents: [],
+      agentDefinitions: {},
+      defaultShell: "bash",
+      restoreCohort: null,
+      failedRestoreTabIds: [],
+      terminalConnecting: {},
+      terminalDisconnectErrors: {},
+      terminalRetryCounters: {},
+      settings: { ...useAppStore.getState().settings, restoreLastSessionOnStartup: true },
+    });
+  });
+
+  it("captures the failed tab ids from a settled partial-restore cohort", async () => {
+    const ids = await restoreWithOneFailure();
+
+    // The partial summary fired and the failed terminal tab is remembered.
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+    // Action affordance is attached to the summary toast so it can be triggered.
+    const opts = toastInfo.mock.calls[0][1] as { action?: { label: string; onClick: () => void } };
+    expect(opts?.action).toBeDefined();
+    expect(typeof opts.action?.onClick).toBe("function");
+  });
+
+  it("re-drives ONLY the failed tab of the cohort, not the already-connected ones", async () => {
+    const ids = await restoreWithOneFailure();
+    vi.clearAllMocks();
+
+    useAppStore.getState().reconnectFailedRestoreTabs();
+
+    // A fresh cohort covers exactly the previously-failed tab.
+    const cohort = useAppStore.getState().restoreCohort;
+    expect(cohort).not.toBeNull();
+    expect([...(cohort?.pending ?? [])]).toEqual([ids[2]]);
+    expect(cohort?.total).toBe(1);
+
+    // The failed tab is being re-driven: its disconnect error is cleared and it
+    // is marked connecting again.
+    expect(useAppStore.getState().terminalConnecting[ids[2]]).toBe(true);
+    expect(useAppStore.getState().terminalDisconnectErrors[ids[2]]).toBeUndefined();
+
+    // The already-connected tabs are untouched: not connecting, sessions intact.
+    expect(useAppStore.getState().terminalConnecting[ids[0]]).toBeUndefined();
+    expect(useAppStore.getState().terminalConnecting[ids[1]]).toBeUndefined();
+    expect(tabById(ids[0])?.sessionId).toBe("sess-a");
+    expect(tabById(ids[1])?.sessionId).toBe("sess-b");
+
+    // The captured failed set is consumed by the retry.
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
+  });
+
+  it("re-summarizes as a success when the bulk retry connects all failed tabs", async () => {
+    const ids = await restoreWithOneFailure();
+    vi.clearAllMocks();
+
+    useAppStore.getState().reconnectFailedRestoreTabs();
+    // Pending feedback for the bulk retry.
+    expect(toastLoading).toHaveBeenCalledTimes(1);
+
+    // The retried tab connects.
+    useAppStore.getState().setTabSessionId(ids[2], "sess-c-retry");
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(String(toastSuccess.mock.calls[0][0])).toContain("1");
+    // No failed tabs remain to retry.
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
+    expect(useAppStore.getState().restoreCohort).toBeNull();
+  });
+
+  it("re-summarizes as a partial when the bulk retry still fails, keeping the tab retryable", async () => {
+    const ids = await restoreWithOneFailure();
+    vi.clearAllMocks();
+
+    useAppStore.getState().reconnectFailedRestoreTabs();
+
+    // The retried tab fails again.
+    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "still refused");
+
+    // A partial summary fires again and the tab is still remembered for retry.
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+    expect(useAppStore.getState().restoreCohort).toBeNull();
+  });
+
+  it("is a no-op when there are no failed tabs to reconnect", () => {
+    useAppStore.setState({ failedRestoreTabIds: [], restoreCohort: null });
+    useAppStore.getState().reconnectFailedRestoreTabs();
+
+    expect(useAppStore.getState().restoreCohort).toBeNull();
+    expect(toastLoading).not.toHaveBeenCalled();
+    expect(toastInfo).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("ignores captured tab ids that no longer exist in the tree", async () => {
+    await restoreWithOneFailure();
+    // Simulate the failed tab having been closed since the restore settled.
+    useAppStore.setState({ failedRestoreTabIds: ["ghost-tab-id"] });
+    vi.clearAllMocks();
+
+    useAppStore.getState().reconnectFailedRestoreTabs();
+
+    // Nothing live to re-drive → no cohort, no pending toast.
+    expect(useAppStore.getState().restoreCohort).toBeNull();
+    expect(toastLoading).not.toHaveBeenCalled();
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -579,20 +579,52 @@ interface AppState {
    * and settles them as each connects ({@link setTabSessionId}) or fails
    * ({@link setTerminalDisconnectWithError}); when the last one settles a single
    * summary toast is raised. `null` when no restore/launch is in flight.
+   *
+   * `failedTabIds` is the subset of settled tabs that failed and can be
+   * re-driven through the per-tab reconnect path — it feeds the bulk
+   * "Reconnect failed tabs" control (#1227). `toastId`, when present, is the
+   * id of a pending toast this cohort should resolve in place on settle
+   * (used by {@link reconnectFailedRestoreTabs} for pending → result feedback).
    */
-  restoreCohort: { pending: Set<string>; total: number; failed: number } | null;
+  restoreCohort: {
+    pending: Set<string>;
+    total: number;
+    failed: number;
+    failedTabIds: Set<string>;
+    toastId?: string | number;
+  } | null;
+  /**
+   * The failed terminal tab ids captured from the most recently settled
+   * restore/launch (or bulk-reconnect) cohort. Drives the bulk "Reconnect
+   * failed tabs" control (#1227, audit M2); empty when there is nothing to
+   * retry. Consumed (cleared) by {@link reconnectFailedRestoreTabs}.
+   */
+  failedRestoreTabIds: string[];
   /**
    * Register the cohort of tabs placed by a restore/launch. `pendingTabIds` are
    * the live terminal tabs that will attempt to connect; `preFailedCount` counts
    * tabs already known to have failed at build time (e.g. agent-error tabs that
-   * never emit a connect/fail signal). If nothing is pending, the summary is
-   * raised immediately.
+   * never emit a connect/fail signal). `toastId`, when given, is a pending toast
+   * the settle should resolve in place instead of raising a fresh one. If
+   * nothing is pending, the summary is raised immediately.
    */
-  beginRestoreCohort: (pendingTabIds: string[], preFailedCount: number) => void;
+  beginRestoreCohort: (
+    pendingTabIds: string[],
+    preFailedCount: number,
+    toastId?: string | number
+  ) => void;
   /** Settle one tab of the active restore cohort; raises the summary once the cohort empties. */
   settleRestoreTab: (tabId: string, outcome: "connected" | "failed") => void;
   /** Raise the single aggregate summary toast for the settled cohort and clear it. Internal. */
   settleRestoreCohort: () => void;
+  /**
+   * Bulk-retry every failed tab remembered from the last partial restore
+   * ({@link failedRestoreTabIds}) in one action (#1227, audit M2). Re-drives
+   * only those tabs through the existing per-tab {@link reconnectTerminal}
+   * path, registers a fresh cohort so the outcome re-summarizes, and shows a
+   * pending toast that resolves into the aggregate result.
+   */
+  reconnectFailedRestoreTabs: () => void;
   setTerminalReconnecting: (tabId: string, reconnecting: boolean) => void;
   setTerminalReattaching: (tabId: string, reattaching: boolean) => void;
   setTerminalReconnectTriggerError: (tabId: string, error: string | null) => void;
@@ -906,6 +938,23 @@ function collectRestoreCohort(groups: TabGroup[]): {
   const pendingTabIds = tabs.filter((t) => t.contentType === "terminal").map((t) => t.id);
   const preFailedCount = tabs.filter((t) => t.contentType === "agent-error").length;
   return { pendingTabIds, preFailedCount };
+}
+
+/**
+ * Enumerate every live tab across all tab groups (the active group is
+ * represented by the live `rootPanel`, the others by their stored trees). Used
+ * by the bulk-reconnect control to filter captured failed ids down to tabs that
+ * still exist and can actually be re-driven (#1227).
+ */
+function collectLiveTabs(state: {
+  tabGroups: TabGroup[];
+  activeTabGroupId: string;
+  rootPanel: PanelNode;
+}): TerminalTab[] {
+  const trees = state.tabGroups.map((g) =>
+    g.id === state.activeTabGroupId ? state.rootPanel : g.rootPanel
+  );
+  return trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
 }
 
 /** Unlisten function for the active session-based monitoring event subscription. */
@@ -3182,9 +3231,10 @@ export const useAppStore = create<AppState>((set, get) => {
       }
     },
 
-    // Aggregate partial-restore feedback (#1146, audit G4).
+    // Aggregate partial-restore feedback (#1146, audit G4) + bulk retry (#1227, M2).
     restoreCohort: null,
-    beginRestoreCohort: (pendingTabIds, preFailedCount) => {
+    failedRestoreTabIds: [],
+    beginRestoreCohort: (pendingTabIds, preFailedCount, toastId) => {
       const pending = new Set(pendingTabIds);
       const total = pending.size + preFailedCount;
       if (total === 0) return;
@@ -3192,7 +3242,11 @@ export const useAppStore = create<AppState>((set, get) => {
         "workspace_restore",
         `restore cohort started: ${total} tab(s), ${pending.size} pending, ${preFailedCount} pre-failed`
       );
-      set({ restoreCohort: { pending, total, failed: preFailedCount } });
+      // A fresh cohort supersedes any leftover retry set from the prior one.
+      set({
+        restoreCohort: { pending, total, failed: preFailedCount, failedTabIds: new Set(), toastId },
+        failedRestoreTabIds: [],
+      });
       // A cohort with no live tabs to wait on (e.g. all agent-error) settles now.
       if (pending.size === 0) get().settleRestoreCohort();
     },
@@ -3202,25 +3256,75 @@ export const useAppStore = create<AppState>((set, get) => {
       const pending = new Set(cohort.pending);
       pending.delete(tabId);
       const failed = cohort.failed + (outcome === "failed" ? 1 : 0);
-      set({ restoreCohort: { ...cohort, pending, failed } });
+      // Remember which terminal tabs failed so they can be bulk-reconnected.
+      const failedTabIds = new Set(cohort.failedTabIds);
+      if (outcome === "failed") failedTabIds.add(tabId);
+      set({ restoreCohort: { ...cohort, pending, failed, failedTabIds } });
       if (pending.size === 0) get().settleRestoreCohort();
     },
     settleRestoreCohort: () => {
       const cohort = get().restoreCohort;
       if (!cohort) return;
-      // Clear first so this fires exactly once even if a stray settle races in.
-      set({ restoreCohort: null });
-      const { total, failed } = cohort;
+      // Restrict the retry set to tabs that still exist as live terminal tabs.
+      const liveTerminalIds = new Set(
+        collectLiveTabs(get())
+          .filter((t) => t.contentType === "terminal")
+          .map((t) => t.id)
+      );
+      const retryTabIds = [...cohort.failedTabIds].filter((id) => liveTerminalIds.has(id));
+      // Clear first (and record the retry set) so this fires exactly once even
+      // if a stray settle races in.
+      set({ restoreCohort: null, failedRestoreTabIds: retryTabIds });
+      const { total, failed, toastId } = cohort;
       const restored = total - failed;
       frontendLog(
         "workspace_restore",
         `restore cohort settled: ${restored}/${total} connected, ${failed} failed`
       );
       if (failed === 0) {
-        toast.success(`Restored ${total} ${total === 1 ? "tab" : "tabs"}`);
+        // Resolve the pending bulk-retry toast in place when present.
+        toast.success(`Restored ${total} ${total === 1 ? "tab" : "tabs"}`, { id: toastId });
       } else {
         // No toast.warning primitive — use info for the partial-failure case.
-        toast.info(`Restored ${restored} of ${total} tabs — ${failed} could not reconnect`);
+        // Offer a one-tap bulk retry when there are reconnectable failed tabs.
+        const action =
+          retryTabIds.length > 0
+            ? { label: "Reconnect failed tabs", onClick: () => get().reconnectFailedRestoreTabs() }
+            : undefined;
+        toast.info(`Restored ${restored} of ${total} tabs — ${failed} could not reconnect`, {
+          id: toastId,
+          action,
+          // Persist while a bulk retry is offered so the action is not lost to
+          // auto-dismiss (matches the "recoverable" feedback pillar).
+          duration: action ? Infinity : undefined,
+        });
+      }
+    },
+    reconnectFailedRestoreTabs: () => {
+      const captured = get().failedRestoreTabIds;
+      // Consume the captured set regardless of outcome.
+      set({ failedRestoreTabIds: [] });
+      if (captured.length === 0) return;
+      // Only re-drive tabs that still exist as live terminal tabs.
+      const liveTerminalIds = new Set(
+        collectLiveTabs(get())
+          .filter((t) => t.contentType === "terminal")
+          .map((t) => t.id)
+      );
+      const targets = captured.filter((id) => liveTerminalIds.has(id));
+      if (targets.length === 0) return;
+      frontendLog(
+        "workspace_restore",
+        `bulk reconnect: re-driving ${targets.length} failed tab(s)`
+      );
+      // Pending feedback that resolves into the aggregate cohort summary.
+      const toastId = toast.loading(
+        `Reconnecting ${targets.length} ${targets.length === 1 ? "tab" : "tabs"}…`
+      );
+      // Register the fresh cohort before re-driving so each settle lands in it.
+      get().beginRestoreCohort(targets, 0, toastId);
+      for (const id of targets) {
+        get().reconnectTerminal(id);
       }
     },
     setTerminalReconnecting: (tabId, reconnecting) =>


### PR DESCRIPTION
Closes #1227. Follow-up to #1146 (PR #1226), which added the aggregate partial-restore summary toast. This adds the audit's **M2** bulk control so a user can retry every failed tab from a partial restore at once.

## Approach

- **Cohort now remembers failures.** The restore/launch cohort (from #1226) already tracked pending/total/failed counts; it now also records the set of terminal tab ids that settled as *failed* (`failedTabIds`). When the cohort settles, those (filtered to tabs that still exist) are captured into a new store field `failedRestoreTabIds`.
- **One-action bulk retry.** `reconnectFailedRestoreTabs()` re-drives exactly those still-live tabs through the **existing** per-tab `reconnectTerminal` path — no reconnect logic is reimplemented — registers a fresh cohort so the outcome re-summarizes, and shows a pending `toast.loading` that resolves in place into the aggregate result (a success summary if all come back, or another partial summary with the retry offered again).
- **Affordance = toast action button.** The partial-restore summary toast ("Restored N of M tabs — K could not reconnect") gains a **Reconnect failed tabs** action button (the issue's preferred surface) and persists while that action is offered so it isn't lost to auto-dismiss.
- **Toast primitive extended** with an optional `action` button — a thin, token-styled pass-through to sonner's native `action`, reused by all toast variants. No new one-off UI.

Only the failed tabs of the cohort are re-driven; already-connected tabs are untouched. Stale/closed tab ids are ignored.

Screenshots: not needed (behavior + toast action wiring; no new screen/layout).

## Test plan

New Vitest suite `src/store/appStore.bulkReconnect.test.ts` (TDD — red before, green after):

- Failed tab ids are captured from a settled partial-restore cohort, and the summary toast carries the retry action.
- Bulk retry re-drives **only** the previously-failed tab (fresh cohort = just that tab; already-connected tabs keep their sessions and are not marked connecting).
- A subsequent **success** outcome re-summarizes as success; a subsequent **partial** outcome re-summarizes as partial and keeps the tab retryable.
- No-op when there are no failed tabs; ignores captured ids that no longer exist in the tree.

Existing `appStore.restoreSummary.test.ts` still passes. Verified: `pnpm test` (store + toast suites, 365 passing), `pnpm build` (tsc type-check clean), `pnpm run lint` clean. No `any` types.

Manual test (macOS toast rendering): trigger a partial restore (restore a session with an unreachable connection), confirm the summary toast shows a **Reconnect failed tabs** button, click it, confirm a pending toast then a re-summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)