### PR TITLE
feat(sftp): transfer-progress rendering + Cancel + kill-cascade (Closes #1247)

### DIFF
--- a/docs/changes/dev1/feature/1247-sftp-transfer-progress.md
+++ b/docs/changes/dev1/feature/1247-sftp-transfer-progress.md
@@ -1,0 +1,13 @@
+### Added
+
+- SFTP transfers now render live progress across the app (issue #1247, stage
+  S2/D3). Each in-flight download or upload appears as a row in the Open
+  Connections **Transfers** section with an inline progress bar, live
+  percentage / byte counts, and a **Cancel** button (plus **Cancel All**); as a
+  compact footer in the file browser for the active session; and as a
+  status-bar aggregate showing `N transfers · P%`. Cancelling fires
+  `sftp_cancel_transfer`, and killing an SFTP session first cancels that
+  session's in-flight transfers before closing it, so a transfer can never keep
+  a dead session's channel alive. Indeterminate transfers (unknown size) show
+  an animated bar instead of a percentage. Built on the `transfer-progress`
+  event and cancel command from #1245.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { UpdateNotification } from "@/components/UpdateNotification/UpdateNotifi
 import { ToastProvider, TooltipProvider } from "@/components/ui";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useTunnelEvents } from "@/hooks/useTunnelEvents";
+import { useTransferEvents } from "@/hooks/useTransferEvents";
 import { useEmbeddedServerEvents } from "@/hooks/useEmbeddedServerEvents";
 import { useCredentialStoreEvents } from "@/hooks/useCredentialStoreEvents";
 import { useHttpMonitorNotifications } from "@/hooks/useHttpMonitorNotifications";
@@ -97,6 +98,7 @@ class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryStat
 function App() {
   useKeyboardShortcuts();
   useTunnelEvents();
+  useTransferEvents();
   useEmbeddedServerEvents();
   useCredentialStoreEvents();
   useHttpMonitorNotifications();

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -124,6 +124,34 @@
   color: var(--text-secondary);
 }
 
+/* Transfer row (issue 1247): the icon + Cancel button flank a stacked body that
+   holds the file name, an inline progress bar, and a byte/percentage meta line. */
+.oc-transfer {
+  align-items: flex-start;
+}
+
+.oc-transfer .oc-row__icon {
+  margin-top: 2px;
+}
+
+.oc-transfer__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.oc-transfer__progress {
+  height: 4px;
+}
+
+.oc-transfer__meta {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
 /* termiHub-managed X server: accent to signal termiHub ownership. */
 .oc-row__badge--managed {
   background: color-mix(in srgb, var(--accent-color) 18%, transparent);

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -9,8 +9,14 @@ import {
   MonitorCog,
   Globe,
   Loader2,
+  ArrowDownUp,
+  Download,
+  Upload,
+  Ban,
 } from "lucide-react";
-import { Modal, Button, Tooltip, toast } from "@/components/ui";
+import { Modal, Button, Tooltip, Progress, toast } from "@/components/ui";
+import { formatBytes } from "@/utils/formatters";
+import type { TransferState } from "@/types/connection";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
 import {
@@ -62,6 +68,8 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const tunnelStates = useAppStore((s) => s.tunnelStates);
   const sftpSessions = useAppStore((s) => s.sftpSessions);
   const closeSftpSession = useAppStore((s) => s.closeSftpSession);
+  const transfers = useAppStore((s) => s.transfers);
+  const cancelTransfer = useAppStore((s) => s.cancelTransfer);
   const tabGroups = useAppStore((s) => s.tabGroups);
   const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
   const monitoringHost = useAppStore((s) => s.monitoringHost);
@@ -98,6 +106,10 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     hostLabel: entry.hostLabel,
     orphaned: !liveTabIds.has(entry.owningTabId),
   }));
+
+  // Live in-flight SFTP transfers (#1247). The store keeps only `transferring`
+  // rows; terminal-phase transfers are auto-removed, so every value here is live.
+  const transferList = Object.values(transfers);
 
   const [localSessions, setLocalSessions] = useState<LocalSessionInfo[]>([]);
   const [proxySessions, setProxySessions] = useState<ProxySessionsState>({});
@@ -198,6 +210,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     Object.values(proxySessions).reduce((s, arr) => s + arr.length, 0) +
     Object.values(agentSessions).reduce((s, arr) => s + arr.length, 0) +
     activeTunnels.length +
+    transferList.length +
     sftpSessionEntries.length +
     (monitoringHost ? 1 : 0) +
     httpMonitors.length +
@@ -329,6 +342,26 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     } catch (err) {
       frontendLog("open_connections", `Failed to close SFTP sessions: ${err}`);
       toast.error(`Failed to close SFTP sessions: ${err}`);
+    }
+  };
+
+  const handleCancelTransfer = async (transferId: string) => {
+    try {
+      await cancelTransfer(transferId);
+      toast.success("Transfer cancelled");
+    } catch (err) {
+      frontendLog("open_connections", `Failed to cancel transfer: ${err}`);
+      toast.error(`Failed to cancel transfer: ${err}`);
+    }
+  };
+
+  const handleCancelAllTransfers = async () => {
+    try {
+      await Promise.all(transferList.map((t) => cancelTransfer(t.transferId)));
+      toast.success("All transfers cancelled");
+    } catch (err) {
+      frontendLog("open_connections", `Failed to cancel transfers: ${err}`);
+      toast.error(`Failed to cancel transfers: ${err}`);
     }
   };
 
@@ -561,6 +594,27 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           </Section>
         )}
 
+        {/* Transfers — live in-flight SFTP transfers (#1247), each with an
+            inline progress bar and a Cancel action. */}
+        {transferList.length > 0 && (
+          <Section
+            title="Transfers"
+            icon={<ArrowDownUp size={14} />}
+            count={transferList.length}
+            onKillAll={handleCancelAllTransfers}
+            killAllLabel="Cancel All"
+            data-testid="open-connections-transfers-section"
+          >
+            {transferList.map((t) => (
+              <TransferRow
+                key={t.transferId}
+                transfer={t}
+                onCancel={() => handleCancelTransfer(t.transferId)}
+              />
+            ))}
+          </Section>
+        )}
+
         {/* SFTP — one row per live backend session (#1241). Orphaned sessions
             (owning tab gone) surface with a warning badge so nothing is ever
             invisible/unkillable. */}
@@ -745,6 +799,57 @@ type BadgeVariant =
   | "stopped"
   | "orphaned"
   | "error";
+
+interface TransferRowProps {
+  transfer: TransferState;
+  onCancel: () => void | Promise<void>;
+}
+
+/**
+ * A single in-flight SFTP transfer row: a direction icon, the file name, an
+ * inline {@link Progress} bar, a live byte/percentage label, and a Cancel
+ * action. `total === 0` means an unknown size — render an indeterminate bar and
+ * show only the transferred bytes (no percentage or denominator).
+ */
+function TransferRow({ transfer, onCancel }: TransferRowProps) {
+  const { direction, fileName, transferred, total } = transfer;
+  const indeterminate = total <= 0;
+  const pct = indeterminate ? 0 : Math.round((transferred / total) * 100);
+  const label = indeterminate
+    ? formatBytes(transferred)
+    : `${pct}% · ${formatBytes(transferred)} / ${formatBytes(total)}`;
+
+  return (
+    <div className="oc-row oc-transfer" data-testid="open-connections-transfer">
+      <span className="oc-row__icon">
+        {direction === "download" ? <Download size={14} /> : <Upload size={14} />}
+      </span>
+      <div className="oc-transfer__body">
+        <span className="oc-row__title" title={fileName}>
+          {fileName}
+        </span>
+        <Progress
+          className="oc-transfer__progress"
+          value={transferred}
+          max={total}
+          indeterminate={indeterminate}
+          label={`${direction === "download" ? "Downloading" : "Uploading"} ${fileName}`}
+        />
+        <span className="oc-transfer__meta">{label}</span>
+      </div>
+      <Button
+        variant="danger"
+        size="sm"
+        className="oc-row__kill"
+        icon={<Ban size={14} />}
+        onClick={() => onCancel()}
+        aria-label={`Cancel transfer of ${fileName}`}
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+}
 
 interface ConnectionRowProps {
   icon: React.ReactNode;

--- a/src/components/Sidebar/FileBrowser.css
+++ b/src/components/Sidebar/FileBrowser.css
@@ -269,3 +269,48 @@
   gap: var(--spacing-xs);
   margin-top: var(--spacing-xs);
 }
+
+/* Transfer footer (issue 1247): compact, pinned below the live file list. Each row
+   stacks a header line (verb icon + name + percentage + cancel) over an inline
+   progress bar. The file list above stays scrollable and live. */
+.file-browser__transfers {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border-top: 1px solid var(--border-secondary);
+  background: var(--bg-secondary);
+}
+
+.file-browser__transfer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.file-browser__transfer-head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.file-browser__transfer-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.file-browser__transfer-pct {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.file-browser__transfer-cancel {
+  flex-shrink: 0;
+}

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -28,9 +28,10 @@ import {
   Globe,
   Terminal,
   X,
+  Ban,
 } from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
-import { Button, Tooltip } from "@/components/ui";
+import { Button, Tooltip, Progress, toast } from "@/components/ui";
 import { useFileBrowser } from "@/hooks/useFileBrowser";
 import { onVscodeEditComplete } from "@/services/events";
 import { getHomeDir, sendInput } from "@/services/api";
@@ -704,6 +705,10 @@ export function FileBrowser() {
   // Explicit SFTP lifecycle status (audit gap A1) — used to pick the SFTP
   // placeholder label without inferring it from isConnected + isLoading.
   const sftpStatus = useAppStore((s) => s.sftpStatus);
+  // In-flight SFTP transfers (#1247); the footer shows those owned by the
+  // active browser session, and Cancel fires sftp_cancel_transfer.
+  const transfers = useAppStore((s) => s.transfers);
+  const cancelTransfer = useAppStore((s) => s.cancelTransfer);
   const vscodeAvailable = useAppStore((s) => s.vscodeAvailable);
   const fileClipboard = useAppStore((s) => s.fileClipboard);
   const quickShareServer = useAppStore((s) => s.quickShareServer);
@@ -990,6 +995,22 @@ export function FileBrowser() {
 
   const selectedEntries = sortedEntries.filter((e) => selectedPaths.has(e.path));
 
+  // In-flight transfers owned by the SFTP session this browser is showing
+  // (#1247). Only these belong in the footer; other sessions' transfers live in
+  // the Open Connections panel. The list above stays live regardless.
+  const activeTransfers = sftpSessionId
+    ? Object.values(transfers).filter((t) => t.sessionId === sftpSessionId)
+    : [];
+
+  const handleCancelTransfer = async (transferId: string) => {
+    try {
+      await cancelTransfer(transferId);
+      toast.success("Transfer cancelled");
+    } catch (err) {
+      toast.error(`Failed to cancel transfer: ${err}`);
+    }
+  };
+
   return (
     <div
       className={`file-browser${isDragOver ? " file-browser--drag-over" : ""}`}
@@ -1249,6 +1270,48 @@ export function FileBrowser() {
         }}
         onCancel={() => setDeleteConfirm(null)}
       />
+      {activeTransfers.length > 0 && (
+        <div className="file-browser__transfers" data-testid="file-browser-transfers">
+          {activeTransfers.map((t) => {
+            const indeterminate = t.total <= 0;
+            const pct = indeterminate ? 0 : Math.round((t.transferred / t.total) * 100);
+            const verb = t.direction === "download" ? "Downloading" : "Uploading";
+            return (
+              <div
+                key={t.transferId}
+                className="file-browser__transfer"
+                data-testid="file-browser-transfer"
+              >
+                <div className="file-browser__transfer-head">
+                  {t.direction === "download" ? <Download size={12} /> : <Upload size={12} />}
+                  <span className="file-browser__transfer-name" title={t.fileName}>
+                    {t.fileName}
+                  </span>
+                  <span className="file-browser__transfer-pct">
+                    {indeterminate ? formatBytes(t.transferred) : `${pct}%`}
+                  </span>
+                  <Tooltip content="Cancel transfer" side="top">
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      icon={<Ban size={12} />}
+                      className="file-browser__transfer-cancel"
+                      onClick={() => handleCancelTransfer(t.transferId)}
+                      aria-label={`Cancel transfer of ${t.fileName}`}
+                    />
+                  </Tooltip>
+                </div>
+                <Progress
+                  value={t.transferred}
+                  max={t.total}
+                  indeterminate={indeterminate}
+                  label={`${verb} ${t.fileName}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -9,6 +9,7 @@ import {
   Server,
   Route,
   RotateCw,
+  ArrowDownUp,
 } from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
 import { frontendLog } from "@/utils/frontendLog";
@@ -98,6 +99,7 @@ export function StatusBar() {
         <JumpHostStatus />
         <MonitoringStatus />
         <ServicesIndicator />
+        <TransfersIndicator />
         <CredentialStoreIndicator />
       </div>
       <div className="status-bar__section status-bar__section--center">
@@ -234,6 +236,38 @@ function ServicesIndicator() {
         <Server size={12} />
         {runningCount}
       </button>
+    </Tooltip>
+  );
+}
+
+/**
+ * Aggregate SFTP transfer indicator (#1247). Shows `N transfers · P%` where P is
+ * the aggregate percentage across sized transfers; when every transfer is
+ * indeterminate (unknown total), the percentage is omitted. Renders nothing
+ * when no transfers are in flight.
+ */
+function TransfersIndicator() {
+  const transfers = useAppStore((s) => s.transfers);
+
+  const list = Object.values(transfers);
+  const count = list.length;
+  if (count === 0) return null;
+
+  const sized = list.filter((t) => t.total > 0);
+  const totalBytes = sized.reduce((sum, t) => sum + t.total, 0);
+  const doneBytes = sized.reduce((sum, t) => sum + t.transferred, 0);
+  const pct = totalBytes > 0 ? Math.round((doneBytes / totalBytes) * 100) : null;
+
+  const noun = count === 1 ? "transfer" : "transfers";
+  const label = pct !== null ? `${count} ${noun} · ${pct}%` : `${count} ${noun}`;
+  const tooltip = `${count} active SFTP ${count === 1 ? "transfer" : "transfers"}`;
+
+  return (
+    <Tooltip content={tooltip} side="top">
+      <span className="status-bar__item" data-testid="status-bar-transfers" aria-label={tooltip}>
+        <ArrowDownUp size={12} />
+        {label}
+      </span>
     </Tooltip>
   );
 }

--- a/src/components/ui/Progress.test.tsx
+++ b/src/components/ui/Progress.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Progress } from "./Progress";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+describe("Progress", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a determinate bar with the correct fill width and aria values", () => {
+    render(<Progress value={25} max={100} label="Downloading" />);
+    const bar = container.querySelector('[role="progressbar"]') as HTMLElement;
+    expect(bar).toBeTruthy();
+    expect(bar.classList.contains("ui-progress")).toBe(true);
+    expect(bar.classList.contains("ui-progress--indeterminate")).toBe(false);
+    expect(bar.getAttribute("aria-valuenow")).toBe("25");
+    expect(bar.getAttribute("aria-valuemin")).toBe("0");
+    expect(bar.getAttribute("aria-valuemax")).toBe("100");
+    expect(bar.getAttribute("aria-label")).toBe("Downloading");
+
+    const fill = bar.querySelector(".ui-progress__fill") as HTMLElement;
+    expect(fill.style.width).toBe("25%");
+  });
+
+  it("clamps values above max to 100% width", () => {
+    render(<Progress value={500} max={100} />);
+    const fill = container.querySelector(".ui-progress__fill") as HTMLElement;
+    expect(fill.style.width).toBe("100%");
+  });
+
+  it("renders indeterminate mode without aria-valuenow and no inline width", () => {
+    render(<Progress indeterminate label="Transferring" />);
+    const bar = container.querySelector('[role="progressbar"]') as HTMLElement;
+    expect(bar.classList.contains("ui-progress--indeterminate")).toBe(true);
+    expect(bar.hasAttribute("aria-valuenow")).toBe(false);
+    expect(bar.hasAttribute("aria-valuemax")).toBe(false);
+
+    const fill = bar.querySelector(".ui-progress__fill") as HTMLElement;
+    expect(fill.style.width).toBe("");
+  });
+
+  it("treats max <= 0 as indeterminate", () => {
+    render(<Progress value={0} max={0} />);
+    const bar = container.querySelector('[role="progressbar"]') as HTMLElement;
+    expect(bar.classList.contains("ui-progress--indeterminate")).toBe(true);
+    expect(bar.hasAttribute("aria-valuenow")).toBe(false);
+  });
+});

--- a/src/components/ui/Progress.tsx
+++ b/src/components/ui/Progress.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import "./ui.css";
+
+/**
+ * Props for the shared {@link Progress} primitive — a thin, token-driven
+ * horizontal progress bar.
+ */
+export interface ProgressProps {
+  /** Current value (ignored when {@link indeterminate} or `max <= 0`). */
+  value?: number;
+  /** Maximum value. Defaults to `100`; `max <= 0` renders indeterminate. */
+  max?: number;
+  /** Force the indeterminate (unknown-total) animation. */
+  indeterminate?: boolean;
+  /** Accessible label describing what is progressing. */
+  label?: string;
+  /** Extra class for layout tweaks at the call site. */
+  className?: string;
+}
+
+/**
+ * The single shared progress-bar primitive. Renders a determinate fill
+ * (`value / max`) or, when {@link indeterminate} is set (or `max <= 0`), an
+ * animated indeterminate sweep. All colors/radii/motion come from design
+ * tokens; the sweep is disabled under `prefers-reduced-motion`.
+ *
+ * Uses the ARIA `progressbar` role directly (a few-line accessible div beats
+ * pulling in a dependency for a bar this simple); omitting `aria-valuenow` in
+ * indeterminate mode is the correct signal for "unknown progress".
+ */
+export function Progress({
+  value = 0,
+  max = 100,
+  indeterminate = false,
+  label,
+  className,
+}: ProgressProps): React.ReactElement {
+  const isIndeterminate = indeterminate || max <= 0;
+  const clamped = Math.min(Math.max(value, 0), max);
+  const pct = isIndeterminate ? 0 : (clamped / max) * 100;
+
+  const classes = [
+    "ui-progress",
+    isIndeterminate ? "ui-progress--indeterminate" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={classes}
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={isIndeterminate ? undefined : 0}
+      aria-valuemax={isIndeterminate ? undefined : max}
+      aria-valuenow={isIndeterminate ? undefined : clamped}
+    >
+      <div
+        className="ui-progress__fill"
+        style={isIndeterminate ? undefined : { width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -26,5 +26,8 @@ export type { ToggleProps } from "./Toggle";
 export { Tooltip, TooltipProvider } from "./Tooltip";
 export type { TooltipProps, TooltipProviderProps } from "./Tooltip";
 
+export { Progress } from "./Progress";
+export type { ProgressProps } from "./Progress";
+
 export { ToastProvider, toast } from "./Toast";
 export type { ToastApi, ToastOptions, ToastPromiseMessages } from "./Toast";

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -344,6 +344,41 @@
   background: var(--text-on-accent);
 }
 
+/* ── Progress (accessible div) ──────────────────────────────────────── */
+.ui-progress {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  background: var(--bg-active);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.ui-progress__fill {
+  height: 100%;
+  background: var(--accent-color);
+  border-radius: var(--radius-xl);
+  transition: width var(--transition-normal);
+}
+
+.ui-progress--indeterminate .ui-progress__fill {
+  position: absolute;
+  left: 0;
+  width: 40%;
+  transition: none;
+  animation: ui-progress-sweep var(--transition-slow) linear infinite;
+  animation-duration: 1.1s;
+}
+
+@keyframes ui-progress-sweep {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(250%);
+  }
+}
+
 /* ── Tooltip (Radix Tooltip skin) ───────────────────────────────────── */
 .ui-tooltip__content {
   max-width: 260px;
@@ -536,5 +571,12 @@
   }
   .ui-btn__spinner {
     animation: none;
+  }
+  .ui-progress__fill {
+    transition: none;
+  }
+  .ui-progress--indeterminate .ui-progress__fill {
+    animation: none;
+    width: 100%;
   }
 }

--- a/src/hooks/useTransferEvents.ts
+++ b/src/hooks/useTransferEvents.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { useAppStore } from "@/store/appStore";
+import { onTransferProgress } from "@/services/events";
+
+/**
+ * Hook that listens for `transfer-progress` events from the backend (#1245) and
+ * folds them into the store's `transfers` map (#1247), driving the Open
+ * Connections "Transfers" section, the file-browser footer, and the status-bar
+ * aggregate.
+ */
+export function useTransferEvents(): void {
+  const applyTransferProgress = useAppStore((s) => s.applyTransferProgress);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+
+    const setup = async () => {
+      unlisten = await onTransferProgress((progress) => {
+        applyTransferProgress(progress);
+      });
+    };
+
+    void setup();
+
+    return () => {
+      unlisten?.();
+    };
+  }, [applyTransferProgress]);
+}

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -8,6 +8,7 @@ import { TunnelState, TunnelStats } from "@/types/tunnel";
 import { CredentialStoreStatusInfo } from "@/types/credential";
 import { ServerState } from "@/types/embeddedServer";
 import { XServerProgress } from "@/types/xserver";
+import type { TransferProgress } from "@/services/api";
 
 interface TerminalOutputPayload {
   session_id: string;
@@ -533,6 +534,21 @@ export async function onJumpHostProbeComplete(
   callback: (payload: ProbeCompletePayload) => void
 ): Promise<UnlistenFn> {
   return await listen<ProbeCompletePayload>("jump-host-probe-complete", (event) => {
+    callback(event.payload);
+  });
+}
+
+/**
+ * Subscribe to per-transfer SFTP progress (#1245). Each in-flight transfer
+ * emits `transferring` updates (with `transferred`/`total`; `total = 0` means
+ * indeterminate) then one terminal `done` / `cancelled` / `error` event. The
+ * store folds these into its `transfers` map (#1247). Returns the unlisten
+ * handle.
+ */
+export async function onTransferProgress(
+  callback: (progress: TransferProgress) => void
+): Promise<UnlistenFn> {
+  return await listen<TransferProgress>("transfer-progress", (event) => {
     callback(event.payload);
   });
 }

--- a/src/store/appStore.transfers.test.ts
+++ b/src/store/appStore.transfers.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve("persisted-id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(() => Promise.resolve()),
+  sftpListDir: vi.fn(() => Promise.resolve([])),
+  sftpRealpath: vi.fn(() => Promise.resolve("/home/alice")),
+  sftpCancelTransfer: vi.fn(() => Promise.resolve()),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore } from "./appStore";
+import { sftpClose, sftpCancelTransfer, type TransferProgress } from "@/services/api";
+
+function progress(overrides: Partial<TransferProgress> = {}): TransferProgress {
+  return {
+    transferId: "t1",
+    sessionId: "sess-a",
+    direction: "download",
+    fileName: "file.txt",
+    transferred: 0,
+    total: 100,
+    phase: "transferring",
+    ...overrides,
+  };
+}
+
+describe("appStore — SFTP transfer progress (S2/D3)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+    vi.mocked(sftpClose).mockResolvedValue(undefined);
+    vi.mocked(sftpCancelTransfer).mockResolvedValue(undefined);
+  });
+
+  describe("applyTransferProgress drives the transfers map", () => {
+    it("adds a row on the first transferring event", () => {
+      useAppStore.getState().applyTransferProgress(progress());
+
+      const t = useAppStore.getState().transfers["t1"];
+      expect(t).toEqual({
+        transferId: "t1",
+        sessionId: "sess-a",
+        direction: "download",
+        fileName: "file.txt",
+        transferred: 0,
+        total: 100,
+        phase: "transferring",
+      });
+    });
+
+    it("updates the same row (bytes/phase) on subsequent transferring events", () => {
+      const store = useAppStore.getState();
+      store.applyTransferProgress(progress());
+      store.applyTransferProgress(progress({ transferred: 50 }));
+
+      const transfers = useAppStore.getState().transfers;
+      expect(Object.keys(transfers)).toHaveLength(1);
+      expect(transfers["t1"].transferred).toBe(50);
+    });
+
+    it("tracks multiple concurrent transfers independently", () => {
+      const store = useAppStore.getState();
+      store.applyTransferProgress(progress({ transferId: "t1" }));
+      store.applyTransferProgress(progress({ transferId: "t2", sessionId: "sess-b" }));
+
+      const transfers = useAppStore.getState().transfers;
+      expect(Object.keys(transfers).sort()).toEqual(["t1", "t2"]);
+    });
+  });
+
+  describe("terminal-phase cleanup clears the row", () => {
+    it.each(["done", "cancelled", "error"] as const)("clears the row on %s", (phase) => {
+      const store = useAppStore.getState();
+      store.applyTransferProgress(progress());
+      expect(useAppStore.getState().transfers["t1"]).toBeDefined();
+
+      store.applyTransferProgress(progress({ phase }));
+      expect(useAppStore.getState().transfers["t1"]).toBeUndefined();
+    });
+
+    it("leaves other transfers intact when one reaches a terminal phase", () => {
+      const store = useAppStore.getState();
+      store.applyTransferProgress(progress({ transferId: "t1" }));
+      store.applyTransferProgress(progress({ transferId: "t2" }));
+
+      store.applyTransferProgress(progress({ transferId: "t1", phase: "done" }));
+
+      const transfers = useAppStore.getState().transfers;
+      expect(transfers["t1"]).toBeUndefined();
+      expect(transfers["t2"]).toBeDefined();
+    });
+  });
+
+  describe("cancelTransfer", () => {
+    it("invokes sftpCancelTransfer with the id", async () => {
+      useAppStore.getState().applyTransferProgress(progress());
+      await useAppStore.getState().cancelTransfer("t1");
+      expect(sftpCancelTransfer).toHaveBeenCalledWith("t1");
+    });
+  });
+
+  describe("kill-cascade: closeSftpSession cancels the session's transfers first", () => {
+    it("cancels every transfer owned by the session before closing it", async () => {
+      const order: string[] = [];
+      vi.mocked(sftpCancelTransfer).mockImplementation((id: string) => {
+        order.push(`cancel:${id}`);
+        return Promise.resolve();
+      });
+      vi.mocked(sftpClose).mockImplementation((id: string) => {
+        order.push(`close:${id}`);
+        return Promise.resolve();
+      });
+
+      useAppStore.setState({
+        sftpSessions: { "sess-a": { hostLabel: "alice@a:22", owningTabId: "tab-gone" } },
+      });
+      const store = useAppStore.getState();
+      store.applyTransferProgress(progress({ transferId: "t1", sessionId: "sess-a" }));
+      store.applyTransferProgress(progress({ transferId: "t2", sessionId: "sess-a" }));
+      // A transfer on a different session must not be cancelled.
+      store.applyTransferProgress(progress({ transferId: "t3", sessionId: "sess-b" }));
+
+      await useAppStore.getState().closeSftpSession("sess-a");
+
+      expect(sftpCancelTransfer).toHaveBeenCalledWith("t1");
+      expect(sftpCancelTransfer).toHaveBeenCalledWith("t2");
+      expect(sftpCancelTransfer).not.toHaveBeenCalledWith("t3");
+      // Cancel of the session's transfers happens before the session is closed.
+      expect(order.indexOf("cancel:t1")).toBeLessThan(order.indexOf("close:sess-a"));
+      expect(order.indexOf("cancel:t2")).toBeLessThan(order.indexOf("close:sess-a"));
+
+      // The unrelated transfer survives.
+      expect(useAppStore.getState().transfers["t3"]).toBeDefined();
+    });
+
+    it("closes a session with no transfers without cancelling anything", async () => {
+      useAppStore.setState({
+        sftpSessions: { "sess-a": { hostLabel: "alice@a:22", owningTabId: "tab-gone" } },
+      });
+
+      await useAppStore.getState().closeSftpSession("sess-a");
+
+      expect(sftpCancelTransfer).not.toHaveBeenCalled();
+      expect(sftpClose).toHaveBeenCalledWith("sess-a");
+    });
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -26,6 +26,7 @@ import {
   FileEntry,
   SftpStatus,
   SftpSessionEntry,
+  TransferState,
   AppSettings,
   RemoteAgentDefinition,
   AgentCapabilities,
@@ -56,6 +57,7 @@ import {
 import {
   sftpOpen,
   sftpClose,
+  sftpCancelTransfer,
   sftpListDir,
   sftpRealpath,
   sessionListFiles,
@@ -536,6 +538,24 @@ interface AppState {
    * to idle. Drives the per-session Kill in the Open Connections panel (#1241).
    */
   closeSftpSession: (sessionId: string) => Promise<void>;
+
+  /**
+   * Live in-flight SFTP transfers keyed by `transferId` (concept "SFTP session
+   * tracking + transfers", issue #1247). Fed purely by `transfer-progress`
+   * events (#1245) through {@link applyTransferProgress}; a terminal phase
+   * clears the row. Rendered as the Open Connections "Transfers" section, the
+   * file-browser footer, and the status-bar aggregate.
+   */
+  transfers: Record<string, TransferState>;
+  /**
+   * Apply a `transfer-progress` event to the {@link transfers} map: a
+   * `transferring` phase upserts the row; a terminal phase
+   * (`done`/`cancelled`/`error`) removes it (D2 done/error toasts are handled
+   * separately).
+   */
+  applyTransferProgress: (progress: TransferState) => void;
+  /** Request cancellation of an in-flight transfer (`sftp_cancel_transfer`). */
+  cancelTransfer: (transferId: string) => Promise<void>;
 
   // Per-tab CWD tracking
   tabCwds: Record<string, string>;
@@ -3043,6 +3063,7 @@ export const useAppStore = create<AppState>((set, get) => {
     sftpConnectedHost: null,
     sftpSessions: {},
     sftpLastConfig: null,
+    transfers: {},
 
     setCurrentPath: (path) => set({ currentPath: path }),
     setFileEntries: (entries) => set({ fileEntries: entries }),
@@ -3146,6 +3167,33 @@ export const useAppStore = create<AppState>((set, get) => {
     },
 
     closeSftpSession: async (sessionId: string) => {
+      // Kill-cascade (concept "Edge cases"): cancel every in-flight transfer
+      // owned by this session *before* closing it, so no transfer keeps a dead
+      // session's channel alive. The `cancelled` events D1 emits back clear the
+      // rows; we also drop them optimistically below.
+      const owned = Object.values(useAppStore.getState().transfers).filter(
+        (t) => t.sessionId === sessionId
+      );
+      await Promise.all(
+        owned.map((t) =>
+          sftpCancelTransfer(t.transferId).catch((err) => {
+            frontendLog(
+              "sftp_transfer",
+              `closeSftpSession: cancel of ${t.transferId} failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
+          })
+        )
+      );
+      if (owned.length > 0) {
+        const cancelledIds = new Set(owned.map((t) => t.transferId));
+        set((state) => ({
+          transfers: Object.fromEntries(
+            Object.entries(state.transfers).filter(([id]) => !cancelledIds.has(id))
+          ),
+        }));
+      }
       try {
         await sftpClose(sessionId);
       } catch {
@@ -3169,6 +3217,33 @@ export const useAppStore = create<AppState>((set, get) => {
             : {}),
         };
       });
+    },
+
+    applyTransferProgress: (progress: TransferState) =>
+      set((state) => {
+        // A terminal phase clears the row (D1 already removed any partial local
+        // file on cancel/error). done/error toasts are the D2 follow-up.
+        if (progress.phase !== "transferring") {
+          if (!(progress.transferId in state.transfers)) return {};
+          return { transfers: omitKey(state.transfers, progress.transferId) };
+        }
+        return {
+          transfers: { ...state.transfers, [progress.transferId]: progress },
+        };
+      }),
+
+    cancelTransfer: async (transferId: string) => {
+      try {
+        await sftpCancelTransfer(transferId);
+      } catch (err) {
+        frontendLog(
+          "sftp_transfer",
+          `cancelTransfer: cancel of ${transferId} failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        throw err;
+      }
     },
 
     retrySftp: async () => {

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -32,6 +32,27 @@ export interface SftpSessionEntry {
   owningTabId: string;
 }
 
+/**
+ * Live state of a single in-flight SFTP transfer, keyed by its `transferId` in
+ * the store's `transfers` map (concept "SFTP session tracking + transfers",
+ * issue #1247). Built purely from `transfer-progress` events (#1245): a
+ * `transferring` phase upserts the row; a terminal phase
+ * (`done`/`cancelled`/`error`) clears it.
+ *
+ * - `sessionId`   — the owning SFTP session, used by the kill-cascade to cancel
+ *   a session's transfers before closing it
+ * - `total = 0`   — indeterminate size (render a spinner instead of a bar)
+ */
+export interface TransferState {
+  transferId: string;
+  sessionId: string;
+  direction: "download" | "upload";
+  fileName: string;
+  transferred: number;
+  total: number;
+  phase: "transferring" | "done" | "cancelled" | "error";
+}
+
 export interface SavedConnection {
   id: string;
   name: string;

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -172,6 +172,8 @@ Fixed strings — match exactly.
 | `file-browser-sftp-connecting` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-sftp-dismiss` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-sftp-retry` | `src/components/Sidebar/FileBrowser.tsx` |
+| `file-browser-transfer` | `src/components/Sidebar/FileBrowser.tsx` |
+| `file-browser-transfers` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-up` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-upload` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-editor-error` | `src/components/FileEditor/FileEditor.tsx` |
@@ -267,6 +269,8 @@ Fixed strings — match exactly.
 | `open-connections-establishing-agents-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-http-monitors-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-sftp-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `open-connections-transfer` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `open-connections-transfers-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-empty` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-row` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-setup` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
@@ -368,6 +372,7 @@ Fixed strings — match exactly.
 | `status-bar-jump-host` | `src/components/StatusBar/StatusBar.tsx` |
 | `status-bar-language` | `src/components/StatusBar/StatusBar.tsx` |
 | `status-bar-tab-size` | `src/components/StatusBar/StatusBar.tsx` |
+| `status-bar-transfers` | `src/components/StatusBar/StatusBar.tsx` |
 | `tab-context-clear` | `src/components/Terminal/Tab.tsx` |
 | `tab-context-copy` | `src/components/Terminal/Tab.tsx` |
 | `tab-context-horizontal-scroll` | `src/components/Terminal/Tab.tsx` |


### PR DESCRIPTION
## Summary

SFTP S2 (D3). Surfaces the `transfer-progress` events + `sftp_cancel_transfer` command from #1245 as live UI.

- **events/store**: `onTransferProgress(cb)` subscription; `transfers: Record<transferId, TransferState>` map driven purely by events (upsert on `transferring`, delete on any terminal phase); `cancelTransfer`; **kill-cascade** in `closeSftpSession` — a session's transfers are cancelled (matched by `sessionId`) before `sftp_close`. Wired via a new `useTransferEvents` hook.
- **UI** (via the `ui-design` subagent): new shared `Progress` primitive (`ui/Progress.tsx`, accessible `role="progressbar"`, no new dep); Open Connections **Transfers** section (inline bar, %/bytes, Cancel + Cancel All, counted in the total); file-browser footer scoped to the active session; StatusBar aggregate (`N transfers · P%`). Tokens only.

## Test plan

- `appStore.transfers.test.ts` (event-driven map, terminal-phase cleanup, `cancelTransfer`, kill-cascade order) + `Progress.test.tsx`. TDD, test commit precedes feat.
- `./scripts/test.sh` (frontend 2473) + `./scripts/check.sh` green (only pre-existing agent Docker-integration env failures). Token-discipline reword applied for `#1247`-in-CSS-comment.

Follow-up: #1286 (SFTP D2 — done/error terminal-phase toasts, explicitly deferred).

Closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)