### PR TITLE
fix(ui): ignore folder toggle while connection-tree search filter is active (Closes #1378)

### DIFF
--- a/docs/changes/dev1/bugfix/1378-connection-tree-filter-folder-toggle.md
+++ b/docs/changes/dev1/bugfix/1378-connection-tree-filter-folder-toggle.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Connection tree: toggling a folder while a search filter is active no longer
+  changes the folder's stored expansion state. Filtering force-expands matching
+  folders, so folder toggles (row click and the keyboard
+  ArrowLeft/ArrowRight/Enter/Space paths) previously mutated the stored state
+  invisibly and left folders unexpectedly collapsed or expanded once the filter
+  was cleared. Toggles are now ignored while filtering, so clearing the filter
+  returns the tree to exactly the expansion state it had before (#1378).

--- a/src/components/Sidebar/ConnectionList.filter-folder-toggle.test.tsx
+++ b/src/components/Sidebar/ConnectionList.filter-folder-toggle.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Regression tests for #1378: while a search filter is active, folders are
+ * force-expanded by the render logic and stored `isExpanded` is ignored. Folder
+ * toggles (click and keyboard) must therefore be no-ops while filtering, so
+ * clearing the filter restores exactly the expansion state the tree had before.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import { TooltipProvider } from "@/components/ui";
+import type { SavedConnection, ConnectionFolder, RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  isSshKeyEncrypted: vi.fn(() => Promise.resolve(false)),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({
+    agent,
+    sectionRef,
+  }: {
+    agent: RemoteAgentDefinition;
+    sectionRef?: (el: HTMLDivElement | null) => void;
+  }) => React.createElement("div", { ref: sectionRef, "data-testid": `agent-node-${agent.id}` }),
+}));
+
+function makeConnection(overrides: Partial<SavedConnection> = {}): SavedConnection {
+  const id = overrides.id ?? "conn-1";
+  return {
+    id,
+    name: overrides.name ?? `Connection ${id}`,
+    folderId: null,
+    config: { type: "local", config: {} } as SavedConnection["config"],
+    ...overrides,
+  };
+}
+
+function makeFolder(overrides: Partial<ConnectionFolder> = {}): ConnectionFolder {
+  return { id: "folder-1", name: "Test Folder", parentId: null, isExpanded: true, ...overrides };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: false,
+  fileBrowserEnabled: false,
+  experimentalFeaturesEnabled: false,
+};
+
+function render(_container: HTMLElement, root: Root) {
+  act(() => {
+    root.render(
+      React.createElement(TooltipProvider, {
+        delayDuration: 0,
+        children: React.createElement(ConnectionList),
+      })
+    );
+  });
+}
+
+function typeInto(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function keydown(el: Element, key: string) {
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+function folderExpanded(folderId: string): boolean | undefined {
+  return useAppStore.getState().folders.find((f) => f.id === folderId)?.isExpanded;
+}
+
+describe("ConnectionList — folder toggle ignored while filtering (#1378)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function filterInput(): HTMLInputElement {
+    return container.querySelector('[data-testid="connection-filter-input"]') as HTMLInputElement;
+  }
+
+  it("clicking a folder while filtering does not change its stored expansion state", () => {
+    useAppStore.setState({
+      folders: [makeFolder({ id: "folder-1", isExpanded: true })],
+      connections: [makeConnection({ id: "conn-1", name: "web-server", folderId: "folder-1" })],
+    });
+    render(container, root);
+
+    // Activate a filter that matches the nested connection (force-expands folder).
+    typeInto(filterInput(), "web");
+    expect(folderExpanded("folder-1")).toBe(true);
+
+    // Click the folder row: previously flipped stored isExpanded to false.
+    const folder = container.querySelector('[data-testid="folder-toggle-folder-1"]') as HTMLElement;
+    act(() => folder.click());
+    expect(folderExpanded("folder-1")).toBe(true);
+
+    // Clearing the filter restores the pre-filter expansion state.
+    keydown(filterInput(), "Escape");
+    expect(folderExpanded("folder-1")).toBe(true);
+    expect(container.querySelector('[data-testid="connection-item-conn-1"]')).not.toBeNull();
+  });
+
+  it("keyboard-collapsing a folder while filtering does not change its stored expansion state", () => {
+    useAppStore.setState({
+      folders: [makeFolder({ id: "folder-1", isExpanded: true })],
+      connections: [makeConnection({ id: "conn-1", name: "web-server", folderId: "folder-1" })],
+    });
+    render(container, root);
+
+    typeInto(filterInput(), "web");
+    expect(folderExpanded("folder-1")).toBe(true);
+
+    // ArrowLeft on a (force-)expanded folder previously called toggleFolder.
+    const folder = container.querySelector('[data-testid="folder-toggle-folder-1"]') as HTMLElement;
+    act(() => folder.focus());
+    keydown(folder, "ArrowLeft");
+    expect(folderExpanded("folder-1")).toBe(true);
+
+    // Enter/Space on a folder previously toggled it too.
+    keydown(folder, "Enter");
+    expect(folderExpanded("folder-1")).toBe(true);
+
+    keydown(filterInput(), "Escape");
+    expect(folderExpanded("folder-1")).toBe(true);
+  });
+
+  it("a collapsed folder stays collapsed after filtering force-expands then toggling it", () => {
+    useAppStore.setState({
+      folders: [makeFolder({ id: "folder-1", isExpanded: false })],
+      connections: [makeConnection({ id: "conn-1", name: "web-server", folderId: "folder-1" })],
+    });
+    render(container, root);
+
+    // Collapsed: nested connection not rendered.
+    expect(container.querySelector('[data-testid="connection-item-conn-1"]')).toBeNull();
+
+    typeInto(filterInput(), "web");
+    // Filter force-expands the folder visually but must not mutate stored state.
+    expect(container.querySelector('[data-testid="connection-item-conn-1"]')).not.toBeNull();
+    expect(folderExpanded("folder-1")).toBe(false);
+
+    const folder = container.querySelector('[data-testid="folder-toggle-folder-1"]') as HTMLElement;
+    act(() => folder.click());
+    expect(folderExpanded("folder-1")).toBe(false);
+
+    // Clearing the filter returns the folder to its collapsed state.
+    keydown(filterInput(), "Escape");
+    expect(folderExpanded("folder-1")).toBe(false);
+    expect(container.querySelector('[data-testid="connection-item-conn-1"]')).toBeNull();
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -664,9 +664,21 @@ export function ConnectionList() {
     [addTab, requestPassword]
   );
 
+  // While a search filter is active, folders are force-expanded by the render
+  // logic and their stored `isExpanded` is ignored (#1378). Suppress folder
+  // toggles (click + keyboard) so a toggle has no hidden effect and clearing the
+  // filter restores exactly the expansion state the tree had before filtering.
+  const handleToggleFolder = useCallback(
+    (folderId: string) => {
+      if (filter) return;
+      toggleFolder(folderId);
+    },
+    [filter, toggleFolder]
+  );
+
   const { containerRef, focusedId, setFocusedId, handleKeyDown } = useTreeKeyboardNav(treeNodes, {
     onConnect: handleConnect,
-    onToggleFolder: toggleFolder,
+    onToggleFolder: handleToggleFolder,
   });
 
   // The row that owns tabindex=0: the tracked focus if still present, else the
@@ -1090,7 +1102,7 @@ export function ConnectionList() {
               rootConnections={rootConnections}
               folders={folders}
               connections={connections}
-              onToggle={toggleFolder}
+              onToggle={handleToggleFolder}
               onConnect={handleConnect}
               onEdit={handleEdit}
               onDelete={handleDelete}


### PR DESCRIPTION
## Problem

While a connection-tree search filter is active, the render logic
(`computeVisibleTreeNodes` / `filterConnectionTree`) force-expands matching
folders and ignores each folder's stored `isExpanded`. However, the folder
toggle handlers still fired and mutated the stored `folder.isExpanded`:

- clicking a folder row (`onToggle` in `ConnectionList.tsx`), and
- the keyboard ArrowLeft / ArrowRight / Enter / Space paths in
  `useTreeKeyboardNav` (which call `onToggleFolder`).

The mutation had no visible effect during filtering (the folder stays
force-expanded), but it left folders in an unexpected collapsed/expanded state
once the filter was cleared.

## Fix

Route both the click path and the keyboard path through a single
`handleToggleFolder` callback in `ConnectionList` that **no-ops while a filter is
active** (`if (filter) return;`) and otherwise delegates to the store's
`toggleFolder`. Because it is the shared entry point for both the row click
(`onToggle`) and `useTreeKeyboardNav`'s `onToggleFolder`, clearing the filter now
returns the tree to exactly the expansion state it had before filtering.

Behavioral-only change; no visual change.

## Test plan

- Added `src/components/Sidebar/ConnectionList.filter-folder-toggle.test.tsx`
  with three regression cases (all fail before the fix, pass after):
  - filter active → **click** an (expanded) folder → stored `isExpanded`
    unchanged → clear filter → still expanded;
  - filter active → **keyboard** ArrowLeft + Enter on a folder → stored
    `isExpanded` unchanged → clear filter → still expanded;
  - a **collapsed** folder that the filter force-expands stays collapsed after a
    toggle, and reverts to collapsed once the filter is cleared.
- `pnpm exec vitest run` — 2765 passed.
- `pnpm run lint`, `pnpm build`, `pnpm run format:check` — all clean.

### Manual repro

1. Create a folder with a nested connection; expand the folder.
2. Type in the connections filter so the nested connection matches (folder
   force-expands).
3. Click the folder header (or press ArrowLeft/Enter on it) — nothing appears to
   change while filtering.
4. Clear the filter. Before this fix the folder was now collapsed; after, it
   retains its pre-filter expansion state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)