### PR TITLE
feat(terminal): add connect & waiting-for-agent timeouts → Failed with a hint (Closes #1129)

### DIFF
--- a/docs/changes/dev1/feature/1129-connect-waiting-timeouts.md
+++ b/docs/changes/dev1/feature/1129-connect-waiting-timeouts.md
@@ -1,0 +1,3 @@
+## Added
+
+- Terminal connections that stall now time out on the client side instead of spinning forever. A tab parked "Waiting for agent…" that never comes online now fails after a bounded wait with a clear "Agent did not come online within Ns." message, and a "Connecting…" attempt that never resolves fails with "Connection did not complete within Ns." Both overlays show a live "Times out in Ns" countdown so the bound is visible.

--- a/src/components/Terminal/TerminalConnectionOverlay.timeout.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.timeout.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { TerminalConnectionOverlay } from "./TerminalConnectionOverlay";
+import { useAppStore } from "@/store/appStore";
+import {
+  WAITING_FOR_AGENT_TIMEOUT_MS,
+  CONNECTING_TIMEOUT_MS,
+  connectTimeoutMessage,
+} from "@/utils/connectTimeout";
+
+vi.mock("lucide-react", () => ({
+  ServerCrash: () => null,
+  RefreshCw: () => null,
+  Loader2: () => null,
+}));
+
+const TAB_ID = "tab-timeout";
+const PANEL_ID = "panel-test";
+
+function resetStore() {
+  useAppStore.setState({
+    terminalConnecting: {},
+    terminalSpawnErrors: {},
+    terminalAutoRetryCount: {},
+    terminalWaitingForAgent: {},
+    terminalRetryCounters: {},
+  });
+}
+
+function render(root: ReturnType<typeof createRoot>) {
+  act(() => {
+    root.render(
+      <TerminalConnectionOverlay
+        tabId={TAB_ID}
+        panelId={PANEL_ID}
+        tabTitle="my-server"
+        isVisible={true}
+      />
+    );
+  });
+}
+
+describe("TerminalConnectionOverlay — timeouts", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetStore();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("shows a visible timeout countdown while waiting for the agent", () => {
+    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    render(root);
+    // The overlay must communicate that the wait is bounded.
+    expect(container.textContent).toContain("Times out in");
+  });
+
+  it("transitions the waiting-for-agent tab to Failed after the timeout elapses", () => {
+    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    render(root);
+
+    act(() => {
+      vi.advanceTimersByTime(WAITING_FOR_AGENT_TIMEOUT_MS + 100);
+    });
+
+    expect(useAppStore.getState().terminalWaitingForAgent[TAB_ID]).toBeUndefined();
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBe(
+      connectTimeoutMessage("waiting-for-agent")
+    );
+  });
+
+  it("does not fire the timeout if the agent connects before it elapses", () => {
+    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    render(root);
+
+    // Agent came online: clear the wait before the timeout.
+    act(() => {
+      useAppStore.setState({ terminalWaitingForAgent: {} });
+    });
+    act(() => {
+      vi.advanceTimersByTime(WAITING_FOR_AGENT_TIMEOUT_MS + 100);
+    });
+
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBeUndefined();
+  });
+
+  it("transitions the connecting tab to Failed after the connect timeout elapses", () => {
+    useAppStore.setState({ terminalConnecting: { [TAB_ID]: true } });
+    render(root);
+
+    act(() => {
+      vi.advanceTimersByTime(CONNECTING_TIMEOUT_MS + 100);
+    });
+
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBe(
+      connectTimeoutMessage("connecting")
+    );
+  });
+});

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -3,8 +3,8 @@ import { ServerCrash, RefreshCw, Loader2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { useElapsed } from "@/hooks/useElapsed";
 import {
-  CONNECTING_TIMEOUT_MS,
-  WAITING_FOR_AGENT_TIMEOUT_MS,
+  connectTimeoutMs,
+  connectTimeoutSeconds,
   type ConnectTimeoutKind,
 } from "@/utils/connectTimeout";
 import "./TerminalConnectionOverlay.css";
@@ -86,19 +86,26 @@ export function TerminalConnectionOverlay({
     : isConnecting
       ? "connecting"
       : null;
-  const timeoutMs =
-    timeoutKind === "waiting-for-agent" ? WAITING_FOR_AGENT_TIMEOUT_MS : CONNECTING_TIMEOUT_MS;
 
+  // The timer is armed once per state transition (deps exclude the per-second
+  // elapsed tick), so it is not re-armed every second. Note: because it is tied
+  // to this component's lifetime, unmounting and remounting the overlay while
+  // still connecting (e.g. dragging the tab to another panel) restarts the
+  // countdown — a wall-clock deadline in the store would make it survive
+  // remounts (tracked as a follow-up).
   useEffect(() => {
     if (!timeoutKind) return;
-    const id = setTimeout(() => failTerminalConnectTimeout(tabId, timeoutKind), timeoutMs);
+    const id = setTimeout(
+      () => failTerminalConnectTimeout(tabId, timeoutKind),
+      connectTimeoutMs(timeoutKind)
+    );
     return () => clearTimeout(id);
-  }, [tabId, timeoutKind, timeoutMs, failTerminalConnectTimeout]);
+  }, [tabId, timeoutKind, failTerminalConnectTimeout]);
 
   // Whole seconds remaining before the client-side timeout fires (>= 0), for the
   // visible countdown. Derived from the per-second elapsed tick.
   const remainingSeconds = timeoutKind
-    ? Math.max(0, Math.round(timeoutMs / 1000) - elapsedSeconds)
+    ? Math.max(0, connectTimeoutSeconds(timeoutKind) - elapsedSeconds)
     : 0;
 
   const handleCancel = useCallback(() => {

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -1,7 +1,12 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { ServerCrash, RefreshCw, Loader2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { useElapsed } from "@/hooks/useElapsed";
+import {
+  CONNECTING_TIMEOUT_MS,
+  WAITING_FOR_AGENT_TIMEOUT_MS,
+  type ConnectTimeoutKind,
+} from "@/utils/connectTimeout";
 import "./TerminalConnectionOverlay.css";
 
 interface TerminalConnectionOverlayProps {
@@ -69,6 +74,33 @@ export function TerminalConnectionOverlay({
   const elapsedLabel = formatElapsed(elapsedSeconds);
   const isSlowConnect = elapsedSeconds >= SLOW_CONNECT_THRESHOLD_SECONDS;
 
+  // Client-side timeout: bound the WaitingForAgent and Connecting waits so a tab
+  // can never park on an indefinite spinner. WaitingForAgent has no backend
+  // timeout at all; Connecting relies on the backend one, so this is a safety
+  // net that outlasts it. On expiry the tab transitions to Failed with a
+  // contextual hint (#1129). auto-retry manages its own visible-failure cadence,
+  // so it is intentionally not timed here.
+  const failTerminalConnectTimeout = useAppStore((s) => s.failTerminalConnectTimeout);
+  const timeoutKind: ConnectTimeoutKind | null = waitingForAgent
+    ? "waiting-for-agent"
+    : isConnecting
+      ? "connecting"
+      : null;
+  const timeoutMs =
+    timeoutKind === "waiting-for-agent" ? WAITING_FOR_AGENT_TIMEOUT_MS : CONNECTING_TIMEOUT_MS;
+
+  useEffect(() => {
+    if (!timeoutKind) return;
+    const id = setTimeout(() => failTerminalConnectTimeout(tabId, timeoutKind), timeoutMs);
+    return () => clearTimeout(id);
+  }, [tabId, timeoutKind, timeoutMs, failTerminalConnectTimeout]);
+
+  // Whole seconds remaining before the client-side timeout fires (>= 0), for the
+  // visible countdown. Derived from the per-second elapsed tick.
+  const remainingSeconds = timeoutKind
+    ? Math.max(0, Math.round(timeoutMs / 1000) - elapsedSeconds)
+    : 0;
+
   const handleCancel = useCallback(() => {
     closeTab(tabId, panelId);
   }, [tabId, panelId, closeTab]);
@@ -115,6 +147,12 @@ export function TerminalConnectionOverlay({
           <p className="terminal-connection-overlay__heading">Waiting for agent…</p>
           <p className="terminal-connection-overlay__subheading">
             Waiting for the agent to connect before starting the session.
+          </p>
+          <p
+            className="terminal-connection-overlay__elapsed"
+            data-testid="terminal-connection-timeout"
+          >
+            Times out in {remainingSeconds}s
           </p>
           <div className="terminal-connection-overlay__actions">
             <button
@@ -181,7 +219,7 @@ export function TerminalConnectionOverlay({
             className="terminal-connection-overlay__elapsed"
             data-testid="terminal-connection-elapsed"
           >
-            Elapsed {elapsedLabel}
+            Elapsed {elapsedLabel} · times out in {remainingSeconds}s
           </p>
           {isSlowConnect && (
             <p className="terminal-connection-overlay__hint-text">

--- a/src/store/appStore.connectTimeout.test.ts
+++ b/src/store/appStore.connectTimeout.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore } from "./appStore";
+import { connectTimeoutMessage } from "@/utils/connectTimeout";
+
+describe("failTerminalConnectTimeout — waiting-for-agent", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  it("transitions a parked waiting-for-agent tab to Failed with a contextual hint", () => {
+    useAppStore.getState().setTerminalWaitingForAgent("tab-1", "agent-1");
+    useAppStore.getState().failTerminalConnectTimeout("tab-1", "waiting-for-agent");
+
+    // No longer waiting — cannot hang forever.
+    expect(useAppStore.getState().terminalWaitingForAgent["tab-1"]).toBeUndefined();
+    // Failed state carries the contextual timeout hint.
+    expect(useAppStore.getState().terminalSpawnErrors["tab-1"]).toBe(
+      connectTimeoutMessage("waiting-for-agent")
+    );
+  });
+
+  it("is a no-op if the tab is no longer waiting for the agent (agent came online)", () => {
+    // Tab was waiting, then the agent connected and the wait was cleared.
+    useAppStore.getState().setTerminalWaitingForAgent("tab-1", "agent-1");
+    useAppStore.getState().setTerminalWaitingForAgent("tab-1", null);
+
+    // A late/stale timer fires — it must not resurrect a Failed state.
+    useAppStore.getState().failTerminalConnectTimeout("tab-1", "waiting-for-agent");
+
+    expect(useAppStore.getState().terminalSpawnErrors["tab-1"]).toBeUndefined();
+  });
+});
+
+describe("failTerminalConnectTimeout — connecting", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  it("transitions a stuck connecting tab to Failed with a contextual hint", () => {
+    useAppStore.getState().setTerminalConnecting("tab-1", true);
+    useAppStore.getState().failTerminalConnectTimeout("tab-1", "connecting");
+
+    expect(useAppStore.getState().terminalConnecting["tab-1"]).toBeUndefined();
+    expect(useAppStore.getState().terminalSpawnErrors["tab-1"]).toBe(
+      connectTimeoutMessage("connecting")
+    );
+  });
+
+  it("is a no-op if the tab is no longer connecting (connect succeeded)", () => {
+    useAppStore.getState().setTerminalConnecting("tab-1", true);
+    useAppStore.getState().setTerminalConnecting("tab-1", false);
+
+    useAppStore.getState().failTerminalConnectTimeout("tab-1", "connecting");
+
+    expect(useAppStore.getState().terminalSpawnErrors["tab-1"]).toBeUndefined();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3179,9 +3179,11 @@ export const useAppStore = create<AppState>((set, get) => {
         // state the timeout was armed for. A connect that succeeded, an agent
         // that came online, or a cancelled tab all clear the relevant flag
         // first, making this a no-op.
-        const stillWaiting = state.terminalWaitingForAgent[tabId] !== undefined;
-        const stillConnecting = state.terminalConnecting[tabId] === true;
-        if (kind === "waiting-for-agent" ? !stillWaiting : !stillConnecting) {
+        const stillArmed =
+          kind === "waiting-for-agent"
+            ? state.terminalWaitingForAgent[tabId] !== undefined
+            : state.terminalConnecting[tabId] === true;
+        if (!stillArmed) {
           return {};
         }
         frontendLog(

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -136,6 +136,7 @@ import {
   clearLastSession as apiClearLastSession,
 } from "@/services/lastSessionApi";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
+import { connectTimeoutMessage, type ConnectTimeoutKind } from "@/utils/connectTimeout";
 import { SystemStats } from "@/types/monitoring";
 import { onSessionMonitoringStats, onPersistentSessionStateChanged } from "@/services/events";
 import { applyTheme, onThemeChange } from "@/themes";
@@ -536,6 +537,12 @@ interface AppState {
   terminalWaitingForAgent: Record<string, string>;
   setTerminalAutoRetrying: (tabId: string, count: number) => void;
   setTerminalWaitingForAgent: (tabId: string, agentId: string | null) => void;
+  /**
+   * Client-side timeout for a pre-connect state. Transitions the tab to Failed
+   * with a contextual hint, but only if it is still in the given state — a
+   * stale timer that fires after the tab connected or was woken is a no-op.
+   */
+  failTerminalConnectTimeout: (tabId: string, kind: ConnectTimeoutKind) => void;
 
   // Per-tab terminal session disconnects (runtime-only, cleared on reconnect, dismiss, or tab close)
   terminalExitedTabs: Record<string, boolean>;
@@ -3166,6 +3173,31 @@ export const useAppStore = create<AppState>((set, get) => {
             ? omitKey(state.terminalWaitingForAgent, tabId)
             : { ...state.terminalWaitingForAgent, [tabId]: agentId },
       })),
+    failTerminalConnectTimeout: (tabId, kind) =>
+      set((state) => {
+        // Guard against stale timers: only fail the tab if it is still in the
+        // state the timeout was armed for. A connect that succeeded, an agent
+        // that came online, or a cancelled tab all clear the relevant flag
+        // first, making this a no-op.
+        const stillWaiting = state.terminalWaitingForAgent[tabId] !== undefined;
+        const stillConnecting = state.terminalConnecting[tabId] === true;
+        if (kind === "waiting-for-agent" ? !stillWaiting : !stillConnecting) {
+          return {};
+        }
+        frontendLog(
+          "disconnect",
+          `connect timeout (${kind}) for tab=${tabId} — transitioning to Failed`
+        );
+        return {
+          terminalConnecting: omitKey(state.terminalConnecting, tabId),
+          terminalWaitingForAgent: omitKey(state.terminalWaitingForAgent, tabId),
+          terminalAutoRetryCount: omitKey(state.terminalAutoRetryCount, tabId),
+          terminalSpawnErrors: {
+            ...state.terminalSpawnErrors,
+            [tabId]: connectTimeoutMessage(kind),
+          },
+        };
+      }),
 
     // Per-tab terminal session disconnects (runtime-only)
     terminalExitedTabs: {},

--- a/src/utils/connectTimeout.test.ts
+++ b/src/utils/connectTimeout.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import {
+  CONNECTING_TIMEOUT_MS,
+  WAITING_FOR_AGENT_TIMEOUT_MS,
+  connectTimeoutMessage,
+} from "./connectTimeout";
+
+describe("connectTimeout", () => {
+  it("exposes positive timeout durations", () => {
+    expect(CONNECTING_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(WAITING_FOR_AGENT_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+
+  it("builds a contextual message for the waiting-for-agent timeout that names the agent wait and duration", () => {
+    const msg = connectTimeoutMessage("waiting-for-agent");
+    expect(msg).toContain("Agent did not come online");
+    // The duration in whole seconds must appear in the message.
+    expect(msg).toContain(String(Math.round(WAITING_FOR_AGENT_TIMEOUT_MS / 1000)));
+    expect(msg).toContain("s");
+  });
+
+  it("builds a contextual message for the connecting timeout that mentions the connect wait and duration", () => {
+    const msg = connectTimeoutMessage("connecting");
+    expect(msg.toLowerCase()).toContain("connect");
+    expect(msg).toContain(String(Math.round(CONNECTING_TIMEOUT_MS / 1000)));
+  });
+});

--- a/src/utils/connectTimeout.ts
+++ b/src/utils/connectTimeout.ts
@@ -1,0 +1,45 @@
+/**
+ * Client-side timeouts for the pre-connect terminal lifecycle states.
+ *
+ * `Connecting` relies on the backend connect timeout, but a hung IPC call or a
+ * backend that never resolves would otherwise leave the overlay spinning
+ * forever. `WaitingForAgent` has no backend timeout at all — a tab parks until
+ * the parent agent emits "connected", which may never happen. Both states get a
+ * bounded client-side timeout that transitions the tab to `Failed` with a
+ * contextual hint so the user is never stuck on an indefinite spinner (#1129).
+ */
+
+/** The pre-connect states that carry a client-side timeout. */
+export type ConnectTimeoutKind = "connecting" | "waiting-for-agent";
+
+/**
+ * Max time a `createTerminal` call may stay in-flight before the overlay
+ * gives up and shows a Failed state. Generous enough to outlast the backend's
+ * own connect timeout so this only fires when the backend never answers.
+ */
+export const CONNECTING_TIMEOUT_MS = 90_000;
+
+/**
+ * Max time a tab may park waiting for its parent agent to come online before
+ * transitioning to Failed. The agent transport wakes waiting tabs on
+ * "connected"; this bounds the wait when it never does.
+ */
+export const WAITING_FOR_AGENT_TIMEOUT_MS = 60_000;
+
+/** Whole-second duration used in the user-facing message for a given kind. */
+export function connectTimeoutSeconds(kind: ConnectTimeoutKind): number {
+  const ms = kind === "connecting" ? CONNECTING_TIMEOUT_MS : WAITING_FOR_AGENT_TIMEOUT_MS;
+  return Math.round(ms / 1000);
+}
+
+/**
+ * Build the contextual Failed message shown in the overlay when a pre-connect
+ * state times out.
+ */
+export function connectTimeoutMessage(kind: ConnectTimeoutKind): string {
+  const seconds = connectTimeoutSeconds(kind);
+  if (kind === "waiting-for-agent") {
+    return `Agent did not come online within ${seconds} s.`;
+  }
+  return `Connection did not complete within ${seconds} s.`;
+}

--- a/src/utils/connectTimeout.ts
+++ b/src/utils/connectTimeout.ts
@@ -26,10 +26,14 @@ export const CONNECTING_TIMEOUT_MS = 90_000;
  */
 export const WAITING_FOR_AGENT_TIMEOUT_MS = 60_000;
 
+/** The timeout duration in milliseconds for a given pre-connect kind. */
+export function connectTimeoutMs(kind: ConnectTimeoutKind): number {
+  return kind === "connecting" ? CONNECTING_TIMEOUT_MS : WAITING_FOR_AGENT_TIMEOUT_MS;
+}
+
 /** Whole-second duration used in the user-facing message for a given kind. */
 export function connectTimeoutSeconds(kind: ConnectTimeoutKind): number {
-  const ms = kind === "connecting" ? CONNECTING_TIMEOUT_MS : WAITING_FOR_AGENT_TIMEOUT_MS;
-  return Math.round(ms / 1000);
+  return Math.round(connectTimeoutMs(kind) / 1000);
 }
 
 /**

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -378,6 +378,7 @@ Fixed strings — match exactly.
 | `terminal-connection-elapsed` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-connection-overlay` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-connection-retry-btn` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
+| `terminal-connection-timeout` | `src/components/Terminal/TerminalConnectionOverlay.tsx` |
 | `terminal-context-copy-all` | `src/components/SplitView/SplitView.tsx` |
 | `terminal-context-copy-selection` | `src/components/SplitView/SplitView.tsx` |
 | `terminal-context-paste` | `src/components/SplitView/SplitView.tsx` |


### PR DESCRIPTION
## Summary

The `Connecting` and `WaitingForAgent` pre-connect states had no client-side timeout — `WaitingForAgent` could park a tab on a spinner **indefinitely** waiting for an agent that never comes online. This adds a bounded client-side timeout to both, transitioning to **Failed** with a contextual hint, and surfaces the bound in the overlay.

- `WaitingForAgent` → fails with "Agent did not come online within N s."
- `Connecting` → client-side safety net outlasting the backend timeout, fails with "Connection did not complete within N s."
- Both overlays show a live **"Times out in N s"** countdown.

## Implementation
- `src/utils/connectTimeout.ts` — pure helper (durations + contextual messages).
- `appStore.ts` — guarded `failTerminalConnectTimeout(tabId, kind)` that only transitions if the tab is *still* in the timed state (stale timers that fire after connect/cancel are no-ops).
- `TerminalConnectionOverlay.tsx` — arms the timeout once per state transition and renders the countdown.

## Test plan
- `connectTimeout.test.ts`, `appStore.connectTimeout.test.ts`, `TerminalConnectionOverlay.timeout.test.tsx` (fake timers: countdown visible, fires after timeout, does NOT fire if agent connects first). TDD, test commit precedes feat.
- `./scripts/check.sh` + frontend vitest (2402) + `tsc --noEmit` green (agent-reported; only pre-existing Docker-integration env failures).

## Follow-up
- #1263 — anchor the timeout to a store-side wall-clock deadline (today the component-lifetime timer restarts on overlay remount, e.g. tab drag).

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)