### PR TITLE
feat(xserver): cancellable XQuartz readiness wait via connect-abort token (#1260)

### DIFF
--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -185,7 +185,9 @@ impl SshConnector for RusshSshConnector {
             // without display forwarding rather than aborting the whole connect.
             use super::x11::x_server_provisioner;
             let resolved = match x_server_provisioner() {
-                Some(provisioner) => match provisioner.ensure().await {
+                // Thread the connect-abort token so a Stop while XQuartz is still
+                // coming up (macOS) short-cuts the readiness wait promptly (#1260).
+                Some(provisioner) => match provisioner.ensure(cancel.cloned()).await {
                     Ok(lease) => {
                         // Hold the desktop session-lifetime guard (dependent-session
                         // refcount lease, #1107) for the whole session. Pushing it

--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::config::SshConfig;
@@ -144,9 +145,14 @@ pub trait XServerProvisioner: Send + Sync {
     /// - `lease.guard` — an opaque session-lifetime guard the connect path holds
     ///   until the session ends (see [`XServerLease`]).
     ///
+    /// `cancel` is the connect-abort token (`None` when the caller has none): if
+    /// the user aborts the connect while the provisioner is still bringing a
+    /// server up (e.g. waiting for XQuartz on macOS, #1260), tripping it
+    /// short-cuts that wait promptly instead of blocking to completion.
+    ///
     /// `Err(message)` — provisioning failed; `message` is an actionable,
     /// user-facing explanation surfaced to the UI (never a silent no-op).
-    async fn ensure(&self) -> Result<XServerLease, String>;
+    async fn ensure(&self, cancel: Option<CancellationToken>) -> Result<XServerLease, String>;
 }
 
 static PROVISIONER: OnceLock<Arc<dyn XServerProvisioner>> = OnceLock::new();

--- a/docs/changes/dev2/feature/1260-xserver-connect-abort-token.md
+++ b/docs/changes/dev2/feature/1260-xserver-connect-abort-token.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Aborting an SSH connection with X11 forwarding on macOS while XQuartz is still starting up now
+  stops immediately, instead of waiting out the full (~4s) XQuartz readiness budget before the
+  abort takes effect. The connect-abort signal is now threaded into the XQuartz readiness wait.

--- a/src-tauri/src/terminal/xserver/macos.rs
+++ b/src-tauri/src/terminal/xserver/macos.rs
@@ -292,6 +292,71 @@ mod tests {
         );
     }
 
+    // ── Connect-abort token wiring (#1260) ───────────────────────────────────
+    //
+    // The readiness wait is driven by a `cancelled` predicate. `token_cancelled`
+    // is the bridge from the SSH connect path's `CancellationToken` (threaded
+    // through `ensure_x_server_for_session`) into that predicate, so an aborted
+    // connect short-cuts the wait instead of running out the budget. These cover
+    // the end-to-end wiring (the pure poll-loop cancellation path is already
+    // covered above).
+
+    #[test]
+    fn token_cancelled_maps_absent_live_and_tripped() {
+        // No token (the status/probe path with no connect abort) is never
+        // cancelled; a live token isn't cancelled; a tripped one is.
+        assert!(
+            !token_cancelled(None),
+            "the probe path (no token) must never report cancelled"
+        );
+        let token = tokio_util::sync::CancellationToken::new();
+        assert!(
+            !token_cancelled(Some(&token)),
+            "a live connect token must not report cancelled"
+        );
+        token.cancel();
+        assert!(
+            token_cancelled(Some(&token)),
+            "a tripped connect token must report cancelled"
+        );
+    }
+
+    #[test]
+    fn readiness_wait_bails_on_tripped_token() {
+        // End-to-end wiring: a connect-abort token threaded into the readiness
+        // wait short-cuts it before any sleep, rather than running out the
+        // ~4s budget while the aborted connect waits.
+        let token = tokio_util::sync::CancellationToken::new();
+        token.cancel();
+        let cancel = Some(&token);
+        let probes = Cell::new(0u32);
+        let slept = Cell::new(Duration::ZERO);
+        let ready = poll_until_ready(
+            READINESS_POLL_INTERVAL,
+            READINESS_TOTAL_BUDGET,
+            || {
+                probes.set(probes.get() + 1);
+                false
+            },
+            || token_cancelled(cancel),
+            |d| slept.set(slept.get() + d),
+        );
+        assert!(
+            !ready,
+            "an aborted connect must not report the server ready"
+        );
+        assert_eq!(
+            slept.get(),
+            Duration::ZERO,
+            "an already-tripped token must bail before any sleep"
+        );
+        assert_eq!(
+            probes.get(),
+            0,
+            "cancellation is honored before the first readiness probe"
+        );
+    }
+
     #[test]
     fn final_attempt_does_not_overshoot_budget() {
         // With an interval that doesn't divide the budget evenly, the last sleep

--- a/src-tauri/src/terminal/xserver/macos.rs
+++ b/src-tauri/src/terminal/xserver/macos.rs
@@ -11,6 +11,9 @@ use std::path::Path;
 #[cfg(any(target_os = "macos", test))]
 use std::time::Duration;
 
+#[cfg(any(target_os = "macos", test))]
+use tokio_util::sync::CancellationToken;
+
 use super::types::XServerError;
 
 /// How long to wait between readiness probes after launching XQuartz.
@@ -114,6 +117,22 @@ fn poll_until_ready(
     }
 }
 
+/// Whether an SSH connect-abort token has been tripped, mapping the connect
+/// path's optional [`CancellationToken`] into the boolean predicate
+/// [`poll_until_ready`] consumes.
+///
+/// `None` is the status/probe path (the `x_server_ensure` command), which has no
+/// connect to abort, so it never reports cancelled. `Some(token)` is the SSH
+/// connect path (#1260): when the user aborts the connect the token trips and the
+/// readiness wait short-cuts instead of running out its budget.
+///
+/// Gated to macOS (plus `test`): the only production caller is the macOS
+/// launch-and-wait path.
+#[cfg(any(target_os = "macos", test))]
+fn token_cancelled(cancel: Option<&CancellationToken>) -> bool {
+    cancel.is_some_and(CancellationToken::is_cancelled)
+}
+
 /// Launch XQuartz (best-effort) and wait a short, bounded time for it to become
 /// ready before returning, so the connect path doesn't classify a
 /// still-starting server as unreachable (#1088).
@@ -121,10 +140,13 @@ fn poll_until_ready(
 /// Called from the orchestrator's macOS path in place of a bare launch +
 /// single immediate re-probe. Runs on the `spawn_blocking` thread the ensure
 /// call already uses, so the `std::thread::sleep` between probes never blocks
-/// the async reactor. `cancelled` lets an in-flight connect abort short-cut the
-/// wait; readiness is re-checked via `detect_local_x_server` each attempt.
+/// the async reactor. `cancel` is the SSH connect-abort token threaded from the
+/// connect path (#1260): when the user aborts the connect it short-cuts the wait
+/// promptly instead of running out the readiness budget. `None` (the
+/// status/probe path) is never cancelled. Readiness is re-checked via
+/// `detect_local_x_server` each attempt.
 #[cfg(target_os = "macos")]
-pub(super) fn launch_xquartz_and_wait(cancelled: impl Fn() -> bool) {
+pub(super) fn launch_xquartz_and_wait(cancel: Option<&CancellationToken>) {
     use termihub_core::backends::ssh::x11::detect_local_x_server;
 
     launch_xquartz();
@@ -132,7 +154,7 @@ pub(super) fn launch_xquartz_and_wait(cancelled: impl Fn() -> bool) {
         READINESS_POLL_INTERVAL,
         READINESS_TOTAL_BUDGET,
         || detect_local_x_server().is_some(),
-        cancelled,
+        || token_cancelled(cancel),
         std::thread::sleep,
     );
 }

--- a/src-tauri/src/terminal/xserver/mod.rs
+++ b/src-tauri/src/terminal/xserver/mod.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tauri::{AppHandle, Manager};
 use termihub_core::backends::ssh::x11::{XServerLease, XServerProvisioner};
+use tokio_util::sync::CancellationToken;
 
 use crate::connection::manager::ConnectionManager;
 
@@ -86,16 +87,18 @@ impl XServerProvisionerImpl {
 
 #[async_trait]
 impl XServerProvisioner for XServerProvisionerImpl {
-    async fn ensure(&self) -> Result<XServerLease, String> {
+    async fn ensure(&self, cancel: Option<CancellationToken>) -> Result<XServerLease, String> {
         // Run the orchestrator (adopt / spawn / launch XQuartz / typed error),
         // claiming a dependent session against the manager (#1107). The connect
         // path gets the resolved server — managed or adopted, with its cookie, so
         // the forwarder performs no second probe — plus an opaque
         // [`SessionGuard`] it holds for the session lifetime; dropping the guard
-        // releases the session (respecting idle-shutdown). `Ok` always carries a
-        // resolved server; the "nothing usable" case is an `Err`, and the "no
-        // provisioner registered" case is handled in core.
-        let (outcome, guard) = ensure_session_off_reactor(&self.app, self.manager.clone())
+        // releases the session (respecting idle-shutdown). `cancel` is the SSH
+        // connect-abort token so aborting the connect short-cuts the macOS
+        // XQuartz readiness wait (#1260). `Ok` always carries a resolved server;
+        // the "nothing usable" case is an `Err`, and the "no provisioner
+        // registered" case is handled in core.
+        let (outcome, guard) = ensure_session_off_reactor(&self.app, self.manager.clone(), cancel)
             .await
             .map_err(|e| e.to_string())?;
         Ok(XServerLease {
@@ -128,13 +131,16 @@ pub(crate) async fn ensure_off_reactor(
 pub(crate) async fn ensure_session_off_reactor(
     app: &AppHandle,
     manager: Arc<XServerManager>,
+    cancel: Option<CancellationToken>,
 ) -> Result<(EnsureOutcome, manager::SessionGuard), XServerError> {
     let provide = resolve_provide_automatically(app);
-    tokio::task::spawn_blocking(move || ensure_x_server_for_session(&manager, provide))
-        .await
-        .map_err(|e| XServerError::LaunchFailed {
-            message: format!("X server provisioning task failed: {e}"),
-        })?
+    tokio::task::spawn_blocking(move || {
+        ensure_x_server_for_session(&manager, provide, cancel.as_ref())
+    })
+    .await
+    .map_err(|e| XServerError::LaunchFailed {
+        message: format!("X server provisioning task failed: {e}"),
+    })?
 }
 
 /// Install the X server provisioner into core so the SSH connect path can reach

--- a/src-tauri/src/terminal/xserver/orchestrator.rs
+++ b/src-tauri/src/terminal/xserver/orchestrator.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use termihub_core::backends::ssh::x11::{
     detect_local_x_server, read_local_xauth_cookie, LocalXServerInfo, ResolvedXServer,
 };
+use tokio_util::sync::CancellationToken;
 
 use super::linux_gap::{self, LinuxXEnv};
 use super::manager::{XServerManager, XServerStatus as ManagedStatus};
@@ -43,7 +44,9 @@ pub fn ensure_x_server(
     manager: &XServerManager,
     provide_automatically: bool,
 ) -> Result<EnsureOutcome, XServerError> {
-    ensure_x_server_impl(manager, provide_automatically)
+    // Status/probe path (the `x_server_ensure` command): no connect to abort, so
+    // no cancellation token.
+    ensure_x_server_impl(manager, provide_automatically, None)
 }
 
 /// Ensure a usable local X server **and** claim a session against it, returning
@@ -57,6 +60,7 @@ pub fn ensure_x_server(
 pub fn ensure_x_server_for_session(
     manager: &Arc<XServerManager>,
     provide_automatically: bool,
+    cancel: Option<&CancellationToken>,
 ) -> Result<(EnsureOutcome, super::manager::SessionGuard), XServerError> {
     // Acquire first: this drives the same adopt/reuse/spawn logic as
     // `ensure_running` while bumping the refcount, and hands back a guard that
@@ -68,9 +72,10 @@ pub fn ensure_x_server_for_session(
         })?;
     // Resolve the (now running) server for the report/forwarder. The lease
     // already ensured it, so this reuses the live process without a second
-    // acquire. If resolution somehow fails, dropping `guard` releases the
-    // session we just claimed.
-    let outcome = ensure_x_server_impl(manager, provide_automatically)?;
+    // acquire. `cancel` is the SSH connect-abort token so an aborted connect
+    // short-cuts the macOS XQuartz readiness wait (#1260). If resolution somehow
+    // fails, dropping `guard` releases the session we just claimed.
+    let outcome = ensure_x_server_impl(manager, provide_automatically, cancel)?;
     Ok((outcome, guard))
 }
 
@@ -80,9 +85,15 @@ pub fn ensure_x_server_for_session(
 fn ensure_x_server_impl(
     manager: &XServerManager,
     provide_automatically: bool,
+    cancel: Option<&CancellationToken>,
 ) -> Result<EnsureOutcome, XServerError> {
     let platform = XServerPlatform::current();
     let dependency = dependency_available(platform);
+
+    // `cancel` only feeds the macOS XQuartz readiness wait below; silence the
+    // unused-variable warning on platforms without that path.
+    #[cfg(not(target_os = "macos"))]
+    let _ = cancel;
 
     // macOS: if XQuartz is installed but idle, nudge it up so detection and the
     // SSH `DISPLAY` handshake can succeed. XQuartz takes a second or two to
@@ -90,12 +101,12 @@ fn ensure_x_server_impl(
     // rather than re-probing once immediately and misclassifying a
     // still-starting server as unreachable (#1088). This runs on the
     // `spawn_blocking` thread the ensure call already uses, so the between-probe
-    // sleeps never touch the async reactor. No connect-abort token is threaded
-    // through `ensure_x_server` yet, so cancellation is a no-op for now; the
-    // wait is cancel-ready for when one is wired in.
+    // sleeps never touch the async reactor. `cancel` is the SSH connect-abort
+    // token (#1260): an aborted connect short-cuts the wait promptly instead of
+    // running out the readiness budget.
     #[cfg(target_os = "macos")]
     if dependency && detect_local_x_server().is_none() {
-        super::macos::launch_xquartz_and_wait(|| false);
+        super::macos::launch_xquartz_and_wait(cancel);
     }
 
     // 1. Let the manager adopt/reuse/spawn (TCP-based; covers Windows + managed).
@@ -518,12 +529,12 @@ mod tests {
             // decrement the refcount, so the accumulation assertions below rely
             // on both leases staying in scope.
             let (outcome, _guard1) =
-                ensure_x_server_for_session(&mgr, true).expect("session acquired");
+                ensure_x_server_for_session(&mgr, true, None).expect("session acquired");
             assert_eq!(outcome.report.session_count, 1, "first session counted");
             assert_eq!(mgr.session_count(), 1);
 
             let (outcome, _guard2) =
-                ensure_x_server_for_session(&mgr, true).expect("second session acquired");
+                ensure_x_server_for_session(&mgr, true, None).expect("second session acquired");
             assert_eq!(outcome.report.session_count, 2, "second session counted");
             assert_eq!(mgr.session_count(), 2);
         }
@@ -544,8 +555,10 @@ mod tests {
             let mgr = std::sync::Arc::new(manager(vec![], true));
 
             // Keep both leases alive so the live count stays at 2.
-            let (_o1, _guard1) = ensure_x_server_for_session(&mgr, true).expect("session acquired");
-            let (_o2, _guard2) = ensure_x_server_for_session(&mgr, true).expect("session acquired");
+            let (_o1, _guard1) =
+                ensure_x_server_for_session(&mgr, true, None).expect("session acquired");
+            let (_o2, _guard2) =
+                ensure_x_server_for_session(&mgr, true, None).expect("session acquired");
 
             let status = current_status(&mgr);
             assert_eq!(status.state, XServerState::Running);


### PR DESCRIPTION
Closes #1260. Follow-up to #1088.

## Problem

#1088 added a bounded, cancel-friendly XQuartz readiness wait after launching XQuartz on macOS (`poll_until_ready`, called via `launch_xquartz_and_wait`). The poll loop already checks an injected `cancelled` predicate, so it was cancel-ready — but no connect-abort token was plumbed through `ensure_x_server`, so the call site passed a no-op `|| false`. An SSH X11 connect aborted mid-connect therefore still waited out the full ~4s readiness budget before the abort took effect.

## Approach

Thread the SSH connect path's `tokio_util::sync::CancellationToken` (the same token already used across the SSH connect/jump-host paths) all the way to the readiness wait:

`connector.rs` (`cancel`) → `XServerProvisioner::ensure(cancel)` → `ensure_session_off_reactor` → `ensure_x_server_for_session` → `ensure_x_server_impl` → `launch_xquartz_and_wait(cancel)`.

- New `token_cancelled(Option<&CancellationToken>)` bridge maps the token into the poll loop's `cancelled` predicate. `None` (the status/probe `x_server_ensure` command path — no connect to abort) is never cancelled.
- The core `XServerProvisioner::ensure` trait now takes `Option<CancellationToken>`; the connector passes `cancel.cloned()`.
- macOS-specific code (`token_cancelled`, `launch_xquartz_and_wait`, imports) stays gated behind `#[cfg(any(target_os = "macos", test))]` / `#[cfg(target_os = "macos")]`; `ensure_x_server_impl` discards `cancel` on non-macOS via a gated `let _ = cancel;` so Linux/Windows build clean.

## Test plan

- TDD: added `token_cancelled_maps_absent_live_and_tripped` and `readiness_wait_bails_on_tripped_token` in `macos.rs` (compiled for `test` on every platform, no real XQuartz/sleep). Both were red (missing `token_cancelled`) before the implementation commit, green after.
- `cargo test -p termihub --lib xserver` — all pass (macos poll/wiring + orchestrator session-refcount tests updated for the new signature).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)