### PR TITLE
refactor(ui): extract file-browser roving keyboard-nav into a reusable hook (Closes #1375)

### DIFF
--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -46,13 +46,13 @@ import { formatBytes, formatRelativeTime } from "@/utils/formatters";
 import {
   sortEntries,
   filterEntries,
-  findTypeAheadIndex,
   type FileSortKey,
   type SortDirection,
 } from "@/utils/fileBrowserNav";
 import { resolveFeatureEnabled } from "@/utils/featureFlags";
 import { baseNameSelectionEnd } from "@/utils/fileNameSelection";
 import { frontendLog } from "@/utils/frontendLog";
+import { useRovingListNav } from "@/hooks/useRovingListNav";
 import { useOsFileDrop } from "@/hooks/useOsFileDrop";
 import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
 import { FileBrowserPathBar } from "./FileBrowserPathBar";
@@ -851,11 +851,6 @@ export function FileBrowser() {
     dir: "asc",
   });
   const [filterQuery, setFilterQuery] = useState("");
-  // Roving-tabindex focus index into `displayEntries` for keyboard navigation.
-  const [activeIndex, setActiveIndex] = useState(0);
-  const rowRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const rowRefCbs = useRef<Map<number, (el: HTMLButtonElement | null) => void>>(new Map());
-  const typeAhead = useRef<{ buffer: string; ts: number }>({ buffer: "", ts: 0 });
 
   // Sorted, then filtered — the single source of order for both the rendered
   // rows and keyboard navigation, so the two never disagree. Kept as two memos
@@ -869,23 +864,13 @@ export function FileBrowser() {
     [sortedEntries, filterQuery]
   );
 
-  // Stable per-index ref callback so rows don't detach/reattach every render.
-  const getRowRef = useCallback((index: number) => {
-    const cache = rowRefCbs.current;
-    let cb = cache.get(index);
-    if (!cb) {
-      cb = (el: HTMLButtonElement | null) => {
-        rowRefs.current[index] = el;
-      };
-      cache.set(index, cb);
-    }
-    return cb;
-  }, []);
-
-  // Keep the active index in range as the list length changes.
-  useEffect(() => {
-    setActiveIndex((i) => Math.min(Math.max(0, i), Math.max(0, displayEntries.length - 1)));
-  }, [displayEntries.length]);
+  // Roving-tabindex keyboard navigation over the displayed rows. The hook owns
+  // the active focus index, the type-ahead buffer, and the per-row ref wiring;
+  // selection/navigation semantics are supplied below via makeKeyDownHandler.
+  const { activeIndex, setActiveIndex, getRowRef, reset, makeKeyDownHandler } = useRovingListNav<
+    FileEntry,
+    HTMLButtonElement
+  >(displayEntries, (e) => e.name);
 
   // Listen for VS Code edit-complete events (remote file re-upload)
   useEffect(() => {
@@ -913,9 +898,9 @@ export function FileBrowser() {
   // selection, return roving focus to the top, and clear any active filter.
   const resetNavState = useCallback(() => {
     clearSelection();
-    setActiveIndex(0);
+    reset();
     setFilterQuery("");
-  }, [clearSelection]);
+  }, [clearSelection, reset]);
 
   const handleNavigatePath = useCallback(
     (path: string) => {
@@ -1074,95 +1059,42 @@ export function FileBrowser() {
         setLastClickedPath(entry.path);
       }
     },
-    [displayEntries, lastClickedPath]
+    [displayEntries, lastClickedPath, setActiveIndex]
   );
 
-  // Move the roving focus/selection to `index`. With `extend`, grows the
-  // selection from the anchor (last click) to `index`; otherwise selects just
-  // the target. Focus follows so keyboard and screen-reader users stay in sync.
-  const moveActive = useCallback(
-    (index: number, extend: boolean) => {
-      const entry = displayEntries[index];
-      if (!entry) return;
-      setActiveIndex(index);
-      rowRefs.current[index]?.focus();
-      if (extend && lastClickedPath) {
-        const anchorIdx = displayEntries.findIndex((fe) => fe.path === lastClickedPath);
-        if (anchorIdx >= 0) {
-          const [start, end] = anchorIdx < index ? [anchorIdx, index] : [index, anchorIdx];
-          setSelectedPaths(new Set(displayEntries.slice(start, end + 1).map((fe) => fe.path)));
-          return;
-        }
-      }
-      setSelectedPaths(new Set([entry.path]));
-      setLastClickedPath(entry.path);
-    },
-    [displayEntries, lastClickedPath]
-  );
-
-  const handleListKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      const entries = displayEntries;
-      const len = entries.length;
-      const key = e.key;
-
-      if ((e.ctrlKey || e.metaKey) && key.toLowerCase() === "a") {
-        e.preventDefault();
-        setSelectedPaths(new Set(entries.map((fe) => fe.path)));
-        if (entries.length > 0) setLastClickedPath(entries[entries.length - 1].path);
-        return;
-      }
-      if (key === "Escape") {
-        clearSelection();
-        return;
-      }
-      if (key === "Backspace" || (e.altKey && key === "ArrowLeft")) {
-        e.preventDefault();
-        handleNavigateUp();
-        return;
-      }
-      if (len === 0) return;
-
-      if (key === "ArrowDown" || key === "ArrowUp") {
-        e.preventDefault();
-        const delta = key === "ArrowDown" ? 1 : -1;
-        moveActive(Math.min(len - 1, Math.max(0, activeIndex + delta)), e.shiftKey);
-        return;
-      }
-      if (key === "Home" || key === "End") {
-        e.preventDefault();
-        moveActive(key === "Home" ? 0 : len - 1, e.shiftKey);
-        return;
-      }
-      if (key === "Enter") {
-        e.preventDefault();
-        const entry = entries[activeIndex];
-        if (!entry) return;
-        if (entry.isDirectory) handleNavigate(entry);
-        else handleContextAction(entry, "edit");
-        return;
-      }
-      if (key === "F2") {
-        e.preventDefault();
-        const entry = entries[activeIndex];
-        if (entry) setRenamingPath(entry.path);
-        return;
-      }
-      // Type-ahead: a printable character with no command modifiers.
-      if (key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        const now = Date.now();
-        const ta = typeAhead.current;
-        const fresh = now - ta.ts > 700;
-        ta.buffer = fresh ? key : ta.buffer + key;
-        ta.ts = now;
-        const idx = findTypeAheadIndex(entries, ta.buffer, activeIndex, ta.buffer.length === 1);
-        if (idx >= 0) moveActive(idx, false);
-      }
-    },
+  // Wire the roving-nav keydown handler to this browser's selection and
+  // navigation semantics. The hook owns focus movement and type-ahead; these
+  // callbacks apply selection changes (range/single/all/clear) and route
+  // Enter/F2/Backspace to the corresponding file-browser actions.
+  const handleListKeyDown = useMemo(
+    () =>
+      makeKeyDownHandler({
+        onActivate: (entry) => {
+          if (entry.isDirectory) handleNavigate(entry);
+          else handleContextAction(entry, "edit");
+        },
+        onNavigateUp: handleNavigateUp,
+        onRename: (entry) => setRenamingPath(entry.path),
+        onSelectAll: () => {
+          setSelectedPaths(new Set(displayEntries.map((fe) => fe.path)));
+          if (displayEntries.length > 0) {
+            setLastClickedPath(displayEntries[displayEntries.length - 1].path);
+          }
+        },
+        onClearSelection: clearSelection,
+        getAnchorIndex: () =>
+          lastClickedPath ? displayEntries.findIndex((fe) => fe.path === lastClickedPath) : -1,
+        onSelectRange: (start, end) =>
+          setSelectedPaths(new Set(displayEntries.slice(start, end + 1).map((fe) => fe.path))),
+        onSelectSingle: (entry) => {
+          setSelectedPaths(new Set([entry.path]));
+          setLastClickedPath(entry.path);
+        },
+      }),
     [
+      makeKeyDownHandler,
       displayEntries,
-      activeIndex,
-      moveActive,
+      lastClickedPath,
       clearSelection,
       handleNavigate,
       handleNavigateUp,

--- a/src/hooks/useRovingListNav.test.tsx
+++ b/src/hooks/useRovingListNav.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act, useState } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useRovingListNav, RovingListNav, RovingListNavCallbacks } from "./useRovingListNav";
+
+interface Item {
+  name: string;
+}
+
+const ITEMS: Item[] = [
+  { name: "alpha" },
+  { name: "apple" },
+  { name: "banana" },
+  { name: "cherry" },
+];
+
+/** Build a fully-spied callbacks object with sensible no-op defaults. */
+function makeCallbacks(
+  overrides: Partial<RovingListNavCallbacks<Item>> = {}
+): RovingListNavCallbacks<Item> {
+  return {
+    onActivate: vi.fn(),
+    onNavigateUp: vi.fn(),
+    onRename: vi.fn(),
+    onSelectAll: vi.fn(),
+    onClearSelection: vi.fn(),
+    getAnchorIndex: vi.fn(() => -1),
+    onSelectRange: vi.fn(),
+    onSelectSingle: vi.fn(),
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal list harness mirroring how FileBrowser wires the hook: a keydown
+ * container plus roving-tabindex buttons whose refs flow through getRowRef.
+ */
+function Harness({
+  items,
+  callbacks,
+  onNav,
+}: {
+  items: Item[];
+  callbacks: RovingListNavCallbacks<Item>;
+  onNav: (nav: RovingListNav<Item, HTMLButtonElement>, setItems: (i: Item[]) => void) => void;
+}) {
+  const [list, setList] = useState(items);
+  const nav = useRovingListNav<Item, HTMLButtonElement>(list, (i) => i.name);
+  onNav(nav, setList);
+  return (
+    <div data-testid="list" onKeyDown={nav.makeKeyDownHandler(callbacks)}>
+      {list.map((item, index) => (
+        <button
+          key={item.name}
+          ref={nav.getRowRef(index)}
+          tabIndex={index === nav.activeIndex ? 0 : -1}
+          data-testid={`row-${item.name}`}
+        >
+          {item.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+describe("useRovingListNav", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let nav: RovingListNav<Item, HTMLButtonElement>;
+  let setItems: (i: Item[]) => void;
+
+  function press(key: string, opts: Partial<KeyboardEventInit> = {}) {
+    const list = container.querySelector('[data-testid="list"]') as HTMLElement;
+    act(() => {
+      list.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...opts }));
+    });
+  }
+
+  function render(items: Item[], callbacks: RovingListNavCallbacks<Item>) {
+    act(() => {
+      root.render(
+        <Harness
+          items={items}
+          callbacks={callbacks}
+          onNav={(n, s) => {
+            nav = n;
+            setItems = s;
+          }}
+        />
+      );
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("starts with activeIndex 0", () => {
+    render(ITEMS, makeCallbacks());
+    expect(nav.activeIndex).toBe(0);
+  });
+
+  it("moves the active index down and up within bounds", () => {
+    render(ITEMS, makeCallbacks());
+    press("ArrowDown");
+    expect(nav.activeIndex).toBe(1);
+    press("ArrowDown");
+    expect(nav.activeIndex).toBe(2);
+    press("ArrowUp");
+    expect(nav.activeIndex).toBe(1);
+  });
+
+  it("clamps at the top and bottom of the list", () => {
+    render(ITEMS, makeCallbacks());
+    press("ArrowUp");
+    expect(nav.activeIndex).toBe(0);
+    press("End");
+    expect(nav.activeIndex).toBe(ITEMS.length - 1);
+    press("ArrowDown");
+    expect(nav.activeIndex).toBe(ITEMS.length - 1);
+    press("Home");
+    expect(nav.activeIndex).toBe(0);
+  });
+
+  it("focuses the row at the active index via getRowRef wiring", () => {
+    render(ITEMS, makeCallbacks());
+    press("ArrowDown");
+    expect(document.activeElement).toBe(container.querySelector('[data-testid="row-apple"]'));
+  });
+
+  it("returns a stable ref callback for the same index", () => {
+    render(ITEMS, makeCallbacks());
+    expect(nav.getRowRef(2)).toBe(nav.getRowRef(2));
+    expect(nav.getRowRef(1)).not.toBe(nav.getRowRef(2));
+  });
+
+  it("selects a single row (no anchor) when moving without shift", () => {
+    const cb = makeCallbacks();
+    render(ITEMS, cb);
+    press("ArrowDown");
+    expect(cb.onSelectSingle).toHaveBeenCalledWith(ITEMS[1], 1);
+    expect(cb.onSelectRange).not.toHaveBeenCalled();
+  });
+
+  it("extends the selection from the anchor when moving with shift", () => {
+    const cb = makeCallbacks({ getAnchorIndex: vi.fn(() => 0) });
+    render(ITEMS, cb);
+    press("ArrowDown", { shiftKey: true });
+    press("ArrowDown", { shiftKey: true });
+    expect(cb.onSelectRange).toHaveBeenLastCalledWith(0, 2);
+    expect(cb.onSelectSingle).not.toHaveBeenCalled();
+  });
+
+  it("activates the focused item on Enter", () => {
+    const cb = makeCallbacks();
+    render(ITEMS, cb);
+    press("ArrowDown");
+    press("Enter");
+    expect(cb.onActivate).toHaveBeenCalledWith(ITEMS[1], 1);
+  });
+
+  it("triggers rename on F2 for the focused item", () => {
+    const cb = makeCallbacks();
+    render(ITEMS, cb);
+    press("F2");
+    expect(cb.onRename).toHaveBeenCalledWith(ITEMS[0], 0);
+  });
+
+  it("navigates up on Backspace and Alt+ArrowLeft", () => {
+    const cb = makeCallbacks();
+    render(ITEMS, cb);
+    press("Backspace");
+    press("ArrowLeft", { altKey: true });
+    expect(cb.onNavigateUp).toHaveBeenCalledTimes(2);
+  });
+
+  it("selects all on Ctrl+A and Cmd+A", () => {
+    const cb = makeCallbacks();
+    render(ITEMS, cb);
+    press("a", { ctrlKey: true });
+    press("a", { metaKey: true });
+    expect(cb.onSelectAll).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the selection on Escape", () => {
+    const cb = makeCallbacks();
+    render(ITEMS, cb);
+    press("Escape");
+    expect(cb.onClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("type-ahead jumps to the next matching label", () => {
+    const cb = makeCallbacks();
+    render(ITEMS, cb);
+    // From index 0 (alpha), typing "a" advances to the next "a" match: apple.
+    press("a");
+    expect(nav.activeIndex).toBe(1);
+    // Typing "b" (fresh single key) jumps to banana.
+    press("b");
+    expect(nav.activeIndex).toBe(2);
+  });
+
+  it("does not treat modifier-key combos as type-ahead", () => {
+    const cb = makeCallbacks();
+    render(ITEMS, cb);
+    press("b", { ctrlKey: true });
+    expect(nav.activeIndex).toBe(0);
+  });
+
+  it("reset() returns the active index to the top", () => {
+    render(ITEMS, makeCallbacks());
+    press("End");
+    expect(nav.activeIndex).toBe(ITEMS.length - 1);
+    act(() => nav.reset());
+    expect(nav.activeIndex).toBe(0);
+  });
+
+  it("clamps the active index when the list shrinks", () => {
+    render(ITEMS, makeCallbacks());
+    press("End");
+    expect(nav.activeIndex).toBe(3);
+    act(() => setItems([{ name: "alpha" }, { name: "apple" }]));
+    expect(nav.activeIndex).toBe(1);
+  });
+
+  it("ignores navigation keys on an empty list but still allows Escape", () => {
+    const cb = makeCallbacks();
+    render([], cb);
+    press("ArrowDown");
+    expect(nav.activeIndex).toBe(0);
+    press("Escape");
+    expect(cb.onClearSelection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useRovingListNav.test.tsx
+++ b/src/hooks/useRovingListNav.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import React, { act, useState } from "react";
+import { act, useState } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useRovingListNav, RovingListNav, RovingListNavCallbacks } from "./useRovingListNav";
 
@@ -197,15 +197,41 @@ describe("useRovingListNav", () => {
     expect(cb.onClearSelection).toHaveBeenCalledTimes(1);
   });
 
-  it("type-ahead jumps to the next matching label", () => {
-    const cb = makeCallbacks();
-    render(ITEMS, cb);
+  it("type-ahead advances through successive matches of the same key", () => {
+    render(ITEMS, makeCallbacks());
     // From index 0 (alpha), typing "a" advances to the next "a" match: apple.
     press("a");
     expect(nav.activeIndex).toBe(1);
-    // Typing "b" (fresh single key) jumps to banana.
+  });
+
+  it("type-ahead jumps to a label starting with a fresh key", () => {
+    render(ITEMS, makeCallbacks());
     press("b");
     expect(nav.activeIndex).toBe(2);
+  });
+
+  it("resets the type-ahead buffer after the timeout window", () => {
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(1000);
+    render(ITEMS, makeCallbacks());
+    press("a"); // fresh buffer "a" → apple
+    expect(nav.activeIndex).toBe(1);
+    now.mockReturnValue(1000 + 800); // > 700ms later → buffer resets
+    press("b"); // fresh buffer "b" → banana
+    expect(nav.activeIndex).toBe(2);
+    now.mockRestore();
+  });
+
+  it("accumulates multi-key type-ahead within the timeout window", () => {
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValue(1000);
+    render(ITEMS, makeCallbacks());
+    press("b"); // fresh "b" → banana (index 2)
+    expect(nav.activeIndex).toBe(2);
+    now.mockReturnValue(1100); // within window → buffer becomes "ba"
+    press("a"); // "ba" still matches banana; must NOT reset and wrap to alpha
+    expect(nav.activeIndex).toBe(2);
+    now.mockRestore();
   });
 
   it("does not treat modifier-key combos as type-ahead", () => {

--- a/src/hooks/useRovingListNav.ts
+++ b/src/hooks/useRovingListNav.ts
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { findTypeAheadIndex } from "@/utils/fileBrowserNav";
+
+/** How long (ms) a type-ahead buffer stays "hot" before the next keystroke resets it. */
+const TYPE_AHEAD_RESET_MS = 700;
+
+/**
+ * Callbacks the keydown handler invokes for actions the hook itself does not own.
+ *
+ * The hook owns the roving focus index, the type-ahead buffer, and the row-ref
+ * wiring; selection and navigation semantics live with the consumer and are
+ * reached through these callbacks. This split is what untangles the
+ * nav-reset ↔ keydown ordering cycle: the consumer's nav-reset handlers can
+ * depend on the hook's stable `reset()`, while the keydown handler is built
+ * from these callbacks *after* those handlers are defined (see
+ * `makeKeyDownHandler`).
+ */
+export interface RovingListNavCallbacks<T> {
+  /** Activate (open/edit) the entry at `index` — bound to Enter. */
+  onActivate: (item: T, index: number) => void;
+  /** Navigate up one level — bound to Backspace and Alt+ArrowLeft. */
+  onNavigateUp: () => void;
+  /** Begin renaming the entry at `index` — bound to F2. */
+  onRename: (item: T, index: number) => void;
+  /** Select every entry — bound to Ctrl/Cmd+A. */
+  onSelectAll: () => void;
+  /** Clear the current selection — bound to Escape. */
+  onClearSelection: () => void;
+  /** Index of the current selection anchor, or -1 when there is none. */
+  getAnchorIndex: () => number;
+  /** Replace the selection with the inclusive range `[start, end]`. */
+  onSelectRange: (start: number, end: number) => void;
+  /** Replace the selection with just `item` and set it as the new anchor. */
+  onSelectSingle: (item: T, index: number) => void;
+}
+
+/** Public surface of {@link useRovingListNav}. */
+export interface RovingListNav<T, E extends HTMLElement = HTMLElement> {
+  /** Roving-tabindex focus index into the items array. */
+  activeIndex: number;
+  /** Directly set the active index (e.g. to follow a mouse click). */
+  setActiveIndex: React.Dispatch<React.SetStateAction<number>>;
+  /** Stable per-index ref callback so rows don't detach/reattach each render. */
+  getRowRef: (index: number) => (el: E | null) => void;
+  /** Return roving focus to the top of the list (e.g. after navigation). */
+  reset: () => void;
+  /**
+   * Build the list's `onKeyDown` handler from the supplied callbacks. Call this
+   * in render *after* the consumer's navigation/selection callbacks exist; the
+   * returned handler closes over the current `items` and `activeIndex`.
+   */
+  makeKeyDownHandler: (callbacks: RovingListNavCallbacks<T>) => (e: React.KeyboardEvent) => void;
+}
+
+/**
+ * Roving-tabindex keyboard navigation for a flat list view.
+ *
+ * Owns the active focus index, the type-ahead buffer, and the per-row ref
+ * wiring; keeps the active index in range as the list length changes; and
+ * produces a keydown handler covering arrow/Home/End movement (with optional
+ * Shift range-extend), Enter to activate, F2 to rename, Backspace/Alt+ArrowLeft
+ * to go up, Ctrl/Cmd+A select-all, Escape to clear, and type-ahead jumping.
+ *
+ * Generic over the item type `T` and the row element type `E`, so it can drive
+ * any single-column list (file browser, connection tree, …). Selection and
+ * navigation behavior are supplied by the consumer via
+ * {@link RovingListNavCallbacks}.
+ *
+ * @param items - Items in current display order (the single source of order for
+ *   both the rendered rows and keyboard navigation).
+ * @param getLabel - Extracts the type-ahead label (usually the display name)
+ *   from an item.
+ */
+export function useRovingListNav<T, E extends HTMLElement = HTMLElement>(
+  items: T[],
+  getLabel: (item: T) => string
+): RovingListNav<T, E> {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const rowRefs = useRef<(E | null)[]>([]);
+  const rowRefCbs = useRef<Map<number, (el: E | null) => void>>(new Map());
+  const typeAhead = useRef<{ buffer: string; ts: number }>({ buffer: "", ts: 0 });
+
+  // Keep the label accessor current without churning the memoized handler's
+  // identity when the consumer passes a fresh closure each render.
+  const getLabelRef = useRef(getLabel);
+  getLabelRef.current = getLabel;
+
+  // Stable per-index ref callback so rows don't detach/reattach every render.
+  const getRowRef = useCallback((index: number) => {
+    const cache = rowRefCbs.current;
+    let cb = cache.get(index);
+    if (!cb) {
+      cb = (el: E | null) => {
+        rowRefs.current[index] = el;
+      };
+      cache.set(index, cb);
+    }
+    return cb;
+  }, []);
+
+  // Keep the active index in range as the list length changes.
+  useEffect(() => {
+    setActiveIndex((i) => Math.min(Math.max(0, i), Math.max(0, items.length - 1)));
+  }, [items.length]);
+
+  const reset = useCallback(() => setActiveIndex(0), []);
+
+  const makeKeyDownHandler = useCallback(
+    (callbacks: RovingListNavCallbacks<T>) => (e: React.KeyboardEvent) => {
+      const entries = items;
+      const len = entries.length;
+      const key = e.key;
+
+      // Move the roving focus/selection to `index`. With `extend`, grows the
+      // selection from the anchor to `index`; otherwise selects just the
+      // target. Focus follows so keyboard and screen-reader users stay in sync.
+      const moveActive = (index: number, extend: boolean) => {
+        const item = entries[index];
+        if (!item) return;
+        setActiveIndex(index);
+        rowRefs.current[index]?.focus();
+        if (extend) {
+          const anchorIdx = callbacks.getAnchorIndex();
+          if (anchorIdx >= 0) {
+            const [start, end] = anchorIdx < index ? [anchorIdx, index] : [index, anchorIdx];
+            callbacks.onSelectRange(start, end);
+            return;
+          }
+        }
+        callbacks.onSelectSingle(item, index);
+      };
+
+      if ((e.ctrlKey || e.metaKey) && key.toLowerCase() === "a") {
+        e.preventDefault();
+        callbacks.onSelectAll();
+        return;
+      }
+      if (key === "Escape") {
+        callbacks.onClearSelection();
+        return;
+      }
+      if (key === "Backspace" || (e.altKey && key === "ArrowLeft")) {
+        e.preventDefault();
+        callbacks.onNavigateUp();
+        return;
+      }
+      if (len === 0) return;
+
+      if (key === "ArrowDown" || key === "ArrowUp") {
+        e.preventDefault();
+        const delta = key === "ArrowDown" ? 1 : -1;
+        moveActive(Math.min(len - 1, Math.max(0, activeIndex + delta)), e.shiftKey);
+        return;
+      }
+      if (key === "Home" || key === "End") {
+        e.preventDefault();
+        moveActive(key === "Home" ? 0 : len - 1, e.shiftKey);
+        return;
+      }
+      if (key === "Enter") {
+        e.preventDefault();
+        const item = entries[activeIndex];
+        if (item) callbacks.onActivate(item, activeIndex);
+        return;
+      }
+      if (key === "F2") {
+        e.preventDefault();
+        const item = entries[activeIndex];
+        if (item) callbacks.onRename(item, activeIndex);
+        return;
+      }
+      // Type-ahead: a printable character with no command modifiers.
+      if (key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        const now = Date.now();
+        const ta = typeAhead.current;
+        const fresh = now - ta.ts > TYPE_AHEAD_RESET_MS;
+        ta.buffer = fresh ? key : ta.buffer + key;
+        ta.ts = now;
+        const idx = findTypeAheadIndex(
+          entries,
+          getLabelRef.current,
+          ta.buffer,
+          activeIndex,
+          ta.buffer.length === 1
+        );
+        if (idx >= 0) moveActive(idx, false);
+      }
+    },
+    [items, activeIndex]
+  );
+
+  return { activeIndex, setActiveIndex, getRowRef, reset, makeKeyDownHandler };
+}

--- a/src/utils/fileBrowserNav.test.ts
+++ b/src/utils/fileBrowserNav.test.ts
@@ -138,24 +138,25 @@ describe("filterEntries", () => {
 
 describe("findTypeAheadIndex", () => {
   const entries: FileEntry[] = [entry("alpha"), entry("apple"), entry("banana"), entry("cherry")];
+  const byName = (e: FileEntry) => e.name;
 
   it("finds the first match advancing past the current index", () => {
-    expect(findTypeAheadIndex(entries, "a", 0, true)).toBe(1);
+    expect(findTypeAheadIndex(entries, byName, "a", 0, true)).toBe(1);
   });
 
   it("stays on the current match when extending the buffer", () => {
-    expect(findTypeAheadIndex(entries, "ap", 1, false)).toBe(1);
+    expect(findTypeAheadIndex(entries, byName, "ap", 1, false)).toBe(1);
   });
 
   it("wraps around to the start", () => {
-    expect(findTypeAheadIndex(entries, "a", 1, true)).toBe(0);
+    expect(findTypeAheadIndex(entries, byName, "a", 1, true)).toBe(0);
   });
 
   it("returns -1 when nothing matches", () => {
-    expect(findTypeAheadIndex(entries, "z", 0, true)).toBe(-1);
+    expect(findTypeAheadIndex(entries, byName, "z", 0, true)).toBe(-1);
   });
 
   it("returns -1 for an empty buffer", () => {
-    expect(findTypeAheadIndex(entries, "", 0, true)).toBe(-1);
+    expect(findTypeAheadIndex(entries, byName, "", 0, true)).toBe(-1);
   });
 });

--- a/src/utils/fileBrowserNav.ts
+++ b/src/utils/fileBrowserNav.ts
@@ -95,16 +95,21 @@ export function filterEntries(entries: FileEntry[], query: string): FileEntry[] 
 }
 
 /**
- * Find the index of the next entry whose name starts with `buffer`
+ * Find the index of the next entry whose label starts with `buffer`
  * (case-insensitive), searching circularly from `currentIndex`.
+ *
+ * Generic over the entry type: `getLabel` extracts the string to match against
+ * (a file's name, a tree node's label, …), so the same type-ahead logic drives
+ * any list view.
  *
  * When `advance` is true the search starts just after `currentIndex` (used for
  * repeated single-key presses that step through matches); when false it starts
  * at `currentIndex` (used while a multi-key type-ahead buffer is still growing).
  * Returns -1 when the buffer is empty or nothing matches.
  */
-export function findTypeAheadIndex(
-  entries: FileEntry[],
+export function findTypeAheadIndex<T>(
+  entries: T[],
+  getLabel: (entry: T) => string,
   buffer: string,
   currentIndex: number,
   advance: boolean
@@ -116,7 +121,7 @@ export function findTypeAheadIndex(
   const start = advance ? currentIndex + 1 : currentIndex;
   for (let i = 0; i < n; i++) {
     const idx = (start + i) % n;
-    if (entries[idx].name.toLowerCase().startsWith(needle)) return idx;
+    if (getLabel(entries[idx]).toLowerCase().startsWith(needle)) return idx;
   }
   return -1;
 }


### PR DESCRIPTION
## Summary

Extracts the roving-tabindex / type-ahead keyboard navigation out of the oversized `FileBrowser.tsx` into a reusable hook, `src/hooks/useRovingListNav.ts`. Closes #1375.

The logic was added inline while implementing #1361 (active-index state, `moveActive`, the list keydown handler, the type-ahead buffer, and the stable per-index `getRowRef` factory). It is self-contained and reusable, and `FileBrowser.tsx` was well over the ~500-line guideline.

## The new hook — `useRovingListNav<T, E>`

```ts
const { activeIndex, setActiveIndex, getRowRef, reset, makeKeyDownHandler } =
  useRovingListNav<FileEntry, HTMLButtonElement>(displayEntries, (e) => e.name);
```

The hook owns the mechanics that don't depend on the consumer:

- `activeIndex` / `setActiveIndex` — the roving focus index.
- `getRowRef(index)` — stable per-index ref callback (rows don't detach/reattach each render).
- `reset()` — returns roving focus to the top (used after navigation).
- an internal type-ahead buffer + an effect that keeps `activeIndex` in range as the list length changes.
- `makeKeyDownHandler(callbacks)` — builds the list's `onKeyDown`, covering ArrowUp/Down + Home/End movement (with Shift range-extend), Enter to activate, F2 to rename, Backspace / Alt+ArrowLeft to go up, Ctrl/Cmd+A select-all, Escape to clear, and type-ahead jumping.

Selection/navigation **semantics** stay with the consumer and are supplied through the `RovingListNavCallbacks` object (`onActivate`, `onNavigateUp`, `onRename`, `onSelectAll`, `onClearSelection`, `getAnchorIndex`, `onSelectRange`, `onSelectSingle`). It is generic over the item type `T` and row element `E`, so any single-column list can drive it; `findTypeAheadIndex` was generalized with a `getLabel` accessor to match.

## Untangling the ordering cycle

A clean extraction was previously blocked by a definition-ordering cycle: the nav-reset handlers need the hook's `setActiveIndex`, while the keydown handler needs those nav callbacks. This is resolved by giving the hook ownership of `activeIndex` + a stable `reset()`, and building the keydown handler from a `makeKeyDownHandler(callbacks)` factory:

- `FileBrowser`'s `resetNavState` depends only on the hook's stable `reset()` — no forward reference.
- the nav callbacks (`handleNavigate`, `handleNavigateUp`, …) are defined normally, then passed into `makeKeyDownHandler(...)` **after** they exist.

## Behavior parity

Behavior is unchanged — the existing FileBrowser keyboard-navigation tests (ArrowDown+Enter opens a directory, Backspace goes up, Ctrl+A selects all, Escape clears, type-ahead, filter, sort) pass **without modification**.

## Test plan

- `src/hooks/useRovingListNav.test.tsx` (new, TDD — committed before the implementation): active-index movement + clamping, focus wiring via `getRowRef`, stable ref callbacks, single/range selection, Enter/F2/Backspace/Alt+ArrowLeft/Ctrl+A/Cmd+A/Escape dispatch, type-ahead (fresh key, successive same-key advance, buffer reset after timeout, multi-key accumulation within the window), `reset()`, and list-shrink clamping.
- `src/utils/fileBrowserNav.test.ts` — updated for the generalized `findTypeAheadIndex(entries, getLabel, …)` signature.
- Existing `FileBrowser.test.tsx` keyboard tests — unchanged, green (parity guard).
- Full suite: `pnpm test` (2870 passed), `pnpm build`, `pnpm run lint`, `pnpm run format:check` — all pass.

## Notes

- Pure refactor, no user-facing behavior change → no `docs/changes/` fragment.
- Follow-up filed to consider adopting the hook in the connection tree (which has its own separate roving-tabindex nav): #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
