### PR TITLE
feat(monitoring): honest connect + bounded collect timeout (#1228)

### DIFF
--- a/agent/src/monitoring/mod.rs
+++ b/agent/src/monitoring/mod.rs
@@ -29,6 +29,15 @@ const DEFAULT_INTERVAL_MS: u64 = 2000;
 /// Minimum allowed collection interval in milliseconds.
 const MIN_INTERVAL_MS: u64 = 500;
 
+/// Maximum time a single collect may take before it is treated as a failure.
+///
+/// Bounds a stalled SSH collect (half-dropped TCP, unresponsive remote) so the
+/// task returns to its `select!` — where cancellation is honored — instead of
+/// awaiting the collect forever (#1228, gap G3). The sequential loop is the
+/// in-flight guard: the next tick's collect never starts until this one
+/// resolves or times out.
+const COLLECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 // ── MonitoringManagerApi trait ─────────────────────────────────────
 
 /// Abstract interface over the monitoring manager.
@@ -220,10 +229,19 @@ async fn monitoring_task(
             _ = ticker.tick() => {
                 let collector = collector.clone();
                 let host_label = host.clone();
-                let result = tokio::task::spawn_blocking(move || {
+                let collect = tokio::task::spawn_blocking(move || {
                     let mut c = collector.lock().unwrap();
                     c.collect(&host_label)
-                }).await;
+                });
+                // Bound the collect so a stalled remote cannot pin the loop
+                // and keep it from ever re-checking cancellation (#1228, G3).
+                let result = match tokio::time::timeout(COLLECT_TIMEOUT, collect).await {
+                    Ok(join_result) => join_result,
+                    Err(_elapsed) => {
+                        warn!("Monitoring collection timed out for '{}'", host);
+                        continue;
+                    }
+                };
 
                 match result {
                     Ok(Ok(stats)) => {

--- a/core/src/backends/ssh/monitoring.rs
+++ b/core/src/backends/ssh/monitoring.rs
@@ -2,13 +2,22 @@
 //!
 //! Collects system statistics from a remote host by periodically executing
 //! the monitoring command over an SSH exec channel and parsing the output.
+//!
+//! The provider establishes the SSH connection **synchronously** inside
+//! [`MonitoringProvider::subscribe`] so a connect failure surfaces as an
+//! `Err` to the caller instead of a false "connected" state (#1228, gap G4).
+//! Each collect is bounded by a [`tokio::time::timeout`] so a stalled exec
+//! becomes a collect failure rather than hanging the loop forever (#1228,
+//! gap G3). The single sequential collect loop is the in-flight guard — no
+//! overlapping collects.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use russh::ChannelMsg;
-use tracing::{debug, warn};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
 
 use crate::config::SshConfig;
 use crate::errors::CoreError;
@@ -17,8 +26,8 @@ use crate::monitoring::{
     MONITORING_COMMAND,
 };
 
-use super::handler::SshSession;
-use super::jump_host::connect_target;
+use super::handler::{ForwardedChannelRegistry, SshSession};
+use super::jump_host::{connect_target, GatewayHold};
 
 /// Polling interval for collecting system stats.
 const MONITORING_INTERVAL: Duration = Duration::from_secs(2);
@@ -26,32 +35,116 @@ const MONITORING_INTERVAL: Duration = Duration::from_secs(2);
 /// Channel capacity for monitoring stats updates.
 const MONITORING_CHANNEL_CAPACITY: usize = 16;
 
+/// Maximum time a single collect may take before it is treated as a failure.
+///
+/// Bounds the exec against a half-dropped TCP peer or an unresponsive remote
+/// so the collect loop cannot hang indefinitely (#1228, gap G3).
+const COLLECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Abstraction over the SSH connect + collect steps used by the monitoring
+/// provider.
+///
+/// Extracting these two operations behind a trait lets the honest-connect and
+/// collect-timeout behaviour be exercised with a fake transport in unit tests,
+/// without a real SSH server.
+#[async_trait::async_trait]
+pub(crate) trait MonitoringTransport: Send + Sync + 'static {
+    /// Established session handle carried into the collect loop.
+    type Session: Send + Sync + 'static;
+
+    /// Establish the monitoring session, honoring `cancel`.
+    ///
+    /// Awaited synchronously inside [`MonitoringProvider::subscribe`] so the
+    /// real connect result reaches the caller (#1228, gap G4).
+    async fn connect(&self, cancel: CancellationToken) -> Result<Self::Session, CoreError>;
+
+    /// Run one collection over an established session, returning raw stdout.
+    async fn collect(&self, session: &Self::Session) -> Result<String, CoreError>;
+}
+
+/// Real SSH transport: connects via [`connect_target`] and collects via
+/// [`ssh_exec`].
+pub(crate) struct SshTransport {
+    config: SshConfig,
+}
+
+/// A connected SSH monitoring session and the resources that must outlive it.
+///
+/// The pooled `_gateway` hold and forwarded-channel `_registry` are kept alive
+/// for the session's lifetime so a jump-host chain (#939) stays open while the
+/// collect loop runs.
+pub(crate) struct SshConnectedSession {
+    session: SshSession,
+    _registry: ForwardedChannelRegistry,
+    _gateway: Option<GatewayHold>,
+}
+
+#[async_trait::async_trait]
+impl MonitoringTransport for SshTransport {
+    type Session = SshConnectedSession;
+
+    async fn connect(&self, cancel: CancellationToken) -> Result<Self::Session, CoreError> {
+        // Reach the target directly, or through its pooled jump-host gateway
+        // when a ProxyJump chain is configured (#939).
+        let (session, registry, gateway) = connect_target(&self.config, Some(&cancel)).await?;
+        Ok(SshConnectedSession {
+            session,
+            _registry: registry,
+            _gateway: gateway,
+        })
+    }
+
+    async fn collect(&self, session: &Self::Session) -> Result<String, CoreError> {
+        ssh_exec(&session.session, MONITORING_COMMAND).await
+    }
+}
+
 /// Background monitoring task state.
 struct MonitoringTask {
     alive: Arc<AtomicBool>,
+    /// Cancels an in-flight connect / collect (wired to Cancel controls in a
+    /// follow-up issue). Cancelled on drop so a torn-down subscription aborts
+    /// any pending SSH handshake promptly.
+    cancel: CancellationToken,
 }
 
 impl Drop for MonitoringTask {
     fn drop(&mut self) {
         self.alive.store(false, Ordering::SeqCst);
+        self.cancel.cancel();
     }
 }
 
-/// SSH-based monitoring provider.
+/// SSH-based monitoring provider, generic over its [`MonitoringTransport`].
 ///
-/// Spawns a background tokio task that periodically executes the monitoring
-/// command over SSH, parses the output, and sends stats through a channel.
-pub(crate) struct SshMonitoringProvider {
-    config: SshConfig,
+/// [`subscribe`](MonitoringProvider::subscribe) establishes the connection up
+/// front and, on success, spawns a background tokio task that periodically
+/// collects the monitoring command output, parses it, and sends stats through
+/// a channel.
+pub(crate) struct SshMonitoringProviderImpl<T: MonitoringTransport> {
+    transport: Arc<T>,
+    collect_timeout: Duration,
     task: Arc<Mutex<Option<MonitoringTask>>>,
 }
 
-impl SshMonitoringProvider {
-    pub(crate) fn new(config: SshConfig) -> Self {
+/// SSH monitoring provider backed by the real [`SshTransport`].
+pub(crate) type SshMonitoringProvider = SshMonitoringProviderImpl<SshTransport>;
+
+impl<T: MonitoringTransport> SshMonitoringProviderImpl<T> {
+    /// Construct a provider over an explicit transport and collect timeout.
+    fn with_transport(transport: T, collect_timeout: Duration) -> Self {
         Self {
-            config,
+            transport: Arc::new(transport),
+            collect_timeout,
             task: Arc::new(Mutex::new(None)),
         }
+    }
+}
+
+impl SshMonitoringProviderImpl<SshTransport> {
+    /// Construct a provider that monitors the host described by `config`.
+    pub(crate) fn new(config: SshConfig) -> Self {
+        Self::with_transport(SshTransport { config }, COLLECT_TIMEOUT)
     }
 }
 
@@ -84,37 +177,54 @@ async fn ssh_exec(session: &SshSession, command: &str) -> Result<String, CoreErr
     Ok(output)
 }
 
+/// Run a single collect bounded by `timeout`.
+///
+/// A stalled exec (half-dropped TCP, unresponsive remote) elapses and is
+/// mapped to a collect failure instead of hanging the loop forever (#1228,
+/// gap G3).
+async fn collect_once<T: MonitoringTransport>(
+    transport: &T,
+    session: &T::Session,
+    timeout: Duration,
+) -> Result<String, CoreError> {
+    match tokio::time::timeout(timeout, transport.collect(session)).await {
+        Ok(result) => result,
+        Err(_elapsed) => Err(CoreError::Other(format!(
+            "Monitoring collect timed out after {timeout:?}"
+        ))),
+    }
+}
+
 #[async_trait::async_trait]
-impl MonitoringProvider for SshMonitoringProvider {
+impl<T: MonitoringTransport> MonitoringProvider for SshMonitoringProviderImpl<T> {
     async fn subscribe(&self) -> Result<MonitoringReceiver, CoreError> {
         // Stop any existing monitoring task.
         if let Ok(mut guard) = self.task.lock() {
             *guard = None;
         }
 
-        let config = self.config.clone();
+        let cancel = CancellationToken::new();
+
+        // Establish the connection *before* returning so the caller sees the
+        // real connect result. A failure propagates as `Err` — no false
+        // "connected" and no receiver that waits forever (#1228, gap G4).
+        let session = self.transport.connect(cancel.clone()).await?;
+
         let (tx, rx): (MonitoringSender, MonitoringReceiver) =
             tokio::sync::mpsc::channel(MONITORING_CHANNEL_CAPACITY);
 
         let alive = Arc::new(AtomicBool::new(true));
         let alive_clone = alive.clone();
+        let transport = self.transport.clone();
+        let collect_timeout = self.collect_timeout;
 
+        // The loop owns the already-open session; it never reconnects.
         tokio::spawn(async move {
-            // Reach the target directly, or through its pooled jump-host gateway
-            // when a ProxyJump chain is configured (#939). `_gateway` is held for
-            // the task's lifetime so the bastion session stays open.
-            let (session, _registry, _gateway) = match connect_target(&config, None).await {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!("Monitoring SSH connection failed: {e}");
-                    return;
-                }
-            };
-
+            let session = session;
             let mut cpu_tracker = CpuDeltaTracker::new();
 
             while alive_clone.load(Ordering::SeqCst) {
-                match ssh_exec(&session, MONITORING_COMMAND).await {
+                match collect_once(&*transport, &session, collect_timeout).await {
                     Ok(output) => match parse_stats(&output) {
                         Ok((mut stats, counters)) => {
                             if let Some(pct) = cpu_tracker.update(counters) {
@@ -129,7 +239,7 @@ impl MonitoringProvider for SshMonitoringProvider {
                         }
                     },
                     Err(e) => {
-                        debug!("Monitoring exec failed: {e}");
+                        debug!("Monitoring collect failed: {e}");
                     }
                 }
 
@@ -145,7 +255,7 @@ impl MonitoringProvider for SshMonitoringProvider {
         });
 
         if let Ok(mut guard) = self.task.lock() {
-            *guard = Some(MonitoringTask { alive });
+            *guard = Some(MonitoringTask { alive, cancel });
         }
 
         Ok(rx)

--- a/core/src/backends/ssh/monitoring.rs
+++ b/core/src/backends/ssh/monitoring.rs
@@ -158,3 +158,96 @@ impl MonitoringProvider for SshMonitoringProvider {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    /// Fake transport with scripted connect / collect behaviour for tests.
+    struct FakeTransport {
+        connect_ok: bool,
+        collect_delay: Duration,
+        collect_calls: Arc<AtomicUsize>,
+    }
+
+    impl FakeTransport {
+        fn new(connect_ok: bool, collect_delay: Duration) -> Self {
+            Self {
+                connect_ok,
+                collect_delay,
+                collect_calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MonitoringTransport for FakeTransport {
+        type Session = ();
+
+        async fn connect(&self, _cancel: CancellationToken) -> Result<Self::Session, CoreError> {
+            if self.connect_ok {
+                Ok(())
+            } else {
+                Err(CoreError::Other("connect refused".to_string()))
+            }
+        }
+
+        async fn collect(&self, _session: &Self::Session) -> Result<String, CoreError> {
+            self.collect_calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(self.collect_delay).await;
+            Ok("collected".to_string())
+        }
+    }
+
+    /// G4: a connect failure must surface as `Err` from `subscribe`, so the
+    /// caller never sees a false "connected".
+    #[tokio::test]
+    async fn subscribe_returns_err_when_connect_fails() {
+        let transport = FakeTransport::new(false, Duration::ZERO);
+        let provider = SshMonitoringProviderImpl::with_transport(transport, COLLECT_TIMEOUT);
+
+        let result = provider.subscribe().await;
+
+        assert!(
+            result.is_err(),
+            "connect failure must surface as Err, not a false connected state"
+        );
+    }
+
+    /// G4: a successful connect yields a live receiver.
+    #[tokio::test]
+    async fn subscribe_returns_ok_when_connect_succeeds() {
+        let transport = FakeTransport::new(true, Duration::ZERO);
+        let provider = SshMonitoringProviderImpl::with_transport(transport, COLLECT_TIMEOUT);
+
+        let result = provider.subscribe().await;
+
+        assert!(result.is_ok(), "successful connect must return a receiver");
+        provider.unsubscribe().await.expect("unsubscribe");
+    }
+
+    /// G3: a stalled collect must time out and be reported as a failure rather
+    /// than hanging forever.
+    #[tokio::test]
+    async fn collect_once_times_out_as_failure() {
+        let transport = FakeTransport::new(true, Duration::from_secs(60));
+
+        let result = collect_once(&transport, &(), Duration::from_millis(50)).await;
+
+        assert!(
+            result.is_err(),
+            "a collect that outlasts the timeout must be a failure"
+        );
+    }
+
+    /// A fast collect returns its output unchanged.
+    #[tokio::test]
+    async fn collect_once_returns_output_when_fast() {
+        let transport = FakeTransport::new(true, Duration::ZERO);
+
+        let result = collect_once(&transport, &(), Duration::from_secs(5)).await;
+
+        assert_eq!(result.expect("collect should succeed"), "collected");
+    }
+}


### PR DESCRIPTION
Closes #1228

Part of the **Remote System Monitoring — Lifecycle Redesign** (parent #1193), Stage **S1 (foundational)**. Stops the false "connected" state and the unbounded collect hang on the push-based `MonitoringProvider` path.

- Concept (source of truth): `docs/concepts/backlog/remote-monitoring-lifecycle-redesign.html`
- Audit: `docs/audits/remote-system-monitoring-state-machine.md`

## Approach

**G4 — honest connect.** `SshMonitoringProvider::subscribe` used to return `Ok(rx)` *before* the SSH connection was even attempted; the connect ran later inside the spawned task and a failure only logged a `warn!` and dropped the task, leaving the UI told "monitoring started" while it waited forever for a first stat. `subscribe` now establishes the connection up front and returns `Err(CoreError)` on failure. The already-open session is handed to the collect loop, which therefore never reconnects.

**CancellationToken plumbing.** A `tokio_util::sync::CancellationToken` is threaded into the connect and cancelled when the subscription's task is dropped, so a future Cancel control can abort an in-flight handshake. The Cancel-control wiring itself is a separate issue in the redesign.

**G3 — bounded collect.** Each collect is wrapped in `tokio::time::timeout` (`collect_once`); an elapsed exec becomes a collect failure instead of hanging the single sequential loop (which is itself the in-flight guard — no overlapping collects). The agent's `monitoring_task` gets the same bound so a stalled collect returns to its `select!` where cancellation is honored. The legacy `run_remote_command` is intentionally left untouched (it is removed in the legacy-retirement issue).

**Testability.** The connect + collect steps are factored behind an internal `MonitoringTransport` trait so both behaviours are covered by fast fake-transport unit tests (no real SSH server).

## Test plan

- `cargo test -p termihub-core --features ssh --lib backends::ssh::monitoring` — 4 new tests pass (fail to compile against the un-refactored provider before the fix):
  - connect fails -> `subscribe` returns `Err` (no false "connected")
  - connect succeeds -> `subscribe` returns a receiver
  - stalled collect -> `collect_once` times out and reports a collect failure
  - fast collect -> returns output unchanged
- `cargo test -p termihub-agent` monitoring suite — passes with the added collect timeout.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)