### PR TITLE
feat(agent): cancellable connect + visible/killable connecting agents (Closes #1235)

### DIFF
--- a/docs/changes/dev1/feature/1235-agent-cancellable-connect.md
+++ b/docs/changes/dev1/feature/1235-agent-cancellable-connect.md
@@ -1,0 +1,16 @@
+# Changes — dev1/feature/1235-agent-cancellable-connect
+
+## Added
+
+- **Cancel a connecting remote agent.** A remote agent stuck mid-connect (e.g. to an
+  unreachable or slow host) can now be cancelled instead of waiting out the connect timeout.
+  The blocking SSH + initialize handshake is wrapped in a per-agent cancellation token; firing
+  it aborts the handshake promptly and returns the agent to `disconnected`
+  (via the new `cancel_connect_agent` backend command) (#1235).
+- **Connecting and reconnecting agents are visible and killable in Open Connections.** The
+  panel gained an **Establishing / recovering** section listing agents in the `connecting` or
+  `reconnecting` state. Each row has a **Cancel** button: a connecting agent aborts its
+  handshake; a reconnecting agent ends its backoff loop by disconnecting (#1235).
+- **Sidebar Cancel for a connecting agent.** The agent header now shows an inline **Cancel**
+  control (and a **Cancel Connect** context-menu item) while connecting, so a stuck connect is
+  no longer a dead-end in the sidebar (#1235).

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -49,6 +49,22 @@ pub fn disconnect_agent(
         .map_err(|e| e.to_string())
 }
 
+/// Cancel an in-flight (still connecting) agent connect.
+///
+/// Fires the per-agent cancellation token registered by [`connect_agent`] so a
+/// Cancel while connecting aborts the blocking SSH + initialize handshake
+/// promptly instead of waiting out the connect timeout; the connect path then
+/// emits `disconnected` (single writer). Returns whether a connecting agent was
+/// found. No-op if the connect already finished (G1, #1235).
+#[tauri::command]
+pub fn cancel_connect_agent(
+    agent_id: String,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
+) -> Result<bool, String> {
+    info!(agent_id, "Cancelling in-flight agent connect");
+    Ok(agent_manager.cancel_connect(&agent_id))
+}
+
 /// Gracefully shut down a remote agent and disconnect.
 ///
 /// Sends `agent.shutdown` over JSON-RPC, waits for the response, then

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -522,6 +522,7 @@ pub fn run() {
             commands::monitoring::monitoring_fetch_stats,
             // Agent management
             commands::agent::connect_agent,
+            commands::agent::cancel_connect_agent,
             commands::agent::disconnect_agent,
             commands::agent::shutdown_agent,
             commands::agent::get_agent_capabilities,

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1788,6 +1788,9 @@ mod tests {
         ) -> Result<AgentConnectResult, TerminalError> {
             unimplemented!()
         }
+        fn cancel_connect(&self, _: &str) -> bool {
+            false
+        }
         fn disconnect_agent(&self, _: &str) -> Result<(), TerminalError> {
             unimplemented!()
         }
@@ -2402,6 +2405,9 @@ mod tests {
             _: Option<&AgentSettings>,
         ) -> Result<AgentConnectResult, TerminalError> {
             unimplemented!()
+        }
+        fn cancel_connect(&self, _: &str) -> bool {
+            false
         }
         fn disconnect_agent(&self, _: &str) -> Result<(), TerminalError> {
             unimplemented!()

--- a/src-tauri/src/session/remote_proxy.rs
+++ b/src-tauri/src/session/remote_proxy.rs
@@ -772,6 +772,9 @@ mod tests {
             })
         }
 
+        fn cancel_connect(&self, _agent_id: &str) -> bool {
+            false
+        }
         fn disconnect_agent(&self, _agent_id: &str) -> Result<(), TerminalError> {
             Ok(())
         }
@@ -1351,6 +1354,9 @@ mod tests {
         ) -> Result<AgentConnectResult, TerminalError> {
             unimplemented!()
         }
+        fn cancel_connect(&self, _agent_id: &str) -> bool {
+            false
+        }
         fn disconnect_agent(&self, _agent_id: &str) -> Result<(), TerminalError> {
             Ok(())
         }
@@ -1594,6 +1600,9 @@ mod tests {
             _agent_settings: Option<&AgentSettings>,
         ) -> Result<AgentConnectResult, TerminalError> {
             unimplemented!()
+        }
+        fn cancel_connect(&self, _agent_id: &str) -> bool {
+            false
         }
         fn disconnect_agent(&self, _agent_id: &str) -> Result<(), TerminalError> {
             Ok(())

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use termihub_core::backends::ssh::handler::SshSession;
@@ -25,7 +26,7 @@ use crate::connection::config::AgentSettings;
 use crate::terminal::backend::{OutputSender, RemoteAgentConfig, RemoteStateChangeEvent};
 use crate::terminal::jsonrpc;
 use crate::utils::errors::TerminalError;
-use crate::utils::ssh_auth::connect_and_authenticate;
+use crate::utils::ssh_auth::{connect_and_authenticate, connect_and_authenticate_cancellable};
 
 /// Capabilities returned by the agent after initialization.
 ///
@@ -217,6 +218,10 @@ pub trait AgentRpcClient: Send + Sync + 'static {
         agent_settings: Option<&AgentSettings>,
     ) -> Result<AgentConnectResult, TerminalError>;
 
+    /// Cancel an in-flight (still connecting) agent connect. Returns whether a
+    /// connecting agent was found (G1, #1235).
+    fn cancel_connect(&self, agent_id: &str) -> bool;
+
     /// Disconnect an agent.
     fn disconnect_agent(&self, agent_id: &str) -> Result<(), TerminalError>;
 
@@ -361,12 +366,84 @@ pub trait AgentRpcClient: Send + Sync + 'static {
     ) -> Result<(), TerminalError>;
 }
 
+/// Registry of cancellation tokens for in-flight (still connecting) agents,
+/// keyed by `agent_id`. Lets a Cancel while connecting abort the blocking
+/// handshake promptly instead of waiting out the connect timeout (G1, #1235).
+type ConnectingRegistry = Arc<Mutex<HashMap<String, CancellationToken>>>;
+
+/// Register a cancellation token for an in-flight agent connect.
+fn register_connecting_token(
+    registry: &ConnectingRegistry,
+    agent_id: &str,
+    token: CancellationToken,
+) {
+    if let Ok(mut map) = registry.lock() {
+        map.insert(agent_id.to_string(), token);
+    }
+}
+
+/// Fire the cancellation token for an in-flight agent connect, if one is
+/// registered. Returns `true` when a matching connect was in flight.
+fn cancel_connect_token(registry: &ConnectingRegistry, agent_id: &str) -> bool {
+    let token = registry
+        .lock()
+        .ok()
+        .and_then(|map| map.get(agent_id).cloned());
+    match token {
+        Some(token) => {
+            token.cancel();
+            true
+        }
+        None => false,
+    }
+}
+
+/// Run the blocking connect + initialize handshake future, aborting promptly
+/// when the cancellation token fires (G1, #1235).
+///
+/// The connect body owns the russh session/channel; on cancel the future is
+/// dropped (dropping the channel with it) and a cancellation error is returned
+/// so the caller can emit `disconnected`.
+async fn run_connect_cancellable<T, F>(
+    token: &CancellationToken,
+    fut: F,
+) -> Result<T, TerminalError>
+where
+    F: std::future::Future<Output = Result<T, TerminalError>>,
+{
+    tokio::select! {
+        biased;
+        _ = token.cancelled() => {
+            Err(TerminalError::RemoteError("Connect cancelled".to_string()))
+        }
+        res = fut => res,
+    }
+}
+
+/// Removes an `agent_id` from the connecting registry when the connect attempt
+/// finishes (success, failure, or cancellation) — RAII so the entry is cleared
+/// even when the connect returns early via `?`.
+struct ConnectingGuard {
+    map: ConnectingRegistry,
+    id: String,
+}
+
+impl Drop for ConnectingGuard {
+    fn drop(&mut self) {
+        if let Ok(mut map) = self.map.lock() {
+            map.remove(&self.id);
+        }
+    }
+}
+
 /// Manages connections to remote agents.
 ///
 /// Each agent is identified by its `agent_id` string. Multiple sessions
 /// can be multiplexed over a single SSH connection.
 pub struct AgentConnectionManager {
     agents: Mutex<HashMap<String, AgentConnection>>,
+    /// Cancellation tokens for in-flight connects, keyed by agent id (G1, #1235).
+    connecting: ConnectingRegistry,
     app_handle: AppHandle,
 }
 
@@ -374,8 +451,18 @@ impl AgentConnectionManager {
     pub fn new(app_handle: AppHandle) -> Self {
         Self {
             agents: Mutex::new(HashMap::new()),
+            connecting: Arc::new(Mutex::new(HashMap::new())),
             app_handle,
         }
+    }
+
+    /// Cancel an in-flight (still connecting) agent by its `agent_id`.
+    ///
+    /// Fires the registered cancellation token so a blocking connect+handshake
+    /// aborts promptly; the connect path then emits `disconnected`. Returns
+    /// `true` if a matching connect was in flight (G1, #1235).
+    pub fn cancel_connect(&self, agent_id: &str) -> bool {
+        cancel_connect_token(&self.connecting, agent_id)
     }
 
     /// Connect to a remote agent via SSH.
@@ -405,6 +492,17 @@ impl AgentConnectionManager {
             agents.remove(agent_id);
         }
 
+        // Register a cancellation token so a Cancel while connecting can abort
+        // the in-flight handshake (G1, #1235). The guard clears the entry when
+        // this connect finishes, even on an early `?` return. The token is held
+        // in a registry keyed by agent id, so `cancel_connect` can fire it.
+        let cancel_token = CancellationToken::new();
+        register_connecting_token(&self.connecting, agent_id, cancel_token.clone());
+        let _connecting_guard = ConnectingGuard {
+            map: self.connecting.clone(),
+            id: agent_id.to_string(),
+        };
+
         // Emit connecting state
         emit_agent_state(&self.app_handle, agent_id, "connecting");
 
@@ -423,162 +521,180 @@ impl AgentConnectionManager {
         let config_clone = config.clone();
         let settings_clone = settings_ref.clone();
 
-        // Run the async connect+handshake on the current tokio runtime.
+        // Run the async connect+handshake on the current tokio runtime, wrapped
+        // in a `tokio::select!` against the cancellation token so a Cancel aborts
+        // the blocking handshake promptly and drops the russh channel (G1, #1235).
         let handle = tokio::runtime::Handle::current();
-        let (capabilities, agent_version, protocol_version, command_tx, alive) =
-            handle.block_on(async {
-                // 1. SSH connect and authenticate
-                let session = connect_and_authenticate(&ssh_config).inspect_err(|_| {
-                    emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                })?;
-
-                // 2. Open exec channel and launch agent
-                let mut channel = session.channel_open_session().await.map_err(|e| {
-                    emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                    TerminalError::RemoteError(format!("Channel open failed: {}", e))
-                })?;
-                let exec_cmd = config_clone.agent_exec_command();
-                channel.exec(false, exec_cmd.as_str()).await.map_err(|e| {
-                    emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                    TerminalError::RemoteError(format!("Exec failed: {}", e))
-                })?;
-
-                // 3. Blocking handshake: initialize
-                let enabled_external_files: Vec<&str> = config_clone
-                    .external_connection_files
-                    .iter()
-                    .filter(|f| f.enabled)
-                    .map(|f| f.path.as_str())
-                    .collect();
-
-                let request_id: u64 = 1;
-                let init_params = build_initialize_params(&settings_clone, &enabled_external_files);
-                let req_line =
-                    serialize_request(request_id, "initialize", init_params).map_err(|e| {
+        let cancel_for_task = cancel_token.clone();
+        let result = handle.block_on(run_connect_cancellable(&cancel_for_task, async {
+            // 1. SSH connect and authenticate (cancellable at the TCP/handshake
+            // level so a hung connect to an unreachable host aborts promptly).
+            let session =
+                connect_and_authenticate_cancellable(&ssh_config, cancel_for_task.clone())
+                    .inspect_err(|_| {
                         emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                        TerminalError::RemoteError(format!("Serialize initialize failed: {}", e))
                     })?;
 
-                channel.data(req_line.as_bytes()).await.map_err(|e| {
-                    emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                    TerminalError::RemoteError(format!("Write initialize failed: {}", e))
-                })?;
-
-                // Read the initialize response from the channel, skipping any
-                // notifications the agent emits before it answers (e.g. output
-                // from a session it recovered on startup). We loop until we see
-                // the message whose id matches our initialize request; otherwise
-                // a pre-initialize notification would be misread as the response
-                // ("Unexpected response to initialize"). A generous cap guards
-                // against a runaway agent that never sends the response.
-                const MAX_PRE_INIT_MESSAGES: u32 = 1000;
-                let mut skipped: u32 = 0;
-                let mut line_buf = String::new();
-                let (capabilities, agent_version, protocol_version) = loop {
-                    let resp_line =
-                        match read_handshake_line(&mut channel, &agent_id_str, &mut line_buf).await
-                        {
-                            Some(line) => line,
-                            None => {
-                                emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                                return Err(TerminalError::RemoteError(
-                                    "Channel closed before initialize response".into(),
-                                ));
-                            }
-                        };
-
-                    let msg = jsonrpc::parse_message(&resp_line).map_err(|e| {
-                        emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                        TerminalError::RemoteError(format!("Parse initialize response: {}", e))
-                    })?;
-
-                    match jsonrpc::classify_handshake_message(msg, request_id) {
-                        jsonrpc::HandshakeOutcome::Response(result) => {
-                            let caps = result.get("capabilities").ok_or_else(|| {
-                                emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                                TerminalError::RemoteError(
-                                    "Missing capabilities in initialize response".into(),
-                                )
-                            })?;
-                            let mut capabilities = serde_json::from_value::<AgentCapabilities>(
-                                caps.clone(),
-                            )
-                            .map_err(|e| {
-                                emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                                TerminalError::RemoteError(format!("Parse capabilities: {}", e))
-                            })?;
-                            let agent_version = result
-                                .get("agent_version")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("unknown")
-                                .to_string();
-                            let protocol_version = result
-                                .get("protocol_version")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("unknown")
-                                .to_string();
-                            // Copy agent_version into capabilities so the UI can read it.
-                            capabilities.agent_version = agent_version.clone();
-                            break (capabilities, agent_version, protocol_version);
-                        }
-                        jsonrpc::HandshakeOutcome::Rejected(message) => {
-                            emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                            return Err(TerminalError::RemoteError(format!(
-                                "Initialize rejected: {}",
-                                message
-                            )));
-                        }
-                        jsonrpc::HandshakeOutcome::Skip => {
-                            skipped += 1;
-                            if skipped > MAX_PRE_INIT_MESSAGES {
-                                emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
-                                return Err(TerminalError::RemoteError(
-                                    "Agent sent too many messages before the initialize response"
-                                        .into(),
-                                ));
-                            }
-                            warn!(
-                                "Agent {}: skipping pre-initialize message during handshake",
-                                agent_id_str
-                            );
-                            continue;
-                        }
-                    }
-                };
-
-                // 4. Spawn the async I/O task
-                let alive = Arc::new(AtomicBool::new(true));
-                let (command_tx, command_rx) = mpsc::unbounded_channel::<AgentIoCommand>();
-
-                let alive_clone = alive.clone();
-                let app_handle_task = app_handle_clone.clone();
-                let agent_id_task = agent_id_str.clone();
-                let config_task = config_clone.clone();
-                let settings_task = settings_clone.clone();
-
-                tokio::spawn(async move {
-                    agent_io_task(
-                        session,
-                        channel,
-                        command_rx,
-                        alive_clone,
-                        app_handle_task,
-                        agent_id_task,
-                        config_task,
-                        settings_task,
-                        request_id,
-                    )
-                    .await;
-                });
-
-                Ok::<_, TerminalError>((
-                    capabilities,
-                    agent_version,
-                    protocol_version,
-                    command_tx,
-                    alive,
-                ))
+            // 2. Open exec channel and launch agent
+            let mut channel = session.channel_open_session().await.map_err(|e| {
+                emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                TerminalError::RemoteError(format!("Channel open failed: {}", e))
             })?;
+            let exec_cmd = config_clone.agent_exec_command();
+            channel.exec(false, exec_cmd.as_str()).await.map_err(|e| {
+                emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                TerminalError::RemoteError(format!("Exec failed: {}", e))
+            })?;
+
+            // 3. Blocking handshake: initialize
+            let enabled_external_files: Vec<&str> = config_clone
+                .external_connection_files
+                .iter()
+                .filter(|f| f.enabled)
+                .map(|f| f.path.as_str())
+                .collect();
+
+            let request_id: u64 = 1;
+            let init_params = build_initialize_params(&settings_clone, &enabled_external_files);
+            let req_line =
+                serialize_request(request_id, "initialize", init_params).map_err(|e| {
+                    emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                    TerminalError::RemoteError(format!("Serialize initialize failed: {}", e))
+                })?;
+
+            channel.data(req_line.as_bytes()).await.map_err(|e| {
+                emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                TerminalError::RemoteError(format!("Write initialize failed: {}", e))
+            })?;
+
+            // Read the initialize response from the channel, skipping any
+            // notifications the agent emits before it answers (e.g. output
+            // from a session it recovered on startup). We loop until we see
+            // the message whose id matches our initialize request; otherwise
+            // a pre-initialize notification would be misread as the response
+            // ("Unexpected response to initialize"). A generous cap guards
+            // against a runaway agent that never sends the response.
+            const MAX_PRE_INIT_MESSAGES: u32 = 1000;
+            let mut skipped: u32 = 0;
+            let mut line_buf = String::new();
+            let (capabilities, agent_version, protocol_version) = loop {
+                let resp_line =
+                    match read_handshake_line(&mut channel, &agent_id_str, &mut line_buf).await {
+                        Some(line) => line,
+                        None => {
+                            emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                            return Err(TerminalError::RemoteError(
+                                "Channel closed before initialize response".into(),
+                            ));
+                        }
+                    };
+
+                let msg = jsonrpc::parse_message(&resp_line).map_err(|e| {
+                    emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                    TerminalError::RemoteError(format!("Parse initialize response: {}", e))
+                })?;
+
+                match jsonrpc::classify_handshake_message(msg, request_id) {
+                    jsonrpc::HandshakeOutcome::Response(result) => {
+                        let caps = result.get("capabilities").ok_or_else(|| {
+                            emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                            TerminalError::RemoteError(
+                                "Missing capabilities in initialize response".into(),
+                            )
+                        })?;
+                        let mut capabilities = serde_json::from_value::<AgentCapabilities>(
+                            caps.clone(),
+                        )
+                        .map_err(|e| {
+                            emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                            TerminalError::RemoteError(format!("Parse capabilities: {}", e))
+                        })?;
+                        let agent_version = result
+                            .get("agent_version")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+                        let protocol_version = result
+                            .get("protocol_version")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+                        // Copy agent_version into capabilities so the UI can read it.
+                        capabilities.agent_version = agent_version.clone();
+                        break (capabilities, agent_version, protocol_version);
+                    }
+                    jsonrpc::HandshakeOutcome::Rejected(message) => {
+                        emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                        return Err(TerminalError::RemoteError(format!(
+                            "Initialize rejected: {}",
+                            message
+                        )));
+                    }
+                    jsonrpc::HandshakeOutcome::Skip => {
+                        skipped += 1;
+                        if skipped > MAX_PRE_INIT_MESSAGES {
+                            emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                            return Err(TerminalError::RemoteError(
+                                "Agent sent too many messages before the initialize response"
+                                    .into(),
+                            ));
+                        }
+                        warn!(
+                            "Agent {}: skipping pre-initialize message during handshake",
+                            agent_id_str
+                        );
+                        continue;
+                    }
+                }
+            };
+
+            // 4. Spawn the async I/O task
+            let alive = Arc::new(AtomicBool::new(true));
+            let (command_tx, command_rx) = mpsc::unbounded_channel::<AgentIoCommand>();
+
+            let alive_clone = alive.clone();
+            let app_handle_task = app_handle_clone.clone();
+            let agent_id_task = agent_id_str.clone();
+            let config_task = config_clone.clone();
+            let settings_task = settings_clone.clone();
+
+            tokio::spawn(async move {
+                agent_io_task(
+                    session,
+                    channel,
+                    command_rx,
+                    alive_clone,
+                    app_handle_task,
+                    agent_id_task,
+                    config_task,
+                    settings_task,
+                    request_id,
+                )
+                .await;
+            });
+
+            Ok::<_, TerminalError>((
+                capabilities,
+                agent_version,
+                protocol_version,
+                command_tx,
+                alive,
+            ))
+        }));
+
+        // On cancel the connect future above is dropped before any I/O task is
+        // spawned, so no backend `disconnected` is emitted from there — emit it
+        // here so the agent returns to `disconnected` (single writer, G1 #1235).
+        // Other error paths already emit `disconnected` inline before returning.
+        let (capabilities, agent_version, protocol_version, command_tx, alive) = match result {
+            Ok(v) => v,
+            Err(e) => {
+                if cancel_token.is_cancelled() {
+                    emit_agent_state(&self.app_handle, agent_id, "disconnected");
+                }
+                return Err(e);
+            }
+        };
 
         emit_agent_state(&self.app_handle, agent_id, "connected");
 
@@ -1039,6 +1155,10 @@ impl AgentRpcClient for AgentConnectionManager {
         agent_settings: Option<&AgentSettings>,
     ) -> Result<AgentConnectResult, TerminalError> {
         AgentConnectionManager::connect_agent(self, agent_id, config, agent_settings)
+    }
+
+    fn cancel_connect(&self, agent_id: &str) -> bool {
+        AgentConnectionManager::cancel_connect(self, agent_id)
     }
 
     fn disconnect_agent(&self, agent_id: &str) -> Result<(), TerminalError> {
@@ -2222,5 +2342,97 @@ mod tests {
         assert_eq!(parsed["id"], 42);
         assert_eq!(parsed["method"], "connection.create");
         assert_eq!(parsed["jsonrpc"], "2.0");
+    }
+
+    // ── Cancellable connect (G1, #1235) ──────────────────────────────────
+
+    /// A per-agent cancellation token registered before a connect can be fired
+    /// by `cancel_connect` and reports whether an in-flight connect was found.
+    #[test]
+    fn cancel_connect_fires_registered_token() {
+        let registry: ConnectingRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let token = CancellationToken::new();
+        register_connecting_token(&registry, "agent-1", token.clone());
+
+        assert!(!token.is_cancelled());
+        // A matching agent id fires its token and reports success.
+        assert!(cancel_connect_token(&registry, "agent-1"));
+        assert!(token.is_cancelled());
+
+        // A non-matching id is a no-op.
+        assert!(!cancel_connect_token(&registry, "agent-2"));
+    }
+
+    /// The RAII guard clears the registry entry when the connect finishes, so a
+    /// later cancel targets only live connects (no stale token left behind).
+    #[test]
+    fn connecting_guard_clears_registry_entry() {
+        let registry: ConnectingRegistry = Arc::new(Mutex::new(HashMap::new()));
+        {
+            let token = CancellationToken::new();
+            register_connecting_token(&registry, "agent-1", token);
+            let _guard = ConnectingGuard {
+                map: registry.clone(),
+                id: "agent-1".to_string(),
+            };
+            assert!(registry.lock().unwrap().contains_key("agent-1"));
+        }
+        // Guard dropped → entry gone → cancel finds nothing.
+        assert!(!cancel_connect_token(&registry, "agent-1"));
+    }
+
+    /// A token fired before the connect body begins aborts the blocking
+    /// connect+handshake promptly instead of waiting it out — the core G1
+    /// behaviour. Mirrors the `connect_and_authenticate` + initialize handshake
+    /// being wrapped in `tokio::select!` against the token.
+    #[tokio::test]
+    async fn run_cancellable_aborts_when_token_already_fired() {
+        let token = CancellationToken::new();
+        token.cancel();
+
+        // The connect body would sleep for 30s; a working cancel returns at once.
+        let result: Result<(), TerminalError> = run_connect_cancellable(&token, async {
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            Ok(())
+        })
+        .await;
+
+        assert!(result.is_err(), "a cancelled connect must return an error");
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.to_lowercase().contains("cancel"),
+            "expected a cancellation error, got: {err}"
+        );
+    }
+
+    /// Firing the token while the connect body is in flight aborts it promptly.
+    #[tokio::test]
+    async fn run_cancellable_aborts_in_flight_connect() {
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+
+        let join = tokio::spawn(async move {
+            run_connect_cancellable(&token_clone, async {
+                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                Ok::<(), TerminalError>(())
+            })
+            .await
+        });
+
+        // Give the body a moment to start, then cancel.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        token.cancel();
+
+        let result = join.await.expect("join");
+        assert!(result.is_err(), "an in-flight cancel must return an error");
+    }
+
+    /// Without a cancel the body runs to completion and its value is returned.
+    #[tokio::test]
+    async fn run_cancellable_returns_body_result_when_not_cancelled() {
+        let token = CancellationToken::new();
+        let result: Result<u32, TerminalError> =
+            run_connect_cancellable(&token, async { Ok(42) }).await;
+        assert_eq!(result.unwrap(), 42);
     }
 }

--- a/src-tauri/src/utils/ssh_auth.rs
+++ b/src-tauri/src/utils/ssh_auth.rs
@@ -49,6 +49,27 @@ pub fn connect_with_registry_cancellable(
     .map_err(|e| TerminalError::SshError(e.to_string()))
 }
 
+/// Connect and authenticate, returning just the session, abortable via a
+/// [`CancellationToken`].
+///
+/// Like [`connect_and_authenticate`] but a fired token aborts an in-flight TCP
+/// connect / SSH handshake promptly instead of waiting out the connect or OS
+/// TCP timeout. Used by the agent connect path so a Cancel while connecting
+/// interrupts a hung connect to an unreachable host (G1, #1235).
+///
+/// Same runtime-context requirement as [`connect_and_authenticate`]: call only
+/// from inside `spawn_blocking` or an async task (#828).
+pub fn connect_and_authenticate_cancellable(
+    config: &SshConfig,
+    cancel: CancellationToken,
+) -> Result<SshSession, TerminalError> {
+    tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(core_connect_cancellable(config, Some(cancel)))
+    })
+    .map(|(session, _registry)| session)
+    .map_err(|e| TerminalError::SshError(e.to_string()))
+}
+
 /// Check whether the SSH agent is running or stopped.
 pub fn check_ssh_agent_status() -> String {
     core_check_agent()

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -111,6 +111,7 @@
 }
 
 .oc-row__badge--connecting,
+.oc-row__badge--reconnecting,
 .oc-row__badge--paused {
   background: color-mix(in srgb, var(--color-warning) 18%, transparent);
   color: var(--color-warning);

--- a/src/components/OpenConnections/OpenConnectionsModal.establishing.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.establishing.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests for the "Establishing / recovering" section of the Open Connections
+ * panel (G2, #1235): agents still connecting or reconnecting are now visible
+ * and killable. Connecting → cancel_connect_agent aborts the handshake;
+ * reconnecting → disconnect ends the backoff loop.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+const cancelConnectAgent = vi.fn((_id: string) => Promise.resolve(true));
+const disconnectAgent = vi.fn((_id: string) => Promise.resolve());
+
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() => Promise.resolve([])),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  cancelConnectAgent: (id: string) => cancelConnectAgent(id),
+  disconnectAgent: (id: string) => disconnectAgent(id),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false, sessionCount: 0 })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorStopAll: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+}));
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+function agent(
+  id: string,
+  name: string,
+  connectionState: RemoteAgentDefinition["connectionState"]
+): RemoteAgentDefinition {
+  return {
+    id,
+    name,
+    type: "remote-agent",
+    connectionState,
+    isExpanded: false,
+    config: {
+      host: "h",
+      port: 22,
+      username: "u",
+      authMethod: "password",
+    },
+  } as unknown as RemoteAgentDefinition;
+}
+
+describe("OpenConnectionsModal — Establishing / recovering section", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    cancelConnectAgent.mockClear();
+    disconnectAgent.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderWithAgents(agents: RemoteAgentDefinition[]) {
+    useAppStore.setState({ remoteAgents: agents });
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
+      );
+    });
+  }
+
+  function rowFor(title: string): Element | undefined {
+    return Array.from(document.querySelectorAll(".oc-row")).find((r) =>
+      r.querySelector(".oc-row__title")?.textContent?.includes(title)
+    );
+  }
+
+  it("lists a connecting agent and cancels it via cancel_connect_agent", () => {
+    renderWithAgents([agent("a1", "build-box", "connecting")]);
+
+    const row = rowFor("build-box");
+    expect(row).toBeTruthy();
+    expect(row?.querySelector(".oc-row__badge--connecting")).toBeTruthy();
+
+    const killBtn = row?.querySelector(".oc-row__kill") as HTMLButtonElement;
+    act(() => killBtn.click());
+    expect(cancelConnectAgent).toHaveBeenCalledWith("a1");
+  });
+
+  it("lists a reconnecting agent and kills it via disconnect", () => {
+    renderWithAgents([agent("a2", "edge-node", "reconnecting")]);
+
+    const row = rowFor("edge-node");
+    expect(row).toBeTruthy();
+    expect(row?.querySelector(".oc-row__badge--reconnecting")).toBeTruthy();
+
+    const killBtn = row?.querySelector(".oc-row__kill") as HTMLButtonElement;
+    act(() => killBtn.click());
+    expect(disconnectAgent).toHaveBeenCalledWith("a2");
+  });
+
+  it("shows no Establishing section when no agent is connecting/reconnecting", () => {
+    renderWithAgents([agent("a3", "ready", "connected")]);
+    const titles = Array.from(document.querySelectorAll(".oc-section__title")).map(
+      (t) => t.textContent
+    );
+    expect(titles).not.toContain("Establishing / recovering");
+  });
+});

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -19,6 +19,7 @@ import {
   closeTerminal,
   closeAgentSession,
   cancelConnecting,
+  cancelConnectAgent,
   xServerStatus,
   xServerStop,
   LocalSessionInfo,
@@ -88,6 +89,15 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
 
   const connectedAgents = remoteAgents.filter((a) => a.connectionState === "connected");
 
+  // Agents still establishing (connecting) or recovering (reconnecting) their
+  // transport. Previously hidden — the panel only listed "connected" agents — so
+  // a stuck connect or a failing reconnect had no visible, killable surface (G2,
+  // #1235). Connecting → cancel the in-flight handshake; reconnecting → kill the
+  // backoff loop by disconnecting.
+  const establishingAgents = remoteAgents.filter(
+    (a) => a.connectionState === "connecting" || a.connectionState === "reconnecting"
+  );
+
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
@@ -153,6 +163,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
 
   const totalCount =
     connectingTabs.length +
+    establishingAgents.length +
     localSessions.length +
     connectedAgents.length +
     Object.values(proxySessions).reduce((s, arr) => s + arr.length, 0) +
@@ -171,6 +182,38 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const handleCancelAllConnecting = async () => {
     await Promise.all(connectingTabs.map((t) => cancelConnecting(t.id).catch(() => {})));
     connectingTabs.forEach((t) => closeTab(t.id, t.panelId));
+  };
+
+  // Cancel/kill an establishing (connecting) or recovering (reconnecting) agent.
+  // Connecting → cancel_connect_agent aborts the in-flight handshake; reconnecting
+  // → disconnect ends the backoff loop (sets alive=false). The backend is the
+  // single writer of connectionState, so the row clears when its event lands.
+  const handleCancelEstablishingAgent = async (
+    agentId: string,
+    state: "connecting" | "reconnecting"
+  ) => {
+    try {
+      if (state === "connecting") {
+        await cancelConnectAgent(agentId);
+        toast.success("Connect cancelled");
+      } else {
+        await disconnectRemoteAgent(agentId);
+        toast.success("Reconnect stopped");
+      }
+    } catch (err) {
+      frontendLog("open_connections", `Failed to cancel agent connect: ${err}`);
+      toast.error(`Failed to cancel: ${err}`);
+    }
+  };
+
+  const handleCancelAllEstablishingAgents = async () => {
+    await Promise.all(
+      establishingAgents.map((a) =>
+        a.connectionState === "connecting"
+          ? cancelConnectAgent(a.id).catch(() => {})
+          : disconnectRemoteAgent(a.id).catch(() => {})
+      )
+    );
   };
 
   const handleKillLocal = async (id: string) => {
@@ -310,6 +353,40 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                 title={tab.title}
                 badge="connecting"
                 onKill={() => handleCancelConnecting(tab.id, tab.panelId)}
+              />
+            ))}
+          </Section>
+        )}
+
+        {/* Establishing / recovering agents (connecting or reconnecting) */}
+        {establishingAgents.length > 0 && (
+          <Section
+            title="Establishing / recovering"
+            icon={<Loader2 size={14} />}
+            count={establishingAgents.length}
+            onKillAll={handleCancelAllEstablishingAgents}
+            killAllLabel="Cancel All"
+            data-testid="open-connections-establishing-agents-section"
+          >
+            {establishingAgents.map((a) => (
+              <ConnectionRow
+                key={a.id}
+                icon={
+                  a.connectionState === "reconnecting" ? (
+                    <Server size={14} />
+                  ) : (
+                    <Loader2 size={14} />
+                  )
+                }
+                title={a.name}
+                badge={a.connectionState === "reconnecting" ? "reconnecting" : "connecting"}
+                onKill={() =>
+                  handleCancelEstablishingAgent(
+                    a.id,
+                    a.connectionState === "reconnecting" ? "reconnecting" : "connecting"
+                  )
+                }
+                killLabel="Cancel"
               />
             ))}
           </Section>
@@ -596,6 +673,7 @@ type BadgeVariant =
   | "dead"
   | "connected"
   | "connecting"
+  | "reconnecting"
   | "managed"
   | "external"
   | "up"

--- a/src/components/Sidebar/AgentNode.cancel-connect.test.tsx
+++ b/src/components/Sidebar/AgentNode.cancel-connect.test.tsx
@@ -98,11 +98,10 @@ describe("AgentNode — cancel connect (G1)", () => {
   function renderAgent(agent: RemoteAgentDefinition) {
     act(() => {
       root.render(
-        React.createElement(
-          TooltipProvider,
-          { delayDuration: 0 },
-          React.createElement(AgentNode, { agent })
-        )
+        React.createElement(TooltipProvider, {
+          delayDuration: 0,
+          children: React.createElement(AgentNode, { agent }),
+        })
       );
     });
   }

--- a/src/components/Sidebar/AgentNode.cancel-connect.test.tsx
+++ b/src/components/Sidebar/AgentNode.cancel-connect.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for the sidebar Cancel affordance on a connecting agent (G1, #1235).
+ *
+ * A `connecting` agent is no longer a dead-end: an inline Cancel button fires
+ * cancel_connect_agent, which aborts the in-flight SSH + initialize handshake.
+ * The backend is the single writer of connectionState, so no optimistic write
+ * happens here — the test just verifies the command is invoked.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import { AgentNode } from "./AgentNode";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+
+const cancelConnectAgent = vi.fn((_id: string) => Promise.resolve(true));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({ attributes: {}, listeners: {}, setNodeRef: vi.fn(), isDragging: false }),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  useDndContext: () => ({ active: null }),
+  useDndMonitor: () => {},
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } },
+}));
+
+vi.mock("@/services/api", () => ({
+  removeCredential: vi.fn(() => Promise.resolve()),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  cancelConnectAgent: (id: string) => cancelConnectAgent(id),
+  listAgentDefinitions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("./AgentSetupDialog", () => ({ AgentSetupDialog: () => null }));
+vi.mock("./ConnectionErrorDialog", () => ({ ConnectionErrorDialog: () => null }));
+vi.mock("./InlineFolderInput", () => ({ InlineFolderInput: () => null }));
+
+const AGENT_ID = "agent-cancel-connect-test";
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: AGENT_ID,
+    name: "Test Agent",
+    config: {
+      host: "host.example.com",
+      port: 22,
+      username: "user",
+      authMethod: "password",
+      password: "secret",
+    },
+    connectionState: "disconnected",
+    isExpanded: false,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+describe("AgentNode — cancel connect (G1)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    cancelConnectAgent.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function renderAgent(agent: RemoteAgentDefinition) {
+    act(() => {
+      root.render(
+        React.createElement(
+          TooltipProvider,
+          { delayDuration: 0 },
+          React.createElement(AgentNode, { agent })
+        )
+      );
+    });
+  }
+
+  it("shows an inline Cancel button while connecting and fires cancel_connect_agent", () => {
+    renderAgent(makeAgent({ connectionState: "connecting" }));
+
+    const cancelBtn = container.querySelector(
+      `[data-testid="agent-cancel-connect-${AGENT_ID}"]`
+    ) as HTMLButtonElement;
+    expect(cancelBtn).not.toBeNull();
+
+    act(() => cancelBtn.click());
+    expect(cancelConnectAgent).toHaveBeenCalledWith(AGENT_ID);
+  });
+
+  it("does not show the Cancel button when disconnected", () => {
+    renderAgent(makeAgent({ connectionState: "disconnected" }));
+    const cancelBtn = container.querySelector(`[data-testid="agent-cancel-connect-${AGENT_ID}"]`);
+    expect(cancelBtn).toBeNull();
+  });
+
+  it("does not show the Cancel button when connected", () => {
+    renderAgent(makeAgent({ connectionState: "connected" }));
+    const cancelBtn = container.querySelector(`[data-testid="agent-cancel-connect-${AGENT_ID}"]`);
+    expect(cancelBtn).toBeNull();
+  });
+});

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -32,9 +32,10 @@ import {
   Zap,
   Copy,
   Link,
+  XCircle,
 } from "lucide-react";
 import { ConnectionIcon } from "@/utils/connectionIcons";
-import { Tooltip } from "@/components/ui";
+import { Tooltip, toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { frontendLog } from "@/utils/frontendLog";
 import { RemoteAgentDefinition } from "@/types/connection";
@@ -44,6 +45,7 @@ import {
   AgentFolderInfo,
   removeCredential,
   storeCredential,
+  cancelConnectAgent,
 } from "@/services/api";
 import { classifyAgentError, ClassifiedAgentError } from "@/utils/classifyAgentError";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
@@ -564,6 +566,7 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const isConnected = agent.connectionState === "connected";
   const isReconnecting = agent.connectionState === "reconnecting";
+  const isConnecting = agent.connectionState === "connecting";
   const Chevron = agent.isExpanded ? ChevronDown : ChevronRight;
 
   // Derived: root-level folders and definitions (no parent/folder)
@@ -687,6 +690,21 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
   const handleDisconnect = useCallback(() => {
     disconnectRemoteAgent(agent.id);
   }, [agent.id, disconnectRemoteAgent]);
+
+  // Cancel an in-flight connect (G1, #1235). Fires cancel_connect_agent, which
+  // aborts the blocking SSH + initialize handshake; the backend then emits
+  // `disconnected` (single writer), so the state dot returns on its own — no
+  // optimistic write here. The prompt-driven `connecting` local state (set by
+  // handleConnect) also clears when connectRemoteAgent's promise rejects.
+  const handleCancelConnect = useCallback(async () => {
+    try {
+      await cancelConnectAgent(agent.id);
+      toast.success("Connect cancelled");
+    } catch (err) {
+      frontendLog("agent_node", `Failed to cancel agent connect: ${err}`);
+      toast.error(`Failed to cancel: ${err}`);
+    }
+  }, [agent.id]);
 
   const handleNewShellSession = useCallback(() => {
     const defaultShell = agent.capabilities?.availableShells?.[0];
@@ -887,12 +905,39 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                 </Tooltip>
               </div>
             )}
+            {isConnecting && (
+              // Inline Cancel so a stuck connect is abortable without opening the
+              // context menu (G1, #1235).
+              <div className="connection-list__group-actions">
+                <Tooltip content="Cancel Connect" side="top">
+                  <button
+                    className="connection-list__add-btn"
+                    onClick={() => void handleCancelConnect()}
+                    aria-label="Cancel Connect"
+                    data-testid={`agent-cancel-connect-${agent.id}`}
+                  >
+                    <XCircle size={16} />
+                  </button>
+                </Tooltip>
+              </div>
+            )}
           </div>
         </ContextMenu.Trigger>
 
         <ContextMenu.Portal>
           <ContextMenu.Content className="context-menu__content">
-            {!isConnected && !isReconnecting ? (
+            {isConnecting ? (
+              // A connecting agent is no longer a dead-end: offer Cancel, which
+              // aborts the in-flight handshake (G1, #1235).
+              <ContextMenu.Item
+                className="context-menu__item"
+                onSelect={() => void handleCancelConnect()}
+                data-testid="context-agent-cancel-connect"
+              >
+                <XCircle size={14} />
+                Cancel Connect
+              </ContextMenu.Item>
+            ) : !isConnected && !isReconnecting ? (
               <>
                 <ContextMenu.Item
                   className="context-menu__item"

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -748,6 +748,17 @@ export async function disconnectAgent(agentId: string): Promise<void> {
   await invoke("disconnect_agent", { agentId });
 }
 
+/**
+ * Cancel an in-flight (still connecting) agent connect. Aborts the blocking
+ * SSH + initialize handshake promptly instead of waiting out the connect
+ * timeout; the backend then emits `disconnected` (single writer). No-op if the
+ * connect already finished. Returns whether a connecting agent was found (G1,
+ * #1235).
+ */
+export async function cancelConnectAgent(agentId: string): Promise<boolean> {
+  return await invoke<boolean>("cancel_connect_agent", { agentId });
+}
+
 /** Gracefully shut down a remote agent and disconnect. Returns detached session count. */
 export async function shutdownAgent(agentId: string, reason?: string): Promise<number> {
   return await invoke<number>("shutdown_agent", { agentId, reason: reason ?? null });

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -96,6 +96,7 @@ Fixed strings — match exactly.
 | `connection-picker-inline` | `src/components/WorkspaceEditor/ConnectionPicker.tsx` |
 | `connection-picker-search` | `src/components/WorkspaceEditor/ConnectionPicker.tsx` |
 | `connection-settings-form` | `src/components/DynamicForm/ConnectionSettingsForm.tsx` |
+| `context-agent-cancel-connect` | `src/components/Sidebar/AgentNode.tsx` |
 | `context-agent-connect` | `src/components/Sidebar/AgentNode.tsx` |
 | `context-agent-def-attach-persistent` | `src/components/Sidebar/AgentNode.tsx` |
 | `context-agent-def-duplicate` | `src/components/Sidebar/AgentNode.tsx` |
@@ -261,6 +262,7 @@ Fixed strings — match exactly.
 | `network-monitors-section` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-new-monitor` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-tools-sidebar` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
+| `open-connections-establishing-agents-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-http-monitors-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-empty` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-row` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
@@ -512,6 +514,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `*key-path-validation` | `${prefix}key-path-validation` | `src/components/Settings/KeyPathInput.tsx` |
 | `activity-bar-*` | `activity-bar-${label.toLowerCase().replace(/\s+/g, "-")}` | `src/components/ActivityBar/ActivityBarItem.tsx` |
 | `activity-bar-context-toggle-*` | `activity-bar-context-toggle-${item.view}` | `src/components/ActivityBar/ActivityBar.tsx` |
+| `agent-cancel-connect-*` | `agent-cancel-connect-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-header-*` | `agent-header-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-node-*` | `agent-node-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-state-*` | `agent-state-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |


### PR DESCRIPTION
## Summary

Stage S2 of the Remote Agent Lifecycle Redesign (#1142), covering **G1** (cancellable connect) and **G2** (connecting/reconnecting agents visible + killable in Open Connections). Builds on the single-writer landing (#1234).

**G1 — Cancellable connect (Rust)**
- Per-agent `CancellationToken` registry on `AgentConnectionManager`, keyed by agent id, with an RAII `ConnectingGuard` that clears the entry when the connect finishes (mirrors `cancel_connecting` / `cancel_connection_path_probe`).
- The blocking `connect_and_authenticate` + initialize handshake now runs under `tokio::select!` against the token; on cancel the connect future is dropped (dropping the russh channel) and the connect path emits `disconnected` (single writer per #1234).
- `connect_and_authenticate_cancellable` so a hung TCP connect to an unreachable host also aborts promptly.
- New `cancel_connect_agent` Tauri command + `AgentRpcClient::cancel_connect`.
- Sidebar `AgentNode` gains an inline **Cancel** button + "Cancel Connect" context-menu item while connecting, with toast feedback.

**G2 — Open Connections (frontend)**
- New "Establishing / recovering" section listing agents in `connecting`/`reconnecting` (previously only `connected`). Connecting → `cancel_connect_agent`; reconnecting → `disconnectRemoteAgent`. Composed from existing `Section`/`ConnectionRow`/`Button`/`toast`; token'd `--reconnecting` badge.

## Test plan

- Rust (`agent_manager.rs`): registry fire/no-op, RAII guard clears entry, `run_connect_cancellable` aborts on pre-fired + in-flight tokens and passes through the body result.
- Frontend: `OpenConnectionsModal.establishing.test.tsx`, `AgentNode.cancel-connect.test.tsx`.
- Agent reported `./scripts/check.sh` + `./scripts/test.sh` green (only pre-existing Docker-integration env failures). Merged `origin/develop` before pushing.

Closes #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)