### PR TITLE
fix(ui): bridge select waits for async-mounted Radix listbox option

### DIFF
--- a/src/testbridge/dispatcher.select.test.tsx
+++ b/src/testbridge/dispatcher.select.test.tsx
@@ -76,6 +76,40 @@ describe("dispatchCommand select against the Select primitive", () => {
     expect(onChange).toHaveBeenCalledWith("serial");
   });
 
+  it("waits for a late-mounting listbox option (single call, no retry)", async () => {
+    // Regression for the guided-manual harness (issue: guided-manual Radix
+    // select): the Python bridge's `select` fires exactly one call with no
+    // retry, and Radix portals its listbox asynchronously, so the dispatcher
+    // must itself wait for the option to mount rather than checking once and
+    // failing. Simulate the async portal mount deterministically: the trigger
+    // carries the `ui-select__trigger` marker, and the matching option is
+    // appended a task later (as the real portal does) in response to the
+    // open keystroke. A single dispatch must still locate and click it.
+    const trigger = document.createElement("button");
+    trigger.setAttribute("data-testid", "sel");
+    trigger.className = "ui-select__trigger";
+    document.body.appendChild(trigger);
+
+    const clicked = vi.fn();
+    trigger.addEventListener("keydown", (e) => {
+      if ((e as KeyboardEvent).key !== "Enter") return;
+      setTimeout(() => {
+        const opt = document.createElement("div");
+        opt.className = "ui-select__item";
+        opt.setAttribute("data-value", "serial");
+        opt.addEventListener("click", () => clicked());
+        document.body.appendChild(opt);
+      }, 0);
+    });
+
+    const res = await dispatchCommand({ action: "select", testId: "sel", value: "serial" }, deps());
+
+    expect(res.ok).toBe(true);
+    expect(clicked).toHaveBeenCalledTimes(1);
+    trigger.remove();
+    document.querySelector('.ui-select__item[data-value="serial"]')?.remove();
+  });
+
   it("reports an error when the requested option is absent", async () => {
     act(() => {
       root.render(<Select data-testid="sel" value="local" onChange={() => {}} options={OPTIONS} />);

--- a/src/testbridge/dispatcher.ts
+++ b/src/testbridge/dispatcher.ts
@@ -124,7 +124,11 @@ function clickSequence(el: Element, x: number, y: number): void {
  * Radix portals its content, so options are searched in both the bridge root and
  * the owning document (where the portal lands under `<body>`).
  */
-function selectRadixOption(root: ParentNode, trigger: Element, value: string): string | null {
+async function selectRadixOption(
+  root: ParentNode,
+  trigger: Element,
+  value: string
+): Promise<string | null> {
   const escaped =
     typeof CSS !== "undefined" && typeof CSS.escape === "function"
       ? CSS.escape(value)
@@ -144,9 +148,16 @@ function selectRadixOption(root: ParentNode, trigger: Element, value: string): s
     new KeyboardEvent("keydown", { key: "Enter", code: "Enter", keyCode: 13, bubbles: true })
   );
 
-  // When the option has mounted, click it — otherwise return an error message so
-  // the harness (which wraps `select` in a retry) can try again on the next poll.
-  const option = findOption();
+  // Radix portals the listbox content asynchronously (open-state re-render +
+  // portal mount + position effect), so the option is usually not in the DOM on
+  // the same tick. Poll across a bounded number of frames before giving up — the
+  // live Python bridge issues a single `select` with no retry, so waiting here is
+  // what makes one call sufficient (SELECT_MOUNT_FRAMES × ~2 rAF ≈ up to ~1s).
+  let option = findOption();
+  for (let i = 0; i < SELECT_MOUNT_FRAMES && !option; i++) {
+    await nextFrame();
+    option = findOption();
+  }
   if (!option) {
     return `option "${value}" not found in the open Radix listbox`;
   }
@@ -154,6 +165,9 @@ function selectRadixOption(root: ParentNode, trigger: Element, value: string): s
   clickSequence(option, optAnchor.x, optAnchor.y);
   return null;
 }
+
+/** Frames to wait for a Radix listbox option to portal-mount before failing. */
+const SELECT_MOUNT_FRAMES = 30;
 
 /** Named DOM keys whose `code` / legacy `keyCode` aren't derivable from the char. */
 const NAMED_KEYS: Record<string, { code: string; keyCode: number }> = {
@@ -473,7 +487,7 @@ export async function dispatchCommand(
       // lands on the button trigger, not a native <select>. Drive it like a real
       // user — open the listbox, then click the option whose `data-value` matches.
       if (el.classList.contains("ui-select__trigger")) {
-        const err = selectRadixOption(deps.root, el, command.value);
+        const err = await selectRadixOption(deps.root, el, command.value);
         return err ? fail("select", err) : ok("select");
       }
 


### PR DESCRIPTION
## Summary

Fixes a test-bridge bug that broke **every guided-manual test which fills the SSH connection editor** on the modernized (Radix `Select`) UI — surfaced while running the #957 operator suite:

```
self.driver.select("field-authMethod", "password")
→ BridgeError: option "password" not found in the open Radix listbox
```

## Root cause

The Python bridge's `select` (`tests/system/.../bridge.py`) issues **exactly one** call with no retry. The dispatcher's `selectRadixOption` opened the listbox (focus + Enter) and then **synchronously** looked for the option — but Radix portals its listbox content asynchronously (open-state re-render + portal mount + position effect), so on a real WebView the option is not in the DOM on that tick. The code even assumed "the harness wraps `select` in a retry" — it does not — so the single shot failed and no SSH editor could be driven.

## Fix

Make `selectRadixOption` `async` and poll for the portalled option across a bounded number of frames (`nextFrame`, already used elsewhere in the dispatcher) before giving up, so a single bridge `select` is self-sufficient. `dispatchCommand` already returns a `Promise`, so this is a contained change.

## Testing

- **TDD** (test commit precedes fix): a regression asserting a single `dispatch` waits for a late-mounting listbox option and clicks it — red before the fix, green after.
- `dispatcher.select.test.tsx` + `dispatcher.radix.test.tsx` pass (5 tests); eslint + prettier clean.
- Verified in context: with this fix the guided-manual X11 test drives the SSH editor past the auth-method Select (which previously failed immediately).

This unblocks the automated guided-manual SSH-editor flow needed for the #957 operator run. Discovered during #957 (X11 forwarding verification, #1304/#1311).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
