### PR TITLE
test(agent): harden local_agent_integration readiness wait against CI-load flakiness (Closes #1398)

### DIFF
--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -24,6 +24,7 @@ use base64::Engine as _;
 use serde_json::{json, Value};
 
 use tempfile::{NamedTempFile, TempDir};
+use termihub_core::monitoring::BackoffSchedule;
 
 // ── Binary path ───────────────────────────────────────────────────────────────
 
@@ -43,35 +44,20 @@ const RPC_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ── Readiness retry backoff ───────────────────────────────────────────────────
 
-/// Exponential-backoff schedule for the agent-readiness retry loop.
+/// Cap on the readiness retry backoff (see [`readiness_backoff`]).
+const READINESS_BACKOFF_CAP: Duration = Duration::from_millis(500);
+
+/// Exponential-backoff schedule for the agent-readiness retry loops.
 ///
-/// Starts small so a fast local start returns almost immediately, then doubles
-/// the delay after each attempt up to a cap. This keeps the happy path snappy
-/// (the first probe fires after only [`INITIAL`](Backoff::new) ms) while making
-/// the loop gentle on a **starved CI runner**: instead of hammering `connect()`
-/// hundreds of times a second for the whole timeout — the pattern that let #1398
-/// flake with `connect: Connection refused` — retries space out as the agent
-/// takes longer to come up.
-struct Backoff {
-    current: Duration,
-    max: Duration,
-}
-
-impl Backoff {
-    /// Create a schedule starting at `initial`, doubling up to `max`.
-    fn new(initial: Duration, max: Duration) -> Self {
-        Backoff {
-            current: initial.min(max),
-            max,
-        }
-    }
-
-    /// Return the current delay, then advance the schedule (double, capped).
-    fn next_delay(&mut self) -> Duration {
-        let delay = self.current;
-        self.current = (self.current * 2).min(self.max);
-        delay
-    }
+/// Reuses the production [`BackoffSchedule`] helper instead of a bespoke copy.
+/// Starts at 20ms and doubles to [`READINESS_BACKOFF_CAP`], so a fast local
+/// start returns almost immediately while a **starved CI runner** is not
+/// hammered with hundreds of `connect()` attempts a second — the pattern that
+/// let #1398 flake with `connect: Connection refused`. The attempt budget is
+/// effectively unbounded (`u32::MAX`); these loops stop on their own wall-clock
+/// deadline (or a dead child), never on an attempt count.
+fn readiness_backoff() -> BackoffSchedule {
+    BackoffSchedule::new(Duration::from_millis(20), READINESS_BACKOFF_CAP, u32::MAX)
 }
 
 // ── LocalAgent: process lifecycle manager ────────────────────────────────────
@@ -239,7 +225,7 @@ fn read_stderr(path: &Path) -> String {
 ///   just "connection refused".
 fn wait_for_agent_ready(child: &mut Child, addr: &str, stderr_path: &Path, timeout: Duration) {
     let deadline = Instant::now() + timeout;
-    let mut backoff = Backoff::new(Duration::from_millis(20), Duration::from_millis(500));
+    let mut backoff = readiness_backoff();
 
     // One probe at a time: connect, half-close (send FIN), and wait for the
     // agent to serve it to completion and close its end (EOF). Reaching EOF
@@ -278,7 +264,7 @@ fn wait_for_agent_ready(child: &mut Child, addr: &str, stderr_path: &Path, timeo
                 }
             }
         }
-        std::thread::sleep(backoff.next_delay());
+        std::thread::sleep(backoff.next_delay().unwrap_or(READINESS_BACKOFF_CAP));
     }
 }
 
@@ -318,46 +304,6 @@ fn rpc(stream: &mut TcpStream, msg: &str) -> String {
     response.trim().to_string()
 }
 
-// ── Backoff unit tests ────────────────────────────────────────────────────────
-
-#[test]
-fn backoff_starts_at_initial_and_doubles() {
-    let mut b = Backoff::new(Duration::from_millis(20), Duration::from_millis(500));
-    assert_eq!(b.next_delay(), Duration::from_millis(20));
-    assert_eq!(b.next_delay(), Duration::from_millis(40));
-    assert_eq!(b.next_delay(), Duration::from_millis(80));
-    assert_eq!(b.next_delay(), Duration::from_millis(160));
-    assert_eq!(b.next_delay(), Duration::from_millis(320));
-}
-
-#[test]
-fn backoff_saturates_at_max_and_stays_there() {
-    let mut b = Backoff::new(Duration::from_millis(20), Duration::from_millis(500));
-    // 20 → 40 → 80 → 160 → 320 → 500 (capped, since 640 > 500) → 500 …
-    let delays: Vec<Duration> = (0..8).map(|_| b.next_delay()).collect();
-    assert_eq!(
-        delays,
-        vec![
-            Duration::from_millis(20),
-            Duration::from_millis(40),
-            Duration::from_millis(80),
-            Duration::from_millis(160),
-            Duration::from_millis(320),
-            Duration::from_millis(500),
-            Duration::from_millis(500),
-            Duration::from_millis(500),
-        ]
-    );
-}
-
-#[test]
-fn backoff_clamps_initial_above_max() {
-    // An initial larger than the cap must never exceed the cap.
-    let mut b = Backoff::new(Duration::from_secs(10), Duration::from_millis(500));
-    assert_eq!(b.next_delay(), Duration::from_millis(500));
-    assert_eq!(b.next_delay(), Duration::from_millis(500));
-}
-
 /// A dead agent process must be reported immediately, not waited out.
 ///
 /// Regression guard for #1398's diagnostics: if the child exits before the port
@@ -389,11 +335,10 @@ fn wait_for_agent_ready_fails_fast_when_process_dies() {
     child.wait().ok();
 
     let panic = result.expect_err("readiness wait must panic on a dead child");
+    // A formatted `panic!(…)` always carries a `String` payload.
     let msg = panic
         .downcast_ref::<String>()
-        .cloned()
-        .or_else(|| panic.downcast_ref::<&str>().map(|s| s.to_string()))
-        .unwrap_or_default();
+        .expect("panic payload should be a formatted String");
     assert!(
         msg.contains("exited before becoming ready"),
         "panic must identify the dead child — got: {msg}"

--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -40,6 +40,39 @@ fn agent_binary() -> &'static str {
 /// soon as the response arrives; it only widens the window before we give up.
 const RPC_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
+// ── Readiness retry backoff ───────────────────────────────────────────────────
+
+/// Exponential-backoff schedule for the agent-readiness retry loop.
+///
+/// Starts small so a fast local start returns almost immediately, then doubles
+/// the delay after each attempt up to a cap. This keeps the happy path snappy
+/// (the first probe fires after only [`INITIAL`](Backoff::new) ms) while making
+/// the loop gentle on a **starved CI runner**: instead of hammering `connect()`
+/// hundreds of times a second for the whole timeout — the pattern that let #1398
+/// flake with `connect: Connection refused` — retries space out as the agent
+/// takes longer to come up.
+struct Backoff {
+    current: Duration,
+    max: Duration,
+}
+
+impl Backoff {
+    /// Create a schedule starting at `initial`, doubling up to `max`.
+    fn new(initial: Duration, max: Duration) -> Self {
+        Backoff {
+            current: initial.min(max),
+            max,
+        }
+    }
+
+    /// Return the current delay, then advance the schedule (double, capped).
+    fn next_delay(&mut self) -> Duration {
+        let delay = self.current;
+        self.current = (self.current * 2).min(self.max);
+        delay
+    }
+}
+
 // ── LocalAgent: process lifecycle manager ────────────────────────────────────
 
 /// Spawns a `termihub-agent --listen` process on a free port.
@@ -192,6 +225,46 @@ fn rpc(stream: &mut TcpStream, msg: &str) -> String {
     let mut response = String::new();
     reader.read_line(&mut response).expect("read_line failed");
     response.trim().to_string()
+}
+
+// ── Backoff unit tests ────────────────────────────────────────────────────────
+
+#[test]
+fn backoff_starts_at_initial_and_doubles() {
+    let mut b = Backoff::new(Duration::from_millis(20), Duration::from_millis(500));
+    assert_eq!(b.next_delay(), Duration::from_millis(20));
+    assert_eq!(b.next_delay(), Duration::from_millis(40));
+    assert_eq!(b.next_delay(), Duration::from_millis(80));
+    assert_eq!(b.next_delay(), Duration::from_millis(160));
+    assert_eq!(b.next_delay(), Duration::from_millis(320));
+}
+
+#[test]
+fn backoff_saturates_at_max_and_stays_there() {
+    let mut b = Backoff::new(Duration::from_millis(20), Duration::from_millis(500));
+    // 20 → 40 → 80 → 160 → 320 → 500 (capped, since 640 > 500) → 500 …
+    let delays: Vec<Duration> = (0..8).map(|_| b.next_delay()).collect();
+    assert_eq!(
+        delays,
+        vec![
+            Duration::from_millis(20),
+            Duration::from_millis(40),
+            Duration::from_millis(80),
+            Duration::from_millis(160),
+            Duration::from_millis(320),
+            Duration::from_millis(500),
+            Duration::from_millis(500),
+            Duration::from_millis(500),
+        ]
+    );
+}
+
+#[test]
+fn backoff_clamps_initial_above_max() {
+    // An initial larger than the cap must never exceed the cap.
+    let mut b = Backoff::new(Duration::from_secs(10), Duration::from_millis(500));
+    assert_eq!(b.next_delay(), Duration::from_millis(500));
+    assert_eq!(b.next_delay(), Duration::from_millis(500));
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -15,6 +15,7 @@
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::{Duration, Instant};
@@ -22,7 +23,7 @@ use std::time::{Duration, Instant};
 use base64::Engine as _;
 use serde_json::{json, Value};
 
-use tempfile::TempDir;
+use tempfile::{NamedTempFile, TempDir};
 
 // ── Binary path ───────────────────────────────────────────────────────────────
 
@@ -82,6 +83,9 @@ struct LocalAgent {
     pub addr: String,
     /// Temp config dir kept alive for the agent's lifetime (cleaned on drop).
     _config_dir: TempDir,
+    /// Captured agent stderr, kept alive so `wait_for_agent_ready` can surface
+    /// it in a panic if startup fails.
+    _stderr: NamedTempFile,
 }
 
 impl LocalAgent {
@@ -96,19 +100,13 @@ impl LocalAgent {
         // live in which a connection could be reset.
         let config_dir = TempDir::new().expect("failed to create temp config dir");
 
-        let process = Command::new(agent_binary())
-            .args(["--listen", &addr])
-            .env("XDG_CONFIG_HOME", config_dir.path())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("failed to spawn termihub-agent");
-
-        wait_for_agent_ready(&addr, Duration::from_secs(30));
+        let (mut process, stderr) = spawn_listener_process(&addr, config_dir.path(), None);
+        wait_for_agent_ready(&mut process, &addr, stderr.path(), ready_timeout());
         LocalAgent {
             process,
             addr,
             _config_dir: config_dir,
+            _stderr: stderr,
         }
     }
 }
@@ -138,6 +136,14 @@ static NEXT_TEST_PORT: AtomicU16 = AtomicU16::new(19200);
 /// Advances a per-binary atomic counter so parallel tests never pick the same port.
 /// Skips any port that happens to be in use by an external process (rare on a
 /// dedicated CI runner, but handled to avoid spurious failures).
+///
+/// # Why a counter and not an ephemeral `:0` port
+///
+/// Binding `:0`, reading back the OS-assigned port, dropping the listener, and
+/// letting the agent re-bind it opens a TOCTOU window: a concurrent test can
+/// grab the same port in the gap. The incrementing counter (plus the bind
+/// probe below, which skips ports already held by an unrelated process) gives
+/// each test in this binary a private port with no such race.
 fn unique_agent_port() -> u16 {
     loop {
         let port = NEXT_TEST_PORT.fetch_add(1, Ordering::Relaxed);
@@ -145,6 +151,61 @@ fn unique_agent_port() -> u16 {
         if TcpListener::bind(format!("127.0.0.1:{port}")).is_ok() {
             return port;
         }
+    }
+}
+
+/// Readiness budget for [`wait_for_agent_ready`].
+///
+/// A loaded CI runner can take much longer than a dev box to cold-start the
+/// agent process, so the default is deliberately generous (60s). Because the
+/// wait returns the instant the agent is ready — and fails fast if the child
+/// process dies (see [`wait_for_agent_ready`]) — a high ceiling never slows the
+/// passing path; it only widens the window before we give up on a genuinely
+/// slow start. CI can override it via `TERMIHUB_TEST_READY_TIMEOUT_SECS` without
+/// a code change if a particular runner class needs even more headroom.
+fn ready_timeout() -> Duration {
+    std::env::var("TERMIHUB_TEST_READY_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(60))
+}
+
+/// Spawn a `termihub-agent --listen <addr>` with its stderr captured to a temp
+/// file, isolated from the developer's real config via `XDG_CONFIG_HOME`.
+///
+/// Returns the child plus the [`NamedTempFile`] holding its stderr; the caller
+/// passes the file's path to [`wait_for_agent_ready`] so a failed startup can be
+/// diagnosed from the agent's own error output rather than an opaque timeout.
+fn spawn_listener_process(
+    addr: &str,
+    config_home: &Path,
+    rust_log: Option<&str>,
+) -> (Child, NamedTempFile) {
+    let stderr_file = NamedTempFile::new().expect("failed to create stderr capture file");
+    let stderr_handle = stderr_file
+        .reopen()
+        .expect("failed to reopen stderr capture file");
+
+    let mut cmd = Command::new(agent_binary());
+    cmd.args(["--listen", addr])
+        .env("XDG_CONFIG_HOME", config_home)
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_handle));
+    if let Some(log) = rust_log {
+        cmd.env("RUST_LOG", log);
+    }
+
+    let child = cmd.spawn().expect("failed to spawn termihub-agent");
+    (child, stderr_file)
+}
+
+/// Read the captured agent stderr for inclusion in a diagnostic panic.
+fn read_stderr(path: &Path) -> String {
+    match std::fs::read_to_string(path) {
+        Ok(s) if s.trim().is_empty() => "(agent stderr was empty)".to_string(),
+        Ok(s) => s,
+        Err(e) => format!("(failed to read agent stderr: {e})"),
     }
 }
 
@@ -161,9 +222,24 @@ fn unique_agent_port() -> u16 {
 /// probe, ran its transport loop to completion, and looped back to `accept()` —
 /// i.e. it is live and idle, leaving no overlapping connection for the test's
 /// real connection to race against. Transient errors (not-yet-bound, read
-/// timeout) are retried until the deadline.
-fn wait_for_agent_ready(addr: &str, timeout: Duration) {
+/// timeout) are retried with [exponential backoff](Backoff) until the deadline.
+///
+/// # Robustness for loaded CI (#1398)
+///
+/// Two properties keep this from flaking when a starved runner is slow to start
+/// the agent:
+///
+/// * **Fail fast on a dead child.** Between probes we poll [`Child::try_wait`].
+///   If the agent process has already exited we panic immediately with its exit
+///   status and captured stderr, instead of blindly retrying `connect()` for
+///   the whole timeout against a port that will never open.
+/// * **Rich timeout diagnostics.** On genuine timeout the panic reports whether
+///   the process is still running plus its stderr — so a CI failure says
+///   whether the agent never spawned, crashed, or is merely slow, rather than
+///   just "connection refused".
+fn wait_for_agent_ready(child: &mut Child, addr: &str, stderr_path: &Path, timeout: Duration) {
     let deadline = Instant::now() + timeout;
+    let mut backoff = Backoff::new(Duration::from_millis(20), Duration::from_millis(500));
 
     // One probe at a time: connect, half-close (send FIN), and wait for the
     // agent to serve it to completion and close its end (EOF). Reaching EOF
@@ -173,21 +249,36 @@ fn wait_for_agent_ready(addr: &str, timeout: Duration) {
     //
     // A single probe can still fail transiently while the agent is mid-startup
     // under heavy parallel load (e.g. a brief listener hiccup resets the
-    // connection). The agent's accept loop survives such errors, so we simply
-    // retry with a fresh connection until the deadline. Because each attempt
-    // runs to completion before the next, retries never pile up a backlog.
+    // connection). The agent's accept loop survives such errors, so we retry
+    // with a fresh connection — spacing attempts out via exponential backoff —
+    // until the deadline. Because each attempt runs to completion before the
+    // next, retries never pile up a backlog.
     loop {
         match probe_once(addr, &deadline) {
             None => return,
             Some(err) => {
-                if Instant::now() >= deadline {
+                // If the child has already died, there is no point waiting out
+                // the rest of the timeout — surface the crash straight away.
+                if let Ok(Some(status)) = child.try_wait() {
                     panic!(
-                        "agent did not become ready within {timeout:?} — addr: {addr}, last: {err}"
+                        "agent process exited before becoming ready — addr: {addr}, \
+                         exit: {status}, last probe: {err}\n\
+                         --- agent stderr ---\n{}",
+                        read_stderr(stderr_path)
+                    );
+                }
+                if Instant::now() >= deadline {
+                    let still_running = matches!(child.try_wait(), Ok(None));
+                    panic!(
+                        "agent did not become ready within {timeout:?} — addr: {addr}, \
+                         process still running: {still_running}, last probe: {err}\n\
+                         --- agent stderr ---\n{}",
+                        read_stderr(stderr_path)
                     );
                 }
             }
         }
-        std::thread::sleep(Duration::from_millis(20));
+        std::thread::sleep(backoff.next_delay());
     }
 }
 
@@ -265,6 +356,52 @@ fn backoff_clamps_initial_above_max() {
     let mut b = Backoff::new(Duration::from_secs(10), Duration::from_millis(500));
     assert_eq!(b.next_delay(), Duration::from_millis(500));
     assert_eq!(b.next_delay(), Duration::from_millis(500));
+}
+
+/// A dead agent process must be reported immediately, not waited out.
+///
+/// Regression guard for #1398's diagnostics: if the child exits before the port
+/// ever opens, `wait_for_agent_ready` must fail fast (via `try_wait`) with a
+/// message that identifies the crash — never blindly retry `connect()` for the
+/// whole timeout against a port that will never listen.
+#[test]
+fn wait_for_agent_ready_fails_fast_when_process_dies() {
+    // `--version` makes the agent print and exit at once instead of listening,
+    // standing in for a process that dies during startup.
+    let port = unique_agent_port();
+    let addr = format!("127.0.0.1:{port}");
+    let stderr = NamedTempFile::new().expect("stderr temp file");
+    let stderr_handle = stderr.reopen().expect("reopen stderr");
+    let mut child = Command::new(agent_binary())
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_handle))
+        .spawn()
+        .expect("spawn agent --version");
+
+    let started = Instant::now();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // Generous timeout: if fail-fast is broken this would hang ~10s, which
+        // the elapsed-time assertion below still catches.
+        wait_for_agent_ready(&mut child, &addr, stderr.path(), Duration::from_secs(10));
+    }));
+    let elapsed = started.elapsed();
+    child.wait().ok();
+
+    let panic = result.expect_err("readiness wait must panic on a dead child");
+    let msg = panic
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| panic.downcast_ref::<&str>().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert!(
+        msg.contains("exited before becoming ready"),
+        "panic must identify the dead child — got: {msg}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "readiness wait must fail fast, not wait out the timeout — took {elapsed:?}"
+    );
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -786,6 +923,8 @@ fn spawn_daemon_for_local_shell(session_id: &str, socket_path: &std::path::Path)
 struct IsolatedAgent {
     process: Child,
     pub addr: String,
+    /// Captured agent stderr, kept alive for startup-failure diagnostics.
+    _stderr: NamedTempFile,
 }
 
 #[cfg(unix)]
@@ -793,18 +932,15 @@ impl IsolatedAgent {
     fn spawn(xdg_home: &std::path::Path) -> Self {
         let port = unique_agent_port();
         let addr = format!("127.0.0.1:{port}");
-        let process = Command::new(agent_binary())
-            .args(["--listen", &addr])
-            .env("XDG_CONFIG_HOME", xdg_home)
-            .env("RUST_LOG", "warn")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("failed to spawn isolated agent");
+        let (mut process, stderr) = spawn_listener_process(&addr, xdg_home, Some("warn"));
         // The readiness probe waits until the accept loop is idle, which is
         // after recover_sessions() finishes — no fixed-sleep guess needed.
-        wait_for_agent_ready(&addr, Duration::from_secs(30));
-        IsolatedAgent { process, addr }
+        wait_for_agent_ready(&mut process, &addr, stderr.path(), ready_timeout());
+        IsolatedAgent {
+            process,
+            addr,
+            _stderr: stderr,
+        }
     }
 }
 

--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -458,9 +458,11 @@ struct AgentClient {
 impl AgentClient {
     fn connect(addr: &str) -> Self {
         let stream = TcpStream::connect(addr).expect("connect failed");
-        stream
-            .set_read_timeout(Some(Duration::from_secs(10)))
-            .unwrap();
+        // Match the simple `rpc()` helper's generous per-round-trip budget: a
+        // loaded CI runner can momentarily take several seconds to answer an
+        // RPC, and a 10s ceiling flaked under that load (#1398). The read still
+        // returns as soon as the response arrives.
+        stream.set_read_timeout(Some(RPC_READ_TIMEOUT)).unwrap();
         let writer = stream.try_clone().expect("clone failed");
         AgentClient {
             writer,
@@ -597,7 +599,7 @@ impl AgentClient {
                                 .unwrap_or_default();
                             let text = String::from_utf8_lossy(&bytes);
                             if text.contains(needle) {
-                                self.set_read_timeout(Some(Duration::from_secs(10)));
+                                self.set_read_timeout(Some(RPC_READ_TIMEOUT));
                                 return true;
                             }
                         }
@@ -613,7 +615,7 @@ impl AgentClient {
             }
         }
 
-        self.set_read_timeout(Some(Duration::from_secs(10)));
+        self.set_read_timeout(Some(RPC_READ_TIMEOUT));
         false
     }
 }
@@ -813,21 +815,42 @@ fn shell_session_reattach_after_reconnect() {
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
-/// Poll until `path` exists or `timeout` expires.
+/// Poll until the daemon's `path` socket appears, or panic on timeout.
+///
+/// Hardened the same way as [`wait_for_agent_ready`] (#1398): the previous
+/// version used a fixed non-overridable 5s budget, a flat 20ms spin, and threw
+/// the daemon's stderr away — so a slow/loaded CI runner flaked and the panic
+/// said nothing. Now it fails fast if the daemon process has already died
+/// (with its exit status + captured stderr), uses the shared exponential
+/// [`readiness_backoff`], and appends stderr on genuine timeout.
 #[cfg(unix)]
-fn wait_for_socket(path: &std::path::Path, timeout: Duration) {
+fn wait_for_socket(child: &mut Child, path: &Path, stderr_path: &Path, timeout: Duration) {
     let deadline = Instant::now() + timeout;
+    let mut backoff = readiness_backoff();
     loop {
         if path.exists() {
             return;
         }
-        if Instant::now() >= deadline {
+        // A dead daemon will never create the socket — surface the crash now
+        // instead of spinning until the deadline.
+        if let Ok(Some(status)) = child.try_wait() {
             panic!(
-                "daemon socket did not appear within {timeout:?}: {}",
-                path.display()
+                "daemon process exited before creating its socket — exit: {status}, \
+                 socket: {}\n--- daemon stderr ---\n{}",
+                path.display(),
+                read_stderr(stderr_path)
             );
         }
-        std::thread::sleep(Duration::from_millis(20));
+        if Instant::now() >= deadline {
+            let still_running = matches!(child.try_wait(), Ok(None));
+            panic!(
+                "daemon socket did not appear within {timeout:?} — socket: {}, \
+                 process still running: {still_running}\n--- daemon stderr ---\n{}",
+                path.display(),
+                read_stderr(stderr_path)
+            );
+        }
+        std::thread::sleep(backoff.next_delay().unwrap_or(READINESS_BACKOFF_CAP));
     }
 }
 
@@ -845,10 +868,16 @@ fn test_session_id() -> String {
 /// Spawn `termihub-agent --daemon <session_id>` for a local shell.
 ///
 /// The daemon writes its Unix socket to `socket_path` when it is ready.
-/// Caller must call `wait_for_socket` before using it.
+/// Caller must call [`wait_for_socket`] before using it. Returns the child plus
+/// the [`NamedTempFile`] capturing its stderr, so a startup failure can be
+/// diagnosed from the daemon's own error output.
 #[cfg(unix)]
-fn spawn_daemon_for_local_shell(session_id: &str, socket_path: &std::path::Path) -> Child {
-    Command::new(agent_binary())
+fn spawn_daemon_for_local_shell(session_id: &str, socket_path: &Path) -> (Child, NamedTempFile) {
+    let stderr_file = NamedTempFile::new().expect("failed to create daemon stderr capture file");
+    let stderr_handle = stderr_file
+        .reopen()
+        .expect("failed to reopen daemon stderr capture file");
+    let child = Command::new(agent_binary())
         .arg("--daemon")
         .arg(session_id)
         .env("TERMIHUB_TYPE_ID", "local")
@@ -857,9 +886,10 @@ fn spawn_daemon_for_local_shell(session_id: &str, socket_path: &std::path::Path)
         .env("TERMIHUB_BUFFER_SIZE", "65536")
         .env("RUST_LOG", "warn")
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::from(stderr_handle))
         .spawn()
-        .expect("failed to spawn daemon")
+        .expect("failed to spawn daemon");
+    (child, stderr_file)
 }
 
 /// A TCP listener agent isolated from the developer's real config by setting
@@ -912,6 +942,8 @@ impl Drop for IsolatedAgent {
 struct PersistentShellSetup {
     agent: IsolatedAgent,
     daemon: Child,
+    /// Captured daemon stderr, kept alive for startup-failure diagnostics.
+    _daemon_stderr: NamedTempFile,
     _tmp: TempDir,
     pub session_id: String,
 }
@@ -924,9 +956,15 @@ impl PersistentShellSetup {
         let session_id = test_session_id();
         let socket_path = tmp_path.join(format!("session-{session_id}.sock"));
 
-        // Start daemon, wait for its socket to appear.
-        let daemon = spawn_daemon_for_local_shell(&session_id, &socket_path);
-        wait_for_socket(&socket_path, Duration::from_secs(5));
+        // Start daemon, wait for its socket to appear. Uses the shared
+        // adaptive readiness budget so a loaded CI runner has headroom.
+        let (mut daemon, daemon_stderr) = spawn_daemon_for_local_shell(&session_id, &socket_path);
+        wait_for_socket(
+            &mut daemon,
+            &socket_path,
+            daemon_stderr.path(),
+            ready_timeout(),
+        );
 
         // Write AgentState so the TCP listener's recover_sessions() finds this
         // daemon when it starts.
@@ -953,6 +991,7 @@ impl PersistentShellSetup {
         PersistentShellSetup {
             agent,
             daemon,
+            _daemon_stderr: daemon_stderr,
             _tmp: tmp,
             session_id,
         }

--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -18,6 +18,7 @@ use std::net::{Shutdown, TcpListener, TcpStream};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -76,9 +77,6 @@ struct LocalAgent {
 
 impl LocalAgent {
     fn spawn() -> Self {
-        let port = unique_agent_port();
-        let addr = format!("127.0.0.1:{port}");
-
         // Isolate the agent's config/state from the developer's real
         // `~/.config/termihub-agent` (XDG_CONFIG_HOME is honored on every
         // platform). Without this, recover_sessions() reads real state at
@@ -86,8 +84,7 @@ impl LocalAgent {
         // live in which a connection could be reset.
         let config_dir = TempDir::new().expect("failed to create temp config dir");
 
-        let (mut process, stderr) = spawn_listener_process(&addr, config_dir.path(), None);
-        wait_for_agent_ready(&mut process, &addr, stderr.path(), ready_timeout());
+        let (process, addr, stderr) = spawn_ready_listener(config_dir.path(), None);
         LocalAgent {
             process,
             addr,
@@ -106,34 +103,51 @@ impl Drop for LocalAgent {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Atomic port counter to prevent TOCTOU collisions when many tests run in parallel.
-///
-/// `free_port()` (bind :0, get port, drop listener, return port) has a race window
-/// between dropping the listener and the agent binding the same port: a concurrent
-/// test can claim the same port in that gap, causing both agents to collide and one
-/// test to connect to the other's agent, which gets killed before it can respond.
-///
-/// Using an incrementing counter means each test in this binary gets a unique port.
-/// Ports 19200–19900 are IANA-unassigned and not in use by any well-known service.
-static NEXT_TEST_PORT: AtomicU16 = AtomicU16::new(19200);
+/// Low/high bounds of the test port range. 19200–20200 is IANA-unassigned and
+/// not used by any well-known service.
+const PORT_RANGE_LO: u16 = 19200;
+const PORT_RANGE_HI: u16 = 20200;
 
-/// Reserve a unique TCP port for a test agent.
+/// Per-process port counter, seeded once to a **process-specific** base.
 ///
-/// Advances a per-binary atomic counter so parallel tests never pick the same port.
-/// Skips any port that happens to be in use by an external process (rare on a
-/// dedicated CI runner, but handled to avoid spurious failures).
+/// A plain counter starting at a fixed 19200 for every process means two
+/// concurrent `cargo test` invocations (e.g. parallel CI jobs on one runner)
+/// march through the *same* ports in lockstep and keep colliding. Seeding the
+/// base from the PID desynchronises them so they walk different sub-ranges,
+/// making a collision rare — and [`spawn_ready_listener`] retries on the rare
+/// one that still lands on a `TIME_WAIT`/in-use port left by another run
+/// (#1398).
+fn port_counter() -> &'static AtomicU16 {
+    static COUNTER: OnceLock<AtomicU16> = OnceLock::new();
+    COUNTER.get_or_init(|| {
+        let span = PORT_RANGE_HI - PORT_RANGE_LO;
+        // Reserve headroom (span - 200) so a process starting near the top
+        // still has room for its handful of ports + retries before wrapping.
+        let base = PORT_RANGE_LO + (std::process::id() as u16 % (span - 200));
+        AtomicU16::new(base)
+    })
+}
+
+/// Reserve a candidate TCP port for a test agent.
+///
+/// Advances the per-process counter (wrapping within the range) so tests in the
+/// same process never pick the same port, and skips any port currently held by
+/// an unrelated process via a bind probe.
 ///
 /// # Why a counter and not an ephemeral `:0` port
 ///
 /// Binding `:0`, reading back the OS-assigned port, dropping the listener, and
 /// letting the agent re-bind it opens a TOCTOU window: a concurrent test can
-/// grab the same port in the gap. The incrementing counter (plus the bind
-/// probe below, which skips ports already held by an unrelated process) gives
-/// each test in this binary a private port with no such race.
+/// grab the same port in the gap. The counter (plus the bind probe here, and
+/// [`spawn_ready_listener`]'s retry on a bind failure) gives each test a
+/// private port far more reliably than `:0` round-tripping would.
 fn unique_agent_port() -> u16 {
+    let counter = port_counter();
     loop {
-        let port = NEXT_TEST_PORT.fetch_add(1, Ordering::Relaxed);
-        assert!(port < 19900, "exhausted test port range 19200–19900");
+        // Wrap within [LO, HI) so a long-lived process never runs off the end.
+        let raw = counter.fetch_add(1, Ordering::Relaxed);
+        let port =
+            PORT_RANGE_LO + (raw.wrapping_sub(PORT_RANGE_LO) % (PORT_RANGE_HI - PORT_RANGE_LO));
         if TcpListener::bind(format!("127.0.0.1:{port}")).is_ok() {
             return port;
         }
@@ -208,7 +222,8 @@ fn read_stderr(path: &Path) -> String {
 /// probe, ran its transport loop to completion, and looped back to `accept()` —
 /// i.e. it is live and idle, leaving no overlapping connection for the test's
 /// real connection to race against. Transient errors (not-yet-bound, read
-/// timeout) are retried with [exponential backoff](Backoff) until the deadline.
+/// timeout) are retried with exponential backoff (see [`readiness_backoff`])
+/// until the deadline.
 ///
 /// # Robustness for loaded CI (#1398)
 ///
@@ -216,14 +231,21 @@ fn read_stderr(path: &Path) -> String {
 /// the agent:
 ///
 /// * **Fail fast on a dead child.** Between probes we poll [`Child::try_wait`].
-///   If the agent process has already exited we panic immediately with its exit
-///   status and captured stderr, instead of blindly retrying `connect()` for
-///   the whole timeout against a port that will never open.
-/// * **Rich timeout diagnostics.** On genuine timeout the panic reports whether
-///   the process is still running plus its stderr — so a CI failure says
-///   whether the agent never spawned, crashed, or is merely slow, rather than
-///   just "connection refused".
-fn wait_for_agent_ready(child: &mut Child, addr: &str, stderr_path: &Path, timeout: Duration) {
+///   If the agent process has already exited we return
+///   [`ReadyError::ProcessExited`] at once — with its exit status and captured
+///   stderr — instead of blindly retrying `connect()` for the whole timeout
+///   against a port that will never open. This lets [`spawn_ready_listener`]
+///   retry on a fresh port when the exit was a bind collision (#1398).
+/// * **Rich timeout diagnostics.** On genuine timeout the returned
+///   [`ReadyError::Timeout`] reports whether the process is still running plus
+///   its stderr — so a CI failure says whether the agent never spawned,
+///   crashed, or is merely slow, rather than just "connection refused".
+fn wait_for_agent_ready(
+    child: &mut Child,
+    addr: &str,
+    stderr_path: &Path,
+    timeout: Duration,
+) -> Result<(), ReadyError> {
     let deadline = Instant::now() + timeout;
     let mut backoff = readiness_backoff();
 
@@ -241,31 +263,87 @@ fn wait_for_agent_ready(child: &mut Child, addr: &str, stderr_path: &Path, timeo
     // next, retries never pile up a backlog.
     loop {
         match probe_once(addr, &deadline) {
-            None => return,
+            None => return Ok(()),
             Some(err) => {
                 // If the child has already died, there is no point waiting out
                 // the rest of the timeout — surface the crash straight away.
                 if let Ok(Some(status)) = child.try_wait() {
-                    panic!(
+                    return Err(ReadyError::ProcessExited(format!(
                         "agent process exited before becoming ready — addr: {addr}, \
                          exit: {status}, last probe: {err}\n\
                          --- agent stderr ---\n{}",
                         read_stderr(stderr_path)
-                    );
+                    )));
                 }
                 if Instant::now() >= deadline {
                     let still_running = matches!(child.try_wait(), Ok(None));
-                    panic!(
+                    return Err(ReadyError::Timeout(format!(
                         "agent did not become ready within {timeout:?} — addr: {addr}, \
                          process still running: {still_running}, last probe: {err}\n\
                          --- agent stderr ---\n{}",
                         read_stderr(stderr_path)
-                    );
+                    )));
                 }
             }
         }
         std::thread::sleep(backoff.next_delay().unwrap_or(READINESS_BACKOFF_CAP));
     }
+}
+
+/// Why an agent listener never became ready.
+#[derive(Debug)]
+enum ReadyError {
+    /// The process exited before the port opened — usually a port collision
+    /// with a `TIME_WAIT`/in-use socket from another run, which retrying on a
+    /// fresh port resolves. Carries the full diagnostic (exit status + stderr).
+    ProcessExited(String),
+    /// The deadline elapsed while the process was still running (genuinely slow
+    /// or wedged). Carries the full diagnostic.
+    Timeout(String),
+}
+
+/// Max attempts to bring up a `--listen` agent on a bindable port.
+const MAX_SPAWN_ATTEMPTS: u32 = 5;
+
+/// Spawn a `--listen` agent and block until it is ready, retrying on a fresh
+/// port if the process dies during startup.
+///
+/// The fixed test-port range can collide with a socket left in `TIME_WAIT` (or
+/// held) by a previous or concurrent run on the same host — the agent then
+/// exits with `Address already in use` before its port ever opens (#1398). The
+/// bind probe in [`unique_agent_port`] cannot prevent this because another
+/// process owns the port, so we detect the early exit via
+/// [`ReadyError::ProcessExited`] and simply try the next port. A genuine
+/// startup bug fails the same way on every port and surfaces after the retry
+/// budget with full diagnostics; a slow-but-alive start ([`ReadyError::Timeout`])
+/// is not retried (that would just burn another full timeout).
+fn spawn_ready_listener(
+    config_home: &Path,
+    rust_log: Option<&str>,
+) -> (Child, String, NamedTempFile) {
+    let mut last_diag = String::new();
+    for attempt in 1..=MAX_SPAWN_ATTEMPTS {
+        let port = unique_agent_port();
+        let addr = format!("127.0.0.1:{port}");
+        let (mut child, stderr) = spawn_listener_process(&addr, config_home, rust_log);
+        match wait_for_agent_ready(&mut child, &addr, stderr.path(), ready_timeout()) {
+            Ok(()) => return (child, addr, stderr),
+            Err(ReadyError::ProcessExited(diag)) => {
+                child.kill().ok();
+                child.wait().ok();
+                last_diag = format!("attempt {attempt}/{MAX_SPAWN_ATTEMPTS}: {diag}");
+            }
+            Err(ReadyError::Timeout(diag)) => {
+                child.kill().ok();
+                child.wait().ok();
+                panic!("{diag}");
+            }
+        }
+    }
+    panic!(
+        "agent listener failed to become ready after {MAX_SPAWN_ATTEMPTS} attempts \
+         (each exited during startup) — {last_diag}"
+    );
 }
 
 /// One FIN-readiness probe. Returns `None` on success (EOF observed), or
@@ -308,10 +386,12 @@ fn rpc(stream: &mut TcpStream, msg: &str) -> String {
 ///
 /// Regression guard for #1398's diagnostics: if the child exits before the port
 /// ever opens, `wait_for_agent_ready` must fail fast (via `try_wait`) with a
-/// message that identifies the crash — never blindly retry `connect()` for the
-/// whole timeout against a port that will never listen.
+/// [`ReadyError::ProcessExited`] that identifies the crash — never blindly retry
+/// `connect()` for the whole timeout against a port that will never listen. It
+/// is this fast, classified exit that lets `spawn_ready_listener` retry on a
+/// fresh port when the cause is a bind collision.
 #[test]
-fn wait_for_agent_ready_fails_fast_when_process_dies() {
+fn wait_for_agent_ready_reports_dead_process_fast() {
     // `--version` makes the agent print and exit at once instead of listening,
     // standing in for a process that dies during startup.
     let port = unique_agent_port();
@@ -326,23 +406,19 @@ fn wait_for_agent_ready_fails_fast_when_process_dies() {
         .expect("spawn agent --version");
 
     let started = Instant::now();
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        // Generous timeout: if fail-fast is broken this would hang ~10s, which
-        // the elapsed-time assertion below still catches.
-        wait_for_agent_ready(&mut child, &addr, stderr.path(), Duration::from_secs(10));
-    }));
+    // Generous timeout: if fail-fast is broken this would take ~10s, which the
+    // elapsed-time assertion below still catches.
+    let result = wait_for_agent_ready(&mut child, &addr, stderr.path(), Duration::from_secs(10));
     let elapsed = started.elapsed();
     child.wait().ok();
 
-    let panic = result.expect_err("readiness wait must panic on a dead child");
-    // A formatted `panic!(…)` always carries a `String` payload.
-    let msg = panic
-        .downcast_ref::<String>()
-        .expect("panic payload should be a formatted String");
-    assert!(
-        msg.contains("exited before becoming ready"),
-        "panic must identify the dead child — got: {msg}"
-    );
+    match result {
+        Err(ReadyError::ProcessExited(diag)) => assert!(
+            diag.contains("exited before becoming ready"),
+            "diagnostic must identify the dead child — got: {diag}"
+        ),
+        other => panic!("expected ProcessExited on a dead child, got: {other:?}"),
+    }
     assert!(
         elapsed < Duration::from_secs(5),
         "readiness wait must fail fast, not wait out the timeout — took {elapsed:?}"
@@ -905,12 +981,9 @@ struct IsolatedAgent {
 #[cfg(unix)]
 impl IsolatedAgent {
     fn spawn(xdg_home: &std::path::Path) -> Self {
-        let port = unique_agent_port();
-        let addr = format!("127.0.0.1:{port}");
-        let (mut process, stderr) = spawn_listener_process(&addr, xdg_home, Some("warn"));
-        // The readiness probe waits until the accept loop is idle, which is
-        // after recover_sessions() finishes — no fixed-sleep guess needed.
-        wait_for_agent_ready(&mut process, &addr, stderr.path(), ready_timeout());
+        // spawn_ready_listener waits until the accept loop is idle (after
+        // recover_sessions() finishes) and retries on a port collision.
+        let (process, addr, stderr) = spawn_ready_listener(xdg_home, Some("warn"));
         IsolatedAgent {
             process,
             addr,


### PR DESCRIPTION
## Root cause

`agent_handles_multiple_sequential_connections` (and its siblings) in `agent/tests/local_agent_integration.rs` intermittently failed on loaded macOS/Windows CI runners with:

```
agent did not become ready within 30s — addr: 127.0.0.1:19202, last: connect: Connection refused (os error 61)
```

The starting hypothesis (per #1398) was runner starvation pushing the agent's cold start past the fixed 30s readiness budget. Hardening the readiness wait with **diagnostics that capture the child's stderr and exit status** then revealed the *actual* root cause on a local repro:

```
INFO termihub-agent starting in TCP listener mode on 127.0.0.1:19206
Error: Address already in use (os error 48)
```

It was **not** a slow start — the agent process was **exiting with `EADDRINUSE`**. The fixed test-port range (19200+) collides with a socket left in `TIME_WAIT` (or still held) by a previous or concurrent run on the same host — which matches #1398's observed low fixed addresses (19200/19202). The bind probe in `unique_agent_port` cannot prevent this because another process owns the port, and the old readiness loop reported the resulting refused connections as a generic timeout.

## Fix

Root-cause fix plus defence-in-depth against genuine slow starts:

- **Retry on port collision.** `wait_for_agent_ready` now returns `Result<(), ReadyError>` distinguishing a process that *exited during startup* (retryable — the bind-collision case) from a genuine *timeout* (still-running-but-slow). New `spawn_ready_listener` retries on a fresh port (up to 5 attempts) when the agent exits during startup, and only surfaces diagnostics if every attempt fails.
- **Desynchronised per-process ports.** The port counter base is seeded from the PID so two concurrent `cargo test` invocations (parallel CI jobs on one runner) walk different sub-ranges instead of colliding in lockstep; the counter wraps within the range.
- **Adaptive/longer timeout + exponential backoff.** Default readiness budget is 60s (env-overridable via `TERMIHUB_TEST_READY_TIMEOUT_SECS`), and retries use an exponential backoff (20ms → 500ms cap) instead of a flat 20ms spin. The happy path is unaffected — the wait returns the instant the agent is ready.
- **Real diagnostics.** The agent's stderr is captured to a temp file and appended (with exit status / still-running state) to every failure, so a CI failure says whether the agent never spawned, crashed, or is merely slow.
- **Sibling-test audit (the issue asked for this).** The daemon spawn/socket-wait path (`spawn_daemon_for_local_shell` / `wait_for_socket`) got the same treatment (stderr capture, fail-fast on dead child, shared backoff, adaptive timeout — previously a hard, non-overridable 5s). `AgentClient`'s per-RPC read timeout was aligned from a too-tight 10s to the existing 30s `RPC_READ_TIMEOUT`.
- **Reuse.** The bespoke backoff struct was replaced with the existing `termihub_core::monitoring::BackoffSchedule`.

## Test plan

- `cargo test -p termihub-agent --test local_agent_integration` — 12 tests pass.
- Added regression test `wait_for_agent_ready_reports_dead_process_fast`: a dead child is reported (typed `ReadyError::ProcessExited`) in under 5s rather than waiting out the timeout.
- **Stability:** ran the suite **45 times sequentially** and **5 rounds of 3 concurrent `cargo test` processes** (15 concurrent invocations) — all green. The collision previously reproduced ~1 in 30–50 runs.
- `./scripts/check.sh` — all checks pass (fmt, clippy, lint).

## Follow-up

- #1413 — replace the remaining fixed 200ms post-disconnect sleeps in the persistence tests with condition polling (deferred to keep this PR focused on the readiness waits).

Closes #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)