### PR TITLE
feat(backend): monitoring Stale sub-state + status channel (Closes #1229)

### DIFF
--- a/core/src/backends/ssh/monitoring.rs
+++ b/core/src/backends/ssh/monitoring.rs
@@ -230,8 +230,7 @@ impl<T: MonitoringTransport> MonitoringProvider for SshMonitoringProviderImpl<T>
 
         let (tx, rx): (MonitoringSender, MonitoringReceiver) =
             tokio::sync::mpsc::channel(MONITORING_CHANNEL_CAPACITY);
-        let (status_tx, status_rx) =
-            tokio::sync::mpsc::channel(MONITORING_STATUS_CHANNEL_CAPACITY);
+        let (status_tx, status_rx) = tokio::sync::mpsc::channel(MONITORING_STATUS_CHANNEL_CAPACITY);
 
         let alive = Arc::new(AtomicBool::new(true));
         let alive_clone = alive.clone();

--- a/core/src/backends/ssh/monitoring.rs
+++ b/core/src/backends/ssh/monitoring.rs
@@ -22,8 +22,9 @@ use tracing::debug;
 use crate::config::SshConfig;
 use crate::errors::CoreError;
 use crate::monitoring::{
-    parse_stats, CpuDeltaTracker, MonitoringProvider, MonitoringReceiver, MonitoringSender,
-    MONITORING_COMMAND,
+    parse_stats, CollectLoopState, CpuDeltaTracker, MonitorStatus, MonitorStatusSender,
+    MonitoringProvider, MonitoringReceiver, MonitoringSender, MonitoringSubscription,
+    DEFAULT_STALE_THRESHOLD, MONITORING_COMMAND,
 };
 
 use super::handler::{ForwardedChannelRegistry, SshSession};
@@ -34,6 +35,12 @@ const MONITORING_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Channel capacity for monitoring stats updates.
 const MONITORING_CHANNEL_CAPACITY: usize = 16;
+
+/// Channel capacity for monitoring status updates.
+///
+/// Status transitions are rare (only on Live↔Stale changes), so a small
+/// buffer is ample.
+const MONITORING_STATUS_CHANNEL_CAPACITY: usize = 8;
 
 /// Maximum time a single collect may take before it is treated as a failure.
 ///
@@ -124,6 +131,8 @@ impl Drop for MonitoringTask {
 pub(crate) struct SshMonitoringProviderImpl<T: MonitoringTransport> {
     transport: Arc<T>,
     collect_timeout: Duration,
+    /// Consecutive collect failures tolerated before the loop reports `Stale`.
+    stale_threshold: u32,
     task: Arc<Mutex<Option<MonitoringTask>>>,
 }
 
@@ -136,6 +145,7 @@ impl<T: MonitoringTransport> SshMonitoringProviderImpl<T> {
         Self {
             transport: Arc::new(transport),
             collect_timeout,
+            stale_threshold: DEFAULT_STALE_THRESHOLD,
             task: Arc::new(Mutex::new(None)),
         }
     }
@@ -195,9 +205,17 @@ async fn collect_once<T: MonitoringTransport>(
     }
 }
 
+/// Send a status transition, ignoring a closed receiver.
+///
+/// A dropped status receiver (frontend stopped listening) must not tear down
+/// the collect loop — the stats channel governs the loop's lifetime.
+async fn emit_status(status_tx: &MonitorStatusSender, status: MonitorStatus) {
+    let _ = status_tx.send(status).await;
+}
+
 #[async_trait::async_trait]
 impl<T: MonitoringTransport> MonitoringProvider for SshMonitoringProviderImpl<T> {
-    async fn subscribe(&self) -> Result<MonitoringReceiver, CoreError> {
+    async fn subscribe(&self) -> Result<MonitoringSubscription, CoreError> {
         // Stop any existing monitoring task.
         if let Ok(mut guard) = self.task.lock() {
             *guard = None;
@@ -212,19 +230,28 @@ impl<T: MonitoringTransport> MonitoringProvider for SshMonitoringProviderImpl<T>
 
         let (tx, rx): (MonitoringSender, MonitoringReceiver) =
             tokio::sync::mpsc::channel(MONITORING_CHANNEL_CAPACITY);
+        let (status_tx, status_rx) =
+            tokio::sync::mpsc::channel(MONITORING_STATUS_CHANNEL_CAPACITY);
 
         let alive = Arc::new(AtomicBool::new(true));
         let alive_clone = alive.clone();
         let transport = self.transport.clone();
         let collect_timeout = self.collect_timeout;
+        let stale_threshold = self.stale_threshold;
 
-        // The loop owns the already-open session; it never reconnects.
+        // The loop owns the already-open session; it never reconnects. It
+        // tracks its own status via `CollectLoopState`: the first successful
+        // collect emits `Live`; `stale_threshold` consecutive failures emit
+        // `Stale`; a later success emits `Live` again (#1229, gap G1).
         tokio::spawn(async move {
             let session = session;
             let mut cpu_tracker = CpuDeltaTracker::new();
+            let mut loop_state = CollectLoopState::with_threshold(stale_threshold);
 
             while alive_clone.load(Ordering::SeqCst) {
-                match collect_once(&*transport, &session, collect_timeout).await {
+                // A collect error, a parse error, or a stat send failure all
+                // mean "no fresh sample this tick" → count as a failure.
+                let collected = match collect_once(&*transport, &session, collect_timeout).await {
                     Ok(output) => match parse_stats(&output) {
                         Ok((mut stats, counters)) => {
                             if let Some(pct) = cpu_tracker.update(counters) {
@@ -233,14 +260,26 @@ impl<T: MonitoringTransport> MonitoringProvider for SshMonitoringProviderImpl<T>
                             if tx.send(stats).await.is_err() {
                                 break;
                             }
+                            true
                         }
                         Err(e) => {
                             debug!("Failed to parse monitoring output: {e}");
+                            false
                         }
                     },
                     Err(e) => {
                         debug!("Monitoring collect failed: {e}");
+                        false
                     }
+                };
+
+                let transition = if collected {
+                    loop_state.on_success()
+                } else {
+                    loop_state.on_failure()
+                };
+                if let Some(status) = transition {
+                    emit_status(&status_tx, status).await;
                 }
 
                 // Sleep in 100ms increments to allow quick shutdown.
@@ -258,7 +297,10 @@ impl<T: MonitoringTransport> MonitoringProvider for SshMonitoringProviderImpl<T>
             *guard = Some(MonitoringTask { alive, cancel });
         }
 
-        Ok(rx)
+        Ok(MonitoringSubscription {
+            stats: rx,
+            status: status_rx,
+        })
     }
 
     async fn unsubscribe(&self) -> Result<(), CoreError> {
@@ -272,13 +314,34 @@ impl<T: MonitoringTransport> MonitoringProvider for SshMonitoringProviderImpl<T>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::monitoring::MonitorStatusReceiver;
     use std::sync::atomic::AtomicUsize;
 
+    /// A valid `MONITORING_COMMAND` output that `parse_stats` accepts, so the
+    /// collect loop can produce a real `Live` sample in tests. Matches the
+    /// plain-line layout the parser expects (hostname, loadavg, cpu, meminfo,
+    /// uptime, df, uname).
+    const SAMPLE_STATS: &str = "\
+testhost
+0.15 0.10 0.05 1/234 5678
+cpu  10000 500 3000 80000 1000 0 200 0 0 0
+MemTotal:       16384000 kB
+MemAvailable:   12000000 kB
+12345.67 45678.90
+Filesystem     1024-blocks      Used Available Capacity Mounted on
+/dev/sda1        50000000  20000000  28000000      42% /
+Linux 5.15.0";
+
     /// Fake transport with scripted connect / collect behaviour for tests.
+    ///
+    /// `collect_should_fail` lets a test flip collects between success and
+    /// failure at runtime to exercise the Live↔Stale status transitions.
     struct FakeTransport {
         connect_ok: bool,
         collect_delay: Duration,
         collect_calls: Arc<AtomicUsize>,
+        collect_should_fail: Arc<AtomicBool>,
+        collect_output: String,
     }
 
     impl FakeTransport {
@@ -287,7 +350,23 @@ mod tests {
                 connect_ok,
                 collect_delay,
                 collect_calls: Arc::new(AtomicUsize::new(0)),
+                collect_should_fail: Arc::new(AtomicBool::new(false)),
+                collect_output: "collected".to_string(),
             }
+        }
+
+        /// A transport whose collects return parseable stats and whose failure
+        /// mode is controlled by the returned flag (`true` = fail).
+        fn with_failure_flag() -> (Self, Arc<AtomicBool>) {
+            let flag = Arc::new(AtomicBool::new(false));
+            let transport = Self {
+                connect_ok: true,
+                collect_delay: Duration::ZERO,
+                collect_calls: Arc::new(AtomicUsize::new(0)),
+                collect_should_fail: flag.clone(),
+                collect_output: SAMPLE_STATS.to_string(),
+            };
+            (transport, flag)
         }
     }
 
@@ -306,8 +385,19 @@ mod tests {
         async fn collect(&self, _session: &Self::Session) -> Result<String, CoreError> {
             self.collect_calls.fetch_add(1, Ordering::SeqCst);
             tokio::time::sleep(self.collect_delay).await;
-            Ok("collected".to_string())
+            if self.collect_should_fail.load(Ordering::SeqCst) {
+                return Err(CoreError::Other("collect dropped".to_string()));
+            }
+            Ok(self.collect_output.clone())
         }
+    }
+
+    /// Wait for the next status transition, failing if none arrives in time.
+    async fn next_status(rx: &mut MonitorStatusReceiver) -> MonitorStatus {
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("status should arrive before timeout")
+            .expect("status channel should stay open")
     }
 
     /// G4: a connect failure must surface as `Err` from `subscribe`, so the
@@ -325,7 +415,7 @@ mod tests {
         );
     }
 
-    /// G4: a successful connect yields a live receiver.
+    /// G4: a successful connect yields a live subscription.
     #[tokio::test]
     async fn subscribe_returns_ok_when_connect_succeeds() {
         let transport = FakeTransport::new(true, Duration::ZERO);
@@ -333,7 +423,48 @@ mod tests {
 
         let result = provider.subscribe().await;
 
-        assert!(result.is_ok(), "successful connect must return a receiver");
+        assert!(
+            result.is_ok(),
+            "successful connect must return a subscription"
+        );
+        provider.unsubscribe().await.expect("unsubscribe");
+    }
+
+    /// G1: a mid-stream collect drop flips the status channel to `Stale`, and a
+    /// recovery flips it back to `Live` — the loop-state transitions observed
+    /// through the real collect loop.
+    #[tokio::test]
+    async fn collect_loop_emits_stale_on_drop_and_live_on_recovery() {
+        let (transport, fail) = FakeTransport::with_failure_flag();
+        // Threshold 1 so a single failure is enough to go Stale in the test.
+        let mut provider = SshMonitoringProviderImpl::with_transport(transport, COLLECT_TIMEOUT);
+        provider.stale_threshold = 1;
+
+        let mut sub = provider.subscribe().await.expect("subscribe");
+
+        // First successful collect emits Live.
+        assert_eq!(
+            next_status(&mut sub.status).await,
+            MonitorStatus::Live,
+            "first successful collect must emit Live"
+        );
+
+        // Simulate a mid-stream drop: subsequent collects fail → Stale.
+        fail.store(true, Ordering::SeqCst);
+        assert_eq!(
+            next_status(&mut sub.status).await,
+            MonitorStatus::Stale,
+            "a mid-stream collect drop must emit Stale"
+        );
+
+        // Recover: collects succeed again → Live.
+        fail.store(false, Ordering::SeqCst);
+        assert_eq!(
+            next_status(&mut sub.status).await,
+            MonitorStatus::Live,
+            "recovery must emit Live again"
+        );
+
         provider.unsubscribe().await.expect("unsubscribe");
     }
 

--- a/core/src/monitoring/mod.rs
+++ b/core/src/monitoring/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod parser;
 pub mod provider;
+pub mod status;
 pub mod types;
 
 pub use parser::{
@@ -9,6 +10,10 @@ pub use parser::{
     MONITORING_COMMAND,
 };
 pub use provider::{MonitoringProvider, MonitoringReceiver, MonitoringSender};
+pub use status::{
+    CollectLoopState, MonitorStatus, MonitorStatusReceiver, MonitorStatusSender,
+    DEFAULT_STALE_THRESHOLD,
+};
 pub use types::{CpuCounters, SystemStats};
 
 use crate::errors::CoreError;

--- a/core/src/monitoring/mod.rs
+++ b/core/src/monitoring/mod.rs
@@ -9,7 +9,9 @@ pub use parser::{
     cpu_percent_from_delta, parse_cpu_line, parse_df_output, parse_meminfo_value, parse_stats,
     MONITORING_COMMAND,
 };
-pub use provider::{MonitoringProvider, MonitoringReceiver, MonitoringSender};
+pub use provider::{
+    MonitoringProvider, MonitoringReceiver, MonitoringSender, MonitoringSubscription,
+};
 pub use status::{
     CollectLoopState, MonitorStatus, MonitorStatusReceiver, MonitorStatusSender,
     DEFAULT_STALE_THRESHOLD,

--- a/core/src/monitoring/provider.rs
+++ b/core/src/monitoring/provider.rs
@@ -6,6 +6,7 @@
 //! [`ConnectionType::monitoring()`](crate::connection::ConnectionType::monitoring).
 
 use crate::errors::CoreError;
+use crate::monitoring::status::MonitorStatusReceiver;
 use crate::monitoring::types::SystemStats;
 
 /// Async receiver for periodic [`SystemStats`] updates.
@@ -13,6 +14,20 @@ pub type MonitoringReceiver = tokio::sync::mpsc::Receiver<SystemStats>;
 
 /// Async sender for periodic [`SystemStats`] updates (used by implementations).
 pub type MonitoringSender = tokio::sync::mpsc::Sender<SystemStats>;
+
+/// The two channels returned by [`MonitoringProvider::subscribe`].
+///
+/// `stats` carries the periodic [`SystemStats`] samples; `status` carries the
+/// collector loop's observable lifecycle
+/// ([`MonitorStatus`](crate::monitoring::status::MonitorStatus)) so a
+/// mid-stream drop surfaces as `Stale` rather than silently freezing the last
+/// sample (#1229, audit gap G1).
+pub struct MonitoringSubscription {
+    /// Periodic system-stats samples.
+    pub stats: MonitoringReceiver,
+    /// Collector-loop status transitions (`Connecting` → `Live` → `Stale` → …).
+    pub status: MonitorStatusReceiver,
+}
 
 /// Async monitoring capability exposed by connection types.
 ///
@@ -23,11 +38,12 @@ pub type MonitoringSender = tokio::sync::mpsc::Sender<SystemStats>;
 /// unsubscribed.
 #[async_trait::async_trait]
 pub trait MonitoringProvider: Send {
-    /// Start monitoring and return a receiver for stats updates.
+    /// Start monitoring and return receivers for stats and status updates.
     ///
     /// Implementations typically spawn a background task that periodically
-    /// collects stats and sends them through the channel.
-    async fn subscribe(&self) -> Result<MonitoringReceiver, CoreError>;
+    /// collects stats and sends them (plus status transitions) through the
+    /// channels in the returned [`MonitoringSubscription`].
+    async fn subscribe(&self) -> Result<MonitoringSubscription, CoreError>;
 
     /// Stop monitoring and clean up background tasks.
     async fn unsubscribe(&self) -> Result<(), CoreError>;

--- a/core/src/monitoring/status.rs
+++ b/core/src/monitoring/status.rs
@@ -1,0 +1,233 @@
+//! Monitoring status: the observable lifecycle state of a collector loop.
+//!
+//! A collector loop reports **stats** on one channel and its **status** on a
+//! second channel (see [`MonitorStatusReceiver`]). The status makes a
+//! mid-stream transport drop observable: instead of rendering frozen stats as
+//! if live, the UI can show an explicit [`MonitorStatus::Stale`] arm (#1229,
+//! audit gap G1).
+//!
+//! [`CollectLoopState`] owns the consecutive-failure counting and the
+//! `Live`/`Stale` transitions so the loop stays a thin driver and the
+//! transition logic is unit-testable without a real transport.
+
+use serde::{Deserialize, Serialize};
+
+/// Observable lifecycle state of a monitoring collector loop.
+///
+/// Serialised in `camelCase` (e.g. `"live"`, `"stale"`) to match the
+/// frontend's event payload convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum MonitorStatus {
+    /// Establishing the transport before the first collect.
+    Connecting,
+    /// Collecting successfully; stats are fresh.
+    Live,
+    /// The transport dropped mid-stream; the last stats are frozen and must
+    /// not be shown as live (audit gap G1).
+    Stale,
+    /// Re-establishing the transport after it died (reserved for the reconnect
+    /// stage; not yet driven by the collector loop).
+    Reconnecting,
+    /// Reconnect budget exhausted; the loop is idle awaiting a retry (reserved
+    /// for the reconnect stage).
+    Offline,
+    /// Collection is paused by the user while the transport stays open
+    /// (reserved for the pause/resume stage).
+    Paused,
+}
+
+/// Async sender for [`MonitorStatus`] updates (used by collector loops).
+pub type MonitorStatusSender = tokio::sync::mpsc::Sender<MonitorStatus>;
+
+/// Async receiver for [`MonitorStatus`] updates.
+pub type MonitorStatusReceiver = tokio::sync::mpsc::Receiver<MonitorStatus>;
+
+/// Default number of consecutive collect failures before a `Live` loop is
+/// declared [`MonitorStatus::Stale`].
+///
+/// One failure can be a transient hiccup; requiring a small run avoids
+/// flapping the indicator on a single dropped sample.
+pub const DEFAULT_STALE_THRESHOLD: u32 = 2;
+
+/// Tracks a collector loop's status across collect successes and failures.
+///
+/// The loop calls [`on_success`](CollectLoopState::on_success) after a good
+/// collect and [`on_failure`](CollectLoopState::on_failure) after a failed
+/// one. Each returns `Some(status)` **only when the status changed**, so the
+/// loop emits an event exactly on transitions (not every tick).
+///
+/// Transitions owned here:
+/// - `* → Live` on the first success after any non-live state.
+/// - `Live → Stale` once `stale_threshold` consecutive failures accumulate.
+#[derive(Debug)]
+pub struct CollectLoopState {
+    status: MonitorStatus,
+    consecutive_failures: u32,
+    stale_threshold: u32,
+}
+
+impl CollectLoopState {
+    /// Create a loop-state starting in [`MonitorStatus::Connecting`] with the
+    /// default stale threshold.
+    pub fn new() -> Self {
+        Self::with_threshold(DEFAULT_STALE_THRESHOLD)
+    }
+
+    /// Create a loop-state with an explicit stale threshold (clamped to >= 1).
+    pub fn with_threshold(stale_threshold: u32) -> Self {
+        Self {
+            status: MonitorStatus::Connecting,
+            consecutive_failures: 0,
+            stale_threshold: stale_threshold.max(1),
+        }
+    }
+
+    /// Current status.
+    pub fn status(&self) -> MonitorStatus {
+        self.status
+    }
+
+    /// Record a successful collect.
+    ///
+    /// Resets the failure run and, if the loop was not already `Live`,
+    /// transitions to [`MonitorStatus::Live`] and returns it. Returns `None`
+    /// when already `Live` (no change to emit).
+    pub fn on_success(&mut self) -> Option<MonitorStatus> {
+        self.consecutive_failures = 0;
+        if self.status != MonitorStatus::Live {
+            self.status = MonitorStatus::Live;
+            Some(MonitorStatus::Live)
+        } else {
+            None
+        }
+    }
+
+    /// Record a failed collect.
+    ///
+    /// Increments the failure run. Once `stale_threshold` consecutive failures
+    /// are reached and the loop is currently `Live`, transitions to
+    /// [`MonitorStatus::Stale`] and returns it. Returns `None` otherwise.
+    pub fn on_failure(&mut self) -> Option<MonitorStatus> {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        if self.status == MonitorStatus::Live && self.consecutive_failures >= self.stale_threshold {
+            self.status = MonitorStatus::Stale;
+            Some(MonitorStatus::Stale)
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for CollectLoopState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn monitor_status_serialises_camel_case() {
+        assert_eq!(
+            serde_json::to_string(&MonitorStatus::Live).expect("serialise"),
+            "\"live\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MonitorStatus::Stale).expect("serialise"),
+            "\"stale\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MonitorStatus::Reconnecting).expect("serialise"),
+            "\"reconnecting\""
+        );
+    }
+
+    #[test]
+    fn starts_in_connecting() {
+        let state = CollectLoopState::new();
+        assert_eq!(state.status(), MonitorStatus::Connecting);
+    }
+
+    #[test]
+    fn first_success_transitions_to_live_and_emits() {
+        let mut state = CollectLoopState::new();
+        assert_eq!(state.on_success(), Some(MonitorStatus::Live));
+        assert_eq!(state.status(), MonitorStatus::Live);
+    }
+
+    #[test]
+    fn repeated_success_while_live_emits_nothing() {
+        let mut state = CollectLoopState::new();
+        state.on_success();
+        assert_eq!(state.on_success(), None);
+        assert_eq!(state.on_success(), None);
+        assert_eq!(state.status(), MonitorStatus::Live);
+    }
+
+    #[test]
+    fn consecutive_failures_flip_live_to_stale_at_threshold() {
+        // Default threshold is 2: one failure is not yet stale.
+        let mut state = CollectLoopState::new();
+        state.on_success();
+
+        assert_eq!(
+            state.on_failure(),
+            None,
+            "one failure is a transient hiccup"
+        );
+        assert_eq!(state.status(), MonitorStatus::Live);
+
+        assert_eq!(
+            state.on_failure(),
+            Some(MonitorStatus::Stale),
+            "second consecutive failure flips to Stale"
+        );
+        assert_eq!(state.status(), MonitorStatus::Stale);
+    }
+
+    #[test]
+    fn threshold_of_one_flips_on_first_failure() {
+        let mut state = CollectLoopState::with_threshold(1);
+        state.on_success();
+        assert_eq!(state.on_failure(), Some(MonitorStatus::Stale));
+    }
+
+    #[test]
+    fn recovery_from_stale_transitions_back_to_live() {
+        let mut state = CollectLoopState::with_threshold(1);
+        state.on_success();
+        assert_eq!(state.on_failure(), Some(MonitorStatus::Stale));
+
+        assert_eq!(
+            state.on_success(),
+            Some(MonitorStatus::Live),
+            "a successful collect after Stale recovers to Live"
+        );
+        assert_eq!(state.status(), MonitorStatus::Live);
+    }
+
+    #[test]
+    fn stays_stale_without_re_emitting_on_further_failures() {
+        let mut state = CollectLoopState::with_threshold(1);
+        state.on_success();
+        assert_eq!(state.on_failure(), Some(MonitorStatus::Stale));
+        // Already Stale: further failures must not re-emit Stale.
+        assert_eq!(state.on_failure(), None);
+        assert_eq!(state.on_failure(), None);
+        assert_eq!(state.status(), MonitorStatus::Stale);
+    }
+
+    #[test]
+    fn a_single_success_resets_the_failure_run() {
+        // With threshold 2, a success between failures prevents Stale.
+        let mut state = CollectLoopState::new();
+        state.on_success();
+        assert_eq!(state.on_failure(), None); // 1 failure
+        assert_eq!(state.on_success(), None); // reset run, already Live
+        assert_eq!(state.on_failure(), None); // 1 failure again, not stale
+        assert_eq!(state.status(), MonitorStatus::Live);
+    }
+}

--- a/core/tests/monitoring.rs
+++ b/core/tests/monitoring.rs
@@ -49,7 +49,8 @@ async fn mon_01_cpu_stats() {
     let mut rx = provider
         .subscribe()
         .await
-        .expect("Subscribe should succeed");
+        .expect("Subscribe should succeed")
+        .stats;
 
     // Wait for at least two stats updates — CPU usage needs a delta between
     // two /proc/stat readings to compute percentage.
@@ -101,7 +102,8 @@ async fn mon_02_memory_stats() {
     let mut rx = provider
         .subscribe()
         .await
-        .expect("Subscribe should succeed");
+        .expect("Subscribe should succeed")
+        .stats;
 
     // Memory stats should be available from the first sample.
     let stats = tokio::time::timeout(Duration::from_secs(10), rx.recv())
@@ -146,7 +148,8 @@ async fn mon_03_disk_stats() {
     let mut rx = provider
         .subscribe()
         .await
-        .expect("Subscribe should succeed");
+        .expect("Subscribe should succeed")
+        .stats;
 
     // Disk stats should be available from the first sample.
     let stats = tokio::time::timeout(Duration::from_secs(10), rx.recv())
@@ -191,7 +194,8 @@ async fn mon_04_stats_under_load() {
     let mut rx = provider
         .subscribe()
         .await
-        .expect("Subscribe should succeed");
+        .expect("Subscribe should succeed")
+        .stats;
 
     // Generate CPU load in the container via a separate SSH session.
     let config = common::ssh_password_config(port_ssh_password());

--- a/core/tests/ssh_advanced.rs
+++ b/core/tests/ssh_advanced.rs
@@ -564,7 +564,8 @@ async fn ssh_jump_05_monitoring_through_jump_host() {
     let mut rx = monitoring
         .subscribe()
         .await
-        .expect("SSH-JUMP-05: monitoring subscribe should succeed");
+        .expect("SSH-JUMP-05: monitoring subscribe should succeed")
+        .stats;
 
     let stats = tokio::time::timeout(Duration::from_secs(20), rx.recv())
         .await

--- a/docs/changes/dev1/feature/1229-monitoring-stale-status.md
+++ b/docs/changes/dev1/feature/1229-monitoring-stale-status.md
@@ -1,0 +1,18 @@
+# Monitoring: explicit Stale status on a mid-stream drop
+
+## Added
+
+- Remote system monitoring now tracks an explicit lifecycle **status**
+  (`Connecting` / `Live` / `Stale` / `Reconnecting` / `Offline` / `Paused`)
+  alongside the stats stream. The collector loop counts consecutive collect
+  failures and reports `Stale` when the transport drops mid-stream, then `Live`
+  again on recovery. ([#1229])
+
+## Changed
+
+- The status-bar monitoring segment no longer renders frozen CPU / memory / disk
+  numbers as if they were live. When the connection to a monitored host drops,
+  the numbers are dimmed and a warning **Stale** badge appears; they return to
+  normal automatically once monitoring recovers. ([#1229])
+
+[#1229]: https://github.com/armaxri/termiHub/issues/1229

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -18,7 +18,7 @@ use termihub_core::connection::{
     Capabilities, ConnectionType, ConnectionTypeInfo, ConnectionTypeRegistry,
 };
 use termihub_core::files::FileEntry;
-use termihub_core::monitoring::SystemStats;
+use termihub_core::monitoring::{MonitorStatus, MonitorStatusReceiver, SystemStats};
 use termihub_core::output::coalescer::OutputCoalescer;
 use termihub_core::output::screen_clear::ScreenClearDetector;
 use tracing::{error, info, warn};
@@ -155,6 +155,30 @@ struct SessionEntry {
 pub struct SessionMonitoringStatsEvent {
     pub session_id: String,
     pub stats: SystemStats,
+}
+
+/// Push event emitted via Tauri when a session's monitoring status changes.
+///
+/// Carries the collector loop's lifecycle state so the frontend can render an
+/// explicit `Stale` indicator instead of showing frozen stats as live (#1229,
+/// audit gap G1). `session_id` is snake_case to match the frontend payload.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionMonitoringStatusEvent {
+    pub session_id: String,
+    pub status: MonitorStatus,
+}
+
+/// Receive from an optional status receiver for use inside `tokio::select!`.
+///
+/// When the receiver is `None`, the future never resolves (`pending`), so the
+/// select arm is inert and the other arm drives the loop. This lets the status
+/// arm be disabled after its channel closes without spinning on repeated
+/// `None`s.
+async fn recv_optional(rx: &mut Option<MonitorStatusReceiver>) -> Option<MonitorStatus> {
+    match rx.as_mut() {
+        Some(rx) => rx.recv().await,
+        None => std::future::pending().await,
+    }
 }
 
 /// Manages all active connection sessions.
@@ -622,17 +646,21 @@ impl SessionManager {
             .map(|e| e.connection.capabilities())
     }
 
-    /// Subscribe to a session's monitoring provider and forward stats as Tauri events.
+    /// Subscribe to a session's monitoring provider and forward stats and
+    /// status as Tauri events.
     ///
-    /// Spawns a background task that reads from the `MonitoringReceiver` and emits
-    /// `session-monitoring-stats` events to the frontend.  Call
+    /// Spawns a background task that reads the subscription's stats and status
+    /// channels and emits `session-monitoring-stats` and
+    /// `session-monitoring-status` events to the frontend. The status stream
+    /// lets the UI surface an explicit `Stale` arm on a mid-stream drop instead
+    /// of rendering frozen stats as live (#1229, audit gap G1). Call
     /// [`stop_session_monitoring`] to cancel the task and unsubscribe.
     pub async fn start_session_monitoring<R: tauri::Runtime>(
         &self,
         session_id: &str,
         app_handle: tauri::AppHandle<R>,
     ) -> Result<(), TerminalError> {
-        let rx = {
+        let subscription = {
             let sessions = self.sessions.lock().await;
             let entry = sessions
                 .get(session_id)
@@ -648,14 +676,45 @@ impl SessionManager {
 
         let sid = session_id.to_string();
         let join_handle = tokio::spawn(async move {
-            let mut rx = rx;
-            while let Some(stats) = rx.recv().await {
-                let event = SessionMonitoringStatsEvent {
-                    session_id: sid.clone(),
-                    stats,
-                };
-                if app_handle.emit("session-monitoring-stats", &event).is_err() {
-                    break;
+            let mut stats_rx = subscription.stats;
+            // `Option` so a closed status channel stops being polled instead of
+            // spinning the select loop hot on repeated `None` (the agent path
+            // sends a single `Live` then drops its status sender).
+            let mut status_rx = Some(subscription.status);
+            loop {
+                tokio::select! {
+                    stats = stats_rx.recv() => {
+                        match stats {
+                            Some(stats) => {
+                                let event = SessionMonitoringStatsEvent {
+                                    session_id: sid.clone(),
+                                    stats,
+                                };
+                                if app_handle.emit("session-monitoring-stats", &event).is_err() {
+                                    break;
+                                }
+                            }
+                            // Stats channel closed: the collector loop ended.
+                            None => break,
+                        }
+                    }
+                    status = recv_optional(&mut status_rx) => {
+                        match status {
+                            Some(status) => {
+                                let event = SessionMonitoringStatusEvent {
+                                    session_id: sid.clone(),
+                                    status,
+                                };
+                                if app_handle.emit("session-monitoring-status", &event).is_err() {
+                                    break;
+                                }
+                            }
+                            // Status channel closed: stop polling it, keep
+                            // forwarding stats. Only a closed stats channel ends
+                            // the task.
+                            None => status_rx = None,
+                        }
+                    }
                 }
             }
             info!(session_id = %sid, "Session monitoring push task ended");

--- a/src-tauri/src/session/remote_proxy.rs
+++ b/src-tauri/src/session/remote_proxy.rs
@@ -20,7 +20,7 @@ use tracing::debug;
 use termihub_core::connection::{Capabilities, ConnectionType, OutputReceiver, SettingsSchema};
 use termihub_core::errors::{CoreError, FileError, SessionError};
 use termihub_core::files::{FileBrowser, FileEntry};
-use termihub_core::monitoring::{MonitoringProvider, MonitoringReceiver};
+use termihub_core::monitoring::{MonitorStatus, MonitoringProvider, MonitoringSubscription};
 
 use crate::terminal::agent_manager::AgentRpcClient;
 use crate::terminal::backend::OUTPUT_CHANNEL_CAPACITY;
@@ -647,7 +647,7 @@ impl RemoteMonitoringProxy {
 
 #[async_trait::async_trait]
 impl MonitoringProvider for RemoteMonitoringProxy {
-    async fn subscribe(&self) -> Result<MonitoringReceiver, CoreError> {
+    async fn subscribe(&self) -> Result<MonitoringSubscription, CoreError> {
         let (tx, rx) = tokio::sync::mpsc::channel(16);
 
         // Register monitoring channel so agent_manager routes notifications to it.
@@ -665,7 +665,19 @@ impl MonitoringProvider for RemoteMonitoringProxy {
         )
         .await?;
 
-        Ok(rx)
+        // The agent-mediated path does not yet forward a status stream (that
+        // arrives in a later stage of the lifecycle redesign). Report an
+        // initial `Live` so the frontend renders live agent stats rather than
+        // staying stuck at `Connecting`. Agent-side Stale/Reconnecting will be
+        // wired through this same channel in a follow-up (#1229 is S2, desktop
+        // SSH only).
+        let (status_tx, status_rx) = tokio::sync::mpsc::channel(1);
+        let _ = status_tx.send(MonitorStatus::Live).await;
+
+        Ok(MonitoringSubscription {
+            stats: rx,
+            status: status_rx,
+        })
     }
 
     async fn unsubscribe(&self) -> Result<(), CoreError> {

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -207,10 +207,10 @@
 }
 
 /*
-  Stale (#1229, audit gap G1): the transport dropped mid-stream, so the numbers
-  are frozen at their last-known values. Mute them (like the priming placeholder)
-  so they never read as live, overriding the severity colour. `!important` beats
-  the more specific severity classes on the same element.
+  Stale (issue 1229, audit gap G1): the transport dropped mid-stream, so the
+  numbers are frozen at their last-known values. Mute them (like the priming
+  placeholder) so they never read as live, overriding the severity colour.
+  `!important` beats the more specific severity classes on the same element.
 */
 .monitoring-status__stat--stale {
   color: var(--text-secondary) !important;

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -206,6 +206,24 @@
   color: var(--text-secondary);
 }
 
+/*
+  Stale (#1229, audit gap G1): the transport dropped mid-stream, so the numbers
+  are frozen at their last-known values. Mute them (like the priming placeholder)
+  so they never read as live, overriding the severity colour. `!important` beats
+  the more specific severity classes on the same element.
+*/
+.monitoring-status__stat--stale {
+  color: var(--text-secondary) !important;
+}
+
+/* Warning badge shown alongside the frozen numbers while stale. */
+.monitoring-status__stale-badge {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--color-warning);
+}
+
 .monitoring-status__loading {
   display: flex;
   align-items: center;

--- a/src/components/StatusBar/StatusBar.monitoring-stale.test.tsx
+++ b/src/components/StatusBar/StatusBar.monitoring-stale.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for the status-bar Stale indicator (issue #1229, audit gap G1).
+ *
+ * When the monitoring transport drops mid-stream the collector loop reports a
+ * `stale` status. The status bar must stop rendering the frozen numbers as
+ * "live": it shows a warning "Stale" badge and dims the stats. Once monitoring
+ * recovers (`live`), the badge disappears and the stats un-dim.
+ *
+ * These tests drive the store's `monitoringStatus` signal directly and assert
+ * the render branch.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui";
+import { useAppStore } from "@/store/appStore";
+import { StatusBar } from "./StatusBar";
+import type { SystemStats } from "@/types/monitoring";
+import type { ConnectionTypeInfo } from "@/types/connection";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
+
+vi.mock("@/components/CredentialStoreIndicator", () => ({ CredentialStoreIndicator: () => null }));
+vi.mock("./PortableBadge", () => ({ PortableBadge: () => null }));
+vi.mock("./UpdateIndicator", () => ({ UpdateIndicator: () => null }));
+
+function makeStats(overrides: Partial<SystemStats> = {}): SystemStats {
+  return {
+    hostname: "host",
+    uptimeSeconds: 100,
+    loadAverage: [0, 0, 0],
+    cpuUsagePercent: 30,
+    memoryTotalKb: 1000,
+    memoryAvailableKb: 500,
+    memoryUsedPercent: 50,
+    diskTotalKb: 2000,
+    diskUsedKb: 1000,
+    diskUsedPercent: 50,
+    osInfo: "Linux",
+    ...overrides,
+  };
+}
+
+/** Registers a monitoring-capable SSH type and makes an SSH tab the active tab. */
+function primeMonitoringTab() {
+  const sshType: ConnectionTypeInfo = {
+    typeId: "ssh",
+    displayName: "SSH",
+    icon: "server",
+    schema: { groups: [] } as unknown as ConnectionTypeInfo["schema"],
+    capabilities: { monitoring: true, fileBrowser: true, resize: true, persistent: false },
+  };
+
+  const tab: TerminalTab = {
+    id: "tab-1",
+    sessionId: "sess-1",
+    title: "ssh-host",
+    connectionType: "ssh",
+    contentType: "terminal",
+    config: { type: "ssh", config: {} },
+    panelId: "leaf-1",
+    isActive: true,
+  };
+
+  const leaf: LeafPanel = {
+    type: "leaf",
+    id: "leaf-1",
+    tabs: [tab],
+    activeTabId: "tab-1",
+  };
+
+  useAppStore.setState((state) => ({
+    connectionTypes: [sshType],
+    settings: { ...state.settings, powerMonitoringEnabled: true },
+    rootPanel: leaf,
+    activePanelId: "leaf-1",
+  }));
+}
+
+describe("StatusBar — monitoring Stale indicator (#1229, G1)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    primeMonitoringTab();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderStatusBar() {
+    act(() =>
+      root.render(React.createElement(TooltipProvider, null, React.createElement(StatusBar)))
+    );
+  }
+
+  it("shows a Stale badge and dims the stats when status is 'stale'", () => {
+    useAppStore.setState({
+      monitoringSessionId: "sess-1",
+      monitoringHost: "user@host:22",
+      monitoringStats: makeStats(),
+      monitoringSampleCount: 3,
+      monitoringStatus: "stale",
+    });
+    renderStatusBar();
+
+    // The Stale badge is present.
+    const badge = container.querySelector('[data-testid="monitoring-stale"]');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toContain("Stale");
+
+    // The numbers are still shown (frozen) but dimmed via the stale modifier.
+    const cpu = container.querySelector('[data-testid="monitoring-cpu"]');
+    expect(cpu).not.toBeNull();
+    expect(cpu!.className).toContain("monitoring-status__stat--stale");
+  });
+
+  it("does not show the Stale badge when status is 'live'", () => {
+    useAppStore.setState({
+      monitoringSessionId: "sess-1",
+      monitoringHost: "user@host:22",
+      monitoringStats: makeStats(),
+      monitoringSampleCount: 3,
+      monitoringStatus: "live",
+    });
+    renderStatusBar();
+
+    expect(container.querySelector('[data-testid="monitoring-stale"]')).toBeNull();
+    const cpu = container.querySelector('[data-testid="monitoring-cpu"]');
+    expect(cpu!.className).not.toContain("monitoring-status__stat--stale");
+  });
+});

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -1,6 +1,15 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { Activity, RefreshCw, Unplug, Loader2, Server, Route, RotateCw } from "lucide-react";
+import {
+  Activity,
+  AlertTriangle,
+  RefreshCw,
+  Unplug,
+  Loader2,
+  Server,
+  Route,
+  RotateCw,
+} from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
 import { frontendLog } from "@/utils/frontendLog";
 import { jumpHostStatusLabel } from "@/utils/jumpHost";
@@ -241,6 +250,7 @@ function MonitoringStatus() {
   const monitoringSampleCount = useAppStore((s) => s.monitoringSampleCount);
   const monitoringLoading = useAppStore((s) => s.monitoringLoading);
   const monitoringError = useAppStore((s) => s.monitoringError);
+  const monitoringStatus = useAppStore((s) => s.monitoringStatus);
   const monitoringCancelled = useAppStore((s) => s.monitoringCancelled);
   const connectMonitoring = useAppStore((s) => s.connectMonitoring);
   const disconnectMonitoring = useAppStore((s) => s.disconnectMonitoring);
@@ -539,7 +549,11 @@ function MonitoringStatus() {
     );
   }
 
-  // Connected (or reconnecting with cached stats): show compact stats
+  // Connected (or reconnecting with cached stats): show compact stats.
+  // A "stale" status (mid-stream drop) dims the numbers and shows a warning
+  // badge so frozen data is never rendered as live (#1229, audit gap G1).
+  const isStale = monitoringStatus === "stale";
+  const staleModifier = isStale ? " monitoring-status__stat--stale" : "";
   return (
     <>
       <MonitoringDetailDropdown
@@ -552,6 +566,22 @@ function MonitoringStatus() {
       {monitoringStats && (
         <>
           {/*
+            A mid-stream transport drop moves the collector loop to "stale"
+            (#1229, audit gap G1). The last-known numbers are kept but dimmed and
+            prefixed with a warning badge so frozen data is never shown as live.
+            Recovery flips the status back to "live" and un-dims them.
+          */}
+          {isStale && (
+            <span
+              className="status-bar__item monitoring-status__stale-badge"
+              title="Monitoring data is stale — the connection dropped and the numbers below are frozen at their last-known values."
+              data-testid="monitoring-stale"
+            >
+              <AlertTriangle size={12} />
+              Stale
+            </span>
+          )}
+          {/*
             The remote collectors report CPU 0% on the first sample because there
             is no prior delta to compute a rate from (audit gap G10). Until the
             second sample arrives, show a priming indicator so the placeholder is
@@ -560,7 +590,7 @@ function MonitoringStatus() {
           */}
           {monitoringSampleCount < 2 ? (
             <span
-              className="status-bar__item monitoring-status__stat monitoring-status__stat--priming"
+              className={`status-bar__item monitoring-status__stat monitoring-status__stat--priming${staleModifier}`}
               title="CPU: priming (waiting for second sample)"
               data-testid="monitoring-cpu"
             >
@@ -568,7 +598,7 @@ function MonitoringStatus() {
             </span>
           ) : (
             <span
-              className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.cpuUsagePercent)}`}
+              className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.cpuUsagePercent)}${staleModifier}`}
               title={`CPU: ${monitoringStats.cpuUsagePercent.toFixed(1)}%`}
               data-testid="monitoring-cpu"
             >
@@ -576,14 +606,14 @@ function MonitoringStatus() {
             </span>
           )}
           <span
-            className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.memoryUsedPercent)}`}
+            className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.memoryUsedPercent)}${staleModifier}`}
             title={`Memory: ${formatKb(monitoringStats.memoryTotalKb - monitoringStats.memoryAvailableKb)} / ${formatKb(monitoringStats.memoryTotalKb)}`}
             data-testid="monitoring-mem"
           >
             Mem {monitoringStats.memoryUsedPercent.toFixed(0)}%
           </span>
           <span
-            className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.diskUsedPercent)}`}
+            className={`status-bar__item monitoring-status__stat monitoring-status__stat--${severityLevel(monitoringStats.diskUsedPercent)}${staleModifier}`}
             title={`Disk: ${formatKb(monitoringStats.diskUsedKb)} / ${formatKb(monitoringStats.diskTotalKb)}`}
             data-testid="monitoring-disk"
           >

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -418,7 +418,7 @@ export async function onEmbeddedServerStatusChanged(
   });
 }
 
-import type { SystemStats } from "@/types/monitoring";
+import type { MonitorStatus, SystemStats } from "@/types/monitoring";
 
 interface SessionMonitoringStatsPayload {
   session_id: string;
@@ -431,6 +431,26 @@ export async function onSessionMonitoringStats(
 ): Promise<UnlistenFn> {
   return await listen<SessionMonitoringStatsPayload>("session-monitoring-stats", (event) => {
     callback(event.payload.session_id, event.payload.stats);
+  });
+}
+
+interface SessionMonitoringStatusPayload {
+  session_id: string;
+  status: MonitorStatus;
+}
+
+/**
+ * Subscribe to session-based monitoring status push events.
+ *
+ * Delivers the collector loop's lifecycle transitions (`connecting` → `live` →
+ * `stale` → …) so the status bar can render an explicit stale indicator on a
+ * mid-stream drop (#1229, audit gap G1).
+ */
+export async function onSessionMonitoringStatus(
+  callback: (sessionId: string, status: MonitorStatus) => void
+): Promise<UnlistenFn> {
+  return await listen<SessionMonitoringStatusPayload>("session-monitoring-status", (event) => {
+    callback(event.payload.session_id, event.payload.status);
   });
 }
 

--- a/src/store/appStore.monitoring.test.ts
+++ b/src/store/appStore.monitoring.test.ts
@@ -42,18 +42,27 @@ vi.mock("@/services/api", () => ({
   sessionMonitoringClose: (...args: unknown[]) => mockSessionMonitoringClose(...args),
 }));
 
-// Session-based monitoring subscribes to a Tauri event and stores the returned
-// unlisten fn; the tests below assert that listener is not leaked on a failed open.
+// Session-based monitoring subscribes to Tauri events and stores the returned
+// unlisten fns; the tests below assert those listeners are not leaked on a
+// failed open. Status callbacks are captured so a test can push a transition.
 const mockUnlisten = vi.fn();
+const mockStatusUnlisten = vi.fn();
+type StatusCallback = (sessionId: string, status: MonitorStatus) => void;
+let capturedStatusCallback: StatusCallback | null = null;
 const mockOnSessionMonitoringStats = vi.fn((..._args: unknown[]) => Promise.resolve(mockUnlisten));
+const mockOnSessionMonitoringStatus = vi.fn((cb: StatusCallback) => {
+  capturedStatusCallback = cb;
+  return Promise.resolve(mockStatusUnlisten);
+});
 
 vi.mock("@/services/events", () => ({
   onSessionMonitoringStats: (...args: unknown[]) => mockOnSessionMonitoringStats(...args),
+  onSessionMonitoringStatus: (cb: StatusCallback) => mockOnSessionMonitoringStatus(cb),
   onPersistentSessionStateChanged: vi.fn(() => Promise.resolve(() => {})),
 }));
 
 import { useAppStore } from "./appStore";
-import type { SystemStats } from "@/types/monitoring";
+import type { MonitorStatus, SystemStats } from "@/types/monitoring";
 
 const TEST_SSH_CONFIG = {
   host: "pi.local",
@@ -81,6 +90,7 @@ describe("appStore — monitoring", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
     vi.clearAllMocks();
+    capturedStatusCallback = null;
   });
 
   describe("connectMonitoring", () => {
@@ -526,6 +536,99 @@ describe("appStore — monitoring", () => {
       await useAppStore.getState().disconnectMonitoring();
 
       expect(useAppStore.getState().monitoringCancelled).toBe(false);
+    });
+  });
+
+  // Issue #1229 (audit gap G1): a mid-stream drop must surface as an explicit
+  // "stale" status so frozen stats are not shown as live.
+  describe("monitoringStatus (Stale — G1)", () => {
+    it("defaults to null when nothing is monitored", () => {
+      expect(useAppStore.getState().monitoringStatus).toBeNull();
+    });
+
+    it("is 'live' after a successful SSH connect", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+
+      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+
+      expect(useAppStore.getState().monitoringStatus).toBe("live");
+    });
+
+    it("flips to 'stale' when an SSH refresh poll fails", async () => {
+      mockMonitoringFetchStats.mockRejectedValue(new Error("timeout"));
+      useAppStore.setState({
+        monitoringSessionId: "session-123",
+        monitoringHost: "pi@pi.local:22",
+        monitoringStats: TEST_STATS,
+        monitoringStatus: "live",
+      });
+
+      await useAppStore.getState().refreshMonitoring();
+
+      expect(useAppStore.getState().monitoringStatus).toBe("stale");
+    });
+
+    it("recovers to 'live' when a later SSH refresh poll succeeds", async () => {
+      useAppStore.setState({
+        monitoringSessionId: "session-123",
+        monitoringHost: "pi@pi.local:22",
+        monitoringStats: TEST_STATS,
+        monitoringStatus: "stale",
+      });
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+
+      await useAppStore.getState().refreshMonitoring();
+
+      expect(useAppStore.getState().monitoringStatus).toBe("live");
+    });
+
+    it("is 'live' after a session-based open, then follows status push events", async () => {
+      mockSessionMonitoringOpen.mockResolvedValue(undefined);
+
+      await useAppStore.getState().connectMonitoring({
+        _sessionBased: true,
+        _sessionId: "sess-abc",
+      });
+      expect(useAppStore.getState().monitoringStatus).toBe("live");
+      expect(mockOnSessionMonitoringStatus).toHaveBeenCalledTimes(1);
+      expect(capturedStatusCallback).not.toBeNull();
+
+      // A mid-stream drop pushes "stale" for the active session.
+      capturedStatusCallback?.("sess-abc", "stale" as MonitorStatus);
+      expect(useAppStore.getState().monitoringStatus).toBe("stale");
+
+      // Recovery pushes "live" again.
+      capturedStatusCallback?.("sess-abc", "live" as MonitorStatus);
+      expect(useAppStore.getState().monitoringStatus).toBe("live");
+    });
+
+    it("ignores status events for a different session", async () => {
+      mockSessionMonitoringOpen.mockResolvedValue(undefined);
+
+      await useAppStore.getState().connectMonitoring({
+        _sessionBased: true,
+        _sessionId: "sess-abc",
+      });
+
+      capturedStatusCallback?.("some-other-session", "stale" as MonitorStatus);
+
+      // Unrelated session must not change our status.
+      expect(useAppStore.getState().monitoringStatus).toBe("live");
+    });
+
+    it("resets to null on disconnect", async () => {
+      mockMonitoringClose.mockResolvedValue(undefined);
+      useAppStore.setState({
+        monitoringSessionId: "session-123",
+        monitoringHost: "pi@pi.local:22",
+        monitoringStats: TEST_STATS,
+        monitoringStatus: "stale",
+      });
+
+      await useAppStore.getState().disconnectMonitoring();
+
+      expect(useAppStore.getState().monitoringStatus).toBeNull();
     });
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -138,8 +138,12 @@ import {
 } from "@/services/lastSessionApi";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
 import { connectTimeoutMessage, type ConnectTimeoutKind } from "@/utils/connectTimeout";
-import { SystemStats } from "@/types/monitoring";
-import { onSessionMonitoringStats, onPersistentSessionStateChanged } from "@/services/events";
+import { MonitorStatus, SystemStats } from "@/types/monitoring";
+import {
+  onSessionMonitoringStats,
+  onSessionMonitoringStatus,
+  onPersistentSessionStateChanged,
+} from "@/services/events";
 import { applyTheme, onThemeChange } from "@/themes";
 import { setOverrides as setKeybindingOverrides } from "@/services/keybindings";
 import {
@@ -746,6 +750,15 @@ interface AppState {
   monitoringLoading: boolean;
   monitoringError: string | null;
   /**
+   * Observable lifecycle state of the active monitoring collector loop.
+   *
+   * `null` when no monitor is connected. Set to `"live"` on connect and driven
+   * by `session-monitoring-status` push events for session-based tabs: a
+   * mid-stream drop flips it to `"stale"` so the status bar stops rendering
+   * frozen stats as live (#1229, audit gap G1).
+   */
+  monitoringStatus: MonitorStatus | null;
+  /**
    * Number of stats samples received on the current monitoring connection.
    * The remote collectors report CPU 0% on the first sample (no prior delta),
    * so the UI treats sample #1 as "priming" for the CPU field. Reset to 0 on
@@ -984,8 +997,11 @@ function collectLiveTabs(state: {
   return trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
 }
 
-/** Unlisten function for the active session-based monitoring event subscription. */
+/** Unlisten function for the active session-based monitoring stats subscription. */
 let _monitoringUnlisten: (() => void) | null = null;
+
+/** Unlisten function for the active session-based monitoring status subscription. */
+let _monitoringStatusUnlisten: (() => void) | null = null;
 
 function createTab(
   title: string,
@@ -4053,6 +4069,7 @@ export const useAppStore = create<AppState>((set, get) => {
     monitoringStats: null,
     monitoringLoading: false,
     monitoringError: null,
+    monitoringStatus: null,
     monitoringSampleCount: 0,
     monitoringCancelled: false,
     monitoringStatsCache: {},
@@ -4079,6 +4096,7 @@ export const useAppStore = create<AppState>((set, get) => {
             monitoringError: null,
             monitoringStats: cachedStats,
             monitoringHost: cachedStats ? sessionId : null,
+            monitoringStatus: "connecting",
             // Fresh connection: reset the sample counter so CPU shows the
             // priming indicator until the second push arrives (audit gap G10).
             monitoringSampleCount: 0,
@@ -4099,11 +4117,22 @@ export const useAppStore = create<AppState>((set, get) => {
           // Store unlisten in a module-level variable so disconnectMonitoring can call it.
           _monitoringUnlisten = unlisten;
 
+          // The status stream flips the indicator to `stale` on a mid-stream
+          // drop (and back to `live` on recovery) so frozen stats are never
+          // shown as live (#1229, audit gap G1).
+          const statusUnlisten = await onSessionMonitoringStatus((sid, status) => {
+            if (sid === sessionId) {
+              useAppStore.setState({ monitoringStatus: status });
+            }
+          });
+          _monitoringStatusUnlisten = statusUnlisten;
+
           await sessionMonitoringOpen(sessionId);
           set({
             monitoringSessionId: sessionId,
             monitoringHost: sessionId,
             monitoringLoading: false,
+            monitoringStatus: "live",
           });
           return;
         }
@@ -4116,6 +4145,7 @@ export const useAppStore = create<AppState>((set, get) => {
           monitoringError: null,
           monitoringStats: cachedStats,
           monitoringHost: cachedStats ? hostKey : null,
+          monitoringStatus: "connecting",
           // Fresh connection: reset the sample counter so CPU shows the priming
           // indicator until the second fetch arrives (audit gap G10).
           monitoringSampleCount: 0,
@@ -4130,6 +4160,7 @@ export const useAppStore = create<AppState>((set, get) => {
           monitoringHost: hostKey,
           monitoringStats: stats,
           monitoringLoading: false,
+          monitoringStatus: "live",
           monitoringSampleCount: state.monitoringSampleCount + 1,
           monitoringStatsCache: { ...state.monitoringStatsCache, [hostKey]: stats },
         }));
@@ -4143,9 +4174,14 @@ export const useAppStore = create<AppState>((set, get) => {
           _monitoringUnlisten();
           _monitoringUnlisten = null;
         }
+        if (_monitoringStatusUnlisten) {
+          _monitoringStatusUnlisten();
+          _monitoringStatusUnlisten = null;
+        }
         set({
           monitoringLoading: false,
           monitoringError: err instanceof Error ? err.message : String(err),
+          monitoringStatus: null,
         });
       }
     },
@@ -4169,11 +4205,16 @@ export const useAppStore = create<AppState>((set, get) => {
         _monitoringUnlisten();
         _monitoringUnlisten = null;
       }
+      if (_monitoringStatusUnlisten) {
+        _monitoringStatusUnlisten();
+        _monitoringStatusUnlisten = null;
+      }
       set((state) => ({
         monitoringSessionId: null,
         monitoringHost: null,
         monitoringStats: null,
         monitoringError: null,
+        monitoringStatus: null,
         monitoringSampleCount: 0,
         monitoringCancelled: false,
         // Preserve last-known stats so the UI can show them instantly on reconnect.
@@ -4194,14 +4235,19 @@ export const useAppStore = create<AppState>((set, get) => {
         set((state) => ({
           monitoringStats: stats,
           monitoringError: null,
+          // A successful poll recovers the indicator to live (audit gap G1).
+          monitoringStatus: "live",
           monitoringSampleCount: state.monitoringSampleCount + 1,
           monitoringStatsCache: monitoringHost
             ? { ...state.monitoringStatsCache, [monitoringHost]: stats }
             : state.monitoringStatsCache,
         }));
       } catch (err) {
+        // A failed poll while still "connected" flips to stale so the last-good
+        // numbers are dimmed rather than shown as live (audit gap G1).
         set({
           monitoringError: err instanceof Error ? err.message : String(err),
+          monitoringStatus: "stale",
         });
       }
     },

--- a/src/types/monitoring.ts
+++ b/src/types/monitoring.ts
@@ -1,3 +1,13 @@
+/**
+ * Observable lifecycle state of a monitoring collector loop.
+ *
+ * Mirrors the Rust `MonitorStatus` enum (camelCase). A mid-stream transport
+ * drop moves the loop to `stale` so the UI stops rendering frozen stats as
+ * live (#1229, audit gap G1). `reconnecting`, `offline`, and `paused` are
+ * reserved for later stages of the lifecycle redesign.
+ */
+export type MonitorStatus = "connecting" | "live" | "stale" | "reconnecting" | "offline" | "paused";
+
 /** System statistics retrieved from a remote Linux host. */
 export interface SystemStats {
   hostname: string;

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -255,6 +255,7 @@ Fixed strings — match exactly.
 | `monitoring-not-connected` | `src/components/StatusBar/StatusBar.tsx` |
 | `monitoring-refresh` | `src/components/StatusBar/StatusBar.tsx` |
 | `monitoring-retry-btn` | `src/components/StatusBar/StatusBar.tsx` |
+| `monitoring-stale` | `src/components/StatusBar/StatusBar.tsx` |
 | `multi-select-copy` | `src/components/Sidebar/FileBrowser.tsx` |
 | `multi-select-cut` | `src/components/Sidebar/FileBrowser.tsx` |
 | `multi-select-delete` | `src/components/Sidebar/FileBrowser.tsx` |


### PR DESCRIPTION
## Summary

Monitoring S2 (audit gap G1) of the Remote Monitoring Lifecycle Redesign (#1193). A **status channel** now runs alongside the stats channel so a mid-stream SSH drop is observable instead of silently freezing the last sample as "live".

- `core/src/monitoring/status.rs` (new) — `MonitorStatus` enum (`Connecting|Live|Stale|Reconnecting|Offline|Paused`) + `CollectLoopState` (first success → Live; N consecutive collect/parse failures → Stale; recovery → Live).
- `MonitoringProvider::subscribe()` → `{ stats, status }`; SSH collector loop drives the state and emits transitions.
- `manager.rs` forwards transitions as a new `session-monitoring-status` Tauri event via a `select!` over both receivers (no `.unwrap()`, no hot-loop on a closed channel).
- Frontend: `monitoringStatus` in the store (status push + legacy SSH poll); `StatusBar` renders a warning **Stale** badge and dims the frozen numbers, un-dimming on recovery (tokens only).

## Test plan

- `CollectLoopState` unit tests + SSH-loop integration test (`collect_loop_emits_stale_on_drop_and_live_on_recovery` via a fake transport) + store tests + `StatusBar.monitoring-stale.test.tsx`. TDD, test commit precedes feat.
- `./scripts/check.sh` + `./scripts/test.sh` green (frontend 2433, core 489, desktop 765, agent 244) — only pre-existing agent Docker-integration env failures.

Scope is S2 (desktop SSH). The `Reconnecting/Offline/Paused` arms are defined but driven by later stages of #1193; the agent-mediated path reports an initial `Live` for now.

Closes #1229

🤖 Generated with [Claude Code](https://claude.com/claude-code)