### PR TITLE
feat(monitoring): per-host/session keyed monitoring store (#1231)

### DIFF
--- a/docs/changes/dev2/feature/1231-monitoring-per-host-keying.md
+++ b/docs/changes/dev2/feature/1231-monitoring-per-host-keying.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Multiple hosts can now be monitored simultaneously.** Remote system
+  monitoring state is keyed per host/session instead of a single global monitor,
+  so switching tabs no longer tears down the previous host's monitor — each
+  monitored host keeps updating independently and the status bar shows the
+  active tab's stats (#1231).
+
+### Changed
+
+- The **Open Connections** panel now lists monitored hosts individually — one
+  killable row per host — instead of a single combined Monitoring row. Each row
+  has its own Kill (and shows a "stale" hint when a host's connection dropped),
+  and the section has a Kill All (#1231).

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import {
   Terminal,
   Server,
@@ -64,7 +64,13 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const closeSftpSession = useAppStore((s) => s.closeSftpSession);
   const tabGroups = useAppStore((s) => s.tabGroups);
   const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
-  const monitoringHost = useAppStore((s) => s.monitoringHost);
+  // Every monitored host with a live backend subscription (#1231, audit gap G6);
+  // each renders its own killable row. Derived from the keyed `monitors` map.
+  const monitors = useAppStore((s) => s.monitors);
+  const openMonitors = useMemo(
+    () => Object.values(monitors).filter((m) => m.monitorSessionId !== null),
+    [monitors]
+  );
   const disconnectMonitoring = useAppStore((s) => s.disconnectMonitoring);
   // Live source of truth for HTTP monitors (kept current by the Network Tools
   // sidebar / check events); the panel reads it directly so it stays in sync
@@ -199,7 +205,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     Object.values(agentSessions).reduce((s, arr) => s + arr.length, 0) +
     activeTunnels.length +
     sftpSessionEntries.length +
-    (monitoringHost ? 1 : 0) +
+    openMonitors.length +
     httpMonitors.length +
     (showXServer ? 1 : 0);
 
@@ -585,20 +591,24 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           </Section>
         )}
 
-        {/* Monitoring */}
-        {monitoringHost && (
+        {/* Monitoring — one row per monitored host (#1231, audit gap G6). */}
+        {openMonitors.length > 0 && (
           <Section
             title="Monitoring"
             icon={<Activity size={14} />}
-            count={1}
-            onKillAll={disconnectMonitoring}
+            count={openMonitors.length}
+            onKillAll={() => disconnectMonitoring()}
           >
-            <ConnectionRow
-              icon={<MonitorStop size={14} />}
-              title={monitoringHost}
-              badge="connected"
-              onKill={disconnectMonitoring}
-            />
+            {openMonitors.map((m) => (
+              <ConnectionRow
+                key={m.key}
+                icon={<MonitorStop size={14} />}
+                title={m.host ?? m.key}
+                detail={m.status === "stale" ? "stale — connection dropped" : undefined}
+                badge={m.status === "stale" ? "reconnecting" : "connected"}
+                onKill={() => disconnectMonitoring(m.key)}
+              />
+            ))}
           </Section>
         )}
 

--- a/src/components/StatusBar/StatusBar.monitoring-feedback.test.tsx
+++ b/src/components/StatusBar/StatusBar.monitoring-feedback.test.tsx
@@ -19,6 +19,7 @@ import { useAppStore } from "@/store/appStore";
 import { StatusBar } from "./StatusBar";
 import type { ConnectionTypeInfo, SavedConnection } from "@/types/connection";
 import type { LeafPanel, TerminalTab } from "@/types/terminal";
+import type { MonitoringEntry } from "@/types/monitoring";
 
 vi.mock("@/components/CredentialStoreIndicator", () => ({ CredentialStoreIndicator: () => null }));
 vi.mock("./PortableBadge", () => ({ PortableBadge: () => null }));
@@ -71,6 +72,31 @@ function primeMonitoringTab() {
   }));
 }
 
+/** MonitorKey for the primed SSH tab (`user@host:port`). */
+const MONITOR_KEY = "pi@pi.local:22";
+
+/** Install a keyed monitor entry for the primed tab (#1231, per-host slice). */
+function setActiveMonitor(patch: Partial<MonitoringEntry>) {
+  useAppStore.setState((s) => ({
+    monitors: {
+      ...s.monitors,
+      [MONITOR_KEY]: {
+        key: MONITOR_KEY,
+        host: MONITOR_KEY,
+        sessionBased: false,
+        monitorSessionId: null,
+        stats: null,
+        loading: false,
+        error: null,
+        status: null,
+        sampleCount: 0,
+        cancelled: false,
+        ...patch,
+      },
+    },
+  }));
+}
+
 describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -97,10 +123,8 @@ describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () 
   it("(G7) shows a Retry control when monitoring is in the error state", () => {
     // A no-op connect prevents the mount auto-connect effect from mutating the
     // error/cancelled state we set up for the render assertions.
-    useAppStore.setState({
-      monitoringError: "Connection refused",
-      connectMonitoring: vi.fn(() => Promise.resolve()),
-    });
+    setActiveMonitor({ error: "Connection refused" });
+    useAppStore.setState({ connectMonitoring: vi.fn(() => Promise.resolve()) });
     renderStatusBar();
 
     const err = container.querySelector('[data-testid="monitoring-error"]');
@@ -112,7 +136,8 @@ describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () 
 
   it("(G7 + G9) Retry clears the lingering error and re-invokes connect", async () => {
     const connectSpy = vi.fn(() => Promise.resolve());
-    useAppStore.setState({ monitoringError: "Connection refused", connectMonitoring: connectSpy });
+    setActiveMonitor({ error: "Connection refused" });
+    useAppStore.setState({ connectMonitoring: connectSpy });
     renderStatusBar();
     // Let any mount auto-connect microtasks settle before counting.
     await act(async () => {
@@ -133,16 +158,14 @@ describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () 
     });
 
     // The stale error must be cleared so it does not linger (G9)…
-    expect(useAppStore.getState().monitoringError).toBeNull();
+    expect(useAppStore.getState().monitors[MONITOR_KEY].error).toBeNull();
     // …and a fresh connect attempt must be made (G7).
     expect(connectSpy.mock.calls.length).toBe(before + 1);
   });
 
   it("(G8) shows a 'not connected' affordance with Retry when the password prompt was cancelled", () => {
-    useAppStore.setState({
-      monitoringCancelled: true,
-      connectMonitoring: vi.fn(() => Promise.resolve()),
-    });
+    setActiveMonitor({ cancelled: true });
+    useAppStore.setState({ connectMonitoring: vi.fn(() => Promise.resolve()) });
     renderStatusBar();
 
     const notConnected = container.querySelector('[data-testid="monitoring-not-connected"]');
@@ -155,7 +178,8 @@ describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () 
 
   it("(G8) Retry from the cancelled affordance clears the flag and re-invokes connect", async () => {
     const connectSpy = vi.fn(() => Promise.resolve());
-    useAppStore.setState({ monitoringCancelled: true, connectMonitoring: connectSpy });
+    setActiveMonitor({ cancelled: true });
+    useAppStore.setState({ connectMonitoring: connectSpy });
     renderStatusBar();
     await act(async () => {
       await Promise.resolve();
@@ -170,7 +194,7 @@ describe("StatusBar — monitoring auto-connect feedback (#1148, G7/G8/G9)", () 
       await Promise.resolve();
     });
 
-    expect(useAppStore.getState().monitoringCancelled).toBe(false);
+    expect(useAppStore.getState().monitors[MONITOR_KEY].cancelled).toBe(false);
     expect(connectSpy.mock.calls.length).toBe(before + 1);
   });
 });

--- a/src/components/StatusBar/StatusBar.monitoring-priming.test.tsx
+++ b/src/components/StatusBar/StatusBar.monitoring-priming.test.tsx
@@ -16,7 +16,7 @@ import { createRoot, Root } from "react-dom/client";
 import { TooltipProvider } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { StatusBar } from "./StatusBar";
-import type { SystemStats } from "@/types/monitoring";
+import type { SystemStats, MonitoringEntry } from "@/types/monitoring";
 import type { ConnectionTypeInfo } from "@/types/connection";
 import type { LeafPanel, TerminalTab } from "@/types/terminal";
 
@@ -57,7 +57,7 @@ function primeMonitoringTab() {
     title: "ssh-host",
     connectionType: "ssh",
     contentType: "terminal",
-    config: { type: "ssh", config: {} },
+    config: { type: "ssh", config: { host: "host", port: 22, username: "user" } },
     panelId: "leaf-1",
     isActive: true,
   };
@@ -74,6 +74,31 @@ function primeMonitoringTab() {
     settings: { ...state.settings, powerMonitoringEnabled: true },
     rootPanel: leaf,
     activePanelId: "leaf-1",
+  }));
+}
+
+/** MonitorKey for the primed SSH tab (`user@host:port`). */
+const MONITOR_KEY = "user@host:22";
+
+/** Install a keyed monitor entry for the primed tab (#1231, per-host slice). */
+function setActiveMonitor(patch: Partial<MonitoringEntry>) {
+  useAppStore.setState((s) => ({
+    monitors: {
+      ...s.monitors,
+      [MONITOR_KEY]: {
+        key: MONITOR_KEY,
+        host: MONITOR_KEY,
+        sessionBased: false,
+        monitorSessionId: null,
+        stats: null,
+        loading: false,
+        error: null,
+        status: null,
+        sampleCount: 0,
+        cancelled: false,
+        ...patch,
+      },
+    },
   }));
 }
 
@@ -101,11 +126,11 @@ describe("StatusBar — CPU first-sample priming (#1148, G10)", () => {
   }
 
   it("shows a priming indicator (not '0%') for CPU on the first sample", () => {
-    useAppStore.setState({
-      monitoringSessionId: "sess-1",
-      monitoringHost: "user@host:22",
-      monitoringStats: makeStats({ cpuUsagePercent: 0 }),
-      monitoringSampleCount: 1,
+    setActiveMonitor({
+      monitorSessionId: "sess-1",
+      stats: makeStats({ cpuUsagePercent: 0 }),
+      sampleCount: 1,
+      status: "live",
     });
     renderStatusBar();
 
@@ -119,11 +144,11 @@ describe("StatusBar — CPU first-sample priming (#1148, G10)", () => {
   });
 
   it("shows the real CPU value from the second sample onward", () => {
-    useAppStore.setState({
-      monitoringSessionId: "sess-1",
-      monitoringHost: "user@host:22",
-      monitoringStats: makeStats({ cpuUsagePercent: 42 }),
-      monitoringSampleCount: 2,
+    setActiveMonitor({
+      monitorSessionId: "sess-1",
+      stats: makeStats({ cpuUsagePercent: 42 }),
+      sampleCount: 2,
+      status: "live",
     });
     renderStatusBar();
 

--- a/src/components/StatusBar/StatusBar.monitoring-stale.test.tsx
+++ b/src/components/StatusBar/StatusBar.monitoring-stale.test.tsx
@@ -15,7 +15,7 @@ import { createRoot, Root } from "react-dom/client";
 import { TooltipProvider } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { StatusBar } from "./StatusBar";
-import type { SystemStats } from "@/types/monitoring";
+import type { SystemStats, MonitoringEntry } from "@/types/monitoring";
 import type { ConnectionTypeInfo } from "@/types/connection";
 import type { LeafPanel, TerminalTab } from "@/types/terminal";
 
@@ -56,7 +56,7 @@ function primeMonitoringTab() {
     title: "ssh-host",
     connectionType: "ssh",
     contentType: "terminal",
-    config: { type: "ssh", config: {} },
+    config: { type: "ssh", config: { host: "host", port: 22, username: "user" } },
     panelId: "leaf-1",
     isActive: true,
   };
@@ -73,6 +73,31 @@ function primeMonitoringTab() {
     settings: { ...state.settings, powerMonitoringEnabled: true },
     rootPanel: leaf,
     activePanelId: "leaf-1",
+  }));
+}
+
+/** MonitorKey for the primed SSH tab (`user@host:port`). */
+const MONITOR_KEY = "user@host:22";
+
+/** Install a keyed monitor entry for the primed tab (#1231, per-host slice). */
+function setActiveMonitor(patch: Partial<MonitoringEntry>) {
+  useAppStore.setState((s) => ({
+    monitors: {
+      ...s.monitors,
+      [MONITOR_KEY]: {
+        key: MONITOR_KEY,
+        host: MONITOR_KEY,
+        sessionBased: false,
+        monitorSessionId: null,
+        stats: null,
+        loading: false,
+        error: null,
+        status: null,
+        sampleCount: 0,
+        cancelled: false,
+        ...patch,
+      },
+    },
   }));
 }
 
@@ -100,12 +125,11 @@ describe("StatusBar — monitoring Stale indicator (#1229, G1)", () => {
   }
 
   it("shows a Stale badge and dims the stats when status is 'stale'", () => {
-    useAppStore.setState({
-      monitoringSessionId: "sess-1",
-      monitoringHost: "user@host:22",
-      monitoringStats: makeStats(),
-      monitoringSampleCount: 3,
-      monitoringStatus: "stale",
+    setActiveMonitor({
+      monitorSessionId: "sess-1",
+      stats: makeStats(),
+      sampleCount: 3,
+      status: "stale",
     });
     renderStatusBar();
 
@@ -121,12 +145,11 @@ describe("StatusBar — monitoring Stale indicator (#1229, G1)", () => {
   });
 
   it("does not show the Stale badge when status is 'live'", () => {
-    useAppStore.setState({
-      monitoringSessionId: "sess-1",
-      monitoringHost: "user@host:22",
-      monitoringStats: makeStats(),
-      monitoringSampleCount: 3,
-      monitoringStatus: "live",
+    setActiveMonitor({
+      monitorSessionId: "sess-1",
+      stats: makeStats(),
+      sampleCount: 3,
+      status: "live",
     });
     renderStatusBar();
 

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -10,7 +10,7 @@ import {
   Route,
   RotateCw,
 } from "lucide-react";
-import { useAppStore, getActiveTab } from "@/store/appStore";
+import { useAppStore, getActiveTab, monitorKeyForTab, selectMonitor } from "@/store/appStore";
 import { frontendLog } from "@/utils/frontendLog";
 import { jumpHostStatusLabel } from "@/utils/jumpHost";
 import { ConnectionConfig } from "@/types/terminal";
@@ -244,14 +244,6 @@ function ServicesIndicator() {
  */
 function MonitoringStatus() {
   const globalMonitoringEnabled = useAppStore((s) => s.settings.powerMonitoringEnabled);
-  const monitoringSessionId = useAppStore((s) => s.monitoringSessionId);
-  const monitoringHost = useAppStore((s) => s.monitoringHost);
-  const monitoringStats = useAppStore((s) => s.monitoringStats);
-  const monitoringSampleCount = useAppStore((s) => s.monitoringSampleCount);
-  const monitoringLoading = useAppStore((s) => s.monitoringLoading);
-  const monitoringError = useAppStore((s) => s.monitoringError);
-  const monitoringStatus = useAppStore((s) => s.monitoringStatus);
-  const monitoringCancelled = useAppStore((s) => s.monitoringCancelled);
   const connectMonitoring = useAppStore((s) => s.connectMonitoring);
   const disconnectMonitoring = useAppStore((s) => s.disconnectMonitoring);
   const refreshMonitoring = useAppStore((s) => s.refreshMonitoring);
@@ -264,6 +256,20 @@ function MonitoringStatus() {
   const activeTabConnectionType = useAppStore((s) => getActiveTab(s)?.connectionType ?? null);
   const activeTabConfig = useAppStore((s) => getActiveTab(s)?.config ?? undefined);
   const activeTabExited = useAppStore((s) => !!(activeTabId && s.terminalExitedTabs[activeTabId]));
+
+  // Per-host keying (#1231, audit gap G6): the status bar renders the entry for
+  // the active tab's monitor key. Switching tabs just changes which entry we
+  // show — other hosts keep monitoring independently.
+  const activeMonitorKey = useAppStore((s) => monitorKeyForTab(getActiveTab(s)));
+  const activeMonitor = useAppStore((s) => selectMonitor(s, monitorKeyForTab(getActiveTab(s))));
+  const monitoringConnected = !!activeMonitor?.monitorSessionId;
+  const monitoringHost = activeMonitor?.host ?? null;
+  const monitoringStats = activeMonitor?.stats ?? null;
+  const monitoringSampleCount = activeMonitor?.sampleCount ?? 0;
+  const monitoringLoading = activeMonitor?.loading ?? false;
+  const monitoringError = activeMonitor?.error ?? null;
+  const monitoringStatus = activeMonitor?.status ?? null;
+  const monitoringCancelled = activeMonitor?.cancelled ?? false;
 
   const activeTabSupportsMonitoring = typeSupportsMonitoring(
     connectionTypes,
@@ -297,9 +303,10 @@ function MonitoringStatus() {
 
   // Auto-refresh polling (SSH-based monitoring only; session-based is push).
   useEffect(() => {
-    if (monitoringSessionId && !isRemoteSession) {
+    if (monitoringConnected && !isRemoteSession && activeMonitorKey) {
+      const key = activeMonitorKey;
       intervalRef.current = setInterval(() => {
-        refreshMonitoring();
+        refreshMonitoring(key);
       }, REFRESH_INTERVAL_MS);
     }
     return () => {
@@ -308,7 +315,7 @@ function MonitoringStatus() {
         intervalRef.current = null;
       }
     };
-  }, [monitoringSessionId, isRemoteSession, refreshMonitoring]);
+  }, [monitoringConnected, isRemoteSession, activeMonitorKey, refreshMonitoring]);
 
   // Auto-connect monitoring when active tab supports monitoring
   useEffect(() => {
@@ -323,24 +330,25 @@ function MonitoringStatus() {
     const activeTab = getActiveTab(useAppStore.getState());
     if (!activeTab) return;
 
+    const key = monitorKeyForTab(activeTab);
+    if (!key) return;
+
+    // Already monitoring this host (connected or in flight) → nothing to do.
+    // Switching tabs no longer tears down other hosts (#1231, audit gap G6).
+    const existing = useAppStore.getState().monitors[key];
+    if (existing && (existing.monitorSessionId || existing.loading)) return;
+    if (autoConnectFailedRef.current === key) return;
+    autoConnectFailedRef.current = key;
+
     // ── Remote-session: use session-based (push) monitoring ───────────
     if (activeTab.connectionType === "remote-session") {
       const sessionId = activeTab.sessionId;
       if (!sessionId) return;
-
-      // Already monitoring this session
-      if (monitoringSessionId === sessionId) return;
-      if (autoConnectFailedRef.current === sessionId) return;
-      autoConnectFailedRef.current = sessionId;
-
       const doConnect = async () => {
-        const { disconnectMonitoring: disconnect, connectMonitoring: connect } =
-          useAppStore.getState();
-        if (monitoringSessionId && monitoringSessionId !== sessionId) {
-          await disconnect();
-        }
-        await connect({ _sessionBased: true, _sessionId: sessionId });
-        if (useAppStore.getState().monitoringSessionId) {
+        await useAppStore
+          .getState()
+          .connectMonitoring({ _sessionBased: true, _sessionId: sessionId });
+        if (useAppStore.getState().monitors[key]?.monitorSessionId) {
           autoConnectFailedRef.current = null;
         }
       };
@@ -356,23 +364,13 @@ function MonitoringStatus() {
     const host = (cfg.host as string) ?? "";
     const port = (cfg.port as number) ?? 0;
     const username = (cfg.username as string) ?? "";
-    const hostKey = `${username}@${host}:${port}`;
-
-    if (monitoringSessionId && monitoringHost === hostKey) return;
-    if (autoConnectFailedRef.current === hostKey) return;
-    autoConnectFailedRef.current = hostKey;
 
     const doConnect = async () => {
       const {
         connections: conns,
-        disconnectMonitoring: disconnect,
         connectMonitoring: connect,
         requestPassword,
       } = useAppStore.getState();
-
-      if (monitoringSessionId && monitoringHost !== hostKey) {
-        await disconnect();
-      }
 
       let configToUse = cfg;
       const authMethod = cfg.authMethod as string | undefined;
@@ -388,7 +386,7 @@ function MonitoringStatus() {
           // "Monitoring not connected" affordance instead of returning silently,
           // and keep the Retry/picker reachable (audit gap G8).
           frontendLog("monitoring", "auto-connect cancelled at password prompt");
-          useAppStore.getState().setMonitoringCancelled(true);
+          useAppStore.getState().setMonitoringCancelled(key, true);
           return;
         }
         configToUse = { ...baseConfig, password };
@@ -396,7 +394,7 @@ function MonitoringStatus() {
 
       await connect(configToUse);
 
-      if (useAppStore.getState().monitoringSessionId) {
+      if (useAppStore.getState().monitors[key]?.monitorSessionId) {
         autoConnectFailedRef.current = null;
       }
     };
@@ -405,8 +403,8 @@ function MonitoringStatus() {
   }, [
     activeTabId,
     activeTabSessionId,
-    monitoringSessionId,
-    monitoringHost,
+    activeMonitorKey,
+    monitoringConnected,
     monitoringEnabled,
     activeTabExited,
     // Re-run auto-connect when the user hits Retry (audit gaps G7 + G8).
@@ -432,11 +430,13 @@ function MonitoringStatus() {
   const handleRetry = useCallback(() => {
     frontendLog("monitoring", "user retrying monitoring auto-connect");
     autoConnectFailedRef.current = null;
-    const { clearMonitoringError, setMonitoringCancelled } = useAppStore.getState();
-    clearMonitoringError();
-    setMonitoringCancelled(false);
+    if (activeMonitorKey) {
+      const { clearMonitoringError, setMonitoringCancelled } = useAppStore.getState();
+      clearMonitoringError(activeMonitorKey);
+      setMonitoringCancelled(activeMonitorKey, false);
+    }
     setRetryNonce((n) => n + 1);
-  }, []);
+  }, [activeMonitorKey]);
 
   // Hide monitoring UI when disabled or when active tab doesn't support monitoring
   if (!monitoringEnabled) return null;
@@ -444,10 +444,10 @@ function MonitoringStatus() {
   // While reconnecting we already have cached stats — skip the "Connecting" block
   // so the last-known data is shown immediately instead of a blank loading state.
   const isReconnectingWithCache =
-    !monitoringSessionId && monitoringLoading && monitoringStats !== null;
+    !monitoringConnected && monitoringLoading && monitoringStats !== null;
 
   // Not connected: show connect button (or loading/error/cancelled state)
-  if (!monitoringSessionId && !isReconnectingWithCache) {
+  if (!monitoringConnected && !isReconnectingWithCache) {
     // Remote-session tabs auto-connect; show loading/error/cancelled feedback.
     if (isRemoteSession) {
       if (!monitoringLoading && !monitoringError && !monitoringCancelled) return null;
@@ -560,8 +560,8 @@ function MonitoringStatus() {
         host={monitoringHost}
         stats={monitoringStats}
         loading={monitoringLoading}
-        onRefresh={refreshMonitoring}
-        onDisconnect={disconnectMonitoring}
+        onRefresh={() => activeMonitorKey && refreshMonitoring(activeMonitorKey)}
+        onDisconnect={() => activeMonitorKey && disconnectMonitoring(activeMonitorKey)}
       />
       {monitoringStats && (
         <>

--- a/src/store/appStore.monitoring.test.ts
+++ b/src/store/appStore.monitoring.test.ts
@@ -43,34 +43,61 @@ vi.mock("@/services/api", () => ({
 }));
 
 // Session-based monitoring subscribes to Tauri events and stores the returned
-// unlisten fns; the tests below assert those listeners are not leaked on a
-// failed open. Status callbacks are captured so a test can push a transition.
-const mockUnlisten = vi.fn();
-const mockStatusUnlisten = vi.fn();
+// unlisten fns. Each connect registers its own stats+status callbacks that
+// filter by sessionId. The mocks below capture every registered callback so a
+// test can fan a push event out to all of them (mirroring the real event bus,
+// where every listener receives every event and filters by sessionId).
+type StatsCallback = (sessionId: string, stats: SystemStats) => void;
 type StatusCallback = (sessionId: string, status: MonitorStatus) => void;
-let capturedStatusCallback: StatusCallback | null = null;
-const mockOnSessionMonitoringStats = vi.fn((..._args: unknown[]) => Promise.resolve(mockUnlisten));
+let statsCallbacks: StatsCallback[] = [];
+let statusCallbacks: StatusCallback[] = [];
+const mockStatsUnlisten = vi.fn();
+const mockStatusUnlisten = vi.fn();
+const mockOnSessionMonitoringStats = vi.fn((cb: StatsCallback) => {
+  statsCallbacks.push(cb);
+  return Promise.resolve(mockStatsUnlisten);
+});
 const mockOnSessionMonitoringStatus = vi.fn((cb: StatusCallback) => {
-  capturedStatusCallback = cb;
+  statusCallbacks.push(cb);
   return Promise.resolve(mockStatusUnlisten);
 });
 
+/** Fan a stats push out to every registered listener (they filter by sessionId). */
+function pushStats(sessionId: string, stats: SystemStats) {
+  statsCallbacks.forEach((cb) => cb(sessionId, stats));
+}
+/** Fan a status push out to every registered listener (they filter by sessionId). */
+function pushStatus(sessionId: string, status: MonitorStatus) {
+  statusCallbacks.forEach((cb) => cb(sessionId, status));
+}
+
 vi.mock("@/services/events", () => ({
-  onSessionMonitoringStats: (...args: unknown[]) => mockOnSessionMonitoringStats(...args),
+  onSessionMonitoringStats: (cb: StatsCallback) => mockOnSessionMonitoringStats(cb),
   onSessionMonitoringStatus: (cb: StatusCallback) => mockOnSessionMonitoringStatus(cb),
   onPersistentSessionStateChanged: vi.fn(() => Promise.resolve(() => {})),
 }));
 
-import { useAppStore } from "./appStore";
+import { useAppStore, selectMonitor, selectActiveMonitor, monitorKeyForTab } from "./appStore";
 import type { MonitorStatus, SystemStats } from "@/types/monitoring";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
 
-const TEST_SSH_CONFIG = {
+const HOST_A_CONFIG = {
   host: "pi.local",
   port: 22,
   username: "pi",
   authMethod: "key" as const,
   keyPath: "/home/.ssh/id_rsa",
 };
+const HOST_A_KEY = "pi@pi.local:22";
+
+const HOST_B_CONFIG = {
+  host: "server.local",
+  port: 2222,
+  username: "admin",
+  authMethod: "key" as const,
+  keyPath: "/home/.ssh/id_rsa",
+};
+const HOST_B_KEY = "admin@server.local:2222";
 
 const TEST_STATS: SystemStats = {
   hostname: "pi",
@@ -86,52 +113,72 @@ const TEST_STATS: SystemStats = {
   osInfo: "Linux 6.1",
 };
 
-describe("appStore — monitoring", () => {
+/** Makes the given monitor key the active tab by installing a matching SSH tab. */
+function setActiveSshTab(host: string, port: number, username: string) {
+  const tab: TerminalTab = {
+    id: "tab-active",
+    sessionId: "term-sess",
+    title: "ssh",
+    connectionType: "ssh",
+    contentType: "terminal",
+    config: { type: "ssh", config: { host, port, username } },
+    panelId: "leaf-1",
+    isActive: true,
+  };
+  const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs: [tab], activeTabId: "tab-active" };
+  useAppStore.setState({ rootPanel: leaf, activePanelId: "leaf-1" });
+}
+
+describe("appStore — monitoring (per-host keyed slice, G6)", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
     vi.clearAllMocks();
-    capturedStatusCallback = null;
+    statsCallbacks = [];
+    statusCallbacks = [];
   });
 
-  describe("connectMonitoring", () => {
-    it("sets session, host, and stats on success", async () => {
+  describe("connectMonitoring — SSH", () => {
+    it("creates a keyed entry with session, host, and stats on success", async () => {
       mockMonitoringOpen.mockResolvedValue("session-123");
       mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
 
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
 
-      const state = useAppStore.getState();
-      expect(state.monitoringSessionId).toBe("session-123");
-      expect(state.monitoringHost).toBe("pi@pi.local:22");
-      expect(state.monitoringStats).toEqual(TEST_STATS);
-      expect(state.monitoringLoading).toBe(false);
-      expect(state.monitoringError).toBeNull();
+      const entry = selectMonitor(useAppStore.getState(), HOST_A_KEY);
+      expect(entry).not.toBeNull();
+      expect(entry!.monitorSessionId).toBe("session-123");
+      expect(entry!.host).toBe(HOST_A_KEY);
+      expect(entry!.sessionBased).toBe(false);
+      expect(entry!.stats).toEqual(TEST_STATS);
+      expect(entry!.loading).toBe(false);
+      expect(entry!.error).toBeNull();
+      expect(entry!.status).toBe("live");
     });
 
-    it("sets error without throwing on connection failure", async () => {
+    it("sets error on the entry without throwing on connection failure", async () => {
       mockMonitoringOpen.mockRejectedValue(new Error("Connection refused"));
 
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
 
-      const state = useAppStore.getState();
-      expect(state.monitoringSessionId).toBeNull();
-      expect(state.monitoringLoading).toBe(false);
-      expect(state.monitoringError).toBe("Connection refused");
+      const entry = selectMonitor(useAppStore.getState(), HOST_A_KEY);
+      expect(entry!.monitorSessionId).toBeNull();
+      expect(entry!.loading).toBe(false);
+      expect(entry!.error).toBe("Connection refused");
     });
 
-    it("sets error without throwing on stats fetch failure", async () => {
+    it("sets error on stats fetch failure", async () => {
       mockMonitoringOpen.mockResolvedValue("session-123");
       mockMonitoringFetchStats.mockRejectedValue(new Error("Stats timeout"));
 
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
 
-      const state = useAppStore.getState();
-      expect(state.monitoringSessionId).toBeNull();
-      expect(state.monitoringLoading).toBe(false);
-      expect(state.monitoringError).toBe("Stats timeout");
+      const entry = selectMonitor(useAppStore.getState(), HOST_A_KEY);
+      expect(entry!.monitorSessionId).toBeNull();
+      expect(entry!.loading).toBe(false);
+      expect(entry!.error).toBe("Stats timeout");
     });
 
-    it("sets monitoringLoading to true while connecting", async () => {
+    it("marks the entry loading while connecting", async () => {
       let resolveOpen: (v: string) => void;
       mockMonitoringOpen.mockReturnValue(
         new Promise<string>((r) => {
@@ -140,495 +187,282 @@ describe("appStore — monitoring", () => {
       );
       mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
 
-      const promise = useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-      expect(useAppStore.getState().monitoringLoading).toBe(true);
+      const promise = useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      expect(selectMonitor(useAppStore.getState(), HOST_A_KEY)!.loading).toBe(true);
 
       resolveOpen!("session-123");
       await promise;
-      expect(useAppStore.getState().monitoringLoading).toBe(false);
+      expect(selectMonitor(useAppStore.getState(), HOST_A_KEY)!.loading).toBe(false);
+    });
+  });
+
+  describe("multi-host — two entries coexist (G6)", () => {
+    it("keeps both hosts as independent entries (no clobber)", async () => {
+      mockMonitoringOpen.mockResolvedValueOnce("session-A").mockResolvedValueOnce("session-B");
+      mockMonitoringFetchStats
+        .mockResolvedValueOnce({ ...TEST_STATS, hostname: "A" })
+        .mockResolvedValueOnce({ ...TEST_STATS, hostname: "B" });
+
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      await useAppStore.getState().connectMonitoring(HOST_B_CONFIG);
+
+      const state = useAppStore.getState();
+      expect(Object.keys(state.monitors).sort()).toEqual([HOST_B_KEY, HOST_A_KEY].sort());
+      expect(selectMonitor(state, HOST_A_KEY)!.monitorSessionId).toBe("session-A");
+      expect(selectMonitor(state, HOST_A_KEY)!.stats!.hostname).toBe("A");
+      expect(selectMonitor(state, HOST_B_KEY)!.monitorSessionId).toBe("session-B");
+      expect(selectMonitor(state, HOST_B_KEY)!.stats!.hostname).toBe("B");
+    });
+
+    it("disconnecting one host leaves the other intact", async () => {
+      mockMonitoringOpen.mockResolvedValueOnce("session-A").mockResolvedValueOnce("session-B");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+      mockMonitoringClose.mockResolvedValue(undefined);
+
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      await useAppStore.getState().connectMonitoring(HOST_B_CONFIG);
+
+      await useAppStore.getState().disconnectMonitoring(HOST_A_KEY);
+
+      const state = useAppStore.getState();
+      expect(selectMonitor(state, HOST_A_KEY)).toBeNull();
+      expect(selectMonitor(state, HOST_B_KEY)).not.toBeNull();
+      expect(selectMonitor(state, HOST_B_KEY)!.monitorSessionId).toBe("session-B");
+      // Only host A's backend session was closed.
+      expect(mockMonitoringClose).toHaveBeenCalledTimes(1);
+      expect(mockMonitoringClose).toHaveBeenCalledWith("session-A");
+    });
+
+    it("disconnectMonitoring() with no key tears down every entry", async () => {
+      mockMonitoringOpen.mockResolvedValueOnce("session-A").mockResolvedValueOnce("session-B");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+      mockMonitoringClose.mockResolvedValue(undefined);
+
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      await useAppStore.getState().connectMonitoring(HOST_B_CONFIG);
+
+      await useAppStore.getState().disconnectMonitoring();
+
+      expect(useAppStore.getState().monitors).toEqual({});
+      expect(mockMonitoringClose).toHaveBeenCalledTimes(2);
     });
   });
 
   describe("connectMonitoring — session-based (push)", () => {
-    const SESSION_CONFIG = { _sessionBased: true, _sessionId: "sess-abc" };
-
-    it("sets session and clears loading on successful open", async () => {
+    it("creates a session-keyed entry on successful open", async () => {
       mockSessionMonitoringOpen.mockResolvedValue(undefined);
 
-      await useAppStore.getState().connectMonitoring(SESSION_CONFIG);
+      await useAppStore
+        .getState()
+        .connectMonitoring({ _sessionBased: true, _sessionId: "sess-abc" });
 
-      const state = useAppStore.getState();
-      expect(state.monitoringSessionId).toBe("sess-abc");
-      expect(state.monitoringHost).toBe("sess-abc");
-      expect(state.monitoringLoading).toBe(false);
+      const entry = selectMonitor(useAppStore.getState(), "sess-abc");
+      expect(entry).not.toBeNull();
+      expect(entry!.sessionBased).toBe(true);
+      expect(entry!.monitorSessionId).toBe("sess-abc");
+      expect(entry!.host).toBe("sess-abc");
+      expect(entry!.loading).toBe(false);
+      expect(entry!.status).toBe("live");
       expect(mockOnSessionMonitoringStats).toHaveBeenCalledTimes(1);
     });
 
     it("unlistens the stats listener when session_monitoring_open fails (no leak)", async () => {
       mockSessionMonitoringOpen.mockRejectedValue(new Error("open refused"));
 
-      await useAppStore.getState().connectMonitoring(SESSION_CONFIG);
+      await useAppStore
+        .getState()
+        .connectMonitoring({ _sessionBased: true, _sessionId: "sess-abc" });
 
-      // The event listener was attached before the failing open, so it must be
-      // detached in the catch — otherwise a dangling listener could later update
-      // the wrong host (audit G5).
       expect(mockOnSessionMonitoringStats).toHaveBeenCalledTimes(1);
-      expect(mockUnlisten).toHaveBeenCalledTimes(1);
+      expect(mockStatsUnlisten).toHaveBeenCalledTimes(1);
 
-      const state = useAppStore.getState();
-      expect(state.monitoringSessionId).toBeNull();
-      expect(state.monitoringLoading).toBe(false);
-      expect(state.monitoringError).toBe("open refused");
+      const entry = selectMonitor(useAppStore.getState(), "sess-abc");
+      expect(entry!.monitorSessionId).toBeNull();
+      expect(entry!.loading).toBe(false);
+      expect(entry!.error).toBe("open refused");
     });
 
-    it("does not re-invoke the leaked listener on a later disconnect", async () => {
-      mockSessionMonitoringOpen.mockRejectedValue(new Error("open refused"));
+    it("routes stats push events to the matching entry only", async () => {
+      mockSessionMonitoringOpen.mockResolvedValue(undefined);
+      await useAppStore.getState().connectMonitoring({ _sessionBased: true, _sessionId: "sess-a" });
+      await useAppStore.getState().connectMonitoring({ _sessionBased: true, _sessionId: "sess-b" });
 
-      await useAppStore.getState().connectMonitoring(SESSION_CONFIG);
-      expect(mockUnlisten).toHaveBeenCalledTimes(1);
+      pushStats("sess-a", { ...TEST_STATS, hostname: "A-updated" });
 
-      // A subsequent disconnect must not call the (already-detached) listener again,
-      // proving _monitoringUnlisten was nulled in the catch.
-      await useAppStore.getState().disconnectMonitoring();
-      expect(mockUnlisten).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("disconnectMonitoring", () => {
-    it("clears all monitoring state", async () => {
-      mockMonitoringClose.mockResolvedValue(undefined);
-
-      // Set up connected state
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-        monitoringError: null,
-      });
-
-      await useAppStore.getState().disconnectMonitoring();
-
-      const state = useAppStore.getState();
-      expect(state.monitoringSessionId).toBeNull();
-      expect(state.monitoringHost).toBeNull();
-      expect(state.monitoringStats).toBeNull();
-      expect(state.monitoringError).toBeNull();
+      expect(selectMonitor(useAppStore.getState(), "sess-a")!.stats!.hostname).toBe("A-updated");
+      // sess-b never received a push → still no stats.
+      expect(selectMonitor(useAppStore.getState(), "sess-b")!.stats).toBeNull();
     });
 
-    it("clears state even if close command fails", async () => {
-      mockMonitoringClose.mockRejectedValue(new Error("network down"));
+    it("routes status push events to the matching entry only", async () => {
+      mockSessionMonitoringOpen.mockResolvedValue(undefined);
+      await useAppStore.getState().connectMonitoring({ _sessionBased: true, _sessionId: "sess-a" });
+      await useAppStore.getState().connectMonitoring({ _sessionBased: true, _sessionId: "sess-b" });
 
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-      });
+      pushStatus("sess-a", "stale");
 
-      await useAppStore.getState().disconnectMonitoring();
-
-      const state = useAppStore.getState();
-      expect(state.monitoringSessionId).toBeNull();
-      expect(state.monitoringHost).toBeNull();
-      expect(state.monitoringStats).toBeNull();
-    });
-
-    it("does not call monitoringClose when no session exists", async () => {
-      await useAppStore.getState().disconnectMonitoring();
-      expect(mockMonitoringClose).not.toHaveBeenCalled();
+      expect(selectMonitor(useAppStore.getState(), "sess-a")!.status).toBe("stale");
+      // sess-b is untouched.
+      expect(selectMonitor(useAppStore.getState(), "sess-b")!.status).toBe("live");
     });
   });
 
-  describe("refreshMonitoring", () => {
-    it("does NOT toggle monitoringLoading", async () => {
+  describe("selectActiveMonitor / monitorKeyForTab", () => {
+    it("monitorKeyForTab derives the SSH host key", () => {
+      const tab = {
+        connectionType: "ssh",
+        sessionId: "s",
+        config: { type: "ssh", config: { host: "pi.local", port: 22, username: "pi" } },
+      } as unknown as TerminalTab;
+      expect(monitorKeyForTab(tab)).toBe(HOST_A_KEY);
+    });
+
+    it("monitorKeyForTab uses sessionId for remote-session tabs", () => {
+      const tab = {
+        connectionType: "remote-session",
+        sessionId: "sess-xyz",
+        config: { type: "remote-session", config: {} },
+      } as unknown as TerminalTab;
+      expect(monitorKeyForTab(tab)).toBe("sess-xyz");
+    });
+
+    it("returns the active tab's entry", async () => {
+      mockMonitoringOpen.mockResolvedValueOnce("session-A").mockResolvedValueOnce("session-B");
+      mockMonitoringFetchStats
+        .mockResolvedValueOnce({ ...TEST_STATS, hostname: "A" })
+        .mockResolvedValueOnce({ ...TEST_STATS, hostname: "B" });
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      await useAppStore.getState().connectMonitoring(HOST_B_CONFIG);
+
+      setActiveSshTab("server.local", 2222, "admin");
+      const active = selectActiveMonitor(useAppStore.getState());
+      expect(active).not.toBeNull();
+      expect(active!.key).toBe(HOST_B_KEY);
+      expect(active!.stats!.hostname).toBe("B");
+    });
+
+    it("returns null when the active tab has no monitor", () => {
+      setActiveSshTab("nowhere.local", 22, "nobody");
+      expect(selectActiveMonitor(useAppStore.getState())).toBeNull();
+    });
+  });
+
+  describe("refreshMonitoring(key)", () => {
+    it("does NOT toggle the entry's loading flag", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
       mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringLoading: false,
-      });
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
 
       const loadingStates: boolean[] = [];
       const unsub = useAppStore.subscribe((state) => {
-        loadingStates.push(state.monitoringLoading);
+        const e = state.monitors[HOST_A_KEY];
+        if (e) loadingStates.push(e.loading);
       });
 
-      await useAppStore.getState().refreshMonitoring();
-
+      await useAppStore.getState().refreshMonitoring(HOST_A_KEY);
       unsub();
-      // monitoringLoading should never have been set to true during refresh
       expect(loadingStates.every((v) => v === false)).toBe(true);
     });
 
-    it("updates stats on success", async () => {
-      const updatedStats = { ...TEST_STATS, cpuUsagePercent: 75.0 };
-      mockMonitoringFetchStats.mockResolvedValue(updatedStats);
+    it("updates stats and recovers status to live on success", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      useAppStore.setState((s) => ({
+        monitors: { ...s.monitors, [HOST_A_KEY]: { ...s.monitors[HOST_A_KEY], status: "stale" } },
+      }));
 
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringStats: TEST_STATS,
-      });
+      const updated = { ...TEST_STATS, cpuUsagePercent: 75 };
+      mockMonitoringFetchStats.mockResolvedValue(updated);
+      await useAppStore.getState().refreshMonitoring(HOST_A_KEY);
 
-      await useAppStore.getState().refreshMonitoring();
-
-      expect(useAppStore.getState().monitoringStats).toEqual(updatedStats);
-      expect(useAppStore.getState().monitoringError).toBeNull();
+      const entry = selectMonitor(useAppStore.getState(), HOST_A_KEY)!;
+      expect(entry.stats).toEqual(updated);
+      expect(entry.status).toBe("live");
+      expect(entry.error).toBeNull();
     });
 
-    it("sets error on failure", async () => {
+    it("flips the entry to stale on a failed poll", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+
       mockMonitoringFetchStats.mockRejectedValue(new Error("timeout"));
+      await useAppStore.getState().refreshMonitoring(HOST_A_KEY);
 
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringStats: TEST_STATS,
-      });
-
-      await useAppStore.getState().refreshMonitoring();
-
-      expect(useAppStore.getState().monitoringError).toBe("timeout");
+      const entry = selectMonitor(useAppStore.getState(), HOST_A_KEY)!;
+      expect(entry.status).toBe("stale");
+      expect(entry.error).toBe("timeout");
     });
 
-    it("no-ops when not connected", async () => {
-      await useAppStore.getState().refreshMonitoring();
+    it("no-ops for an unknown key", async () => {
+      await useAppStore.getState().refreshMonitoring("no-such-key");
       expect(mockMonitoringFetchStats).not.toHaveBeenCalled();
-    });
-
-    it("updates the stats cache with fresh stats", async () => {
-      const updatedStats = { ...TEST_STATS, cpuUsagePercent: 80.0 };
-      mockMonitoringFetchStats.mockResolvedValue(updatedStats);
-
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-      });
-
-      await useAppStore.getState().refreshMonitoring();
-
-      expect(useAppStore.getState().monitoringStatsCache["pi@pi.local:22"]).toEqual(updatedStats);
     });
   });
 
-  // Audit gap G10: the first sample reports CPU 0% (no prior delta), so the
-  // status bar shows a priming indicator until the second sample. The store
-  // tracks progress via monitoringSampleCount.
-  describe("monitoringSampleCount (CPU priming)", () => {
+  describe("stats cache (folded, keyed by MonitorKey)", () => {
+    it("connect pre-populates the entry stats from cache while loading", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-456");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+      useAppStore.setState({ monitoringStatsCache: { [HOST_A_KEY]: TEST_STATS } });
+
+      let capturedStats: SystemStats | null = null;
+      const unsub = useAppStore.subscribe((state) => {
+        const e = state.monitors[HOST_A_KEY];
+        if (e && e.loading && e.stats !== null) capturedStats = e.stats;
+      });
+
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      unsub();
+      expect(capturedStats).toEqual(TEST_STATS);
+    });
+
+    it("disconnect saves the entry's last stats back to the cache", async () => {
+      mockMonitoringOpen.mockResolvedValue("session-123");
+      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
+      mockMonitoringClose.mockResolvedValue(undefined);
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+
+      await useAppStore.getState().disconnectMonitoring(HOST_A_KEY);
+
+      expect(useAppStore.getState().monitoringStatsCache[HOST_A_KEY]).toEqual(TEST_STATS);
+    });
+  });
+
+  describe("sampleCount priming (per entry, G10)", () => {
     it("is 1 after the first SSH connect fetch", async () => {
       mockMonitoringOpen.mockResolvedValue("session-123");
       mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-
-      expect(useAppStore.getState().monitoringSampleCount).toBe(1);
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      expect(selectMonitor(useAppStore.getState(), HOST_A_KEY)!.sampleCount).toBe(1);
     });
 
-    it("increments to 2 after a subsequent refresh", async () => {
+    it("increments to 2 after a refresh", async () => {
       mockMonitoringOpen.mockResolvedValue("session-123");
       mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-
-      mockMonitoringFetchStats.mockResolvedValue({ ...TEST_STATS, cpuUsagePercent: 40 });
-      await useAppStore.getState().refreshMonitoring();
-
-      expect(useAppStore.getState().monitoringSampleCount).toBe(2);
-    });
-
-    it("resets to 0 on disconnect", async () => {
-      mockMonitoringClose.mockResolvedValue(undefined);
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-        monitoringSampleCount: 5,
-      });
-
-      await useAppStore.getState().disconnectMonitoring();
-
-      expect(useAppStore.getState().monitoringSampleCount).toBe(0);
-    });
-
-    it("resets to 0 at the start of a fresh connect", async () => {
-      // Simulate a stale counter from a previous session.
-      useAppStore.setState({ monitoringSampleCount: 7 });
-      mockMonitoringOpen.mockResolvedValue("session-456");
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-
-      // Reset to 0, then +1 for the initial fetch = 1.
-      expect(useAppStore.getState().monitoringSampleCount).toBe(1);
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      await useAppStore.getState().refreshMonitoring(HOST_A_KEY);
+      expect(selectMonitor(useAppStore.getState(), HOST_A_KEY)!.sampleCount).toBe(2);
     });
   });
 
-  describe("stats cache", () => {
-    it("disconnectMonitoring saves stats to cache keyed by host", async () => {
-      mockMonitoringClose.mockResolvedValue(undefined);
+  describe("clearMonitoringError(key) / setMonitoringCancelled(key) (G8/G9)", () => {
+    it("clears a lingering error on a specific entry", async () => {
+      mockMonitoringOpen.mockRejectedValue(new Error("boom"));
+      await useAppStore.getState().connectMonitoring(HOST_A_CONFIG);
+      expect(selectMonitor(useAppStore.getState(), HOST_A_KEY)!.error).toBe("boom");
 
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-      });
-
-      await useAppStore.getState().disconnectMonitoring();
-
-      expect(useAppStore.getState().monitoringStatsCache["pi@pi.local:22"]).toEqual(TEST_STATS);
+      useAppStore.getState().clearMonitoringError(HOST_A_KEY);
+      expect(selectMonitor(useAppStore.getState(), HOST_A_KEY)!.error).toBeNull();
     });
 
-    it("disconnectMonitoring does not update cache when there are no stats", async () => {
-      mockMonitoringClose.mockResolvedValue(undefined);
+    it("setMonitoringCancelled toggles the flag on a keyed entry", () => {
+      useAppStore.getState().setMonitoringCancelled(HOST_A_KEY, true);
+      expect(selectMonitor(useAppStore.getState(), HOST_A_KEY)!.cancelled).toBe(true);
 
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: null,
-        monitoringStatsCache: {},
-      });
-
-      await useAppStore.getState().disconnectMonitoring();
-
-      expect(useAppStore.getState().monitoringStatsCache).toEqual({});
-    });
-
-    it("connectMonitoring pre-populates stats from cache on reconnect", async () => {
-      mockMonitoringOpen.mockResolvedValue("session-456");
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      useAppStore.setState({
-        monitoringStatsCache: { "pi@pi.local:22": TEST_STATS },
-      });
-
-      let capturedStats: SystemStats | null = null;
-      let capturedHost: string | null = null;
-      const unsub = useAppStore.subscribe((state) => {
-        if (state.monitoringLoading && state.monitoringStats !== null) {
-          capturedStats = state.monitoringStats;
-          capturedHost = state.monitoringHost;
-        }
-      });
-
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-      unsub();
-
-      // Stats and host should have been set from cache while loading
-      expect(capturedStats).toEqual(TEST_STATS);
-      expect(capturedHost).toBe("pi@pi.local:22");
-    });
-
-    it("connectMonitoring starts with null stats when no cache entry exists", async () => {
-      mockMonitoringOpen.mockResolvedValue("session-789");
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      let statsWhileLoading: SystemStats | null | undefined = undefined;
-      const unsub = useAppStore.subscribe((state) => {
-        if (state.monitoringLoading && statsWhileLoading === undefined) {
-          statsWhileLoading = state.monitoringStats;
-        }
-      });
-
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-      unsub();
-
-      expect(statsWhileLoading).toBeNull();
-    });
-
-    it("connectMonitoring updates cache after successful connect", async () => {
-      mockMonitoringOpen.mockResolvedValue("session-123");
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-
-      expect(useAppStore.getState().monitoringStatsCache["pi@pi.local:22"]).toEqual(TEST_STATS);
-    });
-  });
-
-  // Audit gap G9: a stale monitoringError must not linger across hosts. The
-  // store clears it on every successful stat update and exposes an explicit
-  // clearMonitoringError() so the status bar can reset it when switching hosts.
-  describe("clearMonitoringError (G9)", () => {
-    it("clears a lingering monitoringError", () => {
-      useAppStore.setState({ monitoringError: "stale error from previous host" });
-
-      useAppStore.getState().clearMonitoringError();
-
-      expect(useAppStore.getState().monitoringError).toBeNull();
-    });
-
-    it("is a no-op when there is no error", () => {
-      useAppStore.setState({ monitoringError: null });
-
-      useAppStore.getState().clearMonitoringError();
-
-      expect(useAppStore.getState().monitoringError).toBeNull();
-    });
-
-    it("refreshMonitoring success clears a pre-existing error (does not linger)", async () => {
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-        monitoringError: "old timeout error",
-      });
-
-      await useAppStore.getState().refreshMonitoring();
-
-      expect(useAppStore.getState().monitoringError).toBeNull();
-    });
-
-    it("connectMonitoring start clears a stale error before connecting", async () => {
-      mockMonitoringOpen.mockResolvedValue("session-123");
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      useAppStore.setState({ monitoringError: "error from a previous host" });
-
-      let errorWhileLoading: string | null | undefined = undefined;
-      const unsub = useAppStore.subscribe((state) => {
-        if (state.monitoringLoading && errorWhileLoading === undefined) {
-          errorWhileLoading = state.monitoringError;
-        }
-      });
-
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-      unsub();
-
-      expect(errorWhileLoading).toBeNull();
-    });
-  });
-
-  // Audit gap G8: cancelling the password prompt during auto-connect must leave
-  // a visible "not connected" affordance instead of silently returning. The
-  // store tracks this via monitoringCancelled.
-  describe("monitoringCancelled (G8)", () => {
-    it("defaults to false", () => {
-      expect(useAppStore.getState().monitoringCancelled).toBe(false);
-    });
-
-    it("setMonitoringCancelled toggles the flag", () => {
-      useAppStore.getState().setMonitoringCancelled(true);
-      expect(useAppStore.getState().monitoringCancelled).toBe(true);
-
-      useAppStore.getState().setMonitoringCancelled(false);
-      expect(useAppStore.getState().monitoringCancelled).toBe(false);
-    });
-
-    it("connectMonitoring start clears a stale cancelled flag", async () => {
-      mockMonitoringOpen.mockResolvedValue("session-123");
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      useAppStore.setState({ monitoringCancelled: true });
-
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-
-      expect(useAppStore.getState().monitoringCancelled).toBe(false);
-    });
-
-    it("disconnectMonitoring clears the cancelled flag", async () => {
-      mockMonitoringClose.mockResolvedValue(undefined);
-
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-        monitoringCancelled: true,
-      });
-
-      await useAppStore.getState().disconnectMonitoring();
-
-      expect(useAppStore.getState().monitoringCancelled).toBe(false);
-    });
-  });
-
-  // Issue #1229 (audit gap G1): a mid-stream drop must surface as an explicit
-  // "stale" status so frozen stats are not shown as live.
-  describe("monitoringStatus (Stale — G1)", () => {
-    it("defaults to null when nothing is monitored", () => {
-      expect(useAppStore.getState().monitoringStatus).toBeNull();
-    });
-
-    it("is 'live' after a successful SSH connect", async () => {
-      mockMonitoringOpen.mockResolvedValue("session-123");
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      await useAppStore.getState().connectMonitoring(TEST_SSH_CONFIG);
-
-      expect(useAppStore.getState().monitoringStatus).toBe("live");
-    });
-
-    it("flips to 'stale' when an SSH refresh poll fails", async () => {
-      mockMonitoringFetchStats.mockRejectedValue(new Error("timeout"));
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-        monitoringStatus: "live",
-      });
-
-      await useAppStore.getState().refreshMonitoring();
-
-      expect(useAppStore.getState().monitoringStatus).toBe("stale");
-    });
-
-    it("recovers to 'live' when a later SSH refresh poll succeeds", async () => {
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-        monitoringStatus: "stale",
-      });
-      mockMonitoringFetchStats.mockResolvedValue(TEST_STATS);
-
-      await useAppStore.getState().refreshMonitoring();
-
-      expect(useAppStore.getState().monitoringStatus).toBe("live");
-    });
-
-    it("is 'live' after a session-based open, then follows status push events", async () => {
-      mockSessionMonitoringOpen.mockResolvedValue(undefined);
-
-      await useAppStore.getState().connectMonitoring({
-        _sessionBased: true,
-        _sessionId: "sess-abc",
-      });
-      expect(useAppStore.getState().monitoringStatus).toBe("live");
-      expect(mockOnSessionMonitoringStatus).toHaveBeenCalledTimes(1);
-      expect(capturedStatusCallback).not.toBeNull();
-
-      // A mid-stream drop pushes "stale" for the active session.
-      capturedStatusCallback?.("sess-abc", "stale" as MonitorStatus);
-      expect(useAppStore.getState().monitoringStatus).toBe("stale");
-
-      // Recovery pushes "live" again.
-      capturedStatusCallback?.("sess-abc", "live" as MonitorStatus);
-      expect(useAppStore.getState().monitoringStatus).toBe("live");
-    });
-
-    it("ignores status events for a different session", async () => {
-      mockSessionMonitoringOpen.mockResolvedValue(undefined);
-
-      await useAppStore.getState().connectMonitoring({
-        _sessionBased: true,
-        _sessionId: "sess-abc",
-      });
-
-      capturedStatusCallback?.("some-other-session", "stale" as MonitorStatus);
-
-      // Unrelated session must not change our status.
-      expect(useAppStore.getState().monitoringStatus).toBe("live");
-    });
-
-    it("resets to null on disconnect", async () => {
-      mockMonitoringClose.mockResolvedValue(undefined);
-      useAppStore.setState({
-        monitoringSessionId: "session-123",
-        monitoringHost: "pi@pi.local:22",
-        monitoringStats: TEST_STATS,
-        monitoringStatus: "stale",
-      });
-
-      await useAppStore.getState().disconnectMonitoring();
-
-      expect(useAppStore.getState().monitoringStatus).toBeNull();
+      useAppStore.getState().setMonitoringCancelled(HOST_A_KEY, false);
+      expect(selectMonitor(useAppStore.getState(), HOST_A_KEY)!.cancelled).toBe(false);
     });
   });
 });

--- a/src/store/appStore.settings.test.ts
+++ b/src/store/appStore.settings.test.ts
@@ -47,6 +47,25 @@ vi.mock("@/services/api", () => ({
 }));
 
 import { useAppStore } from "./appStore";
+import type { MonitoringEntry } from "@/types/monitoring";
+
+/** A single connected SSH monitor entry keyed by its backend session id. */
+function openMonitor(sessionId: string, host: string): Record<string, MonitoringEntry> {
+  return {
+    [sessionId]: {
+      key: sessionId,
+      host,
+      sessionBased: false,
+      monitorSessionId: sessionId,
+      stats: null,
+      loading: false,
+      error: null,
+      status: "live",
+      sampleCount: 0,
+      cancelled: false,
+    },
+  };
+}
 
 describe("appStore — settings toggles", () => {
   beforeEach(() => {
@@ -57,8 +76,7 @@ describe("appStore — settings toggles", () => {
   it("disabling power monitoring disconnects active monitoring session", async () => {
     // Set up connected monitoring state
     useAppStore.setState({
-      monitoringSessionId: "mon-1",
-      monitoringHost: "pi@pi.local:22",
+      monitors: openMonitor("mon-1", "pi@pi.local:22"),
       settings: {
         version: "1",
         externalConnectionFiles: [],
@@ -76,8 +94,7 @@ describe("appStore — settings toggles", () => {
 
     const state = useAppStore.getState();
     expect(state.settings.powerMonitoringEnabled).toBe(false);
-    expect(state.monitoringSessionId).toBeNull();
-    expect(state.monitoringHost).toBeNull();
+    expect(state.monitors).toEqual({});
     expect(mockMonitoringClose).toHaveBeenCalledWith("mon-1");
   });
 
@@ -111,8 +128,7 @@ describe("appStore — settings toggles", () => {
 
   it("disabling one feature does not affect the other", async () => {
     useAppStore.setState({
-      monitoringSessionId: "mon-1",
-      monitoringHost: "pi@pi.local:22",
+      monitors: openMonitor("mon-1", "pi@pi.local:22"),
       sftpSessionId: "sftp-1",
       sftpConnectedHost: "pi@pi.local:22",
       sidebarView: "files",
@@ -134,7 +150,7 @@ describe("appStore — settings toggles", () => {
 
     const state = useAppStore.getState();
     // Monitoring disconnected
-    expect(state.monitoringSessionId).toBeNull();
+    expect(state.monitors).toEqual({});
     // SFTP still connected
     expect(state.sftpSessionId).toBe("sftp-1");
     expect(state.sidebarView).toBe("files");
@@ -198,8 +214,7 @@ describe("appStore — settings toggles", () => {
 
   it("disabling global monitoring keeps session when active tab has explicit enableMonitoring=true", async () => {
     useAppStore.setState({
-      monitoringSessionId: "mon-1",
-      monitoringHost: "pi@pi.local:22",
+      monitors: openMonitor("mon-1", "pi@pi.local:22"),
       ...sshTabPanel({ enableMonitoring: true }),
       settings: {
         version: "1",
@@ -218,7 +233,7 @@ describe("appStore — settings toggles", () => {
 
     // Monitoring should NOT be disconnected — the active tab has an explicit override
     expect(mockMonitoringClose).not.toHaveBeenCalled();
-    expect(useAppStore.getState().monitoringSessionId).toBe("mon-1");
+    expect(useAppStore.getState().monitors["mon-1"]).toBeDefined();
   });
 
   it("disabling global file browser keeps SFTP when active tab has explicit enableFileBrowser=true", async () => {
@@ -250,8 +265,7 @@ describe("appStore — settings toggles", () => {
 
   it("disabling global monitoring disconnects when active tab uses default (no override)", async () => {
     useAppStore.setState({
-      monitoringSessionId: "mon-1",
-      monitoringHost: "pi@pi.local:22",
+      monitors: openMonitor("mon-1", "pi@pi.local:22"),
       ...sshTabPanel({}), // No per-connection override
       settings: {
         version: "1",

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -138,7 +138,7 @@ import {
 } from "@/services/lastSessionApi";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
 import { connectTimeoutMessage, type ConnectTimeoutKind } from "@/utils/connectTimeout";
-import { MonitorStatus, SystemStats } from "@/types/monitoring";
+import { MonitoringEntry, SystemStats } from "@/types/monitoring";
 import {
   onSessionMonitoringStats,
   onSessionMonitoringStatus,
@@ -758,44 +758,25 @@ interface AppState {
   setEditorActions: (actions: EditorActions | null) => void;
 
   // Monitoring
-  monitoringSessionId: string | null;
-  monitoringHost: string | null;
-  monitoringStats: SystemStats | null;
-  monitoringLoading: boolean;
-  monitoringError: string | null;
   /**
-   * Observable lifecycle state of the active monitoring collector loop.
-   *
-   * `null` when no monitor is connected. Set to `"live"` on connect and driven
-   * by `session-monitoring-status` push events for session-based tabs: a
-   * mid-stream drop flips it to `"stale"` so the status bar stops rendering
-   * frozen stats as live (#1229, audit gap G1).
+   * Per-host/session monitoring state, keyed by {@link MonitoringEntry.key}
+   * (audit gap G6, #1231). Replaces the former global singleton so multiple
+   * hosts can be monitored at once: the status bar renders the active tab's
+   * entry (see {@link selectActiveMonitor}) while Open Connections iterates
+   * every entry.
    */
-  monitoringStatus: MonitorStatus | null;
-  /**
-   * Number of stats samples received on the current monitoring connection.
-   * The remote collectors report CPU 0% on the first sample (no prior delta),
-   * so the UI treats sample #1 as "priming" for the CPU field. Reset to 0 on
-   * connect/disconnect and incremented on every real stats update. See audit
-   * gap G10.
-   */
-  monitoringSampleCount: number;
-  /**
-   * True when auto-connect was aborted because the user cancelled the password
-   * prompt. The status bar renders a subtle "Monitoring not connected"
-   * affordance (with a reachable Retry) instead of failing silently. Reset on
-   * connect start, disconnect, and retry. See audit gap G8.
-   */
-  monitoringCancelled: boolean;
-  /** Last-known stats per host key, persisted across tab switches for instant display on reconnect. */
+  monitors: Record<string, MonitoringEntry>;
+  /** Last-known stats per MonitorKey, persisted across tab switches for instant display on reconnect. */
   monitoringStatsCache: Record<string, SystemStats>;
   connectMonitoring: (config: Record<string, unknown>) => Promise<void>;
-  disconnectMonitoring: () => Promise<void>;
-  refreshMonitoring: () => Promise<void>;
-  /** Clear a lingering monitoringError so a stale tooltip cannot persist across hosts (audit gap G9). */
-  clearMonitoringError: () => void;
-  /** Set/reset the "connect was cancelled" affordance flag (audit gap G8). */
-  setMonitoringCancelled: (cancelled: boolean) => void;
+  /** Disconnect one monitor by key, or every monitor when `key` is omitted. */
+  disconnectMonitoring: (key?: string) => Promise<void>;
+  /** Poll fresh stats for one SSH monitor (session-based monitors are push-driven). */
+  refreshMonitoring: (key: string) => Promise<void>;
+  /** Clear a lingering error on one entry so a stale tooltip cannot persist (audit gap G9). */
+  clearMonitoringError: (key: string) => void;
+  /** Set/reset the "connect was cancelled" affordance flag on one entry (audit gap G8). */
+  setMonitoringCancelled: (key: string, cancelled: boolean) => void;
   /** Per-session capabilities fetched after session creation (keyed by sessionId). */
   sessionCapabilities: Record<string, { monitoring: boolean; fileBrowser: boolean }>;
   setSessionCapabilities: (
@@ -1011,11 +992,88 @@ function collectLiveTabs(state: {
   return trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
 }
 
-/** Unlisten function for the active session-based monitoring stats subscription. */
-let _monitoringUnlisten: (() => void) | null = null;
+/**
+ * Per-key unlisten functions for session-based monitoring subscriptions, keyed
+ * by MonitorKey. Since multiple hosts can be monitored simultaneously (#1231),
+ * each session monitor owns its own stats + status subscription that must be
+ * detached individually when that host is disconnected (or its open fails).
+ */
+const _monitoringStatsUnlisten = new Map<string, () => void>();
+const _monitoringStatusUnlisten = new Map<string, () => void>();
 
-/** Unlisten function for the active session-based monitoring status subscription. */
-let _monitoringStatusUnlisten: (() => void) | null = null;
+/** Detach and forget both subscriptions for one session-based monitor key. */
+function detachMonitorListeners(key: string): void {
+  _monitoringStatsUnlisten.get(key)?.();
+  _monitoringStatsUnlisten.delete(key);
+  _monitoringStatusUnlisten.get(key)?.();
+  _monitoringStatusUnlisten.delete(key);
+}
+
+/** Build a fresh, idle {@link MonitoringEntry} for a key. */
+function emptyMonitor(key: string, host: string | null, sessionBased: boolean): MonitoringEntry {
+  return {
+    key,
+    host,
+    sessionBased,
+    monitorSessionId: null,
+    stats: null,
+    loading: false,
+    error: null,
+    status: null,
+    sampleCount: 0,
+    cancelled: false,
+  };
+}
+
+/** Merge a partial patch into the entry for `key`, creating it if absent. */
+function upsertMonitor(key: string, patch: Partial<MonitoringEntry>): void {
+  useAppStore.setState((state) => {
+    const entry =
+      state.monitors[key] ?? emptyMonitor(key, patch.host ?? key, patch.sessionBased ?? false);
+    return { monitors: { ...state.monitors, [key]: { ...entry, ...patch } } };
+  });
+}
+
+/**
+ * Derive the {@link MonitoringEntry} key for a tab: the session id for
+ * `remote-session` (session-based) tabs, or the `user@host:port` host key for
+ * desktop-direct SSH tabs. Returns `null` when the tab cannot be monitored
+ * (e.g. missing host/username). Kept in sync with the key `connectMonitoring`
+ * computes so the status bar and auto-connect address the same entry.
+ */
+export function monitorKeyForTab(tab: TerminalTab | null | undefined): string | null {
+  if (!tab) return null;
+  if (tab.connectionType === "remote-session") {
+    return tab.sessionId ?? null;
+  }
+  const cfg = (tab.config?.config ?? {}) as Record<string, unknown>;
+  const host = cfg.host as string | undefined;
+  const username = cfg.username as string | undefined;
+  if (!host || !username) return null;
+  const port = cfg.port as number | undefined;
+  return `${username}@${host}:${port}`;
+}
+
+/** Select one monitor entry by key, or `null` when none exists. */
+export function selectMonitor(state: AppState, key: string | null): MonitoringEntry | null {
+  if (!key) return null;
+  return state.monitors[key] ?? null;
+}
+
+/** Select the monitor entry for the currently active tab, or `null`. */
+export function selectActiveMonitor(state: AppState): MonitoringEntry | null {
+  return selectMonitor(state, monitorKeyForTab(getActiveTab(state)));
+}
+
+/**
+ * Select every monitor with a live backend subscription (a non-null
+ * `monitorSessionId`) — the set Open Connections lists and can kill. Entries
+ * that only carry a transient error/cancelled state (never connected) are
+ * excluded so nothing unkillable-yet-invisible is shown.
+ */
+export function selectOpenMonitors(state: AppState): MonitoringEntry[] {
+  return Object.values(state.monitors).filter((m) => m.monitorSessionId !== null);
+}
 
 function createTab(
   title: string,
@@ -3412,10 +3470,11 @@ export const useAppStore = create<AppState>((set, get) => {
         terminalReconnectingTabs: omitKey(state.terminalReconnectingTabs, tabId),
         terminalReconnectTriggerErrors: omitKey(state.terminalReconnectTriggerErrors, tabId),
       }));
-      // Stop monitoring when the terminal session dies — the stats are no
-      // longer being updated and the overlay hides the terminal anyway.
-      if (get().monitoringSessionId) {
-        get().disconnectMonitoring();
+      // Stop monitoring the dying tab's host — its stats are no longer updated
+      // and the overlay hides the terminal anyway. Other hosts keep monitoring.
+      const deadKey = monitorKeyForTab(collectLiveTabs(get()).find((t) => t.id === tabId));
+      if (deadKey && get().monitors[deadKey]) {
+        get().disconnectMonitoring(deadKey);
       }
     },
     markSessionKilled: (sessionId) =>
@@ -3443,8 +3502,9 @@ export const useAppStore = create<AppState>((set, get) => {
       // A failed (re)connect settles this tab as failed in any in-flight
       // restore/launch cohort so the aggregate summary reflects it (#1146).
       get().settleRestoreTab(tabId, "failed");
-      if (get().monitoringSessionId) {
-        get().disconnectMonitoring();
+      const deadKey = monitorKeyForTab(collectLiveTabs(get()).find((t) => t.id === tabId));
+      if (deadKey && get().monitors[deadKey]) {
+        get().disconnectMonitoring(deadKey);
       }
     },
 
@@ -4105,20 +4165,25 @@ export const useAppStore = create<AppState>((set, get) => {
     editorActions: null,
     setEditorActions: (actions) => set({ editorActions: actions }),
 
-    // Monitoring
-    monitoringSessionId: null,
-    monitoringHost: null,
-    monitoringStats: null,
-    monitoringLoading: false,
-    monitoringError: null,
-    monitoringStatus: null,
-    monitoringSampleCount: 0,
-    monitoringCancelled: false,
+    // Monitoring — per-host/session keyed slice (audit gap G6, #1231).
+    monitors: {},
     monitoringStatsCache: {},
     sessionCapabilities: {},
 
-    clearMonitoringError: () => set({ monitoringError: null }),
-    setMonitoringCancelled: (cancelled) => set({ monitoringCancelled: cancelled }),
+    clearMonitoringError: (key) =>
+      set((state) => {
+        const entry = state.monitors[key];
+        if (!entry || entry.error === null) return {};
+        return { monitors: { ...state.monitors, [key]: { ...entry, error: null } } };
+      }),
+
+    setMonitoringCancelled: (key, cancelled) =>
+      set((state) => {
+        // Auto-connect may cancel at the password prompt before any entry
+        // exists, so create a placeholder entry to carry the affordance (G8).
+        const entry = state.monitors[key] ?? emptyMonitor(key, key, false);
+        return { monitors: { ...state.monitors, [key]: { ...entry, cancelled } } };
+      }),
 
     setSessionCapabilities: (sessionId, caps) =>
       set((state) => ({
@@ -4127,169 +4192,178 @@ export const useAppStore = create<AppState>((set, get) => {
 
     connectMonitoring: async (config: Record<string, unknown>) => {
       const { monitoringStatsCache } = useAppStore.getState();
-      try {
-        // Session-based monitoring: config carries sessionId for "remote-session" tabs.
-        // The agent pushes stats via "session-monitoring-stats" Tauri events.
-        if (config._sessionBased) {
-          const sessionId = config._sessionId as string;
-          const cachedStats = monitoringStatsCache[sessionId] ?? null;
-          set({
-            monitoringLoading: true,
-            monitoringError: null,
-            monitoringStats: cachedStats,
-            monitoringHost: cachedStats ? sessionId : null,
-            monitoringStatus: "connecting",
-            // Fresh connection: reset the sample counter so CPU shows the
-            // priming indicator until the second push arrives (audit gap G10).
-            monitoringSampleCount: 0,
-            // Clear any stale cancel affordance from a previous attempt (G8).
-            monitoringCancelled: false,
-          });
 
-          const unlisten = await onSessionMonitoringStats((sid, stats) => {
-            if (sid === sessionId) {
-              useAppStore.setState((state) => ({
-                monitoringStats: stats,
-                monitoringError: null,
-                monitoringSampleCount: state.monitoringSampleCount + 1,
-                monitoringStatsCache: { ...state.monitoringStatsCache, [sessionId]: stats },
-              }));
-            }
+      // Session-based monitoring: config carries sessionId for "remote-session"
+      // tabs. The agent pushes stats via "session-monitoring-stats" events.
+      const sessionBased = !!config._sessionBased;
+      const key = sessionBased
+        ? (config._sessionId as string)
+        : `${config.username as string}@${config.host as string}:${config.port as number}`;
+      const cachedStats = monitoringStatsCache[key] ?? null;
+
+      // Upsert a fresh loading entry keyed by MonitorKey. monitorSessionId stays
+      // null until the backend connection is established, which the UI reads as
+      // "not yet connected" (matching the former singleton semantics).
+      upsertMonitor(key, {
+        ...emptyMonitor(key, key, sessionBased),
+        stats: cachedStats,
+        loading: true,
+        status: "connecting",
+      });
+
+      try {
+        if (sessionBased) {
+          // Attach the stats listener; it filters by sessionId and folds fresh
+          // samples into this entry + the shared cache.
+          const statsUnlisten = await onSessionMonitoringStats((sid, stats) => {
+            if (sid !== key) return;
+            useAppStore.setState((state) => {
+              const entry = state.monitors[key];
+              if (!entry) return {};
+              return {
+                monitors: {
+                  ...state.monitors,
+                  [key]: { ...entry, stats, error: null, sampleCount: entry.sampleCount + 1 },
+                },
+                monitoringStatsCache: { ...state.monitoringStatsCache, [key]: stats },
+              };
+            });
           });
-          // Store unlisten in a module-level variable so disconnectMonitoring can call it.
-          _monitoringUnlisten = unlisten;
+          _monitoringStatsUnlisten.set(key, statsUnlisten);
 
           // The status stream flips the indicator to `stale` on a mid-stream
           // drop (and back to `live` on recovery) so frozen stats are never
           // shown as live (#1229, audit gap G1).
           const statusUnlisten = await onSessionMonitoringStatus((sid, status) => {
-            if (sid === sessionId) {
-              useAppStore.setState({ monitoringStatus: status });
-            }
+            if (sid !== key) return;
+            useAppStore.setState((state) => {
+              const entry = state.monitors[key];
+              if (!entry) return {};
+              return { monitors: { ...state.monitors, [key]: { ...entry, status } } };
+            });
           });
-          _monitoringStatusUnlisten = statusUnlisten;
+          _monitoringStatusUnlisten.set(key, statusUnlisten);
 
-          await sessionMonitoringOpen(sessionId);
-          set({
-            monitoringSessionId: sessionId,
-            monitoringHost: sessionId,
-            monitoringLoading: false,
-            monitoringStatus: "live",
-          });
+          await sessionMonitoringOpen(key);
+          upsertMonitor(key, { monitorSessionId: key, loading: false, status: "live" });
           return;
         }
 
         // Standard SSH-based monitoring (direct connection from desktop).
-        const hostKey = `${config.username as string}@${config.host as string}:${config.port as number}`;
-        const cachedStats = monitoringStatsCache[hostKey] ?? null;
-        set({
-          monitoringLoading: true,
-          monitoringError: null,
-          monitoringStats: cachedStats,
-          monitoringHost: cachedStats ? hostKey : null,
-          monitoringStatus: "connecting",
-          // Fresh connection: reset the sample counter so CPU shows the priming
-          // indicator until the second fetch arrives (audit gap G10).
-          monitoringSampleCount: 0,
-          // Clear any stale cancel affordance from a previous attempt (G8).
-          monitoringCancelled: false,
-        });
-
         const sessionId = await monitoringOpen(config);
         const stats = await monitoringFetchStats(sessionId);
-        set((state) => ({
-          monitoringSessionId: sessionId,
-          monitoringHost: hostKey,
-          monitoringStats: stats,
-          monitoringLoading: false,
-          monitoringStatus: "live",
-          monitoringSampleCount: state.monitoringSampleCount + 1,
-          monitoringStatsCache: { ...state.monitoringStatsCache, [hostKey]: stats },
-        }));
+        set((state) => {
+          const entry = state.monitors[key] ?? emptyMonitor(key, key, false);
+          return {
+            monitors: {
+              ...state.monitors,
+              [key]: {
+                ...entry,
+                monitorSessionId: sessionId,
+                stats,
+                loading: false,
+                error: null,
+                status: "live",
+                sampleCount: entry.sampleCount + 1,
+              },
+            },
+            monitoringStatsCache: { ...state.monitoringStatsCache, [key]: stats },
+          };
+        });
       } catch (err) {
         // The session-based branch attaches the stats listener before the open
         // that may throw here. Detach it so a failed open never leaks a dangling
-        // Tauri listener (monitoringSessionId stays null, so disconnectMonitoring
+        // Tauri listener (monitorSessionId stays null, so disconnectMonitoring
         // would not clean it up either). See audit gap G5.
-        if (_monitoringUnlisten) {
+        if (sessionBased) {
           frontendLog("monitoring", "detaching stats listener after failed monitoring open");
-          _monitoringUnlisten();
-          _monitoringUnlisten = null;
+          detachMonitorListeners(key);
         }
-        if (_monitoringStatusUnlisten) {
-          _monitoringStatusUnlisten();
-          _monitoringStatusUnlisten = null;
-        }
-        set({
-          monitoringLoading: false,
-          monitoringError: err instanceof Error ? err.message : String(err),
-          monitoringStatus: null,
+        upsertMonitor(key, {
+          monitorSessionId: null,
+          loading: false,
+          error: err instanceof Error ? err.message : String(err),
+          status: null,
         });
       }
     },
 
-    disconnectMonitoring: async () => {
-      const { monitoringSessionId, monitoringHost, monitoringStats, sessionCapabilities } =
-        useAppStore.getState();
-      if (monitoringSessionId) {
-        try {
-          // If this was a session-based monitoring, stop it; otherwise close SSH session.
-          if (sessionCapabilities[monitoringSessionId] !== undefined) {
-            await sessionMonitoringClose(monitoringSessionId);
-          } else {
-            await monitoringClose(monitoringSessionId);
+    disconnectMonitoring: async (key) => {
+      // Kill exactly one entry when a key is given, or every entry otherwise
+      // (Open Connections "Kill All", global toggle-off).
+      const { monitors } = useAppStore.getState();
+      const keys = key !== undefined ? [key] : Object.keys(monitors);
+
+      for (const k of keys) {
+        const entry = monitors[k];
+        if (entry?.monitorSessionId) {
+          try {
+            if (entry.sessionBased) {
+              await sessionMonitoringClose(entry.monitorSessionId);
+            } else {
+              await monitoringClose(entry.monitorSessionId);
+            }
+          } catch {
+            // Ignore close errors — the entry is torn down regardless.
           }
-        } catch {
-          // Ignore close errors
         }
+        detachMonitorListeners(k);
       }
-      if (_monitoringUnlisten) {
-        _monitoringUnlisten();
-        _monitoringUnlisten = null;
-      }
-      if (_monitoringStatusUnlisten) {
-        _monitoringStatusUnlisten();
-        _monitoringStatusUnlisten = null;
-      }
-      set((state) => ({
-        monitoringSessionId: null,
-        monitoringHost: null,
-        monitoringStats: null,
-        monitoringError: null,
-        monitoringStatus: null,
-        monitoringSampleCount: 0,
-        monitoringCancelled: false,
-        // Preserve last-known stats so the UI can show them instantly on reconnect.
-        monitoringStatsCache:
-          monitoringHost && monitoringStats
-            ? { ...state.monitoringStatsCache, [monitoringHost]: monitoringStats }
-            : state.monitoringStatsCache,
-      }));
+
+      set((state) => {
+        const nextMonitors = { ...state.monitors };
+        const nextCache = { ...state.monitoringStatsCache };
+        for (const k of keys) {
+          const entry = state.monitors[k];
+          // Preserve last-known stats so the UI can show them instantly on reconnect.
+          if (entry?.stats) nextCache[k] = entry.stats;
+          delete nextMonitors[k];
+        }
+        return { monitors: nextMonitors, monitoringStatsCache: nextCache };
+      });
     },
 
-    refreshMonitoring: async () => {
-      const { monitoringSessionId, monitoringHost, sessionCapabilities } = useAppStore.getState();
-      if (!monitoringSessionId) return;
-      // Session-based monitoring is push-based; no explicit refresh needed.
-      if (sessionCapabilities[monitoringSessionId] !== undefined) return;
+    refreshMonitoring: async (key) => {
+      const entry = useAppStore.getState().monitors[key];
+      // Only SSH monitors poll; session-based monitoring is push-driven.
+      if (!entry || !entry.monitorSessionId || entry.sessionBased) return;
+      const monitorSessionId = entry.monitorSessionId;
       try {
-        const stats = await monitoringFetchStats(monitoringSessionId);
-        set((state) => ({
-          monitoringStats: stats,
-          monitoringError: null,
-          // A successful poll recovers the indicator to live (audit gap G1).
-          monitoringStatus: "live",
-          monitoringSampleCount: state.monitoringSampleCount + 1,
-          monitoringStatsCache: monitoringHost
-            ? { ...state.monitoringStatsCache, [monitoringHost]: stats }
-            : state.monitoringStatsCache,
-        }));
+        const stats = await monitoringFetchStats(monitorSessionId);
+        set((state) => {
+          const current = state.monitors[key];
+          if (!current) return {};
+          return {
+            monitors: {
+              ...state.monitors,
+              [key]: {
+                ...current,
+                stats,
+                error: null,
+                // A successful poll recovers the indicator to live (audit gap G1).
+                status: "live",
+                sampleCount: current.sampleCount + 1,
+              },
+            },
+            monitoringStatsCache: { ...state.monitoringStatsCache, [key]: stats },
+          };
+        });
       } catch (err) {
         // A failed poll while still "connected" flips to stale so the last-good
         // numbers are dimmed rather than shown as live (audit gap G1).
-        set({
-          monitoringError: err instanceof Error ? err.message : String(err),
-          monitoringStatus: "stale",
+        set((state) => {
+          const current = state.monitors[key];
+          if (!current) return {};
+          return {
+            monitors: {
+              ...state.monitors,
+              [key]: {
+                ...current,
+                error: err instanceof Error ? err.message : String(err),
+                status: "stale",
+              },
+            },
+          };
         });
       }
     },

--- a/src/types/monitoring.ts
+++ b/src/types/monitoring.ts
@@ -8,6 +8,53 @@
  */
 export type MonitorStatus = "connecting" | "live" | "stale" | "reconnecting" | "offline" | "paused";
 
+/**
+ * One monitored host/session, keyed by a stable {@link MonitorKey} in the store
+ * (`monitors: Record<MonitorKey, MonitoringEntry>`). Replaces the former global
+ * singleton so multiple hosts can be monitored simultaneously (#1231, audit gap
+ * G6). The status bar renders the entry for the active tab; Open Connections
+ * iterates every entry.
+ *
+ * `MonitorKey` is the session id for session-based (`remote-session`) tabs and
+ * the `user@host:port` host key for desktop-direct SSH monitoring — matching the
+ * keying that `monitoringStatsCache` already used.
+ */
+export interface MonitoringEntry {
+  /** Stable key identifying this monitor (sessionId or `user@host:port`). */
+  key: string;
+  /** Human-readable host label shown in the UI. */
+  host: string | null;
+  /** True for push-based session monitoring; false for desktop-direct SSH polling. */
+  sessionBased: boolean;
+  /**
+   * Backend session id used for close/refresh RPCs. Equals `key` for
+   * session-based monitors; for SSH it is the id returned by `monitoringOpen`.
+   * `null` until the backend connection is established (or after a failed open),
+   * which the UI reads as "not yet connected".
+   */
+  monitorSessionId: string | null;
+  /** Last-known stats for this host, or `null` before the first sample. */
+  stats: SystemStats | null;
+  /** True while the initial connect (or a cache-primed reconnect) is in flight. */
+  loading: boolean;
+  /** Last error message for this host, or `null`. */
+  error: string | null;
+  /** Observable collector-loop status (`live`/`stale`/…), or `null` when idle. */
+  status: MonitorStatus | null;
+  /**
+   * Number of stats samples received on this connection. The remote collectors
+   * report CPU 0% on the first sample (no prior delta), so the UI treats sample
+   * #1 as "priming" for the CPU field (audit gap G10).
+   */
+  sampleCount: number;
+  /**
+   * True when auto-connect was aborted because the user cancelled the password
+   * prompt. The status bar renders a "Monitoring not connected" affordance with a
+   * reachable Retry instead of failing silently (audit gap G8).
+   */
+  cancelled: boolean;
+}
+
 /** System statistics retrieved from a remote Linux host. */
 export interface SystemStats {
   hostname: string;


### PR DESCRIPTION
## Summary

Closes #1231 — Monitoring stage **S3 (audit gap G6)**: replace the singleton monitoring store slice (one global host) with a per-host/session keyed map so multiple hosts can be monitored simultaneously.

Part of the [Remote System Monitoring lifecycle redesign](../blob/develop/docs/concepts/backlog/remote-monitoring-lifecycle-redesign.html) (parent #1193). Builds on #1228 (honest connect) and #1229 (status channel), both merged.

## Approach

- **Store**: the five singleton fields (`monitoringSessionId`, `monitoringHost`, `monitoringStats`, `monitoringLoading`, `monitoringError`) plus the folded `monitoringStatus` / `monitoringSampleCount` / `monitoringCancelled` are replaced by `monitors: Record<MonitorKey, MonitoringEntry>`. Each entry holds `{ key, host, sessionBased, monitorSessionId, stats, loading, error, status, sampleCount, cancelled }`. `monitoringStatsCache` (already keyed by sessionId) is folded in.
- **MonitorKey**: sessionId for session-based (`remote-session`) tabs; `user@host:port` host key for desktop-direct SSH. This matches the keying the stats cache already used and is the identity available before the async backend open (the connect picker connects a saved host with no owning terminal session). This is a small, reconciled deviation from the concept's "SSH key = owning terminal sessionId" wording — worth a follow-up `/sync-concept` pass, noted below.
- **Selectors**: `monitorKeyForTab`, `selectMonitor`, `selectActiveMonitor`, `selectOpenMonitors`. Per-key Tauri unlisten maps replace the module-level singletons so each session monitor's listeners detach individually.
- **Actions**: `connect`/`disconnect(key?)`/`refresh(key)`/`clearMonitoringError(key)`/`setMonitoringCancelled(key, …)` operate on one entry; `disconnectMonitoring()` with no key tears down all (Kill All / global toggle-off). Auto-connect no longer disconnects the previous host on tab switch — switching tabs just changes which entry the status bar shows. A dying tab's session only tears down that host's monitor.
- **UI**: StatusBar renders the active tab's entry; Open Connections lists one killable row per monitored host (Kill All + per-row Kill, "stale" hint), replacing the single global Monitoring row.

## Test plan

- TDD: added `src/store/appStore.monitoring.test.ts` (keyed model) **before** implementation — 25 tests, red first, green after. Covers: two hosts coexist (no clobber), active selector returns the current tab's entry, disconnecting one host leaves others intact, `disconnectMonitoring()` tears down all, stats/status push events route to the matching entry only, cache fold, sample-count priming, per-key error/cancelled.
- Migrated `appStore.settings.test.ts` and the StatusBar monitoring priming/stale/feedback tests to the keyed model.
- `pnpm test` — 2440 passed. `pnpm build` (tsc) and `pnpm run lint` — clean. No `any` types.

## Follow-up

- `/sync-concept remote-monitoring-lifecycle-redesign` to reconcile the SSH-key wording and refresh the sync ledger now that S3 is implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)