### PR TITLE
feat(backend): spawn core — SpawnRequest types, IPC transport, CLI routing (Closes #1364)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7125,6 +7125,7 @@ dependencies = [
  "hex",
  "if-addrs",
  "keyring",
+ "libc",
  "libunftp",
  "objc2-foundation",
  "portable-pty",

--- a/docs/changes/dev0/feature/1364-spawn-core.md
+++ b/docs/changes/dev0/feature/1364-spawn-core.md
@@ -1,0 +1,12 @@
+### Added
+
+- New `termiHub spawn` command-line subcommand — the foundation for opening a
+  session in termiHub from a terminal or (later) a file-manager context menu. It
+  accepts `--location`, `--entry-id`, `--connection`, `--new-window`, `--pick`,
+  `--container-image`, and `--container-mount`, builds a well-formed request, and
+  forwards it over a per-user local IPC channel (a named pipe on Windows, a
+  domain socket under the runtime dir on Unix) to an already-running termiHub. If
+  no instance is running, the request is stashed and this launch handles it. The
+  app stays multi-instance — the IPC channel is only a rendezvous. Actually
+  opening the session, context-menu registration, and the picker land in
+  follow-up work under epic #1363 (#1364).

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,6 +67,10 @@ unftp-sbe-fs = "0.2"
 # base crate always provides the `mock` backend used in unit tests.
 keyring = { version = "3", default-features = false }
 
+[target.'cfg(unix)'.dependencies]
+# Resolve the current uid for the per-user spawn socket path (#1364).
+libc = "0.2"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-foundation = { version = "0.3", features = ["NSUserDefaults", "NSString"] }
 # macOS Keychain backend for the `keyring` crate.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod embedded_servers;
 pub mod files;
 mod network;
 mod session;
+mod spawn;
 mod terminal;
 mod tunnel;
 mod utils;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,27 +69,25 @@ fn build_xserver_manager() -> terminal::xserver::XServerManager {
 ///
 /// A `--new-window` request always launches a fresh instance; otherwise the
 /// request is forwarded to an already-running instance over the per-user IPC
-/// rendezvous. If no instance is reachable (or the endpoint cannot be
-/// resolved), the request is stashed in `PENDING_SPAWN` and this process
-/// launches as the running instance to handle it in `setup()`.
-fn handle_spawn_command(request: spawn::SpawnRequest) {
+/// rendezvous. On a successful forward the process exits. If no instance is
+/// reachable (or the endpoint cannot be resolved), the request is returned so
+/// the caller can launch as the running instance and handle it in `setup()`.
+fn handle_spawn_command(request: spawn::SpawnRequest) -> Option<spawn::SpawnRequest> {
+    if request.new_window {
+        return Some(request);
+    }
+
     let endpoint = match spawn::SpawnEndpoint::for_current_user() {
         Ok(endpoint) => endpoint,
         Err(e) => {
             eprintln!("Could not resolve spawn endpoint: {e}");
-            spawn::set_pending(request);
-            return;
+            return Some(request);
         }
     };
 
-    if request.new_window {
-        spawn::set_pending(request);
-        return;
-    }
-
     match spawn::forward_to_running_instance(&endpoint, &request) {
         Ok(_response) => std::process::exit(0),
-        Err(_) => spawn::set_pending(request),
+        Err(_) => Some(request),
     }
 }
 
@@ -97,17 +95,19 @@ fn handle_spawn_command(request: spawn::SpawnRequest) {
 pub fn run() {
     // Pre-init CLI routing: `spawn` / `(un)install-shell-integration` must be
     // handled from the raw args before the Tauri window is created, since
-    // `cli().matches()` is only available inside `setup()` (#1364).
+    // `cli().matches()` is only available inside `setup()` (#1364). A spawn
+    // request this instance must handle itself (no running instance accepted
+    // the forward) is threaded into `setup()` via `pending_spawn`.
     let raw_args: Vec<String> = std::env::args().skip(1).collect();
-    match spawn::classify_command(&raw_args) {
+    let pending_spawn = match spawn::classify_command(&raw_args) {
         spawn::Command::Spawn(request) => handle_spawn_command(request),
         spawn::Command::InstallShellIntegration | spawn::Command::UninstallShellIntegration => {
             // Registration lands in a later epic issue (SI-5/6/7).
             eprintln!("Shell integration registration is not yet implemented.");
             std::process::exit(0);
         }
-        spawn::Command::None => {}
-    }
+        spawn::Command::None => None,
+    };
 
     let log_buffer = create_log_buffer();
     let capture_layer = LogCaptureLayer::new(log_buffer.clone());
@@ -496,8 +496,8 @@ pub fn run() {
 
             // Process a spawn request this instance launched to handle itself
             // (no running instance accepted the pre-init forward).
-            if let Some(req) = spawn::take_pending() {
-                if let Err(e) = app.handle().emit("spawn-request", &req) {
+            if let Some(req) = &pending_spawn {
+                if let Err(e) = app.handle().emit("spawn-request", req) {
                     tracing::warn!("failed to emit pending spawn-request: {e}");
                 }
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,8 +64,51 @@ fn build_xserver_manager() -> terminal::xserver::XServerManager {
     )
 }
 
+/// Handle a `termiHub spawn ...` invocation detected from the raw process
+/// arguments before Tauri initialises (#1364).
+///
+/// A `--new-window` request always launches a fresh instance; otherwise the
+/// request is forwarded to an already-running instance over the per-user IPC
+/// rendezvous. If no instance is reachable (or the endpoint cannot be
+/// resolved), the request is stashed in `PENDING_SPAWN` and this process
+/// launches as the running instance to handle it in `setup()`.
+fn handle_spawn_command(request: spawn::SpawnRequest) {
+    let endpoint = match spawn::SpawnEndpoint::for_current_user() {
+        Ok(endpoint) => endpoint,
+        Err(e) => {
+            eprintln!("Could not resolve spawn endpoint: {e}");
+            spawn::set_pending(request);
+            return;
+        }
+    };
+
+    if request.new_window {
+        spawn::set_pending(request);
+        return;
+    }
+
+    match spawn::forward_to_running_instance(&endpoint, &request) {
+        Ok(_response) => std::process::exit(0),
+        Err(_) => spawn::set_pending(request),
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Pre-init CLI routing: `spawn` / `(un)install-shell-integration` must be
+    // handled from the raw args before the Tauri window is created, since
+    // `cli().matches()` is only available inside `setup()` (#1364).
+    let raw_args: Vec<String> = std::env::args().skip(1).collect();
+    match spawn::classify_command(&raw_args) {
+        spawn::Command::Spawn(request) => handle_spawn_command(request),
+        spawn::Command::InstallShellIntegration | spawn::Command::UninstallShellIntegration => {
+            // Registration lands in a later epic issue (SI-5/6/7).
+            eprintln!("Shell integration registration is not yet implemented.");
+            std::process::exit(0);
+        }
+        spawn::Command::None => {}
+    }
+
     let log_buffer = create_log_buffer();
     let capture_layer = LogCaptureLayer::new(log_buffer.clone());
     let app_handle_slot = capture_layer.app_handle_slot();
@@ -420,6 +463,42 @@ pub fn run() {
                             std::process::exit(0);
                         }
                     }
+                }
+            }
+
+            // Start the spawn IPC rendezvous server (#1364). It accepts
+            // SpawnRequests from `termiHub spawn` invocations by other processes
+            // and re-emits them as a `spawn-request` event for the frontend to
+            // act on (session handling itself is out of scope here). Best-effort:
+            // if another instance already owns the endpoint, this instance simply
+            // isn't the rendezvous and continues normally (multi-instance).
+            match spawn::SpawnEndpoint::for_current_user() {
+                Ok(endpoint) => {
+                    let emit_handle = app.handle().clone();
+                    let handler: spawn::SpawnHandler =
+                        Arc::new(move |req: spawn::SpawnRequest| match emit_handle
+                            .emit("spawn-request", &req)
+                        {
+                            Ok(()) => spawn::SpawnResponse::accepted(),
+                            Err(e) => {
+                                tracing::warn!("failed to emit spawn-request event: {e}");
+                                spawn::SpawnResponse::error(format!("emit failed: {e}"))
+                            }
+                        });
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) = spawn::ipc_server::serve(&endpoint, handler).await {
+                            tracing::warn!("spawn IPC server stopped: {e}");
+                        }
+                    });
+                }
+                Err(e) => tracing::warn!("could not start spawn IPC server: {e}"),
+            }
+
+            // Process a spawn request this instance launched to handle itself
+            // (no running instance accepted the pre-init forward).
+            if let Some(req) = spawn::take_pending() {
+                if let Err(e) = app.handle().emit("spawn-request", &req) {
+                    tracing::warn!("failed to emit pending spawn-request: {e}");
                 }
             }
 

--- a/src-tauri/src/spawn/ipc_client.rs
+++ b/src-tauri/src/spawn/ipc_client.rs
@@ -1,0 +1,53 @@
+//! Spawn IPC client: connects to the per-user rendezvous endpoint, sends one
+//! [`SpawnRequest`], and reads the [`SpawnResponse`] (#1364).
+
+use anyhow::Context;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use super::{SpawnEndpoint, SpawnRequest, SpawnResponse};
+
+/// Connect to `endpoint`, send `req`, and return the running instance's
+/// response. Fails fast if no instance is listening.
+pub async fn send(endpoint: &SpawnEndpoint, req: &SpawnRequest) -> anyhow::Result<SpawnResponse> {
+    #[cfg(unix)]
+    {
+        let stream = tokio::net::UnixStream::connect(endpoint.address())
+            .await
+            .context("connect spawn socket")?;
+        exchange(stream, req).await
+    }
+    #[cfg(windows)]
+    {
+        use tokio::net::windows::named_pipe::ClientOptions;
+        let stream = ClientOptions::new()
+            .open(endpoint.address())
+            .context("open spawn pipe")?;
+        exchange(stream, req).await
+    }
+}
+
+/// Perform the request/response exchange over an established stream. Generic so
+/// it is exercised in tests via an in-memory `tokio::io::duplex` pair on every
+/// platform.
+pub(crate) async fn exchange<S>(stream: S, req: &SpawnRequest) -> anyhow::Result<SpawnResponse>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let (reader, mut writer) = tokio::io::split(stream);
+
+    let mut payload = serde_json::to_string(req).context("serialize spawn request")?;
+    payload.push('\n');
+    writer
+        .write_all(payload.as_bytes())
+        .await
+        .context("write spawn request")?;
+    writer.flush().await.context("flush spawn request")?;
+
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .await
+        .context("read spawn response")?;
+    serde_json::from_str(line.trim()).context("parse spawn response")
+}

--- a/src-tauri/src/spawn/ipc_server.rs
+++ b/src-tauri/src/spawn/ipc_server.rs
@@ -1,0 +1,109 @@
+//! Spawn IPC server: listens on the per-user rendezvous endpoint and invokes a
+//! handler for each received [`SpawnRequest`] (#1364).
+//!
+//! Framing is newline-delimited JSON: the client writes one `SpawnRequest` line,
+//! the server replies with one `SpawnResponse` line, then the connection closes.
+
+use anyhow::Context;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use super::{SpawnEndpoint, SpawnHandler, SpawnRequest, SpawnResponse};
+
+/// Serve spawn requests forever on `endpoint`, invoking `handler` per request.
+///
+/// Returns only on a fatal transport error (e.g. the endpoint is already owned
+/// by another instance); the caller should treat that as "not the rendezvous".
+pub async fn serve(endpoint: &SpawnEndpoint, handler: SpawnHandler) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        serve_unix(endpoint.address(), handler).await
+    }
+    #[cfg(windows)]
+    {
+        serve_windows(endpoint.address(), handler).await
+    }
+}
+
+/// Handle a single client connection: read one request line, run the handler,
+/// write one response line. Generic over the stream so it is exercised in tests
+/// via an in-memory `tokio::io::duplex` pair on every platform.
+pub(crate) async fn serve_connection<S>(stream: S, handler: &SpawnHandler) -> anyhow::Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let (reader, mut writer) = tokio::io::split(stream);
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+    let read = reader
+        .read_line(&mut line)
+        .await
+        .context("read spawn request")?;
+    if read == 0 || line.trim().is_empty() {
+        return Ok(());
+    }
+
+    let response = match serde_json::from_str::<SpawnRequest>(line.trim()) {
+        Ok(req) => handler(req),
+        Err(e) => SpawnResponse::error(format!("invalid spawn request: {e}")),
+    };
+
+    let mut payload = serde_json::to_string(&response).context("serialize spawn response")?;
+    payload.push('\n');
+    writer
+        .write_all(payload.as_bytes())
+        .await
+        .context("write spawn response")?;
+    writer.flush().await.context("flush spawn response")?;
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn serve_unix(path: &str, handler: SpawnHandler) -> anyhow::Result<()> {
+    use tokio::net::{UnixListener, UnixStream};
+
+    let path = std::path::Path::new(path);
+    // Clear a stale socket left behind by a crashed instance: if nothing is
+    // listening, the connect fails and the file is safe to remove.
+    if path.exists() && UnixStream::connect(path).await.is_err() {
+        std::fs::remove_file(path).ok();
+    }
+
+    let listener = UnixListener::bind(path)
+        .with_context(|| format!("bind spawn socket at {}", path.display()))?;
+    loop {
+        let (stream, _addr) = listener.accept().await.context("accept spawn connection")?;
+        let handler = handler.clone();
+        tokio::spawn(async move {
+            if let Err(e) = serve_connection(stream, &handler).await {
+                tracing::warn!("spawn connection error: {e}");
+            }
+        });
+    }
+}
+
+#[cfg(windows)]
+async fn serve_windows(name: &str, handler: SpawnHandler) -> anyhow::Result<()> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    // `first_pipe_instance(true)` fails if another instance already owns the
+    // pipe — exactly the "not the rendezvous" signal we want.
+    let mut server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(name)
+        .with_context(|| format!("create spawn pipe {name}"))?;
+    loop {
+        server.connect().await.context("await spawn pipe client")?;
+        let connected = server;
+        // Pre-create the next instance before handling this one so no client
+        // races into a missing pipe.
+        server = ServerOptions::new()
+            .create(name)
+            .with_context(|| format!("recreate spawn pipe {name}"))?;
+        let handler = handler.clone();
+        tokio::spawn(async move {
+            if let Err(e) = serve_connection(connected, &handler).await {
+                tracing::warn!("spawn connection error: {e}");
+            }
+        });
+    }
+}

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -1,0 +1,6 @@
+//! Spawn core: CLI-driven "open in termiHub" rendezvous (#1364).
+//!
+//! Foundation for the Shell Context Menu & CLI Spawn Integration epic (#1363).
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -1,6 +1,254 @@
 //! Spawn core: CLI-driven "open in termiHub" rendezvous (#1364).
 //!
 //! Foundation for the Shell Context Menu & CLI Spawn Integration epic (#1363).
+//!
+//! A `termiHub spawn ...` invocation (from a file-manager context menu or a
+//! terminal) is detected from the raw process arguments *before* Tauri
+//! initialises, turned into a [`SpawnRequest`], and forwarded over a per-user
+//! platform IPC channel to an already-running instance. If no instance is
+//! reachable, the request is stashed in [`PENDING_SPAWN`] and this process
+//! launches as the running instance, handling the request itself.
+//!
+//! This module owns the wire types, the CLI parser, the pre-init command
+//! classifier, and the pending-request store. The transport lives in
+//! [`ipc_server`] and [`ipc_client`].
+
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;
+
+/// A request to open a new session, originating from an external
+/// `termiHub spawn` invocation.
+///
+/// All fields are optional so partially-specified requests round-trip cleanly;
+/// resolution of the effective connection type happens downstream (out of scope
+/// for #1364).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpawnRequest {
+    /// Filesystem path (folder or file) the session should open at.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    /// Identifier of the context-menu entry that triggered the spawn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry_id: Option<String>,
+    /// Explicit connection id override (highest-priority resolution).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection: Option<String>,
+    /// Open in a fresh window instead of attaching to the running instance.
+    #[serde(default)]
+    pub new_window: bool,
+    /// Force the interactive session picker.
+    #[serde(default)]
+    pub pick: bool,
+    /// Docker/Podman image to use for a "new container" spawn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_image: Option<String>,
+    /// Mount target path inside the container (default resolved downstream).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_mount: Option<String>,
+}
+
+/// Outcome status returned by the running instance for a [`SpawnRequest`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpawnStatus {
+    /// The running instance accepted the request.
+    Accepted,
+    /// The request could not be handled.
+    Error,
+}
+
+/// Response sent back to the spawning process over the IPC channel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpawnResponse {
+    /// Outcome status.
+    pub status: SpawnStatus,
+    /// Human-readable detail, present on error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl SpawnResponse {
+    /// Build an accepted response.
+    pub fn accepted() -> Self {
+        Self {
+            status: SpawnStatus::Accepted,
+            message: None,
+        }
+    }
+
+    /// Build an error response carrying a detail message.
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            status: SpawnStatus::Error,
+            message: Some(message.into()),
+        }
+    }
+}
+
+/// Callback invoked by the IPC server for each received [`SpawnRequest`].
+pub type SpawnHandler = std::sync::Arc<dyn Fn(SpawnRequest) -> SpawnResponse + Send + Sync>;
+
+/// A pre-init CLI command recognised from the raw process arguments.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Command {
+    /// `termiHub spawn ...` — forward or launch-and-handle a spawn request.
+    Spawn(SpawnRequest),
+    /// `termiHub install-shell-integration` (stub until SI-5/6/7).
+    InstallShellIntegration,
+    /// `termiHub uninstall-shell-integration` (stub until SI-5/6/7).
+    UninstallShellIntegration,
+    /// No recognised spawn subcommand — proceed with a normal launch.
+    None,
+}
+
+/// Classify the process arguments (with the program name already stripped) into
+/// a pre-init [`Command`]. Pure and side-effect-free so it is unit-testable.
+pub fn classify_command(args: &[String]) -> Command {
+    match args.first().map(String::as_str) {
+        Some("spawn") => Command::Spawn(parse_spawn_args(&args[1..])),
+        Some("install-shell-integration") => Command::InstallShellIntegration,
+        Some("uninstall-shell-integration") => Command::UninstallShellIntegration,
+        _ => Command::None,
+    }
+}
+
+/// Parse the flags following `spawn` into a [`SpawnRequest`].
+///
+/// Both `--flag value` and `--flag=value` forms are accepted. Unknown flags and
+/// stray positional arguments are ignored so the parser never fails — a spawn
+/// invocation should degrade gracefully rather than abort before the app can
+/// surface an error to the user.
+pub fn parse_spawn_args(args: &[String]) -> SpawnRequest {
+    let mut req = SpawnRequest::default();
+    let mut i = 0;
+    while i < args.len() {
+        let raw = args[i].as_str();
+        let (key, inline) = match raw.split_once('=') {
+            Some((k, v)) => (k, Some(v.to_string())),
+            None => (raw, None),
+        };
+        match key {
+            "--new-window" => req.new_window = true,
+            "--pick" => req.pick = true,
+            "--location" | "--entry-id" | "--connection" | "--container-image"
+            | "--container-mount" => {
+                let value = match inline {
+                    Some(v) => Some(v),
+                    None => {
+                        if i + 1 < args.len() {
+                            i += 1;
+                            Some(args[i].clone())
+                        } else {
+                            None
+                        }
+                    }
+                };
+                match key {
+                    "--location" => req.location = value,
+                    "--entry-id" => req.entry_id = value,
+                    "--connection" => req.connection = value,
+                    "--container-image" => req.container_image = value,
+                    "--container-mount" => req.container_mount = value,
+                    _ => unreachable!("guarded by the outer match arm"),
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    req
+}
+
+/// Platform IPC address of the per-user spawn rendezvous.
+///
+/// On Windows this is a named pipe (`\\.\pipe\termihub-spawn-{username}`); on
+/// Unix it is a filesystem path to a domain socket
+/// (`{runtime_dir}/termihub-spawn-{uid}.sock`).
+#[derive(Debug, Clone)]
+pub struct SpawnEndpoint {
+    address: String,
+}
+
+impl SpawnEndpoint {
+    /// Resolve the rendezvous address for the current user.
+    pub fn for_current_user() -> anyhow::Result<Self> {
+        Ok(Self {
+            address: default_address()?,
+        })
+    }
+
+    /// Platform address string (pipe name on Windows, socket path on Unix).
+    pub(crate) fn address(&self) -> &str {
+        &self.address
+    }
+
+    /// Unique per-process endpoint used by tests to avoid collisions.
+    #[cfg(test)]
+    pub fn for_test(tag: &str) -> Self {
+        Self {
+            address: test_address(tag),
+        }
+    }
+}
+
+impl std::fmt::Display for SpawnEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.address)
+    }
+}
+
+#[cfg(windows)]
+fn default_address() -> anyhow::Result<String> {
+    let user = std::env::var("USERNAME").unwrap_or_else(|_| "default".to_string());
+    Ok(format!(r"\\.\pipe\termihub-spawn-{user}"))
+}
+
+#[cfg(unix)]
+fn default_address() -> anyhow::Result<String> {
+    let dir = dirs::runtime_dir().unwrap_or_else(std::env::temp_dir);
+    // SAFETY: `getuid` is always successful and has no preconditions.
+    let uid = unsafe { libc::getuid() };
+    Ok(dir
+        .join(format!("termihub-spawn-{uid}.sock"))
+        .to_string_lossy()
+        .into_owned())
+}
+
+#[cfg(all(test, windows))]
+fn test_address(tag: &str) -> String {
+    format!(
+        r"\\.\pipe\termihub-spawn-test-{}-{tag}",
+        std::process::id()
+    )
+}
+
+#[cfg(all(test, unix))]
+fn test_address(tag: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "termihub-spawn-test-{}-{tag}.sock",
+            std::process::id()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Request that this instance must handle itself because no running instance
+/// accepted it. Populated during pre-init and drained in `setup()`.
+pub static PENDING_SPAWN: Mutex<Option<SpawnRequest>> = Mutex::new(None);
+
+/// Store a spawn request for the launching instance to handle.
+pub fn set_pending(req: SpawnRequest) {
+    if let Ok(mut guard) = PENDING_SPAWN.lock() {
+        *guard = Some(req);
+    }
+}
+
+/// Take and clear the pending spawn request, if any.
+pub fn take_pending() -> Option<SpawnRequest> {
+    PENDING_SPAWN.lock().ok().and_then(|mut guard| guard.take())
+}

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -17,6 +17,9 @@ use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 
+pub mod ipc_client;
+pub mod ipc_server;
+
 #[cfg(test)]
 mod tests;
 
@@ -251,4 +254,19 @@ pub fn set_pending(req: SpawnRequest) {
 /// Take and clear the pending spawn request, if any.
 pub fn take_pending() -> Option<SpawnRequest> {
     PENDING_SPAWN.lock().ok().and_then(|mut guard| guard.take())
+}
+
+/// Attempt to forward a spawn request to an already-running instance,
+/// blocking on a short-lived current-thread runtime.
+///
+/// Returns `Ok` if a running instance accepted the request, `Err` if none is
+/// reachable (in which case the caller should launch and handle it locally).
+pub fn forward_to_running_instance(
+    endpoint: &SpawnEndpoint,
+    req: &SpawnRequest,
+) -> anyhow::Result<SpawnResponse> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(ipc_client::send(endpoint, req))
 }

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -6,16 +6,16 @@
 //! terminal) is detected from the raw process arguments *before* Tauri
 //! initialises, turned into a [`SpawnRequest`], and forwarded over a per-user
 //! platform IPC channel to an already-running instance. If no instance is
-//! reachable, the request is stashed in [`PENDING_SPAWN`] and this process
-//! launches as the running instance, handling the request itself.
+//! reachable, the request is handed back to the caller, which launches as the
+//! running instance and handles the request itself.
 //!
-//! This module owns the wire types, the CLI parser, the pre-init command
-//! classifier, and the pending-request store. The transport lives in
-//! [`ipc_server`] and [`ipc_client`].
-
-use std::sync::Mutex;
+//! This module owns the wire types, the CLI parser, and the pre-init command
+//! classifier. The transport lives in [`ipc_server`] and [`ipc_client`].
 
 use serde::{Deserialize, Serialize};
+
+#[cfg(not(any(unix, windows)))]
+compile_error!("spawn IPC requires a Unix or Windows target");
 
 pub mod ipc_client;
 pub mod ipc_server;
@@ -134,32 +134,30 @@ pub fn parse_spawn_args(args: &[String]) -> SpawnRequest {
             Some((k, v)) => (k, Some(v.to_string())),
             None => (raw, None),
         };
-        match key {
-            "--new-window" => req.new_window = true,
-            "--pick" => req.pick = true,
-            "--location" | "--entry-id" | "--connection" | "--container-image"
-            | "--container-mount" => {
-                let value = match inline {
-                    Some(v) => Some(v),
-                    None => {
-                        if i + 1 < args.len() {
-                            i += 1;
-                            Some(args[i].clone())
-                        } else {
-                            None
-                        }
-                    }
-                };
-                match key {
-                    "--location" => req.location = value,
-                    "--entry-id" => req.entry_id = value,
-                    "--connection" => req.connection = value,
-                    "--container-image" => req.container_image = value,
-                    "--container-mount" => req.container_mount = value,
-                    _ => unreachable!("guarded by the outer match arm"),
-                }
+        // Value flags map to a slot to fill; boolean flags are handled inline
+        // and yield no slot.
+        let slot: Option<&mut Option<String>> = match key {
+            "--new-window" => {
+                req.new_window = true;
+                None
             }
-            _ => {}
+            "--pick" => {
+                req.pick = true;
+                None
+            }
+            "--location" => Some(&mut req.location),
+            "--entry-id" => Some(&mut req.entry_id),
+            "--connection" => Some(&mut req.connection),
+            "--container-image" => Some(&mut req.container_image),
+            "--container-mount" => Some(&mut req.container_mount),
+            _ => None,
+        };
+        if let Some(slot) = slot {
+            // Take an inline `--flag=value`, else the next argument.
+            *slot = inline.or_else(|| {
+                i += 1;
+                args.get(i).cloned()
+            });
         }
         i += 1;
     }
@@ -223,10 +221,7 @@ fn default_address() -> anyhow::Result<String> {
 
 #[cfg(all(test, windows))]
 fn test_address(tag: &str) -> String {
-    format!(
-        r"\\.\pipe\termihub-spawn-test-{}-{tag}",
-        std::process::id()
-    )
+    format!(r"\\.\pipe\termihub-spawn-test-{}-{tag}", std::process::id())
 }
 
 #[cfg(all(test, unix))]
@@ -240,22 +235,6 @@ fn test_address(tag: &str) -> String {
         .into_owned()
 }
 
-/// Request that this instance must handle itself because no running instance
-/// accepted it. Populated during pre-init and drained in `setup()`.
-pub static PENDING_SPAWN: Mutex<Option<SpawnRequest>> = Mutex::new(None);
-
-/// Store a spawn request for the launching instance to handle.
-pub fn set_pending(req: SpawnRequest) {
-    if let Ok(mut guard) = PENDING_SPAWN.lock() {
-        *guard = Some(req);
-    }
-}
-
-/// Take and clear the pending spawn request, if any.
-pub fn take_pending() -> Option<SpawnRequest> {
-    PENDING_SPAWN.lock().ok().and_then(|mut guard| guard.take())
-}
-
 /// Attempt to forward a spawn request to an already-running instance,
 /// blocking on a short-lived current-thread runtime.
 ///
@@ -266,7 +245,7 @@ pub fn forward_to_running_instance(
     req: &SpawnRequest,
 ) -> anyhow::Result<SpawnResponse> {
     let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
+        .enable_io()
         .build()?;
     runtime.block_on(ipc_client::send(endpoint, req))
 }

--- a/src-tauri/src/spawn/tests.rs
+++ b/src-tauri/src/spawn/tests.rs
@@ -7,11 +7,11 @@
 
 use std::sync::{Arc, Mutex};
 
-use super::{ipc_client, ipc_server};
 use super::{
-    classify_command, parse_spawn_args, set_pending, take_pending, Command, SpawnEndpoint,
-    SpawnHandler, SpawnRequest, SpawnResponse, SpawnStatus,
+    classify_command, parse_spawn_args, Command, SpawnEndpoint, SpawnHandler, SpawnRequest,
+    SpawnResponse, SpawnStatus,
 };
+use super::{ipc_client, ipc_server};
 
 fn full_request() -> SpawnRequest {
     SpawnRequest {
@@ -139,19 +139,6 @@ fn classify_shell_integration_and_none() {
         Command::None
     );
     assert_eq!(classify_command(&[]), Command::None);
-}
-
-// ── pending request store ────────────────────────────────────────────────
-
-#[test]
-fn pending_spawn_set_and_take() {
-    let req = SpawnRequest {
-        location: Some("/z".to_string()),
-        ..Default::default()
-    };
-    set_pending(req.clone());
-    assert_eq!(take_pending(), Some(req));
-    assert_eq!(take_pending(), None);
 }
 
 // ── transport over an in-memory duplex (all platforms) ───────────────────

--- a/src-tauri/src/spawn/tests.rs
+++ b/src-tauri/src/spawn/tests.rs
@@ -1,0 +1,240 @@
+//! Unit tests for the spawn core (#1364).
+//!
+//! Covers serde round-tripping of the wire types, CLI argument parsing,
+//! pre-init subcommand classification, and the IPC transport. The transport is
+//! exercised two ways: over an in-memory `tokio::io::duplex` pair (runs on every
+//! platform) and over the real platform socket / named pipe.
+
+use std::sync::{Arc, Mutex};
+
+use super::{ipc_client, ipc_server};
+use super::{
+    classify_command, parse_spawn_args, set_pending, take_pending, Command, SpawnEndpoint,
+    SpawnHandler, SpawnRequest, SpawnResponse, SpawnStatus,
+};
+
+fn full_request() -> SpawnRequest {
+    SpawnRequest {
+        location: Some("/home/user/projects/myapp".to_string()),
+        entry_id: Some("entry-1".to_string()),
+        connection: Some("conn-42".to_string()),
+        new_window: true,
+        pick: true,
+        container_image: Some("ubuntu:22.04".to_string()),
+        container_mount: Some("/workspace".to_string()),
+    }
+}
+
+// ── serde round-trips ────────────────────────────────────────────────────
+
+#[test]
+fn spawn_request_serde_round_trip() {
+    let req = full_request();
+    let json = serde_json::to_string(&req).expect("serialize");
+    // Newline-delimited framing requires each message to be a single line.
+    assert!(!json.contains('\n'), "framing requires single-line JSON");
+    let back: SpawnRequest = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(req, back);
+}
+
+#[test]
+fn spawn_request_minimal_defaults() {
+    let back: SpawnRequest = serde_json::from_str("{}").expect("deserialize empty object");
+    assert_eq!(back, SpawnRequest::default());
+}
+
+#[test]
+fn spawn_status_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&SpawnStatus::Accepted).expect("serialize"),
+        "\"accepted\""
+    );
+    assert_eq!(
+        serde_json::to_string(&SpawnStatus::Error).expect("serialize"),
+        "\"error\""
+    );
+}
+
+#[test]
+fn spawn_response_round_trip() {
+    let resp = SpawnResponse::error("boom");
+    let json = serde_json::to_string(&resp).expect("serialize");
+    let back: SpawnResponse = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(resp, back);
+    assert_eq!(back.status, SpawnStatus::Error);
+    assert_eq!(back.message.as_deref(), Some("boom"));
+}
+
+// ── CLI parsing ──────────────────────────────────────────────────────────
+
+fn to_args(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn parse_spawn_args_full() {
+    let args = to_args(&[
+        "--location",
+        "/p",
+        "--entry-id",
+        "e",
+        "--connection",
+        "c",
+        "--new-window",
+        "--pick",
+        "--container-image",
+        "img",
+        "--container-mount",
+        "/mnt",
+    ]);
+    let req = parse_spawn_args(&args);
+    assert_eq!(req.location.as_deref(), Some("/p"));
+    assert_eq!(req.entry_id.as_deref(), Some("e"));
+    assert_eq!(req.connection.as_deref(), Some("c"));
+    assert!(req.new_window);
+    assert!(req.pick);
+    assert_eq!(req.container_image.as_deref(), Some("img"));
+    assert_eq!(req.container_mount.as_deref(), Some("/mnt"));
+}
+
+#[test]
+fn parse_spawn_args_equals_form_and_unknown_ignored() {
+    let args = to_args(&["--location=/a b", "--unknown", "x", "--pick"]);
+    let req = parse_spawn_args(&args);
+    assert_eq!(req.location.as_deref(), Some("/a b"));
+    assert!(req.pick);
+    assert!(!req.new_window);
+}
+
+#[test]
+fn parse_spawn_args_flag_without_value_is_none() {
+    let args = to_args(&["--location"]);
+    let req = parse_spawn_args(&args);
+    assert_eq!(req.location, None);
+}
+
+// ── pre-init classification ──────────────────────────────────────────────
+
+#[test]
+fn classify_spawn_command() {
+    let args = to_args(&["spawn", "--location", "/p"]);
+    match classify_command(&args) {
+        Command::Spawn(req) => assert_eq!(req.location.as_deref(), Some("/p")),
+        other => panic!("expected spawn, got {other:?}"),
+    }
+}
+
+#[test]
+fn classify_shell_integration_and_none() {
+    assert_eq!(
+        classify_command(&to_args(&["install-shell-integration"])),
+        Command::InstallShellIntegration
+    );
+    assert_eq!(
+        classify_command(&to_args(&["uninstall-shell-integration"])),
+        Command::UninstallShellIntegration
+    );
+    assert_eq!(
+        classify_command(&to_args(&["--workspace", "w"])),
+        Command::None
+    );
+    assert_eq!(classify_command(&[]), Command::None);
+}
+
+// ── pending request store ────────────────────────────────────────────────
+
+#[test]
+fn pending_spawn_set_and_take() {
+    let req = SpawnRequest {
+        location: Some("/z".to_string()),
+        ..Default::default()
+    };
+    set_pending(req.clone());
+    assert_eq!(take_pending(), Some(req));
+    assert_eq!(take_pending(), None);
+}
+
+// ── transport over an in-memory duplex (all platforms) ───────────────────
+
+#[tokio::test]
+async fn transport_round_trips_over_duplex() {
+    let (server_io, client_io) = tokio::io::duplex(4096);
+    let req = full_request();
+    let expected = req.clone();
+    let handler: SpawnHandler = Arc::new(move |got| {
+        assert_eq!(got, expected);
+        SpawnResponse::accepted()
+    });
+    let server =
+        tokio::spawn(async move { ipc_server::serve_connection(server_io, &handler).await });
+    let resp = ipc_client::exchange(client_io, &req)
+        .await
+        .expect("exchange");
+    assert_eq!(resp.status, SpawnStatus::Accepted);
+    server.await.expect("join").expect("serve connection");
+}
+
+#[tokio::test]
+async fn transport_rejects_invalid_request() {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let (server_io, client_io) = tokio::io::duplex(4096);
+    let handler: SpawnHandler = Arc::new(|_| SpawnResponse::accepted());
+    tokio::spawn(async move {
+        let _ = ipc_server::serve_connection(server_io, &handler).await;
+    });
+
+    let (reader, mut writer) = tokio::io::split(client_io);
+    writer
+        .write_all(b"this is not json\n")
+        .await
+        .expect("write garbage");
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.expect("read response");
+    let resp: SpawnResponse = serde_json::from_str(line.trim()).expect("parse response");
+    assert_eq!(resp.status, SpawnStatus::Error);
+}
+
+// ── transport over the real platform socket / named pipe ─────────────────
+
+async fn send_with_retry(endpoint: &SpawnEndpoint, req: &SpawnRequest) -> SpawnResponse {
+    for _ in 0..100 {
+        match ipc_client::send(endpoint, req).await {
+            Ok(resp) => return resp,
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(20)).await,
+        }
+    }
+    panic!("could not reach spawn server");
+}
+
+#[tokio::test]
+async fn ipc_server_client_round_trip() {
+    let endpoint = SpawnEndpoint::for_test("roundtrip");
+    let received: Arc<Mutex<Option<SpawnRequest>>> = Arc::new(Mutex::new(None));
+    let recv = received.clone();
+    let handler: SpawnHandler = Arc::new(move |req| {
+        *recv.lock().expect("lock") = Some(req);
+        SpawnResponse::accepted()
+    });
+
+    let server_ep = endpoint.clone();
+    let server = tokio::spawn(async move {
+        let _ = ipc_server::serve(&server_ep, handler).await;
+    });
+
+    let req = SpawnRequest {
+        location: Some("/home/u/proj".to_string()),
+        new_window: true,
+        ..Default::default()
+    };
+    let resp = send_with_retry(&endpoint, &req).await;
+    assert_eq!(resp.status, SpawnStatus::Accepted);
+    assert_eq!(received.lock().expect("lock").clone(), Some(req));
+
+    server.abort();
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(endpoint.address());
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for the Shell Context Menu & CLI Spawn Integration epic (#1363). This is the standalone base layer — nothing depends on it yet — that lets a `termiHub spawn ...` invocation hand a request to a running instance over a per-user IPC channel.

- **New `src-tauri/src/spawn/` module** — `mod.rs` (wire types + CLI parser + pre-init classifier), `ipc_server.rs`, `ipc_client.rs`.
- **Wire types** — `SpawnRequest` / `SpawnResponse` / `SpawnStatus` with newline-safe serde (compact single-line JSON framing).
- **Platform IPC transport** — Unix domain socket `{runtime_dir}/termihub-spawn-{uid}.sock` (macOS/Linux) and named pipe `\\.\pipe\termihub-spawn-{username}` (Windows). Endpoint resolution wrapped behind an opaque `SpawnEndpoint`; framing is generic over the stream so it's testable in-memory on every platform.
- **Pre-init subcommand routing in `lib.rs`** — the `spawn` / `(un)install-shell-integration` subcommands are detected from the **raw process args at the top of `run()`**, before the Tauri window exists (since `cli().matches()` is only available in `setup()`). A `spawn` request is forwarded to a running instance and the process exits; if none is reachable it's threaded into `setup()` and this instance handles it. `install/uninstall-shell-integration` are stubbed for a later epic issue.
- **CLI flags** — `--location`, `--entry-id`, `--connection`, `--new-window`, `--pick`, `--container-image`, `--container-mount` (both `--flag value` and `--flag=value`).
- **Multi-instance preserved** — the IPC channel is only a rendezvous; `tauri-plugin-single-instance` is **not** added. Server startup is best-effort: if another instance owns the endpoint, this one simply isn't the rendezvous.
- On receipt the server re-emits a `spawn-request` Tauri event (the hook downstream issues subscribe to). Actually opening a session, context-menu registration, the picker, and Docker are **out of scope** here.

## Chosen crate / rationale

I used **tokio's native IPC primitives** (`UnixListener`/`UnixStream` on Unix, `tokio::net::windows::named_pipe` on Windows) rather than adding `interprocess`. tokio is already a core dependency with the `net` feature enabled, it covers both platforms natively, and it keeps exact control over the mandated socket/pipe path scheme (which `interprocess`'s naming abstraction would obscure). The only new dependency is `libc` (Unix-only) to resolve the uid for the socket path via `getuid`.

> Note: the `agent` crate has conceptually similar UDS/named-pipe + NDJSON code (`agent/src/daemon/transport.rs`, `agent/src/io/transport.rs`), but it lives in a binary crate unreachable from `src-tauri` and is bound to the streaming daemon/JSON-RPC frame protocol — the opposite of this tiny fail-fast one-shot exchange. Hoisting a shared transport helper into `core` is a possible future consolidation now that a second consumer exists; filed as a follow-up.

## Test plan

- `cargo test -p termihub --lib spawn::` — 12 tests: serde round-trips + single-line framing, `SpawnStatus` snake_case, CLI parsing (full / `=`-form / unknown-ignored / value-less), pre-init classification, transport over an in-memory `tokio::io::duplex` pair (runs on **all** platforms), transport rejecting invalid JSON, and a real socket / named-pipe client↔server round-trip.
- `./scripts/check.sh` — ALL CHECKS PASSED (fmt, clippy `-D warnings`, lint).
- `cargo test -p termihub --lib` — 849 passed, 0 failed.

Follow-ups: #1386

Closes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
