### PR TITLE
feat(agent): single-writer connectionState + de-duped refresh (#1234)

### DIFF
--- a/docs/changes/dev2/feature/1234-agent-single-writer.md
+++ b/docs/changes/dev2/feature/1234-agent-single-writer.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- Remote agents: a fast connection drop during connect no longer flickers back
+  to "connected". The agent's `connectionState` now has a single writer — the
+  backend `agent-state-change` event — so a late-settling connect can never
+  clobber a "reconnecting" state, and the sidebar dot, tab-strip dot, and
+  terminal overlay stay consistent (#1234).
+
+### Changed
+
+- Connecting to a remote agent now refreshes its sessions and definitions
+  exactly once per connect instead of twice (#1234).

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -176,7 +176,9 @@ export function TerminalView() {
           }
           frontendLog("disconnect", `agent connected: restarted ${restartedRetryCount} retry tabs`);
 
-          store.refreshAgentSessions(session_id);
+          // The sessions/definitions refresh is owned by `setAgentConnectionState`
+          // (called above for the "connected" transition), so it runs exactly
+          // once per connect (G4/#1234) — do not refresh again here.
         } else if (state === "reconnecting") {
           // Show the reconnecting spinner overlay on all tabs with an active
           // session for this agent.

--- a/src/store/appStore.agentConnections.test.ts
+++ b/src/store/appStore.agentConnections.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const {
+  mockConnectAgent,
   mockListAgentSessions,
   mockListAgentConnections,
   mockCreateAgentFolder,
@@ -8,6 +9,7 @@ const {
   mockDeleteAgentFolder,
   mockUpdateAgentDefinition,
 } = vi.hoisted(() => ({
+  mockConnectAgent: vi.fn(),
   mockListAgentSessions: vi.fn(() => Promise.resolve([])),
   mockListAgentConnections: vi.fn(() =>
     Promise.resolve({
@@ -47,7 +49,7 @@ vi.mock("@/services/storage", () => ({
 }));
 
 vi.mock("@/services/api", () => ({
-  connectAgent: vi.fn(),
+  connectAgent: mockConnectAgent,
   disconnectAgent: vi.fn(),
   listAgentSessions: mockListAgentSessions,
   listAgentDefinitions: vi.fn(() => Promise.resolve([])),
@@ -382,6 +384,110 @@ describe("appStore — agent connection management", () => {
 
       const result = useAppStore.getState().remoteAgents;
       expect(result.map((a) => a.id)).toEqual(["a1", "a2"]);
+    });
+  });
+
+  describe("connectRemoteAgent — single-writer connectionState + de-duped refresh (#1234)", () => {
+    const CAPS = { connectionTypes: [], maxSessions: 5 };
+
+    function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+      return {
+        id: AGENT_ID,
+        name: "Test Agent",
+        config: {
+          host: "test.local",
+          port: 22,
+          username: "user",
+          authMethod: "password",
+        },
+        isExpanded: false,
+        // Simulate the backend already having emitted "connecting" (the single writer).
+        connectionState: "connecting",
+        agentSettings: DEFAULT_AGENT_SETTINGS,
+        ...overrides,
+      };
+    }
+
+    it("does not clobber an event-written 'reconnecting' state with a late-settling connect", async () => {
+      useAppStore.setState({ remoteAgents: [makeAgent()] });
+
+      // Hold the connect request open so we can interleave a state-change event.
+      let resolveConnect!: (value: {
+        capabilities: typeof CAPS;
+        agentVersion: string;
+        protocolVersion: string;
+      }) => void;
+      mockConnectAgent.mockReturnValue(
+        new Promise((res) => {
+          resolveConnect = res;
+        })
+      );
+
+      const connectPromise = useAppStore.getState().connectRemoteAgent(AGENT_ID);
+
+      // A fast drop arrives through the single-writer event while the connect
+      // promise is still settling.
+      useAppStore.getState().setAgentConnectionState(AGENT_ID, "reconnecting");
+
+      // The connect request now resolves (late).
+      resolveConnect({ capabilities: CAPS, agentVersion: "1", protocolVersion: "1" });
+      await connectPromise;
+
+      // The late connect must NOT overwrite the event-written "reconnecting".
+      expect(useAppStore.getState().remoteAgents[0].connectionState).toBe("reconnecting");
+    });
+
+    it("consumes capabilities without writing connectionState", async () => {
+      useAppStore.setState({ remoteAgents: [makeAgent()] });
+      mockConnectAgent.mockResolvedValue({
+        capabilities: CAPS,
+        agentVersion: "1",
+        protocolVersion: "1",
+      });
+
+      await useAppStore.getState().connectRemoteAgent(AGENT_ID);
+
+      const agent = useAppStore.getState().remoteAgents[0];
+      expect(agent.capabilities).toEqual(CAPS);
+      // The action performs no terminal-state write; the event remains authoritative.
+      expect(agent.connectionState).toBe("connecting");
+    });
+
+    it("does not refresh agent sessions from the connect action (de-duped)", async () => {
+      useAppStore.setState({ remoteAgents: [makeAgent()] });
+      mockConnectAgent.mockResolvedValue({
+        capabilities: CAPS,
+        agentVersion: "1",
+        protocolVersion: "1",
+      });
+
+      await useAppStore.getState().connectRemoteAgent(AGENT_ID);
+
+      // The refresh is owned by the "connected" event, not the connect action.
+      expect(mockListAgentConnections).not.toHaveBeenCalled();
+      expect(mockListAgentSessions).not.toHaveBeenCalled();
+    });
+
+    it("refreshes agent sessions exactly once when the event writes 'connected'", async () => {
+      useAppStore.setState({ remoteAgents: [makeAgent()] });
+
+      useAppStore.getState().setAgentConnectionState(AGENT_ID, "connected");
+      // The refresh is fired fire-and-forget; let its microtasks flush.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockListAgentConnections).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes only on the transition into 'connected', not on a repeat event", async () => {
+      useAppStore.setState({ remoteAgents: [makeAgent()] });
+
+      useAppStore.getState().setAgentConnectionState(AGENT_ID, "connected");
+      useAppStore.getState().setAgentConnectionState(AGENT_ID, "connected");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockListAgentConnections).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3360,12 +3360,14 @@ export const useAppStore = create<AppState>((set, get) => {
       const agent = state.remoteAgents.find((a) => a.id === agentId);
       if (!agent) return;
 
-      set((s) => ({
-        remoteAgents: s.remoteAgents.map((a) =>
-          a.id === agentId ? { ...a, connectionState: "connecting" as const } : a
-        ),
-      }));
-
+      // Single-writer rule (G4/#1234): `connectionState` is written ONLY by the
+      // backend `agent-state-change` event (via `setAgentConnectionState`). This
+      // action just kicks off the request and consumes the returned
+      // `capabilities` — it writes no `connecting`/`connected`/`disconnected`
+      // states. The backend is authoritative for every transition (it emits
+      // "connecting" up front and "connected"/"disconnected" on the outcome),
+      // so an optimistic write here could clobber a fast drop → "reconnecting"
+      // event that arrives before this promise settles.
       try {
         const config: RemoteAgentConfig = { ...agent.config };
         if (password && config.authMethod === "password") {
@@ -3373,28 +3375,21 @@ export const useAppStore = create<AppState>((set, get) => {
         }
         const result = await apiConnectAgent(agentId, config, agent.agentSettings);
 
+        // Consume capabilities only (no connectionState write). Use a functional
+        // update so a state the event set in the meantime is preserved.
         set((s) => ({
           remoteAgents: s.remoteAgents.map((a) =>
-            a.id === agentId
-              ? {
-                  ...a,
-                  connectionState: "connected" as const,
-                  capabilities: result.capabilities,
-                  isExpanded: true,
-                }
-              : a
+            a.id === agentId ? { ...a, capabilities: result.capabilities, isExpanded: true } : a
           ),
         }));
 
-        // Fetch sessions and definitions
-        await get().refreshAgentSessions(agentId);
+        // The session/definition refresh is owned by the "connected" event
+        // (`setAgentConnectionState`), so it runs exactly once per connect and
+        // also covers the reconnect path — do not refresh here (de-dup, G4).
       } catch (err) {
         console.error(`Failed to connect agent ${agentId}:`, err);
-        set((s) => ({
-          remoteAgents: s.remoteAgents.map((a) =>
-            a.id === agentId ? { ...a, connectionState: "disconnected" as const } : a
-          ),
-        }));
+        // No optimistic "disconnected" write: the backend emits "disconnected"
+        // on every connect-failure path, so the event will drive the state.
         throw err;
       }
     },
@@ -3415,11 +3410,24 @@ export const useAppStore = create<AppState>((set, get) => {
     },
 
     setAgentConnectionState: (agentId, connectionState) => {
+      // Single writer for `connectionState` (G4/#1234): only the backend
+      // `agent-state-change` event reaches this setter.
+      const previous = get().remoteAgents.find((a) => a.id === agentId)?.connectionState;
       set((state) => ({
         remoteAgents: state.remoteAgents.map((a) =>
           a.id === agentId ? { ...a, connectionState } : a
         ),
       }));
+
+      // The refresh of sessions/definitions is owned by the transition INTO
+      // "connected" — this is the single, de-duped refresh per connect (G4).
+      // Guarding on the previous state keeps a redundant/duplicate "connected"
+      // event from triggering a second refresh, and it also covers the
+      // reconnect path (reconnecting → connected) which never runs
+      // `connectRemoteAgent`.
+      if (connectionState === "connected" && previous !== "connected") {
+        void get().refreshAgentSessions(agentId);
+      }
     },
 
     clearAgentSessions: (agentId) => {
@@ -4328,6 +4336,14 @@ export const useAppStore = create<AppState>((set, get) => {
 
         // Connect any disconnected agents that have stored credentials so that
         // buildTabGroupsFromWorkspace can resolve their tabs to live terminals.
+        //
+        // `connectRemoteAgent` no longer writes `connectionState` or refreshes
+        // sessions (single-writer rule, G4/#1234) — those now flow through the
+        // async `agent-state-change` event, which may not have landed by the
+        // time this returns. This restore path builds the layout synchronously,
+        // so it tracks which agents connected (the request resolved) and drives
+        // the build off that set rather than the not-yet-updated store state.
+        const justConnectedAgentIds = new Set<string>();
         if (disconnectedAgentsNeedingCreds.length > 0) {
           await Promise.all(
             disconnectedAgentsNeedingCreds.map(async (agent) => {
@@ -4342,11 +4358,16 @@ export const useAppStore = create<AppState>((set, get) => {
                     ? resolution.password
                     : undefined;
                 await get().connectRemoteAgent(agent.id, password);
+                justConnectedAgentIds.add(agent.id);
               } catch {
                 // Connection failure is surfaced as agent-error tabs below
               }
             })
           );
+          // Populate sessions/definitions for the agents we just connected so
+          // buildTabGroupsFromWorkspace can resolve their tabs now — the
+          // event-driven refresh is fire-and-forget and may not have run yet.
+          await Promise.all([...justConnectedAgentIds].map((id) => get().refreshAgentSessions(id)));
         }
 
         // After the store is unlocked (or was already unlocked), resolve stored
@@ -4375,13 +4396,17 @@ export const useAppStore = create<AppState>((set, get) => {
           })
         );
 
-        // Re-read agent state so newly-connected agents are reflected in tab resolution.
+        // Re-read agent state so newly-connected agents are reflected in tab
+        // resolution. Agents we connected in this pass are treated as connected
+        // even if their `agent-state-change` "connected" event has not yet
+        // updated the store (single-writer rule, G4/#1234): a resolved connect
+        // request means the backend is connected.
         const freshState = get();
         const agentContext = {
           agents: freshState.remoteAgents.map((a) => ({
             id: a.id,
             name: a.name,
-            connected: a.connectionState === "connected",
+            connected: a.connectionState === "connected" || justConnectedAgentIds.has(a.id),
           })),
           definitions: freshState.agentDefinitions,
         };


### PR DESCRIPTION
Closes #1234

Part of the Remote Agent Lifecycle Redesign (#1142), stage 1 — the foundational single-writer fix (covers **G4** and **G11**).

## Problem

An agent's `connectionState` had **two writers**: the store action `connectRemoteAgent` (optimistic `connecting → connected`/`disconnected`) and the backend `agent-state-change` event. This was order-dependent:

- A fast drop → `reconnecting` event arriving before the optimistic `connected` write landed (connect promise still settling) could be **clobbered back to `connected`**, hiding an active reconnect.
- Both paths refreshed sessions on every connect → a **double refresh**.

## Approach

- **`connectRemoteAgent`** no longer writes `connecting`/`connected`/`disconnected`. It only kicks off the request and consumes the returned `capabilities` (via a functional update that preserves any state the event set meanwhile). The backend is the single writer — it already emits `connecting` up front (`agent_manager.rs:409`, G11) and `connected`/`disconnected` on every outcome path, so no backend change was needed.
- **`setAgentConnectionState`** (driven solely by the `agent-state-change` listener) is now the only writer, and it owns the session/definition refresh on the transition **into** `connected` (guarded against repeat events). This makes the refresh run **once per connect** and also covers the reconnect path, which never calls `connectRemoteAgent`.
- Removed the now-duplicate refresh from `connectRemoteAgent` and from the `TerminalView` `connected` handler.
- **`launchWorkspace`** built its layout synchronously off the store's post-connect state. With the optimistic write gone, it now tracks the agents it connected (request resolved) and refreshes/marks them explicitly, so tab resolution still works before the async event lands.

## Test plan

- New store unit tests in `appStore.agentConnections.test.ts` (written first, red before the fix):
  - a late-settling `connectRemoteAgent` does **not** clobber an event-written `reconnecting` state back to `connected`;
  - `connectRemoteAgent` consumes capabilities without writing `connectionState`;
  - `connectRemoteAgent` performs **no** session refresh (de-dup);
  - the refresh fires **exactly once**, on the transition into `connected`, and not on a repeat `connected` event.
- `pnpm test` (2384 tests), `pnpm build` (tsc type-check), and `pnpm run lint` all pass.

### Manual verification (macOS rendering path)

- Connect an agent, then immediately drop the SSH channel so the backend emits `reconnecting` right as the connect settles → the sidebar dot stays on the reconnecting state (no flicker back to connected).
- Launch a saved workspace referencing a stored-credential agent → its tabs still resolve to live terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)