### PR TITLE
feat(agent): zombie reap + Prune dead agents + reconnect key reconcile (Closes #1239)

### DIFF
--- a/docs/changes/dev1/feature/1239-agent-zombie-reap-prune.md
+++ b/docs/changes/dev1/feature/1239-agent-zombie-reap-prune.md
@@ -1,0 +1,19 @@
+# Changes for dev1/feature/1239-agent-zombie-reap-prune
+
+## Added
+
+- **Open Connections: Prune dead agents** — a footer action in the Open
+  Connections panel that sweeps any backend agent whose connection has already
+  died but whose entry lingered in the manager map. Pure resource hygiene; routing
+  was already safe (#1239).
+
+## Fixed
+
+- **Remote agents no longer leave a zombie backend entry after an exhausted
+  reconnect** — when a dropped agent connection cannot be re-established, the I/O
+  task now removes its own entry from the manager map immediately instead of
+  waiting to be lazily evicted on the next connect (#1239).
+- **Stale output/monitoring channels are released after a reconnect** — on a
+  successful reconnect the desktop reconciles its per-session output and
+  monitoring senders against the sessions the agent actually recovered, dropping
+  senders for sessions that did not come back (#1239).

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -49,6 +49,19 @@ pub fn disconnect_agent(
         .map_err(|e| e.to_string())
 }
 
+/// Sweep every agent whose I/O task has already died (`alive == false`).
+///
+/// Manual resource-hygiene escape hatch surfaced in the Open Connections panel
+/// (G6, #1239). Returns the ids that were pruned.
+#[tauri::command]
+pub fn prune_dead_agents(
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
+) -> Result<Vec<String>, String> {
+    let pruned = agent_manager.prune_dead_agents();
+    info!(count = pruned.len(), "Pruned dead remote agents");
+    Ok(pruned)
+}
+
 /// Cancel an in-flight (still connecting) agent connect.
 ///
 /// Fires the per-agent cancellation token registered by [`connect_agent`] so a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -530,6 +530,7 @@ pub fn run() {
             commands::agent::connect_agent,
             commands::agent::cancel_connect_agent,
             commands::agent::disconnect_agent,
+            commands::agent::prune_dead_agents,
             commands::agent::shutdown_agent,
             commands::agent::get_agent_capabilities,
             commands::agent::apply_agent_settings,

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -436,12 +436,50 @@ impl Drop for ConnectingGuard {
     }
 }
 
+/// Shared, reference-countable map of connected agents keyed by `agent_id`.
+///
+/// Held in an `Arc` so the async I/O task can hold a [`Weak`] back-reference and
+/// self-reap its own entry on an exhausted reconnect (G6, #1239) instead of
+/// leaving a zombie behind for lazy eviction on the next `connect_agent`.
+type AgentMap = Arc<Mutex<HashMap<String, AgentConnection>>>;
+
+/// Reap an agent's own entry from the manager map via a weak back-reference.
+///
+/// Called by the I/O task when its reconnect budget is exhausted. A dropped
+/// manager (dead `Weak`) or poisoned lock is treated as a no-op — there is
+/// nothing left to clean up.
+fn reap_agent(agents: &std::sync::Weak<Mutex<HashMap<String, AgentConnection>>>, agent_id: &str) {
+    if let Some(agents) = agents.upgrade() {
+        if let Ok(mut guard) = agents.lock() {
+            guard.remove(agent_id);
+        }
+    }
+}
+
+/// Remove every `alive == false` entry from the agent map, returning the
+/// removed ids. Backs the **Prune dead agents** escape hatch (G6, #1239).
+fn prune_dead_agents_from_map(agents: &Mutex<HashMap<String, AgentConnection>>) -> Vec<String> {
+    let mut removed = Vec::new();
+    if let Ok(mut guard) = agents.lock() {
+        let dead: Vec<String> = guard
+            .iter()
+            .filter(|(_, conn)| !conn.alive.load(Ordering::SeqCst))
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in dead {
+            guard.remove(&id);
+            removed.push(id);
+        }
+    }
+    removed
+}
+
 /// Manages connections to remote agents.
 ///
 /// Each agent is identified by its `agent_id` string. Multiple sessions
 /// can be multiplexed over a single SSH connection.
 pub struct AgentConnectionManager {
-    agents: Mutex<HashMap<String, AgentConnection>>,
+    agents: AgentMap,
     /// Cancellation tokens for in-flight connects, keyed by agent id (G1, #1235).
     connecting: ConnectingRegistry,
     app_handle: AppHandle,
@@ -450,7 +488,7 @@ pub struct AgentConnectionManager {
 impl AgentConnectionManager {
     pub fn new(app_handle: AppHandle) -> Self {
         Self {
-            agents: Mutex::new(HashMap::new()),
+            agents: Arc::new(Mutex::new(HashMap::new())),
             connecting: Arc::new(Mutex::new(HashMap::new())),
             app_handle,
         }
@@ -1667,6 +1705,20 @@ async fn agent_io_task(
     }
 }
 
+/// Drop output/monitoring senders whose session id is not in `live_ids`.
+///
+/// Used after a successful reconnect to reconcile the I/O task's per-session
+/// sender maps against the sessions the agent actually recovered, so senders
+/// for sessions that did not survive the reconnect are released (G7, #1239).
+fn reconcile_output_senders(
+    session_outputs: &mut HashMap<String, OutputSender>,
+    monitoring_outputs: &mut HashMap<String, MonitoringSender>,
+    live_ids: &std::collections::HashSet<String>,
+) {
+    session_outputs.retain(|id, _| live_ids.contains(id));
+    monitoring_outputs.retain(|id, _| live_ids.contains(id));
+}
+
 /// Handle a notification from the agent.
 ///
 /// Routes `connection.output` to session output channels and
@@ -2342,6 +2394,119 @@ mod tests {
         assert_eq!(parsed["id"], 42);
         assert_eq!(parsed["method"], "connection.create");
         assert_eq!(parsed["jsonrpc"], "2.0");
+    }
+
+    // ── Resource-hygiene helpers (#1239: G6 reap / prune, G7 reconcile) ──
+
+    /// Build a placeholder [`AgentConnection`] for map-manipulation tests.
+    ///
+    /// The command channel receiver is dropped immediately — none of the
+    /// hygiene helpers send over it — so only `alive` is meaningful here.
+    fn make_agent_connection(alive: bool) -> AgentConnection {
+        let (command_tx, _command_rx) = mpsc::unbounded_channel::<AgentIoCommand>();
+        AgentConnection {
+            command_tx,
+            alive: Arc::new(AtomicBool::new(alive)),
+            capabilities: AgentCapabilities {
+                connection_types: vec![],
+                max_sessions: 0,
+                available_shells: vec![],
+                available_serial_ports: vec![],
+                docker_available: false,
+                available_docker_images: vec![],
+                monitoring_supported: false,
+                agent_version: String::new(),
+            },
+            agent_version: String::new(),
+            protocol_version: String::new(),
+        }
+    }
+
+    /// G6: an exhausted reconnect self-reaps its own entry from the manager map
+    /// (via a weak reference) instead of leaving a zombie behind for lazy
+    /// eviction on the next `connect_agent`.
+    #[test]
+    fn reap_agent_removes_its_own_map_entry() {
+        let agents: AgentMap = Arc::new(Mutex::new(HashMap::new()));
+        {
+            let mut guard = agents.lock().unwrap();
+            guard.insert("agent-1".to_string(), make_agent_connection(false));
+            guard.insert("agent-2".to_string(), make_agent_connection(true));
+        }
+
+        let weak = Arc::downgrade(&agents);
+        reap_agent(&weak, "agent-1");
+
+        let guard = agents.lock().unwrap();
+        assert!(
+            !guard.contains_key("agent-1"),
+            "reaped agent must be removed from the map"
+        );
+        assert!(
+            guard.contains_key("agent-2"),
+            "unrelated agents must be left untouched"
+        );
+    }
+
+    /// A dead weak reference (manager already dropped) must not panic.
+    #[test]
+    fn reap_agent_tolerates_dropped_manager() {
+        let weak = {
+            let agents: AgentMap = Arc::new(Mutex::new(HashMap::new()));
+            Arc::downgrade(&agents)
+        };
+        // Should be a no-op, not a panic.
+        reap_agent(&weak, "agent-1");
+    }
+
+    /// Prune sweeps every `alive == false` entry and returns the removed ids,
+    /// while surviving (alive) entries remain.
+    #[test]
+    fn prune_dead_agents_removes_only_dead_entries() {
+        let agents: AgentMap = Arc::new(Mutex::new(HashMap::new()));
+        {
+            let mut guard = agents.lock().unwrap();
+            guard.insert("dead-1".to_string(), make_agent_connection(false));
+            guard.insert("alive-1".to_string(), make_agent_connection(true));
+            guard.insert("dead-2".to_string(), make_agent_connection(false));
+        }
+
+        let mut removed = prune_dead_agents_from_map(&agents);
+        removed.sort();
+        assert_eq!(removed, vec!["dead-1".to_string(), "dead-2".to_string()]);
+
+        let guard = agents.lock().unwrap();
+        assert_eq!(guard.len(), 1);
+        assert!(guard.contains_key("alive-1"));
+    }
+
+    /// G7: after a successful reconnect, output/monitoring senders keyed by
+    /// session ids that did *not* recover are dropped, while senders for
+    /// surviving session ids remain.
+    #[test]
+    fn reconcile_output_senders_drops_non_recovered_sessions() {
+        let mut session_outputs: HashMap<String, OutputSender> = HashMap::new();
+        let mut monitoring_outputs: HashMap<String, MonitoringSender> = HashMap::new();
+
+        let (out_survivor, _r1) = std::sync::mpsc::sync_channel(1);
+        let (out_gone, _r2) = std::sync::mpsc::sync_channel(1);
+        session_outputs.insert("survivor".to_string(), out_survivor);
+        session_outputs.insert("gone".to_string(), out_gone);
+
+        let (mon_survivor, _r3) = tokio::sync::mpsc::channel(1);
+        let (mon_gone, _r4) = tokio::sync::mpsc::channel(1);
+        monitoring_outputs.insert("survivor".to_string(), mon_survivor);
+        monitoring_outputs.insert("gone".to_string(), mon_gone);
+
+        let mut live_ids = std::collections::HashSet::new();
+        live_ids.insert("survivor".to_string());
+
+        reconcile_output_senders(&mut session_outputs, &mut monitoring_outputs, &live_ids);
+
+        assert!(session_outputs.contains_key("survivor"));
+        assert!(!session_outputs.contains_key("gone"));
+        assert!(monitoring_outputs.contains_key("survivor"));
+        assert!(!monitoring_outputs.contains_key("gone"));
     }
 
     // ── Cancellable connect (G1, #1235) ──────────────────────────────────

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -449,12 +449,17 @@ impl Drop for ConnectingGuard {
 /// leaving a zombie behind for lazy eviction on the next `connect_agent`.
 type AgentMap = Arc<Mutex<HashMap<String, AgentConnection>>>;
 
+/// Weak back-reference to the [`AgentMap`], held by the async I/O task so it can
+/// self-reap its own entry without keeping the manager alive (G6, #1239).
+type WeakAgentMap = std::sync::Weak<Mutex<HashMap<String, AgentConnection>>>;
+
 /// Reap an agent's own entry from the manager map via a weak back-reference.
 ///
 /// Called by the I/O task when its reconnect budget is exhausted. A dropped
 /// manager (dead `Weak`) or poisoned lock is treated as a no-op — there is
 /// nothing left to clean up.
-fn reap_agent(agents: &std::sync::Weak<Mutex<HashMap<String, AgentConnection>>>, agent_id: &str) {
+fn reap_agent(agents: &WeakAgentMap, agent_id: &str) {
+    // `upgrade()` must be bound so the strong `Arc` outlives the guard it lends.
     if let Some(agents) = agents.upgrade() {
         if let Ok(mut guard) = agents.lock() {
             guard.remove(agent_id);
@@ -467,15 +472,13 @@ fn reap_agent(agents: &std::sync::Weak<Mutex<HashMap<String, AgentConnection>>>,
 fn prune_dead_agents_from_map(agents: &Mutex<HashMap<String, AgentConnection>>) -> Vec<String> {
     let mut removed = Vec::new();
     if let Ok(mut guard) = agents.lock() {
-        let dead: Vec<String> = guard
-            .iter()
-            .filter(|(_, conn)| !conn.alive.load(Ordering::SeqCst))
-            .map(|(id, _)| id.clone())
-            .collect();
-        for id in dead {
-            guard.remove(&id);
-            removed.push(id);
-        }
+        guard.retain(|id, conn| {
+            let alive = conn.alive.load(Ordering::SeqCst);
+            if !alive {
+                removed.push(id.clone());
+            }
+            alive
+        });
     }
     removed
 }
@@ -1520,7 +1523,7 @@ async fn agent_io_task(
     config: RemoteAgentConfig,
     agent_settings: AgentSettings,
     mut request_id: u64,
-    agents: std::sync::Weak<Mutex<HashMap<String, AgentConnection>>>,
+    agents: WeakAgentMap,
 ) {
     let b64 = base64::engine::general_purpose::STANDARD;
     let mut line_buf = String::new();
@@ -1711,14 +1714,18 @@ async fn agent_io_task(
                 // G7 (#1239): reconcile the output/monitoring senders against the
                 // sessions the agent actually recovered. Senders keyed by ids that
                 // did not come back are stale — drop them so the maps don't leak.
-                if let Some(live_ids) =
-                    list_recovered_session_ids(&mut channel, &agent_id, &mut request_id).await
-                {
-                    reconcile_output_senders(
-                        &mut session_outputs,
-                        &mut monitoring_outputs,
-                        &live_ids,
-                    );
+                // Skip the extra round-trip entirely when there is nothing to
+                // reconcile (no registered senders).
+                if !session_outputs.is_empty() || !monitoring_outputs.is_empty() {
+                    if let Some(live_ids) =
+                        list_recovered_session_ids(&mut channel, &agent_id, &mut request_id).await
+                    {
+                        reconcile_output_senders(
+                            &mut session_outputs,
+                            &mut monitoring_outputs,
+                            &live_ids,
+                        );
+                    }
                 }
 
                 emit_agent_state(&app_handle, &agent_id, "connected");

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -228,6 +228,12 @@ pub trait AgentRpcClient: Send + Sync + 'static {
     /// Check if an agent is connected.
     fn is_connected(&self, agent_id: &str) -> bool;
 
+    /// Sweep every agent whose I/O task has already died (`alive == false`),
+    /// returning the swept ids. Manual resource-hygiene escape hatch (G6, #1239).
+    fn prune_dead_agents(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Get the capabilities of a connected agent.
     fn get_capabilities(&self, agent_id: &str) -> Option<AgentCapabilities>;
 
@@ -494,6 +500,14 @@ impl AgentConnectionManager {
         }
     }
 
+    /// Prune every agent whose I/O task has already died (`alive == false`),
+    /// returning the ids that were swept. Pure resource hygiene — routing is
+    /// already safe because `is_connected()` reports `false` for such entries
+    /// (G6, #1239).
+    pub fn prune_dead_agents(&self) -> Vec<String> {
+        prune_dead_agents_from_map(&self.agents)
+    }
+
     /// Cancel an in-flight (still connecting) agent by its `agent_id`.
     ///
     /// Fires the registered cancellation token so a blocking connect+handshake
@@ -558,6 +572,9 @@ impl AgentConnectionManager {
         let agent_id_str = agent_id.to_string();
         let config_clone = config.clone();
         let settings_clone = settings_ref.clone();
+        // Weak back-reference so the spawned I/O task can self-reap its own map
+        // entry on an exhausted reconnect without keeping the manager alive (G6).
+        let agents_weak = Arc::downgrade(&self.agents);
 
         // Run the async connect+handshake on the current tokio runtime, wrapped
         // in a `tokio::select!` against the cancellation token so a Cancel aborts
@@ -695,6 +712,7 @@ impl AgentConnectionManager {
             let agent_id_task = agent_id_str.clone();
             let config_task = config_clone.clone();
             let settings_task = settings_clone.clone();
+            let agents_weak_task = agents_weak.clone();
 
             tokio::spawn(async move {
                 agent_io_task(
@@ -707,6 +725,7 @@ impl AgentConnectionManager {
                     config_task,
                     settings_task,
                     request_id,
+                    agents_weak_task,
                 )
                 .await;
             });
@@ -1207,6 +1226,10 @@ impl AgentRpcClient for AgentConnectionManager {
         AgentConnectionManager::is_connected(self, agent_id)
     }
 
+    fn prune_dead_agents(&self) -> Vec<String> {
+        AgentConnectionManager::prune_dead_agents(self)
+    }
+
     fn get_capabilities(&self, agent_id: &str) -> Option<AgentCapabilities> {
         AgentConnectionManager::get_capabilities(self, agent_id)
     }
@@ -1497,6 +1520,7 @@ async fn agent_io_task(
     config: RemoteAgentConfig,
     agent_settings: AgentSettings,
     mut request_id: u64,
+    agents: std::sync::Weak<Mutex<HashMap<String, AgentConnection>>>,
 ) {
     let b64 = base64::engine::general_purpose::STANDARD;
     let mut line_buf = String::new();
@@ -1683,6 +1707,20 @@ async fn agent_io_task(
                 channel = new_channel;
                 line_buf.clear();
                 connection_error = None;
+
+                // G7 (#1239): reconcile the output/monitoring senders against the
+                // sessions the agent actually recovered. Senders keyed by ids that
+                // did not come back are stale — drop them so the maps don't leak.
+                if let Some(live_ids) =
+                    list_recovered_session_ids(&mut channel, &agent_id, &mut request_id).await
+                {
+                    reconcile_output_senders(
+                        &mut session_outputs,
+                        &mut monitoring_outputs,
+                        &live_ids,
+                    );
+                }
+
                 emit_agent_state(&app_handle, &agent_id, "connected");
                 info!("Agent {}: reconnected successfully", agent_id);
                 // Notify all pending requests that the connection was lost
@@ -1695,6 +1733,9 @@ async fn agent_io_task(
                 error!("Agent {}: reconnection failed: {}", agent_id, e);
                 emit_agent_state_with_error(&app_handle, &agent_id, "disconnected", Some(&e));
                 alive.store(false, Ordering::SeqCst);
+                // G6 (#1239): self-reap our own map entry instead of leaving a
+                // zombie for lazy eviction on the next `connect_agent`.
+                reap_agent(&agents, &agent_id);
                 // Notify all pending requests
                 for (_, tx) in pending_responses.drain() {
                     let _ = tx.send(Err("Agent disconnected".to_string()));
@@ -1717,6 +1758,56 @@ fn reconcile_output_senders(
 ) {
     session_outputs.retain(|id, _| live_ids.contains(id));
     monitoring_outputs.retain(|id, _| live_ids.contains(id));
+}
+
+/// List the session ids the agent currently reports over the (freshly
+/// reconnected) channel, for post-reconnect reconciliation (G7, #1239).
+///
+/// Sends `connection.list` and reads until the matching response arrives,
+/// skipping any interleaved notifications. Returns `None` on any I/O or parse
+/// failure so the caller leaves the sender maps untouched rather than dropping
+/// senders it could not confirm as dead.
+async fn list_recovered_session_ids(
+    channel: &mut russh::Channel<russh::client::Msg>,
+    agent_id: &str,
+    request_id: &mut u64,
+) -> Option<std::collections::HashSet<String>> {
+    *request_id += 1;
+    let req_id = *request_id;
+    let line = serialize_request(req_id, "connection.list", serde_json::json!({})).ok()?;
+    channel.data(line.as_bytes()).await.ok()?;
+
+    const MAX_SKIPPED: u32 = 1000;
+    let mut buf = String::new();
+    let mut skipped: u32 = 0;
+    loop {
+        let resp = read_handshake_line(channel, agent_id, &mut buf).await?;
+        if resp.is_empty() {
+            continue;
+        }
+        match jsonrpc::parse_message(&resp) {
+            Ok(jsonrpc::JsonRpcMessage::Response { id, result }) if id == req_id => {
+                let ids = result["sessions"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|s| s["session_id"].as_str().map(|s| s.to_string()))
+                    .collect();
+                return Some(ids);
+            }
+            Ok(jsonrpc::JsonRpcMessage::Error { id, .. }) if id == req_id => return None,
+            _ => {
+                skipped += 1;
+                if skipped > MAX_SKIPPED {
+                    warn!(
+                        "Agent {}: too many messages before connection.list response",
+                        agent_id
+                    );
+                    return None;
+                }
+            }
+        }
+    }
 }
 
 /// Handle a notification from the agent.

--- a/src/components/OpenConnections/OpenConnectionsModal.prune.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.prune.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tests for the "Prune dead agents" footer action of the Open Connections
+ * panel (G6, #1239): a manual escape hatch that sweeps backend agent entries
+ * whose I/O task has already died (`alive=false`) but which linger in the
+ * manager map. Routing is already safe, so this is pure resource hygiene.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+
+const pruneDeadAgents = vi.fn(() => Promise.resolve<string[]>([]));
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() => Promise.resolve([])),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  cancelConnectAgent: vi.fn(() => Promise.resolve(true)),
+  pruneDeadAgents: () => pruneDeadAgents(),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false, sessionCount: 0 })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorStopAll: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return {
+    ...actual,
+    toast: { success: (m: string) => toastSuccess(m), error: (m: string) => toastError(m) },
+  };
+});
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+/** Flush pending microtasks so async click handlers settle. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("OpenConnectionsModal — Prune dead agents footer action", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    pruneDeadAgents.mockClear();
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render() {
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
+      );
+    });
+  }
+
+  function pruneButton(): HTMLButtonElement {
+    return document.querySelector(
+      '[data-testid="open-connections-prune-dead-agents"]'
+    ) as HTMLButtonElement;
+  }
+
+  it("renders a Prune dead agents footer action", () => {
+    render();
+    expect(pruneButton()).toBeTruthy();
+    expect(pruneButton().textContent).toContain("Prune dead agents");
+  });
+
+  it("calls pruneDeadAgents and reports the swept count", async () => {
+    pruneDeadAgents.mockResolvedValueOnce(["dead-1", "dead-2"]);
+    render();
+
+    await act(async () => {
+      pruneButton().click();
+    });
+    await flush();
+
+    expect(pruneDeadAgents).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledWith("Pruned 2 dead agents");
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("reports when there were no dead agents to prune", async () => {
+    pruneDeadAgents.mockResolvedValueOnce([]);
+    render();
+
+    await act(async () => {
+      pruneButton().click();
+    });
+    await flush();
+
+    expect(toastSuccess).toHaveBeenCalledWith("No dead agents to prune");
+  });
+
+  it("surfaces a failure as an error toast", async () => {
+    pruneDeadAgents.mockRejectedValueOnce(new Error("boom"));
+    render();
+
+    await act(async () => {
+      pruneButton().click();
+    });
+    await flush();
+
+    expect(toastError).toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -20,6 +20,7 @@ import {
   closeAgentSession,
   cancelConnecting,
   cancelConnectAgent,
+  pruneDeadAgents,
   xServerStatus,
   xServerStop,
   LocalSessionInfo,
@@ -272,6 +273,26 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     await Promise.all(connectedAgents.map((a) => disconnectRemoteAgent(a.id)));
   };
 
+  /**
+   * Sweep any backend agent whose I/O task has already died (`alive=false`) but
+   * whose entry lingered in the manager map. Pure resource hygiene — routing is
+   * already safe (G6, #1239).
+   */
+  const handlePruneDeadAgents = async () => {
+    try {
+      const pruned = await pruneDeadAgents();
+      await loadData();
+      if (pruned.length === 0) {
+        toast.success("No dead agents to prune");
+      } else {
+        toast.success(`Pruned ${pruned.length} dead agent${pruned.length === 1 ? "" : "s"}`);
+      }
+    } catch (err) {
+      frontendLog("open_connections", `Failed to prune dead agents: ${err}`);
+      toast.error(`Failed to prune dead agents: ${err}`);
+    }
+  };
+
   const handleKillProxy = async (agentId: string, id: string) => {
     markSessionKilled(id);
     await closeTerminal(id).catch(() => {});
@@ -379,6 +400,21 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           Open Connections
           {totalCount > 0 && <span className="oc-section__count">{totalCount}</span>}
         </span>
+      }
+      footer={
+        <Tooltip
+          content="Remove backend agent entries whose connection has already died"
+          side="top"
+        >
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handlePruneDeadAgents}
+            data-testid="open-connections-prune-dead-agents"
+          >
+            Prune dead agents
+          </Button>
+        </Tooltip>
       }
     >
       <div className="open-connections__body">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -821,6 +821,16 @@ export async function disconnectAgent(agentId: string): Promise<void> {
 }
 
 /**
+ * Sweep every agent whose backend I/O task has already died (`alive=false`).
+ *
+ * Manual resource-hygiene escape hatch for the Open Connections panel. Returns
+ * the ids that were pruned.
+ */
+export async function pruneDeadAgents(): Promise<string[]> {
+  return await invoke<string[]>("prune_dead_agents");
+}
+
+/**
  * Cancel an in-flight (still connecting) agent connect. Aborts the blocking
  * SSH + initialize handshake promptly instead of waiting out the connect
  * timeout; the backend then emits `disconnected` (single writer). No-op if the

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -266,6 +266,7 @@ Fixed strings — match exactly.
 | `network-tools-sidebar` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `open-connections-establishing-agents-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-http-monitors-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `open-connections-prune-dead-agents` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-sftp-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-empty` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-row` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |


### PR DESCRIPTION
## Summary

Agent lifecycle S4 (resource hygiene), G6 + G7.

**G6 — zombie self-reap + Prune escape hatch**
- `AgentConnectionManager.agents` is now `Arc<Mutex<HashMap>>` (`AgentMap`) so the async io-task holds a `WeakAgentMap` back-reference.
- On an exhausted terminal reconnect the io-task self-reaps its own map entry (`reap_agent`) instead of relying on lazy eviction at the next `connect_agent` (the lazy fallback remains).
- New `prune_dead_agents` Tauri command (trait method with an empty default so mock impls are unaffected) + a **Prune dead agents** footer action in `OpenConnectionsModal` (async Button + toast, `ui/` primitives).

**G7 — post-reconnect sender reconcile**
- On a successful reconnect the io-task lists the recovered session ids over the fresh channel and drops `session_outputs`/`monitoring_outputs` senders for ids that did not recover (skips the round-trip when no senders are registered).

## Test plan

- Rust (`agent_manager`): reap removes own entry, reap tolerates a dropped manager, prune removes only dead entries, reconcile drops non-recovered senders while survivors remain. Plus `OpenConnectionsModal.prune.test.tsx` (4). TDD, test commit precedes feat.
- `cargo test --workspace --lib` + `cargo clippy --workspace --all-targets -- -D warnings` + `pnpm run build` + `pnpm test` (2449) green; `cargo fmt --check` verified clean. Only pre-existing agent Docker-integration env failures.

Closes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)