### PR TITLE
test(ftp): add FTP Docker test fixtures (plain + FTPS) (Closes #1333)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -513,6 +513,10 @@ cargo test -p termihub-core --all-features --test network_resilience -- --nocapt
 docker compose -f tests/docker/docker-compose.yml --profile stress up -d
 cargo test -p termihub-core --all-features --test sftp_stress -- --nocapture
 
+# Include the FTP/FTPS server (requires ftp profile) + backend-independent smoke
+docker compose -f tests/docker/docker-compose.yml --profile ftp up -d --wait ftp-server
+bash tests/docker/ftp-server/smoke-test.sh   # lists /pub over plain/explicit/implicit FTPS
+
 # Stop all containers
 docker compose -f tests/docker/docker-compose.yml --profile all down
 ```
@@ -1277,6 +1281,27 @@ server automatically" left at its default/undecided):
    and that Retry re-provisions in place; on a missing-dependency failure an
    **Install** action appears. The screen must match the manual "X Servers → Set
    up" dialog (`XServerSetupContent.tsx`).
+
+### FTP client against the FTP fixture (#1333)
+
+Backs the FTP-client epic (#1331). The `ftp-server` Docker fixture (profile
+`ftp`, see [tests/docker/README.md](../tests/docker/README.md)) provides plain
+FTP, explicit FTPS, and implicit FTPS over a deterministic seeded `/pub` tree.
+The **backend-independent** listing/transfer path is already covered by
+`tests/docker/ftp-server/smoke-test.sh`; this manual step verifies the future
+termiHub FTP **client** end-to-end once the backend sub-issues
+(#1334/#1335/#1336/#1339) land.
+
+1. Start the fixture: `docker compose -f tests/docker/docker-compose.yml --profile ftp up -d --wait ftp-server`.
+2. In termiHub, add an FTP connection to `127.0.0.1:2401`, log in as
+   `ftpuser` / `ftppass` (or anonymous), and open it — the file browser should
+   list `/pub` with **3 folders (docs, images, data) and 14 files** of the
+   documented sizes (e.g. `data/dataset-1m.bin` = 1 048 576 bytes).
+3. Download `pub/data/dataset-1k.bin` and confirm it is exactly 1 024 bytes;
+   upload a file into `/uploads` as `ftpuser` (anonymous uploads must be denied).
+4. Repeat with **explicit FTPS** (TLS Mode = Explicit, port 2401) and **implicit
+   FTPS** (TLS Mode = Implicit, port 2402); accept the self-signed cert. The
+   plain-FTP insecure warning must appear only for TLS Mode = None.
 
 ### Remote system monitoring
 

--- a/scripts/internal/dev-local-env.sh
+++ b/scripts/internal/dev-local-env.sh
@@ -63,6 +63,15 @@ _thdl_port TERMIHUB_TEST_SFTP_STRESS_PORT    2210
 _thdl_port TERMIHUB_TEST_REMOTE_AGENT_PORT   2211
 _thdl_port TERMIHUB_TEST_TELNET_PORT         2301
 _thdl_port TERMIHUB_TEST_NETWORK_TARGET_PORT 8080
+# FTP fixtures (tests/docker/ftp-server). Control ports plus two passive-port
+# ranges; the ranges are advertised 1:1, so both the min AND max of each range
+# are offset in lockstep with the control ports.
+_thdl_port TERMIHUB_TEST_FTP_PORT                  2401
+_thdl_port TERMIHUB_TEST_FTPS_IMPLICIT_PORT        2402
+_thdl_port TERMIHUB_TEST_FTP_PASV_MIN              30000
+_thdl_port TERMIHUB_TEST_FTP_PASV_MAX              30009
+_thdl_port TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MIN    30010
+_thdl_port TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MAX    30019
 # examples/docker quick-start dev target (examples/docker/docker-compose.yml).
 _thdl_port TERMIHUB_TEST_E2E_SSH_PORT        2222
 _thdl_port TERMIHUB_TEST_E2E_TELNET_PORT     2323

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -11,6 +11,9 @@ docker compose -f tests/docker/docker-compose.yml up -d
 # Start everything (including fault injection + stress tests)
 docker compose -f tests/docker/docker-compose.yml --profile all up -d
 
+# Start the FTP/FTPS server only
+docker compose -f tests/docker/docker-compose.yml --profile ftp up -d --wait ftp-server
+
 # Stop all
 docker compose -f tests/docker/docker-compose.yml down
 ```
@@ -63,10 +66,11 @@ podman compose -f tests/docker/docker-compose.yml up -d
 
 ### Profile Containers
 
-| Container             | Port | Profile  | Purpose                             |
-| --------------------- | ---- | -------- | ----------------------------------- |
-| `network-fault-proxy` | 2209 | `fault`  | tc/netem network fault injection    |
-| `sftp-stress`         | 2210 | `stress` | Pre-populated SFTP stress test data |
+| Container             | Port        | Profile  | Purpose                                       |
+| --------------------- | ----------- | -------- | --------------------------------------------- |
+| `network-fault-proxy` | 2209        | `fault`  | tc/netem network fault injection              |
+| `sftp-stress`         | 2210        | `stress` | Pre-populated SFTP stress test data           |
+| `ftp-server`          | 2401 / 2402 | `ftp`    | External FTP/FTPS server + seeded `/pub` tree |
 
 ## Networks
 
@@ -128,6 +132,87 @@ ssh -X -p 2208 testuser@localhost /usr/local/bin/test-x11.sh
 The render check is a genuine in-container capability check; it is **not** a
 stand-in for the end-to-end forward into the operator's real display, which
 remains a manual step (no host X server can be faked in the harness).
+
+## FTP server (profile: `ftp`)
+
+The `ftp-server` container (`ftp-server/`) runs an **independent external FTP
+server (ProFTPD)** — deliberately **not** termiHub's embedded `libunftp` server,
+so the FTP backend sub-issues (#1334 / #1335 / #1336 / #1339) validate real
+interop. One container serves three endpoints over a single seeded `/srv/ftp`
+tree:
+
+| Endpoint      | Host port | Container | Auth                                          |
+| ------------- | --------- | --------- | --------------------------------------------- |
+| plain FTP     | `2401`    | `21`      | `anonymous` (read-only) + `ftpuser`/`ftppass` |
+| explicit FTPS | `2401`    | `21`      | AUTH TLS (STARTTLS) on the same listener      |
+| implicit FTPS | `2402`    | `990`     | TLS from the first byte                       |
+
+> **Why ProFTPD, not vsftpd?** vsftpd 3.0.5 on Ubuntu 24.04 segfaults on any TLS
+> data connection (an OpenSSL-3 incompatibility), which is fatal for the FTPS
+> endpoints. ProFTPD (with `proftpd-mod-crypto`) handles all three modes
+> reliably in a container.
+
+### Logins
+
+- **Anonymous** — user `anonymous` (any password); **read-only** browse of the
+  whole tree. Writes are denied.
+- **`ftpuser` / `ftppass`** — a local account chrooted to the same tree; may
+  **read everything and upload into `/uploads`**.
+
+### Seeded tree (`/srv/ftp`)
+
+Generated deterministically at build time by `ftp-server/generate-test-data.sh`
+(fixed sizes **and** fixed content, so `SIZE` and checksums are reproducible).
+`/pub` holds **3 folders and 14 files**:
+
+```text
+/pub/readme.txt              61 bytes
+/pub/welcome.txt             65 bytes
+/pub/docs/guide.txt          52 bytes
+/pub/docs/manual.txt         54 bytes
+/pub/docs/changelog.txt      44 bytes
+/pub/docs/faq.txt            51 bytes
+/pub/images/logo.bin       2 048 bytes
+/pub/images/banner.bin     4 096 bytes
+/pub/data/dataset-1k.bin   1 024 bytes
+/pub/data/dataset-8k.bin   8 192 bytes
+/pub/data/dataset-64k.bin 65 536 bytes
+/pub/data/dataset-1m.bin  1 048 576 bytes
+/pub/data/empty.bin            0 bytes
+/pub/data/single-byte.bin      1 byte
+/uploads/                  (writable landing zone for STOR tests)
+```
+
+### Passive ports
+
+FTP passive data connections are advertised as the **same** port number the host
+publishes, so the whole passive range is mapped **1:1** (host port == container
+port). Two ranges are used — `30000-30009` (plain/explicit) and `30010-30019`
+(implicit) — and both the port and the range are offset per checkout via
+`scripts/internal/dev-local-env.sh` (`TERMIHUB_TEST_FTP_PORT`,
+`TERMIHUB_TEST_FTPS_IMPLICIT_PORT`, `TERMIHUB_TEST_FTP_PASV_MIN/MAX`,
+`TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MIN/MAX`). The container templates ProFTPD's
+`PassivePorts` from those same values at start-up.
+
+### Verifying the fixture
+
+```bash
+# Bring it up (waits for the healthcheck on port 21)
+docker compose -f tests/docker/docker-compose.yml --profile ftp up -d --wait ftp-server
+
+# Backend-independent smoke test: lists /pub over plain, explicit + implicit
+# FTPS and checks a known-size download. Honours the same port env vars.
+bash tests/docker/ftp-server/smoke-test.sh
+
+# Or by hand with curl (-k trusts the self-signed cert):
+curl ftp://anonymous:test@127.0.0.1:2401/pub/                 # plain, anonymous
+curl -k --ssl-reqd ftp://ftpuser:ftppass@127.0.0.1:2401/pub/  # explicit FTPS
+curl -k ftps://ftpuser:ftppass@127.0.0.1:2402/pub/            # implicit FTPS
+```
+
+The automated app-level integration tests land with the FTP backend sub-issues;
+until then the smoke test above (plus the manual "connect termiHub" step in
+[`docs/testing.md`](../../docs/testing.md)) is the verification path.
 
 ## Requirements
 

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -14,6 +14,7 @@
 #   fault      - Network fault injection proxy
 #   stress     - SFTP stress test container
 #   network    - Network tools live test target (HTTP server on :8080)
+#   ftp        - FTP/FTPS server (plain :2401, implicit FTPS :2402) + seeded tree
 #   all        - Everything
 #
 # Networks:
@@ -279,6 +280,44 @@ services:
       timeout: 3s
       retries: 5
 
+  # ============================================================
+  # FTP Server (profile: ftp)
+  # ============================================================
+
+  # External vsftpd server (NOT the embedded libunftp) with a deterministic
+  # seeded /srv/ftp tree. One container, three endpoints over one tree:
+  #   * plain FTP + explicit FTPS (AUTH TLS) on the control port  -> :21
+  #   * implicit FTPS (TLS from the first byte)                    -> :990
+  # Logins: anonymous (read-only) and ftpuser/ftppass (read + write to uploads/).
+  #
+  # Passive ports must be advertised as the SAME number the host publishes, so
+  # the whole passive range is mapped 1:1 and offset per checkout via env (the
+  # entrypoint templates vsftpd's pasv_min/max_port from these same values).
+  ftp-server:
+    build: ./ftp-server
+    container_name: ${TERMIHUB_TEST_PROJECT:-termihub}-ftp-server
+    environment:
+      PASV_ADDRESS: "127.0.0.1"
+      MAIN_PASV_MIN: "${TERMIHUB_TEST_FTP_PASV_MIN:-30000}"
+      MAIN_PASV_MAX: "${TERMIHUB_TEST_FTP_PASV_MAX:-30009}"
+      IMPLICIT_PASV_MIN: "${TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MIN:-30010}"
+      IMPLICIT_PASV_MAX: "${TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MAX:-30019}"
+    ports:
+      - "127.0.0.1:${TERMIHUB_TEST_FTP_PORT:-2401}:21"
+      - "127.0.0.1:${TERMIHUB_TEST_FTPS_IMPLICIT_PORT:-2402}:990"
+      - "127.0.0.1:${TERMIHUB_TEST_FTP_PASV_MIN:-30000}-${TERMIHUB_TEST_FTP_PASV_MAX:-30009}:${TERMIHUB_TEST_FTP_PASV_MIN:-30000}-${TERMIHUB_TEST_FTP_PASV_MAX:-30009}"
+      - "127.0.0.1:${TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MIN:-30010}-${TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MAX:-30019}:${TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MIN:-30010}-${TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MAX:-30019}"
+    networks:
+      - test-net
+    profiles:
+      - ftp
+      - all
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/21"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
 networks:
   test-net:
     name: ${TERMIHUB_TEST_PROJECT:-termihub}-test-net
@@ -286,4 +325,4 @@ networks:
   jumphost-net:
     name: ${TERMIHUB_TEST_PROJECT:-termihub}-jumphost-net
     driver: bridge
-    internal: true  # No external access — only bastion bridges to test-net
+    internal: true # No external access — only bastion bridges to test-net

--- a/tests/docker/ftp-server/Dockerfile
+++ b/tests/docker/ftp-server/Dockerfile
@@ -1,0 +1,53 @@
+# FTP server for termiHub FTP-client integration fixtures.
+#
+# Provides an INDEPENDENT external FTP server (ProFTPD) — deliberately NOT the
+# embedded libunftp server — so the FTP backend sub-issues validate real interop.
+# One container exposes three endpoints over a single seeded /srv/ftp tree:
+#   * plain FTP           on :21  (anonymous + ftpuser/ftppass)
+#   * explicit FTPS       on :21  (AUTH TLS / STARTTLS on the same listener)
+#   * implicit FTPS       on :990 (TLS from the first byte)
+#
+# ProFTPD (not vsftpd) is used because vsftpd 3.0.5 on Ubuntu 24.04 segfaults on
+# any TLS data connection (an OpenSSL-3 incompatibility), which is fatal for the
+# FTPS endpoints. See tests/docker/README.md for endpoints, logins, and the
+# seeded tree.
+FROM ubuntu:24.04
+
+# proftpd-mod-crypto ships mod_tls (TLS/SSL) as a DSO — required for the FTPS
+# endpoints (proftpd-core alone has no TLS support).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    proftpd-core \
+    proftpd-mod-crypto \
+    openssl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Local FTP account (nologin shell — this account only exists for FTP). Its home
+# is the shared /srv/ftp tree, so DefaultRoot chroots it onto the seeded data.
+RUN useradd -M -d /srv/ftp -s /usr/sbin/nologin ftpuser \
+    && echo "ftpuser:ftppass" | chpasswd
+
+# Ensure the anonymous FTP account exists (home = the seeded tree).
+RUN id ftp >/dev/null 2>&1 || useradd -M -d /srv/ftp -s /usr/sbin/nologin ftp
+
+# Config template + entrypoint (passive ranges templated from env at runtime).
+COPY proftpd.conf.tmpl /etc/proftpd/proftpd.conf.tmpl
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Self-signed TLS material (key + cert in one PEM).
+RUN openssl req -x509 -newkey rsa:2048 -days 3650 -nodes \
+    -subj "/C=US/ST=Test/L=Test/O=termiHub/CN=termihub-ftp" \
+    -keyout /etc/ssl/private/proftpd.pem -out /tmp/ftp-cert.pem \
+    && cat /tmp/ftp-cert.pem >> /etc/ssl/private/proftpd.pem \
+    && rm /tmp/ftp-cert.pem \
+    && chmod 600 /etc/ssl/private/proftpd.pem
+
+# Seed the deterministic /srv/ftp tree at build time.
+COPY generate-test-data.sh /usr/local/bin/generate-test-data.sh
+RUN chmod +x /usr/local/bin/generate-test-data.sh \
+    && /usr/local/bin/generate-test-data.sh \
+    && chown ftpuser:nogroup /srv/ftp/uploads
+
+EXPOSE 21 990
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/tests/docker/ftp-server/entrypoint.sh
+++ b/tests/docker/ftp-server/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Render the ProFTPD config from the container env, then run proftpd in the
+# foreground. A single daemon serves the plain/explicit server (port 21) and the
+# implicit-FTPS VirtualHost (port 990).
+#
+# The passive-port ranges are templated (not baked into the image) because the
+# advertised passive port must equal the host-published port 1:1, so parallel
+# checkouts offset the whole range via env — see tests/docker/README.md.
+set -e
+
+PASV_ADDRESS="${PASV_ADDRESS:-127.0.0.1}"
+MAIN_PASV_MIN="${MAIN_PASV_MIN:-30000}"
+MAIN_PASV_MAX="${MAIN_PASV_MAX:-30009}"
+IMPLICIT_PASV_MIN="${IMPLICIT_PASV_MIN:-30010}"
+IMPLICIT_PASV_MAX="${IMPLICIT_PASV_MAX:-30019}"
+
+sed \
+    -e "s|__PASV_ADDRESS__|${PASV_ADDRESS}|g" \
+    -e "s|__MAIN_PASV_MIN__|${MAIN_PASV_MIN}|g" \
+    -e "s|__MAIN_PASV_MAX__|${MAIN_PASV_MAX}|g" \
+    -e "s|__IMPLICIT_PASV_MIN__|${IMPLICIT_PASV_MIN}|g" \
+    -e "s|__IMPLICIT_PASV_MAX__|${IMPLICIT_PASV_MAX}|g" \
+    /etc/proftpd/proftpd.conf.tmpl >/etc/proftpd/proftpd.conf
+
+echo "[ftp-server] masquerade=${PASV_ADDRESS}"
+echo "[ftp-server] plain + explicit FTPS :21 pasv ${MAIN_PASV_MIN}-${MAIN_PASV_MAX}"
+echo "[ftp-server] implicit FTPS         :990 pasv ${IMPLICIT_PASV_MIN}-${IMPLICIT_PASV_MAX}"
+
+exec /usr/sbin/proftpd --nodaemon --config /etc/proftpd/proftpd.conf

--- a/tests/docker/ftp-server/generate-test-data.sh
+++ b/tests/docker/ftp-server/generate-test-data.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Generate a deterministic FTP test tree for termiHub FTP integration fixtures.
+#
+# Runs at container build time to pre-populate /srv/ftp, which is the shared
+# root for BOTH the anonymous user and the local `ftpuser` account. The tree
+# mirrors the `/pub` layout described in the FTP-client concept
+# (docs/concepts/backlog/ftp-client.html): 3 folders and 14 files under /pub.
+#
+# Determinism matters: listing/transfer assertions in the FTP backend sub-issues
+# (#1334/#1335/#1336/#1339) compare against KNOWN sizes and, where useful, known
+# content. Every file here has a fixed size and fixed byte content (text files
+# hold fixed strings; binary files are zero-filled), so both `SIZE` and a
+# checksum are reproducible across rebuilds and across machines.
+set -e
+
+FTP_ROOT="/srv/ftp"
+PUB="$FTP_ROOT/pub"
+UPLOADS="$FTP_ROOT/uploads"
+
+echo "=== Generating FTP test data ==="
+
+mkdir -p "$PUB/docs" "$PUB/images" "$PUB/data" "$UPLOADS"
+
+# --- Helper: write exactly N zero bytes (deterministic content + size) ---
+zeros() {
+    # $1 = path, $2 = byte count
+    head -c "$2" /dev/zero >"$1"
+}
+
+# --- pub/ root text files (fixed content => fixed size) ---
+printf '%s\n' "termiHub FTP test server. See pub/docs for more information." >"$PUB/readme.txt"
+printf '%s\n' "Welcome to the termiHub FTP fixture. Anonymous browsing enabled." >"$PUB/welcome.txt"
+
+# --- pub/docs/ (4 text files) ---
+printf '%s\n' "Getting started guide for the termiHub FTP fixture." >"$PUB/docs/guide.txt"
+printf '%s\n' "Reference manual placeholder for FTP fixture testing." >"$PUB/docs/manual.txt"
+printf '%s\n' "v1: initial deterministic FTP fixture tree." >"$PUB/docs/changelog.txt"
+printf '%s\n' "Q: Is this deterministic? A: Yes, sizes are fixed." >"$PUB/docs/faq.txt"
+
+# --- pub/images/ (2 binary files, known sizes) ---
+zeros "$PUB/images/logo.bin" 2048
+zeros "$PUB/images/banner.bin" 4096
+
+# --- pub/data/ (6 binary files spanning empty..1 MiB, known sizes) ---
+zeros "$PUB/data/dataset-1k.bin" 1024
+zeros "$PUB/data/dataset-8k.bin" 8192
+zeros "$PUB/data/dataset-64k.bin" 65536
+zeros "$PUB/data/dataset-1m.bin" 1048576
+: >"$PUB/data/empty.bin"
+printf 'X' >"$PUB/data/single-byte.bin"
+
+# --- Ownership / permissions ---
+# The read-only tree is world-readable; the anonymous FTP user (`ftp`) and the
+# local `ftpuser` both only need read access. `uploads/` is writable so
+# STOR/upload tests have a landing zone.
+chmod -R a+rX "$FTP_ROOT"
+chown -R root:root "$PUB"
+chmod 0777 "$UPLOADS"
+
+# --- Emit a manifest so the expected tree is self-documenting in build logs ---
+echo "--- FTP test tree manifest (path : bytes) ---"
+find "$PUB" -type f | sort | while read -r f; do
+    printf '%s : %s\n' "${f#"$FTP_ROOT"}" "$(wc -c <"$f")"
+done
+echo "=== FTP test data generation complete ==="
+echo "Total pub/ size: $(du -sh "$PUB" | cut -f1)"

--- a/tests/docker/ftp-server/proftpd.conf.tmpl
+++ b/tests/docker/ftp-server/proftpd.conf.tmpl
@@ -1,0 +1,93 @@
+# ProFTPD config for the termiHub FTP integration fixtures.
+#
+# One daemon exposes three endpoints over one seeded /srv/ftp tree:
+#   * plain FTP + explicit FTPS (AUTH TLS) on port 21   (TLSRequired off)
+#   * implicit FTPS (TLS from the first byte) on port 990 (VirtualHost below)
+# Logins: anonymous (read-only) and ftpuser/ftppass (read + write to uploads/).
+#
+# __PLACEHOLDERS__ are substituted by entrypoint.sh from the container env so the
+# advertised passive-port ranges can be offset per parallel checkout (the host
+# and container passive ports must match 1:1, so the ranges are templated).
+
+# mod_tls is a DSO (from proftpd-mod-crypto); load it before the TLS blocks.
+<IfModule mod_dso.c>
+  LoadModule mod_tls.c
+</IfModule>
+
+ServerName            "termiHub FTP test server"
+ServerType            standalone
+DefaultServer         on
+UseIPv6               off
+UseReverseDNS         off
+Port                  21
+Umask                 022
+MaxInstances          30
+
+User                  proftpd
+Group                 nogroup
+
+# Chroot every login to its landing directory; the fixture never needs a shell.
+DefaultRoot           ~
+RequireValidShell     off
+RootLogin             off
+
+# Passive data connections for the plain/explicit (port 21) server.
+PassivePorts          __MAIN_PASV_MIN__ __MAIN_PASV_MAX__
+MasqueradeAddress     __PASV_ADDRESS__
+
+# --- TLS shared by every server (explicit on 21, implicit on 990) ---
+<IfModule mod_tls.c>
+  TLSEngine                on
+  TLSProtocol              TLSv1.2 TLSv1.3
+  TLSRSACertificateFile    /etc/ssl/private/proftpd.pem
+  TLSRSACertificateKeyFile /etc/ssl/private/proftpd.pem
+  # Self-signed fixture cert; don't ask clients for one, and don't force TLS
+  # session reuse on the data channel (curl/lftp don't reuse by default).
+  TLSVerifyClient          off
+  TLSOptions               NoSessionReuseRequired
+  # Explicit-only on the main server: plain FTP is still allowed here.
+  TLSRequired              off
+</IfModule>
+
+# --- Anonymous, read-only browse of the seeded tree (applies to all servers) ---
+<Anonymous /srv/ftp>
+  User                     ftp
+  Group                    nogroup
+  UserAlias                anonymous ftp
+  RequireValidShell        off
+  MaxClients               10
+  <Limit WRITE>
+    DenyAll
+  </Limit>
+</Anonymous>
+
+# --- Implicit FTPS: dedicated server on port 990, TLS from the first byte ---
+<VirtualHost 0.0.0.0>
+  Port                     990
+  ServerName               "termiHub FTP test server (implicit FTPS)"
+  DefaultRoot              ~
+  RequireValidShell        off
+  RootLogin                off
+  PassivePorts             __IMPLICIT_PASV_MIN__ __IMPLICIT_PASV_MAX__
+  MasqueradeAddress        __PASV_ADDRESS__
+  <IfModule mod_tls.c>
+    TLSEngine              on
+    TLSProtocol            TLSv1.2 TLSv1.3
+    TLSRSACertificateFile  /etc/ssl/private/proftpd.pem
+    TLSRSACertificateKeyFile /etc/ssl/private/proftpd.pem
+    TLSVerifyClient        off
+    # Enforce TLS and treat connections as implicit FTPS on this port.
+    TLSRequired            on
+    TLSOptions             UseImplicitSSL NoSessionReuseRequired
+  </IfModule>
+  <Anonymous /srv/ftp>
+    User                   ftp
+    Group                  nogroup
+    UserAlias              anonymous ftp
+    RequireValidShell      off
+    MaxClients             10
+    <Limit WRITE>
+      DenyAll
+    </Limit>
+  </Anonymous>
+</VirtualHost>

--- a/tests/docker/ftp-server/smoke-test.sh
+++ b/tests/docker/ftp-server/smoke-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Smoke-test the FTP fixtures from the HOST using curl.
+#
+# Brings nothing up itself — run `docker compose --profile ftp up -d --wait`
+# first. Verifies, against the running container:
+#   1. plain FTP        anonymous listing of /pub
+#   2. plain FTP        ftpuser/ftppass listing of /pub
+#   3. explicit FTPS    (AUTH TLS) listing of /pub
+#   4. implicit FTPS    (TLS from start) listing of /pub
+#   5. a known-size download (pub/data/dataset-1k.bin == 1024 bytes)
+#
+# This is the backend-independent integration smoke referenced by issue #1333;
+# the FTP Rust backend sub-issues (#1334/#1335/#1336/#1339) add app-level tests.
+#
+# Ports honour the same env vars as docker-compose.yml (offset for parallel
+# checkouts via scripts/internal/dev-local-env.sh).
+set -euo pipefail
+
+HOST="127.0.0.1"
+FTP_PORT="${TERMIHUB_TEST_FTP_PORT:-2401}"
+IMPLICIT_PORT="${TERMIHUB_TEST_FTPS_IMPLICIT_PORT:-2402}"
+USER_PW="ftpuser:ftppass"
+
+fail() {
+    echo "SMOKE FAIL: $*" >&2
+    exit 1
+}
+
+check_listing() {
+    # $1 = human label, rest = curl args; expects the /pub listing to contain
+    # the three known folders.
+    local label="$1"
+    shift
+    local out
+    out="$("$@")" || fail "$label: curl exited non-zero"
+    for entry in docs images data readme.txt; do
+        echo "$out" | grep -q "$entry" || fail "$label: '$entry' missing from listing"
+    done
+    echo "OK: $label lists /pub (docs, images, data, readme.txt)"
+}
+
+echo "== FTP fixture smoke test (host $HOST, ftp:$FTP_PORT implicit:$IMPLICIT_PORT) =="
+
+# 1. Plain FTP, anonymous
+check_listing "plain/anonymous" \
+    curl -s --ftp-method nocwd "ftp://anonymous:test@${HOST}:${FTP_PORT}/pub/"
+
+# 2. Plain FTP, ftpuser
+check_listing "plain/ftpuser" \
+    curl -s --ftp-method nocwd "ftp://${USER_PW}@${HOST}:${FTP_PORT}/pub/"
+
+# 3. Explicit FTPS (AUTH TLS). -k: self-signed cert.
+check_listing "explicit-ftps/ftpuser" \
+    curl -s -k --ssl-reqd --ftp-method nocwd "ftp://${USER_PW}@${HOST}:${FTP_PORT}/pub/"
+
+# 4. Implicit FTPS (ftps:// scheme, TLS from the start).
+check_listing "implicit-ftps/ftpuser" \
+    curl -s -k --ftp-method nocwd "ftps://${USER_PW}@${HOST}:${IMPLICIT_PORT}/pub/"
+
+# 5. Known-size download over plain FTP.
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+curl -s "ftp://anonymous:test@${HOST}:${FTP_PORT}/pub/data/dataset-1k.bin" -o "$tmp" \
+    || fail "download: curl exited non-zero"
+size="$(wc -c <"$tmp" | tr -d ' ')"
+[ "$size" = "1024" ] || fail "download: dataset-1k.bin is $size bytes, expected 1024"
+echo "OK: downloaded pub/data/dataset-1k.bin ($size bytes)"
+
+echo "== All FTP smoke checks passed =="


### PR DESCRIPTION
## Summary

Adds an FTP server Docker fixture so the FTP-client backend sub-issues have a deterministic integration target. No FTP fixture existed before. Part of Epic #1331 · Concept #518 (`docs/concepts/backlog/ftp-client.html`).

An **independent external FTP server (ProFTPD)** — deliberately **not** the embedded `libunftp` server — lives in `tests/docker/ftp-server/`, wired into `tests/docker/docker-compose.yml` behind a new `ftp` profile. One container serves three endpoints over a single seeded `/srv/ftp` tree.

### Endpoints / ports / logins

| Endpoint       | Host port | Container | Auth                                            |
| -------------- | --------- | --------- | ----------------------------------------------- |
| plain FTP      | `2401`    | `21`      | `anonymous` (read-only) + `ftpuser` / `ftppass` |
| explicit FTPS  | `2401`    | `21`      | AUTH TLS (STARTTLS) on the same listener        |
| implicit FTPS  | `2402`    | `990`     | TLS from the first byte                         |

- **anonymous** — read-only browse; writes denied.
- **ftpuser / ftppass** — read everything + upload into `/uploads`.

### Seeded tree (deterministic, fixed sizes **and** content)

`/pub` = **3 folders, 14 files**: `readme.txt` (61 B), `welcome.txt` (65 B); `docs/` (guide 52 B, manual 54 B, changelog 44 B, faq 51 B); `images/` (logo 2048 B, banner 4096 B); `data/` (1k/8k/64k/1m `.bin`, `empty.bin` 0 B, `single-byte.bin` 1 B). Plus a writable `/uploads` for STOR tests. Generated by `ftp-server/generate-test-data.sh`, mirroring `sftp-stress/generate-test-data.sh`.

### Passive ports & parallel checkouts

FTP passive data ports are advertised 1:1 (host port == container port), so the whole range is mapped 1:1 and templated from env — the container renders ProFTPD's `PassivePorts` from the same values. `scripts/internal/dev-local-env.sh` gains `TERMIHUB_TEST_FTP_PORT`, `TERMIHUB_TEST_FTPS_IMPLICIT_PORT`, and the two passive-range min/max vars so several checkouts can run it at once.

### Why ProFTPD, not vsftpd

vsftpd 3.0.5 on Ubuntu 24.04 **segfaults on any TLS data connection** (OpenSSL-3 incompatibility) — it takes down the whole server on the first explicit/implicit FTPS transfer, even with Docker seccomp unconfined. ProFTPD (with `proftpd-mod-crypto`) handles all three modes reliably.

## Verification

Built and ran the fixture with Docker; the container reports **healthy** and all endpoints work:

```
$ docker compose --profile ftp up -d --wait ftp-server
 Container termihub-...-ftp-server  Healthy
$ docker ps ... ftp-server
Up (healthy)  127.0.0.1:30000-30019->30000-30019/tcp, 127.0.0.1:2401->21/tcp, 127.0.0.1:2402->990/tcp

$ bash tests/docker/ftp-server/smoke-test.sh
OK: plain/anonymous lists /pub (docs, images, data, readme.txt)
OK: plain/ftpuser lists /pub (docs, images, data, readme.txt)
OK: explicit-ftps/ftpuser lists /pub (docs, images, data, readme.txt)
OK: implicit-ftps/ftpuser lists /pub (docs, images, data, readme.txt)
OK: downloaded pub/data/dataset-1k.bin (1024 bytes)
== All FTP smoke checks passed ==
```

Also verified `ftpuser` can upload into `/uploads` and anonymous uploads are denied (curl exit 25).

## Test angle

Per the issue's test plan, the automated integration smoke is the **backend-independent** `tests/docker/ftp-server/smoke-test.sh` (lists `/pub` over plain/explicit/implicit FTPS + a known-size download via `curl`) — it needs no Rust FTP backend. The app-level FTP client suite lands with the backend sub-issues; a manual "connect termiHub to the FTP fixture" step is documented in `docs/testing.md`.

## Docs

- `tests/docker/README.md` — new **FTP server** section (endpoints, logins, seeded tree, passive ports, verification).
- `docs/testing.md` — `ftp` profile in the comprehensive-tests quick start + a Manual Testing step.

## Unblocks

FTP backend sub-issues #1334 / #1335 / #1336 / #1339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)