### PR TITLE
refactor(agent): re-express daemon transport on shared core::ipc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7274,6 +7274,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "vte",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -52,12 +52,11 @@ nix = { version = "0.29", features = ["signal", "process", "term", "poll", "fs"]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-# Used to build a per-user DACL for the session daemon's named-pipe transport
-# (the security analog of the Unix socket's 0o700 permissions).
+# Named-pipe liveness probe (WaitNamedPipeW) for the session daemon's endpoint
+# and detached-process creation flags. The per-user DACL construction moved to
+# termihub-core's shared IPC transport (`ipc::ListenerSecurity::CurrentUserOnly`).
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
-    "Win32_Security",
-    "Win32_Security_Authorization",
     "Win32_System_Pipes",
     "Win32_System_Threading",
 ] }

--- a/agent/src/daemon/process.rs
+++ b/agent/src/daemon/process.rs
@@ -102,7 +102,7 @@ pub async fn run_daemon(session_id: &str) -> anyhow::Result<()> {
     // Bind the transport listener — this creates the endpoint (socket file on
     // unix, named pipe on windows), restricted to the current user, signalling
     // to callers that the daemon is ready to accept connections.
-    let mut listener = DaemonListener::bind(&config.endpoint)?;
+    let mut listener = DaemonListener::bind(&config.endpoint).await?;
 
     info!("Listening on endpoint: {}", config.endpoint);
 

--- a/agent/src/daemon/transport.rs
+++ b/agent/src/daemon/transport.rs
@@ -2,14 +2,17 @@
 //!
 //! The persistent-session daemon and its agent-side client exchange
 //! length-prefixed frames (see [`super::protocol`]) over a local IPC channel.
-//! This module abstracts that channel so the same daemon logic runs over a
+//! The cross-platform bind/accept/connect plumbing is delegated to the shared
+//! [`termihub_core::ipc`] transport, so the same daemon logic runs over a
 //! **Unix domain socket** on unix and a **Windows named pipe** on windows.
 //!
-//! Both transports are restricted to the current user: on unix via a `0o700`
-//! socket directory and socket file, on windows via a per-pipe DACL that grants
-//! access only to the current user's SID and `LocalSystem`. The named-pipe DACL
-//! is the direct security analog of the Unix socket's `0o700` permissions —
-//! no exposed TCP port, no access for other local users.
+//! Both transports are restricted to the current user via the core
+//! [`ListenerSecurity::CurrentUserOnly`] policy: on unix a `0o700` socket
+//! directory and socket file, on windows a per-pipe DACL that grants access
+//! only to the current user's SID and `LocalSystem`. The daemon reclaims its
+//! own per-session path on restart via [`StaleReclaim::Unconditional`], and the
+//! client [`connect`] retries briefly while the daemon binds its endpoint
+//! during slow cold-start.
 //!
 //! ```text
 //!  bind() ──► DaemonListener ──► accept() ──► (BoxedReader, BoxedWriter)
@@ -18,21 +21,23 @@
 //!
 //! The concrete socket/pipe types are erased behind [`BoxedReader`] and
 //! [`BoxedWriter`] so the daemon event loop in [`super::process`] is fully
-//! platform-independent.
+//! platform-independent. This module keeps only the daemon's **session-policy**
+//! path helpers ([`session_endpoint`], [`endpoint_alive`], [`open_daemon_log`]);
+//! the transport primitives live in [`termihub_core::ipc`].
 
+use std::io;
 use std::time::Duration;
 
-use tokio::io::{AsyncRead, AsyncWrite};
+use termihub_core::ipc::{
+    self, ListenerOptions, ListenerSecurity, LocalSocketListener, StaleReclaim,
+};
 
-/// Boxed reader half of a daemon connection (Unix socket or named pipe).
-pub type BoxedReader = Box<dyn AsyncRead + Send + Unpin>;
-/// Boxed writer half of a daemon connection (Unix socket or named pipe).
-pub type BoxedWriter = Box<dyn AsyncWrite + Send + Unpin>;
+/// Boxed reader/writer halves, re-exported from the shared core transport.
+pub use termihub_core::ipc::{BoxedReader, BoxedWriter};
 
-// `connect` (and the shared retry helper it uses) are the client side of the
-// transport. They are exercised by the round-trip tests below; the production
-// agent client and Windows launcher are wired onto them in #767, so they read
-// as dead code in the plain binary build until then.
+// `connect` is the client side of the transport, exercised by the round-trip
+// tests below; the production agent client and Windows launcher are wired onto
+// it in #767, so it reads as dead code in the plain binary build until then.
 
 /// How long [`connect`] waits for the daemon endpoint to appear before failing.
 ///
@@ -48,53 +53,61 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 #[allow(dead_code)]
 const CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-/// Retry `attempt` until it succeeds or [`CONNECT_TIMEOUT`] elapses, sleeping
-/// [`CONNECT_POLL_INTERVAL`] between tries whenever `retryable` accepts the
-/// error (the daemon binds its endpoint during slow startup work). Once the
-/// deadline passes, the last underlying error is returned.
-///
-/// Shared by the unix and windows [`connect`] implementations so the retry
-/// policy lives in one place; only the per-platform attempt and the
-/// "endpoint not ready yet" error predicate differ.
-#[allow(dead_code)]
-async fn connect_with_retry<A, Fut, R>(
-    mut attempt: A,
-    retryable: R,
-) -> std::io::Result<(BoxedReader, BoxedWriter)>
-where
-    A: FnMut() -> Fut,
-    Fut: std::future::Future<Output = std::io::Result<(BoxedReader, BoxedWriter)>>,
-    R: Fn(&std::io::Error) -> bool,
-{
-    let deadline = tokio::time::Instant::now() + CONNECT_TIMEOUT;
-    loop {
-        match attempt().await {
-            Ok(halves) => return Ok(halves),
-            Err(e) if retryable(&e) && tokio::time::Instant::now() < deadline => {
-                tokio::time::sleep(CONNECT_POLL_INTERVAL).await;
-            }
-            Err(e) => return Err(e),
-        }
+/// A listening daemon endpoint, restricted to the current user, bound through
+/// the shared [`termihub_core::ipc`] transport.
+pub struct DaemonListener {
+    inner: LocalSocketListener,
+}
+
+impl DaemonListener {
+    /// Bind a listener at `endpoint`, creating a current-user-only endpoint
+    /// (`0o700` socket dir + file on unix, per-user DACL on windows) and
+    /// unconditionally reclaiming any stale endpoint left by a previous daemon.
+    /// The endpoint appearing signals readiness to connecting clients.
+    pub async fn bind(endpoint: &str) -> io::Result<Self> {
+        let inner = LocalSocketListener::bind_with_options(
+            endpoint,
+            ListenerOptions {
+                security: ListenerSecurity::CurrentUserOnly,
+                stale_reclaim: StaleReclaim::Unconditional,
+            },
+        )
+        .await?;
+        Ok(Self { inner })
     }
+
+    /// Accept the next agent connection, returning erased read/write halves.
+    pub async fn accept(&mut self) -> io::Result<(BoxedReader, BoxedWriter)> {
+        self.inner.accept().await
+    }
+
+    /// Remove the endpoint. Call on daemon shutdown.
+    pub fn cleanup(&self) {
+        self.inner.cleanup();
+    }
+}
+
+/// Connect to a daemon endpoint, retrying briefly while the endpoint is not yet
+/// present (the daemon binds it during slow startup work).
+#[allow(dead_code)] // wired into the agent client/launcher in #767
+pub async fn connect(endpoint: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
+    ipc::connect_with_retry(endpoint, CONNECT_TIMEOUT, CONNECT_POLL_INTERVAL).await
 }
 
 #[cfg(unix)]
 #[allow(unused_imports)]
-pub use unix_impl::{connect, endpoint_alive, open_daemon_log, session_endpoint, DaemonListener};
+pub use unix_impl::{endpoint_alive, open_daemon_log, session_endpoint};
 #[cfg(windows)]
 #[allow(unused_imports)]
-pub use windows_impl::{connect, endpoint_alive, session_endpoint, DaemonListener};
+pub use windows_impl::{endpoint_alive, session_endpoint};
 
-// ── Unix domain socket transport ────────────────────────────────────
+// ── Unix session-path helpers ───────────────────────────────────────
 
 #[cfg(unix)]
 mod unix_impl {
-    use super::*;
     use std::io;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
-
-    use tokio::net::{UnixListener, UnixStream};
 
     /// Compute the default endpoint (socket path) for a session.
     pub fn session_endpoint(session_id: &str) -> String {
@@ -107,7 +120,7 @@ mod unix_impl {
     /// Cheap liveness pre-check: whether the socket file is present on disk.
     ///
     /// A bound daemon keeps its socket file; recovery uses this to skip dead
-    /// sessions without paying the [`connect`] retry timeout.
+    /// sessions without paying the [`super::connect`] retry timeout.
     pub fn endpoint_alive(endpoint: &str) -> bool {
         Path::new(endpoint).exists()
     }
@@ -139,77 +152,12 @@ mod unix_impl {
         ensure_socket_dir(&dir).ok()?;
         std::fs::File::create(dir.join(format!("session-{session_id}.log"))).ok()
     }
-
-    /// A listening Unix domain socket bound to a per-user, `0o700` path.
-    pub struct DaemonListener {
-        listener: UnixListener,
-        path: PathBuf,
-    }
-
-    impl DaemonListener {
-        /// Bind a listener at `endpoint`, creating the `0o700` socket directory
-        /// and removing any stale socket file. The socket file appearing on
-        /// disk signals readiness to connecting clients.
-        pub fn bind(endpoint: &str) -> io::Result<Self> {
-            let path = PathBuf::from(endpoint);
-            if let Some(parent) = path.parent() {
-                ensure_socket_dir(parent)?;
-            }
-            // Remove a stale socket file from a previous daemon.
-            let _ = std::fs::remove_file(&path);
-            let listener = UnixListener::bind(&path)?;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))?;
-            Ok(Self { listener, path })
-        }
-
-        /// Accept the next agent connection, returning erased read/write halves.
-        pub async fn accept(&mut self) -> io::Result<(BoxedReader, BoxedWriter)> {
-            let (stream, _addr) = self.listener.accept().await?;
-            let (reader, writer) = stream.into_split();
-            Ok((Box::new(reader), Box::new(writer)))
-        }
-
-        /// Remove the socket file. Call on daemon shutdown.
-        pub fn cleanup(&self) {
-            let _ = std::fs::remove_file(&self.path);
-        }
-    }
-
-    /// Connect to a daemon endpoint, retrying briefly while the socket is not
-    /// yet present (the daemon binds it during slow startup work).
-    #[allow(dead_code)] // wired into the agent client/launcher in #767
-    pub async fn connect(endpoint: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
-        super::connect_with_retry(
-            || async {
-                let (reader, writer) = UnixStream::connect(endpoint).await?.into_split();
-                Ok((
-                    Box::new(reader) as BoxedReader,
-                    Box::new(writer) as BoxedWriter,
-                ))
-            },
-            |e| {
-                matches!(
-                    e.kind(),
-                    io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
-                )
-            },
-        )
-        .await
-    }
 }
 
-// ── Windows named-pipe transport ────────────────────────────────────
+// ── Windows session-path helpers ────────────────────────────────────
 
 #[cfg(windows)]
 mod windows_impl {
-    use super::*;
-    use std::ffi::c_void;
-    use std::io;
-
-    use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
-
-    use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PIPE_BUSY};
-
     /// Compute the default endpoint (pipe name) for a session.
     ///
     /// Pipe names live in the `\\.\pipe\` namespace and are unique per session.
@@ -221,7 +169,7 @@ mod windows_impl {
     ///
     /// Uses `WaitNamedPipeW` with a 1 ms timeout, which does not consume an
     /// instance. Recovery uses this to skip dead sessions without paying the
-    /// [`connect`] retry timeout. A non-existent pipe yields
+    /// [`super::connect`] retry timeout. A non-existent pipe yields
     /// `ERROR_FILE_NOT_FOUND` (not alive); a busy one yields `ERROR_SEM_TIMEOUT`
     /// (the daemon is up but every instance is momentarily connected → alive).
     pub fn endpoint_alive(endpoint: &str) -> bool {
@@ -234,233 +182,6 @@ mod windows_impl {
             return true;
         }
         unsafe { GetLastError() == ERROR_SEM_TIMEOUT }
-    }
-
-    /// A listening named pipe restricted to the current user via a DACL.
-    ///
-    /// Named pipes serve one client per server instance, so the listener keeps
-    /// the next (not-yet-connected) instance ready and creates a fresh one each
-    /// time a client is accepted.
-    pub struct DaemonListener {
-        name: String,
-        security: security::SecurityAttributes,
-        /// The next pipe instance, waiting for a client to connect.
-        next: Option<NamedPipeServer>,
-    }
-
-    impl DaemonListener {
-        /// Bind the first pipe instance with a per-user DACL.
-        pub fn bind(endpoint: &str) -> io::Result<Self> {
-            let security = security::SecurityAttributes::for_current_user()?;
-            let next = create_instance(endpoint, &security, true)?;
-            Ok(Self {
-                name: endpoint.to_string(),
-                security,
-                next: Some(next),
-            })
-        }
-
-        /// Accept the next agent connection, returning erased read/write halves.
-        pub async fn accept(&mut self) -> io::Result<(BoxedReader, BoxedWriter)> {
-            let server = self
-                .next
-                .as_ref()
-                .expect("listener always holds a pending pipe instance");
-            server.connect().await?;
-
-            // Hand off the connected instance and stage a fresh one for the
-            // next client before serving this one.
-            let connected = self.next.take().expect("pending instance present");
-            self.next = Some(create_instance(&self.name, &self.security, false)?);
-
-            let (reader, writer) = tokio::io::split(connected);
-            Ok((Box::new(reader), Box::new(writer)))
-        }
-
-        /// No-op on windows: the pipe disappears when its instances are dropped.
-        pub fn cleanup(&self) {}
-    }
-
-    /// Create a named-pipe server instance with the given security descriptor.
-    fn create_instance(
-        name: &str,
-        security: &security::SecurityAttributes,
-        first: bool,
-    ) -> io::Result<NamedPipeServer> {
-        // SAFETY: `security` outlives this call (owned by the `DaemonListener`),
-        // and `attrs_ptr` points at a valid `SECURITY_ATTRIBUTES` whose
-        // descriptor is owned and freed by `security`.
-        unsafe {
-            ServerOptions::new()
-                .first_pipe_instance(first)
-                .create_with_security_attributes_raw(name, security.as_ptr() as *mut c_void)
-        }
-    }
-
-    /// Connect to a daemon pipe, retrying while it is not yet created or all
-    /// instances are momentarily busy.
-    #[allow(dead_code)] // wired into the agent client/launcher in #767
-    pub async fn connect(endpoint: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
-        super::connect_with_retry(
-            || async {
-                let client = ClientOptions::new().open(endpoint)?;
-                let (reader, writer) = tokio::io::split(client);
-                Ok((
-                    Box::new(reader) as BoxedReader,
-                    Box::new(writer) as BoxedWriter,
-                ))
-            },
-            |e| {
-                matches!(
-                    e.raw_os_error(),
-                    Some(code)
-                        if code == ERROR_FILE_NOT_FOUND as i32 || code == ERROR_PIPE_BUSY as i32
-                )
-            },
-        )
-        .await
-    }
-
-    /// Per-user security descriptor construction for the named pipe.
-    mod security {
-        use std::io;
-        use std::ptr;
-
-        use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
-        use windows_sys::Win32::Security::Authorization::{
-            ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
-            SDDL_REVISION_1,
-        };
-        use windows_sys::Win32::Security::{
-            GetTokenInformation, TokenUser, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, TOKEN_QUERY,
-            TOKEN_USER,
-        };
-        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
-
-        /// Owns a security descriptor restricting the pipe to the current user
-        /// and `LocalSystem`, plus the `SECURITY_ATTRIBUTES` referencing it.
-        pub struct SecurityAttributes {
-            descriptor: PSECURITY_DESCRIPTOR,
-            attributes: SECURITY_ATTRIBUTES,
-        }
-
-        // The owned raw pointers are exclusively managed here; sending the
-        // listener (and thus this owner) across threads is safe.
-        unsafe impl Send for SecurityAttributes {}
-        unsafe impl Sync for SecurityAttributes {}
-
-        impl SecurityAttributes {
-            /// Build a DACL granting `GENERIC_ALL` only to the current user's
-            /// SID and `LocalSystem` (`SY`), protected from inheritance (`P`).
-            pub fn for_current_user() -> io::Result<Self> {
-                let sid_string = current_user_sid_string()?;
-                let sddl = format!("D:P(A;;GA;;;{sid_string})(A;;GA;;;SY)");
-                let sddl_wide = to_wide(&sddl);
-
-                let mut descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
-                // SAFETY: `sddl_wide` is a valid null-terminated UTF-16 string;
-                // `descriptor` receives a LocalAlloc'd descriptor we free on drop.
-                let ok = unsafe {
-                    ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                        sddl_wide.as_ptr(),
-                        SDDL_REVISION_1,
-                        &mut descriptor,
-                        ptr::null_mut(),
-                    )
-                };
-                if ok == 0 {
-                    return Err(io::Error::last_os_error());
-                }
-
-                let attributes = SECURITY_ATTRIBUTES {
-                    nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
-                    lpSecurityDescriptor: descriptor,
-                    bInheritHandle: 0,
-                };
-                Ok(Self {
-                    descriptor,
-                    attributes,
-                })
-            }
-
-            /// Pointer to the `SECURITY_ATTRIBUTES` for passing to pipe creation.
-            pub fn as_ptr(&self) -> *const SECURITY_ATTRIBUTES {
-                &self.attributes
-            }
-        }
-
-        impl Drop for SecurityAttributes {
-            fn drop(&mut self) {
-                if !self.descriptor.is_null() {
-                    // SAFETY: `descriptor` was allocated by
-                    // ConvertStringSecurityDescriptorToSecurityDescriptorW.
-                    unsafe { LocalFree(self.descriptor as HLOCAL) };
-                }
-            }
-        }
-
-        /// Resolve the current process user's SID into its string form.
-        fn current_user_sid_string() -> io::Result<String> {
-            // SAFETY: standard token-query FFI sequence; every handle and
-            // allocation is released before returning.
-            unsafe {
-                let mut token: HANDLE = ptr::null_mut();
-                if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
-                    return Err(io::Error::last_os_error());
-                }
-
-                // First call sizes the buffer; it is expected to "fail".
-                let mut len: u32 = 0;
-                GetTokenInformation(token, TokenUser, ptr::null_mut(), 0, &mut len);
-                if len == 0 {
-                    CloseHandle(token);
-                    return Err(io::Error::last_os_error());
-                }
-
-                let mut buf = vec![0u8; len as usize];
-                let ok = GetTokenInformation(
-                    token,
-                    TokenUser,
-                    buf.as_mut_ptr() as *mut _,
-                    len,
-                    &mut len,
-                );
-                CloseHandle(token);
-                if ok == 0 {
-                    return Err(io::Error::last_os_error());
-                }
-
-                let token_user = &*(buf.as_ptr() as *const TOKEN_USER);
-                let mut sid_ptr: *mut u16 = ptr::null_mut();
-                if ConvertSidToStringSidW(token_user.User.Sid, &mut sid_ptr) == 0 {
-                    return Err(io::Error::last_os_error());
-                }
-                let sid_string = wide_to_string(sid_ptr);
-                LocalFree(sid_ptr as HLOCAL);
-                Ok(sid_string)
-            }
-        }
-
-        /// Encode a Rust string as a null-terminated UTF-16 buffer.
-        fn to_wide(s: &str) -> Vec<u16> {
-            s.encode_utf16().chain(std::iter::once(0)).collect()
-        }
-
-        /// Read a null-terminated UTF-16 string into a Rust `String`.
-        fn wide_to_string(ptr: *const u16) -> String {
-            if ptr.is_null() {
-                return String::new();
-            }
-            let mut len = 0usize;
-            // SAFETY: `ptr` is a valid null-terminated wide string from Win32.
-            unsafe {
-                while *ptr.add(len) != 0 {
-                    len += 1;
-                }
-                let slice = std::slice::from_raw_parts(ptr, len);
-                String::from_utf16_lossy(slice)
-            }
-        }
     }
 }
 
@@ -528,7 +249,9 @@ mod tests {
     async fn bind_accept_connect_round_trip() {
         let endpoint = session_endpoint(&unique_session("rt"));
 
-        let mut listener = DaemonListener::bind(&endpoint).expect("bind listener");
+        let mut listener = DaemonListener::bind(&endpoint)
+            .await
+            .expect("bind listener");
         let server = tokio::spawn(async move {
             let (mut reader, mut writer) = listener.accept().await.expect("accept");
             let frame = protocol::read_frame_async(&mut reader)
@@ -562,7 +285,9 @@ mod tests {
     async fn listener_accepts_sequential_connections() {
         let endpoint = session_endpoint(&unique_session("seq"));
 
-        let mut listener = DaemonListener::bind(&endpoint).expect("bind listener");
+        let mut listener = DaemonListener::bind(&endpoint)
+            .await
+            .expect("bind listener");
         let server = tokio::spawn(async move {
             for _ in 0..2 {
                 let (mut reader, mut writer) = listener.accept().await.expect("accept");

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,6 +40,17 @@ ringbuf = "0.5.0"
 shellexpand = "3.1"
 vte = "0.13"
 
+[target.'cfg(windows)'.dependencies]
+# Used to build a per-user DACL for a security-hardened local-IPC listener
+# (the security analog of the Unix socket's 0o700 permissions) — see
+# `ipc::ListenerSecurity::CurrentUserOnly`.
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 tempfile = "3"
 temp-env = "0.3"

--- a/core/src/ipc/local_socket.rs
+++ b/core/src/ipc/local_socket.rs
@@ -11,7 +11,7 @@
 //!  connect(address) ───────────────────────────────► (BoxedReader, BoxedWriter)
 //! ```
 //!
-//! Semantics are deliberately **fail-fast one-shot**:
+//! Semantics are deliberately **fail-fast one-shot** by default:
 //! - [`connect`] tries once and returns the underlying error immediately (no
 //!   retry) — suited to a "is a rendezvous instance already running?" probe.
 //! - [`LocalSocketListener::bind`] only reclaims a socket path that is *stale*
@@ -19,9 +19,19 @@
 //!   endpoint, `bind` fails so the caller can treat that as "not the
 //!   rendezvous". On windows this maps to `first_pipe_instance(true)`.
 //!
-//! Consumers that need a retrying connect or a security-hardened listener
-//! (e.g. the agent session daemon) layer that policy on top rather than baking
-//! it in here.
+//! Consumers that need a **retrying** connect or a **security-hardened**
+//! listener (e.g. the agent session daemon) express that policy additively
+//! rather than baking it into the fail-fast primitives:
+//! - [`connect_with_retry`] wraps [`connect`] with a bounded retry loop.
+//! - [`LocalSocketListener::bind_with_options`] takes a [`ListenerOptions`]
+//!   selecting a [`ListenerSecurity`] policy (unix `0o700` / windows per-user
+//!   DACL) and a [`StaleReclaim`] policy (conservative probe vs. unconditional
+//!   removal). The plain [`LocalSocketListener::bind`] is exactly
+//!   `bind_with_options` with the default (inherit permissions, probe-then-
+//!   remove) options, so existing rendezvous callers are unchanged.
+
+use std::io;
+use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -30,23 +40,100 @@ pub type BoxedReader = Box<dyn AsyncRead + Send + Unpin>;
 /// Boxed writer half of a local-IPC connection (Unix socket or named pipe).
 pub type BoxedWriter = Box<dyn AsyncWrite + Send + Unpin>;
 
+/// Permission policy applied to a listener endpoint at bind time.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ListenerSecurity {
+    /// Default OS permissions — no extra hardening. This is what the desktop
+    /// spawn rendezvous uses.
+    #[default]
+    Inherit,
+    /// Restrict the endpoint to the current user only. On unix the socket's
+    /// parent directory and the socket file are set to `0o700`; on windows the
+    /// pipe is created with a per-user DACL granting `GENERIC_ALL` to the
+    /// current user's SID and `LocalSystem`. The named-pipe DACL is the direct
+    /// security analog of the Unix socket's `0o700` permissions.
+    CurrentUserOnly,
+}
+
+/// How [`LocalSocketListener::bind_with_options`] reclaims a pre-existing
+/// endpoint path.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum StaleReclaim {
+    /// Only remove a unix socket file if a connect probe shows nothing is
+    /// listening; a live owner keeps its path and the subsequent `bind` fails
+    /// with `AddrInUse` (the "not the rendezvous" signal). No-op on windows,
+    /// where `first_pipe_instance(true)` already rejects a live owner.
+    #[default]
+    IfProbeDead,
+    /// Unconditionally remove any pre-existing unix socket file before binding
+    /// — the owner reclaims its own per-session path on restart. No-op on
+    /// windows (a crashed owner's pipe vanishes with its process, so there is
+    /// never a stale path to reclaim).
+    Unconditional,
+}
+
+/// Options controlling how a [`LocalSocketListener`] binds its endpoint.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ListenerOptions {
+    /// Permission hardening applied to the bound endpoint.
+    pub security: ListenerSecurity,
+    /// How a pre-existing endpoint path is reclaimed.
+    pub stale_reclaim: StaleReclaim,
+}
+
 #[cfg(unix)]
 pub use unix_impl::{connect, LocalSocketListener};
 #[cfg(windows)]
 pub use windows_impl::{connect, LocalSocketListener};
 
+#[cfg(unix)]
+use unix_impl::is_retryable;
+#[cfg(windows)]
+use windows_impl::is_retryable;
+
+/// Connect to `address`, retrying while the endpoint is not yet available.
+///
+/// Repeatedly calls the fail-fast [`connect`] until it succeeds or `timeout`
+/// elapses, sleeping `poll_interval` between tries whenever the connect fails
+/// with a "not ready yet" error (the endpoint owner is still binding during
+/// slow startup work). Once the deadline passes, the last underlying error is
+/// returned. A *non*-retryable error (e.g. a permission failure) is returned
+/// immediately, so a caller racing this against the owner process exiting still
+/// fails fast on a real error.
+///
+/// The retry policy lives here in one place; only the per-platform "endpoint
+/// not ready yet" error predicate differs and is supplied internally.
+pub async fn connect_with_retry(
+    address: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> io::Result<(BoxedReader, BoxedWriter)> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match connect(address).await {
+            Ok(halves) => return Ok(halves),
+            Err(e) if is_retryable(&e) && tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(poll_interval).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 // ── Unix domain socket transport ────────────────────────────────────
 
 #[cfg(unix)]
 mod unix_impl {
-    use super::{BoxedReader, BoxedWriter};
+    use super::{BoxedReader, BoxedWriter, ListenerOptions, ListenerSecurity, StaleReclaim};
     use std::io;
-    use std::path::PathBuf;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
     use tokio::net::{UnixListener, UnixStream};
 
     /// A listening Unix domain socket.
     pub struct LocalSocketListener {
         listener: UnixListener,
+        path: PathBuf,
     }
 
     impl LocalSocketListener {
@@ -59,13 +146,50 @@ mod unix_impl {
         /// probe succeeds, the file is left untouched, and the subsequent
         /// `bind` fails with `AddrInUse` — the caller's "not the rendezvous"
         /// signal.
+        ///
+        /// Equivalent to [`Self::bind_with_options`] with the default options
+        /// (inherit permissions, probe-then-remove).
         pub async fn bind(address: &str) -> io::Result<Self> {
+            Self::bind_with_options(address, ListenerOptions::default()).await
+        }
+
+        /// Bind a listener at the socket path `address`, applying the given
+        /// [`ListenerOptions`] security and stale-reclaim policies.
+        pub async fn bind_with_options(
+            address: &str,
+            options: ListenerOptions,
+        ) -> io::Result<Self> {
             let path = PathBuf::from(address);
-            if path.exists() && UnixStream::connect(&path).await.is_err() {
-                let _ = std::fs::remove_file(&path);
+
+            // Security (pre-bind): ensure the socket's parent directory exists
+            // and is restricted to the current user, so the endpoint is only
+            // reachable by its owner.
+            if options.security == ListenerSecurity::CurrentUserOnly {
+                if let Some(parent) = path.parent() {
+                    ensure_current_user_dir(parent)?;
+                }
             }
+
+            // Reclaim any pre-existing socket file.
+            match options.stale_reclaim {
+                StaleReclaim::IfProbeDead => {
+                    if path.exists() && UnixStream::connect(&path).await.is_err() {
+                        let _ = std::fs::remove_file(&path);
+                    }
+                }
+                StaleReclaim::Unconditional => {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+
             let listener = UnixListener::bind(&path)?;
-            Ok(Self { listener })
+
+            // Security (post-bind): restrict the socket file itself.
+            if options.security == ListenerSecurity::CurrentUserOnly {
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))?;
+            }
+
+            Ok(Self { listener, path })
         }
 
         /// Accept the next client connection, returning erased read/write halves.
@@ -74,6 +198,19 @@ mod unix_impl {
             let (reader, writer) = stream.into_split();
             Ok((Box::new(reader), Box::new(writer)))
         }
+
+        /// Remove the socket file. Call on listener shutdown when the endpoint
+        /// owns a per-session path that should not outlive the process.
+        pub fn cleanup(&self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    /// Ensure `dir` exists with mode `0o700`.
+    fn ensure_current_user_dir(dir: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(dir)?;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+        Ok(())
     }
 
     /// Connect once to a socket path, failing fast if nothing is listening.
@@ -81,23 +218,40 @@ mod unix_impl {
         let (reader, writer) = UnixStream::connect(address).await?.into_split();
         Ok((Box::new(reader), Box::new(writer)))
     }
+
+    /// Whether a failed [`connect`] means "endpoint not ready yet" (worth a
+    /// retry) rather than a fatal error.
+    pub(super) fn is_retryable(e: &io::Error) -> bool {
+        matches!(
+            e.kind(),
+            io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+        )
+    }
 }
 
 // ── Windows named-pipe transport ────────────────────────────────────
 
 #[cfg(windows)]
 mod windows_impl {
-    use super::{BoxedReader, BoxedWriter};
+    use super::{BoxedReader, BoxedWriter, ListenerOptions, ListenerSecurity};
+    use std::ffi::c_void;
     use std::io;
+
     use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
+
+    use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PIPE_BUSY};
 
     /// A listening Windows named pipe.
     ///
     /// Named pipes serve one client per server instance, so the listener keeps
     /// the next (not-yet-connected) instance ready and stages a fresh one each
-    /// time a client is accepted.
+    /// time a client is accepted. When a [`ListenerSecurity::CurrentUserOnly`]
+    /// policy is used, every instance is created with the same per-user DACL.
     pub struct LocalSocketListener {
         name: String,
+        /// The per-user security descriptor applied to each pipe instance, or
+        /// `None` for the default (inherit) permission policy.
+        security: Option<security::SecurityAttributes>,
         /// The next pipe instance, waiting for a client to connect.
         next: Option<NamedPipeServer>,
     }
@@ -108,12 +262,33 @@ mod windows_impl {
         /// `first_pipe_instance(true)` fails if another instance already owns
         /// the pipe — the caller's "not the rendezvous" signal, the exact
         /// analog of the unix `AddrInUse` case.
+        ///
+        /// Equivalent to [`Self::bind_with_options`] with the default options
+        /// (inherit permissions).
         pub async fn bind(address: &str) -> io::Result<Self> {
-            let next = ServerOptions::new()
-                .first_pipe_instance(true)
-                .create(address)?;
+            Self::bind_with_options(address, ListenerOptions::default()).await
+        }
+
+        /// Bind the first pipe instance at pipe name `address`, applying the
+        /// given [`ListenerOptions`] security policy.
+        ///
+        /// `stale_reclaim` has no analog on windows: `first_pipe_instance(true)`
+        /// already rejects a live owner, and a crashed owner's pipe vanishes
+        /// with its process, so there is never a stale path to reclaim.
+        pub async fn bind_with_options(
+            address: &str,
+            options: ListenerOptions,
+        ) -> io::Result<Self> {
+            let security = match options.security {
+                ListenerSecurity::CurrentUserOnly => {
+                    Some(security::SecurityAttributes::for_current_user()?)
+                }
+                ListenerSecurity::Inherit => None,
+            };
+            let next = create_instance(address, security.as_ref(), true)?;
             Ok(Self {
                 name: address.to_string(),
+                security,
                 next: Some(next),
             })
         }
@@ -130,10 +305,36 @@ mod windows_impl {
             // next client before serving this one, so no client races into a
             // missing pipe.
             let connected = self.next.take().expect("pending instance present");
-            self.next = Some(ServerOptions::new().create(&self.name)?);
+            self.next = Some(create_instance(&self.name, self.security.as_ref(), false)?);
 
             let (reader, writer) = tokio::io::split(connected);
             Ok((Box::new(reader), Box::new(writer)))
+        }
+
+        /// No-op on windows: the pipe disappears when its instances are dropped.
+        pub fn cleanup(&self) {}
+    }
+
+    /// Create a named-pipe server instance, optionally with a per-user security
+    /// descriptor.
+    fn create_instance(
+        name: &str,
+        security: Option<&security::SecurityAttributes>,
+        first: bool,
+    ) -> io::Result<NamedPipeServer> {
+        match security {
+            Some(security) => {
+                // SAFETY: `security` outlives this call (owned by the
+                // `LocalSocketListener`), and `as_ptr` points at a valid
+                // `SECURITY_ATTRIBUTES` whose descriptor is owned and freed by
+                // `security`.
+                unsafe {
+                    ServerOptions::new()
+                        .first_pipe_instance(first)
+                        .create_with_security_attributes_raw(name, security.as_ptr() as *mut c_void)
+                }
+            }
+            None => ServerOptions::new().first_pipe_instance(first).create(name),
         }
     }
 
@@ -143,6 +344,160 @@ mod windows_impl {
         let (reader, writer) = tokio::io::split(client);
         Ok((Box::new(reader), Box::new(writer)))
     }
+
+    /// Whether a failed [`connect`] means "endpoint not ready yet" (worth a
+    /// retry) rather than a fatal error: the pipe is not yet created
+    /// (`ERROR_FILE_NOT_FOUND`) or every instance is momentarily busy
+    /// (`ERROR_PIPE_BUSY`).
+    pub(super) fn is_retryable(e: &io::Error) -> bool {
+        matches!(
+            e.raw_os_error(),
+            Some(code)
+                if code == ERROR_FILE_NOT_FOUND as i32 || code == ERROR_PIPE_BUSY as i32
+        )
+    }
+
+    /// Per-user security descriptor construction for the named pipe.
+    mod security {
+        use std::io;
+        use std::ptr;
+
+        use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
+        use windows_sys::Win32::Security::Authorization::{
+            ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
+            SDDL_REVISION_1,
+        };
+        use windows_sys::Win32::Security::{
+            GetTokenInformation, TokenUser, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, TOKEN_QUERY,
+            TOKEN_USER,
+        };
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+        /// Owns a security descriptor restricting the pipe to the current user
+        /// and `LocalSystem`, plus the `SECURITY_ATTRIBUTES` referencing it.
+        pub struct SecurityAttributes {
+            descriptor: PSECURITY_DESCRIPTOR,
+            attributes: SECURITY_ATTRIBUTES,
+        }
+
+        // The owned raw pointers are exclusively managed here; sending the
+        // listener (and thus this owner) across threads is safe.
+        unsafe impl Send for SecurityAttributes {}
+        unsafe impl Sync for SecurityAttributes {}
+
+        impl SecurityAttributes {
+            /// Build a DACL granting `GENERIC_ALL` only to the current user's
+            /// SID and `LocalSystem` (`SY`), protected from inheritance (`P`).
+            pub fn for_current_user() -> io::Result<Self> {
+                let sid_string = current_user_sid_string()?;
+                let sddl = format!("D:P(A;;GA;;;{sid_string})(A;;GA;;;SY)");
+                let sddl_wide = to_wide(&sddl);
+
+                let mut descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
+                // SAFETY: `sddl_wide` is a valid null-terminated UTF-16 string;
+                // `descriptor` receives a LocalAlloc'd descriptor we free on drop.
+                let ok = unsafe {
+                    ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                        sddl_wide.as_ptr(),
+                        SDDL_REVISION_1,
+                        &mut descriptor,
+                        ptr::null_mut(),
+                    )
+                };
+                if ok == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+
+                let attributes = SECURITY_ATTRIBUTES {
+                    nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+                    lpSecurityDescriptor: descriptor,
+                    bInheritHandle: 0,
+                };
+                Ok(Self {
+                    descriptor,
+                    attributes,
+                })
+            }
+
+            /// Pointer to the `SECURITY_ATTRIBUTES` for passing to pipe creation.
+            pub fn as_ptr(&self) -> *const SECURITY_ATTRIBUTES {
+                &self.attributes
+            }
+        }
+
+        impl Drop for SecurityAttributes {
+            fn drop(&mut self) {
+                if !self.descriptor.is_null() {
+                    // SAFETY: `descriptor` was allocated by
+                    // ConvertStringSecurityDescriptorToSecurityDescriptorW.
+                    unsafe { LocalFree(self.descriptor as HLOCAL) };
+                }
+            }
+        }
+
+        /// Resolve the current process user's SID into its string form.
+        fn current_user_sid_string() -> io::Result<String> {
+            // SAFETY: standard token-query FFI sequence; every handle and
+            // allocation is released before returning.
+            unsafe {
+                let mut token: HANDLE = ptr::null_mut();
+                if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+
+                // First call sizes the buffer; it is expected to "fail".
+                let mut len: u32 = 0;
+                GetTokenInformation(token, TokenUser, ptr::null_mut(), 0, &mut len);
+                if len == 0 {
+                    CloseHandle(token);
+                    return Err(io::Error::last_os_error());
+                }
+
+                let mut buf = vec![0u8; len as usize];
+                let ok = GetTokenInformation(
+                    token,
+                    TokenUser,
+                    buf.as_mut_ptr() as *mut _,
+                    len,
+                    &mut len,
+                );
+                CloseHandle(token);
+                if ok == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+
+                let token_user = &*(buf.as_ptr() as *const TOKEN_USER);
+                let mut sid_ptr: *mut u16 = ptr::null_mut();
+                if ConvertSidToStringSidW(token_user.User.Sid, &mut sid_ptr) == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                let sid_string = wide_to_string(sid_ptr);
+                LocalFree(sid_ptr as HLOCAL);
+                Ok(sid_string)
+            }
+        }
+
+        /// Encode a Rust string as a null-terminated UTF-16 buffer.
+        fn to_wide(s: &str) -> Vec<u16> {
+            s.encode_utf16().chain(std::iter::once(0)).collect()
+        }
+
+        /// Read a null-terminated UTF-16 string into a Rust `String`.
+        fn wide_to_string(ptr: *const u16) -> String {
+            if ptr.is_null() {
+                return String::new();
+            }
+            let mut len = 0usize;
+            // SAFETY: `ptr` is a valid null-terminated wide string from Win32.
+            unsafe {
+                while *ptr.add(len) != 0 {
+                    len += 1;
+                }
+                let slice = std::slice::from_raw_parts(ptr, len);
+                String::from_utf16_lossy(slice)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -151,10 +506,12 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+    /// Monotonic per-process counter for building unique endpoint addresses.
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
     /// Build a unique per-process endpoint address so concurrent tests don't
     /// collide on the same socket path / pipe name.
     fn unique_address(tag: &str) -> String {
-        static COUNTER: AtomicU32 = AtomicU32::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let pid = std::process::id();
         #[cfg(unix)]
@@ -234,6 +591,62 @@ mod tests {
         assert!(result.is_err(), "connect to a dead endpoint must error");
     }
 
+    /// [`connect_with_retry`] waits for an endpoint that only appears after a
+    /// delay, then connects successfully.
+    #[tokio::test]
+    async fn connect_with_retry_waits_for_a_late_listener() {
+        let address = unique_address("retry-late");
+
+        let listener_address = address.clone();
+        let server = tokio::spawn(async move {
+            // Bind only after a delay so the first connect attempts fail with a
+            // retryable "endpoint not ready yet" error.
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let mut listener = LocalSocketListener::bind(&listener_address)
+                .await
+                .expect("bind");
+            let (mut reader, mut writer) = listener.accept().await.expect("accept");
+            let mut buf = [0u8; 2];
+            reader.read_exact(&mut buf).await.expect("server read");
+            writer.write_all(&buf).await.expect("server echo");
+            writer.flush().await.expect("server flush");
+        });
+
+        let (mut reader, mut writer) =
+            connect_with_retry(&address, Duration::from_secs(5), Duration::from_millis(20))
+                .await
+                .expect("retry connect should succeed once the listener appears");
+        writer.write_all(b"hi").await.expect("client write");
+        writer.flush().await.expect("client flush");
+        let mut got = [0u8; 2];
+        reader.read_exact(&mut got).await.expect("client read");
+        assert_eq!(&got, b"hi");
+
+        server.await.expect("server task");
+    }
+
+    /// [`connect_with_retry`] gives up once the timeout elapses when the
+    /// endpoint never appears, honoring the timeout window.
+    #[tokio::test]
+    async fn connect_with_retry_times_out_when_endpoint_never_appears() {
+        let address = unique_address("retry-timeout");
+        let start = tokio::time::Instant::now();
+        let result = connect_with_retry(
+            &address,
+            Duration::from_millis(200),
+            Duration::from_millis(20),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "retry connect must fail when no listener ever appears"
+        );
+        assert!(
+            start.elapsed() >= Duration::from_millis(200),
+            "retry connect should honor the timeout window before giving up"
+        );
+    }
+
     /// A stale unix socket file (present on disk, nothing listening) is removed
     /// so `bind` succeeds — the crashed-instance recovery path.
     #[cfg(unix)]
@@ -284,5 +697,54 @@ mod tests {
             second.is_err(),
             "binding an endpoint owned by a live listener must fail"
         );
+    }
+
+    /// The [`ListenerSecurity::CurrentUserOnly`] policy creates the socket's
+    /// parent directory and the socket file with `0o700` permissions (the unix
+    /// analog of the windows per-user DACL).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn current_user_only_binds_0700_dir_and_socket() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("termihub-core-ipc-perm-{}-{n}", std::process::id()));
+        // Ensure a clean slate so the policy is what creates the directory.
+        let _ = std::fs::remove_dir_all(&dir);
+        let address = dir.join("perm.sock").to_string_lossy().into_owned();
+
+        let listener = LocalSocketListener::bind_with_options(
+            &address,
+            ListenerOptions {
+                security: ListenerSecurity::CurrentUserOnly,
+                stale_reclaim: StaleReclaim::Unconditional,
+            },
+        )
+        .await
+        .expect("bind with current-user policy");
+
+        let dir_mode = std::fs::metadata(&dir)
+            .expect("dir metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            dir_mode, 0o700,
+            "socket dir must be 0o700, got {dir_mode:o}"
+        );
+
+        let file_mode = std::fs::metadata(&address)
+            .expect("socket metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            file_mode, 0o700,
+            "socket file must be 0o700, got {file_mode:o}"
+        );
+
+        listener.cleanup();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/core/src/ipc/mod.rs
+++ b/core/src/ipc/mod.rs
@@ -7,12 +7,19 @@
 //!
 //! - [`local_socket`] — a protocol-agnostic Unix-domain-socket / named-pipe
 //!   transport: [`LocalSocketListener`] (bind/accept) plus a fail-fast
-//!   [`connect`]. It moves opaque byte streams and imposes no framing.
+//!   [`connect`]. It moves opaque byte streams and imposes no framing. Optional
+//!   policies layer on additively: [`connect_with_retry`] for a bounded retry
+//!   loop, and [`ListenerOptions`] (a [`ListenerSecurity`] hardening policy plus
+//!   a [`StaleReclaim`] policy) for security-hardened, self-reclaiming
+//!   listeners such as the agent session daemon.
 //! - [`ndjson`] — newline-delimited-JSON line read/write helpers layered on top
 //!   of any async reader/writer.
 
 pub mod local_socket;
 pub mod ndjson;
 
-pub use local_socket::{connect, BoxedReader, BoxedWriter, LocalSocketListener};
+pub use local_socket::{
+    connect, connect_with_retry, BoxedReader, BoxedWriter, ListenerOptions, ListenerSecurity,
+    LocalSocketListener, StaleReclaim,
+};
 pub use ndjson::{read_line, write_line};


### PR DESCRIPTION
Closes #1437
Follow-up to #1386.

## Summary

# 1386 hoisted a protocol-agnostic local-socket / named-pipe transport plus NDJSON framing into `termihub_core::ipc` and migrated the desktop spawn IPC and the agent JSON-RPC `write_line` onto it, but deliberately left the agent **session-daemon** transport (`agent/src/daemon/transport.rs`) alone because it carried load-bearing semantics the fail-fast core primitive did not provide. This PR extends `core::ipc` additively so those semantics can be expressed there, then re-expresses the daemon transport on top of the shared helper.

### `core::ipc` extension (additive, backward-compatible)

- **`ListenerOptions` + `ListenerSecurity` + `StaleReclaim`** — `LocalSocketListener` gains `bind_with_options(address, options)` and a `cleanup()` helper. `ListenerSecurity::CurrentUserOnly` applies the unix `0o700` socket-dir + socket-file hardening and the windows per-user DACL; `StaleReclaim::Unconditional` unconditionally removes a pre-existing socket file before binding. The plain `bind()` is exactly `bind_with_options` with the default `Inherit` / `IfProbeDead` options, so the desktop **spawn rendezvous callers are unchanged** (fail-fast, no extra permissions, conservative probe-then-remove).
- **`connect_with_retry(address, timeout, poll_interval)`** — wraps the fail-fast `connect` in a bounded retry loop using per-platform retryable-error predicates. `connect` itself stays one-shot for the spawn use case.

### Daemon transport re-expression

- `DaemonListener` now wraps `core::ipc::LocalSocketListener`, binding via `bind_with_options` with `CurrentUserOnly` + `Unconditional`; `accept()` / `cleanup()` delegate to the core listener.
- `connect` delegates to `core::ipc::connect_with_retry` with the **same** `CONNECT_TIMEOUT` (30 s) / `CONNECT_POLL_INTERVAL` (50 ms).

## What moved vs. what stayed

| Moved into `core::ipc` (transport plumbing)                                         | Stayed in the agent (session policy)                             |
| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| Unix `0o700` socket dir + file hardening                                            | `session_endpoint` (unix socket path / windows pipe name)        |
| Windows per-user DACL (`SecurityAttributes`, `create_with_security_attributes_raw`) | `endpoint_alive` (unix file-exists / windows `WaitNamedPipeW`)   |
| Unconditional stale-socket removal on bind                                          | `open_daemon_log` (per-session log sibling of the socket)        |
| 30 s connect-retry loop + per-platform retryable predicates                         | The binary-frame streaming loop in `daemon::process` (untouched) |

The agent's `windows-sys` feature set drops `Win32_Security` / `Win32_Security_Authorization` (now owned by core); it keeps `Win32_Foundation` / `Win32_System_Pipes` (the `WaitNamedPipeW` liveness probe) and `Win32_System_Threading` (detached-process creation flags).

## Windows arm — CI-validated only

The Windows named-pipe DACL code (`SecurityAttributes::for_current_user`, `create_with_security_attributes_raw`, the SDDL / token FFI) was **relocated verbatim** from the agent into `core::ipc`, preserving every `#[cfg(windows)]` gate and the exact same Win32 calls — a byte-for-byte `diff` of the moved `mod security` block confirmed it is identical. **This code cannot be compiled or run on the macOS dev machine used for this change**, so the Windows arm was validated only by careful visual diff and relies on CI for build/test confirmation. The unix arm (including a new `0o700`-permissions unit test) was built, linted, and tested locally.

## Preserved semantics (no behavior change)

- 30 s connect retry with `50 ms` polling and per-platform retryable-error predicates.
- Security hardening: unix `0o700` socket dir + file; windows per-user DACL.
- Unconditional stale-socket removal on daemon bind.
- `cleanup()` on daemon shutdown.
- The daemon binary-frame streaming loop is byte-identical.

(`DaemonListener::bind` is now `async` — the single call site in `daemon::process::run_daemon` awaits it; behavior is otherwise unchanged.)

## Test plan

- `cargo test -p termihub-core` — 12 `ipc` tests green, including the **new** `current_user_only_binds_0700_dir_and_socket` (asserts the bound socket dir + file are `0o700` on macOS) and `connect_with_retry_waits_for_a_late_listener` / `connect_with_retry_times_out_when_endpoint_never_appears`.
- `cargo test -p termihub-agent` — daemon transport round-trip tests (`bind_accept_connect_round_trip`, `listener_accepts_sequential_connections`) and session-path helper tests green.
- `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` — all clean on macOS.
- Windows named-pipe / DACL path: **not runnable on macOS** — relies on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
