### PR TITLE
fix(tunnel): evict dead pooled SSH endpoints instead of handing them out (Closes #1315)

### DIFF
--- a/core/src/backends/ssh/handler.rs
+++ b/core/src/backends/ssh/handler.rs
@@ -43,6 +43,16 @@ impl LivenessWatch {
     pub async fn dead(&mut self) {
         let _ = self.rx.wait_for(|&dead| dead).await;
     }
+
+    /// Synchronously report whether the session is already dead.
+    ///
+    /// `true` when the handler flipped the flag on disconnect, **or** when the
+    /// watch channel is closed (the sender dropped with the handler at session
+    /// task end) — both mean the session is gone. Lets the endpoint pool skip a
+    /// dead cached session instead of handing it out (#1315).
+    pub fn is_dead(&self) -> bool {
+        *self.rx.borrow() || self.rx.has_changed().is_err()
+    }
 }
 
 /// An incoming forwarded channel from the SSH server (remote-port-forward / X11).

--- a/core/src/backends/ssh/jump_host.rs
+++ b/core/src/backends/ssh/jump_host.rs
@@ -472,11 +472,18 @@ pub async fn connect_target_through_pooled_gateway_with_liveness(
     let key = gateway_pool_key(&target.proxy_jump);
 
     let gateway = pool
-        .get_or_create(&key, || async {
-            connect_gateway_chain(&target.proxy_jump, cancel)
-                .await
-                .map(Arc::new)
-        })
+        .get_or_create_live(
+            &key,
+            // Don't reuse a pooled gateway whose chain has dropped — a closed
+            // innermost or intermediate session can no longer carry a
+            // direct-tcpip channel to the target. Evict it and redial (#1315).
+            |gw| !gw.session.is_closed() && gw.intermediate_sessions.iter().all(|s| !s.is_closed()),
+            || async {
+                connect_gateway_chain(&target.proxy_jump, cancel)
+                    .await
+                    .map(Arc::new)
+            },
+        )
         .await?;
 
     let (session, registry, liveness) =

--- a/core/src/backends/ssh/session_pool.rs
+++ b/core/src/backends/ssh/session_pool.rs
@@ -95,6 +95,26 @@ impl<T: Clone> RefPool<T> {
         Ok(self.make_ref(key, value))
     }
 
+    /// Like [`get_or_create`](Self::get_or_create), but skip and evict a cached
+    /// entry that `is_alive` reports dead, dialing a fresh value instead (#1315).
+    ///
+    /// NOTE: eviction is not yet implemented — this currently delegates to
+    /// [`get_or_create`](Self::get_or_create), so a dead cached entry is still
+    /// handed out (the failing behavior the regression test below pins).
+    pub async fn get_or_create_live<P, F, Fut, E>(
+        self: &Arc<Self>,
+        key: &str,
+        _is_alive: P,
+        connect: F,
+    ) -> Result<PooledRef<T>, E>
+    where
+        P: Fn(&T) -> bool,
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+    {
+        self.get_or_create(key, connect).await
+    }
+
     /// Increment the ref count and clone the value if the key is present.
     fn try_acquire(&self, key: &str) -> Option<T> {
         let mut entries = self.entries.lock().expect("session pool mutex poisoned");
@@ -366,6 +386,81 @@ mod tests {
         );
         assert_eq!(pool.ref_count("k"), 8);
         assert!(refs.iter().all(|r| Arc::ptr_eq(r, &refs[0])));
+    }
+
+    /// A dead cached entry must not be handed to a new acquirer: the pool evicts
+    /// it and dials a fresh value, and the dead entry's stale reference releases
+    /// as a no-op instead of corrupting the replacement's refcount (#1315).
+    #[tokio::test]
+    async fn dead_cached_entry_is_evicted_and_replaced() {
+        use std::sync::atomic::AtomicBool;
+
+        // The pooled value carries its own liveness flag (`true` = alive).
+        let pool = RefPool::<Arc<AtomicBool>>::new();
+        let alive = |v: &Arc<AtomicBool>| v.load(Ordering::SeqCst);
+        let creates = Arc::new(AtomicUsize::new(0));
+        let make = || {
+            let creates = creates.clone();
+            || async move {
+                creates.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(Arc::new(AtomicBool::new(true)))
+            }
+        };
+
+        // First acquire dials E1 (alive).
+        let e1 = pool.get_or_create_live("k", alive, make()).await.unwrap();
+        assert_eq!(creates.load(Ordering::SeqCst), 1);
+        assert_eq!(pool.ref_count("k"), 1);
+
+        // E1's session dies.
+        e1.store(false, Ordering::SeqCst);
+
+        // A new acquire for the same key must dial a fresh E2, not adopt the corpse.
+        let e2 = pool.get_or_create_live("k", alive, make()).await.unwrap();
+        assert_eq!(creates.load(Ordering::SeqCst), 2, "must dial a fresh session");
+        assert!(!Arc::ptr_eq(&e1, &e2), "must not hand out the dead endpoint");
+        assert!(e2.load(Ordering::SeqCst), "the fresh endpoint is alive");
+        assert_eq!(pool.ref_count("k"), 1, "only the fresh entry is counted");
+
+        // Dropping the stale E1 reference must not disturb E2's entry.
+        drop(e1);
+        assert_eq!(pool.ref_count("k"), 1, "stale release is a no-op for the new gen");
+        assert!(!pool.is_empty());
+
+        drop(e2);
+        assert_eq!(pool.ref_count("k"), 0);
+        assert!(pool.is_empty());
+    }
+
+    /// A live cached entry is still reused (the liveness check does not force a
+    /// redial when the session is healthy).
+    #[tokio::test]
+    async fn live_cached_entry_is_reused() {
+        use std::sync::atomic::AtomicBool;
+        let pool = RefPool::<Arc<AtomicBool>>::new();
+        let alive = |v: &Arc<AtomicBool>| v.load(Ordering::SeqCst);
+        let creates = Arc::new(AtomicUsize::new(0));
+
+        let c1 = creates.clone();
+        let a = pool
+            .get_or_create_live("k", alive, || async move {
+                c1.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(Arc::new(AtomicBool::new(true)))
+            })
+            .await
+            .unwrap();
+        let c2 = creates.clone();
+        let b = pool
+            .get_or_create_live("k", alive, || async move {
+                c2.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(Arc::new(AtomicBool::new(true)))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(creates.load(Ordering::SeqCst), 1, "healthy entry is reused");
+        assert!(Arc::ptr_eq(&a, &b));
+        assert_eq!(pool.ref_count("k"), 2);
     }
 
     /// A connect failure must not poison the key: a later acquisition retries.

--- a/core/src/backends/ssh/session_pool.rs
+++ b/core/src/backends/ssh/session_pool.rs
@@ -14,6 +14,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::ops::Deref;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use tokio::sync::Mutex as AsyncMutex;
@@ -21,9 +22,15 @@ use tokio::sync::Mutex as AsyncMutex;
 use super::handler::{ForwardedChannelRegistry, SshSession};
 
 /// One pooled value together with its live-consumer reference count.
+///
+/// `generation` disambiguates successive entries under the same key: when a dead
+/// entry is evicted and replaced (see [`RefPool::get_or_create_live`]), the
+/// replacement gets a fresh generation, so a stale [`PooledRef`] from the evicted
+/// entry releases as a no-op instead of decrementing the replacement (#1315).
 struct Entry<T> {
     value: T,
     ref_count: usize,
+    generation: u64,
 }
 
 /// A reference-counted, single-flight pool of cloneable values keyed by string.
@@ -40,6 +47,8 @@ pub struct RefPool<T: Clone> {
     entries: Mutex<HashMap<String, Entry<T>>>,
     /// Per-key async gates ensuring only one creation runs at a time for a key.
     gates: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
+    /// Monotonic source of per-entry generations (see [`Entry::generation`]).
+    next_generation: AtomicU64,
 }
 
 impl<T: Clone> RefPool<T> {
@@ -48,6 +57,7 @@ impl<T: Clone> RefPool<T> {
         Arc::new(Self {
             entries: Mutex::new(HashMap::new()),
             gates: Mutex::new(HashMap::new()),
+            next_generation: AtomicU64::new(0),
         })
     }
 
@@ -68,43 +78,22 @@ impl<T: Clone> RefPool<T> {
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<T, E>>,
     {
-        if let Some(value) = self.try_acquire(key) {
-            return Ok(self.make_ref(key, value));
-        }
-
-        // Single-flight: only one creator per key proceeds past the gate; the
-        // others block here and re-check the map once the winner inserts.
-        let gate = self.gate_for(key);
-        let _guard = gate.lock().await;
-
-        if let Some(value) = self.try_acquire(key) {
-            return Ok(self.make_ref(key, value));
-        }
-
-        let value = connect().await?;
-        {
-            let mut entries = self.entries.lock().expect("session pool mutex poisoned");
-            entries.insert(
-                key.to_string(),
-                Entry {
-                    value: value.clone(),
-                    ref_count: 1,
-                },
-            );
-        }
-        Ok(self.make_ref(key, value))
+        self.get_or_create_live(key, |_| true, connect).await
     }
 
-    /// Like [`get_or_create`](Self::get_or_create), but skip and evict a cached
-    /// entry that `is_alive` reports dead, dialing a fresh value instead (#1315).
+    /// Like [`get_or_create`](Self::get_or_create), but skip and **evict** a
+    /// cached entry that `is_alive` reports dead, creating a fresh value instead.
     ///
-    /// NOTE: eviction is not yet implemented — this currently delegates to
-    /// [`get_or_create`](Self::get_or_create), so a dead cached entry is still
-    /// handed out (the failing behavior the regression test below pins).
+    /// A pooled SSH session can die while a dying consumer's [`PooledRef`] is
+    /// still in flight (the entry outlives the session until its refcount drops).
+    /// Without this check, a new acquirer for the same key would adopt that dead
+    /// session and fail immediately; here it dials a fresh one. The evicted
+    /// entry's generation is retired, so the stale references release harmlessly
+    /// (#1315).
     pub async fn get_or_create_live<P, F, Fut, E>(
         self: &Arc<Self>,
         key: &str,
-        _is_alive: P,
+        is_alive: P,
         connect: F,
     ) -> Result<PooledRef<T>, E>
     where
@@ -112,15 +101,60 @@ impl<T: Clone> RefPool<T> {
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<T, E>>,
     {
-        self.get_or_create(key, connect).await
+        if let Some((value, generation)) = self.try_acquire(key, &is_alive) {
+            return Ok(self.make_ref(key, value, generation));
+        }
+
+        // Single-flight: only one creator per key proceeds past the gate; the
+        // others block here and re-check the map once the winner inserts.
+        let gate = self.gate_for(key);
+        let _guard = gate.lock().await;
+
+        if let Some((value, generation)) = self.try_acquire(key, &is_alive) {
+            return Ok(self.make_ref(key, value, generation));
+        }
+
+        let value = connect().await?;
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        {
+            let mut entries = self.entries.lock().expect("session pool mutex poisoned");
+            entries.insert(
+                key.to_string(),
+                Entry {
+                    value: value.clone(),
+                    ref_count: 1,
+                    generation,
+                },
+            );
+        }
+        Ok(self.make_ref(key, value, generation))
     }
 
-    /// Increment the ref count and clone the value if the key is present.
-    fn try_acquire(&self, key: &str) -> Option<T> {
-        let mut entries = self.entries.lock().expect("session pool mutex poisoned");
-        let entry = entries.get_mut(key)?;
-        entry.ref_count += 1;
-        Some(entry.value.clone())
+    /// Increment the ref count and clone the live value if the key is present.
+    ///
+    /// Returns the value together with its entry generation. If the cached entry
+    /// is present but `is_alive` reports it dead, it is evicted (removed from the
+    /// map) and `None` is returned so the caller creates a fresh value; the
+    /// evicted value is dropped outside the lock to avoid `Drop` re-entrancy.
+    fn try_acquire(&self, key: &str, is_alive: &impl Fn(&T) -> bool) -> Option<(T, u64)> {
+        let evicted = {
+            let mut entries = self.entries.lock().expect("session pool mutex poisoned");
+            match entries.get_mut(key) {
+                None => return None,
+                Some(entry) => {
+                    if is_alive(&entry.value) {
+                        entry.ref_count += 1;
+                        return Some((entry.value.clone(), entry.generation));
+                    }
+                    // Dead: retire this generation so a fresh session is dialed.
+                    // Existing PooledRefs keep their own clones alive and release
+                    // as no-ops (their generation no longer matches).
+                    entries.remove(key)
+                }
+            }
+        };
+        drop(evicted); // dropped outside the entries lock
+        None
     }
 
     fn gate_for(&self, key: &str) -> Arc<AsyncMutex<()>> {
@@ -134,25 +168,30 @@ impl<T: Clone> RefPool<T> {
             .clone()
     }
 
-    fn make_ref(self: &Arc<Self>, key: &str, value: T) -> PooledRef<T> {
+    fn make_ref(self: &Arc<Self>, key: &str, value: T, generation: u64) -> PooledRef<T> {
         PooledRef {
             value,
             key: key.to_string(),
+            generation,
             pool: Arc::clone(self),
         }
     }
 
-    /// Release one reference for `key`. When the count reaches zero the entry is
-    /// removed and its value dropped.
+    /// Release one reference for `key`'s entry of `generation`. When the count
+    /// reaches zero the entry is removed and its value dropped.
+    ///
+    /// A `generation` that no longer matches the entry at `key` (the entry was
+    /// evicted-and-replaced while this reference was in flight, #1315) is a no-op,
+    /// so a stale reference never decrements the replacement entry.
     ///
     /// The removed value is dropped *outside* the entries lock so that a value
     /// whose `Drop` re-enters the pool (e.g. a pooled session that itself holds a
     /// [`PooledRef`] to a gateway) cannot deadlock on the non-reentrant mutex.
-    pub fn release(&self, key: &str) {
+    pub fn release(&self, key: &str, generation: u64) {
         let removed = {
             let mut entries = self.entries.lock().expect("session pool mutex poisoned");
             match entries.get_mut(key) {
-                Some(entry) => {
+                Some(entry) if entry.generation == generation => {
                     entry.ref_count = entry.ref_count.saturating_sub(1);
                     if entry.ref_count == 0 {
                         entries.remove(key)
@@ -160,7 +199,7 @@ impl<T: Clone> RefPool<T> {
                         None
                     }
                 }
-                None => None,
+                _ => None,
             }
         };
         if removed.is_some() {
@@ -203,6 +242,9 @@ impl<T: Clone> RefPool<T> {
 pub struct PooledRef<T: Clone> {
     value: T,
     key: String,
+    /// Generation of the pool entry this reference was issued against; releases
+    /// only affect a matching entry (see [`RefPool::release`]).
+    generation: u64,
     pool: Arc<RefPool<T>>,
 }
 
@@ -222,7 +264,7 @@ impl<T: Clone> Deref for PooledRef<T> {
 
 impl<T: Clone> Drop for PooledRef<T> {
     fn drop(&mut self) {
-        self.pool.release(&self.key);
+        self.pool.release(&self.key, self.generation);
     }
 }
 
@@ -268,7 +310,7 @@ mod tests {
     #[tokio::test]
     async fn release_unknown_key_is_noop() {
         let pool = RefPool::<Arc<i32>>::new();
-        pool.release("missing");
+        pool.release("missing", 0);
         assert!(pool.is_empty());
     }
 
@@ -417,14 +459,25 @@ mod tests {
 
         // A new acquire for the same key must dial a fresh E2, not adopt the corpse.
         let e2 = pool.get_or_create_live("k", alive, make()).await.unwrap();
-        assert_eq!(creates.load(Ordering::SeqCst), 2, "must dial a fresh session");
-        assert!(!Arc::ptr_eq(&e1, &e2), "must not hand out the dead endpoint");
+        assert_eq!(
+            creates.load(Ordering::SeqCst),
+            2,
+            "must dial a fresh session"
+        );
+        assert!(
+            !Arc::ptr_eq(&e1, &e2),
+            "must not hand out the dead endpoint"
+        );
         assert!(e2.load(Ordering::SeqCst), "the fresh endpoint is alive");
         assert_eq!(pool.ref_count("k"), 1, "only the fresh entry is counted");
 
         // Dropping the stale E1 reference must not disturb E2's entry.
         drop(e1);
-        assert_eq!(pool.ref_count("k"), 1, "stale release is a no-op for the new gen");
+        assert_eq!(
+            pool.ref_count("k"),
+            1,
+            "stale release is a no-op for the new gen"
+        );
         assert!(!pool.is_empty());
 
         drop(e2);

--- a/core/src/backends/ssh/session_pool.rs
+++ b/core/src/backends/ssh/session_pool.rs
@@ -139,19 +139,15 @@ impl<T: Clone> RefPool<T> {
     fn try_acquire(&self, key: &str, is_alive: &impl Fn(&T) -> bool) -> Option<(T, u64)> {
         let evicted = {
             let mut entries = self.entries.lock().expect("session pool mutex poisoned");
-            match entries.get_mut(key) {
-                None => return None,
-                Some(entry) => {
-                    if is_alive(&entry.value) {
-                        entry.ref_count += 1;
-                        return Some((entry.value.clone(), entry.generation));
-                    }
-                    // Dead: retire this generation so a fresh session is dialed.
-                    // Existing PooledRefs keep their own clones alive and release
-                    // as no-ops (their generation no longer matches).
-                    entries.remove(key)
-                }
+            let entry = entries.get_mut(key)?;
+            if is_alive(&entry.value) {
+                entry.ref_count += 1;
+                return Some((entry.value.clone(), entry.generation));
             }
+            // Dead: retire this generation so a fresh session is dialed. Existing
+            // PooledRefs keep their own clones alive and release as no-ops (their
+            // generation no longer matches).
+            entries.remove(key)
         };
         drop(evicted); // dropped outside the entries lock
         None

--- a/docs/changes/dev0/bugfix/1315-evict-dead-pooled-endpoints.md
+++ b/docs/changes/dev0/bugfix/1315-evict-dead-pooled-endpoints.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- SSH tunnels: starting a tunnel for a connection whose shared SSH session had
+  just died no longer fails straight into `Error` by adopting the dead pooled
+  session. The endpoint (and jump-host gateway) pool now evicts a dead cached
+  session on acquire and dials a fresh one instead.

--- a/src-tauri/src/tunnel/tunnel_manager.rs
+++ b/src-tauri/src/tunnel/tunnel_manager.rs
@@ -627,8 +627,13 @@ impl TunnelManager {
                 liveness,
             ))
         } else {
-            let endpoint =
-                block_on_runtime(self.endpoint_pool.get_or_create(conn_id, || async move {
+            let endpoint = block_on_runtime(self.endpoint_pool.get_or_create_live(
+                conn_id,
+                // Never adopt a pooled endpoint whose session has already died —
+                // its cloned watch is already `true`, which would drive the new
+                // tunnel straight to Error. Evict it and dial a fresh one (#1315).
+                |ep| !ep.liveness.is_dead(),
+                || async move {
                     core_connect_cancellable_with_liveness(ssh_config, Some(cancel))
                         .await
                         .map(|(session, _registry, liveness)| {
@@ -638,7 +643,8 @@ impl TunnelManager {
                             })
                         })
                         .map_err(|e| TerminalError::SshError(e.to_string()))
-                }))?;
+                },
+            ))?;
             // Each supervisor gets its own watch receiver clone, so one shared
             // pooled session's death fans out to every tunnel riding it (#1297).
             let session = endpoint.session.clone();


### PR DESCRIPTION
## Summary

Fixes **#1315** — the SSH tunnel endpoint pool could hand out an **already-dead** pooled session.

There is a narrow window after a shared endpoint's SSH session dies but before every dying tunnel's supervisor has dropped its `PooledRef` (the pool entry outlives the session until its refcount hits zero). If a new tunnel for the same `conn_id` acquires in that window, single-flight `get_or_create` returned the dead cached `LiveEndpoint` — whose cloned `LivenessWatch` is already `true` — driving the new tunnel straight to `Error` instead of dialing a fresh session. Pre-existing, but made visible by the native liveness watch (#1297) which reports death fast.

## Fix

`RefPool` gains `get_or_create_live(key, is_alive, connect)`: when the cached entry exists but `is_alive` reports it dead, it is **evicted** and a fresh value is dialed.

To make eviction-while-referenced safe, entries now carry a **generation**. A stale `PooledRef` from an evicted entry releases as a no-op (its generation no longer matches the replacement), so it can't corrupt the new entry's refcount. `get_or_create` is unchanged externally (delegates with an always-alive predicate).

Wired at both pools:
- **Endpoint pool** — predicate `|ep| !ep.liveness.is_dead()`, using a new sync `LivenessWatch::is_dead()` (flag set **or** watch channel closed).
- **Gateway pool** (`shared_gateway_pool`) — predicate on russh `SshSession::is_closed()` across the innermost and intermediate sessions, so a dropped jump-host chain isn't reused either.

## Testing (TDD — test commit precedes fix)

- `dead_cached_entry_is_evicted_and_replaced`: a dead cached entry is evicted, a fresh value is dialed, and the stale reference's release is a no-op (refcount of the replacement is preserved). **Verified red** against the delegating/non-evicting pool, green after the fix.
- `live_cached_entry_is_reused`: a healthy entry is still reused (no needless redial).
- Full core `ssh` lib suite (516) and `tunnel` tests (44) pass; clippy clean; rustfmt clean.

Discovered during #1297; relates to the tunnel lifecycle work (#1191 / #1243).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
