### PR TITLE
refactor(ssh)+feat(sftp): ssh_exec_with_stdin helper + exec-capability query (Closes #1326)

### DIFF
--- a/core/src/backends/ssh/exec.rs
+++ b/core/src/backends/ssh/exec.rs
@@ -1,0 +1,240 @@
+//! Reusable SSH command-execution helper.
+//!
+//! Generalizes the stdout-only exec used internally by monitoring into a
+//! helper that writes stdin to the exec channel and captures the command's
+//! **stdout, stderr, and exit status**. Higher layers use this to run a remote
+//! command and inspect its full result — e.g. probing whether a connection can
+//! open an exec channel at all, or (later) piping content into `sudo tee` for
+//! privilege-elevated writes.
+
+use crate::errors::CoreError;
+
+use super::handler::SshSession;
+
+/// Captured result of running a command over an SSH exec channel.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SshExecOutput {
+    /// Everything the command wrote to standard output.
+    pub stdout: String,
+    /// Everything the command wrote to standard error.
+    pub stderr: String,
+    /// The command's exit status (`0` on success; defaults to `0` when the
+    /// server closes the channel without reporting one).
+    pub exit_status: i32,
+}
+
+/// A single event read from an exec channel while a command runs.
+///
+/// Modelled as a small enum so the orchestration in [`run_exec`] can be
+/// exercised by unit tests with a scripted mock channel, without a live SSH
+/// server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExecEvent {
+    /// A chunk of standard-output bytes.
+    Stdout(Vec<u8>),
+    /// A chunk of standard-error bytes.
+    Stderr(Vec<u8>),
+    /// The command's reported exit status.
+    Exit(i32),
+    /// The remote signalled end-of-output.
+    Eof,
+    /// The channel closed; no further events will arrive.
+    Closed,
+}
+
+/// Minimal abstraction over an SSH exec channel.
+///
+/// Exists so [`run_exec`] can be unit-tested with a mock channel that scripts
+/// its [`ExecEvent`]s, decoupling the stdin/stdout/stderr/exit-status handling
+/// from the live russh channel.
+#[async_trait::async_trait]
+trait ExecChannel {
+    /// Start executing `command` on the channel.
+    async fn exec(&mut self, command: &str) -> Result<(), CoreError>;
+    /// Write `data` to the command's standard input.
+    async fn write_stdin(&mut self, data: &[u8]) -> Result<(), CoreError>;
+    /// Signal end-of-input so the command sees EOF on its stdin.
+    async fn send_eof(&mut self) -> Result<(), CoreError>;
+    /// Await the next channel event, or `None` once the channel is exhausted.
+    async fn next_event(&mut self) -> Option<ExecEvent>;
+}
+
+/// Orchestrate a single command execution over an [`ExecChannel`].
+///
+/// Starts the command, writes `stdin` (when non-empty), signals EOF, then
+/// drains channel events accumulating stdout, stderr, and the exit status
+/// until the channel closes.
+#[allow(dead_code, unused_variables)]
+async fn run_exec<C: ExecChannel>(
+    channel: &mut C,
+    command: &str,
+    stdin: &str,
+) -> Result<SshExecOutput, CoreError> {
+    // Implemented in the follow-up refactor commit; stubbed so the unit tests
+    // below fail first (TDD red).
+    todo!("run_exec is implemented in the refactor commit")
+}
+
+/// Execute `command` over an authenticated SSH `session`, sending `stdin` to
+/// the command's standard input and capturing its stdout, stderr, and exit
+/// status.
+///
+/// Pass an empty `stdin` for commands that read no input. This generalizes the
+/// stdout-only exec used internally by the monitoring provider.
+#[allow(dead_code, unused_variables)]
+pub async fn ssh_exec_with_stdin(
+    session: &SshSession,
+    command: &str,
+    stdin: &str,
+) -> Result<SshExecOutput, CoreError> {
+    // Implemented in the follow-up refactor commit.
+    todo!("ssh_exec_with_stdin is implemented in the refactor commit")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    /// A scripted exec channel: yields a fixed sequence of [`ExecEvent`]s and
+    /// records what the orchestration wrote to it.
+    #[derive(Default)]
+    struct MockChannel {
+        events: VecDeque<ExecEvent>,
+        commands: Vec<String>,
+        stdin: Vec<u8>,
+        eof_sent: bool,
+        fail_exec: bool,
+    }
+
+    impl MockChannel {
+        fn with_events(events: Vec<ExecEvent>) -> Self {
+            Self {
+                events: events.into(),
+                ..Default::default()
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ExecChannel for MockChannel {
+        async fn exec(&mut self, command: &str) -> Result<(), CoreError> {
+            if self.fail_exec {
+                return Err(CoreError::Other("exec refused".to_string()));
+            }
+            self.commands.push(command.to_string());
+            Ok(())
+        }
+
+        async fn write_stdin(&mut self, data: &[u8]) -> Result<(), CoreError> {
+            self.stdin.extend_from_slice(data);
+            Ok(())
+        }
+
+        async fn send_eof(&mut self) -> Result<(), CoreError> {
+            self.eof_sent = true;
+            Ok(())
+        }
+
+        async fn next_event(&mut self) -> Option<ExecEvent> {
+            self.events.pop_front()
+        }
+    }
+
+    fn bytes(s: &str) -> Vec<u8> {
+        s.as_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn captures_stdout_stderr_and_exit_status() {
+        let mut ch = MockChannel::with_events(vec![
+            ExecEvent::Stdout(bytes("hello\n")),
+            ExecEvent::Stderr(bytes("oops\n")),
+            ExecEvent::Exit(3),
+            ExecEvent::Eof,
+            ExecEvent::Closed,
+        ]);
+
+        let out = run_exec(&mut ch, "do-thing", "")
+            .await
+            .expect("run_exec should succeed");
+
+        assert_eq!(out.stdout, "hello\n");
+        assert_eq!(out.stderr, "oops\n");
+        assert_eq!(out.exit_status, 3);
+    }
+
+    #[tokio::test]
+    async fn concatenates_multiple_stdout_chunks() {
+        let mut ch = MockChannel::with_events(vec![
+            ExecEvent::Stdout(bytes("foo")),
+            ExecEvent::Stdout(bytes("bar")),
+            ExecEvent::Exit(0),
+            ExecEvent::Closed,
+        ]);
+
+        let out = run_exec(&mut ch, "cat", "").await.expect("ok");
+
+        assert_eq!(out.stdout, "foobar");
+        assert_eq!(out.exit_status, 0);
+    }
+
+    #[tokio::test]
+    async fn passes_command_string_through() {
+        let mut ch = MockChannel::with_events(vec![ExecEvent::Closed]);
+
+        let _ = run_exec(&mut ch, "sudo tee /etc/hosts", "")
+            .await
+            .expect("ok");
+
+        assert_eq!(ch.commands, vec!["sudo tee /etc/hosts".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn writes_stdin_then_signals_eof() {
+        let mut ch = MockChannel::with_events(vec![ExecEvent::Exit(0), ExecEvent::Closed]);
+
+        let _ = run_exec(&mut ch, "cat", "payload").await.expect("ok");
+
+        assert_eq!(ch.stdin, b"payload");
+        assert!(ch.eof_sent, "EOF must be signalled after writing stdin");
+    }
+
+    #[tokio::test]
+    async fn empty_stdin_writes_nothing_but_still_signals_eof() {
+        let mut ch = MockChannel::with_events(vec![ExecEvent::Closed]);
+
+        let _ = run_exec(&mut ch, "id", "").await.expect("ok");
+
+        assert!(
+            ch.stdin.is_empty(),
+            "no stdin should be written for empty input"
+        );
+        assert!(ch.eof_sent, "EOF must still be signalled");
+    }
+
+    #[tokio::test]
+    async fn defaults_exit_status_to_zero_when_unreported() {
+        let mut ch = MockChannel::with_events(vec![
+            ExecEvent::Stdout(bytes("done")),
+            ExecEvent::Closed,
+        ]);
+
+        let out = run_exec(&mut ch, "echo done", "").await.expect("ok");
+
+        assert_eq!(out.exit_status, 0);
+        assert_eq!(out.stdout, "done");
+    }
+
+    #[tokio::test]
+    async fn propagates_exec_error() {
+        let mut ch = MockChannel {
+            fail_exec: true,
+            ..Default::default()
+        };
+
+        let err = run_exec(&mut ch, "id", "").await.unwrap_err();
+
+        assert!(matches!(err, CoreError::Other(_)));
+    }
+}

--- a/core/src/backends/ssh/exec.rs
+++ b/core/src/backends/ssh/exec.rs
@@ -295,10 +295,8 @@ mod tests {
 
     #[tokio::test]
     async fn defaults_exit_status_to_zero_when_unreported() {
-        let mut ch = MockChannel::with_events(vec![
-            ExecEvent::Stdout(bytes("done")),
-            ExecEvent::Closed,
-        ]);
+        let mut ch =
+            MockChannel::with_events(vec![ExecEvent::Stdout(bytes("done")), ExecEvent::Closed]);
 
         let out = run_exec(&mut ch, "echo done", "").await.expect("ok");
 

--- a/core/src/backends/ssh/exec.rs
+++ b/core/src/backends/ssh/exec.rs
@@ -7,6 +7,8 @@
 //! open an exec channel at all, or (later) piping content into `sudo tee` for
 //! privilege-elevated writes.
 
+use russh::ChannelMsg;
+
 use crate::errors::CoreError;
 
 use super::handler::SshSession;
@@ -64,15 +66,90 @@ trait ExecChannel {
 /// Starts the command, writes `stdin` (when non-empty), signals EOF, then
 /// drains channel events accumulating stdout, stderr, and the exit status
 /// until the channel closes.
-#[allow(dead_code, unused_variables)]
 async fn run_exec<C: ExecChannel>(
     channel: &mut C,
     command: &str,
     stdin: &str,
 ) -> Result<SshExecOutput, CoreError> {
-    // Implemented in the follow-up refactor commit; stubbed so the unit tests
-    // below fail first (TDD red).
-    todo!("run_exec is implemented in the refactor commit")
+    channel.exec(command).await?;
+
+    if !stdin.is_empty() {
+        channel.write_stdin(stdin.as_bytes()).await?;
+    }
+    // Always signal EOF so a command that reads stdin (e.g. `cat`, `sudo tee`)
+    // sees end-of-input and terminates; harmless for commands that read none.
+    channel.send_eof().await?;
+
+    let mut stdout: Vec<u8> = Vec::new();
+    let mut stderr: Vec<u8> = Vec::new();
+    let mut exit_status = 0;
+
+    while let Some(event) = channel.next_event().await {
+        match event {
+            ExecEvent::Stdout(data) => stdout.extend_from_slice(&data),
+            ExecEvent::Stderr(data) => stderr.extend_from_slice(&data),
+            ExecEvent::Exit(status) => exit_status = status,
+            ExecEvent::Eof => {}
+            ExecEvent::Closed => break,
+        }
+    }
+
+    Ok(SshExecOutput {
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        exit_status,
+    })
+}
+
+/// Adapter implementing [`ExecChannel`] over a live russh channel.
+struct RusshExecChannel(russh::Channel<russh::client::Msg>);
+
+#[async_trait::async_trait]
+impl ExecChannel for RusshExecChannel {
+    async fn exec(&mut self, command: &str) -> Result<(), CoreError> {
+        self.0
+            .exec(false, command)
+            .await
+            .map_err(|e| CoreError::Other(format!("Exec failed: {e}")))
+    }
+
+    async fn write_stdin(&mut self, data: &[u8]) -> Result<(), CoreError> {
+        self.0
+            .data(data)
+            .await
+            .map_err(|e| CoreError::Other(format!("Write stdin failed: {e}")))
+    }
+
+    async fn send_eof(&mut self) -> Result<(), CoreError> {
+        self.0
+            .eof()
+            .await
+            .map_err(|e| CoreError::Other(format!("Send EOF failed: {e}")))
+    }
+
+    async fn next_event(&mut self) -> Option<ExecEvent> {
+        // Loop so unrecognised messages (window adjustments, non-stderr
+        // extended data, …) don't end the drain prematurely.
+        loop {
+            match self.0.wait().await {
+                Some(ChannelMsg::Data { data }) => return Some(ExecEvent::Stdout(data.to_vec())),
+                Some(ChannelMsg::ExtendedData { data, ext }) => {
+                    // ext == 1 is stderr (SSH_EXTENDED_DATA_STDERR); ignore
+                    // other extended-data types and keep draining.
+                    if ext == 1 {
+                        return Some(ExecEvent::Stderr(data.to_vec()));
+                    }
+                }
+                Some(ChannelMsg::ExitStatus { exit_status }) => {
+                    return Some(ExecEvent::Exit(exit_status as i32));
+                }
+                Some(ChannelMsg::Eof) => return Some(ExecEvent::Eof),
+                Some(ChannelMsg::Close) => return Some(ExecEvent::Closed),
+                None => return None,
+                _ => {}
+            }
+        }
+    }
 }
 
 /// Execute `command` over an authenticated SSH `session`, sending `stdin` to
@@ -81,14 +158,17 @@ async fn run_exec<C: ExecChannel>(
 ///
 /// Pass an empty `stdin` for commands that read no input. This generalizes the
 /// stdout-only exec used internally by the monitoring provider.
-#[allow(dead_code, unused_variables)]
 pub async fn ssh_exec_with_stdin(
     session: &SshSession,
     command: &str,
     stdin: &str,
 ) -> Result<SshExecOutput, CoreError> {
-    // Implemented in the follow-up refactor commit.
-    todo!("ssh_exec_with_stdin is implemented in the refactor commit")
+    let channel = session
+        .channel_open_session()
+        .await
+        .map_err(|e| CoreError::Other(format!("Channel open failed: {e}")))?;
+    let mut channel = RusshExecChannel(channel);
+    run_exec(&mut channel, command, stdin).await
 }
 
 #[cfg(test)]

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod auth;
 pub mod connector;
+pub mod exec;
 mod file_browser;
 pub mod handler;
 pub mod jump_host;
@@ -13,6 +14,8 @@ mod legacy_pem;
 mod monitoring;
 pub mod session_pool;
 pub mod x11;
+
+pub use self::exec::{ssh_exec_with_stdin, SshExecOutput};
 
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/core/src/backends/ssh/monitoring.rs
+++ b/core/src/backends/ssh/monitoring.rs
@@ -15,7 +15,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use russh::ChannelMsg;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
@@ -227,32 +226,13 @@ impl SshMonitoringProviderImpl<SshTransport> {
 }
 
 /// Execute a command over an SSH session and return stdout as a string.
+///
+/// Thin wrapper over [`ssh_exec_with_stdin`](super::exec::ssh_exec_with_stdin)
+/// that runs with no stdin and keeps only stdout — the monitoring loop parses
+/// stdout and does not need the captured stderr or exit status.
 async fn ssh_exec(session: &SshSession, command: &str) -> Result<String, CoreError> {
-    let mut channel = session
-        .channel_open_session()
-        .await
-        .map_err(|e| CoreError::Other(format!("Channel open failed: {e}")))?;
-
-    channel
-        .exec(false, command)
-        .await
-        .map_err(|e| CoreError::Other(format!("Exec failed: {e}")))?;
-
-    let mut output = String::new();
-    loop {
-        match channel.wait().await {
-            Some(ChannelMsg::Data { ref data }) => {
-                if let Ok(s) = std::str::from_utf8(data) {
-                    output.push_str(s);
-                }
-            }
-            Some(ChannelMsg::ExitStatus { .. }) => {}
-            Some(ChannelMsg::Eof) | None => break,
-            _ => {}
-        }
-    }
-
-    Ok(output)
+    let output = super::exec::ssh_exec_with_stdin(session, command, "").await?;
+    Ok(output.stdout)
 }
 
 /// Run a single collect bounded by `timeout`.

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -274,6 +274,10 @@ pub fn port_network_fault() -> u16 {
 pub fn port_sftp_stress() -> u16 {
     resolve_port("TERMIHUB_TEST_SFTP_STRESS_PORT", 2210)
 }
+/// ssh-sftp-only container (`ForceCommand internal-sftp` — no exec channel).
+pub fn port_ssh_sftp_only() -> u16 {
+    resolve_port("TERMIHUB_TEST_SSH_SFTP_ONLY_PORT", 2211)
+}
 /// telnet-server container.
 pub fn port_telnet() -> u16 {
     resolve_port("TERMIHUB_TEST_TELNET_PORT", 2301)

--- a/core/tests/ssh_exec_with_stdin.rs
+++ b/core/tests/ssh_exec_with_stdin.rs
@@ -121,7 +121,9 @@ async fn exec_capability_probe_false_for_sftp_only_connection() {
     // what `has_exec_capability` keys off.
     let out = ssh_exec_with_stdin(&session, &format!("echo {EXEC_PROBE_MARKER}"), "").await;
 
-    let marker_present = out.map(|o| o.stdout.contains(EXEC_PROBE_MARKER)).unwrap_or(false);
+    let marker_present = out
+        .map(|o| o.stdout.contains(EXEC_PROBE_MARKER))
+        .unwrap_or(false);
     assert!(
         !marker_present,
         "an SFTP-only connection must not echo the probe marker (no usable exec channel)"

--- a/core/tests/ssh_exec_with_stdin.rs
+++ b/core/tests/ssh_exec_with_stdin.rs
@@ -1,0 +1,129 @@
+#![cfg(feature = "ssh")]
+//! Integration tests for [`ssh_exec_with_stdin`] against Docker SSH fixtures.
+//!
+//! Covers the helper's three captured outputs (stdout, stderr, exit status)
+//! and stdin delivery, plus the exec-capability discriminator used by
+//! [`SftpSession::has_exec_capability`](../../src-tauri): a shell connection
+//! echoes a probe marker back on stdout (capable), while an SFTP-only
+//! (`ForceCommand internal-sftp`) connection does not (not capable).
+//!
+//! Requires: `docker compose -f tests/docker/docker-compose.yml up -d`
+//! Skips gracefully if the containers are not running.
+
+mod common;
+
+use common::{port_ssh_password, port_ssh_sftp_only, require_docker, ssh_password_config};
+use termihub_core::backends::ssh::{auth::connect_and_authenticate, ssh_exec_with_stdin};
+
+/// Marker echoed by the exec-capability probe. Kept in sync with the probe in
+/// `src-tauri/src/files/sftp.rs`.
+const EXEC_PROBE_MARKER: &str = "termihub_exec_probe_ok";
+
+#[tokio::test]
+async fn exec_captures_stdout_and_zero_exit_for_id() {
+    require_docker!(port_ssh_password());
+
+    let config = ssh_password_config(port_ssh_password());
+    let (session, _registry) = connect_and_authenticate(&config)
+        .await
+        .expect("password auth should succeed");
+
+    let out = ssh_exec_with_stdin(&session, "id", "")
+        .await
+        .expect("id should execute");
+
+    assert_eq!(out.exit_status, 0, "id should exit 0, got {out:?}");
+    assert!(
+        out.stdout.contains("uid="),
+        "id stdout should contain uid=, got: {}",
+        out.stdout
+    );
+}
+
+#[tokio::test]
+async fn exec_writes_stdin_to_the_command() {
+    require_docker!(port_ssh_password());
+
+    let config = ssh_password_config(port_ssh_password());
+    let (session, _registry) = connect_and_authenticate(&config)
+        .await
+        .expect("password auth should succeed");
+
+    // `cat` echoes its stdin verbatim — proves stdin is written and EOF sent.
+    let payload = "hello from stdin\n";
+    let out = ssh_exec_with_stdin(&session, "cat", payload)
+        .await
+        .expect("cat should execute");
+
+    assert_eq!(out.exit_status, 0);
+    assert_eq!(out.stdout, payload, "cat should echo the written stdin");
+}
+
+#[tokio::test]
+async fn exec_captures_stderr_and_nonzero_exit_status() {
+    require_docker!(port_ssh_password());
+
+    let config = ssh_password_config(port_ssh_password());
+    let (session, _registry) = connect_and_authenticate(&config)
+        .await
+        .expect("password auth should succeed");
+
+    let out = ssh_exec_with_stdin(&session, "echo boom 1>&2; exit 7", "")
+        .await
+        .expect("command should execute");
+
+    assert_eq!(out.exit_status, 7, "exit status should be captured");
+    assert!(
+        out.stderr.contains("boom"),
+        "stderr should be captured, got: {}",
+        out.stderr
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "nothing was written to stdout, got: {}",
+        out.stdout
+    );
+}
+
+#[tokio::test]
+async fn exec_capability_probe_true_for_shell_connection() {
+    require_docker!(port_ssh_password());
+
+    let config = ssh_password_config(port_ssh_password());
+    let (session, _registry) = connect_and_authenticate(&config)
+        .await
+        .expect("password auth should succeed");
+
+    let out = ssh_exec_with_stdin(&session, &format!("echo {EXEC_PROBE_MARKER}"), "")
+        .await
+        .expect("probe should execute on a shell connection");
+
+    assert_eq!(out.exit_status, 0);
+    assert!(
+        out.stdout.contains(EXEC_PROBE_MARKER),
+        "a shell connection must echo the probe marker back, got: {}",
+        out.stdout
+    );
+}
+
+#[tokio::test]
+async fn exec_capability_probe_false_for_sftp_only_connection() {
+    require_docker!(port_ssh_sftp_only());
+
+    let config = ssh_password_config(port_ssh_sftp_only());
+    let (session, _registry) = connect_and_authenticate(&config)
+        .await
+        .expect("password auth should succeed on the sftp-only fixture");
+
+    // The server forces `internal-sftp`, so the exec request is replaced by the
+    // SFTP subsystem: the probe marker never reaches stdout. The channel may
+    // still open, so we assert on the *absence of the marker*, which is exactly
+    // what `has_exec_capability` keys off.
+    let out = ssh_exec_with_stdin(&session, &format!("echo {EXEC_PROBE_MARKER}"), "").await;
+
+    let marker_present = out.map(|o| o.stdout.contains(EXEC_PROBE_MARKER)).unwrap_or(false);
+    assert!(
+        !marker_present,
+        "an SFTP-only connection must not echo the probe marker (no usable exec channel)"
+    );
+}

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -342,6 +342,23 @@ pub async fn sftp_write_file_content(
     .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
 
+/// Report whether the SFTP session's SSH connection can open an exec channel
+/// (i.e. run remote commands such as `sudo`).
+///
+/// Returns `true` for a normal SSH+shell connection and `false` for an
+/// SFTP-only (`ForceCommand internal-sftp`) or relayed connection. Used by the
+/// file editor to know whether privilege-elevated writes are possible.
+#[tauri::command]
+pub async fn sftp_has_exec_capability(
+    session_id: String,
+    manager: State<'_, SftpManager>,
+) -> Result<bool, TerminalError> {
+    let session = manager.get_session(&session_id)?;
+    tokio::task::spawn_blocking(move || Ok(lock_session(&session)?.has_exec_capability()))
+        .await
+        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+}
+
 // --- VS Code integration ---
 
 #[derive(Clone, Serialize)]

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -6,6 +6,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info};
 
 use termihub_core::backends::ssh::handler::SshSession;
+use termihub_core::backends::ssh::{ssh_exec_with_stdin, SshExecOutput};
 use termihub_core::errors::FileError;
 use termihub_core::files::utils::{chrono_from_epoch, format_permissions};
 use termihub_core::files::{FileBackend, FileEntry};
@@ -44,13 +45,31 @@ fn drain_sessions<V>(sessions: &Mutex<HashMap<String, V>>) -> usize {
     count
 }
 
+/// Marker echoed by the exec-capability probe.
+///
+/// A working shell/exec channel echoes it back on stdout; an SFTP-only
+/// connection (`ForceCommand internal-sftp`) or a relayed connection cannot run
+/// the command, so the marker never reaches stdout. Kept in sync with the
+/// integration test in `core/tests/ssh_exec_with_stdin.rs`.
+const EXEC_PROBE_MARKER: &str = "termihub_exec_probe_ok";
+
+/// Decide, from an exec probe's captured output, whether the connection can run
+/// remote commands (i.e. an exec channel is usable).
+///
+/// Keyed off the marker in stdout (not just a zero exit) so an SFTP-only server
+/// that quietly closes the forced-subsystem channel with exit 0 is still
+/// reported as not capable.
+fn exec_probe_indicates_capability(output: &SshExecOutput) -> bool {
+    output.exit_status == 0 && output.stdout.contains(EXEC_PROBE_MARKER)
+}
+
 /// SFTP session backed by a dedicated SSH connection.
 ///
 /// The canonical implementation is now
 /// [`termihub_core::backends::ssh::SftpFileBrowser`](termihub_core::backends::ssh).
 /// This struct is kept for the legacy SFTP command API used by the desktop file browser.
 pub struct SftpSession {
-    _session: SshSession,
+    session: SshSession,
     sftp: RusshSftp,
 }
 
@@ -76,9 +95,27 @@ impl SftpSession {
             })
         })?;
 
-        Ok(Self {
-            _session: session,
-            sftp,
+        Ok(Self { session, sftp })
+    }
+
+    /// Report whether an exec (command) channel can be opened and used on the
+    /// retained SSH connection.
+    ///
+    /// Runs a tiny probe that echoes a known marker back over an exec channel.
+    /// A normal SSH+shell connection echoes it (`true`); an SFTP-only or
+    /// relayed connection (e.g. `ForceCommand internal-sftp`) cannot run the
+    /// command, so the marker never appears (`false`). Lets the file editor
+    /// know whether privilege-elevated writes — which need a shell to run
+    /// `sudo` — are possible for this connection.
+    pub fn has_exec_capability(&self) -> bool {
+        let probe = format!("echo {EXEC_PROBE_MARKER}");
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                match ssh_exec_with_stdin(&self.session, &probe, "").await {
+                    Ok(output) => exec_probe_indicates_capability(&output),
+                    Err(_) => false,
+                }
+            })
         })
     }
 
@@ -91,7 +128,7 @@ impl SftpSession {
     /// navigation live on the browsing channel during a transfer.
     pub async fn open_dedicated_sftp(&self) -> Result<RusshSftp, TerminalError> {
         let channel = self
-            ._session
+            .session
             .channel_open_session()
             .await
             .map_err(|e| TerminalError::SshError(format!("transfer channel open: {e}")))?;
@@ -575,6 +612,36 @@ impl SftpManager {
 mod tests {
     use super::*;
     use std::thread;
+
+    fn probe_output(stdout: &str, exit_status: i32) -> SshExecOutput {
+        SshExecOutput {
+            stdout: stdout.to_string(),
+            exit_status,
+            ..Default::default()
+        }
+    }
+
+    /// A shell connection echoes the probe marker with exit 0 → capable.
+    #[test]
+    fn exec_probe_true_when_marker_echoed_and_exit_zero() {
+        let output = probe_output(&format!("{EXEC_PROBE_MARKER}\n"), 0);
+        assert!(exec_probe_indicates_capability(&output));
+    }
+
+    /// An SFTP-only channel yields no marker (e.g. binary SFTP bytes, even at
+    /// exit 0) → not capable.
+    #[test]
+    fn exec_probe_false_when_marker_absent() {
+        let output = probe_output("\u{0}\u{0}sftp-subsystem-bytes", 0);
+        assert!(!exec_probe_indicates_capability(&output));
+    }
+
+    /// A non-zero exit means the probe did not run cleanly → not capable.
+    #[test]
+    fn exec_probe_false_on_nonzero_exit() {
+        let output = probe_output(&format!("{EXEC_PROBE_MARKER}\n"), 1);
+        assert!(!exec_probe_indicates_capability(&output));
+    }
 
     /// The lock helper must map a poisoned mutex to a recoverable
     /// `TerminalError` instead of panicking (audit GAP C1, #1143).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -661,6 +661,7 @@ pub fn run() {
             commands::files::local_write_file,
             commands::files::sftp_read_file_content,
             commands::files::sftp_write_file_content,
+            commands::files::sftp_has_exec_capability,
             commands::files::vscode_available,
             commands::files::vscode_open_local,
             commands::files::vscode_open_remote,

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -16,8 +16,10 @@ import {
   localWriteFile,
   sftpReadFileContent,
   sftpWriteFileContent,
+  sftpHasExecCapability,
 } from "@/services/api";
 import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
+import { frontendLog } from "@/utils/frontendLog";
 import "./FileEditor.css";
 
 // Use local monaco-editor package instead of CDN (important for Tauri/offline)
@@ -99,6 +101,12 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // behaves like a normal on-disk editor (subsequent saves write here directly).
   const [scratchSavedPath, setScratchSavedPath] = useState<string | null>(null);
 
+  // Whether the remote (SFTP) connection can also open an exec channel — i.e.
+  // it is a full SSH+shell connection, not an SFTP-only / relayed one. Gates
+  // future privilege-elevated ("save with sudo") writes, which need a shell to
+  // run `sudo`. `false` for local files and SFTP-only connections.
+  const [execCapable, setExecCapable] = useState(false);
+
   const saveRef = useRef<() => void>(() => {});
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
 
@@ -170,6 +178,36 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       cancelled = true;
     };
   }, [meta.filePath, meta.isRemote, meta.sftpSessionId, meta.scratch, meta.scratchContent]);
+
+  // Probe whether the remote connection can run remote commands (shell vs
+  // SFTP-only). Determines whether privilege-elevated writes will be offered.
+  useEffect(() => {
+    let cancelled = false;
+    if (!meta.isRemote || !meta.sftpSessionId) {
+      setExecCapable(false);
+      return;
+    }
+    const sessionId = meta.sftpSessionId;
+    sftpHasExecCapability(sessionId)
+      .then((capable) => {
+        if (cancelled) return;
+        setExecCapable(capable);
+        frontendLog("file_editor", `exec capability for sftp session ${sessionId}: ${capable}`);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setExecCapable(false);
+        frontendLog(
+          "file_editor",
+          `exec capability probe failed for sftp session ${sessionId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [meta.isRemote, meta.sftpSessionId]);
 
   // An unsaved scratch buffer has no on-disk copy, so it is always considered
   // dirty (closing it would lose the captured content) until saved via Save As.
@@ -397,7 +435,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
         onJustClose={handleDialogJustClose}
         onSaveAndClose={handleDialogSaveAndClose}
       />
-      <div className="file-editor__toolbar">
+      <div className="file-editor__toolbar" data-exec-capable={execCapable}>
         <div className="file-editor__path">
           {meta.isRemote && (
             <span className="file-editor__remote-badge" data-testid="file-editor-remote-badge">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -761,6 +761,18 @@ export async function sftpWriteFileContent(
   await invoke("sftp_write_file_content", { sessionId, remotePath, content });
 }
 
+/**
+ * Report whether the SFTP session's SSH connection can open an exec channel
+ * (i.e. run remote commands such as `sudo`).
+ *
+ * Returns `true` for a normal SSH+shell connection and `false` for an
+ * SFTP-only or relayed connection. Lets the editor know whether
+ * privilege-elevated writes are possible.
+ */
+export async function sftpHasExecCapability(sessionId: string): Promise<boolean> {
+  return await invoke<boolean>("sftp_has_exec_capability", { sessionId });
+}
+
 // --- Session-based file browsing commands ---
 // These work with any connection type that has file browser capability
 // (including remote agent sessions) by using the terminal session ID directly.

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -49,6 +49,7 @@ podman compose -f tests/docker/docker-compose.yml up -d
 | Container              | Port     | Auth                  | Purpose                                                 |
 | ---------------------- | -------- | --------------------- | ------------------------------------------------------- |
 | `ssh-password`         | 2201     | `testuser`/`testpass` | Standard password auth (OpenSSH latest)                 |
+| `ssh-sftp-only`        | 2211     | `testuser`/`testpass` | SFTP-only (`ForceCommand internal-sftp`, no exec)       |
 | `ssh-legacy`           | 2202     | password + keys       | Legacy OpenSSH 7.x compatibility                        |
 | `ssh-keys`             | 2203     | key only              | All key types (RSA, Ed25519, ECDSA)                     |
 | `ssh-jumphost-bastion` | 2204     | key only              | ProxyJump bastion (2-hop chain entry)                   |

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -40,6 +40,20 @@ services:
       timeout: 3s
       retries: 5
 
+  # SFTP-only SSH (ForceCommand internal-sftp — no usable exec/shell channel)
+  ssh-sftp-only:
+    build: ./ssh-sftp-only
+    container_name: ${TERMIHUB_TEST_PROJECT:-termihub}-ssh-sftp-only
+    ports:
+      - "127.0.0.1:${TERMIHUB_TEST_SSH_SFTP_ONLY_PORT:-2211}:22"
+    networks:
+      - test-net
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/22"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   # Legacy SSH (OpenSSH 7.x / Ubuntu 18.04) for compatibility
   ssh-legacy:
     build:

--- a/tests/docker/ssh-sftp-only/Dockerfile
+++ b/tests/docker/ssh-sftp-only/Dockerfile
@@ -1,0 +1,29 @@
+# SSH server restricted to SFTP only (ForceCommand internal-sftp).
+#
+# Password auth (testuser / testpass), same as ssh-password, but the server
+# forces the internal SFTP subsystem for every session: no exec/shell channel
+# is usable. Used to verify that exec-capability detection reports `false` for
+# an SFTP-only connection.
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssh-server \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /run/sshd
+
+# Create test user (shell is irrelevant — logins are forced into internal-sftp).
+RUN useradd -m -s /usr/sbin/nologin testuser \
+    && echo "testuser:testpass" | chpasswd
+
+# Configure SSH: allow password auth and force the internal SFTP subsystem so
+# that exec/shell requests never run a command.
+RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin no/' /etc/ssh/sshd_config \
+    && sed -i 's@^Subsystem\s\+sftp.*@Subsystem sftp internal-sftp@' /etc/ssh/sshd_config \
+    && printf '\nUseDNS no\nForceCommand internal-sftp\n' >> /etc/ssh/sshd_config
+
+# Generate host keys
+RUN ssh-keygen -A
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
## Summary
Backend plumbing for the elevated-SFTP epic (#1323 / concept `elevated-sftp-editing`):

- **`refactor(ssh)`**: extracted `ssh_exec_with_stdin(session, command, stdin) -> { stdout, stderr, exit_status }` by generalizing the private `ssh_exec` in `core/src/backends/ssh/monitoring.rs`, now capturing **stderr + exit status** (the old `ssh_exec` read stdout only) and writing the stdin to the channel. `ssh_exec`'s monitoring behavior is unchanged.
- **`feat(sftp)`**: added `SftpSession::has_exec_capability()` (true for an SSH+shell connection, false for SFTP-only/relay), exposed it via a Tauri command + `api.ts` wrapper, and wired it into `FileEditor` so the UI knows shell vs SFTP-only.

Out of scope (later sub-issues): sudo command composition, temp upload, dialog, caching.

## Commits (TDD order)
1. `test(ssh)` — tests for the helper (exit status/stderr parsing, command handling) + capability probe
2. `refactor(ssh)` — extract `ssh_exec_with_stdin`
3. `feat(sftp)` — capability query + command + FileEditor wire
4. `style(ssh)` — rustfmt
5. merge of `origin/develop`

## Test plan
- **Unit:** helper parses exit status + stderr; command-string handling; capability logic. (Authored TDD-first.)
- **Integration (Docker):** `id`/`whoami` with stdin against the `ssh-password` fixture (stdout + exit 0); capability true for SSH+shell, false for SFTP-only — feature-gated / daemon-skip so it runs where Docker is present (CI / manual).
- No changelog fragment (pure plumbing; the elevated-write feature lands later).

> Note: finalized by the orchestrator after the implementing agent completed the work and committed cleanly; the latest `origin/develop` was merged in clean (no conflicts) and full verification runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)