### PR TITLE
fix(terminal): anchor connect/waiting timeout to a wall-clock deadline (Closes #1263)

### DIFF
--- a/docs/changes/dev1/feature/1263-connect-timeout-wallclock.md
+++ b/docs/changes/dev1/feature/1263-connect-timeout-wallclock.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The connect / waiting-for-agent timeout is now anchored to a wall-clock
+  deadline stored per tab, so dragging a still-connecting tab to another
+  panel/split (or a zoom toggle that re-keys the panel tree) no longer restarts
+  its countdown. Previously the timer was tied to the overlay component's
+  lifetime, so an unmount/remount reset the bound — the advertised "times out in
+  N s" was really "N s of continuous overlay mounting". Now the visible
+  countdown and the actual timeout fire from the same stored deadline and both
+  survive a remount (#1263).

--- a/src/components/Terminal/TerminalConnectionOverlay.timeout.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.timeout.test.tsx
@@ -23,6 +23,7 @@ const PANEL_ID = "panel-test";
 function resetStore() {
   useAppStore.setState({
     terminalConnecting: {},
+    terminalConnectDeadline: {},
     terminalSpawnErrors: {},
     terminalAutoRetryCount: {},
     terminalWaitingForAgent: {},
@@ -62,14 +63,14 @@ describe("TerminalConnectionOverlay — timeouts", () => {
   });
 
   it("shows a visible timeout countdown while waiting for the agent", () => {
-    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    useAppStore.getState().setTerminalWaitingForAgent(TAB_ID, "agent-1");
     render(root);
     // The overlay must communicate that the wait is bounded.
     expect(container.textContent).toContain("Times out in");
   });
 
   it("transitions the waiting-for-agent tab to Failed after the timeout elapses", () => {
-    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    useAppStore.getState().setTerminalWaitingForAgent(TAB_ID, "agent-1");
     render(root);
 
     act(() => {
@@ -83,12 +84,12 @@ describe("TerminalConnectionOverlay — timeouts", () => {
   });
 
   it("does not fire the timeout if the agent connects before it elapses", () => {
-    useAppStore.setState({ terminalWaitingForAgent: { [TAB_ID]: "agent-1" } });
+    useAppStore.getState().setTerminalWaitingForAgent(TAB_ID, "agent-1");
     render(root);
 
     // Agent came online: clear the wait before the timeout.
     act(() => {
-      useAppStore.setState({ terminalWaitingForAgent: {} });
+      useAppStore.getState().setTerminalWaitingForAgent(TAB_ID, null);
     });
     act(() => {
       vi.advanceTimersByTime(WAITING_FOR_AGENT_TIMEOUT_MS + 100);
@@ -98,13 +99,49 @@ describe("TerminalConnectionOverlay — timeouts", () => {
   });
 
   it("transitions the connecting tab to Failed after the connect timeout elapses", () => {
-    useAppStore.setState({ terminalConnecting: { [TAB_ID]: true } });
+    useAppStore.getState().setTerminalConnecting(TAB_ID, true);
     render(root);
 
     act(() => {
       vi.advanceTimersByTime(CONNECTING_TIMEOUT_MS + 100);
     });
 
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBe(
+      connectTimeoutMessage("connecting")
+    );
+  });
+
+  // Regression for #1263: the timeout is anchored to a store-held wall-clock
+  // deadline, so remounting the overlay mid-connect (tab drag to another
+  // panel/split, zoom re-key) must NOT restart the countdown — it fires at the
+  // original deadline, not a fresh full budget later.
+  it("keeps the wall-clock deadline across an overlay remount and fires on time", () => {
+    useAppStore.getState().setTerminalConnecting(TAB_ID, true);
+    const deadlineBefore = useAppStore.getState().terminalConnectDeadline[TAB_ID]?.at;
+    expect(deadlineBefore).toBeGreaterThan(0);
+
+    render(root);
+
+    // Spend all but ~5s of the budget, then unmount/remount the overlay.
+    act(() => {
+      vi.advanceTimersByTime(CONNECTING_TIMEOUT_MS - 5_000);
+    });
+    act(() => root.unmount());
+
+    // The stored deadline is untouched by the unmount/remount.
+    expect(useAppStore.getState().terminalConnectDeadline[TAB_ID]?.at).toBe(deadlineBefore);
+    expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBeUndefined();
+
+    root = createRoot(container);
+    render(root);
+
+    // A timer that restarted from zero would need the full budget again;
+    // advancing only the ~5s that actually remained still fires it.
+    act(() => {
+      vi.advanceTimersByTime(5_000 + 100);
+    });
+
+    expect(useAppStore.getState().terminalConnecting[TAB_ID]).toBeUndefined();
     expect(useAppStore.getState().terminalSpawnErrors[TAB_ID]).toBe(
       connectTimeoutMessage("connecting")
     );

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -3,11 +3,6 @@ import { ServerCrash, RefreshCw, Loader2, Zap, Ban } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { useAppStore } from "@/store/appStore";
 import { useElapsed } from "@/hooks/useElapsed";
-import {
-  connectTimeoutMs,
-  connectTimeoutSeconds,
-  type ConnectTimeoutKind,
-} from "@/utils/connectTimeout";
 import "./TerminalConnectionOverlay.css";
 
 interface TerminalConnectionOverlayProps {
@@ -84,32 +79,30 @@ export function TerminalConnectionOverlay({
   // contextual hint (#1129). auto-retry manages its own visible-failure cadence,
   // so it is intentionally not timed here.
   const failTerminalConnectTimeout = useAppStore((s) => s.failTerminalConnectTimeout);
-  const timeoutKind: ConnectTimeoutKind | null = waitingForAgent
-    ? "waiting-for-agent"
-    : isConnecting
-      ? "connecting"
-      : null;
+  // The timeout is anchored to a wall-clock deadline held in the store (set on
+  // entry to the timed state), not to this component's lifetime. The overlay
+  // only reads it, so unmounting and remounting mid-connect (dragging the tab to
+  // another panel/split, a zoom re-key) re-arms the timer for the REMAINING time
+  // rather than restarting the countdown from zero (#1263).
+  const connectDeadline = useAppStore((s) => s.terminalConnectDeadline[tabId]);
+  const deadlineAt = connectDeadline?.at;
+  const deadlineKind = connectDeadline?.kind;
 
-  // The timer is armed once per state transition (deps exclude the per-second
-  // elapsed tick), so it is not re-armed every second. Note: because it is tied
-  // to this component's lifetime, unmounting and remounting the overlay while
-  // still connecting (e.g. dragging the tab to another panel) restarts the
-  // countdown — a wall-clock deadline in the store would make it survive
-  // remounts (tracked as a follow-up).
   useEffect(() => {
-    if (!timeoutKind) return;
+    if (deadlineAt === undefined || !deadlineKind) return;
     const id = setTimeout(
-      () => failTerminalConnectTimeout(tabId, timeoutKind),
-      connectTimeoutMs(timeoutKind)
+      () => failTerminalConnectTimeout(tabId, deadlineKind),
+      Math.max(0, deadlineAt - Date.now())
     );
     return () => clearTimeout(id);
-  }, [tabId, timeoutKind, failTerminalConnectTimeout]);
+  }, [tabId, deadlineAt, deadlineKind, failTerminalConnectTimeout]);
 
-  // Whole seconds remaining before the client-side timeout fires (>= 0), for the
-  // visible countdown. Derived from the per-second elapsed tick.
-  const remainingSeconds = timeoutKind
-    ? Math.max(0, connectTimeoutSeconds(timeoutKind) - elapsedSeconds)
-    : 0;
+  // Whole seconds remaining before the timeout fires (>= 0), for the visible
+  // countdown. Derived from the same stored deadline as the timer above and
+  // recomputed on the per-second elapsed tick (elapsedSeconds), so the display
+  // and the actual fire share one clock and both survive a remount.
+  const remainingSeconds =
+    deadlineAt !== undefined ? Math.max(0, Math.ceil((deadlineAt - Date.now()) / 1000)) : 0;
 
   const handleCancel = useCallback(() => {
     closeTab(tabId, panelId);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -138,7 +138,11 @@ import {
   clearLastSession as apiClearLastSession,
 } from "@/services/lastSessionApi";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
-import { connectTimeoutMessage, type ConnectTimeoutKind } from "@/utils/connectTimeout";
+import {
+  connectTimeoutMessage,
+  connectTimeoutMs,
+  type ConnectTimeoutKind,
+} from "@/utils/connectTimeout";
 import { MonitorStatus, SystemStats } from "@/types/monitoring";
 import {
   onSessionMonitoringStats,
@@ -189,6 +193,30 @@ export interface FileClipboard {
 function omitKey<V>(rec: Record<string, V>, key: string): Record<string, V> {
   const { [key]: _, ...rest } = rec;
   return rest;
+}
+
+/**
+ * A per-tab wall-clock deadline for a timed pre-connect state. Stored so the
+ * connect/waiting timeout survives an overlay remount (tab drag, split re-key):
+ * the deadline is set once on entry and the overlay only reads it, so
+ * unmounting/remounting the overlay can never restart the countdown (#1263).
+ */
+type ConnectDeadline = { kind: ConnectTimeoutKind; at: number };
+
+/**
+ * Arm the connect deadline for `tabId`, idempotently: if a deadline for the
+ * same kind already exists it is kept (so re-entering the state — or the
+ * overlay remounting and the effect re-running — does not push the deadline
+ * out). A different kind (connecting -> waiting-for-agent) arms a fresh one.
+ */
+function armConnectDeadline(
+  deadlines: Record<string, ConnectDeadline>,
+  tabId: string,
+  kind: ConnectTimeoutKind
+): Record<string, ConnectDeadline> {
+  const current = deadlines[tabId];
+  if (current && current.kind === kind) return deadlines;
+  return { ...deadlines, [tabId]: { kind, at: Date.now() + connectTimeoutMs(kind) } };
 }
 
 /**
@@ -560,6 +588,13 @@ interface AppState {
   terminalRetryCounters: Record<string, number>;
   /** True while a createTerminal call is in-flight — drives the "Connecting…" overlay. */
   terminalConnecting: Record<string, boolean>;
+  /**
+   * Per-tab wall-clock deadline (epoch ms + kind) for the active timed
+   * pre-connect state. Set on entry to `Connecting` / `WaitingForAgent` and
+   * cleared on every exit; the overlay reads it so the timeout survives a
+   * remount instead of restarting the countdown (#1263).
+   */
+  terminalConnectDeadline: Record<string, ConnectDeadline>;
   setTerminalSpawnError: (tabId: string, error: string | null) => void;
   retryTerminalSpawn: (tabId: string) => void;
   setTerminalConnecting: (tabId: string, connecting: boolean) => void;
@@ -2225,6 +2260,7 @@ export const useAppStore = create<AppState>((set, get) => {
         const remainingSpawnErrors = omitKey(state.terminalSpawnErrors, tabId);
         const remainingRetryCounters = omitKey(state.terminalRetryCounters, tabId);
         const remainingConnecting = omitKey(state.terminalConnecting, tabId);
+        const remainingConnectDeadline = omitKey(state.terminalConnectDeadline, tabId);
         const remainingExited = omitKey(state.terminalExitedTabs, tabId);
         const remainingExitInfo = omitKey(state.terminalExitInfo, tabId);
         const remainingDiscErr = omitKey(state.terminalDisconnectErrors, tabId);
@@ -2295,6 +2331,7 @@ export const useAppStore = create<AppState>((set, get) => {
             terminalSpawnErrors: remainingSpawnErrors,
             terminalRetryCounters: remainingRetryCounters,
             terminalConnecting: remainingConnecting,
+            terminalConnectDeadline: remainingConnectDeadline,
             terminalExitedTabs: remainingExited,
             terminalExitInfo: remainingExitInfo,
             terminalDisconnectErrors: remainingDiscErr,
@@ -2322,6 +2359,7 @@ export const useAppStore = create<AppState>((set, get) => {
           terminalSpawnErrors: remainingSpawnErrors,
           terminalRetryCounters: remainingRetryCounters,
           terminalConnecting: remainingConnecting,
+          terminalConnectDeadline: remainingConnectDeadline,
           terminalExitedTabs: remainingExited,
           terminalExitInfo: remainingExitInfo,
           terminalDisconnectErrors: remainingDiscErr,
@@ -3302,6 +3340,7 @@ export const useAppStore = create<AppState>((set, get) => {
     terminalSpawnErrors: {},
     terminalRetryCounters: {},
     terminalConnecting: {},
+    terminalConnectDeadline: {},
     terminalAutoRetryCount: {},
     terminalWaitingForAgent: {},
     setTerminalSpawnError: (tabId, error) =>
@@ -3316,6 +3355,7 @@ export const useAppStore = create<AppState>((set, get) => {
         terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
         terminalAutoRetryCount: omitKey(state.terminalAutoRetryCount, tabId),
         terminalWaitingForAgent: omitKey(state.terminalWaitingForAgent, tabId),
+        terminalConnectDeadline: omitKey(state.terminalConnectDeadline, tabId),
         terminalRetryCounters: {
           ...state.terminalRetryCounters,
           [tabId]: (state.terminalRetryCounters[tabId] ?? 0) + 1,
@@ -3326,10 +3366,14 @@ export const useAppStore = create<AppState>((set, get) => {
         terminalConnecting: connecting
           ? { ...state.terminalConnecting, [tabId]: true }
           : omitKey(state.terminalConnecting, tabId),
+        terminalConnectDeadline: connecting
+          ? armConnectDeadline(state.terminalConnectDeadline, tabId, "connecting")
+          : omitKey(state.terminalConnectDeadline, tabId),
       })),
     setTerminalAutoRetrying: (tabId, count) =>
       set((state) => ({
         terminalConnecting: omitKey(state.terminalConnecting, tabId),
+        terminalConnectDeadline: omitKey(state.terminalConnectDeadline, tabId),
         terminalAutoRetryCount:
           count === 0
             ? omitKey(state.terminalAutoRetryCount, tabId)
@@ -3342,6 +3386,10 @@ export const useAppStore = create<AppState>((set, get) => {
           agentId === null
             ? omitKey(state.terminalWaitingForAgent, tabId)
             : { ...state.terminalWaitingForAgent, [tabId]: agentId },
+        terminalConnectDeadline:
+          agentId === null
+            ? omitKey(state.terminalConnectDeadline, tabId)
+            : armConnectDeadline(state.terminalConnectDeadline, tabId, "waiting-for-agent"),
       })),
     failTerminalConnectTimeout: (tabId, kind) =>
       set((state) => {
@@ -3363,6 +3411,7 @@ export const useAppStore = create<AppState>((set, get) => {
         return {
           terminalConnecting: omitKey(state.terminalConnecting, tabId),
           terminalWaitingForAgent: omitKey(state.terminalWaitingForAgent, tabId),
+          terminalConnectDeadline: omitKey(state.terminalConnectDeadline, tabId),
           terminalAutoRetryCount: omitKey(state.terminalAutoRetryCount, tabId),
           terminalSpawnErrors: {
             ...state.terminalSpawnErrors,
@@ -3382,6 +3431,7 @@ export const useAppStore = create<AppState>((set, get) => {
         return {
           terminalConnecting: omitKey(state.terminalConnecting, tabId),
           terminalWaitingForAgent: omitKey(state.terminalWaitingForAgent, tabId),
+          terminalConnectDeadline: omitKey(state.terminalConnectDeadline, tabId),
           terminalAutoRetryCount: omitKey(state.terminalAutoRetryCount, tabId),
           terminalSpawnErrors: {
             ...state.terminalSpawnErrors,
@@ -3594,6 +3644,12 @@ export const useAppStore = create<AppState>((set, get) => {
         // without a gap between the disconnect overlay disappearing and the effect
         // re-running to call setTerminalConnecting().
         terminalConnecting: { ...state.terminalConnecting, [tabId]: true },
+        // Fresh reconnect attempt: arm a new connecting deadline (any prior one
+        // was cleared on disconnect) so the wall-clock timeout starts now.
+        terminalConnectDeadline: {
+          ...state.terminalConnectDeadline,
+          [tabId]: { kind: "connecting" as const, at: Date.now() + connectTimeoutMs("connecting") },
+        },
         terminalRetryCounters: {
           ...state.terminalRetryCounters,
           [tabId]: (state.terminalRetryCounters[tabId] ?? 0) + 1,


### PR DESCRIPTION
## Summary

Follow-up to #1129. The `Connecting` / `WaitingForAgent` client-side timeout was a `setTimeout` tied to `TerminalConnectionOverlay`'s lifetime, so unmounting/remounting the overlay mid-connect (dragging the tab to another panel/split, a zoom toggle that re-keys the panel tree) restarted the countdown from zero — the advertised bound was really "N s of continuous overlay mounting".

Now the deadline lives in the store:

- New `terminalConnectDeadline: Record<tabId, { kind; at }>` — armed (idempotently, per kind) on entry to `Connecting` / `WaitingForAgent` in the store reducers, and cleared on **every** exit path (success via `setTerminalConnecting(false)`, `failTerminalConnectTimeout`, `abortTerminalConnect`, `retryTerminalSpawn`, `setTerminalAutoRetrying`, `setTerminalWaitingForAgent(null)`, `reconnectTerminal` re-arms fresh, `closeTab`).
- The overlay only **reads** the deadline; its `setTimeout` fires at `deadlineAt - Date.now()` and the visible "times out in N s" is derived from the same deadline — so display and fire share one clock and both survive a remount. The idempotent arm means a re-mount / state re-entry never pushes the deadline out, and switching connecting → waiting-for-agent arms a fresh one for the new duration.

## Test plan

- New regression test: enter `Connecting`, spend all but ~5s of the budget, unmount + remount the overlay, assert the stored deadline is unchanged and the timeout fires after only the remaining ~5s (not a fresh full budget). TDD, test commit precedes the fix.
- Updated the #1129 timeout tests to arm via the store actions (which now set the deadline).
- `tsc --noEmit`, eslint, and the affected vitest suites (`TerminalConnectionOverlay.timeout`, `appStore.connectTimeout`, `TerminalConnectionOverlay`, `appStore.abortConnect`) all green.

Closes #1263

🤖 Generated with [Claude Code](https://claude.com/claude-code)