### PR TITLE
ux: replace unsaved-editor-close window.confirm with shared Modal

### DIFF
--- a/docs/changes/dev0/feature/1389-unsaved-editor-close-modal.md
+++ b/docs/changes/dev0/feature/1389-unsaved-editor-close-modal.md
@@ -1,0 +1,5 @@
+### Changed
+
+- The tab-close "unsaved changes" confirmation now uses the in-app shared
+  confirm dialog instead of a native browser `window.confirm`, so it matches the
+  rest of the app's look, motion, and theming (#1389).

--- a/src/components/Terminal/TabBar.close-editor.test.tsx
+++ b/src/components/Terminal/TabBar.close-editor.test.tsx
@@ -52,6 +52,22 @@ function makeEditorTab(id = TAB_ID): TerminalTab {
   };
 }
 
+// A dirty tab whose contentType is NOT in the editor set
+// (settings/editor/connection-editor). This is the fallback branch that used
+// to trigger the native window.confirm and now surfaces the shared dialog.
+function makeDirtyOtherTab(id = TAB_ID): TerminalTab {
+  return {
+    id,
+    sessionId: null,
+    title: "tunnel.json",
+    connectionType: "local",
+    contentType: "tunnel-editor",
+    config: { type: "local", config: {} },
+    panelId: PANEL_ID,
+    isActive: true,
+  };
+}
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -65,6 +81,9 @@ function resetStore() {
   useAppStore.setState({
     editorDirtyTabs: {},
     pendingCloseRequest: null,
+    pendingSessionCloseConfirm: null,
+    // Restore the real action so a per-test spy from a prior case cannot leak.
+    closeTab: useAppStore.getInitialState().closeTab,
   });
 }
 
@@ -143,5 +162,68 @@ describe("TabBar — close file editor tab with unsaved changes", () => {
 
     expect(confirmSpy).not.toHaveBeenCalled();
     expect(useAppStore.getState().pendingCloseRequest).toBeNull();
+  });
+});
+
+describe("TabBar — unsaved-changes fallback dialog (shared Modal, no window.confirm)", () => {
+  const DIALOG = '[data-testid="unsaved-editor-close-dialog"]';
+
+  it("shows the shared confirm dialog instead of a native window.confirm", () => {
+    const confirmSpy = vi.spyOn(window, "confirm");
+    const closeTab = vi.fn();
+    useAppStore.setState({ closeTab });
+    render([makeDirtyOtherTab()]);
+
+    useAppStore.setState({ editorDirtyTabs: { [TAB_ID]: true } });
+
+    act(() => {
+      (container.querySelector(`[data-testid="tab-close-${TAB_ID}"]`) as HTMLElement).click();
+    });
+
+    // Native confirm is never used; the in-app dialog is rendered instead.
+    expect(confirmSpy).not.toHaveBeenCalled();
+    const dialog = document.querySelector(DIALOG);
+    expect(dialog).toBeTruthy();
+    expect(dialog?.textContent).toContain("unsaved changes");
+    // Nothing closes until the user confirms.
+    expect(closeTab).not.toHaveBeenCalled();
+  });
+
+  it("confirming proceeds with the close", () => {
+    const closeTab = vi.fn();
+    useAppStore.setState({ closeTab });
+    render([makeDirtyOtherTab()]);
+
+    useAppStore.setState({ editorDirtyTabs: { [TAB_ID]: true } });
+
+    act(() => {
+      (container.querySelector(`[data-testid="tab-close-${TAB_ID}"]`) as HTMLElement).click();
+    });
+
+    act(() => {
+      (document.querySelector('[data-testid="confirm-dialog-confirm"]') as HTMLElement).click();
+    });
+
+    expect(closeTab).toHaveBeenCalledWith(TAB_ID, PANEL_ID);
+    expect(document.querySelector(DIALOG)).toBeNull();
+  });
+
+  it("cancelling keeps the tab open and closes the dialog", () => {
+    const closeTab = vi.fn();
+    useAppStore.setState({ closeTab });
+    render([makeDirtyOtherTab()]);
+
+    useAppStore.setState({ editorDirtyTabs: { [TAB_ID]: true } });
+
+    act(() => {
+      (container.querySelector(`[data-testid="tab-close-${TAB_ID}"]`) as HTMLElement).click();
+    });
+
+    act(() => {
+      (document.querySelector('[data-testid="confirm-dialog-cancel"]') as HTMLElement).click();
+    });
+
+    expect(closeTab).not.toHaveBeenCalled();
+    expect(document.querySelector(DIALOG)).toBeNull();
   });
 });

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -5,6 +5,7 @@ import { TerminalTab } from "@/types/terminal";
 import { deriveTabStatus } from "@/utils/tabStatus";
 import { tabHasLiveSession } from "@/utils/tabLiveSession";
 import { reopenPayloadForTab, showReopenToast } from "@/utils/reopenTab";
+import { ConfirmDialog } from "@/components/ui";
 import { useTerminalRegistry } from "./TerminalRegistry";
 import { Tab } from "./Tab";
 import { ColorPickerDialog } from "./ColorPickerDialog";
@@ -39,25 +40,15 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
 
   const [colorPickerTabId, setColorPickerTabId] = useState<string | null>(null);
   const [renameTabId, setRenameTabId] = useState<string | null>(null);
+  // Tab awaiting confirmation in the shared unsaved-changes dialog (fallback for
+  // dirty tabs whose editor does not route through `setPendingCloseRequest`).
+  const [unsavedCloseTabId, setUnsavedCloseTabId] = useState<string | null>(null);
 
-  const handleCloseTab = (tabId: string) => {
-    // Read fresh state directly from the store to avoid stale closure values:
-    // the render-time editorDirtyTabs snapshot may lag behind a setEditorDirty
-    // call that hasn't caused a re-render yet (e.g. the user reverted changes).
+  // Continue the close flow once any unsaved-changes gate has been cleared:
+  // warn before tearing down a live session, otherwise close and offer Undo.
+  const finishCloseTab = (tabId: string) => {
     const state = useAppStore.getState();
     const tab = tabs.find((t) => t.id === tabId);
-    const isDirty = state.editorDirtyTabs[tabId];
-    if (isDirty) {
-      if (
-        tab?.contentType === "connection-editor" ||
-        tab?.contentType === "settings" ||
-        tab?.contentType === "editor"
-      ) {
-        setPendingCloseRequest({ tabId, panelId });
-        return;
-      }
-      if (!window.confirm("This file has unsaved changes. Close anyway?")) return;
-    }
 
     if (!tab) {
       closeTab(tabId, panelId);
@@ -84,6 +75,31 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
 
     closeTab(tabId, panelId);
     showReopenToast(reopenPayloadForTab(tab));
+  };
+
+  const handleCloseTab = (tabId: string) => {
+    // Read fresh state directly from the store to avoid stale closure values:
+    // the render-time editorDirtyTabs snapshot may lag behind a setEditorDirty
+    // call that hasn't caused a re-render yet (e.g. the user reverted changes).
+    const state = useAppStore.getState();
+    const tab = tabs.find((t) => t.id === tabId);
+    const isDirty = state.editorDirtyTabs[tabId];
+    if (isDirty) {
+      if (
+        tab?.contentType === "connection-editor" ||
+        tab?.contentType === "settings" ||
+        tab?.contentType === "editor"
+      ) {
+        setPendingCloseRequest({ tabId, panelId });
+        return;
+      }
+      // Any other dirty tab is gated by the shared confirm dialog; the actual
+      // close is deferred to `finishCloseTab` once the user confirms.
+      setUnsavedCloseTabId(tabId);
+      return;
+    }
+
+    finishCloseTab(tabId);
   };
 
   const renameTabData = renameTabId ? tabs.find((t) => t.id === renameTabId) : null;
@@ -147,6 +163,20 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
         onRename={(newTitle) => {
           if (renameTabId) renameTab(renameTabId, newTitle);
         }}
+      />
+      <ConfirmDialog
+        open={unsavedCloseTabId !== null}
+        title="Unsaved changes"
+        message="This file has unsaved changes. Close anyway?"
+        confirmLabel="Close anyway"
+        cancelLabel="Cancel"
+        data-testid="unsaved-editor-close-dialog"
+        onConfirm={() => {
+          const tabId = unsavedCloseTabId;
+          setUnsavedCloseTabId(null);
+          if (tabId) finishCloseTab(tabId);
+        }}
+        onCancel={() => setUnsavedCloseTabId(null)}
       />
     </div>
   );

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -501,6 +501,7 @@ Fixed strings — match exactly.
 | `unsaved-changes-cancel` | `src/components/ConnectionEditor/UnsavedChangesDialog.tsx` |
 | `unsaved-changes-just-close` | `src/components/ConnectionEditor/UnsavedChangesDialog.tsx` |
 | `unsaved-changes-save-and-close` | `src/components/ConnectionEditor/UnsavedChangesDialog.tsx` |
+| `unsaved-editor-close-dialog` | `src/components/Terminal/TabBar.tsx` |
 | `update-auto-check-off` | `src/components/Settings/UpdateSettings.tsx` |
 | `update-auto-check-on` | `src/components/Settings/UpdateSettings.tsx` |
 | `update-build-hash` | `src/components/Settings/UpdateSettings.tsx` |


### PR DESCRIPTION
Closes #1389

## Summary

The dirty-tab close flow in `src/components/Terminal/TabBar.tsx` used a native
`window.confirm("This file has unsaved changes. Close anyway?")` as the fallback
for dirty tabs that do not route through `setPendingCloseRequest`. This replaces
that native dialog with the shared `ConfirmDialog` primitive (Modal + Button) so
the prompt matches the app's look, motion, and theming.

- Introduced `unsavedCloseTabId` state to hold the tab awaiting confirmation and
  render a controlled `ConfirmDialog` ("Unsaved changes" / "Close anyway" /
  "Cancel").
- Extracted the post-dirty-check close continuation (live-session guard +
  `closeTab` + reopen toast) into `finishCloseTab`, deferred until the user
  confirms.
- The existing `setPendingCloseRequest` routing for `editor` / `settings` /
  `connection-editor` tabs is preserved exactly, along with its tests.
- No `window.confirm` remains in the editor-close flow.

## Test plan

- `test(terminal)` commit adds regression coverage in
  `TabBar.close-editor.test.tsx`: closing a dirty tab renders the shared confirm
  dialog (never `window.confirm`); confirming proceeds with `closeTab`;
  cancelling keeps the tab open and closes the dialog.
- `pnpm exec vitest run src/components/Terminal/` → 187 passed.
- `pnpm run lint`, `pnpm exec tsc --noEmit`, `pnpm run format:check` all clean.

No manual test steps: the fallback branch is only reachable for dirty tabs whose
content type is not in the editor set, and the normal editor path continues to
use FileEditor's own `UnsavedChangesDialog`. Unit tests are the correct coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)