### PR TITLE
refactor(ui): consolidate getAppInfo() consumers onto shared cached hook (Closes #1407)

### DIFF
--- a/src/components/Settings/AboutSettings.tsx
+++ b/src/components/Settings/AboutSettings.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect } from "react";
 import { Github, ExternalLink, ScrollText } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { getAppInfo, type AppInfo } from "@/services/api";
+import { useAppInfo } from "@/hooks/useAppInfo";
 import { frontendLog } from "@/utils/frontendLog";
 import { Button } from "@/components/ui";
 import "./AboutSettings.css";
@@ -13,13 +12,7 @@ const THIRD_PARTY_LICENSES_URL =
 
 /** Settings page section showing app version, project links, and license info. */
 export function AboutSettings() {
-  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
-
-  useEffect(() => {
-    getAppInfo()
-      .then(setAppInfo)
-      .catch((err) => frontendLog("about", `Failed to load app info: ${err}`));
-  }, []);
+  const appInfo = useAppInfo();
 
   const handleGitHub = async () => {
     try {

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -32,7 +32,7 @@ import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
 import { SerialPortSettings } from "./SerialPortSettings";
 import { ShellIntegrationSettings } from "./ShellIntegrationSettings";
 import { PortableModeSettings } from "./PortableModeSettings";
-import { getAppInfo, type AppInfo } from "@/services/api";
+import { useAppInfo } from "@/hooks/useAppInfo";
 import "./SettingsPanel.css";
 
 const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
@@ -69,7 +69,7 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
   const [activeCategory, setActiveCategory] = useState<SettingsCategory>("general");
   const [searchQuery, setSearchQuery] = useState("");
   const [isCompact, setIsCompact] = useState(false);
-  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+  const appInfo = useAppInfo();
   const [showSavedAck, setShowSavedAck] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -105,12 +105,6 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
       updateSettings(toSave);
     }
   }, [updateSettings]);
-
-  useEffect(() => {
-    getAppInfo()
-      .then(setAppInfo)
-      .catch(() => setAppInfo(null));
-  }, []);
 
   // ResizeObserver for compact mode
   useEffect(() => {

--- a/src/components/Settings/UpdateSettings.tsx
+++ b/src/components/Settings/UpdateSettings.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { RefreshCw, Loader2 } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useAppStore } from "@/store/appStore";
-import { setUpdateAutoCheck, getAppInfo, type AppInfo } from "@/services/api";
+import { setUpdateAutoCheck } from "@/services/api";
+import { useAppInfo } from "@/hooks/useAppInfo";
 import { frontendLog } from "@/utils/frontendLog";
 import { Button } from "@/components/ui";
 import "./UpdateSettings.css";
@@ -30,13 +31,7 @@ export function UpdateSettings({ visibleFields }: UpdateSettingsProps) {
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const [savingAutoCheck, setSavingAutoCheck] = useState(false);
-  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
-
-  useEffect(() => {
-    getAppInfo()
-      .then(setAppInfo)
-      .catch(() => setAppInfo(null));
-  }, []);
+  const appInfo = useAppInfo();
 
   const autoCheck = settings.updates?.autoCheck ?? true;
   const lastCheckTime = settings.updates?.lastCheckTime;

--- a/src/components/StatusBar/UpdateIndicator.tsx
+++ b/src/components/StatusBar/UpdateIndicator.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
 import { useAppStore } from "@/store/appStore";
-import { getAppInfo, type AppInfo } from "@/services/api";
+import { useAppInfo } from "@/hooks/useAppInfo";
 
 /**
  * Version chip in the status bar.  Shows an amber or red dot when an update
@@ -8,15 +7,9 @@ import { getAppInfo, type AppInfo } from "@/services/api";
  * Shows a "develop" badge when running a develop-branch build.
  */
 export function UpdateIndicator() {
-  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+  const appInfo = useAppInfo();
   const updateInfo = useAppStore((s) => s.updateInfo);
   const updateCheckState = useAppStore((s) => s.updateCheckState);
-
-  useEffect(() => {
-    getAppInfo()
-      .then(setAppInfo)
-      .catch(() => null);
-  }, []);
 
   const hasUpdate = updateCheckState === "available" && updateInfo?.available === true;
   const isSecurity = hasUpdate && updateInfo?.isSecurity === true;

--- a/src/components/UpdateNotification/UpdateNotification.tsx
+++ b/src/components/UpdateNotification/UpdateNotification.tsx
@@ -3,7 +3,7 @@ import { X, Shield, RefreshCw } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useAppStore } from "@/store/appStore";
 import { Button } from "@/components/ui";
-import { getAppInfo } from "@/services/api";
+import { useDesktopVersion } from "@/hooks/useAppInfo";
 import { frontendLog } from "@/utils/frontendLog";
 import "./UpdateNotification.css";
 
@@ -23,13 +23,7 @@ export function UpdateNotification() {
   const settings = useAppStore((s) => s.settings);
 
   const [showNotes, setShowNotes] = useState(false);
-  const [runningVersion, setRunningVersion] = useState("");
-
-  useEffect(() => {
-    getAppInfo()
-      .then((info) => setRunningVersion(info.version))
-      .catch(() => setRunningVersion(""));
-  }, []);
+  const runningVersion = useDesktopVersion();
 
   // Reset "what's new" panel whenever the detected version changes.
   useEffect(() => {

--- a/src/hooks/useAppInfo.test.ts
+++ b/src/hooks/useAppInfo.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { createElement } from "react";
+import type { AppInfo } from "@/services/api";
+import { useAppInfo, useDesktopVersion, resetAppInfoCache } from "./useAppInfo";
+
+vi.mock("@/services/api", () => ({
+  getAppInfo: vi.fn(),
+}));
+
+import { getAppInfo } from "@/services/api";
+
+const mockGetAppInfo = vi.mocked(getAppInfo);
+
+const APP_INFO: AppInfo = {
+  version: "1.2.3",
+  gitHash: "abcdef1",
+  isDev: false,
+  buildBranch: "develop",
+};
+
+/** Helper component that exposes the full app info via a callback. */
+function AppInfoReader({ onState }: { onState: (s: AppInfo | null) => void }) {
+  const info = useAppInfo();
+  onState(info);
+  return null;
+}
+
+/** Helper component that exposes the desktop version via a callback. */
+function VersionReader({ onState }: { onState: (s: string | null) => void }) {
+  const version = useDesktopVersion();
+  onState(version);
+  return null;
+}
+
+describe("useAppInfo", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    resetAppInfoCache();
+    mockGetAppInfo.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    resetAppInfoCache();
+  });
+
+  it("resolves with the full app info", async () => {
+    mockGetAppInfo.mockResolvedValue(APP_INFO);
+
+    let latest: AppInfo | null | undefined;
+    await act(async () => {
+      root.render(createElement(AppInfoReader, { onState: (s) => (latest = s) }));
+    });
+
+    expect(latest).toEqual(APP_INFO);
+  });
+
+  it("exposes the version through the useDesktopVersion wrapper", async () => {
+    mockGetAppInfo.mockResolvedValue(APP_INFO);
+
+    let latest: string | null | undefined;
+    await act(async () => {
+      root.render(createElement(VersionReader, { onState: (s) => (latest = s) }));
+    });
+
+    expect(latest).toBe("1.2.3");
+  });
+
+  it("degrades to null when the fetch fails", async () => {
+    mockGetAppInfo.mockRejectedValue(new Error("ipc unavailable"));
+
+    let latest: AppInfo | null | undefined = APP_INFO;
+    await act(async () => {
+      root.render(createElement(AppInfoReader, { onState: (s) => (latest = s) }));
+    });
+
+    expect(latest).toBeNull();
+  });
+
+  it("fetches app info at most once across many consumers", async () => {
+    mockGetAppInfo.mockResolvedValue(APP_INFO);
+
+    // Render several consumers (both hooks) mounted at the same time.
+    await act(async () => {
+      root.render(
+        createElement("div", null, [
+          createElement(AppInfoReader, { key: "a", onState: () => {} }),
+          createElement(AppInfoReader, { key: "b", onState: () => {} }),
+          createElement(VersionReader, { key: "c", onState: () => {} }),
+          createElement(VersionReader, { key: "d", onState: () => {} }),
+        ])
+      );
+    });
+
+    // Unmount and re-render a fresh consumer — should hit the cache.
+    act(() => root.unmount());
+    root = createRoot(container);
+    let second: AppInfo | null | undefined;
+    act(() => {
+      root.render(createElement(AppInfoReader, { onState: (s) => (second = s) }));
+    });
+
+    expect(second).toEqual(APP_INFO);
+    expect(mockGetAppInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useAppInfo.ts
+++ b/src/hooks/useAppInfo.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { getAppInfo, type AppInfo } from "@/services/api";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * Module-level cache so build-time app info is fetched at most once per session
+ * and shared across every consumer (About/Update settings, status-bar version
+ * chip, update notification, agent badges).
+ */
+let cachedInfo: AppInfo | null = null;
+let inflight: Promise<AppInfo> | null = null;
+
+/**
+ * Return the running desktop app's build info ({@link AppInfo}), or `null`
+ * until the one-time {@link getAppInfo} fetch resolves. The result is cached at
+ * module scope, so mounting any number of consumers triggers the underlying IPC
+ * call at most once per session.
+ */
+export function useAppInfo(): AppInfo | null {
+  const [info, setInfo] = useState<AppInfo | null>(cachedInfo);
+
+  useEffect(() => {
+    if (cachedInfo !== null) {
+      setInfo(cachedInfo);
+      return;
+    }
+    let active = true;
+    // Wrapped in try/catch so a failed or unavailable IPC degrades to a null
+    // info (hidden badge / "—" version) instead of crashing the tree.
+    const load = async () => {
+      try {
+        if (!inflight) {
+          inflight = getAppInfo().then((fetched) => {
+            cachedInfo = fetched;
+            return fetched;
+          });
+        }
+        const loaded = await inflight;
+        if (active) setInfo(loaded);
+      } catch (err) {
+        inflight = null;
+        frontendLog("use_app_info", `Failed to fetch app info: ${err}`);
+      }
+    };
+    void load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return info;
+}
+
+/**
+ * Return just the running desktop app version (e.g. `0.1.0`), or `null` until
+ * the shared {@link useAppInfo} fetch resolves. Thin wrapper kept for the
+ * agent-badge / status-bar consumers that only need the version string.
+ */
+export function useDesktopVersion(): string | null {
+  return useAppInfo()?.version ?? null;
+}
+
+/**
+ * Reset the cached app info and any in-flight fetch.
+ * Exposed for testing only.
+ */
+export function resetAppInfoCache(): void {
+  cachedInfo = null;
+  inflight = null;
+}

--- a/src/hooks/useDesktopVersion.ts
+++ b/src/hooks/useDesktopVersion.ts
@@ -1,50 +1,7 @@
-import { useEffect, useState } from "react";
-import { getAppInfo } from "@/services/api";
-import { frontendLog } from "@/utils/frontendLog";
-
 /**
- * Module-level cache so the desktop version is fetched at most once per session
- * and shared across every consumer (agent badges, status-bar summary).
+ * Re-export of the desktop-version wrapper. The implementation now lives in
+ * {@link useAppInfo}, which owns the single cached `getAppInfo` fetch shared by
+ * every consumer; this module is kept so existing `@/hooks/useDesktopVersion`
+ * imports (agent badges, status-bar summary) keep working unchanged.
  */
-let cachedVersion: string | null = null;
-let inflight: Promise<string> | null = null;
-
-/**
- * Return the running desktop app version (e.g. `0.1.0`), or `null` until the
- * one-time {@link getAppInfo} fetch resolves. Used to derive each agent's
- * update state against the version the desktop expects.
- */
-export function useDesktopVersion(): string | null {
-  const [version, setVersion] = useState<string | null>(cachedVersion);
-
-  useEffect(() => {
-    if (cachedVersion !== null) {
-      setVersion(cachedVersion);
-      return;
-    }
-    let active = true;
-    // Wrapped in try/catch so a failed or unavailable IPC degrades to a hidden
-    // badge (version stays null / "unknown") instead of crashing the tree.
-    const load = async () => {
-      try {
-        if (!inflight) {
-          inflight = getAppInfo().then((info) => {
-            cachedVersion = info.version;
-            return info.version;
-          });
-        }
-        const v = await inflight;
-        if (active) setVersion(v);
-      } catch (err) {
-        inflight = null;
-        frontendLog("use_desktop_version", `Failed to fetch app info: ${err}`);
-      }
-    };
-    void load();
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  return version;
-}
+export { useDesktopVersion } from "./useAppInfo";


### PR DESCRIPTION
## Summary

#1347 introduced a cached `useDesktopVersion` hook that fetched `getAppInfo()` once per session, but several pre-existing components still ran their own ad-hoc `useEffect(() => getAppInfo().then(...))`, so the IPC call fired multiple times.

This refactor generalizes the cached hook into `useAppInfo()` (returns the full `AppInfo`, cached at module scope) and migrates every ad-hoc consumer onto it. `useDesktopVersion()` is now a thin wrapper (`useAppInfo()?.version ?? null`), and its old `@/hooks/useDesktopVersion` module re-exports it so existing imports (agent badges, status-bar summary) keep working unchanged.

## Migrated consumers

- `src/components/Settings/AboutSettings.tsx`
- `src/components/Settings/SettingsPanel.tsx`
- `src/components/Settings/UpdateSettings.tsx`
- `src/components/StatusBar/UpdateIndicator.tsx`
- `src/components/UpdateNotification/UpdateNotification.tsx` (uses the version-only `useDesktopVersion` wrapper)

## Result

- `getAppInfo()` is now invoked **at most once per session** regardless of how many of these mount simultaneously (module-level cache + in-flight promise dedupe).
- **No user-facing behavior change**: develop-branch badge, version display, and update dot are all identical.

## Test plan

- New `src/hooks/useAppInfo.test.ts` (TDD, committed before the refactor) proves: full `AppInfo` resolution, the `useDesktopVersion` wrapper, graceful `null` on fetch failure, and — the core guarantee — `getAppInfo` called exactly once across many concurrent consumers plus a later fresh mount.
- Full frontend suite green: 2766 tests / 290 files.
- `pnpm build` (typecheck), `pnpm run lint`, and `pnpm run format:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)