### PR TITLE
feat(backend): wire native macOS Services provider for the app-level NSServices entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,10 +4086,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -4109,6 +4116,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -4167,6 +4175,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -7165,6 +7186,8 @@ dependencies = [
  "keyring",
  "libc",
  "libunftp",
+ "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "portable-pty",
  "quick-xml",

--- a/docs/changes/dev0/feature/1409-macos-services-provider.md
+++ b/docs/changes/dev0/feature/1409-macos-services-provider.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- macOS app-level **"Open in termiHub"** Services-menu entry now works (#1409).
+  #1369 declared the app-level `NSServices` entry in the app bundle, but an
+  app-provided macOS Service needs a native Cocoa provider registered on
+  `NSApp.servicesProvider` implementing the `openInTermiHub` selector — without
+  it the entry was inert. termiHub now registers that provider at startup: it
+  reads the selected file/folder paths off the pasteboard and opens a session at
+  each, reusing the same spawn flow as the per-entry Automator Quick Action
+  bundles. macOS-only; Windows and Linux are unaffected.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -954,6 +954,40 @@ settings UI lands; until then, seed `shellIntegration.entries` in `settings.json
    remain under `HKCU\Software\Classes\Directory\shell`,
    `…\Directory\Background\shell`, or `…\*\shell` (verify with `regedit`).
 
+### macOS app-level Services provider (#1409)
+
+Verifies the app-level **"Open in termiHub"** entry in the macOS **Services**
+menu is functional — i.e. it opens a session at the selected path rather than
+being an inert menu item. **macOS only** — the native Cocoa service provider is
+`#[cfg(target_os = "macos")]`-gated and needs a running GUI, so it cannot be
+automated (no WKWebView driver; see [ADR-5](#platform-support)). The app-level
+`NSServices` entry (`openInTermiHub`) is declared in `src-tauri/Info.plist`
+(#1369) and wired to `NSApp.servicesProvider` at startup (#1409). See PR for
+issue #1409.
+
+Prerequisites: an **installed** `termiHub.app` bundle (a plain `cargo run`/dev
+build is not registered with Launch Services, so the OS will not surface its app
+Services). Build the bundle with `./scripts/build.sh`, then move
+`termiHub.app` into `/Applications` and launch it at least once.
+
+1. **Register with Launch Services.** After first launch, open **System
+   Settings → Keyboard → Keyboard Shortcuts → Services** (or right-click a
+   Finder item → **Services**) and confirm **"Open in termiHub"** is listed. If
+   it does not appear immediately, run
+   `/System/Library/CoreServices/pbs -flush` (or log out/in) and re-check.
+2. **Folder.** In Finder, **right-click a folder → Services → "Open in
+   termiHub"** → the running termiHub opens a new session at that folder.
+3. **File.** **Right-click a file → Services → "Open in termiHub"** → a session
+   opens at (or targeting) the selected file's path.
+4. **Multiple selection.** Select several items, invoke the Service → one
+   session opens per selected path.
+5. **No dead item.** Confirm the entry never does nothing: every invocation
+   results in a session (this is the regression the app-level entry previously
+   exhibited — it was declared but not backed by a provider).
+6. The per-entry **Automator Quick Action** bundles under
+   `~/Library/Services` (#1369) remain the primary path and continue to work
+   independently; both surfaces can coexist.
+
 ### Agent GitHub self-update (opt-in, #1355)
 
 Verifies the optional agent-side self-update check is gated behind

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -975,8 +975,7 @@ being an inert menu item. **macOS only** — the native Cocoa service provider i
 `#[cfg(target_os = "macos")]`-gated and needs a running GUI, so it cannot be
 automated (no WKWebView driver; see [ADR-5](#platform-support)). The app-level
 `NSServices` entry (`openInTermiHub`) is declared in `src-tauri/Info.plist`
-(#1369) and wired to `NSApp.servicesProvider` at startup (#1409). See PR for
-issue #1409.
+(#1369) and wired to `NSApp.servicesProvider` at startup (#1409). See PR #1449.
 
 Prerequisites: an **installed** `termiHub.app` bundle (a plain `cargo run`/dev
 build is not registered with Launch Services, so the OS will not surface its app

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,7 +76,20 @@ keyring = { version = "3", default-features = false }
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-foundation = { version = "0.3", features = ["NSUserDefaults", "NSString"] }
+objc2-foundation = { version = "0.3", features = [
+    "NSUserDefaults",
+    "NSString",
+    "NSArray",
+] }
+# Native Cocoa Services provider for the app-level "Open in termiHub"
+# Services-menu entry (#1409): register on NSApp.servicesProvider and read the
+# selection off the pasteboard. macOS-only by nature.
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", features = [
+    "NSApplication",
+    "NSResponder",
+    "NSPasteboard",
+] }
 # macOS Keychain backend for the `keyring` crate.
 keyring = { version = "3", default-features = false, features = ["apple-native"] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,10 @@ mod embedded_servers;
 /// subsystem (public so integration tests can drive `SftpSession` /
 /// `TransferRegistry` directly — issue #1245).
 pub mod files;
+/// Native macOS Services provider wiring the app-level "Open in termiHub"
+/// Services-menu entry (#1409). macOS-only.
+#[cfg(target_os = "macos")]
+mod macos_services;
 mod network;
 mod session;
 mod spawn;
@@ -185,6 +189,16 @@ pub fn run() {
                 use objc2_foundation::{NSString, NSUserDefaults};
                 let defaults = NSUserDefaults::standardUserDefaults();
                 defaults.setBool_forKey(false, &NSString::from_str("ApplePressAndHoldEnabled"));
+
+                // Register the native Cocoa Services provider so the app-level
+                // "Open in termiHub" Services-menu entry (declared in Info.plist
+                // by #1369) actually opens a session at the selected path (#1409).
+                // Best-effort: a failure leaves the entry inert but never blocks
+                // startup. The per-entry Automator Quick Action bundles remain
+                // the primary, self-contained path.
+                if let Err(e) = macos_services::register(app.handle().clone()) {
+                    tracing::warn!("could not register macOS Services provider: {e}");
+                }
             }
 
             // Inject AppHandle into the log capture layer so it can emit events
@@ -500,7 +514,7 @@ pub fn run() {
                     let emit_handle = app.handle().clone();
                     let handler: spawn::SpawnHandler =
                         Arc::new(move |req: spawn::SpawnRequest| match emit_handle
-                            .emit("spawn-request", &req)
+                            .emit(spawn::SPAWN_REQUEST_EVENT, &req)
                         {
                             Ok(()) => spawn::SpawnResponse::accepted(),
                             Err(e) => {
@@ -520,7 +534,7 @@ pub fn run() {
             // Process a spawn request this instance launched to handle itself
             // (no running instance accepted the pre-init forward).
             if let Some(req) = &pending_spawn {
-                if let Err(e) = app.handle().emit("spawn-request", req) {
+                if let Err(e) = app.handle().emit(spawn::SPAWN_REQUEST_EVENT, req) {
                     tracing::warn!("failed to emit pending spawn-request: {e}");
                 }
             }

--- a/src-tauri/src/macos_services.rs
+++ b/src-tauri/src/macos_services.rs
@@ -1,0 +1,212 @@
+//! Native macOS Services provider for the app-level "Open in termiHub"
+//! Services-menu entry (#1409).
+//!
+//! #1369 declared an app-level [`NSServices`] entry (`openInTermiHub`) in
+//! `src-tauri/Info.plist` so the Finder integration is discoverable in file
+//! managers that surface *app* Services rather than the per-entry Automator
+//! Quick Action bundles. That declaration alone is inert: an app-provided
+//! Service is only functional once a native Cocoa object implementing the
+//! declared `NSMessage` selector is registered on `NSApp.servicesProvider`.
+//! Tauri does not expose that hook, so this module registers one.
+//!
+//! When the user picks the entry, macOS invokes
+//! `openInTermiHub:userData:error:` on our provider with the selected
+//! file-system objects on an [`NSPasteboard`]. We read the selected paths and
+//! forward each into the **same** spawn flow the Quick Action bundles use: a
+//! [`SpawnRequest`] re-emitted as the [`SPAWN_REQUEST_EVENT`] Tauri event, which
+//! the running instance already handles (see `lib.rs`). This is the internal
+//! equivalent of the bundles' `termiHub spawn --location <path>` invocation — no
+//! separate spawn mechanism is introduced.
+//!
+//! Everything here is `#[cfg(target_os = "macos")]`-gated at the module
+//! declaration in `lib.rs`, so Windows/Linux builds never see this code. The
+//! only unavoidable `unsafe` is the Objective-C FFI (declaring the class,
+//! reading the AppKit pasteboard-type constant, and installing the provider);
+//! each block is kept tight and documented.
+//!
+//! [`NSServices`]: https://developer.apple.com/documentation/bundleresources/information_property_list/nsservices
+
+use crate::spawn::{SpawnRequest, SPAWN_REQUEST_EVENT};
+use anyhow::{Context, Result};
+use objc2::rc::Retained;
+use objc2::runtime::NSObject;
+use objc2::{define_class, msg_send, AnyThread, DefinedClass, MainThreadMarker};
+use objc2_app_kit::{NSApplication, NSPasteboard, NSUpdateDynamicServices};
+// `NSFilenamesPboardType` is deprecated in favour of per-item file URLs, but it
+// is the pasteboard format the system fills for a legacy `NSSendFileTypes`
+// service invocation, so it is the correct constant to read here (#1409).
+#[allow(deprecated)]
+use objc2_app_kit::NSFilenamesPboardType;
+use objc2_foundation::{NSArray, NSString};
+use tauri::{AppHandle, Emitter};
+
+/// Map the file-system paths carried by a Services invocation into the spawn
+/// requests forwarded to the running instance.
+///
+/// Each non-empty (trimmed) path becomes a location-only [`SpawnRequest`]: the
+/// app-level Services entry is generic (not bound to a specific configured
+/// context-menu entry), so it carries no `entry_id`, letting the downstream
+/// resolver fall back to the configured default connection — exactly the
+/// semantics of a plain "Open in termiHub".
+///
+/// Pure and free of Objective-C so the path→request mapping is unit-testable
+/// without a GUI.
+pub fn spawn_requests_from_paths(paths: &[String]) -> Vec<SpawnRequest> {
+    paths
+        .iter()
+        .map(|path| path.trim())
+        .filter(|path| !path.is_empty())
+        .map(|path| SpawnRequest {
+            location: Some(path.to_string()),
+            ..SpawnRequest::default()
+        })
+        .collect()
+}
+
+/// Instance state for the provider: the handle used to re-emit spawn requests.
+struct Ivars {
+    app_handle: AppHandle,
+}
+
+define_class!(
+    /// Objective-C object registered on `NSApp.servicesProvider`. Its single
+    /// method implements the `openInTermiHub` `NSMessage` selector declared in
+    /// `Info.plist`.
+    #[unsafe(super(NSObject))]
+    #[name = "TermiHubServicesProvider"]
+    #[ivars = Ivars]
+    struct ServicesProvider;
+
+    impl ServicesProvider {
+        /// Handler for the app-level "Open in termiHub" Service.
+        ///
+        /// macOS forms the selector by appending `:userData:error:` to the
+        /// declared `NSMessage` (`openInTermiHub`). `pboard` carries the
+        /// selected file-system objects; `user_data` and `error` are unused
+        /// (we never report a Service error back to the system).
+        #[unsafe(method(openInTermiHub:userData:error:))]
+        fn open_in_termihub(
+            &self,
+            pboard: &NSPasteboard,
+            _user_data: *mut NSString,
+            _error: *mut *mut NSString,
+        ) {
+            let paths = read_filenames(pboard);
+            self.forward_spawn_requests(&paths);
+        }
+    }
+);
+
+impl ServicesProvider {
+    /// Allocate a provider bound to `app_handle`.
+    fn new(app_handle: AppHandle) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(Ivars { app_handle });
+        // SAFETY: standard NSObject designated-initializer chain for a class
+        // defined via `define_class!`.
+        unsafe { msg_send![super(this), init] }
+    }
+
+    /// Emit one [`SPAWN_REQUEST_EVENT`] per selected path, reusing the running
+    /// instance's existing spawn handling.
+    fn forward_spawn_requests(&self, paths: &[String]) {
+        let handle = &self.ivars().app_handle;
+        for request in spawn_requests_from_paths(paths) {
+            if let Err(e) = handle.emit(SPAWN_REQUEST_EVENT, &request) {
+                tracing::warn!("failed to emit spawn-request from Services provider: {e}");
+            }
+        }
+    }
+}
+
+/// Read the selected file-system paths from a Services-invocation pasteboard.
+///
+/// The classic Services pasteboard format stores the selection under
+/// `NSFilenamesPboardType` as an `NSArray<NSString>` of absolute paths, which
+/// is what a `NSSendFileTypes` service receives. Returns an empty vec when the
+/// type is absent or holds an unexpected shape.
+///
+/// `NSFilenamesPboardType` is formally deprecated in favour of per-item file
+/// URLs, but it remains the format the system fills for a legacy
+/// `NSSendFileTypes` service invocation, so it is the correct constant here.
+#[allow(deprecated)]
+fn read_filenames(pboard: &NSPasteboard) -> Vec<String> {
+    // SAFETY: reading the AppKit-provided static pasteboard-type constant.
+    let file_type = unsafe { NSFilenamesPboardType };
+    let Some(plist) = pboard.propertyListForType(file_type) else {
+        return Vec::new();
+    };
+    let Ok(array) = plist.downcast::<NSArray>() else {
+        return Vec::new();
+    };
+    array
+        .to_vec()
+        .into_iter()
+        .filter_map(|obj| obj.downcast::<NSString>().ok())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Register the native Services provider on `NSApp` so the app-level
+/// "Open in termiHub" Services-menu entry becomes functional (#1409).
+///
+/// Must run on the main thread, after `NSApplication` exists (i.e. from the
+/// Tauri `setup` hook). Best-effort: a failure to acquire the main-thread
+/// marker leaves the entry inert but never blocks startup.
+pub fn register(app_handle: AppHandle) -> Result<()> {
+    let mtm = MainThreadMarker::new()
+        .context("register macOS Services provider must run on the main thread")?;
+    let provider = ServicesProvider::new(app_handle);
+    let app = NSApplication::sharedApplication(mtm);
+    // SAFETY: installing the provider. AppKit does *not* retain the services
+    // provider, so we intentionally leak the single app-lifetime instance
+    // (below) to keep it alive for as long as the Service can be invoked.
+    unsafe { app.setServicesProvider(Some(&*provider)) };
+    // Keep the provider alive for the process lifetime; `setServicesProvider`
+    // stores an unretained reference.
+    std::mem::forget(provider);
+    // Refresh the dynamic services table so the freshly-installed provider is
+    // picked up without requiring a re-login.
+    NSUpdateDynamicServices();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_each_path_to_a_location_only_request() {
+        let paths = vec!["/Users/me/project".to_string(), "/tmp/file.txt".to_string()];
+        let requests = spawn_requests_from_paths(&paths);
+
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].location.as_deref(), Some("/Users/me/project"));
+        assert_eq!(requests[1].location.as_deref(), Some("/tmp/file.txt"));
+        // The generic app-level entry carries no entry-id / connection override,
+        // and never forces a new window or the picker.
+        for request in &requests {
+            assert!(request.entry_id.is_none());
+            assert!(request.connection.is_none());
+            assert!(!request.new_window);
+            assert!(!request.pick);
+        }
+    }
+
+    #[test]
+    fn trims_paths_and_drops_blank_entries() {
+        let paths = vec![
+            "  /Users/me/dir  ".to_string(),
+            "   ".to_string(),
+            String::new(),
+        ];
+        let requests = spawn_requests_from_paths(&paths);
+
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].location.as_deref(), Some("/Users/me/dir"));
+    }
+
+    #[test]
+    fn empty_selection_yields_no_requests() {
+        assert!(spawn_requests_from_paths(&[]).is_empty());
+    }
+}

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -17,6 +17,12 @@ use serde::{Deserialize, Serialize};
 #[cfg(not(any(unix, windows)))]
 compile_error!("spawn IPC requires a Unix or Windows target");
 
+/// Tauri event name emitted (to the frontend) for each received
+/// [`SpawnRequest`], whether it arrives over the IPC rendezvous, as a
+/// self-handled pending request, or from the native macOS Services provider
+/// (#1409). Centralised so every producer stays in sync.
+pub const SPAWN_REQUEST_EVENT: &str = "spawn-request";
+
 pub mod ipc_client;
 pub mod ipc_server;
 pub mod registry;


### PR DESCRIPTION
Closes #1409
Follow-up to #1369 (PR #1410)

## Summary

#1369 declared an app-level `NSServices` entry (`openInTermiHub`) in `src-tauri/Info.plist` so the Finder integration is discoverable in file managers that surface *app* Services. That declaration alone was inert: an app-provided macOS Service is only functional once a native Cocoa object implementing the declared `NSMessage` selector is registered on `NSApp.servicesProvider`, which Tauri does not expose. Selecting the app-level "Open in termiHub" entry therefore did nothing.

This PR registers that provider:

- New macOS-only module `src-tauri/src/macos_services.rs` defines an objc2 class (`define_class!`) implementing `openInTermiHub:userData:error:`.
- The handler reads the selected file/folder paths off the `NSPasteboard` and forwards each into the **existing** spawn flow as a `spawn-request` Tauri event — the same downstream handling the Automator Quick Action bundles trigger via `termiHub spawn --location <path>`. No parallel spawn mechanism is introduced.
- The provider is installed on `NSApp.servicesProvider` during Tauri `setup` (main thread, after `NSApplication` exists), followed by `NSUpdateDynamicServices()`.
- All native code is `#[cfg(target_os = "macos")]`-gated (module declaration + registration call), so Windows/Linux builds are byte-unaffected.
- Small refactor: the `spawn-request` event name is centralized as `spawn::SPAWN_REQUEST_EVENT` and reused by all three producers (IPC handler, pending self-handled request, and the new provider).
- `Info.plist`'s `NSServices` entry (selector `openInTermiHub`, `NSSendFileTypes` = `public.folder` + `public.item`) already matches the implemented handler, which accepts any selected path — no drift, left as-is.

New deps (macOS target only): `objc2`, `objc2-app-kit` (+ `NSArray` feature on the existing `objc2-foundation`).

## Testing

- **Automated (this machine, macOS):** `cargo build -p termihub`, `cargo clippy -p termihub --all-targets -- -D warnings`, and `cargo fmt` all clean. Added 3 unit tests for the pure path→spawn-request mapping (`spawn_requests_from_paths`) — location-only requests, trimming/blank-dropping, empty selection — all passing. Windows/Linux are unaffected by construction (cfg-gated).
- **Manual (requires GUI, cannot be automated):** a live Services-menu invocation needs a running GUI and a Launch-Services-registered app bundle, so it is verified by hand. Steps added to `docs/testing.md` under "macOS app-level Services provider (#1409)".

## Test plan

1. Build an installed bundle (`./scripts/build.sh`), move `termiHub.app` to `/Applications`, launch once.
2. In Finder, right-click a folder -> Services -> "Open in termiHub" -> a session opens at that folder.
3. Right-click a file -> Services -> "Open in termiHub" -> a session opens for that path.
4. Select multiple items -> one session opens per selected path.
5. Confirm the entry is no longer a dead menu item, and the Automator Quick Action bundles still work independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
