### PR TITLE
refactor(backend): extract shared config-dir resolver (Closes #1403)

### DIFF
--- a/src-tauri/src/commands/portable.rs
+++ b/src-tauri/src/commands/portable.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
+use crate::utils::config_paths::resolve_config_dir;
 use crate::utils::portable::AppMode;
 
 /// Frontend-facing representation of the current app mode.
@@ -128,15 +129,10 @@ pub fn export_config_to_portable(
     dest_dir: String,
     files: Vec<String>,
 ) -> Result<ConfigMigrationResult, String> {
-    let src_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-        Ok(dir) => dir,
-        Err(_) => app_handle
-            .path()
-            .app_config_dir()
-            .map_err(|e| format!("Failed to resolve config directory: {e}"))?
-            .to_string_lossy()
-            .into_owned(),
-    };
+    let src_dir = resolve_config_dir(Some(&app_handle))
+        .map_err(|e| format!("Failed to resolve config directory: {e}"))?
+        .to_string_lossy()
+        .into_owned();
 
     export_config(src_dir, dest_dir, files)
 }
@@ -151,15 +147,10 @@ pub fn import_config_from_portable(
     src_dir: String,
     files: Vec<String>,
 ) -> Result<ConfigMigrationResult, String> {
-    let dest_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-        Ok(dir) => dir,
-        Err(_) => app_handle
-            .path()
-            .app_config_dir()
-            .map_err(|e| format!("Failed to resolve config directory: {e}"))?
-            .to_string_lossy()
-            .into_owned(),
-    };
+    let dest_dir = resolve_config_dir(Some(&app_handle))
+        .map_err(|e| format!("Failed to resolve config directory: {e}"))?
+        .to_string_lossy()
+        .into_owned();
 
     export_config(src_dir, dest_dir, files)
 }

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -3,18 +3,13 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use super::recovery::{RecoveryResult, RecoveryWarning};
 use super::shell_integration::ShellIntegrationSettings;
+use crate::utils::config_paths::resolve_config_dir;
 
 const FILE_NAME: &str = "settings.json";
-
-/// Application bundle identifier, mirroring `tauri.conf.json`'s `identifier`.
-/// Used by [`SettingsStorage::new_standalone`] to resolve the config directory
-/// where an `AppHandle` (and thus Tauri's own path resolver) is not yet
-/// available — i.e. from pre-init CLI subcommands.
-const APP_IDENTIFIER: &str = "com.termihub.app";
 
 /// Configuration for a single external connection file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -283,13 +278,7 @@ impl SettingsStorage {
     ///
     /// Uses the same directory as `ConnectionStorage` (respects `TERMIHUB_CONFIG_DIR`).
     pub fn new(app_handle: &AppHandle) -> Result<Self> {
-        let config_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-            Ok(dir) => PathBuf::from(dir),
-            Err(_) => app_handle
-                .path()
-                .app_config_dir()
-                .context("Failed to resolve app config directory")?,
-        };
+        let config_dir = resolve_config_dir(Some(app_handle))?;
 
         fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
 
@@ -301,15 +290,13 @@ impl SettingsStorage {
     /// Create a settings storage instance without a Tauri [`AppHandle`].
     ///
     /// Used by the pre-init CLI subcommands (`install/uninstall-shell-integration`)
-    /// which run before the Tauri app — and its path resolver — exist. Mirrors the
-    /// startup config-dir resolution in `run()`'s setup (`TERMIHUB_CONFIG_DIR`
-    /// override → portable `data/` directory → per-user config dir joined with the
-    /// app identifier, equivalent to Tauri's `app_config_dir()`). It cannot reuse
-    /// [`new`](Self::new), which relies on `run()` having already exported
-    /// `TERMIHUB_CONFIG_DIR` for portable mode — an env var this pre-init path
-    /// runs *before*, so it must detect portable mode itself.
+    /// which run before the Tauri app — and its path resolver — exist. Passing
+    /// `None` to [`resolve_config_dir`] selects the pre-init resolution branch,
+    /// which detects portable mode itself (it runs *before* `run()` exports
+    /// `TERMIHUB_CONFIG_DIR`) and otherwise reconstructs the OS config dir from
+    /// the bundle identifier — equivalent to Tauri's `app_config_dir()`.
     pub fn new_standalone() -> Result<Self> {
-        let config_dir = resolve_standalone_config_dir()?;
+        let config_dir = resolve_config_dir(None)?;
         fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
         Ok(Self {
             file_path: config_dir.join(FILE_NAME),
@@ -385,27 +372,6 @@ impl SettingsStorage {
     }
 }
 
-/// Resolve the settings config directory without a Tauri `AppHandle`.
-///
-/// Resolution order: an explicit `TERMIHUB_CONFIG_DIR` override wins; otherwise
-/// the portable `data/` directory is used when running portably; otherwise the OS
-/// per-user config directory joined with [`APP_IDENTIFIER`] (equivalent to
-/// Tauri's `app_config_dir()`). Unlike [`SettingsStorage::new`], this detects
-/// portable mode itself because it runs before `run()` exports
-/// `TERMIHUB_CONFIG_DIR`.
-fn resolve_standalone_config_dir() -> Result<PathBuf> {
-    if let Ok(dir) = std::env::var("TERMIHUB_CONFIG_DIR") {
-        return Ok(PathBuf::from(dir));
-    }
-    if let Ok(mode) = crate::utils::portable::detect_app_mode() {
-        if let Some(data_dir) = mode.data_dir() {
-            return Ok(data_dir.to_path_buf());
-        }
-    }
-    let base = dirs::config_dir().context("Failed to resolve user config directory")?;
-    Ok(base.join(APP_IDENTIFIER))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -415,27 +381,6 @@ mod tests {
         SettingsStorage {
             file_path: dir.path().join(FILE_NAME),
         }
-    }
-
-    #[test]
-    fn app_identifier_matches_tauri_conf() {
-        // `new_standalone()` resolves the config dir as `<config>/APP_IDENTIFIER`,
-        // duplicating the bundle identifier that Tauri's own `app_config_dir()`
-        // reads from `tauri.conf.json`. If the identifier there is ever changed
-        // without updating this constant, the pre-init CLI subcommands would
-        // read/write a different `settings.json` than the running app. Guard the
-        // duplication with a build-time assertion.
-        let conf = include_str!("../../tauri.conf.json");
-        let parsed: serde_json::Value =
-            serde_json::from_str(conf).expect("tauri.conf.json is valid JSON");
-        let identifier = parsed
-            .get("identifier")
-            .and_then(serde_json::Value::as_str)
-            .expect("tauri.conf.json has a string identifier");
-        assert_eq!(
-            identifier, APP_IDENTIFIER,
-            "APP_IDENTIFIER is out of sync with tauri.conf.json's identifier"
-        );
     }
 
     #[test]

--- a/src-tauri/src/connection/storage.rs
+++ b/src-tauri/src/connection/storage.rs
@@ -2,11 +2,12 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use super::config::{ConnectionStore, ConnectionTreeNode, FlatConnectionStore, SavedRemoteAgent};
 use super::recovery::{RecoveryResult, RecoveryWarning};
 use super::tree::flatten_tree;
+use crate::utils::config_paths::resolve_config_dir;
 
 const FILE_NAME: &str = "connections.json";
 
@@ -20,13 +21,7 @@ impl ConnectionStorage {
     ///
     /// If `TERMIHUB_CONFIG_DIR` is set, it overrides the default Tauri config directory.
     pub fn new(app_handle: &AppHandle) -> Result<Self> {
-        let config_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-            Ok(dir) => PathBuf::from(dir),
-            Err(_) => app_handle
-                .path()
-                .app_config_dir()
-                .context("Failed to resolve app config directory")?,
-        };
+        let config_dir = resolve_config_dir(Some(app_handle))?;
 
         tracing::info!("Using config directory: {}", config_dir.display());
 

--- a/src-tauri/src/embedded_servers/storage.rs
+++ b/src-tauri/src/embedded_servers/storage.rs
@@ -2,10 +2,11 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use super::config::EmbeddedServerStore;
 use crate::connection::recovery::{RecoveryResult, RecoveryWarning};
+use crate::utils::config_paths::resolve_config_dir;
 
 const FILE_NAME: &str = "embedded_servers.json";
 
@@ -19,13 +20,7 @@ impl EmbeddedServerStorage {
     ///
     /// If `TERMIHUB_CONFIG_DIR` is set it overrides the default Tauri config directory.
     pub fn new(app_handle: &AppHandle) -> Result<Self> {
-        let config_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-            Ok(dir) => PathBuf::from(dir),
-            Err(_) => app_handle
-                .path()
-                .app_config_dir()
-                .context("Failed to resolve app config directory")?,
-        };
+        let config_dir = resolve_config_dir(Some(app_handle))?;
         fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
         Ok(Self {
             file_path: config_dir.join(FILE_NAME),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -241,14 +241,10 @@ pub fn run() {
 
             // Load settings to determine the credential storage mode.
             // On failure, fall back to defaults so the app can still start.
-            let config_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-                Ok(dir) => std::path::PathBuf::from(dir),
-                Err(_) => app
-                    .handle()
-                    .path()
-                    .app_config_dir()
-                    .expect("Failed to resolve app config directory"),
-            };
+            // Portable mode already exported `TERMIHUB_CONFIG_DIR` above, so the
+            // shared resolver's handle branch yields the correct directory.
+            let config_dir = utils::config_paths::resolve_config_dir(Some(app.handle()))
+                .expect("Failed to resolve app config directory");
             std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
 
             // Capture path for the connections file watcher before config_dir is moved.

--- a/src-tauri/src/tunnel/storage.rs
+++ b/src-tauri/src/tunnel/storage.rs
@@ -2,10 +2,11 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use super::config::TunnelStore;
 use crate::connection::recovery::{RecoveryResult, RecoveryWarning};
+use crate::utils::config_paths::resolve_config_dir;
 
 const FILE_NAME: &str = "tunnels.json";
 
@@ -19,13 +20,7 @@ impl TunnelStorage {
     ///
     /// If `TERMIHUB_CONFIG_DIR` is set, it overrides the default Tauri config directory.
     pub fn new(app_handle: &AppHandle) -> Result<Self> {
-        let config_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-            Ok(dir) => PathBuf::from(dir),
-            Err(_) => app_handle
-                .path()
-                .app_config_dir()
-                .context("Failed to resolve app config directory")?,
-        };
+        let config_dir = resolve_config_dir(Some(app_handle))?;
 
         fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
 

--- a/src-tauri/src/utils/config_paths.rs
+++ b/src-tauri/src/utils/config_paths.rs
@@ -1,0 +1,129 @@
+//! Shared resolution of termiHub's per-user config directory.
+//!
+//! The same three-branch rule is needed from many storage modules and from the
+//! pre-init CLI path, so it lives here once instead of being copy-pasted:
+//!
+//! 1. an explicit `TERMIHUB_CONFIG_DIR` override always wins (this is also how
+//!    `run()`'s setup redirects storage to the portable `data/` directory — it
+//!    exports the var before any storage module resolves its path);
+//! 2. with a Tauri [`AppHandle`], defer to Tauri's own path resolver
+//!    (`app_config_dir()`), which reads the bundle identifier from
+//!    `tauri.conf.json`;
+//! 3. without an `AppHandle` (pre-init CLI subcommands, which run before the
+//!    Tauri app and its path resolver exist), detect portable mode directly and
+//!    otherwise fall back to the OS per-user config directory joined with
+//!    [`APP_IDENTIFIER`] — equivalent to what `app_config_dir()` would return.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tauri::{AppHandle, Manager};
+
+use super::portable::detect_app_mode;
+
+/// Application bundle identifier, mirroring `tauri.conf.json`'s `identifier`.
+///
+/// Used to reconstruct the OS per-user config directory when no Tauri
+/// [`AppHandle`] (and thus no `app_config_dir()`) is available — i.e. from
+/// pre-init CLI subcommands. The `app_identifier_matches_tauri_conf` test guards
+/// this against drift from `tauri.conf.json`.
+const APP_IDENTIFIER: &str = "com.termihub.app";
+
+/// Resolve termiHub's per-user config directory.
+///
+/// Applies the shared three-branch rule (env override → portable `data/`
+/// directory → OS config dir + identifier). Pass `Some(handle)` when a Tauri
+/// [`AppHandle`] is available (the common case) and `None` from pre-init CLI
+/// paths that run before the Tauri app exists.
+///
+/// This does not create the directory — callers that need it materialized
+/// should `fs::create_dir_all` the returned path.
+pub fn resolve_config_dir(app_handle: Option<&AppHandle>) -> Result<PathBuf> {
+    // 1. An explicit override always wins. `run()`'s setup also exports this for
+    //    portable mode, so the handle branch below never sees portable mode.
+    if let Ok(dir) = std::env::var("TERMIHUB_CONFIG_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+
+    // 2. With a handle, Tauri's resolver already knows the OS config dir joined
+    //    with the bundle identifier from `tauri.conf.json`.
+    if let Some(handle) = app_handle {
+        return handle
+            .path()
+            .app_config_dir()
+            .context("Failed to resolve app config directory");
+    }
+
+    // 3. Pre-init: no handle. Detect portable mode ourselves, otherwise fall
+    //    back to the OS per-user config directory joined with the identifier.
+    let portable_data_dir = detect_app_mode()
+        .ok()
+        .and_then(|mode| mode.data_dir().map(Path::to_path_buf));
+    standalone_config_dir(portable_data_dir, dirs::config_dir())
+}
+
+/// Pure resolver for the no-`AppHandle` (pre-init) path, split out for testing.
+///
+/// Prefers the portable `data/` directory when present; otherwise joins the OS
+/// per-user config base with [`APP_IDENTIFIER`].
+fn standalone_config_dir(
+    portable_data_dir: Option<PathBuf>,
+    fallback_base: Option<PathBuf>,
+) -> Result<PathBuf> {
+    if let Some(data_dir) = portable_data_dir {
+        return Ok(data_dir);
+    }
+    let base = fallback_base.context("Failed to resolve user config directory")?;
+    Ok(base.join(APP_IDENTIFIER))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_identifier_matches_tauri_conf() {
+        // The pre-init path reconstructs the config dir as
+        // `<os-config>/APP_IDENTIFIER`, duplicating the bundle identifier that
+        // Tauri's own `app_config_dir()` reads from `tauri.conf.json`. If the
+        // identifier there is ever changed without updating this constant, the
+        // pre-init CLI subcommands would read/write a different config than the
+        // running app. Guard the duplication with a build-time assertion.
+        let conf = include_str!("../../tauri.conf.json");
+        let parsed: serde_json::Value =
+            serde_json::from_str(conf).expect("tauri.conf.json is valid JSON");
+        let identifier = parsed
+            .get("identifier")
+            .and_then(serde_json::Value::as_str)
+            .expect("tauri.conf.json has a string identifier");
+        assert_eq!(
+            identifier, APP_IDENTIFIER,
+            "APP_IDENTIFIER is out of sync with tauri.conf.json's identifier"
+        );
+    }
+
+    #[test]
+    fn standalone_prefers_portable_data_dir() {
+        let portable = PathBuf::from("/usb/termiHub/data");
+        let resolved = standalone_config_dir(
+            Some(portable.clone()),
+            Some(PathBuf::from("/home/u/.config")),
+        )
+        .expect("resolution succeeds");
+        assert_eq!(resolved, portable);
+    }
+
+    #[test]
+    fn standalone_falls_back_to_config_base_with_identifier() {
+        let base = PathBuf::from("/home/u/.config");
+        let resolved =
+            standalone_config_dir(None, Some(base.clone())).expect("resolution succeeds");
+        assert_eq!(resolved, base.join(APP_IDENTIFIER));
+    }
+
+    #[test]
+    fn standalone_errors_without_portable_or_base() {
+        let result = standalone_config_dir(None, None);
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod config_paths;
 pub mod docker_detect;
 pub mod download;
 pub mod errors;

--- a/src-tauri/src/workspace/last_session.rs
+++ b/src-tauri/src/workspace/last_session.rs
@@ -3,9 +3,10 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use super::config::WorkspaceTabGroupDef;
+use crate::utils::config_paths::resolve_config_dir;
 
 const FILE_NAME: &str = "last-session.json";
 
@@ -45,13 +46,7 @@ impl LastSessionStorage {
     ///
     /// If `TERMIHUB_CONFIG_DIR` is set, it overrides the default Tauri config directory.
     pub fn new(app_handle: &AppHandle) -> Result<Self> {
-        let config_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-            Ok(dir) => PathBuf::from(dir),
-            Err(_) => app_handle
-                .path()
-                .app_config_dir()
-                .context("Failed to resolve app config directory")?,
-        };
+        let config_dir = resolve_config_dir(Some(app_handle))?;
 
         fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
 

--- a/src-tauri/src/workspace/storage.rs
+++ b/src-tauri/src/workspace/storage.rs
@@ -2,10 +2,11 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use super::config::WorkspaceStore;
 use crate::connection::recovery::{RecoveryResult, RecoveryWarning};
+use crate::utils::config_paths::resolve_config_dir;
 
 const FILE_NAME: &str = "workspaces.json";
 
@@ -19,13 +20,7 @@ impl WorkspaceStorage {
     ///
     /// If `TERMIHUB_CONFIG_DIR` is set, it overrides the default Tauri config directory.
     pub fn new(app_handle: &AppHandle) -> Result<Self> {
-        let config_dir = match std::env::var("TERMIHUB_CONFIG_DIR") {
-            Ok(dir) => PathBuf::from(dir),
-            Err(_) => app_handle
-                .path()
-                .app_config_dir()
-                .context("Failed to resolve app config directory")?,
-        };
+        let config_dir = resolve_config_dir(Some(app_handle))?;
 
         fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
 


### PR DESCRIPTION
## Summary

Extracts the config-directory resolution pattern (`TERMIHUB_CONFIG_DIR` env override → portable `data/` directory → OS per-user config dir joined with the app identifier) into a single shared helper, `utils::config_paths::resolve_config_dir(app_handle: Option<&AppHandle>)`, and routes every previously-inline copy through it.

Before this change the pattern was copy-pasted across ~8 sites, and the pre-init variant added in #1368 hardcoded its own `APP_IDENTIFIER = "com.termihub.app"` constant that could drift from `tauri.conf.json`'s `identifier`. There is now **one** identifier source and **one** resolver.

## Design

`resolve_config_dir` applies the shared three-branch rule:

1. an explicit `TERMIHUB_CONFIG_DIR` override always wins (this is also how `run()`'s setup redirects storage to the portable `data/` dir — it exports the var before any storage module resolves its path);
2. with a Tauri `AppHandle` (`Some`), defer to Tauri's own `app_config_dir()`;
3. without an `AppHandle` (`None`, from pre-init CLI subcommands that run before the Tauri app exists), detect portable mode directly and otherwise reconstruct the OS config dir from `APP_IDENTIFIER` — equivalent to what `app_config_dir()` would return.

The pre-init branch is split into a pure `standalone_config_dir(portable_data_dir, fallback_base)` helper so it can be unit-tested without env or a Tauri handle.

## Call sites migrated

- `connection/storage.rs` — `ConnectionStorage::new`
- `connection/settings.rs` — `SettingsStorage::new` + `new_standalone` (removes the duplicated `APP_IDENTIFIER` const and `resolve_standalone_config_dir`)
- `embedded_servers/storage.rs` — `EmbeddedServerStorage::new`
- `workspace/storage.rs` — `WorkspaceStorage::new`
- `workspace/last_session.rs` — `LastSessionStorage::new`
- `tunnel/storage.rs` — `TunnelStorage::new`
- `commands/portable.rs` — `export_config_to_portable` / `import_config_from_portable`
- `lib.rs` — setup block

The only remaining `TERMIHUB_CONFIG_DIR` read outside the helper is `lib.rs`'s portable-mode export guard (deciding whether to *set* the env var), which is a distinct concern, not resolution.

## Identifier-drift guard

The `app_identifier_matches_tauri_conf` assertion (parses `tauri.conf.json` and compares its `identifier` to `APP_IDENTIFIER`) was moved into `utils::config_paths` alongside the now-single constant, so the guard still fails the build if the bundle identifier ever drifts.

## Test plan

- `cargo clippy --all-targets --all-features` — clean (no warnings)
- `cargo test --lib` (src-tauri) — 894 passed, including the new `config_paths` tests:
  - `app_identifier_matches_tauri_conf`
  - `standalone_prefers_portable_data_dir`
  - `standalone_falls_back_to_config_base_with_identifier`
  - `standalone_errors_without_portable_or_base`
- `./scripts/check.sh` — ALL CHECKS PASSED

No user-facing behavior change (pure refactor), so no changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)