### PR TITLE
feat(config): real file-manager detection for shell-integration status

### DIFF
--- a/docs/changes/dev0/feature/1397-file-manager-detection.md
+++ b/docs/changes/dev0/feature/1397-file-manager-detection.md
@@ -1,0 +1,8 @@
+### Changed
+
+- The **Shell Integration** settings now show the file managers actually
+  detected on the host instead of an empty list (#1397). On Linux, the Nautilus,
+  KDE (Dolphin) and Thunar rows annotate each enabled toggle with whether the
+  manager was detected and, where available, its version (parsed from the
+  manager's `--version` output) — e.g. "detected: Nautilus 43.2". On macOS and
+  Windows the native always-present manager (Finder / File Explorer) is reported.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1017,6 +1017,31 @@ settings UI lands; until then, seed `shellIntegration.entries` in `settings.json
    remain under `HKCU\Software\Classes\Directory\shell`,
    `…\Directory\Background\shell`, or `…\*\shell` (verify with `regedit`).
 
+### Linux file-manager detection in Shell Integration settings (#1397)
+
+Verifies that the Shell Integration settings report the file managers actually
+installed on the host, with versions. **Linux only** — detection shells out to
+each manager's `--version` and reads the per-user file-manager directories,
+which are `#[cfg(target_os = "linux")]`-gated and depend on the live environment,
+so they cannot be validated from macOS CI. The pure version parsers are unit
+tested on every platform; these steps confirm the live probe. See PR for #1397.
+
+Prerequisites: a Linux build of termiHub on a desktop with at least one of
+Nautilus, Dolphin (KDE) or Thunar installed (`nautilus --version` /
+`dolphin --version` / `thunar --version` should print a version at a shell).
+
+1. Open **Settings → Shell Integration**. Under **Linux — File Manager
+   Integrations**, each of Nautilus / KDE service menu / Thunar shows either
+   "— detected: `<Name> <version>`" (e.g. "detected: Nautilus 43.2") for an
+   installed manager, or "— not detected" for an absent one.
+2. Cross-check the shown version against the manager's own `--version` output —
+   they must match.
+3. On a host with **none** of the three installed, all three rows read
+   "— not detected" (the previous behavior was an always-empty list, so nothing
+   was annotated at all).
+4. Install or remove a manager (e.g. `apt install thunar`), reopen the settings
+   panel, and confirm the detected/not-detected state updates accordingly.
+
 ### macOS app-level Services provider (#1409)
 
 Verifies the app-level **"Open in termiHub"** entry in the macOS **Services**

--- a/src-tauri/src/commands/shell_integration.rs
+++ b/src-tauri/src/commands/shell_integration.rs
@@ -37,8 +37,9 @@ fn current_status(manager: &ConnectionManager) -> ShellIntegrationStatus {
 /// Combines the persisted settings with runtime facts: whether the integration
 /// is registered, whether the executable path recorded at registration still
 /// matches the current executable (staleness), whether the app runs in portable
-/// mode (where staleness is expected), and the detected file managers (stubbed
-/// empty until per-OS detection lands).
+/// mode (where staleness is expected), and the file managers detected on the
+/// host (Linux: Nautilus / Dolphin / Thunar with versions; macOS/Windows: the
+/// native manager).
 #[tauri::command]
 pub fn get_shell_integration_status(
     manager: State<'_, ConnectionManager>,

--- a/src-tauri/src/connection/shell_integration.rs
+++ b/src-tauri/src/connection/shell_integration.rs
@@ -222,8 +222,10 @@ pub fn exe_path_matches(registered_exe_path: Option<&str>, current_exe_path: Opt
 
 /// A file manager detected on the host, reported by the status command.
 ///
-/// Detection itself is a **stub** in this issue — real per-OS detection lands
-/// with the Linux registration work (SI-7).
+/// Populated by `detect_file_managers` in the spawn registry: on Linux from the
+/// per-user file-manager directories / `$PATH` binaries (with the version from
+/// each manager's `--version` output), and on macOS/Windows from the native
+/// always-present manager (Finder / File Explorer).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DetectedFileManager {
@@ -259,7 +261,8 @@ pub struct ShellIntegrationStatus {
     /// the recorded path stale as a matter of course; the UI can present this as
     /// expected rather than an error.
     pub portable: bool,
-    /// File managers detected on the host (STUB — empty until detection lands).
+    /// File managers detected on the host (Linux: Nautilus / Dolphin / Thunar
+    /// with versions where available; macOS/Windows: the native manager).
     pub detected_file_managers: Vec<DetectedFileManager>,
 }
 

--- a/src-tauri/src/connection/shell_integration.rs
+++ b/src-tauri/src/connection/shell_integration.rs
@@ -506,6 +506,43 @@ mod tests {
         assert_eq!(status.detected_file_managers, managers);
     }
 
+    #[test]
+    fn status_reflects_undetected_manager_without_version() {
+        // An injected "not found" manager round-trips as detected=false / no version.
+        let managers = vec![DetectedFileManager {
+            id: "thunar".to_string(),
+            name: "Thunar".to_string(),
+            detected: false,
+            version: None,
+        }];
+        let status = build_status(
+            &ShellIntegrationSettings::default(),
+            None,
+            false,
+            managers.clone(),
+        );
+        assert_eq!(status.detected_file_managers, managers);
+        assert!(!status.detected_file_managers[0].detected);
+        assert!(status.detected_file_managers[0].version.is_none());
+    }
+
+    #[test]
+    fn status_reflects_detected_manager_with_version() {
+        // A detected manager surfaces its version verbatim through build_status.
+        let managers = vec![DetectedFileManager {
+            id: "nautilus".to_string(),
+            name: "Nautilus".to_string(),
+            detected: true,
+            version: Some("43.2".to_string()),
+        }];
+        let status = build_status(&ShellIntegrationSettings::default(), None, false, managers);
+        assert!(status.detected_file_managers[0].detected);
+        assert_eq!(
+            status.detected_file_managers[0].version.as_deref(),
+            Some("43.2")
+        );
+    }
+
     // ── Settings serde round-trip + forward-compat ───────────────────────
 
     #[test]

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -75,6 +75,67 @@ pub fn detect_file_managers() -> Vec<DetectedFileManager> {
     }
 }
 
+#[cfg(test)]
+mod version_parsing_tests {
+    use super::{parse_dolphin_version, parse_nautilus_version, parse_thunar_version};
+
+    #[test]
+    fn nautilus_version_extracted() {
+        // `nautilus --version` → "GNOME nautilus 43.2".
+        assert_eq!(
+            parse_nautilus_version("GNOME nautilus 43.2"),
+            Some("43.2".to_string())
+        );
+        assert_eq!(
+            parse_nautilus_version("GNOME nautilus 3.26.4"),
+            Some("3.26.4".to_string())
+        );
+    }
+
+    #[test]
+    fn dolphin_version_extracted() {
+        // `dolphin --version` → "dolphin 22.12.3".
+        assert_eq!(
+            parse_dolphin_version("dolphin 22.12.3"),
+            Some("22.12.3".to_string())
+        );
+        assert_eq!(
+            parse_dolphin_version("dolphin 24.08.1\n"),
+            Some("24.08.1".to_string())
+        );
+    }
+
+    #[test]
+    fn thunar_version_extracted() {
+        // `thunar --version` → "Thunar 4.18.4\nCopyright ...".
+        assert_eq!(
+            parse_thunar_version("Thunar 4.18.4\nCopyright (c) 2004-2023"),
+            Some("4.18.4".to_string())
+        );
+        // A leading "xfce4" token must not be mistaken for the version.
+        assert_eq!(
+            parse_thunar_version("xfce4 Thunar 4.16.0"),
+            Some("4.16.0".to_string())
+        );
+    }
+
+    #[test]
+    fn malformed_or_absent_output_yields_none() {
+        assert_eq!(parse_nautilus_version(""), None);
+        assert_eq!(parse_dolphin_version("no version here"), None);
+        assert_eq!(parse_thunar_version("Thunar"), None);
+    }
+
+    #[test]
+    fn trailing_prerelease_suffix_trimmed_to_numeric() {
+        // A "45.0-beta" token is reduced to its leading numeric run.
+        assert_eq!(
+            parse_nautilus_version("GNOME nautilus 45.0-beta"),
+            Some("45.0".to_string())
+        );
+    }
+}
+
 /// Remove the integration and clear the recorded registration facts from
 /// `settings`. Cross-platform counterpart to [`register`].
 pub fn unregister(settings: &mut ShellIntegrationSettings) -> anyhow::Result<()> {

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -59,9 +59,13 @@ pub fn register(settings: &mut ShellIntegrationSettings) -> anyhow::Result<()> {
 
 /// Detect the file managers installed on the host, for the status command.
 ///
-/// On Linux this probes the per-user file-manager directories and `$PATH`
-/// binaries for Nautilus, KDE (Dolphin) and Thunar. On other platforms it
-/// returns an empty list (their context-menu surfaces are not per-manager).
+/// * **Linux** probes the per-user file-manager directories and `$PATH`
+///   binaries for Nautilus, KDE (Dolphin) and Thunar, annotating each detected
+///   manager with the version reported by its `--version` output.
+/// * **macOS** and **Windows** report their single always-present native
+///   manager (Finder / File Explorer); neither exposes a queryable version, so
+///   `version` is `None`.
+/// * Other platforms return an empty list.
 pub fn detect_file_managers() -> Vec<DetectedFileManager> {
     #[cfg(target_os = "linux")]
     {
@@ -69,10 +73,71 @@ pub fn detect_file_managers() -> Vec<DetectedFileManager> {
             .map(|r| r.detect())
             .unwrap_or_default()
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    {
+        vec![native_manager("finder", "Finder")]
+    }
+    #[cfg(target_os = "windows")]
+    {
+        vec![native_manager("explorer", "File Explorer")]
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
         Vec::new()
     }
+}
+
+/// A native, always-present OS file manager (macOS Finder / Windows File
+/// Explorer). These have no user-queryable version string, so `version` is
+/// `None`.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn native_manager(id: &str, name: &str) -> DetectedFileManager {
+    DetectedFileManager {
+        id: id.to_string(),
+        name: name.to_string(),
+        detected: true,
+        version: None,
+    }
+}
+
+/// Extract the first whitespace-delimited token that looks like a version
+/// number (starts with an ASCII digit) from a `--version` output string,
+/// keeping only its leading run of digits and dots (so a `45.0-beta` token
+/// reduces to `45.0`). Returns `None` when no such token exists.
+///
+/// Pure and platform-independent so it is exhaustively unit-testable without
+/// invoking any binary.
+#[cfg(any(target_os = "linux", test))]
+fn first_version_token(output: &str) -> Option<String> {
+    output.split_whitespace().find_map(|token| {
+        if !token.starts_with(|c: char| c.is_ascii_digit()) {
+            return None;
+        }
+        let version: String = token
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '.')
+            .collect();
+        let version = version.trim_end_matches('.');
+        (!version.is_empty()).then(|| version.to_string())
+    })
+}
+
+/// Parse `nautilus --version` output (e.g. `GNOME nautilus 43.2` → `43.2`).
+#[cfg(any(target_os = "linux", test))]
+fn parse_nautilus_version(output: &str) -> Option<String> {
+    first_version_token(output)
+}
+
+/// Parse `dolphin --version` output (e.g. `dolphin 22.12.3` → `22.12.3`).
+#[cfg(any(target_os = "linux", test))]
+fn parse_dolphin_version(output: &str) -> Option<String> {
+    first_version_token(output)
+}
+
+/// Parse `thunar --version` output (e.g. `Thunar 4.18.4` → `4.18.4`).
+#[cfg(any(target_os = "linux", test))]
+fn parse_thunar_version(output: &str) -> Option<String> {
+    first_version_token(output)
 }
 
 #[cfg(test)]
@@ -1391,6 +1456,22 @@ mod linux {
     /// spawning the real `update-desktop-database` binary.
     type DesktopDbHook = Arc<dyn Fn(&Path) + Send + Sync>;
 
+    /// Run `<binary> --version` and return its version output, preferring
+    /// stdout but falling back to stderr (some tools print their banner there).
+    /// Best-effort: a missing or failing binary yields `None`.
+    fn query_version(binary: &str) -> Option<String> {
+        let output = std::process::Command::new(binary)
+            .arg("--version")
+            .output()
+            .ok()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !stdout.trim().is_empty() {
+            return Some(stdout.into_owned());
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        (!stderr.trim().is_empty()).then(|| stderr.into_owned())
+    }
+
     /// Spawn `update-desktop-database <apps_dir>`, ignoring any failure (the
     /// tool is absent on minimal systems and the registration still works).
     fn run_update_desktop_database(apps_dir: &Path) {
@@ -1479,18 +1560,60 @@ mod linux {
         }
 
         /// Report the file managers detected on this host for the status command.
+        ///
+        /// A detected manager is annotated with the version parsed from its
+        /// `--version` output. Version probing only runs when `$PATH` probing is
+        /// enabled (i.e. not in tests), so directory-only detection never shells
+        /// out.
         pub fn detect(&self) -> Vec<DetectedFileManager> {
-            let mk = |id: &str, name: &str, detected: bool| DetectedFileManager {
+            vec![
+                self.detected_manager(
+                    "nautilus",
+                    "Nautilus",
+                    "nautilus",
+                    self.nautilus_detected(),
+                    super::parse_nautilus_version,
+                ),
+                self.detected_manager(
+                    "kde",
+                    "Dolphin",
+                    "dolphin",
+                    self.kde_detected(),
+                    super::parse_dolphin_version,
+                ),
+                self.detected_manager(
+                    "thunar",
+                    "Thunar",
+                    "thunar",
+                    self.thunar_detected(),
+                    super::parse_thunar_version,
+                ),
+            ]
+        }
+
+        /// Build a [`DetectedFileManager`], querying `binary --version` and
+        /// parsing it with `parse` when the manager is detected and `$PATH`
+        /// probing is enabled. Version detection is best-effort: a missing or
+        /// unparseable version simply yields `None`.
+        fn detected_manager(
+            &self,
+            id: &str,
+            name: &str,
+            binary: &str,
+            detected: bool,
+            parse: fn(&str) -> Option<String>,
+        ) -> DetectedFileManager {
+            let version = if detected && self.probe_path {
+                query_version(binary).as_deref().and_then(parse)
+            } else {
+                None
+            };
+            DetectedFileManager {
                 id: id.to_string(),
                 name: name.to_string(),
                 detected,
-                version: None,
-            };
-            vec![
-                mk("nautilus", "Nautilus", self.nautilus_detected()),
-                mk("kde", "Dolphin", self.kde_detected()),
-                mk("thunar", "Thunar", self.thunar_detected()),
-            ]
+                version,
+            }
         }
 
         // ── Install / uninstall ─────────────────────────────────────────

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -345,7 +345,11 @@ export interface ShellIntegrationStatus {
   stale: boolean;
   /** Whether the app runs in portable mode (where staleness is expected). */
   portable: boolean;
-  /** File managers detected on the host (empty until detection lands). */
+  /**
+   * File managers detected on the host. On Linux this lists Nautilus, Dolphin
+   * (KDE) and Thunar with their versions where available; on macOS/Windows the
+   * native manager (Finder / File Explorer).
+   */
   detectedFileManagers: DetectedFileManager[];
 }
 


### PR DESCRIPTION
Closes #1397
Follow-up to #1367 (PR #1396).

## Summary

Replaces the empty-list stub `detect_file_managers()` with real per-OS
detection, wired into `get_shell_integration_status`. The Shell Integration
settings now show the file managers actually installed on the host, with
versions where available, instead of an always-empty list.

- **Linux**: annotates each detected Nautilus / Dolphin (KDE) / Thunar with the
  version parsed from its `--version` output. The `Registrar::detect()` already
  reported presence via the per-user file-manager dirs + `$PATH` binaries; this
  adds the version by querying `<binary> --version`.
- **macOS / Windows**: report the native always-present manager (Finder / File
  Explorer) with no queryable version.
- Other platforms: empty list.

### Testable parser split

Detection is split into two concerns:

- **Side-effecting, per-OS, `#[cfg]`-gated**: `query_version(binary)` (runs
  `--version`) and the directory/`$PATH` probes.
- **Pure, unit-tested**: `parse_nautilus_version` / `parse_dolphin_version` /
  `parse_thunar_version`, built on a shared `first_version_token` extractor
  (first whitespace token starting with a digit, reduced to its leading
  digits-and-dots run). These compile on any platform under `test`, so the
  high-value tests run on macOS too.

Every OS arm is `#[cfg(target_os = "...")]`-gated so the default and
all-platform builds stay clean.

## Validation

- **Verified locally on macOS**: `cargo test -p termihub` (parser + `build_status`
  tests green), `cargo fmt --check`, `cargo clippy -p termihub --all-targets -D
  warnings` clean. The macOS `detect_file_managers` arm compiles and is exercised.
- **Linux / Windows arms are CI + manual-validated**: they are `#[cfg]`-gated and
  cannot be run from macOS (a full cross-compile is blocked by Linux/Windows
  system libs, e.g. `glib-sys`/`winreg`, not by this code). Reviewed manually to
  mirror the existing `mod linux` / `which`-based detection patterns. CI builds
  all three platforms.

## Test plan

- [x] `parse_*` version parsers extract the right version from captured
  `nautilus`/`dolphin`/`thunar` `--version` strings, skip non-version tokens
  (e.g. leading `xfce4`), trim a `45.0-beta` suffix to `45.0`, and return `None`
  for malformed/absent output.
- [x] `build_status` round-trips an injected detected list — a detected manager
  keeps its version, an undetected one has none.
- [ ] **Manual (Linux)**: on a host with Nautilus/Dolphin/Thunar installed, the
  Shell Integration settings show each as "detected: `<Name> <version>`" matching
  the manager's own `--version`; absent managers read "not detected". See the new
  "Linux file-manager detection in Shell Integration settings (#1397)" entry in
  `docs/testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)