### PR TITLE
feat(ui): first-class icon-only Button variant (#1284)

### DIFF
--- a/docs/changes/dev2/feature/1284-button-icon-only-variant.md
+++ b/docs/changes/dev2/feature/1284-button-icon-only-variant.md
@@ -1,0 +1,12 @@
+# Changes
+
+## Changed
+
+- The shared `Button` primitive now has a first-class `iconOnly` affordance for
+  dense icon-only action rows: it squares the control to its height and drops the
+  label padding while keeping the ghost skin (color, hover, radius, focus ring,
+  and the async pending/success states) from the primitive. Icon-only buttons
+  require an accessible name; the primitive warns in the LogViewer when one is
+  missing. The tunnel sidebar action row and the Network Tools sidebar monitor
+  controls now use this variant instead of component-local geometry overrides,
+  so dense icon buttons look and behave consistently across the app. (#1284)

--- a/src/components/NetworkTools/NetworkToolsSidebar.tsx
+++ b/src/components/NetworkTools/NetworkToolsSidebar.tsx
@@ -136,6 +136,7 @@ function MonitorRow({
           <Button
             variant="ghost"
             size="sm"
+            iconOnly
             aria-label="Pause monitor"
             icon={<Pause size={12} />}
             onClick={() => onPause(config.id)}
@@ -147,6 +148,7 @@ function MonitorRow({
           <Button
             variant="ghost"
             size="sm"
+            iconOnly
             aria-label="Resume monitor"
             icon={<Play size={12} />}
             onClick={() => onResume(config.id)}
@@ -158,6 +160,7 @@ function MonitorRow({
           <Button
             variant="ghost"
             size="sm"
+            iconOnly
             aria-label="Stop monitor"
             icon={<StopCircle size={12} />}
             onClick={() => onStop(config.id)}
@@ -168,6 +171,7 @@ function MonitorRow({
         <Button
           variant="ghost"
           size="sm"
+          iconOnly
           aria-label="Remove monitor"
           icon={<Trash2 size={12} />}
           onClick={() => onRemove(config.id)}
@@ -321,6 +325,7 @@ export function NetworkToolsSidebar() {
             <Button
               variant="ghost"
               size="sm"
+              iconOnly
               aria-label="Refresh monitors"
               icon={<RefreshCw size={11} />}
               onClick={refreshMonitors}

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -78,7 +78,7 @@ export function TunnelListItem({
               <Button
                 variant="ghost"
                 size="sm"
-                className="tunnel-item__action"
+                iconOnly
                 aria-label="Stop"
                 data-testid={`tunnel-stop-${tunnel.id}`}
                 icon={<Square size={12} />}
@@ -98,7 +98,7 @@ export function TunnelListItem({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="tunnel-item__action"
+                  iconOnly
                   aria-label="View last error"
                   data-testid={`tunnel-view-error-${tunnel.id}`}
                   icon={<Info size={12} />}
@@ -112,7 +112,7 @@ export function TunnelListItem({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="tunnel-item__action"
+                  iconOnly
                   aria-label="Retry"
                   data-testid={`tunnel-retry-${tunnel.id}`}
                   icon={<RotateCw size={12} />}
@@ -130,7 +130,7 @@ export function TunnelListItem({
               <Button
                 variant="ghost"
                 size="sm"
-                className="tunnel-item__action"
+                iconOnly
                 aria-label="Start"
                 data-testid={`tunnel-start-${tunnel.id}`}
                 icon={<Play size={12} />}
@@ -146,7 +146,7 @@ export function TunnelListItem({
             <Button
               variant="ghost"
               size="sm"
-              className="tunnel-item__action"
+              iconOnly
               aria-label="Edit"
               data-testid={`tunnel-edit-${tunnel.id}`}
               icon={<Pencil size={12} />}
@@ -160,7 +160,7 @@ export function TunnelListItem({
             <Button
               variant="ghost"
               size="sm"
-              className="tunnel-item__action"
+              iconOnly
               aria-label="Duplicate"
               data-testid={`tunnel-duplicate-${tunnel.id}`}
               icon={<Copy size={12} />}
@@ -174,7 +174,7 @@ export function TunnelListItem({
             <Button
               variant="ghost"
               size="sm"
-              className="tunnel-item__action"
+              iconOnly
               aria-label="Delete"
               data-testid={`tunnel-delete-${tunnel.id}`}
               icon={<Trash2 size={12} />}

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -110,19 +110,6 @@
   opacity: 1;
 }
 
-/*
- * Geometry-only override for the shared ghost Button primitive in the dense
- * tunnel row (issue 1259). All visual styling — color, hover, radius, focus
- * ring, and the async pending/success affordances — comes from `.ui-btn--ghost`;
- * this only makes each icon-only action a compact square so the error-state row
- * (up to five actions) stays tidy in the narrow sidebar.
- */
-.tunnel-item__action.ui-btn {
-  width: var(--control-height-md);
-  padding: 0;
-  flex-shrink: 0;
-}
-
 .tunnel-item__details {
   display: flex;
   flex-direction: column;

--- a/src/components/ui/Button.test.tsx
+++ b/src/components/ui/Button.test.tsx
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { Button } from "./Button";
+import { frontendLog } from "@/utils/frontendLog";
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
 
 let container: HTMLDivElement;
 let root: Root;
@@ -114,6 +117,51 @@ describe("Button", () => {
     );
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
     expect(ref.current).toBe(document.querySelector('[data-testid="btn"]'));
+  });
+
+  it("applies the icon-only modifier when iconOnly is set and omits it otherwise", () => {
+    render(
+      <Button data-testid="icon" iconOnly aria-label="Play">
+        <span />
+      </Button>
+    );
+    expect(
+      document.querySelector('[data-testid="icon"]')!.classList.contains("ui-btn--icon-only")
+    ).toBe(true);
+
+    render(
+      <Button data-testid="plain" aria-label="Play">
+        <span />
+      </Button>
+    );
+    expect(
+      document.querySelector('[data-testid="plain"]')!.classList.contains("ui-btn--icon-only")
+    ).toBe(false);
+  });
+
+  it("warns via frontendLog when an icon-only Button has no accessible name", () => {
+    render(
+      <Button data-testid="anon" iconOnly>
+        <span />
+      </Button>
+    );
+    expect(frontendLog).toHaveBeenCalledWith("ui_button", expect.stringContaining("accessible"));
+  });
+
+  it("does not warn when the icon-only Button has an accessible name", () => {
+    render(
+      <Button data-testid="named" iconOnly aria-label="Play">
+        <span />
+      </Button>
+    );
+    expect(frontendLog).not.toHaveBeenCalled();
+
+    render(
+      <Button data-testid="titled" iconOnly title="Play">
+        <span />
+      </Button>
+    );
+    expect(frontendLog).not.toHaveBeenCalled();
   });
 
   it("spreads native button props such as type and aria-label", () => {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import { frontendLog } from "@/utils/frontendLog";
 import { toast } from "./Toast";
 import "./ui.css";
 
@@ -39,6 +40,16 @@ export interface ButtonProps extends Omit<
   size?: ButtonSize;
   /** Stretch the button to fill the width of its container. */
   fullWidth?: boolean;
+  /**
+   * Render as a compact icon-only square (a dense action-row affordance — e.g.
+   * a tunnel row or a network-monitor row). Drops the label padding and squares
+   * the control to its height; the ghost skin (color/hover/radius/focus/pending/
+   * success) still comes from the primitive. Icon-only buttons carry no visible
+   * text, so an accessible name is required: pass `aria-label` (or `title`, or
+   * wrap in a `Tooltip` and set `aria-label`). The primitive warns in the
+   * LogViewer when one is missing.
+   */
+  iconOnly?: boolean;
   /** Optional leading icon rendered before the label (typically a lucide icon). */
   icon?: React.ReactNode;
   /**
@@ -83,6 +94,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     variant = "primary",
     size = "md",
     fullWidth = false,
+    iconOnly = false,
     icon,
     type,
     className,
@@ -106,6 +118,21 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       if (successTimer.current) clearTimeout(successTimer.current);
     };
   }, []);
+
+  // Icon-only buttons carry no visible label, so an accessible name is
+  // mandatory. Surface a misuse (no aria-label / aria-labelledby / title) in the
+  // LogViewer rather than shipping a silently unlabeled control (issue 1284).
+  const ariaLabel = rest["aria-label"];
+  const ariaLabelledby = rest["aria-labelledby"];
+  const title = rest.title;
+  useEffect(() => {
+    if (iconOnly && !ariaLabel && !ariaLabelledby && !title) {
+      frontendLog(
+        "ui_button",
+        "icon-only Button is missing an accessible name — add aria-label, aria-labelledby, or title"
+      );
+    }
+  }, [iconOnly, ariaLabel, ariaLabelledby, title]);
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -142,6 +169,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     "ui-btn",
     VARIANT_CLASS[variant],
     size === "sm" ? "ui-btn--sm" : "",
+    iconOnly ? "ui-btn--icon-only" : "",
     fullWidth ? "ui-btn--full" : "",
     pending ? "ui-btn--pending" : "",
     success ? "ui-btn--success" : "",

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -53,6 +53,21 @@
   width: 100%;
 }
 
+/*
+ * Icon-only / dense affordance: squares the control to its current height and
+ * drops the label padding, for dense action rows (tunnel rows, network-monitor
+ * rows). Geometry only — color, hover, radius, focus ring, and the async
+ * pending/success affordances all come from the variant + base classes.
+ * `aspect-ratio: 1` keeps it square at either size (32px for md, 28px for sm).
+ * Icon-only buttons require an accessible name (aria-label/tooltip); the
+ * primitive warns in the LogViewer when one is missing (issue 1284).
+ */
+.ui-btn--icon-only {
+  aspect-ratio: 1;
+  padding: 0;
+  flex-shrink: 0;
+}
+
 .ui-btn--primary {
   background: var(--accent-color);
   color: var(--text-on-accent);


### PR DESCRIPTION
Closes #1284. Follow-up to #1259 (PR #1282).

## Approach
Adds a first-class `iconOnly` prop to the shared `Button` primitive (`src/components/ui/Button.tsx`) instead of leaving each dense icon row to hand-roll its own geometry:

- **Primitive**: `iconOnly` adds a token-only `.ui-btn--icon-only` class that squares the control to its current height (`aspect-ratio: 1` → 32px for `md`, 28px for `sm`) and drops the label padding. The ghost skin — color, hover, radius, focus ring, and the async pending/success affordances — still comes entirely from the variant + base classes; no per-component skinning.
- **Accessible name required**: icon-only buttons carry no visible label, so the primitive warns in the LogViewer (`frontendLog`) when `aria-label` / `aria-labelledby` / `title` are all absent.
- **Migrations** (local geometry overrides removed):
  - `TunnelListItem` — dropped the `.tunnel-item__action.ui-btn` square-compaction rule (from #1259) and the now-unused `tunnel-item__action` className; the action buttons use `iconOnly`.
  - `NetworkToolsSidebar` — the monitor Pause/Resume/Stop/Remove controls and the Monitors Refresh button use `iconOnly`.

All values reference tokens from `src/styles/variables.css`; no raw hex/px/rgba, and CSS-comment issue refs are written without a leading `#` to satisfy the token-discipline guard.

## Test plan
- `test(ui)` commit adds Vitest coverage: the `ui-btn--icon-only` class is applied only when `iconOnly` is set, and the primitive warns via `frontendLog` when an icon-only button has no accessible name (and stays quiet with `aria-label`/`title`). Verified red before implementing.
- FULL `pnpm test` (242 files, 2471 tests) passes — including the `tokenDiscipline` guard.
- `pnpm build` (tsc) and `pnpm run lint` pass; `prettier --check` clean. No `any` types. No `data-testid` changes (catalog unchanged).
- Manual visual check recommended: confirm the tunnel action row and the Network Tools monitor rows render as compact squares (hover reveals them in the tunnel row) and that focus ring / hover match the rest of the ghost buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)