### PR TITLE
refactor(backend): hoist shared local-IPC + NDJSON transport into core (Closes #1386)

### DIFF
--- a/agent/src/io/transport.rs
+++ b/agent/src/io/transport.rs
@@ -85,13 +85,14 @@ where
 }
 
 /// Write a pre-serialised JSON string as an NDJSON line to the writer.
+///
+/// Delegates to the shared [`termihub_core::ipc::write_line`] framing helper so
+/// the desktop spawn IPC and the agent transport share one NDJSON writer (#1386).
 pub async fn write_line<W: AsyncWriteExt + Unpin>(
     writer: &mut W,
     json: &str,
 ) -> anyhow::Result<()> {
-    writer.write_all(json.as_bytes()).await?;
-    writer.write_all(b"\n").await?;
-    writer.flush().await?;
+    termihub_core::ipc::write_line(writer, json).await?;
     Ok(())
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "sync", "net", "time", "macros", "io-util"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 surge-ping = "0.8"
 hickory-resolver = { version = "0.26", features = ["tokio", "system-config"] }

--- a/core/src/ipc/local_socket.rs
+++ b/core/src/ipc/local_socket.rs
@@ -1,0 +1,198 @@
+//! Protocol-agnostic local-IPC transport: a Unix domain socket on unix and a
+//! Windows named pipe on windows, behind one small bind/accept/connect API.
+//!
+//! The transport moves opaque byte streams — it imposes no framing — so any
+//! protocol (NDJSON request/response, length-prefixed binary frames, …) can be
+//! layered on top. Concrete socket/pipe types are erased behind [`BoxedReader`]
+//! and [`BoxedWriter`] so consumers stay fully platform-independent.
+//!
+//! ```text
+//!  bind(address) ─► LocalSocketListener ─► accept() ─► (BoxedReader, BoxedWriter)
+//!  connect(address) ───────────────────────────────► (BoxedReader, BoxedWriter)
+//! ```
+//!
+//! Semantics are deliberately **fail-fast one-shot**:
+//! - [`connect`] tries once and returns the underlying error immediately (no
+//!   retry) — suited to a "is a rendezvous instance already running?" probe.
+//! - [`LocalSocketListener::bind`] only reclaims a socket path that is *stale*
+//!   (present on disk but with nothing listening); if a live instance owns the
+//!   endpoint, `bind` fails so the caller can treat that as "not the
+//!   rendezvous". On windows this maps to `first_pipe_instance(true)`.
+//!
+//! Consumers that need a retrying connect or a security-hardened listener
+//! (e.g. the agent session daemon) layer that policy on top rather than baking
+//! it in here.
+
+use std::io;
+
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Boxed reader half of a local-IPC connection (Unix socket or named pipe).
+pub type BoxedReader = Box<dyn AsyncRead + Send + Unpin>;
+/// Boxed writer half of a local-IPC connection (Unix socket or named pipe).
+pub type BoxedWriter = Box<dyn AsyncWrite + Send + Unpin>;
+
+/// A listening local-IPC endpoint (Unix domain socket or Windows named pipe).
+pub struct LocalSocketListener {
+    _private: (),
+}
+
+impl LocalSocketListener {
+    /// Bind a listener at `address`, reclaiming a stale endpoint if present.
+    ///
+    /// `address` is a filesystem path on unix and a `\\.\pipe\…` name on
+    /// windows. Fails if a live instance already owns the endpoint.
+    pub async fn bind(_address: &str) -> io::Result<Self> {
+        todo!("implemented in the following commit")
+    }
+
+    /// Accept the next client connection, returning erased read/write halves.
+    pub async fn accept(&mut self) -> io::Result<(BoxedReader, BoxedWriter)> {
+        todo!("implemented in the following commit")
+    }
+}
+
+/// Connect once to `address`, failing fast if nothing is listening.
+pub async fn connect(_address: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
+    todo!("implemented in the following commit")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Build a unique per-process endpoint address so concurrent tests don't
+    /// collide on the same socket path / pipe name.
+    fn unique_address(tag: &str) -> String {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        #[cfg(unix)]
+        {
+            std::env::temp_dir()
+                .join(format!("termihub-core-ipc-{tag}-{pid}-{n}.sock"))
+                .to_string_lossy()
+                .into_owned()
+        }
+        #[cfg(windows)]
+        {
+            format!(r"\\.\pipe\termihub-core-ipc-{tag}-{pid}-{n}")
+        }
+    }
+
+    /// Round-trip opaque bytes through the platform transport: bind, accept on a
+    /// server task, connect from the client, echo the bytes back.
+    #[tokio::test]
+    async fn bind_accept_connect_round_trip() {
+        let address = unique_address("rt");
+        let mut listener = LocalSocketListener::bind(&address).await.expect("bind");
+
+        let server = tokio::spawn(async move {
+            let (mut reader, mut writer) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 5];
+            reader.read_exact(&mut buf).await.expect("server read");
+            writer.write_all(&buf).await.expect("server echo");
+            writer.flush().await.expect("server flush");
+        });
+
+        let (mut reader, mut writer) = connect(&address).await.expect("connect");
+        writer.write_all(b"hello").await.expect("client write");
+        writer.flush().await.expect("client flush");
+        let mut got = [0u8; 5];
+        reader.read_exact(&mut got).await.expect("client read");
+        assert_eq!(&got, b"hello");
+
+        server.await.expect("server task");
+    }
+
+    /// A second connection to the same listener must also succeed (verifies the
+    /// listener stages a fresh instance after each accept on windows).
+    #[tokio::test]
+    async fn listener_accepts_sequential_connections() {
+        let address = unique_address("seq");
+        let mut listener = LocalSocketListener::bind(&address).await.expect("bind");
+
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (mut reader, mut writer) = listener.accept().await.expect("accept");
+                let mut b = [0u8; 1];
+                reader.read_exact(&mut b).await.expect("server read");
+                writer.write_all(&b).await.expect("server echo");
+                writer.flush().await.expect("server flush");
+            }
+        });
+
+        for i in 0..2u8 {
+            let (mut reader, mut writer) = connect(&address).await.expect("connect");
+            writer.write_all(&[i]).await.expect("client write");
+            writer.flush().await.expect("client flush");
+            let mut got = [0u8; 1];
+            reader.read_exact(&mut got).await.expect("client read");
+            assert_eq!(got[0], i);
+            drop(reader);
+            drop(writer);
+        }
+
+        server.await.expect("server task");
+    }
+
+    /// `connect` fails fast (does not hang/retry) when no listener is present.
+    #[tokio::test]
+    async fn connect_fails_fast_when_absent() {
+        let address = unique_address("absent");
+        let result = connect(&address).await;
+        assert!(result.is_err(), "connect to a dead endpoint must error");
+    }
+
+    /// A stale unix socket file (present on disk, nothing listening) is removed
+    /// so `bind` succeeds — the crashed-instance recovery path.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bind_reclaims_stale_unix_socket() {
+        let address = unique_address("stale");
+
+        // Bind then drop a listener: tokio does not unlink the socket file on
+        // drop, so the path is left behind with nothing listening (stale).
+        let first = tokio::net::UnixListener::bind(&address).expect("first bind");
+        drop(first);
+        assert!(
+            std::path::Path::new(&address).exists(),
+            "stale socket file should remain on disk"
+        );
+
+        // A fresh bind must reclaim the stale path and be usable.
+        let mut listener = LocalSocketListener::bind(&address)
+            .await
+            .expect("bind reclaims stale socket");
+        let server = tokio::spawn(async move {
+            let (mut reader, mut writer) = listener.accept().await.expect("accept");
+            let mut b = [0u8; 2];
+            reader.read_exact(&mut b).await.expect("server read");
+            writer.write_all(&b).await.expect("server echo");
+            writer.flush().await.expect("server flush");
+        });
+        let (mut reader, mut writer) = connect(&address).await.expect("connect");
+        writer.write_all(b"ok").await.expect("write");
+        writer.flush().await.expect("flush");
+        let mut got = [0u8; 2];
+        reader.read_exact(&mut got).await.expect("read");
+        assert_eq!(&got, b"ok");
+        server.await.expect("server task");
+    }
+
+    /// Binding an endpoint a live instance already owns fails (the "not the
+    /// rendezvous" signal), rather than stealing it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bind_rejects_live_endpoint() {
+        let address = unique_address("live");
+        let _held = LocalSocketListener::bind(&address).await.expect("first bind");
+        let second = LocalSocketListener::bind(&address).await;
+        assert!(
+            second.is_err(),
+            "binding an endpoint owned by a live listener must fail"
+        );
+    }
+}

--- a/core/src/ipc/local_socket.rs
+++ b/core/src/ipc/local_socket.rs
@@ -276,7 +276,9 @@ mod tests {
     #[tokio::test]
     async fn bind_rejects_live_endpoint() {
         let address = unique_address("live");
-        let _held = LocalSocketListener::bind(&address).await.expect("first bind");
+        let _held = LocalSocketListener::bind(&address)
+            .await
+            .expect("first bind");
         let second = LocalSocketListener::bind(&address).await;
         assert!(
             second.is_err(),

--- a/core/src/ipc/local_socket.rs
+++ b/core/src/ipc/local_socket.rs
@@ -23,8 +23,6 @@
 //! (e.g. the agent session daemon) layer that policy on top rather than baking
 //! it in here.
 
-use std::io;
-
 use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Boxed reader half of a local-IPC connection (Unix socket or named pipe).
@@ -32,29 +30,119 @@ pub type BoxedReader = Box<dyn AsyncRead + Send + Unpin>;
 /// Boxed writer half of a local-IPC connection (Unix socket or named pipe).
 pub type BoxedWriter = Box<dyn AsyncWrite + Send + Unpin>;
 
-/// A listening local-IPC endpoint (Unix domain socket or Windows named pipe).
-pub struct LocalSocketListener {
-    _private: (),
+#[cfg(unix)]
+pub use unix_impl::{connect, LocalSocketListener};
+#[cfg(windows)]
+pub use windows_impl::{connect, LocalSocketListener};
+
+// ── Unix domain socket transport ────────────────────────────────────
+
+#[cfg(unix)]
+mod unix_impl {
+    use super::{BoxedReader, BoxedWriter};
+    use std::io;
+    use std::path::PathBuf;
+    use tokio::net::{UnixListener, UnixStream};
+
+    /// A listening Unix domain socket.
+    pub struct LocalSocketListener {
+        listener: UnixListener,
+    }
+
+    impl LocalSocketListener {
+        /// Bind a listener at the socket path `address`, reclaiming a stale
+        /// socket file if present.
+        ///
+        /// "Stale" means the file exists on disk but nothing is listening: a
+        /// connect probe fails, so the file is safe to remove (a crashed
+        /// instance left it behind). If a *live* instance owns the path, the
+        /// probe succeeds, the file is left untouched, and the subsequent
+        /// `bind` fails with `AddrInUse` — the caller's "not the rendezvous"
+        /// signal.
+        pub async fn bind(address: &str) -> io::Result<Self> {
+            let path = PathBuf::from(address);
+            if path.exists() && UnixStream::connect(&path).await.is_err() {
+                let _ = std::fs::remove_file(&path);
+            }
+            let listener = UnixListener::bind(&path)?;
+            Ok(Self { listener })
+        }
+
+        /// Accept the next client connection, returning erased read/write halves.
+        pub async fn accept(&mut self) -> io::Result<(BoxedReader, BoxedWriter)> {
+            let (stream, _addr) = self.listener.accept().await?;
+            let (reader, writer) = stream.into_split();
+            Ok((Box::new(reader), Box::new(writer)))
+        }
+    }
+
+    /// Connect once to a socket path, failing fast if nothing is listening.
+    pub async fn connect(address: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
+        let (reader, writer) = UnixStream::connect(address).await?.into_split();
+        Ok((Box::new(reader), Box::new(writer)))
+    }
 }
 
-impl LocalSocketListener {
-    /// Bind a listener at `address`, reclaiming a stale endpoint if present.
+// ── Windows named-pipe transport ────────────────────────────────────
+
+#[cfg(windows)]
+mod windows_impl {
+    use super::{BoxedReader, BoxedWriter};
+    use std::io;
+    use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
+
+    /// A listening Windows named pipe.
     ///
-    /// `address` is a filesystem path on unix and a `\\.\pipe\…` name on
-    /// windows. Fails if a live instance already owns the endpoint.
-    pub async fn bind(_address: &str) -> io::Result<Self> {
-        todo!("implemented in the following commit")
+    /// Named pipes serve one client per server instance, so the listener keeps
+    /// the next (not-yet-connected) instance ready and stages a fresh one each
+    /// time a client is accepted.
+    pub struct LocalSocketListener {
+        name: String,
+        /// The next pipe instance, waiting for a client to connect.
+        next: Option<NamedPipeServer>,
     }
 
-    /// Accept the next client connection, returning erased read/write halves.
-    pub async fn accept(&mut self) -> io::Result<(BoxedReader, BoxedWriter)> {
-        todo!("implemented in the following commit")
-    }
-}
+    impl LocalSocketListener {
+        /// Bind the first pipe instance at pipe name `address`.
+        ///
+        /// `first_pipe_instance(true)` fails if another instance already owns
+        /// the pipe — the caller's "not the rendezvous" signal, the exact
+        /// analog of the unix `AddrInUse` case.
+        pub async fn bind(address: &str) -> io::Result<Self> {
+            let next = ServerOptions::new()
+                .first_pipe_instance(true)
+                .create(address)?;
+            Ok(Self {
+                name: address.to_string(),
+                next: Some(next),
+            })
+        }
 
-/// Connect once to `address`, failing fast if nothing is listening.
-pub async fn connect(_address: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
-    todo!("implemented in the following commit")
+        /// Accept the next client connection, returning erased read/write halves.
+        pub async fn accept(&mut self) -> io::Result<(BoxedReader, BoxedWriter)> {
+            let server = self
+                .next
+                .as_ref()
+                .expect("listener always holds a pending pipe instance");
+            server.connect().await?;
+
+            // Hand off the connected instance and stage a fresh one for the
+            // next client before serving this one, so no client races into a
+            // missing pipe.
+            let connected = self.next.take().expect("pending instance present");
+            self.next = Some(ServerOptions::new().create(&self.name)?);
+
+            let (reader, writer) = tokio::io::split(connected);
+            Ok((Box::new(reader), Box::new(writer)))
+        }
+    }
+
+    /// Connect once to a pipe name, failing fast if it is not present.
+    pub async fn connect(address: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
+        let client = ClientOptions::new().open(address)?;
+        let (reader, writer) = tokio::io::split(client);
+        Ok((Box::new(reader), Box::new(writer)))
+    }
 }
 
 #[cfg(test)]

--- a/core/src/ipc/mod.rs
+++ b/core/src/ipc/mod.rs
@@ -1,0 +1,18 @@
+//! Shared local-IPC transport and NDJSON framing (#1386).
+//!
+//! Consolidates the cross-platform local-socket / named-pipe transport plus
+//! newline-delimited-JSON framing that was previously duplicated between the
+//! desktop spawn IPC (`src-tauri/src/spawn`) and the agent daemon/JSON-RPC
+//! transports.
+//!
+//! - [`local_socket`] — a protocol-agnostic Unix-domain-socket / named-pipe
+//!   transport: [`LocalSocketListener`] (bind/accept) plus a fail-fast
+//!   [`connect`]. It moves opaque byte streams and imposes no framing.
+//! - [`ndjson`] — newline-delimited-JSON line read/write helpers layered on top
+//!   of any async reader/writer.
+
+pub mod local_socket;
+pub mod ndjson;
+
+pub use local_socket::{connect, BoxedReader, BoxedWriter, LocalSocketListener};
+pub use ndjson::{read_line, write_line};

--- a/core/src/ipc/ndjson.rs
+++ b/core/src/ipc/ndjson.rs
@@ -1,0 +1,101 @@
+//! Newline-delimited JSON (NDJSON) framing helpers.
+//!
+//! A single serialized JSON message per line, terminated by `\n`. This is the
+//! framing shared by the desktop spawn IPC and the agent's JSON-RPC transport.
+//! The helpers are protocol-agnostic — they move opaque `&str`/`String` lines
+//! and never inspect the JSON — so any newline-delimited protocol can reuse
+//! them.
+
+use std::io;
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Write `line` followed by a single `\n` and flush the writer.
+///
+/// The caller is responsible for ensuring `line` itself contains no interior
+/// newline (i.e. it is one serialized JSON value); NDJSON framing relies on
+/// `\n` being a message boundary.
+pub async fn write_line<W>(_writer: &mut W, _line: &str) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    todo!("implemented in the following commit")
+}
+
+/// Read one newline-delimited line into `buf` (cleared first).
+///
+/// Returns the number of bytes read, or `0` at end-of-stream. The trailing
+/// newline is included in `buf` when present, matching
+/// [`tokio::io::AsyncBufReadExt::read_line`]; callers typically `trim()` before
+/// parsing. A line split across multiple underlying reads is transparently
+/// reassembled by the buffered reader.
+pub async fn read_line<R>(_reader: &mut R, _buf: &mut String) -> io::Result<usize>
+where
+    R: AsyncBufRead + Unpin + ?Sized,
+{
+    todo!("implemented in the following commit")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::BufReader;
+
+    #[tokio::test]
+    async fn write_line_appends_single_newline_and_flushes() {
+        let mut buf: Vec<u8> = Vec::new();
+        let json = r#"{"jsonrpc":"2.0","result":{},"id":1}"#;
+        write_line(&mut buf, json).await.expect("write_line");
+        let output = String::from_utf8(buf).expect("utf8");
+        assert!(output.ends_with('\n'), "must terminate with newline");
+        assert_eq!(output.matches('\n').count(), 1, "exactly one newline");
+        assert_eq!(output.trim_end(), json, "payload preserved verbatim");
+    }
+
+    #[tokio::test]
+    async fn read_line_reads_one_framed_line() {
+        let data = b"first line\nsecond line\n";
+        let mut reader = BufReader::new(&data[..]);
+        let mut line = String::new();
+
+        let n = read_line(&mut reader, &mut line).await.expect("read first");
+        assert_eq!(n, "first line\n".len());
+        assert_eq!(line.trim(), "first line");
+
+        // A second read advances past the frame boundary.
+        read_line(&mut reader, &mut line).await.expect("read second");
+        assert_eq!(line.trim(), "second line");
+    }
+
+    #[tokio::test]
+    async fn read_line_reassembles_partial_reads() {
+        // Simulate a line delivered across two separate writes: the buffered
+        // reader must reassemble it into a single framed line.
+        let (client, server) = tokio::io::duplex(64);
+        let writer = tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            let mut client = client;
+            client.write_all(b"hel").await.expect("write chunk 1");
+            client.flush().await.expect("flush 1");
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            client.write_all(b"lo world\n").await.expect("write chunk 2");
+            client.flush().await.expect("flush 2");
+        });
+
+        let mut reader = BufReader::new(server);
+        let mut line = String::new();
+        let n = read_line(&mut reader, &mut line).await.expect("read_line");
+        assert_eq!(n, "hello world\n".len());
+        assert_eq!(line.trim(), "hello world");
+        writer.await.expect("writer task");
+    }
+
+    #[tokio::test]
+    async fn read_line_returns_zero_at_eof() {
+        let empty: &[u8] = b"";
+        let mut reader = BufReader::new(empty);
+        let mut line = String::new();
+        let n = read_line(&mut reader, &mut line).await.expect("read_line");
+        assert_eq!(n, 0, "EOF yields zero bytes");
+    }
+}

--- a/core/src/ipc/ndjson.rs
+++ b/core/src/ipc/ndjson.rs
@@ -67,7 +67,9 @@ mod tests {
         assert_eq!(line.trim(), "first line");
 
         // A second read advances past the frame boundary.
-        read_line(&mut reader, &mut line).await.expect("read second");
+        read_line(&mut reader, &mut line)
+            .await
+            .expect("read second");
         assert_eq!(line.trim(), "second line");
     }
 
@@ -82,7 +84,10 @@ mod tests {
             client.write_all(b"hel").await.expect("write chunk 1");
             client.flush().await.expect("flush 1");
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            client.write_all(b"lo world\n").await.expect("write chunk 2");
+            client
+                .write_all(b"lo world\n")
+                .await
+                .expect("write chunk 2");
             client.flush().await.expect("flush 2");
         });
 

--- a/core/src/ipc/ndjson.rs
+++ b/core/src/ipc/ndjson.rs
@@ -15,11 +15,14 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 /// The caller is responsible for ensuring `line` itself contains no interior
 /// newline (i.e. it is one serialized JSON value); NDJSON framing relies on
 /// `\n` being a message boundary.
-pub async fn write_line<W>(_writer: &mut W, _line: &str) -> io::Result<()>
+pub async fn write_line<W>(writer: &mut W, line: &str) -> io::Result<()>
 where
     W: AsyncWrite + Unpin + ?Sized,
 {
-    todo!("implemented in the following commit")
+    writer.write_all(line.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
+    Ok(())
 }
 
 /// Read one newline-delimited line into `buf` (cleared first).
@@ -29,11 +32,12 @@ where
 /// [`tokio::io::AsyncBufReadExt::read_line`]; callers typically `trim()` before
 /// parsing. A line split across multiple underlying reads is transparently
 /// reassembled by the buffered reader.
-pub async fn read_line<R>(_reader: &mut R, _buf: &mut String) -> io::Result<usize>
+pub async fn read_line<R>(reader: &mut R, buf: &mut String) -> io::Result<usize>
 where
     R: AsyncBufRead + Unpin + ?Sized,
 {
-    todo!("implemented in the following commit")
+    buf.clear();
+    reader.read_line(buf).await
 }
 
 #[cfg(test)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod connection;
 pub mod errors;
 pub mod files;
+pub mod ipc;
 pub mod monitoring;
 #[cfg(any(feature = "telnet", feature = "ssh"))]
 pub mod net;

--- a/src-tauri/src/spawn/ipc_client.rs
+++ b/src-tauri/src/spawn/ipc_client.rs
@@ -1,29 +1,22 @@
 //! Spawn IPC client: connects to the per-user rendezvous endpoint, sends one
 //! [`SpawnRequest`], and reads the [`SpawnResponse`] (#1364).
+//!
+//! The cross-platform transport (Unix socket / Windows named pipe) and NDJSON
+//! framing come from the shared [`termihub_core::ipc`] helper (#1386).
 
 use anyhow::Context;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use termihub_core::ipc;
+use tokio::io::{AsyncRead, AsyncWrite, BufReader};
 
 use super::{SpawnEndpoint, SpawnRequest, SpawnResponse};
 
 /// Connect to `endpoint`, send `req`, and return the running instance's
 /// response. Fails fast if no instance is listening.
 pub async fn send(endpoint: &SpawnEndpoint, req: &SpawnRequest) -> anyhow::Result<SpawnResponse> {
-    #[cfg(unix)]
-    {
-        let stream = tokio::net::UnixStream::connect(endpoint.address())
-            .await
-            .context("connect spawn socket")?;
-        exchange(stream, req).await
-    }
-    #[cfg(windows)]
-    {
-        use tokio::net::windows::named_pipe::ClientOptions;
-        let stream = ClientOptions::new()
-            .open(endpoint.address())
-            .context("open spawn pipe")?;
-        exchange(stream, req).await
-    }
+    let (reader, writer) = ipc::connect(endpoint.address())
+        .await
+        .with_context(|| format!("connect spawn endpoint {endpoint}"))?;
+    exchange_halves(reader, writer, req).await
 }
 
 /// Perform the request/response exchange over an established stream. Generic so
@@ -31,22 +24,30 @@ pub async fn send(endpoint: &SpawnEndpoint, req: &SpawnRequest) -> anyhow::Resul
 /// platform.
 pub(crate) async fn exchange<S>(stream: S, req: &SpawnRequest) -> anyhow::Result<SpawnResponse>
 where
-    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
-    let (reader, mut writer) = tokio::io::split(stream);
+    let (reader, writer) = tokio::io::split(stream);
+    exchange_halves(reader, writer, req).await
+}
 
-    let mut payload = serde_json::to_string(req).context("serialize spawn request")?;
-    payload.push('\n');
-    writer
-        .write_all(payload.as_bytes())
+/// Request/response exchange over already-split read/write halves.
+async fn exchange_halves<R, W>(
+    reader: R,
+    mut writer: W,
+    req: &SpawnRequest,
+) -> anyhow::Result<SpawnResponse>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let payload = serde_json::to_string(req).context("serialize spawn request")?;
+    ipc::write_line(&mut writer, &payload)
         .await
         .context("write spawn request")?;
-    writer.flush().await.context("flush spawn request")?;
 
     let mut reader = BufReader::new(reader);
     let mut line = String::new();
-    reader
-        .read_line(&mut line)
+    ipc::read_line(&mut reader, &mut line)
         .await
         .context("read spawn response")?;
     serde_json::from_str(line.trim()).context("parse spawn response")

--- a/src-tauri/src/spawn/ipc_client.rs
+++ b/src-tauri/src/spawn/ipc_client.rs
@@ -19,9 +19,11 @@ pub async fn send(endpoint: &SpawnEndpoint, req: &SpawnRequest) -> anyhow::Resul
     exchange_halves(reader, writer, req).await
 }
 
-/// Perform the request/response exchange over an established stream. Generic so
-/// it is exercised in tests via an in-memory `tokio::io::duplex` pair on every
-/// platform.
+/// Perform the request/response exchange over a combined stream: split it and
+/// run the worker. A test-only convenience so the transport is exercised via an
+/// in-memory `tokio::io::duplex` pair on every platform; the production path
+/// calls [`exchange_halves`] directly with the connection's halves.
+#[cfg(test)]
 pub(crate) async fn exchange<S>(stream: S, req: &SpawnRequest) -> anyhow::Result<SpawnResponse>
 where
     S: AsyncRead + AsyncWrite + Unpin,

--- a/src-tauri/src/spawn/ipc_server.rs
+++ b/src-tauri/src/spawn/ipc_server.rs
@@ -31,9 +31,11 @@ pub async fn serve(endpoint: &SpawnEndpoint, handler: SpawnHandler) -> anyhow::R
     }
 }
 
-/// Handle a single client connection: read one request line, run the handler,
-/// write one response line. Generic over the stream so it is exercised in tests
-/// via an in-memory `tokio::io::duplex` pair on every platform.
+/// Handle a single client connection over a combined stream: split it and run
+/// the request/response worker. A test-only convenience so the transport is
+/// exercised via an in-memory `tokio::io::duplex` pair on every platform; the
+/// production path calls [`serve_halves`] directly with the listener's halves.
+#[cfg(test)]
 pub(crate) async fn serve_connection<S>(stream: S, handler: &SpawnHandler) -> anyhow::Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin,

--- a/src-tauri/src/spawn/ipc_server.rs
+++ b/src-tauri/src/spawn/ipc_server.rs
@@ -3,9 +3,12 @@
 //!
 //! Framing is newline-delimited JSON: the client writes one `SpawnRequest` line,
 //! the server replies with one `SpawnResponse` line, then the connection closes.
+//! The cross-platform transport (Unix socket / Windows named pipe) and NDJSON
+//! framing come from the shared [`termihub_core::ipc`] helper (#1386).
 
 use anyhow::Context;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use termihub_core::ipc::{self, LocalSocketListener};
+use tokio::io::{AsyncRead, AsyncWrite, BufReader};
 
 use super::{SpawnEndpoint, SpawnHandler, SpawnRequest, SpawnResponse};
 
@@ -14,13 +17,17 @@ use super::{SpawnEndpoint, SpawnHandler, SpawnRequest, SpawnResponse};
 /// Returns only on a fatal transport error (e.g. the endpoint is already owned
 /// by another instance); the caller should treat that as "not the rendezvous".
 pub async fn serve(endpoint: &SpawnEndpoint, handler: SpawnHandler) -> anyhow::Result<()> {
-    #[cfg(unix)]
-    {
-        serve_unix(endpoint.address(), handler).await
-    }
-    #[cfg(windows)]
-    {
-        serve_windows(endpoint.address(), handler).await
+    let mut listener = LocalSocketListener::bind(endpoint.address())
+        .await
+        .with_context(|| format!("bind spawn endpoint {endpoint}"))?;
+    loop {
+        let (reader, writer) = listener.accept().await.context("accept spawn connection")?;
+        let handler = handler.clone();
+        tokio::spawn(async move {
+            if let Err(e) = serve_halves(reader, writer, &handler).await {
+                tracing::warn!("spawn connection error: {e}");
+            }
+        });
     }
 }
 
@@ -29,13 +36,21 @@ pub async fn serve(endpoint: &SpawnEndpoint, handler: SpawnHandler) -> anyhow::R
 /// via an in-memory `tokio::io::duplex` pair on every platform.
 pub(crate) async fn serve_connection<S>(stream: S, handler: &SpawnHandler) -> anyhow::Result<()>
 where
-    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
-    let (reader, mut writer) = tokio::io::split(stream);
+    let (reader, writer) = tokio::io::split(stream);
+    serve_halves(reader, writer, handler).await
+}
+
+/// Request/response worker over already-split read/write halves.
+async fn serve_halves<R, W>(reader: R, mut writer: W, handler: &SpawnHandler) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
     let mut reader = BufReader::new(reader);
     let mut line = String::new();
-    let read = reader
-        .read_line(&mut line)
+    let read = ipc::read_line(&mut reader, &mut line)
         .await
         .context("read spawn request")?;
     if read == 0 || line.trim().is_empty() {
@@ -47,63 +62,9 @@ where
         Err(e) => SpawnResponse::error(format!("invalid spawn request: {e}")),
     };
 
-    let mut payload = serde_json::to_string(&response).context("serialize spawn response")?;
-    payload.push('\n');
-    writer
-        .write_all(payload.as_bytes())
+    let payload = serde_json::to_string(&response).context("serialize spawn response")?;
+    ipc::write_line(&mut writer, &payload)
         .await
         .context("write spawn response")?;
-    writer.flush().await.context("flush spawn response")?;
     Ok(())
-}
-
-#[cfg(unix)]
-async fn serve_unix(path: &str, handler: SpawnHandler) -> anyhow::Result<()> {
-    use tokio::net::{UnixListener, UnixStream};
-
-    let path = std::path::Path::new(path);
-    // Clear a stale socket left behind by a crashed instance: if nothing is
-    // listening, the connect fails and the file is safe to remove.
-    if path.exists() && UnixStream::connect(path).await.is_err() {
-        std::fs::remove_file(path).ok();
-    }
-
-    let listener = UnixListener::bind(path)
-        .with_context(|| format!("bind spawn socket at {}", path.display()))?;
-    loop {
-        let (stream, _addr) = listener.accept().await.context("accept spawn connection")?;
-        let handler = handler.clone();
-        tokio::spawn(async move {
-            if let Err(e) = serve_connection(stream, &handler).await {
-                tracing::warn!("spawn connection error: {e}");
-            }
-        });
-    }
-}
-
-#[cfg(windows)]
-async fn serve_windows(name: &str, handler: SpawnHandler) -> anyhow::Result<()> {
-    use tokio::net::windows::named_pipe::ServerOptions;
-
-    // `first_pipe_instance(true)` fails if another instance already owns the
-    // pipe — exactly the "not the rendezvous" signal we want.
-    let mut server = ServerOptions::new()
-        .first_pipe_instance(true)
-        .create(name)
-        .with_context(|| format!("create spawn pipe {name}"))?;
-    loop {
-        server.connect().await.context("await spawn pipe client")?;
-        let connected = server;
-        // Pre-create the next instance before handling this one so no client
-        // races into a missing pipe.
-        server = ServerOptions::new()
-            .create(name)
-            .with_context(|| format!("recreate spawn pipe {name}"))?;
-        let handler = handler.clone();
-        tokio::spawn(async move {
-            if let Err(e) = serve_connection(connected, &handler).await {
-                tracing::warn!("spawn connection error: {e}");
-            }
-        });
-    }
 }


### PR DESCRIPTION
## Summary

Consolidates the cross-platform local-IPC transport (Unix domain socket / Windows named pipe) plus newline-delimited-JSON framing that was duplicated across the desktop spawn IPC and the agent, into a single protocol-agnostic helper in `termihub-core`.

### New shared abstraction — `termihub_core::ipc`

- **`ipc::local_socket`** — a protocol-agnostic transport that moves *opaque byte streams* (imposes no framing, so NDJSON request/response, length-prefixed binary frames, etc. all layer on top):
  - `LocalSocketListener::bind(address).await` / `.accept().await -> (BoxedReader, BoxedWriter)`
  - `connect(address).await -> (BoxedReader, BoxedWriter)` — **fail-fast one-shot** (no retry)
  - Unix: reclaims a socket path only when *stale* (connect-probe fails), leaving a live socket so `bind` fails with `AddrInUse`. Windows: `first_pipe_instance(true)` + stages the next instance on each accept. Both map to the caller's "not the rendezvous" signal.
- **`ipc::ndjson`** — `write_line` / `read_line` NDJSON framing over any async reader/writer.

Uses `std::io::Result` (core has no `anyhow` dep); consumers add `.context(...)` at call sites. Added the `io-util` tokio feature to `core`.

### Consumers migrated

- **Desktop spawn IPC** (`src-tauri/src/spawn/{ipc_server,ipc_client}.rs`) — the per-platform `serve_unix`/`serve_windows`/`connect` code collapses into one implementation over `core::ipc`; framing now uses the shared `write_line`/`read_line`. Behavior unchanged (same fail-fast one-shot request/response, same stale-socket / `first_pipe_instance` semantics). The combined-stream `serve_connection`/`exchange` wrappers become `#[cfg(test)]` duplex-test helpers; production uses `serve_halves`/`exchange_halves`.
- **Agent JSON-RPC transport** (`agent/src/io/transport.rs`) — `write_line` now delegates to `termihub_core::ipc::write_line` (byte-identical), so both consumers share one NDJSON writer.

### Deferred (with follow-up) — agent session-daemon transport

`agent/src/daemon/transport.rs` was **not** migrated. Its semantics are load-bearing and intentionally absent from the fail-fast, protocol-agnostic core primitive: a **30s connect-retry loop**, **security hardening** (unix `0o700` dir+socket, windows per-user DACL), **unconditional** stale-socket removal, and session-specific helpers (`session_endpoint`, `endpoint_alive`, `open_daemon_log`, `cleanup`). Adopting the core listener as-is would regress retry/streaming and security. Deferred per the issue guidance and tracked in **#1437** (extend `core::ipc` with an optional security policy + retrying-connect wrapper, then re-express the daemon on top without behavior change).

### Path-scheme reconciliation

The two per-user schemes are intentionally **not** unified at the path level because they serve different purposes and live in different crates/processes:

| | Spawn (desktop) | Agent daemon |
|---|---|---|
| Unix | `{runtime_dir}/termihub-spawn-{uid}.sock` | `/tmp/termihub/{USER}/session-{id}.sock` |
| Windows | `\\.\pipe\termihub-spawn-{username}` | `\\.\pipe\termihub-session-{id}` |
| Cardinality | **one** singleton rendezvous per user | **N** per-session endpoints |

`core::ipc` is **address-agnostic** (takes `&str`), so each consumer keeps its own scheme while sharing the bind/accept/connect machinery. The unification happens at the transport layer, which is the correct seam — not at path policy.

## Test plan

- TDD: `test(core)` commit (9 unit tests, red via `todo!()`) precedes the implementation commit.
- New `core::ipc` unit tests (all green locally on **macOS/unix**): bind/accept/connect round-trip, sequential connections, fail-fast connect, unix stale-socket reclamation, live-endpoint rejection, and NDJSON framing including **partial reads** and EOF.
- `cargo test --workspace --all-features` green except the `agent` `docker_integration` tests, which fail **environmentally** (Docker running but `alpine:latest` not pulled → daemon container never starts); those touch neither the daemon transport nor docker code changed here.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo fmt --all -- --check` clean.
- Existing spawn transport tests (duplex + real socket round-trip) and the agent `write_line` test remain green.

### Cross-platform note

The **Windows named-pipe** paths (`windows_impl` in `core::ipc::local_socket`, the spawn Windows branch) are compiled out on this macOS host and were verified by inspection only — **not** run locally. They rely on CI for compile + test. All **unix** paths were exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)