### PR TITLE
feat(xserver): unify connect + manual X server consent UI + error recovery (#1296)

### DIFF
--- a/docs/changes/dev2/feature/1296-xserver-consent-ui-unify.md
+++ b/docs/changes/dev2/feature/1296-xserver-consent-ui-unify.md
@@ -1,0 +1,13 @@
+# Changes for feature/1296-xserver-consent-ui-unify
+
+## Changed
+
+- The connect-triggered and manual "Set up X server" dialogs now share one
+  consent / progress / error body, so both flows look and behave identically.
+
+## Fixed
+
+- A connect-time X server provisioning failure now shows a recoverable error
+  screen with **Retry** (and, when a dependency is missing, an **Install**
+  action) instead of a toast that dismisses the dialog. Provisioning can be
+  retried in place without restarting the connection.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -983,6 +983,12 @@ server automatically" left at its default/undecided):
    aborts promptly rather than hanging.
 5. Sanity: a non-Windows connect, or a connect with a server already running, is
    unaffected apart from gaining progress feedback (no prompt).
+6. Force a provisioning **failure** after choosing Enable (e.g. block the VcXsrv
+   download, or use a fault-injected environment). Confirm the dialog now shows a
+   **recoverable error screen** with **Retry** — not a toast-and-close (#1296) —
+   and that Retry re-provisions in place; on a missing-dependency failure an
+   **Install** action appears. The screen must match the manual "X Servers → Set
+   up" dialog (`XServerSetupContent.tsx`).
 
 #### Monitoring auto-reconnect on a mid-stream drop (#1230)
 

--- a/src/components/OpenConnections/XServerConnectConsent.test.tsx
+++ b/src/components/OpenConnections/XServerConnectConsent.test.tsx
@@ -7,9 +7,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
-import type { XServerConsentRequest, XServerProgress } from "@/types/xserver";
+import type {
+  XServerConsentRequest,
+  XServerError,
+  XServerProgress,
+  XServerStatusReport,
+} from "@/types/xserver";
 
 const xServerConnectConsentReply = vi.fn<(id: string, decision: string) => Promise<boolean>>();
+const xServerEnsure = vi.fn<() => Promise<XServerStatusReport>>();
+const xServerInstallDependency = vi.fn<() => Promise<void>>();
 
 let consentCallback: ((req: XServerConsentRequest) => void) | undefined;
 let progressCallback: ((p: XServerProgress) => void) | undefined;
@@ -17,6 +24,8 @@ let progressCallback: ((p: XServerProgress) => void) | undefined;
 vi.mock("@/services/api", () => ({
   xServerConnectConsentReply: (id: string, decision: string) =>
     xServerConnectConsentReply(id, decision),
+  xServerEnsure: () => xServerEnsure(),
+  xServerInstallDependency: () => xServerInstallDependency(),
 }));
 
 vi.mock("@/services/events", () => ({
@@ -54,6 +63,8 @@ describe("XServerConnectConsent", () => {
     root = createRoot(container);
     xServerConnectConsentReply.mockReset();
     xServerConnectConsentReply.mockResolvedValue(true);
+    xServerEnsure.mockReset();
+    xServerInstallDependency.mockReset();
     consentCallback = undefined;
     progressCallback = undefined;
   });
@@ -121,4 +132,126 @@ describe("XServerConnectConsent", () => {
     expect(xServerConnectConsentReply).toHaveBeenCalledWith("abc-123", "notNow");
     expect(query("x-server-connect-consent-dialog")).toBeNull();
   });
+
+  it("shows a recoverable error screen (not toast+close) on a failed step", async () => {
+    render();
+    await flush();
+    act(() => consentCallback?.(REQUEST));
+    await flush();
+
+    await act(async () => {
+      click("x-server-connect-consent-enable");
+      await Promise.resolve();
+    });
+    await flush();
+
+    // A failed terminal step surfaces the error screen instead of closing.
+    act(() => progressCallback?.({ step: "failed", message: "Download failed.", progress: 1 }));
+    await flush();
+
+    expect(query("x-server-connect-consent-dialog")).not.toBeNull();
+    expect(query("x-server-connect-consent-error")?.textContent).toContain("Download failed.");
+    expect(query("x-server-connect-consent-retry")).not.toBeNull();
+  });
+
+  it("retries provisioning via x_server_ensure from the error screen", async () => {
+    const ensure = deferred<XServerStatusReport>();
+    xServerEnsure.mockReturnValue(ensure.promise);
+
+    render();
+    await flush();
+    act(() => consentCallback?.(REQUEST));
+    await flush();
+    await act(async () => {
+      click("x-server-connect-consent-enable");
+      await Promise.resolve();
+    });
+    await flush();
+    act(() => progressCallback?.({ step: "failed", message: "Download failed.", progress: 1 }));
+    await flush();
+
+    // Retry drives the frontend x_server_ensure provisioning path.
+    await act(async () => {
+      click("x-server-connect-consent-retry");
+      await Promise.resolve();
+    });
+    await flush();
+    expect(xServerEnsure).toHaveBeenCalledTimes(1);
+    expect(query("x-server-connect-consent-progress")).not.toBeNull();
+
+    const report: XServerStatusReport = {
+      state: "running",
+      platform: "windows",
+      displayNumber: 0,
+      managed: true,
+      sessionCount: 0,
+    };
+    await act(async () => {
+      ensure.resolve(report);
+      await Promise.resolve();
+    });
+    await flush();
+    expect(query("x-server-connect-consent-dialog")).toBeNull();
+  });
+
+  it("offers Install on a dependencyMissing ensure failure after retry", async () => {
+    const ensure = deferred<XServerStatusReport>();
+    xServerEnsure.mockReturnValue(ensure.promise);
+    xServerInstallDependency.mockResolvedValue(undefined);
+
+    render();
+    await flush();
+    act(() => consentCallback?.(REQUEST));
+    await flush();
+    await act(async () => {
+      click("x-server-connect-consent-enable");
+      await Promise.resolve();
+    });
+    await flush();
+    act(() => progressCallback?.({ step: "failed", message: "Download failed.", progress: 1 }));
+    await flush();
+
+    await act(async () => {
+      click("x-server-connect-consent-retry");
+      await Promise.resolve();
+    });
+    await flush();
+
+    const err: XServerError = {
+      kind: "dependencyMissing",
+      message: "XQuartz is not installed",
+      dependency: "XQuartz",
+      installHint: "Install XQuartz from xquartz.org",
+      installCommand: "brew install --cask xquartz",
+    };
+    await act(async () => {
+      ensure.reject(err);
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(query("x-server-connect-consent-error")?.textContent).toContain(
+      "XQuartz is not installed"
+    );
+    const install = query("x-server-connect-consent-install-dep");
+    expect(install).not.toBeNull();
+
+    await act(async () => {
+      click("x-server-connect-consent-install-dep");
+      await Promise.resolve();
+    });
+    await flush();
+    expect(xServerInstallDependency).toHaveBeenCalledTimes(1);
+  });
 });
+
+/** A deferred promise whose resolve/reject can be triggered by the test. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/src/components/OpenConnections/XServerConnectConsent.tsx
+++ b/src/components/OpenConnections/XServerConnectConsent.tsx
@@ -1,37 +1,56 @@
 import { useEffect, useRef, useState } from "react";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { AppWindow } from "lucide-react";
-import { Modal, Button, toast } from "@/components/ui";
-import { xServerConnectConsentReply } from "@/services/api";
+import { toast } from "@/components/ui";
+import { xServerConnectConsentReply, xServerInstallDependency } from "@/services/api";
 import { onXServerConsentNeeded, onXServerProgress } from "@/services/events";
 import { frontendLog } from "@/utils/frontendLog";
-import type { XServerConsentRequest, XServerProgress } from "@/types/xserver";
-import "./XServerSetupDialog.css";
+import {
+  isXServerError,
+  type XServerConsentRequest,
+  type XServerError,
+  type XServerProgress,
+} from "@/types/xserver";
+import { XServerSetupContent, type XServerSetupPhase } from "./XServerSetupContent";
+import { driveXServerEnsure } from "./xServerProvisioning";
 
-/** Which screen of the connect-triggered flow is showing. */
-type Phase = "consent" | "provisioning";
-
-/** Progress steps that end the flow (dialog closes when one arrives). */
+/** Progress steps that end the backend-driven connect provisioning. */
 const TERMINAL_STEPS = new Set(["ready", "failed", "skipped"]);
 
 /**
- * Connect-triggered X server download-consent + live progress dialog (#1116).
- *
- * Mounted once at the app root. It listens for the backend's
+ * Which path is provisioning while in the `provisioning` phase:
+ * - `backend` — the paused connect resumed on Enable; progress (and its terminal
+ *   step) is driven entirely by the backend.
+ * - `ensure` — a frontend-driven `x_server_ensure` retry from the error screen,
+ *   whose promise resolution (not a progress step) decides the outcome.
+ */
+type Driver = "backend" | "ensure";
+
+/**
+ * Connect-triggered X server download-consent + live progress dialog (#1116,
+ * #1296). Mounted once at the app root. It listens for the backend's
  * `x-server-consent-needed` event (emitted when opening an X11-forwarding SSH
  * connection would need to download the X dependency and the user has not
- * consented yet), shows the same consent screen as the manual setup dialog, and
- * — unlike the manual flow — hands the decision back to the **paused connect**
- * via `x_server_connect_consent_reply`. On "Enable" the backend resumes and
- * provisions, streaming `x-server-progress`; a terminal step closes the dialog.
- * "Not now" replies `notNow`, and the connect continues without X forwarding.
+ * consented yet), shows the shared consent screen, and — unlike the manual flow
+ * — hands the decision back to the **paused connect** via
+ * `x_server_connect_consent_reply`. On "Enable" the backend resumes and
+ * provisions, streaming `x-server-progress`. A `ready`/`skipped` step closes the
+ * dialog; a `failed` step drops into the same recoverable error screen as the
+ * manual dialog (Retry re-provisions via `x_server_ensure`; a `dependencyMissing`
+ * failure adds an Install action). "Not now" replies `notNow` and the connect
+ * continues without X forwarding. The consent / progress / error markup is the
+ * shared {@link XServerSetupContent}.
  */
 export function XServerConnectConsent() {
   const [request, setRequest] = useState<XServerConsentRequest | null>(null);
-  const [phase, setPhase] = useState<Phase>("consent");
+  const [phase, setPhase] = useState<XServerSetupPhase>("consent");
   const [progress, setProgress] = useState<XServerProgress | null>(null);
+  const [error, setError] = useState<XServerError | null>(null);
+  const [rawError, setRawError] = useState<unknown>(null);
   // Guards against replying twice for the same prompt (e.g. Enable then close).
   const repliedRef = useRef(false);
+  // Which provisioning path the current `provisioning` phase is running.
+  const driverRef = useRef<Driver>("backend");
 
   // Subscribe to connect-time consent prompts for the lifetime of the app.
   useEffect(() => {
@@ -42,9 +61,12 @@ export function XServerConnectConsent() {
         if (cancelled) return;
         frontendLog("x_server_connect_consent", `consent needed (id=${req.id})`);
         repliedRef.current = false;
+        driverRef.current = "backend";
         setRequest(req);
         setPhase("consent");
         setProgress(null);
+        setError(null);
+        setRawError(null);
       });
     })();
     return () => {
@@ -53,9 +75,29 @@ export function XServerConnectConsent() {
     };
   }, []);
 
-  // While provisioning, stream progress and close on a terminal step.
+  // While provisioning, stream progress. The backend path resolves on a terminal
+  // step; the ensure (retry) path resolves via the x_server_ensure promise.
   useEffect(() => {
     if (phase !== "provisioning") return;
+    setProgress(null);
+
+    if (driverRef.current === "ensure") {
+      return driveXServerEnsure({
+        onProgress: setProgress,
+        onSuccess: () => {
+          toast.success("X server ready");
+          close();
+        },
+        onFailure: (typed, raw) => {
+          frontendLog("x_server_connect_consent", `retry failed: ${String(raw)}`);
+          setRawError(raw);
+          setError(typed);
+          setPhase("error");
+        },
+      });
+    }
+
+    // Backend-driven: the resumed connect emits progress and a terminal step.
     let unlisten: UnlistenFn | undefined;
     let cancelled = false;
     void (async () => {
@@ -63,22 +105,32 @@ export function XServerConnectConsent() {
         if (cancelled) return;
         setProgress(p);
         if (!TERMINAL_STEPS.has(p.step)) return;
-        if (p.step === "ready") toast.success("X server ready");
-        else if (p.step === "failed") toast.error(p.message);
-        close();
+        if (p.step === "ready") {
+          toast.success("X server ready");
+          close();
+        } else if (p.step === "skipped") {
+          close();
+        } else {
+          // failed — surface a recoverable error screen instead of closing.
+          frontendLog("x_server_connect_consent", `provisioning failed: ${p.message}`);
+          setError(null);
+          setRawError(p.message);
+          setPhase("error");
+        }
       });
     })();
     return () => {
       cancelled = true;
       unlisten?.();
     };
-    // Only the phase transition should (re)start the progress listener; the
-    // helper callbacks it uses are stable function declarations.
+    // Only the phase transition should (re)start provisioning; driverRef is read
+    // fresh each run and the helper callbacks are stable.
   }, [phase]);
 
   const handleEnable = async () => {
     if (!request) return;
     repliedRef.current = true;
+    driverRef.current = "backend";
     await xServerConnectConsentReply(request.id, "enable");
     frontendLog("x_server_connect_consent", `enabled (id=${request.id})`);
     setPhase("provisioning");
@@ -90,20 +142,49 @@ export function XServerConnectConsent() {
     close();
   };
 
+  const handleRetry = () => {
+    driverRef.current = "ensure";
+    setPhase("provisioning");
+  };
+
+  const handleInstallDependency = async () => {
+    const dep = error?.dependency ?? "dependency";
+    try {
+      await xServerInstallDependency();
+      frontendLog("x_server_connect_consent", `installed dependency ${dep}`);
+      toast.success(`${dep} installed`);
+      driverRef.current = "ensure";
+      setPhase("provisioning");
+    } catch (e) {
+      const msg = isXServerError(e) ? e.message : String(e);
+      frontendLog("x_server_connect_consent", `dependency install failed: ${msg}`);
+      toast.error(msg);
+      throw e; // return the Button to idle without a success flash
+    }
+  };
+
   const handleOpenChange = (open: boolean) => {
-    if (!open) handleNotNow();
+    if (open) return;
+    if (phase === "consent") handleNotNow();
+    else close();
   };
 
   return (
-    <Modal
+    <XServerSetupContent
       open={request !== null}
       onOpenChange={handleOpenChange}
-      title="Set up X server"
-      data-testid="x-server-connect-consent-dialog"
-      footer={renderFooter()}
-    >
-      {phase === "consent" ? renderConsent() : renderProvisioning()}
-    </Modal>
+      testIdPrefix="x-server-connect-consent"
+      phase={phase}
+      progress={progress}
+      error={error}
+      rawError={rawError}
+      consent={renderConsent()}
+      onEnable={handleEnable}
+      onNotNow={handleNotNow}
+      onRetry={handleRetry}
+      onInstallDependency={handleInstallDependency}
+      onClose={close}
+    />
   );
 
   /** Reply to the current prompt exactly once (later replies are no-ops). */
@@ -119,6 +200,9 @@ export function XServerConnectConsent() {
     setRequest(null);
     setPhase("consent");
     setProgress(null);
+    setError(null);
+    setRawError(null);
+    driverRef.current = "backend";
   }
 
   function renderConsent() {
@@ -135,55 +219,6 @@ export function XServerConnectConsent() {
           <strong>Enable</strong>.
         </p>
       </div>
-    );
-  }
-
-  function renderProvisioning() {
-    const indeterminate = progress === null || progress.progress < 0;
-    const pct = indeterminate ? 0 : Math.round(Math.min(1, Math.max(0, progress.progress)) * 100);
-    return (
-      <div className="x-server-setup__provisioning">
-        <p className="x-server-setup__step">{progress?.message ?? "Starting…"}</p>
-        <div
-          className="x-server-setup__progress"
-          data-testid="x-server-connect-consent-progress"
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={indeterminate ? undefined : pct}
-        >
-          <div
-            className={
-              indeterminate
-                ? "x-server-setup__progress-fill x-server-setup__progress-fill--indeterminate"
-                : "x-server-setup__progress-fill"
-            }
-            style={indeterminate ? undefined : { width: `${pct}%` }}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  function renderFooter() {
-    if (phase !== "consent") return null;
-    return (
-      <>
-        <Button
-          variant="secondary"
-          onClick={handleNotNow}
-          data-testid="x-server-connect-consent-not-now"
-        >
-          Not now
-        </Button>
-        <Button
-          variant="primary"
-          onClick={handleEnable}
-          data-testid="x-server-connect-consent-enable"
-        >
-          Enable
-        </Button>
-      </>
     );
   }
 }

--- a/src/components/OpenConnections/XServerSetupContent.test.tsx
+++ b/src/components/OpenConnections/XServerSetupContent.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for the shared X server consent/progress/error body (#1296). The same
+ * presentational component backs both the manual setup dialog and the
+ * connect-triggered consent dialog, so it is exercised here with both testid
+ * prefixes: it renders the consent slot, the progress bar, and a recoverable
+ * error screen (Retry always; Install only for a dependencyMissing failure).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { XServerError, XServerProgress } from "@/types/xserver";
+import { XServerSetupContent } from "./XServerSetupContent";
+
+describe("XServerSetupContent", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  interface Overrides {
+    prefix?: string;
+    phase?: "consent" | "provisioning" | "error";
+    progress?: XServerProgress | null;
+    error?: XServerError | null;
+    rawError?: unknown;
+    onEnable?: () => void;
+    onNotNow?: () => void;
+    onRetry?: () => void;
+    onInstallDependency?: () => Promise<void>;
+    onClose?: () => void;
+  }
+
+  function renderContent(o: Overrides = {}) {
+    const prefix = o.prefix ?? "x-server-setup";
+    act(() => {
+      root.render(
+        React.createElement(XServerSetupContent, {
+          open: true,
+          onOpenChange: () => {},
+          testIdPrefix: prefix,
+          phase: o.phase ?? "consent",
+          progress: o.progress ?? null,
+          error: o.error ?? null,
+          rawError: o.rawError,
+          consent: React.createElement("div", { "data-testid": `${prefix}-body` }, "consent copy"),
+          onEnable: o.onEnable ?? (() => {}),
+          onNotNow: o.onNotNow ?? (() => {}),
+          onRetry: o.onRetry ?? (() => {}),
+          onInstallDependency: o.onInstallDependency ?? (() => Promise.resolve()),
+          onClose: o.onClose ?? (() => {}),
+        })
+      );
+    });
+  }
+
+  function query(testId: string): Element | null {
+    return document.querySelector(`[data-testid="${testId}"]`);
+  }
+
+  function click(testId: string) {
+    const el = query(testId) as HTMLButtonElement | null;
+    if (!el) throw new Error(`missing element: ${testId}`);
+    el.click();
+  }
+
+  it("renders the consent slot and footer actions for both prefixes", () => {
+    for (const prefix of ["x-server-setup", "x-server-connect-consent"]) {
+      renderContent({ prefix });
+      expect(query(`${prefix}-dialog`)).not.toBeNull();
+      expect(query(`${prefix}-body`)).not.toBeNull();
+      expect(query(`${prefix}-enable`)).not.toBeNull();
+      expect(query(`${prefix}-not-now`)).not.toBeNull();
+    }
+  });
+
+  it("wires Enable and Not now to their handlers", () => {
+    const onEnable = vi.fn();
+    const onNotNow = vi.fn();
+    renderContent({ onEnable, onNotNow });
+    click("x-server-setup-enable");
+    click("x-server-setup-not-now");
+    expect(onEnable).toHaveBeenCalledTimes(1);
+    expect(onNotNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a determinate progress bar in the provisioning phase", () => {
+    renderContent({
+      phase: "provisioning",
+      progress: { step: "download", message: "Downloading…", progress: 0.5 },
+    });
+    const bar = query("x-server-setup-progress");
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute("aria-valuenow")).toBe("50");
+    // No footer actions while work is in flight.
+    expect(query("x-server-setup-enable")).toBeNull();
+    expect(query("x-server-setup-not-now")).toBeNull();
+  });
+
+  it("shows Retry (no Install) on a generic error", () => {
+    const onRetry = vi.fn();
+    renderContent({
+      phase: "error",
+      error: { kind: "provisioningUnavailable", message: "Not available here" },
+      onRetry,
+    });
+    expect(query("x-server-setup-error")?.textContent).toContain("Not available here");
+    expect(query("x-server-setup-retry")).not.toBeNull();
+    expect(query("x-server-setup-install-dep")).toBeNull();
+    click("x-server-setup-retry");
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an Install action for a dependencyMissing error", async () => {
+    const onInstallDependency = vi.fn(() => Promise.resolve());
+    renderContent({
+      phase: "error",
+      error: {
+        kind: "dependencyMissing",
+        message: "XQuartz is not installed",
+        dependency: "XQuartz",
+        installHint: "Install XQuartz from xquartz.org",
+        installCommand: "brew install --cask xquartz",
+      },
+      onInstallDependency,
+    });
+    expect(query("x-server-setup-error")?.textContent).toContain("XQuartz is not installed");
+    expect(document.body.textContent).toContain("brew install --cask xquartz");
+    const install = query("x-server-setup-install-dep");
+    expect(install).not.toBeNull();
+    expect(install?.textContent).toContain("Install XQuartz");
+    await act(async () => {
+      click("x-server-setup-install-dep");
+      await Promise.resolve();
+    });
+    expect(onInstallDependency).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the raw error message when no typed error is present", () => {
+    renderContent({ phase: "error", error: null, rawError: "boom on connect" });
+    expect(query("x-server-setup-error")?.textContent).toContain("boom on connect");
+  });
+});

--- a/src/components/OpenConnections/XServerSetupContent.tsx
+++ b/src/components/OpenConnections/XServerSetupContent.tsx
@@ -1,0 +1,174 @@
+import type { ReactNode } from "react";
+import { Modal, Button } from "@/components/ui";
+import type { XServerError, XServerProgress } from "@/types/xserver";
+import "./XServerSetupDialog.css";
+
+/** Which screen of the setup flow is showing. */
+export type XServerSetupPhase = "consent" | "provisioning" | "error";
+
+interface XServerSetupContentProps {
+  /** Whether the dialog is open (controlled). */
+  open: boolean;
+  /** Called with the next open state (Modal fires `false` on ESC / close / scrim). */
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Prefix for the derived `data-testid`s (dialog, progress, error, and footer
+   * buttons), e.g. `x-server-setup` (manual) or `x-server-connect-consent`
+   * (connect-triggered). Keeps the two flows' hooks distinct while sharing markup.
+   */
+  testIdPrefix: string;
+  /** Which screen to render. */
+  phase: XServerSetupPhase;
+  /** Progress driving the provisioning bar (indeterminate when `null` / `< 0`). */
+  progress: XServerProgress | null;
+  /**
+   * Typed failure driving error-screen recovery: `dependencyMissing` offers an
+   * install action, everything else offers a plain Retry. `null` renders the
+   * plain message from {@link rawError}.
+   */
+  error: XServerError | null;
+  /** Fallback error used for the message when no typed {@link error} is present. */
+  rawError?: unknown;
+  /**
+   * Consent-screen copy (differs between the manual and connect flows). Owns its
+   * own `data-testid` so each flow keeps its established hook.
+   */
+  consent: ReactNode;
+  /** Enable → begin provisioning. Returning a promise opts into pending feedback. */
+  onEnable: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  /** Decline on the consent screen (skip / not now). */
+  onNotNow: () => void;
+  /** Retry provisioning from the error screen. May be async. */
+  onRetry: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>;
+  /** Install the missing dependency (dependencyMissing only). Async for feedback. */
+  onInstallDependency: () => Promise<void>;
+  /** Close from the error screen. */
+  onClose: () => void;
+}
+
+/**
+ * Shared consent / provisioning / error body for the X server setup flows
+ * (#1296). One markup surface backs both the manual "Set up X server" dialog
+ * (`x_server_ensure`) and the connect-triggered consent dialog (the paused
+ * connect + `x_server_connect_consent_reply`); the two differ only in who drives
+ * provisioning and in the consent copy, which the container supplies. All values
+ * reference design tokens; motion respects `prefers-reduced-motion`.
+ */
+export function XServerSetupContent({
+  open,
+  onOpenChange,
+  testIdPrefix,
+  phase,
+  progress,
+  error,
+  rawError,
+  consent,
+  onEnable,
+  onNotNow,
+  onRetry,
+  onInstallDependency,
+  onClose,
+}: XServerSetupContentProps) {
+  const title = phase === "error" ? "X server setup failed" : "Set up X server";
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      data-testid={`${testIdPrefix}-dialog`}
+      footer={renderFooter()}
+    >
+      {phase === "consent" && consent}
+      {phase === "provisioning" && renderProvisioning()}
+      {phase === "error" && renderError()}
+    </Modal>
+  );
+
+  function renderProvisioning() {
+    const indeterminate = progress === null || progress.progress < 0;
+    const pct = indeterminate ? 0 : Math.round(Math.min(1, Math.max(0, progress.progress)) * 100);
+    return (
+      <div className="x-server-setup__provisioning">
+        <p className="x-server-setup__step">{progress?.message ?? "Starting…"}</p>
+        <div
+          className="x-server-setup__progress"
+          data-testid={`${testIdPrefix}-progress`}
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={indeterminate ? undefined : pct}
+        >
+          <div
+            className={
+              indeterminate
+                ? "x-server-setup__progress-fill x-server-setup__progress-fill--indeterminate"
+                : "x-server-setup__progress-fill"
+            }
+            style={indeterminate ? undefined : { width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  function renderError() {
+    const message =
+      error?.message ?? (rawError instanceof Error ? rawError.message : String(rawError));
+    const isDependencyMissing = error?.kind === "dependencyMissing";
+    return (
+      <div className="x-server-setup__error">
+        <p className="x-server-setup__error-message" data-testid={`${testIdPrefix}-error`}>
+          {message}
+        </p>
+        {isDependencyMissing && error?.installHint && (
+          <p className="x-server-setup__hint">{error.installHint}</p>
+        )}
+        {isDependencyMissing && error?.installCommand && (
+          <pre className="x-server-setup__command">
+            <code>{error.installCommand}</code>
+          </pre>
+        )}
+      </div>
+    );
+  }
+
+  function renderFooter() {
+    if (phase === "consent") {
+      return (
+        <>
+          <Button variant="secondary" onClick={onNotNow} data-testid={`${testIdPrefix}-not-now`}>
+            Not now
+          </Button>
+          <Button variant="primary" onClick={onEnable} data-testid={`${testIdPrefix}-enable`}>
+            Enable
+          </Button>
+        </>
+      );
+    }
+    if (phase === "error") {
+      return (
+        <>
+          <Button variant="secondary" onClick={onClose} data-testid={`${testIdPrefix}-close`}>
+            Close
+          </Button>
+          {error?.kind === "dependencyMissing" && (
+            <Button
+              variant="secondary"
+              onClick={onInstallDependency}
+              errorToast={false}
+              data-testid={`${testIdPrefix}-install-dep`}
+            >
+              Install {error.dependency ?? "dependency"}
+            </Button>
+          )}
+          <Button variant="primary" onClick={onRetry} data-testid={`${testIdPrefix}-retry`}>
+            Retry
+          </Button>
+        </>
+      );
+    }
+    // provisioning — no footer actions (work is in flight).
+    return null;
+  }
+}

--- a/src/components/OpenConnections/XServerSetupDialog.tsx
+++ b/src/components/OpenConnections/XServerSetupDialog.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from "react";
-import type { UnlistenFn } from "@tauri-apps/api/event";
 import { AppWindow } from "lucide-react";
-import { Modal, Button, toast } from "@/components/ui";
-import { xServerEnsure, xServerInstallDependency } from "@/services/api";
-import { onXServerProgress } from "@/services/events";
+import { toast } from "@/components/ui";
+import { xServerInstallDependency } from "@/services/api";
 import { frontendLog } from "@/utils/frontendLog";
 import {
   isXServerError,
@@ -11,10 +9,8 @@ import {
   type XServerProgress,
   type XServerStatusReport,
 } from "@/types/xserver";
-import "./XServerSetupDialog.css";
-
-/** Which screen of the setup flow is showing. */
-type Phase = "consent" | "provisioning" | "error";
+import { XServerSetupContent, type XServerSetupPhase } from "./XServerSetupContent";
+import { driveXServerEnsure } from "./xServerProvisioning";
 
 interface XServerSetupDialogProps {
   /** Whether the dialog is open (controlled). */
@@ -28,12 +24,15 @@ interface XServerSetupDialogProps {
 /**
  * Consent-gated setup and live provisioning-progress flow for the shared X
  * server (#1053). Nothing is downloaded or launched before the user hits
- * "Enable". Once consented, it subscribes to `x-server-progress` events, calls
- * `x_server_ensure`, and resolves in place — a failure drops into a recoverable
- * error screen (with an install action when a dependency is missing).
+ * "Enable". Once consented, it drives `x_server_ensure` (streaming
+ * `x-server-progress`) and resolves in place — a failure drops into a
+ * recoverable error screen (with an install action when a dependency is
+ * missing). The consent / progress / error markup is the shared
+ * {@link XServerSetupContent}; this container owns the frontend-driven state
+ * machine.
  */
 export function XServerSetupDialog({ open, onOpenChange, onProvisioned }: XServerSetupDialogProps) {
-  const [phase, setPhase] = useState<Phase>("consent");
+  const [phase, setPhase] = useState<XServerSetupPhase>("consent");
   const [progress, setProgress] = useState<XServerProgress | null>(null);
   const [error, setError] = useState<XServerError | null>(null);
   const [rawError, setRawError] = useState<unknown>(null);
@@ -51,38 +50,25 @@ export function XServerSetupDialog({ open, onOpenChange, onProvisioned }: XServe
   // Drive provisioning: subscribe to progress events, then run x_server_ensure.
   useEffect(() => {
     if (phase !== "provisioning") return;
-
-    let cancelled = false;
-    let unlisten: UnlistenFn | undefined;
     setProgress(null);
-
-    void (async () => {
-      unlisten = await onXServerProgress((p) => {
-        if (!cancelled) setProgress(p);
-      });
-      try {
-        const report = await xServerEnsure();
-        if (cancelled) return;
+    return driveXServerEnsure({
+      onProgress: setProgress,
+      onSuccess: (report) => {
         frontendLog("x_server_setup", `provisioning succeeded (state=${report.state})`);
         toast.success("X server ready");
         onProvisioned?.(report);
         onOpenChange(false);
-      } catch (e) {
-        if (cancelled) return;
+      },
+      onFailure: (typed, raw) => {
         frontendLog(
           "x_server_setup",
-          `provisioning failed: ${isXServerError(e) ? e.message : String(e)}`
+          `provisioning failed: ${isXServerError(raw) ? raw.message : String(raw)}`
         );
-        setRawError(e);
-        setError(isXServerError(e) ? e : null);
+        setRawError(raw);
+        setError(typed);
         setPhase("error");
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      unlisten?.();
-    };
+      },
+    });
     // Callbacks are stable per open cycle; re-running would restart provisioning.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phase]);
@@ -106,20 +92,22 @@ export function XServerSetupDialog({ open, onOpenChange, onProvisioned }: XServe
     }
   };
 
-  const title = phase === "error" ? "X server setup failed" : "Set up X server";
-
   return (
-    <Modal
+    <XServerSetupContent
       open={open}
       onOpenChange={onOpenChange}
-      title={title}
-      data-testid="x-server-setup-dialog"
-      footer={renderFooter()}
-    >
-      {phase === "consent" && renderConsent()}
-      {phase === "provisioning" && renderProvisioning()}
-      {phase === "error" && renderError()}
-    </Modal>
+      testIdPrefix="x-server-setup"
+      phase={phase}
+      progress={progress}
+      error={error}
+      rawError={rawError}
+      consent={renderConsent()}
+      onEnable={handleEnable}
+      onNotNow={handleClose}
+      onRetry={handleRetry}
+      onInstallDependency={handleInstallDependency}
+      onClose={handleClose}
+    />
   );
 
   function renderConsent() {
@@ -136,92 +124,5 @@ export function XServerSetupDialog({ open, onOpenChange, onProvisioned }: XServe
         </p>
       </div>
     );
-  }
-
-  function renderProvisioning() {
-    const indeterminate = progress === null || progress.progress < 0;
-    const pct = indeterminate ? 0 : Math.round(Math.min(1, Math.max(0, progress.progress)) * 100);
-    return (
-      <div className="x-server-setup__provisioning">
-        <p className="x-server-setup__step">{progress?.message ?? "Starting…"}</p>
-        <div
-          className="x-server-setup__progress"
-          data-testid="x-server-setup-progress"
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={indeterminate ? undefined : pct}
-        >
-          <div
-            className={
-              indeterminate
-                ? "x-server-setup__progress-fill x-server-setup__progress-fill--indeterminate"
-                : "x-server-setup__progress-fill"
-            }
-            style={indeterminate ? undefined : { width: `${pct}%` }}
-          />
-        </div>
-      </div>
-    );
-  }
-
-  function renderError() {
-    const message =
-      error?.message ?? (rawError instanceof Error ? rawError.message : String(rawError));
-    const isDependencyMissing = error?.kind === "dependencyMissing";
-    return (
-      <div className="x-server-setup__error">
-        <p className="x-server-setup__error-message" data-testid="x-server-setup-error">
-          {message}
-        </p>
-        {isDependencyMissing && error?.installHint && (
-          <p className="x-server-setup__hint">{error.installHint}</p>
-        )}
-        {isDependencyMissing && error?.installCommand && (
-          <pre className="x-server-setup__command">
-            <code>{error.installCommand}</code>
-          </pre>
-        )}
-      </div>
-    );
-  }
-
-  function renderFooter() {
-    if (phase === "consent") {
-      return (
-        <>
-          <Button variant="secondary" onClick={handleClose} data-testid="x-server-setup-cancel">
-            Not now
-          </Button>
-          <Button variant="primary" onClick={handleEnable} data-testid="x-server-setup-enable">
-            Enable
-          </Button>
-        </>
-      );
-    }
-    if (phase === "error") {
-      return (
-        <>
-          <Button variant="secondary" onClick={handleClose} data-testid="x-server-setup-close">
-            Close
-          </Button>
-          {error?.kind === "dependencyMissing" && (
-            <Button
-              variant="secondary"
-              onClick={handleInstallDependency}
-              errorToast={false}
-              data-testid="x-server-setup-install-dep"
-            >
-              Install {error.dependency ?? "dependency"}
-            </Button>
-          )}
-          <Button variant="primary" onClick={handleRetry} data-testid="x-server-setup-retry">
-            Retry
-          </Button>
-        </>
-      );
-    }
-    // provisioning — no footer actions (work is in flight).
-    return null;
   }
 }

--- a/src/components/OpenConnections/xServerProvisioning.ts
+++ b/src/components/OpenConnections/xServerProvisioning.ts
@@ -1,0 +1,46 @@
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { xServerEnsure } from "@/services/api";
+import { onXServerProgress } from "@/services/events";
+import { isXServerError, type XServerError, type XServerStatusReport } from "@/types/xserver";
+import type { XServerProgress } from "@/types/xserver";
+
+/** Callbacks invoked by {@link driveXServerEnsure} as provisioning advances. */
+export interface XServerEnsureHandlers {
+  /** A progress event for the live bar. */
+  onProgress: (progress: XServerProgress) => void;
+  /** Provisioning succeeded with the final status report. */
+  onSuccess: (report: XServerStatusReport) => void;
+  /** Provisioning failed; `error` is the typed failure when one was surfaced. */
+  onFailure: (error: XServerError | null, raw: unknown) => void;
+}
+
+/**
+ * Run the frontend-driven X server provisioning path: subscribe to
+ * `x-server-progress` for the live bar, call `x_server_ensure`, and route the
+ * outcome to {@link XServerEnsureHandlers}. Shared by the manual setup dialog
+ * and the connect-triggered dialog's retry/install recovery (#1296).
+ *
+ * Returns a cleanup that unsubscribes and suppresses any late callbacks, so an
+ * unmount or a phase change mid-provision never updates a stale component.
+ */
+export function driveXServerEnsure(handlers: XServerEnsureHandlers): () => void {
+  let cancelled = false;
+  let unlisten: UnlistenFn | undefined;
+
+  void (async () => {
+    unlisten = await onXServerProgress((p) => {
+      if (!cancelled) handlers.onProgress(p);
+    });
+    try {
+      const report = await xServerEnsure();
+      if (!cancelled) handlers.onSuccess(report);
+    } catch (e) {
+      if (!cancelled) handlers.onFailure(isXServerError(e) ? e : null, e);
+    }
+  })();
+
+  return () => {
+    cancelled = true;
+    unlisten?.();
+  };
+}

--- a/src/components/Settings/SettingsPanel.test.tsx
+++ b/src/components/Settings/SettingsPanel.test.tsx
@@ -210,6 +210,28 @@ describe("SettingsPanel — dirty state on revert to default", () => {
     expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(false);
   });
 
+  it("reflects consent persisted on connect in the Provide X Server toggle (#1296)", async () => {
+    // After a connect-time Enable, the backend persists
+    // provide_x_server_automatically = Some(true); the Settings toggle must show
+    // that as checked so the decision is visible and reversible in one place.
+    useAppStore.setState({
+      settings: { ...FULL_SETTINGS, provideXServerAutomatically: true },
+      savedSettings: { ...FULL_SETTINGS, provideXServerAutomatically: true },
+    });
+    render();
+    expect(findProvideXServerCheckbox()!.checked).toBe(true);
+
+    // A persisted decline (Some(false)) shows as unchecked.
+    act(() => root.unmount());
+    root = createRoot(container);
+    useAppStore.setState({
+      settings: { ...FULL_SETTINGS, provideXServerAutomatically: false },
+      savedSettings: { ...FULL_SETTINGS, provideXServerAutomatically: false },
+    });
+    render();
+    expect(findProvideXServerCheckbox()!.checked).toBe(false);
+  });
+
   it("marks settings dirty when toggling Stop X Server When Idle", async () => {
     useAppStore.setState({ settings: FULL_SETTINGS, savedSettings: FULL_SETTINGS });
     render();

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -481,19 +481,7 @@ Fixed strings — match exactly.
 | `workspace-save-current-btn` | `src/components/WorkspaceSidebar/WorkspaceSidebar.tsx` |
 | `workspace-sidebar` | `src/components/WorkspaceSidebar/WorkspaceSidebar.tsx` |
 | `x-server-connect-consent-body` | `src/components/OpenConnections/XServerConnectConsent.tsx` |
-| `x-server-connect-consent-dialog` | `src/components/OpenConnections/XServerConnectConsent.tsx` |
-| `x-server-connect-consent-enable` | `src/components/OpenConnections/XServerConnectConsent.tsx` |
-| `x-server-connect-consent-not-now` | `src/components/OpenConnections/XServerConnectConsent.tsx` |
-| `x-server-connect-consent-progress` | `src/components/OpenConnections/XServerConnectConsent.tsx` |
-| `x-server-setup-cancel` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
-| `x-server-setup-close` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
 | `x-server-setup-consent` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
-| `x-server-setup-dialog` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
-| `x-server-setup-enable` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
-| `x-server-setup-error` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
-| `x-server-setup-install-dep` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
-| `x-server-setup-progress` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
-| `x-server-setup-retry` | `src/components/OpenConnections/XServerSetupDialog.tsx` |
 | `zoom-context-clear` | `src/components/SplitView/SplitView.tsx` |
 | `zoom-context-copy` | `src/components/SplitView/SplitView.tsx` |
 | `zoom-context-horizontal-scroll` | `src/components/SplitView/SplitView.tsx` |
@@ -509,16 +497,24 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | pattern | example template | source |
 | ------- | ---------------- | ------ |
 | `*-*` | `${rowTestIdPrefix}-${index}` | `src/components/NetworkTools/DiagnosticResultsTable.tsx` |
+| `*-close` | `${testIdPrefix}-close` | `src/components/OpenConnections/XServerSetupContent.tsx` |
 | `*-copy` | `${testIdPrefix}-copy` | `src/components/Sidebar/FileBrowser.tsx` |
 | `*-copy-name` | `${testIdPrefix}-copy-name` | `src/components/Sidebar/FileBrowser.tsx` |
 | `*-copy-path` | `${testIdPrefix}-copy-path` | `src/components/Sidebar/FileBrowser.tsx` |
 | `*-cut` | `${testIdPrefix}-cut` | `src/components/Sidebar/FileBrowser.tsx` |
 | `*-delete` | `${testIdPrefix}-delete` | `src/components/Sidebar/FileBrowser.tsx` |
+| `*-dialog` | `${testIdPrefix}-dialog` | `src/components/OpenConnections/XServerSetupContent.tsx` |
 | `*-download` | `${testIdPrefix}-download` | `src/components/Sidebar/FileBrowser.tsx` |
 | `*-edit` | `${testIdPrefix}-edit` | `src/components/Sidebar/FileBrowser.tsx` |
+| `*-enable` | `${testIdPrefix}-enable` | `src/components/OpenConnections/XServerSetupContent.tsx` |
+| `*-error` | `${testIdPrefix}-error` | `src/components/OpenConnections/XServerSetupContent.tsx` |
+| `*-install-dep` | `${testIdPrefix}-install-dep` | `src/components/OpenConnections/XServerSetupContent.tsx` |
+| `*-not-now` | `${testIdPrefix}-not-now` | `src/components/OpenConnections/XServerSetupContent.tsx` |
 | `*-open` | `${testIdPrefix}-open` | `src/components/Sidebar/FileBrowser.tsx` |
 | `*-paste` | `${testIdPrefix}-paste` | `src/components/Sidebar/FileBrowser.tsx` |
+| `*-progress` | `${testIdPrefix}-progress` | `src/components/OpenConnections/XServerSetupContent.tsx` |
 | `*-rename` | `${testIdPrefix}-rename` | `src/components/Sidebar/FileBrowser.tsx` |
+| `*-retry` | `${testIdPrefix}-retry` | `src/components/OpenConnections/XServerSetupContent.tsx` |
 | `*-share-ftp` | `${testIdPrefix}-share-ftp` | `src/components/Sidebar/FileBrowser.tsx` |
 | `*-share-http` | `${testIdPrefix}-share-http` | `src/components/Sidebar/FileBrowser.tsx` |
 | `*-share-tftp` | `${testIdPrefix}-share-tftp` | `src/components/Sidebar/FileBrowser.tsx` |


### PR DESCRIPTION
Closes #1296. Deferred frontend polish from #1116.

## What & why

The connect-triggered (`XServerConnectConsent`) and manual (`XServerSetupDialog`)
X server dialogs duplicated the consent screen and progress-bar markup, and the
connect path had no error recovery — a failed provisioning step just toasted and
closed the dialog.

## Approach

- **One shared body.** Extracted the consent / progress / error markup + footer
  into a single presentational primitive `XServerSetupContent`, parameterized by
  a `testIdPrefix` and a consent-copy slot. Both dialogs now render through it, so
  there is no duplicated markup. Each container keeps its own state machine and
  driver (frontend `x_server_ensure` for manual; the backend-paused connect +
  `x_server_connect_consent_reply` for connect).
- **Connect-path error recovery to parity.** On a `failed` progress step the
  connect dialog now shows the same recoverable error screen as the manual flow:
  **Retry** re-provisions via `x_server_ensure`, and a `dependencyMissing` failure
  adds an **Install <dependency>** action (macOS XQuartz guidance). The shared,
  frontend-driven ensure+progress logic lives in `driveXServerEnsure`.
- **Settings reflection.** Confirmed the "Provide X server automatically" toggle
  reflects consent persisted on connect (`persist_consent` sets
  `provide_x_server_automatically = Some(true)`); added an explicit test.
- All values remain on design tokens; motion respects `prefers-reduced-motion`.

## Test plan

- `pnpm test` — full suite (247 files, 2497 tests) passes, incl. the
  token-discipline guard.
- `pnpm build` (tsc) and `pnpm run lint` pass; no `any`.
- New/updated unit tests: shared body renders for both drivers; connect `failed`
  step surfaces Retry (and Install for `dependencyMissing`) instead of closing;
  Settings toggle reflects a persisted decision.
- Manual visual step (macOS, no automated WKWebView driver): trigger an X11
  connect prompt, hit Enable, force a provisioning failure, and confirm the error
  screen with Retry (and Install on a missing dependency) renders and recovers in
  place — matching the manual "X Servers → Set up" dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)