### PR TITLE
feat(ui): connection tree search/filter + keyboard navigation (Closes #1356)

### DIFF
--- a/docs/changes/dev0/feature/1356-connection-tree-search-kbd-nav.md
+++ b/docs/changes/dev0/feature/1356-connection-tree-search-kbd-nav.md
@@ -1,0 +1,11 @@
+### Added
+
+- Connections panel search and keyboard navigation (#1356): a filter box pinned
+  in the Connections header live-filters the tree by connection name or host,
+  auto-expands folders that contain a match, connects the top hit on Enter, and
+  clears on Escape. The tree is now fully keyboard-operable with roving-tabindex
+  arrow navigation (Up/Down move, Right expands or descends, Left collapses or
+  ascends, Enter/Space connects the focused connection or toggles a folder,
+  Home/End jump to the first/last row) and correct ARIA tree semantics
+  (`role="tree"`/`treeitem"`/`group"` with `aria-expanded`). Each connection row
+  also surfaces a hover/focus "Connect" affordance beyond the native tooltip.

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -299,6 +299,111 @@
   outline-offset: -1px;
 }
 
+/* Search / filter input pinned in the Connections header */
+.connection-list__filter {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+.connection-list__filter-icon {
+  position: absolute;
+  left: calc(var(--spacing-sm) + var(--spacing-xs));
+  color: var(--text-secondary);
+  pointer-events: none;
+}
+
+.connection-list__filter-input.ui-input {
+  height: var(--control-height-md);
+  padding-left: calc(var(--spacing-lg) + var(--spacing-xs));
+  padding-right: var(--control-height-md);
+  font-size: var(--font-size-sm);
+}
+
+.connection-list__filter-clear {
+  position: absolute;
+  right: calc(var(--spacing-sm) + 2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.connection-list__filter-clear:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.connection-list__empty {
+  padding: var(--spacing-sm);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+/* Keyboard-focus ring for roving-tabindex tree rows */
+.connection-tree__folder:focus-visible,
+.connection-tree__item:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
+}
+
+/* Row wrapper hosting a connection button + its hover Connect affordance */
+.connection-tree__item-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.connection-tree__connect-btn {
+  position: absolute;
+  right: var(--spacing-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    opacity var(--transition-fast);
+}
+
+.connection-tree__item-row:hover .connection-tree__connect-btn,
+.connection-tree__item-row:focus-within .connection-tree__connect-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.connection-tree__connect-btn:hover {
+  color: var(--accent-color);
+  background-color: var(--bg-hover);
+}
+
+/* The Connect affordance replaces the type tag on hover/focus to avoid overlap */
+.connection-tree__item-row:hover .connection-tree__type,
+.connection-tree__item-row:focus-within .connection-tree__type {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .connection-tree__connect-btn {
+    transition: none;
+  }
+}
+
 .connection-tree__drag-overlay {
   display: flex;
   align-items: center;

--- a/src/components/Sidebar/ConnectionList.filter.test.tsx
+++ b/src/components/Sidebar/ConnectionList.filter.test.tsx
@@ -55,7 +55,7 @@ const baseSettings = {
   experimentalFeaturesEnabled: false,
 };
 
-function render(container: HTMLElement, root: Root) {
+function render(_container: HTMLElement, root: Root) {
   act(() => {
     root.render(
       React.createElement(TooltipProvider, {

--- a/src/components/Sidebar/ConnectionList.filter.test.tsx
+++ b/src/components/Sidebar/ConnectionList.filter.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Tests for the connection tree filter/search input (#1356): live filtering by
+ * name/host, auto-expanding folders that contain matches, Enter connecting the
+ * top hit, and Escape clearing the query.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import { TooltipProvider } from "@/components/ui";
+import type { SavedConnection, ConnectionFolder, RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  isSshKeyEncrypted: vi.fn(() => Promise.resolve(false)),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({
+    agent,
+    sectionRef,
+  }: {
+    agent: RemoteAgentDefinition;
+    sectionRef?: (el: HTMLDivElement | null) => void;
+  }) => React.createElement("div", { ref: sectionRef, "data-testid": `agent-node-${agent.id}` }),
+}));
+
+function makeConnection(overrides: Partial<SavedConnection> = {}): SavedConnection {
+  const id = overrides.id ?? "conn-1";
+  return {
+    id,
+    name: overrides.name ?? `Connection ${id}`,
+    folderId: null,
+    config: { type: "local", config: {} } as SavedConnection["config"],
+    ...overrides,
+  };
+}
+
+function makeFolder(overrides: Partial<ConnectionFolder> = {}): ConnectionFolder {
+  return { id: "folder-1", name: "Test Folder", parentId: null, isExpanded: true, ...overrides };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: false,
+  fileBrowserEnabled: false,
+  experimentalFeaturesEnabled: false,
+};
+
+function render(container: HTMLElement, root: Root) {
+  act(() => {
+    root.render(
+      React.createElement(TooltipProvider, {
+        delayDuration: 0,
+        children: React.createElement(ConnectionList),
+      })
+    );
+  });
+}
+
+function typeInto(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function keydown(el: Element, key: string) {
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+describe("ConnectionList — filter/search", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders a filter input in the Connections header", () => {
+    render(container, root);
+    expect(container.querySelector('[data-testid="connection-filter-input"]')).not.toBeNull();
+  });
+
+  it("live-filters connections by name", () => {
+    useAppStore.setState({
+      connections: [
+        makeConnection({ id: "conn-1", name: "web-server" }),
+        makeConnection({ id: "conn-2", name: "database" }),
+      ],
+    });
+    render(container, root);
+
+    const input = container.querySelector(
+      '[data-testid="connection-filter-input"]'
+    ) as HTMLInputElement;
+    typeInto(input, "web");
+
+    expect(container.querySelector('[data-testid="connection-item-conn-1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="connection-item-conn-2"]')).toBeNull();
+  });
+
+  it("auto-expands a collapsed folder that contains a match", () => {
+    useAppStore.setState({
+      folders: [makeFolder({ id: "folder-1", isExpanded: false })],
+      connections: [makeConnection({ id: "conn-1", name: "web-server", folderId: "folder-1" })],
+    });
+    render(container, root);
+
+    // Collapsed: nested connection not rendered yet.
+    expect(container.querySelector('[data-testid="connection-item-conn-1"]')).toBeNull();
+
+    const input = container.querySelector(
+      '[data-testid="connection-filter-input"]'
+    ) as HTMLInputElement;
+    typeInto(input, "web");
+
+    // Filter reveals the match without a manual expand.
+    expect(container.querySelector('[data-testid="connection-item-conn-1"]')).not.toBeNull();
+  });
+
+  it("Enter connects the top hit", () => {
+    const addTab = vi.fn();
+    useAppStore.setState({
+      connections: [
+        makeConnection({ id: "conn-1", name: "database" }),
+        makeConnection({ id: "conn-2", name: "web-server" }),
+      ],
+      addTab,
+    });
+    render(container, root);
+
+    const input = container.querySelector(
+      '[data-testid="connection-filter-input"]'
+    ) as HTMLInputElement;
+    typeInto(input, "web");
+    keydown(input, "Enter");
+
+    expect(addTab).toHaveBeenCalledWith(
+      "web-server",
+      "local",
+      expect.anything(),
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it("Escape clears the query and restores all connections", () => {
+    useAppStore.setState({
+      connections: [
+        makeConnection({ id: "conn-1", name: "web-server" }),
+        makeConnection({ id: "conn-2", name: "database" }),
+      ],
+    });
+    render(container, root);
+
+    const input = container.querySelector(
+      '[data-testid="connection-filter-input"]'
+    ) as HTMLInputElement;
+    typeInto(input, "web");
+    expect(container.querySelector('[data-testid="connection-item-conn-2"]')).toBeNull();
+
+    keydown(input, "Escape");
+
+    expect(input.value).toBe("");
+    expect(container.querySelector('[data-testid="connection-item-conn-2"]')).not.toBeNull();
+  });
+});

--- a/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
+++ b/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
@@ -55,7 +55,7 @@ const baseSettings = {
   experimentalFeaturesEnabled: false,
 };
 
-function render(container: HTMLElement, root: Root) {
+function render(_container: HTMLElement, root: Root) {
   act(() => {
     root.render(
       React.createElement(TooltipProvider, {

--- a/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
+++ b/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Tests for keyboard navigation and ARIA tree semantics in the connection
+ * sidebar (#1356): role="tree"/role="treeitem", roving tabindex, arrow-key
+ * navigation, and Enter/Space to connect the focused connection.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import { TooltipProvider } from "@/components/ui";
+import type { SavedConnection, ConnectionFolder, RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  isSshKeyEncrypted: vi.fn(() => Promise.resolve(false)),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({
+    agent,
+    sectionRef,
+  }: {
+    agent: RemoteAgentDefinition;
+    sectionRef?: (el: HTMLDivElement | null) => void;
+  }) => React.createElement("div", { ref: sectionRef, "data-testid": `agent-node-${agent.id}` }),
+}));
+
+function makeConnection(overrides: Partial<SavedConnection> = {}): SavedConnection {
+  const id = overrides.id ?? "conn-1";
+  return {
+    id,
+    name: `Connection ${id}`,
+    folderId: null,
+    config: { type: "local", config: {} } as SavedConnection["config"],
+    ...overrides,
+  };
+}
+
+function makeFolder(overrides: Partial<ConnectionFolder> = {}): ConnectionFolder {
+  return { id: "folder-1", name: "Test Folder", parentId: null, isExpanded: true, ...overrides };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: false,
+  fileBrowserEnabled: false,
+  experimentalFeaturesEnabled: false,
+};
+
+function render(container: HTMLElement, root: Root) {
+  act(() => {
+    root.render(
+      React.createElement(TooltipProvider, {
+        delayDuration: 0,
+        children: React.createElement(ConnectionList),
+      })
+    );
+  });
+}
+
+function keydown(el: Element, key: string) {
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+describe("ConnectionList — keyboard navigation & ARIA", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("exposes role=tree with treeitem rows", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+    render(container, root);
+
+    expect(container.querySelector('[role="tree"]')).not.toBeNull();
+    const items = container.querySelectorAll('[role="treeitem"]');
+    expect(items.length).toBe(2);
+  });
+
+  it("uses roving tabindex: only the first item is tabbable initially", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+    render(container, root);
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+    expect(item1.getAttribute("tabindex")).toBe("0");
+    expect(item2.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("ArrowDown moves focus (roving tabindex) to the next item", () => {
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" }), makeConnection({ id: "conn-2" })],
+    });
+    render(container, root);
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    const item2 = container.querySelector('[data-testid="connection-item-conn-2"]') as HTMLElement;
+    act(() => item1.focus());
+    keydown(item1, "ArrowDown");
+
+    expect(item2.getAttribute("tabindex")).toBe("0");
+    expect(item1.getAttribute("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(item2);
+  });
+
+  it("Enter on a focused connection connects it", () => {
+    const addTab = vi.fn();
+    useAppStore.setState({
+      connections: [makeConnection({ id: "conn-1" })],
+      addTab,
+    });
+    render(container, root);
+
+    const item1 = container.querySelector('[data-testid="connection-item-conn-1"]') as HTMLElement;
+    act(() => item1.focus());
+    keydown(item1, "Enter");
+
+    expect(addTab).toHaveBeenCalledWith(
+      "Connection conn-1",
+      "local",
+      expect.anything(),
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it("folder rows expose aria-expanded and ArrowRight expands a collapsed folder", () => {
+    useAppStore.setState({
+      folders: [makeFolder({ id: "folder-1", isExpanded: false })],
+      connections: [makeConnection({ id: "conn-1", folderId: "folder-1" })],
+    });
+    render(container, root);
+
+    const folder = container.querySelector('[data-testid="folder-toggle-folder-1"]') as HTMLElement;
+    expect(folder.getAttribute("role")).toBe("treeitem");
+    expect(folder.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => folder.focus());
+    keydown(folder, "ArrowRight");
+
+    const folderAfter = container.querySelector(
+      '[data-testid="folder-toggle-folder-1"]'
+    ) as HTMLElement;
+    expect(folderAfter.getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -28,6 +28,8 @@ import {
   Server,
   ArrowLeftRight,
   Route,
+  Search,
+  X,
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { SavedConnection, ConnectionFolder } from "@/types/connection";
@@ -41,12 +43,15 @@ import {
 import { frontendLog } from "@/utils/frontendLog";
 import { openLocalCommandTab } from "@/utils/openLocalCommandTab";
 import { ConnectionIcon } from "@/utils/connectionIcons";
-import { Tooltip } from "@/components/ui";
+import { Tooltip, Input } from "@/components/ui";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
 import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
 import { useSectionResize } from "@/hooks/useSectionResize";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
+import { useTreeKeyboardNav } from "@/hooks/useTreeKeyboardNav";
 import { computeFlatVisibleIds } from "@/utils/computeFlatVisibleIds";
+import { computeVisibleTreeNodes } from "@/utils/computeVisibleTreeNodes";
+import { filterConnectionTree, type ConnectionTreeFilter } from "@/utils/connectionSearch";
 import {
   getJumpHosts,
   jumpHostTooltip,
@@ -60,7 +65,22 @@ import { InlineFolderInput } from "./InlineFolderInput";
 import { useExperimentalFeatures } from "@/hooks/useExperimentalFeatures";
 import "./ConnectionList.css";
 
-interface TreeNodeProps {
+/**
+ * Shared keyboard-navigation / filter plumbing threaded through the tree so
+ * every row participates in roving-tabindex focus and search filtering (#1356).
+ */
+interface TreeNavProps {
+  /** Active search filter, or `null` when no query is entered. */
+  filter: ConnectionTreeFilter | null;
+  /** Row that currently owns `tabindex=0`. */
+  focusedId: string | null;
+  /** Keyboard handler for a tree row, keyed by its node id. */
+  onTreeKeyDown: (event: React.KeyboardEvent, nodeId: string) => void;
+  /** Sync the roving-tabindex focus when a row gains DOM focus. */
+  onFocusNode: (id: string) => void;
+}
+
+interface TreeNodeProps extends TreeNavProps {
   folder: ConnectionFolder;
   connections: SavedConnection[];
   childFolders: ConnectionFolder[];
@@ -98,9 +118,22 @@ function TreeNode({
   selectedConnectionIds,
   onConnectionClick,
   depth,
+  filter,
+  focusedId,
+  onTreeKeyDown,
+  onFocusNode,
 }: TreeNodeProps) {
   const [creatingSubfolder, setCreatingSubfolder] = useState(false);
-  const Chevron = folder.isExpanded ? ChevronDown : ChevronRight;
+  // Under an active filter, matched folders are force-expanded regardless of
+  // their stored state (auto-expand matches).
+  const expanded = filter ? filter.visibleFolderIds.has(folder.id) : folder.isExpanded;
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+  const visibleChildFolders = filter
+    ? childFolders.filter((f) => filter.visibleFolderIds.has(f.id))
+    : childFolders;
+  const visibleConnections = filter
+    ? connections.filter((c) => filter.matchingConnectionIds.has(c.id))
+    : connections;
 
   const { setNodeRef, isOver } = useDroppable({
     id: folder.id,
@@ -113,7 +146,7 @@ function TreeNode({
     active?.data.current?.type !== "agent-connection";
 
   return (
-    <div className="connection-tree__node">
+    <div className="connection-tree__node" role="none">
       <ContextMenu.Root>
         <ContextMenu.Trigger asChild>
           <button
@@ -122,6 +155,13 @@ function TreeNode({
             onClick={() => onToggle(folder.id)}
             style={{ paddingLeft: `${depth * 16 + 8}px` }}
             data-testid={`folder-toggle-${folder.id}`}
+            role="treeitem"
+            aria-expanded={expanded}
+            aria-level={depth + 1}
+            tabIndex={focusedId === folder.id ? 0 : -1}
+            data-tree-node-id={folder.id}
+            onKeyDown={(e) => onTreeKeyDown(e, folder.id)}
+            onFocus={() => onFocusNode(folder.id)}
           >
             <Folder size={16} />
             <span className="connection-tree__label">{folder.name}</span>
@@ -155,8 +195,8 @@ function TreeNode({
           </ContextMenu.Content>
         </ContextMenu.Portal>
       </ContextMenu.Root>
-      {folder.isExpanded && (
-        <div className="connection-tree__children">
+      {expanded && (
+        <div className="connection-tree__children" role="group">
           {creatingSubfolder && (
             <InlineFolderInput
               depth={depth + 1}
@@ -167,7 +207,7 @@ function TreeNode({
               onCancel={() => setCreatingSubfolder(false)}
             />
           )}
-          {childFolders.map((child) => (
+          {visibleChildFolders.map((child) => (
             <TreeNode
               key={child.id}
               folder={child}
@@ -187,9 +227,13 @@ function TreeNode({
               selectedConnectionIds={selectedConnectionIds}
               onConnectionClick={onConnectionClick}
               depth={depth + 1}
+              filter={filter}
+              focusedId={focusedId}
+              onTreeKeyDown={onTreeKeyDown}
+              onFocusNode={onFocusNode}
             />
           ))}
-          {connections.map((conn) => (
+          {visibleConnections.map((conn) => (
             <ConnectionItem
               key={conn.id}
               connection={conn}
@@ -201,6 +245,9 @@ function TreeNode({
               onDuplicate={onDuplicate}
               onPingHost={onPingHost}
               onConnectionClick={onConnectionClick}
+              focusedId={focusedId}
+              onTreeKeyDown={onTreeKeyDown}
+              onFocusNode={onFocusNode}
             />
           ))}
         </div>
@@ -209,7 +256,10 @@ function TreeNode({
   );
 }
 
-interface ConnectionItemProps {
+interface ConnectionItemProps extends Pick<
+  TreeNavProps,
+  "focusedId" | "onTreeKeyDown" | "onFocusNode"
+> {
   connection: SavedConnection;
   depth: number;
   isSelected: boolean;
@@ -231,6 +281,9 @@ function ConnectionItem({
   onDuplicate,
   onPingHost,
   onConnectionClick,
+  focusedId,
+  onTreeKeyDown,
+  onFocusNode,
 }: ConnectionItemProps) {
   const {
     attributes,
@@ -260,33 +313,57 @@ function ConnectionItem({
       )}
       <ContextMenu.Root>
         <ContextMenu.Trigger asChild>
-          <button
-            ref={setDragRef}
-            className={className}
-            style={{ paddingLeft: `${depth * 16 + 8}px` }}
-            onClick={(e) => onConnectionClick(connection.id, e)}
-            onDoubleClick={() => onConnect(connection)}
-            title={`Double-click to connect: ${connection.name}`}
-            data-testid={`connection-item-${connection.id}`}
-            {...attributes}
-            {...listeners}
-          >
-            <ConnectionIcon config={connection.config} customIcon={connection.icon} size={16} />
-            <span className="connection-tree__label">{connection.name}</span>
-            {jumpHosts.length > 0 && (
-              <span
-                className="connection-tree__jump-badge"
-                title={jumpHostTooltip(jumpHosts, connection.name)}
-                data-testid={`connection-jump-badge-${connection.id}`}
+          <div className="connection-tree__item-row" role="none">
+            <button
+              ref={setDragRef}
+              className={className}
+              style={{ paddingLeft: `${depth * 16 + 8}px` }}
+              onClick={(e) => onConnectionClick(connection.id, e)}
+              onDoubleClick={() => onConnect(connection)}
+              title={`Double-click to connect: ${connection.name}`}
+              data-testid={`connection-item-${connection.id}`}
+              {...attributes}
+              {...listeners}
+              role="treeitem"
+              aria-level={depth + 1}
+              aria-selected={isSelected}
+              tabIndex={focusedId === connection.id ? 0 : -1}
+              data-tree-node-id={connection.id}
+              onKeyDown={(e) => onTreeKeyDown(e, connection.id)}
+              onFocus={() => onFocusNode(connection.id)}
+            >
+              <ConnectionIcon config={connection.config} customIcon={connection.icon} size={16} />
+              <span className="connection-tree__label">{connection.name}</span>
+              {jumpHosts.length > 0 && (
+                <span
+                  className="connection-tree__jump-badge"
+                  title={jumpHostTooltip(jumpHosts, connection.name)}
+                  data-testid={`connection-jump-badge-${connection.id}`}
+                >
+                  <ArrowLeftRight size={12} />
+                  {jumpHosts.length > 1 && (
+                    <span className="connection-tree__jump-count">{jumpHosts.length}</span>
+                  )}
+                </span>
+              )}
+              <span className="connection-tree__type">{connection.config.type}</span>
+            </button>
+            <Tooltip content="Connect" side="right">
+              <button
+                type="button"
+                className="connection-tree__connect-btn"
+                aria-label={`Connect to ${connection.name}`}
+                tabIndex={-1}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onConnect(connection);
+                }}
+                data-testid={`connection-connect-${connection.id}`}
               >
-                <ArrowLeftRight size={12} />
-                {jumpHosts.length > 1 && (
-                  <span className="connection-tree__jump-count">{jumpHosts.length}</span>
-                )}
-              </span>
-            )}
-            <span className="connection-tree__type">{connection.config.type}</span>
-          </button>
+                <Play size={14} />
+              </button>
+            </Tooltip>
+          </div>
         </ContextMenu.Trigger>
         <ContextMenu.Portal>
           <ContextMenu.Content className="context-menu__content">
@@ -369,6 +446,7 @@ function buildExpandedIndexMap(sectionsExpanded: boolean[]): { map: number[]; co
 
 export function ConnectionList() {
   const [creatingFolder, setCreatingFolder] = useState(false);
+  const [filterQuery, setFilterQuery] = useState("");
   const [draggingConnection, setDraggingConnection] = useState<SavedConnection | null>(null);
   const [draggingAgentName, setDraggingAgentName] = useState<string | null>(null);
   const [draggingAgentDef, setDraggingAgentDef] = useState<AgentDefinitionInfo | null>(null);
@@ -571,6 +649,46 @@ export function ConnectionList() {
       );
     },
     [addTab, requestPassword]
+  );
+
+  // Live search filter over the connection tree (name/host). `null` when empty.
+  const filter = useMemo(
+    () => filterConnectionTree(filterQuery, folders, connections),
+    [filterQuery, folders, connections]
+  );
+
+  // Flattened, in-order list of the rows actually rendered — drives roving
+  // tabindex keyboard navigation.
+  const treeNodes = useMemo(
+    () => computeVisibleTreeNodes(folders, connections, filter),
+    [folders, connections, filter]
+  );
+
+  const { containerRef, focusedId, setFocusedId, handleKeyDown } = useTreeKeyboardNav(treeNodes, {
+    onConnect: handleConnect,
+    onToggleFolder: toggleFolder,
+  });
+
+  // The row that owns tabindex=0: the tracked focus if still present, else the
+  // first visible row (so Tab always lands somewhere sensible).
+  const effectiveFocusedId =
+    focusedId && treeNodes.some((n) => n.id === focusedId) ? focusedId : (treeNodes[0]?.id ?? null);
+
+  const handleFilterKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        const topHitId = filter?.topHitId;
+        if (topHitId) {
+          const target = connections.find((c) => c.id === topHitId);
+          if (target) handleConnect(target);
+        }
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        setFilterQuery("");
+      }
+    },
+    [filter, connections, handleConnect]
   );
 
   const handleEdit = useCallback(
@@ -869,7 +987,7 @@ export function ConnectionList() {
   );
 
   return (
-    <div className="connection-list">
+    <div className="connection-list" ref={containerRef}>
       <DndContext
         sensors={sensors}
         collisionDetection={pointerWithin}
@@ -923,6 +1041,33 @@ export function ConnectionList() {
             </div>
           </div>
           {!localCollapsed && (
+            <div className="connection-list__filter">
+              <Search size={14} className="connection-list__filter-icon" aria-hidden="true" />
+              <Input
+                className="connection-list__filter-input"
+                value={filterQuery}
+                onChange={(e) => setFilterQuery(e.target.value)}
+                onKeyDown={handleFilterKeyDown}
+                placeholder="Filter connections…"
+                aria-label="Filter connections"
+                data-testid="connection-filter-input"
+              />
+              {filterQuery && (
+                <Tooltip content="Clear filter" side="top">
+                  <button
+                    type="button"
+                    className="connection-list__filter-clear"
+                    onClick={() => setFilterQuery("")}
+                    aria-label="Clear filter"
+                    data-testid="connection-filter-clear"
+                  >
+                    <X size={14} />
+                  </button>
+                </Tooltip>
+              )}
+            </div>
+          )}
+          {!localCollapsed && (
             <RootDropZone
               isCreatingFolder={creatingFolder}
               onCreateFolder={(name) => {
@@ -948,6 +1093,10 @@ export function ConnectionList() {
               selectedConnectionIds={selectedConnectionIds}
               onConnectionClick={handleConnectionClick}
               onTreeAreaClick={handleTreeAreaClick}
+              filter={filter}
+              focusedId={effectiveFocusedId}
+              onTreeKeyDown={handleKeyDown}
+              onFocusNode={setFocusedId}
             />
           )}
         </div>
@@ -1067,7 +1216,7 @@ export function ConnectionList() {
   );
 }
 
-interface RootDropZoneProps {
+interface RootDropZoneProps extends TreeNavProps {
   isCreatingFolder: boolean;
   onCreateFolder: (name: string) => void;
   onCancelCreateFolder: () => void;
@@ -1113,11 +1262,22 @@ function RootDropZone({
   selectedConnectionIds,
   onConnectionClick,
   onTreeAreaClick,
+  filter,
+  focusedId,
+  onTreeKeyDown,
+  onFocusNode,
 }: RootDropZoneProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: "root",
     data: { type: "root" },
   });
+  const visibleRootFolders = filter
+    ? rootFolders.filter((f) => filter.visibleFolderIds.has(f.id))
+    : rootFolders;
+  const visibleRootConnections = filter
+    ? rootConnections.filter((c) => filter.matchingConnectionIds.has(c.id))
+    : rootConnections;
+  const hasVisibleResults = visibleRootFolders.length + visibleRootConnections.length > 0;
   const { active } = useDndContext();
   const isConnectionOver =
     isOver &&
@@ -1131,6 +1291,8 @@ function RootDropZone({
           ref={setNodeRef}
           className={`connection-list__tree${isConnectionOver ? " connection-tree__root-drop--over" : ""}`}
           onClick={onTreeAreaClick}
+          role="tree"
+          aria-label="Connections"
         >
           {isCreatingFolder && (
             <InlineFolderInput
@@ -1139,7 +1301,12 @@ function RootDropZone({
               onCancel={onCancelCreateFolder}
             />
           )}
-          {rootFolders.map((folder) => (
+          {filter && !hasVisibleResults && (
+            <p className="connection-list__empty" role="status">
+              No connections match “{filter.query}”.
+            </p>
+          )}
+          {visibleRootFolders.map((folder) => (
             <TreeNode
               key={folder.id}
               folder={folder}
@@ -1159,9 +1326,13 @@ function RootDropZone({
               selectedConnectionIds={selectedConnectionIds}
               onConnectionClick={onConnectionClick}
               depth={0}
+              filter={filter}
+              focusedId={focusedId}
+              onTreeKeyDown={onTreeKeyDown}
+              onFocusNode={onFocusNode}
             />
           ))}
-          {rootConnections.map((conn) => (
+          {visibleRootConnections.map((conn) => (
             <ConnectionItem
               key={conn.id}
               connection={conn}
@@ -1173,6 +1344,9 @@ function RootDropZone({
               onDuplicate={onDuplicate}
               onPingHost={onPingHost}
               onConnectionClick={onConnectionClick}
+              focusedId={focusedId}
+              onTreeKeyDown={onTreeKeyDown}
+              onFocusNode={onFocusNode}
             />
           ))}
         </div>

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -49,7 +49,6 @@ import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlo
 import { useSectionResize } from "@/hooks/useSectionResize";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
 import { useTreeKeyboardNav } from "@/hooks/useTreeKeyboardNav";
-import { computeFlatVisibleIds } from "@/utils/computeFlatVisibleIds";
 import { computeVisibleTreeNodes } from "@/utils/computeVisibleTreeNodes";
 import { filterConnectionTree, type ConnectionTreeFilter } from "@/utils/connectionSearch";
 import {
@@ -488,9 +487,23 @@ export function ConnectionList() {
     [connections]
   );
 
+  // Live search filter over the connection tree (name/host). `null` when empty.
+  const filter = useMemo(
+    () => filterConnectionTree(filterQuery, folders, connections),
+    [filterQuery, folders, connections]
+  );
+
+  // Flattened, in-order list of the rows actually rendered — drives both
+  // roving-tabindex keyboard navigation and Shift+Click range selection, so
+  // both stay in sync with the active filter.
+  const treeNodes = useMemo(
+    () => computeVisibleTreeNodes(folders, connections, filter),
+    [folders, connections, filter]
+  );
+
   const flatVisibleConnectionIds = useMemo(
-    () => computeFlatVisibleIds(rootFolders, rootConnections, folders, connections),
-    [rootFolders, rootConnections, folders, connections]
+    () => treeNodes.filter((n) => n.kind === "connection").map((n) => n.id),
+    [treeNodes]
   );
 
   const {
@@ -651,19 +664,6 @@ export function ConnectionList() {
     [addTab, requestPassword]
   );
 
-  // Live search filter over the connection tree (name/host). `null` when empty.
-  const filter = useMemo(
-    () => filterConnectionTree(filterQuery, folders, connections),
-    [filterQuery, folders, connections]
-  );
-
-  // Flattened, in-order list of the rows actually rendered — drives roving
-  // tabindex keyboard navigation.
-  const treeNodes = useMemo(
-    () => computeVisibleTreeNodes(folders, connections, filter),
-    [folders, connections, filter]
-  );
-
   const { containerRef, focusedId, setFocusedId, handleKeyDown } = useTreeKeyboardNav(treeNodes, {
     onConnect: handleConnect,
     onToggleFolder: toggleFolder,
@@ -678,7 +678,8 @@ export function ConnectionList() {
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (event.key === "Enter") {
         event.preventDefault();
-        const topHitId = filter?.topHitId;
+        // Top hit = first connection row in filter-aware visual order.
+        const topHitId = flatVisibleConnectionIds[0];
         if (topHitId) {
           const target = connections.find((c) => c.id === topHitId);
           if (target) handleConnect(target);
@@ -688,7 +689,7 @@ export function ConnectionList() {
         setFilterQuery("");
       }
     },
-    [filter, connections, handleConnect]
+    [flatVisibleConnectionIds, connections, handleConnect]
   );
 
   const handleEdit = useCallback(

--- a/src/hooks/useTreeKeyboardNav.ts
+++ b/src/hooks/useTreeKeyboardNav.ts
@@ -1,0 +1,135 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import type { SavedConnection } from "@/types/connection";
+import type { VisibleTreeNode } from "@/utils/computeVisibleTreeNodes";
+
+export interface TreeKeyboardNavResult {
+  /** Container ref: scopes DOM focus queries to this tree. */
+  containerRef: React.RefObject<HTMLDivElement>;
+  /** The row that currently owns `tabindex=0` (roving tabindex). */
+  focusedId: string | null;
+  /** Update the focused row when the user tabs/clicks into it (no DOM focus move). */
+  setFocusedId: (id: string) => void;
+  /** `onKeyDown` handler to attach to every tree row. */
+  handleKeyDown: (event: React.KeyboardEvent, nodeId: string) => void;
+}
+
+interface TreeKeyboardNavOptions {
+  onConnect: (connection: SavedConnection) => void;
+  onToggleFolder: (folderId: string) => void;
+}
+
+/**
+ * Roving-tabindex keyboard navigation for a flattened tree (#1356).
+ *
+ * Given the visible rows in visual order, this manages which row is tabbable
+ * and moves DOM focus in response to arrow keys:
+ * - Up/Down move between visible rows.
+ * - Right expands a collapsed folder, or descends into an expanded one.
+ * - Left collapses an expanded folder, or ascends to the parent row.
+ * - Enter/Space connects a focused connection or toggles a focused folder.
+ * - Home/End jump to the first/last row.
+ *
+ * DOM focus is moved by locating `[data-tree-node-id]` inside {@link containerRef}
+ * after the render that reveals the target row.
+ */
+export function useTreeKeyboardNav(
+  nodes: VisibleTreeNode[],
+  { onConnect, onToggleFolder }: TreeKeyboardNavOptions
+): TreeKeyboardNavResult {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const pendingFocusRef = useRef<string | null>(null);
+
+  // After the tree re-renders, move DOM focus to a pending target once it exists.
+  useLayoutEffect(() => {
+    const target = pendingFocusRef.current;
+    if (!target || !containerRef.current) return;
+    const rows = containerRef.current.querySelectorAll<HTMLElement>("[data-tree-node-id]");
+    const el = Array.from(rows).find((row) => row.dataset.treeNodeId === target);
+    if (el) {
+      el.focus();
+      pendingFocusRef.current = null;
+    }
+  });
+
+  const focusNode = useCallback((id: string) => {
+    setFocusedId(id);
+    pendingFocusRef.current = id;
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent, nodeId: string) => {
+      const index = nodes.findIndex((n) => n.id === nodeId);
+      if (index === -1) return;
+      const node = nodes[index];
+
+      switch (event.key) {
+        case "ArrowDown": {
+          const next = nodes[index + 1];
+          if (next) {
+            event.preventDefault();
+            focusNode(next.id);
+          }
+          break;
+        }
+        case "ArrowUp": {
+          const prev = nodes[index - 1];
+          if (prev) {
+            event.preventDefault();
+            focusNode(prev.id);
+          }
+          break;
+        }
+        case "ArrowRight": {
+          if (node.kind !== "folder") break;
+          event.preventDefault();
+          if (!node.isExpanded && node.hasChildren) {
+            onToggleFolder(node.id);
+            focusNode(node.id);
+          } else if (node.isExpanded) {
+            const child = nodes[index + 1];
+            if (child && child.depth > node.depth) focusNode(child.id);
+          }
+          break;
+        }
+        case "ArrowLeft": {
+          event.preventDefault();
+          if (node.kind === "folder" && node.isExpanded) {
+            onToggleFolder(node.id);
+            focusNode(node.id);
+          } else if (node.parentId) {
+            focusNode(node.parentId);
+          }
+          break;
+        }
+        case "Enter":
+        case " ": {
+          event.preventDefault();
+          if (node.kind === "connection" && node.connection) onConnect(node.connection);
+          else if (node.kind === "folder") onToggleFolder(node.id);
+          break;
+        }
+        case "Home": {
+          if (nodes[0]) {
+            event.preventDefault();
+            focusNode(nodes[0].id);
+          }
+          break;
+        }
+        case "End": {
+          const last = nodes[nodes.length - 1];
+          if (last) {
+            event.preventDefault();
+            focusNode(last.id);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [nodes, focusNode, onConnect, onToggleFolder]
+  );
+
+  return { containerRef, focusedId, setFocusedId, handleKeyDown };
+}

--- a/src/utils/computeVisibleTreeNodes.test.ts
+++ b/src/utils/computeVisibleTreeNodes.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { computeVisibleTreeNodes } from "./computeVisibleTreeNodes";
+import { filterConnectionTree } from "./connectionSearch";
+import type { SavedConnection, ConnectionFolder } from "@/types/connection";
+
+function conn(id: string, name: string, folderId: string | null = null): SavedConnection {
+  return {
+    id,
+    name,
+    folderId,
+    config: { type: "local", config: {} } as SavedConnection["config"],
+  };
+}
+
+function folder(id: string, parentId: string | null = null, isExpanded = true): ConnectionFolder {
+  return { id, name: id, parentId, isExpanded };
+}
+
+describe("computeVisibleTreeNodes (no filter)", () => {
+  it("flattens expanded folders before sibling connections in visual order", () => {
+    const folders = [folder("f1")];
+    const conns = [conn("c-nested", "n", "f1"), conn("c-root", "r", null)];
+    const nodes = computeVisibleTreeNodes(folders, conns, null);
+    expect(nodes.map((n) => n.id)).toEqual(["f1", "c-nested", "c-root"]);
+    expect(nodes[0].kind).toBe("folder");
+    expect(nodes[0].isExpanded).toBe(true);
+    expect(nodes[0].hasChildren).toBe(true);
+  });
+
+  it("omits children of a collapsed folder", () => {
+    const folders = [folder("f1", null, false)];
+    const conns = [conn("c-nested", "n", "f1")];
+    const nodes = computeVisibleTreeNodes(folders, conns, null);
+    expect(nodes.map((n) => n.id)).toEqual(["f1"]);
+    expect(nodes[0].isExpanded).toBe(false);
+  });
+
+  it("records parentId for ArrowLeft navigation", () => {
+    const nodes = computeVisibleTreeNodes([folder("f1")], [conn("c1", "c", "f1")], null);
+    const child = nodes.find((n) => n.id === "c1");
+    expect(child?.parentId).toBe("f1");
+    expect(child?.depth).toBe(1);
+  });
+});
+
+describe("computeVisibleTreeNodes (filtered)", () => {
+  it("includes only matches and their ancestors, always expanded", () => {
+    const folders = [folder("f1", null, false), folder("f2", null, true)];
+    const conns = [conn("c1", "web", "f1"), conn("c2", "db", "f2")];
+    const filter = filterConnectionTree("web", folders, conns);
+    const nodes = computeVisibleTreeNodes(folders, conns, filter);
+    // f1 collapsed in storage, but a match inside forces it visible + expanded.
+    expect(nodes.map((n) => n.id)).toEqual(["f1", "c1"]);
+    expect(nodes[0].isExpanded).toBe(true);
+  });
+});

--- a/src/utils/computeVisibleTreeNodes.ts
+++ b/src/utils/computeVisibleTreeNodes.ts
@@ -1,0 +1,92 @@
+import { SavedConnection, ConnectionFolder } from "@/types/connection";
+import { ConnectionTreeFilter } from "./connectionSearch";
+
+/**
+ * A single rendered row of the connection tree, flattened into visual order.
+ * Drives roving-tabindex keyboard navigation: the array index is the row's
+ * position, `depth` its indent level, and `parentId` the row to jump to on
+ * ArrowLeft.
+ */
+export interface VisibleTreeNode {
+  id: string;
+  kind: "folder" | "connection";
+  depth: number;
+  /** Folders: effective expansion state. Connections: always `false`. */
+  isExpanded: boolean;
+  /** Folders: whether any child folder/connection is currently rendered. */
+  hasChildren: boolean;
+  /** Folder's `parentId`, or a connection's `folderId` (`null` at the root). */
+  parentId: string | null;
+  /** Present for connection rows only. */
+  connection?: SavedConnection;
+}
+
+/**
+ * Flatten the connection tree into the exact list of rows that are rendered,
+ * in top-to-bottom visual order.
+ *
+ * When `filter` is provided (an active search), only matching connections and
+ * their ancestor folders are included, and those folders are treated as
+ * expanded regardless of stored state. When `filter` is `null`, the full tree
+ * is walked honoring each folder's `isExpanded`.
+ */
+export function computeVisibleTreeNodes(
+  folders: ConnectionFolder[],
+  connections: SavedConnection[],
+  filter: ConnectionTreeFilter | null
+): VisibleTreeNode[] {
+  const nodes: VisibleTreeNode[] = [];
+
+  const isFolderRendered = (folder: ConnectionFolder) =>
+    filter ? filter.visibleFolderIds.has(folder.id) : true;
+  const isFolderExpanded = (folder: ConnectionFolder) => (filter ? true : folder.isExpanded);
+  const isConnRendered = (conn: SavedConnection) =>
+    filter ? filter.matchingConnectionIds.has(conn.id) : true;
+
+  const childFolders = (parentId: string | null) =>
+    folders.filter((f) => f.parentId === parentId && isFolderRendered(f));
+  const folderConnections = (folderId: string | null) =>
+    connections.filter((c) => c.folderId === folderId && isConnRendered(c));
+
+  function pushFolder(folder: ConnectionFolder, depth: number): void {
+    const kids = childFolders(folder.id);
+    const conns = folderConnections(folder.id);
+    const expanded = isFolderExpanded(folder);
+    nodes.push({
+      id: folder.id,
+      kind: "folder",
+      depth,
+      isExpanded: expanded,
+      hasChildren: kids.length + conns.length > 0,
+      parentId: folder.parentId,
+    });
+    if (!expanded) return;
+    kids.forEach((k) => pushFolder(k, depth + 1));
+    conns.forEach((c) =>
+      nodes.push({
+        id: c.id,
+        kind: "connection",
+        depth: depth + 1,
+        isExpanded: false,
+        hasChildren: false,
+        parentId: folder.id,
+        connection: c,
+      })
+    );
+  }
+
+  childFolders(null).forEach((f) => pushFolder(f, 0));
+  folderConnections(null).forEach((c) =>
+    nodes.push({
+      id: c.id,
+      kind: "connection",
+      depth: 0,
+      isExpanded: false,
+      hasChildren: false,
+      parentId: null,
+      connection: c,
+    })
+  );
+
+  return nodes;
+}

--- a/src/utils/connectionSearch.test.ts
+++ b/src/utils/connectionSearch.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { filterConnectionTree, connectionMatchesQuery } from "./connectionSearch";
+import type { SavedConnection, ConnectionFolder } from "@/types/connection";
+
+function conn(
+  id: string,
+  name: string,
+  opts: { folderId?: string | null; host?: string } = {}
+): SavedConnection {
+  return {
+    id,
+    name,
+    folderId: opts.folderId ?? null,
+    config: {
+      type: opts.host ? "ssh" : "local",
+      config: opts.host ? { host: opts.host } : {},
+    } as SavedConnection["config"],
+  };
+}
+
+function folder(id: string, name: string, parentId: string | null = null): ConnectionFolder {
+  return { id, name, parentId, isExpanded: false };
+}
+
+describe("connectionMatchesQuery", () => {
+  it("matches by name (case-insensitive)", () => {
+    expect(connectionMatchesQuery(conn("c1", "Production DB"), "prod")).toBe(true);
+    expect(connectionMatchesQuery(conn("c1", "Production DB"), "xyz")).toBe(false);
+  });
+
+  it("matches by host", () => {
+    expect(connectionMatchesQuery(conn("c1", "Box", { host: "10.0.0.5" }), "10.0.0")).toBe(true);
+  });
+
+  it("empty query matches everything", () => {
+    expect(connectionMatchesQuery(conn("c1", "Anything"), "")).toBe(true);
+  });
+});
+
+describe("filterConnectionTree", () => {
+  it("returns null for an empty query", () => {
+    expect(filterConnectionTree("   ", [], [conn("c1", "A")])).toBeNull();
+  });
+
+  it("keeps only matching connections", () => {
+    const filter = filterConnectionTree("web", [], [conn("c1", "web-1"), conn("c2", "db-1")]);
+    expect(filter?.matchingConnectionIds.has("c1")).toBe(true);
+    expect(filter?.matchingConnectionIds.has("c2")).toBe(false);
+  });
+
+  it("marks ancestor folders of matches as visible", () => {
+    const folders = [folder("f1", "Servers"), folder("f2", "Prod", "f1")];
+    const conns = [conn("c1", "web-1", { folderId: "f2" }), conn("c2", "db-1", { folderId: null })];
+    const filter = filterConnectionTree("web", folders, conns);
+    expect(filter?.visibleFolderIds.has("f1")).toBe(true);
+    expect(filter?.visibleFolderIds.has("f2")).toBe(true);
+  });
+
+  it("hides folders with no matching descendants", () => {
+    const folders = [folder("f1", "Servers"), folder("f2", "Empty")];
+    const conns = [conn("c1", "web-1", { folderId: "f1" })];
+    const filter = filterConnectionTree("web", folders, conns);
+    expect(filter?.visibleFolderIds.has("f1")).toBe(true);
+    expect(filter?.visibleFolderIds.has("f2")).toBe(false);
+  });
+
+  it("reports the first match in visual order as the top hit", () => {
+    const folders = [folder("f1", "Servers")];
+    const conns = [
+      conn("c-root", "web-root", { folderId: null }),
+      conn("c-nested", "web-nested", { folderId: "f1" }),
+    ];
+    // Folder contents render before root connections, so the nested match wins.
+    const filter = filterConnectionTree("web", folders, conns);
+    expect(filter?.topHitId).toBe("c-nested");
+  });
+
+  it("top hit is null when nothing matches", () => {
+    const filter = filterConnectionTree("zzz", [], [conn("c1", "web")]);
+    expect(filter?.topHitId).toBeNull();
+    expect(filter?.matchingConnectionIds.size).toBe(0);
+  });
+});

--- a/src/utils/connectionSearch.test.ts
+++ b/src/utils/connectionSearch.test.ts
@@ -64,20 +64,9 @@ describe("filterConnectionTree", () => {
     expect(filter?.visibleFolderIds.has("f2")).toBe(false);
   });
 
-  it("reports the first match in visual order as the top hit", () => {
-    const folders = [folder("f1", "Servers")];
-    const conns = [
-      conn("c-root", "web-root", { folderId: null }),
-      conn("c-nested", "web-nested", { folderId: "f1" }),
-    ];
-    // Folder contents render before root connections, so the nested match wins.
-    const filter = filterConnectionTree("web", folders, conns);
-    expect(filter?.topHitId).toBe("c-nested");
-  });
-
-  it("top hit is null when nothing matches", () => {
+  it("matches nothing for a non-matching query", () => {
     const filter = filterConnectionTree("zzz", [], [conn("c1", "web")]);
-    expect(filter?.topHitId).toBeNull();
     expect(filter?.matchingConnectionIds.size).toBe(0);
+    expect(filter?.visibleFolderIds.size).toBe(0);
   });
 });

--- a/src/utils/connectionSearch.ts
+++ b/src/utils/connectionSearch.ts
@@ -15,8 +15,6 @@ export interface ConnectionTreeFilter {
   matchingConnectionIds: Set<string>;
   /** Folders that contain a match (transitively) and should be rendered + expanded. */
   visibleFolderIds: Set<string>;
-  /** First matching connection in visual (tree) order — the "top hit". */
-  topHitId: string | null;
 }
 
 /** Extract the connection's host, if its config declares one. */
@@ -44,9 +42,9 @@ export function connectionMatchesQuery(
  * query is empty (meaning: no filtering, render the full tree with stored
  * expansion state).
  *
- * Visual order mirrors the tree render order (child folders before sibling
- * connections at each level; root folders before root connections), so the
- * `topHitId` is the first match a user sees top-to-bottom.
+ * The "top hit" (first match in visual order) is not computed here — callers
+ * derive it from the flattened, filter-aware visible-node list
+ * ({@link computeVisibleTreeNodes}), which already encodes render order.
  */
 export function filterConnectionTree(
   query: string,
@@ -77,28 +75,5 @@ export function filterConnectionTree(
   }
   childFolders(null).forEach(markVisible);
 
-  // Pre-order pass over the visible tree to find the first match (top hit).
-  let topHitId: string | null = null;
-  function findTopHit(folder: ConnectionFolder): void {
-    if (topHitId !== null || !visibleFolderIds.has(folder.id)) return;
-    for (const child of childFolders(folder.id)) findTopHit(child);
-    if (topHitId !== null) return;
-    for (const c of folderConnections(folder.id)) {
-      if (matchingConnectionIds.has(c.id)) {
-        topHitId = c.id;
-        return;
-      }
-    }
-  }
-  childFolders(null).forEach(findTopHit);
-  if (topHitId === null) {
-    for (const c of folderConnections(null)) {
-      if (matchingConnectionIds.has(c.id)) {
-        topHitId = c.id;
-        break;
-      }
-    }
-  }
-
-  return { query: normalizedQuery, matchingConnectionIds, visibleFolderIds, topHitId };
+  return { query: normalizedQuery, matchingConnectionIds, visibleFolderIds };
 }

--- a/src/utils/connectionSearch.ts
+++ b/src/utils/connectionSearch.ts
@@ -1,0 +1,104 @@
+import { SavedConnection, ConnectionFolder } from "@/types/connection";
+
+/**
+ * Result of filtering a connection tree by a search query.
+ *
+ * When a query is active, only connections whose name or host matches are kept,
+ * along with every ancestor folder needed to reveal them. Folders in
+ * {@link ConnectionTreeFilter.visibleFolderIds} are always shown expanded (the
+ * "auto-expand matches" behaviour), regardless of their stored `isExpanded`.
+ */
+export interface ConnectionTreeFilter {
+  /** Normalized (trimmed, lower-cased) query the filter was built from. */
+  query: string;
+  /** Connections that match the query and should be rendered. */
+  matchingConnectionIds: Set<string>;
+  /** Folders that contain a match (transitively) and should be rendered + expanded. */
+  visibleFolderIds: Set<string>;
+  /** First matching connection in visual (tree) order — the "top hit". */
+  topHitId: string | null;
+}
+
+/** Extract the connection's host, if its config declares one. */
+function connectionHost(connection: SavedConnection): string {
+  const cfg = connection.config.config as unknown as Record<string, unknown>;
+  return typeof cfg.host === "string" ? cfg.host : "";
+}
+
+/**
+ * Whether a connection matches the (already normalized) query by name or host.
+ * An empty query matches everything.
+ */
+export function connectionMatchesQuery(
+  connection: SavedConnection,
+  normalizedQuery: string
+): boolean {
+  if (!normalizedQuery) return true;
+  if (connection.name.toLowerCase().includes(normalizedQuery)) return true;
+  if (connectionHost(connection).toLowerCase().includes(normalizedQuery)) return true;
+  return false;
+}
+
+/**
+ * Build a {@link ConnectionTreeFilter} for the given query, or `null` when the
+ * query is empty (meaning: no filtering, render the full tree with stored
+ * expansion state).
+ *
+ * Visual order mirrors the tree render order (child folders before sibling
+ * connections at each level; root folders before root connections), so the
+ * `topHitId` is the first match a user sees top-to-bottom.
+ */
+export function filterConnectionTree(
+  query: string,
+  folders: ConnectionFolder[],
+  connections: SavedConnection[]
+): ConnectionTreeFilter | null {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return null;
+
+  const matchingConnectionIds = new Set<string>();
+  for (const c of connections) {
+    if (connectionMatchesQuery(c, normalizedQuery)) matchingConnectionIds.add(c.id);
+  }
+
+  const childFolders = (parentId: string | null) => folders.filter((f) => f.parentId === parentId);
+  const folderConnections = (folderId: string | null) =>
+    connections.filter((c) => c.folderId === folderId);
+
+  // Post-order pass: a folder is visible when any of its descendant connections match.
+  const visibleFolderIds = new Set<string>();
+  function markVisible(folder: ConnectionFolder): boolean {
+    let hasMatch = folderConnections(folder.id).some((c) => matchingConnectionIds.has(c.id));
+    for (const child of childFolders(folder.id)) {
+      if (markVisible(child)) hasMatch = true;
+    }
+    if (hasMatch) visibleFolderIds.add(folder.id);
+    return hasMatch;
+  }
+  childFolders(null).forEach(markVisible);
+
+  // Pre-order pass over the visible tree to find the first match (top hit).
+  let topHitId: string | null = null;
+  function findTopHit(folder: ConnectionFolder): void {
+    if (topHitId !== null || !visibleFolderIds.has(folder.id)) return;
+    for (const child of childFolders(folder.id)) findTopHit(child);
+    if (topHitId !== null) return;
+    for (const c of folderConnections(folder.id)) {
+      if (matchingConnectionIds.has(c.id)) {
+        topHitId = c.id;
+        return;
+      }
+    }
+  }
+  childFolders(null).forEach(findTopHit);
+  if (topHitId === null) {
+    for (const c of folderConnections(null)) {
+      if (matchingConnectionIds.has(c.id)) {
+        topHitId = c.id;
+        break;
+      }
+    }
+  }
+
+  return { query: normalizedQuery, matchingConnectionIds, visibleFolderIds, topHitId };
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -84,6 +84,8 @@ Fixed strings — match exactly.
 | `connection-error-message` | `src/components/Sidebar/ConnectionErrorDialog.tsx` |
 | `connection-error-setup-agent` | `src/components/Sidebar/ConnectionErrorDialog.tsx` |
 | `connection-error-title` | `src/components/Sidebar/ConnectionErrorDialog.tsx` |
+| `connection-filter-clear` | `src/components/Sidebar/ConnectionList.tsx` |
+| `connection-filter-input` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-list-group-connections` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-list-group-toggle` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-list-new-agent` | `src/components/Sidebar/ConnectionList.tsx` |
@@ -539,6 +541,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `agent-shutdown-*` | `agent-shutdown-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-state-*` | `agent-state-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `color-picker-swatch-*` | `color-picker-swatch-${color.replace("#", "")}` | `src/components/Terminal/ColorPickerDialog.tsx` |
+| `connection-connect-*` | `connection-connect-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-item-*` | `connection-item-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-jump-badge-*` | `connection-jump-badge-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-picker-agent-def-*` | `connection-picker-agent-def-${def.id}` | `src/components/WorkspaceEditor/ConnectionPicker.tsx` |


### PR DESCRIPTION
## Summary

Makes the Connections sidebar tree fully keyboard-operable and searchable (previously mouse-only).

- **Filter input** pinned in the Connections header (shared `Input` primitive + Search/clear icons): live-filters by connection **name or host**, auto-expands folders that contain a match, connects the **top hit on Enter**, clears on **Esc**, and shows a "no matches" status when empty.
- **Roving-tabindex arrow navigation** over the visible rows via the new `useTreeKeyboardNav` hook, driven by a flattened, filter-aware `computeVisibleTreeNodes` list: Up/Down move, Right expands or descends, Left collapses or ascends, **Enter/Space** connects the focused connection or toggles a folder, Home/End jump to first/last.
- **Proper ARIA tree semantics**: `role="tree"`/`treeitem"`/`group"` with `aria-expanded`, `aria-level`, `aria-selected`.
- **Hover/focus "Connect" affordance** (play button) on each connection row, beyond the native tooltip.

The same filter-aware flattened node list now also backs Shift+Click range selection, so range selection respects the active filter.

### Implementation notes
- New pure utils `src/utils/connectionSearch.ts` (filter) and `src/utils/computeVisibleTreeNodes.ts` (flatten), plus the `src/hooks/useTreeKeyboardNav.ts` hook — all unit-tested.
- Tokens-only CSS; connect-button motion wrapped in `prefers-reduced-motion`.

## Test plan

Automated (Vitest):
- `src/utils/connectionSearch.test.ts` — name/host matching, ancestor-folder visibility, non-matching query.
- `src/utils/computeVisibleTreeNodes.test.ts` — visual-order flatten, collapsed-folder omission, filter-aware inclusion.
- `src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx` — role=tree/treeitem, roving tabindex, ArrowDown focus move, Enter connects, folder aria-expanded + ArrowRight expand.
- `src/components/Sidebar/ConnectionList.filter.test.tsx` — filter input present, live filter, auto-expand match, Enter connects top hit, Esc clears.
- Existing `ConnectionList.multiselect.test.tsx` and all Sidebar tests still pass.

Manual:
1. Open the Connections panel, type in the filter box → tree narrows to name/host matches; collapsed folders containing a match auto-expand.
2. With a filter active, press Enter → the first (top) match connects.
3. Press Esc in the filter → query clears, full tree returns.
4. Click a connection, then use Up/Down/Left/Right to move focus; press Enter/Space to connect the focused connection; Left/Right collapse/expand folders.
5. Hover (or keyboard-focus) a connection row → the "Connect" play button appears; clicking it opens the connection.

`./scripts/check.sh`, `pnpm build`, and the full `pnpm test` suite (2541 tests) all pass.

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-ups
- #1378 — ignore folder collapse/expand while a search filter is active (latent expansion-state mutation).
- #1379 — reuse the search + keyboard-nav pattern in the Tunnels/Workspaces/Remote Agents sidebars.
