### PR TITLE
refactor(ui): adopt shared NumberInput in TunnelEditor, JumpHostEntry, DynamicForm

### DIFF
--- a/docs/changes/dev0/refactor/1444-numberinput-adoption.md
+++ b/docs/changes/dev0/refactor/1444-numberinput-adoption.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Numeric form fields (SSH tunnel ports, jump-host port and connect timeout,
+  and schema-driven connection number/port fields) now share the same
+  blank-value behavior: clearing a numeric field leaves it blank and flags it
+  as required/invalid — blocking Save — instead of silently snapping back to a
+  default (previously `0` for tunnel ports, `22` for a jump-host port). Valid
+  values still save exactly as before (#1444).

--- a/src/components/ConnectionEditor/JumpHostEntry.tsx
+++ b/src/components/ConnectionEditor/JumpHostEntry.tsx
@@ -2,7 +2,7 @@ import type { JumpHostConfig } from "@/types/connection";
 import type { SavedConnectionOption } from "@/utils/jumpHost";
 import { KeyPathInput } from "@/components/Settings/KeyPathInput";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
-import { Input, Select, SelectItem } from "@/components/ui";
+import { Input, NumberInput, Select, SelectItem } from "@/components/ui";
 
 interface JumpHostEntryProps {
   /** The hop being edited. */
@@ -112,14 +112,11 @@ export function JumpHostEntry({ hop, index, onChange, savedConnections }: JumpHo
 
           <div className="settings-form__field">
             <span className="settings-form__label">Port</span>
-            <Input
-              type="number"
+            <NumberInput
               value={hop.port}
               min={1}
               max={65535}
-              onChange={(e) =>
-                onChange({ port: e.target.value === "" ? 22 : Number(e.target.value) })
-              }
+              onValueChange={(v) => onChange({ port: v })}
               data-testid={tid("port")}
             />
           </div>
@@ -174,17 +171,12 @@ export function JumpHostEntry({ hop, index, onChange, savedConnections }: JumpHo
 
       <div className="settings-form__field">
         <span className="settings-form__label">Connect Timeout (s)</span>
-        <Input
-          type="number"
+        <NumberInput
           value={hop.connectTimeoutSecs ?? ""}
           min={1}
           max={300}
           placeholder="Default (20 s)"
-          onChange={(e) =>
-            onChange({
-              connectTimeoutSecs: e.target.value === "" ? undefined : Number(e.target.value),
-            })
-          }
+          onValueChange={(v) => onChange({ connectTimeoutSecs: v === "" ? undefined : v })}
           data-testid={tid("connect-timeout")}
         />
       </div>

--- a/src/components/ConnectionEditor/JumpHostSection.test.tsx
+++ b/src/components/ConnectionEditor/JumpHostSection.test.tsx
@@ -173,6 +173,20 @@ describe("JumpHostSection", () => {
     expect(onChange).toHaveBeenCalledWith([{ ...HOP, host: "edge.example.com" }]);
   });
 
+  it("editing the port merges the parsed number into the hop (#1444)", () => {
+    const onChange = vi.fn();
+    render([HOP], onChange);
+    setValue(query("jump-host-port-0") as HTMLInputElement, "2200");
+    expect(onChange).toHaveBeenCalledWith([{ ...HOP, port: 2200 }]);
+  });
+
+  it("clearing the port keeps it blank instead of coercing to a default (#1444)", () => {
+    const onChange = vi.fn();
+    render([HOP], onChange);
+    setValue(query("jump-host-port-0") as HTMLInputElement, "");
+    expect(onChange).toHaveBeenCalledWith([{ ...HOP, port: "" }]);
+  });
+
   it("shows the password field for password auth and hides the key path", () => {
     render([{ ...HOP, authMethod: "password" }], vi.fn());
     expect(query("jump-host-password-0")).toBeTruthy();

--- a/src/components/DynamicForm/DynamicField.test.tsx
+++ b/src/components/DynamicForm/DynamicField.test.tsx
@@ -140,20 +140,49 @@ describe("DynamicField", () => {
     });
   });
 
+  /** Set an input's value the React-controlled way (native setter + input event). */
+  function setNumber(input: HTMLInputElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+    act(() => {
+      setter?.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
   describe("number field", () => {
+    const numberField: SettingsField = {
+      key: "timeout",
+      label: "Timeout",
+      fieldType: { type: "number", min: 0, max: 300 },
+      required: false,
+    };
+
     it("renders number input with min/max", () => {
-      const field: SettingsField = {
-        key: "timeout",
-        label: "Timeout",
-        fieldType: { type: "number", min: 0, max: 300 },
-        required: false,
-      };
-      renderField(field, 30, vi.fn());
+      renderField(numberField, 30, vi.fn());
       const input = query("field-timeout") as HTMLInputElement;
       expect(input.type).toBe("number");
       expect(input.min).toBe("0");
       expect(input.max).toBe("300");
       expect(input.valueAsNumber).toBe(30);
+    });
+
+    it("renders a blank box when the value is undefined (#1444)", () => {
+      renderField(numberField, undefined, vi.fn());
+      expect((query("field-timeout") as HTMLInputElement).value).toBe("");
+    });
+
+    it("emits a parsed number when a value is typed (#1444)", () => {
+      const onChange = vi.fn();
+      renderField(numberField, 30, onChange);
+      setNumber(query("field-timeout") as HTMLInputElement, "120");
+      expect(onChange).toHaveBeenCalledWith(120);
+    });
+
+    it("clears to undefined (not 0) when the input is emptied (#1444)", () => {
+      const onChange = vi.fn();
+      renderField(numberField, 30, onChange);
+      setNumber(query("field-timeout") as HTMLInputElement, "");
+      expect(onChange).toHaveBeenCalledWith(undefined);
     });
   });
 
@@ -263,6 +292,19 @@ describe("DynamicField", () => {
       expect(input.min).toBe("1");
       expect(input.max).toBe("65535");
       expect(input.valueAsNumber).toBe(22);
+    });
+
+    it("clears to undefined (not 0) when the input is emptied (#1444)", () => {
+      const field: SettingsField = {
+        key: "port",
+        label: "Port",
+        fieldType: { type: "port" },
+        required: true,
+      };
+      const onChange = vi.fn();
+      renderField(field, 22, onChange);
+      setNumber(query("field-port") as HTMLInputElement, "");
+      expect(onChange).toHaveBeenCalledWith(undefined);
     });
   });
 

--- a/src/components/DynamicForm/DynamicField.tsx
+++ b/src/components/DynamicForm/DynamicField.tsx
@@ -5,7 +5,7 @@ import type { SettingsField, FieldType } from "@/types/schema";
 import { KeyPathInput } from "@/components/Settings/KeyPathInput";
 import { listSerialPorts } from "@/services/api";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
-import { Button, Input, Select, Toggle } from "@/components/ui";
+import { Button, Input, NumberInput, Select, Toggle } from "@/components/ui";
 
 interface DynamicFieldProps {
   field: SettingsField;
@@ -178,13 +178,9 @@ function NumberField({
   return (
     <>
       <FieldLabel field={field} />
-      <Input
-        type="number"
+      <NumberInput
         value={value != null ? Number(value) : ""}
-        onChange={(e) => {
-          const v = e.target.value === "" ? undefined : Number(e.target.value);
-          onChange(v);
-        }}
+        onValueChange={(v) => onChange(v === "" ? undefined : v)}
         min={fieldType.min}
         max={fieldType.max}
         placeholder={field.placeholder}
@@ -293,13 +289,9 @@ function PortField({ field, value, onChange }: FieldProps) {
   return (
     <>
       <FieldLabel field={field} />
-      <Input
-        type="number"
+      <NumberInput
         value={value != null ? Number(value) : ""}
-        onChange={(e) => {
-          const v = e.target.value === "" ? undefined : Number(e.target.value);
-          onChange(v);
-        }}
+        onValueChange={(v) => onChange(v === "" ? undefined : v)}
         min={1}
         max={65535}
         placeholder={field.placeholder}

--- a/src/components/TunnelEditor/TunnelEditor.port.test.tsx
+++ b/src/components/TunnelEditor/TunnelEditor.port.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Blank-port-policy tests for the TunnelEditor (#1444): a cleared port field
+ * stays blank (`""`) — surfacing as an invalid/required field that blocks Save —
+ * instead of the old `parseInt(...) || 0` coercion that snapped it back to "0".
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TunnelEditor } from "./TunnelEditor";
+import { TooltipProvider } from "@/components/ui";
+import type { SavedConnection } from "@/types/connection";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+const TAB_ID = "tab-tun-port";
+const PANEL_ID = "panel-tun-port";
+
+const SSH_CONN: SavedConnection = {
+  id: "ssh-1",
+  name: "My SSH",
+  config: { type: "ssh", config: { host: "h", username: "u" } },
+  folderId: null,
+};
+
+const ROOT_PANEL = {
+  type: "leaf",
+  id: PANEL_ID,
+  tabs: [{ id: TAB_ID }],
+  activeTabId: TAB_ID,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <TunnelEditor tabId={TAB_ID} meta={{ tunnelId: null }} isVisible={true} />
+      </TooltipProvider>
+    );
+  });
+}
+
+function localPortInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('[data-testid="tunnel-editor-local-port"]')!;
+}
+
+function saveButton(): HTMLButtonElement {
+  return container.querySelector<HTMLButtonElement>('[data-testid="tunnel-editor-save"]')!;
+}
+
+/** Set a value on a React-controlled <input> and fire the native input event. */
+function setValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  act(() => {
+    setter?.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("TunnelEditor — blank port policy (#1444)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      connections: [SSH_CONN],
+      tunnels: [],
+      saveTunnel: vi.fn(() => Promise.resolve()),
+      startTunnel: vi.fn(() => Promise.resolve()),
+      closeTab: vi.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      rootPanel: ROOT_PANEL as any,
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the local port as a number input", () => {
+    render();
+    const input = localPortInput();
+    expect(input.type).toBe("number");
+    expect(input.value).toBe("8080");
+  });
+
+  it("keeps a cleared port blank instead of snapping it back to 0", () => {
+    render();
+    setValue(localPortInput(), "");
+    expect(localPortInput().value).toBe("");
+  });
+
+  it("disables Save while a port is blank", () => {
+    render();
+    setValue(localPortInput(), "");
+    expect(saveButton().disabled).toBe(true);
+  });
+});

--- a/src/components/TunnelEditor/TunnelEditor.tsx
+++ b/src/components/TunnelEditor/TunnelEditor.tsx
@@ -8,7 +8,7 @@ import {
   DynamicForwardConfig,
 } from "@/types/tunnel";
 import { TunnelEditorMeta } from "@/types/terminal";
-import { Button, Input, Select, Field, Toggle, toast } from "@/components/ui";
+import { Button, Input, NumberInput, Select, Field, Toggle, toast } from "@/components/ui";
 import { useEditorKeyboard } from "@/hooks/useEditorKeyboard";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import { frontendLog } from "@/utils/frontendLog";
@@ -96,7 +96,7 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
     [tunnelType.type]
   );
 
-  const updateConfig = useCallback((field: string, value: string | number) => {
+  const updateConfig = useCallback((field: string, value: string | number | "") => {
     setTunnelType((prev) => {
       switch (prev.type) {
         case "local":
@@ -108,17 +108,6 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
       }
     });
   }, []);
-
-  // Store the raw numeric value (0 for blank) so out-of-range/blank ports are
-  // caught by validation instead of the previous `parseInt(...) || 0` which
-  // silently coerced them to 0 and let an invalid tunnel save.
-  const updatePort = useCallback(
-    (field: string, raw: string) => {
-      const n = parseInt(raw, 10);
-      updateConfig(field, Number.isNaN(n) ? 0 : n);
-    },
-    [updateConfig]
-  );
 
   // Inline validation of the forwarding host/port fields. Blocks Save while any
   // visible field is invalid. `tunnelType` is a fresh object on every edit, so
@@ -281,11 +270,10 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
                 className="tunnel-editor__port-field"
                 error={errors.localPort}
               >
-                <Input
+                <NumberInput
                   id={`tunnel-local-port-${tabId}`}
-                  type="number"
                   value={tunnelType.config.localPort}
-                  onChange={(e) => updatePort("localPort", e.target.value)}
+                  onValueChange={(v) => updateConfig("localPort", v)}
                   error={!!errors.localPort}
                   data-testid="tunnel-editor-local-port"
                 />
@@ -313,11 +301,10 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
                 className="tunnel-editor__port-field"
                 error={errors.remotePort}
               >
-                <Input
+                <NumberInput
                   id={`tunnel-remote-port-${tabId}`}
-                  type="number"
                   value={tunnelType.config.remotePort}
-                  onChange={(e) => updatePort("remotePort", e.target.value)}
+                  onValueChange={(v) => updateConfig("remotePort", v)}
                   error={!!errors.remotePort}
                   data-testid="tunnel-editor-remote-port"
                 />
@@ -350,11 +337,10 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
                 className="tunnel-editor__port-field"
                 error={errors.remotePort}
               >
-                <Input
+                <NumberInput
                   id={`tunnel-r-remote-port-${tabId}`}
-                  type="number"
                   value={tunnelType.config.remotePort}
-                  onChange={(e) => updatePort("remotePort", e.target.value)}
+                  onValueChange={(v) => updateConfig("remotePort", v)}
                   error={!!errors.remotePort}
                   data-testid="tunnel-editor-remote-port"
                 />
@@ -381,11 +367,10 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
                 className="tunnel-editor__port-field"
                 error={errors.localPort}
               >
-                <Input
+                <NumberInput
                   id={`tunnel-r-local-port-${tabId}`}
-                  type="number"
                   value={tunnelType.config.localPort}
-                  onChange={(e) => updatePort("localPort", e.target.value)}
+                  onValueChange={(v) => updateConfig("localPort", v)}
                   error={!!errors.localPort}
                   data-testid="tunnel-editor-local-port"
                 />
@@ -417,11 +402,10 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
                 className="tunnel-editor__port-field"
                 error={errors.localPort}
               >
-                <Input
+                <NumberInput
                   id={`tunnel-d-local-port-${tabId}`}
-                  type="number"
                   value={tunnelType.config.localPort}
-                  onChange={(e) => updatePort("localPort", e.target.value)}
+                  onValueChange={(v) => updateConfig("localPort", v)}
                   error={!!errors.localPort}
                   data-testid="tunnel-editor-local-port"
                 />

--- a/src/components/TunnelEditor/tunnelValidation.test.ts
+++ b/src/components/TunnelEditor/tunnelValidation.test.ts
@@ -26,6 +26,12 @@ describe("validateTunnelType", () => {
     expect(errors.localPort).toBe("Local port must be between 1 and 65535");
   });
 
+  it("rejects a blank ('') port as required (#1444)", () => {
+    const { valid, errors } = validateTunnelType(local({ localPort: "" }));
+    expect(valid).toBe(false);
+    expect(errors.localPort).toBe("Local port is required");
+  });
+
   it("rejects a port above 65535", () => {
     const { valid, errors } = validateTunnelType(local({ remotePort: 70000 }));
     expect(valid).toBe(false);

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -83,7 +83,12 @@ export interface JumpHostConfig {
   /** Reference to a saved SSH connection (reserved; resolved by a later phase). */
   connectionId?: string;
   host: string;
-  port: number;
+  /**
+   * SSH port. While editing, a cleared field is `""` (the shared `number | ""`
+   * blank-value convention, #1444) which `validateProxyJump` flags as required
+   * rather than coercing to a default; a persisted hop always holds a number.
+   */
+  port: number | "";
   username: string;
   /** "key" | "password" | "agent". */
   authMethod: string;

--- a/src/types/tunnel.ts
+++ b/src/types/tunnel.ts
@@ -1,23 +1,31 @@
+/**
+ * A port field while it is being edited. Empty (`""`) represents a cleared
+ * input — the shared `number | ""` blank-value convention (#1444) — which the
+ * tunnel editor flags as required/invalid and blocks Save on, rather than
+ * coercing to `0`. A persisted config always holds a real port number.
+ */
+export type PortValue = number | "";
+
 /** Configuration for local port forwarding (ssh -L). */
 export interface LocalForwardConfig {
   localHost: string;
-  localPort: number;
+  localPort: PortValue;
   remoteHost: string;
-  remotePort: number;
+  remotePort: PortValue;
 }
 
 /** Configuration for remote port forwarding (ssh -R). */
 export interface RemoteForwardConfig {
   remoteHost: string;
-  remotePort: number;
+  remotePort: PortValue;
   localHost: string;
-  localPort: number;
+  localPort: PortValue;
 }
 
 /** Configuration for dynamic (SOCKS5) forwarding (ssh -D). */
 export interface DynamicForwardConfig {
   localHost: string;
-  localPort: number;
+  localPort: PortValue;
 }
 
 /** Tagged union of tunnel types matching the Rust TunnelType enum. */

--- a/src/utils/validateProxyJump.test.ts
+++ b/src/utils/validateProxyJump.test.ts
@@ -37,6 +37,25 @@ describe("validateProxyJump", () => {
     expect(errors).toContain("Jump host: username is required.");
   });
 
+  it("flags a blank inline port as required (#1444)", () => {
+    const { errors } = validateProxyJump([hop({ port: "" })]);
+    expect(errors).toContain("Jump host: port is required.");
+  });
+
+  it("flags an out-of-range inline port (#1444)", () => {
+    const { errors } = validateProxyJump([hop({ port: 70000 })]);
+    expect(errors).toContain("Jump host: port must be between 1 and 65535.");
+  });
+
+  it("does not require a port for a saved-connection reference (#1444)", () => {
+    const ctx = { connections: [sshConn("Work/bastion")] };
+    const { errors } = validateProxyJump(
+      [{ connectionId: "Work/bastion", host: "", port: "", username: "", authMethod: "" }],
+      ctx
+    );
+    expect(errors).toEqual([]);
+  });
+
   it("labels errors per hop number when there are multiple hops", () => {
     const { errors } = validateProxyJump([hop(), hop({ host: "" })]);
     expect(errors).toContain("Hop 2: host is required.");

--- a/src/utils/validateProxyJump.ts
+++ b/src/utils/validateProxyJump.ts
@@ -1,5 +1,6 @@
 import type { JumpHostConfig, SavedConnection } from "@/types/connection";
 import { getJumpHosts } from "@/utils/jumpHost";
+import { validatePort } from "@/utils/fieldValidation";
 
 export interface ProxyJumpValidation {
   /** Blocking problems — save is prevented while any exist. */
@@ -52,9 +53,13 @@ export function validateProxyJump(
         }
       }
     } else {
-      // Inline hop: require the fields needed to open the connection.
+      // Inline hop: require the fields needed to open the connection. The port
+      // follows the shared `number | ""` blank-value convention (#1444) — a
+      // cleared field is `""`, flagged required here rather than coerced.
       if (!hop.host?.trim()) errors.push(`${label}: host is required.`);
       if (!hop.username?.trim()) errors.push(`${label}: username is required.`);
+      const portErr = validatePort(hop.port, { label: "Port" });
+      if (portErr) errors.push(`${label}: ${portErr.charAt(0).toLowerCase()}${portErr.slice(1)}.`);
     }
   });
 


### PR DESCRIPTION
Closes #1444
Follow-up to #1435 (PR #1443).

## Summary

Migrates the remaining first-batch numeric form inputs onto the shared `ui/NumberInput` primitive introduced in #1443, and standardises on its `number | ""` blank-value convention. Removes hand-rolled `type="number"` + inline `Number(...)`/`parseInt(...)` parsing at these call sites.

### Blank-value policy (the deliberate behavior change)

Chosen policy: **`number | ""`** everywhere, matching the primitive — a cleared numeric field stays blank (`""`) and is surfaced as required/invalid, rather than being silently coerced to a default. Previously a cleared tunnel port snapped to `0` (`parseInt || 0`) and a cleared jump-host port snapped to `22`.

Submit/validation adjusted so valid saves are unchanged but blanks are no longer silently accepted:

- **TunnelEditor** — port fields use `NumberInput`; dropped `updatePort` (the `parseInt || 0` coercion). The three tunnel forward-config port fields widen to `number | ""`. `validateTunnelType` already flags a blank/invalid port (`validatePort`), so a blank port now blocks Save instead of saving `0`.
- **JumpHostEntry** — port and connect-timeout use `NumberInput`. `JumpHostConfig.port` widens to `number | ""`. `validateProxyJump` now **requires a valid inline port (1–65535)** for inline hops — previously there was no port check and a blank port coerced to `22`. Saved-connection reference hops are unaffected (port not validated).
- **DynamicForm** `NumberField`/`PortField` delegate to `NumberInput`, keeping the schema-driven `undefined`-on-unset semantics (a cleared field emits `undefined`, so zod required-validation still flags it). The form stays fully schema-driven.

A persisted tunnel/jump-host config always holds a real port number because Save is gated by the validation above; the `number | ""` widening only covers the in-editor draft state.

### Follow-up

Six other bespoke `type="number"` call sites are outside this issues named scope and are tracked in #1453 so this PR stays reviewable.

## Test plan

- TDD: added red tests first, then implemented.
  - `TunnelEditor.port.test.tsx` — cleared local port stays blank (not `0`); Save disabled while blank; renders as a number input.
  - `JumpHostSection.test.tsx` — clearing the port emits `""` (not `22`); typing a number round-trips.
  - `validateProxyJump.test.ts` — blank inline port flagged required; out-of-range flagged; saved-connection reference needs no port.
  - `tunnelValidation.test.ts` — blank (`""`) port flagged required.
  - `DynamicField.test.tsx` — number/port fields clear to `undefined`, render blank for `undefined`, parse typed numbers.
- `pnpm exec vitest run` — 306 files / 2855 tests pass.
- `pnpm run lint`, `pnpm exec tsc --noEmit`, `pnpm run format:check`, `pnpm run markdownlint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)