### PR TITLE
feat(agent): surface Disconnect/Shutdown intents for agents in Open Connections (Closes #1277)

### DIFF
--- a/docs/changes/dev1/feature/1277-oc-agent-disconnect-shutdown.md
+++ b/docs/changes/dev1/feature/1277-oc-agent-disconnect-shutdown.md
@@ -1,0 +1,9 @@
+# Changes
+
+## Added
+
+- Open Connections panel: connected agent rows now offer both **Disconnect**
+  (detach transport, keep persistent remote sessions running) and **Shutdown**
+  (stop the remote sessions and disconnect), mirroring the agent header's two
+  teardown intents. Shutdown reports how many remote sessions were stopped
+  (#1277).

--- a/src/components/OpenConnections/OpenConnectionsModal.agentShutdown.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.agentShutdown.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Tests for the two teardown intents on a connected agent row in the Open
+ * Connections panel (#1277, follow-up to #1237). Each connected agent exposes
+ * both Disconnect (detach transport, keep remote sessions) → disconnectRemoteAgent,
+ * and Shutdown (stop remote sessions and disconnect) → shutdownRemoteAgent, which
+ * toasts the detached-session count.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() => Promise.resolve([])),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  cancelConnectAgent: vi.fn(() => Promise.resolve(true)),
+  pruneDeadAgents: vi.fn(() => Promise.resolve([])),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false, sessionCount: 0 })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorStopAll: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return {
+    ...actual,
+    toast: { success: (m: string) => toastSuccess(m), error: (m: string) => toastError(m) },
+  };
+});
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+function agent(id: string, name: string): RemoteAgentDefinition {
+  return {
+    id,
+    name,
+    type: "remote-agent",
+    connectionState: "connected",
+    isExpanded: false,
+    config: {
+      host: "h",
+      port: 22,
+      username: "u",
+      authMethod: "password",
+    },
+  } as unknown as RemoteAgentDefinition;
+}
+
+/** Flush pending microtasks so async click handlers settle. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("OpenConnectionsModal — agent Disconnect / Shutdown intents", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const disconnectRemoteAgent = vi.fn((_id: string) => Promise.resolve());
+  const shutdownRemoteAgent = vi.fn((_id: string) => Promise.resolve(0));
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    disconnectRemoteAgent.mockClear();
+    disconnectRemoteAgent.mockResolvedValue(undefined);
+    shutdownRemoteAgent.mockClear();
+    shutdownRemoteAgent.mockResolvedValue(0);
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderWithAgent(a: RemoteAgentDefinition) {
+    useAppStore.setState({ remoteAgents: [a], disconnectRemoteAgent, shutdownRemoteAgent });
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
+      );
+    });
+  }
+
+  function agentRow(): Element | undefined {
+    return Array.from(document.querySelectorAll(".oc-row")).find((r) =>
+      r.querySelector(".oc-row__title")?.textContent?.includes("build-box")
+    );
+  }
+
+  it("exposes both Disconnect and Shutdown actions on a connected agent row", () => {
+    renderWithAgent(agent("a1", "build-box"));
+    const row = agentRow();
+    expect(row).toBeTruthy();
+    expect(row?.querySelector('[data-testid="oc-agent-disconnect-a1"]')).toBeTruthy();
+    expect(row?.querySelector('[data-testid="oc-agent-shutdown-a1"]')).toBeTruthy();
+  });
+
+  it("Disconnect invokes the detach path (disconnectRemoteAgent)", async () => {
+    renderWithAgent(agent("a1", "build-box"));
+    const btn = agentRow()?.querySelector(
+      '[data-testid="oc-agent-disconnect-a1"]'
+    ) as HTMLButtonElement;
+    await act(async () => btn.click());
+    await flush();
+    expect(disconnectRemoteAgent).toHaveBeenCalledWith("a1");
+    expect(shutdownRemoteAgent).not.toHaveBeenCalled();
+  });
+
+  it("Shutdown invokes shutdownRemoteAgent and toasts the stopped-session count", async () => {
+    shutdownRemoteAgent.mockResolvedValueOnce(3);
+    renderWithAgent(agent("a1", "build-box"));
+    const btn = agentRow()?.querySelector(
+      '[data-testid="oc-agent-shutdown-a1"]'
+    ) as HTMLButtonElement;
+    await act(async () => btn.click());
+    await flush();
+    expect(shutdownRemoteAgent).toHaveBeenCalledWith("a1");
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining("3 sessions"));
+    expect(disconnectRemoteAgent).not.toHaveBeenCalled();
+  });
+
+  it("Shutdown with a single detached session uses the singular form", async () => {
+    shutdownRemoteAgent.mockResolvedValueOnce(1);
+    renderWithAgent(agent("a1", "build-box"));
+    const btn = agentRow()?.querySelector(
+      '[data-testid="oc-agent-shutdown-a1"]'
+    ) as HTMLButtonElement;
+    await act(async () => btn.click());
+    await flush();
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining("1 session"));
+    expect(toastSuccess).not.toHaveBeenCalledWith(expect.stringContaining("1 sessions"));
+  });
+
+  it("Shutdown with no detached sessions still reports success", async () => {
+    shutdownRemoteAgent.mockResolvedValueOnce(0);
+    renderWithAgent(agent("a1", "build-box"));
+    const btn = agentRow()?.querySelector(
+      '[data-testid="oc-agent-shutdown-a1"]'
+    ) as HTMLButtonElement;
+    await act(async () => btn.click());
+    await flush();
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+});

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -97,6 +97,15 @@
   flex-shrink: 0;
 }
 
+/* Trailing action cluster for rows that expose more than one intent
+   (e.g. an agent's Disconnect vs Shutdown). */
+.oc-row__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
 .oc-row__badge--alive,
 .oc-row__badge--connected,
 .oc-row__badge--up {

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -13,6 +13,8 @@ import {
   Download,
   Upload,
   Ban,
+  Unplug,
+  Power,
 } from "lucide-react";
 import { Modal, Button, Tooltip, Progress, toast } from "@/components/ui";
 import { formatBytes } from "@/utils/formatters";
@@ -62,6 +64,7 @@ interface ProxySessionsState {
 export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModalProps) {
   const remoteAgents = useAppStore((s) => s.remoteAgents);
   const disconnectRemoteAgent = useAppStore((s) => s.disconnectRemoteAgent);
+  const shutdownRemoteAgent = useAppStore((s) => s.shutdownRemoteAgent);
   const stopTunnel = useAppStore((s) => s.stopTunnel);
   const tunnels = useAppStore((s) => s.tunnels);
   // Live single source of truth for tunnel status (kept in sync by tunnel
@@ -279,13 +282,36 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     setLocalSessions([]);
   };
 
-  const handleKillAgent = async (agentId: string) => {
-    await disconnectRemoteAgent(agentId);
+  // Clear the cached native-session rows for an agent once its transport is gone
+  // (both teardown intents drop the transport, so the "Sessions on <agent>"
+  // section must disappear together with the agent row).
+  const clearAgentSessionCache = (agentId: string) => {
     setAgentSessions((prev) => {
       const next = { ...prev };
       delete next[agentId];
       return next;
     });
+  };
+
+  // Disconnect (detach) — drop the transport but leave persistent daemon-backed
+  // remote sessions running so they re-list on the next connect (G9, #1237).
+  // Mirrors the agent header's Disconnect intent.
+  const handleKillAgent = async (agentId: string) => {
+    await disconnectRemoteAgent(agentId);
+    clearAgentSessionCache(agentId);
+  };
+
+  // Shutdown (stop remote) — stop the remote sessions and disconnect, reporting
+  // how many sessions the agent detached/killed as a success toast (G9, #1237).
+  // Mirrors the agent header's Shutdown intent.
+  const handleShutdownAgent = async (agentId: string) => {
+    const detached = await shutdownRemoteAgent(agentId);
+    clearAgentSessionCache(agentId);
+    toast.success(
+      detached > 0
+        ? `Agent shut down — ${detached} session${detached === 1 ? "" : "s"} stopped`
+        : "Agent shut down"
+    );
   };
 
   const handleKillAllAgents = async () => {
@@ -550,7 +576,42 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                 icon={<Server size={14} />}
                 title={a.name}
                 badge="connected"
-                onKill={() => handleKillAgent(a.id)}
+                actions={
+                  // Two distinct teardown intents mirroring the agent header
+                  // (G9, #1237/#1277). Disconnect detaches the transport but keeps
+                  // persistent remote sessions running; Shutdown stops them and
+                  // reports the count. Both use the async Button for pending/error
+                  // feedback; Shutdown adds a success toast.
+                  <div className="oc-row__actions">
+                    <Tooltip
+                      content="Detach transport — keep persistent remote sessions"
+                      side="top"
+                    >
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        icon={<Unplug size={14} />}
+                        onClick={() => handleKillAgent(a.id)}
+                        aria-label={`Disconnect (detach) ${a.name}`}
+                        data-testid={`oc-agent-disconnect-${a.id}`}
+                      >
+                        Disconnect
+                      </Button>
+                    </Tooltip>
+                    <Tooltip content="Stop remote sessions and disconnect" side="top">
+                      <Button
+                        variant="danger"
+                        size="sm"
+                        icon={<Power size={14} />}
+                        onClick={() => handleShutdownAgent(a.id)}
+                        aria-label={`Shutdown (stop remote) ${a.name}`}
+                        data-testid={`oc-agent-shutdown-${a.id}`}
+                      >
+                        Shutdown
+                      </Button>
+                    </Tooltip>
+                  </div>
+                }
               />
             ))}
           </Section>
@@ -910,6 +971,12 @@ interface ConnectionRowProps {
   "data-testid"?: string;
   /** data-testid forwarded to the kill button. */
   killTestId?: string;
+  /**
+   * Custom trailing actions, rendered in place of the default kill button. Used
+   * by rows that expose more than one teardown intent (e.g. an agent's
+   * Disconnect vs Shutdown). When set, `onKill` is ignored.
+   */
+  actions?: React.ReactNode;
 }
 
 function ConnectionRow({
@@ -921,6 +988,7 @@ function ConnectionRow({
   killLabel = "Kill",
   "data-testid": testId,
   killTestId,
+  actions,
 }: ConnectionRowProps) {
   return (
     <div className="oc-row" data-testid={testId}>
@@ -930,17 +998,18 @@ function ConnectionRow({
         {detail && <span className="oc-row__detail">{detail}</span>}
       </span>
       <span className={`oc-row__badge oc-row__badge--${badge}`}>{badge}</span>
-      {onKill && (
-        <Button
-          variant="danger"
-          size="sm"
-          className="oc-row__kill"
-          onClick={() => onKill()}
-          data-testid={killTestId}
-        >
-          {killLabel}
-        </Button>
-      )}
+      {actions ??
+        (onKill && (
+          <Button
+            variant="danger"
+            size="sm"
+            className="oc-row__kill"
+            onClick={() => onKill()}
+            data-testid={killTestId}
+          >
+            {killLabel}
+          </Button>
+        ))}
     </div>
   );
 }

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -594,6 +594,8 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `monitor-stale-*` | `monitor-stale-${config.id}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `monitoring-connect-*` | `monitoring-connect-${conn.id}` | `src/components/StatusBar/StatusBar.tsx` |
 | `network-quick-action-*` | `network-quick-action-${tool}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
+| `oc-agent-disconnect-*` | `oc-agent-disconnect-${a.id}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `oc-agent-shutdown-*` | `oc-agent-shutdown-${a.id}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `persistent-attach-*` | `persistent-attach-${definition.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `persistent-start-*` | `persistent-start-${definition.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `persistent-stop-*` | `persistent-stop-${definition.id}` | `src/components/Sidebar/AgentNode.tsx` |


### PR DESCRIPTION
## Summary

Follow-up to #1237. The agent header split the single teardown control into **Disconnect (detach)** vs **Shutdown (stop remote)**; the Open Connections panel still offered only Disconnect for agents. This mirrors both intents there.

Each connected agent row in `OpenConnectionsModal` now renders:
- **Disconnect** (ghost, `Unplug`) → `disconnectRemoteAgent` (detach, keeps persistent remote sessions). Tooltip: "Detach transport — keep persistent remote sessions".
- **Shutdown** (danger, `Power`) → `shutdownRemoteAgent`, toasting the stopped-session count ("Agent shut down — N session(s) stopped"). Tooltip: "Stop remote sessions and disconnect".

Both use the async Button (pending/error feedback); wording/testids match the header. `ConnectionRow` gained an optional `actions` slot (no `any`) so a row can render multiple intents; token'd `.oc-row__actions` container. The section "Kill All" keeps its non-destructive detach bulk behavior.

## Test plan

- `OpenConnectionsModal.agentShutdown.test.tsx` (5): a connected agent row exposes Disconnect + Shutdown; Shutdown invokes `shutdownRemoteAgent` and toasts the count; Disconnect invokes the detach path. TDD, test commit precedes feat.
- Verified on-branch (the agent's sandbox denied final checks): `tsc --noEmit`, eslint, prettier clean; OpenConnections suite 35/35 green.

Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)