### PR TITLE
feat(tunnel): surface tunnel Error in sidebar + Open Connections (Closes #1240)

### DIFF
--- a/docs/changes/dev1/feature/1240-tunnel-error-sidebar.md
+++ b/docs/changes/dev1/feature/1240-tunnel-error-sidebar.md
@@ -1,0 +1,9 @@
+### Added
+
+- SSH tunnels: a tunnel that fails now shows as a red resting row in the tunnel
+  sidebar with its persisted error message inline. The row offers **Retry**
+  (restarts the tunnel and clears the stored error) and **View last error**
+  (shows the full message) in place of the Play button, and the state survives a
+  window reload. The errored tunnel also appears in the **Open Connections**
+  panel with a working force-**Stop** so its leaked connection resources can be
+  released (#1240).

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -105,7 +105,8 @@
 }
 
 .oc-row__badge--dead,
-.oc-row__badge--down {
+.oc-row__badge--down,
+.oc-row__badge--error {
   background: color-mix(in srgb, var(--color-error) 18%, transparent);
   color: var(--color-error);
 }

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -124,9 +124,19 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     }
   }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Include errored / reconnecting tunnels, not just connected/connecting: an
+  // errored tunnel still holds a leaked `active_tunnels` entry + pool guards, so
+  // it must be force-Stoppable from the canonical kill panel (#1240). stop_tunnel
+  // releases the leak and clears the persisted error (#1238).
   const activeTunnels = tunnels.filter((t) => {
     const state = tunnelStates[t.id];
-    return state && (state.status === "connected" || state.status === "connecting");
+    return (
+      state &&
+      (state.status === "connected" ||
+        state.status === "connecting" ||
+        state.status === "reconnecting" ||
+        state.status === "error")
+    );
   });
 
   // Only surface a live X server: a managed one that is running, or an adopted
@@ -415,13 +425,20 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           >
             {activeTunnels.map((t) => {
               const state = tunnelStates[t.id];
+              const status = state?.status ?? "connecting";
+              // Map the tunnel status onto a badge; connecting/reconnecting share
+              // the "connecting" badge, error surfaces its persisted message.
+              const badge: BadgeVariant =
+                status === "connected" ? "connected" : status === "error" ? "error" : "connecting";
               return (
                 <ConnectionRow
                   key={t.id}
                   icon={<ArrowLeftRight size={14} />}
                   title={t.name}
-                  badge={state?.status === "connected" ? "connected" : "connecting"}
+                  detail={status === "error" ? state?.error : undefined}
+                  badge={badge}
                   onKill={() => handleKillTunnel(t.id)}
+                  killLabel="Stop"
                 />
               );
             })}
@@ -601,7 +618,8 @@ type BadgeVariant =
   | "up"
   | "down"
   | "paused"
-  | "stopped";
+  | "stopped"
+  | "error";
 
 interface ConnectionRowProps {
   icon: React.ReactNode;

--- a/src/components/OpenConnections/OpenConnectionsModal.tunnelError.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tunnelError.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Tests for errored / stale tunnels in the Open Connections kill panel (#1240,
+ * Stage S1 / GAP 3).
+ *
+ * The canonical kill panel must list an `error` tunnel (its leaked
+ * `active_tunnels` entry is still holding resources) and offer a working
+ * force-**Stop** that calls `stop_tunnel` (which, per #1238, also clears the
+ * persisted error).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { TunnelConfig, TunnelState } from "@/types/tunnel";
+
+// jsdom lacks the observer/pointer-capture APIs Radix Tooltip touches.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+    ResizeObserverStub;
+}
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() => Promise.resolve([])),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+const getTunnelStatuses = vi.fn(() => Promise.resolve([] as TunnelState[]));
+const stopTunnel = vi.fn((_id: string) => Promise.resolve());
+vi.mock("@/services/tunnelApi", () => ({
+  getTunnelStatuses: () => getTunnelStatuses(),
+  stopTunnel: (id: string) => stopTunnel(id),
+}));
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+function tunnelConfig(id: string, name: string): TunnelConfig {
+  return {
+    id,
+    name,
+    sshConnectionId: "ssh-1",
+    tunnelType: {
+      type: "local",
+      config: {
+        localHost: "127.0.0.1",
+        localPort: 8080,
+        remoteHost: "example.com",
+        remotePort: 80,
+      },
+    },
+    autoStart: false,
+    reconnectOnDisconnect: false,
+  };
+}
+
+function erroredState(id: string, error: string): TunnelState {
+  return {
+    tunnelId: id,
+    status: "error",
+    error,
+    stats: { bytesSent: 0, bytesReceived: 0, activeConnections: 0, totalConnections: 0 },
+  };
+}
+
+function tunnelRows(): Element[] {
+  const section = Array.from(document.querySelectorAll(".oc-section__title")).find(
+    (t) => t.textContent === "SSH Tunnels"
+  );
+  if (!section) return [];
+  const sectionEl = section.closest("div")?.parentElement;
+  return Array.from(sectionEl?.querySelectorAll(".oc-row") ?? []);
+}
+
+describe("OpenConnectionsModal — errored tunnels (#1240)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    getTunnelStatuses.mockClear();
+    stopTunnel.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderModal() {
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
+      );
+    });
+  }
+
+  it("lists an errored tunnel so its leaked resources can be force-stopped", () => {
+    useAppStore.setState({
+      tunnels: [tunnelConfig("t1", "expose-web")],
+      tunnelStates: { t1: erroredState("t1", "SSH session closed by peer") },
+    });
+
+    renderModal();
+
+    const rows = tunnelRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("expose-web");
+  });
+
+  it("force-Stop on an errored tunnel invokes stop_tunnel", () => {
+    useAppStore.setState({
+      tunnels: [tunnelConfig("t1", "expose-web")],
+      tunnelStates: { t1: erroredState("t1", "SSH session closed by peer") },
+    });
+
+    renderModal();
+
+    const killBtn = tunnelRows()[0].querySelector<HTMLButtonElement>(".oc-row__kill");
+    expect(killBtn).not.toBeNull();
+    act(() => {
+      killBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(stopTunnel).toHaveBeenCalledWith("t1");
+  });
+});

--- a/src/components/TunnelSidebar/TunnelListItem.error.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.error.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Tests for the errored resting state of a tunnel row (#1240, Stage S1 / GAP 3).
+ *
+ * When `get_statuses()` returns a persisted `Error`, the sidebar row must:
+ *   - replace the Play/Start button with a **Retry** control that fires
+ *     `onStart` (Error → Connecting, clears the stored error via `start_tunnel`),
+ *   - offer a **View last error** control that surfaces the persisted message,
+ *   - render the persisted error text inline, and
+ *   - carry the red `tunnel-item__status--error` resting dot.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TunnelListItem } from "./TunnelListItem";
+import { withTooltip } from "@/test/tooltip";
+import type { TunnelConfig, TunnelState } from "@/types/tunnel";
+import type { SavedConnection } from "@/types/connection";
+
+const TUNNEL: TunnelConfig = {
+  id: "tun-1",
+  name: "My Tunnel",
+  sshConnectionId: "ssh-1",
+  autoStart: false,
+  reconnectOnDisconnect: false,
+  tunnelType: {
+    type: "local",
+    config: {
+      localHost: "127.0.0.1",
+      localPort: 8080,
+      remoteHost: "example.com",
+      remotePort: 80,
+    },
+  },
+};
+
+const ERROR_STATE: TunnelState = {
+  tunnelId: "tun-1",
+  status: "error",
+  error: "SSH session closed by peer (bastion.corp)",
+  stats: { bytesSent: 0, bytesReceived: 0, activeConnections: 0, totalConnections: 0 },
+};
+
+const noop = () => {};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function renderItem(
+  state: TunnelState | undefined,
+  handlers: Partial<{
+    onStart: (id: string) => void;
+    onStop: (id: string) => void;
+  }> = {}
+): void {
+  act(() => {
+    root.render(
+      withTooltip(
+        <TunnelListItem
+          tunnel={TUNNEL}
+          state={state}
+          connections={[] as SavedConnection[]}
+          onStart={handlers.onStart ?? noop}
+          onStop={handlers.onStop ?? noop}
+          onEdit={noop}
+          onDuplicate={noop}
+          onDelete={noop}
+        />
+      )
+    );
+  });
+}
+
+describe("TunnelListItem — errored resting state (#1240)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a red status dot and the persisted error inline", async () => {
+    renderItem(ERROR_STATE);
+    await flush();
+
+    const dot = container.querySelector('[data-testid="tunnel-status-tun-1"]');
+    expect(dot?.className).toContain("tunnel-item__status--error");
+    expect(container.textContent).toContain("SSH session closed by peer (bastion.corp)");
+  });
+
+  it("replaces Start with Retry + View last error for an errored tunnel", async () => {
+    renderItem(ERROR_STATE);
+    await flush();
+
+    // Play/Start must be gone; Retry + View-last-error take its place.
+    expect(container.querySelector('[data-testid="tunnel-start-tun-1"]')).toBeNull();
+    expect(container.querySelector('[data-testid="tunnel-stop-tun-1"]')).toBeNull();
+
+    const retry = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-retry-tun-1"]');
+    const viewErr = container.querySelector<HTMLButtonElement>(
+      '[data-testid="tunnel-view-error-tun-1"]'
+    );
+    expect(retry).not.toBeNull();
+    expect(retry?.getAttribute("aria-label")).toBeTruthy();
+    expect(viewErr).not.toBeNull();
+    expect(viewErr?.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("fires onStart when Retry is clicked (Error → Connecting via start_tunnel)", async () => {
+    const onStart = vi.fn();
+    renderItem(ERROR_STATE, { onStart });
+    await flush();
+
+    const retry = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-retry-tun-1"]')!;
+    act(() => {
+      retry.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onStart).toHaveBeenCalledWith("tun-1");
+  });
+
+  it("still shows Start (not Retry) for a disconnected tunnel", async () => {
+    renderItem(undefined);
+    await flush();
+
+    expect(container.querySelector('[data-testid="tunnel-start-tun-1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="tunnel-retry-tun-1"]')).toBeNull();
+    expect(container.querySelector('[data-testid="tunnel-view-error-tun-1"]')).toBeNull();
+  });
+});

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -1,5 +1,5 @@
-import { Play, Square, Pencil, Copy, Trash2 } from "lucide-react";
-import { Tooltip } from "@/components/ui";
+import { Play, Square, Pencil, Copy, Trash2, RotateCw, Info, AlertTriangle } from "lucide-react";
+import { Tooltip, toast } from "@/components/ui";
 import { TunnelConfig, TunnelState } from "@/types/tunnel";
 import { SavedConnection } from "@/types/connection";
 import { formatBytes } from "@/utils/formatters";
@@ -39,14 +39,23 @@ export function TunnelListItem({
 }: TunnelListItemProps) {
   const status = state?.status ?? "disconnected";
   const isActive = status === "connected" || status === "connecting" || status === "reconnecting";
+  const isError = status === "error";
+  const lastError = state?.error;
   const sshConn = connections.find((c) => c.id === tunnel.sshConnectionId);
   const sshLabel = sshConn?.name ?? "Unknown";
   const typeLabel =
     tunnel.tunnelType.type.charAt(0).toUpperCase() + tunnel.tunnelType.type.slice(1);
 
+  /** Surface the persisted last-error message (View last error affordance). */
+  const handleViewError = () => {
+    toast.error(`${tunnel.name}: tunnel error`, {
+      description: lastError ?? "No error details were recorded.",
+    });
+  };
+
   return (
     <div
-      className="tunnel-item"
+      className={`tunnel-item${isError ? " tunnel-item--error" : ""}`}
       data-testid={`tunnel-item-${tunnel.id}`}
       onDoubleClick={() => onEdit(tunnel.id)}
     >
@@ -62,7 +71,7 @@ export function TunnelListItem({
           {typeLabel}
         </span>
         <div className="tunnel-item__actions">
-          {isActive ? (
+          {isActive && (
             <Tooltip content="Stop" side="top">
               <button
                 className="tunnel-item__action"
@@ -76,7 +85,38 @@ export function TunnelListItem({
                 <Square size={12} />
               </button>
             </Tooltip>
-          ) : (
+          )}
+          {isError && (
+            <>
+              <Tooltip content="View last error" side="top">
+                <button
+                  className="tunnel-item__action"
+                  aria-label="View last error"
+                  data-testid={`tunnel-view-error-${tunnel.id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleViewError();
+                  }}
+                >
+                  <Info size={12} />
+                </button>
+              </Tooltip>
+              <Tooltip content="Retry" side="top">
+                <button
+                  className="tunnel-item__action"
+                  aria-label="Retry"
+                  data-testid={`tunnel-retry-${tunnel.id}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onStart(tunnel.id);
+                  }}
+                >
+                  <RotateCw size={12} />
+                </button>
+              </Tooltip>
+            </>
+          )}
+          {!isActive && !isError && (
             <Tooltip content="Start" side="top">
               <button
                 className="tunnel-item__action"
@@ -142,8 +182,11 @@ export function TunnelListItem({
             <span>{state.stats.activeConnections} conn</span>
           </div>
         )}
-        {status === "error" && state?.error && (
-          <span style={{ color: "var(--color-error)" }}>{state.error}</span>
+        {isError && lastError && (
+          <span className="tunnel-item__error" title={lastError}>
+            <AlertTriangle size={12} className="tunnel-item__error-icon" />
+            <span className="tunnel-item__error-text">{lastError}</span>
+          </span>
         )}
       </div>
     </div>

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -156,3 +156,32 @@
   color: var(--text-secondary);
   padding-top: 2px;
 }
+
+/*
+ * Errored resting row (#1240): the persisted error message plus its recovery
+ * controls (Retry / View last error) stay visible without a hover, so the user
+ * always sees why the tunnel failed and how to recover it.
+ */
+.tunnel-item--error .tunnel-item__actions {
+  opacity: 1;
+}
+
+.tunnel-item__error {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-error);
+  min-width: 0;
+}
+
+.tunnel-item__error-icon {
+  flex-shrink: 0;
+}
+
+/* Keep the resting error row a single line; the full text lives in the
+ * "View last error" toast and the row's native title tooltip. */
+.tunnel-item__error-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -158,7 +158,7 @@
 }
 
 /*
- * Errored resting row (#1240): the persisted error message plus its recovery
+ * Errored resting row (issue 1240): the persisted error message plus its recovery
  * controls (Retry / View last error) stay visible without a hover, so the user
  * always sees why the tunnel failed and how to recover it.
  */

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -602,10 +602,12 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `tunnel-edit-*` | `tunnel-edit-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-item-*` | `tunnel-item-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-name-*` | `tunnel-name-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
+| `tunnel-retry-*` | `tunnel-retry-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-start-*` | `tunnel-start-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-status-*` | `tunnel-status-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-stop-*` | `tunnel-stop-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-type-*` | `tunnel-type-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
+| `tunnel-view-error-*` | `tunnel-view-error-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `workspace-delete-*` | `workspace-delete-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 | `workspace-duplicate-*` | `workspace-duplicate-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 | `workspace-edit-*` | `workspace-edit-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |


### PR DESCRIPTION
## Summary

Stage S1 (GAP 3 UI) of the SSH Tunnel Lifecycle Redesign (#1191). Now that `get_statuses()` returns a persisted `Error` (#1238), surface it as the fourth resting colour and add the controls the state machine needs at rest.

- **`TunnelListItem`** — for `status === "error"`, the Play/Start button is replaced by **Retry** (`start_tunnel`, Error → Connecting, clears the stored error) and **View last error** (toast with the full persisted message). The persisted message renders inline with an alert icon; the row stays in its error affordance without hover.
- **`OpenConnectionsModal`** — the `activeTunnels` filter now includes `reconnecting` + `error`, so a leaked `active_tunnels` entry is force-Stoppable from the canonical kill panel (error badge + persisted message + Stop → `stop_tunnel`).
- **Store** — no change needed: `loadTunnels` already maps `get_statuses` (incl. error + message) into `tunnelStates`, so the error survives a window reload (confirmed as a scope item).
- Tokens-only CSS; reused the existing `--color-error`/red state-dot.

## Test plan

- `TunnelListItem.error.test.tsx` and `OpenConnectionsModal.tunnelError.test.tsx` (TDD, test commit precedes impl). All new tests pass.
- Design pass delegated to the `ui-design` subagent.
- CI: `./scripts/test.sh` + `./scripts/check.sh`.

Note: the agent flagged 3 pre-existing `OpenConnectionsModal.xservers.test.tsx` failures as a cross-file `vi.mock` isolation flake unrelated to this change (the OpenConnections suite passes in isolation). Watching CI to confirm.

Follow-up: #1259 — migrate the full `TunnelListItem` icon-button group to the shared `Button` primitive for per-button async feedback.

Closes #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)