### PR TITLE
fix(ui): add success/error feedback to silent mutating actions (partial #1342)

### DIFF
--- a/docs/changes/dev0/feature/1342-eliminate-silent-actions.md
+++ b/docs/changes/dev0/feature/1342-eliminate-silent-actions.md
@@ -1,0 +1,16 @@
+### Changed
+
+- Several mutating actions that previously failed silently now give clear
+  success/error feedback (#1342):
+  - **Embedded servers**: saving, duplicating, and copying a server's URL now
+    show a success toast, and failures surface a recoverable error toast instead
+    of only logging to the (user-inaccessible) console. The create/edit dialog
+    now stays open when a save fails so you can fix the problem and retry.
+  - **SSH tunnels**: duplicating a tunnel now confirms with a toast and reports
+    failures, instead of silently logging errors.
+  - **Connection editor**: saving a connection confirms with a toast, and a
+    failed remote agent-definition save now reports the error instead of failing
+    silently.
+  - **Settings**: General/Appearance/Terminal settings auto-save, so the panel
+    now shows a subtle "Saved" acknowledgment after each change and no longer
+    prompts with a contradictory "unsaved changes" dialog when the tab is closed.

--- a/src/components/ConnectionEditor/ConnectionEditor.save-feedback.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.save-feedback.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Save-feedback tests for the connection editor (#1342).
+ *
+ * Saving a connection used to confirm nothing, and a failed agent-definition
+ * save was fully silent. These tests pin that a successful save surfaces a
+ * success toast, and that a failing agent-definition save rejects (so the async
+ * Button error path fires) instead of silently swallowing the error.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import React from "react";
+import { createRoot, Root } from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import { useAppStore } from "@/store/appStore";
+import { resetRuntimeCache } from "@/hooks/useAvailableRuntimes";
+import { ConnectionEditor } from "./ConnectionEditor";
+import { TooltipProvider } from "@/components/ui";
+import type { ConnectionTypeInfo, SavedConnection } from "@/types/connection";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+const mockedInvoke = vi.mocked(invoke);
+
+const SSH_TYPE: ConnectionTypeInfo = {
+  typeId: "ssh",
+  displayName: "SSH",
+  icon: "ssh",
+  schema: {
+    groups: [
+      {
+        key: "auth",
+        label: "Authentication",
+        fields: [
+          { key: "password", label: "Password", fieldType: { type: "password" }, required: false },
+        ],
+      },
+    ],
+  },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+const CONN_ID = "conn-test-123";
+const EXISTING_CONN: SavedConnection = {
+  id: CONN_ID,
+  name: "My SSH Server",
+  config: { type: "ssh", config: { host: "192.168.1.1", username: "user" } },
+  folderId: null,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <ConnectionEditor
+          tabId="tab-test-1"
+          meta={{ connectionId: CONN_ID, folderId: null }}
+          isVisible={true}
+        />
+      </TooltipProvider>
+    );
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("ConnectionEditor — save feedback (#1342)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetRuntimeCache();
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      connections: [EXISTING_CONN],
+      connectionTypes: [SSH_TYPE],
+      credentialStoreStatus: { mode: "none", status: "unlocked" },
+      // Stub persistence so the save path doesn't hit the mocked-invoke reload
+      // (which would otherwise fail in jsdom and emit an unrelated toast).
+      updateConnection: vi.fn(),
+      addConnection: vi.fn(),
+      moveConnectionToFile: vi.fn(),
+    });
+    mockedInvoke.mockImplementation(() => Promise.resolve(false));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows a success toast when saving a connection", async () => {
+    render();
+    await flush();
+
+    const saveBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="connection-editor-save"]'
+    );
+    expect(saveBtn).not.toBeNull();
+    act(() => {
+      saveBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ConnectionEditor/ConnectionEditor.save-feedback.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.save-feedback.test.tsx
@@ -1,10 +1,14 @@
 /**
  * Save-feedback tests for the connection editor (#1342).
  *
- * Saving a connection used to confirm nothing, and a failed agent-definition
- * save was fully silent. These tests pin that a successful save surfaces a
- * success toast, and that a failing agent-definition save rejects (so the async
- * Button error path fires) instead of silently swallowing the error.
+ * A failed agent-definition save used to be fully silent (swallowed to
+ * console). These tests pin that saving an agent definition confirms with a
+ * success toast, and that a failing save rejects so the async Button surfaces a
+ * recoverable error toast instead of failing silently.
+ *
+ * (Regular local connections get their success/error feedback from the store's
+ * async persist — addConnection/updateConnection — so the editor deliberately
+ * does not double-toast those; that path is covered by the store's behavior.)
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
@@ -15,13 +19,19 @@ import { useAppStore } from "@/store/appStore";
 import { resetRuntimeCache } from "@/hooks/useAvailableRuntimes";
 import { ConnectionEditor } from "./ConnectionEditor";
 import { TooltipProvider } from "@/components/ui";
-import type { ConnectionTypeInfo, SavedConnection } from "@/types/connection";
+import { DEFAULT_AGENT_SETTINGS } from "@/types/connection";
+import type { RemoteAgentDefinition } from "@/types/connection";
 
 const toastSuccess = vi.fn();
 const toastError = vi.fn();
 
-vi.mock("@/components/ui", async () => {
-  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+// Mock the Toast module itself (not the @/components/ui barrel): the barrel
+// re-exports `toast` from here AND the async Button imports it directly from
+// "./Toast", so mocking here captures both the editor's success toast and the
+// Button's error-path toast that fires when handleSave rejects.
+vi.mock("@/components/ui/Toast", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/components/ui/Toast")>("@/components/ui/Toast");
   return {
     ...actual,
     toast: {
@@ -47,46 +57,69 @@ globalThis.ResizeObserver = class {
 
 const mockedInvoke = vi.mocked(invoke);
 
-const SSH_TYPE: ConnectionTypeInfo = {
-  typeId: "ssh",
-  displayName: "SSH",
-  icon: "ssh",
-  schema: {
-    groups: [
-      {
-        key: "auth",
-        label: "Authentication",
-        fields: [
-          { key: "password", label: "Password", fieldType: { type: "password" }, required: false },
-        ],
-      },
-    ],
-  },
-  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
-};
+const AGENT_ID = "agent-1";
 
-const CONN_ID = "conn-test-123";
-const EXISTING_CONN: SavedConnection = {
-  id: CONN_ID,
-  name: "My SSH Server",
-  config: { type: "ssh", config: { host: "192.168.1.1", username: "user" } },
-  folderId: null,
-};
+function makeAgent(): RemoteAgentDefinition {
+  return {
+    id: AGENT_ID,
+    name: "Production Server",
+    config: { host: "host.example.com", port: 22, username: "user", authMethod: "password" },
+    connectionState: "connected",
+    isExpanded: true,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    capabilities: {
+      connectionTypes: [
+        {
+          typeId: "shell",
+          displayName: "Shell",
+          icon: "shell",
+          schema: {
+            groups: [
+              {
+                key: "general",
+                label: "General",
+                fields: [
+                  { key: "shell", label: "Shell", fieldType: { type: "text" }, required: false },
+                ],
+              },
+            ],
+          },
+          capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: true },
+        },
+      ],
+      maxSessions: 10,
+      availableShells: ["bash"],
+      availableSerialPorts: [],
+      availableDockerImages: [],
+    },
+  };
+}
 
 let container: HTMLDivElement;
 let root: Root;
 
-function render() {
+function renderAgentDef() {
   act(() => {
     root.render(
       <TooltipProvider delayDuration={0}>
         <ConnectionEditor
-          tabId="tab-test-1"
-          meta={{ connectionId: CONN_ID, folderId: null }}
+          tabId="tab-agentdef-1"
+          meta={{ connectionId: AGENT_ID, folderId: null, agentDefinitionId: "new" }}
           isVisible={true}
         />
       </TooltipProvider>
     );
+  });
+}
+
+function typeName(value: string) {
+  const input = container.querySelector<HTMLInputElement>(
+    '[data-testid="connection-editor-name-input"]'
+  )!;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
   });
 }
 
@@ -97,7 +130,14 @@ async function flush() {
   });
 }
 
-describe("ConnectionEditor — save feedback (#1342)", () => {
+function clickSave() {
+  const btn = container.querySelector<HTMLButtonElement>('[data-testid="connection-editor-save"]')!;
+  act(() => {
+    btn.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+describe("ConnectionEditor — agent-definition save feedback (#1342)", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -105,14 +145,9 @@ describe("ConnectionEditor — save feedback (#1342)", () => {
     resetRuntimeCache();
     useAppStore.setState({
       ...useAppStore.getInitialState(),
-      connections: [EXISTING_CONN],
-      connectionTypes: [SSH_TYPE],
+      remoteAgents: [makeAgent()],
+      agentDefinitions: { [AGENT_ID]: [] },
       credentialStoreStatus: { mode: "none", status: "unlocked" },
-      // Stub persistence so the save path doesn't hit the mocked-invoke reload
-      // (which would otherwise fail in jsdom and emit an unrelated toast).
-      updateConnection: vi.fn(),
-      addConnection: vi.fn(),
-      moveConnectionToFile: vi.fn(),
     });
     mockedInvoke.mockImplementation(() => Promise.resolve(false));
     vi.clearAllMocks();
@@ -124,20 +159,38 @@ describe("ConnectionEditor — save feedback (#1342)", () => {
     vi.clearAllMocks();
   });
 
-  it("shows a success toast when saving a connection", async () => {
-    render();
+  it("shows a success toast when the agent-definition save succeeds", async () => {
+    const saveAgentDef = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ saveAgentDef });
+
+    renderAgentDef();
+    await flush();
+    typeName("My Session");
     await flush();
 
-    const saveBtn = container.querySelector<HTMLButtonElement>(
-      '[data-testid="connection-editor-save"]'
-    );
-    expect(saveBtn).not.toBeNull();
-    act(() => {
-      saveBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
-    });
+    clickSave();
     await flush();
 
+    expect(saveAgentDef).toHaveBeenCalledTimes(1);
     expect(toastSuccess).toHaveBeenCalledTimes(1);
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast (not a silent failure) when the save rejects", async () => {
+    const saveAgentDef = vi.fn(() => Promise.reject(new Error("agent unreachable")));
+    useAppStore.setState({ saveAgentDef });
+
+    renderAgentDef();
+    await flush();
+    typeName("My Session");
+    await flush();
+
+    clickSave();
+    await flush();
+
+    expect(saveAgentDef).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+    // The async Button's error path surfaces the rejection instead of swallowing it.
+    expect(toastError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ConnectionEditor/ConnectionEditor.save-feedback.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.save-feedback.test.tsx
@@ -12,7 +12,6 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
-import React from "react";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -763,14 +763,24 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
    * Save without closing. Returns true on success. On failure the underlying
    * save rejects, which propagates to the calling async Button so it surfaces a
    * recoverable error toast (rather than the save failing silently).
+   *
+   * Success feedback: regular connections get their success/error toast from the
+   * store's async persist (`addConnection`/`updateConnection`), which is the
+   * accurate source of truth — so we only toast here for the paths the store
+   * leaves silent: agent definitions and remote-agent transport saves.
    */
   const handleSaveOnly = useCallback(async (): Promise<boolean> => {
     if (!canSave) {
       focusFirstInvalidField();
       return false;
     }
-    const ok = isAgentDefinitionMode ? await saveAgentDefinition() : saveConnection() !== null;
-    if (ok) {
+    if (isAgentDefinitionMode) {
+      const ok = await saveAgentDefinition();
+      if (ok) toast.success(`Saved "${name.trim()}"`);
+      return ok;
+    }
+    const ok = saveConnection() !== null;
+    if (ok && isAgentTransportMode) {
       toast.success(`Saved "${name.trim()}"`);
     }
     return ok;
@@ -778,6 +788,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
     canSave,
     focusFirstInvalidField,
     isAgentDefinitionMode,
+    isAgentTransportMode,
     saveAgentDefinition,
     saveConnection,
     name,

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -28,7 +28,7 @@ import {
   JumpHostConfig,
 } from "@/types/connection";
 import { SettingsNav } from "@/components/Settings";
-import { Button, Input, Select, Toggle } from "@/components/ui";
+import { Button, Input, Select, Toggle, toast } from "@/components/ui";
 import { ConnectionSettingsForm, AGENT_SCHEMA } from "@/components/DynamicForm";
 import {
   buildDefaults,
@@ -601,37 +601,36 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
     }
   }, [rootPanel, tabId, closeTab]);
 
-  /** Save agent definition to the remote agent. Returns true on success. */
+  /**
+   * Save agent definition to the remote agent. Returns true on success.
+   * Rejections propagate so the calling async Button surfaces a recoverable
+   * error toast instead of the save failing silently.
+   */
   const saveAgentDefinition = useCallback(async (): Promise<boolean> => {
     if (!name.trim() || !existingAgent) return false;
-    try {
-      const opts = hasTerminalOptions(terminalOptions) ? terminalOptions : undefined;
-      if (existingAgentDef) {
-        await updateAgentDef(existingAgent.id, {
-          id: existingAgentDef.id,
-          name: name.trim(),
-          session_type: selectedType,
-          config: connSettings,
-          persistent,
-          terminal_options: opts ?? null,
-          icon: icon ?? null,
-        });
-      } else {
-        await saveAgentDef(existingAgent.id, {
-          name: name.trim(),
-          type: selectedType,
-          config: connSettings,
-          persistent,
-          folder_id: meta.agentFolderId ?? null,
-          terminal_options: opts,
-          icon,
-        });
-      }
-      return true;
-    } catch (err) {
-      console.error("Failed to save agent definition:", err);
-      return false;
+    const opts = hasTerminalOptions(terminalOptions) ? terminalOptions : undefined;
+    if (existingAgentDef) {
+      await updateAgentDef(existingAgent.id, {
+        id: existingAgentDef.id,
+        name: name.trim(),
+        session_type: selectedType,
+        config: connSettings,
+        persistent,
+        terminal_options: opts ?? null,
+        icon: icon ?? null,
+      });
+    } else {
+      await saveAgentDef(existingAgent.id, {
+        name: name.trim(),
+        type: selectedType,
+        config: connSettings,
+        persistent,
+        folder_id: meta.agentFolderId ?? null,
+        terminal_options: opts,
+        icon,
+      });
     }
+    return true;
   }, [
     name,
     selectedType,
@@ -760,17 +759,29 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
     });
   }, [addTab]);
 
-  /** Save without closing. Returns true on success. */
+  /**
+   * Save without closing. Returns true on success. On failure the underlying
+   * save rejects, which propagates to the calling async Button so it surfaces a
+   * recoverable error toast (rather than the save failing silently).
+   */
   const handleSaveOnly = useCallback(async (): Promise<boolean> => {
     if (!canSave) {
       focusFirstInvalidField();
       return false;
     }
-    if (isAgentDefinitionMode) {
-      return saveAgentDefinition();
+    const ok = isAgentDefinitionMode ? await saveAgentDefinition() : saveConnection() !== null;
+    if (ok) {
+      toast.success(`Saved "${name.trim()}"`);
     }
-    return saveConnection() !== null;
-  }, [canSave, focusFirstInvalidField, isAgentDefinitionMode, saveAgentDefinition, saveConnection]);
+    return ok;
+  }, [
+    canSave,
+    focusFirstInvalidField,
+    isAgentDefinitionMode,
+    saveAgentDefinition,
+    saveConnection,
+    name,
+  ]);
 
   const handleSave = useCallback(async () => {
     if (await handleSaveOnly()) {

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.test.tsx
@@ -67,8 +67,10 @@ describe("EmbeddedServerDialog", () => {
     expect(bind?.getAttribute("data-value")).toBe("127.0.0.1");
   });
 
-  it("Save is disabled until name + root are set, then fires onSave with the config", () => {
-    const onSave = vi.fn();
+  it("Save is disabled until name + root are set, then fires onSave with the config", async () => {
+    // onSave resolves true (saved) so the dialog closes; a false/rejected result
+    // keeps it open (covered by EmbeddedServerSidebar's feedback tests).
+    const onSave = vi.fn(() => Promise.resolve(true));
     const onOpenChange = vi.fn();
     render(<EmbeddedServerDialog {...baseProps} onSave={onSave} onOpenChange={onOpenChange} />);
 
@@ -87,7 +89,11 @@ describe("EmbeddedServerDialog", () => {
     );
 
     expect(saveBtn.disabled).toBe(false);
-    act(() => saveBtn.click());
+    await act(async () => {
+      saveBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
 
     expect(onSave).toHaveBeenCalledTimes(1);
     expect(onSave.mock.calls[0][0]).toMatchObject({

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/services/embeddedServerApi", () => ({
 }));
 
 import { EmbeddedServerDialog } from "./EmbeddedServerDialog";
+import type { EmbeddedServerConfig } from "@/types/embeddedServer";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -34,7 +35,7 @@ const baseProps = {
   open: true,
   onOpenChange: () => {},
   config: null,
-  onSave: () => {},
+  onSave: (_config: EmbeddedServerConfig): boolean => true,
 };
 
 describe("EmbeddedServerDialog", () => {
@@ -70,7 +71,7 @@ describe("EmbeddedServerDialog", () => {
   it("Save is disabled until name + root are set, then fires onSave with the config", async () => {
     // onSave resolves true (saved) so the dialog closes; a false/rejected result
     // keeps it open (covered by EmbeddedServerSidebar's feedback tests).
-    const onSave = vi.fn(() => Promise.resolve(true));
+    const onSave = vi.fn((_config: EmbeddedServerConfig) => Promise.resolve(true));
     const onOpenChange = vi.fn();
     render(<EmbeddedServerDialog {...baseProps} onSave={onSave} onOpenChange={onOpenChange} />);
 

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx
@@ -16,7 +16,11 @@ interface Props {
   onOpenChange: (open: boolean) => void;
   /** Existing config to edit, or null for a new server. */
   config: EmbeddedServerConfig | null;
-  onSave: (config: EmbeddedServerConfig) => void;
+  /**
+   * Persist the config. Resolve `true` when the save succeeded (the dialog
+   * closes) or `false` on failure (the dialog stays open so the user can retry).
+   */
+  onSave: (config: EmbeddedServerConfig) => boolean | Promise<boolean>;
 }
 
 /** Blank default config used when creating a new server. */
@@ -88,10 +92,12 @@ export function EmbeddedServerDialog({ open, onOpenChange, config, onSave }: Pro
     setLanWarning(false);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!form.name.trim() || !form.rootDirectory.trim()) return;
-    onSave(form);
-    onOpenChange(false);
+    // Close only when the save actually succeeded; on failure the dialog stays
+    // open (the sidebar surfaces the error via toast) so the user can retry.
+    const saved = await onSave(form);
+    if (saved) onOpenChange(false);
   };
 
   const ftpAnon = !form.ftpAuth || form.ftpAuth.type === "anonymous";

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.copy.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.copy.test.tsx
@@ -25,9 +25,9 @@ vi.mock("@/components/ui", async () => {
   };
 });
 
-const writeText = vi.fn(() => Promise.resolve());
+const writeText = vi.fn((_text?: string) => Promise.resolve());
 vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
-  writeText: (...args: unknown[]) => writeText(...args),
+  writeText: (text: string) => writeText(text),
 }));
 
 vi.mock("@tauri-apps/plugin-opener", () => ({

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.copy.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.copy.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Clipboard-feedback test for embedded-server "Copy URL" (#1342).
+ *
+ * Copying the server URL used to write to the clipboard silently. This pins
+ * that a successful copy confirms with a success toast.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+const writeText = vi.fn(() => Promise.resolve());
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: (...args: unknown[]) => writeText(...args),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(() => Promise.resolve()),
+}));
+
+import { EmbeddedServerItem } from "./EmbeddedServerItem";
+import { TooltipProvider } from "@/components/ui";
+import { EmbeddedServerConfig } from "@/types/embeddedServer";
+
+let container: HTMLDivElement;
+let root: Root;
+
+const config: EmbeddedServerConfig = {
+  id: "srv-1",
+  name: "My HTTP",
+  serverType: "http",
+  rootDirectory: "/tmp",
+  bindHost: "127.0.0.1",
+  port: 8080,
+  autoStart: false,
+  readOnly: false,
+  directoryListing: true,
+};
+
+function baseProps() {
+  return {
+    config,
+    state: undefined,
+    onStart: vi.fn(() => Promise.resolve()),
+    onStop: vi.fn(() => Promise.resolve()),
+    onEdit: () => {},
+    onDuplicate: () => {},
+    onDelete: () => {},
+  };
+}
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("EmbeddedServerItem — copy URL feedback (#1342)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("confirms with a success toast after copying the URL", async () => {
+    render(<EmbeddedServerItem {...baseProps()} />);
+
+    // Open the context menu and invoke Copy URL. The item is easiest to reach
+    // by calling the context-menu item directly via its testid; open the menu
+    // by dispatching a contextmenu event on the row.
+    const row = container.querySelector('[data-testid="server-item-srv-1"]')!;
+    act(() => {
+      row.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+
+    const copyItem = document.querySelector<HTMLElement>('[data-testid="ctx-copy-url-srv-1"]');
+    expect(copyItem).not.toBeNull();
+    act(() => {
+      copyItem!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+
+    expect(writeText).toHaveBeenCalledWith("http://127.0.0.1:8080");
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
@@ -102,7 +102,11 @@ export function EmbeddedServerItem({
   }, [busy, onStop, config.id, config.name]);
 
   const handleCopyUrl = () => {
-    writeClipboard(url).catch(() => {});
+    writeClipboard(url)
+      .then(() => toast.success("Copied URL to clipboard"))
+      .catch((err: unknown) =>
+        toast.error("Failed to copy URL", { description: errorMessage(err) })
+      );
   };
 
   const handleOpenBrowser = () => {

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Feedback tests for embedded-server save & duplicate (#1342).
+ *
+ * `saveEmbeddedServer` used to swallow failures to `console.error` while the
+ * dialog closed as if the save had worked. These tests pin that:
+ *  - a successful save surfaces a success toast and closes the dialog,
+ *  - a failing save surfaces an error toast and keeps the dialog open,
+ *  - duplicate confirms success / surfaces failure via toast.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { EmbeddedServerConfig } from "@/types/embeddedServer";
+import { TooltipProvider } from "@/components/ui";
+import { EmbeddedServerSidebar } from "./EmbeddedServerSidebar";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+// Network-interface enumeration used by the dialog is not available in jsdom.
+vi.mock("@/services/embeddedServerApi", () => ({
+  listNetworkInterfaces: vi.fn(() => Promise.resolve([{ name: "Loopback", addr: "127.0.0.1" }])),
+}));
+
+vi.mock("@/store/appStore", () => {
+  const state: Record<string, unknown> = {};
+  const useAppStore = (selector: (s: Record<string, unknown>) => unknown) => selector(state);
+  useAppStore.setState = (patch: Record<string, unknown>) => Object.assign(state, patch);
+  return { useAppStore };
+});
+
+function makeServer(id: string, name: string): EmbeddedServerConfig {
+  return {
+    id,
+    name,
+    serverType: "http",
+    rootDirectory: "/tmp",
+    bindHost: "127.0.0.1",
+    port: 8080,
+    autoStart: false,
+    readOnly: false,
+    directoryListing: true,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function seedStore(
+  saveEmbeddedServer: (config: EmbeddedServerConfig) => Promise<void>,
+  servers: EmbeddedServerConfig[] = []
+) {
+  (useAppStore as unknown as { setState: (p: Record<string, unknown>) => void }).setState({
+    embeddedServers: servers,
+    embeddedServerStates: {},
+    saveEmbeddedServer,
+    deleteEmbeddedServer: vi.fn(),
+    startEmbeddedServer: vi.fn(),
+    stopEmbeddedServer: vi.fn(),
+  });
+}
+
+async function renderSidebar() {
+  await act(async () => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <EmbeddedServerSidebar />
+      </TooltipProvider>
+    );
+  });
+  await flush();
+}
+
+async function openNewDialogAndFill() {
+  const newBtn = container.querySelector<HTMLButtonElement>('[data-testid="server-new-btn"]');
+  await act(async () => {
+    newBtn!.click();
+  });
+  await flush();
+
+  const nameInput = document.querySelector<HTMLInputElement>('[data-testid="server-dialog-name"]');
+  const rootInput = document.querySelector<HTMLInputElement>('[data-testid="server-dialog-root"]');
+  setInputValue(nameInput!, "New Share");
+  setInputValue(rootInput!, "/srv/share");
+  await flush();
+}
+
+function setInputValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function clickDialogSave() {
+  const saveBtn = document.querySelector<HTMLButtonElement>('[data-testid="server-dialog-save"]');
+  await act(async () => {
+    saveBtn!.click();
+  });
+  await flush();
+}
+
+describe("EmbeddedServerSidebar — save & duplicate feedback (#1342)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows a success toast and closes the dialog when save succeeds", async () => {
+    const saveEmbeddedServer = vi.fn(() => Promise.resolve());
+    seedStore(saveEmbeddedServer);
+    await renderSidebar();
+    await openNewDialogAndFill();
+    await clickDialogSave();
+
+    expect(saveEmbeddedServer).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+    // Dialog closed.
+    expect(document.querySelector('[data-testid="server-dialog-save"]')).toBeNull();
+  });
+
+  it("shows an error toast and keeps the dialog open when save fails", async () => {
+    const saveEmbeddedServer = vi.fn(() => Promise.reject(new Error("port in use")));
+    seedStore(saveEmbeddedServer);
+    await renderSidebar();
+    await openNewDialogAndFill();
+    await clickDialogSave();
+
+    expect(saveEmbeddedServer).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+    // Dialog stays open so the user can retry.
+    expect(document.querySelector('[data-testid="server-dialog-save"]')).not.toBeNull();
+  });
+
+  it("shows a success toast when duplication succeeds", async () => {
+    const saveEmbeddedServer = vi.fn(() => Promise.resolve());
+    seedStore(saveEmbeddedServer, [makeServer("srv-1", "Original")]);
+    await renderSidebar();
+
+    const dupBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="server-duplicate-srv-1"]'
+    );
+    await act(async () => {
+      dupBtn!.click();
+    });
+    await flush();
+
+    expect(saveEmbeddedServer).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast when duplication fails", async () => {
+    const saveEmbeddedServer = vi.fn(() => Promise.reject(new Error("disk full")));
+    seedStore(saveEmbeddedServer, [makeServer("srv-1", "Original")]);
+    await renderSidebar();
+
+    const dupBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="server-duplicate-srv-1"]'
+    );
+    await act(async () => {
+      dupBtn!.click();
+    });
+    await flush();
+
+    expect(saveEmbeddedServer).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 import { Plus } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
-import { Button } from "@/components/ui";
+import { Button, toast } from "@/components/ui";
 import { EmbeddedServerConfig } from "@/types/embeddedServer";
 import { EmbeddedServerItem } from "./EmbeddedServerItem";
 import { EmbeddedServerDialog } from "./EmbeddedServerDialog";
@@ -37,8 +37,12 @@ export function EmbeddedServerSidebar() {
     [servers]
   );
 
+  /**
+   * Persist a server from the dialog. Resolves `true` when the save succeeded
+   * (so the dialog closes) and `false` on failure (dialog stays open to retry).
+   */
   const handleSave = useCallback(
-    (config: EmbeddedServerConfig) => {
+    async (config: EmbeddedServerConfig): Promise<boolean> => {
       const isNew = !config.id;
       const cfg = isNew
         ? {
@@ -46,13 +50,22 @@ export function EmbeddedServerSidebar() {
             id: `srv-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
           }
         : config;
-      saveEmbeddedServer(cfg).catch((err: unknown) => console.error("Failed to save server:", err));
+      try {
+        await saveEmbeddedServer(cfg);
+        toast.success(isNew ? `Created "${cfg.name}"` : `Saved "${cfg.name}"`);
+        return true;
+      } catch (err) {
+        toast.error(`Failed to save "${cfg.name}"`, {
+          description: err instanceof Error ? err.message : String(err),
+        });
+        return false;
+      }
     },
     [saveEmbeddedServer]
   );
 
   const handleDuplicate = useCallback(
-    (id: string) => {
+    async (id: string) => {
       const original = servers.find((s) => s.id === id);
       if (!original) return;
       const dupe: EmbeddedServerConfig = {
@@ -61,9 +74,14 @@ export function EmbeddedServerSidebar() {
         name: `Copy of ${original.name}`,
         autoStart: false,
       };
-      saveEmbeddedServer(dupe).catch((err: unknown) =>
-        console.error("Failed to duplicate server:", err)
-      );
+      try {
+        await saveEmbeddedServer(dupe);
+        toast.success(`Duplicated "${original.name}"`);
+      } catch (err) {
+        toast.error(`Failed to duplicate "${original.name}"`, {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
     },
     [servers, saveEmbeddedServer]
   );

--- a/src/components/Settings/SettingsPanel.autosave-feedback.test.tsx
+++ b/src/components/Settings/SettingsPanel.autosave-feedback.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Auto-save feedback tests for the Settings panel (#1342).
+ *
+ * The panel auto-saves General/Appearance/Terminal settings (debounced). It
+ * used to also raise an unsaved-changes dialog on close — a contradictory
+ * mental model. These tests pin the resolved model:
+ *  - a debounced save shows a subtle transient "Saved" acknowledgment,
+ *  - a close request flushes and closes directly, never showing a dialog.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { AppSettings } from "@/types/connection";
+import { TooltipProvider } from "@/components/ui";
+import { SettingsPanel } from "./SettingsPanel";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("@/utils/shell-detection", () => ({
+  detectAvailableShells: vi.fn().mockResolvedValue([]),
+  getWslDistroName: vi.fn(() => null),
+}));
+
+const { invoke } = await import("@tauri-apps/api/core");
+const mockedInvoke = vi.mocked(invoke);
+
+const FULL_SETTINGS: AppSettings = {
+  version: "1",
+  externalConnectionFiles: [],
+  powerMonitoringEnabled: true,
+  fileBrowserEnabled: true,
+  defaultShellIntegration: true,
+  defaultX11Forwarding: true,
+  provideXServerAutomatically: true,
+  stopXServerWhenIdle: true,
+  updates: { autoCheck: true },
+};
+
+const TAB_ID = "test-settings-tab";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <SettingsPanel tabId={TAB_ID} isVisible={true} />
+      </TooltipProvider>
+    );
+  });
+}
+
+function ackEl(): HTMLElement | null {
+  return container.querySelector("[data-testid='settings-saved-ack']");
+}
+
+describe("SettingsPanel — auto-save feedback (#1342)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: FULL_SETTINGS, savedSettings: FULL_SETTINGS });
+
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "get_app_info") return Promise.resolve({ version: "0.0.0", gitHash: "abc" });
+      if (cmd === "save_settings") return Promise.resolve(undefined);
+      if (cmd === "list_available_shells") return Promise.resolve([]);
+      if (cmd === "get_default_shell") return Promise.resolve(null);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("shows a transient 'Saved' acknowledgment after a debounced auto-save", async () => {
+    render();
+
+    // No acknowledgment before any change.
+    expect(ackEl()?.textContent ?? "").not.toContain("Saved");
+
+    const toggle = container.querySelector<HTMLElement>(
+      "[data-testid='settings-default-shell-integration']"
+    );
+    expect(toggle).not.toBeNull();
+    await act(async () => {
+      toggle!.click();
+    });
+
+    // Let the 300ms debounce elapse — this persists and fires the ack.
+    await act(async () => {
+      vi.advanceTimersByTime(350);
+    });
+
+    expect(ackEl()?.textContent ?? "").toContain("Saved");
+    expect(ackEl()?.className ?? "").toContain("settings-panel__saved-ack--visible");
+
+    // The acknowledgment is transient — it hides again after its window.
+    await act(async () => {
+      vi.advanceTimersByTime(1600);
+    });
+    expect(ackEl()?.textContent ?? "").not.toContain("Saved");
+  });
+
+  it("closes on a close request without an unsaved-changes dialog", async () => {
+    const closeTab = vi.fn();
+    const setPendingCloseRequest = vi.fn();
+    useAppStore.setState({ closeTab, setPendingCloseRequest });
+
+    render();
+
+    act(() => {
+      useAppStore.setState({ pendingCloseRequest: { tabId: TAB_ID, panelId: "panel-1" } });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // No unsaved-changes dialog is rendered.
+    expect(document.querySelector("[data-testid='unsaved-changes-save-and-close']")).toBeNull();
+    // The tab is closed directly.
+    expect(closeTab).toHaveBeenCalledWith(TAB_ID, "panel-1");
+  });
+});

--- a/src/components/Settings/SettingsPanel.css
+++ b/src/components/Settings/SettingsPanel.css
@@ -131,6 +131,26 @@
   opacity: 0.6;
 }
 
+/* Transient "Saved" acknowledgment (auto-save feedback). */
+.settings-panel__saved-ack {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: var(--color-success);
+  opacity: 0;
+  transition: opacity var(--transition-normal);
+}
+
+.settings-panel__saved-ack--visible {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-panel__saved-ack {
+    transition: none;
+  }
+}
+
 /* === Section (used by ExternalFilesSettings) === */
 .settings-panel__section {
   margin-bottom: var(--spacing-xl);

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -86,6 +86,23 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
     }, SAVED_ACK_MS);
   }, []);
 
+  /**
+   * Cancel any pending debounced save and persist it immediately, so the last
+   * <=300ms of edits aren't lost when the tab closes or the panel unmounts.
+   */
+  const flushPendingSave = useCallback(() => {
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    const toSave = pendingSettingsRef.current;
+    if (toSave) {
+      pendingSettingsRef.current = null;
+      useAppStore.setState({ savedSettings: toSave });
+      updateSettings(toSave);
+    }
+  }, [updateSettings]);
+
   useEffect(() => {
     getAppInfo()
       .then(setAppInfo)
@@ -159,17 +176,7 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
     if (pendingCloseRequest?.tabId !== tabId) return;
     frontendLog("settings_panel", `close request for tabId=${tabId} — flush and close`);
 
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = null;
-    }
-    const toSave = pendingSettingsRef.current;
-    if (toSave) {
-      pendingSettingsRef.current = null;
-      useAppStore.setState({ savedSettings: toSave });
-      updateSettings(toSave);
-    }
-
+    flushPendingSave();
     setEditorDirty(tabId, false);
     const req = pendingCloseRequest;
     setPendingCloseRequest(null);
@@ -177,31 +184,22 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
   }, [
     pendingCloseRequest,
     tabId,
-    updateSettings,
+    flushPendingSave,
     setEditorDirty,
     setPendingCloseRequest,
     closeTab,
   ]);
 
-  // Cleanup debounce timer on unmount
+  // Flush any pending debounced save and clear the ack timer on unmount.
   useEffect(() => {
     return () => {
       if (ackTimerRef.current) {
         clearTimeout(ackTimerRef.current);
         ackTimerRef.current = null;
       }
-      if (saveTimerRef.current) {
-        clearTimeout(saveTimerRef.current);
-        // Flush pending save
-        const toSave = pendingSettingsRef.current;
-        if (toSave) {
-          pendingSettingsRef.current = null;
-          useAppStore.setState({ savedSettings: toSave });
-          updateSettings(toSave);
-        }
-      }
+      flushPendingSave();
     };
-  }, [updateSettings]);
+  }, [flushPendingSave]);
 
   // Search filtering
   const isSearchActive = searchQuery.trim().length > 0;

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -9,6 +9,7 @@ import {
   FileJson,
   FileCode2,
   HardDrive,
+  Check,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
@@ -30,7 +31,6 @@ import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
 import { SerialPortSettings } from "./SerialPortSettings";
 import { PortableModeSettings } from "./PortableModeSettings";
 import { getAppInfo, type AppInfo } from "@/services/api";
-import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
 import "./SettingsPanel.css";
 
 const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
@@ -45,6 +45,7 @@ const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
 };
 
 const SAVE_DEBOUNCE_MS = 300;
+const SAVED_ACK_MS = 1500;
 
 interface SettingsPanelProps {
   tabId: string;
@@ -66,9 +67,24 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [isCompact, setIsCompact] = useState(false);
   const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+  const [showSavedAck, setShowSavedAck] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingSettingsRef = useRef<AppSettings | null>(null);
+  const ackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /**
+   * Briefly surface a transient "Saved" acknowledgment in the footer after a
+   * debounced auto-save has actually persisted, then fade it out.
+   */
+  const acknowledgeSaved = useCallback(() => {
+    setShowSavedAck(true);
+    if (ackTimerRef.current) clearTimeout(ackTimerRef.current);
+    ackTimerRef.current = setTimeout(() => {
+      ackTimerRef.current = null;
+      setShowSavedAck(false);
+    }, SAVED_ACK_MS);
+  }, []);
 
   useEffect(() => {
     getAppInfo()
@@ -125,6 +141,7 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
             useAppStore.setState({ savedSettings: toSave });
             updateSettings(toSave);
             setEditorDirty(tabId, false);
+            acknowledgeSaved();
           }
         }, SAVE_DEBOUNCE_MS);
       } else {
@@ -132,40 +149,47 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
         setEditorDirty(tabId, false);
       }
     },
-    [updateSettings, settings.theme, tabId, setEditorDirty]
+    [updateSettings, settings.theme, tabId, setEditorDirty, acknowledgeSaved]
   );
 
-  // Before showing the unsaved-changes dialog, do a real-time equality check.
-  // The dirty flag may be stale (e.g. the user reverted all changes back to the
-  // saved state). If nothing actually changed, skip the dialog and close directly.
+  // Settings auto-save, so a close request never needs a confirmation dialog.
+  // Flush any pending debounced write (so the last <=300ms of edits aren't lost)
+  // and close the tab directly.
   useEffect(() => {
-    frontendLog(
-      "settings_panel",
-      `pendingCloseRequest=${JSON.stringify(pendingCloseRequest)} tabId=${tabId}`
-    );
     if (pendingCloseRequest?.tabId !== tabId) return;
+    frontendLog("settings_panel", `close request for tabId=${tabId} — flush and close`);
 
     if (saveTimerRef.current) {
       clearTimeout(saveTimerRef.current);
       saveTimerRef.current = null;
     }
-
-    const { settings: currentSettings, savedSettings } = useAppStore.getState();
-    const currentJson = JSON.stringify(currentSettings);
-    const savedJson = JSON.stringify(savedSettings);
-    frontendLog("settings_panel", `close check — equal=${currentJson === savedJson}`);
-    if (currentJson === savedJson) {
+    const toSave = pendingSettingsRef.current;
+    if (toSave) {
       pendingSettingsRef.current = null;
-      setEditorDirty(tabId, false);
-      const req = pendingCloseRequest;
-      setPendingCloseRequest(null);
-      closeTab(req.tabId, req.panelId);
+      useAppStore.setState({ savedSettings: toSave });
+      updateSettings(toSave);
     }
-  }, [pendingCloseRequest, tabId, setEditorDirty, setPendingCloseRequest, closeTab]);
+
+    setEditorDirty(tabId, false);
+    const req = pendingCloseRequest;
+    setPendingCloseRequest(null);
+    closeTab(req.tabId, req.panelId);
+  }, [
+    pendingCloseRequest,
+    tabId,
+    updateSettings,
+    setEditorDirty,
+    setPendingCloseRequest,
+    closeTab,
+  ]);
 
   // Cleanup debounce timer on unmount
   useEffect(() => {
     return () => {
+      if (ackTimerRef.current) {
+        clearTimeout(ackTimerRef.current);
+        ackTimerRef.current = null;
+      }
       if (saveTimerRef.current) {
         clearTimeout(saveTimerRef.current);
         // Flush pending save
@@ -178,50 +202,6 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
       }
     };
   }, [updateSettings]);
-
-  const flushAndClose = useCallback(() => {
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = null;
-    }
-    const toSave = pendingSettingsRef.current;
-    if (toSave) {
-      pendingSettingsRef.current = null;
-      useAppStore.setState({ savedSettings: toSave });
-      updateSettings(toSave);
-    }
-    setEditorDirty(tabId, false);
-    const req = pendingCloseRequest;
-    setPendingCloseRequest(null);
-    if (req) closeTab(req.tabId, req.panelId);
-  }, [
-    updateSettings,
-    tabId,
-    setEditorDirty,
-    pendingCloseRequest,
-    setPendingCloseRequest,
-    closeTab,
-  ]);
-
-  const discardAndClose = useCallback(() => {
-    if (saveTimerRef.current) {
-      clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = null;
-    }
-    pendingSettingsRef.current = null;
-    // Revert in-memory store to last persisted state
-    const revertTo = useAppStore.getState().savedSettings;
-    useAppStore.setState({ settings: revertTo });
-    applyTheme(revertTo.theme);
-    setEditorDirty(tabId, false);
-    const req = pendingCloseRequest;
-    setPendingCloseRequest(null);
-    if (req) closeTab(req.tabId, req.panelId);
-  }, [tabId, setEditorDirty, pendingCloseRequest, setPendingCloseRequest, closeTab]);
-
-  const cancelClose = useCallback(() => {
-    setPendingCloseRequest(null);
-  }, [setPendingCloseRequest]);
 
   // Search filtering
   const isSearchActive = searchQuery.trim().length > 0;
@@ -349,13 +329,22 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
             {appInfo.gitHash}
           </span>
         )}
+        <span
+          data-testid="settings-saved-ack"
+          className={`settings-panel__saved-ack ${
+            showSavedAck ? "settings-panel__saved-ack--visible" : ""
+          }`}
+          role="status"
+          aria-live="polite"
+        >
+          {showSavedAck && (
+            <>
+              <Check size={12} aria-hidden="true" />
+              Saved
+            </>
+          )}
+        </span>
       </div>
-      <UnsavedChangesDialog
-        open={pendingCloseRequest?.tabId === tabId}
-        onCancel={cancelClose}
-        onJustClose={discardAndClose}
-        onSaveAndClose={flushAndClose}
-      />
     </div>
   );
 }

--- a/src/components/TunnelSidebar/TunnelSidebar.duplicate.test.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.duplicate.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Feedback tests for tunnel duplication (#1342).
+ *
+ * Duplicating a tunnel used to `console.error` on failure (invisible to the
+ * user) and confirm nothing on success. These tests pin that a successful
+ * duplicate surfaces a success toast and a failing duplicate surfaces an error
+ * toast instead of a silent console log.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { TunnelConfig } from "@/types/tunnel";
+import { TooltipProvider } from "@/components/ui";
+import { TunnelSidebar } from "./TunnelSidebar";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/store/appStore", () => {
+  const state: Record<string, unknown> = {};
+  const useAppStore = (selector: (s: Record<string, unknown>) => unknown) => selector(state);
+  useAppStore.setState = (patch: Record<string, unknown>) => Object.assign(state, patch);
+  return { useAppStore };
+});
+
+function makeTunnel(id: string, name: string): TunnelConfig {
+  return {
+    id,
+    name,
+    sshConnectionId: "conn-1",
+    tunnelType: {
+      type: "local",
+      config: { localHost: "127.0.0.1", localPort: 8080, remoteHost: "127.0.0.1", remotePort: 80 },
+    },
+    autoStart: false,
+    reconnectOnDisconnect: false,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function seedStore(saveTunnel: (config: TunnelConfig) => Promise<void>) {
+  (useAppStore as unknown as { setState: (p: Record<string, unknown>) => void }).setState({
+    tunnels: [makeTunnel("tun-1", "My Tunnel")],
+    tunnelStates: {},
+    connections: [],
+    startTunnel: vi.fn(),
+    stopTunnel: vi.fn(),
+    reconnectTunnel: vi.fn(),
+    saveTunnel,
+    deleteTunnel: vi.fn(),
+    openTunnelEditorTab: vi.fn(),
+  });
+}
+
+async function renderSidebar() {
+  await act(async () => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <TunnelSidebar />
+      </TooltipProvider>
+    );
+  });
+  await flush();
+}
+
+async function clickDuplicate() {
+  const btn = container.querySelector<HTMLButtonElement>('[data-testid="tunnel-duplicate-tun-1"]');
+  expect(btn).not.toBeNull();
+  await act(async () => {
+    btn!.click();
+  });
+  await flush();
+}
+
+describe("TunnelSidebar — duplicate feedback (#1342)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows a success toast when duplication succeeds", async () => {
+    const saveTunnel = vi.fn(() => Promise.resolve());
+    seedStore(saveTunnel);
+    await renderSidebar();
+    await clickDuplicate();
+
+    expect(saveTunnel).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast when duplication fails", async () => {
+    const saveTunnel = vi.fn(() => Promise.reject(new Error("disk full")));
+    seedStore(saveTunnel);
+    await renderSidebar();
+    await clickDuplicate();
+
+    expect(saveTunnel).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/TunnelSidebar/TunnelSidebar.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { Plus } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { toast } from "@/components/ui";
 import { ConfirmDeleteDialog } from "@/components/Sidebar/ConfirmDeleteDialog";
 import type { TunnelStatus } from "@/types/tunnel";
 import { TunnelListItem } from "./TunnelListItem";
@@ -44,7 +45,13 @@ export function TunnelSidebar() {
         name: `Copy of ${original.name}`,
         autoStart: false,
       };
-      saveTunnel(duplicate).catch((err) => console.error("Failed to duplicate tunnel:", err));
+      saveTunnel(duplicate)
+        .then(() => toast.success(`Duplicated "${original.name}"`))
+        .catch((err: unknown) =>
+          toast.error(`Failed to duplicate "${original.name}"`, {
+            description: err instanceof Error ? err.message : String(err),
+          })
+        );
     },
     [tunnels, saveTunnel]
   );

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -377,6 +377,7 @@ Fixed strings — match exactly.
 | `settings-provide-x-server` | `src/components/Settings/GeneralSettings.tsx` |
 | `settings-restore-last-session` | `src/components/Settings/GeneralSettings.tsx` |
 | `settings-right-click-behavior` | `src/components/Settings/TerminalSettings.tsx` |
+| `settings-saved-ack` | `src/components/Settings/SettingsPanel.tsx` |
 | `settings-serial-port-prefixes` | `src/components/Settings/SerialPortSettings.tsx` |
 | `settings-stop-x-server-idle` | `src/components/Settings/GeneralSettings.tsx` |
 | `shortcuts-overlay` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |


### PR DESCRIPTION
## Summary

Several mutating actions used to `console.error` on failure (invisible to users) and confirm nothing on success, violating the design-system rule "every action gives feedback". This PR wires up feedback for a scoped set of them (partial #1342):

- **Embedded servers** — save, duplicate, and "Copy URL" now show success/error toasts. The create/edit dialog only closes when the save actually succeeds (`onSave` resolves a boolean) and stays open on error so the user can retry.
- **SSH tunnels** — duplicate now confirms with a toast and reports failures instead of silently logging.
- **Connection editor** — saving confirms with a toast; a failed remote **agent-definition** save (previously fully silent) now propagates so the async Button surfaces a recoverable error toast. Regular connections keep getting their accurate success/error toast from the store's async persist (`addConnection`/`updateConnection`), so the editor deliberately does **not** double-toast those.
- **Settings** — General/Appearance/Terminal settings auto-save (debounced), so the panel now shows a subtle transient "Saved" acknowledgment and no longer raises a contradictory "unsaved changes" dialog on close (it flushes any pending write and closes directly). Resolves the mixed auto-save/confirm mental model.

## Deferred (follow-up)

- **FileBrowser** rename / new folder / new file / copy name / copy path feedback was intentionally left out — a concurrent PR (#1348) owned FileBrowser this round. Tracked in **#1399** (Ready2Implement).

## Test plan

- New unit tests (all green):
  - embedded-server save & duplicate toasts + dialog-stays-open-on-error (`EmbeddedServerSidebar.test.tsx`)
  - embedded-server "Copy URL" clipboard confirmation (`EmbeddedServerItem.copy.test.tsx`)
  - tunnel duplicate success/error toasts (`TunnelSidebar.duplicate.test.tsx`)
  - connection agent-definition save success toast + rejection surfaces an error toast (`ConnectionEditor.save-feedback.test.tsx`)
  - settings transient "Saved" ack + close-without-dialog (`SettingsPanel.autosave-feedback.test.tsx`)
- `pnpm build`, full `pnpm test` (2685 tests), and `./scripts/check.sh` all pass.

Refs #1342 (partial — does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)