### PR TITLE
refactor(ssh): type the X-server guided-install discriminator (#1309)

### DIFF
--- a/src-tauri/src/terminal/xserver/types.rs
+++ b/src-tauri/src/terminal/xserver/types.rs
@@ -7,12 +7,6 @@
 
 use serde::{Deserialize, Serialize};
 
-/// The `dependency` name for the macOS brew-absent error (#1117). It doubles as
-/// the discriminator the frontend branches on to show the guided-Homebrew UI
-/// (opening a terminal) instead of the generic install-and-retry, so it must
-/// stay in sync with the TS `HOMEBREW_DEPENDENCY` (`src/types/xserver.ts`).
-pub(crate) const HOMEBREW_DEPENDENCY: &str = "Homebrew";
-
 /// The official Homebrew installer one-liner (brew.sh). The macOS brew-absent
 /// path hands this back as an [`XServerError::DependencyMissing`] `install_command`
 /// so the UI can open a local terminal tab that runs it, guiding the user through
@@ -95,6 +89,29 @@ pub struct XServerStatusReport {
     pub message: Option<String>,
 }
 
+/// How the frontend should carry out the install action a [`DependencyMissing`]
+/// error offers (#1309).
+///
+/// This is the *typed* discriminator that used to be inferred from the
+/// human-facing `dependency` name (the retired `HOMEBREW_DEPENDENCY` magic
+/// string): it decides whether `install_command` is display-only or executed,
+/// so the `dependency` field can stay purely presentational. Adding a second
+/// guided-install dependency needs no new string-match — just this variant.
+///
+/// [`DependencyMissing`]: XServerError::DependencyMissing
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum InstallMode {
+    /// termiHub installs the dependency itself via `x_server_install_dependency`
+    /// (e.g. `brew install --cask xquartz`). Any `install_command` is shown for
+    /// information only; the install button drives the backend command.
+    Backend,
+    /// The user must run `install_command` themselves in a terminal termiHub
+    /// opens for them — the install has interactive prompts termiHub can't drive
+    /// (e.g. the official Homebrew installer's `sudo` / RETURN steps, #1117).
+    GuidedTerminal,
+}
+
 /// A typed, actionable provisioning failure surfaced to the UI.
 ///
 /// Serializes to `{ "kind": "...", "message": "...", ... }` so the frontend can
@@ -117,8 +134,13 @@ pub enum XServerError {
     #[serde(rename_all = "camelCase")]
     DependencyMissing {
         message: String,
-        /// Dependency name (e.g. `XQuartz`).
+        /// Dependency name (e.g. `XQuartz`). Purely presentational — the UI shows
+        /// it in the message and the install button label, never branches on it.
         dependency: String,
+        /// How the frontend should run the install action (#1309): `backend`
+        /// drives `x_server_install_dependency`; `guidedTerminal` opens a terminal
+        /// running `install_command`.
+        install_mode: InstallMode,
         /// Free-text guidance (e.g. a download URL or manual step).
         #[serde(skip_serializing_if = "Option::is_none")]
         install_hint: Option<String>,
@@ -167,6 +189,7 @@ impl XServerError {
         XServerError::DependencyMissing {
             message: "XQuartz is not installed. Install it to use X11 forwarding.".to_string(),
             dependency: "XQuartz".to_string(),
+            install_mode: InstallMode::Backend,
             install_hint: Some(
                 "Download XQuartz from https://www.xquartz.org, then log out and back in so \
                 DISPLAY is set."
@@ -183,16 +206,17 @@ impl XServerError {
     /// Rather than hosting/redistributing a notarized `.pkg`, the UI guides the
     /// user through installing Homebrew first: it opens a local terminal tab
     /// pre-loaded with `install_command` (the official installer), then a retry
-    /// re-detects `brew` and installs the cask. `dependency: "Homebrew"` is the
-    /// stable discriminator the frontend branches on; if the user declines, the
-    /// hint still points at the manual xquartz.org download (help ends there).
+    /// re-detects `brew` and installs the cask. `install_mode: GuidedTerminal`
+    /// is the typed signal the frontend branches on (#1309); if the user declines,
+    /// the hint still points at the manual xquartz.org download (help ends there).
     pub fn homebrew_required() -> Self {
         XServerError::DependencyMissing {
             message: "XQuartz can't be installed automatically because Homebrew is not installed. \
                 Install Homebrew, then retry — or install XQuartz manually from \
                 https://www.xquartz.org."
                 .to_string(),
-            dependency: HOMEBREW_DEPENDENCY.to_string(),
+            dependency: "Homebrew".to_string(),
+            install_mode: InstallMode::GuidedTerminal,
             install_hint: Some(
                 "Installing XQuartz automatically needs Homebrew. \"Install Homebrew\" opens a \
                 terminal with the official installer; once it finishes, retry to install XQuartz. \
@@ -217,6 +241,7 @@ impl XServerError {
         XServerError::DependencyMissing {
             message: "No X server (Xorg/XWayland) was found.".to_string(),
             dependency: "Xorg/XWayland".to_string(),
+            install_mode: InstallMode::Backend,
             install_hint: Some(
                 "Install your distribution's Xorg or XWayland package, or run termiHub inside a \
                 graphical session."
@@ -243,6 +268,7 @@ impl XServerError {
                 X11 forwarding to use."
                 .to_string(),
             dependency: "XWayland".to_string(),
+            install_mode: InstallMode::Backend,
             install_hint: Some(
                 "Install your distribution's XWayland package (e.g. `xwayland`, `xorg-xwayland`, \
                 or `xwayland` via your package manager), then reconnect."
@@ -351,18 +377,21 @@ mod tests {
     }
 
     #[test]
-    fn homebrew_required_carries_the_installer_command_and_manual_fallback() {
-        // Brew-absent post-click response: `dependency: "Homebrew"` (the frontend
-        // discriminator), `install_command` = the official Homebrew installer the
-        // guided terminal runs, and a hint that still points at the manual
+    fn homebrew_required_uses_guided_terminal_install_mode() {
+        // Brew-absent post-click response: the typed `install_mode` (not the
+        // `dependency` name) is what the frontend branches on to open a guided
+        // terminal (#1309); `install_command` = the official Homebrew installer
+        // that terminal runs, and a hint that still points at the manual
         // xquartz.org download for a user who declines Homebrew.
         match XServerError::homebrew_required() {
             XServerError::DependencyMissing {
                 dependency,
+                install_mode,
                 install_hint,
                 install_command,
                 ..
             } => {
+                assert_eq!(install_mode, InstallMode::GuidedTerminal);
                 assert_eq!(dependency, "Homebrew");
                 let cmd = install_command.expect("Homebrew installer command must be present");
                 assert!(
@@ -390,5 +419,17 @@ mod tests {
             err.to_string(),
             "XQuartz is not installed. Install it to use X11 forwarding."
         );
+    }
+
+    #[test]
+    fn install_mode_serializes_camel_case_per_variant() {
+        // The typed discriminator crosses the IPC boundary as `installMode`
+        // (camelCase), mirroring the TS `XServerInstallMode` union (#1309): the
+        // backend-driven XQuartz install vs. the guided-terminal Homebrew install.
+        let backend = serde_json::to_string(&XServerError::xquartz_missing()).unwrap();
+        assert!(backend.contains("\"installMode\":\"backend\""));
+
+        let guided = serde_json::to_string(&XServerError::homebrew_required()).unwrap();
+        assert!(guided.contains("\"installMode\":\"guidedTerminal\""));
     }
 }

--- a/src/components/OpenConnections/XServerSetupContent.test.tsx
+++ b/src/components/OpenConnections/XServerSetupContent.test.tsx
@@ -146,7 +146,7 @@ describe("XServerSetupContent", () => {
     expect(onInstallDependency).toHaveBeenCalledTimes(1);
   });
 
-  it("offers a guided Homebrew install for the Homebrew dependencyMissing error", async () => {
+  it("offers a guided terminal install for an installMode:guidedTerminal error", async () => {
     const onGuideHomebrewInstall = vi.fn(() => Promise.resolve());
     const onInstallDependency = vi.fn(() => Promise.resolve());
     const cmd = '/bin/bash -c "$(curl -fsSL https://example.test/install.sh)"';
@@ -156,13 +156,14 @@ describe("XServerSetupContent", () => {
         kind: "dependencyMissing",
         message: "Homebrew is not installed",
         dependency: "Homebrew",
+        installMode: "guidedTerminal",
         installHint: "Install Homebrew, or install XQuartz manually from xquartz.org",
         installCommand: cmd,
       },
       onGuideHomebrewInstall,
       onInstallDependency,
     });
-    // The generic "Install <dep>" action is replaced by a guided Homebrew action
+    // The generic "Install <dep>" action is replaced by a guided install action
     // (which opens a terminal) plus a manual xquartz.org fallback link.
     expect(query("x-server-setup-install-dep")).toBeNull();
     const brew = query("x-server-setup-install-homebrew");
@@ -175,6 +176,53 @@ describe("XServerSetupContent", () => {
     });
     expect(onGuideHomebrewInstall).toHaveBeenCalledWith(cmd);
     expect(onInstallDependency).not.toHaveBeenCalled();
+  });
+
+  it("keys the guided path on installMode, not the dependency name", async () => {
+    const onGuideHomebrewInstall = vi.fn(() => Promise.resolve());
+    const onInstallDependency = vi.fn(() => Promise.resolve());
+    const cmd = "curl -fsSL https://example.test/install.sh | sh";
+    // A dependency named anything but "Homebrew": the retired magic-string branch
+    // would miss it, but the typed installMode drives the guided terminal (#1309).
+    renderContent({
+      phase: "error",
+      error: {
+        kind: "dependencyMissing",
+        message: "Toolchain is not installed",
+        dependency: "Toolchain",
+        installMode: "guidedTerminal",
+        installCommand: cmd,
+      },
+      onGuideHomebrewInstall,
+      onInstallDependency,
+    });
+    expect(query("x-server-setup-install-dep")).toBeNull();
+    const guided = query("x-server-setup-install-homebrew");
+    expect(guided?.textContent).toContain("Install Toolchain");
+    await act(async () => {
+      click("x-server-setup-install-homebrew");
+      await Promise.resolve();
+    });
+    expect(onGuideHomebrewInstall).toHaveBeenCalledWith(cmd);
+    expect(onInstallDependency).not.toHaveBeenCalled();
+  });
+
+  it("uses the backend install action when dependency is Homebrew but installMode is backend", () => {
+    // The name alone no longer forces the guided terminal: a `backend` install
+    // mode gets the plain install-and-retry, even for a "Homebrew" dependency.
+    renderContent({
+      phase: "error",
+      error: {
+        kind: "dependencyMissing",
+        message: "Homebrew is not installed",
+        dependency: "Homebrew",
+        installMode: "backend",
+        installCommand: "brew install --cask xquartz",
+      },
+    });
+    expect(query("x-server-setup-install-homebrew")).toBeNull();
+    expect(query("x-server-setup-open-xquartz")).toBeNull();
+    expect(query("x-server-setup-install-dep")?.textContent).toContain("Install Homebrew");
   });
 
   it("falls back to the raw error message when no typed error is present", () => {

--- a/src/components/OpenConnections/XServerSetupContent.tsx
+++ b/src/components/OpenConnections/XServerSetupContent.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { Modal, Button } from "@/components/ui";
-import { HOMEBREW_DEPENDENCY, type XServerError, type XServerProgress } from "@/types/xserver";
+import type { XServerError, XServerProgress } from "@/types/xserver";
 import "./XServerSetupDialog.css";
 
 /** Which screen of the setup flow is showing. */
@@ -11,16 +11,18 @@ export type XServerSetupPhase = "consent" | "provisioning" | "error";
 const XQUARTZ_DOWNLOAD_URL = "https://www.xquartz.org";
 
 /**
- * Whether an error is the macOS brew-absent case (#1117), where the recovery is
- * a guided Homebrew install (opening a terminal with `installCommand`) rather
- * than the generic "Install {dependency}" retry.
+ * Whether the recovery is a guided-terminal install (#1309): the user runs
+ * `installCommand` in a terminal termiHub opens, rather than the generic
+ * backend "Install {dependency}" retry. Driven by the typed `installMode`, not
+ * the dependency name — so a second guided-install dependency needs no new
+ * string-match here.
  */
-function isHomebrewRequired(error: XServerError | null): error is XServerError & {
+function isGuidedTerminalInstall(error: XServerError | null): error is XServerError & {
   installCommand: string;
 } {
   return (
     error?.kind === "dependencyMissing" &&
-    error.dependency === HOMEBREW_DEPENDENCY &&
+    error.installMode === "guidedTerminal" &&
     typeof error.installCommand === "string"
   );
 }
@@ -62,9 +64,9 @@ interface XServerSetupContentProps {
   /** Install the missing dependency (dependencyMissing only). Async for feedback. */
   onInstallDependency: () => Promise<void>;
   /**
-   * Guide a Homebrew install for the macOS brew-absent case (#1117): opens a
-   * local terminal tab pre-loaded with `command` (the official installer). Only
-   * used when the error is the `dependency: "Homebrew"` variant.
+   * Run a guided-terminal install (#1309): opens a local terminal tab pre-loaded
+   * with `command` (e.g. the official Homebrew installer) so the user can drive
+   * its interactive prompts. Used for a `guidedTerminal` install-mode error.
    */
   onGuideHomebrewInstall: (command: string) => void | Promise<void>;
   /** Close from the error screen. */
@@ -190,13 +192,13 @@ export function XServerSetupContent({
   }
 
   /**
-   * The dependency-recovery action(s) on the error screen. For the macOS
-   * brew-absent case (#1117) this is a guided Homebrew install (opens a terminal
-   * with the installer) plus a manual xquartz.org fallback for a user who
-   * declines; for any other missing dependency it's the plain install-and-retry.
+   * The dependency-recovery action(s) on the error screen. A `guidedTerminal`
+   * install (#1309, today the macOS brew-absent case) opens a terminal running
+   * the installer plus a manual xquartz.org fallback for a user who declines; a
+   * `backend` install is the plain install-and-retry against the backend.
    */
   function renderInstallAction() {
-    if (isHomebrewRequired(error)) {
+    if (isGuidedTerminalInstall(error)) {
       const command = error.installCommand;
       return (
         <>
@@ -212,7 +214,7 @@ export function XServerSetupContent({
             onClick={() => onGuideHomebrewInstall(command)}
             data-testid={`${testIdPrefix}-install-homebrew`}
           >
-            Install Homebrew
+            Install {error.dependency ?? "dependency"}
           </Button>
         </>
       );

--- a/src/types/xserver.ts
+++ b/src/types/xserver.ts
@@ -92,6 +92,18 @@ export type XServerErrorKind =
   | "unsupported";
 
 /**
+ * How the setup dialog should carry out the install action a `dependencyMissing`
+ * error offers (#1309). The typed signal that replaced the earlier
+ * `dependency === "Homebrew"` magic string; mirrors the Rust `InstallMode`.
+ *
+ * - `backend` — termiHub installs the dependency itself (`x_server_install_dependency`);
+ *   any `installCommand` is shown for information only.
+ * - `guidedTerminal` — the user runs `installCommand` in a terminal termiHub opens
+ *   for them (the install has interactive prompts termiHub can't drive).
+ */
+export type XServerInstallMode = "backend" | "guidedTerminal";
+
+/**
  * Typed error rejected by `x_server_ensure` / `x_server_install_dependency`.
  * Serialized from the tagged Rust `XServerError`; optional fields are omitted
  * when the backend has no value. `dependencyMissing` carries the missing
@@ -102,21 +114,22 @@ export interface XServerError {
   kind: XServerErrorKind;
   /** Human-readable failure detail. */
   message: string;
-  /** Name of the missing dependency (only for `dependencyMissing`). */
+  /**
+   * Name of the missing dependency (only for `dependencyMissing`). Presentational
+   * only — shown in the message and install-button label, never branched on.
+   */
   dependency?: string;
+  /**
+   * How to run the install action (only for `dependencyMissing`, #1309): drives
+   * whether the dialog executes {@link installCommand} in a terminal or triggers
+   * the backend installer.
+   */
+  installMode?: XServerInstallMode;
   /** Human-readable hint on how to install the dependency. */
   installHint?: string;
   /** A concrete shell command that installs the dependency, if available. */
   installCommand?: string;
 }
-
-/**
- * The `dependency` value the macOS brew-absent error carries (#1117). It doubles
- * as the discriminator the setup dialog branches on to offer the guided-Homebrew
- * install (opening a terminal) instead of the generic install-and-retry. Must
- * match the Rust `HOMEBREW_DEPENDENCY` (`src-tauri/src/terminal/xserver/types.rs`).
- */
-export const HOMEBREW_DEPENDENCY = "Homebrew";
 
 /**
  * Type guard for {@link XServerError}: an object carrying a string `kind` and a


### PR DESCRIPTION
Retires the `dependency === "Homebrew"` magic string that decided the X-server
guided-install-vs-generic recovery, replacing it with a typed discriminator.

**Closes #1309.** Follow-up to #1117 (PR #1310), epic #1047.

## What changed
- **Backend** (`XServerError::DependencyMissing`): new `InstallMode` enum
  (`backend` | `guidedTerminal`). `homebrew_required()` carries `GuidedTerminal`;
  every other missing-dependency case carries `Backend`, preserving current
  behavior. The `HOMEBREW_DEPENDENCY` constant is gone.
- **Frontend** (`XServerError` / `XServerSetupContent`): new `installMode`
  field + `XServerInstallMode` union; the dialog branches on
  `installMode === "guidedTerminal"` (`isHomebrewRequired` → `isGuidedTerminalInstall`)
  and `installCommand`'s show-vs-execute treatment follows the typed signal, not
  the dependency name. The guided button label derives from the (now purely
  presentational) `dependency`.

## Why
Reusing a *presentational* label as the *machine discriminator* sat below the
rest of the flow, which already branches on the typed `kind`. Adding a second
guided-install dependency now needs no new string-match — just `GuidedTerminal`.

## Tests
- Rust: per-variant camelCase wire format (`"installMode":"backend"` /
  `"guidedTerminal"`); `homebrew_required` → `GuidedTerminal`.
- Frontend: the guided path keys on `installMode` (proven with a non-"Homebrew"
  dependency); a `"Homebrew"` dependency with `installMode: "backend"` takes the
  plain install-and-retry path.

No user-facing behavior change (pure refactor) → no change fragment.

## Follow-up
- #1312 — generalize the guided-terminal branch **body** (the still-hardcoded
  `Open xquartz.org` fallback link + the `onGuideHomebrewInstall` naming) so a
  second `guidedTerminal` dependency renders correct guidance. Deliberately out
  of scope here, mirroring how #1309 was itself deferred from #1117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)