### PR TITLE
ux: confirm embedded-server delete (even when running)

### DIFF
--- a/docs/changes/dev0/feature/1393-confirm-embedded-server-delete.md
+++ b/docs/changes/dev0/feature/1393-confirm-embedded-server-delete.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Deleting an embedded server (HTTP/FTP/TFTP) in the Services sidebar now
+  requires an explicit confirmation, consistent with tunnels and workspaces
+  (#1393). When the target server is currently running, the confirmation warns
+  that it will be stopped and deleted.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -849,6 +849,23 @@ for #1348.
 3. **Cancel** → the scan does not start. Re-run and **Start scan** → the scan
    proceeds.
 
+### Embedded-server delete confirmation (#1393)
+
+See PR #1426. Verifies that deleting an embedded server now requires an explicit
+confirmation via the shared `ConfirmDialog`, consistent with tunnels and
+workspaces.
+
+1. Open the **Services** sidebar and create (or select) a **stopped** embedded
+   server. Click its **Delete** (trash) action → a themed confirm dialog appears
+   (no instant deletion). **Cancel** → the server remains. Re-open and click
+   **Delete** in the dialog → the server is removed and a success toast appears.
+2. Start an embedded server so it is **running**. Click its **Delete** action →
+   the confirm dialog's wording states it will **stop and delete the running
+   server**. Confirm → the running server is stopped, deleted, and a success
+   toast appears.
+3. Repeat via the right-click **context menu → Delete** → the same confirmation
+   dialog gates the deletion.
+
 ### Remote-agent update-strategy settings persist (#1354)
 
 Verifies the per-agent update settings appear in the editor and round-trip

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.delete.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.delete.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Delete-confirmation regression tests for the embedded-server sidebar (#1393).
+ *
+ * Deleting an embedded server used to fire instantly with no confirmation —
+ * even when the server was running — which was inconsistent with tunnels and
+ * workspaces. These tests pin the confirm-then-delete flow:
+ *  - clicking Delete does NOT delete until the user confirms,
+ *  - confirming runs the delete,
+ *  - cancelling leaves the server untouched,
+ *  - a running server's confirmation wording warns it will be stopped.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { EmbeddedServerConfig, ServerState } from "@/types/embeddedServer";
+import { TooltipProvider } from "@/components/ui";
+import { EmbeddedServerSidebar } from "./EmbeddedServerSidebar";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+// Network-interface enumeration used by the dialog is not available in jsdom.
+vi.mock("@/services/embeddedServerApi", () => ({
+  listNetworkInterfaces: vi.fn(() => Promise.resolve([{ name: "Loopback", addr: "127.0.0.1" }])),
+}));
+
+vi.mock("@/store/appStore", () => {
+  const state: Record<string, unknown> = {};
+  const useAppStore = (selector: (s: Record<string, unknown>) => unknown) => selector(state);
+  useAppStore.setState = (patch: Record<string, unknown>) => Object.assign(state, patch);
+  return { useAppStore };
+});
+
+function makeServer(id: string, name: string): EmbeddedServerConfig {
+  return {
+    id,
+    name,
+    serverType: "http",
+    rootDirectory: "/tmp",
+    bindHost: "127.0.0.1",
+    port: 8080,
+    autoStart: false,
+    readOnly: false,
+    directoryListing: true,
+  };
+}
+
+function runningState(id: string): ServerState {
+  return {
+    serverId: id,
+    status: "running",
+    stats: { activeConnections: 0, totalConnections: 0, bytesSent: 0, bytesReceived: 0 },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function seedStore(
+  deleteEmbeddedServer: (serverId: string) => Promise<void>,
+  servers: EmbeddedServerConfig[],
+  states: Record<string, ServerState> = {}
+) {
+  (useAppStore as unknown as { setState: (p: Record<string, unknown>) => void }).setState({
+    embeddedServers: servers,
+    embeddedServerStates: states,
+    saveEmbeddedServer: vi.fn(() => Promise.resolve()),
+    deleteEmbeddedServer,
+    startEmbeddedServer: vi.fn(),
+    stopEmbeddedServer: vi.fn(),
+  });
+}
+
+async function renderSidebar() {
+  await act(async () => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <EmbeddedServerSidebar />
+      </TooltipProvider>
+    );
+  });
+  await flush();
+}
+
+async function clickDelete(id: string) {
+  const delBtn = container.querySelector<HTMLButtonElement>(`[data-testid="server-delete-${id}"]`);
+  await act(async () => {
+    delBtn!.click();
+  });
+  await flush();
+}
+
+async function clickConfirm() {
+  const btn = document.querySelector<HTMLButtonElement>('[data-testid="confirm-dialog-confirm"]');
+  await act(async () => {
+    btn!.click();
+  });
+  await flush();
+}
+
+async function clickCancel() {
+  const btn = document.querySelector<HTMLButtonElement>('[data-testid="confirm-dialog-cancel"]');
+  await act(async () => {
+    btn!.click();
+  });
+  await flush();
+}
+
+describe("EmbeddedServerSidebar — delete confirmation (#1393)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("does not delete until the user confirms", async () => {
+    const deleteEmbeddedServer = vi.fn(() => Promise.resolve());
+    seedStore(deleteEmbeddedServer, [makeServer("srv-1", "Share")]);
+    await renderSidebar();
+
+    await clickDelete("srv-1");
+    // Nothing deleted yet — a confirmation is required first.
+    expect(deleteEmbeddedServer).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-testid="confirm-dialog-confirm"]')).not.toBeNull();
+
+    await clickConfirm();
+    expect(deleteEmbeddedServer).toHaveBeenCalledTimes(1);
+    expect(deleteEmbeddedServer).toHaveBeenCalledWith("srv-1");
+  });
+
+  it("leaves the server untouched when the user cancels", async () => {
+    const deleteEmbeddedServer = vi.fn(() => Promise.resolve());
+    seedStore(deleteEmbeddedServer, [makeServer("srv-1", "Share")]);
+    await renderSidebar();
+
+    await clickDelete("srv-1");
+    await clickCancel();
+
+    expect(deleteEmbeddedServer).not.toHaveBeenCalled();
+    // Dialog closed.
+    expect(document.querySelector('[data-testid="confirm-dialog-confirm"]')).toBeNull();
+  });
+
+  it("warns that a running server will be stopped before deletion", async () => {
+    const deleteEmbeddedServer = vi.fn(() => Promise.resolve());
+    seedStore(deleteEmbeddedServer, [makeServer("srv-1", "Share")], {
+      "srv-1": runningState("srv-1"),
+    });
+    await renderSidebar();
+
+    await clickDelete("srv-1");
+    expect(document.body.textContent?.toLowerCase()).toContain("stop");
+  });
+});

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Plus } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
-import { Button, toast } from "@/components/ui";
+import { Button, ConfirmDialog, toast } from "@/components/ui";
 import { EmbeddedServerConfig } from "@/types/embeddedServer";
 import { EmbeddedServerItem } from "./EmbeddedServerItem";
 import { EmbeddedServerDialog } from "./EmbeddedServerDialog";
@@ -20,6 +20,8 @@ export function EmbeddedServerSidebar() {
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingConfig, setEditingConfig] = useState<EmbeddedServerConfig | null>(null);
+  // Id of the server pending delete confirmation (null when no confirm is open).
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   const handleNew = useCallback(() => {
     setEditingConfig(null);
@@ -86,12 +88,33 @@ export function EmbeddedServerSidebar() {
     [servers, saveEmbeddedServer]
   );
 
-  const handleDelete = useCallback(
-    (id: string) => {
-      deleteEmbeddedServer(id);
-    },
-    [deleteEmbeddedServer]
+  // Delete is destructive (and stops a running server), so gate it behind an
+  // explicit confirmation — consistent with tunnels and workspaces (#1393).
+  const handleDelete = useCallback((id: string) => {
+    setPendingDeleteId(id);
+  }, []);
+
+  const pendingServer = useMemo(
+    () => servers.find((s) => s.id === pendingDeleteId) ?? null,
+    [servers, pendingDeleteId]
   );
+  const pendingIsRunning = pendingDeleteId
+    ? serverStates[pendingDeleteId]?.status === "running"
+    : false;
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingServer) return;
+    const { id, name } = pendingServer;
+    setPendingDeleteId(null);
+    try {
+      await deleteEmbeddedServer(id);
+      toast.success(`Deleted "${name}"`);
+    } catch (err) {
+      toast.error(`Failed to delete "${name}"`, {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [pendingServer, deleteEmbeddedServer]);
 
   return (
     <div className="server-sidebar" data-testid="server-sidebar">
@@ -134,6 +157,20 @@ export function EmbeddedServerSidebar() {
         onOpenChange={setDialogOpen}
         config={editingConfig}
         onSave={handleSave}
+      />
+
+      <ConfirmDialog
+        open={pendingServer !== null}
+        title="Delete service"
+        message={
+          pendingIsRunning
+            ? `This will stop and delete the running server "${pendingServer?.name}". This cannot be undone.`
+            : `Delete "${pendingServer?.name}"? This cannot be undone.`
+        }
+        confirmLabel="Delete"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPendingDeleteId(null)}
+        data-testid="server-delete-confirm"
       />
     </div>
   );

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -348,6 +348,7 @@ Fixed strings — match exactly.
 | `save-workspace-scope` | `src/components/WorkspaceSidebar/SaveWorkspaceDialog.tsx` |
 | `save-workspace-scope-active` | `src/components/WorkspaceSidebar/SaveWorkspaceDialog.tsx` |
 | `save-workspace-scope-all` | `src/components/WorkspaceSidebar/SaveWorkspaceDialog.tsx` |
+| `server-delete-confirm` | `src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx` |
 | `server-dialog-autostart` | `src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx` |
 | `server-dialog-bind-host` | `src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx` |
 | `server-dialog-cancel` | `src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx` |


### PR DESCRIPTION
Closes #1393

## Summary

Deleting an embedded server in the Services sidebar previously fired instantly with no confirmation — even when the server was running — inconsistent with tunnels and workspaces. This wires the delete action through the shared `ConfirmDialog` primitive (`src/components/ui/ConfirmDialog.tsx`):

- Clicking **Delete** (toolbar or context menu) now opens a confirmation dialog; the delete runs only on confirm.
- When the target server is currently **running**, the dialog wording warns it will be **stopped and deleted** ("This will stop and delete the running server …").
- Deletion now surfaces success/error feedback via toast, per the design system.
- Composes only the shared primitive — no bespoke modal/CSS.

## Test plan

- **Unit (regression, TDD):** `src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.delete.test.tsx` asserts:
  - clicking Delete does **not** delete until the user confirms; confirming calls `deleteEmbeddedServer(id)`,
  - cancelling leaves the server untouched,
  - a running server's confirmation wording warns it will be stopped.
  - Full suite: 2765 tests pass; lint / tsc / prettier clean.
- **Manual:**
  - Delete a **stopped** server → confirmation required; Cancel keeps it, Confirm removes it (success toast).
  - Delete a **running** server → confirmation mentions it will stop + delete the running server; Confirm stops and deletes it.
  - Same confirmation gates the right-click **context menu → Delete**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Follow-up filed:** #1427 — the store's `deleteEmbeddedServer` swallows backend errors to `console.error`, so the error toast added here will not fire on a real backend failure (pre-existing, out of scope for #1393).
