### PR TITLE
feat(terminal): connect + waiting-for-agent timeouts → Failed with a hint (#1129)

### DIFF
--- a/docs/changes/dev2/feature/1129-connect-waiting-timeouts.md
+++ b/docs/changes/dev2/feature/1129-connect-waiting-timeouts.md
@@ -1,0 +1,9 @@
+### Added
+
+- Connecting terminals now have a client-side timeout so they can no longer
+  hang forever. A tab **waiting for its agent** to come online settles as
+  **Connection failed** after 30s ("Agent did not come online within 30s…")
+  instead of parking indefinitely, and a plain connect that never completes
+  falls back to a failed state after 60s. Both surface a hint explaining the
+  cause with Retry and Cancel, and the waiting overlay now shows a
+  "Times out in Ns" countdown so the bounded wait is visible (#1129).

--- a/src/components/Terminal/TerminalConnectionOverlay.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { TerminalConnectionOverlay } from "./TerminalConnectionOverlay";
+import {
+  TerminalConnectionOverlay,
+  CONNECT_TIMEOUT_SECONDS,
+  WAITING_FOR_AGENT_TIMEOUT_SECONDS,
+} from "./TerminalConnectionOverlay";
 import { useAppStore } from "@/store/appStore";
 
 vi.mock("lucide-react", () => ({
@@ -467,5 +471,123 @@ describe("TerminalConnectionOverlay — elapsed time", () => {
       vi.advanceTimersByTime(20000);
     });
     expect(container.textContent).toContain("Taking longer than usual");
+  });
+});
+
+describe("TerminalConnectionOverlay — connect timeouts (#1129)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  function render() {
+    act(() => {
+      root.render(
+        <TerminalConnectionOverlay
+          tabId={TAB_ID}
+          panelId={PANEL_ID}
+          tabTitle="my-server"
+          isVisible={true}
+        />
+      );
+    });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetStore();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("transitions waiting-for-agent to Failed with a cause hint after the bounded wait", () => {
+    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    render();
+    expect(container.textContent).toContain("Waiting for agent");
+
+    // Just before the deadline: still parked, no failure recorded yet.
+    act(() => {
+      vi.advanceTimersByTime((WAITING_FOR_AGENT_TIMEOUT_SECONDS - 1) * 1000);
+    });
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBeUndefined();
+    expect(useAppStore.getState().terminalWaitingForAgent[TAB_ID]).toBe("agent-1");
+
+    // Cross the deadline — the wait must settle as Failed with a hint.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    const error = useAppStore.getState().terminalSpawnErrors[TAB_ID];
+    expect(error).toBeDefined();
+    expect(error).toContain(`${WAITING_FOR_AGENT_TIMEOUT_SECONDS}s`);
+    expect(error?.toLowerCase()).toContain("agent");
+    // Waiting state is cleared so the overlay renders the Failed view.
+    expect(useAppStore.getState().terminalWaitingForAgent[TAB_ID]).toBeUndefined();
+    expect(container.textContent).toContain("Connection failed");
+  });
+
+  it("does not fire the waiting-for-agent timeout when the connect settles first", () => {
+    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    render();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    // Agent came online / session went live — waiting cleared before the deadline.
+    act(() => {
+      useAppStore.setState({ terminalWaitingForAgent: {} });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(WAITING_FOR_AGENT_TIMEOUT_SECONDS * 1000 + 2000);
+    });
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBeUndefined();
+  });
+
+  it("clears the waiting-for-agent timeout on unmount so it never fires against a torn-down attempt", () => {
+    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    render();
+
+    act(() => root.unmount());
+
+    act(() => {
+      vi.advanceTimersByTime(WAITING_FOR_AGENT_TIMEOUT_SECONDS * 1000 + 2000);
+    });
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBeUndefined();
+  });
+
+  it("transitions a plain connecting attempt to Failed after the connect timeout", () => {
+    useAppStore.setState({ terminalConnecting: { [TAB_ID]: true } });
+    render();
+
+    act(() => {
+      vi.advanceTimersByTime((CONNECT_TIMEOUT_SECONDS - 1) * 1000);
+    });
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBeUndefined();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    const error = useAppStore.getState().terminalSpawnErrors[TAB_ID];
+    expect(error).toBeDefined();
+    expect(error).toContain(`${CONNECT_TIMEOUT_SECONDS}s`);
+    expect(useAppStore.getState().terminalConnecting[TAB_ID]).toBeUndefined();
+  });
+
+  it("does not apply the connect timeout during bounded auto-retries", () => {
+    useAppStore.setState({
+      terminalConnecting: { [TAB_ID]: true },
+      terminalAutoRetryCount: { [TAB_ID]: 2 },
+    });
+    render();
+
+    act(() => {
+      vi.advanceTimersByTime(CONNECT_TIMEOUT_SECONDS * 1000 + 2000);
+    });
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBeUndefined();
   });
 });

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -143,9 +143,13 @@ export function TerminalConnectionOverlay({
     setTerminalSpawnError,
   ]);
 
-  // Remaining seconds before the active pending phase times out — surfaced in
-  // the overlay so the bounded wait is visible to the user (#1129, P7).
-  const waitingRemaining = Math.max(0, WAITING_FOR_AGENT_TIMEOUT_SECONDS - elapsedSeconds);
+  // Remaining seconds before the waiting-for-agent park times out — surfaced in
+  // the overlay so the bounded wait is visible to the user (#1129, P7). Keyed
+  // off the waiting phase specifically (not the overall connect elapsed) so the
+  // countdown resets when the park begins and stays in step with the real
+  // deadline scheduled above.
+  const waitingElapsed = useElapsed(!!waitingForAgent);
+  const waitingRemaining = Math.max(0, WAITING_FOR_AGENT_TIMEOUT_SECONDS - waitingElapsed);
 
   const handleCancel = useCallback(() => {
     closeTab(tabId, panelId);

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { ServerCrash, RefreshCw, Loader2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { useElapsed } from "@/hooks/useElapsed";
+import { frontendLog } from "@/utils/frontendLog";
 import "./TerminalConnectionOverlay.css";
 
 interface TerminalConnectionOverlayProps {
@@ -26,6 +27,28 @@ const SERIAL_BUSY_PATTERNS = ["busy", "in use", "Access is denied"];
 
 /** Seconds after which a still-pending connect is flagged as unusually slow. */
 const SLOW_CONNECT_THRESHOLD_SECONDS = 20;
+
+/**
+ * Client-side deadline for a plain `Connecting` attempt (#1129).
+ *
+ * The backend connect itself is bounded (the default SSH connect timeout is
+ * 20 s, see `DEFAULT_SSH_CONNECT_TIMEOUT_SECS`), so this is a safety net set
+ * comfortably above it: it only fires if the backend hangs past its own
+ * timeout and never rejects, which would otherwise leave the overlay spinning
+ * forever. Auto-retry attempts are excluded — those are already bounded by
+ * `MAX_AGENT_SPAWN_ATTEMPTS`.
+ */
+export const CONNECT_TIMEOUT_SECONDS = 60;
+
+/**
+ * Client-side deadline for the `WaitingForAgent` park (#1129).
+ *
+ * A tab parked waiting for its agent transport to come online has no backend
+ * timeout at all — if the agent never connects it would wait indefinitely.
+ * After this bounded wait the tab settles as Failed with a hint so the user
+ * can retry or cancel instead of staring at a permanent spinner.
+ */
+export const WAITING_FOR_AGENT_TIMEOUT_SECONDS = 30;
 
 /** Formats whole seconds as a compact `mm:ss`-ish readout: `5s`, `1m 05s`. */
 function formatElapsed(seconds: number): string {
@@ -56,6 +79,9 @@ export function TerminalConnectionOverlay({
 }: TerminalConnectionOverlayProps) {
   const closeTab = useAppStore((s) => s.closeTab);
   const retryTerminalSpawn = useAppStore((s) => s.retryTerminalSpawn);
+  const setTerminalConnecting = useAppStore((s) => s.setTerminalConnecting);
+  const setTerminalWaitingForAgent = useAppStore((s) => s.setTerminalWaitingForAgent);
+  const setTerminalSpawnError = useAppStore((s) => s.setTerminalSpawnError);
   const isConnecting = useAppStore((s) => s.terminalConnecting[tabId] ?? false);
   const autoRetryCount = useAppStore((s) => s.terminalAutoRetryCount[tabId] ?? 0);
   const waitingForAgent = useAppStore((s) => s.terminalWaitingForAgent[tabId]);
@@ -68,6 +94,58 @@ export function TerminalConnectionOverlay({
   const elapsedSeconds = useElapsed(isActivelyConnecting);
   const elapsedLabel = formatElapsed(elapsedSeconds);
   const isSlowConnect = elapsedSeconds >= SLOW_CONNECT_THRESHOLD_SECONDS;
+
+  // Bound the pending states with a client-side deadline (#1129). Without this,
+  // `WaitingForAgent` parks forever if the agent never comes online, and a
+  // `Connecting` attempt whose backend hangs past its own timeout never
+  // settles. On the deadline the tab transitions to Failed with a hint that
+  // explains the cause, reusing the existing spawn-error → Failed overlay path.
+  //
+  // The effect re-runs whenever the phase changes, so the timer is inherently
+  // cleared on a successful connect, on cancel/unmount (React cleanup), and on
+  // any transition to another phase — it can only fire against an attempt that
+  // has stayed in the same pending phase for the full duration. Reattaching and
+  // bounded auto-retries (already capped by MAX_AGENT_SPAWN_ATTEMPTS) are
+  // excluded.
+  useEffect(() => {
+    if (isReattaching || autoRetryCount > 0) return;
+
+    let timeoutMs: number;
+    let hint: string;
+    let clearActivePhase: () => void;
+    if (waitingForAgent) {
+      timeoutMs = WAITING_FOR_AGENT_TIMEOUT_SECONDS * 1000;
+      hint = `Agent did not come online within ${WAITING_FOR_AGENT_TIMEOUT_SECONDS}s. The agent may be offline or unreachable — check the agent and retry.`;
+      clearActivePhase = () => setTerminalWaitingForAgent(tabId, null);
+    } else if (isConnecting) {
+      timeoutMs = CONNECT_TIMEOUT_SECONDS * 1000;
+      hint = `The connection did not complete within ${CONNECT_TIMEOUT_SECONDS}s. The host may be unreachable or unresponsive — check the connection and retry.`;
+      clearActivePhase = () => setTerminalConnecting(tabId, false);
+    } else {
+      return;
+    }
+
+    const id = setTimeout(() => {
+      frontendLog("terminal", `connect timeout fired for tab=${tabId} after ${timeoutMs}ms`);
+      clearActivePhase();
+      setTerminalSpawnError(tabId, hint);
+    }, timeoutMs);
+
+    return () => clearTimeout(id);
+  }, [
+    tabId,
+    isConnecting,
+    waitingForAgent,
+    isReattaching,
+    autoRetryCount,
+    setTerminalConnecting,
+    setTerminalWaitingForAgent,
+    setTerminalSpawnError,
+  ]);
+
+  // Remaining seconds before the active pending phase times out — surfaced in
+  // the overlay so the bounded wait is visible to the user (#1129, P7).
+  const waitingRemaining = Math.max(0, WAITING_FOR_AGENT_TIMEOUT_SECONDS - elapsedSeconds);
 
   const handleCancel = useCallback(() => {
     closeTab(tabId, panelId);
@@ -115,6 +193,12 @@ export function TerminalConnectionOverlay({
           <p className="terminal-connection-overlay__heading">Waiting for agent…</p>
           <p className="terminal-connection-overlay__subheading">
             Waiting for the agent to connect before starting the session.
+          </p>
+          <p
+            className="terminal-connection-overlay__elapsed"
+            data-testid="terminal-connection-timeout-remaining"
+          >
+            Times out in {waitingRemaining}s
           </p>
           <div className="terminal-connection-overlay__actions">
             <button

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -378,6 +378,7 @@ Fixed strings — match exactly.
 | `terminal-connection-elapsed` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-connection-overlay` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-connection-retry-btn` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
+| `terminal-connection-timeout-remaining` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-context-copy-all` | `src/components/SplitView/SplitView.tsx` |
 | `terminal-context-copy-selection` | `src/components/SplitView/SplitView.tsx` |
 | `terminal-context-paste` | `src/components/SplitView/SplitView.tsx` |


### PR DESCRIPTION
Closes #1129

## Problem

The `Connecting` and `WaitingForAgent` connection-overlay states had **no client-side timeout**. `Connecting` relied entirely on the backend connect timeout; `WaitingForAgent` had none at all — a tab parked waiting for an agent that never came online would spin forever, with no way for the user to recover except closing the tab.

## Approach

Added a client-side deadline in `TerminalConnectionOverlay`, keyed off the same per-tab pending state it already renders — reusing the existing spawn-error → **Failed** overlay path (Retry + Cancel + contextual hint) rather than inventing a parallel mechanism.

- `WAITING_FOR_AGENT_TIMEOUT_SECONDS` (30s): a parked wait settles to **Failed** with _"Agent did not come online within 30s…"_.
- `CONNECT_TIMEOUT_SECONDS` (60s): a plain connect that never settles falls to **Failed** with a hint. Set comfortably above the backend's default connect timeout (`DEFAULT_SSH_CONNECT_TIMEOUT_SECS` = 20s) so it acts purely as a safety net. Bounded auto-retries (`MAX_AGENT_SPAWN_ATTEMPTS`) and reattaching are excluded.
- The effect re-keys on the pending phase, so the timer is inherently cleared on a successful connect, on cancel/unmount (React cleanup), and on any phase change — it can only fire against an attempt that stayed in the same phase for the full duration, respecting the existing per-attempt / cancellation model.
- **P7:** the waiting overlay now shows a `Times out in Ns` countdown so the bounded wait is visible.

## Test plan

TDD — test commit precedes implementation. New Vitest cases (fake timers) in `TerminalConnectionOverlay.test.tsx`:

- [x] `WaitingForAgent` transitions to Failed with a cause hint after the bounded wait
- [x] a plain `Connecting` attempt transitions to Failed after the connect deadline
- [x] a connect that settles before the deadline does **not** fire the timeout
- [x] the timer is cleared on unmount (never fires against a torn-down attempt)
- [x] bounded auto-retries are exempt from the connect timeout

Verified locally: overlay suite 23/23 green, full `src/components/Terminal/` suite 161/161 green, `pnpm run lint` clean, `pnpm build` (tsc) clean pre-merge. (The one post-merge tsc error is an unrelated missing `@xterm/addon-serialize` dep pulled in by a concurrently-merged PR, absent from this worktree's shared node_modules; CI has it installed.)

### Manual test steps

1. Configure a remote-agent connection whose agent host is unreachable (or stop the agent), then open a session on it.
2. Observe the overlay show **Waiting for agent…** with a `Times out in Ns` countdown.
3. After 30s the overlay flips to **Connection failed** with the hint _"Agent did not come online within 30s…"_ and Retry / Cancel buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)