### PR TITLE
fix(terminal): resolve exhaustive-deps warning for persistentConnectionId effect (#1271)

### DIFF
--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -270,6 +270,17 @@ export function Terminal({
   // destroying the live xterm and leaving a blank terminal. Using a mount-time
   // ref keeps setupTerminal stable after the initial connect.
   const initialSessionIdRef = useRef(existingSessionId);
+  // Keep the latest persistentConnectionId in a ref so the terminal-creation
+  // effect below can read it without listing it as a dependency. Adding it to
+  // that effect's deps would dispose and recreate the live xterm instance and
+  // its backend session whenever the prop changed — the same churn we avoid for
+  // existingSessionId above. The value is only read on (re)connect to decide
+  // whether to replay the local scrollback snapshot, so a ref preserves the
+  // exact behavior while satisfying react-hooks/exhaustive-deps (#1271).
+  const persistentConnectionIdRef = useRef(persistentConnectionId);
+  useEffect(() => {
+    persistentConnectionIdRef.current = persistentConnectionId;
+  }, [persistentConnectionId]);
   const {
     register,
     unregister,
@@ -855,7 +866,7 @@ export function Terminal({
     // the scrollback — skip it for those and rely on the server buffer.
     // Always clear the ref so an unrelated re-run starts empty.
     if (scrollbackSnapshotRef.current) {
-      if (!persistentConnectionId) {
+      if (!persistentConnectionIdRef.current) {
         xterm.write(scrollbackSnapshotRef.current);
       }
       scrollbackSnapshotRef.current = null;


### PR DESCRIPTION
## Summary

Follow-up to #1126 (PR #1256). The scrollback-preservation change added a `persistentConnectionId` read inside the xterm-creation `useEffect` (`Terminal.tsx`) but did not add the prop to the effect's dependency array, leaving a `react-hooks/exhaustive-deps` warning that surfaced in every Frontend Code Quality run. It was a warning (not an error), so CI stayed green, but it was noise flagged by later work.

## Root cause

The effect creates and destroys the xterm instance and the backend session. `persistentConnectionId` is read at exactly one point inside it — on (re)connect, to decide whether to replay the locally-snapshotted scrollback (persistent/agent tabs re-fetch an authoritative buffer from the server, so replaying the local snapshot too would double it). Naively adding `persistentConnectionId` to the deps would tear down and recreate the live xterm + session whenever the prop changed — exactly the churn the file already guards against for `existingSessionId` via `initialSessionIdRef`.

## Fix

Mirror the established `initialSessionIdRef` pattern in the same file: keep the latest `persistentConnectionId` in a ref (`persistentConnectionIdRef`, synced by its own small effect) and read the ref inside the creation effect instead of the closed-over prop. The creation effect no longer references the prop, so `exhaustive-deps` is satisfied honestly — **no `eslint-disable` suppression**.

Behavior is identical: `persistentConnectionId` is effectively immutable for a mounted tab (set once at tab creation in `appStore`, never written back), and it is only read on (re)connect to gate the local-scrollback replay. The ref holds the current value at that moment, so the reconnect-scrollback behavior from #1126 is unchanged and the xterm instance is not re-created.

## Test plan

- Before: `pnpm run lint` reported `1117:6 warning ... missing dependency: 'persistentConnectionId' react-hooks/exhaustive-deps` for `Terminal.tsx`.
- After: `pnpm run lint` — 0 warnings, no new warnings/suppressions introduced.
- `pnpm build` (tsc type-check + Vite) — clean.
- `pnpm exec vitest run src/components/Terminal/` — 24 files / 170 tests pass (includes the reconnect + scrollback suites that exercise the replay path).

Closes #1271

🤖 Generated with [Claude Code](https://claude.com/claude-code)