### PR TITLE
fix(ui): block Save/Run on invalid input with inline validation (Closes #1357)

### DIFF
--- a/docs/changes/dev0/feature/1357-form-validation.md
+++ b/docs/changes/dev0/feature/1357-form-validation.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- Form validation is now enforced, not just cosmetic: invalid input is flagged
+  inline at the field and blocks the action instead of saving a broken config
+  that fails later at connect/run time (#1357).
+  - **Connection editor**: Save and Save & Connect are gated on a valid form —
+    the schema-driven form reports overall validity and a per-field error map
+    upward, and attempting to save while invalid flags the Connection tab and
+    scrolls to and focuses the first invalid field. Required fields now render a
+    marker and `aria-required`. A field hidden by a `visibleWhen` rule never
+    blocks Save.
+  - **SSH tunnel editor**: ports are validated to 1–65535 and hosts must be
+    non-empty, with inline errors; Save/Save & Start are disabled while invalid
+    (previously `parseInt(...) || 0` let port 0, a blank host, or a port above
+    65535 save).
+  - **Network tools**: Ping (interval/count), Traceroute (max hops), Port
+    Scanner (timeout/concurrency) and Wake-on-LAN (port) numeric fields are
+    range-checked inline and disable Run/Start/Send while invalid.
+  - **HTTP Monitor**: the URL is validated with a real scheme + host check
+    (replacing the brittle `url === "https://"` guard), so a real URL can be
+    entered from an empty field and an incomplete URL is flagged inline.

--- a/src/components/ConnectionEditor/ConnectionEditor.css
+++ b/src/components/ConnectionEditor/ConnectionEditor.css
@@ -86,6 +86,11 @@
   letter-spacing: 0.3px;
 }
 
+/* Required-field marker (asterisk) appended to a field label. */
+.settings-form__required {
+  color: var(--color-error);
+}
+
 .settings-form__field--checkbox {
   flex-direction: row;
   align-items: center;

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -1406,3 +1406,105 @@ describe("ConnectionEditor — storage-file picker (#1105)", () => {
     expect(trigger?.getAttribute("data-value")).toBeTruthy();
   });
 });
+
+/** Local connection type with a required host field, to exercise Save gating. */
+const LOCAL_REQ_TYPE: ConnectionTypeInfo = {
+  typeId: "local",
+  displayName: "Local",
+  icon: "local",
+  schema: {
+    groups: [
+      {
+        key: "connection",
+        label: "Connection",
+        fields: [{ key: "host", label: "Host", fieldType: { type: "text" }, required: true }],
+      },
+    ],
+  },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+describe("ConnectionEditor — Save gating on invalid input (#1357)", () => {
+  function setValue(el: HTMLInputElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  async function flush() {
+    await act(async () => {
+      for (let i = 0; i < 6; i++) await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+
+  function renderNew() {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <ConnectionEditor
+            tabId="tab-gate-1"
+            meta={{ connectionId: "new", folderId: null }}
+            isVisible={true}
+          />
+        </TooltipProvider>
+      );
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetRuntimeCache();
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      connections: [],
+      connectionTypes: [LOCAL_REQ_TYPE],
+      credentialStoreStatus: { mode: "none", status: "unlocked" },
+    });
+    mockedInvoke.mockImplementation(() => Promise.resolve(false));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("does not save a new connection while name and a required field are empty", async () => {
+    renderNew();
+    await flush();
+
+    const saveBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="connection-editor-save"]'
+    )!;
+    await act(async () => saveBtn.click());
+    await flush();
+
+    expect(useAppStore.getState().connections).toHaveLength(0);
+  });
+
+  it("saves once the name and required field are filled", async () => {
+    renderNew();
+    await flush();
+
+    const nameInput = container.querySelector<HTMLInputElement>(
+      '[data-testid="connection-editor-name-input"]'
+    )!;
+    await act(async () => setValue(nameInput, "My Host"));
+    const hostInput = container.querySelector<HTMLInputElement>('[data-testid="field-host"]')!;
+    await act(async () => setValue(hostInput, "example.com"));
+    await flush();
+
+    const saveBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="connection-editor-save"]'
+    )!;
+    await act(async () => saveBtn.click());
+    await flush();
+
+    const conns = useAppStore.getState().connections;
+    expect(conns).toHaveLength(1);
+    expect(conns[0].name).toBe("My Host");
+  });
+});

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -455,6 +455,21 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
     folderId,
   ]);
 
+  // Client-side validity of the schema-driven connection form (reported upward
+  // by ConnectionSettingsForm). Gates Save/Save & Connect while a visible
+  // required field is empty or a value is out of range, instead of deferring to
+  // a connect-time backend error.
+  const [schemaValid, setSchemaValid] = useState(true);
+  const [schemaErrors, setSchemaErrors] = useState<Record<string, string>>({});
+  const handleFormValidityChange = useCallback((valid: boolean, errors: Record<string, string>) => {
+    setSchemaValid(valid);
+    setSchemaErrors(errors);
+  }, []);
+
+  /** Whether the connection can be saved: named, unique, valid form + jump hosts. */
+  const canSave =
+    !!name.trim() && !nameError && schemaValid && jumpHostValidation.errors.length === 0;
+
   // Category navigation
   const [activeCategory, setActiveCategory] = useState<EditorCategory>("connection");
   const [isCompact, setIsCompact] = useState(false);
@@ -535,6 +550,33 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   const handleCategoryChange = useCallback((category: EditorCategory) => {
     setActiveCategory(category);
   }, []);
+
+  /**
+   * Direct the user to the first blocking validation error: flag the owning
+   * category (all blocking validation — name, schema fields, jump hosts — lives
+   * in the Connection tab), then scroll it into view and focus it. Called when
+   * Save/Save & Connect is attempted while the form is invalid.
+   */
+  const focusFirstInvalidField = useCallback(() => {
+    setActiveCategory("connection");
+    // Defer until the Connection tab content is mounted/visible.
+    requestAnimationFrame(() => {
+      const root = containerRef.current;
+      if (!root) return;
+      let selector: string;
+      if (!name.trim() || nameError) {
+        selector = '[data-testid="connection-editor-name-input"]';
+      } else {
+        const firstKey = Object.keys(schemaErrors)[0];
+        selector = firstKey ? `[data-testid="field-${firstKey}"]` : "";
+      }
+      const target = selector ? root.querySelector<HTMLElement>(selector) : null;
+      if (target) {
+        target.scrollIntoView({ block: "center", behavior: "smooth" });
+        target.focus();
+      }
+    });
+  }, [name, nameError, schemaErrors]);
 
   const handleTypeChange = useCallback(
     (typeId: string) => {
@@ -720,11 +762,15 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
 
   /** Save without closing. Returns true on success. */
   const handleSaveOnly = useCallback(async (): Promise<boolean> => {
+    if (!canSave) {
+      focusFirstInvalidField();
+      return false;
+    }
     if (isAgentDefinitionMode) {
       return saveAgentDefinition();
     }
     return saveConnection() !== null;
-  }, [isAgentDefinitionMode, saveAgentDefinition, saveConnection]);
+  }, [canSave, focusFirstInvalidField, isAgentDefinitionMode, saveAgentDefinition, saveConnection]);
 
   const handleSave = useCallback(async () => {
     if (await handleSaveOnly()) {
@@ -749,6 +795,10 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   }, [handleSaveOnly, setPendingCloseRequest, closeThisTab]);
 
   const handleSaveAndConnect = useCallback(async () => {
+    if (!canSave) {
+      focusFirstInvalidField();
+      return;
+    }
     if (isAgentDefinitionMode && existingAgent) {
       if (!(await saveAgentDefinition())) return;
       addTab(
@@ -882,6 +932,8 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
     selectedType,
     persistent,
     terminalOptions,
+    canSave,
+    focusFirstInvalidField,
   ]);
 
   const handleCancel = useCallback(() => {
@@ -991,6 +1043,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           schema={currentSchema}
           settings={connSettings}
           onChange={handleSchemaSettingsChange}
+          onValidityChange={handleFormValidityChange}
           credentialSavedHint={credentialSavedHint}
           availablePorts={
             isAgentDefinitionMode
@@ -1133,12 +1186,20 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           <Button
             variant="primary"
             onClick={handleSaveAndConnect}
+            aria-disabled={!canSave}
+            data-invalid={!canSave || undefined}
             data-testid="connection-editor-save-connect"
           >
             Save &amp; Connect
           </Button>
         )}
-        <Button variant="primary" onClick={handleSave} data-testid="connection-editor-save">
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          aria-disabled={!canSave}
+          data-invalid={!canSave || undefined}
+          data-testid="connection-editor-save"
+        >
           Save
         </Button>
       </div>

--- a/src/components/DynamicForm/ConnectionSettingsForm.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.tsx
@@ -23,6 +23,13 @@ interface ConnectionSettingsFormProps {
    * agent definition so the dropdown reflects the remote machine's ports.
    */
   availablePorts?: string[];
+  /**
+   * Reports overall client-side validity plus a per-field error map (keyed by
+   * field key) whenever validation state changes. Only currently-visible fields
+   * are considered, so a required field hidden by `visibleWhen` never blocks.
+   * The parent uses this to disable Save/Save & Connect on invalid input.
+   */
+  onValidityChange?: (valid: boolean, errors: Record<string, string>) => void;
 }
 
 /**
@@ -38,6 +45,7 @@ export function ConnectionSettingsForm({
   onChange,
   credentialSavedHint,
   availablePorts,
+  onValidityChange,
 }: ConnectionSettingsFormProps) {
   const zodSchema = useMemo(() => settingsSchemaToZod(schema), [schema]);
 
@@ -98,6 +106,37 @@ export function ConnectionSettingsForm({
 
   // Live form values used for visibleWhen evaluation.
   const watchedValues = useWatch({ control });
+
+  // Overall validity + per-field error map for currently-visible fields. We run
+  // the zod schema directly against the watched values (rather than reading
+  // react-hook-form's async error proxy) so the signal is deterministic and
+  // recomputes on every value change. A required field hidden by `visibleWhen`
+  // is excluded, so it never blocks the parent's Save.
+  const validity = useMemo(() => {
+    const errorMap: Record<string, string> = {};
+    const result = zodSchema.safeParse(watchedValues);
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        const key = issue.path[0];
+        if (typeof key === "string" && !(key in errorMap)) {
+          errorMap[key] = issue.message;
+        }
+      }
+    }
+    const visibleErrors: Record<string, string> = {};
+    for (const group of schema.groups) {
+      for (const field of group.fields) {
+        if (isFieldVisible(field, watchedValues) && errorMap[field.key]) {
+          visibleErrors[field.key] = errorMap[field.key];
+        }
+      }
+    }
+    return { valid: Object.keys(visibleErrors).length === 0, errors: visibleErrors };
+  }, [zodSchema, watchedValues, schema]);
+
+  useEffect(() => {
+    onValidityChange?.(validity.valid, validity.errors);
+  }, [validity, onValidityChange]);
 
   return (
     <div data-testid="connection-settings-form">

--- a/src/components/DynamicForm/ConnectionSettingsForm.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.tsx
@@ -134,7 +134,14 @@ export function ConnectionSettingsForm({
     return { valid: Object.keys(visibleErrors).length === 0, errors: visibleErrors };
   }, [zodSchema, watchedValues, schema]);
 
+  // Only propagate when the reported validity actually changes, so typing more
+  // characters into an already-valid (or already-invalid, same-errors) field
+  // doesn't churn a fresh error object into the parent every keystroke.
+  const lastReportedRef = useRef<string>("");
   useEffect(() => {
+    const signal = `${validity.valid}|${JSON.stringify(validity.errors)}`;
+    if (signal === lastReportedRef.current) return;
+    lastReportedRef.current = signal;
     onValidityChange?.(validity.valid, validity.errors);
   }, [validity, onValidityChange]);
 

--- a/src/components/DynamicForm/ConnectionSettingsForm.validity.test.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.validity.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for ConnectionSettingsForm validity reporting (#1357).
+ *
+ * The form now reports overall client-side validity plus a per-field error map
+ * upward via `onValidityChange`, so the ConnectionEditor can block Save on
+ * invalid input rather than deferring to a connect-time backend error. Only
+ * visible fields count — a required field hidden by `visibleWhen` must not block.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { SettingsSchema } from "@/types/schema";
+import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn().mockResolvedValue(null) }));
+vi.mock("@/services/api", () => ({ listSerialPorts: vi.fn().mockResolvedValue([]) }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+const SCHEMA: SettingsSchema = {
+  groups: [
+    {
+      key: "connection",
+      label: "Connection",
+      fields: [
+        { key: "host", label: "Host", fieldType: { type: "text" }, required: true },
+        { key: "port", label: "Port", fieldType: { type: "port" }, required: true, default: 22 },
+      ],
+    },
+  ],
+};
+
+describe("ConnectionSettingsForm — validity reporting", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("reports invalid with a per-field error when a required field is empty", async () => {
+    const onValidity = vi.fn();
+    await act(async () => {
+      root.render(
+        <ConnectionSettingsForm
+          schema={SCHEMA}
+          settings={{ port: 22 }}
+          onChange={() => {}}
+          onValidityChange={onValidity}
+        />
+      );
+    });
+    await flush();
+
+    const last = onValidity.mock.calls[onValidity.mock.calls.length - 1];
+    expect(last[0]).toBe(false);
+    expect(last[1]).toHaveProperty("host");
+  });
+
+  it("reports valid once all required fields are filled", async () => {
+    const onValidity = vi.fn();
+    await act(async () => {
+      root.render(
+        <ConnectionSettingsForm
+          schema={SCHEMA}
+          settings={{ host: "example.com", port: 22 }}
+          onChange={() => {}}
+          onValidityChange={onValidity}
+        />
+      );
+    });
+    await flush();
+
+    expect(onValidity.mock.calls[onValidity.mock.calls.length - 1][0]).toBe(true);
+  });
+
+  it("flips to invalid when a required field is cleared", async () => {
+    const onValidity = vi.fn();
+    await act(async () => {
+      root.render(
+        <ConnectionSettingsForm
+          schema={SCHEMA}
+          settings={{ host: "example.com", port: 22 }}
+          onChange={() => {}}
+          onValidityChange={onValidity}
+        />
+      );
+    });
+    await flush();
+    expect(onValidity.mock.calls[onValidity.mock.calls.length - 1][0]).toBe(true);
+
+    const hostInput = container.querySelector<HTMLInputElement>('[data-testid="field-host"]')!;
+    await act(async () => setInputValue(hostInput, ""));
+    await flush();
+
+    expect(onValidity.mock.calls[onValidity.mock.calls.length - 1][0]).toBe(false);
+  });
+});

--- a/src/components/DynamicForm/DynamicField.test.tsx
+++ b/src/components/DynamicForm/DynamicField.test.tsx
@@ -540,4 +540,20 @@ describe("DynamicField", () => {
       expect(query("field-host-error")).toBeNull();
     });
   });
+
+  describe("required-field markers", () => {
+    it("renders a required marker and aria-required for a required field", () => {
+      renderField(textField("host", { required: true }), "", vi.fn());
+      const input = query("field-host") as HTMLInputElement;
+      expect(input.getAttribute("aria-required")).toBe("true");
+      expect(container.querySelector(".settings-form__required")).toBeTruthy();
+    });
+
+    it("omits the marker and aria-required for an optional field", () => {
+      renderField(textField("host", { required: false }), "", vi.fn());
+      const input = query("field-host") as HTMLInputElement;
+      expect(input.getAttribute("aria-required")).toBeNull();
+      expect(container.querySelector(".settings-form__required")).toBeNull();
+    });
+  });
 });

--- a/src/components/DynamicForm/DynamicField.tsx
+++ b/src/components/DynamicForm/DynamicField.tsx
@@ -120,16 +120,35 @@ interface FieldProps {
   onChange: (v: unknown) => void;
 }
 
+/**
+ * Field label with a required marker for required fields. The asterisk is
+ * `aria-hidden` (decorative); inputs carry `aria-required` for assistive tech.
+ */
+function FieldLabel({ field }: { field: SettingsField }) {
+  return (
+    <span className="settings-form__label">
+      {field.label}
+      {field.required && (
+        <span className="settings-form__required" aria-hidden="true">
+          {" "}
+          *
+        </span>
+      )}
+    </span>
+  );
+}
+
 function TextField({ field, value, onChange, onBlur }: FieldProps & { onBlur?: () => void }) {
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       <Input
         type="text"
         value={(value as string) ?? ""}
         onChange={(e) => onChange(e.target.value || undefined)}
         onBlur={onBlur}
         placeholder={field.placeholder}
+        aria-required={field.required || undefined}
         data-testid={`field-${field.key}`}
       />
     </>
@@ -139,7 +158,7 @@ function TextField({ field, value, onChange, onBlur }: FieldProps & { onBlur?: (
 function PasswordField({ field, value, onChange }: FieldProps) {
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       <PasswordInput
         value={(value as string) ?? ""}
         onChange={(e) => onChange(e.target.value || undefined)}
@@ -158,7 +177,7 @@ function NumberField({
 }: FieldProps & { fieldType: { type: "number"; min?: number; max?: number } }) {
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       <Input
         type="number"
         value={value != null ? Number(value) : ""}
@@ -169,6 +188,7 @@ function NumberField({
         min={fieldType.min}
         max={fieldType.max}
         placeholder={field.placeholder}
+        aria-required={field.required || undefined}
         data-testid={`field-${field.key}`}
       />
     </>
@@ -255,7 +275,7 @@ function SelectField({
   const isLocked = fieldType.options.length <= 1;
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       <Select
         value={(value as string) || undefined}
         onChange={(v) => onChange(v)}
@@ -272,7 +292,7 @@ function SelectField({
 function PortField({ field, value, onChange }: FieldProps) {
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       <Input
         type="number"
         value={value != null ? Number(value) : ""}
@@ -283,6 +303,7 @@ function PortField({ field, value, onChange }: FieldProps) {
         min={1}
         max={65535}
         placeholder={field.placeholder}
+        aria-required={field.required || undefined}
         data-testid={`field-${field.key}`}
       />
     </>
@@ -315,7 +336,7 @@ function SerialPortField({
 
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       <Input
         type="text"
         value={currentValue}
@@ -324,6 +345,7 @@ function SerialPortField({
         list={listId}
         autoComplete="off"
         spellCheck={false}
+        aria-required={field.required || undefined}
         data-testid={`field-${field.key}`}
       />
       <datalist id={listId}>
@@ -349,7 +371,7 @@ function FilePathField({
   if (field.key === "keyPath") {
     return (
       <>
-        <span className="settings-form__label">{field.label}</span>
+        <FieldLabel field={field} />
         <KeyPathInput
           value={(value as string) ?? ""}
           onChange={(v) => onChange(v || undefined)}
@@ -373,13 +395,14 @@ function FilePathField({
 
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       <div className="settings-form__file-row">
         <Input
           type="text"
           value={(value as string) ?? ""}
           onChange={(e) => onChange(e.target.value || undefined)}
           placeholder={field.placeholder}
+          aria-required={field.required || undefined}
           data-testid={`field-${field.key}`}
         />
         <Button
@@ -420,7 +443,7 @@ function KeyValueListField({ field, value, onChange }: FieldProps) {
 
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       {items.map((item, index) => (
         <div key={index} className="settings-form__list-row">
           <Input
@@ -506,7 +529,7 @@ function ObjectListField({
 
   return (
     <>
-      <span className="settings-form__label">{field.label}</span>
+      <FieldLabel field={field} />
       {items.map((item, index) => (
         <div key={index} className="settings-form__list-row">
           {fieldType.fields.map((subField) => {

--- a/src/components/NetworkTools/HttpMonitorPanel.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/services/networkApi";
 import type { HttpMonitorState, HttpCheckResult } from "@/types/network";
 import { LatencyChart } from "./LatencyChart";
+import { NetworkNumberField } from "./NetworkNumberField";
+import { isValidHttpUrl, validateIntRange } from "@/utils/fieldValidation";
 import { frontendLog } from "@/utils/frontendLog";
 
 const MAX_HISTORY = 120;
@@ -29,10 +31,10 @@ const MAX_HISTORY = 120;
 export function HttpMonitorPanel() {
   const [url, setUrl] = useState("https://");
   // UI uses seconds; API takes milliseconds
-  const [intervalSecs, setIntervalSecs] = useState(30);
+  const [intervalSecs, setIntervalSecs] = useState<number | "">(30);
   const [method, setMethod] = useState("GET");
   const [expectedStatus, setExpectedStatus] = useState<number | "">(200);
-  const [timeoutSecs, setTimeoutSecs] = useState(10);
+  const [timeoutSecs, setTimeoutSecs] = useState<number | "">(10);
   const [monitors, setMonitors] = useState<HttpMonitorState[]>([]);
   const [history, setHistory] = useState<HttpCheckResult[]>([]);
   const [activeMonitorId, setActiveMonitorId] = useState<string | null>(null);
@@ -76,8 +78,22 @@ export function HttpMonitorPanel() {
     stopListening();
   }, [stopListening]);
 
+  // Inline validation. A real scheme+host URL check replaces the brittle
+  // `url === "https://"` sentinel, and the numeric fields are range-checked.
+  const urlValid = isValidHttpUrl(url);
+  const urlError = url.trim() && !urlValid ? "Enter a valid http(s) URL" : null;
+  const intervalError = validateIntRange(intervalSecs, { min: 1, max: 86_400, label: "Interval" });
+  const timeoutError = validateIntRange(timeoutSecs, { min: 1, max: 3600, label: "Timeout" });
+  const statusError = validateIntRange(expectedStatus, {
+    min: 100,
+    max: 599,
+    label: "Expected status",
+    allowEmpty: true,
+  });
+  const canStart = urlValid && !intervalError && !timeoutError && !statusError;
+
   const handleStart = useCallback(async () => {
-    if (!url.trim()) return;
+    if (!canStart) return;
     // Reject a re-entrant start while one is already in flight (#1147, GAP #7).
     if (startInFlightRef.current) return;
     startInFlightRef.current = true;
@@ -102,10 +118,10 @@ export function HttpMonitorPanel() {
 
       const monitorId = await networkHttpMonitorStart(
         url.trim(),
-        intervalSecs * 1000,
+        Number(intervalSecs) * 1000,
         method,
         expectedStatus !== "" ? expectedStatus : undefined,
-        timeoutSecs * 1000
+        Number(timeoutSecs) * 1000
       );
       activeMonitorIdRef.current = monitorId;
       setActiveMonitorId(monitorId);
@@ -117,7 +133,16 @@ export function HttpMonitorPanel() {
     } finally {
       startInFlightRef.current = false;
     }
-  }, [url, intervalSecs, method, expectedStatus, timeoutSecs, loadMonitors, stopListening]);
+  }, [
+    canStart,
+    url,
+    intervalSecs,
+    method,
+    expectedStatus,
+    timeoutSecs,
+    loadMonitors,
+    stopListening,
+  ]);
 
   const handleStop = useCallback(async () => {
     if (!activeMonitorIdRef.current) return;
@@ -234,7 +259,7 @@ export function HttpMonitorPanel() {
               size="sm"
               icon={<Play size={14} />}
               onClick={handleStart}
-              disabled={!url.trim() || url === "https://"}
+              disabled={!canStart}
               data-testid="http-monitor-start"
             >
               Start
@@ -247,12 +272,14 @@ export function HttpMonitorPanel() {
         <label className="network-panel__field">
           <span>URL</span>
           <input
-            className="network-panel__input"
+            className={`network-panel__input${urlError ? " network-panel__input--error" : ""}`}
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://example.com"
+            aria-invalid={urlError ? true : undefined}
             data-testid="http-monitor-url"
           />
+          {urlError && <span className="network-panel__field-error">{urlError}</span>}
         </label>
         <label className="network-panel__field network-panel__field--small">
           <span>Method</span>
@@ -266,36 +293,33 @@ export function HttpMonitorPanel() {
             <option>POST</option>
           </select>
         </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Interval (s)</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={intervalSecs}
-            onChange={(e) => setIntervalSecs(Number(e.target.value))}
-            min={5}
-          />
-        </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Expected status</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={expectedStatus}
-            onChange={(e) => setExpectedStatus(e.target.value === "" ? "" : Number(e.target.value))}
-            placeholder="200"
-          />
-        </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Timeout (s)</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={timeoutSecs}
-            onChange={(e) => setTimeoutSecs(Number(e.target.value))}
-            min={1}
-          />
-        </label>
+        <NetworkNumberField
+          label="Interval (s)"
+          value={intervalSecs}
+          onChange={setIntervalSecs}
+          error={intervalError}
+          small
+          min={1}
+          data-testid="http-monitor-interval"
+        />
+        <NetworkNumberField
+          label="Expected status"
+          value={expectedStatus}
+          onChange={setExpectedStatus}
+          error={statusError}
+          small
+          placeholder="200"
+          data-testid="http-monitor-expected-status"
+        />
+        <NetworkNumberField
+          label="Timeout (s)"
+          value={timeoutSecs}
+          onChange={setTimeoutSecs}
+          error={timeoutError}
+          small
+          min={1}
+          data-testid="http-monitor-timeout"
+        />
       </div>
 
       {error && <div className="network-panel__error">{error}</div>}

--- a/src/components/NetworkTools/HttpMonitorPanel.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.tsx
@@ -13,6 +13,7 @@ import {
 import type { HttpMonitorState, HttpCheckResult } from "@/types/network";
 import { LatencyChart } from "./LatencyChart";
 import { NetworkNumberField } from "./NetworkNumberField";
+import { NetworkTextField } from "./NetworkTextField";
 import { isValidHttpUrl, validateIntRange } from "@/utils/fieldValidation";
 import { frontendLog } from "@/utils/frontendLog";
 
@@ -269,18 +270,14 @@ export function HttpMonitorPanel() {
       </div>
 
       <div className="network-panel__form">
-        <label className="network-panel__field">
-          <span>URL</span>
-          <input
-            className={`network-panel__input${urlError ? " network-panel__input--error" : ""}`}
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            placeholder="https://example.com"
-            aria-invalid={urlError ? true : undefined}
-            data-testid="http-monitor-url"
-          />
-          {urlError && <span className="network-panel__field-error">{urlError}</span>}
-        </label>
+        <NetworkTextField
+          label="URL"
+          value={url}
+          onChange={setUrl}
+          error={urlError}
+          placeholder="https://example.com"
+          data-testid="http-monitor-url"
+        />
         <label className="network-panel__field network-panel__field--small">
           <span>Method</span>
           <select

--- a/src/components/NetworkTools/HttpMonitorPanel.url-validation.test.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.url-validation.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for HTTP monitor URL validation (#1357).
+ *
+ * The Start button previously used the brittle `url === "https://"` sentinel to
+ * decide validity. It now runs a real scheme+host check: the default bare
+ * `https://`, an empty field, and non-http garbage all keep Start disabled and
+ * surface an inline error, while a real URL enables it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { HttpMonitorPanel } from "./HttpMonitorPanel";
+import { withTooltip } from "@/test/tooltip";
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStart: vi.fn(() => Promise.resolve("mon-1")),
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorRemove: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorPause: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorResume: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+  onHttpMonitorCheck: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("./LatencyChart", () => ({ LatencyChart: () => null }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function startButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="http-monitor-start"]')!;
+}
+
+function urlInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="http-monitor-url"]')!;
+}
+
+describe("HttpMonitorPanel — URL validation", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(withTooltip(<HttpMonitorPanel />));
+    });
+    await flush();
+  }
+
+  it("keeps Start disabled for the default bare 'https://'", async () => {
+    await render();
+    expect(startButton().disabled).toBe(true);
+  });
+
+  it("keeps Start disabled for an empty URL", async () => {
+    await render();
+    await act(async () => setInputValue(urlInput(), ""));
+    expect(startButton().disabled).toBe(true);
+  });
+
+  it("flags invalid input inline and blocks Start", async () => {
+    await render();
+    await act(async () => setInputValue(urlInput(), "not-a-url"));
+    expect(startButton().disabled).toBe(true);
+    expect(container.textContent).toContain("Enter a valid http(s) URL");
+  });
+
+  it("enables Start for a real URL", async () => {
+    await render();
+    await act(async () => setInputValue(urlInput(), "https://example.com"));
+    expect(startButton().disabled).toBe(false);
+    expect(container.textContent).not.toContain("Enter a valid http(s) URL");
+  });
+});

--- a/src/components/NetworkTools/NetworkNumberField.tsx
+++ b/src/components/NetworkTools/NetworkNumberField.tsx
@@ -1,0 +1,51 @@
+interface NetworkNumberFieldProps {
+  /** Field label text. */
+  label: string;
+  /** Current value; `""` represents an empty input. */
+  value: number | "";
+  /** Change handler receiving the parsed number, or `""` when cleared. */
+  onChange: (value: number | "") => void;
+  /** Inline validation message; when set, the field renders its error state. */
+  error?: string | null;
+  /** Apply the `--small` compact width modifier. */
+  small?: boolean;
+  /** Placeholder shown when empty. */
+  placeholder?: string;
+  /** Native `min` attribute (spinner hint only; real validation is `error`). */
+  min?: number;
+  /** Test hook forwarded to the input. */
+  "data-testid"?: string;
+}
+
+/**
+ * A labelled numeric input for the network tools panels with inline validation
+ * feedback. Keeps the value as `number | ""` so a cleared field reads blank
+ * (and can be flagged "required") instead of silently coercing to 0.
+ */
+export function NetworkNumberField({
+  label,
+  value,
+  onChange,
+  error,
+  small,
+  placeholder,
+  min,
+  "data-testid": testId,
+}: NetworkNumberFieldProps) {
+  return (
+    <label className={`network-panel__field${small ? " network-panel__field--small" : ""}`}>
+      <span>{label}</span>
+      <input
+        className={`network-panel__input${error ? " network-panel__input--error" : ""}`}
+        type="number"
+        value={value}
+        onChange={(e) => onChange(e.target.value === "" ? "" : Number(e.target.value))}
+        placeholder={placeholder}
+        min={min}
+        aria-invalid={error ? true : undefined}
+        data-testid={testId}
+      />
+      {error && <span className="network-panel__field-error">{error}</span>}
+    </label>
+  );
+}

--- a/src/components/NetworkTools/NetworkTextField.tsx
+++ b/src/components/NetworkTools/NetworkTextField.tsx
@@ -1,0 +1,46 @@
+interface NetworkTextFieldProps {
+  /** Field label text. */
+  label: string;
+  /** Current value. */
+  value: string;
+  /** Change handler receiving the raw string. */
+  onChange: (value: string) => void;
+  /** Inline validation message; when set, the field renders its error state. */
+  error?: string | null;
+  /** Apply the `--small` compact width modifier. */
+  small?: boolean;
+  /** Placeholder shown when empty. */
+  placeholder?: string;
+  /** Test hook forwarded to the input. */
+  "data-testid"?: string;
+}
+
+/**
+ * A labelled text input for the network tools panels with inline validation
+ * feedback — the text counterpart to {@link NetworkNumberField}, so the error
+ * class + `aria-invalid` + error message live in one place.
+ */
+export function NetworkTextField({
+  label,
+  value,
+  onChange,
+  error,
+  small,
+  placeholder,
+  "data-testid": testId,
+}: NetworkTextFieldProps) {
+  return (
+    <label className={`network-panel__field${small ? " network-panel__field--small" : ""}`}>
+      <span>{label}</span>
+      <input
+        className={`network-panel__input${error ? " network-panel__input--error" : ""}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-invalid={error ? true : undefined}
+        data-testid={testId}
+      />
+      {error && <span className="network-panel__field-error">{error}</span>}
+    </label>
+  );
+}

--- a/src/components/NetworkTools/NetworkTools.css
+++ b/src/components/NetworkTools/NetworkTools.css
@@ -81,6 +81,17 @@
   border-color: var(--focus-border);
 }
 
+.network-panel__input--error,
+.network-panel__input--error:focus {
+  border-color: var(--color-error);
+}
+
+/* Inline per-field validation message shown beneath a form control. */
+.network-panel__field-error {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+}
+
 /* Status / info / error messages */
 .network-panel__info {
   padding: var(--spacing-xs) var(--spacing-sm);

--- a/src/components/NetworkTools/PingPanel.tsx
+++ b/src/components/NetworkTools/PingPanel.tsx
@@ -76,7 +76,7 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
   const canStart = !!host.trim() && !intervalError && !countError;
 
   const handleStart = useCallback(async () => {
-    if (!host.trim() || intervalError || countError) return;
+    if (!canStart) return;
 
     setStatus("running");
     setResults([]);
@@ -130,7 +130,7 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
       endSession();
       frontendLog("ping_panel", `Ping failed: ${err}`);
     }
-  }, [host, intervalMs, count, intervalError, countError, endSession]);
+  }, [host, intervalMs, count, canStart, endSession]);
 
   const handleStop = useCallback(async () => {
     if (!taskIdRef.current) return;

--- a/src/components/NetworkTools/PingPanel.tsx
+++ b/src/components/NetworkTools/PingPanel.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/services/networkApi";
 import type { PingResult, PingStats, DiagnosticStatus } from "@/types/network";
 import { LatencyChart } from "./LatencyChart";
+import { NetworkNumberField } from "./NetworkNumberField";
+import { validateIntRange } from "@/utils/fieldValidation";
 import { frontendLog } from "@/utils/frontendLog";
 
 interface PingPanelProps {
@@ -31,7 +33,7 @@ const MAX_CHART_POINTS = 120; // 2 minutes at 1s interval
  */
 export function PingPanel({ prefillHost }: PingPanelProps) {
   const [host, setHost] = useState(prefillHost ?? "");
-  const [intervalMs, setIntervalMs] = useState(1000);
+  const [intervalMs, setIntervalMs] = useState<number | "">(1000);
   const [count, setCount] = useState<number | "">(""); // empty = infinite
   const [status, setStatus] = useState<DiagnosticStatus>("idle");
   const [results, setResults] = useState<PingResult[]>([]);
@@ -59,8 +61,22 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
     taskIdRef.current = null;
   }, [cleanup]);
 
+  // Inline validation of the numeric fields. Blocks Start while invalid.
+  const intervalError = validateIntRange(intervalMs, {
+    min: 1,
+    max: 3_600_000,
+    label: "Interval",
+  });
+  const countError = validateIntRange(count, {
+    min: 1,
+    max: 1_000_000,
+    label: "Count",
+    allowEmpty: true,
+  });
+  const canStart = !!host.trim() && !intervalError && !countError;
+
   const handleStart = useCallback(async () => {
-    if (!host.trim()) return;
+    if (!host.trim() || intervalError || countError) return;
 
     setStatus("running");
     setResults([]);
@@ -105,8 +121,8 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
 
       taskIdRef.current = await networkPingStart(
         host,
-        intervalMs,
-        count !== "" ? count : undefined
+        Number(intervalMs),
+        count !== "" ? Number(count) : undefined
       );
     } catch (err) {
       setError(String(err));
@@ -114,7 +130,7 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
       endSession();
       frontendLog("ping_panel", `Ping failed: ${err}`);
     }
-  }, [host, intervalMs, count, endSession]);
+  }, [host, intervalMs, count, intervalError, countError, endSession]);
 
   const handleStop = useCallback(async () => {
     if (!taskIdRef.current) return;
@@ -159,7 +175,7 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
               size="sm"
               icon={<Play size={14} />}
               onClick={handleStart}
-              disabled={!host.trim()}
+              disabled={!canStart}
               data-testid="ping-start"
             >
               Start
@@ -179,25 +195,23 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
             data-testid="ping-host"
           />
         </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Interval (ms)</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={intervalMs}
-            onChange={(e) => setIntervalMs(Number(e.target.value))}
-          />
-        </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Count (∞ = empty)</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={count}
-            onChange={(e) => setCount(e.target.value === "" ? "" : Number(e.target.value))}
-            placeholder="∞"
-          />
-        </label>
+        <NetworkNumberField
+          label="Interval (ms)"
+          value={intervalMs}
+          onChange={setIntervalMs}
+          error={intervalError}
+          small
+          data-testid="ping-interval"
+        />
+        <NetworkNumberField
+          label="Count (∞ = empty)"
+          value={count}
+          onChange={setCount}
+          error={countError}
+          small
+          placeholder="∞"
+          data-testid="ping-count"
+        />
       </div>
 
       {tcpFallback && (
@@ -210,7 +224,10 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
       {results.length > 0 && (
         <div className="network-panel__chart-section" data-testid="ping-chart">
           <span className="network-panel__chart-title">Latency Graph</span>
-          <LatencyChart points={latencyPoints} intervalMs={intervalMs} />
+          <LatencyChart
+            points={latencyPoints}
+            intervalMs={intervalMs === "" ? undefined : intervalMs}
+          />
         </div>
       )}
 

--- a/src/components/NetworkTools/PingPanel.validation.test.tsx
+++ b/src/components/NetworkTools/PingPanel.validation.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Tests for PingPanel numeric field validation (#1357).
+ *
+ * A blank or out-of-range interval must be flagged inline and must block Start
+ * rather than being silently coerced and failing at run time.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { PingPanel } from "./PingPanel";
+
+vi.mock("@/services/networkApi", () => ({
+  networkPingStart: vi.fn(() => Promise.resolve("task-1")),
+  networkPingStop: vi.fn(() => Promise.resolve()),
+  onPingResult: vi.fn(() => Promise.resolve(() => {})),
+  onPingComplete: vi.fn(() => Promise.resolve(() => {})),
+  onPingError: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("./LatencyChart", () => ({ LatencyChart: () => null }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function startButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="ping-start"]')!;
+}
+
+function intervalInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="ping-interval"]')!;
+}
+
+describe("PingPanel — interval validation", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("enables Start with a valid host and default interval", async () => {
+    await act(async () => {
+      root.render(<PingPanel prefillHost="example.com" />);
+    });
+    expect(startButton().disabled).toBe(false);
+  });
+
+  it("blocks Start and flags the field when the interval is cleared", async () => {
+    await act(async () => {
+      root.render(<PingPanel prefillHost="example.com" />);
+    });
+    await act(async () => setInputValue(intervalInput(), ""));
+    expect(startButton().disabled).toBe(true);
+    expect(container.textContent).toContain("Interval is required");
+  });
+
+  it("blocks Start when the interval is out of range", async () => {
+    await act(async () => {
+      root.render(<PingPanel prefillHost="example.com" />);
+    });
+    await act(async () => setInputValue(intervalInput(), "0"));
+    expect(startButton().disabled).toBe(true);
+    expect(container.textContent).toContain("Interval must be between");
+  });
+});

--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/services/networkApi";
 import type { PortScanSummary } from "@/types/network";
 import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
+import { NetworkNumberField } from "./NetworkNumberField";
+import { validateIntRange } from "@/utils/fieldValidation";
 import { useNetworkTask, type NetworkTaskContext } from "@/hooks/useNetworkTask";
 
 interface PortScannerPanelProps {
@@ -27,10 +29,18 @@ interface ScanRow {
 export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
   const [host, setHost] = useState(prefillHost ?? "");
   const [ports, setPorts] = useState("22,80,443,8080,8443");
-  const [timeoutMs, setTimeoutMs] = useState(2000);
-  const [concurrency, setConcurrency] = useState(100);
+  const [timeoutMs, setTimeoutMs] = useState<number | "">(2000);
+  const [concurrency, setConcurrency] = useState<number | "">(100);
   const [results, setResults] = useState<ScanRow[]>([]);
   const [summary, setSummary] = useState<PortScanSummary | null>(null);
+
+  const timeoutError = validateIntRange(timeoutMs, { min: 1, max: 600_000, label: "Timeout" });
+  const concurrencyError = validateIntRange(concurrency, {
+    min: 1,
+    max: 2000,
+    label: "Concurrency",
+  });
+  const canRun = !!host.trim() && !timeoutError && !concurrencyError;
 
   // Warn user before scanning a very large range.
   const portCount = ports.split(",").reduce((acc, part) => {
@@ -70,7 +80,7 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
   const { status, error, run, stop } = useNetworkTask({
     logScope: "port_scanner",
     start: useCallback(
-      () => networkPortScan(host, ports, timeoutMs, concurrency),
+      () => networkPortScan(host, ports, Number(timeoutMs), Number(concurrency)),
       [host, ports, timeoutMs, concurrency]
     ),
     cancel: networkPortScanCancel,
@@ -82,6 +92,7 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
   });
 
   const handleRun = useCallback(async () => {
+    if (!canRun) return;
     if (portCount > 1000) {
       const confirmed = window.confirm(
         `Scanning ${portCount} ports may take several minutes. Continue?`
@@ -89,7 +100,7 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
       if (!confirmed) return;
     }
     await run();
-  }, [portCount, run]);
+  }, [canRun, portCount, run]);
 
   // Only show the Host column when results span more than one host
   // (single-host scans look cleaner without it). Memoised because results
@@ -131,7 +142,7 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
               size="sm"
               icon={<Play size={14} />}
               onClick={handleRun}
-              disabled={!host.trim()}
+              disabled={!canRun}
               data-testid="port-scanner-run"
             >
               Run
@@ -161,24 +172,22 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
             data-testid="port-scanner-ports"
           />
         </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Timeout (ms)</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={timeoutMs}
-            onChange={(e) => setTimeoutMs(Number(e.target.value))}
-          />
-        </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Concurrency</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={concurrency}
-            onChange={(e) => setConcurrency(Number(e.target.value))}
-          />
-        </label>
+        <NetworkNumberField
+          label="Timeout (ms)"
+          value={timeoutMs}
+          onChange={setTimeoutMs}
+          error={timeoutError}
+          small
+          data-testid="port-scanner-timeout"
+        />
+        <NetworkNumberField
+          label="Concurrency"
+          value={concurrency}
+          onChange={setConcurrency}
+          error={concurrencyError}
+          small
+          data-testid="port-scanner-concurrency"
+        />
       </div>
 
       {error && <div className="network-panel__error">{error}</div>}

--- a/src/components/NetworkTools/TraceroutePanel.tsx
+++ b/src/components/NetworkTools/TraceroutePanel.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/services/networkApi";
 import type { TracerouteHop } from "@/types/network";
 import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
+import { NetworkNumberField } from "./NetworkNumberField";
+import { validateIntRange } from "@/utils/fieldValidation";
 import { useNetworkTask, type NetworkTaskContext } from "@/hooks/useNetworkTask";
 
 interface TraceroutePanelProps {
@@ -19,8 +21,11 @@ interface TraceroutePanelProps {
 /** Traceroute diagnostic tab content. */
 export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
   const [host, setHost] = useState(prefillHost ?? "");
-  const [maxHops, setMaxHops] = useState(30);
+  const [maxHops, setMaxHops] = useState<number | "">(30);
   const [hops, setHops] = useState<TracerouteHop[]>([]);
+
+  const maxHopsError = validateIntRange(maxHops, { min: 1, max: 255, label: "Max hops" });
+  const canRun = !!host.trim() && !maxHopsError;
 
   const subscribe = useCallback(async ({ matchesTask, register, finish }: NetworkTaskContext) => {
     register(
@@ -45,7 +50,7 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
 
   const { status, error, run, stop } = useNetworkTask({
     logScope: "traceroute",
-    start: useCallback(() => networkTraceroute(host, maxHops), [host, maxHops]),
+    start: useCallback(() => networkTraceroute(host, Number(maxHops)), [host, maxHops]),
     cancel: networkTracerouteCancel,
     onReset: useCallback(() => setHops([]), []),
     subscribe,
@@ -87,7 +92,7 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
               size="sm"
               icon={<Play size={14} />}
               onClick={run}
-              disabled={!host.trim()}
+              disabled={!canRun}
               data-testid="traceroute-run"
             >
               Run
@@ -107,15 +112,14 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
             data-testid="traceroute-host"
           />
         </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Max Hops</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={maxHops}
-            onChange={(e) => setMaxHops(Number(e.target.value))}
-          />
-        </label>
+        <NetworkNumberField
+          label="Max Hops"
+          value={maxHops}
+          onChange={setMaxHops}
+          error={maxHopsError}
+          small
+          data-testid="traceroute-max-hops"
+        />
       </div>
 
       {error && <div className="network-panel__error">{error}</div>}

--- a/src/components/NetworkTools/WolPanel.tsx
+++ b/src/components/NetworkTools/WolPanel.tsx
@@ -8,6 +8,8 @@ import {
   networkWolDeviceDelete,
 } from "@/services/networkApi";
 import type { WolDevice } from "@/types/network";
+import { NetworkNumberField } from "./NetworkNumberField";
+import { validatePort, validateHost } from "@/utils/fieldValidation";
 import { frontendLog } from "@/utils/frontendLog";
 
 interface WolHistoryEntry {
@@ -19,7 +21,11 @@ interface WolHistoryEntry {
 export function WolPanel() {
   const [mac, setMac] = useState("");
   const [broadcast, setBroadcast] = useState("255.255.255.255");
-  const [port, setPort] = useState(9);
+  const [port, setPort] = useState<number | "">(9);
+
+  const portError = validatePort(port);
+  const broadcastError = validateHost(broadcast, "Broadcast address");
+  const canSend = !!mac.trim() && !portError && !broadcastError;
   const [savedDevices, setSavedDevices] = useState<WolDevice[]>([]);
   const [history, setHistory] = useState<WolHistoryEntry[]>([]);
   const [status, setStatus] = useState<string | null>(null);
@@ -39,18 +45,18 @@ export function WolPanel() {
   }, [loadDevices]);
 
   const handleSend = useCallback(async () => {
-    if (!mac.trim()) return;
+    if (!mac.trim() || portError || broadcastError) return;
     setError(null);
     setStatus(null);
     try {
-      await networkWolSend(mac, broadcast, port);
+      await networkWolSend(mac, broadcast, Number(port));
       setStatus(`Magic packet sent to ${mac}`);
       setHistory((prev) => [{ mac, sentAt: new Date().toLocaleTimeString() }, ...prev.slice(0, 9)]);
     } catch (err) {
       setError(String(err));
       frontendLog("wol_panel", `WoL send failed: ${err}`);
     }
-  }, [mac, broadcast, port]);
+  }, [mac, broadcast, port, portError, broadcastError]);
 
   const handleWakeDevice = useCallback(async (device: WolDevice) => {
     try {
@@ -68,7 +74,7 @@ export function WolPanel() {
   }, []);
 
   const handleSaveDevice = useCallback(async () => {
-    if (!mac.trim()) return;
+    if (!mac.trim() || portError || broadcastError) return;
     const name = window.prompt("Device name:");
     if (!name) return;
     try {
@@ -77,7 +83,7 @@ export function WolPanel() {
         name,
         mac,
         broadcast,
-        port,
+        port: Number(port),
       });
       await loadDevices();
       toast.success(`Saved device "${name}"`);
@@ -86,7 +92,7 @@ export function WolPanel() {
       frontendLog("wol_panel", `WoL device save failed: ${err}`);
       toast.error(`Save failed: ${err}`);
     }
-  }, [mac, broadcast, port, loadDevices]);
+  }, [mac, broadcast, port, portError, broadcastError, loadDevices]);
 
   const handleDeleteDevice = useCallback(
     async (id: string) => {
@@ -112,7 +118,7 @@ export function WolPanel() {
             size="sm"
             icon={<Power size={14} />}
             onClick={handleSend}
-            disabled={!mac.trim()}
+            disabled={!canSend}
             data-testid="wol-send"
           >
             Send
@@ -134,20 +140,21 @@ export function WolPanel() {
         <label className="network-panel__field">
           <span>Broadcast</span>
           <input
-            className="network-panel__input"
+            className={`network-panel__input${broadcastError ? " network-panel__input--error" : ""}`}
             value={broadcast}
             onChange={(e) => setBroadcast(e.target.value)}
+            aria-invalid={broadcastError ? true : undefined}
           />
+          {broadcastError && <span className="network-panel__field-error">{broadcastError}</span>}
         </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Port</span>
-          <input
-            className="network-panel__input"
-            type="number"
-            value={port}
-            onChange={(e) => setPort(Number(e.target.value))}
-          />
-        </label>
+        <NetworkNumberField
+          label="Port"
+          value={port}
+          onChange={setPort}
+          error={portError}
+          small
+          data-testid="wol-port"
+        />
       </div>
 
       {status && <div className="network-panel__info">{status}</div>}
@@ -188,7 +195,7 @@ export function WolPanel() {
         size="sm"
         icon={<Save size={13} />}
         onClick={handleSaveDevice}
-        disabled={!mac.trim()}
+        disabled={!canSend}
         data-testid="wol-save-device"
         style={{ alignSelf: "flex-start" }}
       >

--- a/src/components/NetworkTools/WolPanel.tsx
+++ b/src/components/NetworkTools/WolPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/services/networkApi";
 import type { WolDevice } from "@/types/network";
 import { NetworkNumberField } from "./NetworkNumberField";
+import { NetworkTextField } from "./NetworkTextField";
 import { validatePort, validateHost } from "@/utils/fieldValidation";
 import { frontendLog } from "@/utils/frontendLog";
 
@@ -45,7 +46,7 @@ export function WolPanel() {
   }, [loadDevices]);
 
   const handleSend = useCallback(async () => {
-    if (!mac.trim() || portError || broadcastError) return;
+    if (!canSend) return;
     setError(null);
     setStatus(null);
     try {
@@ -56,7 +57,7 @@ export function WolPanel() {
       setError(String(err));
       frontendLog("wol_panel", `WoL send failed: ${err}`);
     }
-  }, [mac, broadcast, port, portError, broadcastError]);
+  }, [mac, broadcast, port, canSend]);
 
   const handleWakeDevice = useCallback(async (device: WolDevice) => {
     try {
@@ -74,7 +75,7 @@ export function WolPanel() {
   }, []);
 
   const handleSaveDevice = useCallback(async () => {
-    if (!mac.trim() || portError || broadcastError) return;
+    if (!canSend) return;
     const name = window.prompt("Device name:");
     if (!name) return;
     try {
@@ -92,7 +93,7 @@ export function WolPanel() {
       frontendLog("wol_panel", `WoL device save failed: ${err}`);
       toast.error(`Save failed: ${err}`);
     }
-  }, [mac, broadcast, port, portError, broadcastError, loadDevices]);
+  }, [mac, broadcast, port, canSend, loadDevices]);
 
   const handleDeleteDevice = useCallback(
     async (id: string) => {
@@ -137,16 +138,13 @@ export function WolPanel() {
             data-testid="wol-mac"
           />
         </label>
-        <label className="network-panel__field">
-          <span>Broadcast</span>
-          <input
-            className={`network-panel__input${broadcastError ? " network-panel__input--error" : ""}`}
-            value={broadcast}
-            onChange={(e) => setBroadcast(e.target.value)}
-            aria-invalid={broadcastError ? true : undefined}
-          />
-          {broadcastError && <span className="network-panel__field-error">{broadcastError}</span>}
-        </label>
+        <NetworkTextField
+          label="Broadcast"
+          value={broadcast}
+          onChange={setBroadcast}
+          error={broadcastError}
+          data-testid="wol-broadcast"
+        />
         <NetworkNumberField
           label="Port"
           value={port}

--- a/src/components/TunnelEditor/TunnelEditor.tsx
+++ b/src/components/TunnelEditor/TunnelEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useAppStore } from "@/store/appStore";
 import {
   TunnelConfig,
@@ -11,6 +11,7 @@ import { TunnelEditorMeta } from "@/types/terminal";
 import { Button, Input, Select, Field, Toggle, toast } from "@/components/ui";
 import { frontendLog } from "@/utils/frontendLog";
 import { TunnelDiagram } from "./TunnelDiagram";
+import { validateTunnelType } from "./tunnelValidation";
 import "./TunnelEditor.css";
 
 interface TunnelEditorProps {
@@ -105,6 +106,22 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
       }
     });
   }, []);
+
+  // Store the raw numeric value (0 for blank) so out-of-range/blank ports are
+  // caught by validation instead of the previous `parseInt(...) || 0` which
+  // silently coerced them to 0 and let an invalid tunnel save.
+  const updatePort = useCallback(
+    (field: string, raw: string) => {
+      const n = parseInt(raw, 10);
+      updateConfig(field, Number.isNaN(n) ? 0 : n);
+    },
+    [updateConfig]
+  );
+
+  // Inline validation of the forwarding host/port fields. Blocks Save while any
+  // visible field is invalid.
+  const { errors, valid } = useMemo(() => validateTunnelType(tunnelType), [tunnelType]);
+  const canSave = !!sshConnectionId && valid;
 
   const handleSave = useCallback(
     async (andStart: boolean) => {
@@ -231,36 +248,48 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           <>
             <span className="tunnel-editor__section-title">Local Bind</span>
             <div className="tunnel-editor__row">
-              <Field label="Local Host" htmlFor={`tunnel-local-host-${tabId}`}>
+              <Field
+                label="Local Host"
+                htmlFor={`tunnel-local-host-${tabId}`}
+                error={errors.localHost}
+              >
                 <Input
                   id={`tunnel-local-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.localHost}
                   onChange={(e) => updateConfig("localHost", e.target.value)}
+                  error={!!errors.localHost}
                 />
               </Field>
               <Field
                 label="Local Port"
                 htmlFor={`tunnel-local-port-${tabId}`}
                 className="tunnel-editor__port-field"
+                error={errors.localPort}
               >
                 <Input
                   id={`tunnel-local-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.localPort}
-                  onChange={(e) => updateConfig("localPort", parseInt(e.target.value) || 0)}
+                  onChange={(e) => updatePort("localPort", e.target.value)}
+                  error={!!errors.localPort}
                   data-testid="tunnel-editor-local-port"
                 />
               </Field>
             </div>
             <span className="tunnel-editor__section-title">Remote Target</span>
             <div className="tunnel-editor__row">
-              <Field label="Remote Host" htmlFor={`tunnel-remote-host-${tabId}`}>
+              <Field
+                label="Remote Host"
+                htmlFor={`tunnel-remote-host-${tabId}`}
+                error={errors.remoteHost}
+              >
                 <Input
                   id={`tunnel-remote-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.remoteHost}
                   onChange={(e) => updateConfig("remoteHost", e.target.value)}
+                  error={!!errors.remoteHost}
                   data-testid="tunnel-editor-remote-host"
                 />
               </Field>
@@ -268,12 +297,14 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
                 label="Remote Port"
                 htmlFor={`tunnel-remote-port-${tabId}`}
                 className="tunnel-editor__port-field"
+                error={errors.remotePort}
               >
                 <Input
                   id={`tunnel-remote-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.remotePort}
-                  onChange={(e) => updateConfig("remotePort", parseInt(e.target.value) || 0)}
+                  onChange={(e) => updatePort("remotePort", e.target.value)}
+                  error={!!errors.remotePort}
                   data-testid="tunnel-editor-remote-port"
                 />
               </Field>
@@ -285,47 +316,64 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           <>
             <span className="tunnel-editor__section-title">Remote Bind (on SSH Server)</span>
             <div className="tunnel-editor__row">
-              <Field label="Remote Host" htmlFor={`tunnel-r-remote-host-${tabId}`}>
+              <Field
+                label="Remote Host"
+                htmlFor={`tunnel-r-remote-host-${tabId}`}
+                error={errors.remoteHost}
+              >
                 <Input
                   id={`tunnel-r-remote-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.remoteHost}
                   onChange={(e) => updateConfig("remoteHost", e.target.value)}
+                  error={!!errors.remoteHost}
+                  data-testid="tunnel-editor-remote-host"
                 />
               </Field>
               <Field
                 label="Remote Port"
                 htmlFor={`tunnel-r-remote-port-${tabId}`}
                 className="tunnel-editor__port-field"
+                error={errors.remotePort}
               >
                 <Input
                   id={`tunnel-r-remote-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.remotePort}
-                  onChange={(e) => updateConfig("remotePort", parseInt(e.target.value) || 0)}
+                  onChange={(e) => updatePort("remotePort", e.target.value)}
+                  error={!!errors.remotePort}
+                  data-testid="tunnel-editor-remote-port"
                 />
               </Field>
             </div>
             <span className="tunnel-editor__section-title">Local Target</span>
             <div className="tunnel-editor__row">
-              <Field label="Local Host" htmlFor={`tunnel-r-local-host-${tabId}`}>
+              <Field
+                label="Local Host"
+                htmlFor={`tunnel-r-local-host-${tabId}`}
+                error={errors.localHost}
+              >
                 <Input
                   id={`tunnel-r-local-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.localHost}
                   onChange={(e) => updateConfig("localHost", e.target.value)}
+                  error={!!errors.localHost}
                 />
               </Field>
               <Field
                 label="Local Port"
                 htmlFor={`tunnel-r-local-port-${tabId}`}
                 className="tunnel-editor__port-field"
+                error={errors.localPort}
               >
                 <Input
                   id={`tunnel-r-local-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.localPort}
-                  onChange={(e) => updateConfig("localPort", parseInt(e.target.value) || 0)}
+                  onChange={(e) => updatePort("localPort", e.target.value)}
+                  error={!!errors.localPort}
+                  data-testid="tunnel-editor-local-port"
                 />
               </Field>
             </div>
@@ -336,24 +384,32 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           <>
             <span className="tunnel-editor__section-title">SOCKS5 Proxy Bind</span>
             <div className="tunnel-editor__row">
-              <Field label="Local Host" htmlFor={`tunnel-d-local-host-${tabId}`}>
+              <Field
+                label="Local Host"
+                htmlFor={`tunnel-d-local-host-${tabId}`}
+                error={errors.localHost}
+              >
                 <Input
                   id={`tunnel-d-local-host-${tabId}`}
                   type="text"
                   value={tunnelType.config.localHost}
                   onChange={(e) => updateConfig("localHost", e.target.value)}
+                  error={!!errors.localHost}
                 />
               </Field>
               <Field
                 label="Local Port"
                 htmlFor={`tunnel-d-local-port-${tabId}`}
                 className="tunnel-editor__port-field"
+                error={errors.localPort}
               >
                 <Input
                   id={`tunnel-d-local-port-${tabId}`}
                   type="number"
                   value={tunnelType.config.localPort}
-                  onChange={(e) => updateConfig("localPort", parseInt(e.target.value) || 0)}
+                  onChange={(e) => updatePort("localPort", e.target.value)}
+                  error={!!errors.localPort}
+                  data-testid="tunnel-editor-local-port"
                 />
               </Field>
             </div>
@@ -378,7 +434,7 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           <Button
             variant="primary"
             onClick={() => handleSave(false)}
-            disabled={!sshConnectionId}
+            disabled={!canSave}
             data-testid="tunnel-editor-save"
           >
             Save
@@ -386,7 +442,7 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           <Button
             variant="primary"
             onClick={() => handleSave(true)}
-            disabled={!sshConnectionId}
+            disabled={!canSave}
             data-testid="tunnel-editor-save-start"
           >
             Save &amp; Start

--- a/src/components/TunnelEditor/TunnelEditor.tsx
+++ b/src/components/TunnelEditor/TunnelEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
 import {
   TunnelConfig,
@@ -119,8 +119,9 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
   );
 
   // Inline validation of the forwarding host/port fields. Blocks Save while any
-  // visible field is invalid.
-  const { errors, valid } = useMemo(() => validateTunnelType(tunnelType), [tunnelType]);
+  // visible field is invalid. `tunnelType` is a fresh object on every edit, so
+  // memoizing the check would never hit; it iterates only a few fields.
+  const { errors, valid } = validateTunnelType(tunnelType);
   const canSave = !!sshConnectionId && valid;
 
   const handleSave = useCallback(

--- a/src/components/TunnelEditor/tunnelValidation.test.ts
+++ b/src/components/TunnelEditor/tunnelValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { TunnelType } from "@/types/tunnel";
+import type { TunnelType, LocalForwardConfig } from "@/types/tunnel";
 import { validateTunnelType } from "./tunnelValidation";
 
 const local = (over: Partial<Record<string, unknown>> = {}): TunnelType => ({
@@ -10,7 +10,7 @@ const local = (over: Partial<Record<string, unknown>> = {}): TunnelType => ({
     remoteHost: "localhost",
     remotePort: 80,
     ...over,
-  } as TunnelType["config"],
+  } as unknown as LocalForwardConfig,
 });
 
 describe("validateTunnelType", () => {

--- a/src/components/TunnelEditor/tunnelValidation.test.ts
+++ b/src/components/TunnelEditor/tunnelValidation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import type { TunnelType } from "@/types/tunnel";
+import { validateTunnelType } from "./tunnelValidation";
+
+const local = (over: Partial<Record<string, unknown>> = {}): TunnelType => ({
+  type: "local",
+  config: {
+    localHost: "127.0.0.1",
+    localPort: 8080,
+    remoteHost: "localhost",
+    remotePort: 80,
+    ...over,
+  } as TunnelType["config"],
+});
+
+describe("validateTunnelType", () => {
+  it("accepts a fully-valid local forward", () => {
+    const { valid, errors } = validateTunnelType(local());
+    expect(valid).toBe(true);
+    expect(errors).toEqual({});
+  });
+
+  it("rejects port 0 (the parseInt||0 regression)", () => {
+    const { valid, errors } = validateTunnelType(local({ localPort: 0 }));
+    expect(valid).toBe(false);
+    expect(errors.localPort).toBe("Local port must be between 1 and 65535");
+  });
+
+  it("rejects a port above 65535", () => {
+    const { valid, errors } = validateTunnelType(local({ remotePort: 70000 }));
+    expect(valid).toBe(false);
+    expect(errors.remotePort).toBe("Remote port must be between 1 and 65535");
+  });
+
+  it("rejects a blank host", () => {
+    const { valid, errors } = validateTunnelType(local({ remoteHost: "  " }));
+    expect(valid).toBe(false);
+    expect(errors.remoteHost).toBe("Remote host is required");
+  });
+
+  it("validates only the fields present on a dynamic forward", () => {
+    const dynamic: TunnelType = {
+      type: "dynamic",
+      config: { localHost: "127.0.0.1", localPort: 1080 },
+    };
+    expect(validateTunnelType(dynamic).valid).toBe(true);
+    const bad: TunnelType = {
+      type: "dynamic",
+      config: { localHost: "", localPort: 1080 },
+    };
+    const { valid, errors } = validateTunnelType(bad);
+    expect(valid).toBe(false);
+    expect(errors.localHost).toBe("Local host is required");
+    expect(errors.remotePort).toBeUndefined();
+  });
+});

--- a/src/components/TunnelEditor/tunnelValidation.ts
+++ b/src/components/TunnelEditor/tunnelValidation.ts
@@ -1,0 +1,48 @@
+import type { TunnelType } from "@/types/tunnel";
+import { validateHost, validatePort } from "@/utils/fieldValidation";
+
+/** Field-keyed validation messages for the tunnel forwarding config. */
+export type TunnelFieldErrors = Partial<Record<string, string>>;
+
+/** Result of validating a tunnel's forwarding configuration. */
+export interface TunnelValidation {
+  /** Per-field error messages, keyed by the config field name. */
+  errors: TunnelFieldErrors;
+  /** True when every visible host/port field is valid. */
+  valid: boolean;
+}
+
+const HOST_LABELS: Record<string, string> = {
+  localHost: "Local host",
+  remoteHost: "Remote host",
+};
+
+const PORT_LABELS: Record<string, string> = {
+  localPort: "Local port",
+  remotePort: "Remote port",
+};
+
+/**
+ * Validate the host/port fields of a tunnel's forwarding config.
+ *
+ * Every `*Host` field must be a non-empty string and every `*Port` field must
+ * be an integer in 1–65535. This replaces the previous `parseInt(...) || 0`
+ * coercion that let port 0, a blank host, or a >65535 port save and then fail
+ * at connect time.
+ */
+export function validateTunnelType(tunnelType: TunnelType): TunnelValidation {
+  const errors: TunnelFieldErrors = {};
+  const config = tunnelType.config as Record<string, string | number>;
+
+  for (const [key, value] of Object.entries(config)) {
+    if (key.endsWith("Host")) {
+      const err = validateHost(value as string, HOST_LABELS[key] ?? "Host");
+      if (err) errors[key] = err;
+    } else if (key.endsWith("Port")) {
+      const err = validatePort(value as number, { label: PORT_LABELS[key] ?? "Port" });
+      if (err) errors[key] = err;
+    }
+  }
+
+  return { errors, valid: Object.keys(errors).length === 0 };
+}

--- a/src/components/TunnelEditor/tunnelValidation.ts
+++ b/src/components/TunnelEditor/tunnelValidation.ts
@@ -32,7 +32,7 @@ const PORT_LABELS: Record<string, string> = {
  */
 export function validateTunnelType(tunnelType: TunnelType): TunnelValidation {
   const errors: TunnelFieldErrors = {};
-  const config = tunnelType.config as Record<string, string | number>;
+  const config = tunnelType.config as unknown as Record<string, string | number>;
 
   for (const [key, value] of Object.entries(config)) {
     if (key.endsWith("Host")) {

--- a/src/utils/fieldValidation.test.ts
+++ b/src/utils/fieldValidation.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { validateIntRange, validatePort, validateHost, isValidHttpUrl } from "./fieldValidation";
+
+describe("validateIntRange", () => {
+  it("accepts an in-range integer", () => {
+    expect(validateIntRange(30, { min: 1, max: 255 })).toBeNull();
+    expect(validateIntRange(1, { min: 1, max: 255 })).toBeNull();
+    expect(validateIntRange(255, { min: 1, max: 255 })).toBeNull();
+  });
+
+  it("rejects an empty value unless allowEmpty is set", () => {
+    expect(validateIntRange("", { min: 1, max: 10, label: "Count" })).toBe("Count is required");
+    expect(validateIntRange(null, { min: 1, max: 10, label: "Count" })).toBe("Count is required");
+    expect(validateIntRange(undefined, { min: 1, max: 10 })).toBe("Value is required");
+    expect(validateIntRange("", { min: 1, max: 10, allowEmpty: true })).toBeNull();
+  });
+
+  it("rejects NaN", () => {
+    expect(validateIntRange(Number.NaN, { min: 1, max: 10 })).toBe("Value is required");
+  });
+
+  it("rejects non-integers", () => {
+    expect(validateIntRange(1.5, { min: 1, max: 10, label: "Hops" })).toBe(
+      "Hops must be a whole number"
+    );
+  });
+
+  it("rejects out-of-range values", () => {
+    expect(validateIntRange(0, { min: 1, max: 255, label: "Max hops" })).toBe(
+      "Max hops must be between 1 and 255"
+    );
+    expect(validateIntRange(256, { min: 1, max: 255, label: "Max hops" })).toBe(
+      "Max hops must be between 1 and 255"
+    );
+  });
+});
+
+describe("validatePort", () => {
+  it("accepts 1..65535", () => {
+    expect(validatePort(1)).toBeNull();
+    expect(validatePort(22)).toBeNull();
+    expect(validatePort(65535)).toBeNull();
+  });
+
+  it("rejects 0, blank, and >65535 (the parseInt||0 regressions)", () => {
+    expect(validatePort(0)).toBe("Port must be between 1 and 65535");
+    expect(validatePort(65536)).toBe("Port must be between 1 and 65535");
+    expect(validatePort("")).toBe("Port is required");
+  });
+
+  it("uses a custom label", () => {
+    expect(validatePort(0, { label: "Local port" })).toBe("Local port must be between 1 and 65535");
+  });
+});
+
+describe("validateHost", () => {
+  it("accepts a non-empty host", () => {
+    expect(validateHost("example.com")).toBeNull();
+    expect(validateHost("127.0.0.1")).toBeNull();
+  });
+
+  it("rejects blank/whitespace hosts", () => {
+    expect(validateHost("")).toBe("Host is required");
+    expect(validateHost("   ")).toBe("Host is required");
+    expect(validateHost(undefined)).toBe("Host is required");
+    expect(validateHost("", "Remote host")).toBe("Remote host is required");
+  });
+});
+
+describe("isValidHttpUrl", () => {
+  it("accepts real http(s) URLs", () => {
+    expect(isValidHttpUrl("https://example.com")).toBe(true);
+    expect(isValidHttpUrl("http://example.com/health")).toBe(true);
+    expect(isValidHttpUrl("https://10.0.0.1:8443/status")).toBe(true);
+  });
+
+  it("rejects empty input and the bare scheme sentinel", () => {
+    expect(isValidHttpUrl("")).toBe(false);
+    expect(isValidHttpUrl("   ")).toBe(false);
+    expect(isValidHttpUrl("https://")).toBe(false);
+  });
+
+  it("rejects non-http schemes and garbage", () => {
+    expect(isValidHttpUrl("ftp://example.com")).toBe(false);
+    expect(isValidHttpUrl("not a url")).toBe(false);
+    expect(isValidHttpUrl("example.com")).toBe(false);
+  });
+});

--- a/src/utils/fieldValidation.ts
+++ b/src/utils/fieldValidation.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared inline field-validation helpers.
+ *
+ * These pure functions back the client-side validation used by the network
+ * tools and the tunnel editor so that invalid input (blank hosts, out-of-range
+ * ports, non-integer counts) is flagged inline and blocks the action rather
+ * than being silently coerced (e.g. `parseInt(...) || 0`) and failing later at
+ * connect/run time.
+ */
+
+export interface IntRangeOptions {
+  /** Inclusive lower bound. */
+  min: number;
+  /** Inclusive upper bound. */
+  max: number;
+  /** Human-readable field name used in the returned message. */
+  label?: string;
+  /** When true, an empty value (`""`/`null`/`undefined`) is considered valid. */
+  allowEmpty?: boolean;
+}
+
+/**
+ * Validate that a value is an integer within `[min, max]`.
+ *
+ * @returns an error message when invalid, or `null` when the value is acceptable.
+ */
+export function validateIntRange(
+  value: number | "" | null | undefined,
+  { min, max, label = "Value", allowEmpty = false }: IntRangeOptions
+): string | null {
+  if (value === "" || value === null || value === undefined || Number.isNaN(value)) {
+    return allowEmpty ? null : `${label} is required`;
+  }
+  if (!Number.isInteger(value)) {
+    return `${label} must be a whole number`;
+  }
+  if (value < min || value > max) {
+    return `${label} must be between ${min} and ${max}`;
+  }
+  return null;
+}
+
+/**
+ * Validate a TCP/UDP port number (1–65535).
+ *
+ * @returns an error message when invalid, or `null` when acceptable.
+ */
+export function validatePort(
+  value: number | "" | null | undefined,
+  opts: { label?: string; allowEmpty?: boolean } = {}
+): string | null {
+  return validateIntRange(value, {
+    min: 1,
+    max: 65535,
+    label: opts.label ?? "Port",
+    allowEmpty: opts.allowEmpty,
+  });
+}
+
+/**
+ * Validate that a host/address string is non-empty (after trimming).
+ *
+ * @returns an error message when empty, or `null` when acceptable.
+ */
+export function validateHost(value: string | null | undefined, label = "Host"): string | null {
+  return value && value.trim() !== "" ? null : `${label} is required`;
+}
+
+/**
+ * Check whether a string is a usable HTTP(S) URL — a real scheme + host check,
+ * replacing the brittle `url === "https://"` sentinel comparison.
+ *
+ * An empty string, a bare scheme (`https://`), or a non-http scheme all return
+ * `false`.
+ */
+export function isValidHttpUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  try {
+    const url = new URL(trimmed);
+    return (url.protocol === "http:" || url.protocol === "https:") && url.hostname.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -189,10 +189,13 @@ Fixed strings — match exactly.
 | `file-type-language-input` | `src/components/Settings/FileTypeSettings.tsx` |
 | `file-type-pattern-input` | `src/components/Settings/FileTypeSettings.tsx` |
 | `http-monitor-chart` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
+| `http-monitor-expected-status` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
 | `http-monitor-history` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
+| `http-monitor-interval` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
 | `http-monitor-panel` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
 | `http-monitor-start` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
 | `http-monitor-stop` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
+| `http-monitor-timeout` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
 | `http-monitor-url` | `src/components/NetworkTools/HttpMonitorPanel.tsx` |
 | `icon-picker-apply` | `src/components/ConnectionEditor/IconPickerDialog.tsx` |
 | `icon-picker-clear` | `src/components/ConnectionEditor/IconPickerDialog.tsx` |
@@ -290,15 +293,19 @@ Fixed strings — match exactly.
 | `password-prompt-save-checkbox` | `src/components/PasswordPrompt/PasswordPrompt.tsx` |
 | `password-prompt-save-label` | `src/components/PasswordPrompt/PasswordPrompt.tsx` |
 | `ping-chart` | `src/components/NetworkTools/PingPanel.tsx` |
+| `ping-count` | `src/components/NetworkTools/PingPanel.tsx` |
 | `ping-host` | `src/components/NetworkTools/PingPanel.tsx` |
+| `ping-interval` | `src/components/NetworkTools/PingPanel.tsx` |
 | `ping-panel` | `src/components/NetworkTools/PingPanel.tsx` |
 | `ping-start` | `src/components/NetworkTools/PingPanel.tsx` |
 | `ping-stats` | `src/components/NetworkTools/PingPanel.tsx` |
 | `ping-stop` | `src/components/NetworkTools/PingPanel.tsx` |
+| `port-scanner-concurrency` | `src/components/NetworkTools/PortScannerPanel.tsx` |
 | `port-scanner-host` | `src/components/NetworkTools/PortScannerPanel.tsx` |
 | `port-scanner-panel` | `src/components/NetworkTools/PortScannerPanel.tsx` |
 | `port-scanner-ports` | `src/components/NetworkTools/PortScannerPanel.tsx` |
 | `port-scanner-run` | `src/components/NetworkTools/PortScannerPanel.tsx` |
+| `port-scanner-timeout` | `src/components/NetworkTools/PortScannerPanel.tsx` |
 | `portable-badge` | `src/components/StatusBar/PortableBadge.tsx` |
 | `portable-data-dir` | `src/components/Settings/PortableModeSettings.tsx` |
 | `portable-mode-settings` | `src/components/Settings/PortableModeSettings.tsx` |
@@ -416,6 +423,7 @@ Fixed strings — match exactly.
 | `toggle-file-browser` | `src/components/Settings/ExternalFilesSettings.tsx` |
 | `toggle-power-monitoring` | `src/components/Settings/ExternalFilesSettings.tsx` |
 | `traceroute-host` | `src/components/NetworkTools/TraceroutePanel.tsx` |
+| `traceroute-max-hops` | `src/components/NetworkTools/TraceroutePanel.tsx` |
 | `traceroute-panel` | `src/components/NetworkTools/TraceroutePanel.tsx` |
 | `traceroute-run` | `src/components/NetworkTools/TraceroutePanel.tsx` |
 | `tunnel-diagram` | `src/components/TunnelEditor/TunnelDiagram.tsx` |
@@ -466,6 +474,7 @@ Fixed strings — match exactly.
 | `update-settings` | `src/components/Settings/UpdateSettings.tsx` |
 | `wol-mac` | `src/components/NetworkTools/WolPanel.tsx` |
 | `wol-panel` | `src/components/NetworkTools/WolPanel.tsx` |
+| `wol-port` | `src/components/NetworkTools/WolPanel.tsx` |
 | `wol-save-device` | `src/components/NetworkTools/WolPanel.tsx` |
 | `wol-send` | `src/components/NetworkTools/WolPanel.tsx` |
 | `workspace-cancel-btn` | `src/components/WorkspaceEditor/WorkspaceEditor.tsx` |
@@ -554,7 +563,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `ctx-stop-*` | `ctx-stop-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `custom-grammar-remove-*` | `custom-grammar-remove-${g.id}` | `src/components/Settings/CustomGrammarsSettings.tsx` |
 | `dynamic-field-*` | `dynamic-field-${field.key}` | `src/components/DynamicForm/DynamicField.tsx` |
-| `field-*` | `field-${field.key}` | `src/components/DynamicForm/DynamicField.tsx` |
+| `field-*` | `field-${field.key}` | `src/components/ConnectionEditor/ConnectionEditor.tsx`, `src/components/DynamicForm/DynamicField.tsx` |
 | `field-*-*-*` | `field-${field.key}-${subField.key}-${index}` | `src/components/DynamicForm/DynamicField.tsx` |
 | `field-*-*-browse-*` | `field-${field.key}-${subField.key}-browse-${index}` | `src/components/DynamicForm/DynamicField.tsx` |
 | `field-*-add` | `field-${field.key}-add` | `src/components/DynamicForm/DynamicField.tsx` |
@@ -663,7 +672,7 @@ where the component is used, not at the `data-testid` site.
 | `{paused ? `monitor-resume-${entry.key}` : `monitor-pause-${entry.key}`}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `{rest["data-testid"]}` | `src/components/ui/Modal.tsx`, `src/components/ui/Tooltip.tsx` |
 | `{rowTestIdPrefix ? `${rowTestIdPrefix}-${i}` : undefined}` | `src/components/NetworkTools/DiagnosticResultsTable.tsx` |
-| `{testId}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `{testId}` | `src/components/NetworkTools/NetworkNumberField.tsx`, `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `{testid}` | `src/components/ui/Select.tsx` |
 | `{tid("auth-method")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |
 | `{tid("connect-timeout")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -472,6 +472,7 @@ Fixed strings — match exactly.
 | `update-notification-whats-new` | `src/components/UpdateNotification/UpdateNotification.tsx` |
 | `update-open-downloads` | `src/components/Settings/UpdateSettings.tsx` |
 | `update-settings` | `src/components/Settings/UpdateSettings.tsx` |
+| `wol-broadcast` | `src/components/NetworkTools/WolPanel.tsx` |
 | `wol-mac` | `src/components/NetworkTools/WolPanel.tsx` |
 | `wol-panel` | `src/components/NetworkTools/WolPanel.tsx` |
 | `wol-port` | `src/components/NetworkTools/WolPanel.tsx` |
@@ -672,7 +673,7 @@ where the component is used, not at the `data-testid` site.
 | `{paused ? `monitor-resume-${entry.key}` : `monitor-pause-${entry.key}`}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `{rest["data-testid"]}` | `src/components/ui/Modal.tsx`, `src/components/ui/Tooltip.tsx` |
 | `{rowTestIdPrefix ? `${rowTestIdPrefix}-${i}` : undefined}` | `src/components/NetworkTools/DiagnosticResultsTable.tsx` |
-| `{testId}` | `src/components/NetworkTools/NetworkNumberField.tsx`, `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `{testId}` | `src/components/NetworkTools/NetworkNumberField.tsx`, `src/components/NetworkTools/NetworkTextField.tsx`, `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `{testid}` | `src/components/ui/Select.tsx` |
 | `{tid("auth-method")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |
 | `{tid("connect-timeout")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |


### PR DESCRIPTION
## Summary

Form validation was cosmetic: inline errors rendered but did not block the action, so broken configs saved and failed later at connect/run time. This makes validation authoritative across the connection editor, tunnel editor, and network tools — invalid input is flagged inline at the field and blocks Save/Run.

- **Connection editor** (`DynamicForm/ConnectionSettingsForm.tsx`, `ConnectionEditor.tsx`, `DynamicForm/DynamicField.tsx`): the schema-driven form now reports overall validity + a per-field error map upward (visible fields only, so a `visibleWhen`-hidden required field never blocks). Save / Save & Connect are gated on a valid form; attempting to save while invalid flags the Connection tab and scrolls to + focuses the first invalid field. Required fields render a marker and `aria-required`.
- **Tunnel editor** (`TunnelEditor.tsx`): ports are validated to 1–65535 and hosts must be non-empty, inline; Save / Save & Start are disabled while invalid — replacing the `parseInt(...) || 0` coercion that let port 0, a blank host, or a >65535 port save.
- **Network tools** (`PingPanel`, `TraceroutePanel`, `PortScannerPanel`, `WolPanel`): numeric fields (interval, count, max hops, timeout, concurrency, port) are range-checked inline and disable Run/Start/Send while invalid.
- **HTTP Monitor** (`HttpMonitorPanel.tsx`): the URL is validated with a real scheme + host check (`isValidHttpUrl`) instead of the brittle `url === "https://"` guard, so a real URL can be entered from an empty field and an incomplete URL is flagged inline.

Shared pure validators live in `src/utils/fieldValidation.ts`; tunnel host/port validation in `TunnelEditor/tunnelValidation.ts`; reusable `NetworkNumberField` / `NetworkTextField` centralize the network-panel label+input+inline-error affordance.

## Test plan

Automated (all green): `npx tsc --noEmit -p tsconfig.json`, ESLint, Prettier, `vitest run` (2551 tests, incl. new `fieldValidation`, `tunnelValidation`, `ConnectionSettingsForm.validity`, `DynamicField` required-marker, `HttpMonitorPanel.url-validation`, `PingPanel.validation`, and `ConnectionEditor` Save-gating tests), `vite build`.

Manual:
1. New SSH connection with a blank Host → Save is gated; clicking Save scrolls to and focuses the Host field. Fill Host → Save works.
2. New tunnel: set a port to `0` or `70000`, or clear a host → inline error shows and Save / Save & Start disable. Fix → enabled.
3. Ping/Traceroute/Port Scanner/WoL: clear or set an out-of-range numeric field → inline error, Run/Start/Send disabled.
4. HTTP Monitor: leave the default `https://` or type `not-a-url` → inline "Enter a valid http(s) URL", Start disabled; type `https://example.com` → Start enabled.

> Note: `pnpm build`'s `tsc` step fails in this git-worktree on the unrelated, unchanged `src/hooks/useWebviewZoom.ts` (`style.zoom`) because the worktree's minimal `node_modules` resolves a mismatched TypeScript lib. `npx tsc --noEmit -p tsconfig.json` (TS 5.6.3, correct lib) and `vite build` both pass on this branch.

Closes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Follow-up: #1381 (migrate remaining NetworkTools panel fields to shared field components / ui primitives).
