### PR TITLE
feat(ui): define --radius-full and --text-muted design tokens

### DIFF
--- a/docs/changes/dev0/feature/1406-design-tokens.md
+++ b/docs/changes/dev0/feature/1406-design-tokens.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Defined the previously missing `--radius-full` and `--text-muted` design
+  tokens, which were referenced by several surfaces but never declared and so
+  resolved to invalid/zero values. Pill badges and progress bars in the Open
+  Connections panel and the X server setup dialog now render with their intended
+  fully rounded corners, and muted/incidental text in those surfaces plus the
+  status bar now uses a proper per-theme muted color (light + dark, including
+  the Solarized variants) instead of a broken fallback (#1406).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1269,6 +1269,24 @@ exhausted. Pending a fault-injection system test (follow-up), verify manually:
 4. Repeat against a monitored host **behind the agent** (agent monitoring
    subscription) to confirm the agent mirrors the same behavior.
 
+### Design tokens: pill radius + muted text (#1406)
+
+Verifies the `--radius-full` and `--text-muted` design tokens render their
+intended pill radius / muted color across every theme (they were previously
+referenced but undefined). See PR #1421. Purely visual, so manual.
+
+For **each** theme (Dark, Light, Solarized Dark, Solarized Light — switch via
+Settings):
+
+1. Open the **Open Connections** panel (Settings wheel → Open Connections).
+   Confirm the section-count and `.oc-row__badge` pills have fully rounded
+   (pill) corners, and that muted row text (icons, detail text, muted titles)
+   reads as lower-emphasis than the primary row title — not black/transparent.
+2. Trigger the **X server setup dialog** and confirm the progress bar is fully
+   rounded and any muted helper text renders in the theme's muted color.
+3. Confirm **status bar** muted text renders with the per-theme muted color
+   (visible but de-emphasized) rather than a broken fallback.
+
 ### Legacy Guided Manual Test Runner (YAML)
 
 The remaining manual test items are still defined as machine-readable YAML in [`tests/manual/*.yaml`](../tests/manual/). The standalone runner presents applicable tests one at a time, manages infrastructure, and generates a JSON report. It is being subsumed by the harness flow above:

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -32,6 +32,9 @@
   /* Text colors */
   --text-primary: #dde1ec;
   --text-secondary: #7b8597;
+  /* Muted: lower emphasis than secondary (badges, counts, incidental labels).
+     Per-theme values are supplied by the theme engine; this is the dark default. */
+  --text-muted: #656e80;
   --text-disabled: #3d4557;
   --text-accent: #5aa6ff;
   --text-link: #4190ee;
@@ -119,6 +122,8 @@
   --radius-md: 6px;
   --radius-lg: 10px;
   --radius-xl: 14px;
+  /* Fully rounded — pill badges, progress bars, circular indicators. */
+  --radius-full: 999px;
 
   /* Control heights */
   --control-height-sm: 24px;

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -33,6 +33,7 @@ export const darkTheme: ThemeDefinition = {
     // Text
     textPrimary: "#cccccc",
     textSecondary: "#969696",
+    textMuted: "#7d7d7d",
     textDisabled: "#5a5a5a",
     textAccent: "#4fc1ff",
     textLink: "#3794ff",

--- a/src/themes/engine.ts
+++ b/src/themes/engine.ts
@@ -31,6 +31,7 @@ const COLOR_TO_CSS_VAR: Record<keyof ThemeColors, string> = {
 
   textPrimary: "--text-primary",
   textSecondary: "--text-secondary",
+  textMuted: "--text-muted",
   textDisabled: "--text-disabled",
   textAccent: "--text-accent",
   textLink: "--text-link",

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -33,6 +33,7 @@ export const lightTheme: ThemeDefinition = {
     // Text
     textPrimary: "#383a42",
     textSecondary: "#6a737d",
+    textMuted: "#858a90",
     textDisabled: "#a0a0a0",
     textAccent: "#0366d6",
     textLink: "#0366d6",

--- a/src/themes/solarized-dark.ts
+++ b/src/themes/solarized-dark.ts
@@ -33,6 +33,7 @@ export const solarizedDarkTheme: ThemeDefinition = {
     // Text
     textPrimary: "#839496", // base0
     textSecondary: "#657b83", // base00
+    textMuted: "#586e75", // base01
     textDisabled: "#3d5862",
     textAccent: "#268bd2",
     textLink: "#268bd2",

--- a/src/themes/solarized-light.ts
+++ b/src/themes/solarized-light.ts
@@ -33,6 +33,7 @@ export const solarizedLightTheme: ThemeDefinition = {
     // Text
     textPrimary: "#657b83", // base00
     textSecondary: "#93a1a1", // base1
+    textMuted: "#acb0a7",
     textDisabled: "#c5bfae",
     textAccent: "#268bd2",
     textLink: "#268bd2",

--- a/src/themes/themes.test.ts
+++ b/src/themes/themes.test.ts
@@ -25,6 +25,7 @@ const REQUIRED_KEYS: (keyof ThemeColors)[] = [
   "tabBorder",
   "textPrimary",
   "textSecondary",
+  "textMuted",
   "textDisabled",
   "textAccent",
   "textLink",

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -27,6 +27,7 @@ export interface ThemeColors {
   // Text
   textPrimary: string;
   textSecondary: string;
+  textMuted: string;
   textDisabled: string;
   textAccent: string;
   textLink: string;


### PR DESCRIPTION
Closes #1406.

Follow-up to #1347 (PR #1405).

## Summary

`--radius-full` and `--text-muted` were referenced by CSS surfaces but never
declared in the design system, so they silently resolved to invalid/zero
values — pill badges and progress bars lost their fully-rounded corners, and
muted/incidental text fell back to an unintended color.

- **`--radius-full`** — added as a static `999px` token in
  `src/styles/variables.css` (radius does not vary per theme). Used by
  `.oc-row__badge` / `.oc-section__count` (OpenConnectionsModal.css) and the
  X server setup progress bar (XServerSetupDialog.css).
- **`--text-muted`** — added as a proper **per-theme** text color wired through
  the theme engine (`types.ts`, `COLOR_TO_CSS_VAR` in `engine.ts`, and all four
  themes: dark, light, solarized-dark, solarized-light), with a dark default in
  `variables.css` — matching how `--text-secondary` / `--text-primary` are
  handled. Each value sits between the theme's secondary and disabled text so it
  reads as lower-emphasis in both light and dark. Used by OpenConnectionsModal,
  XServerSetupDialog, and StatusBar.
- Extended the theme-completeness test (`themes.test.ts`) so every theme is
  required to define `textMuted`.

No component CSS was changed — the existing `var(--radius-full)` /
`var(--text-muted)` references now simply resolve. Verified via grep that these
were the only two undefined tokens on the affected surfaces, and that both now
resolve.

## Test plan

- [x] `pnpm test` — all unit tests pass (theme-completeness test now requires `textMuted`).
- [x] `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm run format:check`, `pnpm run markdownlint` — all clean.
- [ ] Manual (light + dark, incl. Solarized variants): open the **Open Connections** panel and confirm `.oc-row__badge` / section-count pills render with fully rounded (pill) corners, and muted row text reads as lower-emphasis.
- [ ] Manual: open the **X server setup dialog** and confirm the progress bar is fully rounded and muted text renders correctly.
- [ ] Manual: confirm StatusBar muted text renders with the per-theme muted color in every theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)