### PR TITLE
feat(backend): FtpFileBrowser + directory-listing parsers (Unix/Windows/MLSD)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -98,6 +98,7 @@ wsl = ["dep:portable-pty", "dep:tracing"]
 ftp = [
     "dep:suppaftp",
     "dep:futures-rustls",
+    "futures-util/io",
     "dep:webpki-roots",
     "dep:tracing",
 ]

--- a/core/src/backends/ftp/file_browser.rs
+++ b/core/src/backends/ftp/file_browser.rs
@@ -1,0 +1,249 @@
+//! FTP-backed file browser implementing [`FileBrowser`].
+//!
+//! Opens a dedicated FTP control connection for file operations (mirroring the
+//! SFTP browser, which likewise runs on its own connection independent of the
+//! terminal session). The connection is established lazily on first use behind
+//! an async [`Mutex`] and reused for subsequent operations.
+//!
+//! Directory listings prefer the machine-readable `MLSD` command and fall back
+//! to `LIST` (parsed by [`listing_parser`](super::listing_parser)) when the
+//! server does not support it.
+
+use std::sync::Arc;
+
+use futures_util::io::{AsyncReadExt, Cursor};
+use suppaftp::{AsyncRustlsFtpStream, FtpError};
+use tokio::sync::Mutex;
+
+use crate::config::FtpConfig;
+use crate::errors::FileError;
+use crate::files::{FileBrowser, FileEntry};
+
+use super::listing_parser::{parse_list, parse_mlsd, parse_mlsd_line};
+
+/// FTP-backed file browser for a single FTP/FTPS connection.
+///
+/// The underlying control connection is opened on first use and reused; it is
+/// dropped (closing the socket) when the browser is dropped on disconnect.
+pub(crate) struct FtpFileBrowser {
+    config: FtpConfig,
+    client: Arc<Mutex<Option<AsyncRustlsFtpStream>>>,
+}
+
+/// Map a [`suppaftp`] error to a [`FileError`], tagging it with the operation.
+fn map_err(op: &str, err: FtpError) -> FileError {
+    FileError::OperationFailed(format!("FTP {op} failed: {err}"))
+}
+
+impl FtpFileBrowser {
+    /// Create a browser for `config`; no connection is opened until first use.
+    pub(crate) fn new(config: FtpConfig) -> Self {
+        Self {
+            config,
+            client: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Ensure the browsing control connection is established.
+    async fn ensure_connected(&self) -> Result<(), FileError> {
+        let mut guard = self.client.lock().await;
+        if guard.is_some() {
+            return Ok(());
+        }
+        let stream = super::establish(&self.config)
+            .await
+            .map_err(|e| FileError::OperationFailed(format!("FTP connection failed: {e}")))?;
+        *guard = Some(stream);
+        Ok(())
+    }
+}
+
+/// Split a path into its parent directory and base name.
+///
+/// The parent defaults to `"."` when the path has no separator, mirroring how
+/// FTP servers interpret a bare name in the working directory.
+fn split_parent(path: &str) -> (String, String) {
+    let trimmed = path.trim_end_matches('/');
+    match trimmed.rsplit_once('/') {
+        Some(("", base)) => ("/".to_string(), base.to_string()),
+        Some((parent, base)) => (parent.to_string(), base.to_string()),
+        None => (".".to_string(), trimmed.to_string()),
+    }
+}
+
+#[async_trait::async_trait]
+impl FileBrowser for FtpFileBrowser {
+    async fn list_dir(&self, path: &str) -> Result<Vec<FileEntry>, FileError> {
+        self.ensure_connected().await?;
+        let mut guard = self.client.lock().await;
+        let stream = guard
+            .as_mut()
+            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
+
+        // Prefer MLSD (machine-readable); fall back to LIST when unsupported.
+        match stream.mlsd(Some(path)).await {
+            Ok(lines) => Ok(parse_mlsd(&lines, path)),
+            Err(_) => {
+                let lines = stream
+                    .list(Some(path))
+                    .await
+                    .map_err(|e| map_err("LIST", e))?;
+                Ok(parse_list(&lines, path))
+            }
+        }
+    }
+
+    async fn read_file(&self, path: &str) -> Result<Vec<u8>, FileError> {
+        self.ensure_connected().await?;
+        let mut guard = self.client.lock().await;
+        let stream = guard
+            .as_mut()
+            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
+
+        let mut data_stream = stream
+            .retr_as_stream(path)
+            .await
+            .map_err(|e| map_err("RETR", e))?;
+        let mut buf = Vec::new();
+        data_stream
+            .read_to_end(&mut buf)
+            .await
+            .map_err(|e| FileError::OperationFailed(format!("FTP read failed: {e}")))?;
+        stream
+            .finalize_retr_stream(data_stream)
+            .await
+            .map_err(|e| map_err("RETR", e))?;
+        Ok(buf)
+    }
+
+    async fn write_file(&self, path: &str, data: &[u8]) -> Result<(), FileError> {
+        self.ensure_connected().await?;
+        let mut guard = self.client.lock().await;
+        let stream = guard
+            .as_mut()
+            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
+
+        let mut cursor = Cursor::new(data);
+        stream
+            .put_file(path, &mut cursor)
+            .await
+            .map_err(|e| map_err("STOR", e))?;
+        Ok(())
+    }
+
+    async fn delete(&self, path: &str) -> Result<(), FileError> {
+        self.ensure_connected().await?;
+        let mut guard = self.client.lock().await;
+        let stream = guard
+            .as_mut()
+            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
+
+        // FTP deletes files with DELE and directories with RMD, and the trait
+        // does not tell us which. Try DELE first; on failure, treat it as a
+        // directory and try RMD.
+        match stream.rm(path).await {
+            Ok(()) => Ok(()),
+            Err(file_err) => stream.rmdir(path).await.map_err(|dir_err| {
+                FileError::OperationFailed(format!(
+                    "FTP delete failed (DELE: {file_err}; RMD: {dir_err})"
+                ))
+            }),
+        }
+    }
+
+    async fn rename(&self, from: &str, to: &str) -> Result<(), FileError> {
+        self.ensure_connected().await?;
+        let mut guard = self.client.lock().await;
+        let stream = guard
+            .as_mut()
+            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
+
+        stream
+            .rename(from, to)
+            .await
+            .map_err(|e| map_err("RNFR/RNTO", e))
+    }
+
+    async fn stat(&self, path: &str) -> Result<FileEntry, FileError> {
+        // The filesystem root has no parent to list; synthesize it.
+        if path == "/" || path.is_empty() {
+            return Ok(FileEntry {
+                name: "/".to_string(),
+                path: "/".to_string(),
+                is_directory: true,
+                size: 0,
+                modified: String::new(),
+                permissions: None,
+            });
+        }
+
+        self.ensure_connected().await?;
+        let (parent, base) = split_parent(path);
+
+        let mut guard = self.client.lock().await;
+        let stream = guard
+            .as_mut()
+            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
+
+        // Prefer MLST (single-entry machine listing).
+        if let Ok(line) = stream.mlst(Some(path)).await {
+            if let Some(entry) = parse_mlsd_line(line.as_bytes(), &parent) {
+                return Ok(entry);
+            }
+        }
+
+        // Fall back to listing the parent and matching by name.
+        let entries = match stream.mlsd(Some(&parent)).await {
+            Ok(lines) => parse_mlsd(&lines, &parent),
+            Err(_) => {
+                let lines = stream
+                    .list(Some(&parent))
+                    .await
+                    .map_err(|e| map_err("LIST", e))?;
+                parse_list(&lines, &parent)
+            }
+        };
+
+        entries
+            .into_iter()
+            .find(|e| e.name == base)
+            .ok_or_else(|| FileError::NotFound(path.to_string()))
+    }
+
+    async fn mkdir(&self, path: &str) -> Result<(), FileError> {
+        self.ensure_connected().await?;
+        let mut guard = self.client.lock().await;
+        let stream = guard
+            .as_mut()
+            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
+
+        stream.mkdir(path).await.map_err(|e| map_err("MKD", e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_parent_handles_common_shapes() {
+        assert_eq!(
+            split_parent("/pub/docs/file.txt"),
+            ("/pub/docs".to_string(), "file.txt".to_string())
+        );
+        assert_eq!(split_parent("/top"), ("/".to_string(), "top".to_string()));
+        assert_eq!(split_parent("bare"), (".".to_string(), "bare".to_string()));
+        // Trailing slash is ignored.
+        assert_eq!(
+            split_parent("/pub/docs/"),
+            ("/pub".to_string(), "docs".to_string())
+        );
+    }
+
+    #[test]
+    fn browser_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<FtpFileBrowser>();
+        assert_send::<Box<dyn FileBrowser>>();
+    }
+}

--- a/core/src/backends/ftp/listing_parser.rs
+++ b/core/src/backends/ftp/listing_parser.rs
@@ -38,7 +38,13 @@ pub(crate) fn decode_bytes(raw: &[u8]) -> String {
 /// Returns `None` for lines the crate cannot parse and for `.` / `..` / empty
 /// names, so malformed lines are skipped rather than failing the whole listing.
 pub(crate) fn parse_mlsd_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
-    todo!()
+    let line = decode_bytes(raw);
+    let file = FtpFile::from_mlsx_line(&line).ok()?;
+    if is_ignored_name(file.name()) {
+        return None;
+    }
+    // MLSD carries machine-readable permissions (default or `unix.mode`).
+    Some(entry_from_file(&file, dir, true))
 }
 
 /// Parse one `LIST` line (Unix `ls -l` first, then Windows/DOS) into a
@@ -47,19 +53,46 @@ pub(crate) fn parse_mlsd_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
 /// Returns `None` for unparseable lines, `total …` summary lines and
 /// `.` / `..` entries.
 pub(crate) fn parse_list_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
-    todo!()
+    let decoded = decode_bytes(raw);
+    let line = decoded.trim_end_matches(['\r', '\n']);
+    // Unix `ls -l` first (the common case), then Windows/DOS. POSIX lines carry
+    // real permissions; DOS lines do not.
+    if let Ok(file) = FtpFile::from_posix_line(line) {
+        if is_ignored_name(file.name()) {
+            return None;
+        }
+        return Some(entry_from_file(&file, dir, true));
+    }
+    if let Ok(file) = FtpFile::from_dos_line(line) {
+        if is_ignored_name(file.name()) {
+            return None;
+        }
+        return Some(entry_from_file(&file, dir, false));
+    }
+    None
 }
 
 /// Parse a full MLSD listing (as returned by [`suppaftp`]) into entries,
 /// skipping any malformed lines.
 pub(crate) fn parse_mlsd(lines: &[String], dir: &str) -> Vec<FileEntry> {
-    todo!()
+    lines
+        .iter()
+        .filter_map(|line| parse_mlsd_line(line.as_bytes(), dir))
+        .collect()
 }
 
 /// Parse a full `LIST` listing (as returned by [`suppaftp`]) into entries,
 /// skipping any malformed lines.
 pub(crate) fn parse_list(lines: &[String], dir: &str) -> Vec<FileEntry> {
-    todo!()
+    lines
+        .iter()
+        .filter_map(|line| parse_list_line(line.as_bytes(), dir))
+        .collect()
+}
+
+/// Names that are never surfaced as listing entries.
+fn is_ignored_name(name: &str) -> bool {
+    name.is_empty() || name == "." || name == ".."
 }
 
 /// Build the 9-character `rwxrwxrwx` POSIX permission string for `file`.

--- a/core/src/backends/ftp/listing_parser.rs
+++ b/core/src/backends/ftp/listing_parser.rs
@@ -1,0 +1,360 @@
+//! Directory-listing parsers for the FTP backend.
+//!
+//! FTP servers return directory listings in several formats. This module maps
+//! each into the shared [`FileEntry`] used across the app:
+//!
+//! * **MLSD** — machine-readable facts lines (`type=dir;size=…;modify=…; name`),
+//!   parsed by [`parse_mlsd_line`].
+//! * **Unix `ls -l`** and **Windows/DOS** `LIST` output, parsed (in that order)
+//!   by [`parse_list_line`].
+//!
+//! Parsing of the individual line formats is delegated to
+//! [`suppaftp::list::File`], which covers POSIX (`ls -l`), DOS and MLSx lines.
+//! This module owns the mapping into [`FileEntry`] (ISO-8601 timestamps, POSIX
+//! `rwxrwxrwx` permission strings, path joining, symlink handling) plus a
+//! byte-level name decode (UTF-8 with a Latin-1 fallback) and the skipping of
+//! malformed / `.` / `..` / `total …` lines.
+
+use suppaftp::list::{File as FtpFile, PosixPexQuery};
+
+use crate::files::utils::chrono_from_epoch;
+use crate::files::FileEntry;
+
+/// Decode raw listing bytes as UTF-8, falling back to Latin-1 (ISO-8859-1).
+///
+/// FTP predates a mandatory charset; names may arrive in either encoding. A
+/// strict UTF-8 decode is attempted first; on failure every byte is mapped to
+/// its Latin-1 code point (`0x00..=0xFF` → `U+0000..=U+00FF`) so no byte is
+/// lost to a replacement character.
+pub(crate) fn decode_bytes(raw: &[u8]) -> String {
+    match std::str::from_utf8(raw) {
+        Ok(s) => s.to_string(),
+        Err(_) => raw.iter().map(|&b| b as char).collect(),
+    }
+}
+
+/// Parse one MLSD facts line into a [`FileEntry`], rooted at `dir`.
+///
+/// Returns `None` for lines the crate cannot parse and for `.` / `..` / empty
+/// names, so malformed lines are skipped rather than failing the whole listing.
+pub(crate) fn parse_mlsd_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
+    todo!()
+}
+
+/// Parse one `LIST` line (Unix `ls -l` first, then Windows/DOS) into a
+/// [`FileEntry`] rooted at `dir`.
+///
+/// Returns `None` for unparseable lines, `total …` summary lines and
+/// `.` / `..` entries.
+pub(crate) fn parse_list_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
+    todo!()
+}
+
+/// Parse a full MLSD listing (as returned by [`suppaftp`]) into entries,
+/// skipping any malformed lines.
+pub(crate) fn parse_mlsd(lines: &[String], dir: &str) -> Vec<FileEntry> {
+    todo!()
+}
+
+/// Parse a full `LIST` listing (as returned by [`suppaftp`]) into entries,
+/// skipping any malformed lines.
+pub(crate) fn parse_list(lines: &[String], dir: &str) -> Vec<FileEntry> {
+    todo!()
+}
+
+/// Build the 9-character `rwxrwxrwx` POSIX permission string for `file`.
+fn perms_string(file: &FtpFile) -> String {
+    let flag = |present: bool, ch: char| if present { ch } else { '-' };
+    let mut s = String::with_capacity(9);
+    for who in [
+        PosixPexQuery::Owner,
+        PosixPexQuery::Group,
+        PosixPexQuery::Others,
+    ] {
+        s.push(flag(file.can_read(who), 'r'));
+        s.push(flag(file.can_write(who), 'w'));
+        s.push(flag(file.can_execute(who), 'x'));
+    }
+    s
+}
+
+/// Render the file's modification time as an ISO-8601 timestamp, or an empty
+/// string when the server did not provide one (epoch sentinel).
+fn modified_iso(file: &FtpFile) -> String {
+    match file.modified().duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) if d.as_secs() > 0 => chrono_from_epoch(d.as_secs()),
+        _ => String::new(),
+    }
+}
+
+/// Join a directory path and an entry name with a single `/` separator.
+fn join_path(dir: &str, name: &str) -> String {
+    format!("{}/{}", dir.trim_end_matches('/'), name)
+}
+
+/// Convert a parsed [`FtpFile`] into a [`FileEntry`] rooted at `dir`.
+///
+/// `with_perms` controls whether a permission string is attached: POSIX and
+/// MLSD lines carry meaningful permissions, whereas DOS listings do not.
+fn entry_from_file(file: &FtpFile, dir: &str, with_perms: bool) -> FileEntry {
+    FileEntry {
+        name: file.name().to_string(),
+        path: join_path(dir, file.name()),
+        is_directory: file.is_directory(),
+        size: file.size() as u64,
+        modified: modified_iso(file),
+        permissions: with_perms.then(|| perms_string(file)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A single parser test case over a captured listing line.
+    struct Case {
+        /// Raw listing line bytes.
+        line: &'static [u8],
+        /// Expected name, or `None` if the line should be skipped.
+        name: Option<&'static str>,
+        is_dir: bool,
+        size: u64,
+        /// Expected ISO-8601 modified timestamp (empty if not parseable).
+        modified: &'static str,
+        /// Expected permission string, or `None`.
+        perms: Option<&'static str>,
+    }
+
+    const DIR: &str = "/pub";
+
+    fn check(entry: Option<FileEntry>, case: &Case) {
+        match (case.name, entry) {
+            (None, None) => {}
+            (None, Some(e)) => panic!("expected line to be skipped, got {e:?}"),
+            (Some(expected), None) => {
+                panic!("expected entry named {expected:?}, line was skipped")
+            }
+            (Some(expected), Some(e)) => {
+                assert_eq!(e.name, expected, "name");
+                assert_eq!(e.path, format!("{DIR}/{expected}"), "path");
+                assert_eq!(e.is_directory, case.is_dir, "is_directory for {expected}");
+                assert_eq!(e.size, case.size, "size for {expected}");
+                assert_eq!(e.modified, case.modified, "modified for {expected}");
+                assert_eq!(
+                    e.permissions.as_deref(),
+                    case.perms,
+                    "permissions for {expected}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parses_unix_ls_l_lines() {
+        let cases = [
+            // Directory.
+            Case {
+                line: b"drwxrwxr-x 1 root  dialout  4096 Nov 5 2018 provola",
+                name: Some("provola"),
+                is_dir: true,
+                size: 4096,
+                modified: "2018-11-05T00:00:00Z",
+                perms: Some("rwxrwxr-x"),
+            },
+            // Regular file.
+            Case {
+                line: b"-rw-r--r--    1 0        0             1337 Mar 18 2018 config.ini",
+                name: Some("config.ini"),
+                is_dir: false,
+                size: 1337,
+                modified: "2018-03-18T00:00:00Z",
+                perms: Some("rw-r--r--"),
+            },
+            // Name containing spaces.
+            Case {
+                line: b"-r--r--r--    1 23        23         1234567 Jan 1  2000 01 1234 foo.mp3",
+                name: Some("01 1234 foo.mp3"),
+                is_dir: false,
+                size: 1234567,
+                modified: "2000-01-01T00:00:00Z",
+                perms: Some("r--r--r--"),
+            },
+            // Symlink: the "-> target" suffix is stripped from the name and the
+            // entry is not a directory.
+            Case {
+                line: b"lrwxrwxrwx 1 0 0 7 Nov 5 2018 link -> target",
+                name: Some("link"),
+                is_dir: false,
+                size: 7,
+                modified: "2018-11-05T00:00:00Z",
+                perms: Some("rwxrwxrwx"),
+            },
+            // "total" summary line and junk are skipped.
+            Case {
+                line: b"total 8",
+                name: None,
+                is_dir: false,
+                size: 0,
+                modified: "",
+                perms: None,
+            },
+            Case {
+                line: b"this is not a listing line",
+                name: None,
+                is_dir: false,
+                size: 0,
+                modified: "",
+                perms: None,
+            },
+        ];
+        for case in &cases {
+            check(parse_list_line(case.line, DIR), case);
+        }
+    }
+
+    #[test]
+    fn parses_windows_dos_lines() {
+        let cases = [
+            // Directory (<DIR> marker, size 0).
+            Case {
+                line: b"04-08-14  03:09PM  <DIR> docs",
+                name: Some("docs"),
+                is_dir: true,
+                size: 0,
+                modified: "2014-04-08T15:09:00Z",
+                perms: None,
+            },
+            // Regular file with a size.
+            Case {
+                line: b"04-08-14  03:09PM  8192 omar.txt",
+                name: Some("omar.txt"),
+                is_dir: false,
+                size: 8192,
+                modified: "2014-04-08T15:09:00Z",
+                perms: None,
+            },
+            // Malformed date → skipped.
+            Case {
+                line: b"-08-14  03:09PM  <DIR> docs",
+                name: None,
+                is_dir: false,
+                size: 0,
+                modified: "",
+                perms: None,
+            },
+        ];
+        for case in &cases {
+            check(parse_list_line(case.line, DIR), case);
+        }
+    }
+
+    #[test]
+    fn parses_mlsd_lines() {
+        let cases = [
+            // File with default (777) permissions.
+            Case {
+                line: b"type=file;size=8192;modify=20181105163248; omar.txt",
+                name: Some("omar.txt"),
+                is_dir: false,
+                size: 8192,
+                modified: "2018-11-05T16:32:48Z",
+                perms: Some("rwxrwxrwx"),
+            },
+            // Directory.
+            Case {
+                line: b"type=dir;size=4096;modify=20181105163248; docs",
+                name: Some("docs"),
+                is_dir: true,
+                size: 4096,
+                modified: "2018-11-05T16:32:48Z",
+                perms: Some("rwxrwxrwx"),
+            },
+            // File carrying an explicit unix.mode fact.
+            Case {
+                line: b"type=file;size=4096;modify=20181105163248;unix.mode=644; data.bin",
+                name: Some("data.bin"),
+                is_dir: false,
+                size: 4096,
+                modified: "2018-11-05T16:32:48Z",
+                perms: Some("rw-r--r--"),
+            },
+            // Symlink (type=link) → not a directory.
+            Case {
+                line: b"type=link;modify=20181105163248; shortcut",
+                name: Some("shortcut"),
+                is_dir: false,
+                size: 0,
+                modified: "2018-11-05T16:32:48Z",
+                perms: Some("rwxrwxrwx"),
+            },
+            // Unknown type → malformed, skipped.
+            Case {
+                line: b"type=bogus;size=1;modify=20181105163248; junk",
+                name: None,
+                is_dir: false,
+                size: 0,
+                modified: "",
+                perms: None,
+            },
+            // Empty line → skipped.
+            Case {
+                line: b"",
+                name: None,
+                is_dir: false,
+                size: 0,
+                modified: "",
+                perms: None,
+            },
+        ];
+        for case in &cases {
+            check(parse_mlsd_line(case.line, DIR), case);
+        }
+    }
+
+    #[test]
+    fn skips_dot_entries() {
+        // MLSD "." / ".." entries are dropped.
+        assert!(parse_mlsd_line(b"type=cdir;modify=20181105163248; .", DIR).is_none());
+        assert!(parse_mlsd_line(b"type=pdir;modify=20181105163248; ..", DIR).is_none());
+    }
+
+    #[test]
+    fn decodes_latin1_names() {
+        // A Unix line whose name ends in a Latin-1 'é' (0xE9), which is not
+        // valid UTF-8. The name must round-trip through the Latin-1 fallback.
+        let mut line = b"-rw-r--r-- 1 0 0 5 Nov 5 2018 caf".to_vec();
+        line.push(0xE9);
+        let entry = parse_list_line(&line, DIR).expect("latin-1 name should parse");
+        assert_eq!(entry.name, "caf\u{00E9}");
+        assert!(!entry.is_directory);
+        assert_eq!(entry.size, 5);
+    }
+
+    #[test]
+    fn decode_bytes_prefers_utf8() {
+        assert_eq!(decode_bytes("näme".as_bytes()), "näme");
+        // Lone 0xFF is invalid UTF-8 → Latin-1 ÿ (U+00FF).
+        assert_eq!(decode_bytes(&[b'x', 0xFF]), "x\u{00FF}");
+    }
+
+    #[test]
+    fn parses_full_listings_skipping_bad_lines() {
+        let list = vec![
+            "total 3".to_string(),
+            "drwxrwxr-x 1 root dialout 4096 Nov 5 2018 docs".to_string(),
+            "garbage".to_string(),
+            "-rw-r--r-- 1 0 0 12 Mar 18 2018 a.txt".to_string(),
+        ];
+        let entries = parse_list(&list, DIR);
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["docs", "a.txt"]);
+
+        let mlsd = vec![
+            "type=dir;modify=20181105163248; sub".to_string(),
+            "type=bogus; junk".to_string(),
+            "type=file;size=1;modify=20181105163248; b.bin".to_string(),
+        ];
+        let names: Vec<String> = parse_mlsd(&mlsd, DIR).into_iter().map(|e| e.name).collect();
+        assert_eq!(names, vec!["sub".to_string(), "b.bin".to_string()]);
+    }
+}

--- a/core/src/backends/ftp/mod.rs
+++ b/core/src/backends/ftp/mod.rs
@@ -9,6 +9,8 @@
 //! (see the FTP client concept); `write`/`resize` are no-ops because FTP has no
 //! terminal channel.
 
+mod listing_parser;
+
 use std::sync::Arc;
 
 use futures_rustls::rustls::crypto::aws_lc_rs;

--- a/core/src/backends/ftp/mod.rs
+++ b/core/src/backends/ftp/mod.rs
@@ -9,9 +9,12 @@
 //! (see the FTP client concept); `write`/`resize` are no-ops because FTP has no
 //! terminal channel.
 
+mod file_browser;
 mod listing_parser;
 
 use std::sync::Arc;
+
+use file_browser::FtpFileBrowser;
 
 use futures_rustls::rustls::crypto::aws_lc_rs;
 use futures_rustls::rustls::{ClientConfig, RootCertStore};
@@ -43,12 +46,19 @@ const ANONYMOUS_PASSWORD: &str = "anonymous@termihub";
 pub struct Ftp {
     /// Active control connection; `None` when disconnected.
     client: Option<AsyncRustlsFtpStream>,
+    /// File browser bound to this connection; created on connect. It runs its
+    /// own control connection (opened lazily) so it can offer the `&self`-based
+    /// [`FileBrowser`] API independently of this session's mutable stream.
+    browser: Option<FtpFileBrowser>,
 }
 
 impl Ftp {
     /// Create a new disconnected `Ftp` instance.
     pub fn new() -> Self {
-        Self { client: None }
+        Self {
+            client: None,
+            browser: None,
+        }
     }
 }
 
@@ -365,10 +375,13 @@ impl ConnectionType for Ftp {
             })??;
 
         self.client = Some(stream);
+        self.browser = Some(FtpFileBrowser::new(config));
         Ok(())
     }
 
     async fn disconnect(&mut self) -> Result<(), SessionError> {
+        // Drop the browser (closing its own control connection, if opened).
+        self.browser = None;
         if let Some(mut client) = self.client.take() {
             if let Err(e) = client.quit().await {
                 debug!("FTP QUIT failed during disconnect: {e}");
@@ -403,9 +416,7 @@ impl ConnectionType for Ftp {
     }
 
     fn file_browser(&self) -> Option<&dyn FileBrowser> {
-        // File browsing (listing/transfers) is added in a later step; the
-        // capability flag is already advertised so the UI can prepare for it.
-        None
+        self.browser.as_ref().map(|b| b as &dyn FileBrowser)
     }
 }
 
@@ -555,5 +566,15 @@ mod tests {
         let ftp = Ftp::new();
         assert!(ftp.write(b"ignored").is_ok());
         assert!(ftp.resize(80, 24).is_ok());
+    }
+
+    #[test]
+    fn file_browser_none_until_connected_then_some() {
+        let mut ftp = Ftp::new();
+        // No browser before connecting.
+        assert!(ftp.file_browser().is_none());
+        // Once a browser is bound (as `connect` does), it is exposed.
+        ftp.browser = Some(FtpFileBrowser::new(FtpConfig::default()));
+        assert!(ftp.file_browser().is_some());
     }
 }

--- a/docs/changes/dev0/feature/1334-ftp-file-browser.md
+++ b/docs/changes/dev0/feature/1334-ftp-file-browser.md
@@ -1,0 +1,12 @@
+### Added
+
+- FTP directory browsing (backend): the FTP / FTPS backend now implements file
+  browsing. It lists directories by preferring the machine-readable `MLSD`
+  command and falling back to `LIST`, parsing Unix `ls -l`, Windows/DOS and MLSD
+  listings into the shared file model (names, directory flag, size, ISO-8601
+  modified time, and POSIX permissions where available), with UTF-8 → Latin-1
+  name decoding and symlink handling. File read/write (`RETR`/`STOR`), delete
+  (`DELE`/`RMD`), rename (`RNFR`/`RNTO`), stat (`MLST` with a `LIST`-parent
+  fallback) and directory creation (`MKD`) are supported. This wires up the
+  parsing/CRUD layer; the FTP file sidebar and transfer UI land in follow-up
+  steps. (#1334, epic #1331, concept #518)


### PR DESCRIPTION
Closes #1334
Part of Epic #1331 · Concept #518 (`docs/concepts/backlog/ftp-client.html`)

## Summary

Implements the `FileBrowser` trait for the FTP/FTPS backend plus the directory-listing parsers, and wires `FtpBackend::file_browser()` to return it (it previously returned `None`, per the #1332 skeleton). All new code is gated behind the `ftp` feature.

### `listing_parser.rs`

Maps FTP listings into the shared `FileEntry` (`core/src/files/mod.rs`). Per-format line parsing is delegated to `suppaftp`'s built-in `list::File` (POSIX `ls -l`, Windows/DOS, and MLSx), as the issue recommends; this module owns the `FileEntry` mapping and everything the crate doesn't do:

- ISO-8601 modified timestamps (epoch sentinel → empty string).
- `rwxrwxrwx` permission strings (POSIX + MLSD; DOS listings carry none).
- Path joining, symlink handling (`-> target` stripped from the name), and skipping of malformed / `.` / `..` / `total …` lines.
- Byte-level name decode: UTF-8 with a **Latin-1 fallback** (`decode_bytes`), exercised in tests with genuinely invalid UTF-8.
- `list_dir` tries **MLSD** and falls back to **LIST** at the browser level.

### `file_browser.rs` — `FtpFileBrowser`

Runs its own lazily-opened FTP control connection behind an async `Mutex`, mirroring the SFTP browser (whose `file_browser()` likewise returns a browser on a separate connection) — this is required because the `FileBrowser` API is `&self` while the `suppaftp` client needs `&mut`.

- `list_dir`: MLSD → LIST fallback.
- `read_file` / `write_file`: RETR / STOR (via `futures-util` async IO over the data stream).
- `delete`: DELE, then RMD on failure (the trait doesn't say which; FTP has no combined command).
- `rename`: RNFR/RNTO.
- `stat`: MLST, with a LIST-parent-and-match fallback; root `/` synthesized.
- `mkdir`: MKD.

No `.unwrap()` in production; `suppaftp` errors are mapped to `FileError` with operation context.

## Parser formats & tests covered

Table-driven unit tests over captured listing strings (`listing_parser.rs`):

- **Unix `ls -l`**: files, directories, symlinks (`->`), sizes/dates, names with spaces, Latin-1 name, `total`/junk skipped.
- **Windows/DOS**: `<DIR>` and file forms, malformed date skipped.
- **MLSD**: `type=dir/file/link`, `size`, `modify`, explicit `unix.mode`, unknown-type/empty lines skipped, `.`/`..` dropped.
- Full-listing aggregation skipping bad lines; `decode_bytes` UTF-8/Latin-1 unit test.
- `FtpFileBrowser` `split_parent` + `Send`/object-safety, and an `Ftp::file_browser()` returns-`Some`-once-bound test.

25 `backends::ftp` tests pass; 447 core tests pass with `--features ftp`.

## Deferred

- **Live Docker CRUD integration test** (`list_dir`/`mkdir`/`rename`/`delete` round-trip against the SI-2 fixture) is **deferred to #1333** — that FTP server fixture is not built yet. No test requiring a live FTP server was added; the parser unit tests + the `file_browser()` returns-`Some` test are the runnable coverage.
- Sidebar wiring (SI-4) and transfers (SI-5) remain out of scope per the issue.

## Deviations from the concept / notes

- **Latin-1 fallback**: `suppaftp`'s high-level `list()`/`mlsd()` return already-decoded (UTF-8-lossy) `String`s, so the byte-level Latin-1 fallback lives in the parser (`decode_bytes`), which the browser feeds the returned strings' bytes into. Fully lossless Latin-1 end-to-end would require reimplementing the raw data-stream read, which contradicts "prefer the crate's helpers".
- **Symlinks**: the shared `FileEntry` has no symlink field (no backend does), so FTP symlinks surface as non-directory entries with the target stripped from the name — consistent with SFTP/local/docker.
- Enabled the `io` feature of the existing `futures-util` dep (for async `AsyncReadExt`/`Cursor` over the `suppaftp` data stream), gated into the `ftp` feature.

## Test plan

- `cargo test -p termihub-core --features ftp` → 447 passed.
- `cargo build --workspace` (default features) and `cargo build -p termihub-core` (no features) → ftp module correctly gated out.
- `cargo clippy -p termihub-core --features ftp --all-targets -- -D warnings` and `cargo clippy --workspace --all-targets -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.
- Live FTP CRUD round-trip: to be added with the #1333 fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)