### PR TITLE
feat(agent): publish SHA-256 checksums + verify binary integrity (Closes #1350)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,10 +241,13 @@ jobs:
       - name: Build agent
         run: CROSS_CONFIG=agent/Cross.toml cross build --release --target ${{ matrix.target }} -p termihub-agent
 
-      - name: Upload agent binary as release asset
+      - name: Upload agent binary and checksum as release assets
         run: |
           cp target/${{ matrix.target }}/release/termihub-agent ${{ matrix.artifact_name }}
-          gh release upload v${{ needs.create-release.outputs.version }} "${{ matrix.artifact_name }}"
+          # Publish a SHA-256 sidecar the desktop verifies before install (#1350).
+          sha256sum "${{ matrix.artifact_name }}" > "${{ matrix.artifact_name }}.sha256"
+          gh release upload v${{ needs.create-release.outputs.version }} \
+            "${{ matrix.artifact_name }}" "${{ matrix.artifact_name }}.sha256"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -280,10 +283,14 @@ jobs:
       - name: Build agent
         run: cargo build --release --target ${{ matrix.target }} -p termihub-agent
 
-      - name: Upload agent binary as release asset
+      - name: Upload agent binary and checksum as release assets
         run: |
           cp target/${{ matrix.target }}/release/termihub-agent ${{ matrix.artifact_name }}
-          gh release upload v${{ needs.create-release.outputs.version }} "${{ matrix.artifact_name }}"
+          # macOS runners have `shasum`, not `sha256sum`; emit the same
+          # "<hex>  <file>" sidecar the desktop verifies before install (#1350).
+          shasum -a 256 "${{ matrix.artifact_name }}" > "${{ matrix.artifact_name }}.sha256"
+          gh release upload v${{ needs.create-release.outputs.version }} \
+            "${{ matrix.artifact_name }}" "${{ matrix.artifact_name }}.sha256"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -319,11 +326,14 @@ jobs:
       - name: Build agent
         run: cargo build --release --target ${{ matrix.target }} -p termihub-agent
 
-      - name: Upload agent binary as release asset
+      - name: Upload agent binary and checksum as release assets
         shell: bash
         run: |
           cp target/${{ matrix.target }}/release/termihub-agent.exe ${{ matrix.artifact_name }}
-          gh release upload v${{ needs.create-release.outputs.version }} "${{ matrix.artifact_name }}"
+          # Git Bash on the Windows runner provides `sha256sum` (#1350).
+          sha256sum "${{ matrix.artifact_name }}" > "${{ matrix.artifact_name }}.sha256"
+          gh release upload v${{ needs.create-release.outputs.version }} \
+            "${{ matrix.artifact_name }}" "${{ matrix.artifact_name }}.sha256"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/changes/dev0/feature/1350-agent-sha256-checksums.md
+++ b/docs/changes/dev0/feature/1350-agent-sha256-checksums.md
@@ -1,0 +1,15 @@
+### Added
+
+- Remote agent binaries now ship a published SHA-256 checksum. Every agent
+  release asset (Linux, macOS, and Windows) is accompanied by a matching
+  `*.sha256` sidecar, and locally built binaries from `build-agents.sh` get one
+  too. Before deploying, redeploying, or exec-replacing an agent, the desktop
+  verifies the binary against its checksum on the whole resolve chain
+  (cache → bundled → download). A tampered, corrupted, or mismatched binary is
+  rejected with a clear error and is never installed or executed (#1350).
+
+### Security
+
+- Agent binary integrity is now verified with SHA-256 across all three
+  platforms before any remote install, closing the gap where a substituted or
+  corrupted agent binary could have been deployed unnoticed (#1350).

--- a/docs/concepts/backlog/remote-agent-update-strategy.html
+++ b/docs/concepts/backlog/remote-agent-update-strategy.html
@@ -1542,8 +1542,14 @@ pub struct UpdatePendingNotification {
           </li>
         </ul>
         <p>
-          Binary integrity verification: SHA-256 checksum published as a release asset
-          (<code>termihub-agent-linux-x64.sha256</code>) and verified before exec-replace.
+          Binary integrity verification (implemented in #1350): a SHA-256 checksum is published
+          as a release asset next to <em>every</em> agent artifact on all three platforms
+          (<code>termihub-agent-linux-x64.sha256</code>,
+          <code>termihub-agent-macos-arm64.sha256</code>,
+          <code>termihub-agent-windows-x64.exe.sha256</code>, …). The desktop verifies the binary
+          against its sidecar on the resolve chain (cache → bundled → download) before deploy,
+          redeploy, or exec-replace — a mismatched or tampered binary is rejected with a clear
+          error and never installed or executed.
         </p>
 
         <h3>Config / State Schema</h3>

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -774,6 +774,42 @@ E2E test coverage: all WebdriverIO specs have been ported to the cross-platform 
 - For serial port tests: host-side virtual serial ports via `socat` + echo server, set up by `scripts/test-system-linux.sh` (see also `examples/serial/`)
 - Test on each target OS (macOS, Linux, Windows) for cross-platform items
 
+### Agent binary SHA-256 checksums (release dry-run, #1350)
+
+Verifies that every published agent binary has a matching `*.sha256` asset and
+that the desktop rejects a tampered binary before install. See PR #1350.
+
+**Release-asset presence (release dry-run).**
+
+1. Trigger a release (or inspect the most recent tagged release) so the
+   `agent-binaries-linux`, `agent-binaries-macos`, and `agent-binaries-windows`
+   jobs in [`release.yml`](../.github/workflows/release.yml) run.
+2. On the GitHub Release page, confirm **each** agent artifact has a sibling
+   `.sha256` asset: `termihub-agent-linux-x64`, `-linux-arm64`, `-linux-armv7`,
+   `-macos-arm64`, `-macos-x64`, and `termihub-agent-windows-x64.exe` each with a
+   matching `<name>.sha256`.
+3. Download one binary and its sidecar and verify locally:
+   `sha256sum -c termihub-agent-linux-x64.sha256` (macOS: `shasum -a 256 -c …`)
+   → prints `OK`.
+
+**Local build sidecars.**
+
+1. Run `./scripts/build-agents.sh --native --dev` (or a cross build).
+2. Confirm a `<binary>.sha256` sidecar sits next to each built agent binary under
+   `target/<triple>/<profile>/` and that `sha256sum -c` on it passes.
+
+**Tampered-binary rejection (desktop).**
+
+1. Let the desktop resolve/deploy an agent once so `~/.cache/termihub/agent-binaries/<version>/termihub-agent-<arch>`
+   and its `.sha256` sidecar are populated.
+2. Corrupt the cached binary without updating the sidecar
+   (e.g. `printf 'x' >> …/termihub-agent-<arch>`).
+3. Deploy/redeploy the agent again → the deploy must **fail** with a checksum
+   verification error naming the expected vs. computed digest, and the corrupted
+   binary must **not** be uploaded/executed on the remote host.
+4. Delete the tampered cache entry; the next deploy re-downloads, re-verifies,
+   and succeeds.
+
 ### Guided-Manual Tests in the Python Harness (preferred)
 
 Guided-manual tests are **first-class `pytest` tests** in the Python system-test harness (`tests/system/`). Each one does all the automatable setup through the existing mixins — launch the app, build connections/state — and then prompts the operator for only the irreducibly-manual step (a native OS dialog, xterm-canvas color fidelity, cursor blink). This is the key difference from the legacy YAML runner: the operator does just the un-automatable bit, and the test shares the harness's app/agent orchestration, fixtures, and reporting.

--- a/scripts/build-agents.sh
+++ b/scripts/build-agents.sh
@@ -41,6 +41,29 @@ agent_binary_name() {
     fi
 }
 
+# Write a "<binary>.sha256" sidecar next to a built binary, matching the format
+# published by release.yml so the desktop can verify integrity before install
+# (#1350). Uses sha256sum where available (Linux, Git Bash) and falls back to
+# `shasum -a 256` (macOS). Runs in the binary's directory so the sidecar records
+# a bare file name rather than a full path.
+write_checksum() {
+    local binary="$1"
+    local dir base
+    dir="$(dirname "$binary")"
+    base="$(basename "$binary")"
+    (
+        cd "$dir" || exit 1
+        if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$base" >"$base.sha256"
+        elif command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "$base" >"$base.sha256"
+        else
+            echo "  WARNING: no sha256sum/shasum found; skipping checksum for $base" >&2
+            return 1
+        fi
+    )
+}
+
 # True if the current host is Windows (Git Bash / MSYS / Cygwin).
 host_is_windows() {
     case "$(uname -s)" in
@@ -290,6 +313,7 @@ if [ "$SEQUENTIAL" = true ] || [ "${#SELECTED_TARGETS[@]}" -le 1 ]; then
             binary="target/$target/$PROFILE_DIR/$(agent_binary_name "$target")"
             if [ -f "$binary" ]; then
                 size=$(du -h "$binary" | cut -f1)
+                write_checksum "$binary" || true
                 results+=("  OK    $target  ($size)")
                 echo "  -> $binary ($size)"
                 built=$((built + 1))
@@ -405,6 +429,7 @@ else
                 mkdir -p "$dst_dir"
                 cp "$src_binary" "$dst_binary"
                 size=$(du -h "$dst_binary" | cut -f1)
+                write_checksum "$dst_binary" || true
                 results+=("  OK    $target  ($size)")
                 echo "  -> $dst_binary ($size)"
                 built=$((built + 1))

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,9 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 serde = { workspace = true }
 hex = "0.4"
+# SHA-256 hashing: agent-binary integrity verification (all platforms) and
+# Windows VcXsrv checksum validation.
+sha2 = "0.10"
 serde_json = { workspace = true }
 portable-pty = "0.8"
 russh = { workspace = true }
@@ -76,11 +79,10 @@ windows = { version = "0.58", features = [
 ] }
 # Windows Credential Manager backend for the `keyring` crate.
 keyring = { version = "3", default-features = false, features = ["windows-native"] }
-# VcXsrv acquisition (X server provisioning): download + checksum + extract.
-# Windows-only — the X server subsystem provisions VcXsrv, which does not exist
-# on other platforms.
+# VcXsrv acquisition (X server provisioning): download + extract. Windows-only —
+# the X server subsystem provisions VcXsrv, which does not exist on other
+# platforms. (SHA-256 hashing is a shared dependency; see `[dependencies]`.)
 zip = "2"
-sha2 = "0.10"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Linux Secret Service backend. The `async-secret-service` backend talks to the

--- a/src-tauri/src/terminal/agent_binary.rs
+++ b/src-tauri/src/terminal/agent_binary.rs
@@ -613,4 +613,177 @@ mod tests {
         assert!(url.contains("agent-branch-main"));
         assert!(url.contains("linux-x64"));
     }
+
+    // --- SHA-256 integrity verification -----------------------------------
+
+    /// Known SHA-256 of the ASCII string "abc" (NIST test vector), used to pin
+    /// the hashing implementation.
+    const SHA256_OF_ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    #[test]
+    fn sha256_hex_of_file_matches_known_vector() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload.bin");
+        fs::write(&path, b"abc").unwrap();
+
+        let digest = sha256_hex_of_file(&path).unwrap();
+        assert_eq!(digest, SHA256_OF_ABC);
+    }
+
+    #[test]
+    fn sha256_hex_of_file_is_lowercase_hex() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload.bin");
+        fs::write(&path, b"some binary content").unwrap();
+
+        let digest = sha256_hex_of_file(&path).unwrap();
+        assert_eq!(digest.len(), 64, "SHA-256 hex must be 64 chars");
+        assert!(
+            digest
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "digest must be lowercase hex, got: {digest}"
+        );
+    }
+
+    #[test]
+    fn sha256_hex_of_file_missing_file_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("does-not-exist.bin");
+        assert!(sha256_hex_of_file(&path).is_err());
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_plain_hex() {
+        assert_eq!(
+            parse_sha256_sidecar(SHA256_OF_ABC),
+            Some(SHA256_OF_ABC.to_string())
+        );
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_sha256sum_text_format() {
+        // Standard `sha256sum` text-mode output: "<hex>  <filename>".
+        let line = format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n");
+        assert_eq!(parse_sha256_sidecar(&line), Some(SHA256_OF_ABC.to_string()));
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_sha256sum_binary_format() {
+        // Binary-mode output prefixes the filename with '*'.
+        let line = format!("{SHA256_OF_ABC} *termihub-agent-windows-x64.exe\n");
+        assert_eq!(parse_sha256_sidecar(&line), Some(SHA256_OF_ABC.to_string()));
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_uppercase_is_normalized() {
+        let upper = SHA256_OF_ABC.to_ascii_uppercase();
+        assert_eq!(
+            parse_sha256_sidecar(&upper),
+            Some(SHA256_OF_ABC.to_string())
+        );
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_rejects_garbage() {
+        assert_eq!(parse_sha256_sidecar(""), None);
+        assert_eq!(parse_sha256_sidecar("   \n"), None);
+        assert_eq!(parse_sha256_sidecar("not-a-hash"), None);
+        // Too short.
+        assert_eq!(parse_sha256_sidecar("deadbeef"), None);
+        // 64 chars but contains a non-hex char ('g').
+        assert_eq!(parse_sha256_sidecar(&"g".repeat(64)), None);
+    }
+
+    #[test]
+    fn verify_file_checksum_ok_on_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload.bin");
+        fs::write(&path, b"abc").unwrap();
+
+        assert!(verify_file_checksum(&path, SHA256_OF_ABC).is_ok());
+        // Case-insensitive on the expected side too.
+        assert!(verify_file_checksum(&path, &SHA256_OF_ABC.to_ascii_uppercase()).is_ok());
+    }
+
+    #[test]
+    fn verify_file_checksum_rejects_mismatch_with_clear_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload.bin");
+        // Content whose digest is NOT SHA256_OF_ABC.
+        fs::write(&path, b"tampered content").unwrap();
+
+        let err = verify_file_checksum(&path, SHA256_OF_ABC).unwrap_err();
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(
+            msg.contains("checksum"),
+            "error should mention checksum, got: {err}"
+        );
+        assert!(
+            msg.contains(SHA256_OF_ABC),
+            "error should include the expected checksum, got: {err}"
+        );
+    }
+
+    #[test]
+    fn checksum_sidecar_path_appends_sha256() {
+        let binary = PathBuf::from("/cache/0.1.0/termihub-agent-linux-x64");
+        let sidecar = checksum_sidecar_path(&binary);
+        assert_eq!(
+            sidecar,
+            PathBuf::from("/cache/0.1.0/termihub-agent-linux-x64.sha256")
+        );
+    }
+
+    #[test]
+    fn verify_with_adjacent_sidecar_ok_when_matching() {
+        let tmp = tempfile::tempdir().unwrap();
+        let binary = tmp.path().join("termihub-agent-linux-x64");
+        fs::write(&binary, b"abc").unwrap();
+        fs::write(
+            checksum_sidecar_path(&binary),
+            format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n"),
+        )
+        .unwrap();
+
+        assert!(verify_with_adjacent_sidecar(&binary).is_ok());
+    }
+
+    #[test]
+    fn verify_with_adjacent_sidecar_rejects_tampered_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let binary = tmp.path().join("termihub-agent-linux-x64");
+        // Sidecar claims the "abc" digest, but the binary has been tampered with.
+        fs::write(&binary, b"tampered").unwrap();
+        fs::write(checksum_sidecar_path(&binary), SHA256_OF_ABC).unwrap();
+
+        assert!(
+            verify_with_adjacent_sidecar(&binary).is_err(),
+            "a binary that does not match its sidecar must be rejected"
+        );
+    }
+
+    #[test]
+    fn verify_with_adjacent_sidecar_ok_when_sidecar_absent() {
+        // No sidecar present → cannot verify, but must not fail (legacy cache
+        // entries and out-of-scope dev builds have no published checksum yet).
+        let tmp = tempfile::tempdir().unwrap();
+        let binary = tmp.path().join("termihub-agent-linux-x64");
+        fs::write(&binary, b"abc").unwrap();
+
+        assert!(verify_with_adjacent_sidecar(&binary).is_ok());
+    }
+
+    #[test]
+    fn verify_with_adjacent_sidecar_errors_on_malformed_sidecar() {
+        let tmp = tempfile::tempdir().unwrap();
+        let binary = tmp.path().join("termihub-agent-linux-x64");
+        fs::write(&binary, b"abc").unwrap();
+        fs::write(checksum_sidecar_path(&binary), "this-is-not-a-checksum").unwrap();
+
+        assert!(
+            verify_with_adjacent_sidecar(&binary).is_err(),
+            "a malformed sidecar must be treated as an integrity failure"
+        );
+    }
 }

--- a/src-tauri/src/terminal/agent_binary.rs
+++ b/src-tauri/src/terminal/agent_binary.rs
@@ -8,9 +8,10 @@
 //! 3. **GitHub Releases download** — fetched on demand and cached locally
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 use crate::utils::download::download_to_file;
@@ -18,6 +19,10 @@ use crate::utils::fs::is_nonempty_file;
 
 /// GitHub repository for release downloads.
 const GITHUB_REPO: &str = "armaxri/termiHub";
+
+/// File-name suffix for the SHA-256 checksum sidecar published next to every
+/// agent binary release asset (e.g. `termihub-agent-linux-x64.sha256`).
+const CHECKSUM_EXT: &str = "sha256";
 
 /// Map a remote OS string and architecture string to the artifact suffix we use.
 ///
@@ -149,7 +154,146 @@ pub fn compute_branch_build_url(branch: &str, arch_suffix: &str) -> String {
     format!("https://github.com/{GITHUB_REPO}/releases/download/{tag}/termihub-agent-{arch_suffix}")
 }
 
+/// Compute the lowercase-hex SHA-256 digest of a file's contents.
+///
+/// The file is streamed through the hasher, so arbitrarily large binaries are
+/// never fully buffered in memory.
+pub fn sha256_hex_of_file(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("Failed to open {} for checksum", path.display()))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)
+        .with_context(|| format!("Failed to read {} for checksum", path.display()))?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Parse the expected SHA-256 digest out of a checksum sidecar's contents.
+///
+/// Accepts both a bare 64-char hex digest and the standard `sha256sum` output
+/// format `"<hex>  <filename>"` (text mode) or `"<hex> *<filename>"` (binary
+/// mode) — only the first whitespace-delimited token is considered. The digest
+/// is normalized to lowercase. Returns `None` when the first token is not a
+/// valid 64-character hex string.
+pub fn parse_sha256_sidecar(content: &str) -> Option<String> {
+    let token = content.split_whitespace().next()?.to_ascii_lowercase();
+    if token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(token)
+    } else {
+        None
+    }
+}
+
+/// Verify that `path`'s SHA-256 digest equals `expected_hex`.
+///
+/// The comparison is case-insensitive. On mismatch this returns an error whose
+/// message names the file and both digests, so a tampered or corrupted binary
+/// is rejected with a clear, actionable message before it is ever installed or
+/// executed.
+pub fn verify_file_checksum(path: &Path, expected_hex: &str) -> Result<()> {
+    let actual = sha256_hex_of_file(path)?;
+    let expected = expected_hex.trim().to_ascii_lowercase();
+    if actual == expected {
+        Ok(())
+    } else {
+        bail!(
+            "Checksum verification failed for {}: expected SHA-256 {expected}, computed {actual}. \
+             Refusing to use an agent binary that does not match its published checksum.",
+            path.display()
+        );
+    }
+}
+
+/// Return the path of the `.sha256` checksum sidecar for a binary path.
+fn checksum_sidecar_path(binary_path: &Path) -> PathBuf {
+    let mut name = binary_path.as_os_str().to_owned();
+    name.push(".");
+    name.push(CHECKSUM_EXT);
+    PathBuf::from(name)
+}
+
+/// Verify a resolved binary against a `.sha256` sidecar sitting next to it.
+///
+/// - Sidecar present and matching → `Ok(())`.
+/// - Sidecar present but the binary does not match, or the sidecar is malformed
+///   → `Err` (the binary is rejected; it must never be installed or executed).
+/// - Sidecar absent → `Ok(())` with a warning: integrity cannot be verified
+///   (e.g. a legacy cache entry, a bundle without the sidecar, or an
+///   out-of-scope dev/branch build that does not yet publish checksums).
+fn verify_with_adjacent_sidecar(binary_path: &Path) -> Result<()> {
+    let sidecar = checksum_sidecar_path(binary_path);
+    match fs::read_to_string(&sidecar) {
+        Ok(content) => {
+            let expected = parse_sha256_sidecar(&content).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Malformed checksum sidecar {} — refusing to use an unverifiable agent binary",
+                    sidecar.display()
+                )
+            })?;
+            verify_file_checksum(binary_path, &expected)
+        }
+        Err(_) => {
+            warn!(
+                "No checksum sidecar for {} — skipping integrity verification",
+                binary_path.display()
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Download a binary and verify it against its published `.sha256` sidecar.
+///
+/// The binary is fetched to `dest`, then the sidecar at `<url>.sha256` is
+/// fetched next to it. When the sidecar is available the binary is verified and
+/// a mismatch aborts with the binary removed, so a tampered download is never
+/// left on disk. When the sidecar cannot be fetched (e.g. an out-of-scope dev
+/// build that does not publish one) the download is kept with a warning.
+fn download_binary_with_checksum<F>(url: &str, dest: &Path, progress_cb: F) -> Result<()>
+where
+    F: Fn(u64, u64),
+{
+    download_to_file(url, dest, progress_cb)?;
+
+    let checksum_url = format!("{url}.{CHECKSUM_EXT}");
+    let sidecar = checksum_sidecar_path(dest);
+    if let Err(e) = download_to_file(&checksum_url, &sidecar, |_, _| {}) {
+        // No published checksum for this artifact — keep the binary but warn.
+        // Release assets always ship a sidecar (see release.yml); this branch is
+        // for out-of-scope dev/branch builds that do not yet publish one.
+        warn!(
+            "No checksum available at {checksum_url} ({e}) — installing agent binary \
+             without integrity verification"
+        );
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&sidecar)
+        .with_context(|| format!("Failed to read checksum sidecar {}", sidecar.display()))?;
+    let expected = match parse_sha256_sidecar(&content) {
+        Some(hex) => hex,
+        None => {
+            let _ = fs::remove_file(dest);
+            let _ = fs::remove_file(&sidecar);
+            bail!(
+                "Malformed checksum downloaded from {checksum_url} — refusing to install \
+                 an unverifiable agent binary"
+            );
+        }
+    };
+    if let Err(e) = verify_file_checksum(dest, &expected) {
+        // Reject a tampered/corrupted download: remove both files so a later
+        // resolve does not treat the bad binary as a valid cache hit.
+        let _ = fs::remove_file(dest);
+        let _ = fs::remove_file(&sidecar);
+        return Err(e);
+    }
+    Ok(())
+}
+
 /// Download the agent binary from an explicit URL and cache it under `cache_key/termihub-agent-{arch}`.
+///
+/// The download is verified against its published `.sha256` sidecar before the
+/// path is returned (see [`download_binary_with_checksum`]).
 pub fn download_agent_binary_from_url<F>(
     url: &str,
     cache_key: &str,
@@ -162,7 +306,7 @@ where
     let dest = cache_dir()
         .join(cache_key)
         .join(format!("termihub-agent-{arch_suffix}"));
-    download_to_file(url, &dest, progress_cb)?;
+    download_binary_with_checksum(url, &dest, progress_cb)?;
     Ok(dest)
 }
 
@@ -185,6 +329,7 @@ where
 
     if is_nonempty_file(&cached) {
         debug!("Using cached branch build binary: {}", cached.display());
+        verify_with_adjacent_sidecar(&cached)?;
         return Ok(cached);
     }
 
@@ -264,7 +409,7 @@ where
 {
     let url = compute_download_url(version, arch_suffix);
     let dest = cached_binary_path(version, arch_suffix);
-    download_to_file(&url, &dest, progress_cb)?;
+    download_binary_with_checksum(&url, &dest, progress_cb)?;
     Ok(dest)
 }
 
@@ -283,19 +428,33 @@ where
     // 1. Check local cache
     if let Some(path) = find_cached_binary(version, arch_suffix) {
         info!("Using cached agent binary: {}", path.display());
+        // Reject a cache entry that has been tampered with since it was fetched.
+        verify_with_adjacent_sidecar(&path)?;
         return Ok(path);
     }
 
     // 2. Check bundled resources
     if let Some(path) = find_bundled_binary(app_handle, arch_suffix) {
         info!("Using bundled agent binary: {}", path.display());
-        // Copy to cache for future use
+        // Verify against a bundled `.sha256` sidecar when one ships next to the
+        // binary; a mismatch rejects the bundle rather than deploying it.
+        verify_with_adjacent_sidecar(&path)?;
+        // Copy to cache for future use, including the checksum sidecar so later
+        // cache hits stay verifiable.
         let cache_path = cached_binary_path(version, arch_suffix);
         if let Some(parent) = cache_path.parent() {
             let _ = fs::create_dir_all(parent);
         }
         if let Err(e) = fs::copy(&path, &cache_path) {
             warn!("Failed to cache bundled binary: {}", e);
+        } else {
+            let bundled_sidecar = checksum_sidecar_path(&path);
+            if bundled_sidecar.is_file() {
+                let cache_sidecar = checksum_sidecar_path(&cache_path);
+                if let Err(e) = fs::copy(&bundled_sidecar, &cache_sidecar) {
+                    warn!("Failed to cache bundled checksum sidecar: {}", e);
+                }
+            }
         }
         return Ok(path);
     }

--- a/src-tauri/src/terminal/agent_binary.rs
+++ b/src-tauri/src/terminal/agent_binary.rs
@@ -244,11 +244,23 @@ fn verify_with_adjacent_sidecar(binary_path: &Path) -> Result<()> {
 /// Download a binary and verify it against its published `.sha256` sidecar.
 ///
 /// The binary is fetched to `dest`, then the sidecar at `<url>.sha256` is
-/// fetched next to it. When the sidecar is available the binary is verified and
-/// a mismatch aborts with the binary removed, so a tampered download is never
-/// left on disk. When the sidecar cannot be fetched (e.g. an out-of-scope dev
-/// build that does not publish one) the download is kept with a warning.
-fn download_binary_with_checksum<F>(url: &str, dest: &Path, progress_cb: F) -> Result<()>
+/// fetched next to it and the binary is verified against it — a mismatch or a
+/// malformed sidecar aborts with both files removed, so a tampered download is
+/// never left on disk to masquerade as a valid cache hit.
+///
+/// `require_checksum` controls the missing-sidecar case:
+/// - `true` (release `v{version}` downloads, where [`release.yml`] always
+///   publishes a sidecar) → a missing sidecar fails closed. This is the primary
+///   substitution defense: an attacker cannot bypass verification by simply
+///   omitting the `.sha256`.
+/// - `false` (out-of-scope dev/branch builds that do not publish checksums yet)
+///   → a missing sidecar is tolerated with a warning.
+fn download_binary_with_checksum<F>(
+    url: &str,
+    dest: &Path,
+    require_checksum: bool,
+    progress_cb: F,
+) -> Result<()>
 where
     F: Fn(u64, u64),
 {
@@ -257,9 +269,19 @@ where
     let checksum_url = format!("{url}.{CHECKSUM_EXT}");
     let sidecar = checksum_sidecar_path(dest);
     if let Err(e) = download_to_file(&checksum_url, &sidecar, |_, _| {}) {
-        // No published checksum for this artifact — keep the binary but warn.
-        // Release assets always ship a sidecar (see release.yml); this branch is
-        // for out-of-scope dev/branch builds that do not yet publish one.
+        if require_checksum {
+            // A release asset must have a published checksum; refusing to
+            // install an unverifiable binary is the whole point of the feature.
+            let _ = fs::remove_file(dest);
+            return Err(e).with_context(|| {
+                format!(
+                    "No published SHA-256 checksum at {checksum_url} — refusing to install an \
+                     unverifiable agent binary"
+                )
+            });
+        }
+        // Out-of-scope dev/branch build with no published checksum — keep the
+        // binary but warn that integrity could not be verified.
         warn!(
             "No checksum available at {checksum_url} ({e}) — installing agent binary \
              without integrity verification"
@@ -267,22 +289,9 @@ where
         return Ok(());
     }
 
-    let content = fs::read_to_string(&sidecar)
-        .with_context(|| format!("Failed to read checksum sidecar {}", sidecar.display()))?;
-    let expected = match parse_sha256_sidecar(&content) {
-        Some(hex) => hex,
-        None => {
-            let _ = fs::remove_file(dest);
-            let _ = fs::remove_file(&sidecar);
-            bail!(
-                "Malformed checksum downloaded from {checksum_url} — refusing to install \
-                 an unverifiable agent binary"
-            );
-        }
-    };
-    if let Err(e) = verify_file_checksum(dest, &expected) {
-        // Reject a tampered/corrupted download: remove both files so a later
-        // resolve does not treat the bad binary as a valid cache hit.
+    // The sidecar was just fetched next to `dest`; verify against it and clean
+    // up both files on any mismatch or malformed sidecar.
+    if let Err(e) = verify_with_adjacent_sidecar(dest) {
         let _ = fs::remove_file(dest);
         let _ = fs::remove_file(&sidecar);
         return Err(e);
@@ -292,8 +301,10 @@ where
 
 /// Download the agent binary from an explicit URL and cache it under `cache_key/termihub-agent-{arch}`.
 ///
-/// The download is verified against its published `.sha256` sidecar before the
-/// path is returned (see [`download_binary_with_checksum`]).
+/// When a `.sha256` sidecar is published next to the URL the download is
+/// verified against it (see [`download_binary_with_checksum`]). This is used for
+/// branch builds, which do not publish checksums yet (out of scope for #1350),
+/// so a missing sidecar is tolerated with a warning rather than failing closed.
 pub fn download_agent_binary_from_url<F>(
     url: &str,
     cache_key: &str,
@@ -306,7 +317,7 @@ where
     let dest = cache_dir()
         .join(cache_key)
         .join(format!("termihub-agent-{arch_suffix}"));
-    download_binary_with_checksum(url, &dest, progress_cb)?;
+    download_binary_with_checksum(url, &dest, /* require_checksum */ false, progress_cb)?;
     Ok(dest)
 }
 
@@ -337,6 +348,16 @@ where
     download_agent_binary_from_url(&url, &cache_key, arch_suffix, progress_cb)
 }
 
+/// Return `true` when the current build downloads agents from a dev/branch tag
+/// (`dev-latest` / `dev-develop-latest`) rather than a release `v{version}` tag.
+///
+/// Dev builds are identified by debug mode, the CI dev-build flag, or a `-dev`
+/// version suffix. Release downloads are the negation, and only they are gated
+/// on a mandatory checksum (see [`download_binary_with_checksum`]).
+fn is_dev_build(version: &str) -> bool {
+    cfg!(debug_assertions) || env!("TERMIHUB_IS_DEV_BUILD") == "1" || version.ends_with("-dev")
+}
+
 /// Return the base download URL (without arch suffix) for the current build.
 ///
 /// Dev builds (debug mode, `-dev` version suffix, or CI dev-build flag) use a
@@ -345,9 +366,7 @@ where
 ///
 /// Append an arch suffix (e.g. `"linux-arm64"`) to obtain the full URL.
 pub fn compute_download_base_url(version: &str) -> String {
-    let is_dev =
-        cfg!(debug_assertions) || env!("TERMIHUB_IS_DEV_BUILD") == "1" || version.ends_with("-dev");
-    let tag = if is_dev {
+    let tag = if is_dev_build(version) {
         if env!("TERMIHUB_BUILD_BRANCH") == "develop" {
             "dev-develop-latest".to_string()
         } else {
@@ -409,7 +428,9 @@ where
 {
     let url = compute_download_url(version, arch_suffix);
     let dest = cached_binary_path(version, arch_suffix);
-    download_binary_with_checksum(&url, &dest, progress_cb)?;
+    // Release downloads (`v{version}`) must carry a published checksum; dev tags
+    // (`dev-latest` / `dev-develop-latest`) do not publish one yet (out of scope).
+    download_binary_with_checksum(&url, &dest, !is_dev_build(version), progress_cb)?;
     Ok(dest)
 }
 
@@ -944,5 +965,130 @@ mod tests {
             verify_with_adjacent_sidecar(&binary).is_err(),
             "a malformed sidecar must be treated as an integrity failure"
         );
+    }
+
+    // --- download + verify integration ------------------------------------
+
+    /// Serve the agent binary and (optionally) its `.sha256` sidecar over an
+    /// ephemeral loopback HTTP server, so `download_binary_with_checksum` can be
+    /// exercised end-to-end. Handles exactly two sequential connections (the
+    /// binary GET then the sidecar GET); the response is chosen by whether the
+    /// requested path ends in `.sha256`. Returns the binary URL and the server
+    /// thread handle. When `sidecar` is `None` the sidecar request gets a 404.
+    fn serve_agent_download(
+        binary: &'static [u8],
+        sidecar: Option<String>,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(s) => s,
+                    Err(_) => return,
+                };
+                let mut buf = [0u8; 1024];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]);
+                let is_sidecar = req
+                    .lines()
+                    .next()
+                    .map(|l| l.contains(".sha256"))
+                    .unwrap_or(false);
+
+                let (status, body): (&str, Vec<u8>) = if is_sidecar {
+                    match &sidecar {
+                        Some(content) => ("200 OK", content.clone().into_bytes()),
+                        None => ("404 Not Found", Vec::new()),
+                    }
+                } else {
+                    ("200 OK", binary.to_vec())
+                };
+                let header = format!(
+                    "HTTP/1.1 {status}\r\nConnection: close\r\nContent-Length: {}\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(header.as_bytes());
+                let _ = stream.write_all(&body);
+                let _ = stream.flush();
+            }
+        });
+        (format!("http://{addr}/termihub-agent-linux-x64"), handle)
+    }
+
+    #[test]
+    fn download_with_checksum_accepts_matching_sidecar() {
+        let (url, server) = serve_agent_download(b"abc", Some(format!("{SHA256_OF_ABC}  bin\n")));
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("termihub-agent-linux-x64");
+
+        download_binary_with_checksum(&url, &dest, true, |_, _| {}).unwrap();
+        server.join().unwrap();
+
+        assert_eq!(fs::read(&dest).unwrap(), b"abc");
+        assert!(
+            checksum_sidecar_path(&dest).is_file(),
+            "the verified sidecar must be cached next to the binary"
+        );
+    }
+
+    #[test]
+    fn download_with_checksum_rejects_mismatched_sidecar_and_removes_binary() {
+        // Sidecar advertises a digest the body does not have.
+        let wrong = "0".repeat(64);
+        let (url, server) = serve_agent_download(b"abc", Some(wrong));
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("termihub-agent-linux-x64");
+
+        let err = download_binary_with_checksum(&url, &dest, true, |_, _| {}).unwrap_err();
+        server.join().unwrap();
+
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("checksum"),
+            "error should mention checksum, got: {err}"
+        );
+        assert!(
+            !dest.exists(),
+            "a mismatched download must be removed, not left as a cache hit"
+        );
+        assert!(!checksum_sidecar_path(&dest).exists());
+    }
+
+    #[test]
+    fn download_with_checksum_fails_closed_when_release_sidecar_missing() {
+        let (url, server) = serve_agent_download(b"abc", None);
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("termihub-agent-linux-x64");
+
+        // require_checksum = true (a release download) → a missing sidecar is a
+        // hard failure and the binary must not be left on disk.
+        let err = download_binary_with_checksum(&url, &dest, true, |_, _| {}).unwrap_err();
+        server.join().unwrap();
+
+        assert!(
+            err.to_string().contains("checksum"),
+            "error should explain the missing checksum, got: {err}"
+        );
+        assert!(
+            !dest.exists(),
+            "a release binary with no checksum must not be installed"
+        );
+    }
+
+    #[test]
+    fn download_with_checksum_tolerates_missing_sidecar_for_dev_builds() {
+        let (url, server) = serve_agent_download(b"abc", None);
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("termihub-agent-linux-x64");
+
+        // require_checksum = false (dev/branch build) → a missing sidecar is
+        // tolerated and the binary is kept.
+        download_binary_with_checksum(&url, &dest, false, |_, _| {}).unwrap();
+        server.join().unwrap();
+
+        assert_eq!(fs::read(&dest).unwrap(), b"abc");
     }
 }


### PR DESCRIPTION
## Summary
Publishes SHA-256 checksum sidecars for every remote-agent artifact (Linux, macOS, Windows) and verifies binary integrity on the desktop resolve chain (cache → bundled → download) before any deploy/redeploy/exec. A tampered, corrupted, or mismatched binary is rejected with a clear error and never installed or executed.

- CI (`.github/workflows/release.yml`): emit + upload `*.sha256` for each agent release asset.
- `scripts/build-agents.sh`: emit `*.sha256` sidecars for locally built binaries.
- Desktop (`src-tauri/src/terminal/agent_binary.rs`): verify checksum before install; fail closed on missing release checksum.

Part of Epic #1345. Out of scope: agent-side self-update download (SI-8, consumes this).

## Test plan
- **Unit (Rust):** checksum match/mismatch paths.
- **Integration:** resolve + verify against a fixture binary.
- **Manual:** release dry-run confirms `*.sha256` assets are present for all platforms (documented in `docs/testing.md`).
- `./scripts/check.sh` green (fmt, clippy, lint, frontend, version drift); `cargo test` green.

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)