### PR TITLE
feat(sftp): keyed SFTP session map + close-on-tab-close + Open Connections rows (#1241)

### DIFF
--- a/docs/changes/dev2/feature/1241-sftp-keyed-sessions.md
+++ b/docs/changes/dev2/feature/1241-sftp-keyed-sessions.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Closing a tab that had an open SFTP file browser now closes its underlying
+  SFTP (and SSH) session instead of leaking it. Previously the backend session
+  stayed connected until the app quit (the L1 leak, #1241).
+
+### Changed
+
+- The **Open Connections** panel now lists SFTP sessions individually — one
+  killable row per live backend session — instead of a single combined row.
+  Each row has its own Kill, and the section has a Kill All. Sessions whose
+  owning tab has gone away are still shown with an "orphaned" warning badge so
+  they can never become invisible or unkillable (#1241).

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -111,7 +111,8 @@
 }
 
 .oc-row__badge--connecting,
-.oc-row__badge--paused {
+.oc-row__badge--paused,
+.oc-row__badge--orphaned {
   background: color-mix(in srgb, var(--color-warning) 18%, transparent);
   color: var(--color-warning);
 }

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -59,8 +59,10 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   // Live single source of truth for tunnel status (kept in sync by tunnel
   // events); the panel reads it directly so it never drifts from the sidebar.
   const tunnelStates = useAppStore((s) => s.tunnelStates);
-  const sftpConnectedHost = useAppStore((s) => s.sftpConnectedHost);
-  const disconnectSftp = useAppStore((s) => s.disconnectSftp);
+  const sftpSessions = useAppStore((s) => s.sftpSessions);
+  const closeSftpSession = useAppStore((s) => s.closeSftpSession);
+  const tabGroups = useAppStore((s) => s.tabGroups);
+  const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
   const monitoringHost = useAppStore((s) => s.monitoringHost);
   const disconnectMonitoring = useAppStore((s) => s.disconnectMonitoring);
   // Live source of truth for HTTP monitors (kept current by the Network Tools
@@ -78,6 +80,23 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const connectingTabs = getAllLeaves(rootPanel)
     .flatMap((leaf) => leaf.tabs)
     .filter((tab) => terminalConnecting[tab.id]);
+
+  // Every live tab id across all tab groups (the active group is the live
+  // rootPanel, the others their stored trees) — used to flag orphaned SFTP
+  // sessions whose owning tab no longer exists (#1241, orphan safety net).
+  const liveTabIds = new Set(
+    tabGroups
+      .flatMap((g) => getAllLeaves(g.id === activeTabGroupId ? rootPanel : g.rootPanel))
+      .flatMap((leaf) => leaf.tabs.map((t) => t.id))
+  );
+
+  // One entry per live backend SFTP session, keyed by its UUID. Orphaned
+  // sessions (owning tab gone) still surface here so they stay killable.
+  const sftpSessionEntries = Object.entries(sftpSessions).map(([id, entry]) => ({
+    id,
+    hostLabel: entry.hostLabel,
+    orphaned: !liveTabIds.has(entry.owningTabId),
+  }));
 
   const [localSessions, setLocalSessions] = useState<LocalSessionInfo[]>([]);
   const [proxySessions, setProxySessions] = useState<ProxySessionsState>({});
@@ -158,7 +177,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     Object.values(proxySessions).reduce((s, arr) => s + arr.length, 0) +
     Object.values(agentSessions).reduce((s, arr) => s + arr.length, 0) +
     activeTunnels.length +
-    (sftpConnectedHost ? 1 : 0) +
+    sftpSessionEntries.length +
     (monitoringHost ? 1 : 0) +
     httpMonitors.length +
     (showXServer ? 1 : 0);
@@ -238,6 +257,26 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
 
   const handleKillAllTunnels = async () => {
     await Promise.all(activeTunnels.map((t) => stopTunnel(t.id)));
+  };
+
+  const handleKillSftp = async (sessionId: string) => {
+    try {
+      await closeSftpSession(sessionId);
+      toast.success("SFTP session closed");
+    } catch (err) {
+      frontendLog("open_connections", `Failed to close SFTP session: ${err}`);
+      toast.error(`Failed to close SFTP session: ${err}`);
+    }
+  };
+
+  const handleKillAllSftp = async () => {
+    try {
+      await Promise.all(sftpSessionEntries.map((s) => closeSftpSession(s.id)));
+      toast.success("All SFTP sessions closed");
+    } catch (err) {
+      frontendLog("open_connections", `Failed to close SFTP sessions: ${err}`);
+      toast.error(`Failed to close SFTP sessions: ${err}`);
+    }
   };
 
   const handleStopXServer = async () => {
@@ -428,20 +467,27 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           </Section>
         )}
 
-        {/* SFTP */}
-        {sftpConnectedHost && (
+        {/* SFTP — one row per live backend session (#1241). Orphaned sessions
+            (owning tab gone) surface with a warning badge so nothing is ever
+            invisible/unkillable. */}
+        {sftpSessionEntries.length > 0 && (
           <Section
             title="SFTP"
             icon={<FolderOpen size={14} />}
-            count={1}
-            onKillAll={disconnectSftp}
+            count={sftpSessionEntries.length}
+            onKillAll={handleKillAllSftp}
+            data-testid="open-connections-sftp-section"
           >
-            <ConnectionRow
-              icon={<FolderOpen size={14} />}
-              title={sftpConnectedHost}
-              badge="connected"
-              onKill={disconnectSftp}
-            />
+            {sftpSessionEntries.map((s) => (
+              <ConnectionRow
+                key={s.id}
+                icon={<FolderOpen size={14} />}
+                title={s.hostLabel}
+                detail={s.orphaned ? "orphaned — owning tab closed" : undefined}
+                badge={s.orphaned ? "orphaned" : "connected"}
+                onKill={() => handleKillSftp(s.id)}
+              />
+            ))}
           </Section>
         )}
 
@@ -601,7 +647,8 @@ type BadgeVariant =
   | "up"
   | "down"
   | "paused"
-  | "stopped";
+  | "stopped"
+  | "orphaned";
 
 interface ConnectionRowProps {
   icon: React.ReactNode;

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -383,7 +383,6 @@ function useFileBrowserSync() {
   const navigateSession = useAppStore((s) => s.navigateSession);
   const setSessionFileBrowserId = useAppStore((s) => s.setSessionFileBrowserId);
   const connectSftp = useAppStore((s) => s.connectSftp);
-  const disconnectSftp = useAppStore((s) => s.disconnectSftp);
   const sftpSessionId = useAppStore((s) => s.sftpSessionId);
   const sftpConnectedHost = useAppStore((s) => s.sftpConnectedHost);
   const sessionFileBrowserId = useAppStore((s) => s.sessionFileBrowserId);
@@ -580,12 +579,13 @@ function useFileBrowserSync() {
     // Already connected to the right host
     if (sftpSessionId && sftpConnectedHost === hostKey) return;
 
-    // Need to connect (or reconnect to different host)
-    const doConnect = async () => {
-      if (sftpSessionId && sftpConnectedHost !== hostKey) {
-        await disconnectSftp();
-      }
+    const owningTabId = activeTabId ?? undefined;
 
+    // Need to connect (or switch to a different host). We no longer close the
+    // previous session here: each tab owns its own SFTP session, so the store's
+    // connectSftp leaves a still-owned previous session registered (and closes
+    // it only if its owning tab is gone). Sessions are closed on tab close (#1241).
+    const doConnect = async () => {
       let configToUse = cfg;
       const authMethod = cfg.authMethod as string | undefined;
       if (authMethod === "password" && !cfg.password) {
@@ -601,7 +601,7 @@ function useFileBrowserSync() {
         configToUse = { ...baseConfig, password };
       }
 
-      connectSftp(configToUse);
+      connectSftp(configToUse, owningTabId);
     };
 
     doConnect();
@@ -614,7 +614,6 @@ function useFileBrowserSync() {
     sftpConnectedHost,
     connections,
     connectSftp,
-    disconnectSftp,
     requestPassword,
   ]);
 

--- a/src/store/appStore.sftpSessions.test.ts
+++ b/src/store/appStore.sftpSessions.test.ts
@@ -159,6 +159,28 @@ describe("appStore — keyed SFTP session map (S1/L1)", () => {
       expect(useAppStore.getState().sftpSessionId).toBe("sess-b");
     });
 
+    it("keeps only one session per owning tab (revisit closes the tab's prior session)", async () => {
+      const tabA = addTabAndGetId("Tab A");
+
+      vi.mocked(sftpOpen).mockResolvedValueOnce("sess-a1");
+      await useAppStore.getState().connectSftp(SAMPLE_CONFIG, tabA);
+      expect(useAppStore.getState().sftpSessions["sess-a1"]).toBeDefined();
+
+      // Reconnect the same tab (e.g. revisiting it): the prior session it owned
+      // must be closed and replaced, not accumulated.
+      vi.mocked(sftpOpen).mockResolvedValueOnce("sess-a2");
+      await useAppStore.getState().connectSftp(SAMPLE_CONFIG, tabA);
+
+      expect(sftpClose).toHaveBeenCalledWith("sess-a1");
+      const sessions = useAppStore.getState().sftpSessions;
+      expect(sessions["sess-a1"]).toBeUndefined();
+      expect(sessions["sess-a2"]).toEqual({
+        hostLabel: "alice@example.com:22",
+        owningTabId: tabA,
+      });
+      expect(Object.keys(sessions)).toHaveLength(1);
+    });
+
     it("closes the previous active session when its owning tab is gone (orphan cleanup)", async () => {
       const tabB = addTabAndGetId("Tab B");
 

--- a/src/store/appStore.sftpSessions.test.ts
+++ b/src/store/appStore.sftpSessions.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve("persisted-id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(() => Promise.resolve()),
+  sftpListDir: vi.fn(() => Promise.resolve([])),
+  sftpRealpath: vi.fn(() => Promise.resolve("/home/alice")),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore, _resetSftpListSeq } from "./appStore";
+import { sftpOpen, sftpClose } from "@/services/api";
+import { findLeaf } from "@/utils/panelTree";
+import type { LeafPanel } from "@/types/terminal";
+
+const SAMPLE_CONFIG = { host: "example.com", port: 22, username: "alice", password: "pw" };
+
+/**
+ * Create a tab via the store and return its generated id, so tests can wire an
+ * SFTP session's `owningTabId` to a genuinely-existing tab in the panel tree.
+ */
+function addTabAndGetId(title: string): string {
+  useAppStore.getState().addTab(title, "ssh");
+  const state = useAppStore.getState();
+  const leaf = findLeaf(state.rootPanel, state.activePanelId!) as LeafPanel;
+  return leaf.tabs[leaf.tabs.length - 1].id;
+}
+
+describe("appStore — keyed SFTP session map (S1/L1)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    _resetSftpListSeq();
+    vi.clearAllMocks();
+    vi.mocked(sftpClose).mockResolvedValue(undefined);
+  });
+
+  describe("closeTab closes owned SFTP sessions (the L1 leak fix)", () => {
+    it("closes and drops every session owned by the closed tab, leaving others", () => {
+      const tabA = addTabAndGetId("Tab A");
+      const tabB = addTabAndGetId("Tab B");
+
+      useAppStore.setState({
+        sftpSessions: {
+          "sess-a": { hostLabel: "alice@a:22", owningTabId: tabA },
+          "sess-b": { hostLabel: "bob@b:22", owningTabId: tabB },
+        },
+      });
+
+      const panelId = useAppStore.getState().activePanelId!;
+      useAppStore.getState().closeTab(tabA, panelId);
+
+      expect(sftpClose).toHaveBeenCalledWith("sess-a");
+      expect(sftpClose).not.toHaveBeenCalledWith("sess-b");
+
+      const sessions = useAppStore.getState().sftpSessions;
+      expect(sessions["sess-a"]).toBeUndefined();
+      expect(sessions["sess-b"]).toEqual({ hostLabel: "bob@b:22", owningTabId: tabB });
+    });
+
+    it("clears the active browser fields when the closed tab owns the active session", () => {
+      const tabA = addTabAndGetId("Tab A");
+
+      useAppStore.setState({
+        sftpSessionId: "sess-a",
+        sftpConnectedHost: "alice@a:22",
+        sftpStatus: "connected",
+        sftpSessions: { "sess-a": { hostLabel: "alice@a:22", owningTabId: tabA } },
+      });
+
+      const panelId = useAppStore.getState().activePanelId!;
+      useAppStore.getState().closeTab(tabA, panelId);
+
+      expect(sftpClose).toHaveBeenCalledWith("sess-a");
+      const state = useAppStore.getState();
+      expect(state.sftpSessionId).toBeNull();
+      expect(state.sftpConnectedHost).toBeNull();
+      expect(state.sftpStatus).toBe("idle");
+      expect(state.sftpSessions["sess-a"]).toBeUndefined();
+    });
+
+    it("leaves SFTP state untouched when the closed tab owns no session", () => {
+      const tabA = addTabAndGetId("Tab A");
+      const tabB = addTabAndGetId("Tab B");
+
+      useAppStore.setState({
+        sftpSessions: { "sess-b": { hostLabel: "bob@b:22", owningTabId: tabB } },
+      });
+
+      const panelId = useAppStore.getState().activePanelId!;
+      useAppStore.getState().closeTab(tabA, panelId);
+
+      expect(sftpClose).not.toHaveBeenCalled();
+      expect(useAppStore.getState().sftpSessions["sess-b"]).toBeDefined();
+    });
+  });
+
+  describe("connectSftp registration (host switch)", () => {
+    it("registers the new session keyed by its UUID with hostLabel + owningTabId", async () => {
+      const tabA = addTabAndGetId("Tab A");
+      vi.mocked(sftpOpen).mockResolvedValue("sess-a");
+
+      await useAppStore.getState().connectSftp(SAMPLE_CONFIG, tabA);
+
+      const sessions = useAppStore.getState().sftpSessions;
+      expect(sessions["sess-a"]).toEqual({
+        hostLabel: "alice@example.com:22",
+        owningTabId: tabA,
+      });
+      expect(useAppStore.getState().sftpSessionId).toBe("sess-a");
+    });
+
+    it("does NOT silently drop or close a still-owned previous session on host switch", async () => {
+      const tabA = addTabAndGetId("Tab A");
+      const tabB = addTabAndGetId("Tab B");
+
+      // tabA already has a live SFTP session and is the active browser.
+      useAppStore.setState({
+        sftpSessionId: "sess-a",
+        sftpConnectedHost: "alice@a:22",
+        sftpStatus: "connected",
+        sftpSessions: { "sess-a": { hostLabel: "alice@a:22", owningTabId: tabA } },
+      });
+
+      // Switch the browser to tabB, connecting a second session.
+      vi.mocked(sftpOpen).mockResolvedValue("sess-b");
+      await useAppStore.getState().connectSftp(SAMPLE_CONFIG, tabB);
+
+      // The still-owned previous session must survive (tabA is still open).
+      expect(sftpClose).not.toHaveBeenCalledWith("sess-a");
+      const sessions = useAppStore.getState().sftpSessions;
+      expect(sessions["sess-a"]).toEqual({ hostLabel: "alice@a:22", owningTabId: tabA });
+      expect(sessions["sess-b"]).toEqual({
+        hostLabel: "alice@example.com:22",
+        owningTabId: tabB,
+      });
+      expect(useAppStore.getState().sftpSessionId).toBe("sess-b");
+    });
+
+    it("closes the previous active session when its owning tab is gone (orphan cleanup)", async () => {
+      const tabB = addTabAndGetId("Tab B");
+
+      // Active session owned by a tab that no longer exists in the tree.
+      useAppStore.setState({
+        sftpSessionId: "sess-gone",
+        sftpConnectedHost: "ghost@g:22",
+        sftpStatus: "connected",
+        sftpSessions: { "sess-gone": { hostLabel: "ghost@g:22", owningTabId: "tab-gone" } },
+      });
+
+      vi.mocked(sftpOpen).mockResolvedValue("sess-b");
+      await useAppStore.getState().connectSftp(SAMPLE_CONFIG, tabB);
+
+      expect(sftpClose).toHaveBeenCalledWith("sess-gone");
+      const sessions = useAppStore.getState().sftpSessions;
+      expect(sessions["sess-gone"]).toBeUndefined();
+      expect(sessions["sess-b"]).toBeDefined();
+    });
+  });
+
+  describe("closeSftpSession action", () => {
+    it("calls sftpClose(id) and drops the entry", async () => {
+      const tabA = addTabAndGetId("Tab A");
+      useAppStore.setState({
+        sftpSessions: {
+          "sess-a": { hostLabel: "alice@a:22", owningTabId: tabA },
+          "sess-b": { hostLabel: "bob@b:22", owningTabId: "tab-gone" },
+        },
+      });
+
+      await useAppStore.getState().closeSftpSession("sess-b");
+
+      expect(sftpClose).toHaveBeenCalledWith("sess-b");
+      const sessions = useAppStore.getState().sftpSessions;
+      expect(sessions["sess-b"]).toBeUndefined();
+      expect(sessions["sess-a"]).toBeDefined();
+    });
+
+    it("clears the active browser fields when the killed session is the active one", async () => {
+      useAppStore.setState({
+        sftpSessionId: "sess-a",
+        sftpConnectedHost: "alice@a:22",
+        sftpStatus: "connected",
+        sftpSessions: { "sess-a": { hostLabel: "alice@a:22", owningTabId: "tab-gone" } },
+      });
+
+      await useAppStore.getState().closeSftpSession("sess-a");
+
+      const state = useAppStore.getState();
+      expect(state.sftpSessionId).toBeNull();
+      expect(state.sftpConnectedHost).toBeNull();
+      expect(state.sftpStatus).toBe("idle");
+      expect(state.sftpSessions["sess-a"]).toBeUndefined();
+    });
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -25,6 +25,7 @@ import {
   ConnectionFolder,
   FileEntry,
   SftpStatus,
+  SftpSessionEntry,
   AppSettings,
   RemoteAgentDefinition,
   AgentCapabilities,
@@ -487,7 +488,20 @@ interface AppState {
    */
   sftpStatus: SftpStatus;
   sftpError: string | null;
+  /**
+   * Host label (`user@host:port`) of the session the browser is currently
+   * viewing. Derived from `sftpSessions[sftpSessionId]`; kept as its own field
+   * so the file browser and status UI can read the active host cheaply.
+   */
   sftpConnectedHost: string | null;
+  /**
+   * Every live backend SFTP session, keyed by its session-id / UUID (Decision 1
+   * of the sftp-session-and-transfers concept, issue #1241). `hostLabel` is
+   * display metadata; `owningTabId` binds the session to the tab that opened it
+   * so it can be closed when that tab closes (the L1 leak fix). `sftpSessionId`
+   * above is the derived "active" pointer into this map for the current browser.
+   */
+  sftpSessions: Record<string, SftpSessionEntry>;
   /**
    * The last config passed to `connectSftp`, retained so a failed connect can be
    * retried (audit gap S1). Cleared on `disconnectSftp`.
@@ -495,7 +509,7 @@ interface AppState {
   sftpLastConfig: Record<string, unknown> | null;
   setCurrentPath: (path: string) => void;
   setFileEntries: (entries: FileEntry[]) => void;
-  connectSftp: (config: Record<string, unknown>) => Promise<void>;
+  connectSftp: (config: Record<string, unknown>, owningTabId?: string) => Promise<void>;
   disconnectSftp: () => Promise<void>;
   navigateSftp: (path: string) => Promise<void>;
   refreshSftp: () => Promise<void>;
@@ -503,6 +517,12 @@ interface AppState {
   retrySftp: () => Promise<void>;
   /** Clear the SFTP error so the failed-connect placeholder resets (audit gap S1). */
   dismissSftpError: () => void;
+  /**
+   * Close a single tracked SFTP session (`sftp_close`) and drop it from
+   * `sftpSessions`. When it is the active browser session, the browser is reset
+   * to idle. Drives the per-session Kill in the Open Connections panel (#1241).
+   */
+  closeSftpSession: (sessionId: string) => Promise<void>;
 
   // Per-tab CWD tracking
   tabCwds: Record<string, string>;
@@ -2140,7 +2160,17 @@ export const useAppStore = create<AppState>((set, get) => {
     pendingShortcutCloseConfirm: null,
     setPendingShortcutCloseConfirm: (req) => set({ pendingShortcutCloseConfirm: req }),
 
-    closeTab: (tabId, panelId) =>
+    closeTab: (tabId, panelId) => {
+      // Close every SFTP session owned by this tab and drop it from the map —
+      // the L1 leak fix (#1241). Fire the async closes here (fire-and-forget)
+      // so the state updater below stays pure; the entries are removed regardless.
+      const ownedSftp = Object.entries(useAppStore.getState().sftpSessions)
+        .filter(([, entry]) => entry.owningTabId === tabId)
+        .map(([sessionId]) => sessionId);
+      ownedSftp.forEach((sessionId) => {
+        sftpClose(sessionId).catch(() => {});
+      });
+
       set((state) => {
         // Clean up per-tab state for the closed tab
         const remainingCwds = omitKey(state.tabCwds, tabId);
@@ -2161,6 +2191,25 @@ export const useAppStore = create<AppState>((set, get) => {
         const remainingPrompt = omitKey(state.terminalReconnectPrompt, tabId);
         const remainingAutoRetry = omitKey(state.terminalAutoRetryCount, tabId);
         const remainingWaiting = omitKey(state.terminalWaitingForAgent, tabId);
+
+        // Drop the SFTP sessions owned by this tab (closed above) from the map,
+        // and reset the browser when the active session was one of them (#1241).
+        const remainingSftp = ownedSftp.reduce(
+          (acc, sessionId) => omitKey(acc, sessionId),
+          state.sftpSessions
+        );
+        const activeSftpClosed =
+          state.sftpSessionId != null && ownedSftp.includes(state.sftpSessionId);
+        const sftpBrowserReset = activeSftpClosed
+          ? {
+              sftpSessionId: null,
+              sftpConnectedHost: null,
+              sftpStatus: "idle" as SftpStatus,
+              fileEntries: [],
+              currentPath: "/",
+              sftpError: null,
+            }
+          : {};
 
         // Remove this tab from any persistent session's attachedTabIds
         const persistentSessions = { ...state.persistentSessions };
@@ -2212,6 +2261,8 @@ export const useAppStore = create<AppState>((set, get) => {
             terminalReconnectPrompt: remainingPrompt,
             terminalAutoRetryCount: remainingAutoRetry,
             terminalWaitingForAgent: remainingWaiting,
+            sftpSessions: remainingSftp,
+            ...sftpBrowserReset,
           };
         }
 
@@ -2237,8 +2288,11 @@ export const useAppStore = create<AppState>((set, get) => {
           terminalReconnectPrompt: remainingPrompt,
           terminalAutoRetryCount: remainingAutoRetry,
           terminalWaitingForAgent: remainingWaiting,
+          sftpSessions: remainingSftp,
+          ...sftpBrowserReset,
         };
-      }),
+      });
+    },
 
     setActiveTab: (tabId, panelId) =>
       set((state) => {
@@ -2944,12 +2998,31 @@ export const useAppStore = create<AppState>((set, get) => {
     sftpStatus: "idle",
     sftpError: null,
     sftpConnectedHost: null,
+    sftpSessions: {},
     sftpLastConfig: null,
 
     setCurrentPath: (path) => set({ currentPath: path }),
     setFileEntries: (entries) => set({ fileEntries: entries }),
 
-    connectSftp: async (config: Record<string, unknown>) => {
+    connectSftp: async (config: Record<string, unknown>, owningTabId?: string) => {
+      // Host switch: do not silently overwrite the previous active session.
+      // Close it only when its owning tab is gone (orphan cleanup); otherwise
+      // leave it registered so it stays visible/killable (issue #1241, L1).
+      const prev = useAppStore.getState();
+      const prevId = prev.sftpSessionId;
+      if (prevId) {
+        const prevEntry = prev.sftpSessions[prevId];
+        const ownerAlive =
+          prevEntry != null && collectLiveTabs(prev).some((t) => t.id === prevEntry.owningTabId);
+        if (!ownerAlive) {
+          try {
+            await sftpClose(prevId);
+          } catch {
+            // Ignore close errors — the entry is dropped regardless.
+          }
+          set((state) => ({ sftpSessions: omitKey(state.sftpSessions, prevId) }));
+        }
+      }
       // Retain the config so a failed connect can be retried (audit gap S1).
       set({ sftpStatus: "connecting", sftpError: null, sftpLastConfig: config });
       try {
@@ -2973,13 +3046,19 @@ export const useAppStore = create<AppState>((set, get) => {
           );
           entries = await sftpListDir(sessionId, "/");
         }
-        set({
+        const hostLabel = `${config.username as string}@${config.host as string}:${config.port as number}`;
+        set((state) => ({
           sftpSessionId: sessionId,
           sftpStatus: "connected",
           currentPath: activePath,
           fileEntries: entries,
-          sftpConnectedHost: `${config.username as string}@${config.host as string}:${config.port as number}`,
-        });
+          sftpConnectedHost: hostLabel,
+          // Register the new session keyed by its UUID. Only tracked when the
+          // owning tab is known so it can be closed on tab close (#1241).
+          sftpSessions: owningTabId
+            ? { ...state.sftpSessions, [sessionId]: { hostLabel, owningTabId } }
+            : state.sftpSessions,
+        }));
       } catch (err) {
         set({
           sftpStatus: "error",
@@ -2997,7 +3076,7 @@ export const useAppStore = create<AppState>((set, get) => {
           // Ignore close errors
         }
       }
-      set({
+      set((state) => ({
         sftpSessionId: null,
         sftpStatus: "idle",
         fileEntries: [],
@@ -3005,6 +3084,33 @@ export const useAppStore = create<AppState>((set, get) => {
         sftpError: null,
         sftpConnectedHost: null,
         sftpLastConfig: null,
+        sftpSessions: sessionId ? omitKey(state.sftpSessions, sessionId) : state.sftpSessions,
+      }));
+    },
+
+    closeSftpSession: async (sessionId: string) => {
+      try {
+        await sftpClose(sessionId);
+      } catch {
+        // Ignore close errors — the entry is dropped regardless.
+      }
+      set((state) => {
+        const isActive = state.sftpSessionId === sessionId;
+        return {
+          sftpSessions: omitKey(state.sftpSessions, sessionId),
+          // When the killed session was the one the browser is viewing, reset
+          // the browser to idle so it stops looking connected.
+          ...(isActive
+            ? {
+                sftpSessionId: null,
+                sftpConnectedHost: null,
+                sftpStatus: "idle" as SftpStatus,
+                fileEntries: [],
+                currentPath: "/",
+                sftpError: null,
+              }
+            : {}),
+        };
       });
     },
 
@@ -3050,11 +3156,17 @@ export const useAppStore = create<AppState>((set, get) => {
         if (sessionDead) {
           frontendLog("sftp", `navigateSftp: session appears dead — clearing session (${message})`);
         }
-        set({
+        set((state) => ({
           sftpStatus: "error",
           sftpError: message,
-          ...(sessionDead ? { sftpSessionId: null, sftpConnectedHost: null } : {}),
-        });
+          ...(sessionDead
+            ? {
+                sftpSessionId: null,
+                sftpConnectedHost: null,
+                sftpSessions: omitKey(state.sftpSessions, sessionId),
+              }
+            : {}),
+        }));
       }
     },
 
@@ -3078,11 +3190,19 @@ export const useAppStore = create<AppState>((set, get) => {
         if (sessionDead) {
           frontendLog("sftp", `refreshSftp: session appears dead — clearing session (${message})`);
         }
-        set({
+        set((state) => ({
           sftpStatus: "error",
           sftpError: message,
-          ...(sessionDead ? { sftpSessionId: null, sftpConnectedHost: null } : {}),
-        });
+          ...(sessionDead
+            ? {
+                sftpSessionId: null,
+                sftpConnectedHost: null,
+                sftpSessions: sftpSessionId
+                  ? omitKey(state.sftpSessions, sftpSessionId)
+                  : state.sftpSessions,
+              }
+            : {}),
+        }));
       }
     },
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3047,18 +3047,32 @@ export const useAppStore = create<AppState>((set, get) => {
           entries = await sftpListDir(sessionId, "/");
         }
         const hostLabel = `${config.username as string}@${config.host as string}:${config.port as number}`;
-        set((state) => ({
-          sftpSessionId: sessionId,
-          sftpStatus: "connected",
-          currentPath: activePath,
-          fileEntries: entries,
-          sftpConnectedHost: hostLabel,
-          // Register the new session keyed by its UUID. Only tracked when the
-          // owning tab is known so it can be closed on tab close (#1241).
-          sftpSessions: owningTabId
-            ? { ...state.sftpSessions, [sessionId]: { hostLabel, owningTabId } }
-            : state.sftpSessions,
-        }));
+        // One SFTP session per owning tab: close any prior session the same tab
+        // owned (e.g. revisiting the tab or reconnecting to a new host) so
+        // sessions don't accumulate for a single browser (#1241).
+        const staleForTab = owningTabId
+          ? Object.entries(useAppStore.getState().sftpSessions)
+              .filter(([sid, e]) => e.owningTabId === owningTabId && sid !== sessionId)
+              .map(([sid]) => sid)
+          : [];
+        staleForTab.forEach((sid) => {
+          sftpClose(sid).catch(() => {});
+        });
+        set((state) => {
+          let sessions = state.sftpSessions;
+          if (owningTabId) {
+            sessions = staleForTab.reduce((acc, sid) => omitKey(acc, sid), sessions);
+            sessions = { ...sessions, [sessionId]: { hostLabel, owningTabId } };
+          }
+          return {
+            sftpSessionId: sessionId,
+            sftpStatus: "connected" as SftpStatus,
+            currentPath: activePath,
+            fileEntries: entries,
+            sftpConnectedHost: hostLabel,
+            sftpSessions: sessions,
+          };
+        });
       } catch (err) {
         set({
           sftpStatus: "error",

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -17,6 +17,21 @@ import { KeybindingOverrideEntry } from "./keybindings";
  */
 export type SftpStatus = "idle" | "connecting" | "connected" | "listing" | "error";
 
+/**
+ * A live backend SFTP session tracked in the keyed session map (issue #1241).
+ *
+ * Sessions are keyed by their session-id / UUID; this record holds only the
+ * display metadata and the binding needed for lifecycle cleanup.
+ *
+ * - `hostLabel`   — `user@host:port`, shown in the Open Connections panel
+ * - `owningTabId` — the tab that opened the session; when that tab closes the
+ *   session is closed (`sftp_close`) and removed (the L1 leak fix)
+ */
+export interface SftpSessionEntry {
+  hostLabel: string;
+  owningTabId: string;
+}
+
 export interface SavedConnection {
   id: string;
   name: string;

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -262,6 +262,7 @@ Fixed strings — match exactly.
 | `network-new-monitor` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `network-tools-sidebar` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `open-connections-http-monitors-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `open-connections-sftp-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-empty` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-row` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-setup` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |


### PR DESCRIPTION
Closes #1241

## Summary

SFTP **S1 (L1)** — the keystone of the SFTP Session Tracking + Transfers set (parent #1192). Replaces the single-slot SFTP model with a **session-id-keyed map** so every live backend session is tracked, visible, and killable, and closes the SFTP session **on owning-tab close** (the L1 leak fix).

Concept (source of truth): `docs/concepts/backlog/sftp-session-and-transfers.html`.

## Approach

- **State** (`src/store/appStore.ts`): add `sftpSessions: Record<sessionId, { hostLabel; owningTabId }>` (keyed by UUID; host is display metadata). `sftpSessionId` stays as the derived "active" pointer for the current browser. New `closeSftpSession(id)` action → `sftp_close` + drop entry (resets the browser when it was the active session).
- **Registration** (`connectSftp(config, owningTabId)`): records the returned UUID with `user@host:port` + owning tab. On host switch it no longer silently overwrites — a still-owned previous session is left registered; an orphaned one (owning tab gone) is closed. Keeps a single session per owning tab so revisiting a tab doesn't accumulate sessions.
- **Close on tab close** (`closeTab`): closes every SFTP session owned by the tab and drops it from the map — the core L1 leak fix (previously `closeTab` never touched SFTP, leaking the backend SSH+SFTP connection).
- **Open Connections** (`OpenConnectionsModal.tsx`): the SFTP section now maps over `sftpSessions`, one killable row per session (per-row **Kill** + **Kill All**), with an **orphaned** warning badge for a session whose owning tab is gone. Connection count counts map entries.
- **FileBrowser**: passes the active tab id as the owning tab and stops force-closing the previous session on host switch (the store handles orphan cleanup).

## Test plan

- Unit (`src/store/appStore.sftpSessions.test.ts`, written first / TDD): closing a tab closes + drops every session it owns (and clears the active browser when it owned the active session); leaves other tabs' sessions; host-switch does not drop/close a still-owned previous session; orphan cleanup closes a previous session whose owning tab is gone; one session per owning tab on reconnect; `closeSftpSession(id)` closes and drops.
- Full suite: `pnpm test` → 2400 passed. `pnpm build` (tsc) and `pnpm run lint` clean.
- Manual: open an SSH tab, browse SFTP, open **Open Connections** → one SFTP row; close the tab → row disappears and the backend session is closed (no leak). Open two SSH tabs to different hosts → two rows, each with its own Kill; Kill All clears the section. Kill the active session → browser resets to idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)