### PR TITLE
fix(ssh): connect to the existing XQuartz socket path for X11 forwarding (Closes #1311)

### DIFF
--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -623,6 +623,43 @@ mod tests {
         assert!(parse_display("").is_none());
     }
 
+    /// XQuartz's launchd `DISPLAY` is `<dir>/org.xquartz:0`, and the actual
+    /// socket file carries the `:0` suffix — there is no bare `<dir>/org.xquartz`
+    /// socket. The resolved Unix socket must point at the file that exists, or
+    /// the forwarder connects to a missing path and X11 forwarding fails with
+    /// ENOENT (#1311).
+    #[cfg(unix)]
+    #[test]
+    fn xquartz_launchd_socket_resolves_with_display_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("org.xquartz");
+        let base = base.to_str().unwrap().to_string();
+        let socket_with_suffix = format!("{base}:0");
+        std::fs::File::create(&socket_with_suffix).unwrap();
+
+        let info = info_from_parsed(Some(base), 0);
+        match info.connection {
+            LocalXConnection::UnixSocket(path) => assert_eq!(path, socket_with_suffix),
+            other => panic!("expected UnixSocket at the `:0` path, got {other:?}"),
+        }
+    }
+
+    /// A bare Unix socket at the exact `DISPLAY` host path is still used as-is.
+    #[cfg(unix)]
+    #[test]
+    fn bare_unix_socket_path_resolves_directly() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("Xserver");
+        let socket = socket.to_str().unwrap().to_string();
+        std::fs::File::create(&socket).unwrap();
+
+        let info = info_from_parsed(Some(socket.clone()), 3);
+        match info.connection {
+            LocalXConnection::UnixSocket(path) => assert_eq!(path, socket),
+            other => panic!("expected the bare UnixSocket path, got {other:?}"),
+        }
+    }
+
     #[test]
     fn parse_display_no_colon() {
         assert!(parse_display("nodisplay").is_none());

--- a/core/src/backends/ssh/x11.rs
+++ b/core/src/backends/ssh/x11.rs
@@ -416,12 +416,23 @@ fn info_from_parsed(host: Option<String>, display_number: u32) -> LocalXServerIn
         Some(ref h) if h.starts_with('/') => {
             #[cfg(unix)]
             {
-                if std::path::Path::new(h).exists()
-                    || std::path::Path::new(&format!("{h}:{display_number}")).exists()
-                {
+                // Connect to whichever socket file actually exists. A bare `<h>`
+                // socket is used directly; XQuartz's launchd socket instead
+                // carries the display suffix (`<h>:<N>`, e.g. `.../org.xquartz:0`)
+                // with no bare file, so we must use that path — connecting to the
+                // bare `<h>` fails with ENOENT (#1311).
+                let with_display = format!("{h}:{display_number}");
+                let socket = if std::path::Path::new(h).exists() {
+                    Some(h.clone())
+                } else if std::path::Path::new(&with_display).exists() {
+                    Some(with_display)
+                } else {
+                    None
+                };
+                if let Some(socket_path) = socket {
                     return LocalXServerInfo {
                         display_number,
-                        connection: LocalXConnection::UnixSocket(h.clone()),
+                        connection: LocalXConnection::UnixSocket(socket_path),
                     };
                 }
             }

--- a/docs/changes/dev0/bugfix/xquartz-socket-path.md
+++ b/docs/changes/dev0/bugfix/xquartz-socket-path.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- SSH X11 forwarding (macOS/XQuartz): forwarded X11 apps now reach the local X
+  server instead of failing with `Can't open display`. The forwarder resolved
+  XQuartz's launchd `DISPLAY` to the bare socket path (`…/org.xquartz`) when the
+  actual socket file is `…/org.xquartz:0` (with the display suffix), so proxying
+  the forwarded connection failed with `No such file or directory`. Local
+  X-server detection now connects to whichever socket path actually exists.

--- a/src-tauri/src/utils/x11_detect.rs
+++ b/src-tauri/src/utils/x11_detect.rs
@@ -74,22 +74,30 @@ fn info_from_parsed(host: Option<String>, display_number: u32) -> LocalXServerIn
             }
         }
         Some(ref h) if h.starts_with('/') => {
-            // macOS XQuartz: /private/tmp/com.apple.launchd.xxx/org.xquartz:0
-            if std::path::Path::new(h).exists()
-                || std::path::Path::new(&format!("{}:{}", h, display_number)).exists()
-            {
-                LocalXServerInfo {
-                    display_number,
-                    connection: LocalXConnection::UnixSocket(h.clone()),
-                }
+            // macOS XQuartz: /private/tmp/com.apple.launchd.xxx/org.xquartz:0.
+            // Connect to whichever socket file exists — XQuartz's launchd socket
+            // carries the `:<N>` display suffix with no bare file, so using the
+            // bare `<h>` would fail with ENOENT (#1311).
+            let with_display = format!("{}:{}", h, display_number);
+            let socket = if std::path::Path::new(h).exists() {
+                Some(h.clone())
+            } else if std::path::Path::new(&with_display).exists() {
+                Some(with_display)
             } else {
-                LocalXServerInfo {
+                None
+            };
+            match socket {
+                Some(socket_path) => LocalXServerInfo {
+                    display_number,
+                    connection: LocalXConnection::UnixSocket(socket_path),
+                },
+                None => LocalXServerInfo {
                     display_number,
                     connection: LocalXConnection::Tcp(
                         "localhost".to_string(),
                         6000 + display_number as u16,
                     ),
-                }
+                },
             }
         }
         Some(ref h) if h == "localhost" || h == "127.0.0.1" || h == "::1" => {

--- a/src-tauri/src/utils/x11_detect.rs
+++ b/src-tauri/src/utils/x11_detect.rs
@@ -232,6 +232,25 @@ mod tests {
         assert_eq!(screen, 0);
     }
 
+    /// XQuartz's launchd socket is `<dir>/org.xquartz:0` (with the `:0` suffix),
+    /// and there is no bare `<dir>/org.xquartz`. Resolution must use the path
+    /// that exists, else the forwarder connects to a missing socket (#1311).
+    #[cfg(unix)]
+    #[test]
+    fn test_xquartz_launchd_socket_resolves_with_display_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path().join("org.xquartz");
+        let base = base.to_str().unwrap().to_string();
+        let socket_with_suffix = format!("{base}:0");
+        std::fs::File::create(&socket_with_suffix).unwrap();
+
+        let info = info_from_parsed(Some(base), 0);
+        match info.connection {
+            LocalXConnection::UnixSocket(path) => assert_eq!(path, socket_with_suffix),
+            other => panic!("expected UnixSocket at the `:0` path, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_parse_display_xquartz() {
         let (host, display, screen) =


### PR DESCRIPTION
## Summary

Fixes **#1311** — on macOS/XQuartz, SSH X11 forwarding negotiated a display and the forwarded channel reached termiHub's forwarder (after #1304), but the forwarder then failed to proxy to the local X server, so `xeyes`/`xclock` reported `Can't open display` and no window appeared.

## Root cause

macOS `DISPLAY` is a launchd path like `/var/run/com.apple.launchd.XX/org.xquartz:0`. The **actual socket file is named `org.xquartz:0`** (with the `:N` display suffix); there is no bare `org.xquartz` socket. `info_from_parsed` checked whether either `<h>` **or** `<h>:<N>` existed but then always connected to the bare `<h>`:

```rust
if Path::new(h).exists() || Path::new(&format!("{h}:{display_number}")).exists() {
    return ... UnixSocket(h.clone())   // ← bare path, which does not exist for XQuartz
}
```

→ the proxy hit `ENOENT` (`No such file or directory`).

Confirmed live (app log, with the #1304 fix in place):

```
X11 forwarding: remote listening on port 6010 (display :10)
Incoming forwarded-tcpip channel  connected_port=6010
X11 forwarding: accepted new channel
X11 proxy: failed to connect to Unix socket
    /var/run/com.apple.launchd.dkmiabEweQ/org.xquartz: No such file or directory (os error 2)
```

## Fix

Resolve the local X server to whichever socket path actually **exists** — the bare `<h>` when present, else `<h>:<N>` (XQuartz). Applied to both detection copies: `core/src/backends/ssh/x11.rs` and `src-tauri/src/utils/x11_detect.rs`.

## Testing

- **TDD** unit tests in both files (test commit precedes fix): a temp socket named `…:0` resolves to the `:0` path; a bare socket path still resolves directly. Confirmed red before the fix, green after.
- All `x11` / `x11_detect` unit tests pass; clippy clean.
- **Verified end to end on macOS**: connecting to the `ssh-x11` fixture with X11 forwarding on, `echo $DISPLAY` → `localhost:10.0`, and `xeyes` now opens a window (rendered via XQuartz). (XQuartz accepts the cookieless local socket connection, so the separate `xauth list :0` gap does not block it here.)

### Manual test plan
1. XQuartz running; bring up the `ssh-x11` fixture (port 2208).
2. SSH to it via termiHub with X11 forwarding on (default).
3. Run `xeyes` → an xeyes window appears.

Follow-up to #1304 (PR #1308); surfaced during the #957 operator run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
