### PR TITLE
feat(tunnel): native russh session-liveness watch (replace keepalive probe) (#1297)

### DIFF
--- a/core/src/backends/ssh/auth.rs
+++ b/core/src/backends/ssh/auth.rs
@@ -14,7 +14,7 @@ use crate::config::expand_config_value;
 use crate::config::SshConfig;
 use crate::errors::SessionError;
 
-use super::handler::{ForwardedChannelRegistry, SshSession, TermiHubHandler};
+use super::handler::{ForwardedChannelRegistry, LivenessWatch, SshSession, TermiHubHandler};
 use super::legacy_pem;
 
 /// Connect to an SSH server, perform handshake, and authenticate.
@@ -42,6 +42,20 @@ pub async fn connect_and_authenticate_cancellable(
     config: &SshConfig,
     cancel: Option<CancellationToken>,
 ) -> Result<(SshSession, ForwardedChannelRegistry), SessionError> {
+    let (session, registry, _liveness) =
+        connect_and_authenticate_cancellable_with_liveness(config, cancel).await?;
+    Ok((session, registry))
+}
+
+/// Like [`connect_and_authenticate_cancellable`], but also returns the native
+/// session-[`LivenessWatch`] (#1297) so a tunnel supervisor can observe true
+/// session death (transport failure / peer disconnect / keepalive miss) without
+/// polling a throwaway channel. Non-tunnel callers use the plain variant, which
+/// drops the watch.
+pub async fn connect_and_authenticate_cancellable_with_liveness(
+    config: &SshConfig,
+    cancel: Option<CancellationToken>,
+) -> Result<(SshSession, ForwardedChannelRegistry, LivenessWatch), SessionError> {
     let timeout = config.connect_timeout();
     let connect = async {
         tokio::time::timeout(timeout, do_connect_and_authenticate(config))
@@ -70,11 +84,11 @@ pub async fn connect_and_authenticate_cancellable(
 
 /// Establish the TCP connection, run the SSH handshake, and authenticate.
 ///
-/// Kept separate so [`connect_and_authenticate_cancellable`] can wrap it in a
-/// timeout and an optional cancellation `select!`.
+/// Kept separate so [`connect_and_authenticate_cancellable_with_liveness`] can
+/// wrap it in a timeout and an optional cancellation `select!`.
 async fn do_connect_and_authenticate(
     config: &SshConfig,
-) -> Result<(SshSession, ForwardedChannelRegistry), SessionError> {
+) -> Result<(SshSession, ForwardedChannelRegistry, LivenessWatch), SessionError> {
     let addr = format!("{}:{}", config.host, config.port);
 
     // Async connect so the surrounding connect timeout / cancellation token can
@@ -100,18 +114,20 @@ async fn do_connect_and_authenticate(
 async fn handshake_and_authenticate<S>(
     config: &SshConfig,
     stream: S,
-) -> Result<(SshSession, ForwardedChannelRegistry), SessionError>
+) -> Result<(SshSession, ForwardedChannelRegistry, LivenessWatch), SessionError>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     let russh_config = Arc::new(russh::client::Config {
-        // SSH-level keepalives: send every 30 s, abort after 3 unanswered.
+        // SSH-level keepalives: send every 30 s, abort after 3 unanswered. On
+        // exhaustion russh ends the session task and fires the handler's
+        // `disconnected`, which drives the native liveness watch (#1297).
         keepalive_interval: Some(Duration::from_secs(30)),
         keepalive_max: 3,
         ..Default::default()
     });
 
-    let (handler, registry) = TermiHubHandler::new();
+    let (handler, registry, liveness) = TermiHubHandler::new();
 
     let mut session = russh::client::connect_stream(russh_config, stream, handler)
         .await
@@ -119,7 +135,7 @@ where
 
     authenticate(&mut session, config).await?;
 
-    Ok((session, registry))
+    Ok((session, registry, liveness))
 }
 
 /// Establish and authenticate an SSH session over an existing forwarded channel.
@@ -138,6 +154,18 @@ pub async fn connect_and_authenticate_over_channel(
     config: &SshConfig,
     channel: russh::Channel<russh::client::Msg>,
 ) -> Result<(SshSession, ForwardedChannelRegistry), SessionError> {
+    let (session, registry, _liveness) =
+        connect_and_authenticate_over_channel_with_liveness(config, channel).await?;
+    Ok((session, registry))
+}
+
+/// Like [`connect_and_authenticate_over_channel`], but also returns the native
+/// session-[`LivenessWatch`] (#1297) for the jump-host tunnel path. Non-tunnel
+/// jump-host callers use the plain variant, which drops the watch.
+pub async fn connect_and_authenticate_over_channel_with_liveness(
+    config: &SshConfig,
+    channel: russh::Channel<russh::client::Msg>,
+) -> Result<(SshSession, ForwardedChannelRegistry, LivenessWatch), SessionError> {
     handshake_and_authenticate(config, channel.into_stream()).await
 }
 

--- a/core/src/backends/ssh/handler.rs
+++ b/core/src/backends/ssh/handler.rs
@@ -23,10 +23,11 @@ pub type SshSession = russh::client::Handle<TermiHubHandler>;
 /// Resolves once the session's russh background task has ended — a transport
 /// failure, a peer `SSH_MSG_DISCONNECT`, or keepalive exhaustion (configured at
 /// 30 s × 3 in `auth.rs`). Event-driven: [`TermiHubHandler`] fires it from russh's
-/// `disconnected` callback (and its `Drop` closes the channel as a backstop), so
-/// the tunnel supervisor observes true session death without polling a throwaway
-/// channel every ~20 s. `Clone` fans one shared pooled session out to every
-/// tunnel supervising it.
+/// `disconnected` callback; and because the handler owns the sender, the sender
+/// dropping with the handler (when the session task ends) closes the channel as a
+/// backstop. Either way the tunnel supervisor observes true session death without
+/// polling a throwaway channel every ~20 s. `Clone` fans one shared pooled session
+/// out to every tunnel supervising it.
 #[derive(Clone)]
 pub struct LivenessWatch {
     rx: watch::Receiver<bool>,
@@ -66,7 +67,8 @@ pub struct TermiHubHandler {
     pub forwarded_channel_registry: ForwardedChannelRegistry,
     /// Fires the session-liveness watch (`true` = dead) when the session dies
     /// (#1297). Lives in the handler — which russh owns inside the session's
-    /// background task — so its `disconnected` callback and `Drop` both signal.
+    /// background task — so `disconnected` signals explicitly, and the sender
+    /// dropping with the handler (task end) closes the channel as a backstop.
     liveness_tx: watch::Sender<bool>,
 }
 

--- a/core/src/backends/ssh/handler.rs
+++ b/core/src/backends/ssh/handler.rs
@@ -8,12 +8,41 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::watch;
 use tracing::debug;
 
 /// Convenience alias for the connected session handle.
 ///
-/// `Handle` is cheaply `Clone + Send + Sync` — share it freely.
+/// In russh 0.61 `Handle` is **not** `Clone` (it owns the session task's join
+/// handle and reply receiver); share it via `Arc<SshSession>`, as the pooled
+/// endpoint / gateway sessions do.
 pub type SshSession = russh::client::Handle<TermiHubHandler>;
+
+/// A watch on an SSH session's liveness (#1297).
+///
+/// Resolves once the session's russh background task has ended — a transport
+/// failure, a peer `SSH_MSG_DISCONNECT`, or keepalive exhaustion (configured at
+/// 30 s × 3 in `auth.rs`). Event-driven: [`TermiHubHandler`] fires it from russh's
+/// `disconnected` callback (and its `Drop` closes the channel as a backstop), so
+/// the tunnel supervisor observes true session death without polling a throwaway
+/// channel every ~20 s. `Clone` fans one shared pooled session out to every
+/// tunnel supervising it.
+#[derive(Clone)]
+pub struct LivenessWatch {
+    rx: watch::Receiver<bool>,
+}
+
+impl LivenessWatch {
+    /// Resolve once the session is dead. Returns immediately if it already died.
+    ///
+    /// `true` means dead — the handler flips it on disconnect. A dropped sender
+    /// (the handler was dropped without an explicit `disconnected`, e.g. the last
+    /// handle went away) makes `wait_for` return `Err` and is likewise treated as
+    /// death, so the watch never hangs a supervisor on a vanished session.
+    pub async fn dead(&mut self) {
+        let _ = self.rx.wait_for(|&dead| dead).await;
+    }
+}
 
 /// An incoming forwarded channel from the SSH server (remote-port-forward / X11).
 pub struct IncomingChannel {
@@ -35,16 +64,23 @@ pub type ForwardedChannelRegistry = Arc<Mutex<HashMap<u32, UnboundedSender<Incom
 /// Forwarded-channel notifications are routed via [`ForwardedChannelRegistry`].
 pub struct TermiHubHandler {
     pub forwarded_channel_registry: ForwardedChannelRegistry,
+    /// Fires the session-liveness watch (`true` = dead) when the session dies
+    /// (#1297). Lives in the handler — which russh owns inside the session's
+    /// background task — so its `disconnected` callback and `Drop` both signal.
+    liveness_tx: watch::Sender<bool>,
 }
 
 impl TermiHubHandler {
-    /// Create a new handler together with the shared channel registry.
-    pub fn new() -> (Self, ForwardedChannelRegistry) {
+    /// Create a new handler together with the shared channel registry and the
+    /// session-liveness watch (#1297) the tunnel supervisor observes.
+    pub fn new() -> (Self, ForwardedChannelRegistry, LivenessWatch) {
         let registry: ForwardedChannelRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (liveness_tx, liveness_rx) = watch::channel(false);
         let handler = Self {
             forwarded_channel_registry: registry.clone(),
+            liveness_tx,
         };
-        (handler, registry)
+        (handler, registry, LivenessWatch { rx: liveness_rx })
     }
 }
 
@@ -56,6 +92,26 @@ impl Default for TermiHubHandler {
 
 impl russh::client::Handler for TermiHubHandler {
     type Error = russh::Error;
+
+    /// Fire the session-liveness watch on session death, then preserve russh's
+    /// default disconnect semantics (#1297).
+    ///
+    /// russh calls this from the session's run loop on both death paths — a peer
+    /// `SSH_MSG_DISCONNECT` (`ReceivedDisconnect`) and a transport error /
+    /// keepalive timeout (`Error`) — so flipping the watch here surfaces true
+    /// session death to the tunnel supervisor promptly and without polling. The
+    /// returned `Result` mirrors the trait default so we don't alter how russh
+    /// treats the disconnect.
+    async fn disconnected(
+        &mut self,
+        reason: russh::client::DisconnectReason<Self::Error>,
+    ) -> Result<(), Self::Error> {
+        let _ = self.liveness_tx.send(true);
+        match reason {
+            russh::client::DisconnectReason::ReceivedDisconnect(_) => Ok(()),
+            russh::client::DisconnectReason::Error(e) => Err(e),
+        }
+    }
 
     /// Accept the server's host key without verification.
     ///
@@ -96,5 +152,77 @@ impl russh::client::Handler for TermiHubHandler {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Session-liveness watch (#1297). The watch is the native, event-driven
+    //! replacement for the tunnel supervisor's ~20 s `channel_open_session`
+    //! keepalive poll: the handler fires it from russh's `disconnected` callback
+    //! (and its `Drop` as a backstop), so these exercise both firing paths and
+    //! the live-session (never-resolve) contract without a real SSH server.
+
+    use super::*;
+    use russh::client::{DisconnectReason, Handler};
+    use std::time::Duration;
+
+    /// A live session's watch must never resolve — the supervisor keeps waiting
+    /// on it rather than tearing a healthy tunnel down.
+    #[tokio::test]
+    async fn watch_pending_while_session_alive() {
+        let (_handler, _registry, mut watch) = TermiHubHandler::new();
+        let res = tokio::time::timeout(Duration::from_millis(50), watch.dead()).await;
+        assert!(res.is_err(), "a live session must not report dead");
+    }
+
+    /// russh's `disconnected` callback (peer disconnect / transport error /
+    /// keepalive timeout) must flip the watch so the supervisor sees death.
+    #[tokio::test]
+    async fn watch_fires_on_disconnected_callback() {
+        let (mut handler, _registry, mut watch) = TermiHubHandler::new();
+        // A keepalive timeout is the silent-death case S2 targets.
+        let _ = handler
+            .disconnected(DisconnectReason::Error(russh::Error::KeepaliveTimeout))
+            .await;
+        tokio::time::timeout(Duration::from_millis(50), watch.dead())
+            .await
+            .expect("watch must resolve after disconnected fired");
+    }
+
+    /// Dropping the handler (the session task ended by any path) also resolves
+    /// the watch — the backstop so a vanished session never hangs a supervisor.
+    #[tokio::test]
+    async fn watch_fires_on_handler_drop() {
+        let (handler, _registry, mut watch) = TermiHubHandler::new();
+        drop(handler);
+        tokio::time::timeout(Duration::from_millis(50), watch.dead())
+            .await
+            .expect("watch must resolve after the handler is dropped");
+    }
+
+    /// A shared pooled session fans out to many supervisors: a cloned watch must
+    /// observe the same death (`watch::Receiver` is multi-consumer).
+    #[tokio::test]
+    async fn cloned_watch_also_fires() {
+        let (mut handler, _registry, watch) = TermiHubHandler::new();
+        let mut clone = watch.clone();
+        let _ = handler
+            .disconnected(DisconnectReason::Error(russh::Error::KeepaliveTimeout))
+            .await;
+        tokio::time::timeout(Duration::from_millis(50), clone.dead())
+            .await
+            .expect("a cloned watch must also see the session die");
+    }
+
+    /// `disconnected` must preserve russh's default result so we don't change how
+    /// russh treats the disconnect: `Error` propagates, `ReceivedDisconnect` is Ok.
+    #[tokio::test]
+    async fn disconnected_preserves_default_result() {
+        let (mut handler, _registry, _watch) = TermiHubHandler::new();
+        let err = handler
+            .disconnected(DisconnectReason::Error(russh::Error::KeepaliveTimeout))
+            .await;
+        assert!(err.is_err(), "an Error disconnect must propagate the error");
     }
 }

--- a/core/src/backends/ssh/jump_host.rs
+++ b/core/src/backends/ssh/jump_host.rs
@@ -19,8 +19,11 @@ use tokio_util::sync::CancellationToken;
 use crate::config::{JumpHostConfig, SshConfig};
 use crate::errors::SessionError;
 
-use super::auth::{connect_and_authenticate_cancellable, connect_and_authenticate_over_channel};
-use super::handler::{ForwardedChannelRegistry, SshSession};
+use super::auth::{
+    connect_and_authenticate_cancellable, connect_and_authenticate_over_channel,
+    connect_and_authenticate_over_channel_with_liveness,
+};
+use super::handler::{ForwardedChannelRegistry, LivenessWatch, SshSession};
 use super::session_pool::{shared_gateway_pool, PooledRef, SshGateway};
 
 /// A reference-counted hold on a pooled, shared gateway session.
@@ -295,6 +298,29 @@ async fn connect_hop_over_channel(
     .await
 }
 
+/// Like [`connect_hop_over_channel`], but also surfaces the target session's
+/// native [`LivenessWatch`] (#1297). Used for the **final target** hop on the
+/// tunnel path so its supervisor can observe session death; the intermediate
+/// gateway hops use the plain variant (a hop's death surfaces through the target
+/// session that rides over it).
+async fn connect_hop_over_channel_with_liveness(
+    current: &SshSession,
+    cfg: &SshConfig,
+    label: &str,
+    cancel: Option<&CancellationToken>,
+) -> Result<(SshSession, ForwardedChannelRegistry, LivenessWatch), SessionError> {
+    run_hop_step(label, cfg.connect_timeout(), cancel, async {
+        let channel = current
+            .channel_open_direct_tcpip(&cfg.host, cfg.port as u32, "localhost", 0)
+            .await
+            .map_err(|e| {
+                SessionError::SpawnFailed(format!("Jump host {label} channel failed: {e}"))
+            })?;
+        connect_and_authenticate_over_channel_with_liveness(cfg, channel).await
+    })
+    .await
+}
+
 /// Stable pool key for a jump-host chain.
 ///
 /// Two connections whose chains resolve to the same ordered hops share one
@@ -390,6 +416,17 @@ async fn open_target_over_gateway(
     connect_hop_over_channel(gateway, target, &label, cancel).await
 }
 
+/// Like [`open_target_over_gateway`], but also surfaces the target session's
+/// native [`LivenessWatch`] (#1297) for the jump-host tunnel path.
+async fn open_target_over_gateway_with_liveness(
+    gateway: &SshSession,
+    target: &SshConfig,
+    cancel: Option<&CancellationToken>,
+) -> Result<(SshSession, ForwardedChannelRegistry, LivenessWatch), SessionError> {
+    let label = format!("target {}:{}", target.host, target.port);
+    connect_hop_over_channel_with_liveness(gateway, target, &label, cancel).await
+}
+
 /// Connect to `target` through its [`SshConfig::proxy_jump`] chain, reusing a
 /// **pooled, shared** gateway session.
 ///
@@ -430,6 +467,38 @@ pub async fn connect_target_through_pooled_gateway(
 
     let (session, registry) = open_target_over_gateway(&gateway.session, target, cancel).await?;
     Ok((session, registry, gateway))
+}
+
+/// Like [`connect_target_through_pooled_gateway`], but also returns the target
+/// session's native [`LivenessWatch`] (#1297) so a jump-host tunnel supervisor
+/// can observe true session death without polling. Non-tunnel callers use the
+/// plain variant, which drops the watch.
+pub async fn connect_target_through_pooled_gateway_with_liveness(
+    target: &SshConfig,
+    cancel: Option<&CancellationToken>,
+) -> Result<
+    (
+        SshSession,
+        ForwardedChannelRegistry,
+        PooledRef<Arc<SshGateway>>,
+        LivenessWatch,
+    ),
+    SessionError,
+> {
+    let pool = shared_gateway_pool();
+    let key = gateway_pool_key(&target.proxy_jump);
+
+    let gateway = pool
+        .get_or_create(&key, || async {
+            connect_gateway_chain(&target.proxy_jump, cancel)
+                .await
+                .map(Arc::new)
+        })
+        .await?;
+
+    let (session, registry, liveness) =
+        open_target_over_gateway_with_liveness(&gateway.session, target, cancel).await?;
+    Ok((session, registry, gateway, liveness))
 }
 
 /// Connect to `target`, honoring its [`SshConfig::proxy_jump`] chain.

--- a/core/src/backends/ssh/jump_host.rs
+++ b/core/src/backends/ssh/jump_host.rs
@@ -20,8 +20,7 @@ use crate::config::{JumpHostConfig, SshConfig};
 use crate::errors::SessionError;
 
 use super::auth::{
-    connect_and_authenticate_cancellable, connect_and_authenticate_over_channel,
-    connect_and_authenticate_over_channel_with_liveness,
+    connect_and_authenticate_cancellable, connect_and_authenticate_over_channel_with_liveness,
 };
 use super::handler::{ForwardedChannelRegistry, LivenessWatch, SshSession};
 use super::session_pool::{shared_gateway_pool, PooledRef, SshGateway};
@@ -286,16 +285,9 @@ async fn connect_hop_over_channel(
     label: &str,
     cancel: Option<&CancellationToken>,
 ) -> Result<(SshSession, ForwardedChannelRegistry), SessionError> {
-    run_hop_step(label, cfg.connect_timeout(), cancel, async {
-        let channel = current
-            .channel_open_direct_tcpip(&cfg.host, cfg.port as u32, "localhost", 0)
-            .await
-            .map_err(|e| {
-                SessionError::SpawnFailed(format!("Jump host {label} channel failed: {e}"))
-            })?;
-        connect_and_authenticate_over_channel(cfg, channel).await
-    })
-    .await
+    let (session, registry, _liveness) =
+        connect_hop_over_channel_with_liveness(current, cfg, label, cancel).await?;
+    Ok((session, registry))
 }
 
 /// Like [`connect_hop_over_channel`], but also surfaces the target session's
@@ -412,8 +404,9 @@ async fn open_target_over_gateway(
     target: &SshConfig,
     cancel: Option<&CancellationToken>,
 ) -> Result<(SshSession, ForwardedChannelRegistry), SessionError> {
-    let label = format!("target {}:{}", target.host, target.port);
-    connect_hop_over_channel(gateway, target, &label, cancel).await
+    let (session, registry, _liveness) =
+        open_target_over_gateway_with_liveness(gateway, target, cancel).await?;
+    Ok((session, registry))
 }
 
 /// Like [`open_target_over_gateway`], but also surfaces the target session's
@@ -454,18 +447,8 @@ pub async fn connect_target_through_pooled_gateway(
     ),
     SessionError,
 > {
-    let pool = shared_gateway_pool();
-    let key = gateway_pool_key(&target.proxy_jump);
-
-    let gateway = pool
-        .get_or_create(&key, || async {
-            connect_gateway_chain(&target.proxy_jump, cancel)
-                .await
-                .map(Arc::new)
-        })
-        .await?;
-
-    let (session, registry) = open_target_over_gateway(&gateway.session, target, cancel).await?;
+    let (session, registry, gateway, _liveness) =
+        connect_target_through_pooled_gateway_with_liveness(target, cancel).await?;
     Ok((session, registry, gateway))
 }
 

--- a/docs/changes/dev2/feature/1297-tunnel-native-liveness.md
+++ b/docs/changes/dev2/feature/1297-tunnel-native-liveness.md
@@ -1,0 +1,9 @@
+### Changed
+
+- SSH tunnels now detect a dead SSH session **natively and event-driven** instead
+  of polling. A tunnel whose SSH session dies (transport failure, peer disconnect,
+  or keepalive miss) transitions to `Error` (or enters reconnect) promptly, driven
+  by a russh session-liveness watch rather than the previous ~20 s keepalive probe
+  that opened a throwaway SSH channel on every tick. Faster, quieter dead-tunnel
+  detection with no extra channel churn; covers both direct and jump-host tunnels
+  (#1297).

--- a/src-tauri/src/tunnel/tunnel_manager.rs
+++ b/src-tauri/src/tunnel/tunnel_manager.rs
@@ -5,9 +5,9 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
-use termihub_core::backends::ssh::auth::connect_and_authenticate_cancellable as core_connect_cancellable;
-use termihub_core::backends::ssh::handler::{ForwardedChannelRegistry, SshSession};
-use termihub_core::backends::ssh::jump_host::connect_target_through_pooled_gateway;
+use termihub_core::backends::ssh::auth::connect_and_authenticate_cancellable_with_liveness as core_connect_cancellable_with_liveness;
+use termihub_core::backends::ssh::handler::{ForwardedChannelRegistry, LivenessWatch, SshSession};
+use termihub_core::backends::ssh::jump_host::connect_target_through_pooled_gateway_with_liveness;
 use termihub_core::backends::ssh::session_pool::{PooledRef, RefPool, SshGateway};
 use tokio_util::sync::CancellationToken;
 
@@ -36,6 +36,28 @@ fn block_on_runtime<F: std::future::Future>(fut: F) -> F::Output {
     tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut))
 }
 
+/// A pooled endpoint SSH session together with its native liveness watch (#1297).
+///
+/// Pooled by connection id so every local/dynamic tunnel sharing the endpoint
+/// session also shares one [`LivenessWatch`] (cloned per supervisor); dropping the
+/// last pool reference drains the session. Bundling the watch with the session in
+/// the pooled value is what lets a shared session's death fan out to every
+/// supervisor riding it.
+struct LiveEndpoint {
+    session: Arc<SshSession>,
+    liveness: LivenessWatch,
+}
+
+/// What a jump-host tunnel connect yields: the target session, its forwarded-
+/// channel registry, the pooled gateway hold to keep alive for the session's
+/// lifetime, and the native session-[`LivenessWatch`] (#1297).
+type GatewayConnect = (
+    SshSession,
+    ForwardedChannelRegistry,
+    PooledRef<Arc<SshGateway>>,
+    LivenessWatch,
+);
+
 /// RAII holder for the pool references a tunnel's SSH session(s) depend on.
 ///
 /// Dropping it returns the references to their pools, draining sessions no
@@ -48,7 +70,7 @@ fn block_on_runtime<F: std::future::Future>(fut: F) -> F::Output {
 struct PooledSessionGuards {
     /// Pooled endpoint session, shared by local/dynamic forwarders on the same
     /// connection. `None` when the endpoint is reached through a jump host.
-    endpoint: Option<PooledRef<Arc<SshSession>>>,
+    endpoint: Option<PooledRef<Arc<LiveEndpoint>>>,
     /// Pooled jump-host gateway session shared across all connections that use
     /// the same bastion. `None` for direct (non-jump) connections.
     gateway: Option<PooledRef<Arc<SshGateway>>>,
@@ -56,7 +78,7 @@ struct PooledSessionGuards {
 
 impl PooledSessionGuards {
     /// Hold a pooled per-connection endpoint session.
-    fn endpoint(endpoint: PooledRef<Arc<SshSession>>) -> Self {
+    fn endpoint(endpoint: PooledRef<Arc<LiveEndpoint>>) -> Self {
         Self {
             endpoint: Some(endpoint),
             gateway: None,
@@ -227,7 +249,7 @@ pub struct TunnelManager {
     /// Pool of SSH endpoint sessions shared by local/dynamic forwarders on the
     /// same connection. Jump-host gateway sessions are pooled separately in the
     /// process-wide [`shared_gateway_pool`](termihub_core::backends::ssh::session_pool::shared_gateway_pool).
-    endpoint_pool: Arc<RefPool<Arc<SshSession>>>,
+    endpoint_pool: Arc<RefPool<Arc<LiveEndpoint>>>,
     app_handle: AppHandle,
     recovery_warnings: Mutex<Vec<RecoveryWarning>>,
     /// Handle to the single periodic live-stats emitter task (GAP 6, #1248).
@@ -421,7 +443,7 @@ impl TunnelManager {
         // handshake). On failure, surface it as `error` status instead of
         // leaving the tunnel stuck in `connecting` (#829) — unless a Stop was
         // requested mid-connect, in which case it has already gone disconnected.
-        let (forwarder, guards, probe) = match self.build_forwarder(&config, cancel) {
+        let (forwarder, guards, liveness) = match self.build_forwarder(&config, cancel) {
             Ok(built) => built,
             Err(e) => {
                 match self.connecting.finish(tunnel_id) {
@@ -456,7 +478,7 @@ impl TunnelManager {
             tunnel_id,
             forwarder,
             guards,
-            probe,
+            liveness,
             config.reconnect_on_disconnect,
         )?;
 
@@ -542,41 +564,32 @@ impl TunnelManager {
         &self,
         config: &TunnelConfig,
         cancel: CancellationToken,
-    ) -> Result<
-        (
-            ActiveForwarder,
-            PooledSessionGuards,
-            Option<Arc<SshSession>>,
-        ),
-        TerminalError,
-    > {
+    ) -> Result<(ActiveForwarder, PooledSessionGuards, Option<LivenessWatch>), TerminalError> {
         let ssh_config = self.resolve_ssh_config(&config.ssh_connection_id)?;
         let conn_id = &config.ssh_connection_id;
         let jumped = !ssh_config.proxy_jump.is_empty();
 
-        // The returned `Arc<SshSession>` is a probe handle the supervisor
-        // keepalive-pings so a dead SSH session surfaces as `Error` even while the
-        // local listener keeps accepting (#1243, GAP 1). Remote forwards own a
-        // dedicated non-`Arc` session (russh `Handle` is not `Clone`), so they get
-        // no probe here and rely on the forwarder death signal.
+        // The returned [`LivenessWatch`] is the native, event-driven session-death
+        // signal the supervisor selects over so a dead SSH session surfaces as
+        // `Error` even while the local listener keeps accepting (#1243/#1297, GAP 1).
+        // Remote forwards own a dedicated session driven purely by the forwarder
+        // death signal, so they get no watch here (`None`).
         match &config.tunnel_type {
             TunnelType::Local(local_config) => {
-                let (session, guards) =
+                let (session, guards, liveness) =
                     self.acquire_endpoint(conn_id, &ssh_config, cancel, jumped)?;
-                let probe = Some(Arc::clone(&session));
                 let f = LocalForwarder::start(local_config, session).map_err(|e| {
                     TerminalError::TunnelError(format!("Failed to start local forwarder: {}", e))
                 })?;
-                Ok((ActiveForwarder::Local(f), guards, probe))
+                Ok((ActiveForwarder::Local(f), guards, Some(liveness)))
             }
             TunnelType::Dynamic(dynamic_config) => {
-                let (session, guards) =
+                let (session, guards, liveness) =
                     self.acquire_endpoint(conn_id, &ssh_config, cancel, jumped)?;
-                let probe = Some(Arc::clone(&session));
                 let f = DynamicForwarder::start(dynamic_config, session).map_err(|e| {
                     TerminalError::TunnelError(format!("Failed to start dynamic forwarder: {}", e))
                 })?;
-                Ok((ActiveForwarder::Dynamic(f), guards, probe))
+                Ok((ActiveForwarder::Dynamic(f), guards, Some(liveness)))
             }
             TunnelType::Remote(remote_config) => {
                 // Remote forwarding needs tcpip_forward (&mut SshSession), so it always gets
@@ -604,20 +617,33 @@ impl TunnelManager {
         ssh_config: &SshConfig,
         cancel: CancellationToken,
         jumped: bool,
-    ) -> Result<(Arc<SshSession>, PooledSessionGuards), TerminalError> {
+    ) -> Result<(Arc<SshSession>, PooledSessionGuards, LivenessWatch), TerminalError> {
         if jumped {
-            let (session, _registry, gateway) = self.connect_through_gateway(ssh_config, cancel)?;
-            Ok((Arc::new(session), PooledSessionGuards::gateway(gateway)))
+            let (session, _registry, gateway, liveness) =
+                self.connect_through_gateway(ssh_config, cancel)?;
+            Ok((
+                Arc::new(session),
+                PooledSessionGuards::gateway(gateway),
+                liveness,
+            ))
         } else {
             let endpoint =
                 block_on_runtime(self.endpoint_pool.get_or_create(conn_id, || async move {
-                    core_connect_cancellable(ssh_config, Some(cancel))
+                    core_connect_cancellable_with_liveness(ssh_config, Some(cancel))
                         .await
-                        .map(|(session, _registry)| Arc::new(session))
+                        .map(|(session, _registry, liveness)| {
+                            Arc::new(LiveEndpoint {
+                                session: Arc::new(session),
+                                liveness,
+                            })
+                        })
                         .map_err(|e| TerminalError::SshError(e.to_string()))
                 }))?;
-            let session = (*endpoint).clone();
-            Ok((session, PooledSessionGuards::endpoint(endpoint)))
+            // Each supervisor gets its own watch receiver clone, so one shared
+            // pooled session's death fans out to every tunnel riding it (#1297).
+            let session = endpoint.session.clone();
+            let liveness = endpoint.liveness.clone();
+            Ok((session, PooledSessionGuards::endpoint(endpoint), liveness))
         }
     }
 
@@ -630,7 +656,10 @@ impl TunnelManager {
         jumped: bool,
     ) -> Result<(SshSession, ForwardedChannelRegistry, PooledSessionGuards), TerminalError> {
         if jumped {
-            let (session, registry, gateway) = self.connect_through_gateway(ssh_config, cancel)?;
+            // Remote forwards rely on the forwarder death signal, not the session
+            // liveness watch, so the watch is dropped here.
+            let (session, registry, gateway, _liveness) =
+                self.connect_through_gateway(ssh_config, cancel)?;
             Ok((session, registry, PooledSessionGuards::gateway(gateway)))
         } else {
             let (session, registry) = connect_with_registry_cancellable(ssh_config, cancel)
@@ -645,21 +674,14 @@ impl TunnelManager {
         &self,
         ssh_config: &SshConfig,
         cancel: CancellationToken,
-    ) -> Result<
-        (
-            SshSession,
-            ForwardedChannelRegistry,
-            PooledRef<Arc<SshGateway>>,
-        ),
-        TerminalError,
-    > {
+    ) -> Result<GatewayConnect, TerminalError> {
         block_on_runtime(async move {
             tokio::select! {
                 biased;
                 _ = cancel.cancelled() => {
                     Err(TerminalError::TunnelError("SSH connect cancelled".to_string()))
                 }
-                res = connect_target_through_pooled_gateway(ssh_config, Some(&cancel)) => {
+                res = connect_target_through_pooled_gateway_with_liveness(ssh_config, Some(&cancel)) => {
                     res.map_err(|e| TerminalError::SshError(e.to_string()))
                 }
             }
@@ -681,7 +703,7 @@ impl TunnelManager {
         tunnel_id: &str,
         mut forwarder: ActiveForwarder,
         guards: PooledSessionGuards,
-        probe: Option<Arc<SshSession>>,
+        liveness: Option<LivenessWatch>,
         reconnect_on_disconnect: bool,
     ) -> Result<(), TerminalError> {
         let death = forwarder.take_death_signal();
@@ -693,7 +715,7 @@ impl TunnelManager {
         let supervisor = self.spawn_supervisor(
             tunnel_id.to_string(),
             death,
-            probe,
+            liveness,
             supervisor_cancel.clone(),
             reconnect_on_disconnect,
         );
@@ -734,13 +756,13 @@ impl TunnelManager {
                 return false;
             }
         };
-        let (forwarder, guards, probe) = built;
+        let (forwarder, guards, liveness) = built;
         if self
             .register_and_supervise(
                 tunnel_id,
                 forwarder,
                 guards,
-                probe,
+                liveness,
                 config.reconnect_on_disconnect,
             )
             .is_err()
@@ -758,7 +780,7 @@ impl TunnelManager {
         &self,
         tunnel_id: String,
         death: Option<tokio::sync::oneshot::Receiver<()>>,
-        probe: Option<Arc<SshSession>>,
+        liveness: Option<LivenessWatch>,
         cancel: CancellationToken,
         reconnect_on_disconnect: bool,
     ) -> tokio::task::JoinHandle<()> {
@@ -774,7 +796,7 @@ impl TunnelManager {
                 app_handle,
                 tunnel_id,
                 death,
-                probe,
+                liveness,
                 cancel,
                 reconnect_on_disconnect,
             )
@@ -962,9 +984,6 @@ impl TunnelManager {
     }
 }
 
-/// How long the supervisor waits between session keepalive probes (#1243).
-const SUPERVISOR_PROBE_INTERVAL: Duration = Duration::from_secs(20);
-
 /// Why a supervised tunnel died, for the recorded `Error` message.
 enum DeathCause {
     Forwarder,
@@ -1002,10 +1021,10 @@ fn emit_tunnel_status(
 /// Per-tunnel supervisor loop (#1243, GAP 1 + GAP 2).
 ///
 /// Waits for the first of: an explicit stop (cancel token — NOT a death), the
-/// forwarder death signal, or a failed session keepalive probe. On a real death
-/// it reaps the tunnel from `active_tunnels` (dropping its pool guards so the
-/// shared session drains exactly once), records the cause as the durable
-/// last-error (#1238), and emits the `Error` resting state.
+/// forwarder death signal, or the native session-liveness watch firing (#1297).
+/// On a real death it reaps the tunnel from `active_tunnels` (dropping its pool
+/// guards so the shared session drains exactly once), records the cause as the
+/// durable last-error (#1238), and emits the `Error` resting state.
 #[allow(clippy::too_many_arguments)]
 async fn supervise(
     active_tunnels: Arc<Mutex<HashMap<String, ActiveTunnel>>>,
@@ -1014,7 +1033,7 @@ async fn supervise(
     app_handle: AppHandle,
     tunnel_id: String,
     death: Option<tokio::sync::oneshot::Receiver<()>>,
-    probe: Option<Arc<SshSession>>,
+    liveness: Option<LivenessWatch>,
     cancel: CancellationToken,
     reconnect_on_disconnect: bool,
 ) {
@@ -1024,7 +1043,7 @@ async fn supervise(
         // Error; the other branches are dropped.
         _ = cancel.cancelled() => return,
         _ = wait_forwarder_death(death) => DeathCause::Forwarder,
-        _ = session_probe_loop(probe, SUPERVISOR_PROBE_INTERVAL) => DeathCause::Session,
+        _ = wait_session_death(liveness) => DeathCause::Session,
     };
 
     let removed = match active_tunnels.lock() {
@@ -1177,30 +1196,23 @@ async fn wait_forwarder_death(death: Option<tokio::sync::oneshot::Receiver<()>>)
         Some(rx) => {
             let _ = rx.await;
         }
-        // No signal wired (should not happen) — never resolve so the keepalive
-        // probe alone governs liveness.
+        // No signal wired (should not happen) — never resolve so the session
+        // liveness watch alone governs liveness.
         None => std::future::pending::<()>().await,
     }
 }
 
-/// Resolve only once the SSH session is dead. Lightweight keepalive: open a
-/// throwaway session channel every `interval`; a failure means the transport is
-/// gone. (A native russh session-liveness watch is the Option-B upgrade.)
-async fn session_probe_loop(session: Option<Arc<SshSession>>, interval: Duration) {
-    // No probe handle (remote forward): never resolve — the forwarder death
-    // signal governs liveness for this tunnel.
-    let session = match session {
-        Some(s) => s,
-        None => {
-            std::future::pending::<()>().await;
-            return;
-        }
-    };
-    loop {
-        tokio::time::sleep(interval).await;
-        if session.channel_open_session().await.is_err() {
-            return;
-        }
+/// Resolve once the SSH session is dead, via the native russh liveness watch
+/// (#1297) — event-driven, no polling. russh fires the watch from its
+/// `disconnected` callback on a transport failure, a peer disconnect, or
+/// keepalive exhaustion (30 s × 3).
+///
+/// `None` (a remote forward, which has no shared endpoint session) never
+/// resolves — the forwarder death signal governs liveness for that tunnel.
+async fn wait_session_death(liveness: Option<LivenessWatch>) {
+    match liveness {
+        Some(mut watch) => watch.dead().await,
+        None => std::future::pending::<()>().await,
     }
 }
 
@@ -1235,7 +1247,7 @@ mod tests {
     use super::super::local_forward::ForwarderStats;
     use super::{
         backoff_delay, clear_last_error, last_error_for, record_last_error, resting_status,
-        run_reconnect_loop, session_probe_loop, snapshot_active_stats, wait_forwarder_death,
+        run_reconnect_loop, snapshot_active_stats, wait_forwarder_death, wait_session_death,
         ActiveTunnel, ReconnectOutcome, TunnelStatsUpdate,
     };
     use crate::tunnel::config::TunnelStatus;
@@ -1521,8 +1533,9 @@ mod tests {
     // As with the GAP-8 tests above, the full `supervise` task cannot run in a
     // unit test (it needs a Tauri `AppHandle` to emit and a real `SshSession`),
     // so these lock in its constituent behaviours with the same production
-    // building blocks: the real `wait_forwarder_death` / `session_probe_loop`
-    // futures and the RefPool guard-drain that the death path performs. The
+    // building blocks: the real `wait_forwarder_death` / `wait_session_death`
+    // futures and the RefPool guard-drain that the death path performs (the
+    // native `LivenessWatch` firing itself is unit-tested in `core`). The
     // end-to-end Connected → Error on a killed sshd is the Docker system test.
 
     /// The forwarder death oneshot resolves when its sender is dropped — i.e. when
@@ -1539,26 +1552,24 @@ mod tests {
             .expect("join");
     }
 
-    /// With no death signal wired, the wait never resolves — the keepalive probe
-    /// alone governs liveness (defensive default).
+    /// With no death signal wired, the wait never resolves — the session
+    /// liveness watch alone governs liveness (defensive default).
     #[tokio::test]
     async fn no_forwarder_signal_never_resolves() {
         let r = tokio::time::timeout(Duration::from_millis(100), wait_forwarder_death(None)).await;
         assert!(r.is_err(), "no death signal ⇒ the wait must never resolve");
     }
 
-    /// A remote-forward tunnel has no probe handle; the probe loop must never
-    /// resolve so the forwarder death signal governs (no spurious Error).
+    /// A remote-forward tunnel has no liveness watch; `wait_session_death(None)`
+    /// must never resolve so the forwarder death signal governs (no spurious
+    /// Error). The watch-fires case is covered by the `LivenessWatch` unit tests
+    /// in `core` (a real `SshSession` can't be fabricated here).
     #[tokio::test]
-    async fn session_probe_without_handle_never_resolves() {
-        let r = tokio::time::timeout(
-            Duration::from_millis(100),
-            session_probe_loop(None, Duration::from_millis(10)),
-        )
-        .await;
+    async fn session_death_without_watch_never_resolves() {
+        let r = tokio::time::timeout(Duration::from_millis(100), wait_session_death(None)).await;
         assert!(
             r.is_err(),
-            "no probe handle ⇒ the probe loop must never resolve"
+            "no liveness watch ⇒ the session-death wait must never resolve"
         );
     }
 


### PR DESCRIPTION
## Summary

Replaces the SSH tunnel supervisor's polling keepalive probe (Option A) with a
**native russh session-liveness watch** (Option B) — the Option-C end state the
tunnel-lifecycle concept prescribes (#1191/#1243). A tunnel whose SSH session
dies now transitions to `Error` (or enters reconnect) **event-driven and
promptly**, instead of via a ~20 s poll that opened a throwaway
`channel_open_session` on every tick.

Follow-up to #1243. Closes #1297.

## How it works

- `TermiHubHandler` holds a `watch::Sender<bool>` and flips it from russh's
  `disconnected` callback on session death — a transport failure, peer
  `SSH_MSG_DISCONNECT`, or keepalive miss (keepalive is already configured 30 s ×
  3). The sender dropping with the handler (session-task end) is a backstop.
- A new `LivenessWatch` (a `watch::Receiver` wrapper with `async fn dead()`) is
  surfaced through the connect chain via `*_with_liveness` sibling functions, so
  the tunnel path gets the watch while the existing public connect signatures —
  and their ~15 terminal / agent / sftp / monitoring callers — stay untouched.
- The tunnel `endpoint_pool` stores `Arc<LiveEndpoint { session, liveness }>` so a
  shared pooled session's death fans out to **every** supervisor riding it (each
  gets its own receiver clone; `watch` is multi-consumer). Covers both direct and
  jump-host / gateway target sessions.
- `supervise()` selects `wait_session_death(liveness)` in place of the poll loop;
  the biased select (stop / forwarder-death / session-death) is otherwise
  unchanged, so the #1243/#1246 teardown, reconnect, and stop-wins guarantees
  hold. Remote forwards keep `None` (governed by the forwarder death signal).
- Removed `session_probe_loop` + `SUPERVISOR_PROBE_INTERVAL` and the per-probe
  channel churn.

## Tests / verification

- **Unit** (`core`): `LivenessWatch` fires on `disconnected()`, on handler drop,
  on a cloned receiver, stays pending while alive, and `disconnected()` preserves
  russh's default result. Tunnel supervisor tests updated (the no-watch remote
  branch never resolves). Core SSH 108 pass, tunnel 44 pass.
- **Adversarial correctness review** (keystone area): all six risks traced against
  the russh 0.61.1 source and confirmed safe — notably the watch **does** fire on
  transport death while the tunnel still holds `Arc<SshSession>` handles (no
  dead-forever-green regression), and a normal Stop cannot launder into `Error`.
- `/simplify` applied (jump_host plain fns delegate to their `_with_liveness`
  siblings). `./scripts/check.sh` passes (workspace fmt + clippy).

### Test plan

The observable Connected → Error on a killed sshd is unchanged from #1243 (only
the detection mechanism swapped), so its existing system/manual coverage applies.
The new liveness mechanism itself is unit-tested in `core` (a real `SshSession`
can't be fabricated in-process). Manual smoke: open a local/dynamic tunnel over a
Docker SSH host, `kill` the sshd session, confirm the row goes `Error` (or
reconnects) promptly — noticeably faster than the previous ~20 s poll.

## Concept

`docs/concepts/backlog/ssh-tunnel-lifecycle-redesign.html` already prescribes the
native watch (Option C) as the target and the "upgrade from the Option-A probe
later" path — code now matches that end state (no divergence).

## Docs

- Change fragment: `docs/changes/dev2/feature/1297-tunnel-native-liveness.md`.

## Follow-up

- #1315 — the endpoint pool can hand out an already-dead cached session (a
  pre-existing `RefPool` eviction gap the fast watch made visible); out of scope
  here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
