### PR TITLE
fix(ssh): allocate X11 forward on a conventional display port (Closes #1304)

### DIFF
--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -169,6 +169,45 @@ pub fn x_server_provisioner() -> Option<Arc<dyn XServerProvisioner>> {
     PROVISIONER.get().cloned()
 }
 
+/// First X11 display number to try when allocating a remote forward.
+///
+/// Matches OpenSSH's default `X11DisplayOffset`, keeping the forwarded display
+/// out of the range a directly-attached X server would use (`:0`, `:1`).
+const X11_DISPLAY_OFFSET: u16 = 10;
+
+/// How many consecutive display numbers to probe before giving up (ports
+/// `6000 + X11_DISPLAY_OFFSET ..`). Bounds the scan so a host with every X11
+/// port taken fails promptly instead of walking thousands of ports.
+const X11_MAX_DISPLAYS: u16 = 64;
+
+/// Request a remote X11 listener on a conventional display port.
+///
+/// Scans display numbers `X11_DISPLAY_OFFSET .. + X11_MAX_DISPLAYS`, asking the
+/// SSH server to bind `localhost:6000+display` for each until one succeeds.
+/// Returns `(bound_port, display_number)` with `bound_port == 6000 + display`.
+///
+/// A specific-port `tcpip_forward` request is answered per RFC 4254 with **no**
+/// port (russh returns `0`), so — unlike a `port 0` request whose reply carries
+/// the actual high ephemeral port — success just means the server bound exactly
+/// the port we asked for. We therefore key off the requested port, yielding a
+/// small standard display number every X client accepts (issue #1304).
+async fn request_x11_display_forward(session: &SshSession) -> Result<(u32, u32), SessionError> {
+    for display_num in X11_DISPLAY_OFFSET..(X11_DISPLAY_OFFSET + X11_MAX_DISPLAYS) {
+        let port = 6000 + display_num as u32;
+        match session.tcpip_forward("localhost", port).await {
+            Ok(_) => return Ok((port, display_num as u32)),
+            Err(e) => {
+                debug!("X11 forwarding: display :{display_num} (port {port}) unavailable ({e})");
+            }
+        }
+    }
+    Err(SessionError::SpawnFailed(format!(
+        "X11 tcpip-forward failed: no free X11 display in :{}..:{}",
+        X11_DISPLAY_OFFSET,
+        X11_DISPLAY_OFFSET + X11_MAX_DISPLAYS
+    )))
+}
+
 /// Manages X11 forwarding over an SSH tunnel.
 pub struct X11Forwarder {
     alive: Arc<AtomicBool>,
@@ -218,12 +257,15 @@ impl X11Forwarder {
             );
         }
 
-        // Request the SSH server to listen for X11 connections on a random port.
-        let bound_port = session.tcpip_forward("localhost", 0).await.map_err(|e| {
-            SessionError::SpawnFailed(format!("X11 tcpip-forward request failed: {e}"))
-        })?;
-
-        let display_number = bound_port.saturating_sub(6000);
+        // Request the SSH server to listen for X11 connections on a conventional
+        // X11 display port. Mirroring OpenSSH (X11DisplayOffset / X11MaxDisplays),
+        // we scan display numbers from the offset and bind `6000 + display`, so
+        // the remote `$DISPLAY` is a small, standard number (`:10`, `:11`, …) that
+        // every X client accepts. Deriving the display from an arbitrary ephemeral
+        // port (a `port 0` request) instead yields values like `:26961` that
+        // stricter X clients refuse to connect to — so the forwarded X11
+        // connection is never opened and no channel reaches this forwarder (#1304).
+        let (bound_port, display_number) = request_x11_display_forward(session).await?;
         info!(
             "X11 forwarding: remote listening on port {} (display :{})",
             bound_port, display_number

--- a/core/tests/ssh_x11.rs
+++ b/core/tests/ssh_x11.rs
@@ -7,6 +7,7 @@
 //! (like OpenSSH's `X11DisplayOffset`) rather than deriving a huge display from
 //! an arbitrary ephemeral port (`:26961`), which stricter X clients reject so no
 //! forwarded channel is ever opened.
+#![cfg(feature = "ssh")]
 
 mod common;
 

--- a/core/tests/ssh_x11.rs
+++ b/core/tests/ssh_x11.rs
@@ -83,7 +83,8 @@ async fn x11_forwarding_delivers_channel_to_local_server() {
     // Run a real X client on the remote with the allocated display. It connects
     // to localhost:<remote_display> → sshd's forwarded listener → forwarded-tcpip
     // channel → our forwarder → the fake local X server.
-    let cmd = format!("DISPLAY=localhost:{remote_display} timeout 5 xdpyinfo >/dev/null 2>&1; echo DONE");
+    let cmd =
+        format!("DISPLAY=localhost:{remote_display} timeout 5 xdpyinfo >/dev/null 2>&1; echo DONE");
     let _ = ssh_exec(&session, &cmd).await;
 
     // Give the proxy a moment to accept the inbound connection.

--- a/core/tests/ssh_x11.rs
+++ b/core/tests/ssh_x11.rs
@@ -1,0 +1,102 @@
+//! Integration tests for SSH X11 forwarding against the `ssh-x11` Docker
+//! fixture (`tests/docker/ssh-x11`, published on 127.0.0.1:2208).
+//!
+//! Regression coverage for issue #1304: the forwarded X11 connection must
+//! actually reach termiHub's forwarder and be proxied to the local X server.
+//! The forwarder must allocate a **conventional, small** remote display number
+//! (like OpenSSH's `X11DisplayOffset`) rather than deriving a huge display from
+//! an arbitrary ephemeral port (`:26961`), which stricter X clients reject so no
+//! forwarded channel is ever opened.
+
+mod common;
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::{port_ssh_x11, require_docker, ssh_exec, ssh_password_config};
+use termihub_core::backends::ssh::x11::{
+    LocalXConnection, LocalXServerInfo, ResolvedXServer, X11Forwarder,
+};
+
+/// End-to-end: run a real X client on the remote and assert the forwarded X11
+/// connection reaches the forwarder and is proxied to the local X server, using
+/// a small conventional remote display number.
+#[tokio::test]
+async fn x11_forwarding_delivers_channel_to_local_server() {
+    require_docker!(port_ssh_x11());
+
+    // Fake local "X server": a loopback TCP listener the forwarder proxies to.
+    // A connection here proves the forwarded X11 channel reached the forwarder
+    // AND was routed through to the local X server.
+    let conns = Arc::new(AtomicU32::new(0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake local X server");
+    let local_port = listener.local_addr().unwrap().port();
+    {
+        let conns = conns.clone();
+        tokio::spawn(async move {
+            while let Ok((sock, _)) = listener.accept().await {
+                conns.fetch_add(1, Ordering::SeqCst);
+                // Hold the socket briefly so the proxy's copy loop stays alive.
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(300)).await;
+                    drop(sock);
+                });
+            }
+        });
+    }
+
+    let config = ssh_password_config(port_ssh_x11());
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (mut session, registry, _hold) =
+        termihub_core::backends::ssh::jump_host::connect_target(&config, Some(&cancel))
+            .await
+            .expect("connect ssh-x11");
+
+    // Point the forwarder at our fake local X server (cookieless).
+    let resolved = ResolvedXServer {
+        info: LocalXServerInfo {
+            display_number: 0,
+            connection: LocalXConnection::Tcp("127.0.0.1".to_string(), local_port),
+        },
+        cookie: None,
+    };
+
+    let alive = Arc::new(AtomicBool::new(true));
+    let (_forwarder, remote_display, _cookie) =
+        X11Forwarder::start(&config, &mut session, registry, alive, Some(resolved))
+            .await
+            .expect("start X11 forwarder");
+
+    // The remote display number must be small and conventional (OpenSSH uses
+    // X11DisplayOffset=10, so :10, :11, ...). The pre-fix code derived it from an
+    // ephemeral port (`bound_port - 6000`), producing values in the tens of
+    // thousands (e.g. :26961) that stricter X clients refuse to connect to.
+    assert!(
+        remote_display < 1000,
+        "remote display :{remote_display} must be a small conventional number, \
+         not an ephemeral-port-derived value"
+    );
+
+    // Run a real X client on the remote with the allocated display. It connects
+    // to localhost:<remote_display> → sshd's forwarded listener → forwarded-tcpip
+    // channel → our forwarder → the fake local X server.
+    let cmd = format!("DISPLAY=localhost:{remote_display} timeout 5 xdpyinfo >/dev/null 2>&1; echo DONE");
+    let _ = ssh_exec(&session, &cmd).await;
+
+    // Give the proxy a moment to accept the inbound connection.
+    for _ in 0..20 {
+        if conns.load(Ordering::SeqCst) > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        conns.load(Ordering::SeqCst) > 0,
+        "the forwarded X11 connection never reached the local X server \
+         (no channel proxied) — issue #1304"
+    );
+}

--- a/docs/changes/dev0/bugfix/1304-x11-forwarding-channel.md
+++ b/docs/changes/dev0/bugfix/1304-x11-forwarding-channel.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- SSH X11 forwarding: forwarded X11 apps (e.g. `xeyes`, `xclock`) now actually
+  open their window. termiHub requested the remote X11 listener on a random
+  ephemeral port and derived the display number from it, producing huge,
+  non-standard values like `:26961` that stricter X clients refuse to connect
+  to — so the forwarded connection was never made and no window appeared. The
+  forward is now allocated on a conventional X11 display port (like OpenSSH's
+  `X11DisplayOffset`, e.g. `:10`), which every X client accepts.

--- a/tests/system/tests/test_ssh.py
+++ b/tests/system/tests/test_ssh.py
@@ -237,6 +237,10 @@ def test_handles_server_disconnect():
     ...
 
 
-@pytest.mark.skip(reason="needs an X server on the host (SSH-07)")
+@pytest.mark.skip(
+    reason="needs an X server on the host (SSH-07); automated end-to-end X11 "
+    "forwarding is instead covered by core/tests/ssh_x11.rs, which uses a fake "
+    "loopback X server and needs no host display (issue #1304)"
+)
 def test_forwards_x11_applications():
     ...


### PR DESCRIPTION
## Summary

Fixes **#1304** — SSH X11 forwarding set up correctly (DISPLAY allocated, xauth cookie added, remote listening) but running an X11 app (`xeyes`/`xclock`) produced no window: the forwarded X11 connection never reached termiHub's forwarder.

## Root cause

`X11Forwarder::start` requested `tcpip_forward("localhost", 0)`, so sshd bound a **random ephemeral port** (e.g. 32961) and the code derived the remote display as `bound_port - 6000` — a huge, non-standard number like `:26961`. Modern Ubuntu Xlib tolerates it, but stricter X clients refuse such large display numbers, so the remote X client never opened a connection and no `forwarded-tcpip` channel ever reached the forwarder.

Reproduced against the `ssh-x11` Docker fixture: a raw TCP connect to the bound port delivered a channel fine, but a real X client with the huge `:26961`-style display did not — confirming the display number, not routing/address-family, was the culprit.

## Fix

Mirror OpenSSH: scan conventional X11 display ports (`6000 + display`, starting at `X11DisplayOffset = 10`) and bind the first free one, yielding small standard displays (`:10`, `:11`, …) every X client accepts. A protocol subtlety: a *specific-port* `tcpip_forward` request is answered per RFC 4254 with **no** port (russh returns `0`), so success means the server bound exactly the requested port — the registry is keyed off that.

The fix is contained entirely to the allocation step; the registry, forwarder task, connector wiring, and DISPLAY/xauth injection all consume `(bound_port, display_number)` unchanged. Exhausting the scan returns an actionable error, which the connector already treats as non-fatal (shell connects without forwarding).

## Testing

- **New regression test** `core/tests/ssh_x11.rs` — end-to-end against the `ssh-x11` fixture with a **fake loopback X server** (needs no host display, so it runs anywhere Docker runs). Asserts (1) the remote display number is small/conventional and (2) a real remote X client's forwarded connection reaches the forwarder and is proxied to the local X server. Confirmed **RED** on the old ephemeral scheme (`:32785`), **GREEN** after the fix.
- All 507 core `ssh` unit tests pass; clippy clean.
- Updated the previously-skipped `test_forwards_x11_applications` stub to point at this new automated coverage.

### Manual test plan
1. Bring up the `ssh-x11` fixture (port 2208), XQuartz running.
2. SSH to it via termiHub with X11 forwarding on (the default).
3. Run `xeyes` (or `xclock`) in the terminal → window appears.
   - Or run the guided-manual test: `./scripts/run-guided-manual.sh -k test_x11_forwarding_window_appears`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
