### PR TITLE
feat(sftp): done/error toasts for completed transfers (Closes #1286)

### DIFF
--- a/docs/changes/dev1/feature/1286-sftp-transfer-toasts.md
+++ b/docs/changes/dev1/feature/1286-sftp-transfer-toasts.md
@@ -1,0 +1,22 @@
+### Added
+
+- Completed SFTP transfers now confirm with a toast (issue #1286, stage D2,
+  follow-up to #1247). When a transfer finishes it shows a single success toast
+  (`Downloaded <file>` / `Uploaded <file>`); when it fails it shows a single
+  recoverable error toast carrying the backend's failure message
+  (`Download/Upload of <file> failed: <reason>`). The toasts are driven off the
+  terminal `transfer-progress` phase, so background transfers that never went
+  through the file-browser's own feedback path are now surfaced too.
+
+### Changed
+
+- Cancelling an SFTP transfer raises no toast from the terminal transfer phase —
+  the Cancel button already shows its own "Transfer cancelled" confirmation and
+  the user initiated the cancel, so a second toast off the `cancelled` phase
+  would be redundant. This is a deliberate choice for the `cancelled` transfer
+  phase (it also prevents a duplicate cancel toast).
+- The file browser's per-transfer success/error toast is now owned exclusively
+  by the `transfer-progress` event path, so a single transfer produces exactly
+  one terminal toast (no duplicate between the file-browser feedback and the new
+  event-driven toast). The file browser keeps its pending "Downloading…/
+  Uploading…" toast and dismisses it on completion.

--- a/src/hooks/useFileSystem.test.ts
+++ b/src/hooks/useFileSystem.test.ts
@@ -35,6 +35,16 @@ vi.mock("@/services/api", () => ({
   sftpRename: vi.fn(() => Promise.resolve()),
   sftpWriteFileContent: vi.fn(() => Promise.resolve()),
   vscodeOpenRemote: vi.fn(() => Promise.resolve()),
+  // The real marker class so `error instanceof TransferTerminalError` in
+  // runTransfer resolves correctly (#1286).
+  TransferTerminalError: class TransferTerminalError extends Error {
+    readonly phase: "cancelled" | "error";
+    constructor(phase: "cancelled" | "error", message: string) {
+      super(message);
+      this.name = "TransferTerminalError";
+      this.phase = phase;
+    }
+  },
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
@@ -223,7 +233,7 @@ describe("useFileSystem (SFTP) — store integration", () => {
 
 // D2 (#1143): a failed transfer must surface an error to the user via toast
 // rather than resolving silently or producing an unhandled rejection.
-import { sftpDownload } from "@/services/api";
+import { sftpDownload, TransferTerminalError } from "@/services/api";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { toast } from "@/components/ui";
 
@@ -343,5 +353,109 @@ describe("useFileSystem (SFTP) — transfer-error feedback (D2, #1143)", () => {
     });
 
     expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+});
+
+// #1286: the terminal success/error toast is owned exclusively by the
+// `transfer-progress` event path (useTransferEvents) so a single transfer
+// yields exactly one terminal toast. `runTransfer` must therefore show only a
+// pending toast and dismiss it on completion — never emit its own terminal
+// success/error toast (which would double up with the event path).
+describe("useFileSystem (SFTP) — no double terminal toast (#1286)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderHook(): Promise<ReturnType<typeof useFileSystem>> {
+    let api: ReturnType<typeof useFileSystem> | undefined;
+    function Harness() {
+      api = useFileSystem();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    return api!;
+  }
+
+  it("does not emit a terminal success toast on a successful upload (event path owns it)", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/uploads" });
+    vi.mocked(open).mockResolvedValueOnce("/local/file.txt");
+    vi.mocked(sftpUpload).mockResolvedValueOnce(0);
+
+    const api = await renderHook();
+
+    await act(async () => {
+      await api.uploadFile();
+    });
+
+    // Pending feedback only; the terminal toast comes from useTransferEvents.
+    expect(vi.mocked(toast.loading)).toHaveBeenCalled();
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.dismiss)).toHaveBeenCalled();
+  });
+
+  it("does not emit a terminal success toast on a successful download", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/" });
+    vi.mocked(save).mockResolvedValueOnce("/local/save.txt");
+    vi.mocked(sftpDownload).mockResolvedValueOnce(0);
+
+    const api = await renderHook();
+
+    await act(async () => {
+      await api.downloadFile("/remote/save.txt", "save.txt");
+    });
+
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.dismiss)).toHaveBeenCalled();
+  });
+
+  it("defers to the event path on a TransferTerminalError (no runTransfer error toast)", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/uploads" });
+    vi.mocked(open).mockResolvedValueOnce("/local/file.txt");
+    // A terminal `error` phase surfaced via awaitTransfer — the event path
+    // (useTransferEvents) already toasts it, so runTransfer must not re-toast.
+    vi.mocked(sftpUpload).mockRejectedValueOnce(
+      new TransferTerminalError("error", "connection reset")
+    );
+
+    const api = await renderHook();
+
+    await act(async () => {
+      await expect(api.uploadFile()).resolves.toBeUndefined();
+    });
+
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.dismiss)).toHaveBeenCalled();
+  });
+
+  it("stays quiet on a cancelled transfer (TransferTerminalError 'cancelled')", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/uploads" });
+    vi.mocked(open).mockResolvedValueOnce("/local/file.txt");
+    vi.mocked(sftpUpload).mockRejectedValueOnce(
+      new TransferTerminalError("cancelled", "Transfer cancelled")
+    );
+
+    const api = await renderHook();
+
+    await act(async () => {
+      await expect(api.uploadFile()).resolves.toBeUndefined();
+    });
+
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.dismiss)).toHaveBeenCalled();
   });
 });

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -9,6 +9,7 @@ import {
   sftpRename,
   sftpWriteFileContent,
   vscodeOpenRemote,
+  TransferTerminalError,
 } from "@/services/api";
 import { FileEntry } from "@/types/connection";
 import { toast } from "@/components/ui";
@@ -22,23 +23,44 @@ function transferErrorMessage(error: unknown): string {
 }
 
 /**
- * Run an SFTP transfer with user feedback: a pending toast that resolves in
- * place into success or a persistent error (audit gap D2 — transfers must
- * never fail silently). The rejection is surfaced via `toast.error` and logged
- * to the LogViewer, then swallowed so callers do not produce an unhandled
- * rejection. Returns whether the transfer succeeded.
+ * Run an SFTP transfer with user feedback: a pending toast shown while the
+ * transfer runs (audit gap D2 — transfers must never fail silently).
+ *
+ * The **terminal** success/error toast is owned exclusively by the
+ * `transfer-progress` event path (`useTransferEvents`, #1286) so a single
+ * transfer produces exactly one terminal toast. This helper therefore does not
+ * emit its own success/error toast for a transfer that reached the backend:
+ *   - success → dismiss the pending toast (the event path raises the "Downloaded
+ *     …/Uploaded …" success toast);
+ *   - a {@link TransferTerminalError} (`done`/`cancelled`/`error` from the
+ *     transfer channel) → dismiss the pending toast; the event path already
+ *     surfaced the outcome (and stays quiet on cancel).
+ *
+ * An **early** failure that never produced a transfer event (invalid session,
+ * permission error thrown before the transfer starts, an sftp→sftp temp-file
+ * paste leg that fails synchronously) is still surfaced here via `toast.error`,
+ * since no `transfer-progress` event will cover it. The rejection is always
+ * swallowed so callers never produce an unhandled rejection. Returns whether
+ * the transfer succeeded.
  */
 async function runTransfer(
   label: string,
   action: () => Promise<unknown>,
-  messages: { loading: string; success: string }
+  messages: { loading: string }
 ): Promise<boolean> {
   const toastId = toast.loading(messages.loading);
   try {
     await action();
-    toast.success(messages.success, { id: toastId });
+    // Success toast is raised by the transfer-progress event path (#1286).
+    toast.dismiss(toastId);
     return true;
   } catch (error) {
+    if (error instanceof TransferTerminalError) {
+      // The event path already surfaced this (success/error toast) or is
+      // intentionally quiet (cancel) — just clear the pending toast.
+      toast.dismiss(toastId);
+      return false;
+    }
     const message = transferErrorMessage(error);
     frontendLog("sftp_transfer", `${label} failed: ${message}`);
     toast.error(`${label} failed: ${message}`, { id: toastId });
@@ -82,7 +104,6 @@ export function useFileSystem() {
       if (!localPath) return;
       await runTransfer("Download", () => sftpDownload(sftpSessionId, remotePath, localPath), {
         loading: `Downloading ${fileName}…`,
-        success: `Downloaded ${fileName}`,
       });
     },
     [sftpSessionId]
@@ -96,7 +117,6 @@ export function useFileSystem() {
     const remotePath = currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
     const ok = await runTransfer("Upload", () => sftpUpload(sftpSessionId, localPath, remotePath), {
       loading: `Uploading ${fileName}…`,
-      success: `Uploaded ${fileName}`,
     });
     if (ok) refreshSftp();
   }, [sftpSessionId, currentPath, refreshSftp]);
@@ -110,7 +130,7 @@ export function useFileSystem() {
       const ok = await runTransfer(
         "Upload",
         () => sftpUpload(sftpSessionId, localPath, remotePath),
-        { loading: `Uploading ${fileName}…`, success: `Uploaded ${fileName}` }
+        { loading: `Uploading ${fileName}…` }
       );
       if (ok) refreshSftp();
     },
@@ -228,7 +248,6 @@ export function useFileSystem() {
     for (const clipEntry of clipboard.entries) {
       const ok = await runTransfer("Paste", () => pasteOne(clipEntry), {
         loading: `Pasting ${clipEntry.name}…`,
-        success: `Pasted ${clipEntry.name}`,
       });
       // Abort on first failure so a cut clipboard is not cleared and the user
       // is not left with a partial, silently-incomplete paste.

--- a/src/hooks/useTransferEvents.test.ts
+++ b/src/hooks/useTransferEvents.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// A settable callback the mocked `onTransferProgress` hands the event stream to,
+// so tests can drive terminal `transfer-progress` phases directly.
+let emit: ((progress: TransferProgress) => void) | undefined;
+const unlisten = vi.fn();
+
+vi.mock("@/services/events", () => ({
+  onTransferProgress: vi.fn((cb: (progress: TransferProgress) => void) => {
+    emit = cb;
+    return Promise.resolve(unlisten);
+  }),
+}));
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn((_message: unknown, _opts?: unknown) => undefined),
+    error: vi.fn((_message: unknown, _opts?: unknown) => undefined),
+    info: vi.fn((_message: unknown, _opts?: unknown) => undefined),
+    loading: vi.fn((_message: unknown, _opts?: unknown) => "toast-id"),
+    promise: vi.fn(),
+    dismiss: vi.fn((_id?: unknown) => undefined),
+  },
+}));
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { useTransferEvents } from "./useTransferEvents";
+import { useAppStore } from "@/store/appStore";
+import { toast } from "@/components/ui";
+import type { TransferProgress } from "@/services/api";
+
+function progress(overrides: Partial<TransferProgress> = {}): TransferProgress {
+  return {
+    transferId: "t1",
+    sessionId: "sess-a",
+    direction: "download",
+    fileName: "file.txt",
+    transferred: 0,
+    total: 100,
+    phase: "transferring",
+    ...overrides,
+  };
+}
+
+describe("useTransferEvents — terminal-phase toasts (D2, #1286)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    emit = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function mountHook(): Promise<void> {
+    function Harness() {
+      useTransferEvents();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    // The subscription is set up asynchronously inside an effect.
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  it("shows exactly one success toast on a completed download", async () => {
+    await mountHook();
+
+    act(() => {
+      emit!(progress({ direction: "download" }));
+      emit!(progress({ transferred: 100, phase: "done" }));
+    });
+
+    expect(vi.mocked(toast.success)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.success).mock.calls[0][0]).toContain("Downloaded");
+    expect(vi.mocked(toast.success).mock.calls[0][0]).toContain("file.txt");
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it("labels an uploaded file with 'Uploaded'", async () => {
+    await mountHook();
+
+    act(() => {
+      emit!(progress({ direction: "upload", fileName: "report.pdf", phase: "done" }));
+    });
+
+    expect(vi.mocked(toast.success)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.success).mock.calls[0][0]).toContain("Uploaded");
+    expect(vi.mocked(toast.success).mock.calls[0][0]).toContain("report.pdf");
+  });
+
+  it("shows exactly one recoverable error toast using the event message on error", async () => {
+    await mountHook();
+
+    act(() => {
+      emit!(progress({ phase: "error", message: "permission denied" }));
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toContain("permission denied");
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a generic error message when the event carries none", async () => {
+    await mountHook();
+
+    act(() => {
+      emit!(progress({ phase: "error" }));
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(toast.error).mock.calls[0][0])).toMatch(/fail/i);
+  });
+
+  it("stays quiet on a user-initiated cancel (no success/error toast)", async () => {
+    await mountHook();
+
+    act(() => {
+      emit!(progress({ phase: "cancelled" }));
+    });
+
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it("does not toast on intermediate transferring updates", async () => {
+    await mountHook();
+
+    act(() => {
+      emit!(progress({ transferred: 25 }));
+      emit!(progress({ transferred: 50 }));
+    });
+
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it("still folds the terminal phase into the store (row cleared)", async () => {
+    await mountHook();
+
+    act(() => {
+      emit!(progress());
+    });
+    expect(useAppStore.getState().transfers["t1"]).toBeDefined();
+
+    act(() => {
+      emit!(progress({ phase: "done" }));
+    });
+    expect(useAppStore.getState().transfers["t1"]).toBeUndefined();
+  });
+});

--- a/src/hooks/useTransferEvents.ts
+++ b/src/hooks/useTransferEvents.ts
@@ -1,12 +1,45 @@
 import { useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
 import { onTransferProgress } from "@/services/events";
+import { toast } from "@/components/ui";
+import type { TransferProgress } from "@/services/api";
+
+/**
+ * Raise the single terminal-phase toast for a settled transfer (#1286).
+ *
+ * This event path is the **sole owner** of the terminal success/error toast, so
+ * a transfer — however it was initiated (file-browser download/upload/paste, or
+ * a background transfer that never went through `runTransfer`) — produces
+ * exactly one terminal toast. The file-browser `runTransfer` helper only shows a
+ * pending toast and dismisses it, deferring the terminal toast here (see
+ * `useFileSystem.ts`).
+ *
+ * - `done`      → `toast.success` ("Downloaded …" / "Uploaded …").
+ * - `error`     → recoverable `toast.error` carrying the backend `message`.
+ * - `cancelled` → stay quiet: the user initiated the cancel, and the Cancel
+ *   button already raises its own "Transfer cancelled" confirmation
+ *   (`FileBrowser`/`OpenConnectionsModal`), so toasting the `cancelled` phase
+ *   here would double up. The in-flight row simply disappears from the
+ *   Transfers UI.
+ */
+function toastTerminalPhase(progress: TransferProgress): void {
+  const { phase, direction, fileName, message } = progress;
+  if (phase === "done") {
+    const verb = direction === "download" ? "Downloaded" : "Uploaded";
+    toast.success(`${verb} ${fileName}`);
+  } else if (phase === "error") {
+    const verb = direction === "download" ? "Download" : "Upload";
+    toast.error(`${verb} of ${fileName} failed: ${message ?? "Transfer failed"}`);
+  }
+  // `cancelled` and `transferring` intentionally emit no toast.
+}
 
 /**
  * Hook that listens for `transfer-progress` events from the backend (#1245) and
  * folds them into the store's `transfers` map (#1247), driving the Open
  * Connections "Transfers" section, the file-browser footer, and the status-bar
- * aggregate.
+ * aggregate. On a terminal phase it also raises the one success/error toast for
+ * the transfer (#1286).
  */
 export function useTransferEvents(): void {
   const applyTransferProgress = useAppStore((s) => s.applyTransferProgress);
@@ -17,6 +50,7 @@ export function useTransferEvents(): void {
     const setup = async () => {
       unlisten = await onTransferProgress((progress) => {
         applyTransferProgress(progress);
+        toastTerminalPhase(progress);
       });
     };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -528,13 +528,37 @@ export interface TransferProgress {
 }
 
 /**
+ * Rejection raised by {@link awaitTransfer} when a transfer settles via a
+ * terminal `transfer-progress` event (`cancelled` / `error`), as opposed to an
+ * early/synchronous failure that never reached the background transfer.
+ *
+ * The terminal success/error toast is owned exclusively by the
+ * `transfer-progress` event path (`useTransferEvents`, #1286) so a single
+ * transfer yields exactly one toast. Callers such as `runTransfer` use this
+ * marker to recognise "the event path already surfaced this outcome" and skip
+ * their own terminal toast (they just dismiss their pending toast), while still
+ * surfacing early failures that produced no transfer event.
+ */
+export class TransferTerminalError extends Error {
+  /** `"cancelled"` when the user aborted; `"error"` on a real failure. */
+  readonly phase: "cancelled" | "error";
+
+  constructor(phase: "cancelled" | "error", message: string) {
+    super(message);
+    this.name = "TransferTerminalError";
+    this.phase = phase;
+  }
+}
+
+/**
  * Await the terminal `transfer-progress` event for `transferId`.
  *
  * The backend now runs transfers in the background on a dedicated channel and
  * returns a `transferId` synchronously (#1245). This bridges that fire-and-return
  * command to the existing await-completion callers: it resolves with the bytes
- * transferred on `done`, and rejects on `cancelled` / `error`. The D3 UI can
- * instead subscribe to `transfer-progress` directly for live progress.
+ * transferred on `done`, and rejects with a {@link TransferTerminalError} on
+ * `cancelled` / `error`. The D3 UI can instead subscribe to `transfer-progress`
+ * directly for live progress.
  */
 async function awaitTransfer(transferId: string): Promise<number> {
   const { listen } = await import("@tauri-apps/api/event");
@@ -548,10 +572,10 @@ async function awaitTransfer(transferId: string): Promise<number> {
         resolve(p.transferred);
       } else if (p.phase === "cancelled") {
         unlisten?.();
-        reject(new Error("Transfer cancelled"));
+        reject(new TransferTerminalError("cancelled", "Transfer cancelled"));
       } else if (p.phase === "error") {
         unlisten?.();
-        reject(new Error(p.message ?? "Transfer failed"));
+        reject(new TransferTerminalError("error", p.message ?? "Transfer failed"));
       }
     }).then((fn) => {
       unlisten = fn;


### PR DESCRIPTION
## Summary

SFTP D2 (follow-up to #1247). Adds success/error toasts for completed SFTP transfers, driven off the terminal `transfer-progress` phase, reconciled with the existing `runTransfer` feedback so a single transfer yields **exactly one** terminal toast.

- The `transfer-progress` event path (`useTransferEvents`) is now the sole owner of the terminal toast: `done` → `toast.success("Downloaded/Uploaded <file>")`; `error` → recoverable `toast.error(... <message>)`.
- `runTransfer` (`useFileSystem.ts`) no longer emits its own terminal toast — it shows only the pending `toast.loading` and dismisses it on completion, deferring to the event path.
- A `TransferTerminalError` marker (thrown by `awaitTransfer` in `api.ts` for `cancelled`/`error`) lets `runTransfer` know the event path already toasted (dismiss only), while still error-toasting any *other* rejection — covering early/synchronous failures and the `useLocalFileSystem` sftp→local paste that bypasses `runTransfer`.
- **cancelled** phase stays quiet (the Cancel button already raises its own confirmation) — documented in code + the fragment.

## Test plan

- `useTransferEvents.test.ts` (done/error/generic-fallback/silent-on-cancel/no-toast-on-intermediate) + extended `useFileSystem.test.ts` (no terminal toast from runTransfer, defers on `TransferTerminalError`, silent on cancelled). TDD, test commit precedes feat.
- `tsc --noEmit` + full vitest (2479) green; eslint + prettier verified clean.

Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)