### PR TITLE
feat(backend): Linux file-manager registration (XDG/Nautilus/KDE/Thunar) (Closes #1370)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7167,6 +7167,7 @@ dependencies = [
  "libunftp",
  "objc2-foundation",
  "portable-pty",
+ "quick-xml",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "russh",

--- a/docs/changes/dev0/feature/1370-linux-file-manager-registration.md
+++ b/docs/changes/dev0/feature/1370-linux-file-manager-registration.md
@@ -1,0 +1,18 @@
+# Changes — Linux file-manager registration (#1370)
+
+## Added
+
+- **Linux file-manager context-menu integration.** "Open in termiHub" entries
+  can now be registered into Linux file managers from the shell-integration
+  settings:
+  - A universal XDG `.desktop` launcher (registered for the `inode/directory`
+    MIME type) so termiHub appears under **Open With** in any XDG-compliant file
+    manager; the desktop database is refreshed automatically.
+  - **Nautilus** (GNOME) scripts, **KDE / Dolphin** service menus (KDE 5 and
+    KDE 6), and a **Thunar** (XFCE) custom action — each installed only when the
+    file manager is detected on the host and enabled by its per-manager toggle.
+  - The settings status now reports which file managers were detected on the
+    host.
+  - Uninstalling removes all four artifacts and, for the shared Thunar
+    `uca.xml`, removes only termiHub's action while preserving any custom
+    actions you added yourself.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1411,3 +1411,44 @@ On macOS:
 > discovery aid; the fully functional path is the per-entry Quick Action bundles
 > above. Wiring a native Services provider so the **app** entry also runs is
 > tracked as a follow-up.
+
+#### Linux file-manager registration (#1370)
+
+termiHub registers each configured shell-integration entry into the Linux file
+managers (`src-tauri/src/spawn/registry.rs`, Linux arm): a universal XDG
+`.desktop` launcher plus per-manager Nautilus scripts, KDE service menus, and a
+Thunar custom action. The file content, `0o755` script mode, detection logic,
+Thunar `uca.xml` append/de-append (foreign-action preservation), and
+owner-aware uninstall are covered by Linux-gated unit tests
+(`spawn::registry::linux::tests`, validated by the Linux CI job). Confirming
+each file manager actually surfaces and runs the entries is desktop-environment
+specific and manual.
+
+On a Linux desktop (run steps for whichever managers you have installed):
+
+1. Configure at least one shell-integration entry with **Show for → Folders**
+   enabled and its per-manager toggles (Nautilus / KDE / Thunar) on. Run the
+   install action (the `install_shell_integration` command, or
+   `termiHub install-shell-integration`).
+2. **XDG (universal):** confirm a `termihub-<slug>.desktop` file appears under
+   `~/.local/share/applications/` and that `update-desktop-database` ran
+   (`grep -l termiHub ~/.local/share/applications/mimeinfo.cache` or simply
+   right-click a folder → **Open With Other Application** and confirm termiHub is
+   listed for folders).
+3. **Nautilus (GNOME Files):** confirm a script named after the entry exists
+   under `~/.local/share/nautilus/scripts/` and is executable (`ls -l`; mode
+   `0o755`). In Files, right-click a folder → **Scripts → <entry name>** and
+   confirm termiHub opens a session at that path.
+4. **KDE (Dolphin):** confirm a `termihub-<slug>.desktop` service menu exists
+   under `~/.local/share/kio/servicemenus/` (KDE 6) and/or
+   `~/.local/share/kservices5/ServiceMenus/` (KDE 5). Right-click a folder in
+   Dolphin → **Actions** (or the top-level menu) → confirm the entry runs.
+5. **Thunar (XFCE):** confirm the action was appended to
+   `~/.config/Thunar/uca.xml` (`grep termihub- ~/.config/Thunar/uca.xml`) and
+   that **any custom actions you had before are still present**. In Thunar,
+   right-click a folder → confirm the entry appears and opens a termiHub session.
+6. Run the uninstall action (`uninstall_shell_integration` /
+   `termiHub uninstall-shell-integration`) and confirm **all four** artifacts are
+   removed: the XDG `.desktop`, the Nautilus script, the KDE service menu, and
+   termiHub's Thunar action — while any **foreign** Thunar actions in `uca.xml`
+   and unrelated Nautilus scripts remain untouched.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,10 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 semver = "1"
 dirs = "6"
 which = "7"
+# Streaming XML reader/writer used to append/remove termiHub's Thunar custom
+# action inside a shared ~/.config/Thunar/uca.xml without disturbing foreign
+# actions (Linux file-manager registration, #1370).
+quick-xml = "0.39"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "fmt", "env-filter"] }
 chrono = "0.4"

--- a/src-tauri/src/commands/shell_integration.rs
+++ b/src-tauri/src/commands/shell_integration.rs
@@ -19,7 +19,7 @@ fn current_status(manager: &ConnectionManager) -> ShellIntegrationStatus {
     let portable = detect_app_mode()
         .map(|mode| mode.is_portable())
         .unwrap_or(false);
-    let detected = shell_integration::detect_file_managers();
+    let detected = registry::detect_file_managers();
 
     shell_integration::build_status(
         &settings.shell_integration,

--- a/src-tauri/src/connection/shell_integration.rs
+++ b/src-tauri/src/connection/shell_integration.rs
@@ -287,15 +287,6 @@ pub fn build_status(
     }
 }
 
-/// Detect file managers installed on the host.
-///
-/// **Stub**: returns an empty list. Real per-OS detection (Nautilus / KDE /
-/// Thunar on Linux, etc.) is implemented with the registration work in a later
-/// epic issue.
-pub fn detect_file_managers() -> Vec<DetectedFileManager> {
-    Vec::new()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,11 +504,6 @@ mod tests {
         let status = build_status(&settings, None, true, managers.clone());
         assert!(status.portable);
         assert_eq!(status.detected_file_managers, managers);
-    }
-
-    #[test]
-    fn detect_file_managers_is_stubbed_empty() {
-        assert!(detect_file_managers().is_empty());
     }
 
     // ── Settings serde round-trip + forward-compat ───────────────────────

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -1438,22 +1438,24 @@ mod linux {
         /// Install the enabled + detected surfaces (idempotent — a prior
         /// registration is cleared first).
         pub fn install(&self, settings: &ShellIntegrationSettings, exe_path: &str) -> Result<()> {
-            self.uninstall()?;
+            // Idempotency: start from a clean slate (without refreshing the
+            // desktop database yet — a single refresh happens at the end).
+            self.remove_all()?;
             let entries = &settings.entries;
-            if entries.is_empty() {
-                return Ok(());
+            if !entries.is_empty() {
+                self.install_xdg(entries, exe_path)?;
+                let toggles = settings.linux_file_managers;
+                if toggles.nautilus && self.nautilus_detected() {
+                    self.install_nautilus(entries, exe_path)?;
+                }
+                if toggles.kde && self.kde_detected() {
+                    self.install_kde(entries, exe_path)?;
+                }
+                if toggles.thunar && self.thunar_detected() {
+                    self.install_thunar(entries, exe_path)?;
+                }
             }
-            self.install_xdg(entries, exe_path)?;
-            let toggles = settings.linux_file_managers;
-            if toggles.nautilus && self.nautilus_detected() {
-                self.install_nautilus(entries, exe_path)?;
-            }
-            if toggles.kde && self.kde_detected() {
-                self.install_kde(entries, exe_path)?;
-            }
-            if toggles.thunar && self.thunar_detected() {
-                self.install_thunar(entries, exe_path)?;
-            }
+            self.refresh_desktop_db();
             Ok(())
         }
 
@@ -1461,11 +1463,30 @@ mod linux {
         /// files and foreign Thunar actions are left untouched. Never fails when
         /// nothing is registered.
         pub fn uninstall(&self) -> Result<()> {
+            self.remove_all()?;
+            self.refresh_desktop_db();
+            Ok(())
+        }
+
+        /// Remove all four termiHub surfaces without refreshing the desktop
+        /// database. Shared by [`install`](Self::install) (clean slate) and
+        /// [`uninstall`](Self::uninstall).
+        fn remove_all(&self) -> Result<()> {
             self.remove_xdg()?;
             self.remove_nautilus()?;
             self.remove_kde()?;
             self.remove_thunar()?;
             Ok(())
+        }
+
+        /// Best-effort refresh of the desktop MIME database, once per public
+        /// operation. Skipped when the applications dir does not exist (nothing
+        /// to index).
+        fn refresh_desktop_db(&self) {
+            let apps = self.applications_dir();
+            if apps.exists() {
+                (self.on_desktop_db_update)(&apps);
+            }
         }
 
         // ── XDG .desktop (universal "Open With") ────────────────────────
@@ -1486,17 +1507,15 @@ mod linux {
                 std::fs::write(&path, xdg_desktop_file(entry, exe_path))
                     .with_context(|| format!("write XDG desktop file {}", path.display()))?;
             }
-            (self.on_desktop_db_update)(&apps);
             Ok(())
         }
 
         fn remove_xdg(&self) -> Result<()> {
-            let apps = self.applications_dir();
-            let removed = remove_managed_files(&apps, Some(DESKTOP_PREFIX), DESKTOP_MARKER)?;
-            if removed && apps.exists() {
-                (self.on_desktop_db_update)(&apps);
-            }
-            Ok(())
+            remove_managed_files(
+                &self.applications_dir(),
+                Some(DESKTOP_PREFIX),
+                DESKTOP_MARKER,
+            )
         }
 
         // ── Nautilus scripts (GNOME) ────────────────────────────────────
@@ -1515,13 +1534,22 @@ mod linux {
         }
 
         fn remove_nautilus(&self) -> Result<()> {
-            remove_managed_files(&self.nautilus_scripts_dir(), None, NAUTILUS_MARKER)?;
-            Ok(())
+            remove_managed_files(&self.nautilus_scripts_dir(), None, NAUTILUS_MARKER)
         }
 
         // ── KDE service menus (Dolphin) ─────────────────────────────────
 
         fn install_kde(&self, entries: &[ShellEntry], exe_path: &str) -> Result<()> {
+            // The service menu targets the `inode/directory` MIME type, so only
+            // directory-applicable entries get one (consistent with the XDG
+            // launcher).
+            let dir_entries: Vec<&ShellEntry> = entries
+                .iter()
+                .filter(|e| e.show_for.folders || e.show_for.folder_background)
+                .collect();
+            if dir_entries.is_empty() {
+                return Ok(());
+            }
             // Write into whichever service-menu dirs already exist (KDE 5 and/or
             // KDE 6). If detection succeeded via the binary but no dir exists
             // yet, default to the modern KDE 6 location.
@@ -1538,7 +1566,7 @@ mod linux {
             for dir in targets {
                 std::fs::create_dir_all(&dir)
                     .with_context(|| format!("create KDE service-menu dir {}", dir.display()))?;
-                for entry in entries {
+                for entry in &dir_entries {
                     let path = dir.join(format!("{DESKTOP_PREFIX}{}.desktop", slug(entry)));
                     std::fs::write(&path, kde_service_menu(entry, exe_path))
                         .with_context(|| format!("write KDE service menu {}", path.display()))?;
@@ -1581,7 +1609,7 @@ mod linux {
 
         fn remove_thunar(&self) -> Result<()> {
             let uca = self.thunar_uca();
-            let Some(existing) = std::fs::read_to_string(&uca).ok() else {
+            let Ok(existing) = std::fs::read_to_string(&uca) else {
                 return Ok(());
             };
             let xml = thunar::rewrite(Some(&existing), &[], THUNAR_ID_PREFIX)
@@ -1593,17 +1621,15 @@ mod linux {
     }
 
     /// Remove files in `dir` that termiHub owns: matching `name_prefix` (when
-    /// given) and containing `content_marker`. Returns whether anything was
-    /// removed. Tolerates a missing directory.
+    /// given) and containing `content_marker`. Tolerates a missing directory.
     fn remove_managed_files(
         dir: &Path,
         name_prefix: Option<&str>,
         content_marker: &str,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         if !dir.exists() {
-            return Ok(false);
+            return Ok(());
         }
-        let mut removed = false;
         for dir_entry in
             std::fs::read_dir(dir).with_context(|| format!("read dir {}", dir.display()))?
         {
@@ -1625,10 +1651,9 @@ mod linux {
             if is_ours {
                 std::fs::remove_file(&path)
                     .with_context(|| format!("remove {}", path.display()))?;
-                removed = true;
             }
         }
-        Ok(removed)
+        Ok(())
     }
 
     /// The spawn command line invoked by a surface, with the clicked path
@@ -1735,8 +1760,8 @@ mod linux {
         )
     }
 
-    /// Set mode `0o755` on `path` (Unix only; a no-op on other targets).
-    #[cfg(unix)]
+    /// Set mode `0o755` on `path`. This module is Linux-gated, so `unix` always
+    /// holds and `PermissionsExt` is always available.
     fn set_executable(path: &Path) -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
         let mut perms = std::fs::metadata(path)
@@ -1745,11 +1770,6 @@ mod linux {
         perms.set_mode(0o755);
         std::fs::set_permissions(path, perms)
             .with_context(|| format!("chmod 0o755 {}", path.display()))?;
-        Ok(())
-    }
-
-    #[cfg(not(unix))]
-    fn set_executable(_path: &Path) -> Result<()> {
         Ok(())
     }
 

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -1305,16 +1305,34 @@ mod imp {
 #[cfg(target_os = "linux")]
 mod linux {
     use super::{DetectedFileManager, ShellIntegrationSettings};
+    use crate::connection::shell_integration::ShellEntry;
     use anyhow::{Context, Result};
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
+
+    /// Filename prefix for the `.desktop` files termiHub owns (XDG + KDE).
+    const DESKTOP_PREFIX: &str = "termihub-";
+    /// Marker line stamped into every `.desktop` file so uninstall removes only
+    /// termiHub-owned files and never foreign ones.
+    const DESKTOP_MARKER: &str = "X-TermiHub-Managed=true";
+    /// Marker comment stamped into every Nautilus script. Nautilus script files
+    /// are named after the display name (no prefix), so ownership is detected
+    /// from the file contents.
+    const NAUTILUS_MARKER: &str =
+        "# termiHub shell integration (managed) — safe to remove via termiHub";
+    /// `unique-id` prefix identifying termiHub's Thunar actions inside the shared
+    /// `uca.xml`; used to de-append ours while preserving foreign actions.
+    const THUNAR_ID_PREFIX: &str = "termihub-";
+    /// Icon name referenced by every generated launcher/action.
+    const ICON: &str = "termihub";
 
     /// Best-effort callback that refreshes the desktop MIME database after the
     /// XDG launchers change. Injected so tests can assert it ran without
     /// spawning the real `update-desktop-database` binary.
     type DesktopDbHook = Arc<dyn Fn(&Path) + Send + Sync>;
 
-    /// Spawn `update-desktop-database <apps_dir>`, ignoring any failure.
+    /// Spawn `update-desktop-database <apps_dir>`, ignoring any failure (the
+    /// tool is absent on minimal systems and the registration still works).
     fn run_update_desktop_database(apps_dir: &Path) {
         let _ = std::process::Command::new("update-desktop-database")
             .arg(apps_dir)
@@ -1322,16 +1340,16 @@ mod linux {
     }
 
     /// Writes and removes the Linux file-manager artifacts under a set of XDG
-    /// base directories. Implementation lands in the following commit; this
-    /// scaffold exists so the behaviour tests below fail meaningfully first.
+    /// base directories.
+    ///
+    /// `data_local` (`~/.local/share`) and `config` (`~/.config`) are injectable
+    /// so tests target throwaway directories instead of the user's real ones.
     pub struct Registrar {
-        #[allow(dead_code)]
         data_local: PathBuf,
-        #[allow(dead_code)]
         config: PathBuf,
-        #[allow(dead_code)]
+        /// Whether detection may consult `$PATH` for file-manager binaries.
+        /// Disabled in tests so detection depends only on the injected dirs.
         probe_path: bool,
-        #[allow(dead_code)]
         on_desktop_db_update: DesktopDbHook,
     }
 
@@ -1350,7 +1368,8 @@ mod linux {
         }
 
         /// Registrar targeting throwaway directories so a test never touches the
-        /// user's real file-manager configuration.
+        /// user's real file-manager configuration. Detection is limited to the
+        /// injected dirs (no `$PATH` probing) for determinism.
         #[cfg(test)]
         pub fn for_test(data_local: PathBuf, config: PathBuf, hook: DesktopDbHook) -> Self {
             Self {
@@ -1361,19 +1380,539 @@ mod linux {
             }
         }
 
-        /// Report the file managers detected on this host (not yet implemented).
+        // ── Directory layout ────────────────────────────────────────────
+
+        fn applications_dir(&self) -> PathBuf {
+            self.data_local.join("applications")
+        }
+        fn nautilus_scripts_dir(&self) -> PathBuf {
+            self.data_local.join("nautilus/scripts")
+        }
+        fn kde5_dir(&self) -> PathBuf {
+            self.data_local.join("kservices5/ServiceMenus")
+        }
+        fn kde6_dir(&self) -> PathBuf {
+            self.data_local.join("kio/servicemenus")
+        }
+        fn thunar_dir(&self) -> PathBuf {
+            self.config.join("Thunar")
+        }
+        fn thunar_uca(&self) -> PathBuf {
+            self.thunar_dir().join("uca.xml")
+        }
+
+        // ── Detection ───────────────────────────────────────────────────
+
+        fn has_binary(&self, name: &str) -> bool {
+            self.probe_path && which::which(name).is_ok()
+        }
+        fn nautilus_detected(&self) -> bool {
+            self.has_binary("nautilus")
+                || self.nautilus_scripts_dir().exists()
+                || self.data_local.join("nautilus").exists()
+        }
+        fn kde_detected(&self) -> bool {
+            self.has_binary("dolphin") || self.kde5_dir().exists() || self.kde6_dir().exists()
+        }
+        fn thunar_detected(&self) -> bool {
+            self.has_binary("thunar") || self.thunar_dir().exists()
+        }
+
+        /// Report the file managers detected on this host for the status command.
         pub fn detect(&self) -> Vec<DetectedFileManager> {
-            Vec::new()
+            let mk = |id: &str, name: &str, detected: bool| DetectedFileManager {
+                id: id.to_string(),
+                name: name.to_string(),
+                detected,
+                version: None,
+            };
+            vec![
+                mk("nautilus", "Nautilus", self.nautilus_detected()),
+                mk("kde", "Dolphin", self.kde_detected()),
+                mk("thunar", "Thunar", self.thunar_detected()),
+            ]
         }
 
-        /// Install the enabled + detected surfaces (not yet implemented).
-        pub fn install(&self, _settings: &ShellIntegrationSettings, _exe_path: &str) -> Result<()> {
-            anyhow::bail!("Linux file-manager registration not yet implemented (#1370)")
+        // ── Install / uninstall ─────────────────────────────────────────
+
+        /// Install the enabled + detected surfaces (idempotent — a prior
+        /// registration is cleared first).
+        pub fn install(&self, settings: &ShellIntegrationSettings, exe_path: &str) -> Result<()> {
+            self.uninstall()?;
+            let entries = &settings.entries;
+            if entries.is_empty() {
+                return Ok(());
+            }
+            self.install_xdg(entries, exe_path)?;
+            let toggles = settings.linux_file_managers;
+            if toggles.nautilus && self.nautilus_detected() {
+                self.install_nautilus(entries, exe_path)?;
+            }
+            if toggles.kde && self.kde_detected() {
+                self.install_kde(entries, exe_path)?;
+            }
+            if toggles.thunar && self.thunar_detected() {
+                self.install_thunar(entries, exe_path)?;
+            }
+            Ok(())
         }
 
-        /// Remove every termiHub artifact (not yet implemented).
+        /// Remove every termiHub artifact across all four surfaces. Foreign
+        /// files and foreign Thunar actions are left untouched. Never fails when
+        /// nothing is registered.
         pub fn uninstall(&self) -> Result<()> {
-            anyhow::bail!("Linux file-manager registration not yet implemented (#1370)")
+            self.remove_xdg()?;
+            self.remove_nautilus()?;
+            self.remove_kde()?;
+            self.remove_thunar()?;
+            Ok(())
+        }
+
+        // ── XDG .desktop (universal "Open With") ────────────────────────
+
+        fn install_xdg(&self, entries: &[ShellEntry], exe_path: &str) -> Result<()> {
+            let dir_entries: Vec<&ShellEntry> = entries
+                .iter()
+                .filter(|e| e.show_for.folders || e.show_for.folder_background)
+                .collect();
+            if dir_entries.is_empty() {
+                return Ok(());
+            }
+            let apps = self.applications_dir();
+            std::fs::create_dir_all(&apps)
+                .with_context(|| format!("create applications dir {}", apps.display()))?;
+            for entry in &dir_entries {
+                let path = apps.join(format!("{DESKTOP_PREFIX}{}.desktop", slug(entry)));
+                std::fs::write(&path, xdg_desktop_file(entry, exe_path))
+                    .with_context(|| format!("write XDG desktop file {}", path.display()))?;
+            }
+            (self.on_desktop_db_update)(&apps);
+            Ok(())
+        }
+
+        fn remove_xdg(&self) -> Result<()> {
+            let apps = self.applications_dir();
+            let removed = remove_managed_files(&apps, Some(DESKTOP_PREFIX), DESKTOP_MARKER)?;
+            if removed && apps.exists() {
+                (self.on_desktop_db_update)(&apps);
+            }
+            Ok(())
+        }
+
+        // ── Nautilus scripts (GNOME) ────────────────────────────────────
+
+        fn install_nautilus(&self, entries: &[ShellEntry], exe_path: &str) -> Result<()> {
+            let dir = self.nautilus_scripts_dir();
+            std::fs::create_dir_all(&dir)
+                .with_context(|| format!("create nautilus scripts dir {}", dir.display()))?;
+            for entry in entries {
+                let path = dir.join(nautilus_script_name(entry));
+                std::fs::write(&path, nautilus_script(entry, exe_path))
+                    .with_context(|| format!("write nautilus script {}", path.display()))?;
+                set_executable(&path)?;
+            }
+            Ok(())
+        }
+
+        fn remove_nautilus(&self) -> Result<()> {
+            remove_managed_files(&self.nautilus_scripts_dir(), None, NAUTILUS_MARKER)?;
+            Ok(())
+        }
+
+        // ── KDE service menus (Dolphin) ─────────────────────────────────
+
+        fn install_kde(&self, entries: &[ShellEntry], exe_path: &str) -> Result<()> {
+            // Write into whichever service-menu dirs already exist (KDE 5 and/or
+            // KDE 6). If detection succeeded via the binary but no dir exists
+            // yet, default to the modern KDE 6 location.
+            let mut targets: Vec<PathBuf> = Vec::new();
+            if self.kde5_dir().exists() {
+                targets.push(self.kde5_dir());
+            }
+            if self.kde6_dir().exists() {
+                targets.push(self.kde6_dir());
+            }
+            if targets.is_empty() {
+                targets.push(self.kde6_dir());
+            }
+            for dir in targets {
+                std::fs::create_dir_all(&dir)
+                    .with_context(|| format!("create KDE service-menu dir {}", dir.display()))?;
+                for entry in entries {
+                    let path = dir.join(format!("{DESKTOP_PREFIX}{}.desktop", slug(entry)));
+                    std::fs::write(&path, kde_service_menu(entry, exe_path))
+                        .with_context(|| format!("write KDE service menu {}", path.display()))?;
+                }
+            }
+            Ok(())
+        }
+
+        fn remove_kde(&self) -> Result<()> {
+            for dir in [self.kde5_dir(), self.kde6_dir()] {
+                remove_managed_files(&dir, Some(DESKTOP_PREFIX), DESKTOP_MARKER)?;
+            }
+            Ok(())
+        }
+
+        // ── Thunar custom action (XFCE) ─────────────────────────────────
+
+        fn install_thunar(&self, entries: &[ShellEntry], exe_path: &str) -> Result<()> {
+            let uca = self.thunar_uca();
+            std::fs::create_dir_all(self.thunar_dir()).with_context(|| {
+                format!("create Thunar config dir {}", self.thunar_dir().display())
+            })?;
+            let existing = std::fs::read_to_string(&uca).ok();
+            let ours: Vec<thunar::Action> = entries
+                .iter()
+                .map(|entry| thunar::Action {
+                    name: entry.name.clone(),
+                    unique_id: format!("{THUNAR_ID_PREFIX}{}", slug(entry)),
+                    command: spawn_command(exe_path, &entry.id, "%f"),
+                    directories: entry.show_for.folders || entry.show_for.folder_background,
+                    other_files: entry.show_for.files,
+                })
+                .collect();
+            let xml = thunar::rewrite(existing.as_deref(), &ours, THUNAR_ID_PREFIX)
+                .context("rebuild Thunar uca.xml")?;
+            std::fs::write(&uca, xml)
+                .with_context(|| format!("write Thunar uca.xml {}", uca.display()))?;
+            Ok(())
+        }
+
+        fn remove_thunar(&self) -> Result<()> {
+            let uca = self.thunar_uca();
+            let Some(existing) = std::fs::read_to_string(&uca).ok() else {
+                return Ok(());
+            };
+            let xml = thunar::rewrite(Some(&existing), &[], THUNAR_ID_PREFIX)
+                .context("strip termiHub actions from Thunar uca.xml")?;
+            std::fs::write(&uca, xml)
+                .with_context(|| format!("write Thunar uca.xml {}", uca.display()))?;
+            Ok(())
+        }
+    }
+
+    /// Remove files in `dir` that termiHub owns: matching `name_prefix` (when
+    /// given) and containing `content_marker`. Returns whether anything was
+    /// removed. Tolerates a missing directory.
+    fn remove_managed_files(
+        dir: &Path,
+        name_prefix: Option<&str>,
+        content_marker: &str,
+    ) -> Result<bool> {
+        if !dir.exists() {
+            return Ok(false);
+        }
+        let mut removed = false;
+        for dir_entry in
+            std::fs::read_dir(dir).with_context(|| format!("read dir {}", dir.display()))?
+        {
+            let path = dir_entry
+                .with_context(|| format!("enumerate dir {}", dir.display()))?
+                .path();
+            if !path.is_file() {
+                continue;
+            }
+            if let Some(prefix) = name_prefix {
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if !name.starts_with(prefix) {
+                    continue;
+                }
+            }
+            let is_ours = std::fs::read_to_string(&path)
+                .map(|c| c.contains(content_marker))
+                .unwrap_or(false);
+            if is_ours {
+                std::fs::remove_file(&path)
+                    .with_context(|| format!("remove {}", path.display()))?;
+                removed = true;
+            }
+        }
+        Ok(removed)
+    }
+
+    /// The spawn command line invoked by a surface, with the clicked path
+    /// substituted via `placeholder` (`%f` for desktop/Thunar, `"$1"` for
+    /// Nautilus scripts).
+    fn spawn_command(exe_path: &str, entry_id: &str, placeholder: &str) -> String {
+        format!(r#""{exe_path}" spawn --entry-id {entry_id} --location {placeholder}"#)
+    }
+
+    /// Filesystem-safe slug for an entry id: lowercase ASCII alphanumerics, all
+    /// other characters collapsed to `-`. Falls back to `entry` when empty.
+    fn slug(entry: &ShellEntry) -> String {
+        let mapped: String = entry
+            .id
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() {
+                    c.to_ascii_lowercase()
+                } else {
+                    '-'
+                }
+            })
+            .collect();
+        let trimmed = mapped.trim_matches('-');
+        if trimmed.is_empty() {
+            "entry".to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
+
+    /// Nautilus script filename — the display name shown in the Scripts submenu,
+    /// with path separators replaced. Falls back to the slug when empty.
+    fn nautilus_script_name(entry: &ShellEntry) -> String {
+        let sanitized: String = entry
+            .name
+            .chars()
+            .map(|c| match c {
+                '/' | '\\' => '-',
+                other => other,
+            })
+            .collect();
+        let trimmed = sanitized.trim();
+        if trimmed.is_empty() {
+            slug(entry)
+        } else {
+            trimmed.to_string()
+        }
+    }
+
+    /// Escape a value for a Desktop Entry key: strip the newlines that would
+    /// otherwise split the key/value line.
+    fn desktop_value(value: &str) -> String {
+        value.replace(['\n', '\r'], " ")
+    }
+
+    /// Render the universal XDG `.desktop` launcher registering termiHub for the
+    /// `inode/directory` MIME type. `NoDisplay=true` keeps it out of the app
+    /// menu — it only surfaces under "Open With" for folders.
+    fn xdg_desktop_file(entry: &ShellEntry, exe_path: &str) -> String {
+        format!(
+            "[Desktop Entry]\n\
+             Type=Application\n\
+             Name={name}\n\
+             Exec={exec}\n\
+             Icon={ICON}\n\
+             Terminal=false\n\
+             NoDisplay=true\n\
+             MimeType=inode/directory;\n\
+             {DESKTOP_MARKER}\n",
+            name = desktop_value(&entry.name),
+            exec = spawn_command(exe_path, &entry.id, "%f"),
+        )
+    }
+
+    /// Render a Nautilus script: a POSIX shell wrapper that spawns termiHub for
+    /// the first selected path. Carries the owner marker for uninstall.
+    fn nautilus_script(entry: &ShellEntry, exe_path: &str) -> String {
+        format!(
+            "#!/bin/sh\n\
+             {NAUTILUS_MARKER}\n\
+             {command}\n",
+            command = spawn_command(exe_path, &entry.id, "\"$1\""),
+        )
+    }
+
+    /// Render a KDE service-menu `.desktop` (KService plugin) exposing the entry
+    /// on the folder context menu. Carries the owner marker for uninstall.
+    fn kde_service_menu(entry: &ShellEntry, exe_path: &str) -> String {
+        format!(
+            "[Desktop Entry]\n\
+             Type=Service\n\
+             ServiceTypes=KonqPopupMenu/Plugin\n\
+             MimeType=inode/directory;\n\
+             Actions=termihubOpen;\n\
+             {DESKTOP_MARKER}\n\
+             \n\
+             [Desktop Action termihubOpen]\n\
+             Name={name}\n\
+             Icon={ICON}\n\
+             Exec={exec}\n",
+            name = desktop_value(&entry.name),
+            exec = spawn_command(exe_path, &entry.id, "%f"),
+        )
+    }
+
+    /// Set mode `0o755` on `path` (Unix only; a no-op on other targets).
+    #[cfg(unix)]
+    fn set_executable(path: &Path) -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path)
+            .with_context(|| format!("stat {}", path.display()))?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms)
+            .with_context(|| format!("chmod 0o755 {}", path.display()))?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    fn set_executable(_path: &Path) -> Result<()> {
+        Ok(())
+    }
+
+    /// Thunar `uca.xml` editing via a streaming XML reader/writer. termiHub's
+    /// actions are appended to the shared file and de-appended on uninstall,
+    /// preserving every foreign action already present.
+    mod thunar {
+        use anyhow::{Context, Result};
+        use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
+        use quick_xml::{Reader, Writer};
+
+        /// One termiHub custom action to embed in `uca.xml`.
+        pub struct Action {
+            pub name: String,
+            pub unique_id: String,
+            pub command: String,
+            /// Show for directories.
+            pub directories: bool,
+            /// Show for regular files.
+            pub other_files: bool,
+        }
+
+        /// Produce the new `uca.xml` content: preserve every foreign `<action>`,
+        /// drop any prior termiHub action (unique-id starting `our_id_prefix`),
+        /// then append `ours`. A `None`/blank/invalid `existing` yields a fresh
+        /// document containing only `ours`.
+        pub fn rewrite(
+            existing: Option<&str>,
+            ours: &[Action],
+            our_id_prefix: &str,
+        ) -> Result<String> {
+            let mut writer = Writer::new(Vec::new());
+            writer
+                .write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))
+                .context("write xml decl")?;
+            writer
+                .write_event(Event::Start(BytesStart::new("actions")))
+                .context("write <actions>")?;
+            if let Some(xml) = existing {
+                copy_foreign_actions(xml, our_id_prefix, &mut writer)?;
+            }
+            for action in ours {
+                write_action(&mut writer, action)?;
+            }
+            writer
+                .write_event(Event::End(BytesEnd::new("actions")))
+                .context("write </actions>")?;
+            let bytes = writer.into_inner();
+            let mut out = String::from_utf8(bytes).context("uca.xml is not valid UTF-8")?;
+            out.push('\n');
+            Ok(out)
+        }
+
+        /// Stream the existing document and replay each top-level `<action>`
+        /// subtree into `out`, except those termiHub owns (unique-id prefixed).
+        fn copy_foreign_actions(
+            xml: &str,
+            our_id_prefix: &str,
+            out: &mut Writer<Vec<u8>>,
+        ) -> Result<()> {
+            let mut reader = Reader::from_str(xml);
+            // Depth relative to the <actions> root: 0 = outside, 1 = inside
+            // <actions>, 2 = inside an <action> subtree we are buffering.
+            let mut depth = 0usize;
+            let mut buffered: Vec<Event<'_>> = Vec::new();
+            let mut is_ours = false;
+            let mut in_unique_id = false;
+
+            loop {
+                let event = reader.read_event().context("parse uca.xml")?;
+                match &event {
+                    Event::Eof => break,
+                    Event::Decl(_) => {}
+                    Event::Start(e) if e.name().as_ref() == b"actions" && depth == 0 => {
+                        depth = 1;
+                    }
+                    Event::End(e) if e.name().as_ref() == b"actions" && depth == 1 => {
+                        depth = 0;
+                    }
+                    Event::Start(e) if e.name().as_ref() == b"action" && depth == 1 => {
+                        depth = 2;
+                        buffered.clear();
+                        is_ours = false;
+                        in_unique_id = false;
+                        buffered.push(event.clone());
+                    }
+                    Event::End(e) if e.name().as_ref() == b"action" && depth == 2 => {
+                        buffered.push(event.clone());
+                        if !is_ours {
+                            for buffered_event in buffered.drain(..) {
+                                out.write_event(buffered_event)
+                                    .context("copy foreign action")?;
+                            }
+                        } else {
+                            buffered.clear();
+                        }
+                        depth = 1;
+                    }
+                    _ if depth == 2 => {
+                        match &event {
+                            Event::Start(e) if e.name().as_ref() == b"unique-id" => {
+                                in_unique_id = true;
+                            }
+                            Event::End(e) if e.name().as_ref() == b"unique-id" => {
+                                in_unique_id = false;
+                            }
+                            Event::Text(t) if in_unique_id => {
+                                if let Ok(text) = t.xml_content() {
+                                    if text.trim().starts_with(our_id_prefix) {
+                                        is_ours = true;
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                        buffered.push(event.clone());
+                    }
+                    // Insignificant whitespace / comments between actions: drop.
+                    _ => {}
+                }
+            }
+            Ok(())
+        }
+
+        /// Write one termiHub `<action>` element.
+        fn write_action(writer: &mut Writer<Vec<u8>>, action: &Action) -> Result<()> {
+            writer
+                .write_event(Event::Start(BytesStart::new("action")))
+                .context("write <action>")?;
+            text_element(writer, "icon", super::ICON)?;
+            text_element(writer, "name", &action.name)?;
+            text_element(writer, "unique-id", &action.unique_id)?;
+            text_element(writer, "command", &action.command)?;
+            text_element(writer, "description", "Open in termiHub")?;
+            text_element(writer, "patterns", "*")?;
+            if action.directories {
+                writer
+                    .write_event(Event::Empty(BytesStart::new("directories")))
+                    .context("write <directories/>")?;
+            }
+            if action.other_files {
+                writer
+                    .write_event(Event::Empty(BytesStart::new("other-files")))
+                    .context("write <other-files/>")?;
+            }
+            writer
+                .write_event(Event::End(BytesEnd::new("action")))
+                .context("write </action>")?;
+            Ok(())
+        }
+
+        /// Write `<name>value</name>`, escaping `value` via the writer.
+        fn text_element(writer: &mut Writer<Vec<u8>>, name: &str, value: &str) -> Result<()> {
+            writer
+                .write_event(Event::Start(BytesStart::new(name)))
+                .with_context(|| format!("write <{name}>"))?;
+            writer
+                .write_event(Event::Text(BytesText::new(value)))
+                .with_context(|| format!("write text for <{name}>"))?;
+            writer
+                .write_event(Event::End(BytesEnd::new(name)))
+                .with_context(|| format!("write </{name}>"))?;
+            Ok(())
         }
     }
 

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -11,9 +11,19 @@
 //!   bundles under `~/Library/Services/<name>.workflow`, each carrying its own
 //!   `NSServices` declaration so the entry surfaces under Finder's Quick Actions
 //!   and the Services menu. User-level only.
+//! * **Linux** (#1370): writes a universal XDG `.desktop` launcher under
+//!   `~/.local/share/applications/` (registered for the `inode/directory` MIME
+//!   type, refreshed via `update-desktop-database`) plus per-file-manager
+//!   surfaces that are installed only when the manager is detected *and* enabled
+//!   in [`LinuxFileManagerToggles`]: Nautilus scripts
+//!   (`~/.local/share/nautilus/scripts/`, mode `0o755`), KDE service menus
+//!   (`kservices5/ServiceMenus` for KDE 5, `kio/servicemenus` for KDE 6), and a
+//!   Thunar custom action appended into the shared `~/.config/Thunar/uca.xml`.
+//!   All user-level; no root required.
 //!
-//! Registration is idempotent on both platforms: install first clears any prior
-//! termiHub registration, then rewrites it from the current entry list.
+//! Registration is idempotent on every platform: install first clears any prior
+//! termiHub registration, then rewrites it from the current entry list. The
+//! Thunar de-append preserves foreign actions already present in `uca.xml`.
 //!
 //! Callers use the cross-platform [`register`] / [`unregister`] seam, which
 //! records the registration facts into [`ShellIntegrationSettings`]. On
@@ -21,12 +31,14 @@
 //! "unsupported on this platform" error before any state changes, so the calling
 //! Tauri commands and CLI subcommands behave predictably everywhere.
 
-use crate::connection::shell_integration::{ShellEntry, ShellIntegrationSettings};
+use crate::connection::shell_integration::{
+    DetectedFileManager, ShellEntry, ShellIntegrationSettings,
+};
 use anyhow::Context;
 
 /// Message returned by the install / uninstall entry points on platforms that
 /// have no context-menu / Quick Action registration implementation.
-#[cfg(not(any(windows, target_os = "macos")))]
+#[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
 const UNSUPPORTED_MESSAGE: &str =
     "file-manager context-menu registration is not supported on this platform";
 
@@ -39,10 +51,28 @@ const UNSUPPORTED_MESSAGE: &str =
 /// touched, so `settings` is left unchanged.
 pub fn register(settings: &mut ShellIntegrationSettings) -> anyhow::Result<()> {
     let exe = current_exe_path()?;
-    install(&settings.entries, &exe)?;
+    install(settings, &exe)?;
     settings.registered = true;
     settings.registered_exe_path = Some(exe);
     Ok(())
+}
+
+/// Detect the file managers installed on the host, for the status command.
+///
+/// On Linux this probes the per-user file-manager directories and `$PATH`
+/// binaries for Nautilus, KDE (Dolphin) and Thunar. On other platforms it
+/// returns an empty list (their context-menu surfaces are not per-manager).
+pub fn detect_file_managers() -> Vec<DetectedFileManager> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::Registrar::user()
+            .map(|r| r.detect())
+            .unwrap_or_default()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Vec::new()
+    }
 }
 
 /// Remove the integration and clear the recorded registration facts from
@@ -62,14 +92,14 @@ fn current_exe_path() -> anyhow::Result<String> {
         .into_owned())
 }
 
-/// Register the given shell-integration entries as Explorer context-menu items.
+/// Register `settings.entries` as Explorer context-menu items.
 ///
 /// Windows-only. Idempotent — an existing registration is replaced. `exe_path`
 /// is the absolute path to the termiHub executable that the menu commands invoke.
 /// Private: callers go through the cross-platform [`register`] seam.
 #[cfg(windows)]
-fn install(entries: &[ShellEntry], exe_path: &str) -> anyhow::Result<()> {
-    imp::Registrar::system().install(entries, exe_path)
+fn install(settings: &ShellIntegrationSettings, exe_path: &str) -> anyhow::Result<()> {
+    imp::Registrar::system().install(&settings.entries, exe_path)
 }
 
 /// Remove every termiHub Explorer context-menu registration (Windows-only).
@@ -79,12 +109,12 @@ fn uninstall() -> anyhow::Result<()> {
     imp::Registrar::system().uninstall()
 }
 
-/// Register the given entries as macOS Finder Quick Action bundles under
+/// Register `settings.entries` as macOS Finder Quick Action bundles under
 /// `~/Library/Services`. Idempotent — an existing registration is replaced.
 /// Private: callers go through the cross-platform [`register`] seam.
 #[cfg(target_os = "macos")]
-fn install(entries: &[ShellEntry], exe_path: &str) -> anyhow::Result<()> {
-    macos::Registrar::user()?.install(entries, exe_path)
+fn install(settings: &ShellIntegrationSettings, exe_path: &str) -> anyhow::Result<()> {
+    macos::Registrar::user()?.install(&settings.entries, exe_path)
 }
 
 /// Remove every termiHub Quick Action bundle from `~/Library/Services`
@@ -95,14 +125,31 @@ fn uninstall() -> anyhow::Result<()> {
     macos::Registrar::user()?.uninstall()
 }
 
+/// Register `settings.entries` across the detected Linux file-manager surfaces
+/// (XDG `.desktop`, plus Nautilus / KDE / Thunar when detected and enabled).
+/// Idempotent — an existing registration is replaced. Private: callers go
+/// through the cross-platform [`register`] seam.
+#[cfg(target_os = "linux")]
+fn install(settings: &ShellIntegrationSettings, exe_path: &str) -> anyhow::Result<()> {
+    linux::Registrar::user()?.install(settings, exe_path)
+}
+
+/// Remove every termiHub Linux file-manager artifact (all four surfaces),
+/// preserving foreign Thunar actions. Private: callers go through the
+/// cross-platform [`unregister`] seam.
+#[cfg(target_os = "linux")]
+fn uninstall() -> anyhow::Result<()> {
+    linux::Registrar::user()?.uninstall()
+}
+
 /// Stub for platforms without a context-menu registration implementation.
-#[cfg(not(any(windows, target_os = "macos")))]
-fn install(_entries: &[ShellEntry], _exe_path: &str) -> anyhow::Result<()> {
+#[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
+fn install(_settings: &ShellIntegrationSettings, _exe_path: &str) -> anyhow::Result<()> {
     anyhow::bail!(UNSUPPORTED_MESSAGE)
 }
 
 /// Stub for platforms without a context-menu registration implementation.
-#[cfg(not(any(windows, target_os = "macos")))]
+#[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
 fn uninstall() -> anyhow::Result<()> {
     anyhow::bail!(UNSUPPORTED_MESSAGE)
 }
@@ -1243,6 +1290,545 @@ mod imp {
         fn uninstall_without_prior_install_is_ok() {
             let scope = TestScope::new("uninstall-empty");
             scope.registrar.uninstall().unwrap();
+        }
+    }
+}
+
+/// Linux file-manager registration (#1370).
+///
+/// Writes a universal XDG `.desktop` launcher plus per-file-manager surfaces
+/// (Nautilus scripts, KDE service menus, a Thunar custom action) that are only
+/// installed when the manager is both **detected** on the host and **enabled**
+/// in [`LinuxFileManagerToggles`]. Every artifact carries a termiHub owner
+/// marker so uninstall removes only our files and, for the shared Thunar
+/// `uca.xml`, preserves any foreign actions.
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::{DetectedFileManager, ShellIntegrationSettings};
+    use anyhow::{Context, Result};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    /// Best-effort callback that refreshes the desktop MIME database after the
+    /// XDG launchers change. Injected so tests can assert it ran without
+    /// spawning the real `update-desktop-database` binary.
+    type DesktopDbHook = Arc<dyn Fn(&Path) + Send + Sync>;
+
+    /// Spawn `update-desktop-database <apps_dir>`, ignoring any failure.
+    fn run_update_desktop_database(apps_dir: &Path) {
+        let _ = std::process::Command::new("update-desktop-database")
+            .arg(apps_dir)
+            .status();
+    }
+
+    /// Writes and removes the Linux file-manager artifacts under a set of XDG
+    /// base directories. Implementation lands in the following commit; this
+    /// scaffold exists so the behaviour tests below fail meaningfully first.
+    pub struct Registrar {
+        #[allow(dead_code)]
+        data_local: PathBuf,
+        #[allow(dead_code)]
+        config: PathBuf,
+        #[allow(dead_code)]
+        probe_path: bool,
+        #[allow(dead_code)]
+        on_desktop_db_update: DesktopDbHook,
+    }
+
+    impl Registrar {
+        /// Registrar targeting the real per-user XDG directories.
+        pub fn user() -> Result<Self> {
+            let data_local =
+                dirs::data_local_dir().context("resolve XDG data dir (~/.local/share)")?;
+            let config = dirs::config_dir().context("resolve XDG config dir (~/.config)")?;
+            Ok(Self {
+                data_local,
+                config,
+                probe_path: true,
+                on_desktop_db_update: Arc::new(run_update_desktop_database),
+            })
+        }
+
+        /// Registrar targeting throwaway directories so a test never touches the
+        /// user's real file-manager configuration.
+        #[cfg(test)]
+        pub fn for_test(data_local: PathBuf, config: PathBuf, hook: DesktopDbHook) -> Self {
+            Self {
+                data_local,
+                config,
+                probe_path: false,
+                on_desktop_db_update: hook,
+            }
+        }
+
+        /// Report the file managers detected on this host (not yet implemented).
+        pub fn detect(&self) -> Vec<DetectedFileManager> {
+            Vec::new()
+        }
+
+        /// Install the enabled + detected surfaces (not yet implemented).
+        pub fn install(&self, _settings: &ShellIntegrationSettings, _exe_path: &str) -> Result<()> {
+            anyhow::bail!("Linux file-manager registration not yet implemented (#1370)")
+        }
+
+        /// Remove every termiHub artifact (not yet implemented).
+        pub fn uninstall(&self) -> Result<()> {
+            anyhow::bail!("Linux file-manager registration not yet implemented (#1370)")
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::connection::shell_integration::{
+            LinuxFileManagerToggles, ShellEntry, ShellEntryVisibility, ShowForTargets,
+        };
+        use std::sync::Mutex;
+
+        const EXE: &str = "/opt/termihub/termiHub";
+
+        /// Throwaway XDG base dirs deleted on drop, plus a recorder for the
+        /// desktop-database refresh hook.
+        struct TempXdg {
+            data_local: PathBuf,
+            config: PathBuf,
+            db_calls: Arc<Mutex<Vec<PathBuf>>>,
+        }
+
+        impl TempXdg {
+            fn new(tag: &str) -> Self {
+                let base = std::env::temp_dir()
+                    .join(format!("termihub-linux-si-{}-{tag}", std::process::id()));
+                let _ = std::fs::remove_dir_all(&base);
+                let data_local = base.join("data");
+                let config = base.join("config");
+                std::fs::create_dir_all(&data_local).expect("create temp data dir");
+                std::fs::create_dir_all(&config).expect("create temp config dir");
+                Self {
+                    data_local,
+                    config,
+                    db_calls: Arc::new(Mutex::new(Vec::new())),
+                }
+            }
+
+            fn registrar(&self) -> Registrar {
+                let calls = Arc::clone(&self.db_calls);
+                let hook: DesktopDbHook = Arc::new(move |p: &Path| {
+                    calls.lock().expect("db hook lock").push(p.to_path_buf());
+                });
+                Registrar::for_test(self.data_local.clone(), self.config.clone(), hook)
+            }
+
+            fn read(&self, path: &Path) -> String {
+                std::fs::read_to_string(path)
+                    .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+            }
+        }
+
+        impl Drop for TempXdg {
+            fn drop(&mut self) {
+                if let Some(base) = self.data_local.parent() {
+                    let _ = std::fs::remove_dir_all(base);
+                }
+            }
+        }
+
+        fn targets(folders: bool, files: bool, background: bool) -> ShowForTargets {
+            ShowForTargets {
+                folders,
+                files,
+                folder_background: background,
+            }
+        }
+
+        fn entry(id: &str, name: &str, show_for: ShowForTargets) -> ShellEntry {
+            ShellEntry {
+                id: id.to_string(),
+                name: name.to_string(),
+                connection_id: None,
+                visibility: ShellEntryVisibility::Always,
+                show_for,
+            }
+        }
+
+        fn settings(
+            entries: Vec<ShellEntry>,
+            toggles: LinuxFileManagerToggles,
+        ) -> ShellIntegrationSettings {
+            ShellIntegrationSettings {
+                entries,
+                linux_file_managers: toggles,
+                ..Default::default()
+            }
+        }
+
+        fn all_on() -> LinuxFileManagerToggles {
+            LinuxFileManagerToggles {
+                nautilus: true,
+                kde: true,
+                thunar: true,
+            }
+        }
+
+        // ── XDG .desktop ────────────────────────────────────────────────
+
+        #[test]
+        fn install_writes_xdg_desktop_and_refreshes_database() {
+            let xdg = TempXdg::new("xdg");
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                LinuxFileManagerToggles::default(),
+            );
+            reg.install(&s, EXE).unwrap();
+
+            let desktop = xdg.data_local.join("applications/termihub-open.desktop");
+            assert!(desktop.is_file(), "XDG desktop file missing");
+            let content = xdg.read(&desktop);
+            assert!(content.contains("MimeType=inode/directory;"));
+            assert!(content
+                .contains(r#"Exec="/opt/termihub/termiHub" spawn --entry-id open --location %f"#));
+            assert!(content.contains("X-TermiHub-Managed=true"));
+
+            // update-desktop-database was invoked with the applications dir.
+            let calls = xdg.db_calls.lock().unwrap();
+            assert_eq!(calls.as_slice(), &[xdg.data_local.join("applications")]);
+        }
+
+        #[test]
+        fn xdg_desktop_only_for_directory_entries() {
+            let xdg = TempXdg::new("xdg-files-only");
+            let reg = xdg.registrar();
+            // A files-only entry does not register a directory launcher.
+            let s = settings(
+                vec![entry("f", "Files", targets(false, true, false))],
+                LinuxFileManagerToggles::default(),
+            );
+            reg.install(&s, EXE).unwrap();
+            assert!(!xdg
+                .data_local
+                .join("applications/termihub-f.desktop")
+                .exists());
+        }
+
+        // ── Nautilus ────────────────────────────────────────────────────
+
+        #[test]
+        fn nautilus_installed_when_detected_and_enabled() {
+            let xdg = TempXdg::new("nautilus");
+            // Simulate a Nautilus install: the scripts dir exists.
+            std::fs::create_dir_all(xdg.data_local.join("nautilus/scripts")).unwrap();
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                all_on(),
+            );
+            reg.install(&s, EXE).unwrap();
+
+            let script = xdg.data_local.join("nautilus/scripts/Open in termiHub");
+            assert!(script.is_file(), "nautilus script missing");
+            let content = xdg.read(&script);
+            assert!(content.starts_with("#!/bin/sh"));
+            assert!(content.contains(r#"spawn --entry-id open --location "$1""#));
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = std::fs::metadata(&script).unwrap().permissions().mode();
+                assert_eq!(mode & 0o777, 0o755, "nautilus script must be 0o755");
+            }
+        }
+
+        #[test]
+        fn nautilus_skipped_when_not_detected() {
+            let xdg = TempXdg::new("nautilus-absent");
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                all_on(),
+            );
+            reg.install(&s, EXE).unwrap();
+            assert!(!xdg.data_local.join("nautilus/scripts").exists());
+        }
+
+        #[test]
+        fn nautilus_skipped_when_toggle_off_and_foreign_scripts_preserved() {
+            let xdg = TempXdg::new("nautilus-toggle-off");
+            let scripts = xdg.data_local.join("nautilus/scripts");
+            std::fs::create_dir_all(&scripts).unwrap();
+            std::fs::write(scripts.join("Foreign Script"), "#!/bin/sh\necho hi\n").unwrap();
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                LinuxFileManagerToggles {
+                    nautilus: false,
+                    kde: true,
+                    thunar: true,
+                },
+            );
+            reg.install(&s, EXE).unwrap();
+            assert!(!scripts.join("Open in termiHub").exists());
+            assert!(scripts.join("Foreign Script").is_file());
+        }
+
+        // ── KDE ─────────────────────────────────────────────────────────
+
+        #[test]
+        fn kde_service_menu_written_to_both_kde5_and_kde6_when_present() {
+            let xdg = TempXdg::new("kde-both");
+            let kde5 = xdg.data_local.join("kservices5/ServiceMenus");
+            let kde6 = xdg.data_local.join("kio/servicemenus");
+            std::fs::create_dir_all(&kde5).unwrap();
+            std::fs::create_dir_all(&kde6).unwrap();
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                all_on(),
+            );
+            reg.install(&s, EXE).unwrap();
+
+            for dir in [&kde5, &kde6] {
+                let file = dir.join("termihub-open.desktop");
+                assert!(file.is_file(), "KDE menu missing in {}", dir.display());
+                let content = xdg.read(&file);
+                assert!(content.contains("Type=Service"));
+                assert!(content.contains("ServiceTypes=KonqPopupMenu/Plugin"));
+                assert!(content.contains("[Desktop Action termihubOpen]"));
+                assert!(content.contains(
+                    r#"Exec="/opt/termihub/termiHub" spawn --entry-id open --location %f"#
+                ));
+            }
+        }
+
+        #[test]
+        fn kde_skipped_when_not_detected() {
+            let xdg = TempXdg::new("kde-absent");
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                all_on(),
+            );
+            reg.install(&s, EXE).unwrap();
+            assert!(!xdg.data_local.join("kio/servicemenus").exists());
+            assert!(!xdg.data_local.join("kservices5/ServiceMenus").exists());
+        }
+
+        // ── Thunar ──────────────────────────────────────────────────────
+
+        #[test]
+        fn thunar_appends_action_preserving_foreign() {
+            let xdg = TempXdg::new("thunar-append");
+            let thunar_dir = xdg.config.join("Thunar");
+            std::fs::create_dir_all(&thunar_dir).unwrap();
+            // Pre-existing foreign action written by the user.
+            let foreign = r#"<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+<action>
+	<icon>utilities-terminal</icon>
+	<name>Open Terminal Here</name>
+	<unique-id>1616000000000000-1</unique-id>
+	<command>exo-open --working-directory %f --launch TerminalEmulator</command>
+	<description>Foreign action</description>
+	<patterns>*</patterns>
+	<directories/>
+</action>
+</actions>
+"#;
+            let uca = thunar_dir.join("uca.xml");
+            std::fs::write(&uca, foreign).unwrap();
+
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                all_on(),
+            );
+            reg.install(&s, EXE).unwrap();
+
+            let content = xdg.read(&uca);
+            // Foreign action preserved.
+            assert!(content.contains("Open Terminal Here"));
+            assert!(content.contains("1616000000000000-1"));
+            // Ours appended.
+            assert!(content.contains("<unique-id>termihub-open</unique-id>"));
+            assert!(content.contains("spawn --entry-id open --location %f"));
+            // Valid single <actions> root with both actions.
+            assert_eq!(content.matches("<actions>").count(), 1);
+            assert_eq!(content.matches("<action>").count(), 2);
+        }
+
+        #[test]
+        fn thunar_detected_via_config_dir_without_prior_uca() {
+            let xdg = TempXdg::new("thunar-fresh");
+            std::fs::create_dir_all(xdg.config.join("Thunar")).unwrap();
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                all_on(),
+            );
+            reg.install(&s, EXE).unwrap();
+            let content = xdg.read(&xdg.config.join("Thunar/uca.xml"));
+            assert!(content.contains("<unique-id>termihub-open</unique-id>"));
+            assert_eq!(content.matches("<action>").count(), 1);
+        }
+
+        #[test]
+        fn thunar_reinstall_keeps_single_owned_action() {
+            let xdg = TempXdg::new("thunar-idempotent");
+            std::fs::create_dir_all(xdg.config.join("Thunar")).unwrap();
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                all_on(),
+            );
+            reg.install(&s, EXE).unwrap();
+            reg.install(&s, EXE).unwrap();
+            let content = xdg.read(&xdg.config.join("Thunar/uca.xml"));
+            assert_eq!(
+                content
+                    .matches("<unique-id>termihub-open</unique-id>")
+                    .count(),
+                1
+            );
+        }
+
+        // ── Detection ───────────────────────────────────────────────────
+
+        #[test]
+        fn detect_reports_managers_by_directory_existence() {
+            let xdg = TempXdg::new("detect");
+            std::fs::create_dir_all(xdg.data_local.join("nautilus/scripts")).unwrap();
+            std::fs::create_dir_all(xdg.config.join("Thunar")).unwrap();
+            let reg = xdg.registrar();
+            let detected = reg.detect();
+
+            let by_id = |id: &str| detected.iter().find(|m| m.id == id).unwrap().detected;
+            assert!(by_id("nautilus"));
+            assert!(!by_id("kde"));
+            assert!(by_id("thunar"));
+        }
+
+        // ── Uninstall ───────────────────────────────────────────────────
+
+        #[test]
+        fn uninstall_removes_all_four_and_preserves_foreign_thunar_action() {
+            let xdg = TempXdg::new("uninstall-all");
+            // Detect all managers.
+            std::fs::create_dir_all(xdg.data_local.join("nautilus/scripts")).unwrap();
+            std::fs::create_dir_all(xdg.data_local.join("kio/servicemenus")).unwrap();
+            let thunar_dir = xdg.config.join("Thunar");
+            std::fs::create_dir_all(&thunar_dir).unwrap();
+            let foreign = r#"<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+<action>
+	<icon>utilities-terminal</icon>
+	<name>Open Terminal Here</name>
+	<unique-id>1616000000000000-1</unique-id>
+	<command>xterm</command>
+	<description>Foreign</description>
+	<patterns>*</patterns>
+	<directories/>
+</action>
+</actions>
+"#;
+            let uca = thunar_dir.join("uca.xml");
+            std::fs::write(&uca, foreign).unwrap();
+
+            let reg = xdg.registrar();
+            let s = settings(
+                vec![entry(
+                    "open",
+                    "Open in termiHub",
+                    targets(true, false, false),
+                )],
+                all_on(),
+            );
+            reg.install(&s, EXE).unwrap();
+            // Sanity: everything got installed.
+            assert!(xdg
+                .data_local
+                .join("applications/termihub-open.desktop")
+                .exists());
+            assert!(xdg
+                .data_local
+                .join("nautilus/scripts/Open in termiHub")
+                .exists());
+            assert!(xdg
+                .data_local
+                .join("kio/servicemenus/termihub-open.desktop")
+                .exists());
+
+            reg.uninstall().unwrap();
+
+            // All four termiHub artifacts gone.
+            assert!(!xdg
+                .data_local
+                .join("applications/termihub-open.desktop")
+                .exists());
+            assert!(!xdg
+                .data_local
+                .join("nautilus/scripts/Open in termiHub")
+                .exists());
+            assert!(!xdg
+                .data_local
+                .join("kio/servicemenus/termihub-open.desktop")
+                .exists());
+            let content = xdg.read(&uca);
+            assert!(
+                !content.contains("termihub-open"),
+                "termiHub Thunar action must be removed"
+            );
+            // Foreign action survives.
+            assert!(content.contains("Open Terminal Here"));
+            assert!(content.contains("1616000000000000-1"));
+        }
+
+        #[test]
+        fn uninstall_without_install_is_ok() {
+            let xdg = TempXdg::new("uninstall-empty");
+            xdg.registrar().uninstall().unwrap();
+        }
+
+        #[test]
+        fn install_empty_entries_is_noop() {
+            let xdg = TempXdg::new("empty");
+            let reg = xdg.registrar();
+            reg.install(&settings(Vec::new(), all_on()), EXE).unwrap();
+            assert!(!xdg.data_local.join("applications").exists());
         }
     }
 }

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -1304,8 +1304,7 @@ mod imp {
 /// `uca.xml`, preserves any foreign actions.
 #[cfg(target_os = "linux")]
 mod linux {
-    use super::{DetectedFileManager, ShellIntegrationSettings};
-    use crate::connection::shell_integration::ShellEntry;
+    use super::{DetectedFileManager, ShellEntry, ShellIntegrationSettings};
     use anyhow::{Context, Result};
     use std::path::{Path, PathBuf};
     use std::sync::Arc;


### PR DESCRIPTION
## Summary

Implements the **Linux arm** of the shell-integration registry seam
(`src-tauri/src/spawn/registry.rs`), alongside the existing Windows (HKCU) and
macOS (Quick Actions) arms — completing SI-7 of the Shell Context Menu & CLI
Spawn epic (#1363). All artifacts are user-level; no root required.

On install, for the configured shell-integration entries:

- **XDG `.desktop` (universal):** writes `~/.local/share/applications/termihub-<slug>.desktop`
  registered for the `inode/directory` MIME type, then calls
  `update-desktop-database` (once per operation). Surfaces under **Open With**
  in any XDG-compliant file manager.
- **Nautilus (GNOME):** shell scripts in `~/.local/share/nautilus/scripts/`,
  mode `0o755` — installed only when Nautilus is detected and its toggle is on.
- **KDE (Dolphin):** service menus written to `kservices5/ServiceMenus` (KDE 5)
  and/or `kio/servicemenus` (KDE 6), whichever exist (default KDE 6).
- **Thunar (XFCE):** a custom action appended into the shared
  `~/.config/Thunar/uca.xml`.

**Detection** (`registry::detect_file_managers`) now feeds
`get_shell_integration_status` via existence checks of the manager dirs plus
`$PATH` binaries, replacing the config-model stub. Per-manager enable toggles
are honoured, and **uninstall removes all four artifacts** — the Thunar
de-append removes only termiHub's action (by `unique-id` prefix) and preserves
foreign actions. Every artifact carries a termiHub owner marker so removal never
touches foreign files.

## XML crate choice

Thunar's `uca.xml` is a shared file that may already contain the user's own
custom actions, so it must be edited surgically rather than overwritten. Per the
issue's "prefer a small XML crate over hand-editing" guidance, I used
**`quick-xml` 0.39** (already a transitive dep in the lock, pinned as a direct
dep here): a streaming reader/writer copies every foreign `<action>` verbatim,
drops any prior termiHub action, and appends the current ones — the library
handles escaping and structure so we never hand-splice XML.

## Cross-platform safety

The entire Linux arm is `#[cfg(target_os = "linux")]` and all mode-bit code is
`#[cfg(unix)]`, so the Windows and macOS builds are untouched (their arms are
unchanged apart from the shared `install` seam now taking `&ShellIntegrationSettings`).
`./scripts/check.sh` passes on macOS (build + clippy + fmt + lint green).

## Validation / Linux tested by CI

The 14 Linux-gated unit tests (`spawn::registry::linux::tests`) cover each
artifact's content, `0o755` mode, detection by directory existence, the Thunar
append preserving a foreign action, idempotent reinstall, and uninstall removing
all four while keeping foreign Thunar actions. **These run on the Linux CI job**
(they are `#[cfg(target_os = "linux")]`); I additionally validated them locally
on macOS by temporarily widening the cfg, and they pass.

## Test plan

- [x] `cargo check --all-targets` green on macOS (non-Linux build intact)
- [x] `./scripts/check.sh` — ALL CHECKS PASSED (macOS)
- [x] 14 Linux registration unit tests pass (validated locally; run by Linux CI)
- [ ] **Manual (Linux desktop):** Nautilus / Dolphin / Thunar install→right-click→run→uninstall, per the new steps in `docs/testing.md` (§ *Linux file-manager registration (#1370)*), confirming foreign Thunar actions and unrelated Nautilus scripts survive uninstall.

## Follow-ups

- #1416 — consolidate the per-OS registry helpers (spawn command / slug / marker
  check) once the Win/mac arms can be touched (out of scope here by design).
- #1417 — Thunar rewrite: also preserve inter-action comments/whitespace via a
  span-based scan.

Closes #1370

🤖 Generated with [Claude Code](https://claude.com/claude-code)