### PR TITLE
fix(terminal): detect half-open direct connections via TCP keepalive (Closes #1123)

### DIFF
--- a/core/src/backends/ssh/auth.rs
+++ b/core/src/backends/ssh/auth.rs
@@ -8,7 +8,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use socket2::TcpKeepalive;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::expand_config_value;
@@ -84,22 +83,10 @@ async fn do_connect_and_authenticate(
         .await
         .map_err(|e| SessionError::SpawnFailed(format!("Connection failed: {e}")))?;
 
-    // Configure TCP keepalives on the connected socket before the SSH handshake.
-    // This mirrors the libssh2 setup: probe after 2 s idle, retry every 2 s,
-    // give up after 1 failed probe.
-    {
-        let ka = {
-            let base = TcpKeepalive::new()
-                .with_time(Duration::from_secs(2))
-                .with_interval(Duration::from_secs(2));
-            #[cfg(not(target_os = "windows"))]
-            let base = base.with_retries(1);
-            base
-        };
-        if let Err(e) = socket2::SockRef::from(&tokio_tcp).set_tcp_keepalive(&ka) {
-            tracing::warn!("TCP keepalive setup failed: {e}");
-        }
-    }
+    // Configure TCP keepalives on the connected socket before the SSH
+    // handshake so a half-open transport is torn down promptly. Shared with the
+    // telnet backend via `crate::net` to keep the tuning identical (#1123).
+    crate::net::enable_tcp_keepalive(&tokio_tcp);
 
     handshake_and_authenticate(config, tokio_tcp).await
 }

--- a/core/src/backends/telnet.rs
+++ b/core/src/backends/telnet.rs
@@ -554,6 +554,42 @@ mod tests {
             .expect("disconnect should not fail");
     }
 
+    /// Regression test for #1123: a half-open telnet connection (peer vanishes
+    /// with no FIN/RST) must eventually be torn down instead of hanging in
+    /// "Connected" forever. The mechanism is TCP keepalive on the socket — the
+    /// OS probes the dead peer, the read fails, the reader thread breaks, and
+    /// the session emits `terminal-exit`. Without keepalive the socket never
+    /// fails and the read loop spins on `TimedOut` indefinitely.
+    ///
+    /// We assert the observable precondition: after a successful connect, the
+    /// underlying socket has keepalive enabled.
+    #[tokio::test]
+    async fn connect_enables_tcp_keepalive() {
+        // Local listener stands in for a telnet server; accept and hold the
+        // peer so the connection stays established for the assertion.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let accept = std::thread::spawn(move || listener.accept());
+
+        let mut telnet = Telnet::new();
+        let settings = serde_json::json!({
+            "host": addr.ip().to_string(),
+            "port": addr.port(),
+        });
+        telnet.connect(settings).await.expect("connect should succeed");
+        let _peer = accept.join().expect("accept thread").expect("accept");
+
+        let state = telnet.state.as_ref().expect("connected state");
+        let writer = state.writer.lock().expect("lock writer");
+        let keepalive = socket2::SockRef::from(&*writer)
+            .keepalive()
+            .expect("read keepalive flag");
+        assert!(
+            keepalive,
+            "telnet socket must have TCP keepalive enabled to detect half-open connections (#1123)"
+        );
+    }
+
     /// Create a dummy TCP stream for testing `filter_telnet_commands`.
     ///
     /// We connect to a loopback address that won't actually be used for

--- a/core/src/backends/telnet.rs
+++ b/core/src/backends/telnet.rs
@@ -223,6 +223,13 @@ impl ConnectionType for Telnet {
         let stream = TcpStream::connect_timeout(&socket_addr, CONNECT_TIMEOUT)
             .map_err(|e| SessionError::SpawnFailed(format!("TCP connect failed: {e}")))?;
 
+        // Enable TCP keepalive so a half-open connection (peer vanishes with no
+        // FIN/RST — cable pull, NAT timeout, crashed host) is eventually torn
+        // down by the OS instead of hanging in "Connected" forever. The dead
+        // socket surfaces as a read error, the reader thread breaks, and the
+        // session emits `terminal-exit` (#1123).
+        crate::net::enable_tcp_keepalive(&stream);
+
         stream
             .set_read_timeout(Some(READ_TIMEOUT))
             .map_err(|e| SessionError::SpawnFailed(format!("Failed to set read timeout: {e}")))?;

--- a/core/src/backends/telnet.rs
+++ b/core/src/backends/telnet.rs
@@ -583,7 +583,10 @@ mod tests {
             "host": addr.ip().to_string(),
             "port": addr.port(),
         });
-        telnet.connect(settings).await.expect("connect should succeed");
+        telnet
+            .connect(settings)
+            .await
+            .expect("connect should succeed");
         let _peer = accept.join().expect("accept thread").expect("accept");
 
         let state = telnet.state.as_ref().expect("connected state");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,8 @@ pub mod connection;
 pub mod errors;
 pub mod files;
 pub mod monitoring;
+#[cfg(any(feature = "telnet", feature = "ssh"))]
+pub mod net;
 pub mod network;
 pub mod output;
 pub mod protocol;

--- a/core/src/net.rs
+++ b/core/src/net.rs
@@ -1,0 +1,85 @@
+//! Shared low-level networking helpers for TCP-based backends.
+//!
+//! Centralises socket tuning that must be identical across backends. The main
+//! concern is **half-open connection detection**: a TCP peer that vanishes
+//! silently (cable pull, NAT timeout, crashed host) never sends a FIN or RST,
+//! so a plain blocking `read` waits forever and the session appears "connected"
+//! indefinitely. Enabling TCP keepalive lets the OS probe the dead peer and
+//! eventually fail the socket, which surfaces to the reader as an error and
+//! drives the normal disconnect path (`terminal-exit` -> disconnect overlay).
+
+use std::time::Duration;
+
+use socket2::TcpKeepalive;
+
+/// Idle time before the first keepalive probe is sent.
+const KEEPALIVE_IDLE: Duration = Duration::from_secs(2);
+
+/// Interval between keepalive probes once probing has started.
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Number of unanswered probes before the connection is considered dead.
+///
+/// Not configurable on Windows (the platform derives the retry count from the
+/// registry), so the `.with_retries` call is gated below.
+#[cfg(not(target_os = "windows"))]
+const KEEPALIVE_RETRIES: u32 = 1;
+
+/// Build the shared [`TcpKeepalive`] configuration used by all TCP backends.
+///
+/// Mirrors the SSH transport tuning: probe after a short idle period, retry a
+/// couple of times, then give up so a half-open connection is torn down
+/// promptly rather than hanging.
+fn keepalive_config() -> TcpKeepalive {
+    let base = TcpKeepalive::new()
+        .with_time(KEEPALIVE_IDLE)
+        .with_interval(KEEPALIVE_INTERVAL);
+    #[cfg(not(target_os = "windows"))]
+    let base = base.with_retries(KEEPALIVE_RETRIES);
+    base
+}
+
+/// Enable TCP keepalive on a connected socket so half-open connections are
+/// detected and torn down instead of hanging forever.
+///
+/// Accepts anything convertible to a [`socket2::SockRef`] (e.g. a
+/// [`std::net::TcpStream`] or [`tokio::net::TcpStream`]). Failure is logged and
+/// swallowed: keepalive is a robustness improvement, not a hard requirement for
+/// the connection to function.
+pub fn enable_tcp_keepalive<'s, S>(stream: &'s S)
+where
+    socket2::SockRef<'s>: From<&'s S>,
+{
+    let ka = keepalive_config();
+    if let Err(e) = socket2::SockRef::from(stream).set_tcp_keepalive(&ka) {
+        tracing::warn!("TCP keepalive setup failed: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{TcpListener, TcpStream};
+
+    /// A connected socket has keepalive enabled after calling the helper.
+    #[test]
+    fn enable_tcp_keepalive_turns_keepalive_on() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let stream = TcpStream::connect(addr).expect("connect");
+        let _peer = listener.accept().expect("accept");
+
+        // Sanity: a freshly connected socket has keepalive off by default.
+        let before = socket2::SockRef::from(&stream)
+            .keepalive()
+            .expect("read keepalive");
+        assert!(!before, "expected keepalive off before enabling");
+
+        enable_tcp_keepalive(&stream);
+
+        let after = socket2::SockRef::from(&stream)
+            .keepalive()
+            .expect("read keepalive");
+        assert!(after, "expected keepalive on after enabling");
+    }
+}

--- a/docs/changes/dev1/bugfix/1123-half-open-direct-connections.md
+++ b/docs/changes/dev1/bugfix/1123-half-open-direct-connections.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Half-open direct connections no longer hang in "Connected" forever. When a
+  telnet peer vanishes silently (cable pull, NAT timeout, crashed host) with no
+  TCP FIN/RST, the socket now has TCP keepalive enabled, so the OS tears down
+  the dead connection, the terminal shows the disconnect overlay, and the tab
+  leaves the Connected state instead of freezing indefinitely (#1123).

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -29,6 +29,15 @@ export function TerminalView() {
   // Handle backend-reported remote-connection state changes: a "disconnected"
   // state marks the owning tab exited (which drives the per-tab status dot via
   // the tab-id-keyed lifecycle maps — see deriveTabStatus).
+  //
+  // NOTE (#1123): direct sessions (SSH / telnet / serial) do NOT currently
+  // reach this path — the backend never emits `remote-state-change` for them.
+  // Their disconnects — including half-open TCP drops (cable pull, NAT timeout,
+  // crashed host) — surface via `terminal-exit`: TCP keepalive on the socket
+  // (`core::net::enable_tcp_keepalive`) tears the dead connection down, the
+  // reader thread sees the error, and `terminal-exit` fires the overlay. This
+  // listener is retained as the forward-compatible hook for any future backend
+  // that emits explicit `remote-state-change` transitions.
   useEffect(() => {
     let unlisten: (() => void) | null = null;
     listen<{ session_id: string; state: string }>("remote-state-change", (event) => {


### PR DESCRIPTION
## Summary

Half-open direct connections (SSH/telnet/serial) could hang in **Connected** forever when a peer vanished silently (cable pull, NAT timeout, crashed host) with no TCP FIN/RST — the output reader never closed, so no `terminal-exit` fired and the tab froze with no disconnect overlay.

This enables TCP keepalive on direct-connection sockets so the OS detects the dead peer, tears down the connection, and the existing exit path surfaces the disconnect overlay and leaves the Connected state.

## Test plan

- Added a regression test for half-open telnet detection (test commit precedes the fix).
- CI: `./scripts/test.sh` + `./scripts/check.sh`.

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)