### PR TITLE
feat(agent): tab-dot agreement + Reconnect-with-lastError (Closes #1236)

### DIFF
--- a/docs/changes/dev1/feature/1236-agent-tabdot-reconnect.md
+++ b/docs/changes/dev1/feature/1236-agent-tabdot-reconnect.md
@@ -1,0 +1,17 @@
+# Changes — dev1/feature/1236-agent-tabdot-reconnect
+
+## Added
+
+- **First-class Reconnect on a disconnected agent.** When a remote agent's auto-reconnect
+  exhausts its retries and the agent drops to `disconnected`, its sidebar header now shows a
+  **Reconnect** button. The button's tooltip carries the last error reported by the agent (so
+  you learn _why_ it went down), and clicking it re-runs the normal connect path
+  (disconnected → connecting) with pending/success feedback and an error toast on failure
+  (#1236).
+
+## Fixed
+
+- **Tab-strip dot no longer stays green through an agent drop.** The compact per-tab status
+  dot for a remote-session tab now follows the agent's live state — a drop, reconnect, or
+  disconnect updates the dot to match the terminal overlay instead of leaving a stale green
+  dot during the outage (#1236).

--- a/src/components/Sidebar/AgentNode.reconnect-button.test.tsx
+++ b/src/components/Sidebar/AgentNode.reconnect-button.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * G3 (#1236): a disconnected agent header exposes a first-class Reconnect
+ * affordance.
+ *
+ * After auto-reconnect exhausts its retries the backend emits `disconnected`
+ * with the terminal error; the store records it as `lastError`. The header must
+ * then render a Reconnect button whose tooltip carries that `lastError`, and
+ * clicking it must re-invoke the normal connect path (which drives the agent
+ * back through disconnected → connecting).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { AgentNode } from "./AgentNode";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+
+// --- mocks required by AgentNode --------------------------------------------
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({ attributes: {}, listeners: {}, setNodeRef: vi.fn(), isDragging: false }),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  useDndContext: () => ({ active: null }),
+  useDndMonitor: () => {},
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } },
+}));
+
+vi.mock("@/services/api", () => ({
+  removeCredential: vi.fn(() => Promise.resolve()),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  cancelConnectAgent: vi.fn(() => Promise.resolve()),
+  listAgentDefinitions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("@/utils/resolveConnectionCredential", () => ({
+  resolveConnectionCredential: vi.fn(() =>
+    Promise.resolve({ usedStoredCredential: false, password: null })
+  ),
+}));
+vi.mock("@/utils/ensureCredentialStoreUnlocked", () => ({
+  ensureCredentialStoreUnlocked: vi.fn(() => Promise.resolve(true)),
+}));
+vi.mock("./AgentSetupDialog", () => ({ AgentSetupDialog: () => null }));
+vi.mock("./ConnectionErrorDialog", () => ({ ConnectionErrorDialog: () => null }));
+vi.mock("./InlineFolderInput", () => ({ InlineFolderInput: () => null }));
+
+// The header's other action buttons wrap their icons in the Radix-backed
+// Tooltip, which needs a TooltipProvider. Stub it to a passthrough so these
+// isolated renders don't require the app-root provider — the Reconnect button
+// carries its help text via a native `title`, not this primitive.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return { ...actual, Tooltip: ({ children }: { children: React.ReactNode }) => children };
+});
+
+// --- helpers -----------------------------------------------------------------
+
+const AGENT_ID = "agent-reconnect-btn-test";
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: AGENT_ID,
+    name: "Test Agent",
+    config: {
+      host: "host.example.com",
+      port: 22,
+      username: "user",
+      authMethod: "password",
+      password: "secret",
+    },
+    connectionState: "disconnected",
+    isExpanded: true,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderAgent(agent: RemoteAgentDefinition) {
+  useAppStore.setState({
+    agentDefinitions: { [AGENT_ID]: [] },
+    agentFolders: { [AGENT_ID]: [] },
+    agentSessions: { [AGENT_ID]: [] },
+    remoteAgents: [agent],
+  });
+  act(() => {
+    root.render(React.createElement(AgentNode, { agent }));
+  });
+}
+
+function reconnectButton(): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(`[data-testid="agent-reconnect-${AGENT_ID}"]`);
+}
+
+// --- tests -------------------------------------------------------------------
+
+describe("AgentNode — Reconnect button (G3, #1236)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a Reconnect button when the agent is disconnected", () => {
+    renderAgent(makeAgent({ lastError: "Failed to reconnect after 10 attempts" }));
+
+    expect(reconnectButton()).not.toBeNull();
+  });
+
+  it("does not render a Reconnect button while connected", () => {
+    renderAgent(makeAgent({ connectionState: "connected" }));
+
+    expect(reconnectButton()).toBeNull();
+  });
+
+  it("carries lastError as the Reconnect button's tooltip/title", () => {
+    const error = "Failed to reconnect after 10 attempts";
+    renderAgent(makeAgent({ lastError: error }));
+
+    const btn = reconnectButton();
+    expect(btn).not.toBeNull();
+    // Tooltip content is mirrored onto the accessible title attribute.
+    expect(btn!.getAttribute("title")).toContain(error);
+  });
+
+  it("invokes the connect path when clicked", async () => {
+    const mockConnect = vi.fn().mockResolvedValue(undefined);
+    // The connect handler captures connectRemoteAgent at render time, so the
+    // mock must be installed before the component renders.
+    useAppStore.setState({ connectRemoteAgent: mockConnect });
+    renderAgent(makeAgent({ lastError: "boom" }));
+
+    const btn = reconnectButton();
+    expect(btn).not.toBeNull();
+
+    await act(async () => {
+      btn!.click();
+      // Let the async handleConnect chain settle.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockConnect).toHaveBeenCalled();
+    expect(mockConnect.mock.calls[0][0]).toBe(AGENT_ID);
+  });
+});

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -35,7 +35,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { ConnectionIcon } from "@/utils/connectionIcons";
-import { Tooltip, toast } from "@/components/ui";
+import { Button, Tooltip, toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { frontendLog } from "@/utils/frontendLog";
 import { RemoteAgentDefinition } from "@/types/connection";
@@ -567,6 +567,7 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
   const isConnected = agent.connectionState === "connected";
   const isReconnecting = agent.connectionState === "reconnecting";
   const isConnecting = agent.connectionState === "connecting";
+  const isDisconnected = agent.connectionState === "disconnected";
   const Chevron = agent.isExpanded ? ChevronDown : ChevronRight;
 
   // Derived: root-level folders and definitions (no parent/folder)
@@ -919,6 +920,27 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                     <XCircle size={16} />
                   </button>
                 </Tooltip>
+              </div>
+            )}
+            {isDisconnected && (
+              // First-class Reconnect after a drop / auto-reconnect exhaustion
+              // (G3, #1236). The native `title` carries the stored last error so
+              // the user learns *why* the agent went down (matching the sidebar
+              // tree's title-based hover help); clicking re-runs the normal
+              // connect path (disconnected → connecting). The async Button gives
+              // pending/success feedback and a toast on failure.
+              <div className="connection-list__group-actions">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={<RefreshCw size={14} />}
+                  onClick={handleConnect}
+                  aria-label="Reconnect"
+                  title={agent.lastError ?? "Reconnect"}
+                  data-testid={`agent-reconnect-${agent.id}`}
+                >
+                  Reconnect
+                </Button>
               </div>
             )}
           </div>

--- a/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
+++ b/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * G5 (#1236): the compact tab-strip dot must agree with the agent state.
+ *
+ * The tab-strip dot for a remote-session tab has two independent inputs: the
+ * tab-id-keyed lifecycle maps (drive `deriveTabStatus`) and the legacy
+ * session-id-keyed `remoteStates` map. Before this change the agent path never
+ * wrote `remoteStates`, so a consumer of `remoteStates[sessionId]` saw a stale
+ * "connected"/green value straight through a drop or reconnect.
+ *
+ * These tests render the real TerminalView, capture the `agent-state-change`
+ * Tauri listener it registers, and fire synthetic events — asserting that the
+ * handler now mirrors the agent state into `remoteStates[tab.sessionId]`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+
+// ── Capture the `agent-state-change` listener callback ──────────────────────
+
+type AgentStatePayload = { session_id: string; state: string; error?: string };
+type ListenCb = (event: { payload: AgentStatePayload }) => void | Promise<void>;
+
+const listeners = new Map<string, ListenCb>();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn((eventName: string, cb: ListenCb) => {
+    listeners.set(eventName, cb);
+    return Promise.resolve(() => listeners.delete(eventName));
+  }),
+}));
+
+// ── Stub the heavy child tree so we can render TerminalView in isolation ─────
+
+vi.mock("./TerminalRegistry", () => ({
+  TerminalPortalProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("./TerminalCommandBridge", () => ({ TerminalCommandBridge: () => null }));
+vi.mock("@/testbridge/TestBridge", () => ({ TestBridge: () => null }));
+vi.mock("./Terminal", () => ({ Terminal: () => null }));
+vi.mock("@/components/ui", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("./TabGroupChips", () => ({ TabGroupChips: () => null }));
+vi.mock("@/components/SplitView", () => ({ SplitView: () => null }));
+vi.mock("@/services/events", () => ({ terminalDispatcher: { init: vi.fn() } }));
+vi.mock("@/services/api", () => ({
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  sessionGetCapabilities: vi.fn(() => Promise.resolve({ monitoring: false, fileBrowser: false })),
+  sessionMonitoringOpen: vi.fn(() => Promise.resolve()),
+  sessionMonitoringClose: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+// eslint-disable-next-line import/first
+import { TerminalView } from "./TerminalView";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function firstTerminalTab() {
+  const store = useAppStore.getState();
+  return getAllLeaves(store.rootPanel).flatMap((l) => l.tabs)[0];
+}
+
+async function fireAgentState(payload: AgentStatePayload) {
+  const cb = listeners.get("agent-state-change");
+  if (!cb) throw new Error("agent-state-change listener was not registered");
+  await act(async () => {
+    await cb({ payload });
+  });
+}
+
+describe("TerminalView agent-state-change → tab-strip dot (G5, #1236)", () => {
+  beforeEach(() => {
+    listeners.clear();
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    // A remote-session tab bound to agent-1 with an established session.
+    const store = useAppStore.getState();
+    store.addTab("Shell", "remote-session", {
+      type: "remote-session",
+      config: { agentId: "agent-1", sessionType: "shell" },
+    });
+    const tab = firstTerminalTab();
+    store.setTabSessionId(tab.id, "session-123");
+
+    act(() => {
+      root.render(React.createElement(TerminalView));
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("mirrors a 'reconnecting' agent event into remoteStates[tab.sessionId]", async () => {
+    await fireAgentState({ session_id: "agent-1", state: "reconnecting" });
+
+    expect(useAppStore.getState().remoteStates["session-123"]).toBe("reconnecting");
+  });
+
+  it("mirrors a 'disconnected' agent event into remoteStates[tab.sessionId]", async () => {
+    await fireAgentState({ session_id: "agent-1", state: "disconnected", error: "boom" });
+
+    expect(useAppStore.getState().remoteStates["session-123"]).toBe("disconnected");
+  });
+
+  it("does not write remoteStates for a tab without an established session", async () => {
+    // Open a second tab that never established a session.
+    const store = useAppStore.getState();
+    store.addTab("Shell 2", "remote-session", {
+      type: "remote-session",
+      config: { agentId: "agent-1", sessionType: "shell" },
+    });
+
+    await fireAgentState({ session_id: "agent-1", state: "reconnecting" });
+
+    // Only the established session was mirrored; no `null`/undefined key leaks in.
+    const remoteStates = useAppStore.getState().remoteStates;
+    expect(remoteStates["session-123"]).toBe("reconnecting");
+    expect(Object.keys(remoteStates)).toEqual(["session-123"]);
+  });
+});

--- a/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
+++ b/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
@@ -53,7 +53,6 @@ vi.mock("@/services/api", () => ({
 }));
 vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
 
-// eslint-disable-next-line import/first
 import { TerminalView } from "./TerminalView";
 
 let container: HTMLDivElement;

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -79,7 +79,8 @@ export function TerminalView() {
         const store = useAppStore.getState();
         store.setAgentConnectionState(
           session_id,
-          state as "disconnected" | "connecting" | "connected" | "reconnecting"
+          state as "disconnected" | "connecting" | "connected" | "reconnecting",
+          error
         );
 
         // Build the full tab list once and reuse across all branches.
@@ -97,6 +98,14 @@ export function TerminalView() {
           const cfg = tab.config.config as { agentId?: string };
           return cfg.agentId === session_id;
         });
+
+        // G5 (#1236): mirror the agent state into the session-id-keyed
+        // `remoteStates` map for every active-session tab so the compact
+        // tab-strip dot agrees with the terminal overlay. The agent path used
+        // to skip this, leaving the dot stale-green through a drop/reconnect.
+        for (const tab of agentTerminalTabs) {
+          if (tab.sessionId) store.setRemoteState(tab.sessionId, state);
+        }
 
         if (state === "connected") {
           // Query the agent for sessions it actually recovered. Daemons that

--- a/src/store/appStore.agentConnections.test.ts
+++ b/src/store/appStore.agentConnections.test.ts
@@ -491,6 +491,71 @@ describe("appStore — agent connection management", () => {
     });
   });
 
+  describe("setAgentConnectionState — lastError (G3, #1236)", () => {
+    function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+      return {
+        id: AGENT_ID,
+        name: "Test Agent",
+        config: {
+          host: "test.local",
+          port: 22,
+          username: "user",
+          authMethod: "password",
+        },
+        isExpanded: false,
+        connectionState: "connected",
+        agentSettings: DEFAULT_AGENT_SETTINGS,
+        ...overrides,
+      };
+    }
+
+    it("stores lastError when transitioning to 'disconnected' with an error", () => {
+      useAppStore.setState({ remoteAgents: [makeAgent({ connectionState: "reconnecting" })] });
+
+      useAppStore
+        .getState()
+        .setAgentConnectionState(AGENT_ID, "disconnected", "Failed to reconnect after 10 attempts");
+
+      const agent = useAppStore.getState().remoteAgents[0];
+      expect(agent.connectionState).toBe("disconnected");
+      expect(agent.lastError).toBe("Failed to reconnect after 10 attempts");
+    });
+
+    it("leaves lastError unset when 'disconnected' arrives without an error", () => {
+      useAppStore.setState({ remoteAgents: [makeAgent({ connectionState: "connected" })] });
+
+      useAppStore.getState().setAgentConnectionState(AGENT_ID, "disconnected");
+
+      const agent = useAppStore.getState().remoteAgents[0];
+      expect(agent.connectionState).toBe("disconnected");
+      expect(agent.lastError).toBeUndefined();
+    });
+
+    it("clears a stored lastError on the next 'connecting' attempt", () => {
+      useAppStore.setState({
+        remoteAgents: [makeAgent({ connectionState: "disconnected", lastError: "old failure" })],
+      });
+
+      useAppStore.getState().setAgentConnectionState(AGENT_ID, "connecting");
+
+      const agent = useAppStore.getState().remoteAgents[0];
+      expect(agent.connectionState).toBe("connecting");
+      expect(agent.lastError).toBeUndefined();
+    });
+
+    it("clears a stored lastError once the agent reaches 'connected'", () => {
+      useAppStore.setState({
+        remoteAgents: [makeAgent({ connectionState: "reconnecting", lastError: "old failure" })],
+      });
+
+      useAppStore.getState().setAgentConnectionState(AGENT_ID, "connected");
+
+      const agent = useAppStore.getState().remoteAgents[0];
+      expect(agent.connectionState).toBe("connected");
+      expect(agent.lastError).toBeUndefined();
+    });
+  });
+
   describe("clearAgentSessions", () => {
     it("empties agentSessions for the given agent", () => {
       useAppStore.setState({

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -679,7 +679,8 @@ interface AppState {
   disconnectRemoteAgent: (agentId: string) => Promise<void>;
   setAgentConnectionState: (
     agentId: string,
-    state: RemoteAgentDefinition["connectionState"]
+    state: RemoteAgentDefinition["connectionState"],
+    error?: string
   ) => void;
   setAgentCapabilities: (agentId: string, capabilities: AgentCapabilities) => void;
   clearAgentSessions: (agentId: string) => void;
@@ -3681,13 +3682,22 @@ export const useAppStore = create<AppState>((set, get) => {
       }));
     },
 
-    setAgentConnectionState: (agentId, connectionState) => {
+    setAgentConnectionState: (agentId, connectionState, error) => {
       // Single writer for `connectionState` (G4/#1234): only the backend
       // `agent-state-change` event reaches this setter.
       const previous = get().remoteAgents.find((a) => a.id === agentId)?.connectionState;
+      // Track the terminal error across auto-reconnect exhaustion (G3/#1236):
+      // record it on `disconnected` so the header's Reconnect button can surface
+      // it, and clear it once a fresh attempt starts (`connecting`) or succeeds
+      // (`connected`). Other transitions leave the stored value untouched.
+      const nextLastError = (agent: RemoteAgentDefinition): string | undefined => {
+        if (connectionState === "disconnected") return error ?? agent.lastError;
+        if (connectionState === "connecting" || connectionState === "connected") return undefined;
+        return agent.lastError;
+      };
       set((state) => ({
         remoteAgents: state.remoteAgents.map((a) =>
-          a.id === agentId ? { ...a, connectionState } : a
+          a.id === agentId ? { ...a, connectionState, lastError: nextLastError(a) } : a
         ),
       }));
 

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -153,6 +153,13 @@ export interface RemoteAgentDefinition {
   isExpanded: boolean;
   connectionState: "disconnected" | "connecting" | "connected" | "reconnecting";
   capabilities?: AgentCapabilities;
+  /**
+   * The last error reported when the agent transitioned to `disconnected` after
+   * auto-reconnect exhausted its retries (G3, #1236). Surfaced as the tooltip on
+   * the disconnected header's Reconnect button. Cleared on the next connect
+   * attempt (`connecting`) or a successful `connected` transition.
+   */
+  lastError?: string;
 }
 
 // ── Persistent connection session state ──────────────────────────────────

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -519,6 +519,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `agent-cancel-connect-*` | `agent-cancel-connect-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-header-*` | `agent-header-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-node-*` | `agent-node-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
+| `agent-reconnect-*` | `agent-reconnect-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-state-*` | `agent-state-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `color-picker-swatch-*` | `color-picker-swatch-${color.replace("#", "")}` | `src/components/Terminal/ColorPickerDialog.tsx` |
 | `connection-item-*` | `connection-item-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |


### PR DESCRIPTION
## Summary

Agent lifecycle Stage 3 (#1142), covering **G5** (honest tab-dot) and **G3** (reversible after reconnect exhaustion).

- **G5** — the `agent-state-change` handler (`TerminalView.tsx`) now mirrors the agent `state` into the session-id-keyed `remoteStates[tab.sessionId]` for every active-session tab, so the compact tab-strip dot agrees with the terminal overlay (no more stale green through a drop/reconnect).
- **G3** — `lastError?: string` added to `RemoteAgentDefinition`; `setAgentConnectionState(agentId, state, error?)` records `lastError` on a `disconnected`-with-error transition and clears it on the next `connecting`/`connected`.
- **G3 UI** — disconnected agent header renders a first-class **Reconnect** button (shared `ui/Button`, async pending → success/error toast) whose `title` carries `lastError` and whose click re-runs the normal connect path. No new infinite retry.

## Test plan

- `appStore.agentConnections.test.ts` (4, lastError store/clear), `TerminalView.agent-tabdot.test.tsx` (3, real listener → `remoteStates[tab.sessionId]`), `AgentNode.reconnect-button.test.tsx` (4). TDD, tests precede impl.
- `./scripts/check.sh` + frontend Vitest (2435) green; only pre-existing agent Docker-integration env failures (frontend-only change).

Note: the Reconnect hover uses a native `title` (consistent with the rest of the sidebar tree) rather than the Radix Tooltip, to avoid coupling isolated sidebar renders to a root TooltipProvider.

Closes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)