### PR TITLE
feat(agent): agent version chip + update-state badge in sidebar & Open Connections (Closes #1347)

### DIFF
--- a/docs/changes/dev0/feature/1347-agent-version-badge.md
+++ b/docs/changes/dev0/feature/1347-agent-version-badge.md
@@ -1,0 +1,12 @@
+### Added
+
+- Remote agents now surface their **version and update state** across the UI
+  (#1347). Each agent shows a monospace version chip (e.g. `v0.1.0`) plus an
+  update-state badge — up-to-date, update available, incompatible, or updating —
+  in the connections sidebar header and (with a text label) in the Open
+  Connections panel. The status bar gains a connected-agents summary showing
+  `N agents` and `· M updates available` when any connected agent's version is
+  older than the desktop's; clicking it opens the Connections sidebar. The state
+  is derived from the agent's reported version against the desktop version using
+  the same major/minor compatibility rule as agent deployment. This is
+  visibility only — no update is triggered yet.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -901,6 +901,35 @@ See PR #1389.
 > Note: automatic apply-on-idle of a staged update is deferred to #1352; this PR
 > stops after staging and notifying.
 
+### Agent version + update-state badge — light/dark colors (#1347)
+
+Verifies the agent version chip and update-state badge render with the correct,
+legible colors in both themes, across all four states. See PR for #1347. Badge
+colors: up-to-date = success/green, update available = notice/amber,
+incompatible = error/red, updating = accent/blue.
+
+1. Connect a remote agent whose version matches the desktop. In the Connections
+   sidebar, confirm the agent header shows a neutral monospace version chip
+   (e.g. `v0.1.0`) followed by a green check badge (**up to date**). Hover the
+   badge — the tooltip reads "Agent up to date (v…)".
+2. Toggle the app between light and dark themes (Settings → Appearance). In both
+   themes confirm the chip text stays legible against its neutral background and
+   the green badge is clearly readable (not washed out).
+3. Open **Open Connections** (Settings wheel → Open Connections). Confirm the
+   agent row shows the same version chip plus a **labelled** state badge
+   (e.g. "Up to date"). Verify legibility in both themes.
+4. Simulate the other states (e.g. point the agent at an older/newer/mismatched
+   binary, or temporarily adjust the compared versions): confirm an **amber**
+   up-arrow badge for _update available_, a **red** warning badge for
+   _incompatible_ (major mismatch or unparseable version), and — for the
+   transient _updating_ state — a **blue** spinner that respects
+   `prefers-reduced-motion` (no spin when reduced motion is enabled). Each must
+   remain legible in light and dark.
+5. In the status bar, with at least one agent connected, confirm the
+   `N agents` summary appears; when an agent has an update available, confirm the
+   amber `· M updates available` count shows and clicking the item opens the
+   Connections sidebar.
+
 ### Guided-Manual Tests in the Python Harness (preferred)
 
 Guided-manual tests are **first-class `pytest` tests** in the Python system-test harness (`tests/system/`). Each one does all the automatable setup through the existing mixins — launch the app, build connections/state — and then prompts the operator for only the irreducibly-manual step (a native OS dialog, xterm-canvas color fidelity, cursor blink). This is the key difference from the legacy YAML runner: the operator does just the un-automatable bit, and the test shares the harness's app/agent orchestration, fixtures, and reporting.

--- a/src/components/AgentVersionBadge/AgentVersionBadge.css
+++ b/src/components/AgentVersionBadge/AgentVersionBadge.css
@@ -1,0 +1,83 @@
+.agent-version-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+}
+
+/* Version chip — neutral, monospace, subtle. Resets the sidebar header's
+   uppercase/letter-spacing so the version reads as-is (v0.1.0). */
+.agent-version-badge__chip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: normal;
+  text-transform: none;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+}
+
+/* Update-state badge — icon (+ optional label). */
+.agent-version-badge__state {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  line-height: 1;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: normal;
+  text-transform: none;
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+}
+
+.agent-version-badge__icon {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
+.agent-version-badge__state--up-to-date {
+  color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 18%, transparent);
+}
+
+.agent-version-badge__state--update-available {
+  color: var(--color-notice);
+  background: color-mix(in srgb, var(--color-notice) 18%, transparent);
+}
+
+.agent-version-badge__state--incompatible {
+  color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 18%, transparent);
+}
+
+.agent-version-badge__state--updating {
+  color: var(--accent-color);
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+}
+
+.agent-version-badge__state--updating .agent-version-badge__icon {
+  animation: agent-version-badge-spin 0.8s linear infinite;
+}
+
+@keyframes agent-version-badge-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-version-badge__state--updating .agent-version-badge__icon {
+    animation: none;
+  }
+}
+
+.agent-version-badge__label {
+  white-space: nowrap;
+}

--- a/src/components/AgentVersionBadge/AgentVersionBadge.test.tsx
+++ b/src/components/AgentVersionBadge/AgentVersionBadge.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AgentVersionBadge } from "./AgentVersionBadge";
+
+describe("AgentVersionBadge", () => {
+  it("renders the version chip prefixed with v", () => {
+    render(<AgentVersionBadge version="0.1.0" state="up-to-date" />);
+    expect(screen.getByText("v0.1.0")).toBeInTheDocument();
+  });
+
+  it("applies the state modifier class for each state", () => {
+    const { rerender, container } = render(
+      <AgentVersionBadge version="0.1.0" state="up-to-date" />
+    );
+    expect(container.querySelector(".agent-version-badge__state--up-to-date")).toBeTruthy();
+
+    rerender(<AgentVersionBadge version="0.1.0" state="update-available" />);
+    expect(container.querySelector(".agent-version-badge__state--update-available")).toBeTruthy();
+
+    rerender(<AgentVersionBadge version="1.0.0" state="incompatible" />);
+    expect(container.querySelector(".agent-version-badge__state--incompatible")).toBeTruthy();
+
+    rerender(<AgentVersionBadge version="0.1.0" state="updating" />);
+    expect(container.querySelector(".agent-version-badge__state--updating")).toBeTruthy();
+  });
+
+  it("exposes an accessible label describing the update state", () => {
+    render(<AgentVersionBadge version="0.1.0" state="update-available" />);
+    expect(screen.getByLabelText(/update available/i)).toBeInTheDocument();
+  });
+
+  it("renders a text label when showLabel is set", () => {
+    render(<AgentVersionBadge version="0.1.0" state="update-available" showLabel />);
+    expect(screen.getByText(/update available/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing when the state is unknown", () => {
+    const { container } = render(<AgentVersionBadge version="" state="unknown" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when no version is supplied", () => {
+    const { container } = render(<AgentVersionBadge state="up-to-date" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("forwards a data-testid to the root", () => {
+    render(
+      <AgentVersionBadge version="0.1.0" state="up-to-date" data-testid="agent-version-badge-x" />
+    );
+    expect(screen.getByTestId("agent-version-badge-x")).toBeInTheDocument();
+  });
+});

--- a/src/components/AgentVersionBadge/AgentVersionBadge.test.tsx
+++ b/src/components/AgentVersionBadge/AgentVersionBadge.test.tsx
@@ -1,53 +1,71 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
 import { AgentVersionBadge } from "./AgentVersionBadge";
 
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
 describe("AgentVersionBadge", () => {
-  it("renders the version chip prefixed with v", () => {
-    render(<AgentVersionBadge version="0.1.0" state="up-to-date" />);
-    expect(screen.getByText("v0.1.0")).toBeInTheDocument();
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
   });
 
-  it("applies the state modifier class for each state", () => {
-    const { rerender, container } = render(
-      <AgentVersionBadge version="0.1.0" state="up-to-date" />
-    );
-    expect(container.querySelector(".agent-version-badge__state--up-to-date")).toBeTruthy();
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
 
-    rerender(<AgentVersionBadge version="0.1.0" state="update-available" />);
-    expect(container.querySelector(".agent-version-badge__state--update-available")).toBeTruthy();
+  it("renders the version chip prefixed with v", () => {
+    render(<AgentVersionBadge version="0.1.0" state="up-to-date" />);
+    const chip = container.querySelector(".agent-version-badge__chip");
+    expect(chip?.textContent).toBe("v0.1.0");
+  });
 
-    rerender(<AgentVersionBadge version="1.0.0" state="incompatible" />);
-    expect(container.querySelector(".agent-version-badge__state--incompatible")).toBeTruthy();
-
-    rerender(<AgentVersionBadge version="0.1.0" state="updating" />);
-    expect(container.querySelector(".agent-version-badge__state--updating")).toBeTruthy();
+  it.each([
+    ["up-to-date", "agent-version-badge__state--up-to-date"],
+    ["update-available", "agent-version-badge__state--update-available"],
+    ["incompatible", "agent-version-badge__state--incompatible"],
+    ["updating", "agent-version-badge__state--updating"],
+  ] as const)("applies the %s state modifier class", (state, expectedClass) => {
+    render(<AgentVersionBadge version="0.1.0" state={state} />);
+    expect(container.querySelector(`.${expectedClass}`)).toBeTruthy();
   });
 
   it("exposes an accessible label describing the update state", () => {
     render(<AgentVersionBadge version="0.1.0" state="update-available" />);
-    expect(screen.getByLabelText(/update available/i)).toBeInTheDocument();
+    const badge = container.querySelector(".agent-version-badge__state");
+    expect(badge?.getAttribute("aria-label")).toMatch(/update available/i);
   });
 
   it("renders a text label when showLabel is set", () => {
     render(<AgentVersionBadge version="0.1.0" state="update-available" showLabel />);
-    expect(screen.getByText(/update available/i)).toBeInTheDocument();
+    const label = container.querySelector(".agent-version-badge__label");
+    expect(label?.textContent).toMatch(/update available/i);
   });
 
   it("renders nothing when the state is unknown", () => {
-    const { container } = render(<AgentVersionBadge version="" state="unknown" />);
-    expect(container.firstChild).toBeNull();
+    render(<AgentVersionBadge version="" state="unknown" />);
+    expect(container.querySelector(".agent-version-badge")).toBeNull();
   });
 
   it("renders nothing when no version is supplied", () => {
-    const { container } = render(<AgentVersionBadge state="up-to-date" />);
-    expect(container.firstChild).toBeNull();
+    render(<AgentVersionBadge state="up-to-date" />);
+    expect(container.querySelector(".agent-version-badge")).toBeNull();
   });
 
   it("forwards a data-testid to the root", () => {
     render(
       <AgentVersionBadge version="0.1.0" state="up-to-date" data-testid="agent-version-badge-x" />
     );
-    expect(screen.getByTestId("agent-version-badge-x")).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="agent-version-badge-x"]')).toBeTruthy();
   });
 });

--- a/src/components/AgentVersionBadge/AgentVersionBadge.tsx
+++ b/src/components/AgentVersionBadge/AgentVersionBadge.tsx
@@ -1,0 +1,82 @@
+import { CheckCircle2, ArrowUpCircle, AlertTriangle, Loader2 } from "lucide-react";
+import type { AgentUpdateState } from "@/utils/agentVersion";
+import "./AgentVersionBadge.css";
+
+/** Per-state icon, short label, and accessible description (version interpolated). */
+const STATE_META: Record<
+  Exclude<AgentUpdateState, "unknown">,
+  {
+    Icon: typeof CheckCircle2;
+    label: string;
+    describe: (version: string) => string;
+  }
+> = {
+  "up-to-date": {
+    Icon: CheckCircle2,
+    label: "Up to date",
+    describe: (v) => `Agent up to date (v${v})`,
+  },
+  "update-available": {
+    Icon: ArrowUpCircle,
+    label: "Update available",
+    describe: (v) => `Update available — agent v${v}, a newer version can be deployed`,
+  },
+  incompatible: {
+    Icon: AlertTriangle,
+    label: "Incompatible",
+    describe: (v) => `Incompatible agent version (v${v}) — reinstall required`,
+  },
+  updating: {
+    Icon: Loader2,
+    label: "Updating…",
+    describe: () => "Updating agent…",
+  },
+};
+
+/** Props for {@link AgentVersionBadge}. */
+export interface AgentVersionBadgeProps {
+  /** Agent binary version string, e.g. `0.1.0`. */
+  version?: string;
+  /** Derived update state controlling the badge icon/colour. */
+  state: AgentUpdateState;
+  /** Render the state word next to the icon (used where horizontal room exists). */
+  showLabel?: boolean;
+  "data-testid"?: string;
+}
+
+/**
+ * Compact version chip + update-state badge for a remote agent.
+ *
+ * Shown in the sidebar agent header, the Open Connections modal, and (in
+ * summary form) the status bar. Renders nothing when the version is unknown
+ * (agent disconnected / no version reported), so callers can mount it
+ * unconditionally.
+ */
+export function AgentVersionBadge({
+  version,
+  state,
+  showLabel = false,
+  "data-testid": testId,
+}: AgentVersionBadgeProps) {
+  if (state === "unknown" || !version) return null;
+
+  const meta = STATE_META[state];
+  const description = meta.describe(version);
+
+  return (
+    <span className="agent-version-badge" data-testid={testId}>
+      <span className="agent-version-badge__chip" title={`Agent binary version v${version}`}>
+        v{version}
+      </span>
+      <span
+        className={`agent-version-badge__state agent-version-badge__state--${state}`}
+        role="status"
+        aria-label={description}
+        title={description}
+      >
+        <meta.Icon className="agent-version-badge__icon" aria-hidden="true" />
+        {showLabel && <span className="agent-version-badge__label">{meta.label}</span>}
+      </span>
+    </span>
+  );
+}

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -631,11 +631,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                 meta={
                   <AgentVersionBadge
                     version={a.capabilities?.agentVersion}
-                    state={
-                      desktopVersion
-                        ? resolveAgentUpdateState(a.capabilities?.agentVersion, desktopVersion)
-                        : "unknown"
-                    }
+                    state={resolveAgentUpdateState(a.capabilities?.agentVersion, desktopVersion)}
                     showLabel
                     data-testid={`oc-agent-version-${a.id}`}
                   />

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -49,6 +49,9 @@ import {
 } from "@/services/networkApi";
 import { frontendLog } from "@/utils/frontendLog";
 import { XServerStatusReport } from "@/types/xserver";
+import { resolveAgentUpdateState } from "@/utils/agentVersion";
+import { useDesktopVersion } from "@/hooks/useDesktopVersion";
+import { AgentVersionBadge } from "@/components/AgentVersionBadge/AgentVersionBadge";
 import { XServerSetupDialog } from "./XServerSetupDialog";
 import "./OpenConnectionsModal.css";
 
@@ -71,6 +74,7 @@ interface ProxySessionsState {
  */
 export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModalProps) {
   const remoteAgents = useAppStore((s) => s.remoteAgents);
+  const desktopVersion = useDesktopVersion();
   const disconnectRemoteAgent = useAppStore((s) => s.disconnectRemoteAgent);
   const shutdownRemoteAgent = useAppStore((s) => s.shutdownRemoteAgent);
   const stopTunnel = useAppStore((s) => s.stopTunnel);
@@ -624,6 +628,18 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                 icon={<Server size={14} />}
                 title={a.name}
                 badge="connected"
+                meta={
+                  <AgentVersionBadge
+                    version={a.capabilities?.agentVersion}
+                    state={
+                      desktopVersion
+                        ? resolveAgentUpdateState(a.capabilities?.agentVersion, desktopVersion)
+                        : "unknown"
+                    }
+                    showLabel
+                    data-testid={`oc-agent-version-${a.id}`}
+                  />
+                }
                 actions={
                   // Two distinct teardown intents mirroring the agent header
                   // (G9, #1237/#1277). Disconnect detaches the transport but keeps
@@ -1095,6 +1111,8 @@ interface ConnectionRowProps {
   /** Secondary line of context (e.g. the X display number). */
   detail?: string;
   badge: BadgeVariant;
+  /** Extra info rendered between the title and the status badge (e.g. agent version). */
+  meta?: React.ReactNode;
   /** When omitted, no per-row kill button is rendered. */
   onKill?: () => void | Promise<void>;
   /** Label for the kill button (defaults to "Kill"). */
@@ -1115,6 +1133,7 @@ function ConnectionRow({
   title,
   detail,
   badge,
+  meta,
   onKill,
   killLabel = "Kill",
   "data-testid": testId,
@@ -1128,6 +1147,7 @@ function ConnectionRow({
         {title}
         {detail && <span className="oc-row__detail">{detail}</span>}
       </span>
+      {meta}
       <span className={`oc-row__badge oc-row__badge--${badge}`}>{badge}</span>
       {actions ??
         (onKill && (

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -582,10 +582,9 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
   // loading, the badge stays hidden ("unknown") rather than flashing incompatible.
   const desktopVersion = useDesktopVersion();
   const agentVersion = agent.capabilities?.agentVersion;
-  const agentUpdateState =
-    isConnected && desktopVersion
-      ? resolveAgentUpdateState(agentVersion, desktopVersion)
-      : "unknown";
+  const agentUpdateState = isConnected
+    ? resolveAgentUpdateState(agentVersion, desktopVersion)
+    : "unknown";
 
   // Derived: root-level folders and definitions (no parent/folder)
   const rootFolders = useMemo(

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -50,6 +50,9 @@ import {
   cancelConnectAgent,
 } from "@/services/api";
 import { classifyAgentError, ClassifiedAgentError } from "@/utils/classifyAgentError";
+import { resolveAgentUpdateState } from "@/utils/agentVersion";
+import { useDesktopVersion } from "@/hooks/useDesktopVersion";
+import { AgentVersionBadge } from "@/components/AgentVersionBadge/AgentVersionBadge";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
 import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
@@ -573,6 +576,17 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
   const isDisconnected = agent.connectionState === "disconnected";
   const Chevron = agent.isExpanded ? ChevronDown : ChevronRight;
 
+  // Agent version + derived update state (visible only; no update triggering yet, #1347).
+  // The desktop version is the expected version the agent is checked against,
+  // mirroring the Rust `check_version` rule. While the desktop version is still
+  // loading, the badge stays hidden ("unknown") rather than flashing incompatible.
+  const desktopVersion = useDesktopVersion();
+  const agentVersion = agent.capabilities?.agentVersion;
+  const agentUpdateState =
+    isConnected && desktopVersion
+      ? resolveAgentUpdateState(agentVersion, desktopVersion)
+      : "unknown";
+
   // Derived: root-level folders and definitions (no parent/folder)
   const rootFolders = useMemo(
     () => agentFolders.filter((f) => f.parentId === null || f.parentId === undefined),
@@ -900,6 +914,11 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
               />
               <Server size={14} />
               <span className="connection-list__group-title">{agent.name}</span>
+              <AgentVersionBadge
+                version={agentVersion}
+                state={agentUpdateState}
+                data-testid={`agent-version-badge-${agent.id}`}
+              />
             </button>
             {isConnected && (
               <div className="connection-list__group-actions">

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -80,6 +80,8 @@
 }
 
 .connection-list__group-title {
+  flex: 0 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -52,7 +52,7 @@
   color: var(--text-primary);
 }
 
-/* Update-available count next to the connected-agents indicator (#1347). */
+/* Update-available count next to the connected-agents indicator (issue 1347). */
 .status-bar__agent-updates {
   display: inline-flex;
   align-items: center;

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -52,6 +52,15 @@
   color: var(--text-primary);
 }
 
+/* Update-available count next to the connected-agents indicator (#1347). */
+.status-bar__agent-updates {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: var(--spacing-xs);
+  color: var(--color-notice);
+}
+
 /* Indent selection dropdown */
 .indent-menu__content {
   min-width: 160px;

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -13,9 +13,12 @@ import {
   Play,
   X,
   Check,
+  ArrowUpCircle,
 } from "lucide-react";
 import { useAppStore, getActiveTab, monitorKeyForTab, selectMonitor } from "@/store/appStore";
 import { frontendLog } from "@/utils/frontendLog";
+import { useDesktopVersion } from "@/hooks/useDesktopVersion";
+import { summarizeAgentUpdates } from "@/utils/agentVersion";
 import { jumpHostStatusLabel } from "@/utils/jumpHost";
 import type { ConnectionTypeInfo } from "@/services/api";
 import {
@@ -102,6 +105,7 @@ export function StatusBar() {
         <JumpHostStatus />
         <MonitoringStatus />
         <ServicesIndicator />
+        <AgentUpdatesIndicator />
         <TransfersIndicator />
         <CredentialStoreIndicator />
       </div>
@@ -238,6 +242,47 @@ function ServicesIndicator() {
       >
         <Server size={12} />
         {runningCount}
+      </button>
+    </Tooltip>
+  );
+}
+
+/**
+ * Connected-agent summary in the status bar (#1347). Shows `N agents` and, when
+ * any connected agent's version is older than the desktop's, `· M updates
+ * available`. Clicking opens the Connections sidebar. Renders nothing when no
+ * agent is connected.
+ */
+function AgentUpdatesIndicator() {
+  const remoteAgents = useAppStore((s) => s.remoteAgents);
+  const setSidebarView = useAppStore((s) => s.setSidebarView);
+  const desktopVersion = useDesktopVersion();
+
+  const { connectedCount, updatesAvailable } = summarizeAgentUpdates(remoteAgents, desktopVersion);
+  if (connectedCount === 0) return null;
+
+  const agentLabel = `${connectedCount} agent${connectedCount !== 1 ? "s" : ""}`;
+  const summary =
+    updatesAvailable > 0
+      ? `${agentLabel} · ${updatesAvailable} update${updatesAvailable !== 1 ? "s" : ""} available — click to open Connections`
+      : `${agentLabel} connected — click to open Connections`;
+
+  return (
+    <Tooltip content={summary} side="top">
+      <button
+        className="status-bar__item status-bar__item--interactive"
+        aria-label={summary}
+        data-testid="agent-updates-indicator"
+        onClick={() => setSidebarView("connections")}
+      >
+        <Server size={12} />
+        {connectedCount}
+        {updatesAvailable > 0 && (
+          <span className="status-bar__agent-updates" data-testid="agent-updates-count">
+            <ArrowUpCircle size={11} />
+            {updatesAvailable}
+          </span>
+        )}
       </button>
     </Tooltip>
   );

--- a/src/hooks/useDesktopVersion.ts
+++ b/src/hooks/useDesktopVersion.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { getAppInfo } from "@/services/api";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * Module-level cache so the desktop version is fetched at most once per session
+ * and shared across every consumer (agent badges, status-bar summary).
+ */
+let cachedVersion: string | null = null;
+let inflight: Promise<string> | null = null;
+
+/**
+ * Return the running desktop app version (e.g. `0.1.0`), or `null` until the
+ * one-time {@link getAppInfo} fetch resolves. Used to derive each agent's
+ * update state against the version the desktop expects.
+ */
+export function useDesktopVersion(): string | null {
+  const [version, setVersion] = useState<string | null>(cachedVersion);
+
+  useEffect(() => {
+    if (cachedVersion !== null) {
+      setVersion(cachedVersion);
+      return;
+    }
+    let active = true;
+    // Wrapped in try/catch so a failed or unavailable IPC degrades to a hidden
+    // badge (version stays null / "unknown") instead of crashing the tree.
+    const load = async () => {
+      try {
+        if (!inflight) {
+          inflight = getAppInfo().then((info) => {
+            cachedVersion = info.version;
+            return info.version;
+          });
+        }
+        const v = await inflight;
+        if (active) setVersion(v);
+      } catch (err) {
+        inflight = null;
+        frontendLog("use_desktop_version", `Failed to fetch app info: ${err}`);
+      }
+    };
+    void load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return version;
+}

--- a/src/utils/agentVersion.test.ts
+++ b/src/utils/agentVersion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseAgentSemver, resolveAgentUpdateState } from "./agentVersion";
+import { parseAgentSemver, resolveAgentUpdateState, summarizeAgentUpdates } from "./agentVersion";
 
 describe("parseAgentSemver", () => {
   it("parses a plain major.minor.patch version", () => {
@@ -60,5 +60,45 @@ describe("resolveAgentUpdateState", () => {
   it("returns unknown when no agent version is known", () => {
     expect(resolveAgentUpdateState("", "0.1.0")).toBe("unknown");
     expect(resolveAgentUpdateState(undefined, "0.1.0")).toBe("unknown");
+  });
+});
+
+describe("summarizeAgentUpdates", () => {
+  const agent = (connectionState: string, agentVersion?: string) => ({
+    connectionState,
+    capabilities: agentVersion ? { agentVersion } : undefined,
+  });
+
+  it("counts only connected agents", () => {
+    const summary = summarizeAgentUpdates(
+      [
+        agent("connected", "0.1.0"),
+        agent("connecting", "0.1.0"),
+        agent("disconnected"),
+        agent("connected", "0.1.0"),
+      ],
+      "0.1.0"
+    );
+    expect(summary.connectedCount).toBe(2);
+  });
+
+  it("counts connected agents that have an update available", () => {
+    const summary = summarizeAgentUpdates(
+      [
+        agent("connected", "0.1.0"), // update-available vs 0.2.0
+        agent("connected", "0.2.0"), // up-to-date
+        agent("connected", "1.0.0"), // incompatible (not counted as update)
+        agent("connecting", "0.1.0"), // not connected
+      ],
+      "0.2.0"
+    );
+    expect(summary.connectedCount).toBe(3);
+    expect(summary.updatesAvailable).toBe(1);
+  });
+
+  it("reports zero updates while the desktop version is unknown", () => {
+    const summary = summarizeAgentUpdates([agent("connected", "0.1.0")], null);
+    expect(summary.connectedCount).toBe(1);
+    expect(summary.updatesAvailable).toBe(0);
   });
 });

--- a/src/utils/agentVersion.test.ts
+++ b/src/utils/agentVersion.test.ts
@@ -61,6 +61,13 @@ describe("resolveAgentUpdateState", () => {
     expect(resolveAgentUpdateState("", "0.1.0")).toBe("unknown");
     expect(resolveAgentUpdateState(undefined, "0.1.0")).toBe("unknown");
   });
+
+  it("returns unknown while the desktop version is not yet loaded", () => {
+    // Avoids flashing "incompatible" during the async app-info fetch.
+    expect(resolveAgentUpdateState("0.1.0", "")).toBe("unknown");
+    expect(resolveAgentUpdateState("0.1.0", undefined)).toBe("unknown");
+    expect(resolveAgentUpdateState("0.1.0", null)).toBe("unknown");
+  });
 });
 
 describe("summarizeAgentUpdates", () => {

--- a/src/utils/agentVersion.test.ts
+++ b/src/utils/agentVersion.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { parseAgentSemver, resolveAgentUpdateState } from "./agentVersion";
+
+describe("parseAgentSemver", () => {
+  it("parses a plain major.minor.patch version", () => {
+    expect(parseAgentSemver("0.1.0")).toEqual({ major: 0, minor: 1, patch: 0 });
+    expect(parseAgentSemver("2.15.3")).toEqual({ major: 2, minor: 15, patch: 3 });
+  });
+
+  it("strips a -prerelease or +build suffix (dev builds)", () => {
+    expect(parseAgentSemver("0.1.0-dev")).toEqual({ major: 0, minor: 1, patch: 0 });
+    expect(parseAgentSemver("1.2.3+abc123")).toEqual({ major: 1, minor: 2, patch: 3 });
+  });
+
+  it("returns null for unparseable versions", () => {
+    expect(parseAgentSemver("invalid")).toBeNull();
+    expect(parseAgentSemver("1.0")).toBeNull();
+    expect(parseAgentSemver("1.0.0.0")).toBeNull();
+    expect(parseAgentSemver("")).toBeNull();
+    expect(parseAgentSemver("v1.0.0")).toBeNull();
+  });
+});
+
+describe("resolveAgentUpdateState", () => {
+  // ── up-to-date (Compatible) ─────────────────────────────────────────
+  it("returns up-to-date for an exact match", () => {
+    expect(resolveAgentUpdateState("0.1.0", "0.1.0")).toBe("up-to-date");
+  });
+
+  it("returns up-to-date when the agent minor is newer", () => {
+    expect(resolveAgentUpdateState("0.2.0", "0.1.0")).toBe("up-to-date");
+    expect(resolveAgentUpdateState("0.5.0", "0.1.0")).toBe("up-to-date");
+  });
+
+  it("ignores the patch version (up-to-date)", () => {
+    expect(resolveAgentUpdateState("0.1.5", "0.1.0")).toBe("up-to-date");
+  });
+
+  it("treats a -dev suffix as its base version (up-to-date)", () => {
+    expect(resolveAgentUpdateState("0.1.0", "0.1.0-dev")).toBe("up-to-date");
+    expect(resolveAgentUpdateState("0.1.0-dev", "0.1.0")).toBe("up-to-date");
+  });
+
+  // ── update-available (AgentTooOld) ──────────────────────────────────
+  it("returns update-available when the agent minor is older", () => {
+    expect(resolveAgentUpdateState("0.1.0", "0.2.0")).toBe("update-available");
+  });
+
+  // ── incompatible (MajorMismatch / InvalidVersion) ───────────────────
+  it("returns incompatible on a major mismatch", () => {
+    expect(resolveAgentUpdateState("1.0.0", "0.1.0")).toBe("incompatible");
+    expect(resolveAgentUpdateState("0.1.0", "1.0.0")).toBe("incompatible");
+  });
+
+  it("returns incompatible for an unparseable but present agent version", () => {
+    expect(resolveAgentUpdateState("garbage", "0.1.0")).toBe("incompatible");
+  });
+
+  // ── unknown (no version reported) ───────────────────────────────────
+  it("returns unknown when no agent version is known", () => {
+    expect(resolveAgentUpdateState("", "0.1.0")).toBe("unknown");
+    expect(resolveAgentUpdateState(undefined, "0.1.0")).toBe("unknown");
+  });
+});

--- a/src/utils/agentVersion.ts
+++ b/src/utils/agentVersion.ts
@@ -46,7 +46,8 @@ export function parseAgentSemver(version: string | undefined | null): SemVer | n
  * Resolve an agent's update state from its reported version and the desktop's
  * expected version.
  *
- * - no/empty agent version -> `"unknown"` (nothing to show)
+ * - no/empty agent version, or desktop version not yet known -> `"unknown"`
+ *   (nothing to show; the desktop version loads asynchronously)
  * - unparseable (but present) agent version, or major mismatch -> `"incompatible"`
  * - agent minor older than desktop -> `"update-available"`
  * - otherwise -> `"up-to-date"`
@@ -56,6 +57,9 @@ export function resolveAgentUpdateState(
   desktopVersion: string | undefined | null
 ): ResolvedAgentUpdateState {
   if (!agentVersion || !agentVersion.trim()) return "unknown";
+  // Desktop version not loaded yet -> hide the badge rather than flashing
+  // "incompatible" while the app-info fetch is in flight.
+  if (!desktopVersion || !desktopVersion.trim()) return "unknown";
 
   const agent = parseAgentSemver(agentVersion);
   const desktop = parseAgentSemver(desktopVersion);
@@ -90,12 +94,11 @@ export function summarizeAgentUpdates(
   desktopVersion: string | undefined | null
 ): AgentUpdateSummary {
   const connected = agents.filter((a) => a.connectionState === "connected");
-  const updatesAvailable = desktopVersion
-    ? connected.filter(
-        (a) =>
-          resolveAgentUpdateState(a.capabilities?.agentVersion, desktopVersion) ===
-          "update-available"
-      ).length
-    : 0;
+  // resolveAgentUpdateState already yields "unknown" (never "update-available")
+  // when the desktop version is not yet known, so no separate guard is needed.
+  const updatesAvailable = connected.filter(
+    (a) =>
+      resolveAgentUpdateState(a.capabilities?.agentVersion, desktopVersion) === "update-available"
+  ).length;
   return { connectedCount: connected.length, updatesAvailable };
 }

--- a/src/utils/agentVersion.ts
+++ b/src/utils/agentVersion.ts
@@ -1,0 +1,101 @@
+/**
+ * Agent version / update-state helpers.
+ *
+ * Mirrors the desktop-side compatibility rule in `src-tauri/src/utils/version.rs`
+ * (`check_version`): same major required, agent minor >= desktop minor, patch
+ * ignored. Unlike the Rust helper this also tolerates a `-prerelease` / `+build`
+ * suffix (dev builds report e.g. `0.1.0-dev`) by stripping it before comparing.
+ */
+
+/** Parsed semantic version components. */
+export interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/** Derived update state for a remote agent, shown as a badge in the UI. */
+export type AgentUpdateState =
+  | "up-to-date"
+  | "update-available"
+  | "incompatible"
+  | "updating"
+  | "unknown";
+
+/** States that {@link resolveAgentUpdateState} can derive purely from versions. */
+export type ResolvedAgentUpdateState = Exclude<AgentUpdateState, "updating">;
+
+/**
+ * Parse a `major.minor.patch` version string into its numeric components.
+ *
+ * Any `-prerelease` or `+build` suffix is stripped first so dev builds
+ * (e.g. `0.1.0-dev`) compare against their base version. Returns `null` when
+ * the string does not contain exactly three dot-separated unsigned integers.
+ */
+export function parseAgentSemver(version: string | undefined | null): SemVer | null {
+  if (!version) return null;
+  const core = version.split(/[-+]/, 1)[0];
+  const parts = core.split(".");
+  if (parts.length !== 3) return null;
+  const nums = parts.map((p) => (/^\d+$/.test(p) ? Number(p) : NaN));
+  if (nums.some((n) => Number.isNaN(n))) return null;
+  return { major: nums[0], minor: nums[1], patch: nums[2] };
+}
+
+/**
+ * Resolve an agent's update state from its reported version and the desktop's
+ * expected version.
+ *
+ * - no/empty agent version -> `"unknown"` (nothing to show)
+ * - unparseable (but present) agent version, or major mismatch -> `"incompatible"`
+ * - agent minor older than desktop -> `"update-available"`
+ * - otherwise -> `"up-to-date"`
+ */
+export function resolveAgentUpdateState(
+  agentVersion: string | undefined | null,
+  desktopVersion: string | undefined | null
+): ResolvedAgentUpdateState {
+  if (!agentVersion || !agentVersion.trim()) return "unknown";
+
+  const agent = parseAgentSemver(agentVersion);
+  const desktop = parseAgentSemver(desktopVersion);
+  if (!agent || !desktop) return "incompatible";
+
+  if (agent.major !== desktop.major) return "incompatible";
+  if (agent.minor < desktop.minor) return "update-available";
+  return "up-to-date";
+}
+
+/** Minimal agent shape needed to summarise update state (structural). */
+export interface AgentUpdateSummaryInput {
+  connectionState: string;
+  capabilities?: { agentVersion?: string };
+}
+
+/** Aggregate counts for the status-bar summary. */
+export interface AgentUpdateSummary {
+  /** Number of currently connected agents. */
+  connectedCount: number;
+  /** How many connected agents have an update available. */
+  updatesAvailable: number;
+}
+
+/**
+ * Summarise connected agents and how many have an update available, for the
+ * status-bar "N agents · M updates available" indicator. Only `connected`
+ * agents are counted (a disconnected agent reports no live version).
+ */
+export function summarizeAgentUpdates(
+  agents: AgentUpdateSummaryInput[],
+  desktopVersion: string | undefined | null
+): AgentUpdateSummary {
+  const connected = agents.filter((a) => a.connectionState === "connected");
+  const updatesAvailable = desktopVersion
+    ? connected.filter(
+        (a) =>
+          resolveAgentUpdateState(a.capabilities?.agentVersion, desktopVersion) ===
+          "update-available"
+      ).length
+    : 0;
+  return { connectedCount: connected.length, updatesAvailable };
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -47,6 +47,8 @@ Fixed strings — match exactly.
 | `agent-setup-source-github` | `src/components/Sidebar/AgentSetupDialog.tsx` |
 | `agent-setup-source-local` | `src/components/Sidebar/AgentSetupDialog.tsx` |
 | `agent-setup-submit` | `src/components/Sidebar/AgentSetupDialog.tsx` |
+| `agent-updates-count` | `src/components/StatusBar/StatusBar.tsx` |
+| `agent-updates-indicator` | `src/components/StatusBar/StatusBar.tsx` |
 | `appearance-theme-select` | `src/components/Settings/AppearanceSettings.tsx` |
 | `auto-lock-timeout` | `src/components/Settings/SecuritySettings.tsx` |
 | `change-master-password-btn` | `src/components/Settings/SecuritySettings.tsx` |
@@ -575,6 +577,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `agent-reconnect-*` | `agent-reconnect-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-shutdown-*` | `agent-shutdown-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-state-*` | `agent-state-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
+| `agent-version-badge-*` | `agent-version-badge-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `color-picker-swatch-*` | `color-picker-swatch-${color.replace("#", "")}` | `src/components/Terminal/ColorPickerDialog.tsx` |
 | `connection-connect-*` | `connection-connect-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-item-*` | `connection-item-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |
@@ -643,6 +646,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `network-quick-action-*` | `network-quick-action-${tool}` | `src/components/NetworkTools/NetworkToolsSidebar.tsx` |
 | `oc-agent-disconnect-*` | `oc-agent-disconnect-${a.id}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `oc-agent-shutdown-*` | `oc-agent-shutdown-${a.id}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `oc-agent-version-*` | `oc-agent-version-${a.id}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `persistent-attach-*` | `persistent-attach-${definition.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `persistent-start-*` | `persistent-start-${definition.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `persistent-stop-*` | `persistent-stop-${definition.id}` | `src/components/Sidebar/AgentNode.tsx` |
@@ -699,7 +703,7 @@ where the component is used, not at the `data-testid` site.
 | `{paused ? `monitor-resume-${entry.key}` : `monitor-pause-${entry.key}`}` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `{rest["data-testid"]}` | `src/components/ui/ConfirmDialog.tsx`, `src/components/ui/Modal.tsx`, `src/components/ui/Tooltip.tsx` |
 | `{rowTestIdPrefix ? `${rowTestIdPrefix}-${i}` : undefined}` | `src/components/NetworkTools/DiagnosticResultsTable.tsx` |
-| `{testId}` | `src/components/NetworkTools/NetworkNumberField.tsx`, `src/components/NetworkTools/NetworkTextField.tsx`, `src/components/OpenConnections/OpenConnectionsModal.tsx`, `src/components/SidebarListItem/SidebarListItem.tsx` |
+| `{testId}` | `src/components/AgentVersionBadge/AgentVersionBadge.tsx`, `src/components/NetworkTools/NetworkNumberField.tsx`, `src/components/NetworkTools/NetworkTextField.tsx`, `src/components/OpenConnections/OpenConnectionsModal.tsx`, `src/components/SidebarListItem/SidebarListItem.tsx` |
 | `{testid}` | `src/components/ui/Select.tsx` |
 | `{tid("auth-method")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |
 | `{tid("connect-timeout")}` | `src/components/ConnectionEditor/JumpHostEntry.tsx` |


### PR DESCRIPTION
## Summary

Makes each remote agent's **version and update state** visible across the UI (#1347) — visibility only, no update triggering yet.

- **Sidebar (`AgentNode`)**: each connected agent's header shows a monospace version chip (`v0.1.0`) + an update-state badge — up-to-date / update-available / incompatible / updating — with a lucide icon and token color per state.
- **Open Connections**: connected-agent rows show the same badge with a text label, via a new `ConnectionRow` `meta` slot.
- **Status bar**: a connected-agents summary — `N agents` plus `· M updates available` (amber) when any connected agent is older than the desktop; clicking opens the Connections sidebar.

State is derived on the frontend by `resolveAgentUpdateState`, which mirrors the Rust `check_version` rule (`src-tauri/src/utils/version.rs`): same major required, agent minor ≥ desktop minor, patch (and a `-dev` suffix) ignored. The desktop version is fetched once and cached via a new `useDesktopVersion` hook. A failed/unavailable app-info IPC degrades to a hidden badge rather than crashing.

Out of scope (unchanged): update triggering, the connected-host guard, broadcast — those remain for the follow-up update work (#1352 etc.). The `updating` badge state is wired to render but is not yet produced by any code path.

## Test plan

- **Unit** (`src/utils/agentVersion.test.ts`, `src/components/AgentVersionBadge/AgentVersionBadge.test.tsx`): the (agentVer, desktopVer) → state mapping for all four states + unknown/loading cases, the version-chip rendering, per-state modifier classes, a11y labels, and the status-bar summary counting.
- **Full frontend suite**: `npx vitest run` — all green.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check`, `pnpm run markdownlint` — all pass.
- **Manual (light/dark badge colors)**: added to `docs/testing.md` under "Agent version + update-state badge — light/dark colors (#1347)".

Closes #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-ups filed

- #1406 — define the missing `--radius-full` / `--text-muted` design tokens (pre-existing latent bug surfaced during review; the badge avoided them).
- #1407 — consolidate the ad-hoc `getAppInfo()` consumers onto the new `useDesktopVersion` hook.
