### PR TITLE
feat(agent): optional agent-side GitHub self-update, off by default (partial #1355)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1518,24 @@ dependencies = [
  "sha2 0.10.9",
  "zeroize",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deflate64"
@@ -4006,6 +4034,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -7171,12 +7209,16 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs",
+ "hex",
  "jsonrpsee",
  "libc",
  "nix 0.29.0",
+ "reqwest 0.12.28",
  "russh",
+ "semver",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "shellexpand",
  "sysinfo",
  "tempfile",
@@ -7188,6 +7230,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "windows-sys 0.59.0",
+ "wiremock",
 ]
 
 [[package]]
@@ -8940,6 +8983,29 @@ checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -35,6 +35,17 @@ russh = { workspace = true }
 shellexpand = "3"
 sysinfo = "0.38"
 dirs = "6"
+# Agent-side GitHub self-update (#1355): outbound HTTP to the Releases API and
+# asset download, semver comparison, and SHA-256 integrity verification of the
+# downloaded binary. rustls-tls avoids an OpenSSL dependency for musl
+# cross-compilation of the agent.
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+    "json",
+] }
+semver = "1"
+sha2 = "0.10"
+hex = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["signal", "process", "term", "poll", "fs"] }
@@ -56,3 +67,5 @@ windows-sys = { version = "0.59", features = [
 tempfile = "3"
 serde_json = { workspace = true }
 base64 = "0.22"
+# Mock GitHub Releases HTTP endpoints in self-update tests without real network.
+wiremock = "0.6"

--- a/agent/src/io/stdio.rs
+++ b/agent/src/io/stdio.rs
@@ -17,13 +17,17 @@ use crate::session::manager::SessionManager;
 /// Reads JSON-RPC messages from stdin (one per line) and writes
 /// responses to stdout. Backend notifications are interleaved via
 /// a `tokio::select!` loop. Logs go to stderr.
-pub async fn run_stdio_loop(shutdown: CancellationToken) -> anyhow::Result<()> {
+pub async fn run_stdio_loop(
+    shutdown: CancellationToken,
+    allow_self_update: bool,
+) -> anyhow::Result<()> {
     let (notification_tx, mut notification_rx) =
         tokio::sync::mpsc::unbounded_channel::<JsonRpcNotification>();
 
     let registry = Arc::new(build_registry());
     let session_manager = Arc::new(SessionManager::new(notification_tx.clone(), registry));
     let connection_store = Arc::new(ConnectionStore::new(ConnectionStore::default_path()));
+    let update_tx = notification_tx.clone();
     let monitoring_manager = Arc::new(MonitoringManager::new(
         notification_tx,
         connection_store.clone(),
@@ -34,6 +38,14 @@ pub async fn run_stdio_loop(shutdown: CancellationToken) -> anyhow::Result<()> {
 
     // Recover sessions from previous agent run
     session_manager.recover_sessions().await;
+
+    // Optional background GitHub self-update check (off unless opted in).
+    crate::update::spawn_self_update_task(
+        crate::update::UpdateConfig::from_env(allow_self_update, env!("CARGO_PKG_VERSION")),
+        session_manager.clone(),
+        update_tx,
+        shutdown.child_token(),
+    );
 
     let handler = AgentHandler::new(
         session_manager.clone(),

--- a/agent/src/io/tcp.rs
+++ b/agent/src/io/tcp.rs
@@ -21,7 +21,11 @@ use crate::session::manager::SessionManager;
 /// persist when a client disconnects and reconnects.
 ///
 /// The accept loop exits when the cancellation token is triggered.
-pub async fn run_tcp_listener(addr: &str, shutdown: CancellationToken) -> anyhow::Result<()> {
+pub async fn run_tcp_listener(
+    addr: &str,
+    shutdown: CancellationToken,
+    allow_self_update: bool,
+) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr).await?;
     info!("Listening on {}", listener.local_addr()?);
 
@@ -30,6 +34,7 @@ pub async fn run_tcp_listener(addr: &str, shutdown: CancellationToken) -> anyhow
     let registry = Arc::new(build_registry());
     let session_manager = Arc::new(SessionManager::new(notification_tx.clone(), registry));
     let connection_store = Arc::new(ConnectionStore::new(ConnectionStore::default_path()));
+    let update_tx = notification_tx.clone();
     let monitoring_manager = Arc::new(MonitoringManager::new(
         notification_tx,
         connection_store.clone(),
@@ -40,6 +45,14 @@ pub async fn run_tcp_listener(addr: &str, shutdown: CancellationToken) -> anyhow
 
     // Recover sessions from previous agent run
     session_manager.recover_sessions().await;
+
+    // Optional background GitHub self-update check (off unless opted in).
+    crate::update::spawn_self_update_task(
+        crate::update::UpdateConfig::from_env(allow_self_update, env!("CARGO_PKG_VERSION")),
+        session_manager.clone(),
+        update_tx,
+        shutdown.child_token(),
+    );
 
     loop {
         tokio::select! {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -28,8 +28,30 @@ fn print_usage() {
     eprintln!("  --daemon <id>        Run as a session daemon (internal use only)");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  --version   Print version and exit");
-    eprintln!("  --help      Print this help message");
+    eprintln!("  --version             Print version and exit");
+    eprintln!("  --help                Print this help message");
+    eprintln!(
+        "  --allow-self-update   Enable the background GitHub self-update check (off by default)"
+    );
+}
+
+/// CLI flag / env var that opts the agent into the background self-update check.
+const SELF_UPDATE_FLAG: &str = "--allow-self-update";
+const SELF_UPDATE_ENV: &str = "TERMIHUB_AGENT_ALLOW_SELF_UPDATE";
+
+/// Determine whether the agent should run the optional self-update check.
+///
+/// Enabled when the `--allow-self-update` flag is passed (the desktop appends it
+/// to the SSH exec command when the connection has self-update enabled) or when
+/// `TERMIHUB_AGENT_ALLOW_SELF_UPDATE` is set to a truthy value. Off by default.
+fn self_update_enabled(args: &[String]) -> bool {
+    if args.iter().any(|a| a == SELF_UPDATE_FLAG) {
+        return true;
+    }
+    matches!(
+        std::env::var(SELF_UPDATE_ENV).ok().as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
 }
 
 #[tokio::main]
@@ -59,22 +81,27 @@ async fn main() -> anyhow::Result<()> {
             init_tracing();
 
             let shutdown = setup_shutdown_signal();
+            let allow_self_update = self_update_enabled(&args);
             info!("termihub-agent {} starting in stdio mode", VERSION);
-            io::stdio::run_stdio_loop(shutdown).await
+            io::stdio::run_stdio_loop(shutdown, allow_self_update).await
         }
         "--listen" => {
             init_tracing();
 
+            // The listen address is optional; skip it (and any other flags) when
+            // resolving the address so `--allow-self-update` is not mistaken for it.
             let addr = args
                 .get(2)
+                .filter(|s| !s.starts_with("--"))
                 .map(|s| s.as_str())
                 .unwrap_or(DEFAULT_LISTEN_ADDR);
             let shutdown = setup_shutdown_signal();
+            let allow_self_update = self_update_enabled(&args);
             info!(
                 "termihub-agent {} starting in TCP listener mode on {}",
                 VERSION, addr
             );
-            io::tcp::run_tcp_listener(addr, shutdown).await
+            io::tcp::run_tcp_listener(addr, shutdown, allow_self_update).await
         }
         "--daemon" => {
             init_tracing();
@@ -140,4 +167,34 @@ fn setup_shutdown_signal() -> CancellationToken {
     });
 
     token
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn self_update_flag_present_enables() {
+        assert!(self_update_enabled(&args(&[
+            "termihub-agent",
+            "--stdio",
+            SELF_UPDATE_FLAG
+        ])));
+        assert!(self_update_enabled(&args(&[
+            "termihub-agent",
+            "--listen",
+            "127.0.0.1:7685",
+            SELF_UPDATE_FLAG
+        ])));
+    }
+
+    #[test]
+    fn self_update_absent_is_disabled_by_default() {
+        // No flag, and the env var is not set in this test process.
+        assert!(!self_update_enabled(&args(&["termihub-agent", "--stdio"])));
+    }
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -9,6 +9,7 @@ mod registry;
 mod session;
 mod state;
 mod transport;
+mod update;
 
 use tokio_util::sync::CancellationToken;
 use tracing::info;

--- a/agent/src/protocol/methods.rs
+++ b/agent/src/protocol/methods.rs
@@ -503,10 +503,71 @@ pub struct MonitoringData {
     pub os_info: String,
 }
 
+// ── agent.update_available (notification payload) ───────────────────
+
+/// JSON-RPC method name for the agent self-update notification (#1355).
+///
+/// Emitted (Agent → Desktop) when the agent's background GitHub poll finds a
+/// newer release; the desktop surfaces it as the self-update toast.
+pub const AGENT_UPDATE_AVAILABLE: &str = "agent.update_available";
+
+/// Payload of an [`AGENT_UPDATE_AVAILABLE`] notification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateAvailableNotification {
+    /// The agent's currently running version (`CARGO_PKG_VERSION`).
+    pub current_version: String,
+    /// The newer version available on GitHub Releases (release tag semver).
+    pub available_version: String,
+    /// Download URL of the matching binary asset, when one is published for
+    /// this platform.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub download_url: Option<String>,
+    /// `true` once the binary has been downloaded and SHA-256-verified to the
+    /// agent's staging path; `false` when only a newer version was detected.
+    pub staged: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn update_available_notification_serializes_camel_case() {
+        let payload = UpdateAvailableNotification {
+            current_version: "0.2.1".to_string(),
+            available_version: "0.3.0".to_string(),
+            download_url: Some("https://example.test/termihub-agent-linux-x64".to_string()),
+            staged: true,
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert_eq!(value["currentVersion"], "0.2.1");
+        assert_eq!(value["availableVersion"], "0.3.0");
+        assert_eq!(
+            value["downloadUrl"],
+            "https://example.test/termihub-agent-linux-x64"
+        );
+        assert_eq!(value["staged"], true);
+    }
+
+    #[test]
+    fn update_available_notification_omits_absent_download_url() {
+        let payload = UpdateAvailableNotification {
+            current_version: "0.2.1".to_string(),
+            available_version: "0.3.0".to_string(),
+            download_url: None,
+            staged: false,
+        };
+        let value = serde_json::to_value(&payload).unwrap();
+        assert!(value.get("downloadUrl").is_none());
+        assert_eq!(value["staged"], false);
+    }
+
+    #[test]
+    fn agent_update_available_method_name() {
+        assert_eq!(AGENT_UPDATE_AVAILABLE, "agent.update_available");
+    }
 
     #[test]
     fn initialize_params_serde() {

--- a/agent/src/state/persistence.rs
+++ b/agent/src/state/persistence.rs
@@ -13,6 +13,40 @@ use tracing::{debug, warn};
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AgentState {
     pub sessions: HashMap<String, PersistedSession>,
+    /// Self-update bookkeeping (last GitHub poll time, staged pending update).
+    ///
+    /// `#[serde(default)]` so a `state.json` written by an agent that predates
+    /// the self-update feature still loads (the field defaults to empty).
+    #[serde(default)]
+    pub update: UpdateState,
+}
+
+/// Self-update state persisted across agent restarts (#1355).
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct UpdateState {
+    /// RFC 3339 timestamp of the last GitHub `releases/latest` poll, or `None`
+    /// if the agent has never polled.
+    #[serde(default)]
+    pub last_check_time: Option<String>,
+    /// A downloaded-and-verified binary awaiting application, or `None`.
+    #[serde(default)]
+    pub pending_update: Option<PendingUpdate>,
+}
+
+/// A self-update binary that has been downloaded and SHA-256-verified but not
+/// yet applied.
+///
+/// Applying it on idle (deferred apply) depends on SI-6 (#1352) and is
+/// intentionally not wired up yet — until then the agent only stages the binary
+/// and records it here so a later change can pick it up.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PendingUpdate {
+    /// Target version (release tag semver, e.g. `"0.3.0"`).
+    pub version: String,
+    /// Absolute path to the staged, verified binary.
+    pub binary_path: String,
+    /// RFC 3339 timestamp when the binary was staged.
+    pub staged_at: String,
 }
 
 /// Minimal session info stored for recovery.
@@ -41,7 +75,7 @@ impl AgentState {
     ///
     /// Returns an empty state if the file is missing or corrupt.
     pub fn load() -> Self {
-        let path = Self::state_path();
+        let path = Self::default_path();
         Self::load_from(&path)
     }
 
@@ -71,7 +105,7 @@ impl AgentState {
 
     /// Save state to the default state file.
     pub fn save(&self) {
-        let path = Self::state_path();
+        let path = Self::default_path();
         self.save_to(&path);
     }
 
@@ -111,13 +145,18 @@ impl AgentState {
         self.save();
     }
 
-    /// Get the default state file path under the platform config dir.
+    /// The default `state.json` path under the platform config dir.
     ///
     /// Resolves to `$XDG_CONFIG_HOME/termihub-agent/state.json` on Linux,
     /// `~/Library/Application Support/termihub-agent/state.json` on macOS,
     /// and `%APPDATA%\termihub-agent\state.json` on Windows.
-    fn state_path() -> PathBuf {
-        config_dir().join("state.json")
+    pub fn default_path() -> PathBuf {
+        Self::config_dir().join("state.json")
+    }
+
+    /// The platform config directory the agent stores its state under.
+    pub fn config_dir() -> PathBuf {
+        config_dir()
     }
 }
 
@@ -302,7 +341,7 @@ mod tests {
 
     #[test]
     fn state_path_lives_inside_config_dir() {
-        let path = AgentState::state_path();
+        let path = AgentState::default_path();
         assert_eq!(
             path.file_name().and_then(|s| s.to_str()),
             Some("state.json")
@@ -312,6 +351,54 @@ mod tests {
             "state_path must be absolute, got {}",
             path.display()
         );
+    }
+
+    #[test]
+    fn update_state_round_trips() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.json");
+
+        let mut state = AgentState::default();
+        state.update.last_check_time = Some("2026-07-10T12:00:00Z".to_string());
+        state.update.pending_update = Some(PendingUpdate {
+            version: "0.3.0".to_string(),
+            binary_path: "/tmp/updates/termihub-agent-linux-x64".to_string(),
+            staged_at: "2026-07-10T12:00:01Z".to_string(),
+        });
+        state.save_to(&path);
+
+        let loaded = AgentState::load_from(&path);
+        assert_eq!(
+            loaded.update.last_check_time.as_deref(),
+            Some("2026-07-10T12:00:00Z")
+        );
+        let pending = loaded
+            .update
+            .pending_update
+            .expect("pending update present");
+        assert_eq!(pending.version, "0.3.0");
+        assert_eq!(pending.binary_path, "/tmp/updates/termihub-agent-linux-x64");
+    }
+
+    #[test]
+    fn legacy_state_without_update_field_loads() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.json");
+        // Pre-existing state.json from an agent version that predates #1355 —
+        // must still load, defaulting `update` to an empty UpdateState.
+        std::fs::write(
+            &path,
+            r#"{
+              "sessions": {}
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = AgentState::load_from(&path);
+        assert!(loaded.sessions.is_empty());
+        assert_eq!(loaded.update, UpdateState::default());
+        assert!(loaded.update.last_check_time.is_none());
+        assert!(loaded.update.pending_update.is_none());
     }
 
     #[test]

--- a/agent/src/update/checksum.rs
+++ b/agent/src/update/checksum.rs
@@ -1,0 +1,136 @@
+//! SHA-256 integrity verification for downloaded agent binaries.
+//!
+//! Mirrors the desktop-side verification introduced in #1350
+//! (`src-tauri/src/terminal/agent_binary.rs`) so the agent applies the same
+//! fail-closed rule to any binary it downloads for a self-update: a binary is
+//! never staged unless its published `.sha256` sidecar matches.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
+
+/// File-name suffix for the SHA-256 checksum sidecar published next to every
+/// agent binary release asset (e.g. `termihub-agent-linux-x64.sha256`).
+pub const CHECKSUM_EXT: &str = "sha256";
+
+/// Compute the lowercase-hex SHA-256 digest of a file's contents.
+///
+/// The file is streamed through the hasher, so arbitrarily large binaries are
+/// never fully buffered in memory.
+pub fn sha256_hex_of_file(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("Failed to open {} for checksum", path.display()))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)
+        .with_context(|| format!("Failed to read {} for checksum", path.display()))?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Parse the expected SHA-256 digest out of a checksum sidecar's contents.
+///
+/// Accepts both a bare 64-char hex digest and the standard `sha256sum` output
+/// format `"<hex>  <filename>"` (text mode) or `"<hex> *<filename>"` (binary
+/// mode) — only the first whitespace-delimited token is considered. The digest
+/// is normalized to lowercase. Returns `None` when the first token is not a
+/// valid 64-character hex string.
+pub fn parse_sha256_sidecar(content: &str) -> Option<String> {
+    let token = content.split_whitespace().next()?.to_ascii_lowercase();
+    if token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(token)
+    } else {
+        None
+    }
+}
+
+/// Verify that `path`'s SHA-256 digest equals `expected_hex`.
+///
+/// The comparison is case-insensitive. On mismatch this returns an error whose
+/// message names the file and both digests, so a tampered or corrupted binary
+/// is rejected with a clear, actionable message before it is ever staged or
+/// executed.
+pub fn verify_file_checksum(path: &Path, expected_hex: &str) -> Result<()> {
+    let actual = sha256_hex_of_file(path)?;
+    let expected = expected_hex.trim().to_ascii_lowercase();
+    if actual == expected {
+        Ok(())
+    } else {
+        bail!(
+            "Checksum verification failed for {}: expected SHA-256 {expected}, computed {actual}. \
+             Refusing to use an agent binary that does not match its published checksum.",
+            path.display()
+        );
+    }
+}
+
+/// Return the path of the `.sha256` checksum sidecar for a binary path.
+pub fn checksum_sidecar_path(binary_path: &Path) -> PathBuf {
+    let mut name = binary_path.as_os_str().to_owned();
+    name.push(".");
+    name.push(CHECKSUM_EXT);
+    PathBuf::from(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Known SHA-256 of the ASCII string "abc" (NIST test vector).
+    const SHA256_OF_ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    #[test]
+    fn sha256_hex_of_file_matches_known_vector() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload.bin");
+        fs::write(&path, b"abc").unwrap();
+        assert_eq!(sha256_hex_of_file(&path).unwrap(), SHA256_OF_ABC);
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_plain_and_sha256sum_formats() {
+        assert_eq!(
+            parse_sha256_sidecar(SHA256_OF_ABC),
+            Some(SHA256_OF_ABC.to_string())
+        );
+        let line = format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n");
+        assert_eq!(parse_sha256_sidecar(&line), Some(SHA256_OF_ABC.to_string()));
+        let bin = format!("{SHA256_OF_ABC} *termihub-agent-linux-x64\n");
+        assert_eq!(parse_sha256_sidecar(&bin), Some(SHA256_OF_ABC.to_string()));
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_rejects_garbage() {
+        assert_eq!(parse_sha256_sidecar(""), None);
+        assert_eq!(parse_sha256_sidecar("not-a-hash"), None);
+        assert_eq!(parse_sha256_sidecar("deadbeef"), None);
+        assert_eq!(parse_sha256_sidecar(&"g".repeat(64)), None);
+    }
+
+    #[test]
+    fn verify_file_checksum_ok_on_match_case_insensitive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload.bin");
+        fs::write(&path, b"abc").unwrap();
+        assert!(verify_file_checksum(&path, SHA256_OF_ABC).is_ok());
+        assert!(verify_file_checksum(&path, &SHA256_OF_ABC.to_ascii_uppercase()).is_ok());
+    }
+
+    #[test]
+    fn verify_file_checksum_rejects_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload.bin");
+        fs::write(&path, b"tampered content").unwrap();
+        let err = verify_file_checksum(&path, SHA256_OF_ABC).unwrap_err();
+        assert!(err.to_string().to_ascii_lowercase().contains("checksum"));
+    }
+
+    #[test]
+    fn checksum_sidecar_path_appends_sha256() {
+        let binary = PathBuf::from("/tmp/updates/termihub-agent-linux-x64");
+        assert_eq!(
+            checksum_sidecar_path(&binary),
+            PathBuf::from("/tmp/updates/termihub-agent-linux-x64.sha256")
+        );
+    }
+}

--- a/agent/src/update/download.rs
+++ b/agent/src/update/download.rs
@@ -80,9 +80,7 @@ async fn verify_downloaded(
 ) -> Result<()> {
     download_to_file(client, checksum_url, sidecar)
         .await
-        .with_context(|| {
-            format!("failed to download published checksum from {checksum_url}")
-        })?;
+        .with_context(|| format!("failed to download published checksum from {checksum_url}"))?;
     let content = tokio::fs::read_to_string(sidecar)
         .await
         .with_context(|| format!("failed to read checksum sidecar {}", sidecar.display()))?;
@@ -132,7 +130,11 @@ mod tests {
     async fn stages_binary_when_checksum_matches() {
         let server = MockServer::start().await;
         mount_binary(&server, b"abc").await;
-        mount_checksum(&server, format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n")).await;
+        mount_checksum(
+            &server,
+            format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n"),
+        )
+        .await;
 
         let tmp = tempfile::tempdir().unwrap();
         let dest = tmp.path().join("termihub-agent-linux-x64");
@@ -190,6 +192,9 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().to_ascii_lowercase().contains("checksum"));
-        assert!(!dest.exists(), "binary must not remain without verification");
+        assert!(
+            !dest.exists(),
+            "binary must not remain without verification"
+        );
     }
 }

--- a/agent/src/update/download.rs
+++ b/agent/src/update/download.rs
@@ -1,0 +1,195 @@
+//! Download and SHA-256-verify an agent binary for a self-update.
+//!
+//! Applies the same fail-closed rule as the desktop deploy path (#1350): a
+//! release binary is only staged if it is accompanied by a matching `.sha256`
+//! sidecar. A missing sidecar, a malformed sidecar, or a digest mismatch aborts
+//! the staging and removes any partially written files, so a tampered or
+//! corrupt binary is never left on disk to be executed.
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use tracing::debug;
+
+use super::checksum::{checksum_sidecar_path, parse_sha256_sidecar, verify_file_checksum};
+use super::github::AssetUrls;
+
+/// Download `url` into `dest`, replacing any existing file.
+async fn download_to_file(client: &reqwest::Client, url: &str, dest: &Path) -> Result<()> {
+    let bytes = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("failed to download {url}"))?
+        .error_for_status()
+        .with_context(|| format!("download of {url} returned an error status"))?
+        .bytes()
+        .await
+        .with_context(|| format!("failed to read response body for {url}"))?;
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("failed to create staging directory {}", parent.display()))?;
+    }
+    tokio::fs::write(dest, &bytes)
+        .await
+        .with_context(|| format!("failed to write {}", dest.display()))?;
+    Ok(())
+}
+
+/// Download the agent binary described by `urls` into `dest` and verify it
+/// against its published `.sha256` sidecar.
+///
+/// On success `dest` holds the verified binary and its sidecar sits next to it
+/// (`<dest>.sha256`). On any failure both files are removed and an error is
+/// returned. A release with no published checksum is rejected — self-update
+/// never installs an unverifiable binary.
+pub async fn download_and_verify(
+    client: &reqwest::Client,
+    urls: &AssetUrls,
+    dest: &Path,
+) -> Result<()> {
+    let checksum_url = match urls.checksum_url.as_deref() {
+        Some(url) => url,
+        None => bail!(
+            "No published SHA-256 checksum for {} — refusing to stage an unverifiable agent binary",
+            urls.binary_url
+        ),
+    };
+
+    if let Err(e) = download_to_file(client, &urls.binary_url, dest).await {
+        let _ = tokio::fs::remove_file(dest).await;
+        return Err(e);
+    }
+
+    let sidecar = checksum_sidecar_path(dest);
+    let result = verify_downloaded(client, checksum_url, dest, &sidecar).await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(dest).await;
+        let _ = tokio::fs::remove_file(&sidecar).await;
+    }
+    result
+}
+
+/// Fetch the checksum sidecar and verify the downloaded binary against it.
+async fn verify_downloaded(
+    client: &reqwest::Client,
+    checksum_url: &str,
+    dest: &Path,
+    sidecar: &Path,
+) -> Result<()> {
+    download_to_file(client, checksum_url, sidecar)
+        .await
+        .with_context(|| {
+            format!("failed to download published checksum from {checksum_url}")
+        })?;
+    let content = tokio::fs::read_to_string(sidecar)
+        .await
+        .with_context(|| format!("failed to read checksum sidecar {}", sidecar.display()))?;
+    let expected = parse_sha256_sidecar(&content).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Malformed checksum sidecar from {checksum_url} — refusing to stage an \
+             unverifiable agent binary"
+        )
+    })?;
+    verify_file_checksum(dest, &expected)?;
+    debug!("Verified downloaded agent binary at {}", dest.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const SHA256_OF_ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    async fn mount_binary(server: &MockServer, body: &'static [u8]) {
+        Mock::given(method("GET"))
+            .and(path("/bin"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_checksum(server: &MockServer, body: String) {
+        Mock::given(method("GET"))
+            .and(path("/bin.sha256"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(server)
+            .await;
+    }
+
+    fn urls(server: &MockServer, with_checksum: bool) -> AssetUrls {
+        AssetUrls {
+            binary_url: format!("{}/bin", server.uri()),
+            checksum_url: with_checksum.then(|| format!("{}/bin.sha256", server.uri())),
+        }
+    }
+
+    #[tokio::test]
+    async fn stages_binary_when_checksum_matches() {
+        let server = MockServer::start().await;
+        mount_binary(&server, b"abc").await;
+        mount_checksum(&server, format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n")).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("termihub-agent-linux-x64");
+        download_and_verify(&reqwest::Client::new(), &urls(&server, true), &dest)
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"abc");
+        assert!(checksum_sidecar_path(&dest).is_file());
+    }
+
+    #[tokio::test]
+    async fn rejects_and_removes_binary_on_checksum_mismatch() {
+        let server = MockServer::start().await;
+        mount_binary(&server, b"abc").await;
+        mount_checksum(&server, "0".repeat(64)).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("termihub-agent-linux-x64");
+        let err = download_and_verify(&reqwest::Client::new(), &urls(&server, true), &dest)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().to_ascii_lowercase().contains("checksum"));
+        assert!(!dest.exists(), "mismatched binary must be removed");
+        assert!(!checksum_sidecar_path(&dest).exists());
+    }
+
+    #[tokio::test]
+    async fn fails_closed_when_no_checksum_asset_published() {
+        let server = MockServer::start().await;
+        mount_binary(&server, b"abc").await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("termihub-agent-linux-x64");
+        // checksum_url = None → refuse before downloading anything.
+        let err = download_and_verify(&reqwest::Client::new(), &urls(&server, false), &dest)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().to_ascii_lowercase().contains("checksum"));
+        assert!(!dest.exists());
+    }
+
+    #[tokio::test]
+    async fn fails_closed_when_checksum_download_404s() {
+        let server = MockServer::start().await;
+        mount_binary(&server, b"abc").await;
+        // No checksum mock mounted → the .sha256 GET gets wiremock's default 404.
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("termihub-agent-linux-x64");
+        let err = download_and_verify(&reqwest::Client::new(), &urls(&server, true), &dest)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().to_ascii_lowercase().contains("checksum"));
+        assert!(!dest.exists(), "binary must not remain without verification");
+    }
+}

--- a/agent/src/update/github.rs
+++ b/agent/src/update/github.rs
@@ -1,0 +1,210 @@
+//! GitHub Releases API access for the agent self-update check.
+//!
+//! The agent polls `GET /repos/{repo}/releases/latest`, parses the release JSON
+//! into [`ReleaseInfo`], and resolves the binary + checksum asset URLs matching
+//! its own platform. Parsing is separated from the HTTP call so it can be unit
+//! tested without a network.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+/// The default GitHub repository agent releases are published to.
+pub const DEFAULT_REPO: &str = "armaxri/termiHub";
+
+/// Base name of the agent binary release asset (an arch suffix is appended,
+/// e.g. `termihub-agent-linux-x64`).
+const ASSET_BASE: &str = "termihub-agent";
+
+/// A single downloadable asset attached to a GitHub release.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ReleaseAsset {
+    pub name: String,
+    #[serde(rename = "browser_download_url")]
+    pub browser_download_url: String,
+}
+
+/// The subset of the GitHub `releases/latest` response the agent needs.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ReleaseInfo {
+    pub tag_name: String,
+    #[serde(default)]
+    pub assets: Vec<ReleaseAsset>,
+}
+
+impl ReleaseInfo {
+    /// Find the download URL for the binary asset matching `arch_suffix`
+    /// (e.g. `"linux-x64"`) and, when present, its `.sha256` sidecar.
+    ///
+    /// Returns `None` when no binary asset for this platform is published.
+    pub fn asset_urls_for(&self, arch_suffix: &str) -> Option<AssetUrls> {
+        let binary_name = format!("{ASSET_BASE}-{arch_suffix}");
+        let checksum_name = format!("{binary_name}.sha256");
+
+        let binary_url = self
+            .assets
+            .iter()
+            .find(|a| a.name == binary_name)
+            .map(|a| a.browser_download_url.clone())?;
+        let checksum_url = self
+            .assets
+            .iter()
+            .find(|a| a.name == checksum_name)
+            .map(|a| a.browser_download_url.clone());
+
+        Some(AssetUrls {
+            binary_url,
+            checksum_url,
+        })
+    }
+}
+
+/// Resolved download URLs for a platform's agent binary and its checksum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetUrls {
+    pub binary_url: String,
+    /// `None` when the release does not publish a `.sha256` sidecar asset.
+    pub checksum_url: Option<String>,
+}
+
+/// Parse a GitHub `releases/latest` JSON body into a [`ReleaseInfo`].
+pub fn parse_release_json(body: &str) -> Result<ReleaseInfo> {
+    serde_json::from_str(body).context("failed to parse GitHub releases/latest JSON")
+}
+
+/// Map the compile-time OS/arch to the published agent asset suffix.
+///
+/// Agent binaries are published for Linux only (`linux-x64`, `linux-arm64`,
+/// `linux-armv7`). Returns `None` on any other platform, so the self-update
+/// check skips cleanly rather than downloading a non-existent asset.
+pub fn asset_suffix_for(os: &str, arch: &str) -> Option<&'static str> {
+    if os != "linux" {
+        return None;
+    }
+    match arch {
+        "x86_64" => Some("linux-x64"),
+        "aarch64" => Some("linux-arm64"),
+        // `std::env::consts::ARCH` reports "arm" for 32-bit ARM (armv7).
+        "arm" => Some("linux-armv7"),
+        _ => None,
+    }
+}
+
+/// The published asset suffix for the platform the agent is running on.
+pub fn current_asset_suffix() -> Option<&'static str> {
+    asset_suffix_for(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+/// Build the `releases/latest` API URL for a repository.
+pub fn releases_latest_url(repo: &str) -> String {
+    format!("https://api.github.com/repos/{repo}/releases/latest")
+}
+
+/// Fetch and parse the latest release from the GitHub API.
+///
+/// GitHub requires a `User-Agent` header on API requests; the caller-provided
+/// [`reqwest::Client`] is expected to set one. Any transport or HTTP-status
+/// error is returned so the caller can log a warning and skip the cycle.
+pub async fn fetch_latest_release(client: &reqwest::Client, url: &str) -> Result<ReleaseInfo> {
+    let resp = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .with_context(|| format!("failed to reach GitHub releases API at {url}"))?
+        .error_for_status()
+        .with_context(|| format!("GitHub releases API returned an error status for {url}"))?;
+    let body = resp
+        .text()
+        .await
+        .context("failed to read GitHub releases API response body")?;
+    parse_release_json(&body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+        "tag_name": "v0.3.0",
+        "name": "termiHub 0.3.0",
+        "assets": [
+            { "name": "termihub-agent-linux-x64", "browser_download_url": "https://example.test/dl/termihub-agent-linux-x64" },
+            { "name": "termihub-agent-linux-x64.sha256", "browser_download_url": "https://example.test/dl/termihub-agent-linux-x64.sha256" },
+            { "name": "termihub-agent-linux-arm64", "browser_download_url": "https://example.test/dl/termihub-agent-linux-arm64" }
+        ]
+    }"#;
+
+    #[test]
+    fn parse_release_json_extracts_tag_and_assets() {
+        let info = parse_release_json(SAMPLE).unwrap();
+        assert_eq!(info.tag_name, "v0.3.0");
+        assert_eq!(info.assets.len(), 3);
+        assert_eq!(info.assets[0].name, "termihub-agent-linux-x64");
+    }
+
+    #[test]
+    fn parse_release_json_tolerates_missing_assets() {
+        let info = parse_release_json(r#"{ "tag_name": "v1.0.0" }"#).unwrap();
+        assert_eq!(info.tag_name, "v1.0.0");
+        assert!(info.assets.is_empty());
+    }
+
+    #[test]
+    fn parse_release_json_rejects_garbage() {
+        assert!(parse_release_json("not json").is_err());
+        assert!(parse_release_json("{}").is_err()); // missing tag_name
+    }
+
+    #[test]
+    fn asset_urls_for_resolves_binary_and_sidecar() {
+        let info = parse_release_json(SAMPLE).unwrap();
+        let urls = info.asset_urls_for("linux-x64").unwrap();
+        assert_eq!(
+            urls.binary_url,
+            "https://example.test/dl/termihub-agent-linux-x64"
+        );
+        assert_eq!(
+            urls.checksum_url.as_deref(),
+            Some("https://example.test/dl/termihub-agent-linux-x64.sha256")
+        );
+    }
+
+    #[test]
+    fn asset_urls_for_binary_without_sidecar() {
+        let info = parse_release_json(SAMPLE).unwrap();
+        let urls = info.asset_urls_for("linux-arm64").unwrap();
+        assert_eq!(
+            urls.binary_url,
+            "https://example.test/dl/termihub-agent-linux-arm64"
+        );
+        assert_eq!(urls.checksum_url, None);
+    }
+
+    #[test]
+    fn asset_urls_for_missing_platform_is_none() {
+        let info = parse_release_json(SAMPLE).unwrap();
+        assert!(info.asset_urls_for("linux-armv7").is_none());
+    }
+
+    #[test]
+    fn asset_suffix_maps_linux_arches() {
+        assert_eq!(asset_suffix_for("linux", "x86_64"), Some("linux-x64"));
+        assert_eq!(asset_suffix_for("linux", "aarch64"), Some("linux-arm64"));
+        assert_eq!(asset_suffix_for("linux", "arm"), Some("linux-armv7"));
+    }
+
+    #[test]
+    fn asset_suffix_rejects_non_linux_and_unknown_arch() {
+        assert_eq!(asset_suffix_for("macos", "aarch64"), None);
+        assert_eq!(asset_suffix_for("windows", "x86_64"), None);
+        assert_eq!(asset_suffix_for("linux", "mips"), None);
+    }
+
+    #[test]
+    fn releases_latest_url_uses_repo() {
+        assert_eq!(
+            releases_latest_url("armaxri/termiHub"),
+            "https://api.github.com/repos/armaxri/termiHub/releases/latest"
+        );
+    }
+}

--- a/agent/src/update/mod.rs
+++ b/agent/src/update/mod.rs
@@ -6,5 +6,7 @@
 //! SHA-256-verified download, the `agent.update_available` notification, and the
 //! background 24-hour timer.
 
+mod checksum;
+mod download;
 mod github;
 mod version;

--- a/agent/src/update/mod.rs
+++ b/agent/src/update/mod.rs
@@ -6,4 +6,5 @@
 //! SHA-256-verified download, the `agent.update_available` notification, and the
 //! background 24-hour timer.
 
+mod github;
 mod version;

--- a/agent/src/update/mod.rs
+++ b/agent/src/update/mod.rs
@@ -1,0 +1,9 @@
+//! Optional agent-side GitHub self-update (#1355, Approach 1 of the remote-agent
+//! update strategy).
+//!
+//! Off by default; gated behind `allow_self_update`. This module is built up
+//! across the #1355 change set: version comparison, GitHub release polling,
+//! SHA-256-verified download, the `agent.update_available` notification, and the
+//! background 24-hour timer.
+
+mod version;

--- a/agent/src/update/mod.rs
+++ b/agent/src/update/mod.rs
@@ -1,12 +1,494 @@
 //! Optional agent-side GitHub self-update (#1355, Approach 1 of the remote-agent
 //! update strategy).
 //!
-//! Off by default; gated behind `allow_self_update`. This module is built up
-//! across the #1355 change set: version comparison, GitHub release polling,
-//! SHA-256-verified download, the `agent.update_available` notification, and the
-//! background 24-hour timer.
+//! When enabled via `allow_self_update` (off by default), the agent runs a
+//! background 24-hour timer that polls GitHub `releases/latest`, compares the
+//! published version against its own `CARGO_PKG_VERSION`, and — when a newer
+//! release exists — notifies connected desktops via an
+//! [`agent.update_available`](crate::protocol::methods::AGENT_UPDATE_AVAILABLE)
+//! notification. When no sessions are active it also downloads and
+//! SHA-256-verifies the new binary and stages it for a later apply.
+//!
+//! The whole feature is gated behind `allow_self_update`: with the flag off the
+//! background task is never spawned, so there is zero outbound network activity.
+//! Every failure path (no internet, GitHub error, bad checksum) logs a warning
+//! and skips the cycle — the agent never crashes because of a self-update check.
+//!
+//! # Partial implementation (#1355)
+//!
+//! This lands the poll → semver → verified-download → notify/stage pipeline. The
+//! deferred **auto-apply on idle** step depends on SI-6 (#1352, not yet built);
+//! until it lands the agent stops after staging the verified binary and
+//! recording it in `state.json`. Wiring auto-apply is tracked as a follow-up.
 
 mod checksum;
 mod download;
 mod github;
 mod version;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::io::transport::NotificationSender;
+use crate::protocol::messages::JsonRpcNotification;
+use crate::protocol::methods::{UpdateAvailableNotification, AGENT_UPDATE_AVAILABLE};
+use crate::session::manager::SessionManager;
+use crate::state::persistence::{AgentState, PendingUpdate};
+
+pub use github::{current_asset_suffix, DEFAULT_REPO};
+
+/// Default interval between self-update checks (24 hours).
+pub const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Timeout for a single GitHub API / download request.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Configuration for the self-update background task.
+///
+/// Field-level overrides (`api_url`, `asset_suffix`, `staging_dir`,
+/// `state_path`) exist so the check cycle can be unit tested against a mock HTTP
+/// server and a temporary state file. Production callers build defaults via
+/// [`UpdateConfig::from_env`].
+#[derive(Debug, Clone)]
+pub struct UpdateConfig {
+    /// Master gate — when `false` the background task is never spawned.
+    pub allow_self_update: bool,
+    /// Interval between checks.
+    pub check_interval: Duration,
+    /// GitHub `releases/latest` API URL.
+    pub api_url: String,
+    /// The agent's own version (`CARGO_PKG_VERSION`).
+    pub current_version: String,
+    /// Published asset suffix for this platform (e.g. `"linux-x64"`), or `None`
+    /// on a platform with no published agent binary.
+    pub asset_suffix: Option<String>,
+    /// Directory a verified update binary is staged into.
+    pub staging_dir: PathBuf,
+    /// Path to the agent's `state.json`.
+    pub state_path: PathBuf,
+    /// `User-Agent` header sent to the GitHub API (GitHub requires one).
+    pub user_agent: String,
+}
+
+impl UpdateConfig {
+    /// Build the production configuration for the current agent process.
+    pub fn from_env(allow_self_update: bool, current_version: &str) -> Self {
+        Self {
+            allow_self_update,
+            check_interval: DEFAULT_CHECK_INTERVAL,
+            api_url: github::releases_latest_url(DEFAULT_REPO),
+            current_version: current_version.to_string(),
+            asset_suffix: current_asset_suffix().map(str::to_string),
+            staging_dir: AgentState::config_dir().join("updates"),
+            state_path: AgentState::default_path(),
+            user_agent: format!("termihub-agent/{current_version}"),
+        }
+    }
+
+    /// Path a staged binary for `arch_suffix` would be written to.
+    fn staged_binary_path(&self, arch_suffix: &str) -> PathBuf {
+        self.staging_dir
+            .join(format!("termihub-agent-{arch_suffix}"))
+    }
+}
+
+/// Spawn the background self-update task when enabled.
+///
+/// A no-op when `allow_self_update` is `false` — nothing is spawned and there is
+/// no outbound network activity. Otherwise a Tokio task runs the check
+/// immediately and then every [`UpdateConfig::check_interval`] until `shutdown`
+/// is triggered.
+pub fn spawn_self_update_task(
+    config: UpdateConfig,
+    session_manager: Arc<SessionManager>,
+    notification_tx: NotificationSender,
+    shutdown: CancellationToken,
+) {
+    if !config.allow_self_update {
+        debug!("Agent self-update disabled (allow_self_update = false)");
+        return;
+    }
+
+    info!(
+        "Agent self-update enabled — checking GitHub for a newer agent every {}h",
+        config.check_interval.as_secs() / 3600
+    );
+
+    tokio::spawn(async move {
+        let client = match reqwest::Client::builder()
+            .user_agent(config.user_agent.clone())
+            .timeout(HTTP_TIMEOUT)
+            .build()
+        {
+            Ok(client) => client,
+            Err(e) => {
+                warn!("Could not build HTTP client for self-update; disabling: {e}");
+                return;
+            }
+        };
+
+        let mut interval = tokio::time::interval(config.check_interval);
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => {
+                    debug!("Shutdown signal received, stopping self-update task");
+                    break;
+                }
+                _ = interval.tick() => {
+                    let active = session_manager.active_count().await;
+                    if let Err(e) = run_check_once(&config, &client, active, &notification_tx).await {
+                        // run_check_once already logs its own warnings; this is a
+                        // defensive backstop so an unexpected error never leaks.
+                        warn!("Self-update check failed: {e}");
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Run a single self-update check cycle.
+///
+/// Resilient by design: unreachable network, GitHub errors, unparsable
+/// versions, unsupported platforms and checksum failures all log a warning and
+/// return `Ok(())` so the caller's timer simply retries next cycle. The last
+/// poll time is always persisted, even when the poll itself failed.
+async fn run_check_once(
+    config: &UpdateConfig,
+    client: &reqwest::Client,
+    active_sessions: u32,
+    notification_tx: &NotificationSender,
+) -> anyhow::Result<()> {
+    // Record the attempt up-front so `last_check_time` reflects reality even if
+    // the network call below fails.
+    let mut state = AgentState::load_from(&config.state_path);
+    state.update.last_check_time = Some(now_rfc3339());
+    state.save_to(&config.state_path);
+
+    let release = match github::fetch_latest_release(client, &config.api_url).await {
+        Ok(release) => release,
+        Err(e) => {
+            // Offline / firewalled / GitHub down — the whole point is to skip
+            // cleanly and try again next cycle.
+            warn!("Self-update: could not reach GitHub, skipping this cycle: {e:#}");
+            return Ok(());
+        }
+    };
+
+    let newer = match version::is_newer(&release.tag_name, &config.current_version) {
+        Ok(newer) => newer,
+        Err(e) => {
+            warn!("Self-update: could not compare versions, skipping: {e:#}");
+            return Ok(());
+        }
+    };
+    if !newer {
+        info!(
+            "Self-update: agent is up to date (running {}, latest {})",
+            config.current_version, release.tag_name
+        );
+        return Ok(());
+    }
+
+    let available_version = version::parse_version(&release.tag_name)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| release.tag_name.clone());
+    info!(
+        "Self-update: newer agent {} available (running {})",
+        available_version, config.current_version
+    );
+
+    // Resolve the download for this platform, if one is published.
+    let asset_urls = config
+        .asset_suffix
+        .as_deref()
+        .and_then(|suffix| release.asset_urls_for(suffix));
+
+    // When idle and we have a downloadable asset, stage a verified binary.
+    let mut staged = false;
+    if active_sessions == 0 {
+        if let (Some(suffix), Some(urls)) = (config.asset_suffix.as_deref(), asset_urls.as_ref()) {
+            let dest = config.staged_binary_path(suffix);
+            match download::download_and_verify(client, urls, &dest).await {
+                Ok(()) => {
+                    state.update.pending_update = Some(PendingUpdate {
+                        version: available_version.clone(),
+                        binary_path: dest.to_string_lossy().into_owned(),
+                        staged_at: now_rfc3339(),
+                    });
+                    state.save_to(&config.state_path);
+                    staged = true;
+                    info!(
+                        "Self-update: staged verified agent {} at {}",
+                        available_version,
+                        dest.display()
+                    );
+                    // Deferred auto-apply on idle depends on SI-6 (#1352), which
+                    // is not implemented yet — stop after staging. A follow-up
+                    // wires the apply step once SI-6 lands.
+                    debug!(
+                        "Self-update: auto-apply deferred (SI-6 / #1352 not implemented); \
+                         binary staged and recorded in state.json"
+                    );
+                }
+                Err(e) => {
+                    warn!("Self-update: download/verify failed, skipping: {e:#}");
+                }
+            }
+        } else {
+            warn!(
+                "Self-update: no published agent binary for this platform ({:?}); \
+                 notifying only",
+                config.asset_suffix
+            );
+        }
+    } else {
+        debug!(
+            "Self-update: {active_sessions} active session(s) — notifying connected hosts \
+             instead of self-applying"
+        );
+    }
+
+    notify_update_available(
+        notification_tx,
+        &config.current_version,
+        &available_version,
+        asset_urls.map(|u| u.binary_url),
+        staged,
+    );
+
+    Ok(())
+}
+
+/// Emit an `agent.update_available` notification to connected desktops.
+///
+/// Best-effort: a closed channel (no client currently attached) is logged at
+/// debug and ignored — the persisted state and the next cycle cover that case.
+fn notify_update_available(
+    notification_tx: &NotificationSender,
+    current_version: &str,
+    available_version: &str,
+    download_url: Option<String>,
+    staged: bool,
+) {
+    let payload = UpdateAvailableNotification {
+        current_version: current_version.to_string(),
+        available_version: available_version.to_string(),
+        download_url,
+        staged,
+    };
+    let params = match serde_json::to_value(&payload) {
+        Ok(params) => params,
+        Err(e) => {
+            warn!("Self-update: failed to serialize update notification: {e}");
+            return;
+        }
+    };
+    let notification = JsonRpcNotification::new(AGENT_UPDATE_AVAILABLE, params);
+    if let Err(e) = notification_tx.send(notification) {
+        debug!("Self-update: no client attached to receive update notification ({e})");
+    }
+}
+
+/// Current UTC time as an RFC 3339 string.
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::messages::JsonRpcNotification;
+    use tokio::sync::mpsc;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const SHA256_OF_ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    fn test_config(api_url: String, state_path: PathBuf, staging_dir: PathBuf) -> UpdateConfig {
+        UpdateConfig {
+            allow_self_update: true,
+            check_interval: DEFAULT_CHECK_INTERVAL,
+            api_url,
+            current_version: "0.2.1".to_string(),
+            asset_suffix: Some("linux-x64".to_string()),
+            staging_dir,
+            state_path,
+            user_agent: "termihub-agent/test".to_string(),
+        }
+    }
+
+    fn try_recv(
+        rx: &mut mpsc::UnboundedReceiver<JsonRpcNotification>,
+    ) -> Option<JsonRpcNotification> {
+        rx.try_recv().ok()
+    }
+
+    #[tokio::test]
+    async fn offline_skips_cleanly_and_records_last_check() {
+        // An unreachable API URL simulates no internet / firewall.
+        let tmp = tempfile::tempdir().unwrap();
+        let state_path = tmp.path().join("state.json");
+        let config = test_config(
+            "http://127.0.0.1:1/repos/x/y/releases/latest".to_string(),
+            state_path.clone(),
+            tmp.path().join("updates"),
+        );
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(500))
+            .build()
+            .unwrap();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // Must not error despite the network being unreachable.
+        run_check_once(&config, &client, 0, &tx).await.unwrap();
+
+        // No notification emitted, but the attempt was recorded.
+        assert!(try_recv(&mut rx).is_none());
+        let state = AgentState::load_from(&state_path);
+        assert!(state.update.last_check_time.is_some());
+        assert!(state.update.pending_update.is_none());
+    }
+
+    #[tokio::test]
+    async fn up_to_date_does_not_notify() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/releases/latest"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(r#"{"tag_name":"v0.2.1","assets":[]}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(
+            format!("{}/releases/latest", server.uri()),
+            tmp.path().join("state.json"),
+            tmp.path().join("updates"),
+        );
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        run_check_once(&config, &reqwest::Client::new(), 0, &tx)
+            .await
+            .unwrap();
+
+        assert!(try_recv(&mut rx).is_none(), "no update → no notification");
+    }
+
+    #[tokio::test]
+    async fn newer_with_active_sessions_notifies_without_staging() {
+        let server = MockServer::start().await;
+        let body = r#"{"tag_name":"v0.3.0","assets":[
+            {"name":"termihub-agent-linux-x64","browser_download_url":"https://example.test/bin"},
+            {"name":"termihub-agent-linux-x64.sha256","browser_download_url":"https://example.test/bin.sha256"}
+        ]}"#;
+        Mock::given(method("GET"))
+            .and(path("/releases/latest"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let state_path = tmp.path().join("state.json");
+        let config = test_config(
+            format!("{}/releases/latest", server.uri()),
+            state_path.clone(),
+            tmp.path().join("updates"),
+        );
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // 2 active sessions → notify only, never download.
+        run_check_once(&config, &reqwest::Client::new(), 2, &tx)
+            .await
+            .unwrap();
+
+        let notif = try_recv(&mut rx).expect("update notification emitted");
+        assert_eq!(notif.method, AGENT_UPDATE_AVAILABLE);
+        assert_eq!(notif.params["availableVersion"], "0.3.0");
+        assert_eq!(notif.params["staged"], false);
+        // Nothing staged with sessions active.
+        let state = AgentState::load_from(&state_path);
+        assert!(state.update.pending_update.is_none());
+    }
+
+    #[tokio::test]
+    async fn newer_when_idle_downloads_verifies_and_stages() {
+        let server = MockServer::start().await;
+        // Release JSON points binary + checksum assets back at this mock server.
+        let body = format!(
+            r#"{{"tag_name":"v0.3.0","assets":[
+                {{"name":"termihub-agent-linux-x64","browser_download_url":"{base}/bin"}},
+                {{"name":"termihub-agent-linux-x64.sha256","browser_download_url":"{base}/bin.sha256"}}
+            ]}}"#,
+            base = server.uri()
+        );
+        Mock::given(method("GET"))
+            .and(path("/releases/latest"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/bin"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"abc".to_vec()))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/bin.sha256"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n")),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let state_path = tmp.path().join("state.json");
+        let staging_dir = tmp.path().join("updates");
+        let config = test_config(
+            format!("{}/releases/latest", server.uri()),
+            state_path.clone(),
+            staging_dir.clone(),
+        );
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // 0 active sessions → download + verify + stage.
+        run_check_once(&config, &reqwest::Client::new(), 0, &tx)
+            .await
+            .unwrap();
+
+        let staged_path = staging_dir.join("termihub-agent-linux-x64");
+        assert_eq!(std::fs::read(&staged_path).unwrap(), b"abc");
+
+        let notif = try_recv(&mut rx).expect("update notification emitted");
+        assert_eq!(notif.params["availableVersion"], "0.3.0");
+        assert_eq!(notif.params["staged"], true);
+
+        let state = AgentState::load_from(&state_path);
+        let pending = state.update.pending_update.expect("pending update recorded");
+        assert_eq!(pending.version, "0.3.0");
+        assert_eq!(pending.binary_path, staged_path.to_string_lossy());
+    }
+
+    #[test]
+    fn spawn_is_noop_when_disabled() {
+        // With the gate off, spawn returns without creating a task or client.
+        // (Smoke test: it must not panic and must not require a runtime.)
+        let tmp = tempfile::tempdir().unwrap();
+        let mut config = test_config(
+            "http://127.0.0.1:1/".to_string(),
+            tmp.path().join("state.json"),
+            tmp.path().join("updates"),
+        );
+        config.allow_self_update = false;
+        // Build the pieces spawn needs without a running check.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let registry = std::sync::Arc::new(crate::registry::build_registry());
+        let session_manager = std::sync::Arc::new(SessionManager::new(tx.clone(), registry));
+        spawn_self_update_task(config, session_manager, tx, CancellationToken::new());
+    }
+}

--- a/agent/src/update/mod.rs
+++ b/agent/src/update/mod.rs
@@ -469,7 +469,10 @@ mod tests {
         assert_eq!(notif.params["staged"], true);
 
         let state = AgentState::load_from(&state_path);
-        let pending = state.update.pending_update.expect("pending update recorded");
+        let pending = state
+            .update
+            .pending_update
+            .expect("pending update recorded");
         assert_eq!(pending.version, "0.3.0");
         assert_eq!(pending.binary_path, staged_path.to_string_lossy());
     }

--- a/agent/src/update/version.rs
+++ b/agent/src/update/version.rs
@@ -12,8 +12,13 @@ use semver::Version;
 ///
 /// A single leading `v`/`V` (as used by GitHub tags like `v0.3.0`) is stripped
 /// before parsing. Surrounding whitespace is ignored.
-pub fn parse_version(_tag: &str) -> Result<Version> {
-    todo!("parse_version not yet implemented")
+pub fn parse_version(tag: &str) -> Result<Version> {
+    let trimmed = tag.trim();
+    let stripped = trimmed
+        .strip_prefix('v')
+        .or_else(|| trimmed.strip_prefix('V'))
+        .unwrap_or(trimmed);
+    Version::parse(stripped).with_context(|| format!("invalid semantic version: {tag:?}"))
 }
 
 /// Return `true` when `candidate` is strictly newer than `current`.
@@ -21,8 +26,10 @@ pub fn parse_version(_tag: &str) -> Result<Version> {
 /// Both inputs are parsed via [`parse_version`]; a parse failure on either side
 /// yields `Ok(false)` semantics only through the caller — this function returns
 /// the raw comparison and surfaces parse errors so the caller can log and skip.
-pub fn is_newer(_candidate: &str, _current: &str) -> Result<bool> {
-    todo!("is_newer not yet implemented")
+pub fn is_newer(candidate: &str, current: &str) -> Result<bool> {
+    let candidate = parse_version(candidate)?;
+    let current = parse_version(current)?;
+    Ok(candidate > current)
 }
 
 #[cfg(test)]

--- a/agent/src/update/version.rs
+++ b/agent/src/update/version.rs
@@ -1,0 +1,83 @@
+//! Semantic-version parsing and comparison for the agent self-update check.
+//!
+//! GitHub release tags follow the `v{semver}` convention (e.g. `v0.3.0`); the
+//! agent's own version comes from `env!("CARGO_PKG_VERSION")`. This module
+//! normalizes both through the maintained [`semver`] crate rather than
+//! hand-rolling version parsing.
+
+use anyhow::{Context, Result};
+use semver::Version;
+
+/// Parse a release tag or version string into a [`Version`].
+///
+/// A single leading `v`/`V` (as used by GitHub tags like `v0.3.0`) is stripped
+/// before parsing. Surrounding whitespace is ignored.
+pub fn parse_version(_tag: &str) -> Result<Version> {
+    todo!("parse_version not yet implemented")
+}
+
+/// Return `true` when `candidate` is strictly newer than `current`.
+///
+/// Both inputs are parsed via [`parse_version`]; a parse failure on either side
+/// yields `Ok(false)` semantics only through the caller — this function returns
+/// the raw comparison and surfaces parse errors so the caller can log and skip.
+pub fn is_newer(_candidate: &str, _current: &str) -> Result<bool> {
+    todo!("is_newer not yet implemented")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_strips_v_prefix() {
+        assert_eq!(parse_version("v0.3.0").unwrap(), Version::new(0, 3, 0));
+        assert_eq!(parse_version("V1.2.3").unwrap(), Version::new(1, 2, 3));
+        assert_eq!(parse_version("0.1.0").unwrap(), Version::new(0, 1, 0));
+    }
+
+    #[test]
+    fn parse_version_trims_whitespace() {
+        assert_eq!(parse_version("  v2.0.1\n").unwrap(), Version::new(2, 0, 1));
+    }
+
+    #[test]
+    fn parse_version_rejects_garbage() {
+        assert!(parse_version("not-a-version").is_err());
+        assert!(parse_version("").is_err());
+        assert!(parse_version("v").is_err());
+    }
+
+    #[test]
+    fn is_newer_true_for_higher_patch_minor_major() {
+        assert!(is_newer("v0.3.1", "v0.3.0").unwrap());
+        assert!(is_newer("v0.4.0", "v0.3.9").unwrap());
+        assert!(is_newer("v1.0.0", "v0.99.99").unwrap());
+    }
+
+    #[test]
+    fn is_newer_false_for_equal_or_older() {
+        assert!(!is_newer("v0.3.0", "v0.3.0").unwrap());
+        assert!(!is_newer("v0.2.9", "v0.3.0").unwrap());
+        assert!(!is_newer("v0.3.0", "v1.0.0").unwrap());
+    }
+
+    #[test]
+    fn is_newer_handles_mixed_prefixes() {
+        // Tag has the `v`, current (CARGO_PKG_VERSION) does not.
+        assert!(is_newer("v0.3.0", "0.2.0").unwrap());
+        assert!(!is_newer("0.2.0", "v0.3.0").unwrap());
+    }
+
+    #[test]
+    fn is_newer_prerelease_is_older_than_release() {
+        // Standard semver: 0.3.0-rc.1 < 0.3.0.
+        assert!(is_newer("v0.3.0", "v0.3.0-rc.1").unwrap());
+        assert!(!is_newer("v0.3.0-rc.1", "v0.3.0").unwrap());
+    }
+
+    #[test]
+    fn is_newer_surfaces_parse_errors() {
+        assert!(is_newer("garbage", "v0.3.0").is_err());
+    }
+}

--- a/docs/changes/dev0/feature/1355-agent-self-update.md
+++ b/docs/changes/dev0/feature/1355-agent-self-update.md
@@ -1,0 +1,18 @@
+### Added
+
+- Remote agents can now optionally check GitHub for a newer agent build and keep
+  themselves current in the background. When the connection's **Allow agent
+  self-update** setting is on (#1354; off by default), the deployed agent runs a
+  24-hour timer that polls the GitHub `releases/latest` API, compares the
+  published version against its own, and — when a newer release exists — notifies
+  connected desktops via an `agent.update_available` message (surfaced as the
+  self-update toast). When no sessions are active it also downloads the new
+  binary, verifies it against its published SHA-256 checksum (fail-closed, same
+  rule as desktop deploys in #1350), and stages it, recording the pending update
+  in the agent's `state.json`. The whole feature is gated behind the setting: with
+  it off nothing is spawned and the agent makes no outbound requests. Any failure
+  (no internet, GitHub error, bad checksum) logs a warning and skips the cycle —
+  the agent never crashes because of a self-update check. Automatic apply-on-idle
+  of a staged update is deferred until the coordinated deferred-apply mechanism
+  lands (#1352); for now the agent stops after staging (part of the remote-agent
+  update-strategy epic, #1345; #1355).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -828,6 +828,40 @@ through save/load. See PR #1388.
    the update still succeeds via the immediate path, and the app log records a
    warning that the coordinated/deferred strategy is not yet honored (#1351/#1352).
 
+### Agent GitHub self-update (opt-in, #1355)
+
+Verifies the optional agent-side self-update check is gated behind
+`allow_self_update`, notifies on a newer release, verifies checksums, and skips
+cleanly offline. Requires a Linux remote host (agent binaries are Linux-only).
+See PR #1389.
+
+1. **Off by default (no network).** Deploy an agent to a Linux host with **Allow
+   agent self-update** left **off**. Confirm the SSH exec command is
+   `…/termihub-agent --stdio` (no `--allow-self-update`) — e.g. inspect the app
+   log or run `agent_exec_command`. On the host, confirm the agent makes no
+   outbound request to `api.github.com` (e.g. `ss -tnp | grep termihub-agent`
+   shows no GitHub connection).
+2. **Opt in.** Edit the agent, turn **Allow agent self-update** on in **Agent →
+   Updates**, save, and reconnect. Confirm the exec command now ends with
+   `--stdio --allow-self-update` and the agent log records
+   `Agent self-update enabled — checking GitHub … every 24h`.
+3. **Newer release notifies.** With self-update on and the host's agent an older
+   version than the latest published release, wait for (or force) a check. Confirm
+   the desktop receives an `agent.update_available` notification (self-update
+   toast) naming the available version.
+4. **Verified staging when idle.** With no active sessions on that agent, confirm
+   the agent downloads the new binary, verifies its `.sha256`, and records a
+   `pending_update` in the host's `state.json`
+   (`~/.config/termihub-agent/state.json`). A binary whose checksum does not
+   match must be rejected and removed (not staged).
+5. **Offline is graceful.** Block the host's outbound access to `api.github.com`
+   (firewall) with self-update on. Confirm the agent logs a warning
+   (`could not reach GitHub, skipping this cycle`) and keeps serving sessions —
+   it must not crash. `last_check_time` in `state.json` still updates.
+
+> Note: automatic apply-on-idle of a staged update is deferred to #1352; this PR
+> stops after staging and notifying.
+
 ### Guided-Manual Tests in the Python Harness (preferred)
 
 Guided-manual tests are **first-class `pytest` tests** in the Python system-test harness (`tests/system/`). Each one does all the automatable setup through the existing mixins — launch the app, build connections/state — and then prompts the operator for only the irreducibly-manual step (a native OS dialog, xterm-canvas color fidelity, cursor blink). This is the key difference from the legacy YAML runner: the operator does just the un-automatable bit, and the test shares the harness's app/agent orchestration, fixtures, and reporting.

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -142,15 +142,22 @@ impl RemoteAgentConfig {
     /// [`windows_agent_command`]).
     pub fn agent_exec_command(&self) -> String {
         let path = self.agent_path();
+        // Opt the agent into its background GitHub self-update check only when
+        // the connection enables it (#1355); off by default.
+        let args = if self.allow_self_update {
+            "--stdio --allow-self-update"
+        } else {
+            "--stdio"
+        };
         if crate::terminal::agent_install::is_windows_path(path) {
-            return windows_agent_command(path, "--stdio");
+            return windows_agent_command(path, args);
         }
         let resolved = if let Some(rest) = path.strip_prefix("~/") {
             format!("$HOME/{rest}")
         } else {
             path.to_string()
         };
-        format!("{resolved} --stdio")
+        format!("{resolved} {args}")
     }
 
     /// Build the shell command to check the agent version on a remote host.
@@ -491,6 +498,31 @@ mod tests {
             config.agent_exec_command(),
             "$HOME/.local/bin/termihub-agent --stdio"
         );
+    }
+
+    #[test]
+    fn agent_exec_command_appends_self_update_flag_when_enabled() {
+        let config = RemoteAgentConfig {
+            host: "pi.local".to_string(),
+            username: "pi".to_string(),
+            allow_self_update: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.agent_exec_command(),
+            "$HOME/.local/bin/termihub-agent --stdio --allow-self-update"
+        );
+    }
+
+    #[test]
+    fn agent_exec_command_omits_self_update_flag_by_default() {
+        let config = RemoteAgentConfig {
+            host: "pi.local".to_string(),
+            username: "pi".to_string(),
+            ..Default::default()
+        };
+        // Default is off — no self-update flag on the command line.
+        assert!(!config.agent_exec_command().contains("--allow-self-update"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an **optional, off-by-default** agent-side GitHub self-update check (Approach 1 of the remote-agent update-strategy epic, #1345). Builds on the SHA-256 verified-download rule (#1350) and the `allow_self_update` / `update_strategy` connection settings (#1354).

When a connection has **Allow agent self-update** enabled, the deployed agent runs a background **24-hour timer** that:

1. Polls the GitHub `releases/latest` API (`reqwest`, rustls-tls so musl cross-compiles stay OpenSSL-free).
2. Semver-compares the published tag against its own `CARGO_PKG_VERSION` (`semver` crate).
3. On a newer release, emits an `agent.update_available` JSON-RPC notification (new protocol type) that drives the desktop self-update toast.
4. When **no sessions are active**, downloads the new binary, verifies it against its published `.sha256` sidecar (fail-closed, mirroring #1350), and **stages** it — recording `update.pending_update` + `last_check_time` in `state.json`.

The whole feature is gated behind `allow_self_update`: with it off, **no background task is spawned and there is zero outbound network activity**. Every failure path (offline, GitHub error, unparsable version, checksum mismatch) logs a warning and skips the cycle — the agent never crashes because of a self-update check.

Gate is completed end-to-end: the desktop appends `--allow-self-update` to the agent's SSH exec command only when the connection enables it (agent also honors `TERMIHUB_AGENT_ALLOW_SELF_UPDATE`).

## Deferred (follow-up)

Per the partial boundary, **auto-apply on idle is NOT included** — it depends on the deferred-apply / exec-replace mechanism from **SI-6 (#1352)**, which is not yet built. Until then the agent stops after staging + notifying. Wiring the apply step once #1352 lands is tracked in **#1401**.

This PR references #1355 but does **not** close it (auto-apply remains).

## Commits (TDD)

- `test(agent):` failing unit tests for semver comparison (red), then feat commits split by area: version+GitHub poll, SHA-256 verified download, `agent.update_available` protocol + persisted state, 24h timer wiring, desktop exec flag.

## Test plan

- **Automated:** 285 agent unit tests + desktop `agent_exec_command` tests pass. New coverage: semver (prefix/prerelease/ordering), release-JSON parsing, arch→asset mapping, SHA-256 verified download against a mock HTTP server (`wiremock`) incl. mismatch/missing-checksum fail-closed, offline graceful-skip, up-to-date no-op, newer-with-sessions notifies-without-staging, newer-when-idle downloads+verifies+stages, `state.json` back-compat, exec-flag on/off. `./scripts/check.sh` green.
- **Manual:** see `docs/testing.md` → "Agent GitHub self-update (opt-in, #1355)" — off-by-default (no network), opt-in exec flag, newer-release toast, verified staging + `pending_update`, offline graceful-skip. Requires a Linux host (agent binaries are Linux-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)