### PR TITLE
feat(tunnel): migrate TunnelListItem actions to shared Button primitive (#1259)

### DIFF
--- a/docs/changes/dev2/feature/1259-tunnel-listitem-button-primitive.md
+++ b/docs/changes/dev2/feature/1259-tunnel-listitem-button-primitive.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Tunnel sidebar rows now compose their action controls (Start, Stop, Retry,
+  View last error, Edit, Duplicate, Delete) from the shared `Button` primitive
+  instead of bespoke icon buttons. The async actions (Start / Stop / Retry) show
+  a per-button pending spinner tied to the real backend call and flash success on
+  completion, so the whole row is visually consistent with the rest of the app
+  and every action gives immediate feedback (#1259, follow-up to #1240).

--- a/src/components/TunnelSidebar/TunnelListItem.button.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.button.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Verifies the tunnel list-item action row is composed from the shared `Button`
+ * primitive (issue #1259, follow-up to #1240) rather than bespoke
+ * `.tunnel-item__action` buttons.
+ *
+ * Every action button must carry the `ui-btn` primitive classes (ghost variant),
+ * and the async actions (Start / Stop / Retry) must drive the Button's async
+ * lifecycle — a pending spinner state while the underlying promise is in flight,
+ * returning to idle once it resolves. The stable `data-testid`s survive.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TunnelListItem } from "./TunnelListItem";
+import { withTooltip } from "@/test/tooltip";
+import type { TunnelConfig, TunnelState } from "@/types/tunnel";
+import type { SavedConnection } from "@/types/connection";
+
+const TUNNEL: TunnelConfig = {
+  id: "tun-1",
+  name: "My Tunnel",
+  sshConnectionId: "ssh-1",
+  autoStart: false,
+  reconnectOnDisconnect: false,
+  tunnelType: {
+    type: "local",
+    config: {
+      localHost: "127.0.0.1",
+      localPort: 8080,
+      remoteHost: "example.com",
+      remotePort: 80,
+    },
+  },
+};
+
+const noop = () => {};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+interface Handlers {
+  onStart?: (id: string) => void | Promise<void>;
+  onStop?: (id: string) => void | Promise<void>;
+}
+
+function renderItem(state: TunnelState | undefined, handlers: Handlers = {}): void {
+  act(() => {
+    root.render(
+      withTooltip(
+        <TunnelListItem
+          tunnel={TUNNEL}
+          state={state}
+          connections={[] as SavedConnection[]}
+          onStart={handlers.onStart ?? noop}
+          onStop={handlers.onStop ?? noop}
+          onEdit={noop}
+          onDuplicate={noop}
+          onDelete={noop}
+        />
+      )
+    );
+  });
+}
+
+function click(el: HTMLElement): void {
+  act(() => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("TunnelListItem — shared Button primitive (#1259)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders every action as a shared ghost Button primitive", async () => {
+    renderItem(undefined);
+    await flush();
+
+    const ids = [
+      "tunnel-start-tun-1",
+      "tunnel-edit-tun-1",
+      "tunnel-duplicate-tun-1",
+      "tunnel-delete-tun-1",
+    ];
+    for (const id of ids) {
+      const btn = container.querySelector<HTMLButtonElement>(`[data-testid="${id}"]`);
+      expect(btn, id).not.toBeNull();
+      expect(btn?.classList.contains("ui-btn"), id).toBe(true);
+      expect(btn?.classList.contains("ui-btn--ghost"), id).toBe(true);
+    }
+  });
+
+  it("drives the Button async lifecycle on Start: pending while in flight, then idle", async () => {
+    let resolveStart!: () => void;
+    const onStart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        })
+    );
+    renderItem(undefined, { onStart });
+    await flush();
+
+    const start = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-start-tun-1"]')!;
+    click(start);
+    await flush();
+
+    // In flight → pending state (disabled + spinner class).
+    expect(onStart).toHaveBeenCalledWith("tun-1");
+    expect(start.classList.contains("ui-btn--pending")).toBe(true);
+    expect(start.disabled).toBe(true);
+
+    await act(async () => {
+      resolveStart();
+      await Promise.resolve();
+    });
+
+    // Resolved → no longer pending.
+    expect(start.classList.contains("ui-btn--pending")).toBe(false);
+  });
+
+  it("drives the Button async lifecycle on Stop when the tunnel is active", async () => {
+    let resolveStop!: () => void;
+    const onStop = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStop = resolve;
+        })
+    );
+    renderItem({ tunnelId: "tun-1", status: "connected" } as TunnelState, { onStop });
+    await flush();
+
+    const stop = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-stop-tun-1"]')!;
+    click(stop);
+    await flush();
+
+    expect(onStop).toHaveBeenCalledWith("tun-1");
+    expect(stop.classList.contains("ui-btn--pending")).toBe(true);
+
+    await act(async () => {
+      resolveStop();
+      await Promise.resolve();
+    });
+
+    expect(stop.classList.contains("ui-btn--pending")).toBe(false);
+  });
+
+  it("drives the Button async lifecycle on Retry when the tunnel is in error", async () => {
+    let resolveRetry!: () => void;
+    const onStart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        })
+    );
+    renderItem({ tunnelId: "tun-1", status: "error", error: "boom" } as TunnelState, { onStart });
+    await flush();
+
+    const retry = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-retry-tun-1"]')!;
+    expect(retry.classList.contains("ui-btn")).toBe(true);
+    click(retry);
+    await flush();
+
+    expect(onStart).toHaveBeenCalledWith("tun-1");
+    expect(retry.classList.contains("ui-btn--pending")).toBe(true);
+
+    await act(async () => {
+      resolveRetry();
+      await Promise.resolve();
+    });
+
+    expect(retry.classList.contains("ui-btn--pending")).toBe(false);
+  });
+});

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -1,5 +1,5 @@
 import { Play, Square, Pencil, Copy, Trash2, RotateCw, Info, AlertTriangle } from "lucide-react";
-import { Tooltip, toast } from "@/components/ui";
+import { Button, Tooltip, toast } from "@/components/ui";
 import { TunnelConfig, TunnelState } from "@/types/tunnel";
 import { SavedConnection } from "@/types/connection";
 import { formatBytes } from "@/utils/formatters";
@@ -8,8 +8,10 @@ interface TunnelListItemProps {
   tunnel: TunnelConfig;
   state: TunnelState | undefined;
   connections: SavedConnection[];
-  onStart: (tunnelId: string) => void;
-  onStop: (tunnelId: string) => void;
+  /** Start (also Retry) the tunnel. May be async so the button shows a pending state. */
+  onStart: (tunnelId: string) => void | Promise<void>;
+  /** Stop the tunnel. May be async so the button shows a pending state. */
+  onStop: (tunnelId: string) => void | Promise<void>;
   onEdit: (tunnelId: string) => void;
   onDuplicate: (tunnelId: string) => void;
   onDelete: (tunnelId: string) => void;
@@ -73,102 +75,114 @@ export function TunnelListItem({
         <div className="tunnel-item__actions">
           {isActive && (
             <Tooltip content="Stop" side="top">
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 className="tunnel-item__action"
                 aria-label="Stop"
                 data-testid={`tunnel-stop-${tunnel.id}`}
+                icon={<Square size={12} />}
+                // The store surfaces its own start/stop toast; suppress the
+                // Button's duplicate error toast and keep the pending spinner.
+                errorToast={false}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onStop(tunnel.id);
+                  return onStop(tunnel.id);
                 }}
-              >
-                <Square size={12} />
-              </button>
+              />
             </Tooltip>
           )}
           {isError && (
             <>
               <Tooltip content="View last error" side="top">
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   className="tunnel-item__action"
                   aria-label="View last error"
                   data-testid={`tunnel-view-error-${tunnel.id}`}
+                  icon={<Info size={12} />}
                   onClick={(e) => {
                     e.stopPropagation();
                     handleViewError();
                   }}
-                >
-                  <Info size={12} />
-                </button>
+                />
               </Tooltip>
               <Tooltip content="Retry" side="top">
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   className="tunnel-item__action"
                   aria-label="Retry"
                   data-testid={`tunnel-retry-${tunnel.id}`}
+                  icon={<RotateCw size={12} />}
+                  errorToast={false}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onStart(tunnel.id);
+                    return onStart(tunnel.id);
                   }}
-                >
-                  <RotateCw size={12} />
-                </button>
+                />
               </Tooltip>
             </>
           )}
           {!isActive && !isError && (
             <Tooltip content="Start" side="top">
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 className="tunnel-item__action"
                 aria-label="Start"
                 data-testid={`tunnel-start-${tunnel.id}`}
+                icon={<Play size={12} />}
+                errorToast={false}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onStart(tunnel.id);
+                  return onStart(tunnel.id);
                 }}
-              >
-                <Play size={12} />
-              </button>
+              />
             </Tooltip>
           )}
           <Tooltip content="Edit" side="top">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               className="tunnel-item__action"
               aria-label="Edit"
               data-testid={`tunnel-edit-${tunnel.id}`}
+              icon={<Pencil size={12} />}
               onClick={(e) => {
                 e.stopPropagation();
                 onEdit(tunnel.id);
               }}
-            >
-              <Pencil size={12} />
-            </button>
+            />
           </Tooltip>
           <Tooltip content="Duplicate" side="top">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               className="tunnel-item__action"
               aria-label="Duplicate"
               data-testid={`tunnel-duplicate-${tunnel.id}`}
+              icon={<Copy size={12} />}
               onClick={(e) => {
                 e.stopPropagation();
                 onDuplicate(tunnel.id);
               }}
-            >
-              <Copy size={12} />
-            </button>
+            />
           </Tooltip>
           <Tooltip content="Delete" side="top">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               className="tunnel-item__action"
               aria-label="Delete"
               data-testid={`tunnel-delete-${tunnel.id}`}
+              icon={<Trash2 size={12} />}
               onClick={(e) => {
                 e.stopPropagation();
                 onDelete(tunnel.id);
               }}
-            >
-              <Trash2 size={12} />
-            </button>
+            />
           </Tooltip>
         </div>
       </div>

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -112,7 +112,7 @@
 
 /*
  * Geometry-only override for the shared ghost Button primitive in the dense
- * tunnel row (issue #1259). All visual styling — color, hover, radius, focus
+ * tunnel row (issue 1259). All visual styling — color, hover, radius, focus
  * ring, and the async pending/success affordances — comes from `.ui-btn--ghost`;
  * this only makes each icon-only action a compact square so the error-state row
  * (up to five actions) stays tidy in the narrow sidebar.

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -110,23 +110,17 @@
   opacity: 1;
 }
 
-.tunnel-item__action {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border: none;
-  background: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
+/*
+ * Geometry-only override for the shared ghost Button primitive in the dense
+ * tunnel row (issue #1259). All visual styling — color, hover, radius, focus
+ * ring, and the async pending/success affordances — comes from `.ui-btn--ghost`;
+ * this only makes each icon-only action a compact square so the error-state row
+ * (up to five actions) stays tidy in the narrow sidebar.
+ */
+.tunnel-item__action.ui-btn {
+  width: var(--control-height-md);
   padding: 0;
-}
-
-.tunnel-item__action:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
+  flex-shrink: 0;
 }
 
 .tunnel-item__details {


### PR DESCRIPTION
Closes #1259 (follow-up to #1240).

## Approach

Migrates the entire `.tunnel-item__actions` icon-button group in
`TunnelListItem` (Start, Stop, Retry, View last error, Edit, Duplicate, Delete)
from bespoke `.tunnel-item__action` buttons to the shared ghost `Button`
primitive, matching the merged NetworkTools sidebar precedent.

- **Real async feedback**: Start / Stop / Retry return the store's
  `startTunnel` / `stopTunnel` promise from `onClick`, so the Button drives a
  per-button pending spinner (disabled + `aria-busy`) tied to the actual backend
  call and flashes success on completion. The store already emits its own
  loading→success/error toast and re-throws, so `errorToast={false}` avoids a
  duplicate error toast while the Button still returns to idle on rejection.
- **Prop types**: `onStart` / `onStop` widened to `(id) => void | Promise<void>`
  so the async lifecycle is wired to the real calls, not cosmetic.
- **Tokens only**: removed the dead bespoke button CSS (color/hover/radius/size);
  all skinning now comes from `.ui-btn--ghost`. A single geometry-only override
  keeps the dense error-state row (up to five actions) compact.
- Stable `data-testid`s and `aria-label`s are preserved; the testid catalog is
  unchanged.

## Test plan

- New `TunnelListItem.button.test.tsx` (TDD, committed before the impl): asserts
  the actions render as `ui-btn ui-btn--ghost` primitives and that Start / Stop /
  Retry enter `ui-btn--pending` while the promise is in flight and return to idle
  on resolve. Written red → green.
- `pnpm test` (TunnelSidebar suite: 13 passed), `pnpm build` (tsc), `pnpm run lint`,
  and `./scripts/check.sh` all pass. No `any` types.
- **Manual visual check (macOS, not automatable here)**: open the Tunnel sidebar,
  hover a row and confirm the ghost action buttons look consistent with the rest
  of the app; start a tunnel and confirm the per-button pending spinner appears
  and clears; trigger an error and confirm the Retry / View-last-error row stays
  visible and Retry shows a spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)