### PR TITLE
refactor(ui): adopt shared NumberInput in remaining bespoke number inputs

### DIFF
--- a/docs/changes/dev0/refactor/1453-numberinput-remaining.md
+++ b/docs/changes/dev0/refactor/1453-numberinput-remaining.md
@@ -1,0 +1,9 @@
+### Changed
+
+- More numeric form fields now share one blank-value behavior: clearing a
+  numeric input leaves it blank instead of silently snapping back to a default.
+  This covers the embedded-server port (a blank port now blocks Save), the
+  global Terminal scrollback buffer and Appearance font-size/line-height, the
+  per-connection font-size/scrollback overrides, the agent persistent-buffer
+  size, and the workspace panel-size editor. Valid values still save exactly as
+  before (#1453).

--- a/src/components/ConnectionEditor/AgentSettingsForm.test.tsx
+++ b/src/components/ConnectionEditor/AgentSettingsForm.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { AgentSettingsForm } from "./AgentSettingsForm";
+import { DEFAULT_AGENT_SETTINGS, AgentSettings } from "@/types/connection";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderWith(settings: AgentSettings, onChange = vi.fn()) {
+  act(() => {
+    root.render(<AgentSettingsForm settings={settings} onChange={onChange} />);
+  });
+  return onChange;
+}
+
+/** Drive a controlled input the way a real keystroke would. */
+function setValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function scrollbackInput(): HTMLInputElement {
+  const el = Array.from(container.querySelectorAll(".settings-form__label")).find(
+    (l) => l.textContent === "Persistent Scrollback Buffer"
+  );
+  return el?.closest(".settings-form__field")?.querySelector("input") as HTMLInputElement;
+}
+
+describe("AgentSettingsForm — persistent scrollback buffer", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the buffer size through the shared NumberInput primitive (#1453)", () => {
+    renderWith({ ...DEFAULT_AGENT_SETTINGS, persistentScrollbackBufferSizeMb: 8 });
+    expect(scrollbackInput().classList.contains("ui-input")).toBe(true);
+    expect(scrollbackInput().type).toBe("number");
+    expect(scrollbackInput().value).toBe("8");
+  });
+
+  it("editing to a valid size emits that number (#1453)", () => {
+    const onChange = renderWith({ ...DEFAULT_AGENT_SETTINGS, persistentScrollbackBufferSizeMb: 8 });
+    setValue(scrollbackInput(), "32");
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ persistentScrollbackBufferSizeMb: 32 })
+    );
+  });
+
+  it("clearing the field leaves it blank without coercing to a default (#1453)", () => {
+    const onChange = renderWith({ ...DEFAULT_AGENT_SETTINGS, persistentScrollbackBufferSizeMb: 8 });
+    setValue(scrollbackInput(), "");
+    // The cleared field reads blank...
+    expect(scrollbackInput().value).toBe("");
+    // ...and is never persisted as a silently-coerced default (previously `1`).
+    for (const call of onChange.mock.calls) {
+      expect(call[0].persistentScrollbackBufferSizeMb).not.toBe(1);
+    }
+  });
+});

--- a/src/components/ConnectionEditor/AgentSettingsForm.tsx
+++ b/src/components/ConnectionEditor/AgentSettingsForm.tsx
@@ -7,8 +7,9 @@
  * a hint when the agent is not connected.
  */
 
+import { useEffect, useState } from "react";
 import { AgentCapabilities, AgentSettings } from "@/types/connection";
-import { Input, Select, Toggle } from "@/components/ui";
+import { Input, NumberInput, Select, Toggle } from "@/components/ui";
 
 const LOG_LEVELS = ["error", "warn", "info", "debug", "trace"] as const;
 
@@ -32,6 +33,25 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
   const update = <K extends keyof AgentSettings>(key: K, value: AgentSettings[K]) => {
     onChange({ ...settings, [key]: value });
+  };
+
+  // The persisted buffer size is a required `number`, but the field must be
+  // able to read blank while the user retypes a value. Track the editable
+  // `number | ""` locally and only persist an in-range number — a blank or
+  // out-of-range entry leaves the last valid value untouched rather than
+  // silently coercing to a default.
+  const [scrollbackMb, setScrollbackMb] = useState<number | "">(
+    settings.persistentScrollbackBufferSizeMb
+  );
+  useEffect(() => {
+    setScrollbackMb(settings.persistentScrollbackBufferSizeMb);
+  }, [settings.persistentScrollbackBufferSizeMb]);
+
+  const handleScrollbackChange = (value: number | "") => {
+    setScrollbackMb(value);
+    if (value !== "" && value >= 1 && value <= 64) {
+      update("persistentScrollbackBufferSizeMb", value);
+    }
   };
 
   return (
@@ -134,18 +154,12 @@ export function AgentSettingsForm({ settings, onChange, capabilities }: AgentSet
 
         <label className="settings-form__field">
           <span className="settings-form__label">Persistent Scrollback Buffer</span>
-          <Input
-            type="number"
+          <NumberInput
             min={1}
             max={64}
             step={1}
-            value={settings.persistentScrollbackBufferSizeMb}
-            onChange={(e) =>
-              update(
-                "persistentScrollbackBufferSizeMb",
-                Math.min(64, Math.max(1, parseInt(e.target.value, 10) || 1))
-              )
-            }
+            value={scrollbackMb}
+            onValueChange={handleScrollbackChange}
           />
           <span className="settings-form__hint">
             Size of the ring buffer kept on the agent for persistent sessions (1–64 MiB). Changes

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
@@ -52,6 +52,22 @@ function renderWith(options: TerminalOptions, onChange = vi.fn()) {
   return onChange;
 }
 
+/** Drive a controlled input the way a real keystroke would. */
+function setValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function fieldInput(label: string): HTMLInputElement {
+  const el = Array.from(container.querySelectorAll(".settings-form__label")).find(
+    (l) => l.textContent === label
+  );
+  return el?.closest(".settings-form__field")?.querySelector("input") as HTMLInputElement;
+}
+
 describe("ConnectionTerminalSettings — scrollback buffer", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
@@ -128,5 +144,60 @@ describe("ConnectionTerminalSettings — scrollback buffer", () => {
       ?.closest(".settings-form__field");
     const hint = field?.querySelector(".settings-form__hint");
     expect(hint?.textContent?.toLowerCase()).toContain("memory");
+  });
+
+  it("editing the scrollback buffer emits the parsed number (#1453)", () => {
+    const onChange = renderWith(emptyOptions);
+    setValue(fieldInput("Scrollback Buffer"), "30000");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ scrollbackBuffer: 30000 }));
+  });
+
+  it("clearing the scrollback buffer emits undefined (#1453)", () => {
+    const onChange = renderWith({ ...emptyOptions, scrollbackBuffer: 25000 });
+    setValue(fieldInput("Scrollback Buffer"), "");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ scrollbackBuffer: undefined }));
+  });
+});
+
+describe("ConnectionTerminalSettings — font size", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the font size through the shared NumberInput primitive (#1453)", () => {
+    renderWith(emptyOptions);
+    expect(fieldInput("Font Size").classList.contains("ui-input")).toBe(true);
+    expect(fieldInput("Font Size").type).toBe("number");
+  });
+
+  it("shows a blank field when no per-connection override is set", () => {
+    renderWith(emptyOptions);
+    expect(fieldInput("Font Size").value).toBe("");
+  });
+
+  it("reflects the per-connection font size", () => {
+    renderWith({ ...emptyOptions, fontSize: 18 });
+    expect(fieldInput("Font Size").value).toBe("18");
+  });
+
+  it("editing the font size emits the parsed number (#1453)", () => {
+    const onChange = renderWith(emptyOptions);
+    setValue(fieldInput("Font Size"), "20");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fontSize: 20 }));
+  });
+
+  it("clearing the font size emits undefined (#1453)", () => {
+    const onChange = renderWith({ ...emptyOptions, fontSize: 16 });
+    setValue(fieldInput("Font Size"), "");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fontSize: undefined }));
   });
 });

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
@@ -1,7 +1,7 @@
 import { useAppStore } from "@/store/appStore";
 import { TerminalOptions, LineEnding } from "@/types/terminal";
 import { DEFAULT_LINE_ENDING, LINE_ENDING_OPTIONS, lineEndingLabel } from "@/utils/lineEndings";
-import { Input, Select, Toggle } from "@/components/ui";
+import { Input, NumberInput, Select, Toggle } from "@/components/ui";
 
 interface ConnectionTerminalSettingsProps {
   options: TerminalOptions;
@@ -44,15 +44,11 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
 
       <label className="settings-form__field">
         <span className="settings-form__label">Font Size</span>
-        <Input
-          type="number"
+        <NumberInput
           min={8}
           max={72}
           value={options.fontSize ?? ""}
-          onChange={(e) => {
-            const val = parseInt(e.target.value);
-            onChange({ ...options, fontSize: isNaN(val) ? undefined : val });
-          }}
+          onValueChange={(v) => onChange({ ...options, fontSize: v === "" ? undefined : v })}
           placeholder={`Use global default (${globalFontSize})`}
         />
         <span className="settings-form__hint">Leave empty to use the global setting.</span>
@@ -60,18 +56,13 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
 
       <label className="settings-form__field">
         <span className="settings-form__label">Scrollback Buffer</span>
-        <Input
-          type="number"
+        <NumberInput
           min={100}
           max={1000000}
           value={options.scrollbackBuffer ?? ""}
-          onChange={(e) => {
-            const val = parseInt(e.target.value);
-            onChange({
-              ...options,
-              scrollbackBuffer: isNaN(val) ? undefined : val,
-            });
-          }}
+          onValueChange={(v) =>
+            onChange({ ...options, scrollbackBuffer: v === "" ? undefined : v })
+          }
           placeholder={`Use global default (${globalScrollback})`}
         />
         <span className="settings-form__hint">

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.test.tsx
@@ -137,4 +137,63 @@ describe("EmbeddedServerDialog", () => {
     // And the bind host must NOT have committed to 0.0.0.0 until confirmed.
     expect(bind.getAttribute("data-value")).toBe("127.0.0.1");
   });
+
+  it("renders the port as a token'd number input defaulting to the protocol port", () => {
+    render(<EmbeddedServerDialog {...baseProps} />);
+    const port = document.querySelector('[data-testid="server-dialog-port"]') as HTMLInputElement;
+    expect(port.type).toBe("number");
+    expect(port.classList.contains("ui-input")).toBe(true);
+    expect(port.value).toBe("8080");
+  });
+
+  it("editing the port carries the new number into the saved config", async () => {
+    const onSave = vi.fn((_config: EmbeddedServerConfig) => Promise.resolve(true));
+    render(<EmbeddedServerDialog {...baseProps} onSave={onSave} />);
+
+    typeInto(
+      document.querySelector('[data-testid="server-dialog-name"]') as HTMLInputElement,
+      "Firmware"
+    );
+    typeInto(
+      document.querySelector('[data-testid="server-dialog-root"]') as HTMLInputElement,
+      "/srv/fw"
+    );
+    typeInto(
+      document.querySelector('[data-testid="server-dialog-port"]') as HTMLInputElement,
+      "9000"
+    );
+
+    await act(async () => {
+      (document.querySelector('[data-testid="server-dialog-save"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onSave.mock.calls[0][0]).toMatchObject({ port: 9000 });
+  });
+
+  it("clearing the port keeps it blank and blocks Save (#1453)", () => {
+    render(<EmbeddedServerDialog {...baseProps} />);
+
+    typeInto(
+      document.querySelector('[data-testid="server-dialog-name"]') as HTMLInputElement,
+      "Firmware"
+    );
+    typeInto(
+      document.querySelector('[data-testid="server-dialog-root"]') as HTMLInputElement,
+      "/srv/fw"
+    );
+
+    const saveBtn = document.querySelector(
+      '[data-testid="server-dialog-save"]'
+    ) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(false);
+
+    const port = document.querySelector('[data-testid="server-dialog-port"]') as HTMLInputElement;
+    typeInto(port, "");
+    // The cleared field stays blank rather than snapping back to the old port,
+    // and the invalid (missing) port blocks Save.
+    expect(port.value).toBe("");
+    expect(saveBtn.disabled).toBe(true);
+  });
 });

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import "./EmbeddedServerSidebar.css";
 import { AlertTriangle } from "lucide-react";
-import { Modal, Button, Input, Select } from "@/components/ui";
+import { Modal, Button, Input, NumberInput, Select } from "@/components/ui";
 import {
   EmbeddedServerConfig,
   NetworkInterface,
@@ -23,8 +23,15 @@ interface Props {
   onSave: (config: EmbeddedServerConfig) => boolean | Promise<boolean>;
 }
 
+/**
+ * Editing shape of {@link EmbeddedServerConfig}. `port` widens to `number | ""`
+ * so a cleared port field reads blank (and blocks Save) instead of silently
+ * snapping back to the previous value; it is narrowed back to a number on save.
+ */
+type ServerFormState = Omit<EmbeddedServerConfig, "port"> & { port: number | "" };
+
 /** Blank default config used when creating a new server. */
-function defaultConfig(): EmbeddedServerConfig {
+function defaultConfig(): ServerFormState {
   return {
     id: "",
     name: "",
@@ -43,7 +50,7 @@ function defaultConfig(): EmbeddedServerConfig {
  * Create / edit dialog for an embedded server configuration.
  */
 export function EmbeddedServerDialog({ open, onOpenChange, config, onSave }: Props) {
-  const [form, setForm] = useState<EmbeddedServerConfig>(defaultConfig());
+  const [form, setForm] = useState<ServerFormState>(defaultConfig());
   const [lanWarning, setLanWarning] = useState(false);
   const [interfaces, setInterfaces] = useState<NetworkInterface[]>([
     { name: "Loopback", addr: "127.0.0.1" },
@@ -62,7 +69,7 @@ export function EmbeddedServerDialog({ open, onOpenChange, config, onSave }: Pro
     }
   }, [open, config]);
 
-  const set = <K extends keyof EmbeddedServerConfig>(key: K, value: EmbeddedServerConfig[K]) =>
+  const set = <K extends keyof ServerFormState>(key: K, value: ServerFormState[K]) =>
     setForm((f) => ({ ...f, [key]: value }));
 
   const handleProtocolChange = (type: ServerType) => {
@@ -93,10 +100,10 @@ export function EmbeddedServerDialog({ open, onOpenChange, config, onSave }: Pro
   };
 
   const handleSubmit = async () => {
-    if (!form.name.trim() || !form.rootDirectory.trim()) return;
+    if (!form.name.trim() || !form.rootDirectory.trim() || form.port === "") return;
     // Close only when the save actually succeeded; on failure the dialog stays
     // open (the sidebar surfaces the error via toast) so the user can retry.
-    const saved = await onSave(form);
+    const saved = await onSave({ ...form, port: form.port });
     if (saved) onOpenChange(false);
   };
 
@@ -152,7 +159,7 @@ export function EmbeddedServerDialog({ open, onOpenChange, config, onSave }: Pro
             <Button
               variant="primary"
               onClick={handleSubmit}
-              disabled={!form.name.trim() || !form.rootDirectory.trim()}
+              disabled={!form.name.trim() || !form.rootDirectory.trim() || form.port === ""}
               data-testid="server-dialog-save"
             >
               Save
@@ -226,13 +233,12 @@ export function EmbeddedServerDialog({ open, onOpenChange, config, onSave }: Pro
               </label>
               <label className="server-dialog__label server-dialog__label--inline">
                 Port
-                <Input
+                <NumberInput
                   className="server-dialog__input--port"
-                  type="number"
                   min={1}
                   max={65535}
                   value={form.port}
-                  onChange={(e) => set("port", parseInt(e.target.value, 10) || form.port)}
+                  onValueChange={(v) => set("port", v)}
                   data-testid="server-dialog-port"
                 />
               </label>

--- a/src/components/Settings/AppearanceSettings.test.tsx
+++ b/src/components/Settings/AppearanceSettings.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { AppSettings } from "@/types/connection";
+import { AppearanceSettings } from "./AppearanceSettings";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+const defaultSettings: AppSettings = {
+  version: "1",
+  externalConnectionFiles: [],
+  powerMonitoringEnabled: true,
+  fileBrowserEnabled: true,
+};
+
+function renderWith(settings: AppSettings, onChange = vi.fn()) {
+  act(() => {
+    root.render(<AppearanceSettings settings={settings} onChange={onChange} />);
+  });
+  return onChange;
+}
+
+/** Drive a controlled input the way a real keystroke would. */
+function setValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function fieldInput(label: string): HTMLInputElement {
+  const el = Array.from(container.querySelectorAll(".settings-form__label")).find(
+    (l) => l.textContent === label
+  );
+  return el?.closest(".settings-form__field")?.querySelector("input") as HTMLInputElement;
+}
+
+describe("AppearanceSettings — numeric fields", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders font size and line height through the shared NumberInput primitive (#1453)", () => {
+    renderWith(defaultSettings);
+    expect(fieldInput("Font Size").classList.contains("ui-input")).toBe(true);
+    expect(fieldInput("Font Size").type).toBe("number");
+    expect(fieldInput("Line Height").classList.contains("ui-input")).toBe(true);
+    expect(fieldInput("Line Height").type).toBe("number");
+  });
+
+  it("shows a blank font size and line height when unset (#1453)", () => {
+    renderWith(defaultSettings);
+    expect(fieldInput("Font Size").value).toBe("");
+    expect(fieldInput("Line Height").value).toBe("");
+  });
+
+  it("reflects the configured font size and line height", () => {
+    renderWith({ ...defaultSettings, fontSize: 18, lineHeight: 1.4 });
+    expect(fieldInput("Font Size").value).toBe("18");
+    expect(fieldInput("Line Height").value).toBe("1.4");
+  });
+
+  it("editing the font size emits the parsed number (#1453)", () => {
+    const onChange = renderWith(defaultSettings);
+    setValue(fieldInput("Font Size"), "20");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fontSize: 20 }));
+  });
+
+  it("editing the line height emits the parsed float (#1453)", () => {
+    const onChange = renderWith(defaultSettings);
+    setValue(fieldInput("Line Height"), "1.2");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ lineHeight: 1.2 }));
+  });
+
+  it("clearing the font size emits undefined instead of coercing (#1453)", () => {
+    const onChange = renderWith({ ...defaultSettings, fontSize: 16 });
+    setValue(fieldInput("Font Size"), "");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fontSize: undefined }));
+  });
+
+  it("clearing the line height emits undefined instead of coercing (#1453)", () => {
+    const onChange = renderWith({ ...defaultSettings, lineHeight: 1.5 });
+    setValue(fieldInput("Line Height"), "");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ lineHeight: undefined }));
+  });
+});

--- a/src/components/Settings/AppearanceSettings.tsx
+++ b/src/components/Settings/AppearanceSettings.tsx
@@ -1,5 +1,5 @@
 import { AppSettings } from "@/types/connection";
-import { Select } from "@/components/ui";
+import { NumberInput, Select } from "@/components/ui";
 import type { SelectOption } from "@/components/ui";
 import { SettingsField } from "./SettingsField";
 
@@ -57,15 +57,11 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
       )}
       {show("fontSize") && (
         <SettingsField label="Font Size" hint="Terminal font size in pixels (8–32).">
-          <input
-            type="number"
+          <NumberInput
             min={8}
             max={32}
-            value={settings.fontSize ?? 14}
-            onChange={(e) => {
-              const val = parseInt(e.target.value);
-              onChange({ ...settings, fontSize: isNaN(val) ? undefined : val });
-            }}
+            value={settings.fontSize ?? ""}
+            onValueChange={(v) => onChange({ ...settings, fontSize: v === "" ? undefined : v })}
           />
         </SettingsField>
       )}
@@ -74,16 +70,12 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
           label="Line Height"
           hint="Terminal line height (0.8–2.0). Use 1.0 for seamless box-drawing characters."
         >
-          <input
-            type="number"
+          <NumberInput
             min={0.8}
             max={2.0}
             step={0.1}
-            value={settings.lineHeight ?? 1.0}
-            onChange={(e) => {
-              const val = parseFloat(e.target.value);
-              onChange({ ...settings, lineHeight: isNaN(val) ? undefined : val });
-            }}
+            value={settings.lineHeight ?? ""}
+            onValueChange={(v) => onChange({ ...settings, lineHeight: v === "" ? undefined : v })}
           />
         </SettingsField>
       )}

--- a/src/components/Settings/TerminalSettings.test.tsx
+++ b/src/components/Settings/TerminalSettings.test.tsx
@@ -26,6 +26,22 @@ function renderWith(settings: AppSettings, onChange = vi.fn()) {
   return onChange;
 }
 
+/** Drive a controlled input the way a real keystroke would. */
+function setValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function scrollbackInput(): HTMLInputElement {
+  const label = Array.from(container.querySelectorAll(".settings-form__label")).find(
+    (el) => el.textContent === "Scrollback Buffer"
+  );
+  return label?.closest(".settings-form__field")?.querySelector("input") as HTMLInputElement;
+}
+
 describe("TerminalSettings", () => {
   beforeEach(() => {
     container = document.createElement("div");
@@ -111,14 +127,27 @@ describe("TerminalSettings", () => {
     expect(input).not.toBeNull();
   });
 
-  it("shows 10000 as default when scrollbackBuffer is undefined", () => {
+  it("shows a blank field when scrollbackBuffer is undefined (#1453)", () => {
     renderWith(defaultSettings);
-    const labels = Array.from(container.querySelectorAll(".settings-form__label"));
-    const field = labels
-      .find((el) => el.textContent === "Scrollback Buffer")
-      ?.closest(".settings-form__field");
-    const input = field?.querySelector("input[type='number']") as HTMLInputElement;
-    expect(input.value).toBe("10000");
+    // An unset value now reads blank instead of coercing to the built-in default.
+    expect(scrollbackInput().value).toBe("");
+  });
+
+  it("renders the scrollback buffer through the shared NumberInput primitive (#1453)", () => {
+    renderWith(defaultSettings);
+    expect(scrollbackInput().classList.contains("ui-input")).toBe(true);
+  });
+
+  it("editing the scrollback buffer emits the parsed number (#1453)", () => {
+    const onChange = renderWith(defaultSettings);
+    setValue(scrollbackInput(), "50000");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ scrollbackBuffer: 50000 }));
+  });
+
+  it("clearing the scrollback buffer emits undefined instead of coercing (#1453)", () => {
+    const onChange = renderWith({ ...defaultSettings, scrollbackBuffer: 25000 });
+    setValue(scrollbackInput(), "");
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ scrollbackBuffer: undefined }));
   });
 
   it("reflects a custom scrollbackBuffer value", () => {

--- a/src/components/Settings/TerminalSettings.tsx
+++ b/src/components/Settings/TerminalSettings.tsx
@@ -1,7 +1,7 @@
 import { AppSettings } from "@/types/connection";
 import { LineEnding } from "@/types/terminal";
 import { DEFAULT_LINE_ENDING, LINE_ENDING_OPTIONS } from "@/utils/lineEndings";
-import { Select, Toggle } from "@/components/ui";
+import { NumberInput, Select, Toggle } from "@/components/ui";
 import type { SelectOption } from "@/components/ui";
 import { SettingsField } from "./SettingsField";
 
@@ -56,15 +56,13 @@ export function TerminalSettings({ settings, onChange, visibleFields }: Terminal
           label="Scrollback Buffer"
           hint="Number of lines kept in the terminal scrollback (100–1 000 000). Larger values consume more memory — roughly 1–2 MB per 10 000 lines of typical output."
         >
-          <input
-            type="number"
+          <NumberInput
             min={100}
             max={1000000}
-            value={settings.scrollbackBuffer ?? 10000}
-            onChange={(e) => {
-              const val = parseInt(e.target.value);
-              onChange({ ...settings, scrollbackBuffer: isNaN(val) ? undefined : val });
-            }}
+            value={settings.scrollbackBuffer ?? ""}
+            onValueChange={(v) =>
+              onChange({ ...settings, scrollbackBuffer: v === "" ? undefined : v })
+            }
           />
         </SettingsField>
       )}

--- a/src/components/WorkspaceEditor/LayoutDesigner.test.tsx
+++ b/src/components/WorkspaceEditor/LayoutDesigner.test.tsx
@@ -38,6 +38,15 @@ function query(testId: string): HTMLElement | null {
   return container.querySelector(`[data-testid="${testId}"]`);
 }
 
+/** Drive a controlled input the way a real keystroke would. */
+function setValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
 describe("LayoutDesigner", () => {
   beforeEach(() => {
     container = document.createElement("div");
@@ -223,5 +232,53 @@ describe("LayoutDesigner", () => {
     const resultLeaf = lastLayout! as unknown as WorkspaceLeafNode;
     expect(resultLeaf.tabs).toHaveLength(1);
     expect(resultLeaf.tabs[0].connectionRef).toBe("b");
+  });
+
+  it("edits a panel size through the shared NumberInput and commits on blur (#1453)", () => {
+    let lastLayout: WorkspaceLayoutNode | null = null;
+    const onChange = vi.fn((l: WorkspaceLayoutNode) => {
+      lastLayout = l;
+    });
+    const layout = hsplit(leaf(tab("a")), leaf(tab("b")));
+    act(() => {
+      root.render(withTooltip(<LayoutDesigner layout={layout} onChange={onChange} />));
+    });
+
+    act(() => {
+      query("layout-size-badge")?.click();
+    });
+    const input = query("layout-size-input") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.type).toBe("number");
+    expect(input.classList.contains("ui-input")).toBe(true);
+
+    setValue(input, "70");
+    act(() => {
+      input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(lastLayout!.type).toBe("split");
+    const split = lastLayout! as unknown as { sizes?: number[] };
+    expect(split.sizes?.[0]).toBe(70);
+  });
+
+  it("committing a blank size does not change the layout (#1453)", () => {
+    const onChange = vi.fn();
+    const layout = hsplit(leaf(tab("a")), leaf(tab("b")));
+    act(() => {
+      root.render(withTooltip(<LayoutDesigner layout={layout} onChange={onChange} />));
+    });
+
+    act(() => {
+      query("layout-size-badge")?.click();
+    });
+    const input = query("layout-size-input") as HTMLInputElement;
+    setValue(input, "");
+    act(() => {
+      input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/WorkspaceEditor/LayoutDesigner.tsx
+++ b/src/components/WorkspaceEditor/LayoutDesigner.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { SplitSquareHorizontal, SplitSquareVertical, Plus, X, RotateCcw } from "lucide-react";
-import { Tooltip } from "@/components/ui";
+import { NumberInput, Tooltip } from "@/components/ui";
 import { WorkspaceLayoutNode, WorkspaceSplitNode, WorkspaceTabDef } from "@/types/workspace";
 import {
   getWorkspaceLeaves,
@@ -261,18 +261,18 @@ interface SizeBadgeProps {
 
 function SizeBadge({ size, isCustom, splitNode, childIndex, onUpdateSizes }: SizeBadgeProps) {
   const [editing, setEditing] = useState(false);
-  const [editValue, setEditValue] = useState("");
+  const [editValue, setEditValue] = useState<number | "">("");
 
   const handleStartEdit = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setEditValue(Math.round(size).toString());
+    setEditValue(Math.round(size));
     setEditing(true);
   };
 
   const handleCommit = () => {
     setEditing(false);
-    const newSize = parseFloat(editValue);
-    if (isNaN(newSize) || newSize < 10) return;
+    if (editValue === "" || editValue < 10) return;
+    const newSize = editValue;
 
     const count = splitNode.children.length;
     const currentSizes = splitNode.sizes ?? Array(count).fill(100 / count);
@@ -301,13 +301,12 @@ function SizeBadge({ size, isCustom, splitNode, childIndex, onUpdateSizes }: Siz
 
   if (editing) {
     return (
-      <input
+      <NumberInput
         className="layout-size-input"
-        type="number"
         min={10}
         max={90}
         value={editValue}
-        onChange={(e) => setEditValue(e.target.value)}
+        onValueChange={setEditValue}
         onBlur={handleCommit}
         onKeyDown={handleKeyDown}
         autoFocus

--- a/src/components/WorkspaceEditor/WorkspaceEditor.css
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.css
@@ -651,8 +651,11 @@
   background: color-mix(in srgb, var(--accent-color) 10%, transparent);
 }
 
-.layout-size-input {
+/* Compact inline editor. Element+class specificity keeps it winning over the
+   shared `.ui-input` base that the NumberInput primitive applies. */
+input.layout-size-input {
   width: 40px;
+  height: auto;
   padding: 1px 2px;
   font-size: 9px;
   text-align: center;
@@ -665,6 +668,6 @@
   flex-shrink: 0;
 }
 
-.layout-size-input:focus {
+input.layout-size-input:focus {
   box-shadow: 0 0 0 1px var(--accent-color);
 }


### PR DESCRIPTION
Closes #1453
Follow-up to #1444 (PR #1454).

## Summary

Migrates the last hand-rolled `type="number"` inputs (inline `Number(...)`/`parseInt(...)` at the call site) onto the shared `ui/NumberInput` primitive, standardizing on its `number | ""` blank-value convention. A cleared numeric field now stays blank instead of silently coercing to a default. Valid input still saves exactly as before.

### Sites migrated + per-site blank handling

- **EmbeddedServerDialog** (port) — form state widened locally to `port: number | ""`; a blank port reads blank and **blocks Save** (required), narrowed back to a number on save. Previously `parseInt(...) || form.port` silently snapped back to the old value.
- **TerminalSettings** (scrollback buffer) — optional: blank → `undefined` (unset), field reads blank. Previously an unset value displayed the coerced default `10000`.
- **AppearanceSettings** (font size, line height) — optional: blank → `undefined`; unset now reads blank instead of showing `14` / `1.0`.
- **ConnectionTerminalSettings** (font size, scrollback) — optional `?? ""`: blank → `undefined` (already blanked when unset; parsing removed).
- **AgentSettingsForm** (persistent scrollback buffer, MiB) — required `number`: a small local `number | ""` edit state lets the field read blank while retyping; only an in-range value (1–64) is persisted, so a blank/out-of-range entry leaves the last valid value untouched rather than coercing to `1`.
- **LayoutDesigner** (panel-size editor) — transient edit state moved from `string` to `number | ""`; commit-on-blur logic unchanged in behavior. The compact `layout-size-input` CSS is scoped with element+class specificity so it composes on top of the primitive's `ui-input` base.

## Test plan

- Extended/added unit tests (TDD, test commit precedes implementation) asserting: fields render via the `ui-input` primitive, a cleared field stays blank (or blocks Save / is not persisted as a coerced default), and valid numbers round-trip unchanged.
- New focused suites for `AppearanceSettings` and `AgentSettingsForm` (previously untested).
- `pnpm test` (vitest): 2888 passed. `tsc --noEmit`, `eslint`, `prettier --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)