### PR TITLE
fix(sftp): report per-item outcome on file multi-delete (allSettled + toasts)

### DIFF
--- a/docs/changes/dev0/feature/1394-sftp-multidelete-allsettled.md
+++ b/docs/changes/dev0/feature/1394-sftp-multidelete-allsettled.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- File browser multi-delete no longer hides partial failures. Deleting several
+  files or folders at once now settles each item independently and reports the
+  outcome in a single toast — "Deleted N items" on full success, or "Deleted N
+  items, M failed: <names>" when some fail — instead of aborting the whole batch
+  on the first error and leaving the result invisible. Single-file delete
+  failures are likewise surfaced with an error toast instead of failing
+  silently (#1394).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -829,6 +829,21 @@ for #1348.
 4. Start another rename and press **Escape** (or click away with no change) →
    the edit is abandoned and no rename occurs.
 
+**File multi-delete outcome reporting (#1394).**
+
+1. Open the file browser on a local or SFTP directory. Prepare at least one entry
+   that cannot be deleted (e.g. a read-only / permission-protected file) alongside
+   ordinary files.
+2. Multi-select several files including the undeletable one (Ctrl/Cmd-click), then
+   right-click → **Delete (N items)** and confirm the dialog.
+3. The batch does **not** abort on the first failure: the deletable files are
+   removed and a single toast reports the outcome — "Deleted N items, M failed:
+   \<names>" naming the failed entries. When every item deletes, a "Deleted N
+   items" success toast appears instead.
+4. Delete a **single** undeletable file (right-click → **Delete**, confirm) → an
+   error toast naming the file appears instead of failing silently; deleting a
+   normal single file shows a success toast.
+
 **Wake-on-LAN "Save Current".**
 
 1. Open **Network Tools → Wake-on-LAN**, enter a valid MAC address, then click

--- a/src/components/Sidebar/FileBrowser.multidelete.test.tsx
+++ b/src/components/Sidebar/FileBrowser.multidelete.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Regression tests for file multi-delete outcome reporting (#1394).
+ *
+ * The multi-delete path must use `Promise.allSettled` so a partial failure
+ * never hides which items actually deleted, and it must surface the per-item
+ * outcome via the shared toast API ("Deleted N items, M failed: <names>").
+ * A single-delete failure must likewise be surfaced (error toast) instead of
+ * failing silently.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import type { InvokeArgs } from "@tauri-apps/api/core";
+import { useAppStore } from "@/store/appStore";
+import { FileBrowser } from "./FileBrowser";
+import { TooltipProvider } from "@/components/ui";
+import type { TerminalTab, LeafPanel } from "@/types/terminal";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+// Mock the Toast module itself (not the @/components/ui barrel) so the toast
+// calls made from FileBrowser are captured regardless of import path.
+vi.mock("@/components/ui/Toast", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/components/ui/Toast")>("@/components/ui/Toast");
+  return {
+    ...actual,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    onDragDropEvent: vi.fn(() => Promise.resolve(vi.fn())),
+  }),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/events", () => ({
+  onVscodeEditComplete: vi.fn(() => Promise.resolve(vi.fn())),
+}));
+
+vi.mock("@/services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/api")>();
+  return {
+    ...actual,
+    getHomeDir: vi.fn(() => Promise.resolve("/home/test")),
+  };
+});
+
+const mockedInvoke = vi.mocked(invoke);
+
+async function flushAsync() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+const entries = [
+  { name: "a.txt", path: "/home/a.txt", isDirectory: false, size: 1, modified: "" },
+  { name: "b.txt", path: "/home/b.txt", isDirectory: false, size: 1, modified: "" },
+  { name: "c.txt", path: "/home/c.txt", isDirectory: false, size: 1, modified: "" },
+];
+
+function makeTab(overrides: Partial<TerminalTab>): TerminalTab {
+  return {
+    id: "tab-1",
+    sessionId: "sess-1",
+    title: "Test Tab",
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: {} },
+    panelId: "panel-1",
+    isActive: true,
+    ...overrides,
+  };
+}
+
+function setActiveTab(tab: TerminalTab) {
+  const panel: LeafPanel = { type: "leaf", id: tab.panelId, tabs: [tab], activeTabId: tab.id };
+  useAppStore.setState({ activePanelId: tab.panelId, rootPanel: panel });
+}
+
+async function renderLocal() {
+  setActiveTab(makeTab({ connectionType: "local", config: { type: "local", config: {} } }));
+  useAppStore.setState({ sidebarView: "files", tabCwds: { "tab-1": "/home" } });
+  await act(async () => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <FileBrowser />
+      </TooltipProvider>
+    );
+  });
+  await flushAsync();
+}
+
+function row(name: string): HTMLElement {
+  return container.querySelector(`[data-testid="file-row-${name}"]`) as HTMLElement;
+}
+
+const q = (testId: string) => document.querySelector(`[data-testid="${testId}"]`) as HTMLElement;
+
+/** Read the `path` field from an invoke args payload, tolerating its union type. */
+function argPath(args?: InvokeArgs): string | undefined {
+  if (args && typeof args === "object" && "path" in args) {
+    return (args as Record<string, unknown>).path as string;
+  }
+  return undefined;
+}
+
+describe("FileBrowser — multi-delete outcome reporting (#1394)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    toastSuccess.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("reports surviving deletions and lists failures when a batch partially fails", async () => {
+    // b.txt fails to delete; a.txt and c.txt succeed.
+    mockedInvoke.mockImplementation((cmd: string, args?: InvokeArgs) => {
+      if (cmd === "local_list_dir") return Promise.resolve(entries);
+      if (cmd === "local_delete") {
+        if (argPath(args) === "/home/b.txt") return Promise.reject(new Error("permission denied"));
+        return Promise.resolve(undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await renderLocal();
+
+    // Select all three rows.
+    await act(async () => {
+      row("a.txt").click();
+    });
+    await act(async () => {
+      row("b.txt").dispatchEvent(new MouseEvent("click", { ctrlKey: true, bubbles: true }));
+    });
+    await act(async () => {
+      row("c.txt").dispatchEvent(new MouseEvent("click", { ctrlKey: true, bubbles: true }));
+    });
+
+    // Open the context menu on a selected row and trigger the multi-delete.
+    await act(async () => {
+      row("b.txt").dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+    });
+    await act(async () => {
+      q("multi-select-delete").click();
+    });
+
+    // Confirm the destructive-action dialog.
+    await act(async () => {
+      q("confirm-delete-confirm").click();
+    });
+    await flushAsync();
+
+    // All three deletes were attempted (Promise.allSettled, not Promise.all).
+    const deleteCalls = mockedInvoke.mock.calls.filter(([cmd]) => cmd === "local_delete");
+    expect(deleteCalls).toHaveLength(3);
+
+    // A single summary error toast reports the two successes and names the failure.
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+    const message = String(toastError.mock.calls[0][0]);
+    expect(message).toContain("2");
+    expect(message).toContain("1 failed");
+    expect(message).toContain("b.txt");
+  });
+
+  it("reports success when every item in the batch deletes", async () => {
+    mockedInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "local_list_dir") return Promise.resolve(entries);
+      return Promise.resolve(undefined);
+    });
+
+    await renderLocal();
+
+    await act(async () => {
+      row("a.txt").click();
+    });
+    await act(async () => {
+      row("b.txt").dispatchEvent(new MouseEvent("click", { ctrlKey: true, bubbles: true }));
+    });
+
+    await act(async () => {
+      row("a.txt").dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+    });
+    await act(async () => {
+      q("multi-select-delete").click();
+    });
+    await act(async () => {
+      q("confirm-delete-confirm").click();
+    });
+    await flushAsync();
+
+    expect(toastError).not.toHaveBeenCalled();
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(String(toastSuccess.mock.calls[0][0])).toContain("2");
+  });
+
+  it("surfaces a single-delete failure via an error toast instead of failing silently", async () => {
+    mockedInvoke.mockImplementation((cmd: string, args?: InvokeArgs) => {
+      if (cmd === "local_list_dir") return Promise.resolve(entries);
+      if (cmd === "local_delete" && argPath(args) === "/home/a.txt") {
+        return Promise.reject(new Error("permission denied"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await renderLocal();
+
+    await act(async () => {
+      row("a.txt").click();
+    });
+
+    // Single-selection context menu → delete.
+    await act(async () => {
+      row("a.txt").dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+    });
+    await act(async () => {
+      q("context-file-delete").click();
+    });
+    await act(async () => {
+      q("confirm-delete-confirm").click();
+    });
+    await flushAsync();
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(String(toastError.mock.calls[0][0])).toContain("a.txt");
+  });
+});

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -990,9 +990,9 @@ export function FileBrowser() {
           setDeleteConfirm({
             message: `Delete ${entry.isDirectory ? "directory" : "file"} "${entry.name}"?`,
             onConfirm: () => {
-              deleteEntry(entry.path, entry.isDirectory).catch((err: unknown) =>
-                console.error("Delete failed:", err)
-              );
+              deleteEntry(entry.path, entry.isDirectory)
+                .then(() => toast.success(`Deleted "${entry.name}"`))
+                .catch((err: unknown) => toast.error(`Failed to delete "${entry.name}": ${err}`));
             },
           });
           break;
@@ -1176,8 +1176,22 @@ export function FileBrowser() {
           setDeleteConfirm({
             message: `Delete ${entries.length} items?`,
             onConfirm: () => {
-              Promise.all(entries.map((e) => deleteEntry(e.path, e.isDirectory))).catch(
-                (err: unknown) => console.error("Delete failed:", err)
+              // Settle every delete independently so a partial failure never
+              // hides which items were actually removed (#1394).
+              void Promise.allSettled(entries.map((e) => deleteEntry(e.path, e.isDirectory))).then(
+                (results) => {
+                  const failed = entries.filter((_, i) => results[i].status === "rejected");
+                  const deleted = entries.length - failed.length;
+                  const noun = (n: number) => (n === 1 ? "item" : "items");
+                  if (failed.length === 0) {
+                    toast.success(`Deleted ${deleted} ${noun(deleted)}`);
+                  } else {
+                    const names = failed.map((e) => e.name).join(", ");
+                    toast.error(
+                      `Deleted ${deleted} ${noun(deleted)}, ${failed.length} failed: ${names}`
+                    );
+                  }
+                }
               );
               setSelectedPaths(new Set());
               setLastClickedPath(null);


### PR DESCRIPTION
Closes #1394

## Problem

File multi-delete in `src/components/Sidebar/FileBrowser.tsx` used `Promise.all`, so the first rejection aborted the whole batch and hid which items actually deleted. Single-delete failures were swallowed to `console.error`, so the user got no feedback at all.

## Change

- **Multi-delete** now uses `Promise.allSettled`: every item is deleted independently, then a single summary toast reports the outcome — `toast.success("Deleted N items")` when all succeed, or `toast.error("Deleted N items, M failed: <names>")` when some fail. The listing still refreshes regardless (each `deleteEntry` refreshes on success).
- **Single-delete** now emits `toast.success` on success and `toast.error` (naming the file) on failure, satisfying the design system's every-action-gives-feedback rule instead of failing silently.
- Uses the shared `toast` API already imported in the file (`@/components/ui`); no new UI mechanism.

Follow-up to #1343 (destructive-action confirmations), deferred there because this file was owned by a concurrent PR.

## Test plan

- **Unit regression** (`src/components/Sidebar/FileBrowser.multidelete.test.tsx`): drives a 3-item multi-delete where one item rejects and asserts all three deletes are attempted, no success toast fires, and a single error toast reports the two successes and names the failure; plus an all-success batch (success toast) and a single-delete failure (error toast). Written test-first; fails against the old `Promise.all` path.
- **Manual**: select multiple files in the file browser, force a partial failure (e.g. one read-only / permission-denied entry), confirm delete, and observe the "Deleted N items, M failed: <names>" toast; delete a single undeletable file and observe the error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)