### PR TITLE
refactor(ui): adopt shared async Button pending lifecycle across tools & editors (Closes #1344)

### DIFF
--- a/docs/changes/dev0/feature/1344-async-button-lifecycle.md
+++ b/docs/changes/dev0/feature/1344-async-button-lifecycle.md
@@ -1,0 +1,21 @@
+### Changed
+
+- Primary actions across several surfaces now drive their "working" feedback
+  through the shared Button's async lifecycle (spinner + disabled + a
+  `pendingLabel` on the pressed control) instead of a hand-rolled flag or a
+  distant footer message (#1344):
+  - **Network Tools**: verbs are now consistent per tool class. Streaming tools
+    (Ping, Traceroute, Port Scanner, HTTP Monitor) share one **Start ↔ Stop**
+    toggle — Traceroute and Port Scanner moved off "Run" to "Start" — with
+    Starting…/Stopping… pending labels. One-shot tools (DNS Lookup, Open Ports,
+    Wake-on-LAN) show their pending state on the button (Looking up…/Refreshing…/
+    Sending…) rather than the gray "Querying…"/"Loading…" footer text, which was
+    removed. Live streaming progress footers (e.g. "Scanning… N ports checked")
+    are unchanged.
+  - **Embedded servers**: the Start/Stop buttons now show the spinner on the
+    pressed control while the action is in flight (replacing an internal busy
+    flag).
+  - **Connection editor**: Save & Connect now shows its pending state and, when
+    the password prompt or credential-store unlock is dismissed, surfaces a
+    recoverable "Connect canceled — your changes were saved." notice instead of
+    silently finishing with a false success.

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -6,7 +6,24 @@ import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
 import { resetRuntimeCache } from "@/hooks/useAvailableRuntimes";
 import { ConnectionEditor } from "./ConnectionEditor";
-import { TooltipProvider } from "@/components/ui";
+import { TooltipProvider, toast } from "@/components/ui";
+
+// Partial-mock the toast surface so Save & Connect feedback can be asserted
+// without a real Sonner portal. Other ui exports (TooltipProvider, Button, …)
+// keep their real implementations.
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
 import type { ConnectionTypeInfo } from "@/types/connection";
 import type { SavedConnection, RemoteAgentDefinition } from "@/types/connection";
 import { DEFAULT_AGENT_SETTINGS } from "@/types/connection";
@@ -326,6 +343,46 @@ describe("ConnectionEditor — Save & Connect credential handling", () => {
 
     // No stored credential → password dialog must appear
     expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+  });
+
+  it("surfaces a recoverable state (no silent success) when the password prompt is cancelled", async () => {
+    // #1344: handleSaveAndConnect previously returned silently when the user
+    // dismissed the password prompt, so the async Button flashed success even
+    // though nothing connected. It must instead surface a recoverable state
+    // (toast) and never open a session / close the editor.
+    const addTab = vi.fn();
+    useAppStore.setState({
+      requestPassword: vi.fn().mockResolvedValue(null), // user dismisses the prompt
+      addTab,
+    });
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "resolve_credential") return Promise.resolve(null);
+      if (cmd === "save_connection") return Promise.resolve();
+      if (cmd === "load_connections_and_folders")
+        return Promise.resolve({ connections: [SSH_CONN_PASSWORD, SSH_CONN_KEY], folders: [] });
+      return Promise.resolve(null);
+    });
+
+    renderFor(SSH_CONN_PASSWORD.id);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const btn = container.querySelector(
+      '[data-testid="connection-editor-save-connect"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // No session was opened (connect aborted)…
+    expect(addTab).not.toHaveBeenCalled();
+    // …and the cancellation surfaced a recoverable state instead of silence.
+    expect(toast.info).toHaveBeenCalled();
   });
 
   it("prompts to unlock the credential store before resolving when locked (G3, #1144)", async () => {

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -54,6 +54,20 @@ import "./ConnectionEditor.css";
 
 type EditorCategory = "connection" | "terminal" | "appearance" | "agent";
 
+/**
+ * Thrown from `handleSaveAndConnect` when the user dismisses a credential prompt
+ * (password or store-unlock). The Save & Connect Button suppresses its default
+ * error toast (`errorToast={false}`), so this rejection lands the Button back at
+ * idle — no false success flash — while the handler surfaces its own recoverable
+ * `toast.info`. See #1344.
+ */
+class PromptCanceledError extends Error {
+  constructor() {
+    super("Connect canceled by user");
+    this.name = "PromptCanceledError";
+  }
+}
+
 const EDITOR_CATEGORIES = [
   { id: "connection", label: "Connection" },
   { id: "terminal", label: "Terminal" },
@@ -824,7 +838,16 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
       return;
     }
     if (isAgentDefinitionMode && existingAgent) {
-      if (!(await saveAgentDefinition())) return;
+      try {
+        if (!(await saveAgentDefinition())) return;
+      } catch (err) {
+        // Save & Connect suppresses the Button's default error toast so it can
+        // choose the right severity; surface the save failure explicitly here.
+        toast.error("Failed to save agent connection", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
       addTab(
         name.trim(),
         "remote-session",
@@ -893,7 +916,13 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
             authMethod,
             savePassword: savePasswordFlag,
           });
-          if (!proceed) return;
+          if (!proceed) {
+            // The connection was saved; only the connect step was aborted. Surface
+            // a recoverable state (rather than silently resolving, which would flash
+            // a false success on the Button) and stop here — see #1344.
+            toast.info("Connect canceled — your changes were saved.");
+            throw new PromptCanceledError();
+          }
 
           const resolution = await resolveConnectionCredential(
             saved.id,
@@ -907,7 +936,13 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
 
         if (!resolvedPassword) {
           resolvedPassword = await requestPassword(host, username);
-          if (resolvedPassword === null) return;
+          if (resolvedPassword === null) {
+            // Same recoverable-state handling as the unlock gate above (#1344):
+            // the save persisted, so inform the user the connect was canceled
+            // instead of returning silently into a false success flash.
+            toast.info("Connect canceled — your changes were saved.");
+            throw new PromptCanceledError();
+          }
           // Persist the freshly-entered secret when the prompt's Save box is
           // checked. The sidebar connect path did this but Save & Connect did not,
           // so "Save password" was silently ignored here (#874, #879). The
@@ -1234,6 +1269,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           <Button
             variant="primary"
             onClick={handleSaveAndConnect}
+            errorToast={false}
             aria-disabled={!canSave}
             data-invalid={!canSave || undefined}
             data-testid="connection-editor-save-connect"

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.test.tsx
@@ -145,6 +145,41 @@ describe("EmbeddedServerItem", () => {
     ).toBe(false);
   });
 
+  it("drives the shared Button async lifecycle (aria-busy) while starting", async () => {
+    // Regression for #1344: the pending state must come from the shared Button's
+    // async lifecycle (onClick returns the promise), not a hand-rolled `busy`
+    // flag. A hand-rolled flag never sets aria-busy on the pressed control.
+    let resolveStart!: () => void;
+    const onStart = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        })
+    );
+    render(<EmbeddedServerItem {...baseProps({ onStart })} />);
+
+    const startBtn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="server-start-srv-1"]'
+    )!;
+    click(startBtn);
+
+    expect(startBtn.getAttribute("aria-busy")).toBe("true");
+    expect(startBtn.disabled).toBe(true);
+
+    await act(async () => {
+      resolveStart();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Returns to idle after the promise settles.
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="server-start-srv-1"]')!
+        .getAttribute("aria-busy")
+    ).toBeNull();
+  });
+
   it("surfaces a toast.error when stopping fails", async () => {
     const onStop = vi.fn(() => Promise.reject("stop boom"));
     render(<EmbeddedServerItem {...baseProps({ onStop, state: runningState })} />);

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { Play, Square, Pencil, Copy, Trash2, ExternalLink, Clipboard } from "lucide-react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manager";
@@ -75,31 +75,29 @@ export function EmbeddedServerItem({
   const status = state?.status;
   const active = isActive(status);
   const url = serverUrl(config);
-  const [busy, setBusy] = useState(false);
 
+  // Start/Stop drive the shared Button's async lifecycle: returning the promise
+  // makes the pressed control show the spinner + disable itself while in flight
+  // (no hand-rolled `busy` flag). We keep the server-scoped error toast and set
+  // `errorToast={false}` on the Button, then re-throw so the Button lands in its
+  // error path (idle, no false success flash) — see #1344.
   const handleStart = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
     try {
       await onStart(config.id);
     } catch (err) {
       toast.error(`Failed to start ${config.name}`, { description: errorMessage(err) });
-    } finally {
-      setBusy(false);
+      throw err;
     }
-  }, [busy, onStart, config.id, config.name]);
+  }, [onStart, config.id, config.name]);
 
   const handleStop = useCallback(async () => {
-    if (busy) return;
-    setBusy(true);
     try {
       await onStop(config.id);
     } catch (err) {
       toast.error(`Failed to stop ${config.name}`, { description: errorMessage(err) });
-    } finally {
-      setBusy(false);
+      throw err;
     }
-  }, [busy, onStop, config.id, config.name]);
+  }, [onStop, config.id, config.name]);
 
   const handleCopyUrl = () => {
     writeClipboard(url)
@@ -142,11 +140,11 @@ export function EmbeddedServerItem({
                     iconOnly
                     aria-label="Stop"
                     data-testid={`server-stop-${config.id}`}
-                    disabled={busy}
+                    errorToast={false}
                     icon={<Square size={12} />}
                     onClick={(e) => {
                       e.stopPropagation();
-                      void handleStop();
+                      return handleStop();
                     }}
                   />
                 </Tooltip>
@@ -158,11 +156,11 @@ export function EmbeddedServerItem({
                     iconOnly
                     aria-label="Start"
                     data-testid={`server-start-${config.id}`}
-                    disabled={busy}
+                    errorToast={false}
                     icon={<Play size={12} />}
                     onClick={(e) => {
                       e.stopPropagation();
-                      void handleStart();
+                      return handleStart();
                     }}
                   />
                 </Tooltip>
@@ -230,7 +228,7 @@ export function EmbeddedServerItem({
           {active ? (
             <ContextMenu.Item
               className="context-menu__item"
-              onSelect={() => void handleStop()}
+              onSelect={() => void handleStop().catch(() => {})}
               data-testid={`ctx-stop-${config.id}`}
             >
               <Square size={14} /> Stop
@@ -238,7 +236,7 @@ export function EmbeddedServerItem({
           ) : (
             <ContextMenu.Item
               className="context-menu__item"
-              onSelect={() => void handleStart()}
+              onSelect={() => void handleStart().catch(() => {})}
               data-testid={`ctx-start-${config.id}`}
             >
               <Play size={14} /> Start

--- a/src/components/NetworkTools/DnsLookupPanel.test.tsx
+++ b/src/components/NetworkTools/DnsLookupPanel.test.tsx
@@ -66,6 +66,40 @@ describe("DnsLookupPanel — Button migration", () => {
     expect(container.textContent).toContain("93.184.216.34");
   });
 
+  it("shows the pending affordance on the Button (not the gray footer) while in flight", async () => {
+    // #1344: pending must be driven by the shared Button lifecycle + pendingLabel,
+    // not the footer "Querying…" text.
+    let resolve!: (v: { records: []; queryMs: number }) => void;
+    vi.mocked(networkDnsLookup).mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolve = r;
+        })
+    );
+    await act(async () => {
+      root.render(<DnsLookupPanel prefillHost="example.com" />);
+    });
+
+    const btn = container.querySelector<HTMLButtonElement>('[data-testid="dns-run"]')!;
+    await act(async () => {
+      btn.click();
+    });
+
+    expect(btn.getAttribute("aria-busy")).toBe("true");
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toContain("Looking up…");
+    // The old gray-footer pending indicator is gone.
+    expect(container.textContent).not.toContain("Querying…");
+
+    await act(async () => {
+      resolve({ records: [], queryMs: 5 });
+      await Promise.resolve();
+    });
+
+    const after = container.querySelector<HTMLButtonElement>('[data-testid="dns-run"]')!;
+    expect(after.getAttribute("aria-busy")).toBeNull();
+  });
+
   it("shows the error inline when the lookup fails", async () => {
     vi.mocked(networkDnsLookup).mockRejectedValueOnce(new Error("NXDOMAIN"));
     await act(async () => {

--- a/src/components/NetworkTools/DnsLookupPanel.tsx
+++ b/src/components/NetworkTools/DnsLookupPanel.tsx
@@ -54,8 +54,9 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
   }, [hostname, recordType, server]);
 
   // Enter submits the form; a mouse click goes through the Button's onClick so its
-  // async lifecycle drives the pending affordance (Enter path ignores the throw).
-  const handleSubmit = useFormSubmit(!!hostname.trim(), () => void handleRun().catch(() => {}));
+  // async lifecycle drives the pending affordance (useFormSubmit swallows the
+  // Enter-path rejection that the click path uses to drive the Button error state).
+  const handleSubmit = useFormSubmit(!!hostname.trim(), handleRun);
 
   const columns = [
     { key: "recordType", label: "Type" },

--- a/src/components/NetworkTools/DnsLookupPanel.tsx
+++ b/src/components/NetworkTools/DnsLookupPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 import { Play } from "lucide-react";
 import { Button } from "@/components/ui";
 import { networkDnsLookup } from "@/services/networkApi";
-import type { DnsRecord, DnsRecordType, DiagnosticStatus } from "@/types/network";
+import type { DnsRecord, DnsRecordType } from "@/types/network";
 import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import { useFormSubmit } from "@/hooks/useFormSubmit";
@@ -30,7 +30,6 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
   const [hostname, setHostname] = useState(prefillHost ?? "");
   const [recordType, setRecordType] = useState<DnsRecordType>("A");
   const [server, setServer] = useState("");
-  const [status, setStatus] = useState<DiagnosticStatus>("idle");
   const [records, setRecords] = useState<DnsRecord[]>([]);
   const [queryMs, setQueryMs] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -39,7 +38,6 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
 
   const handleRun = useCallback(async () => {
     if (!hostname.trim()) return;
-    setStatus("running");
     setRecords([]);
     setQueryMs(null);
     setError(null);
@@ -48,16 +46,16 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
       const result = await networkDnsLookup(hostname, recordType, server.trim() || undefined);
       setRecords(result.records);
       setQueryMs(result.queryMs);
-      setStatus("completed");
     } catch (err) {
       setError(String(err));
-      setStatus("error");
       frontendLog("dns_lookup", `DNS lookup failed: ${err}`);
+      throw err; // keep the async Button in its error path (no false success flash)
     }
   }, [hostname, recordType, server]);
 
-  // Enter submits the form (respects the Run button's disabled state).
-  const handleSubmit = useFormSubmit(status !== "running" && !!hostname.trim(), handleRun);
+  // Enter submits the form; a mouse click goes through the Button's onClick so its
+  // async lifecycle drives the pending affordance (Enter path ignores the throw).
+  const handleSubmit = useFormSubmit(!!hostname.trim(), () => void handleRun().catch(() => {}));
 
   const columns = [
     { key: "recordType", label: "Type" },
@@ -83,7 +81,13 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
             variant="primary"
             size="sm"
             icon={<Play size={14} />}
-            disabled={!hostname.trim() || status === "running"}
+            pendingLabel="Looking up…"
+            errorToast={false}
+            disabled={!hostname.trim()}
+            onClick={(e) => {
+              e.preventDefault();
+              return handleRun();
+            }}
             data-testid="dns-run"
           >
             Run
@@ -136,11 +140,7 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
         rows={formattedRows}
         rowTestIdPrefix="dns-result"
         footer={
-          queryMs != null
-            ? `Query time: ${queryMs}ms · ${records.length} record(s) found`
-            : status === "running"
-              ? "Querying…"
-              : null
+          queryMs != null ? `Query time: ${queryMs}ms · ${records.length} record(s) found` : null
         }
       />
     </form>

--- a/src/components/NetworkTools/HttpMonitorPanel.tsx
+++ b/src/components/NetworkTools/HttpMonitorPanel.tsx
@@ -257,6 +257,8 @@ export function HttpMonitorPanel() {
               variant="danger"
               size="sm"
               icon={<StopCircle size={14} />}
+              pendingLabel="Stopping…"
+              errorToast={false}
               onClick={handleStop}
               data-testid="http-monitor-stop"
             >
@@ -268,7 +270,13 @@ export function HttpMonitorPanel() {
               variant="primary"
               size="sm"
               icon={<Play size={14} />}
+              pendingLabel="Starting…"
+              errorToast={false}
               disabled={!canStart}
+              onClick={(e) => {
+                e.preventDefault();
+                return handleStart();
+              }}
               data-testid="http-monitor-start"
             >
               Start

--- a/src/components/NetworkTools/OpenPortsPanel.tsx
+++ b/src/components/NetworkTools/OpenPortsPanel.tsx
@@ -2,29 +2,28 @@ import { useState, useCallback } from "react";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui";
 import { networkOpenPorts } from "@/services/networkApi";
-import type { OpenPort, PortProtocol, DiagnosticStatus } from "@/types/network";
+import type { OpenPort, PortProtocol } from "@/types/network";
 import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
 import { frontendLog } from "@/utils/frontendLog";
 
 /** Open Ports Viewer diagnostic tab content. */
 export function OpenPortsPanel() {
-  const [status, setStatus] = useState<DiagnosticStatus>("idle");
+  const [loaded, setLoaded] = useState(false);
   const [ports, setPorts] = useState<OpenPort[]>([]);
   const [filter, setFilter] = useState("");
   const [protocolFilter, setProtocolFilter] = useState<PortProtocol | "All">("All");
   const [error, setError] = useState<string | null>(null);
 
   const handleRefresh = useCallback(async () => {
-    setStatus("running");
     setError(null);
     try {
       const result = await networkOpenPorts();
       setPorts(result);
-      setStatus("completed");
+      setLoaded(true);
     } catch (err) {
       setError(String(err));
-      setStatus("error");
       frontendLog("open_ports", `Failed to list open ports: ${err}`);
+      throw err; // keep the async Button in its error path (no false success flash)
     }
   }, []);
 
@@ -64,8 +63,9 @@ export function OpenPortsPanel() {
             variant="primary"
             size="sm"
             icon={<RefreshCw size={14} />}
+            pendingLabel="Refreshing…"
+            errorToast={false}
             onClick={handleRefresh}
-            disabled={status === "running"}
             data-testid="open-ports-refresh"
           >
             Refresh
@@ -99,7 +99,7 @@ export function OpenPortsPanel() {
 
       {error && <div className="network-panel__error">{error}</div>}
 
-      {status === "idle" && ports.length === 0 && (
+      {!loaded && ports.length === 0 && (
         <div className="network-panel__placeholder">Click Refresh to list listening ports</div>
       )}
 
@@ -107,11 +107,9 @@ export function OpenPortsPanel() {
         columns={columns}
         rows={formattedRows}
         footer={
-          status === "completed"
+          loaded
             ? `${filtered.length} listening port(s)${filter ? ` (filtered from ${ports.length})` : ""}`
-            : status === "running"
-              ? "Loading…"
-              : null
+            : null
         }
       />
     </div>

--- a/src/components/NetworkTools/OpenPortsPanel.tsx
+++ b/src/components/NetworkTools/OpenPortsPanel.tsx
@@ -99,7 +99,7 @@ export function OpenPortsPanel() {
 
       {error && <div className="network-panel__error">{error}</div>}
 
-      {!loaded && ports.length === 0 && (
+      {!loaded && (
         <div className="network-panel__placeholder">Click Refresh to list listening ports</div>
       )}
 

--- a/src/components/NetworkTools/PingPanel.tsx
+++ b/src/components/NetworkTools/PingPanel.tsx
@@ -171,6 +171,8 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
               variant="danger"
               size="sm"
               icon={<StopCircle size={14} />}
+              pendingLabel="Stopping…"
+              errorToast={false}
               onClick={handleStop}
               data-testid="ping-stop"
             >
@@ -182,7 +184,13 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
               variant="primary"
               size="sm"
               icon={<Play size={14} />}
+              pendingLabel="Starting…"
+              errorToast={false}
               disabled={!canStart}
+              onClick={(e) => {
+                e.preventDefault();
+                return handleStart();
+              }}
               data-testid="ping-start"
             >
               Start

--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -144,7 +144,14 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
         <span className="network-panel__title">Port Scanner</span>
         <div className="network-panel__actions">
           {status === "running" ? (
-            <Button variant="danger" size="sm" icon={<StopCircle size={14} />} onClick={stop}>
+            <Button
+              variant="danger"
+              size="sm"
+              icon={<StopCircle size={14} />}
+              pendingLabel="Stopping…"
+              errorToast={false}
+              onClick={stop}
+            >
               Stop
             </Button>
           ) : (
@@ -153,10 +160,16 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
               variant="primary"
               size="sm"
               icon={<Play size={14} />}
+              pendingLabel="Starting…"
+              errorToast={false}
               disabled={!canRun}
+              onClick={(e) => {
+                e.preventDefault();
+                return handleRun();
+              }}
               data-testid="port-scanner-run"
             >
-              Run
+              Start
             </Button>
           )}
         </div>

--- a/src/components/NetworkTools/TraceroutePanel.error.test.tsx
+++ b/src/components/NetworkTools/TraceroutePanel.error.test.tsx
@@ -52,6 +52,16 @@ describe("TraceroutePanel — error handling", () => {
     vi.clearAllMocks();
   });
 
+  it("labels the idle primary action 'Start' (streaming tools share Start↔Stop)", async () => {
+    // #1344: streaming diagnostics share one Start↔Stop verb pair.
+    await act(async () => {
+      root.render(<TraceroutePanel prefillHost="example.com" />);
+    });
+    const btn = container.querySelector<HTMLButtonElement>('[data-testid="traceroute-run"]')!;
+    expect(btn.textContent).toContain("Start");
+    expect(btn.textContent).not.toContain("Run");
+  });
+
   it("registers all listeners before starting (no event race)", async () => {
     await act(async () => {
       root.render(<TraceroutePanel prefillHost="does-not-exist.invalid" />);

--- a/src/components/NetworkTools/TraceroutePanel.tsx
+++ b/src/components/NetworkTools/TraceroutePanel.tsx
@@ -90,7 +90,14 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
         <span className="network-panel__title">Traceroute</span>
         <div className="network-panel__actions">
           {status === "running" ? (
-            <Button variant="danger" size="sm" icon={<StopCircle size={14} />} onClick={stop}>
+            <Button
+              variant="danger"
+              size="sm"
+              icon={<StopCircle size={14} />}
+              pendingLabel="Stopping…"
+              errorToast={false}
+              onClick={stop}
+            >
               Stop
             </Button>
           ) : (
@@ -99,10 +106,16 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
               variant="primary"
               size="sm"
               icon={<Play size={14} />}
+              pendingLabel="Starting…"
+              errorToast={false}
               disabled={!canRun}
+              onClick={(e) => {
+                e.preventDefault();
+                return run();
+              }}
               data-testid="traceroute-run"
             >
-              Run
+              Start
             </Button>
           )}
         </div>

--- a/src/components/NetworkTools/WolPanel.tsx
+++ b/src/components/NetworkTools/WolPanel.tsx
@@ -92,8 +92,8 @@ export function WolPanel() {
 
   // Enter submits the form → send the magic packet (respects the disabled state).
   // A mouse click goes through the Button's onClick so its async lifecycle drives
-  // the pending affordance; the Enter path ignores the throw.
-  const handleSubmit = useFormSubmit(canSend, () => void handleSend().catch(() => {}));
+  // the pending affordance; useFormSubmit swallows the Enter-path rejection.
+  const handleSubmit = useFormSubmit(canSend, handleSend);
 
   const handleConfirmSave = useCallback(async () => {
     const name = saveName.trim();

--- a/src/components/NetworkTools/WolPanel.tsx
+++ b/src/components/NetworkTools/WolPanel.tsx
@@ -33,7 +33,7 @@ export function WolPanel() {
   const canSend = !!mac.trim() && !portError && !broadcastError;
   const [savedDevices, setSavedDevices] = useState<WolDevice[]>([]);
   const [history, setHistory] = useState<WolHistoryEntry[]>([]);
-  const [status, setStatus] = useState<string | null>(null);
+  const [sentMessage, setSentMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saveModalOpen, setSaveModalOpen] = useState(false);
   const [saveName, setSaveName] = useState("");
@@ -57,14 +57,15 @@ export function WolPanel() {
   const handleSend = useCallback(async () => {
     if (!canSend) return;
     setError(null);
-    setStatus(null);
+    setSentMessage(null);
     try {
       await networkWolSend(mac, broadcast, Number(port));
-      setStatus(`Magic packet sent to ${mac}`);
+      setSentMessage(`Magic packet sent to ${mac}`);
       setHistory((prev) => [{ mac, sentAt: new Date().toLocaleTimeString() }, ...prev.slice(0, 9)]);
     } catch (err) {
       setError(String(err));
       frontendLog("wol_panel", `WoL send failed: ${err}`);
+      throw err; // keep the async Button in its error path (no false success flash)
     }
   }, [mac, broadcast, port, canSend]);
 
@@ -90,7 +91,9 @@ export function WolPanel() {
   }, [canSend]);
 
   // Enter submits the form → send the magic packet (respects the disabled state).
-  const handleSubmit = useFormSubmit(canSend, handleSend);
+  // A mouse click goes through the Button's onClick so its async lifecycle drives
+  // the pending affordance; the Enter path ignores the throw.
+  const handleSubmit = useFormSubmit(canSend, () => void handleSend().catch(() => {}));
 
   const handleConfirmSave = useCallback(async () => {
     const name = saveName.trim();
@@ -138,7 +141,13 @@ export function WolPanel() {
             variant="primary"
             size="sm"
             icon={<Power size={14} />}
+            pendingLabel="Sending…"
+            errorToast={false}
             disabled={!canSend}
+            onClick={(e) => {
+              e.preventDefault();
+              return handleSend();
+            }}
             data-testid="wol-send"
           >
             Send
@@ -175,7 +184,7 @@ export function WolPanel() {
         />
       </div>
 
-      {status && <div className="network-panel__info">{status}</div>}
+      {sentMessage && <div className="network-panel__info">{sentMessage}</div>}
       {error && <div className="network-panel__error">{error}</div>}
 
       {/* Saved Devices */}

--- a/src/hooks/useFormSubmit.ts
+++ b/src/hooks/useFormSubmit.ts
@@ -8,14 +8,25 @@ import { useCallback, type FormEvent } from "react";
  * Used by the Network Tools panels, whose fields are wrapped in a `<form>` with
  * the primary action as the submit button.
  *
+ * The action may return a promise and may reject: one-shot panels re-throw so a
+ * mouse click drives the Button's async error path, but the Enter path has no
+ * Button lifecycle, so any rejection is swallowed here (the handler already
+ * surfaced the error inline/toast). This lets callers pass their stable
+ * `useCallback` handler directly instead of an inline `.catch()` wrapper.
+ *
  * @param canSubmit whether the form is currently valid/runnable.
  * @param action the primary action to run on submit.
  */
-export function useFormSubmit(canSubmit: boolean, action: () => void): (e: FormEvent) => void {
+export function useFormSubmit(
+  canSubmit: boolean,
+  action: () => void | Promise<void>
+): (e: FormEvent) => void {
   return useCallback(
     (e: FormEvent) => {
       e.preventDefault();
-      if (canSubmit) action();
+      if (!canSubmit) return;
+      const result = action();
+      if (result) void result.catch(() => {});
     },
     [canSubmit, action]
   );


### PR DESCRIPTION
## Summary

Adopts the shared async `Button` idle→pending→success lifecycle consistently across three surfaces, so "working" feedback lands on the pressed control instead of a hand-rolled flag or a distant footer. Builds on the merged #1341 (Enter-submit forms) and #1342 (feedback toasts) — their behavior is preserved.

### Network Tools (`src/components/NetworkTools/`)
- **Streaming tools** (Ping, Traceroute, Port Scanner, HTTP Monitor) share one **Start ↔ Stop** toggle — Traceroute and Port Scanner moved off "Run" to "Start". Start/Stop route through the Button's async `onClick` (keeping the `<form>` Enter-submit: `onClick` `preventDefault` runs the action on click, `onSubmit` on Enter) with `Starting…`/`Stopping…` `pendingLabel`s. Live-progress stream footers ("Scanning… N ports checked", "Tracing… hop N") are unchanged.
- **One-shot tools** (DNS, Open Ports, Wake-on-LAN) drive pending through the Button lifecycle + `pendingLabel` (`Looking up…`/`Refreshing…`/`Sending…`) instead of the gray `Querying…`/`Loading…` footer text (removed). Per ui-design ruling, one-shot verbs stay semantically distinct (Run/Refresh/Send) — consistency is in the pattern, not a single word. The hand-rolled `DiagnosticStatus` running/completed flag is dropped from DNS/Open Ports (Open Ports uses a plain `loaded` flag); WoL's `status` message state is renamed `sentMessage` to disambiguate it from a pending flag.

### Embedded servers (`EmbeddedServerItem.tsx`)
- Start/Stop drop the internal `busy` flag; `onClick` returns the promise so the pressed control shows the spinner + disables itself. The server-scoped error toast is preserved via `errorToast={false}` + re-throw (matching the `TunnelListItem` reference), so the Button lands idle with no false success.

### Connection editor (`ConnectionEditor.tsx`)
- Save & Connect shows pending via the async lifecycle and, when the password prompt or store-unlock is dismissed, now **surfaces a recoverable state** ("Connect canceled — your changes were saved.") and throws `PromptCanceledError` instead of silently returning into a false success flash. `errorToast={false}` on the button with an explicit `toast.error` for genuine agent-save failures.

### Cleanup (/simplify)
- `useFormSubmit` widened to accept `() => void | Promise<void>` and swallow the Enter-path rejection internally, so DNS/WoL pass their stable `useCallback` handler directly (removing an inline `.catch()` wrapper that defeated memoization).

## Test plan
- `test(embedded-servers)`: Start drives the shared Button lifecycle (`aria-busy` while in flight, back to idle after).
- `test(network)`: DNS shows the Button pending affordance (`Looking up…`, `aria-busy`, no footer `Querying…`); Traceroute idle verb is `Start`.
- `test(ui)`: Save & Connect surfaces a recoverable state (`toast.info`, no session opened) when the password prompt is cancelled.
- Full suite green: `pnpm test` (2762 passed), `pnpm build`, `pnpm lint`/`format:check`/`markdownlint` clean. Streaming panel data-testids kept stable (`traceroute-run`, `port-scanner-run`, …) so the Python system tests and testid catalog are unaffected.

## Follow-ups
- #1414 — unify the submit-button + async lifecycle so **Enter** (not just click) shows the pending affordance and the `preventDefault + return action()` snippet stops being duplicated per panel (a deeper primitive change, deliberately out of scope here).

Closes #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)
