### PR TITLE
feat(ui): Shell Integration settings panel + entry editor + first-launch banner (Closes #1371)

### DIFF
--- a/docs/changes/dev0/feature/1371-shell-integration-settings-panel.md
+++ b/docs/changes/dev0/feature/1371-shell-integration-settings-panel.md
@@ -1,0 +1,19 @@
+### Added
+
+- **Shell Integration settings panel.** A new **Shell Integration** section in
+  Settings surfaces the OS context-menu integration (epic #1363). It shows the
+  registration status with **Reinstall / Update** and **Uninstall** actions
+  (full loading → success/error feedback), a draggable **Quick-Access Entries**
+  list (reorder, add, edit, delete), a **Fallback when no entry matches** choice
+  (session picker / system default shell), a **new-window** toggle, and — on
+  Linux only — per-file-manager install toggles (Nautilus / KDE / Thunar) with
+  detection labels. When the integration is registered and the executable has
+  moved, a staleness banner prompts a reinstall.
+- **Quick-access entry editor.** Add or edit an entry's name, the connection it
+  opens (or "Show session picker"), its Windows context-menu visibility
+  (Always / Extended-only), and which right-click targets it appears for
+  (folders / files / folder background).
+- **First-launch install banner.** A one-time, non-blocking banner offers to add
+  "Open in termiHub" to your file manager. "Install Now" registers the
+  integration; "Don't ask again" persists the opt-out
+  (`shellIntegration.firstLaunchBannerDismissed`).

--- a/src-tauri/src/commands/shell_integration.rs
+++ b/src-tauri/src/commands/shell_integration.rs
@@ -4,7 +4,10 @@
 use tauri::State;
 
 use crate::connection::manager::ConnectionManager;
-use crate::connection::shell_integration::{self, ShellIntegrationStatus};
+use crate::connection::settings::AppSettings;
+use crate::connection::shell_integration::{
+    self, ShellIntegrationSettings, ShellIntegrationStatus,
+};
 use crate::spawn::registry;
 use crate::utils::portable::detect_app_mode;
 
@@ -70,4 +73,79 @@ pub fn uninstall_shell_integration(
     registry::unregister(&mut settings.shell_integration).map_err(|e| format!("{e:#}"))?;
     manager.save_settings(settings).map_err(|e| e.to_string())?;
     Ok(current_status(&manager))
+}
+
+/// Replace the shell-integration settings on `settings` and report whether the
+/// OS registration must be refreshed afterwards.
+///
+/// Re-registration only runs when the integration **was** registered and the
+/// incoming settings keep it registered — editing entries while registered
+/// should keep the OS context-menu items in sync. Turning registration off is
+/// handled by [`uninstall_shell_integration`], not here, so a `registered:
+/// false` payload never triggers a registry write.
+fn stage_shell_integration(settings: &mut AppSettings, new_si: ShellIntegrationSettings) -> bool {
+    let re_register = settings.shell_integration.registered && new_si.registered;
+    settings.shell_integration = new_si;
+    re_register
+}
+
+/// Persist the shell-integration settings and, when currently registered,
+/// refresh the OS context-menu registration so it reflects the edited entries.
+///
+/// The settings UI calls this for every mutation (entry add/edit/reorder/delete,
+/// fallback + window-behaviour radios, Linux per-manager toggles, and the
+/// first-launch banner dismissal). Returns the recomputed status so the UI can
+/// surface the staleness banner without a second round-trip.
+#[tauri::command]
+pub fn save_shell_integration_settings(
+    manager: State<'_, ConnectionManager>,
+    shell_integration: ShellIntegrationSettings,
+) -> Result<ShellIntegrationStatus, String> {
+    let mut settings = manager.get_settings();
+    let re_register = stage_shell_integration(&mut settings, shell_integration);
+    if re_register {
+        registry::register(&mut settings.shell_integration).map_err(|e| format!("{e:#}"))?;
+    }
+    manager.save_settings(settings).map_err(|e| e.to_string())?;
+    Ok(current_status(&manager))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::shell_integration::{ShellEntry, ShellEntryVisibility, ShowForTargets};
+
+    fn entry(id: &str) -> ShellEntry {
+        ShellEntry {
+            id: id.to_string(),
+            name: "Open in termiHub".to_string(),
+            connection_id: None,
+            visibility: ShellEntryVisibility::Always,
+            show_for: ShowForTargets::default(),
+        }
+    }
+
+    #[test]
+    fn stage_replaces_entries_and_gates_reregistration() {
+        // Was registered, stays registered → re-register to keep the OS in sync.
+        let mut settings = AppSettings::default();
+        settings.shell_integration.registered = true;
+        let mut new_si = ShellIntegrationSettings {
+            registered: true,
+            entries: vec![entry("a")],
+            ..ShellIntegrationSettings::default()
+        };
+        assert!(stage_shell_integration(&mut settings, new_si.clone()));
+        assert_eq!(settings.shell_integration.entries, vec![entry("a")]);
+
+        // Not previously registered → never touches the registry.
+        let mut fresh = AppSettings::default();
+        assert!(!stage_shell_integration(&mut fresh, new_si.clone()));
+
+        // Payload turns registration off → no registry write (uninstall owns that).
+        let mut on = AppSettings::default();
+        on.shell_integration.registered = true;
+        new_si.registered = false;
+        assert!(!stage_shell_integration(&mut on, new_si));
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -619,6 +619,7 @@ pub fn run() {
             commands::shell_integration::get_shell_integration_status,
             commands::shell_integration::install_shell_integration,
             commands::shell_integration::uninstall_shell_integration,
+            commands::shell_integration::save_shell_integration_settings,
             commands::connection::move_connection_to_file,
             commands::connection::save_external_file,
             commands::connection::reload_external_connections,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { ErrorInfo, ReactNode } from "react";
 import { ActivityBar } from "@/components/ActivityBar";
 import { Sidebar } from "@/components/Sidebar";
 import { StatusBar } from "@/components/StatusBar";
+import { ShellIntegrationBanner } from "@/components/ShellIntegrationBanner";
 import { TerminalView } from "@/components/Terminal";
 import { PasswordPrompt } from "@/components/PasswordPrompt";
 import { CustomizeLayoutDialog } from "@/components/Settings/CustomizeLayoutDialog";
@@ -267,6 +268,7 @@ function App() {
             )}
             {layoutConfig.activityBarPosition === "right" && <ActivityBar />}
           </div>
+          <ShellIntegrationBanner />
           {layoutConfig.statusBarVisible && <StatusBar />}
           <PasswordPrompt />
           <CustomizeLayoutDialog />

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -252,9 +252,7 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
         );
       }
       if (highlightedCategories?.has("shell-integration")) {
-        sections.push(
-          <ShellIntegrationSettings key="shell-integration" visibleFields={visibleFields} />
-        );
+        sections.push(<ShellIntegrationSettings key="shell-integration" />);
       }
       if (highlightedCategories?.has("keyboard")) {
         sections.push(<KeyboardSettings key="keyboard" visibleFields={visibleFields} />);

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import {
   Settings2,
   Palette,
   TerminalSquare,
+  SquareMenu,
   Keyboard,
   Shield,
   FileJson,
@@ -29,6 +30,7 @@ import { FileTypeSettings } from "./FileTypeSettings";
 import { LanguagePackagesSettings } from "./LanguagePackagesSettings";
 import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
 import { SerialPortSettings } from "./SerialPortSettings";
+import { ShellIntegrationSettings } from "./ShellIntegrationSettings";
 import { PortableModeSettings } from "./PortableModeSettings";
 import { getAppInfo, type AppInfo } from "@/services/api";
 import "./SettingsPanel.css";
@@ -37,6 +39,7 @@ const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
   general: Settings2,
   appearance: Palette,
   terminal: TerminalSquare,
+  "shell-integration": SquareMenu,
   keyboard: Keyboard,
   security: Shield,
   "external-files": FileJson,
@@ -248,6 +251,11 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
           />
         );
       }
+      if (highlightedCategories?.has("shell-integration")) {
+        sections.push(
+          <ShellIntegrationSettings key="shell-integration" visibleFields={visibleFields} />
+        );
+      }
       if (highlightedCategories?.has("keyboard")) {
         sections.push(<KeyboardSettings key="keyboard" visibleFields={visibleFields} />);
       }
@@ -284,6 +292,8 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
         return <AppearanceSettings settings={settings} onChange={handleSettingsChange} />;
       case "terminal":
         return <TerminalSettings settings={settings} onChange={handleSettingsChange} />;
+      case "shell-integration":
+        return <ShellIntegrationSettings />;
       case "keyboard":
         return <KeyboardSettings />;
       case "security":

--- a/src/components/Settings/ShellIntegrationEntryEditor.tsx
+++ b/src/components/Settings/ShellIntegrationEntryEditor.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from "react";
+import type { SavedConnection, ShellEntry, ShellEntryVisibility } from "@/types/connection";
+import { Button, Field, Input, Modal, Select, Toggle } from "@/components/ui";
+import type { SelectOption } from "@/components/ui";
+import { getPlatform } from "@/utils/platform";
+
+/** Sentinel Select value for the "show the session picker" (no fixed connection) choice. */
+const PICKER_VALUE = "__picker__";
+
+interface ShellIntegrationEntryEditorProps {
+  /** Whether the editor modal is open. */
+  open: boolean;
+  /** Called with the next open state (false on cancel / escape / scrim). */
+  onOpenChange: (open: boolean) => void;
+  /** The entry being edited (a fresh entry for the add flow). */
+  entry: ShellEntry;
+  /** Whether this is a new entry (affects the modal title). */
+  isNew: boolean;
+  /** Saved connections offered in the connection picker. */
+  connections: SavedConnection[];
+  /** Commit the edited entry. */
+  onSave: (entry: ShellEntry) => void;
+}
+
+/**
+ * Add / edit dialog for a shell-integration quick-access entry. Captures the
+ * display name, the connection it opens (or the session picker), the Windows
+ * context-menu visibility, and which right-click targets it appears for.
+ */
+export function ShellIntegrationEntryEditor({
+  open,
+  onOpenChange,
+  entry,
+  isNew,
+  connections,
+  onSave,
+}: ShellIntegrationEntryEditorProps) {
+  const [draft, setDraft] = useState<ShellEntry>(entry);
+
+  // Re-seed the local form whenever a different entry is opened.
+  useEffect(() => {
+    if (open) setDraft(entry);
+  }, [open, entry]);
+
+  const connectionOptions = useMemo<SelectOption[]>(
+    () => [
+      { value: PICKER_VALUE, label: "Show session picker" },
+      ...connections.map((c) => ({ value: c.id, label: c.name })),
+    ],
+    [connections]
+  );
+
+  const nameError = draft.name.trim().length === 0 ? "Name is required." : undefined;
+  const isWindows = getPlatform() === "windows";
+
+  const handleSave = () => {
+    if (nameError) return;
+    onSave({ ...draft, name: draft.name.trim() });
+  };
+
+  const setShowFor = (key: keyof ShellEntry["showFor"], value: boolean) =>
+    setDraft((d) => ({ ...d, showFor: { ...d.showFor, [key]: value } }));
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isNew ? "Add Entry" : "Edit Entry"}
+      data-testid="shell-integration-entry-editor"
+      footer={
+        <>
+          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            disabled={!!nameError}
+            data-testid="shell-integration-entry-save"
+          >
+            Save
+          </Button>
+        </>
+      }
+    >
+      <div className="shell-integration-editor">
+        <Field label="Name" htmlFor="si-entry-name" error={nameError}>
+          <Input
+            id="si-entry-name"
+            value={draft.name}
+            error={!!nameError}
+            data-testid="shell-integration-entry-name"
+            onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+          />
+        </Field>
+
+        <Field label="Connection" htmlFor="si-entry-connection">
+          <Select
+            value={draft.connectionId ?? PICKER_VALUE}
+            onChange={(value) =>
+              setDraft((d) => ({
+                ...d,
+                connectionId: value === PICKER_VALUE ? undefined : value,
+              }))
+            }
+            options={connectionOptions}
+            aria-label="Connection"
+            data-testid="shell-integration-entry-connection"
+          />
+        </Field>
+
+        <Field label="Visibility (Windows only)" htmlFor="si-entry-visibility">
+          <Select
+            value={draft.visibility}
+            onChange={(value) =>
+              setDraft((d) => ({ ...d, visibility: value as ShellEntryVisibility }))
+            }
+            disabled={!isWindows}
+            options={[
+              { value: "always", label: "Always visible in context menu" },
+              { value: "extended", label: "Extended menu only (Shift+Right-click)" },
+            ]}
+            aria-label="Visibility"
+            data-testid="shell-integration-entry-visibility"
+          />
+        </Field>
+
+        <div className="shell-integration-editor__group" role="group" aria-label="Show for">
+          <span className="shell-integration-editor__group-label">Show for</span>
+          <label className="shell-integration-editor__toggle-row">
+            <Toggle
+              checked={draft.showFor.folders}
+              onCheckedChange={(v) => setShowFor("folders", v)}
+              aria-label="Show for folders"
+            />
+            <span>Folders</span>
+          </label>
+          <label className="shell-integration-editor__toggle-row">
+            <Toggle
+              checked={draft.showFor.files}
+              onCheckedChange={(v) => setShowFor("files", v)}
+              aria-label="Show for files"
+            />
+            <span>
+              Files <span className="shell-integration-editor__meta">(opens parent directory)</span>
+            </span>
+          </label>
+          <label className="shell-integration-editor__toggle-row">
+            <Toggle
+              checked={draft.showFor.folderBackground}
+              onCheckedChange={(v) => setShowFor("folderBackground", v)}
+              aria-label="Show for folder background"
+            />
+            <span>Folder background (right-click empty space)</span>
+          </label>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Settings/ShellIntegrationSettings.css
+++ b/src/components/Settings/ShellIntegrationSettings.css
@@ -1,0 +1,173 @@
+/* Shell Integration settings section (issue 1371). Composed on tokens only. */
+
+.shell-integration__card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+}
+
+.shell-integration__status-line {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+}
+
+.shell-integration__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: var(--radius-xl);
+  background: var(--text-disabled);
+  flex-shrink: 0;
+}
+
+.shell-integration__dot--on {
+  background: var(--color-success);
+}
+
+.shell-integration__stale {
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  color: var(--color-warning);
+}
+
+.shell-integration__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+/* Quick-access entry list */
+.shell-integration__entry-list {
+  list-style: none;
+  margin: 0 0 var(--spacing-sm);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.shell-integration__entry-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+}
+
+.shell-integration__grip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: grab;
+}
+
+.shell-integration__grip:active {
+  cursor: grabbing;
+}
+
+.shell-integration__entry-idx {
+  min-width: 1.2em;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  text-align: right;
+}
+
+.shell-integration__entry-name {
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+  font-weight: var(--font-weight-medium);
+}
+
+.shell-integration__entry-conn {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.shell-integration__badge {
+  margin-left: auto;
+  padding: 2px var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+}
+
+.shell-integration__badge--always {
+  color: var(--text-on-accent);
+  background: var(--accent-color);
+}
+
+.shell-integration__badge--extended {
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+}
+
+.shell-integration__entry-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+/* Fallback / new-window / Linux toggles */
+.shell-integration__toggle-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin: var(--spacing-sm) 0;
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.shell-integration__linux {
+  margin-top: var(--spacing-lg);
+}
+
+.shell-integration__meta {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+/* Entry editor dialog */
+.shell-integration-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.shell-integration-editor__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.shell-integration-editor__group-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-secondary);
+  letter-spacing: var(--letter-spacing-label);
+}
+
+.shell-integration-editor__toggle-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.shell-integration-editor__meta {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}

--- a/src/components/Settings/ShellIntegrationSettings.test.tsx
+++ b/src/components/Settings/ShellIntegrationSettings.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { ShellIntegrationStatus } from "@/types/connection";
+import * as api from "@/services/api";
+import { ShellIntegrationSettings } from "./ShellIntegrationSettings";
+import { defaultShellIntegrationSettings } from "./shellIntegrationEntries";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/api")>();
+  return {
+    ...actual,
+    getShellIntegrationStatus: vi.fn(),
+    saveShellIntegrationSettings: vi.fn(),
+    installShellIntegration: vi.fn(),
+    uninstallShellIntegration: vi.fn(),
+  };
+});
+
+const mockedApi = vi.mocked(api);
+
+function status(overrides: Partial<ShellIntegrationStatus> = {}): ShellIntegrationStatus {
+  return {
+    registered: false,
+    exePathMatches: true,
+    stale: false,
+    portable: false,
+    detectedFileManagers: [],
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render() {
+  await act(async () => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <ShellIntegrationSettings />
+      </TooltipProvider>
+    );
+  });
+}
+
+function byTestId(id: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${id}"]`);
+}
+
+describe("ShellIntegrationSettings", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings,
+        shellIntegration: defaultShellIntegrationSettings(),
+      },
+    });
+    mockedApi.getShellIntegrationStatus.mockResolvedValue(status());
+    mockedApi.saveShellIntegrationSettings.mockResolvedValue(status());
+    mockedApi.installShellIntegration.mockResolvedValue(status({ registered: true }));
+    mockedApi.uninstallShellIntegration.mockResolvedValue(status({ registered: false }));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the registration status card as Not registered", async () => {
+    await render();
+    expect(byTestId("shell-integration-status-card")).not.toBeNull();
+    expect(byTestId("shell-integration-status-text")?.textContent).toBe("Not registered");
+  });
+
+  it("shows Registered when the status reports it", async () => {
+    mockedApi.getShellIntegrationStatus.mockResolvedValue(status({ registered: true }));
+    await render();
+    expect(byTestId("shell-integration-status-text")?.textContent).toBe("Registered");
+  });
+
+  it("surfaces the staleness banner when the executable moved", async () => {
+    mockedApi.getShellIntegrationStatus.mockResolvedValue(
+      status({
+        registered: true,
+        stale: true,
+        registeredExePath: "/old/th",
+        currentExePath: "/new/th",
+      })
+    );
+    await render();
+    expect(byTestId("shell-integration-stale-banner")).not.toBeNull();
+  });
+
+  it("triggers registration when Reinstall is clicked", async () => {
+    await render();
+    await act(async () => {
+      byTestId("shell-integration-reinstall")?.click();
+    });
+    expect(mockedApi.installShellIntegration).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists a new entry added through the editor", async () => {
+    await render();
+    await act(async () => {
+      byTestId("shell-integration-add-entry")?.click();
+    });
+    // Editor modal is portalled; its Save button commits the default entry.
+    await act(async () => {
+      byTestId("shell-integration-entry-save")?.click();
+    });
+    expect(mockedApi.saveShellIntegrationSettings).toHaveBeenCalledTimes(1);
+    const savedArg = mockedApi.saveShellIntegrationSettings.mock.calls[0][0];
+    expect(savedArg.entries).toHaveLength(1);
+    expect(savedArg.entries[0].name).toBe("Open in termiHub");
+  });
+
+  it("persists deletion of an existing entry", async () => {
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings,
+        shellIntegration: {
+          ...defaultShellIntegrationSettings(),
+          entries: [
+            {
+              id: "e1",
+              name: "Open in termiHub",
+              visibility: "always",
+              showFor: { folders: true, files: false, folderBackground: false },
+            },
+          ],
+        },
+      },
+    });
+    await render();
+    await act(async () => {
+      byTestId("shell-integration-entry-delete-e1")?.click();
+    });
+    expect(mockedApi.saveShellIntegrationSettings).toHaveBeenCalledTimes(1);
+    expect(mockedApi.saveShellIntegrationSettings.mock.calls[0][0].entries).toHaveLength(0);
+  });
+
+  it("renders the Linux file-manager toggles on Linux", async () => {
+    // jsdom's user agent contains neither "Windows" nor "Macintosh" → treated as Linux.
+    await render();
+    expect(byTestId("shell-integration-linux")).not.toBeNull();
+  });
+});

--- a/src/components/Settings/ShellIntegrationSettings.tsx
+++ b/src/components/Settings/ShellIntegrationSettings.tsx
@@ -1,0 +1,444 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { GripVertical, Pencil, Plus, Trash2 } from "lucide-react";
+import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useAppStore } from "@/store/appStore";
+import { frontendLog } from "@/utils/frontendLog";
+import { getPlatform } from "@/utils/platform";
+import type {
+  DetectedFileManager,
+  ShellEntry,
+  ShellIntegrationSettings as ShellIntegrationSettingsType,
+  ShellIntegrationStatus,
+} from "@/types/connection";
+import { Button, Field, Select, Toggle, Tooltip, toast } from "@/components/ui";
+import {
+  getShellIntegrationStatus,
+  installShellIntegration,
+  saveShellIntegrationSettings,
+  uninstallShellIntegration,
+} from "@/services/api";
+import {
+  addEntry,
+  createEntry,
+  defaultShellIntegrationSettings,
+  removeEntry,
+  reorderEntries,
+  updateEntry,
+} from "./shellIntegrationEntries";
+import { ShellIntegrationEntryEditor } from "./ShellIntegrationEntryEditor";
+import "./ShellIntegrationSettings.css";
+
+/** The searchable setting ids owned by this section (see settingsRegistry). */
+const OWNED_FIELD_IDS = [
+  "shellIntegrationRegistration",
+  "shellIntegrationEntries",
+  "shellIntegrationFallback",
+  "shellIntegrationLinux",
+];
+
+/** The Linux file managers rendered as install toggles, with their detection id. */
+const LINUX_MANAGERS: {
+  key: keyof ShellIntegrationSettingsType["linuxFileManagers"];
+  id: string;
+  label: string;
+}[] = [
+  { key: "nautilus", id: "nautilus", label: "Install Nautilus scripts" },
+  { key: "kde", id: "kde", label: "Install KDE service menu" },
+  { key: "thunar", id: "thunar", label: "Install Thunar custom action" },
+];
+
+interface ShellIntegrationSettingsProps {
+  /** When search is active, only render if one of the owned fields matches. */
+  visibleFields?: Set<string>;
+}
+
+/**
+ * Settings section for the shell context-menu integration: registration status
+ * with Reinstall / Uninstall actions, a draggable Quick-Access entry list, the
+ * no-match fallback, the new-window behaviour, and Linux per-file-manager
+ * install toggles.
+ */
+export function ShellIntegrationSettings({ visibleFields }: ShellIntegrationSettingsProps) {
+  const settings = useAppStore((s) => s.settings);
+  const connections = useAppStore((s) => s.connections);
+
+  const si = useMemo<ShellIntegrationSettingsType>(
+    () => settings.shellIntegration ?? defaultShellIntegrationSettings(),
+    [settings.shellIntegration]
+  );
+
+  const [status, setStatus] = useState<ShellIntegrationStatus | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingEntry, setEditingEntry] = useState<ShellEntry | null>(null);
+  const [editingIsNew, setEditingIsNew] = useState(false);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const platform = getPlatform();
+
+  useEffect(() => {
+    getShellIntegrationStatus()
+      .then(setStatus)
+      .catch((e) => frontendLog("shell_integration", `status load failed: ${String(e)}`));
+  }, []);
+
+  /** Push refreshed registration facts from a status into the store. */
+  const applyStatusToStore = useCallback((st: ShellIntegrationStatus) => {
+    useAppStore.setState((s) => {
+      const prev = s.settings.shellIntegration ?? defaultShellIntegrationSettings();
+      const merged: ShellIntegrationSettingsType = {
+        ...prev,
+        registered: st.registered,
+        registeredExePath: st.registeredExePath,
+      };
+      const next = { ...s.settings, shellIntegration: merged };
+      return { settings: next, savedSettings: next };
+    });
+  }, []);
+
+  /** Persist an edited shell-integration settings value + refresh status. */
+  const persist = useCallback(async (nextSi: ShellIntegrationSettingsType) => {
+    const current = useAppStore.getState().settings;
+    const next = { ...current, shellIntegration: nextSi };
+    useAppStore.setState({ settings: next, savedSettings: next });
+    try {
+      const st = await saveShellIntegrationSettings(nextSi);
+      setStatus(st);
+    } catch (e) {
+      frontendLog("shell_integration", `save failed: ${String(e)}`);
+      toast.error("Failed to save shell integration settings", { description: String(e) });
+      getShellIntegrationStatus()
+        .then(setStatus)
+        .catch(() => {});
+    }
+  }, []);
+
+  const handleReinstall = useCallback(
+    () =>
+      toast.promise(
+        installShellIntegration().then((st) => {
+          setStatus(st);
+          applyStatusToStore(st);
+        }),
+        {
+          loading: "Registering shell integration…",
+          success: "Shell integration registered",
+          error: (e) => `Registration failed: ${String(e)}`,
+        }
+      ),
+    [applyStatusToStore]
+  );
+
+  const handleUninstall = useCallback(
+    () =>
+      toast.promise(
+        uninstallShellIntegration().then((st) => {
+          setStatus(st);
+          applyStatusToStore(st);
+        }),
+        {
+          loading: "Removing shell integration…",
+          success: "Shell integration removed",
+          error: (e) => `Removal failed: ${String(e)}`,
+        }
+      ),
+    [applyStatusToStore]
+  );
+
+  const openAddEntry = useCallback(() => {
+    setEditingEntry(createEntry());
+    setEditingIsNew(true);
+    setEditorOpen(true);
+  }, []);
+
+  const openEditEntry = useCallback((entry: ShellEntry) => {
+    setEditingEntry(entry);
+    setEditingIsNew(false);
+    setEditorOpen(true);
+  }, []);
+
+  const handleSaveEntry = useCallback(
+    (entry: ShellEntry) => {
+      const entries = editingIsNew ? addEntry(si.entries, entry) : updateEntry(si.entries, entry);
+      setEditorOpen(false);
+      void persist({ ...si, entries });
+      toast.success(editingIsNew ? "Entry added" : "Entry updated");
+    },
+    [editingIsNew, si, persist]
+  );
+
+  const handleDeleteEntry = useCallback(
+    (id: string) => {
+      void persist({ ...si, entries: removeEntry(si.entries, id) });
+    },
+    [si, persist]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const from = si.entries.findIndex((e) => e.id === active.id);
+      const to = si.entries.findIndex((e) => e.id === over.id);
+      if (from === -1 || to === -1) return;
+      void persist({ ...si, entries: reorderEntries(si.entries, from, to) });
+    },
+    [si, persist]
+  );
+
+  const detectedById = useMemo(() => {
+    const map = new Map<string, DetectedFileManager>();
+    for (const m of status?.detectedFileManagers ?? []) map.set(m.id, m);
+    return map;
+  }, [status]);
+
+  if (visibleFields && !OWNED_FIELD_IDS.some((id) => visibleFields.has(id))) {
+    return null;
+  }
+
+  const connectionName = (id?: string) =>
+    id ? (connections.find((c) => c.id === id)?.name ?? "(missing)") : "(picker)";
+
+  return (
+    <div className="settings-panel__section" data-testid="settings-shell-integration">
+      <div className="settings-panel__section-header">
+        <h3 className="settings-panel__section-title">Shell Integration</h3>
+      </div>
+
+      {/* Registration status + actions */}
+      <div className="shell-integration__card" data-testid="shell-integration-status-card">
+        <div className="shell-integration__status-line">
+          <span
+            className={`shell-integration__dot${status?.registered ? " shell-integration__dot--on" : ""}`}
+            aria-hidden
+          />
+          <span data-testid="shell-integration-status-text">
+            {status?.registered ? "Registered" : "Not registered"}
+          </span>
+          {status?.stale && !status.portable && (
+            <span className="shell-integration__stale" data-testid="shell-integration-stale-badge">
+              Executable moved — reinstall to update
+            </span>
+          )}
+        </div>
+        {status?.stale && !status.portable && (
+          <p className="settings-panel__description" data-testid="shell-integration-stale-banner">
+            Shell integration points to <code>{status.registeredExePath}</code>, but termiHub now
+            runs from <code>{status.currentExePath}</code>. Reinstall to update the context-menu
+            entries.
+          </p>
+        )}
+        <div className="shell-integration__actions">
+          <Button
+            variant="primary"
+            onClick={handleReinstall}
+            data-testid="shell-integration-reinstall"
+          >
+            Reinstall / Update
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={handleUninstall}
+            disabled={!status?.registered}
+            data-testid="shell-integration-uninstall"
+          >
+            Uninstall
+          </Button>
+        </div>
+      </div>
+
+      {/* Quick-access entries */}
+      <div className="settings-panel__section-header">
+        <h4 className="settings-panel__subsection-title">Quick-Access Entries</h4>
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={<Plus size={14} />}
+          onClick={openAddEntry}
+          data-testid="shell-integration-add-entry"
+        >
+          Add entry
+        </Button>
+      </div>
+
+      {si.entries.length === 0 ? (
+        <p className="settings-panel__description" data-testid="shell-integration-entries-empty">
+          No quick-access entries yet. Add one to show it in your file manager's right-click menu.
+        </p>
+      ) : (
+        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+          <SortableContext
+            items={si.entries.map((e) => e.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul
+              className="shell-integration__entry-list"
+              data-testid="shell-integration-entry-list"
+            >
+              {si.entries.map((entry, index) => (
+                <SortableEntryRow
+                  key={entry.id}
+                  entry={entry}
+                  index={index}
+                  connectionLabel={connectionName(entry.connectionId)}
+                  onEdit={() => openEditEntry(entry)}
+                  onDelete={() => handleDeleteEntry(entry.id)}
+                />
+              ))}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
+      <p className="settings-panel__description">
+        Drag the handle to reorder. The first “Always” entry is the default.
+      </p>
+
+      {/* Fallback + window behaviour */}
+      <Field label="Fallback when no entry matches" htmlFor="shell-integration-fallback">
+        <Select
+          value={si.fallback}
+          onChange={(value) =>
+            void persist({ ...si, fallback: value as ShellIntegrationSettingsType["fallback"] })
+          }
+          options={[
+            { value: "picker", label: "Show session picker" },
+            { value: "systemDefaultShell", label: "Use system default shell" },
+          ]}
+          aria-label="Fallback when no entry matches"
+          data-testid="shell-integration-fallback"
+        />
+      </Field>
+
+      <label className="shell-integration__toggle-row">
+        <Toggle
+          checked={si.openInNewWindow}
+          onCheckedChange={(v) => void persist({ ...si, openInNewWindow: v })}
+          aria-label="Always open spawned sessions in a new window"
+          data-testid="shell-integration-new-window"
+        />
+        <span>Always open a new window (instead of the running instance)</span>
+      </label>
+
+      {/* Linux per-file-manager toggles */}
+      {platform === "linux" && (
+        <div className="shell-integration__linux" data-testid="shell-integration-linux">
+          <h4 className="settings-panel__subsection-title">Linux — File Manager Integrations</h4>
+          {LINUX_MANAGERS.map(({ key, id, label }) => {
+            const detected = detectedById.get(id);
+            return (
+              <label key={key} className="shell-integration__toggle-row">
+                <Toggle
+                  checked={si.linuxFileManagers[key]}
+                  onCheckedChange={(v) =>
+                    void persist({
+                      ...si,
+                      linuxFileManagers: { ...si.linuxFileManagers, [key]: v },
+                    })
+                  }
+                  aria-label={label}
+                  data-testid={`shell-integration-linux-${id}`}
+                />
+                <span>
+                  {label}{" "}
+                  <span className="shell-integration__meta">
+                    {detected?.detected
+                      ? `— detected: ${detected.name}${detected.version ? ` ${detected.version}` : ""}`
+                      : "— not detected"}
+                  </span>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      )}
+
+      {editingEntry && (
+        <ShellIntegrationEntryEditor
+          open={editorOpen}
+          onOpenChange={setEditorOpen}
+          entry={editingEntry}
+          isNew={editingIsNew}
+          connections={connections}
+          onSave={handleSaveEntry}
+        />
+      )}
+    </div>
+  );
+}
+
+interface SortableEntryRowProps {
+  entry: ShellEntry;
+  index: number;
+  connectionLabel: string;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+/** A single reorderable quick-access entry row. */
+function SortableEntryRow({
+  entry,
+  index,
+  connectionLabel,
+  onEdit,
+  onDelete,
+}: SortableEntryRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: entry.id,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="shell-integration__entry-row"
+      data-testid={`shell-integration-entry-${entry.id}`}
+    >
+      <button
+        type="button"
+        className="shell-integration__grip"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical size={14} />
+      </button>
+      <span className="shell-integration__entry-idx">{index + 1}</span>
+      <span className="shell-integration__entry-name">{entry.name}</span>
+      <span className="shell-integration__entry-conn">{connectionLabel}</span>
+      <span className={`shell-integration__badge shell-integration__badge--${entry.visibility}`}>
+        {entry.visibility === "always" ? "Always" : "Extended"}
+      </span>
+      <div className="shell-integration__entry-actions">
+        <Tooltip content="Edit entry">
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            icon={<Pencil size={14} />}
+            onClick={onEdit}
+            aria-label="Edit entry"
+            data-testid={`shell-integration-entry-edit-${entry.id}`}
+          />
+        </Tooltip>
+        <Tooltip content="Delete entry">
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            icon={<Trash2 size={14} />}
+            onClick={onDelete}
+            aria-label="Delete entry"
+            data-testid={`shell-integration-entry-delete-${entry.id}`}
+          />
+        </Tooltip>
+      </div>
+    </li>
+  );
+}

--- a/src/components/Settings/ShellIntegrationSettings.tsx
+++ b/src/components/Settings/ShellIntegrationSettings.tsx
@@ -13,6 +13,7 @@ import type {
   ShellIntegrationStatus,
 } from "@/types/connection";
 import { Button, Field, Select, Toggle, Tooltip, toast } from "@/components/ui";
+import type { ToastPromiseMessages } from "@/components/ui";
 import {
   getShellIntegrationStatus,
   installShellIntegration,
@@ -27,16 +28,15 @@ import {
   reorderEntries,
   updateEntry,
 } from "./shellIntegrationEntries";
+import {
+  INSTALL_TOAST,
+  UNINSTALL_TOAST,
+  currentShellIntegration,
+  syncRegistrationFacts,
+  writeShellIntegration,
+} from "./shellIntegrationStore";
 import { ShellIntegrationEntryEditor } from "./ShellIntegrationEntryEditor";
 import "./ShellIntegrationSettings.css";
-
-/** The searchable setting ids owned by this section (see settingsRegistry). */
-const OWNED_FIELD_IDS = [
-  "shellIntegrationRegistration",
-  "shellIntegrationEntries",
-  "shellIntegrationFallback",
-  "shellIntegrationLinux",
-];
 
 /** The Linux file managers rendered as install toggles, with their detection id. */
 const LINUX_MANAGERS: {
@@ -49,30 +49,24 @@ const LINUX_MANAGERS: {
   { key: "thunar", id: "thunar", label: "Install Thunar custom action" },
 ];
 
-interface ShellIntegrationSettingsProps {
-  /** When search is active, only render if one of the owned fields matches. */
-  visibleFields?: Set<string>;
-}
-
 /**
  * Settings section for the shell context-menu integration: registration status
  * with Reinstall / Uninstall actions, a draggable Quick-Access entry list, the
  * no-match fallback, the new-window behaviour, and Linux per-file-manager
  * install toggles.
  */
-export function ShellIntegrationSettings({ visibleFields }: ShellIntegrationSettingsProps) {
-  const settings = useAppStore((s) => s.settings);
+export function ShellIntegrationSettings() {
+  const storedSi = useAppStore((s) => s.settings.shellIntegration);
   const connections = useAppStore((s) => s.connections);
 
   const si = useMemo<ShellIntegrationSettingsType>(
-    () => settings.shellIntegration ?? defaultShellIntegrationSettings(),
-    [settings.shellIntegration]
+    () => storedSi ?? defaultShellIntegrationSettings(),
+    [storedSi]
   );
 
   const [status, setStatus] = useState<ShellIntegrationStatus | null>(null);
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingEntry, setEditingEntry] = useState<ShellEntry | null>(null);
-  const [editingIsNew, setEditingIsNew] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
   const platform = getPlatform();
@@ -83,89 +77,62 @@ export function ShellIntegrationSettings({ visibleFields }: ShellIntegrationSett
       .catch((e) => frontendLog("shell_integration", `status load failed: ${String(e)}`));
   }, []);
 
-  /** Push refreshed registration facts from a status into the store. */
-  const applyStatusToStore = useCallback((st: ShellIntegrationStatus) => {
-    useAppStore.setState((s) => {
-      const prev = s.settings.shellIntegration ?? defaultShellIntegrationSettings();
-      const merged: ShellIntegrationSettingsType = {
-        ...prev,
-        registered: st.registered,
-        registeredExePath: st.registeredExePath,
-      };
-      const next = { ...s.settings, shellIntegration: merged };
-      return { settings: next, savedSettings: next };
-    });
-  }, []);
-
   /** Persist an edited shell-integration settings value + refresh status. */
   const persist = useCallback(async (nextSi: ShellIntegrationSettingsType) => {
-    const current = useAppStore.getState().settings;
-    const next = { ...current, shellIntegration: nextSi };
-    useAppStore.setState({ settings: next, savedSettings: next });
+    const prevSi = currentShellIntegration();
+    writeShellIntegration(nextSi);
     try {
-      const st = await saveShellIntegrationSettings(nextSi);
-      setStatus(st);
+      setStatus(await saveShellIntegrationSettings(nextSi));
     } catch (e) {
       frontendLog("shell_integration", `save failed: ${String(e)}`);
       toast.error("Failed to save shell integration settings", { description: String(e) });
-      getShellIntegrationStatus()
-        .then(setStatus)
-        .catch(() => {});
+      // Roll the optimistic store write back to the last persisted value.
+      writeShellIntegration(prevSi);
     }
   }, []);
 
-  const handleReinstall = useCallback(
-    () =>
+  /** Run a register/unregister action with toast feedback + store status sync. */
+  const runRegistration = useCallback(
+    (action: () => Promise<ShellIntegrationStatus>, messages: ToastPromiseMessages<unknown>) =>
       toast.promise(
-        installShellIntegration().then((st) => {
+        action().then((st) => {
           setStatus(st);
-          applyStatusToStore(st);
+          syncRegistrationFacts(st);
         }),
-        {
-          loading: "Registering shell integration…",
-          success: "Shell integration registered",
-          error: (e) => `Registration failed: ${String(e)}`,
-        }
+        messages
       ),
-    [applyStatusToStore]
+    []
+  );
+
+  const handleReinstall = useCallback(
+    () => runRegistration(installShellIntegration, INSTALL_TOAST),
+    [runRegistration]
   );
 
   const handleUninstall = useCallback(
-    () =>
-      toast.promise(
-        uninstallShellIntegration().then((st) => {
-          setStatus(st);
-          applyStatusToStore(st);
-        }),
-        {
-          loading: "Removing shell integration…",
-          success: "Shell integration removed",
-          error: (e) => `Removal failed: ${String(e)}`,
-        }
-      ),
-    [applyStatusToStore]
+    () => runRegistration(uninstallShellIntegration, UNINSTALL_TOAST),
+    [runRegistration]
   );
 
   const openAddEntry = useCallback(() => {
     setEditingEntry(createEntry());
-    setEditingIsNew(true);
     setEditorOpen(true);
   }, []);
 
   const openEditEntry = useCallback((entry: ShellEntry) => {
     setEditingEntry(entry);
-    setEditingIsNew(false);
     setEditorOpen(true);
   }, []);
 
   const handleSaveEntry = useCallback(
     (entry: ShellEntry) => {
-      const entries = editingIsNew ? addEntry(si.entries, entry) : updateEntry(si.entries, entry);
+      const exists = si.entries.some((e) => e.id === entry.id);
+      const entries = exists ? updateEntry(si.entries, entry) : addEntry(si.entries, entry);
       setEditorOpen(false);
       void persist({ ...si, entries });
-      toast.success(editingIsNew ? "Entry added" : "Entry updated");
+      toast.success(exists ? "Entry updated" : "Entry added");
     },
-    [editingIsNew, si, persist]
+    [si, persist]
   );
 
   const handleDeleteEntry = useCallback(
@@ -192,10 +159,6 @@ export function ShellIntegrationSettings({ visibleFields }: ShellIntegrationSett
     for (const m of status?.detectedFileManagers ?? []) map.set(m.id, m);
     return map;
   }, [status]);
-
-  if (visibleFields && !OWNED_FIELD_IDS.some((id) => visibleFields.has(id))) {
-    return null;
-  }
 
   const connectionName = (id?: string) =>
     id ? (connections.find((c) => c.id === id)?.name ?? "(missing)") : "(picker)";
@@ -358,7 +321,7 @@ export function ShellIntegrationSettings({ visibleFields }: ShellIntegrationSett
           open={editorOpen}
           onOpenChange={setEditorOpen}
           entry={editingEntry}
-          isNew={editingIsNew}
+          isNew={!si.entries.some((e) => e.id === editingEntry.id)}
           connections={connections}
           onSave={handleSaveEntry}
         />

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -2,6 +2,7 @@ export type SettingsCategory =
   | "general"
   | "appearance"
   | "terminal"
+  | "shell-integration"
   | "keyboard"
   | "security"
   | "external-files"
@@ -25,6 +26,7 @@ export const CATEGORIES: CategoryDefinition[] = [
   { id: "general", label: "General" },
   { id: "appearance", label: "Appearance" },
   { id: "terminal", label: "Terminal" },
+  { id: "shell-integration", label: "Shell Integration" },
   { id: "keyboard", label: "Keyboard" },
   { id: "security", label: "Security" },
   { id: "external-files", label: "External Files" },
@@ -135,6 +137,45 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     description: "Offer to open terminal content in an editor tab after saving it to a file",
     category: "terminal",
     keywords: ["save", "file", "tab", "editor", "monaco", "terminal", "open", "prompt"],
+  },
+  {
+    id: "shellIntegrationRegistration",
+    label: "Context Menu Registration",
+    description: "Register or remove the file-manager right-click integration",
+    category: "shell-integration",
+    keywords: [
+      "shell integration",
+      "context menu",
+      "right-click",
+      "explorer",
+      "finder",
+      "nautilus",
+      "register",
+      "reinstall",
+      "uninstall",
+      "open in termihub",
+    ],
+  },
+  {
+    id: "shellIntegrationEntries",
+    label: "Quick-Access Entries",
+    description: "Configure the entries shown in your file manager's right-click menu",
+    category: "shell-integration",
+    keywords: ["entry", "quick access", "context menu", "shell", "connection", "picker", "reorder"],
+  },
+  {
+    id: "shellIntegrationFallback",
+    label: "Shell Integration Fallback",
+    description: "What to open when no quick-access entry matches a request",
+    category: "shell-integration",
+    keywords: ["fallback", "picker", "default shell", "shell integration", "new window"],
+  },
+  {
+    id: "shellIntegrationLinux",
+    label: "Linux File Manager Integrations",
+    description: "Install Nautilus, KDE, or Thunar file-manager integrations on Linux",
+    category: "shell-integration",
+    keywords: ["linux", "nautilus", "kde", "dolphin", "thunar", "file manager", "service menu"],
   },
   {
     id: "keybindings",

--- a/src/components/Settings/shellIntegrationEntries.test.ts
+++ b/src/components/Settings/shellIntegrationEntries.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import type { ShellEntry } from "@/types/connection";
+import {
+  addEntry,
+  createEntry,
+  defaultShellIntegrationSettings,
+  removeEntry,
+  reorderEntries,
+  updateEntry,
+} from "./shellIntegrationEntries";
+
+function entry(id: string, name: string): ShellEntry {
+  return {
+    id,
+    name,
+    visibility: "always",
+    showFor: { folders: true, files: false, folderBackground: false },
+  };
+}
+
+describe("shellIntegrationEntries", () => {
+  it("defaultShellIntegrationSettings mirrors the backend defaults", () => {
+    const si = defaultShellIntegrationSettings();
+    expect(si.entries).toEqual([]);
+    expect(si.fallback).toBe("picker");
+    expect(si.openInNewWindow).toBe(false);
+    expect(si.registered).toBe(false);
+    expect(si.firstLaunchBannerDismissed).toBe(false);
+    expect(si.linuxFileManagers).toEqual({ nautilus: false, kde: false, thunar: false });
+  });
+
+  it("createEntry produces a folders-only, always-visible picker entry with a unique id", () => {
+    const a = createEntry();
+    const b = createEntry();
+    expect(a.id).not.toBe(b.id);
+    expect(a.connectionId).toBeUndefined();
+    expect(a.visibility).toBe("always");
+    expect(a.showFor).toEqual({ folders: true, files: false, folderBackground: false });
+  });
+
+  it("addEntry appends without mutating the input", () => {
+    const list = [entry("1", "One")];
+    const next = addEntry(list, entry("2", "Two"));
+    expect(next.map((e) => e.id)).toEqual(["1", "2"]);
+    expect(list).toHaveLength(1);
+  });
+
+  it("updateEntry replaces the matching entry by id", () => {
+    const list = [entry("1", "One"), entry("2", "Two")];
+    const next = updateEntry(list, { ...entry("2", "Renamed"), visibility: "extended" });
+    expect(next[1].name).toBe("Renamed");
+    expect(next[1].visibility).toBe("extended");
+    expect(next[0]).toBe(list[0]);
+  });
+
+  it("removeEntry drops the matching entry by id", () => {
+    const list = [entry("1", "One"), entry("2", "Two")];
+    expect(removeEntry(list, "1").map((e) => e.id)).toEqual(["2"]);
+  });
+
+  it("reorderEntries moves an entry from one index to another", () => {
+    const list = [entry("1", "One"), entry("2", "Two"), entry("3", "Three")];
+    expect(reorderEntries(list, 0, 2).map((e) => e.id)).toEqual(["2", "3", "1"]);
+    expect(reorderEntries(list, 2, 0).map((e) => e.id)).toEqual(["3", "1", "2"]);
+  });
+
+  it("reorderEntries returns the original list for out-of-range or no-op moves", () => {
+    const list = [entry("1", "One"), entry("2", "Two")];
+    expect(reorderEntries(list, 0, 0)).toBe(list);
+    expect(reorderEntries(list, -1, 1)).toBe(list);
+    expect(reorderEntries(list, 0, 5)).toBe(list);
+  });
+});

--- a/src/components/Settings/shellIntegrationEntries.ts
+++ b/src/components/Settings/shellIntegrationEntries.ts
@@ -1,0 +1,81 @@
+import type { ShellEntry, ShellIntegrationSettings } from "@/types/connection";
+
+/**
+ * Factory for a fresh {@link ShellIntegrationSettings} value. Mirrors the Rust
+ * `ShellIntegrationSettings::default()` (see
+ * `src-tauri/src/connection/shell_integration.rs`) so the frontend fallback used
+ * when `settings.shellIntegration` is absent matches what the backend persists.
+ */
+export function defaultShellIntegrationSettings(): ShellIntegrationSettings {
+  return {
+    entries: [],
+    fallback: "picker",
+    openInNewWindow: false,
+    registered: false,
+    linuxFileManagers: { nautilus: false, kde: false, thunar: false },
+    firstLaunchBannerDismissed: false,
+  };
+}
+
+/**
+ * Build a new quick-access entry with sensible defaults (folders-only, always
+ * visible, shows the session picker until a connection is chosen).
+ */
+export function createEntry(): ShellEntry {
+  return {
+    id: generateEntryId(),
+    name: "Open in termiHub",
+    connectionId: undefined,
+    visibility: "always",
+    showFor: { folders: true, files: false, folderBackground: false },
+  };
+}
+
+/** Generate a stable, collision-resistant id for a new entry. */
+export function generateEntryId(): string {
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
+    return cryptoObj.randomUUID();
+  }
+  return `entry-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Append an entry to the end of the list, returning a new array. */
+export function addEntry(entries: ShellEntry[], entry: ShellEntry): ShellEntry[] {
+  return [...entries, entry];
+}
+
+/** Replace the entry with a matching id, returning a new array. */
+export function updateEntry(entries: ShellEntry[], entry: ShellEntry): ShellEntry[] {
+  return entries.map((e) => (e.id === entry.id ? entry : e));
+}
+
+/** Remove the entry with the given id, returning a new array. */
+export function removeEntry(entries: ShellEntry[], id: string): ShellEntry[] {
+  return entries.filter((e) => e.id !== id);
+}
+
+/**
+ * Move the entry at `fromIndex` to `toIndex`, returning a new array. Out-of-range
+ * indices yield the original order (defensive; the caller resolves indices from
+ * the current list).
+ */
+export function reorderEntries(
+  entries: ShellEntry[],
+  fromIndex: number,
+  toIndex: number
+): ShellEntry[] {
+  if (
+    fromIndex < 0 ||
+    toIndex < 0 ||
+    fromIndex >= entries.length ||
+    toIndex >= entries.length ||
+    fromIndex === toIndex
+  ) {
+    return entries;
+  }
+  const next = [...entries];
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
+}

--- a/src/components/Settings/shellIntegrationStore.ts
+++ b/src/components/Settings/shellIntegrationStore.ts
@@ -1,0 +1,44 @@
+import { useAppStore } from "@/store/appStore";
+import type { ShellIntegrationSettings, ShellIntegrationStatus } from "@/types/connection";
+import type { ToastPromiseMessages } from "@/components/ui";
+import { defaultShellIntegrationSettings } from "./shellIntegrationEntries";
+
+/** Read the current shell-integration settings from the store, with a default fallback. */
+export function currentShellIntegration(): ShellIntegrationSettings {
+  return useAppStore.getState().settings.shellIntegration ?? defaultShellIntegrationSettings();
+}
+
+/**
+ * Write shell-integration settings into the store, keeping `settings` and
+ * `savedSettings` in lockstep (mirrors `updateSettings`, but for the value
+ * persisted out-of-band via the dedicated shell-integration command).
+ */
+export function writeShellIntegration(nextSi: ShellIntegrationSettings): void {
+  useAppStore.setState((s) => {
+    const next = { ...s.settings, shellIntegration: nextSi };
+    return { settings: next, savedSettings: next };
+  });
+}
+
+/** Merge the registration facts from a refreshed status back into the store. */
+export function syncRegistrationFacts(status: ShellIntegrationStatus): void {
+  writeShellIntegration({
+    ...currentShellIntegration(),
+    registered: status.registered,
+    registeredExePath: status.registeredExePath,
+  });
+}
+
+/** Toast messages for the register (install / reinstall) lifecycle. */
+export const INSTALL_TOAST: ToastPromiseMessages<unknown> = {
+  loading: "Registering shell integration…",
+  success: "Shell integration registered",
+  error: (e) => `Registration failed: ${String(e)}`,
+};
+
+/** Toast messages for the unregister (uninstall) lifecycle. */
+export const UNINSTALL_TOAST: ToastPromiseMessages<unknown> = {
+  loading: "Removing shell integration…",
+  success: "Shell integration removed",
+  error: (e) => `Removal failed: ${String(e)}`,
+};

--- a/src/components/ShellIntegrationBanner/ShellIntegrationBanner.css
+++ b/src/components/ShellIntegrationBanner/ShellIntegrationBanner.css
@@ -1,0 +1,43 @@
+/* First-launch shell-integration install banner (issue 1371). Tokens only. */
+
+.shell-integration-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: color-mix(in srgb, var(--accent-color) 10%, var(--bg-secondary));
+  border-top: 1px solid var(--border-primary);
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+}
+
+.shell-integration-banner__icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--accent-color);
+  flex-shrink: 0;
+}
+
+.shell-integration-banner__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.shell-integration-banner__text strong {
+  font-weight: var(--font-weight-semibold);
+}
+
+.shell-integration-banner__text span {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.shell-integration-banner__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-shrink: 0;
+}

--- a/src/components/ShellIntegrationBanner/ShellIntegrationBanner.test.tsx
+++ b/src/components/ShellIntegrationBanner/ShellIntegrationBanner.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { ShellIntegrationStatus } from "@/types/connection";
+import * as api from "@/services/api";
+import { ShellIntegrationBanner } from "./ShellIntegrationBanner";
+import { defaultShellIntegrationSettings } from "@/components/Settings/shellIntegrationEntries";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/api")>();
+  return {
+    ...actual,
+    getShellIntegrationStatus: vi.fn(),
+    saveShellIntegrationSettings: vi.fn(),
+    installShellIntegration: vi.fn(),
+  };
+});
+
+const mockedApi = vi.mocked(api);
+
+function status(overrides: Partial<ShellIntegrationStatus> = {}): ShellIntegrationStatus {
+  return {
+    registered: false,
+    exePathMatches: true,
+    stale: false,
+    portable: false,
+    detectedFileManagers: [],
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render() {
+  await act(async () => {
+    root.render(<ShellIntegrationBanner />);
+  });
+}
+
+function byTestId(id: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${id}"]`);
+}
+
+describe("ShellIntegrationBanner", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings,
+        shellIntegration: defaultShellIntegrationSettings(),
+      },
+    });
+    mockedApi.getShellIntegrationStatus.mockResolvedValue(status());
+    mockedApi.saveShellIntegrationSettings.mockResolvedValue(status());
+    mockedApi.installShellIntegration.mockResolvedValue(status({ registered: true }));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows the banner when not registered and not dismissed", async () => {
+    await render();
+    expect(byTestId("shell-integration-banner")).not.toBeNull();
+  });
+
+  it("hides the banner once the integration is registered", async () => {
+    mockedApi.getShellIntegrationStatus.mockResolvedValue(status({ registered: true }));
+    await render();
+    expect(byTestId("shell-integration-banner")).toBeNull();
+  });
+
+  it("hides the banner when previously dismissed", async () => {
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings,
+        shellIntegration: {
+          ...defaultShellIntegrationSettings(),
+          firstLaunchBannerDismissed: true,
+        },
+      },
+    });
+    await render();
+    expect(byTestId("shell-integration-banner")).toBeNull();
+  });
+
+  it("dismisses for the session without persisting on Not now", async () => {
+    await render();
+    await act(async () => {
+      byTestId("shell-integration-banner-not-now")?.click();
+    });
+    expect(byTestId("shell-integration-banner")).toBeNull();
+    expect(mockedApi.saveShellIntegrationSettings).not.toHaveBeenCalled();
+  });
+
+  it("persists firstLaunchBannerDismissed on Don't ask again", async () => {
+    await render();
+    await act(async () => {
+      byTestId("shell-integration-banner-dismiss")?.click();
+    });
+    expect(mockedApi.saveShellIntegrationSettings).toHaveBeenCalledTimes(1);
+    expect(mockedApi.saveShellIntegrationSettings.mock.calls[0][0].firstLaunchBannerDismissed).toBe(
+      true
+    );
+  });
+});

--- a/src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx
+++ b/src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx
@@ -10,6 +10,12 @@ import {
   saveShellIntegrationSettings,
 } from "@/services/api";
 import { defaultShellIntegrationSettings } from "@/components/Settings/shellIntegrationEntries";
+import {
+  INSTALL_TOAST,
+  currentShellIntegration,
+  syncRegistrationFacts,
+  writeShellIntegration,
+} from "@/components/Settings/shellIntegrationStore";
 import "./ShellIntegrationBanner.css";
 
 /**
@@ -20,44 +26,49 @@ import "./ShellIntegrationBanner.css";
  * Modelled on {@link TerminalViewModeBanner}.
  */
 export function ShellIntegrationBanner() {
-  const settings = useAppStore((s) => s.settings);
-  const si = settings.shellIntegration ?? defaultShellIntegrationSettings();
+  const storedSi = useAppStore((s) => s.settings.shellIntegration);
+  const si = storedSi ?? defaultShellIntegrationSettings();
+  // The banner can never show once dismissed or registered, so it need not even
+  // resolve the runtime status in the steady-state case.
+  const eligible = !si.firstLaunchBannerDismissed && !si.registered;
 
   const [status, setStatus] = useState<ShellIntegrationStatus | null>(null);
   const [dismissedThisSession, setDismissedThisSession] = useState(false);
 
   useEffect(() => {
+    if (!eligible) return;
     getShellIntegrationStatus()
       .then(setStatus)
       .catch((e) => frontendLog("shell_integration", `banner status load failed: ${String(e)}`));
-  }, []);
+  }, [eligible]);
 
   const persistDismissed = useCallback(async () => {
-    const current = useAppStore.getState().settings;
-    const currentSi = current.shellIntegration ?? defaultShellIntegrationSettings();
-    const nextSi = { ...currentSi, firstLaunchBannerDismissed: true };
-    const next = { ...current, shellIntegration: nextSi };
-    useAppStore.setState({ settings: next, savedSettings: next });
+    const prevSi = currentShellIntegration();
+    const nextSi = { ...prevSi, firstLaunchBannerDismissed: true };
+    writeShellIntegration(nextSi);
     try {
       await saveShellIntegrationSettings(nextSi);
     } catch (e) {
       frontendLog("shell_integration", `banner dismiss persist failed: ${String(e)}`);
+      writeShellIntegration(prevSi);
     }
   }, []);
 
   const handleInstall = useCallback(
     () =>
-      toast.promise(installShellIntegration().then(setStatus), {
-        loading: "Registering shell integration…",
-        success: "Shell integration registered",
-        error: (e) => `Registration failed: ${String(e)}`,
-      }),
+      toast.promise(
+        installShellIntegration().then((st) => {
+          setStatus(st);
+          syncRegistrationFacts(st);
+        }),
+        INSTALL_TOAST
+      ),
     []
   );
 
   // Hide until status is known, once registered, after a session dismiss, or
   // when the user opted out permanently.
-  if (!status || status.registered || si.firstLaunchBannerDismissed || dismissedThisSession) {
+  if (!eligible || !status || status.registered || dismissedThisSession) {
     return null;
   }
 

--- a/src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx
+++ b/src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from "react";
+import { FolderOpen } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { frontendLog } from "@/utils/frontendLog";
+import type { ShellIntegrationStatus } from "@/types/connection";
+import { Button, toast } from "@/components/ui";
+import {
+  getShellIntegrationStatus,
+  installShellIntegration,
+  saveShellIntegrationSettings,
+} from "@/services/api";
+import { defaultShellIntegrationSettings } from "@/components/Settings/shellIntegrationEntries";
+import "./ShellIntegrationBanner.css";
+
+/**
+ * Non-blocking first-launch banner offering to add the "Open in termiHub"
+ * entries to the user's file manager. Shown once, at the bottom of the app
+ * shell, until the integration is registered or the user opts out
+ * ("Don't ask again" persists `shellIntegration.firstLaunchBannerDismissed`).
+ * Modelled on {@link TerminalViewModeBanner}.
+ */
+export function ShellIntegrationBanner() {
+  const settings = useAppStore((s) => s.settings);
+  const si = settings.shellIntegration ?? defaultShellIntegrationSettings();
+
+  const [status, setStatus] = useState<ShellIntegrationStatus | null>(null);
+  const [dismissedThisSession, setDismissedThisSession] = useState(false);
+
+  useEffect(() => {
+    getShellIntegrationStatus()
+      .then(setStatus)
+      .catch((e) => frontendLog("shell_integration", `banner status load failed: ${String(e)}`));
+  }, []);
+
+  const persistDismissed = useCallback(async () => {
+    const current = useAppStore.getState().settings;
+    const currentSi = current.shellIntegration ?? defaultShellIntegrationSettings();
+    const nextSi = { ...currentSi, firstLaunchBannerDismissed: true };
+    const next = { ...current, shellIntegration: nextSi };
+    useAppStore.setState({ settings: next, savedSettings: next });
+    try {
+      await saveShellIntegrationSettings(nextSi);
+    } catch (e) {
+      frontendLog("shell_integration", `banner dismiss persist failed: ${String(e)}`);
+    }
+  }, []);
+
+  const handleInstall = useCallback(
+    () =>
+      toast.promise(installShellIntegration().then(setStatus), {
+        loading: "Registering shell integration…",
+        success: "Shell integration registered",
+        error: (e) => `Registration failed: ${String(e)}`,
+      }),
+    []
+  );
+
+  // Hide until status is known, once registered, after a session dismiss, or
+  // when the user opted out permanently.
+  if (!status || status.registered || si.firstLaunchBannerDismissed || dismissedThisSession) {
+    return null;
+  }
+
+  return (
+    <div className="shell-integration-banner" data-testid="shell-integration-banner">
+      <span className="shell-integration-banner__icon">
+        <FolderOpen size={16} />
+      </span>
+      <div className="shell-integration-banner__text">
+        <strong>Add “Open in termiHub” to your file manager?</strong>
+        <span>Right-click any folder to open it directly in termiHub.</span>
+      </div>
+      <div className="shell-integration-banner__actions">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setDismissedThisSession(true)}
+          data-testid="shell-integration-banner-not-now"
+        >
+          Not now
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={persistDismissed}
+          data-testid="shell-integration-banner-dismiss"
+        >
+          Don't ask again
+        </Button>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleInstall}
+          data-testid="shell-integration-banner-install"
+        >
+          Install Now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ShellIntegrationBanner/index.ts
+++ b/src/components/ShellIntegrationBanner/index.ts
@@ -1,0 +1,1 @@
+export { ShellIntegrationBanner } from "./ShellIntegrationBanner";

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,6 +21,7 @@ import {
   ExternalFileError,
   AppSettings,
   ShellIntegrationStatus,
+  ShellIntegrationSettings,
   AgentCapabilities,
   AgentSettings,
   RecoveryWarning,
@@ -490,6 +491,35 @@ export async function saveSettings(settings: AppSettings): Promise<void> {
  */
 export async function getShellIntegrationStatus(): Promise<ShellIntegrationStatus> {
   return await invoke<ShellIntegrationStatus>("get_shell_integration_status");
+}
+
+/**
+ * Persist the shell-integration settings and, when the integration is currently
+ * registered, refresh the OS context-menu registration so it reflects the edited
+ * entries. Returns the recomputed registration + staleness status.
+ */
+export async function saveShellIntegrationSettings(
+  shellIntegration: ShellIntegrationSettings
+): Promise<ShellIntegrationStatus> {
+  return await invoke<ShellIntegrationStatus>("save_shell_integration_settings", {
+    shellIntegration,
+  });
+}
+
+/**
+ * Register the configured entries as OS file-manager context-menu items and
+ * persist the updated registration status. Returns the refreshed status.
+ */
+export async function installShellIntegration(): Promise<ShellIntegrationStatus> {
+  return await invoke<ShellIntegrationStatus>("install_shell_integration");
+}
+
+/**
+ * Remove all OS file-manager context-menu registrations and persist the updated
+ * registration status. Returns the refreshed status.
+ */
+export async function uninstallShellIntegration(): Promise<ShellIntegrationStatus> {
+  return await invoke<ShellIntegrationStatus>("uninstall_shell_integration");
 }
 
 /** Save an external connection file to disk */

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -389,7 +389,29 @@ Fixed strings — match exactly.
 | `settings-right-click-behavior` | `src/components/Settings/TerminalSettings.tsx` |
 | `settings-saved-ack` | `src/components/Settings/SettingsPanel.tsx` |
 | `settings-serial-port-prefixes` | `src/components/Settings/SerialPortSettings.tsx` |
+| `settings-shell-integration` | `src/components/Settings/ShellIntegrationSettings.tsx` |
 | `settings-stop-x-server-idle` | `src/components/Settings/GeneralSettings.tsx` |
+| `shell-integration-add-entry` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-banner` | `src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx` |
+| `shell-integration-banner-dismiss` | `src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx` |
+| `shell-integration-banner-install` | `src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx` |
+| `shell-integration-banner-not-now` | `src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx` |
+| `shell-integration-entries-empty` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-entry-connection` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
+| `shell-integration-entry-editor` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
+| `shell-integration-entry-list` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-entry-name` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
+| `shell-integration-entry-save` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
+| `shell-integration-entry-visibility` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
+| `shell-integration-fallback` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-linux` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-new-window` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-reinstall` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-stale-badge` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-stale-banner` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-status-card` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-status-text` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-uninstall` | `src/components/Settings/ShellIntegrationSettings.tsx` |
 | `shortcuts-overlay` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |
 | `shortcuts-overlay-search` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |
 | `sidebar` | `src/components/Sidebar/Sidebar.tsx` |
@@ -657,6 +679,10 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `server-start-*` | `server-start-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `server-stop-*` | `server-stop-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `settings-nav-*` | `settings-nav-${cat.id}` | `src/components/Settings/SettingsNav.tsx` |
+| `shell-integration-entry-*` | `shell-integration-entry-${entry.id}` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-entry-delete-*` | `shell-integration-entry-delete-${entry.id}` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-entry-edit-*` | `shell-integration-entry-edit-${entry.id}` | `src/components/Settings/ShellIntegrationSettings.tsx` |
+| `shell-integration-linux-*` | `shell-integration-linux-${id}` | `src/components/Settings/ShellIntegrationSettings.tsx` |
 | `shortcut-row-*` | `shortcut-row-${binding.action}` | `src/components/KeyboardShortcuts/ShortcutsOverlay.tsx` |
 | `sidebar-group-separator-*` | `sidebar-group-separator-${i - 1}` | `src/components/Sidebar/ConnectionList.tsx` |
 | `tab-*` | `tab-${tab.id}` | `src/components/Terminal/Tab.tsx` |


### PR DESCRIPTION
## Summary

Adds the **Shell Integration** settings section (epic #1363), building on the merged config model (#1367) and Windows registration seam (#1368):

- **Registration status card** with **Reinstall / Update** and **Uninstall** actions (full `toast.promise` loading → success/error feedback) and a staleness banner when the registered executable has moved.
- **Draggable Quick-Access entry list** (dnd-kit sortable) — add, edit, reorder, delete.
- **Entry-editor Modal** — name, connection / "Show session picker", Windows visibility (Always / Extended-only), and "Show for" targets (folders / files / folder background).
- **Fallback** Select (session picker / system default shell) and a **new-window** Toggle.
- **Linux-only** per-file-manager install toggles (Nautilus / KDE / Thunar) with detection labels.
- **First-launch install banner** (persists `firstLaunchBannerDismissed`; modeled on `TerminalViewModeBanner`), mounted in the app shell.
- Backend `save_shell_integration_settings` command that persists the settings and re-registers via the existing #1368/#1369 seam when already registered.

Composed entirely from the shared `src/components/ui/` primitives (Modal, Button, Toggle, Select, Field, Input) on design tokens; the two-way choices use `Select` and booleans use `Toggle` (no bespoke radios — no Radio primitive exists). All actions give feedback; no `console.*` (uses `frontendLog`).

Wires the four SettingsPanel registration points: the `SettingsCategory` union + `CATEGORIES` + `SETTINGS_REGISTRY` in `settingsRegistry.ts`, and the icon map + switch + search block in `SettingsPanel.tsx`.

**Out of scope** (per the issue): the OS-write logic itself (SI-5/6/7) and the session picker dialog (SI-3 / #1366).

## Test plan

- **Unit (Vitest):** pure entry helpers (CRUD + reorder + defaults); panel (status card, Registered/Not-registered, staleness banner, Reinstall trigger, entry add/delete, Linux-toggle platform gating); banner (visibility gating, session vs persisted dismissal). `pnpm test` → 2758 passing; `pnpm build` clean.
- **Rust:** `save_shell_integration_settings` staging/re-register gating unit test; `cargo test --lib shell_integration` green; `cargo clippy` clean.
- **CI mirror:** `./scripts/check.sh` passes (format, lint, clippy).
- **Manual (per OS):** register → right-click a folder in the file manager → confirm the entry opens termiHub; verify the staleness banner after moving the executable; verify the first-launch banner appears once and respects "Don't ask again".

## Follow-ups

- #1411 — move shell-integration persistence into a store action (the panel/banner currently centralize the `settings`/`savedSettings` write + rollback in a helper rather than routing through the shared `updateSettings` store action).

Closes #1371

🤖 Generated with [Claude Code](https://claude.com/claude-code)