### PR TITLE
fix(terminal): preserve xterm scrollback across reconnect (Closes #1126)

### DIFF
--- a/docs/changes/dev1/bugfix/1126-reconnect-xterm-scrollback.md
+++ b/docs/changes/dev1/bugfix/1126-reconnect-xterm-scrollback.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Clicking **Reconnect** on a disconnected terminal no longer wipes the
+  scrollback when the reconnect fails. The terminal's scrollback is now
+  snapshotted before the xterm instance is torn down and replayed into the
+  fresh instance, so the "Scrollback is preserved below" promise on the
+  disconnect / "Reconnect failed" overlay actually holds for direct
+  connections (#1126).

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-serialize": "^0.13.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/xterm": "^6.0.0",
     "html-to-image": "^1.11.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@xterm/addon-search':
         specifier: ^0.16.0
         version: 0.16.0
+      '@xterm/addon-serialize':
+        specifier: ^0.13.0
+        version: 0.13.0(@xterm/xterm@6.0.0)
       '@xterm/addon-unicode11':
         specifier: ^0.9.0
         version: 0.9.0
@@ -1914,6 +1917,11 @@ packages:
 
   '@xterm/addon-search@0.16.0':
     resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
+
+  '@xterm/addon-serialize@0.13.0':
+    resolution: {integrity: sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
 
   '@xterm/addon-unicode11@0.9.0':
     resolution: {integrity: sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==}
@@ -4890,6 +4898,10 @@ snapshots:
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-search@0.16.0': {}
+
+  '@xterm/addon-serialize@0.13.0(@xterm/xterm@6.0.0)':
+    dependencies:
+      '@xterm/xterm': 6.0.0
 
   '@xterm/addon-unicode11@0.9.0': {}
 

--- a/src/components/Terminal/Terminal.reconnect-scrollback.test.tsx
+++ b/src/components/Terminal/Terminal.reconnect-scrollback.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Regression test for #1126 — reconnect must preserve the xterm scrollback.
+ *
+ * `reconnectTerminal` bumps `terminalRetryCounters`, which is a dependency of
+ * the terminal-creation effect. That re-runs the effect: the cleanup disposes
+ * the current xterm instance and a fresh one is created. For a *direct*
+ * connection there is no server-side buffer to re-fetch, so without an explicit
+ * snapshot/replay the scrollback the disconnect overlay promises
+ * ("Scrollback is preserved below") is gone — and if the reconnect then fails,
+ * the pane is blank, contradicting the overlay copy.
+ *
+ * The fix serializes the old instance's scrollback in cleanup (before dispose)
+ * and replays it into the fresh instance right after `xterm.open()`, before the
+ * new session resolves. This test asserts that replay happens.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+import { useAppStore } from "@/store/appStore";
+
+// --- Mocks ---
+
+// A distinctive serialized snapshot the SerializeAddon mock returns, so the
+// test can prove the fresh instance replayed the previous instance's buffer.
+const SERIALIZED_SCROLLBACK = "\x1b[32mprevious scrollback line\x1b[0m\r\n";
+
+// Track every xterm instance created, in order, with its write() spy so the
+// test can distinguish the disposed instance from the fresh one.
+interface TrackedXTerm {
+  write: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+}
+const xtermInstances: TrackedXTerm[] = [];
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    onCursorMove = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    write = vi.fn((_data: unknown, cb?: () => void) => cb?.());
+    writeln = vi.fn();
+    reset = vi.fn();
+    scrollToBottom = vi.fn();
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn();
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = { active: { viewportY: 0, baseY: 0, length: 0, getLine: vi.fn() } };
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+    constructor() {
+      xtermInstances.push({ write: this.write, dispose: this.dispose });
+    }
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class MockFitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-unicode11", () => {
+  class MockUnicode11Addon {
+    dispose = vi.fn();
+  }
+  return { Unicode11Addon: MockUnicode11Addon };
+});
+
+vi.mock("@xterm/addon-search", () => {
+  class MockSearchAddon {
+    dispose = vi.fn();
+  }
+  return { SearchAddon: MockSearchAddon };
+});
+
+// The SerializeAddon returns the distinctive snapshot only once a session has
+// been established (i.e. the instance has "content"). We approximate that by
+// returning the snapshot unconditionally; the production guard only replays a
+// non-empty snapshot, and only for a subsequent instance.
+vi.mock("@xterm/addon-serialize", () => {
+  class MockSerializeAddon {
+    serialize = vi.fn(() => SERIALIZED_SCROLLBACK);
+    dispose = vi.fn();
+  }
+  return { SerializeAddon: MockSerializeAddon };
+});
+
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+const mockCreateTerminal = vi.fn().mockResolvedValue("fresh-session");
+
+vi.mock("@/services/api", () => ({
+  createTerminal: (...args: unknown[]) => mockCreateTerminal(...args),
+  cancelConnecting: vi.fn().mockResolvedValue(undefined),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  setSessionLineEnding: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+  detachPersistentTab: vi.fn().mockResolvedValue(0),
+  getAgentSessionBuffer: vi.fn().mockResolvedValue(new Uint8Array()),
+}));
+
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: vi.fn(() => vi.fn()),
+    subscribeExit: vi.fn(() => vi.fn()),
+    clearPendingExit: vi.fn(),
+    clearPendingOutput: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+  isShellReservedKey: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  mockCreateTerminal.mockClear();
+  mockCreateTerminal.mockResolvedValue("fresh-session");
+  xtermInstances.length = 0;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const LOCAL_CONFIG = {
+  type: "local" as const,
+  config: { shell: "/bin/bash" },
+};
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Terminal — scrollback survives reconnect (#1126)", () => {
+  it("replays the prior xterm scrollback into the fresh instance on reconnect", async () => {
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal tabId="tab-1" config={LOCAL_CONFIG} isVisible={true} />
+        </TerminalPortalProvider>
+      );
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    // One xterm instance created on mount; it connected the initial session.
+    const initialInstanceCount = xtermInstances.length;
+    expect(initialInstanceCount).toBeGreaterThanOrEqual(1);
+    const firstInstance = xtermInstances[initialInstanceCount - 1];
+
+    // User clicks "Reconnect": bumps the retry counter, which re-runs the
+    // terminal-creation effect (dispose old xterm → create new xterm).
+    act(() => {
+      useAppStore.getState().reconnectTerminal("tab-1");
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    // A fresh xterm instance must have been created for the reconnect, and the
+    // previous instance disposed.
+    expect(xtermInstances.length).toBeGreaterThan(initialInstanceCount);
+    expect(firstInstance.dispose).toHaveBeenCalled();
+
+    // The fresh instance must have replayed the previous instance's serialized
+    // scrollback — this is what keeps "Scrollback is preserved below" true when
+    // a reconnect fails. Without the fix, the fresh instance never receives it.
+    const freshInstance = xtermInstances[xtermInstances.length - 1];
+    const replayed = freshInstance.write.mock.calls.some(
+      (call) => call[0] === SERIALIZED_SCROLLBACK
+    );
+    expect(replayed).toBe(true);
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -3,6 +3,7 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { SearchAddon } from "@xterm/addon-search";
+import { SerializeAddon } from "@xterm/addon-serialize";
 import "@xterm/xterm/css/xterm.css";
 import "./Terminal.css";
 import { ConnectionConfig } from "@/types/terminal";
@@ -242,6 +243,12 @@ export function Terminal({
   const xtermRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const sessionIdRef = useRef<string | null>(null);
+  // Serialized scrollback of the previous xterm instance, captured just before
+  // it is disposed on a reconnect (retryCount bump re-runs the creation effect
+  // and tears the instance down). Replayed into the fresh xterm so the
+  // scrollback the disconnect overlay promises survives — and, if the reconnect
+  // itself fails, is still visible under the "Reconnect failed" overlay (#1126).
+  const scrollbackSnapshotRef = useRef<string | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
   // The set of connect ids (`${tabId}:${retryCount}`) whose backend handshake is
   // currently in flight, so teardown can abort them (#952). Tracked PER attempt
@@ -834,7 +841,25 @@ export function Terminal({
     xterm.loadAddon(searchAddon);
     registerSearchAddon(tabId, searchAddon);
 
+    const serializeAddon = new SerializeAddon();
+    xterm.loadAddon(serializeAddon);
+
     xterm.open(scrollViewport);
+
+    // Replay the previous instance's scrollback captured on the last teardown
+    // (a reconnect disposes the old xterm — see cleanup below). Writing it here,
+    // before the new session connects, means a failed reconnect still shows the
+    // prior scrollback under the disconnect overlay instead of a blank pane
+    // (#1126). Persistent/agent tabs re-fetch an authoritative buffer from the
+    // server during reattach, so replaying the local snapshot too would double
+    // the scrollback — skip it for those and rely on the server buffer.
+    // Always clear the ref so an unrelated re-run starts empty.
+    if (scrollbackSnapshotRef.current) {
+      if (!persistentConnectionId) {
+        xterm.write(scrollbackSnapshotRef.current);
+      }
+      scrollbackSnapshotRef.current = null;
+    }
 
     // The terminal's vertical scrollbar lives in the gutter in every mode (xterm's
     // own overlay scrollbar is hidden via CSS), so it looks and behaves the same
@@ -1068,6 +1093,18 @@ export function Terminal({
       }
       scrollbar.dispose();
       scrollbarRef.current = null;
+      // Snapshot the scrollback so the next effect run (a reconnect re-runs this
+      // effect via the retryCount dep) can replay it into the fresh xterm. This
+      // is what makes the disconnect overlay's "Scrollback is preserved below"
+      // hold true even when the reconnect fails (#1126). Serialize before
+      // dispose; guard so a serialize failure never blocks teardown.
+      try {
+        const snapshot = serializeAddon.serialize();
+        scrollbackSnapshotRef.current = snapshot.length > 0 ? snapshot : null;
+      } catch (err) {
+        frontendLog("terminal", `Failed to snapshot scrollback tab=${tabId}: ${String(err)}`);
+        scrollbackSnapshotRef.current = null;
+      }
       xterm.dispose();
       el.remove();
       terminalElRef.current = null;


### PR DESCRIPTION
## Summary

Clicking **Reconnect** bumped a retry counter that is a dependency of the terminal-creation effect, tearing down and recreating the xterm instance *before* the new session resolved. If the reconnect then failed, the scrollback the disconnect overlay promised ("Scrollback is preserved below") was already gone — a blank terminal contradicting the overlay copy.

This preserves the xterm scrollback across a reconnect so a failed reconnect re-displays the prior buffer, making the overlay copy and behavior agree.

## Test plan

- Added a regression test for reconnect scrollback loss (test commit precedes the fix).
- CI: `./scripts/test.sh` + `./scripts/check.sh`.

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)