### PR TITLE
docs(xserver): X11 forwarding testing + architecture/ADR consolidation (#1057)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1057,6 +1057,74 @@ if (!experimental) return null;
 
 Experimental features may ship in public releases. The flag is not a hidden developer tool — it is a user-visible opt-in that makes the lack of guarantees explicit.
 
+### X Server Provisioning (SSH X11 Forwarding)
+
+SSH **X11 forwarding** renders a remote GUI app (`xeyes`, a graphical IDE) as a native window on the machine running termiHub. That requires a **local X server** — something Linux users usually already have, macOS users install (XQuartz), and Windows users historically had to source and configure by hand. The X-server provisioning subsystem (epic #1047, concept `docs/concepts/backlog/x-server-provisioning.html`) makes a usable local X server available, forwards to it, and tears it down cleanly — with the acquisition **strategy chosen per platform** (see [ADR-10](#adr-10-per-platform-x-server-provisioning)).
+
+#### Where it lives
+
+The subsystem straddles the core/desktop boundary because core cannot provision servers itself — process lifecycle, VcXsrv acquisition, and the native install flows are desktop concerns:
+
+| Layer                                                  | Responsibility                                                                                                                                                                                                                                                         |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `core/src/backends/ssh/x11.rs`                         | The forwarding mechanism (russh reverse `tcpip_forward` → local X socket/TCP), the `XServerProvisioner` **seam** (trait + `set_x_server_provisioner`), `ResolvedXServer`/`XServerLease`, and the no-provisioner fallback `detect_local_x_server` for a user-run server |
+| `src-tauri/src/terminal/xserver/`                      | The desktop provisioner: `orchestrator` (cross-platform decision), `manager` (managed-server lifecycle + session refcount), `acquire` (Windows VcXsrv), `macos` (XQuartz), `linux_gap` (Linux hint classifier), `consent` (connect-time gate), `auth` (MIT cookie)     |
+| `src-tauri/src/commands/xserver.rs`                    | Tauri command surface: `x_server_status`, `x_server_ensure`, `x_server_stop`, `x_server_install_dependency`, `x_server_connect_consent_reply`                                                                                                                          |
+| `src/components/OpenConnections/XServer*`, `Settings/` | Frontend: settings toggles (`provideXServerAutomatically`, `stopXServerWhenIdle`), the Open Connections **X Servers** section, the manual **Set up** dialog, and the connect-time consent dialog                                                                       |
+
+Core stays transport-only: at startup the desktop registers `XServerProvisionerImpl` via `set_x_server_provisioner`, and `SshConnector` consults it whenever `enable_x11_forwarding` is set. With no provisioner registered (core standalone / tests), behavior is unchanged — the forwarder falls back to detecting a user-run server.
+
+#### Per-platform strategy
+
+- **Windows — bundle / download VcXsrv.** No native X server exists, so termiHub provides one. `acquire.rs` resolves a pinned, minimal VcXsrv install in order **cache → bundled resource → download**, SHA-256-verifies the `.zip`, and extracts it atomically under `<data>/xserver/vcxsrv-<version>/` (portable mode uses the `data/` folder). The download source is termiHub's own GitHub releases (same host as the agent binaries). The server runs as a separate process. _Current status:_ managed auto-acquisition is being wired incrementally (#1048); the pinned artifact SHA-256 is a placeholder until published (#1076), so a real download is intentionally rejected by verification until then — a user-run/already-running VcXsrv is still adopted via the TCP probe.
+- **macOS — detect + guide XQuartz.** macOS cannot embed an X server. `macos.rs` detects XQuartz (`/opt/X11`, `/Applications/Utilities/XQuartz.app`); on connect it best-effort launches it (`open -a XQuartz`) and polls for readiness (≤ ~4 s, cancellable, #1260). An install **never runs silently** — only the explicit `x_server_install_dependency` action runs `brew install --cask xquartz` (or returns xquartz.org guidance when Homebrew is absent).
+- **Linux — native X, guide-only.** termiHub never bundles or installs anything. It adopts the running server; when forwarding fails, `linux_gap.rs` snapshots the environment (`DISPLAY`, `WAYLAND_DISPLAY`, sockets, `Xwayland`/`Xorg` on PATH, Flatpak/Snap sandbox) and classifies the gap into a **targeted, actionable hint** (install XWayland; grant the `--socket=x11` sandbox permission; start a graphical session / Xvfb) rather than a generic error.
+
+#### Managed-server lifecycle
+
+At most one managed X server exists per termiHub instance, shared across sessions and reference-counted (#1107). The manager either **adopts** an already-reachable server (TCP `127.0.0.1:6000`, never terminated by termiHub) or, on a provider platform, **spawns** one on the first free display with a fresh MIT-MAGIC-COOKIE-1 (falling back to loopback-only `-ac`). Each X11-forwarding session holds a RAII `SessionGuard`; when the last one drops **and** "shut down when idle" is set, a termiHub-spawned server is stopped — so a clean disconnect leaves **no orphan process**.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Absent
+    Absent --> Adopted: external server<br/>reachable on :6000
+    Absent --> Running: spawn managed<br/>(Windows / provider)
+    Absent --> Failed: no server + typed<br/>per-platform error
+    Adopted --> Adopted: sessions acquire / release<br/>(never terminated)
+    Running --> Running: reuse across sessions<br/>(refcount > 0)
+    Running --> Absent: refcount → 0 &&<br/>stop-when-idle
+    Failed --> Absent: retry / dependency installed
+    Running --> [*]: app exit (child reaped)
+```
+
+#### Connect-time consent handshake
+
+Downloading an X dependency on someone's behalf requires consent. On a first-time, download-backed Windows connect with automatic provisioning **undecided** and no server already present, the provisioner pauses the connect: it emits `x-server-consent-needed`, streams `x-server-progress`, and awaits the frontend's `x_server_connect_consent_reply`. **Enable** provisions and persists the decision (later connects never re-prompt); **Not now** continues the SSH connection without X forwarding; **Stop** while the prompt is up aborts the connect promptly (#1260). macOS/Linux never download, so they never prompt — they only gain progress feedback.
+
+```mermaid
+sequenceDiagram
+    participant UI as Frontend
+    participant Conn as SSH connect (core)
+    participant Prov as XServerProvisionerImpl
+    participant Mgr as XServerManager
+
+    Conn->>Prov: ensure(cancel)
+    Prov->>Prov: consent required?<br/>(Windows · undecided · no server)
+    alt prompt needed
+        Prov-->>UI: x-server-consent-needed {id}
+        UI-->>Prov: x_server_connect_consent_reply(id, Enable | NotNow)
+    end
+    alt Enable / not needed
+        Prov->>Mgr: ensure_running() + acquire lease
+        Mgr-->>Prov: ResolvedXServer + SessionGuard
+        Prov-->>Conn: XServerLease (forward here)
+    else Not now
+        Prov-->>Conn: empty lease (connect without X)
+    else Stop during prompt
+        Prov-->>Conn: Err (connect aborted)
+    end
+```
+
 ---
 
 ## 9. Architecture Decisions
@@ -1229,6 +1297,27 @@ flowchart LR
 - External connection files and plugin-provided types work without schema changes
 
 **Trade-off:** Loss of compile-time type safety for connection settings. The settings are `serde_json::Value` / `Record<string, unknown>` rather than strongly-typed structs. Validation happens at runtime via the schema, not at compile time.
+
+### ADR-10: Per-Platform X Server Provisioning
+
+**Context:** SSH X11 forwarding needs a local X server to render remote GUI apps (see [X Server Provisioning](#x-server-provisioning-ssh-x11-forwarding)). The three desktop platforms differ fundamentally: Linux almost always has a running X (or Wayland+XWayland) server; macOS needs XQuartz, which Apple does not ship and which cannot be embedded; Windows has no native X server at all and no first-class package manager we can assume. A single strategy ("bundle an X server", or "tell the user to install one") is wrong on at least two of the three, and silently downloading or installing software is a trust violation.
+
+**Decision:** Provision **per platform**, behind one `XServerProvisioner` seam in `termihub-core` that the desktop implements:
+
+- **Windows — bundle / download.** Ship (or fetch on first use) a pinned, minimal, SHA-256-verified VcXsrv, cached under the app data dir and run as a managed process. termiHub owns the whole lifecycle because the user has nothing to fall back on.
+- **macOS — detect / guide.** Detect XQuartz and offer an **explicit, consent-gated** install (`brew install --cask xquartz`, else a link). Never install silently; launch and wait for XQuartz on connect, cancellably.
+- **Linux — native, guide-only.** Adopt the running server; never bundle or install. On failure, classify the environment into a specific, actionable hint (missing XWayland, sandbox socket, headless).
+
+A first-time, download-backed Windows provision is gated on a connect-time consent prompt; the decision is persisted so later connects are silent. Adopted (user-run) servers are never terminated; only termiHub-spawned servers are stopped when idle.
+
+**Rationale:**
+
+- Matches each platform's reality and user expectations instead of forcing one model everywhere.
+- Keeps core transport-agnostic — the provisioning policy and OS-specific flows live in `src-tauri`, registered via a trait, so core (and the agent) carry no X-server code.
+- Consent + verified download + "adopt but never kill external servers" keeps the trust and resource-cleanup contracts explicit (no silent installs, no orphan processes).
+- The per-platform decision, lifecycle, and consent gate are pure/injectable, so they are covered by host-agnostic unit tests; only the irreducible "a real window renders" step stays manual (per [ADR-5](#adr-5-e2e-system-tests-run-in-docker-linux-only); see the X11 matrix in [testing.md](testing.md#x11--gui-forwarding)).
+
+**Trade-off:** Three code paths instead of one, and the Windows path carries a redistribution concern (VcXsrv is GPL-3.0, shipped as a pinned artifact with license notices). Full E2E rendering cannot be automated in CI, so the cross-platform release matrix is a documented human step. Windows managed auto-acquisition is being wired incrementally (#1048) and depends on publishing the pinned artifact (#1076); until then Windows adopts a user-run VcXsrv via the TCP probe.
 
 ---
 

--- a/docs/changes/dev2/docs/1057-xserver-testing-docs.md
+++ b/docs/changes/dev2/docs/1057-xserver-testing-docs.md
@@ -1,0 +1,11 @@
+### Added
+
+- **SSH X11 / GUI forwarding** is now documented end to end for the X-server
+  provisioning epic (#1047): `docs/testing.md` gains a consolidated
+  **X11 / GUI forwarding** section with the per-platform release matrix (Windows
+  auto-provision → forwarded `xeyes` → no-orphan shutdown; macOS XQuartz
+  detect/guide + consent; Linux native, guide-only), and `docs/architecture.md`
+  documents the X-server-provisioning subsystem plus **ADR-10** (bundle/download
+  on Windows, guide on macOS/Linux). The `ssh-x11` Docker fixture adds a
+  self-contained headless render check (in-container Xvfb) for CI-automatable
+  forwarded-GUI verification (#1057).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -868,6 +868,69 @@ To verify SSH tunnels actually work on macOS, do this manually against the tunne
 4. Confirm the tunnel reaches a running state (sidebar shows Stop control) and `curl http://127.0.0.1:18083` returns `TUNNEL_TEST_OK`.
 5. Click **Stop** and confirm the tunnel returns to disconnected and the Start control reappears.
 
+### X11 / GUI forwarding
+
+SSH **X11 forwarding** lets a remote GUI app (`xeyes`, `xclock`, a graphical IDE)
+render as a native window on the machine running termiHub. Making a usable **local
+X server** available — and tearing it down cleanly afterwards — is the X-server
+provisioning subsystem (epic #1047). The strategy is chosen **per platform**, so the
+verification is too. Architecture:
+[X Server Provisioning](architecture.md#x-server-provisioning-ssh-x11-forwarding) and
+[ADR-10](architecture.md#adr-10-per-platform-x-server-provisioning).
+
+**Shipped across:** manual UI — settings toggles + X Servers section + setup dialog
+(#1053, PRs #1110 / #1111 / #1118); connect-triggered consent + live progress (#1116,
+PR #1298); unified consent UI + recoverable error / Retry (#1296, PR #1302);
+cancellable readiness wait (#1260, PR #1285). This section consolidates their manual
+steps in one place.
+
+Everything below the "automated" line needs a **real local X server rendering a real
+window** (or a native OS install dialog), which the harness cannot fake (per ADR-5);
+those steps are the deliverable, executed by a human for the release.
+
+#### What is automated vs. manual
+
+| Layer                                                                                                                                                                                              | Coverage                                                                                                        |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Per-platform decision, adopt/spawn lifecycle, session refcount (#1107), consent gate, Linux gap classifier, VcXsrv acquire/verify/extract, XQuartz detect + brew args, readiness-wait cancellation | **Rust unit tests** (`src-tauri/src/terminal/xserver/*`, `core/src/backends/ssh/x11.rs`) — run on every CI host |
+| Setup dialog, connect-time consent dialog, X Servers section rows/actions                                                                                                                          | **Vitest/RTL** component tests (`XServerSetupDialog`, `XServerConnectConsent`, `OpenConnectionsModal.xservers`) |
+| A GUI app renders to an X server **headlessly, in-container** (Xvfb)                                                                                                                               | **Docker fixture** `ssh-x11` → `render-check.sh` (automatable anywhere Docker runs)                             |
+| Forwarded GUI renders into the **operator's real X server** end to end; per-OS provisioning UX; clean shutdown / no orphan                                                                         | **Manual** (the release matrix below)                                                                           |
+
+#### Docker fixture: `ssh-x11`
+
+`tests/docker/ssh-x11/` is an sshd container with X11 forwarding enabled plus
+`xeyes` / `xclock` / `xdpyinfo` (host port `2208`; `core/tests/common` exposes
+`port_ssh_x11()`). Two baked-in helper scripts:
+
+- **`render-check.sh`** — brings up an in-container **Xvfb** X server, launches
+  `xeyes` against it, and asserts the client actually mapped a window
+  (`RENDER_CHECK_OK`). This proves the "a GUI client renders to an X server"
+  pipeline with **no host X server**, so it runs in any Docker environment:
+  `docker compose -f tests/docker/docker-compose.yml exec ssh-x11 render-check.sh`.
+- **`test-x11.sh`** — run _inside a forwarded session_
+  (`ssh -X -p 2208 testuser@localhost test-x11.sh`); asserts `DISPLAY` is set and a
+  client can reach the forwarded server (`X11_FORWARDING_OK`). Automatable on Linux
+  with an Xvfb `:0`; on macOS it needs XQuartz (manual). See
+  [`tests/docker/README.md`](../tests/docker/README.md) → _X11 forwarding_.
+
+The container render-check is a genuine capability check, not a stand-in for the
+end-to-end forward into the operator's real display — that remains the manual matrix.
+
+#### Cross-platform release matrix
+
+Execute once per release on a **clean box** of each OS. **This is a human release
+step — it cannot be run by CI or an AI agent** (no real X server, and the per-OS
+install dialogs are native). Record the result against the release.
+
+| OS          | Strategy                                                 | Clean-box procedure                                                                                                                                                                                                     | Pass criteria                                                                                                                                                                |
+| ----------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Windows** | Bundle / download VcXsrv                                 | Enable X11 on an SSH connection → first connect **pauses for consent** → **Enable** → VcXsrv auto-provisions (download → verify → extract, or reuse cache) → a forwarded `xeyes` / `xclock` renders as a native window. | Window renders; choice remembered (2nd X11 connect does **not** prompt); on disconnect the managed server shuts down when idle — **no orphan `vcxsrv.exe`** in Task Manager. |
+| **macOS**   | Detect / guide XQuartz (`brew --cask`, else xquartz.org) | Without XQuartz → connect surfaces **XQuartz-missing** guidance; run **Install** (brew cask, admin prompt) or follow the link. With XQuartz → connect launches it (`open -a XQuartz`) and a forwarded `xclock` renders. | Guidance never auto-installs silently; window renders; aborting the connect **while XQuartz is still starting** stops promptly (#1260).                                      |
+| **Linux**   | Native X, guide-only                                     | On a normal X / Wayland-with-XWayland desktop → connect **adopts** the running server (no prompt), forwarded `xeyes` renders. On a gap env (Wayland-only, headless, sandboxed) → connect shows the **targeted hint**.   | Window renders on a normal desktop; each gap yields its specific actionable hint, never a silent failure or generic error (#1055).                                           |
+
+Detailed per-OS procedures follow.
+
 #### Linux X server detect-and-guide edge cases (#1055)
 
 The Linux X-server gap classifier (`src-tauri/src/terminal/xserver/linux_gap.rs`)
@@ -923,6 +986,12 @@ With XQuartz **present**:
    the remote window renders locally. (XQuartz's "Allow connections from network
    clients" preference may be required.)
 
+**Cancellable readiness wait (#1260, PR #1285):** XQuartz takes ~1-2 s to create
+its socket, so termiHub polls for readiness (≤ ~4 s budget). Start an X11-forwarding
+connect on a box where XQuartz is **not yet running**, then **Stop** the connect
+while it is still coming up. Confirm the abort takes effect **promptly** — it must
+not block for the full readiness budget before the Stop is honored.
+
 #### VcXsrv provisioning: first-run download + offline re-run (Windows, #1076)
 
 termiHub downloads a pinned, minimal VcXsrv `.zip` from its GitHub releases on
@@ -958,7 +1027,6 @@ Verify acquisition end-to-end on a **clean Windows box** (no VcXsrv installed):
 3. Tamper check (optional): corrupt the cached `vcxsrv.exe` to zero bytes and
    confirm the next provisioning re-resolves (download when online, or a clear
    error offline) rather than launching a broken server.
-   > > > > > > > origin/develop
 
 #### Connect-triggered X server consent + live progress (Windows, #1116)
 
@@ -989,6 +1057,8 @@ server automatically" left at its default/undecided):
    and that Retry re-provisions in place; on a missing-dependency failure an
    **Install** action appears. The screen must match the manual "X Servers → Set
    up" dialog (`XServerSetupContent.tsx`).
+
+### Remote system monitoring
 
 #### Monitoring auto-reconnect on a mid-stream drop (#1230)
 

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -43,17 +43,17 @@ podman compose -f tests/docker/docker-compose.yml up -d
 
 ### SSH Containers
 
-| Container              | Port     | Auth                  | Purpose                                       |
-| ---------------------- | -------- | --------------------- | --------------------------------------------- |
-| `ssh-password`         | 2201     | `testuser`/`testpass` | Standard password auth (OpenSSH latest)       |
-| `ssh-legacy`           | 2202     | password + keys       | Legacy OpenSSH 7.x compatibility              |
-| `ssh-keys`             | 2203     | key only              | All key types (RSA, Ed25519, ECDSA)           |
-| `ssh-jumphost-bastion` | 2204     | key only              | ProxyJump bastion (2-hop chain entry)         |
-| `ssh-jumphost-target`  | internal | key only              | ProxyJump target (reachable only via bastion) |
-| `ssh-restricted`       | 2205     | `testuser`/`testpass` | Restricted shell (rbash)                      |
-| `ssh-banner`           | 2206     | `testuser`/`testpass` | Pre-auth banner + MOTD                        |
-| `ssh-tunnel-target`    | 2207     | password + keys       | Internal HTTP/echo servers for tunnel testing |
-| `ssh-x11`              | 2208     | password + keys       | X11 forwarding with xterm/xclock/xeyes        |
+| Container              | Port     | Auth                  | Purpose                                                 |
+| ---------------------- | -------- | --------------------- | ------------------------------------------------------- |
+| `ssh-password`         | 2201     | `testuser`/`testpass` | Standard password auth (OpenSSH latest)                 |
+| `ssh-legacy`           | 2202     | password + keys       | Legacy OpenSSH 7.x compatibility                        |
+| `ssh-keys`             | 2203     | key only              | All key types (RSA, Ed25519, ECDSA)                     |
+| `ssh-jumphost-bastion` | 2204     | key only              | ProxyJump bastion (2-hop chain entry)                   |
+| `ssh-jumphost-target`  | internal | key only              | ProxyJump target (reachable only via bastion)           |
+| `ssh-restricted`       | 2205     | `testuser`/`testpass` | Restricted shell (rbash)                                |
+| `ssh-banner`           | 2206     | `testuser`/`testpass` | Pre-auth banner + MOTD                                  |
+| `ssh-tunnel-target`    | 2207     | password + keys       | Internal HTTP/echo servers for tunnel testing           |
+| `ssh-x11`              | 2208     | password + keys       | X11 forwarding (xterm/xclock/xeyes) + Xvfb render-check |
 
 ### Other Protocols
 
@@ -103,6 +103,31 @@ ssh -o ProxyJump=testuser@localhost:2204 testuser@termihub-ssh-target -i tests/f
 # Verify you reached the target
 cat /home/testuser/marker.txt  # Should print: JUMPHOST_TARGET_REACHED
 ```
+
+## X11 forwarding
+
+The `ssh-x11` container (host port `2208`) enables SSH X11 forwarding and ships
+`xeyes` / `xclock` / `xdpyinfo` plus two helper scripts for verifying the
+forwarded-GUI path. It backs the X-server provisioning epic (#1047); see
+[`docs/testing.md`](../../docs/testing.md) → _X11 / GUI forwarding_ for the full
+cross-platform manual matrix.
+
+```bash
+# Headless render check — proves a GUI client renders to an X server with NO
+# host X server (in-container Xvfb). Automatable anywhere Docker runs.
+docker compose -f tests/docker/docker-compose.yml exec ssh-x11 render-check.sh
+# Prints RENDER_CHECK_OK on success.
+
+# Forwarded-session assertion — run inside a real forwarded session. DISPLAY
+# must be set and reachable. Needs a local X server on the client side (an
+# Xvfb :0 on Linux CI, or XQuartz on macOS).
+ssh -X -p 2208 testuser@localhost /usr/local/bin/test-x11.sh
+# Prints X11_FORWARDING_OK on success.
+```
+
+The render check is a genuine in-container capability check; it is **not** a
+stand-in for the end-to-end forward into the operator's real display, which
+remains a manual step (no host X server can be faked in the harness).
 
 ## Requirements
 

--- a/tests/docker/ssh-x11/Dockerfile
+++ b/tests/docker/ssh-x11/Dockerfile
@@ -1,5 +1,6 @@
 # SSH server with X11 forwarding support and test X11 applications
-# Contains: xterm, xclock, xeyes, xdpyinfo for X11 forwarding verification
+# Contains: xterm, xclock, xeyes, xdpyinfo for X11 forwarding verification,
+# plus Xvfb + a self-contained headless render-check (see render-check.sh).
 # Test user: testuser / testpass
 FROM ubuntu:24.04
 
@@ -11,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     x11-apps \
     x11-utils \
     xterm \
+    xvfb \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /run/sshd
 
@@ -33,7 +35,9 @@ RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/
     && sed -i 's/#X11UseLocalhost yes/X11UseLocalhost yes/' /etc/ssh/sshd_config \
     && echo "UseDNS no" >> /etc/ssh/sshd_config
 
-# Create an X11 test script that checks if DISPLAY is set and X11 works
+# X11 forwarding assertion, run *inside a forwarded session*: checks DISPLAY is
+# set (forwarding is up) and that a client can talk to the forwarded X server.
+# Prints X11_FORWARDING_OK / X11_FORWARDING_FAILED.
 RUN printf '%s\n' \
     '#!/bin/bash' \
     'if [ -z "$DISPLAY" ]; then' \
@@ -49,6 +53,14 @@ RUN printf '%s\n' \
     'fi' \
     > /usr/local/bin/test-x11.sh \
     && chmod +x /usr/local/bin/test-x11.sh
+
+# Self-contained headless render check: brings up an in-container Xvfb X server,
+# launches a real GUI client (xeyes) against it, and asserts the client actually
+# mapped a window — proving the "a GUI app renders to an X server" pipeline end
+# to end with no host X server. Automatable anywhere Docker runs, unlike a
+# forward into the operator's real X server (which the harness cannot fake).
+# See tests/docker/README.md -> "X11 forwarding".
+COPY --chmod=755 render-check.sh /usr/local/bin/render-check.sh
 
 # Generate host keys
 RUN ssh-keygen -A

--- a/tests/docker/ssh-x11/render-check.sh
+++ b/tests/docker/ssh-x11/render-check.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Self-contained headless X11 render check for the ssh-x11 fixture.
+#
+# Brings up an in-container Xvfb X server, launches a real GUI client (xeyes)
+# against it, and asserts the client actually mapped a window. This proves the
+# "a GUI app renders to an X server" pipeline end to end WITHOUT needing a host
+# X server, so it is automatable anywhere Docker runs — unlike a forward into
+# the operator's real display, which the system-test harness cannot fake.
+#
+# Usage (from the repo root, container up):
+#   docker compose -f tests/docker/docker-compose.yml exec ssh-x11 render-check.sh
+#
+# Exit 0 and prints RENDER_CHECK_OK on success; non-zero + RENDER_CHECK_FAILED
+# otherwise. Deterministic: no timing-sensitive pixel diffing, only window map.
+set -euo pipefail
+
+DISPLAY_NUM="${1:-99}"
+DISPLAY_ID=":${DISPLAY_NUM}"
+XVFB_PID=""
+APP_PID=""
+
+cleanup() {
+  [ -n "${APP_PID}" ] && kill "${APP_PID}" 2>/dev/null || true
+  [ -n "${XVFB_PID}" ] && kill "${XVFB_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Start a virtual framebuffer X server.
+Xvfb "${DISPLAY_ID}" -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 &
+XVFB_PID=$!
+export DISPLAY="${DISPLAY_ID}"
+
+# Wait for the server to accept connections.
+ready=0
+for _ in $(seq 1 50); do
+  if xdpyinfo >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 0.2
+done
+if [ "${ready}" -ne 1 ]; then
+  echo "RENDER_CHECK_FAILED: Xvfb did not become ready on ${DISPLAY_ID}"
+  cat /tmp/xvfb.log || true
+  exit 1
+fi
+
+# Launch a real GUI client and wait for it to map a window.
+xeyes >/tmp/xeyes.log 2>&1 &
+APP_PID=$!
+
+mapped=0
+for _ in $(seq 1 50); do
+  if xwininfo -root -children 2>/dev/null | grep -qi 'xeyes'; then
+    mapped=1
+    break
+  fi
+  # Bail early if the client died.
+  if ! kill -0 "${APP_PID}" 2>/dev/null; then
+    break
+  fi
+  sleep 0.2
+done
+
+if [ "${mapped}" -eq 1 ]; then
+  echo "RENDER_CHECK_OK: xeyes mapped a window on ${DISPLAY_ID}"
+  exit 0
+fi
+
+echo "RENDER_CHECK_FAILED: xeyes never mapped a window on ${DISPLAY_ID}"
+cat /tmp/xeyes.log || true
+exit 1


### PR DESCRIPTION
## Summary

Testing + documentation capstone for the **X-server provisioning epic (#1047)** — the cross-cutting verification and docs the individual feature issues (#1053, #1116, #1296, #1260, #1076) couldn't own. Docs + fixtures only; **no product source changed**.

Closes #1057.

## What was added

**Integration fixture — `tests/docker/ssh-x11/`**
- Added `render-check.sh`: an in-container **Xvfb** X server + `xeyes`, asserting a window was actually mapped (`RENDER_CHECK_OK`). Proves the "a GUI app renders to an X server" pipeline with **no host X server**, so it is automatable anywhere Docker runs. Correct-by-construction (`bash -n` clean); not run here (no Docker host in this environment).
- Dockerfile now installs `xvfb` and bakes in the render-check alongside the existing forwarded-session `test-x11.sh`.
- Documented both helpers in `tests/docker/README.md` → *X11 forwarding*.

**`docs/testing.md`** — new consolidated **X11 / GUI forwarding** section:
- Automated-vs-manual coverage table; the `ssh-x11` fixture helpers.
- The **cross-platform release matrix**: Windows (enable X11 → auto-provision → forwarded `xeyes` renders → clean shutdown, **no orphan `vcxsrv.exe`**), macOS (XQuartz guide/pkg + consent), Linux (native X, guide-only).
- References the shipping PRs (#1053 → #1110/#1111/#1118, #1116 → #1298, #1296 → #1302, #1260 → #1285) and adds the cancellable-readiness-wait manual step.
- Removed a stray `>>>>>>> origin/develop` merge-conflict marker left in the VcXsrv section on `develop`.

**`docs/architecture.md`**
- New cross-cutting **X Server Provisioning (SSH X11 Forwarding)** section: module map (core seam vs. desktop provisioner), per-platform strategy, a managed-server **lifecycle state diagram**, and a connect-time **consent sequence diagram** (Mermaid).
- **ADR-10: Per-Platform X Server Provisioning** (bundle/download on Windows, guide on macOS/Linux), in the existing arc42/ADR style.
- Both note the honest current status: Windows managed auto-acquisition is being wired incrementally (#1048) and depends on publishing the pinned VcXsrv artifact (#1076).

**Changelog fragment** — `docs/changes/dev2/docs/1057-xserver-testing-docs.md`.

## Acceptance status

- ✅ `docs/testing.md` X11 matrix consolidated + discoverable (this is the manual-tracking deliverable).
- ✅ `docs/architecture.md` subsystem section + ADR-10.
- ✅ Changelog fragment.
- ✅ Fixture extended where feasible (headless render-check automatable; full forwarded-GUI-into-real-display documented as manual, not faked).
- ✅ Verified green for the touched lanes: `markdownlint` (0 errors), `prettier --check`, `bash -n` on the new script. No Rust/TS source changed, so those `test.sh`/`check.sh` lanes are unaffected. No new `data-testid`, so the testid catalog needs no regeneration.
- ⏳ **Manual matrix (Win/mac/Linux) execution is an inherently human release step** — it needs real X servers and native install dialogs and cannot be run by CI or an agent. It is fully documented; **executing it for the release is left to a human.**

## Test plan

The consolidated manual matrix in `docs/testing.md` → *X11 / GUI forwarding* is the deliverable. On a clean box per OS: enable X11 forwarding, provision (per platform), confirm a forwarded `xeyes`/`xclock` renders, and confirm clean shutdown with no orphan process. Automatable slices: `render-check.sh` in the `ssh-x11` container; the xserver Rust/Vitest unit suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)