### PR TITLE
refactor(ui): extract shared SettingsField wrapper across Settings panels

### DIFF
--- a/src/components/Settings/AppearanceSettings.tsx
+++ b/src/components/Settings/AppearanceSettings.tsx
@@ -1,6 +1,7 @@
 import { AppSettings } from "@/types/connection";
 import { Select } from "@/components/ui";
 import type { SelectOption } from "@/components/ui";
+import { SettingsField } from "./SettingsField";
 
 /** Static theme options, hoisted so they are not rebuilt on every render. */
 const THEME_OPTIONS: SelectOption[] = [
@@ -27,10 +28,8 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
     <div className="settings-panel__category">
       <h3 className="settings-panel__category-title">Appearance</h3>
       {show("theme") && (
-        <div className="settings-form__field">
-          <span className="settings-form__label">Theme</span>
+        <SettingsField label="Theme" hint="Application color theme.">
           <Select
-            aria-label="Theme"
             data-testid="appearance-theme-select"
             value={settings.theme ?? "dark"}
             onChange={(value) =>
@@ -41,26 +40,23 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
             }
             options={THEME_OPTIONS}
           />
-          <span className="settings-form__hint">Application color theme.</span>
-        </div>
+        </SettingsField>
       )}
       {show("fontFamily") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Font Family</span>
+        <SettingsField
+          label="Font Family"
+          hint="Terminal font family. Leave empty to use the default Nerd Font chain."
+        >
           <input
             type="text"
             value={settings.fontFamily ?? ""}
             onChange={(e) => onChange({ ...settings, fontFamily: e.target.value || undefined })}
             placeholder={DEFAULT_FONT_FAMILY}
           />
-          <span className="settings-form__hint">
-            Terminal font family. Leave empty to use the default Nerd Font chain.
-          </span>
-        </label>
+        </SettingsField>
       )}
       {show("fontSize") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Font Size</span>
+        <SettingsField label="Font Size" hint="Terminal font size in pixels (8–32).">
           <input
             type="number"
             min={8}
@@ -71,12 +67,13 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
               onChange({ ...settings, fontSize: isNaN(val) ? undefined : val });
             }}
           />
-          <span className="settings-form__hint">Terminal font size in pixels (8–32).</span>
-        </label>
+        </SettingsField>
       )}
       {show("lineHeight") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Line Height</span>
+        <SettingsField
+          label="Line Height"
+          hint="Terminal line height (0.8–2.0). Use 1.0 for seamless box-drawing characters."
+        >
           <input
             type="number"
             min={0.8}
@@ -88,10 +85,7 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
               onChange({ ...settings, lineHeight: isNaN(val) ? undefined : val });
             }}
           />
-          <span className="settings-form__hint">
-            Terminal line height (0.8–2.0). Use 1.0 for seamless box-drawing characters.
-          </span>
-        </label>
+        </SettingsField>
       )}
     </div>
   );

--- a/src/components/Settings/ExternalFilesSettings.tsx
+++ b/src/components/Settings/ExternalFilesSettings.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from "@/store/appStore";
 import { ExternalFileConfig } from "@/types/connection";
 import { Button, Toggle, Tooltip } from "@/components/ui";
 import { frontendLog } from "@/utils/frontendLog";
+import { SettingsField } from "./SettingsField";
 
 /**
  * External connection file management, extracted from SettingsPanel.
@@ -208,10 +209,11 @@ export function ExternalFilesSettings() {
           Default settings for new SSH connections. Individual connections can override these in
           their SSH settings. Disabling a default disconnects active sessions that use the default.
         </p>
-        <div className="settings-form__field">
-          <span className="settings-form__label">Power Monitoring</span>
+        <SettingsField
+          label="Power Monitoring"
+          hint="Monitor CPU, memory, and power events via SSH agent connections."
+        >
           <Toggle
-            aria-label="Power Monitoring"
             checked={settings.powerMonitoringEnabled}
             onCheckedChange={() =>
               updateSettings({
@@ -221,15 +223,13 @@ export function ExternalFilesSettings() {
             }
             data-testid="toggle-power-monitoring"
           />
-          <span className="settings-form__hint">
-            Monitor CPU, memory, and power events via SSH agent connections.
-          </span>
-        </div>
+        </SettingsField>
 
-        <div className="settings-form__field">
-          <span className="settings-form__label">File Browser</span>
+        <SettingsField
+          label="File Browser"
+          hint="Enable the SFTP file browser for SSH agent sessions."
+        >
           <Toggle
-            aria-label="File Browser"
             checked={settings.fileBrowserEnabled}
             onCheckedChange={() =>
               updateSettings({
@@ -239,10 +239,7 @@ export function ExternalFilesSettings() {
             }
             data-testid="toggle-file-browser"
           />
-          <span className="settings-form__hint">
-            Enable the SFTP file browser for SSH agent sessions.
-          </span>
-        </div>
+        </SettingsField>
       </div>
     </div>
   );

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "@/store/appStore";
 import { isWindows } from "@/utils/platform";
 import { Select, SelectItem, Toggle } from "@/components/ui";
 import { KeyPathInput } from "./KeyPathInput";
+import { SettingsField } from "./SettingsField";
 
 /** Sentinel value for the "platform default" shell option (Radix Select forbids empty-string item values). */
 const PLATFORM_DEFAULT_SHELL = "__platform_default__";
@@ -55,8 +56,10 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
         <h3 className="settings-panel__category-title">General</h3>
 
         {show("defaultUser") && (
-          <label className="settings-form__field">
-            <span className="settings-form__label">Default User</span>
+          <SettingsField
+            label="Default User"
+            hint="Default username pre-filled for new SSH connections."
+          >
             <input
               type="text"
               value={settings.defaultUser ?? ""}
@@ -64,32 +67,29 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
               placeholder="e.g. admin"
               data-testid="settings-default-user"
             />
-            <span className="settings-form__hint">
-              Default username pre-filled for new SSH connections.
-            </span>
-          </label>
+          </SettingsField>
         )}
 
         {show("defaultSshKeyPath") && (
-          <div className="settings-form__field">
-            <span className="settings-form__label">Default SSH Key Path</span>
+          <SettingsField
+            label="Default SSH Key Path"
+            hint="Default private key path for SSH key authentication."
+          >
             <KeyPathInput
               value={settings.defaultSshKeyPath ?? ""}
               onChange={(value) => onChange({ ...settings, defaultSshKeyPath: value || undefined })}
               placeholder="~/.ssh/id_ed25519"
               testIdPrefix="general-settings"
             />
-            <span className="settings-form__hint">
-              Default private key path for SSH key authentication.
-            </span>
-          </div>
+          </SettingsField>
         )}
 
         {show("defaultShell") && (
-          <div className="settings-form__field">
-            <span className="settings-form__label">Default Shell</span>
+          <SettingsField
+            label="Default Shell"
+            hint="Default shell for new local terminal sessions."
+          >
             <Select
-              aria-label="Default Shell"
               data-testid="settings-default-shell"
               value={settings.defaultShell ?? PLATFORM_DEFAULT_SHELL}
               onChange={(value) =>
@@ -113,81 +113,68 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
                 </SelectItem>
               ))}
             </Select>
-            <span className="settings-form__hint">
-              Default shell for new local terminal sessions.
-            </span>
-          </div>
+          </SettingsField>
         )}
 
         {show("confirmCloseTabOnShortcut") && (
-          <div className="settings-form__field">
-            <span className="settings-form__label">Confirm Close Tab on Shortcut</span>
+          <SettingsField
+            label="Confirm Close Tab on Shortcut"
+            hint="Ask for confirmation when closing a tab or tab group via keyboard shortcut."
+          >
             <Toggle
-              aria-label="Confirm Close Tab on Shortcut"
               checked={settings.confirmCloseTabOnShortcut ?? true}
               onCheckedChange={(checked) =>
                 onChange({ ...settings, confirmCloseTabOnShortcut: checked })
               }
               data-testid="settings-confirm-close-tab-on-shortcut"
             />
-            <span className="settings-form__hint">
-              Ask for confirmation when closing a tab or tab group via keyboard shortcut.
-            </span>
-          </div>
+          </SettingsField>
         )}
 
         {show("confirmCloseLiveSession") && (
-          <div className="settings-form__field">
-            <span className="settings-form__label">Confirm Closing a Live Session</span>
+          <SettingsField
+            label="Confirm Closing a Live Session"
+            hint="Ask for confirmation before closing a tab (X or middle-click) or split panel that holds a live SSH, serial, or shell session."
+          >
             <Toggle
-              aria-label="Confirm Closing a Live Session"
               checked={settings.confirmCloseLiveSession ?? true}
               onCheckedChange={(checked) =>
                 onChange({ ...settings, confirmCloseLiveSession: checked })
               }
               data-testid="settings-confirm-close-live-session"
             />
-            <span className="settings-form__hint">
-              Ask for confirmation before closing a tab (X or middle-click) or split panel that
-              holds a live SSH, serial, or shell session.
-            </span>
-          </div>
+          </SettingsField>
         )}
 
         {show("experimentalFeaturesEnabled") && (
-          <div className="settings-form__field">
-            <span className="settings-form__label">Allow Experimental Features</span>
+          <SettingsField
+            label="Allow Experimental Features"
+            hint="Enables hidden features under active development. Experimental features may change, break, or be removed at any time without notice."
+            hintVariant="warning"
+          >
             <Toggle
-              aria-label="Allow Experimental Features"
               checked={settings.experimentalFeaturesEnabled ?? false}
               onCheckedChange={(checked) =>
                 onChange({ ...settings, experimentalFeaturesEnabled: checked })
               }
               data-testid="settings-experimental-features"
             />
-            <span className="settings-form__hint settings-form__hint--warning">
-              Enables hidden features under active development. Experimental features may change,
-              break, or be removed at any time without notice.
-            </span>
-          </div>
+          </SettingsField>
         )}
 
         {show("restoreLastSessionOnStartup") && (
-          <div className="settings-form__field">
-            <span className="settings-form__label">Restore Last Session on Startup</span>
+          <SettingsField
+            label="Restore Last Session on Startup"
+            hint="Reopen the tabs and panel layout from your previous session when the app starts. Sessions that can no longer reconnect are shown in a disconnected state."
+          >
             <Toggle
-              aria-label="Restore Last Session on Startup"
               checked={settings.restoreLastSessionOnStartup ?? true}
               onCheckedChange={(checked) =>
                 onChange({ ...settings, restoreLastSessionOnStartup: checked })
               }
               data-testid="settings-restore-last-session"
             />
-            <span className="settings-form__hint">
-              Reopen the tabs and panel layout from your previous session when the app starts.
-              Sessions that can no longer reconnect are shown in a disconnected state.
-            </span>
-          </div>
+          </SettingsField>
         )}
       </div>
 
@@ -196,37 +183,33 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
           <h3 className="settings-panel__category-title">SSH Defaults</h3>
 
           {show("defaultShellIntegration") && (
-            <div className="settings-form__field">
-              <span className="settings-form__label">Shell Integration by Default</span>
+            <SettingsField
+              label="Shell Integration by Default"
+              hint="Pre-enable Shell Integration (OSC 7 CWD tracking) for new SSH connections."
+            >
               <Toggle
-                aria-label="Shell Integration by Default"
                 checked={settings.defaultShellIntegration ?? true}
                 onCheckedChange={(checked) =>
                   onChange({ ...settings, defaultShellIntegration: checked })
                 }
                 data-testid="settings-default-shell-integration"
               />
-              <span className="settings-form__hint">
-                Pre-enable Shell Integration (OSC 7 CWD tracking) for new SSH connections.
-              </span>
-            </div>
+            </SettingsField>
           )}
 
           {show("defaultX11Forwarding") && (
-            <div className="settings-form__field">
-              <span className="settings-form__label">X11 Forwarding by Default</span>
+            <SettingsField
+              label="X11 Forwarding by Default"
+              hint="Pre-enable X11 Forwarding for new SSH connections."
+            >
               <Toggle
-                aria-label="X11 Forwarding by Default"
                 checked={settings.defaultX11Forwarding ?? true}
                 onCheckedChange={(checked) =>
                   onChange({ ...settings, defaultX11Forwarding: checked })
                 }
                 data-testid="settings-default-x11-forwarding"
               />
-              <span className="settings-form__hint">
-                Pre-enable X11 Forwarding for new SSH connections.
-              </span>
-            </div>
+            </SettingsField>
           )}
         </div>
       )}
@@ -236,38 +219,33 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
           <h3 className="settings-panel__category-title">X Server</h3>
 
           {show("provideXServerAutomatically") && (
-            <div className="settings-form__field">
-              <span className="settings-form__label">Provide X Server Automatically</span>
+            <SettingsField
+              label="Provide X Server Automatically"
+              hint="Windows: download & run VcXsrv automatically. macOS/Linux: use the detected/guided server."
+            >
               <Toggle
-                aria-label="Provide X Server Automatically"
                 checked={settings.provideXServerAutomatically ?? isWindows()}
                 onCheckedChange={(checked) =>
                   onChange({ ...settings, provideXServerAutomatically: checked })
                 }
                 data-testid="settings-provide-x-server"
               />
-              <span className="settings-form__hint">
-                Windows: download &amp; run VcXsrv automatically. macOS/Linux: use the
-                detected/guided server.
-              </span>
-            </div>
+            </SettingsField>
           )}
 
           {show("stopXServerWhenIdle") && (
-            <div className="settings-form__field">
-              <span className="settings-form__label">Stop X Server When Idle</span>
+            <SettingsField
+              label="Stop X Server When Idle"
+              hint="Shut the managed X server down once no connection is using it."
+            >
               <Toggle
-                aria-label="Stop X Server When Idle"
                 checked={settings.stopXServerWhenIdle ?? true}
                 onCheckedChange={(checked) =>
                   onChange({ ...settings, stopXServerWhenIdle: checked })
                 }
                 data-testid="settings-stop-x-server-idle"
               />
-              <span className="settings-form__hint">
-                Shut the managed X server down once no connection is using it.
-              </span>
-            </div>
+            </SettingsField>
           )}
         </div>
       )}

--- a/src/components/Settings/SecuritySettings.tsx
+++ b/src/components/Settings/SecuritySettings.tsx
@@ -5,6 +5,7 @@ import { CredentialStorageMode } from "@/types/credential";
 import { switchCredentialStore, changeMasterPassword, setAutoLockTimeout } from "@/services/api";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
 import { Button, Select, toast } from "@/components/ui";
+import { SettingsField } from "./SettingsField";
 
 interface SecuritySettingsProps {
   visibleFields?: Set<string>;
@@ -373,19 +374,17 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
             <div className="settings-panel__section">
               <h3 className="settings-panel__section-title">Master Password Options</h3>
 
-              <div className="settings-form__field">
-                <span className="settings-form__label">Auto-Lock Timeout</span>
+              <SettingsField
+                label="Auto-Lock Timeout"
+                hint="Lock the credential store after a period of inactivity."
+              >
                 <Select
-                  aria-label="Auto-Lock Timeout"
                   data-testid="auto-lock-timeout"
                   value={String(settings.credentialAutoLockMinutes ?? 15)}
                   onChange={(value) => handleAutoLockChange(Number(value))}
                   options={AUTO_LOCK_SELECT_OPTIONS}
                 />
-                <span className="settings-form__hint">
-                  Lock the credential store after a period of inactivity.
-                </span>
-              </div>
+              </SettingsField>
 
               <div className="settings-panel__field">
                 <Button

--- a/src/components/Settings/SettingsField.test.tsx
+++ b/src/components/Settings/SettingsField.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { SettingsField } from "./SettingsField";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(node: React.ReactElement) {
+  act(() => {
+    root.render(node);
+  });
+}
+
+describe("SettingsField", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders the field scaffold with label, control, and hint", () => {
+    render(
+      <SettingsField label="My Label" hint="My hint text">
+        <input type="text" data-testid="my-control" />
+      </SettingsField>
+    );
+
+    const field = container.querySelector(".settings-form__field");
+    expect(field).not.toBeNull();
+
+    const label = field?.querySelector(".settings-form__label");
+    expect(label?.textContent).toBe("My Label");
+
+    const control = field?.querySelector('[data-testid="my-control"]');
+    expect(control).not.toBeNull();
+
+    const hint = field?.querySelector(".settings-form__hint");
+    expect(hint?.textContent).toBe("My hint text");
+  });
+
+  it("derives the control's aria-label from the label", () => {
+    render(
+      <SettingsField label="Cursor Blink">
+        <input type="text" data-testid="my-control" />
+      </SettingsField>
+    );
+
+    const control = container.querySelector('[data-testid="my-control"]');
+    expect(control?.getAttribute("aria-label")).toBe("Cursor Blink");
+  });
+
+  it("preserves an explicit aria-label already set on the control", () => {
+    render(
+      <SettingsField label="Field Label">
+        <input type="text" aria-label="Explicit Label" data-testid="my-control" />
+      </SettingsField>
+    );
+
+    const control = container.querySelector('[data-testid="my-control"]');
+    expect(control?.getAttribute("aria-label")).toBe("Explicit Label");
+  });
+
+  it("preserves the child's own props and data-testid", () => {
+    render(
+      <SettingsField label="Field Label">
+        <input type="number" placeholder="42" data-testid="my-control" />
+      </SettingsField>
+    );
+
+    const control = container.querySelector<HTMLInputElement>('[data-testid="my-control"]');
+    expect(control?.getAttribute("type")).toBe("number");
+    expect(control?.getAttribute("placeholder")).toBe("42");
+  });
+
+  it("omits the hint element when no hint is provided", () => {
+    render(
+      <SettingsField label="No Hint">
+        <input type="text" data-testid="my-control" />
+      </SettingsField>
+    );
+
+    expect(container.querySelector(".settings-form__hint")).toBeNull();
+  });
+
+  it("applies the warning hint variant", () => {
+    render(
+      <SettingsField label="Warned" hint="Careful" hintVariant="warning">
+        <input type="text" data-testid="my-control" />
+      </SettingsField>
+    );
+
+    const hint = container.querySelector(".settings-form__hint");
+    expect(hint?.classList.contains("settings-form__hint--warning")).toBe(true);
+  });
+
+  it("uses the default hint variant when unspecified", () => {
+    render(
+      <SettingsField label="Plain" hint="Plain hint">
+        <input type="text" data-testid="my-control" />
+      </SettingsField>
+    );
+
+    const hint = container.querySelector(".settings-form__hint");
+    expect(hint?.classList.contains("settings-form__hint--warning")).toBe(false);
+  });
+});

--- a/src/components/Settings/SettingsField.tsx
+++ b/src/components/Settings/SettingsField.tsx
@@ -1,0 +1,55 @@
+import { cloneElement } from "react";
+import type { ReactElement, ReactNode } from "react";
+
+/** Visual variant applied to the field's hint text. */
+export type SettingsHintVariant = "default" | "warning";
+
+export interface SettingsFieldProps {
+  /**
+   * The visible field label. Also derives the control's `aria-label` so the
+   * label text is stated once per field instead of being repeated as a manual
+   * `aria-label` at each call site.
+   */
+  label: string;
+  /** Optional explanatory hint rendered below the control. */
+  hint?: ReactNode;
+  /** Hint styling — `"warning"` colors the hint as a caution. Defaults to `"default"`. */
+  hintVariant?: SettingsHintVariant;
+  /**
+   * The single control the field wraps (a `Toggle`, `Select`, `input`, etc.).
+   * Its `aria-label` is set from {@link SettingsFieldProps.label} unless the
+   * control already declares its own.
+   */
+  children: ReactElement<{ "aria-label"?: string }>;
+}
+
+/**
+ * Shared wrapper for a Settings panel field: renders the `settings-form__field`
+ * label/control/hint scaffold once and wires the control's accessible name from
+ * the label, collapsing the field markup that every Settings panel used to
+ * hand-repeat.
+ */
+export function SettingsField({
+  label,
+  hint,
+  hintVariant = "default",
+  children,
+}: SettingsFieldProps): ReactElement {
+  const control =
+    children.props["aria-label"] === undefined
+      ? cloneElement(children, { "aria-label": label })
+      : children;
+
+  const hintClassName =
+    hintVariant === "warning"
+      ? "settings-form__hint settings-form__hint--warning"
+      : "settings-form__hint";
+
+  return (
+    <div className="settings-form__field">
+      <span className="settings-form__label">{label}</span>
+      {control}
+      {hint !== undefined && hint !== null && <span className={hintClassName}>{hint}</span>}
+    </div>
+  );
+}

--- a/src/components/Settings/TerminalSettings.tsx
+++ b/src/components/Settings/TerminalSettings.tsx
@@ -3,6 +3,7 @@ import { LineEnding } from "@/types/terminal";
 import { DEFAULT_LINE_ENDING, LINE_ENDING_OPTIONS } from "@/utils/lineEndings";
 import { Select, Toggle } from "@/components/ui";
 import type { SelectOption } from "@/components/ui";
+import { SettingsField } from "./SettingsField";
 
 /** Sentinel for the "platform default" right-click option (Radix Select forbids empty-string item values). */
 const RIGHT_CLICK_PLATFORM_DEFAULT = "__platform_default__";
@@ -38,23 +39,23 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
     <div className="settings-panel__category">
       <h3 className="settings-panel__category-title">Terminal</h3>
       {show("defaultHorizontalScrolling") && (
-        <div className="settings-form__field">
-          <span className="settings-form__label">Default Horizontal Scrolling</span>
+        <SettingsField
+          label="Default Horizontal Scrolling"
+          hint="Enable horizontal scrolling for new terminals by default."
+        >
           <Toggle
-            aria-label="Default Horizontal Scrolling"
             checked={settings.defaultHorizontalScrolling ?? false}
             onCheckedChange={(checked) =>
               onChange({ ...settings, defaultHorizontalScrolling: checked })
             }
           />
-          <span className="settings-form__hint">
-            Enable horizontal scrolling for new terminals by default.
-          </span>
-        </div>
+        </SettingsField>
       )}
       {show("scrollbackBuffer") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Scrollback Buffer</span>
+        <SettingsField
+          label="Scrollback Buffer"
+          hint="Number of lines kept in the terminal scrollback (100–1 000 000). Larger values consume more memory — roughly 1–2 MB per 10 000 lines of typical output."
+        >
           <input
             type="number"
             min={100}
@@ -65,17 +66,11 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
               onChange({ ...settings, scrollbackBuffer: isNaN(val) ? undefined : val });
             }}
           />
-          <span className="settings-form__hint">
-            Number of lines kept in the terminal scrollback (100–1 000 000). Larger values consume
-            more memory — roughly 1–2 MB per 10 000 lines of typical output.
-          </span>
-        </label>
+        </SettingsField>
       )}
       {show("cursorStyle") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Cursor Style</span>
+        <SettingsField label="Cursor Style" hint="Terminal cursor shape.">
           <Select
-            aria-label="Cursor Style"
             data-testid="settings-cursor-style"
             value={settings.cursorStyle ?? "block"}
             onChange={(value) =>
@@ -86,25 +81,22 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
             }
             options={CURSOR_STYLE_OPTIONS}
           />
-          <span className="settings-form__hint">Terminal cursor shape.</span>
-        </label>
+        </SettingsField>
       )}
       {show("cursorBlink") && (
-        <div className="settings-form__field">
-          <span className="settings-form__label">Cursor Blink</span>
+        <SettingsField label="Cursor Blink" hint="Whether the terminal cursor blinks.">
           <Toggle
-            aria-label="Cursor Blink"
             checked={settings.cursorBlink ?? true}
             onCheckedChange={(checked) => onChange({ ...settings, cursorBlink: checked })}
           />
-          <span className="settings-form__hint">Whether the terminal cursor blinks.</span>
-        </div>
+        </SettingsField>
       )}
       {show("defaultLineEnding") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Line Ending (Enter &amp; Paste)</span>
+        <SettingsField
+          label="Line Ending (Enter & Paste)"
+          hint="Sequence sent when pressing Enter and used to normalize line endings in pasted text. Prevents Windows CRLF from inserting blank lines on Unix shells and serial devices. Can be overridden per connection."
+        >
           <Select
-            aria-label="Line Ending (Enter & Paste)"
             data-testid="settings-line-ending"
             value={settings.defaultLineEnding ?? DEFAULT_LINE_ENDING}
             onChange={(value) =>
@@ -115,18 +107,14 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
             }
             options={LINE_ENDING_SELECT_OPTIONS}
           />
-          <span className="settings-form__hint">
-            Sequence sent when pressing Enter and used to normalize line endings in pasted text.
-            Prevents Windows CRLF from inserting blank lines on Unix shells and serial devices. Can
-            be overridden per connection.
-          </span>
-        </label>
+        </SettingsField>
       )}
       {show("rightClickBehavior") && (
-        <label className="settings-form__field">
-          <span className="settings-form__label">Right-Click Behavior</span>
+        <SettingsField
+          label="Right-Click Behavior"
+          hint="Context Menu shows the full right-click menu. Quick Copy/Paste copies selected text or pastes if nothing is selected. Default: Context Menu on macOS/Linux, Quick Copy/Paste on Windows."
+        >
           <Select
-            aria-label="Right-Click Behavior"
             data-testid="settings-right-click-behavior"
             value={settings.rightClickBehavior ?? RIGHT_CLICK_PLATFORM_DEFAULT}
             onChange={(value) =>
@@ -140,27 +128,19 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
             }
             options={RIGHT_CLICK_OPTIONS}
           />
-          <span className="settings-form__hint">
-            Context Menu shows the full right-click menu. Quick Copy/Paste copies selected text or
-            pastes if nothing is selected. Default: Context Menu on macOS/Linux, Quick Copy/Paste on
-            Windows.
-          </span>
-        </label>
+        </SettingsField>
       )}
       {show("askOpenSavedFileInTab") && (
-        <div className="settings-form__field">
-          <span className="settings-form__label">Open Saved File in Tab</span>
+        <SettingsField
+          label="Open Saved File in Tab"
+          hint="After saving terminal content to a file, ask whether to open it in an editor tab. When off, files are saved without prompting and are not opened."
+        >
           <Toggle
-            aria-label="Open Saved File in Tab"
             checked={settings.askOpenSavedFileInTab ?? true}
             onCheckedChange={(checked) => onChange({ ...settings, askOpenSavedFileInTab: checked })}
             data-testid="settings-ask-open-saved-file-in-tab"
           />
-          <span className="settings-form__hint">
-            After saving terminal content to a file, ask whether to open it in an editor tab. When
-            off, files are saved without prompting and are not opened.
-          </span>
-        </div>
+        </SettingsField>
       )}
     </div>
   );


### PR DESCRIPTION
Closes #1384

## Summary

Every Settings field hand-repeated the same triple — a `settings-form__field` container, a `settings-form__label` span, a `Toggle`/`Select`/`input` control, and a `settings-form__hint` span — while restating the label as a manual `aria-label` at each call site (~24 sites). The existing `ui/Field` primitive doesn't fit (it has an error slot, not a hint slot, and a label-on-top layout).

This adds a new **local** wrapper `src/components/Settings/SettingsField.tsx` that:

- renders the `settings-form__field` / `__label` / `__hint` scaffold once (same DOM classes, so no CSS changes),
- takes `label` / `hint` / `hintVariant` (`"default" | "warning"`) props plus a control child,
- derives the control's `aria-label` from `label` (unless the control already declares its own), removing the per-site label/aria-label restatement.

Adopted across all five panels — **25 field sites collapsed**:

- `GeneralSettings` (11)
- `TerminalSettings` (7)
- `AppearanceSettings` (4)
- `ExternalFilesSettings` (2)
- `SecuritySettings` (1)

Pure refactor: no user-facing behavior or visual change; every existing `data-testid` is preserved. (Native-input rows that previously used a wrapping `<label>` now render the same `settings-form__field` `<div>` and gain an explicit `aria-label` from the label — a small a11y improvement, no visual change.)

## Test plan

- New unit test `SettingsField.test.tsx` — asserts the label/control/hint scaffold renders, the control's `aria-label` is derived from the label (and an explicit control `aria-label` is preserved), child props/`data-testid` are preserved, the hint is omitted when absent, and the `warning` variant applies.
- All existing Settings panel tests stay green (full suite: 2769 passing).
- `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm run format:check` all pass.
- No change fragment: internal refactor with no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)