### PR TITLE
feat(agent): RemoteAgentConfig update-strategy settings + persistence (Closes #1354)

### DIFF
--- a/docs/changes/dev0/feature/1354-agent-update-strategy-config.md
+++ b/docs/changes/dev0/feature/1354-agent-update-strategy-config.md
@@ -1,0 +1,12 @@
+### Added
+
+- Remote agents now carry two persisted update-strategy settings, editable in
+  the connection editor's **Agent → Updates** section: an **Update Strategy**
+  (Immediate / Coordinated / Deferred, default Immediate) and an **Allow agent
+  self-update** toggle (opt-in, default off). Both round-trip per agent through
+  save/load. Only the Immediate strategy (shut down & redeploy) is active today;
+  Coordinated and Deferred persist the preference and take effect once those
+  update-dispatch subsystems land (part of the remote-agent update-strategy
+  epic, #1345). At update time the agent routes via the effective strategy,
+  falling back to Immediate with a log warning for the not-yet-implemented
+  strategies (#1354).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -810,6 +810,24 @@ that the desktop rejects a tampered binary before install. See PR #1350.
 4. Delete the tampered cache entry; the next deploy re-downloads, re-verifies,
    and succeeds.
 
+### Remote-agent update-strategy settings persist (#1354)
+
+Verifies the per-agent update settings appear in the editor and round-trip
+through save/load. See PR #1388.
+
+1. In the **Remote Agents** sidebar, edit an existing agent (or create one) to
+   open the connection editor, then open the **Agent** tab.
+2. In the **Updates** section confirm two controls appear: an **Update Strategy**
+   select (Immediate / Coordinated / Deferred, defaulting to **Immediate**) and an
+   **Allow agent self-update** toggle (defaulting to **off**).
+3. Set Update Strategy to **Deferred** and turn **Allow agent self-update** on,
+   then save.
+4. Reopen the same agent's editor → the Agent → Updates section still shows
+   **Deferred** and the toggle **on** (values persisted to disk).
+5. Trigger an agent update (redeploy) with a non-Immediate strategy selected →
+   the update still succeeds via the immediate path, and the app log records a
+   warning that the coordinated/deferred strategy is not yet honored (#1351/#1352).
+
 ### Guided-Manual Tests in the Python Harness (preferred)
 
 Guided-manual tests are **first-class `pytest` tests** in the Python system-test harness (`tests/system/`). Each one does all the automatable setup through the existing mixins — launch the app, build connections/state — and then prompts the operator for only the irreducibly-manual step (a native OS dialog, xterm-canvas color fidelity, cursor blink). This is the key difference from the legacy YAML runner: the operator does just the un-automatable bit, and the test shares the harness's app/agent orchestration, fixtures, and reporting.

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use tauri::State;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::connection::config::AgentSettings;
 use crate::connection::manager::ConnectionManager;
@@ -468,7 +468,25 @@ pub async fn update_agent(
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
     cancellation: State<'_, AgentDeployCancellation>,
 ) -> Result<AgentDeployResult, String> {
-    info!(agent_id, host = %config.host, "Updating agent on remote host");
+    // Route to the update path for the configured strategy. Only the immediate
+    // path (hard shutdown + redeploy) exists today; coordinated/deferred fall
+    // back to it until SI-5/SI-6 land (see #1354 and its follow-ups).
+    let requested = config.update_strategy;
+    let effective = config.effective_update_strategy();
+    if requested != effective {
+        warn!(
+            agent_id,
+            ?requested,
+            ?effective,
+            "Update strategy not yet implemented; falling back to immediate update"
+        );
+    }
+    info!(
+        agent_id,
+        host = %config.host,
+        strategy = ?effective,
+        "Updating agent on remote host"
+    );
     let manager = agent_manager.inner().clone();
     let aid = agent_id.clone();
     let token = cancellation.register(&agent_id);

--- a/src-tauri/src/connection/config.rs
+++ b/src-tauri/src/connection/config.rs
@@ -378,6 +378,7 @@ mod tests {
                 save_password: None,
                 agent_path: None,
                 external_connection_files: vec![],
+                ..Default::default()
             },
             agent_settings: AgentSettings::default(),
         };

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -1305,6 +1305,7 @@ mod tests {
                 save_password,
                 agent_path: None,
                 external_connection_files: vec![],
+                ..Default::default()
             },
             agent_settings: Default::default(),
         }

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -2468,6 +2468,7 @@ mod tests {
             save_password: None,
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         let settings = AgentSettings::default();
         let mut request_id = 0u64;

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -29,6 +29,28 @@ pub struct ExternalAgentFile {
     pub enabled: bool,
 }
 
+/// Strategy governing how a shared remote agent binary is updated.
+///
+/// Only [`UpdateStrategy::Immediate`] has an implemented dispatch path today
+/// (hard shutdown + redeploy). `Coordinated` (SI-5) and `Deferred` (SI-6) are
+/// configuration-only until those subsystems land; selecting them currently
+/// resolves back to `Immediate` at update time (see
+/// [`RemoteAgentConfig::effective_update_strategy`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdateStrategy {
+    /// Shut the running agent down and redeploy immediately (the only path
+    /// implemented today). Active sessions on other hosts are cut over hard.
+    #[default]
+    Immediate,
+    /// Broadcast an update notice to connected hosts and wait for a clean
+    /// disconnect before applying. Not yet implemented (SI-5).
+    Coordinated,
+    /// Defer the update until the last session disconnects. Not yet
+    /// implemented (SI-6).
+    Deferred,
+}
+
 /// SSH transport configuration for a remote agent (no session details).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,10 +76,41 @@ pub struct RemoteAgentConfig {
     /// External connection files to load on the remote host.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub external_connection_files: Vec<ExternalAgentFile>,
+    /// Whether the agent may check GitHub and update itself in the background.
+    ///
+    /// Opt-in (`false` by default). The self-update mechanism (SI-8) is not yet
+    /// implemented; this flag persists the user's preference until it lands.
+    #[serde(default)]
+    pub allow_self_update: bool,
+    /// How this agent's binary is updated when a newer desktop version deploys.
+    ///
+    /// Defaults to [`UpdateStrategy::Immediate`]. See
+    /// [`RemoteAgentConfig::effective_update_strategy`] for how non-immediate
+    /// strategies are currently resolved.
+    #[serde(default)]
+    pub update_strategy: UpdateStrategy,
 }
 
 fn default_auth_method() -> String {
     "password".to_string()
+}
+
+impl Default for RemoteAgentConfig {
+    fn default() -> Self {
+        Self {
+            host: String::new(),
+            port: 22,
+            username: String::new(),
+            auth_method: default_auth_method(),
+            password: None,
+            key_path: None,
+            save_password: None,
+            agent_path: None,
+            external_connection_files: Vec::new(),
+            allow_self_update: false,
+            update_strategy: UpdateStrategy::default(),
+        }
+    }
 }
 
 /// Build a Windows agent invocation: `<path> <args>`.
@@ -131,6 +184,21 @@ impl RemoteAgentConfig {
         self
     }
 
+    /// The update strategy that can actually be honored at update time today.
+    ///
+    /// Only [`UpdateStrategy::Immediate`] has an implemented dispatch path
+    /// (hard shutdown + redeploy). `Coordinated` (SI-5) and `Deferred` (SI-6)
+    /// have no dispatch path yet, so they fall back to `Immediate` — the
+    /// configured preference is still persisted so it takes effect once those
+    /// subsystems land. See #1354.
+    pub fn effective_update_strategy(&self) -> UpdateStrategy {
+        match self.update_strategy {
+            UpdateStrategy::Immediate => UpdateStrategy::Immediate,
+            // No coordinated/deferred dispatch path exists yet — fall back.
+            UpdateStrategy::Coordinated | UpdateStrategy::Deferred => UpdateStrategy::Immediate,
+        }
+    }
+
     /// Build an `SshConfig` from this agent config for SSH connection.
     pub fn to_ssh_config(&self) -> SshConfig {
         SshConfig {
@@ -193,6 +261,7 @@ mod tests {
             save_password: None,
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: RemoteAgentConfig = serde_json::from_str(&json).unwrap();
@@ -225,6 +294,7 @@ mod tests {
                     save_password: None,
                     agent_path: None,
                     external_connection_files: vec![],
+                    ..Default::default()
                 };
                 let expanded = config.expand();
                 assert_eq!(expanded.host, "10.0.0.99");
@@ -251,6 +321,7 @@ mod tests {
                     save_password: None,
                     agent_path: None,
                     external_connection_files: vec![],
+                    ..Default::default()
                 };
                 let expanded = config.expand();
                 assert_eq!(expanded.host, "10.20.30.40");
@@ -271,6 +342,7 @@ mod tests {
             save_password: None,
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         let ssh = agent.to_ssh_config();
         assert_eq!(ssh.host, "pi.local");
@@ -292,6 +364,7 @@ mod tests {
             save_password: Some(true),
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: RemoteAgentConfig = serde_json::from_str(&json).unwrap();
@@ -310,6 +383,7 @@ mod tests {
             save_password: None,
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -331,6 +405,7 @@ mod tests {
             save_password: Some(true),
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         let ssh = agent.to_ssh_config();
         assert_eq!(ssh.save_password, Some(true));
@@ -410,6 +485,7 @@ mod tests {
             save_password: None,
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         assert_eq!(
             config.agent_exec_command(),
@@ -429,6 +505,7 @@ mod tests {
             save_password: None,
             agent_path: Some("~/bin/termihub-agent".to_string()),
             external_connection_files: vec![],
+            ..Default::default()
         };
         assert_eq!(
             config.agent_exec_command(),
@@ -448,6 +525,7 @@ mod tests {
             save_password: None,
             agent_path: Some("/usr/local/bin/termihub-agent".to_string()),
             external_connection_files: vec![],
+            ..Default::default()
         };
         assert_eq!(
             config.agent_exec_command(),
@@ -467,6 +545,7 @@ mod tests {
             save_password: None,
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         assert_eq!(
             config.agent_version_command(),
@@ -486,6 +565,7 @@ mod tests {
             save_password: None,
             agent_path: Some("/opt/termihub-agent".to_string()),
             external_connection_files: vec![],
+            ..Default::default()
         };
         assert_eq!(
             config.agent_version_command(),
@@ -505,6 +585,7 @@ mod tests {
             save_password: None,
             agent_path: path.map(str::to_string),
             external_connection_files: vec![],
+            ..Default::default()
         }
     }
 
@@ -595,6 +676,7 @@ mod tests {
                 save_password: None,
                 agent_path,
                 external_connection_files: vec![],
+                ..Default::default()
             };
             let cmd = config.agent_exec_command();
             let binary = cmd.split_whitespace().next().unwrap();
@@ -624,6 +706,7 @@ mod tests {
             save_password: None,
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -654,6 +737,7 @@ mod tests {
                     enabled: false,
                 },
             ],
+            ..Default::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: RemoteAgentConfig = serde_json::from_str(&json).unwrap();
@@ -678,6 +762,7 @@ mod tests {
             save_password: None,
             agent_path: None,
             external_connection_files: vec![],
+            ..Default::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -694,4 +694,75 @@ mod tests {
         let config: RemoteAgentConfig = serde_json::from_str(json).unwrap();
         assert!(config.external_connection_files.is_empty());
     }
+
+    // ── Update strategy (#1354) ─────────────────────────────────────────
+
+    #[test]
+    fn update_strategy_defaults_to_immediate() {
+        assert_eq!(UpdateStrategy::default(), UpdateStrategy::Immediate);
+    }
+
+    /// New fields must round-trip through save/load per agent.
+    #[test]
+    fn update_settings_serde_round_trip() {
+        let config = RemoteAgentConfig {
+            allow_self_update: true,
+            update_strategy: UpdateStrategy::Deferred,
+            ..RemoteAgentConfig::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: RemoteAgentConfig = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.allow_self_update);
+        assert_eq!(deserialized.update_strategy, UpdateStrategy::Deferred);
+    }
+
+    /// The camelCase wire names must match the TS type + schema keys.
+    #[test]
+    fn update_settings_use_camel_case_wire_names() {
+        let config = RemoteAgentConfig {
+            allow_self_update: true,
+            update_strategy: UpdateStrategy::Coordinated,
+            ..RemoteAgentConfig::default()
+        };
+        let v: serde_json::Value = serde_json::to_value(&config).unwrap();
+        assert_eq!(
+            v.get("allowSelfUpdate").and_then(|b| b.as_bool()),
+            Some(true)
+        );
+        assert_eq!(
+            v.get("updateStrategy").and_then(|s| s.as_str()),
+            Some("coordinated")
+        );
+    }
+
+    /// Configs saved before these fields existed must deserialize with defaults:
+    /// `update_strategy` = immediate, `allow_self_update` = false (opt-in).
+    #[test]
+    fn update_settings_default_when_missing_from_json() {
+        let json = r#"{"host":"pi.local","port":22,"username":"pi","authMethod":"key"}"#;
+        let config: RemoteAgentConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.update_strategy, UpdateStrategy::Immediate);
+        assert!(!config.allow_self_update);
+    }
+
+    /// Only the immediate dispatch path exists today; coordinated/deferred fall
+    /// back to it until SI-5/SI-6 land.
+    #[test]
+    fn effective_update_strategy_falls_back_to_immediate() {
+        for requested in [
+            UpdateStrategy::Immediate,
+            UpdateStrategy::Coordinated,
+            UpdateStrategy::Deferred,
+        ] {
+            let config = RemoteAgentConfig {
+                update_strategy: requested,
+                ..RemoteAgentConfig::default()
+            };
+            assert_eq!(
+                config.effective_update_strategy(),
+                UpdateStrategy::Immediate,
+                "requested {requested:?} should currently resolve to Immediate"
+            );
+        }
+    }
 }

--- a/src/components/DynamicForm/agentSchema.ts
+++ b/src/components/DynamicForm/agentSchema.ts
@@ -84,5 +84,39 @@ export const AGENT_SCHEMA: SettingsSchema = {
         },
       ],
     },
+    {
+      key: "updates",
+      label: "Updates",
+      fields: [
+        {
+          key: "updateStrategy",
+          label: "Update Strategy",
+          fieldType: {
+            type: "select",
+            options: [
+              { value: "immediate", label: "Immediate (shut down & redeploy)" },
+              { value: "coordinated", label: "Coordinated (notify connected hosts)" },
+              { value: "deferred", label: "Deferred (apply on last disconnect)" },
+            ],
+          },
+          required: false,
+          default: "immediate",
+          description:
+            "How this agent's binary is updated when a newer desktop version deploys. " +
+            "Only Immediate is active today; Coordinated and Deferred are saved and take " +
+            "effect once those subsystems land.",
+        },
+        {
+          key: "allowSelfUpdate",
+          label: "Allow agent self-update",
+          fieldType: { type: "boolean" },
+          required: false,
+          default: false,
+          description:
+            "Let the agent check GitHub and update itself in the background. Opt-in; the " +
+            "self-update mechanism is not yet implemented, so this only persists the preference.",
+        },
+      ],
+    },
   ],
 };

--- a/src/components/DynamicForm/agentSchema.updateStrategy.test.ts
+++ b/src/components/DynamicForm/agentSchema.updateStrategy.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { AGENT_SCHEMA } from "./agentSchema";
+import { buildDefaults } from "@/utils/schemaDefaults";
+
+/**
+ * Regression tests for the remote-agent update-strategy settings (#1354).
+ *
+ * The two fields live in the DynamicForm-driven AGENT_SCHEMA so they round-trip
+ * through the connection editor and persist with the rest of the transport
+ * config. Defaults must be `updateStrategy: "immediate"` and
+ * `allowSelfUpdate: false` (opt-in).
+ */
+describe("AGENT_SCHEMA update settings", () => {
+  const allFields = AGENT_SCHEMA.groups.flatMap((g) => g.fields);
+  const updateStrategy = allFields.find((f) => f.key === "updateStrategy");
+  const allowSelfUpdate = allFields.find((f) => f.key === "allowSelfUpdate");
+
+  it("exposes an updateStrategy select with immediate/coordinated/deferred", () => {
+    expect(updateStrategy).toBeDefined();
+    expect(updateStrategy?.fieldType.type).toBe("select");
+    if (updateStrategy?.fieldType.type === "select") {
+      expect(updateStrategy.fieldType.options.map((o) => o.value)).toEqual([
+        "immediate",
+        "coordinated",
+        "deferred",
+      ]);
+    }
+  });
+
+  it("exposes an allowSelfUpdate boolean toggle", () => {
+    expect(allowSelfUpdate).toBeDefined();
+    expect(allowSelfUpdate?.fieldType.type).toBe("boolean");
+  });
+
+  it("defaults updateStrategy to immediate and allowSelfUpdate to false", () => {
+    const defaults = buildDefaults(AGENT_SCHEMA);
+    expect(defaults.updateStrategy).toBe("immediate");
+    expect(defaults.allowSelfUpdate).toBe(false);
+  });
+});

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -139,6 +139,15 @@ export interface ExternalAgentFile {
   enabled: boolean;
 }
 
+/**
+ * How a shared remote agent binary is updated when a newer desktop deploys.
+ *
+ * Only `"immediate"` (hard shutdown + redeploy) is honored today; `"coordinated"`
+ * (SI-5) and `"deferred"` (SI-6) persist the preference until those subsystems
+ * land. See #1354.
+ */
+export type UpdateStrategy = "immediate" | "coordinated" | "deferred";
+
 /** SSH transport configuration for a remote agent (no session details). */
 export interface RemoteAgentConfig {
   host: string;
@@ -152,6 +161,14 @@ export interface RemoteAgentConfig {
   agentPath?: string;
   /** External connection files to load on the remote host (read-only). */
   externalConnectionFiles?: ExternalAgentFile[];
+  /**
+   * Whether the agent may check GitHub and update itself in the background.
+   * Opt-in; defaults to `false`. The self-update mechanism (SI-8) is not yet
+   * implemented — this persists the preference until it lands.
+   */
+  allowSelfUpdate?: boolean;
+  /** Update strategy for this agent's binary. Defaults to `"immediate"`. */
+  updateStrategy?: UpdateStrategy;
 }
 
 /** Key-value pair for Docker environment variables. */


### PR DESCRIPTION
## Summary

Part of the remote-agent update-strategy epic (#1345). Adds two persisted,
per-agent update settings and wires the selection into the existing update path.

- **`update_strategy`** — `immediate` | `coordinated` | `deferred` (default
  `immediate`, since the coordinated/deferred dispatch paths haven't landed yet).
- **`allow_self_update`** — `bool`, opt-in (default `false`).

Both fields are added to `RemoteAgentConfig` (Rust `src-tauri/src/terminal/backend.rs`
and TS `src/types/terminal.ts`) and exposed through an **Updates** group in the
DynamicForm-driven `AGENT_SCHEMA`, so the connection editor's Agent transport tab
renders them automatically and they round-trip through save/load with the rest of
the transport config (persistence is pure serde — new fields carry `#[serde(default)]`
so pre-existing saved agents deserialize unchanged).

At update time `update_agent` routes via a new `RemoteAgentConfig::effective_update_strategy()`
seam. Only the **immediate** path (hard shutdown + redeploy) is implemented today;
`coordinated` and `deferred` resolve to `immediate` with a log warning, so the
persisted preference simply takes effect once those subsystems land. Per issue
scope, the SI-5/SI-6 dispatch paths and the SI-8 self-update mechanism are **out of
scope** here — this change only persists the preference and honors what exists.

Placement of both fields on `RemoteAgentConfig` follows the issue and the concept
doc (`docs/concepts/backlog/remote-agent-update-strategy.html`, Config/State Schema
section), which is the source of truth.

## Where the persisted preferences get honored (already-tracked follow-ups)

- `update_strategy = "coordinated"` → #1351 (broadcast `request_update`/`update_pending`)
- `update_strategy = "deferred"` → #1352 (apply on last disconnect)
- `allow_self_update = true` → #1355 (agent-side GitHub self-update)

## Test plan

- `cargo test --lib` (desktop crate): serde round-trip for the new fields,
  camelCase wire names (`allowSelfUpdate` / `updateStrategy`), backward-compat
  defaults for configs missing the fields, and `effective_update_strategy()`
  fallback to immediate for all three strategies — all green (841 tests).
- `pnpm exec vitest run` — new `agentSchema.updateStrategy.test.ts` asserts the
  schema exposes the select + toggle and that `buildDefaults(AGENT_SCHEMA)` yields
  `updateStrategy: "immediate"` / `allowSelfUpdate: false`; full suite green (2611 tests).
- `./scripts/check.sh` (fmt + eslint + clippy) and `pnpm build` — green.
- Manual: open a remote agent in the connection editor → **Agent** tab → the
  **Updates** section shows the Update Strategy select and Allow agent self-update
  toggle; changing them, saving, reopening shows the values persisted.

Closes #1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
