### PR TITLE
feat(agent): split Disconnect (detach) vs Shutdown (stop remote) (Closes #1237)

### DIFF
--- a/docs/changes/dev1/feature/1237-agent-disconnect-vs-shutdown.md
+++ b/docs/changes/dev1/feature/1237-agent-disconnect-vs-shutdown.md
@@ -1,0 +1,12 @@
+# Changelog fragment — feature/1237-agent-disconnect-vs-shutdown
+
+## Added
+
+- **Remote agents — separate Disconnect and Shutdown:** The connected agent
+  header (and its right-click menu) now exposes two distinct teardown actions
+  instead of one overloaded "Disconnect". **Disconnect (detach)** drops the
+  connection but leaves persistent remote sessions running on the agent, so they
+  reappear the next time you connect. **Shutdown (stop remote)** stops the remote
+  sessions and disconnects, then reports how many sessions were stopped as a
+  success toast. Tooltips distinguish the two: "Detach transport — keep
+  persistent remote sessions" vs "Stop remote sessions and disconnect". (#1237)

--- a/src/components/Sidebar/AgentNode.lifecycle.test.tsx
+++ b/src/components/Sidebar/AgentNode.lifecycle.test.tsx
@@ -37,8 +37,8 @@ vi.mock("@dnd-kit/utilities", () => ({
   CSS: { Transform: { toString: () => "" } },
 }));
 
-const disconnectAgentMock = vi.fn(() => Promise.resolve());
-const shutdownAgentMock = vi.fn(() => Promise.resolve(3));
+const disconnectAgentMock = vi.fn((..._args: unknown[]) => Promise.resolve());
+const shutdownAgentMock = vi.fn((..._args: unknown[]) => Promise.resolve(3));
 
 vi.mock("@/services/api", () => ({
   removeCredential: vi.fn(() => Promise.resolve()),
@@ -201,7 +201,9 @@ describe("appStore — shutdownRemoteAgent (#1237)", () => {
     useAppStore.setState({
       remoteAgents: [makeAgent()],
       agentSessions: {
-        [AGENT_ID]: [{ sessionId: "s1", title: "s", type: "shell", status: "running" }],
+        [AGENT_ID]: [
+          { sessionId: "s1", title: "s", type: "shell", status: "running", attached: false },
+        ],
       },
     });
     disconnectAgentMock.mockClear();

--- a/src/components/Sidebar/AgentNode.lifecycle.test.tsx
+++ b/src/components/Sidebar/AgentNode.lifecycle.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Tests for agent lifecycle stage 3 (#1237, G9): the connected agent header
+ * surfaces two distinct intents.
+ *
+ *  - **Disconnect (detach)** → `disconnect_agent`: drops the transport, leaves
+ *    persistent daemon-backed remote sessions running (they re-list on the next
+ *    connect). Must NOT call `shutdown_agent`.
+ *  - **Shutdown (stop remote)** → `shutdown_agent`: stops remote sessions and
+ *    disconnects, surfacing the returned `detached_sessions` count as a toast.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { AgentNode } from "./AgentNode";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({ attributes: {}, listeners: {}, setNodeRef: vi.fn(), isDragging: false }),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  useDndContext: () => ({ active: null }),
+  useDndMonitor: () => {},
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } },
+}));
+
+const disconnectAgentMock = vi.fn(() => Promise.resolve());
+const shutdownAgentMock = vi.fn(() => Promise.resolve(3));
+
+vi.mock("@/services/api", () => ({
+  removeCredential: vi.fn(() => Promise.resolve()),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  cancelConnectAgent: vi.fn(() => Promise.resolve()),
+  disconnectAgent: (...args: unknown[]) => disconnectAgentMock(...args),
+  shutdownAgent: (...args: unknown[]) => shutdownAgentMock(...args),
+  listAgentDefinitions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+// Stub the Radix-backed Tooltip to a passthrough so these isolated renders do
+// not need the app-root TooltipProvider, and stub `toast` so we can assert the
+// Shutdown success feedback carries the detached-session count.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return {
+    ...actual,
+    Tooltip: ({ children }: { children: React.ReactNode }) => children,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+      promise: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("@/utils/classifyAgentError", () => ({
+  classifyAgentError: vi.fn((e) => ({ type: "unknown", message: String(e) })),
+}));
+vi.mock("@/utils/resolveConnectionCredential", () => ({
+  resolveConnectionCredential: vi.fn(() =>
+    Promise.resolve({ usedStoredCredential: false, password: null })
+  ),
+}));
+vi.mock("@/utils/ensureCredentialStoreUnlocked", () => ({
+  ensureCredentialStoreUnlocked: vi.fn(() => Promise.resolve(true)),
+}));
+vi.mock("./AgentSetupDialog", () => ({ AgentSetupDialog: () => null }));
+vi.mock("./ConnectionErrorDialog", () => ({ ConnectionErrorDialog: () => null }));
+vi.mock("./InlineFolderInput", () => ({ InlineFolderInput: () => null }));
+
+const AGENT_ID = "agent-lifecycle-test";
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: AGENT_ID,
+    name: "Test Agent",
+    config: {
+      host: "host.example.com",
+      port: 22,
+      username: "user",
+      authMethod: "password",
+    },
+    connectionState: "connected",
+    isExpanded: true,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    capabilities: {
+      connectionTypes: [],
+      maxSessions: 10,
+      availableShells: ["bash"],
+      availableSerialPorts: [],
+      availableDockerImages: [],
+    },
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("AgentNode — disconnect (detach) vs shutdown (stop remote) (#1237, G9)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ remoteAgents: [makeAgent()] });
+    disconnectAgentMock.mockClear();
+    shutdownAgentMock.mockClear();
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function render(): void {
+    act(() => {
+      root.render(React.createElement(AgentNode, { agent: makeAgent() }));
+    });
+  }
+
+  it("exposes a Disconnect (detach) control that routes to disconnect_agent only", async () => {
+    render();
+
+    const btn = container.querySelector(
+      `[data-testid="agent-disconnect-${AGENT_ID}"]`
+    ) as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+
+    act(() => {
+      btn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(disconnectAgentMock).toHaveBeenCalledTimes(1);
+    expect(disconnectAgentMock).toHaveBeenCalledWith(AGENT_ID);
+    // Detach must never stop the remote sessions.
+    expect(shutdownAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("exposes a Shutdown (stop remote) control that routes to shutdown_agent and toasts the detached count", async () => {
+    render();
+
+    const btn = container.querySelector(
+      `[data-testid="agent-shutdown-${AGENT_ID}"]`
+    ) as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+
+    act(() => {
+      btn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    await flush();
+
+    expect(shutdownAgentMock).toHaveBeenCalledTimes(1);
+    expect(shutdownAgentMock).toHaveBeenCalledWith(AGENT_ID);
+    // Detach path must not run for a shutdown.
+    expect(disconnectAgentMock).not.toHaveBeenCalled();
+    // The returned detached_sessions count (3) is surfaced as a success toast.
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(String(toastSuccess.mock.calls[0][0])).toContain("3");
+  });
+});
+
+describe("appStore — shutdownRemoteAgent (#1237)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({
+      remoteAgents: [makeAgent()],
+      agentSessions: {
+        [AGENT_ID]: [{ sessionId: "s1", title: "s", type: "shell", status: "running" }],
+      },
+    });
+    disconnectAgentMock.mockClear();
+    shutdownAgentMock.mockClear();
+    toastSuccess.mockClear();
+  });
+
+  it("returns the detached_sessions count and marks the agent disconnected", async () => {
+    const count = await useAppStore.getState().shutdownRemoteAgent(AGENT_ID);
+
+    expect(shutdownAgentMock).toHaveBeenCalledWith(AGENT_ID);
+    expect(count).toBe(3);
+    const agent = useAppStore.getState().remoteAgents.find((a) => a.id === AGENT_ID);
+    expect(agent?.connectionState).toBe("disconnected");
+    expect(useAppStore.getState().agentSessions[AGENT_ID]).toEqual([]);
+  });
+});

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -33,6 +33,8 @@ import {
   Copy,
   Link,
   XCircle,
+  Unplug,
+  Power,
 } from "lucide-react";
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { Button, Tooltip, toast } from "@/components/ui";
@@ -548,6 +550,7 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
   const toggleRemoteAgent = useAppStore((s) => s.toggleRemoteAgent);
   const connectRemoteAgent = useAppStore((s) => s.connectRemoteAgent);
   const disconnectRemoteAgent = useAppStore((s) => s.disconnectRemoteAgent);
+  const shutdownRemoteAgent = useAppStore((s) => s.shutdownRemoteAgent);
   const deleteRemoteAgent = useAppStore((s) => s.deleteRemoteAgent);
   const openConnectionEditorTab = useAppStore((s) => s.openConnectionEditorTab);
   const requestPassword = useAppStore((s) => s.requestPassword);
@@ -688,9 +691,23 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
     void handleConnect();
   }, [agent.id, disconnectRemoteAgent, handleConnect]);
 
+  // Disconnect (detach) — drop the transport but leave persistent daemon-backed
+  // remote sessions running so they re-list on the next connect (G9, #1237).
   const handleDisconnect = useCallback(() => {
     disconnectRemoteAgent(agent.id);
   }, [agent.id, disconnectRemoteAgent]);
+
+  // Shutdown (stop remote) — stop the remote sessions and disconnect, reporting
+  // how many sessions the agent detached/killed as a success toast (G9, #1237).
+  // Returns the promise so the async Button surfaces pending/error feedback.
+  const handleShutdown = useCallback(async () => {
+    const detached = await shutdownRemoteAgent(agent.id);
+    toast.success(
+      detached > 0
+        ? `Agent shut down — ${detached} session${detached === 1 ? "" : "s"} stopped`
+        : "Agent shut down"
+    );
+  }, [agent.id, shutdownRemoteAgent]);
 
   // Cancel an in-flight connect (G1, #1235). Fires cancel_connect_agent, which
   // aborts the blocking SSH + initialize handshake; the backend then emits
@@ -904,6 +921,30 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                     <Plus size={16} />
                   </button>
                 </Tooltip>
+                {/* Two distinct teardown intents (G9, #1237). Detach keeps the
+                    remote sessions running; Shutdown stops them. Both go through
+                    the async Button so every action gives pending/error feedback;
+                    Shutdown adds a success toast with the stopped-session count. */}
+                <Tooltip content="Detach transport — keep persistent remote sessions" side="top">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<Unplug size={14} />}
+                    onClick={handleDisconnect}
+                    aria-label="Disconnect (detach)"
+                    data-testid={`agent-disconnect-${agent.id}`}
+                  />
+                </Tooltip>
+                <Tooltip content="Stop remote sessions and disconnect" side="top">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<Power size={14} />}
+                    onClick={handleShutdown}
+                    aria-label="Shutdown (stop remote)"
+                    data-testid={`agent-shutdown-${agent.id}`}
+                  />
+                </Tooltip>
               </div>
             )}
             {isConnecting && (
@@ -985,8 +1026,16 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                   onSelect={handleDisconnect}
                   data-testid="context-agent-disconnect"
                 >
-                  <Square size={14} />
-                  Disconnect
+                  <Unplug size={14} />
+                  Disconnect (detach)
+                </ContextMenu.Item>
+                <ContextMenu.Item
+                  className="context-menu__item"
+                  onSelect={() => void handleShutdown()}
+                  data-testid="context-agent-shutdown"
+                >
+                  <Power size={14} />
+                  Shutdown (stop remote)
                 </ContextMenu.Item>
                 <ContextMenu.Item
                   className="context-menu__item"

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -71,6 +71,7 @@ import {
   getDefaultShell,
   connectAgent as apiConnectAgent,
   disconnectAgent as apiDisconnectAgent,
+  shutdownAgent as apiShutdownAgent,
   applyAgentSettings as apiApplyAgentSettings,
   listAgentSessions,
   listAgentConnections,
@@ -690,6 +691,11 @@ interface AppState {
   toggleRemoteAgent: (agentId: string) => void;
   connectRemoteAgent: (agentId: string, password?: string) => Promise<void>;
   disconnectRemoteAgent: (agentId: string) => Promise<void>;
+  /**
+   * Gracefully shut down a remote agent (stop remote sessions) and disconnect.
+   * Resolves to the number of sessions the agent reported as detached/killed.
+   */
+  shutdownRemoteAgent: (agentId: string) => Promise<number>;
   setAgentConnectionState: (
     agentId: string,
     state: RemoteAgentDefinition["connectionState"],
@@ -3712,6 +3718,21 @@ export const useAppStore = create<AppState>((set, get) => {
         agentSessions: { ...s.agentSessions, [agentId]: [] },
         agentFolders: { ...s.agentFolders, [agentId]: [] },
       }));
+    },
+
+    shutdownRemoteAgent: async (agentId) => {
+      // Unlike disconnect (detach), shutdown stops the remote sessions and then
+      // drops the transport. The backend returns how many sessions were
+      // detached/killed so the UI can report the impact.
+      const detached = await apiShutdownAgent(agentId);
+      set((s) => ({
+        remoteAgents: s.remoteAgents.map((a) =>
+          a.id === agentId ? { ...a, connectionState: "disconnected" as const } : a
+        ),
+        agentSessions: { ...s.agentSessions, [agentId]: [] },
+        agentFolders: { ...s.agentFolders, [agentId]: [] },
+      }));
+      return detached;
     },
 
     setAgentConnectionState: (agentId, connectionState, error) => {

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -112,6 +112,7 @@ Fixed strings — match exactly.
 | `context-agent-new-shell` | `src/components/Sidebar/AgentNode.tsx` |
 | `context-agent-refresh` | `src/components/Sidebar/AgentNode.tsx` |
 | `context-agent-setup` | `src/components/Sidebar/AgentNode.tsx` |
+| `context-agent-shutdown` | `src/components/Sidebar/AgentNode.tsx` |
 | `context-bg-new-file` | `src/components/Sidebar/FileBrowser.tsx` |
 | `context-bg-new-folder` | `src/components/Sidebar/FileBrowser.tsx` |
 | `context-bg-paste` | `src/components/Sidebar/FileBrowser.tsx` |
@@ -519,9 +520,11 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `activity-bar-*` | `activity-bar-${label.toLowerCase().replace(/\s+/g, "-")}` | `src/components/ActivityBar/ActivityBarItem.tsx` |
 | `activity-bar-context-toggle-*` | `activity-bar-context-toggle-${item.view}` | `src/components/ActivityBar/ActivityBar.tsx` |
 | `agent-cancel-connect-*` | `agent-cancel-connect-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
+| `agent-disconnect-*` | `agent-disconnect-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-header-*` | `agent-header-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-node-*` | `agent-node-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-reconnect-*` | `agent-reconnect-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
+| `agent-shutdown-*` | `agent-shutdown-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-state-*` | `agent-state-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `color-picker-swatch-*` | `color-picker-swatch-${color.replace("#", "")}` | `src/components/Terminal/ColorPickerDialog.tsx` |
 | `connection-item-*` | `connection-item-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |


### PR DESCRIPTION
## Summary

Agent lifecycle Stage 3 (G9). Splits the single overloaded teardown control into two clear intents on the connected agent header + context menu:

- **Disconnect (detach)** → `disconnect_agent` only (drops transport, leaves persistent daemon-backed remote sessions running for re-listing on next connect). Tooltip: "Detach transport — keep persistent remote sessions".
- **Shutdown (stop remote)** → the existing `shutdown_agent` path (new `shutdownRemoteAgent` store action), surfacing the returned `detached_sessions` count as `toast.success()`. Tooltip: "Stop remote sessions and disconnect".

Both compose from `ui/` Button (ghost/sm, async feedback) + Tooltip; icons `Unplug` / `Power`; tokens only.

## Test plan

- `AgentNode.lifecycle.test.tsx` (3): Disconnect routes to `disconnect_agent` (not shutdown); Shutdown routes to `shutdown_agent` and toasts the detached count; store `shutdownRemoteAgent` returns the count. TDD, tests precede impl.
- `./scripts/check.sh` + frontend Vitest (2448) green; only pre-existing agent Docker-integration env failures.

Follow-up: #1277 — mirror the two-intent split into the Open Connections panel (out of this issue's header scope).

Closes #1237

🤖 Generated with [Claude Code](https://claude.com/claude-code)