### PR TITLE
feat(backend): macOS Services / Quick Actions registration (Closes #1369)

### DIFF
--- a/docs/changes/dev0/feature/1369-macos-services-registration.md
+++ b/docs/changes/dev0/feature/1369-macos-services-registration.md
@@ -1,0 +1,11 @@
+### Added
+
+- macOS Finder integration for shell context-menu entries (#1369): installing
+  the shell integration now writes an Automator Quick Action bundle per
+  configured entry to `~/Library/Services/<name>.workflow`, so each "Open in
+  termiHub" entry appears under Finder's **Quick Actions** and the **Services**
+  menu. Selecting one runs `termiHub spawn --entry-id <id> --location "$@"` for
+  the clicked folder or file. Registration is user-level (no admin rights) and
+  idempotent; uninstalling removes only termiHub's bundles, leaving unrelated
+  Quick Actions untouched. The app bundle also declares an app-level
+  `NSServices` menu entry for file managers that surface app Services.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1376,3 +1376,38 @@ array-`PROMPT_COMMAND` shape is covered by Rust unit tests
 (`osc7_bash_handles_array_prompt_command`, `osc7_wsl_handles_array_prompt_command`
 in `core/src/session/shell.rs`) and was manually verified end-to-end on
 FedoraLinux-44 (bash 5.3): `cd /mnt/c` emits `file:///mnt/c` → `C:/`.
+
+#### macOS Finder Quick Actions / Services registration (#1369)
+
+termiHub registers each configured shell-integration entry as an Automator
+Quick Action bundle under `~/Library/Services/<name>.workflow`
+(`src-tauri/src/spawn/registry.rs`, macOS arm). The generated bundle layout,
+`document.wflow` command line, `Info.plist` NSServices declaration, XML escaping,
+idempotent install, and owner-aware uninstall are covered by macOS-gated unit
+tests (`spawn::registry::macos_tests`). Confirming that Finder actually surfaces
+and runs the entries is macOS-only and manual (per ADR-5).
+
+On macOS:
+
+1. Configure at least one shell-integration entry, then run the install action
+   (the `install_shell_integration` command, or `termiHub install-shell-integration`).
+2. Confirm a `<entry-name>.workflow` bundle appears under `~/Library/Services/`
+   for each entry (`ls ~/Library/Services`), each containing
+   `Contents/document.wflow` and `Contents/Info.plist`.
+3. In **System Settings → Keyboard → Keyboard Shortcuts → Services** (or
+   right-click a folder/file in Finder → **Quick Actions** / **Services**),
+   confirm the entry is listed. If a new entry does not appear, log out/in or run
+   `/System/Library/CoreServices/pbs -flush` to refresh the Services cache.
+4. Right-click a folder in Finder → choose the entry → confirm termiHub opens a
+   session at that path (the workflow runs
+   `termiHub spawn --entry-id <id> --location "$@"`). Repeat on a file for an
+   entry whose **Show for → Files** is enabled.
+5. Run the uninstall action (`uninstall_shell_integration` /
+   `termiHub uninstall-shell-integration`) and confirm the termiHub `.workflow`
+   bundles are removed from `~/Library/Services/` while any unrelated
+   third-party Quick Actions there are left untouched.
+
+> Note: the app-level `NSServices` entry declared in `src-tauri/Info.plist` is a
+> discovery aid; the fully functional path is the per-entry Quick Action bundles
+> above. Wiring a native Services provider so the **app** entry also runs is
+> tracked as a follow-up.

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Partial Info.plist merged into the generated macOS app bundle by tauri-bundler
+  (it auto-discovers `src-tauri/Info.plist`; tauri.conf.json has no NSServices
+  field). Declares the app-level "Open in termiHub" Services-menu entry so the
+  integration is discoverable in file managers that surface app Services rather
+  than Automator Quick Actions. The per-entry Automator Quick Action bundles
+  written to ~/Library/Services by spawn/registry.rs (#1369) are the primary,
+  fully self-contained path.
+-->
+<plist version="1.0">
+  <dict>
+    <key>NSServices</key>
+    <array>
+      <dict>
+        <key>NSMenuItem</key>
+        <dict>
+          <key>default</key>
+          <string>Open in termiHub</string>
+        </dict>
+        <key>NSMessage</key>
+        <string>openInTermiHub</string>
+        <key>NSSendFileTypes</key>
+        <array>
+          <string>public.folder</string>
+          <string>public.item</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -1,28 +1,34 @@
-//! Windows Explorer context-menu registry registration (#1368).
+//! OS context-menu / Quick Action registration.
 //!
-//! Part of the Shell Context Menu & CLI Spawn Integration epic (#1363). Writes
-//! and removes the user-level (`HKCU\Software\Classes\…`) registry keys that make
-//! configured [`ShellEntry`]s appear as "Open in termiHub" entries in Windows
-//! Explorer's right-click menus — for folders, folder backgrounds, and files.
+//! Part of the Shell Context Menu & CLI Spawn Integration epic (#1363).
 //!
-//! All keys live under `HKEY_CURRENT_USER`, so **no administrator rights** are
-//! required. Registration is idempotent: install first clears any prior termiHub
-//! keys, then rewrites them from the current entry list.
+//! * **Windows** (#1368): writes and removes the user-level
+//!   (`HKCU\Software\Classes\…`) registry keys that make configured
+//!   [`ShellEntry`]s appear as "Open in termiHub" entries in Explorer's
+//!   right-click menus — for folders, folder backgrounds, and files. All keys
+//!   live under `HKEY_CURRENT_USER`, so **no administrator rights** are required.
+//! * **macOS** (#1369): writes and removes per-entry Automator Quick Action
+//!   bundles under `~/Library/Services/<name>.workflow`, each carrying its own
+//!   `NSServices` declaration so the entry surfaces under Finder's Quick Actions
+//!   and the Services menu. User-level only.
+//!
+//! Registration is idempotent on both platforms: install first clears any prior
+//! termiHub registration, then rewrites it from the current entry list.
 //!
 //! Callers use the cross-platform [`register`] / [`unregister`] seam, which
 //! records the registration facts into [`ShellIntegrationSettings`]. On
-//! non-Windows platforms the underlying registry work returns a clear
+//! platforms without an implementation the underlying work returns a clear
 //! "unsupported on this platform" error before any state changes, so the calling
 //! Tauri commands and CLI subcommands behave predictably everywhere.
 
 use crate::connection::shell_integration::{ShellEntry, ShellIntegrationSettings};
 use anyhow::Context;
 
-/// Message returned by the install / uninstall entry points on non-Windows
-/// platforms, where Explorer registry registration does not apply.
-#[cfg(not(windows))]
+/// Message returned by the install / uninstall entry points on platforms that
+/// have no context-menu / Quick Action registration implementation.
+#[cfg(not(any(windows, target_os = "macos")))]
 const UNSUPPORTED_MESSAGE: &str =
-    "Windows Explorer context-menu registration is only supported on Windows";
+    "file-manager context-menu registration is not supported on this platform";
 
 /// Register the integration for `settings.entries`, recording the registration
 /// facts (`registered` flag + executable path) back into `settings`.
@@ -73,16 +79,376 @@ fn uninstall() -> anyhow::Result<()> {
     imp::Registrar::system().uninstall()
 }
 
-/// Non-Windows stub: Explorer registry registration does not apply here.
-#[cfg(not(windows))]
+/// Register the given entries as macOS Finder Quick Action bundles under
+/// `~/Library/Services`. Idempotent — an existing registration is replaced.
+/// Private: callers go through the cross-platform [`register`] seam.
+#[cfg(target_os = "macos")]
+fn install(entries: &[ShellEntry], exe_path: &str) -> anyhow::Result<()> {
+    macos::Registrar::user()?.install(entries, exe_path)
+}
+
+/// Remove every termiHub Quick Action bundle from `~/Library/Services`
+/// (macOS-only). Private: callers go through the cross-platform [`unregister`]
+/// seam.
+#[cfg(target_os = "macos")]
+fn uninstall() -> anyhow::Result<()> {
+    macos::Registrar::user()?.uninstall()
+}
+
+/// Stub for platforms without a context-menu registration implementation.
+#[cfg(not(any(windows, target_os = "macos")))]
 fn install(_entries: &[ShellEntry], _exe_path: &str) -> anyhow::Result<()> {
     anyhow::bail!(UNSUPPORTED_MESSAGE)
 }
 
-/// Non-Windows stub: Explorer registry registration does not apply here.
-#[cfg(not(windows))]
+/// Stub for platforms without a context-menu registration implementation.
+#[cfg(not(any(windows, target_os = "macos")))]
 fn uninstall() -> anyhow::Result<()> {
     anyhow::bail!(UNSUPPORTED_MESSAGE)
+}
+
+/// macOS Finder Quick Action / Services registration (#1369).
+///
+/// Each configured [`ShellEntry`] is written as a self-contained Automator
+/// "Run Shell Script" workflow bundle under `~/Library/Services/<name>.workflow`.
+/// The bundle's `document.wflow` runs `termiHub spawn --entry-id <id> --location
+/// "$@"` with the selected paths passed as arguments; its `Info.plist` declares
+/// an `NSServices` entry so Finder surfaces it under both Quick Actions and the
+/// Services menu. Every generated `Info.plist` carries the [`MARKER_KEY`] so
+/// uninstall removes only termiHub-owned bundles and never touches foreign ones.
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::ShellEntry;
+    use crate::connection::shell_integration::ShowForTargets;
+    use anyhow::{Context, Result};
+    use std::path::{Path, PathBuf};
+
+    /// Custom `Info.plist` key stamped into every generated bundle so uninstall
+    /// can distinguish termiHub bundles from unrelated Quick Actions.
+    pub(super) const MARKER_KEY: &str = "TermiHubShellIntegration";
+
+    /// Writes and removes the per-entry Quick Action bundles under a
+    /// `Library/Services` directory.
+    ///
+    /// The `services_dir` is injectable so tests target a throwaway directory
+    /// instead of the user's real `~/Library/Services`.
+    pub struct Registrar {
+        services_dir: PathBuf,
+    }
+
+    impl Registrar {
+        /// Registrar targeting the real per-user `~/Library/Services`.
+        pub fn user() -> Result<Self> {
+            let services_dir = dirs::home_dir()
+                .context("resolve home directory for macOS Services registration")?
+                .join("Library/Services");
+            Ok(Self { services_dir })
+        }
+
+        /// Registrar targeting a throwaway directory so a test never touches the
+        /// user's real Quick Actions.
+        #[cfg(test)]
+        pub fn for_test(services_dir: PathBuf) -> Self {
+            Self { services_dir }
+        }
+
+        /// Install a Quick Action bundle per entry (idempotent).
+        ///
+        /// Any prior termiHub registration is cleared first, so calling this with
+        /// the current entry list always converges to exactly that set.
+        pub fn install(&self, entries: &[ShellEntry], exe_path: &str) -> Result<()> {
+            // Idempotency: start from a clean slate.
+            self.uninstall()?;
+            if entries.is_empty() {
+                return Ok(());
+            }
+            std::fs::create_dir_all(&self.services_dir)
+                .with_context(|| format!("create services dir {}", self.services_dir.display()))?;
+            for entry in entries {
+                self.write_bundle(entry, exe_path)
+                    .with_context(|| format!("write workflow bundle for entry {}", entry.id))?;
+            }
+            Ok(())
+        }
+
+        /// Remove every termiHub-owned Quick Action bundle. Foreign bundles (no
+        /// [`MARKER_KEY`]) are left untouched. Never fails when nothing is
+        /// registered or the services directory does not exist.
+        pub fn uninstall(&self) -> Result<()> {
+            if !self.services_dir.exists() {
+                return Ok(());
+            }
+            for dir_entry in std::fs::read_dir(&self.services_dir)
+                .with_context(|| format!("read services dir {}", self.services_dir.display()))?
+            {
+                let path = dir_entry
+                    .with_context(|| {
+                        format!("enumerate services dir {}", self.services_dir.display())
+                    })?
+                    .path();
+                if is_workflow_bundle(&path) && bundle_is_ours(&path) {
+                    std::fs::remove_dir_all(&path)
+                        .with_context(|| format!("remove workflow bundle {}", path.display()))?;
+                }
+            }
+            Ok(())
+        }
+
+        /// Write one entry's `<name>.workflow` bundle (`Contents/document.wflow`
+        /// + `Contents/Info.plist`).
+        fn write_bundle(&self, entry: &ShellEntry, exe_path: &str) -> Result<()> {
+            let contents = self
+                .services_dir
+                .join(bundle_dir_name(entry))
+                .join("Contents");
+            std::fs::create_dir_all(&contents)
+                .with_context(|| format!("create bundle contents {}", contents.display()))?;
+            std::fs::write(
+                contents.join("document.wflow"),
+                workflow_xml(entry, exe_path),
+            )
+            .context("write document.wflow")?;
+            std::fs::write(contents.join("Info.plist"), info_plist_xml(entry))
+                .context("write bundle Info.plist")?;
+            Ok(())
+        }
+    }
+
+    /// True when `path` is a `*.workflow` bundle directory.
+    fn is_workflow_bundle(path: &Path) -> bool {
+        path.is_dir() && path.extension().and_then(|e| e.to_str()) == Some("workflow")
+    }
+
+    /// True when the bundle's `Info.plist` carries the termiHub owner marker.
+    fn bundle_is_ours(bundle: &Path) -> bool {
+        std::fs::read_to_string(bundle.join("Contents/Info.plist"))
+            .map(|contents| contents.contains(MARKER_KEY))
+            .unwrap_or(false)
+    }
+
+    /// Filesystem-safe `<name>.workflow` directory name for an entry.
+    ///
+    /// Path separators (`/`, `\`) and the colon (`:`, shown as `/` in Finder)
+    /// are replaced with `-`; an entry whose name reduces to empty falls back to
+    /// its stable id.
+    fn bundle_dir_name(entry: &ShellEntry) -> String {
+        let sanitized: String = entry
+            .name
+            .chars()
+            .map(|c| match c {
+                '/' | '\\' | ':' => '-',
+                other => other,
+            })
+            .collect();
+        let base = sanitized.trim();
+        let base = if base.is_empty() {
+            entry.id.as_str()
+        } else {
+            base
+        };
+        format!("{base}.workflow")
+    }
+
+    /// The Uniform Type Identifiers a bundle accepts, derived from the entry's
+    /// `show_for` targets. Folders (and folder-background) map to `public.folder`;
+    /// files map to `public.data`. An entry with neither falls back to the
+    /// catch-all `public.item` so it still surfaces somewhere.
+    pub(super) fn send_file_types(show_for: &ShowForTargets) -> Vec<&'static str> {
+        let mut types = Vec::new();
+        if show_for.folders || show_for.folder_background {
+            types.push("public.folder");
+        }
+        if show_for.files {
+            types.push("public.data");
+        }
+        if types.is_empty() {
+            types.push("public.item");
+        }
+        types
+    }
+
+    /// The shell script the Quick Action runs: the spawn subcommand with the
+    /// selected paths passed as positional arguments.
+    fn shell_command(entry: &ShellEntry, exe_path: &str) -> String {
+        format!(
+            r#""{exe_path}" spawn --entry-id {id} --location "$@""#,
+            id = entry.id,
+        )
+    }
+
+    /// Escape the five XML predefined entities so arbitrary names / paths embed
+    /// safely into the plist templates.
+    fn xml_escape(s: &str) -> String {
+        s.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+            .replace('\'', "&apos;")
+    }
+
+    /// Render the bundle's `Info.plist`: an `NSServices` declaration plus the
+    /// termiHub owner marker.
+    fn info_plist_xml(entry: &ShellEntry) -> String {
+        let name = xml_escape(&entry.name);
+        let types = send_file_types(&entry.show_for)
+            .iter()
+            .map(|t| format!("\t\t\t\t<string>{t}</string>"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>{name}</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>runWorkflowAsService</string>
+			<key>NSSendFileTypes</key>
+			<array>
+{types}
+			</array>
+		</dict>
+	</array>
+	<key>{MARKER_KEY}</key>
+	<true/>
+</dict>
+</plist>
+"#
+        )
+    }
+
+    /// Render the Automator `document.wflow` for the entry: a single "Run Shell
+    /// Script" action wired as a Finder services-menu workflow, receiving the
+    /// selected file-system objects as arguments.
+    fn workflow_xml(entry: &ShellEntry, exe_path: &str) -> String {
+        let command = xml_escape(&shell_command(entry, exe_path));
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AMApplicationBuild</key>
+	<string>521</string>
+	<key>AMApplicationVersion</key>
+	<string>2.10</string>
+	<key>AMDocumentVersion</key>
+	<string>2</string>
+	<key>actions</key>
+	<array>
+		<dict>
+			<key>action</key>
+			<dict>
+				<key>AMAccepts</key>
+				<dict>
+					<key>Container</key>
+					<string>List</string>
+					<key>Optional</key>
+					<true/>
+					<key>Types</key>
+					<array>
+						<string>com.apple.cocoa.string</string>
+					</array>
+				</dict>
+				<key>AMActionVersion</key>
+				<string>2.0.3</string>
+				<key>AMApplication</key>
+				<array>
+					<string>Automator</string>
+				</array>
+				<key>AMProvides</key>
+				<dict>
+					<key>Container</key>
+					<string>List</string>
+					<key>Types</key>
+					<array>
+						<string>com.apple.cocoa.string</string>
+					</array>
+				</dict>
+				<key>ActionBundlePath</key>
+				<string>/System/Library/Automator/Run Shell Script.action</string>
+				<key>ActionName</key>
+				<string>Run Shell Script</string>
+				<key>ActionParameters</key>
+				<dict>
+					<key>COMMAND_STRING</key>
+					<string>{command}</string>
+					<key>CheckedForUserDefaultShell</key>
+					<true/>
+					<key>inputMethod</key>
+					<integer>1</integer>
+					<key>shell</key>
+					<string>/bin/zsh</string>
+					<key>source</key>
+					<string></string>
+				</dict>
+				<key>BundleIdentifier</key>
+				<string>com.apple.RunShellScript</string>
+				<key>CFBundleVersion</key>
+				<string>2.0.3</string>
+				<key>CanShowSelectedItemsWhenRun</key>
+				<false/>
+				<key>CanShowWhenRun</key>
+				<true/>
+				<key>Category</key>
+				<array>
+					<string>AMCategoryUtilities</string>
+				</array>
+				<key>Class Name</key>
+				<string>RunShellScriptAction</string>
+				<key>InputUUID</key>
+				<string>4F1C9A20-1369-4A11-9C01-000000000001</string>
+				<key>Keywords</key>
+				<array>
+					<string>Shell</string>
+					<string>Script</string>
+					<string>Command</string>
+					<string>Run</string>
+					<string>Unix</string>
+				</array>
+				<key>OutputUUID</key>
+				<string>4F1C9A20-1369-4A11-9C01-000000000002</string>
+				<key>UUID</key>
+				<string>4F1C9A20-1369-4A11-9C01-000000000003</string>
+				<key>UnlocalizedApplications</key>
+				<array>
+					<string>Automator</string>
+				</array>
+				<key>isViewVisible</key>
+				<integer>1</integer>
+			</dict>
+			<key>isViewVisible</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>connectors</key>
+	<dict/>
+	<key>workflowMetaData</key>
+	<dict>
+		<key>serviceApplicationBundleID</key>
+		<string>com.apple.finder</string>
+		<key>serviceApplicationPath</key>
+		<string>/System/Library/CoreServices/Finder.app</string>
+		<key>serviceInputTypeIdentifier</key>
+		<string>com.apple.Automator.fileSystemObject</string>
+		<key>serviceOutputTypeIdentifier</key>
+		<string>com.apple.Automator.nothing</string>
+		<key>serviceProcessesInput</key>
+		<integer>0</integer>
+		<key>workflowTypeIdentifier</key>
+		<string>com.apple.Automator.servicesMenu</string>
+	</dict>
+</dict>
+</plist>
+"#
+        )
+    }
 }
 
 #[cfg(all(test, target_os = "macos"))]

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -125,7 +125,7 @@ mod macos {
 
     /// Custom `Info.plist` key stamped into every generated bundle so uninstall
     /// can distinguish termiHub bundles from unrelated Quick Actions.
-    pub(super) const MARKER_KEY: &str = "TermiHubShellIntegration";
+    const MARKER_KEY: &str = "TermiHubShellIntegration";
 
     /// Writes and removes the per-entry Quick Action bundles under a
     /// `Library/Services` directory.
@@ -253,7 +253,7 @@ mod macos {
     /// `show_for` targets. Folders (and folder-background) map to `public.folder`;
     /// files map to `public.data`. An entry with neither falls back to the
     /// catch-all `public.item` so it still surfaces somewhere.
-    pub(super) fn send_file_types(show_for: &ShowForTargets) -> Vec<&'static str> {
+    fn send_file_types(show_for: &ShowForTargets) -> Vec<&'static str> {
         let mut types = Vec::new();
         if show_for.folders || show_for.folder_background {
             types.push("public.folder");
@@ -449,247 +449,244 @@ mod macos {
 "#
         )
     }
-}
 
-#[cfg(all(test, target_os = "macos"))]
-mod macos_tests {
-    use super::macos::{self, Registrar};
-    use crate::connection::shell_integration::{ShellEntry, ShellEntryVisibility, ShowForTargets};
-    use std::path::PathBuf;
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::connection::shell_integration::{ShellEntryVisibility, ShowForTargets};
+        use std::path::PathBuf;
 
-    const EXE: &str = "/Applications/termiHub.app/Contents/MacOS/termiHub";
+        const EXE: &str = "/Applications/termiHub.app/Contents/MacOS/termiHub";
 
-    /// A throwaway `Library/Services` directory that is deleted on drop, so a
-    /// test never touches the user's real `~/Library/Services`.
-    struct TempServices {
-        dir: PathBuf,
-    }
-
-    impl TempServices {
-        fn new(tag: &str) -> Self {
-            let dir = std::env::temp_dir().join(format!(
-                "termihub-services-test-{}-{tag}",
-                std::process::id()
-            ));
-            let _ = std::fs::remove_dir_all(&dir);
-            std::fs::create_dir_all(&dir).expect("create temp services dir");
-            Self { dir }
+        /// A throwaway `Library/Services` directory that is deleted on drop, so a
+        /// test never touches the user's real `~/Library/Services`.
+        struct TempServices {
+            dir: PathBuf,
         }
 
-        fn registrar(&self) -> Registrar {
-            Registrar::for_test(self.dir.clone())
+        impl TempServices {
+            fn new(tag: &str) -> Self {
+                let dir = std::env::temp_dir().join(format!(
+                    "termihub-services-test-{}-{tag}",
+                    std::process::id()
+                ));
+                let _ = std::fs::remove_dir_all(&dir);
+                std::fs::create_dir_all(&dir).expect("create temp services dir");
+                Self { dir }
+            }
+
+            fn registrar(&self) -> Registrar {
+                Registrar::for_test(self.dir.clone())
+            }
+
+            fn bundle(&self, dir_name: &str) -> PathBuf {
+                self.dir.join(dir_name)
+            }
+
+            fn read(&self, relative: &str) -> String {
+                std::fs::read_to_string(self.dir.join(relative))
+                    .unwrap_or_else(|e| panic!("read {relative}: {e}"))
+            }
         }
 
-        fn bundle(&self, dir_name: &str) -> PathBuf {
-            self.dir.join(dir_name)
+        impl Drop for TempServices {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.dir);
+            }
         }
 
-        fn read(&self, relative: &str) -> String {
-            std::fs::read_to_string(self.dir.join(relative))
-                .unwrap_or_else(|e| panic!("read {relative}: {e}"))
-        }
-    }
-
-    impl Drop for TempServices {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.dir);
-        }
-    }
-
-    fn all_targets() -> ShowForTargets {
-        ShowForTargets {
-            folders: true,
-            files: true,
-            folder_background: true,
-        }
-    }
-
-    fn folders_only() -> ShowForTargets {
-        ShowForTargets {
-            folders: true,
-            files: false,
-            folder_background: false,
-        }
-    }
-
-    fn entry(id: &str, name: &str, show_for: ShowForTargets) -> ShellEntry {
-        ShellEntry {
-            id: id.to_string(),
-            name: name.to_string(),
-            connection_id: None,
-            visibility: ShellEntryVisibility::Always,
-            show_for,
-        }
-    }
-
-    #[test]
-    fn install_creates_one_workflow_bundle_per_entry() {
-        let services = TempServices::new("per-entry");
-        let entries = vec![
-            entry("open", "Open in termiHub", all_targets()),
-            entry("pick", "Pick session", folders_only()),
-        ];
-        services.registrar().install(&entries, EXE).unwrap();
-
-        for name in ["Open in termiHub", "Pick session"] {
-            let bundle = services.bundle(&format!("{name}.workflow"));
-            assert!(
-                bundle.join("Contents/document.wflow").is_file(),
-                "missing document.wflow for {name}"
-            );
-            assert!(
-                bundle.join("Contents/Info.plist").is_file(),
-                "missing Info.plist for {name}"
-            );
-        }
-    }
-
-    #[test]
-    fn document_wflow_carries_the_spawn_command_and_service_metadata() {
-        let services = TempServices::new("wflow-command");
-        let entries = vec![entry("open", "Open in termiHub", all_targets())];
-        services.registrar().install(&entries, EXE).unwrap();
-
-        let wflow = services.read("Open in termiHub.workflow/Contents/document.wflow");
-        // The Run Shell Script action invokes the spawn subcommand with the
-        // selected paths passed as arguments (&quot; is the XML-escaped quote).
-        assert!(
-            wflow.contains("spawn --entry-id open --location &quot;$@&quot;"),
-            "wflow missing spawn command: {wflow}"
-        );
-        assert!(wflow.contains(EXE), "wflow missing exe path");
-        // It must be a Finder services-menu workflow.
-        assert!(wflow.contains("com.apple.Automator.servicesMenu"));
-        assert!(wflow.contains("Run Shell Script"));
-        assert!(wflow.starts_with("<?xml"));
-    }
-
-    #[test]
-    fn info_plist_declares_nsservices_menu_item_and_owner_marker() {
-        let services = TempServices::new("info-plist");
-        let entries = vec![entry("open", "Open in termiHub", folders_only())];
-        services.registrar().install(&entries, EXE).unwrap();
-
-        let plist = services.read("Open in termiHub.workflow/Contents/Info.plist");
-        assert!(plist.contains("<key>NSServices</key>"));
-        assert!(plist.contains("<string>runWorkflowAsService</string>"));
-        assert!(plist.contains("<string>Open in termiHub</string>"));
-        assert!(plist.contains("<string>public.folder</string>"));
-        // Owner marker lets uninstall recognise our bundles.
-        assert!(plist.contains(macos::MARKER_KEY));
-    }
-
-    #[test]
-    fn send_file_types_map_show_for_targets() {
-        assert_eq!(
-            macos::send_file_types(&all_targets()),
-            vec!["public.folder", "public.data"]
-        );
-        assert_eq!(
-            macos::send_file_types(&folders_only()),
-            vec!["public.folder"]
-        );
-        assert_eq!(
-            macos::send_file_types(&ShowForTargets {
-                folders: false,
+        fn all_targets() -> ShowForTargets {
+            ShowForTargets {
+                folders: true,
                 files: true,
+                folder_background: true,
+            }
+        }
+
+        fn folders_only() -> ShowForTargets {
+            ShowForTargets {
+                folders: true,
+                files: false,
                 folder_background: false,
-            }),
-            vec!["public.data"]
-        );
-    }
+            }
+        }
 
-    #[test]
-    fn xml_special_characters_in_name_are_escaped() {
-        let services = TempServices::new("escaping");
-        let entries = vec![entry("amp", "Open & Run", folders_only())];
-        services.registrar().install(&entries, EXE).unwrap();
+        fn entry(id: &str, name: &str, show_for: ShowForTargets) -> ShellEntry {
+            ShellEntry {
+                id: id.to_string(),
+                name: name.to_string(),
+                connection_id: None,
+                visibility: ShellEntryVisibility::Always,
+                show_for,
+            }
+        }
 
-        let plist = services.read("Open & Run.workflow/Contents/Info.plist");
-        assert!(plist.contains("<string>Open &amp; Run</string>"));
-    }
+        #[test]
+        fn install_creates_one_workflow_bundle_per_entry() {
+            let services = TempServices::new("per-entry");
+            let entries = vec![
+                entry("open", "Open in termiHub", all_targets()),
+                entry("pick", "Pick session", folders_only()),
+            ];
+            services.registrar().install(&entries, EXE).unwrap();
 
-    #[test]
-    fn bundle_name_sanitizes_path_separators() {
-        let services = TempServices::new("sanitize");
-        let entries = vec![entry("slash", "Open / Here", folders_only())];
-        services.registrar().install(&entries, EXE).unwrap();
+            for name in ["Open in termiHub", "Pick session"] {
+                let bundle = services.bundle(&format!("{name}.workflow"));
+                assert!(
+                    bundle.join("Contents/document.wflow").is_file(),
+                    "missing document.wflow for {name}"
+                );
+                assert!(
+                    bundle.join("Contents/Info.plist").is_file(),
+                    "missing Info.plist for {name}"
+                );
+            }
+        }
 
-        // The `/` is illegal in a filename and is replaced with `-`.
-        assert!(services.bundle("Open - Here.workflow").is_dir());
-    }
+        #[test]
+        fn document_wflow_carries_the_spawn_command_and_service_metadata() {
+            let services = TempServices::new("wflow-command");
+            let entries = vec![entry("open", "Open in termiHub", all_targets())];
+            services.registrar().install(&entries, EXE).unwrap();
 
-    #[test]
-    fn install_is_idempotent() {
-        let services = TempServices::new("idempotent");
-        let entries = vec![entry("open", "Open in termiHub", folders_only())];
-        services.registrar().install(&entries, EXE).unwrap();
-        services.registrar().install(&entries, EXE).unwrap();
+            let wflow = services.read("Open in termiHub.workflow/Contents/document.wflow");
+            // The Run Shell Script action invokes the spawn subcommand with the
+            // selected paths passed as arguments (&quot; is the XML-escaped quote).
+            assert!(
+                wflow.contains("spawn --entry-id open --location &quot;$@&quot;"),
+                "wflow missing spawn command: {wflow}"
+            );
+            assert!(wflow.contains(EXE), "wflow missing exe path");
+            // It must be a Finder services-menu workflow.
+            assert!(wflow.contains("com.apple.Automator.servicesMenu"));
+            assert!(wflow.contains("Run Shell Script"));
+            assert!(wflow.starts_with("<?xml"));
+        }
 
-        let count = std::fs::read_dir(&services.dir)
-            .unwrap()
-            .filter_map(Result::ok)
-            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("workflow"))
-            .count();
-        assert_eq!(count, 1);
-    }
+        #[test]
+        fn info_plist_declares_nsservices_menu_item_and_owner_marker() {
+            let services = TempServices::new("info-plist");
+            let entries = vec![entry("open", "Open in termiHub", folders_only())];
+            services.registrar().install(&entries, EXE).unwrap();
 
-    #[test]
-    fn reinstall_drops_removed_entries() {
-        let services = TempServices::new("drop-removed");
-        let first = vec![
-            entry("a", "Entry A", folders_only()),
-            entry("b", "Entry B", folders_only()),
-        ];
-        services.registrar().install(&first, EXE).unwrap();
+            let plist = services.read("Open in termiHub.workflow/Contents/Info.plist");
+            assert!(plist.contains("<key>NSServices</key>"));
+            assert!(plist.contains("<string>runWorkflowAsService</string>"));
+            assert!(plist.contains("<string>Open in termiHub</string>"));
+            assert!(plist.contains("<string>public.folder</string>"));
+            // Owner marker lets uninstall recognise our bundles.
+            assert!(plist.contains(MARKER_KEY));
+        }
 
-        let second = vec![entry("a", "Entry A", folders_only())];
-        services.registrar().install(&second, EXE).unwrap();
+        #[test]
+        fn send_file_types_map_show_for_targets() {
+            assert_eq!(
+                send_file_types(&all_targets()),
+                vec!["public.folder", "public.data"]
+            );
+            assert_eq!(send_file_types(&folders_only()), vec!["public.folder"]);
+            assert_eq!(
+                send_file_types(&ShowForTargets {
+                    folders: false,
+                    files: true,
+                    folder_background: false,
+                }),
+                vec!["public.data"]
+            );
+        }
 
-        assert!(services.bundle("Entry A.workflow").is_dir());
-        assert!(!services.bundle("Entry B.workflow").exists());
-    }
+        #[test]
+        fn xml_special_characters_in_name_are_escaped() {
+            let services = TempServices::new("escaping");
+            let entries = vec![entry("amp", "Open & Run", folders_only())];
+            services.registrar().install(&entries, EXE).unwrap();
 
-    #[test]
-    fn uninstall_removes_our_bundles() {
-        let services = TempServices::new("uninstall");
-        let entries = vec![
-            entry("a", "Entry A", all_targets()),
-            entry("b", "Entry B", all_targets()),
-        ];
-        services.registrar().install(&entries, EXE).unwrap();
-        services.registrar().uninstall().unwrap();
+            let plist = services.read("Open & Run.workflow/Contents/Info.plist");
+            assert!(plist.contains("<string>Open &amp; Run</string>"));
+        }
 
-        assert!(!services.bundle("Entry A.workflow").exists());
-        assert!(!services.bundle("Entry B.workflow").exists());
-    }
+        #[test]
+        fn bundle_name_sanitizes_path_separators() {
+            let services = TempServices::new("sanitize");
+            let entries = vec![entry("slash", "Open / Here", folders_only())];
+            services.registrar().install(&entries, EXE).unwrap();
 
-    #[test]
-    fn uninstall_preserves_foreign_bundles() {
-        let services = TempServices::new("foreign");
-        // A pre-existing, non-termiHub Quick Action bundle.
-        let foreign = services.bundle("Someone Else.workflow");
-        std::fs::create_dir_all(foreign.join("Contents")).unwrap();
-        std::fs::write(
-            foreign.join("Contents/Info.plist"),
-            "<plist><dict/></plist>",
-        )
-        .unwrap();
+            // The `/` is illegal in a filename and is replaced with `-`.
+            assert!(services.bundle("Open - Here.workflow").is_dir());
+        }
 
-        let entries = vec![entry("a", "Entry A", folders_only())];
-        services.registrar().install(&entries, EXE).unwrap();
-        services.registrar().uninstall().unwrap();
+        #[test]
+        fn install_is_idempotent() {
+            let services = TempServices::new("idempotent");
+            let entries = vec![entry("open", "Open in termiHub", folders_only())];
+            services.registrar().install(&entries, EXE).unwrap();
+            services.registrar().install(&entries, EXE).unwrap();
 
-        assert!(!services.bundle("Entry A.workflow").exists());
-        assert!(foreign.is_dir(), "foreign bundle must survive uninstall");
-    }
+            let count = std::fs::read_dir(&services.dir)
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("workflow"))
+                .count();
+            assert_eq!(count, 1);
+        }
 
-    #[test]
-    fn uninstall_without_prior_install_is_ok() {
-        let services = TempServices::new("uninstall-empty");
-        // Remove the dir entirely so uninstall must tolerate a missing dir.
-        std::fs::remove_dir_all(&services.dir).unwrap();
-        services.registrar().uninstall().unwrap();
+        #[test]
+        fn reinstall_drops_removed_entries() {
+            let services = TempServices::new("drop-removed");
+            let first = vec![
+                entry("a", "Entry A", folders_only()),
+                entry("b", "Entry B", folders_only()),
+            ];
+            services.registrar().install(&first, EXE).unwrap();
+
+            let second = vec![entry("a", "Entry A", folders_only())];
+            services.registrar().install(&second, EXE).unwrap();
+
+            assert!(services.bundle("Entry A.workflow").is_dir());
+            assert!(!services.bundle("Entry B.workflow").exists());
+        }
+
+        #[test]
+        fn uninstall_removes_our_bundles() {
+            let services = TempServices::new("uninstall");
+            let entries = vec![
+                entry("a", "Entry A", all_targets()),
+                entry("b", "Entry B", all_targets()),
+            ];
+            services.registrar().install(&entries, EXE).unwrap();
+            services.registrar().uninstall().unwrap();
+
+            assert!(!services.bundle("Entry A.workflow").exists());
+            assert!(!services.bundle("Entry B.workflow").exists());
+        }
+
+        #[test]
+        fn uninstall_preserves_foreign_bundles() {
+            let services = TempServices::new("foreign");
+            // A pre-existing, non-termiHub Quick Action bundle.
+            let foreign = services.bundle("Someone Else.workflow");
+            std::fs::create_dir_all(foreign.join("Contents")).unwrap();
+            std::fs::write(
+                foreign.join("Contents/Info.plist"),
+                "<plist><dict/></plist>",
+            )
+            .unwrap();
+
+            let entries = vec![entry("a", "Entry A", folders_only())];
+            services.registrar().install(&entries, EXE).unwrap();
+            services.registrar().uninstall().unwrap();
+
+            assert!(!services.bundle("Entry A.workflow").exists());
+            assert!(foreign.is_dir(), "foreign bundle must survive uninstall");
+        }
+
+        #[test]
+        fn uninstall_without_prior_install_is_ok() {
+            let services = TempServices::new("uninstall-empty");
+            // Remove the dir entirely so uninstall must tolerate a missing dir.
+            std::fs::remove_dir_all(&services.dir).unwrap();
+            services.registrar().uninstall().unwrap();
+        }
     }
 }
 

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -85,6 +85,248 @@ fn uninstall() -> anyhow::Result<()> {
     anyhow::bail!(UNSUPPORTED_MESSAGE)
 }
 
+#[cfg(all(test, target_os = "macos"))]
+mod macos_tests {
+    use super::macos::{self, Registrar};
+    use crate::connection::shell_integration::{ShellEntry, ShellEntryVisibility, ShowForTargets};
+    use std::path::PathBuf;
+
+    const EXE: &str = "/Applications/termiHub.app/Contents/MacOS/termiHub";
+
+    /// A throwaway `Library/Services` directory that is deleted on drop, so a
+    /// test never touches the user's real `~/Library/Services`.
+    struct TempServices {
+        dir: PathBuf,
+    }
+
+    impl TempServices {
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "termihub-services-test-{}-{tag}",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("create temp services dir");
+            Self { dir }
+        }
+
+        fn registrar(&self) -> Registrar {
+            Registrar::for_test(self.dir.clone())
+        }
+
+        fn bundle(&self, dir_name: &str) -> PathBuf {
+            self.dir.join(dir_name)
+        }
+
+        fn read(&self, relative: &str) -> String {
+            std::fs::read_to_string(self.dir.join(relative))
+                .unwrap_or_else(|e| panic!("read {relative}: {e}"))
+        }
+    }
+
+    impl Drop for TempServices {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn all_targets() -> ShowForTargets {
+        ShowForTargets {
+            folders: true,
+            files: true,
+            folder_background: true,
+        }
+    }
+
+    fn folders_only() -> ShowForTargets {
+        ShowForTargets {
+            folders: true,
+            files: false,
+            folder_background: false,
+        }
+    }
+
+    fn entry(id: &str, name: &str, show_for: ShowForTargets) -> ShellEntry {
+        ShellEntry {
+            id: id.to_string(),
+            name: name.to_string(),
+            connection_id: None,
+            visibility: ShellEntryVisibility::Always,
+            show_for,
+        }
+    }
+
+    #[test]
+    fn install_creates_one_workflow_bundle_per_entry() {
+        let services = TempServices::new("per-entry");
+        let entries = vec![
+            entry("open", "Open in termiHub", all_targets()),
+            entry("pick", "Pick session", folders_only()),
+        ];
+        services.registrar().install(&entries, EXE).unwrap();
+
+        for name in ["Open in termiHub", "Pick session"] {
+            let bundle = services.bundle(&format!("{name}.workflow"));
+            assert!(
+                bundle.join("Contents/document.wflow").is_file(),
+                "missing document.wflow for {name}"
+            );
+            assert!(
+                bundle.join("Contents/Info.plist").is_file(),
+                "missing Info.plist for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn document_wflow_carries_the_spawn_command_and_service_metadata() {
+        let services = TempServices::new("wflow-command");
+        let entries = vec![entry("open", "Open in termiHub", all_targets())];
+        services.registrar().install(&entries, EXE).unwrap();
+
+        let wflow = services.read("Open in termiHub.workflow/Contents/document.wflow");
+        // The Run Shell Script action invokes the spawn subcommand with the
+        // selected paths passed as arguments (&quot; is the XML-escaped quote).
+        assert!(
+            wflow.contains("spawn --entry-id open --location &quot;$@&quot;"),
+            "wflow missing spawn command: {wflow}"
+        );
+        assert!(wflow.contains(EXE), "wflow missing exe path");
+        // It must be a Finder services-menu workflow.
+        assert!(wflow.contains("com.apple.Automator.servicesMenu"));
+        assert!(wflow.contains("Run Shell Script"));
+        assert!(wflow.starts_with("<?xml"));
+    }
+
+    #[test]
+    fn info_plist_declares_nsservices_menu_item_and_owner_marker() {
+        let services = TempServices::new("info-plist");
+        let entries = vec![entry("open", "Open in termiHub", folders_only())];
+        services.registrar().install(&entries, EXE).unwrap();
+
+        let plist = services.read("Open in termiHub.workflow/Contents/Info.plist");
+        assert!(plist.contains("<key>NSServices</key>"));
+        assert!(plist.contains("<string>runWorkflowAsService</string>"));
+        assert!(plist.contains("<string>Open in termiHub</string>"));
+        assert!(plist.contains("<string>public.folder</string>"));
+        // Owner marker lets uninstall recognise our bundles.
+        assert!(plist.contains(macos::MARKER_KEY));
+    }
+
+    #[test]
+    fn send_file_types_map_show_for_targets() {
+        assert_eq!(
+            macos::send_file_types(&all_targets()),
+            vec!["public.folder", "public.data"]
+        );
+        assert_eq!(
+            macos::send_file_types(&folders_only()),
+            vec!["public.folder"]
+        );
+        assert_eq!(
+            macos::send_file_types(&ShowForTargets {
+                folders: false,
+                files: true,
+                folder_background: false,
+            }),
+            vec!["public.data"]
+        );
+    }
+
+    #[test]
+    fn xml_special_characters_in_name_are_escaped() {
+        let services = TempServices::new("escaping");
+        let entries = vec![entry("amp", "Open & Run", folders_only())];
+        services.registrar().install(&entries, EXE).unwrap();
+
+        let plist = services.read("Open & Run.workflow/Contents/Info.plist");
+        assert!(plist.contains("<string>Open &amp; Run</string>"));
+    }
+
+    #[test]
+    fn bundle_name_sanitizes_path_separators() {
+        let services = TempServices::new("sanitize");
+        let entries = vec![entry("slash", "Open / Here", folders_only())];
+        services.registrar().install(&entries, EXE).unwrap();
+
+        // The `/` is illegal in a filename and is replaced with `-`.
+        assert!(services.bundle("Open - Here.workflow").is_dir());
+    }
+
+    #[test]
+    fn install_is_idempotent() {
+        let services = TempServices::new("idempotent");
+        let entries = vec![entry("open", "Open in termiHub", folders_only())];
+        services.registrar().install(&entries, EXE).unwrap();
+        services.registrar().install(&entries, EXE).unwrap();
+
+        let count = std::fs::read_dir(&services.dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("workflow"))
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn reinstall_drops_removed_entries() {
+        let services = TempServices::new("drop-removed");
+        let first = vec![
+            entry("a", "Entry A", folders_only()),
+            entry("b", "Entry B", folders_only()),
+        ];
+        services.registrar().install(&first, EXE).unwrap();
+
+        let second = vec![entry("a", "Entry A", folders_only())];
+        services.registrar().install(&second, EXE).unwrap();
+
+        assert!(services.bundle("Entry A.workflow").is_dir());
+        assert!(!services.bundle("Entry B.workflow").exists());
+    }
+
+    #[test]
+    fn uninstall_removes_our_bundles() {
+        let services = TempServices::new("uninstall");
+        let entries = vec![
+            entry("a", "Entry A", all_targets()),
+            entry("b", "Entry B", all_targets()),
+        ];
+        services.registrar().install(&entries, EXE).unwrap();
+        services.registrar().uninstall().unwrap();
+
+        assert!(!services.bundle("Entry A.workflow").exists());
+        assert!(!services.bundle("Entry B.workflow").exists());
+    }
+
+    #[test]
+    fn uninstall_preserves_foreign_bundles() {
+        let services = TempServices::new("foreign");
+        // A pre-existing, non-termiHub Quick Action bundle.
+        let foreign = services.bundle("Someone Else.workflow");
+        std::fs::create_dir_all(foreign.join("Contents")).unwrap();
+        std::fs::write(
+            foreign.join("Contents/Info.plist"),
+            "<plist><dict/></plist>",
+        )
+        .unwrap();
+
+        let entries = vec![entry("a", "Entry A", folders_only())];
+        services.registrar().install(&entries, EXE).unwrap();
+        services.registrar().uninstall().unwrap();
+
+        assert!(!services.bundle("Entry A.workflow").exists());
+        assert!(foreign.is_dir(), "foreign bundle must survive uninstall");
+    }
+
+    #[test]
+    fn uninstall_without_prior_install_is_ok() {
+        let services = TempServices::new("uninstall-empty");
+        // Remove the dir entirely so uninstall must tolerate a missing dir.
+        std::fs::remove_dir_all(&services.dir).unwrap();
+        services.registrar().uninstall().unwrap();
+    }
+}
+
 #[cfg(windows)]
 mod imp {
     use super::ShellEntry;


### PR DESCRIPTION
## Summary

Adds the **macOS arm** to the cross-platform shell-integration `register` / `unregister` seam in `src-tauri/src/spawn/registry.rs` (epic #1363), building on the Windows path (#1368), config model (#1367), and spawn core (#1364).

Each configured shell-integration entry is written as a self-contained **Automator Quick Action bundle** under `~/Library/Services/<name>.workflow`:

- `Contents/document.wflow` — a "Run Shell Script" services-menu workflow that runs `termiHub spawn --entry-id <id> --location "$@"` with the Finder-selected paths passed as arguments.
- `Contents/Info.plist` — an `NSServices` declaration (`runWorkflowAsService`) whose `NSSendFileTypes` are derived from the entry's `show_for` targets (`public.folder` / `public.data`), plus a `TermiHubShellIntegration` owner marker.

Registration is **user-level** (no admin rights; plain `std::fs` + `dirs::home_dir()`, no new crates) and **idempotent** (install clears prior bundles first). **Uninstall** removes only bundles carrying the owner marker, leaving unrelated third-party Quick Actions untouched.

Also declares an app-level `NSServices` menu entry via a merged `src-tauri/Info.plist` (tauri-bundler auto-merges it; `tauri.conf.json` has no `NSServices` field). This is a discovery aid — the fully functional path is the per-entry Quick Action bundles. Wiring a native Services provider so the **app** entry runs is tracked as follow-up #1409.

The Windows `#[cfg(windows)]` path and the non-macOS/non-Windows `"unsupported on this platform"` fallback are preserved; the three cfg arms are mutually exclusive and exhaustive.

## Test plan

**Automated (macOS-gated unit tests, `spawn::registry::macos::tests`, 11 tests — run locally, green):**
- Bundle layout: one `<name>.workflow` per entry with `Contents/document.wflow` + `Contents/Info.plist`.
- `document.wflow` carries the `spawn --entry-id … --location "$@"` command, exe path, and `servicesMenu` metadata.
- `Info.plist` declares `NSServices` / `runWorkflowAsService` / menu name / send-file-types + owner marker.
- `send_file_types` mapping, XML escaping, filename sanitization, idempotent install, reinstall drops removed entries, owner-aware uninstall preserves foreign bundles, uninstall tolerates a missing dir.
- `./scripts/check.sh` passes (fmt + clippy + build); full `cargo test` spawn suite green (28 tests).

**Manual (macOS is primarily manual per ADR-5 — added to `docs/testing.md`):**
1. Configure an entry, run install → confirm `~/Library/Services/<name>.workflow` bundles appear.
2. In Finder, right-click a folder/file → **Quick Actions** / **Services** → confirm the entry is listed (flush with `pbs -flush` if needed).
3. Select it → confirm termiHub opens a session at that path.
4. Run uninstall → confirm termiHub bundles are removed while unrelated Quick Actions remain.

## Follow-ups
- #1409 — wire a native macOS Services provider so the app-level `NSServices` entry also functions (currently a declaration only).

Closes #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)