### PR TITLE
ux: unify NetworkTools panel fields on shared field components

### DIFF
--- a/docs/changes/dev0/feature/1381-networktools-shared-fields.md
+++ b/docs/changes/dev0/feature/1381-networktools-shared-fields.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Network Tools panels: every text input (Ping / Traceroute / Port Scanner
+  host, DNS hostname + server, Wake-on-LAN MAC, Port Scanner ports) now shares
+  the same label + input + inline-error affordance as the numeric fields. The
+  Run/Send button stays disabled while a field is invalid, and obviously-invalid
+  input — an empty host/hostname, a malformed MAC, or an empty port list — is
+  flagged inline as soon as you engage the field instead of only greying the
+  button (#1381).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -867,7 +867,7 @@ for #1348.
 ### Network Tools shared field validation (#1381)
 
 Verifies every Network Tools text input shares one label + input + inline-error
-affordance and blocks the Run/Send button on invalid input. See PR #1435.
+affordance and blocks the Run/Send button on invalid input. See PR #1436.
 
 1. Open **Network Tools → Ping** (repeat for **Traceroute** and **Port
    Scanner**). Clear the **Host** field → an inline "Host is required" error

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -864,6 +864,27 @@ for #1348.
 3. **Cancel** → the scan does not start. Re-run and **Start scan** → the scan
    proceeds.
 
+### Network Tools shared field validation (#1381)
+
+Verifies every Network Tools text input shares one label + input + inline-error
+affordance and blocks the Run/Send button on invalid input. See PR #1435.
+
+1. Open **Network Tools → Ping** (repeat for **Traceroute** and **Port
+   Scanner**). Clear the **Host** field → an inline "Host is required" error
+   appears under the field and the **Start** button is disabled. Type a host →
+   the error clears and the button enables.
+2. Open **Network Tools → DNS Lookup**. Clear the **Hostname** field → an inline
+   "Hostname is required" error appears and **Run** is disabled. The **Server**
+   field renders through the same shared field (optional, no error).
+3. Open **Network Tools → Port Scanner**. Clear the **Ports** field → an inline
+   "Enter at least one port" error appears and **Start** is disabled.
+4. Open **Network Tools → Wake-on-LAN**. Type a malformed MAC (e.g. `zz:zz`) →
+   an inline "Enter a valid MAC address" error appears and **Send** is disabled.
+   Enter a valid MAC (e.g. `AA:BB:CC:DD:EE:FF`) → the error clears and **Send**
+   enables.
+5. In every case a pristine, never-touched field shows no error text (only the
+   disabled button) — the inline message appears once you engage the field.
+
 ### Remote-agent update-strategy settings persist (#1354)
 
 Verifies the per-agent update settings appear in the editor and round-trip

--- a/src/components/NetworkTools/DnsLookupPanel.tsx
+++ b/src/components/NetworkTools/DnsLookupPanel.tsx
@@ -4,6 +4,8 @@ import { Button } from "@/components/ui";
 import { networkDnsLookup } from "@/services/networkApi";
 import type { DnsRecord, DnsRecordType } from "@/types/network";
 import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
+import { NetworkTextField } from "./NetworkTextField";
+import { validateHost } from "@/utils/fieldValidation";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import { useFormSubmit } from "@/hooks/useFormSubmit";
 import { frontendLog } from "@/utils/frontendLog";
@@ -36,6 +38,8 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
 
   const hostnameRef = useAutofocusSelect<HTMLInputElement>();
 
+  const hostnameError = validateHost(hostname, "Hostname");
+
   const handleRun = useCallback(async () => {
     if (!hostname.trim()) return;
     setRecords([]);
@@ -56,7 +60,7 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
   // Enter submits the form; a mouse click goes through the Button's onClick so its
   // async lifecycle drives the pending affordance (useFormSubmit swallows the
   // Enter-path rejection that the click path uses to drive the Button error state).
-  const handleSubmit = useFormSubmit(!!hostname.trim(), handleRun);
+  const handleSubmit = useFormSubmit(!hostnameError, handleRun);
 
   const columns = [
     { key: "recordType", label: "Type" },
@@ -84,7 +88,7 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
             icon={<Play size={14} />}
             pendingLabel="Looking up…"
             errorToast={false}
-            disabled={!hostname.trim()}
+            disabled={!!hostnameError}
             onClick={(e) => {
               e.preventDefault();
               return handleRun();
@@ -97,17 +101,15 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
       </div>
 
       <div className="network-panel__form">
-        <label className="network-panel__field">
-          <span>Hostname</span>
-          <input
-            ref={hostnameRef}
-            className="network-panel__input"
-            value={hostname}
-            onChange={(e) => setHostname(e.target.value)}
-            placeholder="example.com"
-            data-testid="dns-hostname"
-          />
-        </label>
+        <NetworkTextField
+          label="Hostname"
+          value={hostname}
+          onChange={setHostname}
+          error={hostnameError}
+          inputRef={hostnameRef}
+          placeholder="example.com"
+          data-testid="dns-hostname"
+        />
         <label className="network-panel__field network-panel__field--small">
           <span>Type</span>
           <select
@@ -123,15 +125,14 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
             ))}
           </select>
         </label>
-        <label className="network-panel__field network-panel__field--small">
-          <span>Server (auto)</span>
-          <input
-            className="network-panel__input"
-            value={server}
-            onChange={(e) => setServer(e.target.value)}
-            placeholder="8.8.8.8"
-          />
-        </label>
+        <NetworkTextField
+          label="Server (auto)"
+          value={server}
+          onChange={setServer}
+          small
+          placeholder="8.8.8.8"
+          data-testid="dns-server"
+        />
       </div>
 
       {error && <div className="network-panel__error">{error}</div>}

--- a/src/components/NetworkTools/DnsLookupPanel.validation.test.tsx
+++ b/src/components/NetworkTools/DnsLookupPanel.validation.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Tests for DnsLookupPanel field validation (#1381).
+ *
+ * The Hostname (and optional Server) fields are routed through the shared
+ * {@link NetworkTextField}; a cleared hostname surfaces the inline error and
+ * blocks Run.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { DnsLookupPanel } from "./DnsLookupPanel";
+
+vi.mock("@/services/networkApi", () => ({
+  networkDnsLookup: vi.fn(() => Promise.resolve({ records: [], queryMs: 0 })),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function runButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="dns-run"]')!;
+}
+
+function hostnameInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="dns-hostname"]')!;
+}
+
+function fieldError(): Element | null {
+  return container.querySelector(".network-panel__field-error");
+}
+
+describe("DnsLookupPanel — hostname validation", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("blocks Run when the hostname is empty", async () => {
+    await act(async () => {
+      root.render(<DnsLookupPanel />);
+    });
+    expect(runButton().disabled).toBe(true);
+  });
+
+  it("routes the Server field through the shared field component", async () => {
+    await act(async () => {
+      root.render(<DnsLookupPanel />);
+    });
+    expect(container.querySelector('[data-testid="dns-server"]')).not.toBeNull();
+  });
+
+  it("renders the hostname through the shared field and flags it inline once cleared", async () => {
+    await act(async () => {
+      root.render(<DnsLookupPanel prefillHost="example.com" />);
+    });
+    await act(async () => setInputValue(hostnameInput(), ""));
+    expect(runButton().disabled).toBe(true);
+    expect(fieldError()?.textContent).toContain("Hostname is required");
+  });
+});

--- a/src/components/NetworkTools/NetworkTextField.tsx
+++ b/src/components/NetworkTools/NetworkTextField.tsx
@@ -1,4 +1,4 @@
-import type { Ref } from "react";
+import { useState, type Ref } from "react";
 
 interface NetworkTextFieldProps {
   /** Field label text. */
@@ -7,7 +7,7 @@ interface NetworkTextFieldProps {
   value: string;
   /** Change handler receiving the raw string. */
   onChange: (value: string) => void;
-  /** Inline validation message; when set, the field renders its error state. */
+  /** Inline validation message; surfaced once the field has been touched. */
   error?: string | null;
   /** Apply the `--small` compact width modifier. */
   small?: boolean;
@@ -15,6 +15,8 @@ interface NetworkTextFieldProps {
   placeholder?: string;
   /** Ref forwarded to the underlying input (e.g. to autofocus the primary field). */
   inputRef?: Ref<HTMLInputElement>;
+  /** Called when the input loses focus (fires after the field is marked touched). */
+  onBlur?: () => void;
   /** Test hook forwarded to the input. */
   "data-testid"?: string;
 }
@@ -23,6 +25,11 @@ interface NetworkTextFieldProps {
  * A labelled text input for the network tools panels with inline validation
  * feedback — the text counterpart to {@link NetworkNumberField}, so the error
  * class + `aria-invalid` + error message live in one place.
+ *
+ * The `error` is only surfaced once the user has touched the field (typed into
+ * it or blurred it), so a pristine required field reads calm — the Run/Send
+ * button stays disabled for the gating, and the inline message appears as soon
+ * as the user engages.
  */
 export function NetworkTextField({
   label,
@@ -32,21 +39,32 @@ export function NetworkTextField({
   small,
   placeholder,
   inputRef,
+  onBlur,
   "data-testid": testId,
 }: NetworkTextFieldProps) {
+  const [touched, setTouched] = useState(false);
+  const showError = touched ? error : null;
+
   return (
     <label className={`network-panel__field${small ? " network-panel__field--small" : ""}`}>
       <span>{label}</span>
       <input
         ref={inputRef}
-        className={`network-panel__input${error ? " network-panel__input--error" : ""}`}
+        className={`network-panel__input${showError ? " network-panel__input--error" : ""}`}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => {
+          setTouched(true);
+          onChange(e.target.value);
+        }}
+        onBlur={() => {
+          setTouched(true);
+          onBlur?.();
+        }}
         placeholder={placeholder}
-        aria-invalid={error ? true : undefined}
+        aria-invalid={showError ? true : undefined}
         data-testid={testId}
       />
-      {error && <span className="network-panel__field-error">{error}</span>}
+      {showError && <span className="network-panel__field-error">{showError}</span>}
     </label>
   );
 }

--- a/src/components/NetworkTools/PingPanel.host-validation.test.tsx
+++ b/src/components/NetworkTools/PingPanel.host-validation.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for PingPanel host-field validation (#1381).
+ *
+ * The Host field is routed through the shared {@link NetworkTextField}, so a
+ * cleared host surfaces the inline `network-panel__field-error` affordance and
+ * blocks Start rather than only greying the button.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { PingPanel } from "./PingPanel";
+
+vi.mock("@/services/networkApi", () => ({
+  networkPingStart: vi.fn(() => Promise.resolve("task-1")),
+  networkPingStop: vi.fn(() => Promise.resolve()),
+  onPingResult: vi.fn(() => Promise.resolve(() => {})),
+  onPingComplete: vi.fn(() => Promise.resolve(() => {})),
+  onPingError: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("./LatencyChart", () => ({ LatencyChart: () => null }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function startButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="ping-start"]')!;
+}
+
+function hostInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="ping-host"]')!;
+}
+
+function fieldError(): Element | null {
+  return container.querySelector(".network-panel__field-error");
+}
+
+describe("PingPanel — host validation", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("blocks Start when the host is empty", async () => {
+    await act(async () => {
+      root.render(<PingPanel />);
+    });
+    expect(startButton().disabled).toBe(true);
+  });
+
+  it("renders the host through the shared field and flags it inline once cleared", async () => {
+    await act(async () => {
+      root.render(<PingPanel prefillHost="example.com" />);
+    });
+    await act(async () => setInputValue(hostInput(), ""));
+    expect(startButton().disabled).toBe(true);
+    expect(fieldError()?.textContent).toContain("Host is required");
+  });
+
+  it("enables Start and shows no host error for a valid host", async () => {
+    await act(async () => {
+      root.render(<PingPanel prefillHost="example.com" />);
+    });
+    expect(startButton().disabled).toBe(false);
+    expect(container.textContent).not.toContain("Host is required");
+  });
+});

--- a/src/components/NetworkTools/PingPanel.tsx
+++ b/src/components/NetworkTools/PingPanel.tsx
@@ -13,7 +13,8 @@ import {
 import type { PingResult, PingStats, DiagnosticStatus } from "@/types/network";
 import { LatencyChart } from "./LatencyChart";
 import { NetworkNumberField } from "./NetworkNumberField";
-import { validateIntRange } from "@/utils/fieldValidation";
+import { NetworkTextField } from "./NetworkTextField";
+import { validateHost, validateIntRange } from "@/utils/fieldValidation";
 import { frontendLog } from "@/utils/frontendLog";
 
 interface PingPanelProps {
@@ -77,7 +78,8 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
     label: "Count",
     allowEmpty: true,
   });
-  const canStart = !!host.trim() && !intervalError && !countError;
+  const hostError = validateHost(host);
+  const canStart = !hostError && !intervalError && !countError;
 
   const handleStart = useCallback(async () => {
     if (!canStart) return;
@@ -200,17 +202,15 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
       </div>
 
       <div className="network-panel__form">
-        <label className="network-panel__field">
-          <span>Host</span>
-          <input
-            ref={hostRef}
-            className="network-panel__input"
-            value={host}
-            onChange={(e) => setHost(e.target.value)}
-            placeholder="example.com"
-            data-testid="ping-host"
-          />
-        </label>
+        <NetworkTextField
+          label="Host"
+          value={host}
+          onChange={setHost}
+          error={hostError}
+          inputRef={hostRef}
+          placeholder="example.com"
+          data-testid="ping-host"
+        />
         <NetworkNumberField
           label="Interval (ms)"
           value={intervalMs}

--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -13,7 +13,8 @@ import {
 import type { PortScanSummary } from "@/types/network";
 import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
 import { NetworkNumberField } from "./NetworkNumberField";
-import { validateIntRange } from "@/utils/fieldValidation";
+import { NetworkTextField } from "./NetworkTextField";
+import { validateHost, validateIntRange } from "@/utils/fieldValidation";
 import { estimateScanProbes } from "@/utils/scanEstimate";
 import { useNetworkTask, type NetworkTaskContext } from "@/hooks/useNetworkTask";
 
@@ -49,7 +50,9 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
     max: 2000,
     label: "Concurrency",
   });
-  const canRun = !!host.trim() && !timeoutError && !concurrencyError;
+  const hostError = validateHost(host);
+  const portsError = ports.trim() ? null : "Enter at least one port";
+  const canRun = !hostError && !portsError && !timeoutError && !concurrencyError;
 
   // Warn before a very large scan. The estimate factors in the CIDR host-count
   // as well as the port count, so a small port list over a wide block still
@@ -176,27 +179,23 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
       </div>
 
       <div className="network-panel__form">
-        <label className="network-panel__field">
-          <span>Host / CIDR</span>
-          <input
-            ref={hostRef}
-            className="network-panel__input"
-            value={host}
-            onChange={(e) => setHost(e.target.value)}
-            placeholder="192.168.1.1, 10.0.0.0/24, example.com"
-            data-testid="port-scanner-host"
-          />
-        </label>
-        <label className="network-panel__field">
-          <span>Ports</span>
-          <input
-            className="network-panel__input"
-            value={ports}
-            onChange={(e) => setPorts(e.target.value)}
-            placeholder="22,80,443,8080-8090"
-            data-testid="port-scanner-ports"
-          />
-        </label>
+        <NetworkTextField
+          label="Host / CIDR"
+          value={host}
+          onChange={setHost}
+          error={hostError}
+          inputRef={hostRef}
+          placeholder="192.168.1.1, 10.0.0.0/24, example.com"
+          data-testid="port-scanner-host"
+        />
+        <NetworkTextField
+          label="Ports"
+          value={ports}
+          onChange={setPorts}
+          error={portsError}
+          placeholder="22,80,443,8080-8090"
+          data-testid="port-scanner-ports"
+        />
         <NetworkNumberField
           label="Timeout (ms)"
           value={timeoutMs}

--- a/src/components/NetworkTools/PortScannerPanel.validation.test.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.validation.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for PortScannerPanel host/ports validation (#1381).
+ *
+ * The Host / CIDR and Ports fields are routed through the shared
+ * {@link NetworkTextField}; clearing either one surfaces the inline error and
+ * blocks Start.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { PortScannerPanel } from "./PortScannerPanel";
+
+vi.mock("@/services/networkApi", () => ({
+  networkPortScan: vi.fn(() => Promise.resolve("task-1")),
+  networkPortScanCancel: vi.fn(() => Promise.resolve()),
+  onScanResult: vi.fn(() => Promise.resolve(() => {})),
+  onScanComplete: vi.fn(() => Promise.resolve(() => {})),
+  onScanError: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function runButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="port-scanner-run"]')!;
+}
+
+function hostInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="port-scanner-host"]')!;
+}
+
+function portsInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="port-scanner-ports"]')!;
+}
+
+describe("PortScannerPanel — host/ports validation", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("blocks Start when the host is empty", async () => {
+    await act(async () => {
+      root.render(<PortScannerPanel />);
+    });
+    expect(runButton().disabled).toBe(true);
+  });
+
+  it("flags the host inline and blocks Start once cleared", async () => {
+    await act(async () => {
+      root.render(<PortScannerPanel prefillHost="example.com" />);
+    });
+    await act(async () => setInputValue(hostInput(), ""));
+    expect(runButton().disabled).toBe(true);
+    expect(container.querySelector(".network-panel__field-error")?.textContent).toContain(
+      "Host is required"
+    );
+  });
+
+  it("flags the ports inline and blocks Start once cleared", async () => {
+    await act(async () => {
+      root.render(<PortScannerPanel prefillHost="example.com" />);
+    });
+    await act(async () => setInputValue(portsInput(), ""));
+    expect(runButton().disabled).toBe(true);
+    expect(container.textContent).toContain("at least one port");
+  });
+
+  it("enables Start with a valid host and default ports", async () => {
+    await act(async () => {
+      root.render(<PortScannerPanel prefillHost="example.com" />);
+    });
+    expect(runButton().disabled).toBe(false);
+  });
+});

--- a/src/components/NetworkTools/TraceroutePanel.host-validation.test.tsx
+++ b/src/components/NetworkTools/TraceroutePanel.host-validation.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for TraceroutePanel host-field validation (#1381).
+ *
+ * The Host field is routed through the shared {@link NetworkTextField}; a
+ * cleared host surfaces the inline error affordance and blocks Start.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TraceroutePanel } from "./TraceroutePanel";
+
+vi.mock("@/services/networkApi", () => ({
+  networkTraceroute: vi.fn(() => Promise.resolve("task-1")),
+  networkTracerouteCancel: vi.fn(() => Promise.resolve()),
+  onTracerouteHop: vi.fn(() => Promise.resolve(() => {})),
+  onTracerouteComplete: vi.fn(() => Promise.resolve(() => {})),
+  onTracerouteError: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function runButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="traceroute-run"]')!;
+}
+
+function hostInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="traceroute-host"]')!;
+}
+
+function fieldError(): Element | null {
+  return container.querySelector(".network-panel__field-error");
+}
+
+describe("TraceroutePanel — host validation", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("blocks Start when the host is empty", async () => {
+    await act(async () => {
+      root.render(<TraceroutePanel />);
+    });
+    expect(runButton().disabled).toBe(true);
+  });
+
+  it("renders the host through the shared field and flags it inline once cleared", async () => {
+    await act(async () => {
+      root.render(<TraceroutePanel prefillHost="example.com" />);
+    });
+    await act(async () => setInputValue(hostInput(), ""));
+    expect(runButton().disabled).toBe(true);
+    expect(fieldError()?.textContent).toContain("Host is required");
+  });
+
+  it("enables Start for a valid host", async () => {
+    await act(async () => {
+      root.render(<TraceroutePanel prefillHost="example.com" />);
+    });
+    expect(runButton().disabled).toBe(false);
+  });
+});

--- a/src/components/NetworkTools/TraceroutePanel.tsx
+++ b/src/components/NetworkTools/TraceroutePanel.tsx
@@ -11,7 +11,8 @@ import {
 import type { TracerouteHop } from "@/types/network";
 import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
 import { NetworkNumberField } from "./NetworkNumberField";
-import { validateIntRange } from "@/utils/fieldValidation";
+import { NetworkTextField } from "./NetworkTextField";
+import { validateHost, validateIntRange } from "@/utils/fieldValidation";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import { useFormSubmit } from "@/hooks/useFormSubmit";
 import { useNetworkTask, type NetworkTaskContext } from "@/hooks/useNetworkTask";
@@ -29,7 +30,8 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
   const hostRef = useAutofocusSelect<HTMLInputElement>();
 
   const maxHopsError = validateIntRange(maxHops, { min: 1, max: 255, label: "Max hops" });
-  const canRun = !!host.trim() && !maxHopsError;
+  const hostError = validateHost(host);
+  const canRun = !hostError && !maxHopsError;
 
   const subscribe = useCallback(async ({ matchesTask, register, finish }: NetworkTaskContext) => {
     register(
@@ -122,17 +124,15 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
       </div>
 
       <div className="network-panel__form">
-        <label className="network-panel__field">
-          <span>Host</span>
-          <input
-            ref={hostRef}
-            className="network-panel__input"
-            value={host}
-            onChange={(e) => setHost(e.target.value)}
-            placeholder="example.com"
-            data-testid="traceroute-host"
-          />
-        </label>
+        <NetworkTextField
+          label="Host"
+          value={host}
+          onChange={setHost}
+          error={hostError}
+          inputRef={hostRef}
+          placeholder="example.com"
+          data-testid="traceroute-host"
+        />
         <NetworkNumberField
           label="Max Hops"
           value={maxHops}

--- a/src/components/NetworkTools/WolPanel.mac-validation.test.tsx
+++ b/src/components/NetworkTools/WolPanel.mac-validation.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for WolPanel MAC-field validation (#1381).
+ *
+ * The MAC Address field is routed through the shared {@link NetworkTextField};
+ * a malformed MAC surfaces the inline error and blocks Send, while a valid MAC
+ * clears the error and enables it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { withTooltip } from "@/test/tooltip";
+import { WolPanel } from "./WolPanel";
+
+vi.mock("@/services/networkApi", () => ({
+  networkWolSend: vi.fn(() => Promise.resolve()),
+  networkWolDevicesList: vi.fn(() => Promise.resolve([])),
+  networkWolDeviceSave: vi.fn(() => Promise.resolve()),
+  networkWolDeviceDelete: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function sendButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="wol-send"]')!;
+}
+
+function macInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="wol-mac"]')!;
+}
+
+async function renderPanel() {
+  await act(async () => {
+    root.render(withTooltip(<WolPanel />));
+  });
+  await flush();
+}
+
+describe("WolPanel — MAC validation", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("blocks Send while the MAC is empty", async () => {
+    await renderPanel();
+    expect(sendButton().disabled).toBe(true);
+  });
+
+  it("flags a malformed MAC inline and blocks Send", async () => {
+    await renderPanel();
+    await act(async () => setInputValue(macInput(), "zz:zz"));
+    await flush();
+    expect(sendButton().disabled).toBe(true);
+    expect(container.querySelector(".network-panel__field-error")?.textContent).toContain(
+      "valid MAC address"
+    );
+  });
+
+  it("enables Send and clears the error for a valid MAC", async () => {
+    await renderPanel();
+    await act(async () => setInputValue(macInput(), "AA:BB:CC:DD:EE:FF"));
+    await flush();
+    expect(sendButton().disabled).toBe(false);
+    expect(container.querySelector(".network-panel__field-error")).toBeNull();
+  });
+});

--- a/src/components/NetworkTools/WolPanel.tsx
+++ b/src/components/NetworkTools/WolPanel.tsx
@@ -28,9 +28,10 @@ export function WolPanel() {
 
   const macRef = useAutofocusSelect<HTMLInputElement>();
 
+  const macError = useMemo(() => validateMac(mac), [mac]);
   const portError = validatePort(port);
   const broadcastError = validateHost(broadcast, "Broadcast address");
-  const canSend = !!mac.trim() && !portError && !broadcastError;
+  const canSend = !macError && !portError && !broadcastError;
   const [savedDevices, setSavedDevices] = useState<WolDevice[]>([]);
   const [history, setHistory] = useState<WolHistoryEntry[]>([]);
   const [sentMessage, setSentMessage] = useState<string | null>(null);
@@ -38,7 +39,6 @@ export function WolPanel() {
   const [saveModalOpen, setSaveModalOpen] = useState(false);
   const [saveName, setSaveName] = useState("");
 
-  const macError = useMemo(() => validateMac(mac), [mac]);
   const canSaveDevice = saveName.trim().length > 0 && !macError;
 
   const loadDevices = useCallback(async () => {
@@ -156,17 +156,15 @@ export function WolPanel() {
       </div>
 
       <div className="network-panel__form">
-        <label className="network-panel__field">
-          <span>MAC Address</span>
-          <input
-            ref={macRef}
-            className="network-panel__input"
-            value={mac}
-            onChange={(e) => setMac(e.target.value)}
-            placeholder="AA:BB:CC:DD:EE:FF"
-            data-testid="wol-mac"
-          />
-        </label>
+        <NetworkTextField
+          label="MAC Address"
+          value={mac}
+          onChange={setMac}
+          error={macError}
+          inputRef={macRef}
+          placeholder="AA:BB:CC:DD:EE:FF"
+          data-testid="wol-mac"
+        />
         <NetworkTextField
           label="Broadcast"
           value={broadcast}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -153,6 +153,7 @@ Fixed strings — match exactly.
 | `dns-lookup-panel` | `src/components/NetworkTools/DnsLookupPanel.tsx` |
 | `dns-record-type` | `src/components/NetworkTools/DnsLookupPanel.tsx` |
 | `dns-run` | `src/components/NetworkTools/DnsLookupPanel.tsx` |
+| `dns-server` | `src/components/NetworkTools/DnsLookupPanel.tsx` |
 | `export-config-btn` | `src/components/Settings/PortableModeSettings.tsx` |
 | `export-confirm-password` | `src/components/ExportImport/ExportDialog.tsx` |
 | `export-dialog-title` | `src/components/ExportImport/ExportDialog.tsx` |


### PR DESCRIPTION
Closes #1381
Refs #1357 #1380

## Summary

PR #1380 introduced `NetworkTextField` / `NetworkNumberField` but several plain
text inputs still hand-rolled `network-panel__input` markup with no shared
inline-error affordance. This routes the remaining NetworkTools text inputs
through the shared `NetworkTextField` so label + input + inline-error live in one
place, and adds inline validation that gates the Run/Send buttons:

- **Ping / Traceroute / Port Scanner host** → `NetworkTextField`, required (host).
- **DNS hostname** → `NetworkTextField`, required; **DNS server** → shared field
  (optional).
- **Port Scanner ports** → `NetworkTextField`, required ("Enter at least one port").
- **Wake-on-LAN MAC** → `NetworkTextField`, validated MAC format (Send now gates
  on a valid MAC, not just a non-empty one).

`NetworkTextField` now surfaces its `error` only once the field has been touched
(typed into or blurred), so a pristine required field reads calm — the disabled
button provides the gating and the inline message appears as soon as the user
engages. Existing validation helpers (`validateHost`, `validateMac`) are reused.

Per the issue, the larger migration of the whole `NetworkTools/` directory to the
app-wide `ui/Field` + `ui/Input` primitives is deferred to a follow-up:
**#1435**.

## Test plan

Automated (`pnpm test`, NetworkTools suite):

- New per-panel inline-validation tests assert each field renders via the shared
  component, an invalid/cleared value shows the inline `network-panel__field-error`,
  and the Run/Send button is disabled while invalid.
- Full frontend suite green (2801 tests); `tsc --noEmit`, `eslint`, `prettier`,
  and `markdownlint` all pass.

Manual: see `docs/testing.md` → "Network Tools shared field validation (#1381)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
