### PR TITLE
refactor(ui): migrate TunnelListItem onto shared SidebarListItem shell (Closes #1383)

### DIFF
--- a/src/components/TunnelSidebar/TunnelListItem.error.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.error.test.tsx
@@ -6,7 +6,8 @@
  *     `onStart` (Error → Connecting, clears the stored error via `start_tunnel`),
  *   - offer a **View last error** control that surfaces the persisted message,
  *   - render the persisted error text inline, and
- *   - carry the red `tunnel-item__status--error` resting dot.
+ *   - carry the red `sidebar-list-item__status--error` resting dot (the shared
+ *     shell maps the tunnel's error status onto the `error` tone, issue #1383).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
@@ -96,7 +97,7 @@ describe("TunnelListItem — errored resting state (#1240)", () => {
     await flush();
 
     const dot = container.querySelector('[data-testid="tunnel-status-tun-1"]');
-    expect(dot?.className).toContain("tunnel-item__status--error");
+    expect(dot?.className).toContain("sidebar-list-item__status--error");
     expect(container.textContent).toContain("SSH session closed by peer (bastion.corp)");
   });
 

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -1,6 +1,8 @@
 import { Play, Square, Pencil, Copy, Trash2, RotateCw, Info, AlertTriangle } from "lucide-react";
 import { Button, Tooltip, toast } from "@/components/ui";
-import { TunnelConfig, TunnelState } from "@/types/tunnel";
+import { SidebarListItem, SidebarStatusDot } from "@/components/SidebarListItem";
+import type { SidebarStatusTone } from "@/components/SidebarListItem";
+import { TunnelConfig, TunnelState, TunnelStatus } from "@/types/tunnel";
 import { SavedConnection } from "@/types/connection";
 import { formatBytes } from "@/utils/formatters";
 
@@ -35,6 +37,28 @@ function getPortMapping(tunnel: TunnelConfig): string {
   }
 }
 
+/** Map a tunnel status onto the shared status-dot tone. */
+function statusTone(status: TunnelStatus): SidebarStatusTone {
+  switch (status) {
+    case "connected":
+      return "success";
+    case "connecting":
+    case "reconnecting":
+      return "warning";
+    case "error":
+      return "error";
+    default:
+      return "neutral";
+  }
+}
+
+/**
+ * A single SSH tunnel entry in the Tunnels sidebar. Composes the shared
+ * {@link SidebarListItem} shell (status dot / badge / name / actions / details)
+ * so tunnel rows share one structure and token'd styling with the other
+ * management sidebars; only the stats / error / reconnecting detail lines stay
+ * tunnel-specific.
+ */
 export function TunnelListItem({
   tunnel,
   state,
@@ -63,23 +87,17 @@ export function TunnelListItem({
   };
 
   return (
-    <div
-      className={`tunnel-item${isError ? " tunnel-item--error" : ""}`}
-      data-testid={`tunnel-item-${tunnel.id}`}
+    <SidebarListItem
+      testId={`tunnel-item-${tunnel.id}`}
+      nameTestId={`tunnel-name-${tunnel.id}`}
+      name={tunnel.name}
+      error={isError}
       onDoubleClick={() => onEdit(tunnel.id)}
-    >
-      <div className="tunnel-item__header">
-        <span
-          className={`tunnel-item__status tunnel-item__status--${status}`}
-          data-testid={`tunnel-status-${tunnel.id}`}
-        />
-        <span className="tunnel-item__name" data-testid={`tunnel-name-${tunnel.id}`}>
-          {tunnel.name}
-        </span>
-        <span className="tunnel-item__type-badge" data-testid={`tunnel-type-${tunnel.id}`}>
-          {typeLabel}
-        </span>
-        <div className="tunnel-item__actions">
+      status={<SidebarStatusDot tone={statusTone(status)} testId={`tunnel-status-${tunnel.id}`} />}
+      badge={typeLabel}
+      badgeTestId={`tunnel-type-${tunnel.id}`}
+      actions={
+        <>
           {status === "connected" && (
             <Tooltip content="Reconnect (force)" side="top">
               <Button
@@ -208,31 +226,33 @@ export function TunnelListItem({
               }}
             />
           </Tooltip>
-        </div>
-      </div>
-      <div className="tunnel-item__details">
-        <span>{getPortMapping(tunnel)}</span>
-        <span>via {sshLabel}</span>
-        {isActive && state?.stats && (
-          <div className="tunnel-item__stats">
-            <span>↑ {formatBytes(state.stats.bytesSent)}</span>
-            <span>↓ {formatBytes(state.stats.bytesReceived)}</span>
-            <span>{state.stats.activeConnections} conn</span>
-          </div>
-        )}
-        {isError && lastError && (
-          <span className="tunnel-item__error" title={lastError}>
-            <AlertTriangle size={12} className="tunnel-item__error-icon" />
-            <span className="tunnel-item__error-text">{lastError}</span>
-          </span>
-        )}
-        {status === "reconnecting" && lastError && (
-          <span className="tunnel-item__reconnecting" title={lastError}>
-            <RotateCw size={12} className="tunnel-item__reconnecting-icon" />
-            <span className="tunnel-item__reconnecting-text">{lastError}</span>
-          </span>
-        )}
-      </div>
-    </div>
+        </>
+      }
+      details={
+        <>
+          <span>{getPortMapping(tunnel)}</span>
+          <span>via {sshLabel}</span>
+          {isActive && state?.stats && (
+            <div className="tunnel-item__stats">
+              <span>↑ {formatBytes(state.stats.bytesSent)}</span>
+              <span>↓ {formatBytes(state.stats.bytesReceived)}</span>
+              <span>{state.stats.activeConnections} conn</span>
+            </div>
+          )}
+          {isError && lastError && (
+            <span className="tunnel-item__error" title={lastError}>
+              <AlertTriangle size={12} className="tunnel-item__error-icon" />
+              <span className="tunnel-item__error-text">{lastError}</span>
+            </span>
+          )}
+          {status === "reconnecting" && lastError && (
+            <span className="tunnel-item__reconnecting" title={lastError}>
+              <RotateCw size={12} className="tunnel-item__reconnecting-icon" />
+              <span className="tunnel-item__reconnecting-text">{lastError}</span>
+            </span>
+          )}
+        </>
+      }
+    />
   );
 }

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -49,102 +49,17 @@
   gap: 8px;
 }
 
-.tunnel-item {
-  display: flex;
-  flex-direction: column;
-  padding: 6px 12px;
-  cursor: pointer;
-  user-select: none;
-}
-
-.tunnel-item:hover {
-  background: var(--bg-hover);
-}
-
-.tunnel-item__header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.tunnel-item__status {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.tunnel-item__status--disconnected {
-  background-color: var(--text-secondary);
-}
-
-.tunnel-item__status--connecting,
-.tunnel-item__status--reconnecting {
-  background-color: var(--color-warning);
-}
-
-.tunnel-item__status--connected {
-  background-color: var(--color-success);
-}
-
-.tunnel-item__status--error {
-  background-color: var(--color-error);
-}
-
-.tunnel-item__name {
-  flex: 1;
-  font-size: 13px;
-  color: var(--text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.tunnel-item__actions {
-  display: flex;
-  gap: 2px;
-  opacity: 0;
-}
-
-.tunnel-item:hover .tunnel-item__actions {
-  opacity: 1;
-}
-
-.tunnel-item__details {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 2px 0 0 14px;
-  font-size: 11px;
-  color: var(--text-secondary);
-}
-
-.tunnel-item__type-badge {
-  font-size: 10px;
-  padding: 1px 4px;
-  border-radius: 3px;
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  font-weight: 500;
-  flex-shrink: 0;
-}
-
+/*
+ * Tunnel rows are composed from the shared `SidebarListItem` shell (issue 1383),
+ * so the row layout (container, header, status dot, name, badge, actions,
+ * details) lives in `SidebarListItem.css`. Only the tunnel-specific detail lines
+ * — stats, the errored resting row, and the reconnecting row — remain here.
+ */
 .tunnel-item__stats {
   display: flex;
   gap: 8px;
-  font-size: 10px;
   color: var(--text-secondary);
   padding-top: 2px;
-}
-
-/*
- * Errored resting row (issue 1240): the persisted error message plus its recovery
- * controls (Retry / View last error) stay visible without a hover, so the user
- * always sees why the tunnel failed and how to recover it.
- */
-.tunnel-item--error .tunnel-item__actions {
-  opacity: 1;
 }
 
 .tunnel-item__error {

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -694,14 +694,10 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `tunnel-delete-*` | `tunnel-delete-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-duplicate-*` | `tunnel-duplicate-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-edit-*` | `tunnel-edit-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
-| `tunnel-item-*` | `tunnel-item-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
-| `tunnel-name-*` | `tunnel-name-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-reconnect-*` | `tunnel-reconnect-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-retry-*` | `tunnel-retry-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-start-*` | `tunnel-start-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
-| `tunnel-status-*` | `tunnel-status-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-stop-*` | `tunnel-stop-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
-| `tunnel-type-*` | `tunnel-type-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-view-error-*` | `tunnel-view-error-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `workspace-delete-*` | `workspace-delete-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 | `workspace-duplicate-*` | `workspace-duplicate-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |


### PR DESCRIPTION
## Summary

Migrates `TunnelListItem` onto the shared `SidebarListItem` + `SidebarStatusDot` shell (Closes #1383), so tunnel rows share one structure, hover behaviour, and token'd styling with the other management sidebars (services, workspaces) instead of hand-rolling the `tunnel-item*` row layout.

### What changed
- **`TunnelListItem.tsx`** now composes `SidebarListItem`:
  - tunnel status → status-dot **tone** (`connected`→success, `connecting`/`reconnecting`→warning, `error`→error, else neutral)
  - tunnel type → shell **`badge`**
  - port mapping / via / stats / error / reconnecting → shell **`details`**
  - `error={isError}` keeps the **Retry** / **View last error** recovery actions visible without a hover (preserves the existing #1240 behaviour, now via the shared shell's `--error` modifier)
- All action controls remain shared `Button` (ghost) + `Tooltip` primitives — no behaviour change.

### Removed CSS (`TunnelSidebar.css`)
Retired the bespoke row-layout blocks now owned by `SidebarListItem.css`:
`.tunnel-item`, `:hover`, `__header`, `__status` + `__status--*`, `__name`, `__actions` (+ hover), `__details`, `__type-badge`, and `.tunnel-item--error .tunnel-item__actions`.

Kept the genuinely tunnel-specific detail bits: `__stats`, `__error`/`__error-icon`/`__error-text`, `__reconnecting`/`__reconnecting-icon`/`__reconnecting-text` (the `__stats` 10px magic value was dropped so it inherits the shared details `--font-size-xs`).

### Preserved test-ids
`tunnel-item-<id>`, `tunnel-status-<id>`, `tunnel-name-<id>`, `tunnel-type-<id>`, and every action id (`tunnel-start/stop/reconnect/retry/view-error/edit/duplicate/delete-<id>`) are unchanged, so the Python system tests and unit tests keep working. The one test assertion updated: the errored status dot now carries `sidebar-list-item__status--error` (shared tone) instead of `tunnel-item__status--error` — committed as the leading `test(ui)` commit.

## Test plan
- `pnpm test` — 2762 passed
- `pnpm build` (typecheck) — clean
- `pnpm run lint` / `pnpm run format:check` — clean
- Focused `src/components/TunnelSidebar` suite — 17 passed (button/error/tooltip/delete-confirm/duplicate)

No user-facing behaviour change (recovery-action visibility was already the case pre-refactor), so no change fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up
- #1431 — the testid-catalog generator only scans literal `data-testid=` attributes, so ids forwarded through `SidebarListItem` props (tunnel row/name/status/type, and the pre-existing server/workspace consumers) are omitted from `testid-catalog.md`. The ids are still emitted at runtime and exercised by the system tests; this PR commits the regenerated catalog to keep `--check` green.
