### PR TITLE
feat(credential): add CredentialType::SudoPassword

### DIFF
--- a/src-tauri/src/credential/manager.rs
+++ b/src-tauri/src/credential/manager.rs
@@ -338,6 +338,40 @@ mod tests {
     }
 
     #[test]
+    fn sudo_password_round_trip_and_removal() {
+        let dir = tempfile::tempdir().unwrap();
+        let mgr = CredentialManager::new(StorageMode::MasterPassword, dir.path().to_path_buf());
+
+        // Set up the master password store
+        mgr.with_master_password_store(|s| s.setup("test-pw"))
+            .unwrap()
+            .unwrap();
+
+        // store -> get -> remove of a SudoPassword credential
+        let sudo_key = CredentialKey::new("conn-sudo", CredentialType::SudoPassword);
+        mgr.set(&sudo_key, "elevated-secret").unwrap();
+        assert_eq!(
+            mgr.get(&sudo_key).unwrap(),
+            Some("elevated-secret".to_string())
+        );
+        mgr.remove(&sudo_key).unwrap();
+        assert_eq!(mgr.get(&sudo_key).unwrap(), None);
+
+        // remove_all_for_connection clears SudoPassword alongside Password/KeyPassphrase
+        let pw_key = CredentialKey::new("conn-sudo", CredentialType::Password);
+        let kp_key = CredentialKey::new("conn-sudo", CredentialType::KeyPassphrase);
+        mgr.set(&pw_key, "pass").unwrap();
+        mgr.set(&kp_key, "phrase").unwrap();
+        mgr.set(&sudo_key, "elevated-secret").unwrap();
+
+        mgr.remove_all_for_connection("conn-sudo").unwrap();
+
+        assert_eq!(mgr.get(&pw_key).unwrap(), None);
+        assert_eq!(mgr.get(&kp_key).unwrap(), None);
+        assert_eq!(mgr.get(&sudo_key).unwrap(), None);
+    }
+
+    #[test]
     fn get_on_locked_store_returns_error() {
         let dir = tempfile::tempdir().unwrap();
         let mgr = CredentialManager::new(StorageMode::MasterPassword, dir.path().to_path_buf());

--- a/src-tauri/src/credential/types.rs
+++ b/src-tauri/src/credential/types.rs
@@ -9,6 +9,8 @@ pub enum CredentialType {
     Password,
     /// A passphrase protecting an SSH private key.
     KeyPassphrase,
+    /// A password used to elevate a save (e.g., `sudo` for an elevated write).
+    SudoPassword,
 }
 
 impl fmt::Display for CredentialType {
@@ -16,6 +18,7 @@ impl fmt::Display for CredentialType {
         match self {
             CredentialType::Password => write!(f, "password"),
             CredentialType::KeyPassphrase => write!(f, "key_passphrase"),
+            CredentialType::SudoPassword => write!(f, "sudo_password"),
         }
     }
 }
@@ -44,6 +47,7 @@ impl CredentialKey {
         let credential_type = match type_str {
             "password" => CredentialType::Password,
             "key_passphrase" => CredentialType::KeyPassphrase,
+            "sudo_password" => CredentialType::SudoPassword,
             _ => return None,
         };
         Some(Self::new(conn_id, credential_type))

--- a/src-tauri/src/credential/types.rs
+++ b/src-tauri/src/credential/types.rs
@@ -145,6 +145,11 @@ mod tests {
     }
 
     #[test]
+    fn credential_type_display_sudo_password() {
+        assert_eq!(CredentialType::SudoPassword.to_string(), "sudo_password");
+    }
+
+    #[test]
     fn credential_key_new_constructs_correctly() {
         let key = CredentialKey::new("conn-abc123", CredentialType::Password);
         assert_eq!(key.connection_id, "conn-abc123");
@@ -175,6 +180,27 @@ mod tests {
         let key = CredentialKey::from_map_key("conn-abc123:key_passphrase").unwrap();
         assert_eq!(key.connection_id, "conn-abc123");
         assert_eq!(key.credential_type, CredentialType::KeyPassphrase);
+    }
+
+    #[test]
+    fn credential_key_display_sudo_password() {
+        let key = CredentialKey::new("conn-abc123", CredentialType::SudoPassword);
+        assert_eq!(key.to_string(), "conn-abc123:sudo_password");
+    }
+
+    #[test]
+    fn credential_key_from_map_key_sudo_password() {
+        let key = CredentialKey::from_map_key("conn-abc123:sudo_password").unwrap();
+        assert_eq!(key.connection_id, "conn-abc123");
+        assert_eq!(key.credential_type, CredentialType::SudoPassword);
+    }
+
+    #[test]
+    fn credential_key_sudo_password_round_trip() {
+        let key = CredentialKey::new("my-conn", CredentialType::SudoPassword);
+        let map_key = key.to_string();
+        let parsed = CredentialKey::from_map_key(&map_key).unwrap();
+        assert_eq!(parsed, key);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1327
Part of Epic #1323

## Summary

Adds a `SudoPassword` variant to `CredentialType` so an elevated-save password can optionally be persisted (opt-in), inheriting the existing Argon2id + AES-256-GCM master-password encryption, auto-lock, and per-connection removal semantics.

- New `SudoPassword` variant in `enum CredentialType` (`src-tauri/src/credential/types.rs`).
- `Display` arm and `from_map_key` parse arm using the string `"sudo_password"`, keyed by `connection_id` like the other types.
- No changes needed to `CredentialManager` / `MasterPasswordStore`: get/set/remove and `remove_all_for_connection` are generic over the enum (via `CredentialKey` + `connection_id:` prefix matching) — verified, not assumed.
- No new crypto — reuses the existing store.

Out of scope (per issue): any UI, the elevated write itself, deciding when to persist.

## Test plan (TDD)

Test commit lands first (fails to compile without the variant), then the implementation.

- **Unit (`types.rs`):** `Display` → `"sudo_password"`, `CredentialKey::new`, map-key parse and Display/parse round-trip for `SudoPassword`.
- **Unit (`manager.rs`):** `MasterPassword` temp-dir harness — store → get → remove round-trip of a `SudoPassword` credential, and `remove_all_for_connection` clears `SudoPassword` alongside `Password`/`KeyPassphrase`.

Results: `cargo test -p termihub credential` green (all 5 new tests pass); `cargo fmt` clean; `cargo clippy -p termihub --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)