### PR TITLE
feat(tunnel): liveness supervisor → Connected→Error on death + force-Reconnect (Closes #1243)

### DIFF
--- a/docs/changes/dev1/feature/1243-tunnel-liveness-supervisor.md
+++ b/docs/changes/dev1/feature/1243-tunnel-liveness-supervisor.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **SSH tunnels now detect death instead of showing green forever.** When a
+  tunnel's forwarder accept loop exits or its SSH session dies, a per-tunnel
+  supervisor tears the tunnel down, releases its pooled session/port, and
+  transitions the row to a persisted **Error** with the cause — so a dead tunnel
+  no longer sits green while leaking a pooled session and bound port (#1243).
+
+### Added
+
+- **Force-Reconnect** control on a connected tunnel row: tears the tunnel down
+  and restarts it even if liveness has not fired yet, covering a stale-but-green
+  tunnel the supervisor is slow to notice (#1243).

--- a/src-tauri/src/tunnel/dynamic_forward.rs
+++ b/src-tauri/src/tunnel/dynamic_forward.rs
@@ -15,6 +15,9 @@ use super::local_forward::ForwarderStats;
 pub struct DynamicForwarder {
     task_handle: Option<tokio::task::JoinHandle<()>>,
     stats: Arc<ForwarderStats>,
+    /// Fires when the accept loop exits, so the tunnel supervisor can observe
+    /// forwarder death and drive the tunnel to `Error` (#1243, GAP 2).
+    death: Option<tokio::sync::oneshot::Receiver<()>>,
 }
 
 const SOCKS5_VERSION: u8 = 0x05;
@@ -40,19 +43,27 @@ impl DynamicForwarder {
         let stats = Arc::new(ForwarderStats::new());
         let stats_clone = Arc::clone(&stats);
 
+        let (death_tx, death_rx) = tokio::sync::oneshot::channel();
         let task_handle = tokio::spawn(async move {
+            let _death = death_tx;
             Self::accept_loop(listener, session, stats_clone).await;
         });
 
         Ok(Self {
             task_handle: Some(task_handle),
             stats,
+            death: Some(death_rx),
         })
     }
 
     /// Get current tunnel statistics.
     pub fn get_stats(&self) -> TunnelStats {
         self.stats.to_tunnel_stats()
+    }
+
+    /// Take the forwarder-death receiver (once) for the tunnel supervisor.
+    pub fn take_death_signal(&mut self) -> Option<tokio::sync::oneshot::Receiver<()>> {
+        self.death.take()
     }
 
     /// Stop the forwarder by aborting the accept task.

--- a/src-tauri/src/tunnel/local_forward.rs
+++ b/src-tauri/src/tunnel/local_forward.rs
@@ -12,6 +12,11 @@ use super::config::{LocalForwardConfig, TunnelStats};
 pub struct LocalForwarder {
     task_handle: Option<tokio::task::JoinHandle<()>>,
     stats: Arc<ForwarderStats>,
+    /// Fires when the accept loop exits (bind lost / listener error), so the
+    /// tunnel supervisor can observe forwarder death and drive the tunnel to
+    /// `Error` instead of leaving it green-forever (#1243, GAP 2). Taken once by
+    /// the supervisor; `None` afterwards.
+    death: Option<tokio::sync::oneshot::Receiver<()>>,
 }
 
 /// Shared atomic counters for tracking tunnel statistics.
@@ -79,14 +84,26 @@ impl LocalForwarder {
         let remote_host = config.remote_host.clone();
         let remote_port = config.remote_port;
 
+        // `death_tx` is moved into the accept task and dropped when it ends — on
+        // a clean `break` (listener error) or an `abort()` from `stop()`. The
+        // receiver resolves either way; the supervisor distinguishes a real death
+        // from a user stop via its own cancel token (#1243).
+        let (death_tx, death_rx) = tokio::sync::oneshot::channel();
         let task_handle = tokio::spawn(async move {
+            let _death = death_tx;
             Self::accept_loop(listener, session, remote_host, remote_port, stats_clone).await;
         });
 
         Ok(Self {
             task_handle: Some(task_handle),
             stats,
+            death: Some(death_rx),
         })
+    }
+
+    /// Take the forwarder-death receiver (once) for the tunnel supervisor.
+    pub fn take_death_signal(&mut self) -> Option<tokio::sync::oneshot::Receiver<()>> {
+        self.death.take()
     }
 
     /// Get current tunnel statistics.

--- a/src-tauri/src/tunnel/remote_forward.rs
+++ b/src-tauri/src/tunnel/remote_forward.rs
@@ -17,6 +17,9 @@ pub struct RemoteForwarder {
     registry: ForwardedChannelRegistry,
     bound_port: u32,
     _session: SshSession,
+    /// Fires when the forward loop exits (the server-side channel source closed),
+    /// so the tunnel supervisor can observe forwarder death (#1243, GAP 2).
+    death: Option<tokio::sync::oneshot::Receiver<()>>,
 }
 
 impl RemoteForwarder {
@@ -54,7 +57,9 @@ impl RemoteForwarder {
         let local_host = config.local_host.clone();
         let local_port = config.local_port;
 
+        let (death_tx, death_rx) = tokio::sync::oneshot::channel();
         let task_handle = tokio::spawn(async move {
+            let _death = death_tx;
             Self::forward_loop(rx, &local_host, local_port, stats_clone).await;
         });
 
@@ -64,12 +69,18 @@ impl RemoteForwarder {
             registry,
             bound_port,
             _session: session,
+            death: Some(death_rx),
         })
     }
 
     /// Get current tunnel statistics.
     pub fn get_stats(&self) -> TunnelStats {
         self.stats.to_tunnel_stats()
+    }
+
+    /// Take the forwarder-death receiver (once) for the tunnel supervisor.
+    pub fn take_death_signal(&mut self) -> Option<tokio::sync::oneshot::Receiver<()>> {
+        self.death.take()
     }
 
     /// Stop the forwarder and deregister from the channel registry.

--- a/src-tauri/src/tunnel/tunnel_manager.rs
+++ b/src-tauri/src/tunnel/tunnel_manager.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tauri::{AppHandle, Emitter, Manager};
@@ -126,12 +127,32 @@ enum ActiveForwarder {
     Dynamic(DynamicForwarder),
 }
 
+impl ActiveForwarder {
+    /// Take the forwarder's death receiver (once) for the tunnel supervisor.
+    fn take_death_signal(&mut self) -> Option<tokio::sync::oneshot::Receiver<()>> {
+        match self {
+            ActiveForwarder::Local(f) => f.take_death_signal(),
+            ActiveForwarder::Remote(f) => f.take_death_signal(),
+            ActiveForwarder::Dynamic(f) => f.take_death_signal(),
+        }
+    }
+}
+
 /// An active tunnel instance.
 struct ActiveTunnel {
     forwarder: ActiveForwarder,
     /// Pool references kept alive for the tunnel's lifetime; dropped on teardown
     /// to release the shared endpoint / gateway sessions.
     guards: PooledSessionGuards,
+    /// Per-tunnel supervisor task that watches for forwarder / session death and
+    /// drives the tunnel to `Error` (#1243). `None` only in the brief window
+    /// before it is spawned. Dropped (detached) when the supervisor self-reaps on
+    /// death; aborted by `stop_tunnel`/`stop_all`.
+    supervisor: Option<tokio::task::JoinHandle<()>>,
+    /// Cancelled by `stop_tunnel`/`stop_all` before teardown so the supervisor
+    /// exits cleanly — a user stop must never be mistaken for a real death and
+    /// launder the tunnel into `Error`.
+    supervisor_cancel: CancellationToken,
 }
 
 /// Central manager for SSH tunnels.
@@ -141,12 +162,15 @@ struct ActiveTunnel {
 pub struct TunnelManager {
     tunnel_configs: Mutex<TunnelStore>,
     storage: TunnelStorage,
-    active_tunnels: Mutex<HashMap<String, ActiveTunnel>>,
+    /// `Arc`-shared so each per-tunnel supervisor task can hold a handle and
+    /// self-reap its own entry on death (#1243) without a `&self` reference.
+    active_tunnels: Arc<Mutex<HashMap<String, ActiveTunnel>>>,
     /// Last error per tunnel id, making a failed start a durable, queryable
     /// resting state that survives a `loadTunnels` reload (GAP 3, #1238). An
     /// entry is set when a start fails and committed (not cancelled), and
-    /// cleared on a successful start or an explicit stop.
-    last_errors: Mutex<HashMap<String, String>>,
+    /// cleared on a successful start or an explicit stop. `Arc`-shared so the
+    /// supervisor can record a death cause (#1243).
+    last_errors: Arc<Mutex<HashMap<String, String>>>,
     connecting: ConnectingTracker,
     /// Pool of SSH endpoint sessions shared by local/dynamic forwarders on the
     /// same connection. Jump-host gateway sessions are pooled separately in the
@@ -169,8 +193,8 @@ impl TunnelManager {
         Ok(Self {
             tunnel_configs: Mutex::new(result.data),
             storage,
-            active_tunnels: Mutex::new(HashMap::new()),
-            last_errors: Mutex::new(HashMap::new()),
+            active_tunnels: Arc::new(Mutex::new(HashMap::new())),
+            last_errors: Arc::new(Mutex::new(HashMap::new())),
             connecting: ConnectingTracker::new(),
             endpoint_pool: RefPool::new(),
             app_handle: app_handle.clone(),
@@ -331,7 +355,7 @@ impl TunnelManager {
         // handshake). On failure, surface it as `error` status instead of
         // leaving the tunnel stuck in `connecting` (#829) — unless a Stop was
         // requested mid-connect, in which case it has already gone disconnected.
-        let (forwarder, guards) = match self.build_forwarder(&config, cancel) {
+        let (mut forwarder, guards, probe) = match self.build_forwarder(&config, cancel) {
             Ok(built) => built,
             Err(e) => {
                 match self.connecting.finish(tunnel_id) {
@@ -360,13 +384,32 @@ impl TunnelManager {
             return Ok(());
         }
 
-        // Register as active
+        // Register as active and spawn the per-tunnel supervisor. The supervisor
+        // watches the forwarder death signal + a session keepalive probe and, on
+        // a real death (not a user stop), reaps the tunnel, drops its pool guards,
+        // records the cause, and drives the resting state to Error (#1243).
+        let death = forwarder.take_death_signal();
+        let supervisor_cancel = CancellationToken::new();
         {
             let mut active = self
                 .active_tunnels
                 .lock()
                 .map_err(|e| TerminalError::TunnelError(format!("Lock error: {}", e)))?;
-            active.insert(tunnel_id.to_string(), ActiveTunnel { forwarder, guards });
+            let supervisor = self.spawn_supervisor(
+                tunnel_id.to_string(),
+                death,
+                probe,
+                supervisor_cancel.clone(),
+            );
+            active.insert(
+                tunnel_id.to_string(),
+                ActiveTunnel {
+                    forwarder,
+                    guards,
+                    supervisor: Some(supervisor),
+                    supervisor_cancel,
+                },
+            );
         }
 
         // A successful start clears any recorded failure so the tunnel no longer
@@ -392,27 +435,41 @@ impl TunnelManager {
         &self,
         config: &TunnelConfig,
         cancel: CancellationToken,
-    ) -> Result<(ActiveForwarder, PooledSessionGuards), TerminalError> {
+    ) -> Result<
+        (
+            ActiveForwarder,
+            PooledSessionGuards,
+            Option<Arc<SshSession>>,
+        ),
+        TerminalError,
+    > {
         let ssh_config = self.resolve_ssh_config(&config.ssh_connection_id)?;
         let conn_id = &config.ssh_connection_id;
         let jumped = !ssh_config.proxy_jump.is_empty();
 
+        // The returned `Arc<SshSession>` is a probe handle the supervisor
+        // keepalive-pings so a dead SSH session surfaces as `Error` even while the
+        // local listener keeps accepting (#1243, GAP 1). Remote forwards own a
+        // dedicated non-`Arc` session (russh `Handle` is not `Clone`), so they get
+        // no probe here and rely on the forwarder death signal.
         match &config.tunnel_type {
             TunnelType::Local(local_config) => {
                 let (session, guards) =
                     self.acquire_endpoint(conn_id, &ssh_config, cancel, jumped)?;
+                let probe = Some(Arc::clone(&session));
                 let f = LocalForwarder::start(local_config, session).map_err(|e| {
                     TerminalError::TunnelError(format!("Failed to start local forwarder: {}", e))
                 })?;
-                Ok((ActiveForwarder::Local(f), guards))
+                Ok((ActiveForwarder::Local(f), guards, probe))
             }
             TunnelType::Dynamic(dynamic_config) => {
                 let (session, guards) =
                     self.acquire_endpoint(conn_id, &ssh_config, cancel, jumped)?;
+                let probe = Some(Arc::clone(&session));
                 let f = DynamicForwarder::start(dynamic_config, session).map_err(|e| {
                     TerminalError::TunnelError(format!("Failed to start dynamic forwarder: {}", e))
                 })?;
-                Ok((ActiveForwarder::Dynamic(f), guards))
+                Ok((ActiveForwarder::Dynamic(f), guards, probe))
             }
             TunnelType::Remote(remote_config) => {
                 // Remote forwarding needs tcpip_forward (&mut SshSession), so it always gets
@@ -422,7 +479,7 @@ impl TunnelManager {
                 let f = RemoteForwarder::start(remote_config, session, registry).map_err(|e| {
                     TerminalError::TunnelError(format!("Failed to start remote forwarder: {}", e))
                 })?;
-                Ok((ActiveForwarder::Remote(f), guards))
+                Ok((ActiveForwarder::Remote(f), guards, None))
             }
         }
     }
@@ -503,16 +560,34 @@ impl TunnelManager {
     }
 
     /// Stop a forwarder and release the pool references it held.
-    fn teardown_forwarder(&self, mut forwarder: ActiveForwarder, guards: PooledSessionGuards) {
-        match &mut forwarder {
-            ActiveForwarder::Local(f) => f.stop(),
-            ActiveForwarder::Remote(f) => f.stop(),
-            ActiveForwarder::Dynamic(f) => f.stop(),
-        }
-        // Dropping the guards (at end of scope) releases the pooled endpoint /
-        // gateway references, draining sessions no longer used by any tunnel or
-        // terminal.
-        drop(guards);
+    fn teardown_forwarder(&self, forwarder: ActiveForwarder, guards: PooledSessionGuards) {
+        teardown_parts(forwarder, guards);
+    }
+
+    /// Spawn the per-tunnel supervisor task (#1243). Holds `Arc` clones of the
+    /// shared state so it can self-reap its tunnel on death without `&self`.
+    fn spawn_supervisor(
+        &self,
+        tunnel_id: String,
+        death: Option<tokio::sync::oneshot::Receiver<()>>,
+        probe: Option<Arc<SshSession>>,
+        cancel: CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        let active_tunnels = Arc::clone(&self.active_tunnels);
+        let last_errors = Arc::clone(&self.last_errors);
+        let app_handle = self.app_handle.clone();
+        tokio::spawn(async move {
+            supervise(
+                active_tunnels,
+                last_errors,
+                app_handle,
+                tunnel_id,
+                death,
+                probe,
+                cancel,
+            )
+            .await;
+        })
     }
 
     /// Stop an active tunnel by ID.
@@ -530,7 +605,19 @@ impl TunnelManager {
         };
 
         if let Some(tunnel) = tunnel {
-            let ActiveTunnel { forwarder, guards } = tunnel;
+            let ActiveTunnel {
+                forwarder,
+                guards,
+                supervisor,
+                supervisor_cancel,
+            } = tunnel;
+            // Cancel + abort the supervisor first so the teardown-induced forwarder
+            // death is not mistaken for a real death that would re-emit `Error`
+            // over this `Disconnected` (#1243).
+            supervisor_cancel.cancel();
+            if let Some(handle) = supervisor {
+                handle.abort();
+            }
             self.teardown_forwarder(forwarder, guards);
             self.emit_status(tunnel_id, TunnelStatus::Disconnected, None);
             tracing::info!("Tunnel {} stopped", tunnel_id);
@@ -633,13 +720,127 @@ impl TunnelManager {
 
     /// Emit a tunnel status change event to the frontend.
     fn emit_status(&self, tunnel_id: &str, status: TunnelStatus, error: Option<String>) {
-        let state = TunnelState {
-            tunnel_id: tunnel_id.to_string(),
-            status,
-            error,
-            stats: TunnelStats::default(),
-        };
-        let _ = self.app_handle.emit("tunnel-status-changed", &state);
+        emit_tunnel_status(&self.app_handle, tunnel_id, status, error);
+    }
+}
+
+/// How long the supervisor waits between session keepalive probes (#1243).
+const SUPERVISOR_PROBE_INTERVAL: Duration = Duration::from_secs(20);
+
+/// Why a supervised tunnel died, for the recorded `Error` message.
+enum DeathCause {
+    Forwarder,
+    Session,
+}
+
+/// Stop a forwarder and drop its pool guards (RAII drains the pool). Free
+/// function so the supervisor task can tear a dead tunnel down without `&self`.
+fn teardown_parts(mut forwarder: ActiveForwarder, guards: PooledSessionGuards) {
+    match &mut forwarder {
+        ActiveForwarder::Local(f) => f.stop(),
+        ActiveForwarder::Remote(f) => f.stop(),
+        ActiveForwarder::Dynamic(f) => f.stop(),
+    }
+    drop(guards);
+}
+
+/// Emit a tunnel status change event to the frontend (free function so the
+/// supervisor task can emit without `&self`).
+fn emit_tunnel_status(
+    app_handle: &AppHandle,
+    tunnel_id: &str,
+    status: TunnelStatus,
+    error: Option<String>,
+) {
+    let state = TunnelState {
+        tunnel_id: tunnel_id.to_string(),
+        status,
+        error,
+        stats: TunnelStats::default(),
+    };
+    let _ = app_handle.emit("tunnel-status-changed", &state);
+}
+
+/// Per-tunnel supervisor loop (#1243, GAP 1 + GAP 2).
+///
+/// Waits for the first of: an explicit stop (cancel token — NOT a death), the
+/// forwarder death signal, or a failed session keepalive probe. On a real death
+/// it reaps the tunnel from `active_tunnels` (dropping its pool guards so the
+/// shared session drains exactly once), records the cause as the durable
+/// last-error (#1238), and emits the `Error` resting state.
+#[allow(clippy::too_many_arguments)]
+async fn supervise(
+    active_tunnels: Arc<Mutex<HashMap<String, ActiveTunnel>>>,
+    last_errors: Arc<Mutex<HashMap<String, String>>>,
+    app_handle: AppHandle,
+    tunnel_id: String,
+    death: Option<tokio::sync::oneshot::Receiver<()>>,
+    probe: Option<Arc<SshSession>>,
+    cancel: CancellationToken,
+) {
+    let cause = tokio::select! {
+        biased;
+        // An explicit stop wins the race so a user stop is never laundered into
+        // Error; the other branches are dropped.
+        _ = cancel.cancelled() => return,
+        _ = wait_forwarder_death(death) => DeathCause::Forwarder,
+        _ = session_probe_loop(probe, SUPERVISOR_PROBE_INTERVAL) => DeathCause::Session,
+    };
+
+    let removed = match active_tunnels.lock() {
+        Ok(mut map) => map.remove(&tunnel_id),
+        Err(_) => None,
+    };
+    // If a concurrent stop already removed the entry, it owns the resting state.
+    let Some(ActiveTunnel {
+        forwarder, guards, ..
+    }) = removed
+    else {
+        return;
+    };
+    teardown_parts(forwarder, guards);
+
+    let reason = match cause {
+        DeathCause::Forwarder => "connection lost: forwarder stopped".to_string(),
+        DeathCause::Session => "connection lost: SSH session closed".to_string(),
+    };
+    record_last_error(&last_errors, &tunnel_id, reason.clone());
+    emit_tunnel_status(&app_handle, &tunnel_id, TunnelStatus::Error, Some(reason));
+    tracing::warn!("Tunnel {tunnel_id} died — transitioned to Error");
+}
+
+/// Resolve when the forwarder's accept/forward loop ends. The oneshot resolves
+/// on `Ok` (never sent explicitly) or `Err` (its sender dropped when the task
+/// ended — a `break` or an `abort()`), so either way signals the loop is gone.
+async fn wait_forwarder_death(death: Option<tokio::sync::oneshot::Receiver<()>>) {
+    match death {
+        Some(rx) => {
+            let _ = rx.await;
+        }
+        // No signal wired (should not happen) — never resolve so the keepalive
+        // probe alone governs liveness.
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// Resolve only once the SSH session is dead. Lightweight keepalive: open a
+/// throwaway session channel every `interval`; a failure means the transport is
+/// gone. (A native russh session-liveness watch is the Option-B upgrade.)
+async fn session_probe_loop(session: Option<Arc<SshSession>>, interval: Duration) {
+    // No probe handle (remote forward): never resolve — the forwarder death
+    // signal governs liveness for this tunnel.
+    let session = match session {
+        Some(s) => s,
+        None => {
+            std::future::pending::<()>().await;
+            return;
+        }
+    };
+    loop {
+        tokio::time::sleep(interval).await;
+        if session.channel_open_session().await.is_err() {
+            return;
+        }
     }
 }
 
@@ -668,11 +869,16 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use super::super::connecting::{ConnectingTracker, FinishOutcome};
-    use super::{clear_last_error, last_error_for, record_last_error, resting_status};
+    use super::{
+        clear_last_error, last_error_for, record_last_error, resting_status, session_probe_loop,
+        wait_forwarder_death,
+    };
     use crate::tunnel::config::TunnelStatus;
     use termihub_core::backends::ssh::session_pool::{PooledRef, RefPool};
+    use tokio_util::sync::CancellationToken;
 
     /// Stand-in for a pooled `Arc<SshSession>` that records when the underlying
     /// value is dropped, so we can assert the session is actually torn down (not
@@ -946,5 +1152,159 @@ mod tests {
         let second = resting_status(false, last_error_for(&errors, TUNNEL_ID));
         assert_eq!(second.0, TunnelStatus::Error);
         assert_eq!(second.1.as_deref(), Some("session died"));
+    }
+
+    // ── Supervisor: liveness signals + death-driven Error (S2, GAP 1 + GAP 2, #1243) ──
+    //
+    // As with the GAP-8 tests above, the full `supervise` task cannot run in a
+    // unit test (it needs a Tauri `AppHandle` to emit and a real `SshSession`),
+    // so these lock in its constituent behaviours with the same production
+    // building blocks: the real `wait_forwarder_death` / `session_probe_loop`
+    // futures and the RefPool guard-drain that the death path performs. The
+    // end-to-end Connected → Error on a killed sshd is the Docker system test.
+
+    /// The forwarder death oneshot resolves when its sender is dropped — i.e. when
+    /// the accept/forward task ends (a `break` or a `stop()`-abort), so the
+    /// supervisor observes forwarder death however the loop exits (GAP 2).
+    #[tokio::test]
+    async fn forwarder_death_resolves_when_task_ends() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let waiter = tokio::spawn(wait_forwarder_death(Some(rx)));
+        drop(tx); // the accept task "ended"
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("death wait must resolve when the forwarder task ends")
+            .expect("join");
+    }
+
+    /// With no death signal wired, the wait never resolves — the keepalive probe
+    /// alone governs liveness (defensive default).
+    #[tokio::test]
+    async fn no_forwarder_signal_never_resolves() {
+        let r = tokio::time::timeout(Duration::from_millis(100), wait_forwarder_death(None)).await;
+        assert!(r.is_err(), "no death signal ⇒ the wait must never resolve");
+    }
+
+    /// A remote-forward tunnel has no probe handle; the probe loop must never
+    /// resolve so the forwarder death signal governs (no spurious Error).
+    #[tokio::test]
+    async fn session_probe_without_handle_never_resolves() {
+        let r = tokio::time::timeout(
+            Duration::from_millis(100),
+            session_probe_loop(None, Duration::from_millis(10)),
+        )
+        .await;
+        assert!(
+            r.is_err(),
+            "no probe handle ⇒ the probe loop must never resolve"
+        );
+    }
+
+    /// A user Stop cancels the supervisor token *and* (via teardown/abort) ends
+    /// the forwarder task, so both signals fire. The supervisor's biased select
+    /// must let the cancel win so the stop is never laundered into `Error`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stop_cancel_wins_the_race_over_forwarder_death() {
+        let cancel = CancellationToken::new();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        cancel.cancel();
+        drop(tx); // teardown-induced forwarder death also fires
+
+        let outcome = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => "stopped",
+            _ = wait_forwarder_death(Some(rx)) => "died",
+        };
+        assert_eq!(
+            outcome, "stopped",
+            "a user stop must win over the teardown-induced forwarder death"
+        );
+    }
+
+    /// The supervisor death path reaps the tunnel from the active set, dropping
+    /// its pool guards (RAII drains the shared session) and recording the cause as
+    /// the durable `Error` resting state (#1238). Reproduced with the same
+    /// RefPool building blocks the manager holds.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn death_reap_drains_pool_and_records_error() {
+        let pool = RefPool::<Arc<TrackedSession>>::new();
+        let live = Arc::new(AtomicUsize::new(0));
+        let errors = Mutex::new(HashMap::new());
+
+        let mut active: HashMap<String, EndpointGuard> = HashMap::new();
+        active.insert(TUNNEL_ID.to_string(), acquire_guard(&pool, &live).await);
+        assert_eq!(pool.ref_count(CONN_ID), 1);
+        assert_eq!(live.load(Ordering::SeqCst), 1);
+
+        // Supervisor on death: remove the entry (drops guards → RAII pool drain)
+        // and record the cause as the resting Error.
+        let removed = active.remove(TUNNEL_ID).expect("was active");
+        drop(removed);
+        record_last_error(
+            &errors,
+            TUNNEL_ID,
+            "connection lost: SSH session closed".to_string(),
+        );
+
+        assert!(active.is_empty(), "dead tunnel reaped from the active set");
+        assert_eq!(pool.ref_count(CONN_ID), 0, "pool ref count drained to zero");
+        assert_eq!(
+            live.load(Ordering::SeqCst),
+            0,
+            "shared session dropped exactly once"
+        );
+        let (status, msg) = resting_status(false, last_error_for(&errors, TUNNEL_ID));
+        assert_eq!(status, TunnelStatus::Error);
+        assert_eq!(msg.as_deref(), Some("connection lost: SSH session closed"));
+    }
+
+    /// A shared pooled session backing two tunnels: when it dies, each tunnel's
+    /// supervisor reaps its own guard and records `Error`, and the underlying
+    /// session drains exactly once (ref-count → 0), not once per tunnel.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shared_session_death_errors_both_tunnels_and_drains_once() {
+        let pool = RefPool::<Arc<TrackedSession>>::new();
+        let live = Arc::new(AtomicUsize::new(0));
+        let errors = Mutex::new(HashMap::new());
+
+        let g1 = acquire_guard(&pool, &live).await;
+        let g2 = acquire_guard(&pool, &live).await;
+        assert_eq!(pool.ref_count(CONN_ID), 2);
+        assert_eq!(live.load(Ordering::SeqCst), 1, "one shared session");
+
+        // First tunnel's supervisor reaps; the session lives while a ref remains.
+        drop(g1);
+        record_last_error(
+            &errors,
+            "tunnel-a",
+            "connection lost: SSH session closed".to_string(),
+        );
+        assert_eq!(
+            live.load(Ordering::SeqCst),
+            1,
+            "session stays alive while one ref remains"
+        );
+
+        // Second tunnel's supervisor reaps; now the shared session drains once.
+        drop(g2);
+        record_last_error(
+            &errors,
+            "tunnel-b",
+            "connection lost: SSH session closed".to_string(),
+        );
+        assert_eq!(pool.ref_count(CONN_ID), 0);
+        assert_eq!(
+            live.load(Ordering::SeqCst),
+            0,
+            "shared session drained exactly once"
+        );
+        assert_eq!(
+            resting_status(false, last_error_for(&errors, "tunnel-a")).0,
+            TunnelStatus::Error
+        );
+        assert_eq!(
+            resting_status(false, last_error_for(&errors, "tunnel-b")).0,
+            TunnelStatus::Error
+        );
     }
 }

--- a/src/components/TunnelSidebar/TunnelListItem.button.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.button.test.tsx
@@ -47,6 +47,7 @@ async function flush() {
 interface Handlers {
   onStart?: (id: string) => void | Promise<void>;
   onStop?: (id: string) => void | Promise<void>;
+  onReconnect?: (id: string) => void | Promise<void>;
 }
 
 function renderItem(state: TunnelState | undefined, handlers: Handlers = {}): void {
@@ -59,6 +60,7 @@ function renderItem(state: TunnelState | undefined, handlers: Handlers = {}): vo
           connections={[] as SavedConnection[]}
           onStart={handlers.onStart ?? noop}
           onStop={handlers.onStop ?? noop}
+          onReconnect={handlers.onReconnect ?? noop}
           onEdit={noop}
           onDuplicate={noop}
           onDelete={noop}
@@ -158,6 +160,40 @@ describe("TunnelListItem — shared Button primitive (#1259)", () => {
     });
 
     expect(stop.classList.contains("ui-btn--pending")).toBe(false);
+  });
+
+  it("offers a force-Reconnect on a connected tunnel that fires onReconnect (#1243)", async () => {
+    let resolveReconnect!: () => void;
+    const onReconnect = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReconnect = resolve;
+        })
+    );
+    renderItem({ tunnelId: "tun-1", status: "connected" } as TunnelState, { onReconnect });
+    await flush();
+
+    const reconnect = container.querySelector<HTMLButtonElement>(
+      '[data-testid="tunnel-reconnect-tun-1"]'
+    )!;
+    expect(reconnect).toBeTruthy();
+    click(reconnect);
+    await flush();
+
+    expect(onReconnect).toHaveBeenCalledWith("tun-1");
+    expect(reconnect.classList.contains("ui-btn--pending")).toBe(true);
+
+    await act(async () => {
+      resolveReconnect();
+      await Promise.resolve();
+    });
+
+    expect(reconnect.classList.contains("ui-btn--pending")).toBe(false);
+  });
+
+  it("does not offer Reconnect on a disconnected tunnel", () => {
+    renderItem(undefined);
+    expect(container.querySelector('[data-testid="tunnel-reconnect-tun-1"]')).toBeNull();
   });
 
   it("drives the Button async lifecycle on Retry when the tunnel is in error", async () => {

--- a/src/components/TunnelSidebar/TunnelListItem.error.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.error.test.tsx
@@ -56,6 +56,7 @@ function renderItem(
   handlers: Partial<{
     onStart: (id: string) => void;
     onStop: (id: string) => void;
+    onReconnect: (id: string) => void;
   }> = {}
 ): void {
   act(() => {
@@ -67,6 +68,7 @@ function renderItem(
           connections={[] as SavedConnection[]}
           onStart={handlers.onStart ?? noop}
           onStop={handlers.onStop ?? noop}
+          onReconnect={handlers.onReconnect ?? noop}
           onEdit={noop}
           onDuplicate={noop}
           onDelete={noop}

--- a/src/components/TunnelSidebar/TunnelListItem.tooltip.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tooltip.test.tsx
@@ -54,6 +54,7 @@ function renderItem(state: TunnelState | undefined): void {
           connections={[] as SavedConnection[]}
           onStart={noop}
           onStop={noop}
+          onReconnect={noop}
           onEdit={noop}
           onDuplicate={noop}
           onDelete={noop}

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -12,6 +12,12 @@ interface TunnelListItemProps {
   onStart: (tunnelId: string) => void | Promise<void>;
   /** Stop the tunnel. May be async so the button shows a pending state. */
   onStop: (tunnelId: string) => void | Promise<void>;
+  /**
+   * Force-reconnect a connected tunnel (tear down + restart) even if liveness
+   * has not fired yet — covers a stale-but-green tunnel the supervisor is slow
+   * to notice (#1243). May be async so the button shows a pending state.
+   */
+  onReconnect: (tunnelId: string) => void | Promise<void>;
   onEdit: (tunnelId: string) => void;
   onDuplicate: (tunnelId: string) => void;
   onDelete: (tunnelId: string) => void;
@@ -35,6 +41,7 @@ export function TunnelListItem({
   connections,
   onStart,
   onStop,
+  onReconnect,
   onEdit,
   onDuplicate,
   onDelete,
@@ -73,6 +80,23 @@ export function TunnelListItem({
           {typeLabel}
         </span>
         <div className="tunnel-item__actions">
+          {status === "connected" && (
+            <Tooltip content="Reconnect (force)" side="top">
+              <Button
+                variant="ghost"
+                size="sm"
+                iconOnly
+                aria-label="Reconnect"
+                data-testid={`tunnel-reconnect-${tunnel.id}`}
+                icon={<RotateCw size={12} />}
+                errorToast={false}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  return onReconnect(tunnel.id);
+                }}
+              />
+            </Tooltip>
+          )}
           {isActive && (
             <Tooltip content="Stop" side="top">
               <Button

--- a/src/components/TunnelSidebar/TunnelSidebar.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.tsx
@@ -15,6 +15,7 @@ export function TunnelSidebar() {
   const connections = useAppStore((s) => s.connections);
   const startTunnel = useAppStore((s) => s.startTunnel);
   const stopTunnel = useAppStore((s) => s.stopTunnel);
+  const reconnectTunnel = useAppStore((s) => s.reconnectTunnel);
   const saveTunnel = useAppStore((s) => s.saveTunnel);
   const deleteTunnel = useAppStore((s) => s.deleteTunnel);
   const openTunnelEditorTab = useAppStore((s) => s.openTunnelEditorTab);
@@ -99,6 +100,7 @@ export function TunnelSidebar() {
               connections={connections}
               onStart={startTunnel}
               onStop={stopTunnel}
+              onReconnect={reconnectTunnel}
               onEdit={handleEdit}
               onDuplicate={handleDuplicate}
               onDelete={handleDelete}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -173,12 +173,7 @@ import {
 } from "@/utils/panelTree";
 
 export type SidebarView =
-  | "connections"
-  | "files"
-  | "tunnels"
-  | "services"
-  | "workspaces"
-  | "network-tools";
+  "connections" | "files" | "tunnels" | "services" | "workspaces" | "network-tools";
 
 /** Clipboard state for file browser copy/cut operations. */
 export interface FileClipboard {
@@ -853,6 +848,8 @@ interface AppState {
   deleteTunnel: (tunnelId: string) => Promise<void>;
   startTunnel: (tunnelId: string) => Promise<void>;
   stopTunnel: (tunnelId: string) => Promise<void>;
+  /** Force-reconnect a connected tunnel (stop + start), for a stale-but-green tunnel (#1243). */
+  reconnectTunnel: (tunnelId: string) => Promise<void>;
   updateTunnelState: (state: TunnelState) => void;
   openTunnelEditorTab: (tunnelId: string | null) => void;
 
@@ -4616,6 +4613,33 @@ export const useAppStore = create<AppState>((set, get) => {
         throw err;
       } finally {
         _tunnelStopInFlight.delete(tunnelId);
+      }
+    },
+
+    reconnectTunnel: async (tunnelId) => {
+      // Force-reconnect a connected tunnel: tear it down and start it again,
+      // even if the backend supervisor's liveness has not fired yet — covers a
+      // stale-but-green tunnel (#1243). Guarded by the same in-flight sets as
+      // start/stop so a rapid double-click cannot overlap the sequence.
+      if (_tunnelStartInFlight.has(tunnelId) || _tunnelStopInFlight.has(tunnelId)) return;
+      _tunnelStopInFlight.add(tunnelId);
+      _tunnelStartInFlight.add(tunnelId);
+      const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
+      const toastId = toast.loading(`Reconnecting ${name}…`);
+      try {
+        await apiStopTunnel(tunnelId);
+        await apiStartTunnel(tunnelId);
+        toast.success(`Reconnected ${name}`, { id: toastId });
+      } catch (err) {
+        console.error("Failed to reconnect tunnel:", err);
+        toast.error(
+          `Failed to reconnect ${name}: ${err instanceof Error ? err.message : String(err)}`,
+          { id: toastId }
+        );
+        throw err;
+      } finally {
+        _tunnelStopInFlight.delete(tunnelId);
+        _tunnelStartInFlight.delete(tunnelId);
       }
     },
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -173,7 +173,12 @@ import {
 } from "@/utils/panelTree";
 
 export type SidebarView =
-  "connections" | "files" | "tunnels" | "services" | "workspaces" | "network-tools";
+  | "connections"
+  | "files"
+  | "tunnels"
+  | "services"
+  | "workspaces"
+  | "network-tools";
 
 /** Clipboard state for file browser copy/cut operations. */
 export interface FileClipboard {

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -624,6 +624,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `tunnel-edit-*` | `tunnel-edit-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-item-*` | `tunnel-item-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-name-*` | `tunnel-name-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
+| `tunnel-reconnect-*` | `tunnel-reconnect-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-retry-*` | `tunnel-retry-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-start-*` | `tunnel-start-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-status-*` | `tunnel-status-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |


### PR DESCRIPTION
## ⚠️ Human checkpoint (tunnel S2 keystone)

This is the tunnel lifecycle "risky keystone" — please review before merge. Implemented directly (agents could not run git in this environment).

## Summary

Makes SSH session death and post-bind forwarder death **observable**, so a dead tunnel stops showing green + leaking its pooled session/port and transitions to the persisted `Error` resting state (#1238).

**Option A shipped** (per the concept's de-risk guidance):
- **Forwarder death signal** (GAP 2) — each forwarder (`local_forward`/`dynamic_forward`/`remote_forward`) moves a `oneshot::Sender` into its accept/forward task; the receiver resolves when the loop ends (a `break` or a `stop()` abort).
- **Session keepalive probe** (GAP 1, lightweight) — the supervisor opens a throwaway `channel_open_session` every ~20s to detect a dead SSH session even while the local listener keeps accepting. (russh's `Handle` exposes no native liveness API — a native watch is the **Option-B follow-up #1297**.)
- **Supervisor** — on `start_tunnel` success, a `supervise(id)` task `tokio::select!`s over {forwarder death, keepalive probe, per-tunnel cancel token}. On a real death it reaps the tunnel from `active_tunnels`, drops its `PooledSessionGuards` (RAII drains the shared session exactly once), `record_last_error`, and emits `Error`. `stop_tunnel`/`stop_all` cancel+abort the supervisor first so a user stop is never laundered into `Error`.
- Shared state (`active_tunnels`, `last_errors`) is now `Arc<Mutex<…>>` so the task can self-reap without `&self`.
- **Force-Reconnect** control on a connected tunnel row (`TunnelListItem`) + `reconnectTunnel` store action (stop→start), for a stale-but-green tunnel.

## Test plan

- Rust (extends the GAP-8 teardown tests, same stand-in RefPool/oneshot building blocks since `SshSession`/`AppHandle` can't be fabricated): forwarder-death resolves the wait however the loop exits; no-signal / no-probe never resolve; **stop cancel wins the race** over teardown-induced death; **death reap drains the pool + records Error**; **shared-session death errors both tunnels and drains once**. 37 tunnel tests pass.
- Frontend: connected row offers force-Reconnect firing `onReconnect` (async Button lifecycle); disconnected row does not. 15 TunnelSidebar tests pass.
- `tsc`, eslint, `cargo clippy -D warnings`, `cargo fmt --check` all clean.
- **Deferred (per concept):** the end-to-end Docker system test (kill sshd mid-tunnel → Connected→Error, force-Stoppable) — the automated coverage here is unit-level; the Docker harness is a follow-up. Manual verification recommended before/at merge.

Closes #1243 · Option-B follow-up: #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)