### PR TITLE
test(agent): poll for detach/reattach instead of fixed 200ms sleeps

### DIFF
--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -171,6 +171,34 @@ fn ready_timeout() -> Duration {
         .unwrap_or(Duration::from_secs(60))
 }
 
+/// Poll `condition` until it returns `true` or `timeout` elapses, sleeping the
+/// [`readiness_backoff`] schedule between attempts.
+///
+/// Returns `true` as soon as the condition holds — the happy path returns on the
+/// **first** poll and never sleeps — or `false` once the ceiling is hit. This is
+/// the eventually-consistent counterpart to the readiness waits: use it to await
+/// an agent state that arrives asynchronously (e.g. a session flipping to
+/// `attached: false` after a client TCP disconnect triggers `detach_all()`),
+/// rather than a fixed sleep. A fixed budget is a guess — under a starved CI
+/// runner the agent may not have processed the detach in time, so the next
+/// `connection.list` still reports the stale `attached: true` and the test
+/// flakes; polling with backoff is robust without slowing the normal case. The
+/// ceiling reuses [`ready_timeout`] (env-overridable via
+/// `TERMIHUB_TEST_READY_TIMEOUT_SECS`).
+fn wait_until(mut condition: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    let mut backoff = readiness_backoff();
+    loop {
+        if condition() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(backoff.next_delay().unwrap_or(READINESS_BACKOFF_CAP));
+    }
+}
+
 /// Spawn a `termihub-agent --listen <addr>` with its stderr captured to a temp
 /// file, isolated from the developer's real config via `XDG_CONFIG_HOME`.
 ///
@@ -638,6 +666,17 @@ impl AgentClient {
             .unwrap_or_default()
     }
 
+    /// Return `true` if `connection.list` reports `session_id` with
+    /// `attached: false` — the eventually-consistent state the agent reaches
+    /// after a client TCP disconnect triggers `detach_all()`. Used with
+    /// [`wait_until`] to await the detach instead of a fixed post-disconnect
+    /// sleep.
+    fn session_detached(&mut self, session_id: &str) -> bool {
+        self.list_sessions()
+            .iter()
+            .any(|s| s["session_id"].as_str() == Some(session_id) && s["attached"] == false)
+    }
+
     fn write_input(&mut self, session_id: &str, data: &str) -> Value {
         let encoded = base64::engine::general_purpose::STANDARD.encode(data.as_bytes());
         self.rpc(
@@ -772,11 +811,16 @@ fn shell_session_persists_across_client_disconnect() {
         // implicit drop → TCP connection closes → agent calls detach_all()
     }
 
-    // Allow the agent's async runtime to process the disconnect.
-    std::thread::sleep(Duration::from_millis(200));
-
     let mut client2 = AgentClient::connect(&agent.addr);
     client2.initialize();
+
+    // Wait for the agent's async runtime to process the disconnect and mark the
+    // session detached, rather than guessing with a fixed sleep (a starved CI
+    // runner may need longer). Returns on the first successful poll.
+    assert!(
+        wait_until(|| client2.session_detached(&session_id), ready_timeout()),
+        "session {session_id} not reported detached after client disconnect"
+    );
 
     let sessions = client2.list_sessions();
     let entry = sessions
@@ -832,10 +876,15 @@ fn shell_session_reattach_after_reconnect() {
         // implicit drop → disconnects
     }
 
-    std::thread::sleep(Duration::from_millis(200));
-
     let mut client2 = AgentClient::connect(&agent.addr);
     client2.initialize();
+
+    // Poll until the agent reports the session detached instead of a fixed sleep
+    // that flakes under CI load. Returns on the first successful poll.
+    assert!(
+        wait_until(|| client2.session_detached(&session_id), ready_timeout()),
+        "session {session_id} not reported detached before re-attach"
+    );
 
     let sessions = client2.list_sessions();
     let entry = sessions
@@ -1193,11 +1242,18 @@ fn persistent_shell_buffer_replayed_after_tcp_reconnect() {
         // The daemon keeps the shell running and the ring buffer intact.
     }
 
-    std::thread::sleep(Duration::from_millis(200));
-
     // ── Connection 2: TCP reconnect → re-attach → buffer replay ───────────────
     {
         let mut client = setup.connect_client();
+
+        // Poll until the daemon has processed the detach (session shows
+        // `attached: false`) instead of a fixed sleep that flakes under CI load.
+        // Returns on the first successful poll.
+        let session_id = setup.session_id.clone();
+        assert!(
+            wait_until(|| client.session_detached(&session_id), ready_timeout()),
+            "session {session_id} not reported detached after TCP reconnect"
+        );
 
         let sessions = client.list_sessions();
         let entry = sessions


### PR DESCRIPTION
## Summary

Closes #1413. Follow-up to #1398.

Three persistence tests in `agent/tests/local_agent_integration.rs` used a hard-coded `std::thread::sleep(Duration::from_millis(200))` after a client TCP disconnect to let the agent process `detach_all()` before asserting the session shows `attached: false`:

- `shell_session_persists_across_client_disconnect`
- `shell_session_reattach_after_reconnect`
- `persistent_shell_buffer_replayed_after_tcp_reconnect`

A fixed 200ms budget is a guess. Under a starved CI runner the agent may not have processed the detach within 200ms, so the subsequent `connection.list` still reports the stale `attached: true` and the test flakes — the same fixed-budget pattern #1398 replaced for the readiness waits.

## Change

- Add a `wait_until(condition, timeout)` helper that polls a closure until it returns `true`, sleeping the existing `readiness_backoff()` schedule between attempts and using `ready_timeout()` (env-overridable via `TERMIHUB_TEST_READY_TIMEOUT_SECS`) as the ceiling — reusing the #1398 helpers.
- Add `AgentClient::session_detached()` which queries `connection.list` and returns whether the session is present with `attached: false`.
- Replace each fixed sleep with a poll on that actual awaited condition. **The happy path returns on the first successful poll and never sleeps**, so the normal case stays fast; only a genuinely slow runner waits longer, up to the generous ceiling.
- No assertions were weakened — the original `list_sessions()` / `attached == false` assertions remain and still run after the poll.

## Test plan

- `cargo test -p termihub-agent --test local_agent_integration -- shell_session_persists_across_client_disconnect shell_session_reattach_after_reconnect persistent_shell_buffer_replayed_after_tcp_reconnect` → all 3 pass, test binary finished in 3.70s (happy path stays fast).
- `cargo clippy -p termihub-agent --tests --all-features -- -D warnings` → clean.

Test-only / non-user-facing change, so no changelog fragment (per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)