### PR TITLE
feat(ui): consume spawn-request → open Spawned Docker tab + separate tracking

### DIFF
--- a/docs/changes/dev0/feature/1446-consume-spawn-request.md
+++ b/docs/changes/dev0/feature/1446-consume-spawn-request.md
@@ -1,0 +1,14 @@
+### Added
+
+- Shell context-menu / CLI container spawns now open a session. When an external
+  `termiHub spawn --location <dir> --container-image <image>` reaches the running
+  instance, termiHub resolves the Docker settings and opens a Docker terminal tab
+  with the target directory bind-mounted (working directory set to the mount).
+  The tab shows a **"Spawned"** badge, a confirmation toast reports the opened
+  container, and the spawned container is tracked in its own **Spawned
+  Containers** section of the Open Connections panel — separate from configured
+  Docker connections (spawned containers have no saved connection id) and no
+  longer double-listed under Local Sessions (#1446, epic #1363).
+
+  Non-container spawns (local / WSL / SSH) are handled by a follow-up work item
+  (SI-2) and are ignored for now.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -843,8 +843,8 @@ tab → "Spawned" badge → separate Open Connections tracking → confirmation 
 is covered by unit tests (`src/hooks/useSpawnRequests.test.ts`,
 `src/components/Terminal/Tab.spawned-badge.test.tsx`,
 `src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx`). A live
-end-to-end run needs Docker + a built app, so the full path is manual. See the
-PR that closes #1446.
+end-to-end run needs Docker + a built app (PR #1464), so the full path below is
+manual.
 
 **Container spawn from the CLI opens a bind-mounted Spawned tab.**
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -836,6 +836,36 @@ daemon). The Podman variant is manual because CI has no Podman daemon. See PR #1
 5. Restarting that container (`podman start`) and re-attaching should still see
    the mounted directory. Remove it manually to clean up.
 
+### Container spawn opens a Spawned Docker tab (frontend consumption, #1446)
+
+The frontend wiring (event listener → `resolve_container_spawn` → open Docker
+tab → "Spawned" badge → separate Open Connections tracking → confirmation toast)
+is covered by unit tests (`src/hooks/useSpawnRequests.test.ts`,
+`src/components/Terminal/Tab.spawned-badge.test.tsx`,
+`src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx`). A live
+end-to-end run needs Docker + a built app, so the full path is manual. See the
+PR that closes #1446.
+
+**Container spawn from the CLI opens a bind-mounted Spawned tab.**
+
+1. With a working Docker daemon and the built app already running, create a
+   scratch directory and drop a marker file (e.g. `echo hi > ~/tmp/spawn/hi.txt`).
+2. From another terminal run
+   `termiHub spawn --location ~/tmp/spawn --container-image alpine:3`.
+3. Confirm a **new Docker terminal tab** opens in the running app, titled
+   `Container: alpine:3 (Spawned)`, and that a brief **confirmation toast**
+   reports the spawn (mentions the location).
+4. Confirm the tab shows a **"Spawned"** badge next to its title.
+5. In the terminal, `pwd` prints `/workspace` and `cat hi.txt` prints `hi` —
+   proving the host directory is bind-mounted at the working directory.
+6. Open **Settings → Open Connections**. Confirm a dedicated **Spawned
+   Containers** section lists the container (with a `spawned` badge) and that it
+   is **not** also listed under **Local Sessions**. Its **Kill** action stops the
+   backend session.
+7. (Boundary) Run `termiHub spawn --location ~/tmp/spawn` with **no**
+   `--container-image`. Confirm no tab opens (non-container spawns are SI-2; the
+   request is ignored, logged in the LogViewer under `frontend::spawn`).
+
 ### Native-dialog → Modal migration (#1348)
 
 Verifies the three flows that previously used native `window.prompt` /

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { useTunnelEvents } from "@/hooks/useTunnelEvents";
 import { useTransferEvents } from "@/hooks/useTransferEvents";
 import { useEmbeddedServerEvents } from "@/hooks/useEmbeddedServerEvents";
 import { useCredentialStoreEvents } from "@/hooks/useCredentialStoreEvents";
+import { useSpawnRequests } from "@/hooks/useSpawnRequests";
 import { useHttpMonitorNotifications } from "@/hooks/useHttpMonitorNotifications";
 import { useWebviewZoom } from "@/hooks/useWebviewZoom";
 import { useSidebarResize } from "@/hooks/useSidebarResize";
@@ -104,6 +105,7 @@ function App() {
   useTransferEvents();
   useEmbeddedServerEvents();
   useCredentialStoreEvents();
+  useSpawnRequests();
   useHttpMonitorNotifications();
   useWebviewZoom();
   const loadFromBackend = useAppStore((s) => s.loadFromBackend);

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -141,6 +141,11 @@
   color: var(--text-secondary);
 }
 
+.oc-row__badge--spawned {
+  background: color-mix(in srgb, var(--color-info) 18%, transparent);
+  color: var(--color-info);
+}
+
 /* Transfer row (issue 1247): the icon + Cancel button flank a stacked body that
    holds the file name, an inline progress bar, and a byte/percentage meta line. */
 .oc-transfer {

--- a/src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx
@@ -108,12 +108,8 @@ describe("OpenConnectionsModal — Spawned Containers section", () => {
 
   it("does not double-list the spawned session under Local Sessions", async () => {
     await renderWithSpawnedTab();
-    // The plain local session still shows, the spawned one does not appear under
-    // Local Sessions (it is tracked in its own section instead).
-    const localSection = Array.from(document.querySelectorAll("[data-testid]")).find(
-      (el) => el.getAttribute("data-testid") === "open-connections-local-sessions-section"
-    );
-    // Fall back to scanning all rows: exactly one row mentions the spawned title.
+    // Exactly one row mentions the spawned container — it lives in its own
+    // section, not also under Local Sessions.
     const spawnedRows = Array.from(document.querySelectorAll(".oc-row")).filter((r) =>
       r.querySelector(".oc-row__title")?.textContent?.includes("Container: alpine:3")
     );
@@ -123,7 +119,6 @@ describe("OpenConnectionsModal — Spawned Containers section", () => {
       r.querySelector(".oc-row__title")?.textContent?.includes("My Shell")
     );
     expect(plainRows).toHaveLength(1);
-    void localSection;
   });
 
   it("kills a spawned container via close_terminal", async () => {

--- a/src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for the "Spawned Containers" section of the Open Connections panel
+ * (#1446): spawned containers (opened from a CLI/context-menu spawn, no saved
+ * connection id) are tracked separately from configured Docker connections and
+ * are not double-listed under "Local Sessions".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { TerminalTab } from "@/types/terminal";
+
+const closeTerminal = vi.fn((_id: string) => Promise.resolve());
+vi.mock("@/services/api", () => ({
+  listLocalSessions: vi.fn(() =>
+    Promise.resolve([
+      {
+        id: "sess-spawn",
+        title: "Container: alpine:3 (Spawned)",
+        connectionType: "docker",
+        alive: true,
+      },
+      { id: "sess-plain", title: "My Shell", connectionType: "local", alive: true },
+    ])
+  ),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  closeTerminal: (id: string) => closeTerminal(id),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  cancelConnectAgent: vi.fn(() => Promise.resolve()),
+  pruneDeadAgents: vi.fn(() => Promise.resolve([])),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false, sessionCount: 0 })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorStopAll: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+}));
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+function spawnedTab(id: string, title: string, sessionId: string, panelId: string): TerminalTab {
+  return {
+    id,
+    sessionId,
+    title,
+    connectionType: "docker",
+    contentType: "terminal",
+    config: { type: "docker", config: {} },
+    panelId,
+    isActive: true,
+    spawned: true,
+  };
+}
+
+describe("OpenConnectionsModal — Spawned Containers section", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    closeTerminal.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderWithSpawnedTab() {
+    const leafId = useAppStore.getState().rootPanel.id;
+    const tab = spawnedTab("tab-1", "Container: alpine:3 (Spawned)", "sess-spawn", leafId);
+    useAppStore.setState({
+      rootPanel: { type: "leaf", id: leafId, tabs: [tab], activeTabId: tab.id },
+      activePanelId: leafId,
+    });
+    await act(async () => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("lists the spawned container in its own section", async () => {
+    await renderWithSpawnedTab();
+    const titles = Array.from(document.querySelectorAll(".oc-section__title")).map(
+      (t) => t.textContent
+    );
+    expect(titles).toContain("Spawned Containers");
+
+    const rows = Array.from(document.querySelectorAll(".oc-row")).filter((r) =>
+      r.querySelector(".oc-row__title")?.textContent?.includes("Container: alpine:3")
+    );
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not double-list the spawned session under Local Sessions", async () => {
+    await renderWithSpawnedTab();
+    // The plain local session still shows, the spawned one does not appear under
+    // Local Sessions (it is tracked in its own section instead).
+    const localSection = Array.from(document.querySelectorAll("[data-testid]")).find(
+      (el) => el.getAttribute("data-testid") === "open-connections-local-sessions-section"
+    );
+    // Fall back to scanning all rows: exactly one row mentions the spawned title.
+    const spawnedRows = Array.from(document.querySelectorAll(".oc-row")).filter((r) =>
+      r.querySelector(".oc-row__title")?.textContent?.includes("Container: alpine:3")
+    );
+    expect(spawnedRows).toHaveLength(1);
+    // The plain local session is still listed.
+    const plainRows = Array.from(document.querySelectorAll(".oc-row")).filter((r) =>
+      r.querySelector(".oc-row__title")?.textContent?.includes("My Shell")
+    );
+    expect(plainRows).toHaveLength(1);
+    void localSection;
+  });
+
+  it("kills a spawned container via close_terminal", async () => {
+    await renderWithSpawnedTab();
+    const row = Array.from(document.querySelectorAll(".oc-row")).find((r) =>
+      r.querySelector(".oc-row__title")?.textContent?.includes("Container: alpine:3")
+    );
+    const killBtn = row?.querySelector(".oc-row__kill") as HTMLButtonElement;
+    expect(killBtn).not.toBeNull();
+    await act(async () => {
+      killBtn.click();
+      await Promise.resolve();
+    });
+    expect(closeTerminal).toHaveBeenCalledWith("sess-spawn");
+  });
+});

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -20,6 +20,7 @@ import {
   Check,
   Unplug,
   Power,
+  Package,
 } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Modal, Button, Tooltip, Progress, ConfirmDialog, toast } from "@/components/ui";
@@ -124,6 +125,18 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
       .flatMap((leaf) => leaf.tabs.map((t) => t.id))
   );
 
+  // Session ids of spawned containers (#1446): tabs opened from an external
+  // `termiHub spawn` with no saved connection id. They are backend-local
+  // sessions, so they must be pulled OUT of "Local Sessions" and tracked in
+  // their own "Spawned Containers" section.
+  const spawnedSessionIds = new Set(
+    tabGroups
+      .flatMap((g) => getAllLeaves(g.id === activeTabGroupId ? rootPanel : g.rootPanel))
+      .flatMap((leaf) => leaf.tabs)
+      .filter((t) => t.spawned && t.sessionId)
+      .map((t) => t.sessionId as string)
+  );
+
   // One entry per live backend SFTP session, keyed by its UUID. Orphaned
   // sessions (owning tab gone) still surface here so they stay killable.
   const sftpSessionEntries = Object.entries(sftpSessions).map(([id, entry]) => ({
@@ -142,6 +155,12 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const [xServer, setXServer] = useState<XServerStatusReport | null>(null);
   const [xServerSetupOpen, setXServerSetupOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+
+  // Split backend-local sessions: spawned containers get their own section, the
+  // rest stay under "Local Sessions" (#1446). Keeps spawned containers tracked
+  // separately from configured connections and avoids double-listing.
+  const spawnedSessions = localSessions.filter((s) => spawnedSessionIds.has(s.id));
+  const plainLocalSessions = localSessions.filter((s) => !spawnedSessionIds.has(s.id));
 
   const connectedAgents = remoteAgents.filter((a) => a.connectionState === "connected");
 
@@ -292,9 +311,17 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   };
 
   const handleKillAllLocal = async () => {
-    localSessions.forEach((s) => markSessionKilled(s.id));
-    await Promise.all(localSessions.map((s) => closeTerminal(s.id).catch(() => {})));
-    setLocalSessions([]);
+    plainLocalSessions.forEach((s) => markSessionKilled(s.id));
+    await Promise.all(plainLocalSessions.map((s) => closeTerminal(s.id).catch(() => {})));
+    setLocalSessions((prev) => prev.filter((s) => spawnedSessionIds.has(s.id)));
+  };
+
+  // Kill every spawned container at once (#1446). Mirrors the local-session
+  // kill: end the backend session and drop the cached rows.
+  const handleKillAllSpawned = async () => {
+    spawnedSessions.forEach((s) => markSessionKilled(s.id));
+    await Promise.all(spawnedSessions.map((s) => closeTerminal(s.id).catch(() => {})));
+    setLocalSessions((prev) => prev.filter((s) => !spawnedSessionIds.has(s.id)));
   };
 
   // Clear the cached native-session rows for an agent once its transport is gone
@@ -594,20 +621,43 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           </Section>
         )}
 
-        {/* Local Sessions */}
-        {localSessions.length > 0 && (
+        {/* Local Sessions (excluding spawned containers, tracked below) */}
+        {plainLocalSessions.length > 0 && (
           <Section
             title="Local Sessions"
             icon={<Terminal size={14} />}
-            count={localSessions.length}
+            count={plainLocalSessions.length}
             onKillAll={handleKillAllLocal}
           >
-            {localSessions.map((s) => (
+            {plainLocalSessions.map((s) => (
               <ConnectionRow
                 key={s.id}
                 icon={<Terminal size={14} />}
                 title={s.title}
                 badge={s.alive ? "alive" : "dead"}
+                onKill={() => handleKillLocal(s.id)}
+              />
+            ))}
+          </Section>
+        )}
+
+        {/* Spawned Containers — opened from an external `termiHub spawn`, no
+            saved connection id, so tracked separately from configured Docker
+            connections (#1446). */}
+        {spawnedSessions.length > 0 && (
+          <Section
+            title="Spawned Containers"
+            icon={<Package size={14} />}
+            count={spawnedSessions.length}
+            onKillAll={handleKillAllSpawned}
+            data-testid="open-connections-spawned-section"
+          >
+            {spawnedSessions.map((s) => (
+              <ConnectionRow
+                key={s.id}
+                icon={<Package size={14} />}
+                title={s.title}
+                badge={s.alive ? "spawned" : "dead"}
                 onKill={() => handleKillLocal(s.id)}
               />
             ))}
@@ -1048,6 +1098,7 @@ type BadgeVariant =
   | "paused"
   | "stopped"
   | "orphaned"
+  | "spawned"
   | "error";
 
 interface TransferRowProps {

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -116,25 +116,22 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     .flatMap((leaf) => leaf.tabs)
     .filter((tab) => terminalConnecting[tab.id]);
 
-  // Every live tab id across all tab groups (the active group is the live
-  // rootPanel, the others their stored trees) — used to flag orphaned SFTP
-  // sessions whose owning tab no longer exists (#1241, orphan safety net).
-  const liveTabIds = new Set(
-    tabGroups
-      .flatMap((g) => getAllLeaves(g.id === activeTabGroupId ? rootPanel : g.rootPanel))
-      .flatMap((leaf) => leaf.tabs.map((t) => t.id))
+  // Every tab across all tab groups (the active group is the live rootPanel, the
+  // others their stored trees), walked once and reused below.
+  const allTabs = tabGroups.flatMap((g) =>
+    getAllLeaves(g.id === activeTabGroupId ? rootPanel : g.rootPanel).flatMap((leaf) => leaf.tabs)
   );
+
+  // Every live tab id — used to flag orphaned SFTP sessions whose owning tab no
+  // longer exists (#1241, orphan safety net).
+  const liveTabIds = new Set(allTabs.map((t) => t.id));
 
   // Session ids of spawned containers (#1446): tabs opened from an external
   // `termiHub spawn` with no saved connection id. They are backend-local
   // sessions, so they must be pulled OUT of "Local Sessions" and tracked in
   // their own "Spawned Containers" section.
   const spawnedSessionIds = new Set(
-    tabGroups
-      .flatMap((g) => getAllLeaves(g.id === activeTabGroupId ? rootPanel : g.rootPanel))
-      .flatMap((leaf) => leaf.tabs)
-      .filter((t) => t.spawned && t.sessionId)
-      .map((t) => t.sessionId as string)
+    allTabs.filter((t) => t.spawned && t.sessionId).map((t) => t.sessionId as string)
   );
 
   // One entry per live backend SFTP session, keyed by its UUID. Orphaned
@@ -310,19 +307,20 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     setLocalSessions((prev) => prev.filter((s) => s.id !== id));
   };
 
-  const handleKillAllLocal = async () => {
-    plainLocalSessions.forEach((s) => markSessionKilled(s.id));
-    await Promise.all(plainLocalSessions.map((s) => closeTerminal(s.id).catch(() => {})));
-    setLocalSessions((prev) => prev.filter((s) => spawnedSessionIds.has(s.id)));
+  // Kill a set of backend-local sessions at once, marking each kill intentional
+  // (#1121) and dropping the killed rows from the cache. Shared by the "Local
+  // Sessions" and "Spawned Containers" bulk actions (#1446).
+  const killSessions = async (sessions: LocalSessionInfo[]) => {
+    const ids = new Set(sessions.map((s) => s.id));
+    sessions.forEach((s) => markSessionKilled(s.id));
+    await Promise.all(sessions.map((s) => closeTerminal(s.id).catch(() => {})));
+    setLocalSessions((prev) => prev.filter((s) => !ids.has(s.id)));
   };
 
-  // Kill every spawned container at once (#1446). Mirrors the local-session
-  // kill: end the backend session and drop the cached rows.
-  const handleKillAllSpawned = async () => {
-    spawnedSessions.forEach((s) => markSessionKilled(s.id));
-    await Promise.all(spawnedSessions.map((s) => closeTerminal(s.id).catch(() => {})));
-    setLocalSessions((prev) => prev.filter((s) => !spawnedSessionIds.has(s.id)));
-  };
+  const handleKillAllLocal = () => killSessions(plainLocalSessions);
+
+  // Kill every spawned container at once (#1446).
+  const handleKillAllSpawned = () => killSessions(spawnedSessions);
 
   // Clear the cached native-session rows for an agent once its transport is gone
   // (both teardown intents drop the transport, so the "Sessions on <agent>"

--- a/src/components/Terminal/Tab.spawned-badge.test.tsx
+++ b/src/components/Terminal/Tab.spawned-badge.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Tab } from "./Tab";
+import { TooltipProvider } from "@/components/ui";
+import { TerminalTab } from "@/types/terminal";
+
+// Stub the dnd-kit sortable wrapper so the Tab mounts without a DndContext.
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+const PANEL_ID = "panel-1";
+
+function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: "t1",
+    sessionId: "sess-1",
+    title: "Container: alpine:3 (Spawned)",
+    connectionType: "docker",
+    contentType: "terminal",
+    config: { type: "docker", config: {} },
+    panelId: PANEL_ID,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+function renderTab(tab: TerminalTab) {
+  const root = createRoot(document.body.appendChild(document.createElement("div")));
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <Tab tab={tab} onActivate={() => {}} onClose={() => {}} />
+      </TooltipProvider>
+    );
+  });
+  return root;
+}
+
+describe("Tab — Spawned badge (#1446)", () => {
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    root = null;
+    document.body.innerHTML = "";
+  });
+
+  it("renders a Spawned badge for a spawned tab", () => {
+    root = renderTab(makeTab({ spawned: true }));
+    const badge = document.querySelector(".tab__spawned-badge");
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain("Spawned");
+  });
+
+  it("does not render the badge for a regular tab", () => {
+    root = renderTab(makeTab({ spawned: false }));
+    expect(document.querySelector(".tab__spawned-badge")).toBeNull();
+  });
+});

--- a/src/components/Terminal/Tab.spawned-badge.test.tsx
+++ b/src/components/Terminal/Tab.spawned-badge.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import React from "react";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { Tab } from "./Tab";

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -127,6 +127,11 @@ export function Tab({
         {tab.title}
       </span>
       {tab.persistentConnectionId && <span className="tab__persistent-badge">∞</span>}
+      {tab.spawned && (
+        <span className="tab__spawned-badge" title="Spawned container">
+          Spawned
+        </span>
+      )}
       <Tooltip content="Close" side="bottom">
         <button
           className="tab__close"

--- a/src/components/Terminal/TabBar.css
+++ b/src/components/Terminal/TabBar.css
@@ -98,6 +98,18 @@
   top: -3px;
 }
 
+.tab__spawned-badge {
+  flex-shrink: 0;
+  margin-left: var(--spacing-xs);
+  padding: 0 var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.4;
+  border-radius: var(--radius-full);
+  color: var(--color-info);
+  background: color-mix(in srgb, var(--color-info) 18%, transparent);
+}
+
 .tab__dirty-dot {
   display: inline-block;
   width: 8px;

--- a/src/hooks/useSpawnRequests.test.ts
+++ b/src/hooks/useSpawnRequests.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// A settable callback the mocked `onSpawnRequest` hands the event stream to, so
+// tests can drive `spawn-request` events directly (mirrors useTransferEvents).
+let emit: ((payload: SpawnRequestPayload) => void) | undefined;
+const unlisten = vi.fn();
+
+vi.mock("@/services/events", () => ({
+  onSpawnRequest: vi.fn((cb: (payload: SpawnRequestPayload) => void) => {
+    emit = cb;
+    return Promise.resolve(unlisten);
+  }),
+}));
+
+const resolveContainerSpawn = vi.fn();
+vi.mock("@/services/api", () => ({
+  resolveContainerSpawn: (location: string, image?: string, mount?: string) =>
+    resolveContainerSpawn(location, image, mount),
+}));
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn((_message: unknown, _opts?: unknown) => undefined),
+    error: vi.fn((_message: unknown, _opts?: unknown) => undefined),
+    info: vi.fn((_message: unknown, _opts?: unknown) => undefined),
+    loading: vi.fn((_message: unknown, _opts?: unknown) => "toast-id"),
+    dismiss: vi.fn((_id?: unknown) => undefined),
+  },
+}));
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { useSpawnRequests } from "./useSpawnRequests";
+import { useAppStore } from "@/store/appStore";
+import { toast } from "@/components/ui";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { SpawnRequestPayload } from "@/services/events";
+import type { ContainerSpawn } from "@/services/api";
+import type { TerminalTab } from "@/types/terminal";
+
+const SAMPLE_SPAWN: ContainerSpawn = {
+  settings: {
+    image: "alpine:3",
+    volumes: [{ hostPath: "/home/user/app", containerPath: "/workspace", readOnly: false }],
+    workingDirectory: "/workspace",
+    removeOnExit: false,
+  },
+  title: "Container: alpine:3 (Spawned)",
+  spawned: true,
+};
+
+function containerRequest(overrides: Partial<SpawnRequestPayload> = {}): SpawnRequestPayload {
+  return {
+    location: "/home/user/app",
+    container_image: "alpine:3",
+    container_mount: "/workspace",
+    ...overrides,
+  };
+}
+
+/** Collect every terminal tab across the live root panel. */
+function allTabs(): TerminalTab[] {
+  return getAllLeaves(useAppStore.getState().rootPanel).flatMap((leaf) => leaf.tabs);
+}
+
+describe("useSpawnRequests — container spawn wiring (#1446)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    emit = undefined;
+    resolveContainerSpawn.mockReset();
+    resolveContainerSpawn.mockResolvedValue(SAMPLE_SPAWN);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function mountHook(): Promise<void> {
+    function Harness() {
+      useSpawnRequests();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    // The subscription is set up asynchronously inside an effect.
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  it("resolves a container spawn with the request args", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!(containerRequest());
+      await Promise.resolve();
+    });
+
+    expect(resolveContainerSpawn).toHaveBeenCalledWith("/home/user/app", "alpine:3", "/workspace");
+  });
+
+  it("opens a Docker tab with the resolved settings and title, marked spawned", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!(containerRequest());
+      await Promise.resolve();
+    });
+
+    const tab = allTabs().find((t) => t.spawned);
+    expect(tab).toBeDefined();
+    expect(tab?.connectionType).toBe("docker");
+    expect(tab?.config.type).toBe("docker");
+    expect(tab?.config.config).toEqual(SAMPLE_SPAWN.settings);
+    expect(tab?.title).toBe(SAMPLE_SPAWN.title);
+    expect(tab?.spawned).toBe(true);
+  });
+
+  it("shows a confirmation toast on a successful spawn", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!(containerRequest());
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(toast.success)).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(toast.success).mock.calls[0][0])).toContain("/home/user/app");
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a recoverable error toast when resolution fails", async () => {
+    resolveContainerSpawn.mockRejectedValue("no such location");
+    await mountHook();
+
+    await act(async () => {
+      emit!(containerRequest());
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(toast.error).mock.calls[0][0])).toContain("no such location");
+    expect(allTabs().some((t) => t.spawned)).toBe(false);
+  });
+
+  it("ignores a non-container spawn (SI-2 owns local/WSL/SSH)", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!({ location: "/home/user/app" });
+      await Promise.resolve();
+    });
+
+    expect(resolveContainerSpawn).not.toHaveBeenCalled();
+    expect(allTabs().some((t) => t.spawned)).toBe(false);
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes on unmount", async () => {
+    await mountHook();
+    act(() => root.unmount());
+    // Re-create the root so afterEach's unmount is a no-op.
+    root = createRoot(container);
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useSpawnRequests.ts
+++ b/src/hooks/useSpawnRequests.ts
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+import { useAppStore } from "@/store/appStore";
+import { toast } from "@/components/ui";
+import { onSpawnRequest, SpawnRequestPayload } from "@/services/events";
+import { resolveContainerSpawn } from "@/services/api";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * Whether a spawn request targets a "new container" spawn (#1446). The CLI
+ * container path (`termiHub spawn --location … --container-image …`) always
+ * carries an image; a mount override alone also signals container intent. All
+ * other spawns (local / WSL / SSH) are owned by SI-2 and ignored here.
+ */
+function isContainerSpawn(req: SpawnRequestPayload): boolean {
+  return (
+    (req.container_image?.trim() ?? "").length > 0 || (req.container_mount?.trim() ?? "").length > 0
+  );
+}
+
+/**
+ * App-scoped hook that consumes `spawn-request` events (#1364/#1446). For a
+ * container spawn it resolves the Docker settings via `resolve_container_spawn`
+ * and opens a Docker session tab (badged "Spawned" and tracked separately from
+ * configured connections), confirming with a toast. Non-container spawns are
+ * short-circuited with a log — the local/WSL/SSH open path is SI-2's scope.
+ *
+ * Registered once at app scope; the subscription is torn down on unmount.
+ */
+export function useSpawnRequests(): void {
+  const openSpawnedContainer = useAppStore((s) => s.openSpawnedContainer);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let disposed = false;
+
+    const setup = async () => {
+      const off = await onSpawnRequest(async (req) => {
+        if (!isContainerSpawn(req)) {
+          // TODO(SI-2): local / WSL / SSH spawns are resolved and opened by a
+          // separate work item. Ignore them here rather than half-opening a
+          // session with the wrong backend.
+          frontendLog(
+            "spawn",
+            `Ignoring non-container spawn-request (SI-2 owns local/WSL/SSH): ${JSON.stringify(req)}`
+          );
+          return;
+        }
+
+        const location = req.location ?? "";
+        try {
+          const spawn = await resolveContainerSpawn(
+            location,
+            req.container_image,
+            req.container_mount
+          );
+          openSpawnedContainer(spawn);
+          toast.success(`Spawned container at ${location || "."}`);
+        } catch (err) {
+          frontendLog("spawn", `Failed to resolve container spawn: ${err}`);
+          toast.error(`Failed to open spawned container: ${err}`);
+        }
+      });
+      // If the effect was cleaned up before the async listen() resolved, tear
+      // the listener down immediately so it does not leak.
+      if (disposed) {
+        off();
+        return;
+      }
+      unlisten = off;
+    };
+
+    void setup();
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [openSpawnedContainer]);
+}

--- a/src/hooks/useSpawnRequests.ts
+++ b/src/hooks/useSpawnRequests.ts
@@ -12,9 +12,7 @@ import { frontendLog } from "@/utils/frontendLog";
  * other spawns (local / WSL / SSH) are owned by SI-2 and ignored here.
  */
 function isContainerSpawn(req: SpawnRequestPayload): boolean {
-  return (
-    (req.container_image?.trim() ?? "").length > 0 || (req.container_mount?.trim() ?? "").length > 0
-  );
+  return !!req.container_image?.trim() || !!req.container_mount?.trim();
 }
 
 /**

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -119,6 +119,39 @@ export async function createTerminal(
   return await createConnection(config.type, config.config, undefined, connectId);
 }
 
+/**
+ * A resolved directory-mount container spawn (#1372/#1446). Mirrors the Rust
+ * `ContainerSpawn`: the camelCase Docker backend `settings` to open the session
+ * with, a `"… (Spawned)"` tab `title`, and `spawned: true` so the frontend can
+ * badge and track it separately from configured Docker connections.
+ */
+export interface ContainerSpawn {
+  /** Docker backend settings (camelCase) for the spawned session. */
+  settings: Record<string, unknown>;
+  /** Display title carrying the "Spawned" marker for the tab badge. */
+  title: string;
+  /** Always `true` — distinguishes spawned containers from saved connections. */
+  spawned: boolean;
+}
+
+/**
+ * Resolve a directory-mount container spawn into Docker session settings
+ * (#1446). Given a spawn `location` (and optional image / mount overrides),
+ * returns the Docker settings + tab title used to open a "new container" tab
+ * with the target directory bind-mounted.
+ */
+export async function resolveContainerSpawn(
+  location: string,
+  containerImage?: string,
+  containerMount?: string
+): Promise<ContainerSpawn> {
+  return await invoke<ContainerSpawn>("resolve_container_spawn", {
+    location,
+    containerImage,
+    containerMount,
+  });
+}
+
 /** Send input data to a terminal session */
 export async function sendInput(sessionId: SessionId, data: string): Promise<void> {
   await invoke("send_input", { sessionId, data });

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -567,6 +567,41 @@ export async function onXServerProgress(
 }
 
 /**
+ * Payload of a `spawn-request` event (#1364). Emitted by the backend IPC
+ * rendezvous when an external `termiHub spawn …` invocation reaches the running
+ * instance. Fields mirror the Rust `SpawnRequest` (snake_case, all optional).
+ */
+export interface SpawnRequestPayload {
+  /** Filesystem path (folder or file) the session should open at. */
+  location?: string;
+  /** Identifier of the context-menu entry that triggered the spawn. */
+  entry_id?: string;
+  /** Explicit connection id override. */
+  connection?: string;
+  /** Open in a fresh window instead of attaching to the running instance. */
+  new_window?: boolean;
+  /** Force the interactive session picker. */
+  pick?: boolean;
+  /** Docker/Podman image for a "new container" spawn (marks a container spawn). */
+  container_image?: string;
+  /** Mount target path inside the container. */
+  container_mount?: string;
+}
+
+/**
+ * Subscribe to `spawn-request` events (#1364/#1446). Each event is one external
+ * spawn invocation the running instance should act on. Returns the unlisten
+ * handle.
+ */
+export async function onSpawnRequest(
+  callback: (payload: SpawnRequestPayload) => void
+): Promise<UnlistenFn> {
+  return await listen<SpawnRequestPayload>("spawn-request", (event) => {
+    callback(event.payload);
+  });
+}
+
+/**
  * Subscribe to connect-time X server download-consent prompts (#1116). Emitted
  * when opening an X11-forwarding SSH connection would need to download the X
  * dependency and the user has not consented yet; the connect pauses until the

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -103,7 +103,7 @@ import {
   detachPersistentTab as apiDetachPersistentTab,
   saveShellIntegrationSettings,
 } from "@/services/api";
-import type { ConnectionTypeInfo } from "@/services/api";
+import type { ConnectionTypeInfo, ContainerSpawn } from "@/services/api";
 import { RemoteAgentConfig } from "@/types/terminal";
 import { TunnelConfig, TunnelState } from "@/types/tunnel";
 import { EmbeddedServerConfig, ServerState as EmbeddedServerState } from "@/types/embeddedServer";
@@ -315,8 +315,16 @@ interface AppState {
     contentType?: TabContentType,
     terminalOptions?: TerminalOptions,
     sessionId?: string | null,
-    persistentConnectionId?: string
+    persistentConnectionId?: string,
+    spawned?: boolean
   ) => string;
+  /**
+   * Open a Docker session tab for a resolved external container spawn (#1446).
+   * Reuses the standard {@link addTab} open path with the spawn's Docker
+   * settings + tab title and marks the tab `spawned` (no saved connection id).
+   * Returns the created tab id.
+   */
+  openSpawnedContainer: (spawn: ContainerSpawn) => string;
 
   // Persistent connection sessions
   /** Live state of all persistent connection sessions, keyed by connectionId. */
@@ -1176,7 +1184,8 @@ function createTab(
   panelId: string,
   contentType: TabContentType = "terminal",
   sessionId: string | null = null,
-  persistentConnectionId?: string
+  persistentConnectionId?: string,
+  spawned?: boolean
 ): TerminalTab {
   tabCounter++;
   return {
@@ -1189,6 +1198,7 @@ function createTab(
     panelId,
     isActive: true,
     ...(persistentConnectionId ? { persistentConnectionId } : {}),
+    ...(spawned ? { spawned: true } : {}),
   };
 }
 
@@ -2017,7 +2027,8 @@ export const useAppStore = create<AppState>((set, get) => {
       contentType,
       terminalOptions,
       sessionId,
-      persistentConnectionId
+      persistentConnectionId,
+      spawned
     ) => {
       let createdTabId = "";
       set((state) => {
@@ -2036,7 +2047,8 @@ export const useAppStore = create<AppState>((set, get) => {
           targetPanelId,
           contentType,
           sessionId ?? null,
-          persistentConnectionId
+          persistentConnectionId,
+          spawned
         );
         createdTabId = newTab.id;
         const rootPanel = updateLeaf(state.rootPanel, targetPanelId, (leaf) => {
@@ -2070,6 +2082,19 @@ export const useAppStore = create<AppState>((set, get) => {
       });
       return createdTabId;
     },
+
+    openSpawnedContainer: (spawn) =>
+      get().addTab(
+        spawn.title,
+        "docker",
+        { type: "docker", config: spawn.settings },
+        undefined,
+        "terminal",
+        undefined,
+        undefined,
+        undefined,
+        true
+      ),
 
     openSettingsTab: () =>
       set((state) => {

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -219,6 +219,13 @@ export interface TerminalTab {
    * rather than terminating it.
    */
   persistentConnectionId?: string;
+  /**
+   * Set when this tab was opened from an external spawn (`termiHub spawn …`,
+   * #1446) as a "new container". Spawned containers have no saved connection id;
+   * this flag drives the tab's "Spawned" badge and the separate grouping in the
+   * Open Connections panel.
+   */
+  spawned?: boolean;
 }
 
 /**

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -291,6 +291,7 @@ Fixed strings — match exactly.
 | `open-connections-http-monitors-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-prune-dead-agents` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-sftp-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
+| `open-connections-spawned-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-transfer` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-transfers-section` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |
 | `open-connections-x-server-empty` | `src/components/OpenConnections/OpenConnectionsModal.tsx` |


### PR DESCRIPTION
Closes #1446
Follow-up to #1372 (PR #1448), part of epic #1363.

## Summary

Wires the frontend to consume the backend `spawn-request` Tauri event (#1364). Until now nothing on the frontend acted on it. For a **container** spawn it now:

- Adds `onSpawnRequest` (`src/services/events.ts`) and a typed `resolveContainerSpawn` / `ContainerSpawn` wrapper (`src/services/api.ts`).
- A new app-scoped `useSpawnRequests` hook (registered once in `App.tsx`, torn down on unmount) resolves the Docker settings via `resolve_container_spawn` and opens a Docker session tab via the **existing** open-session path (`addTab` → `openSpawnedContainer` store action) — bind-mounted at the target directory, working directory set to the mount.
- The tab carries a **"Spawned"** badge (`Tab.tsx`, tokened CSS), driven by a new minimal `spawned` flag on `TerminalTab`.
- Spawned containers are tracked in their own **Spawned Containers** section of the Open Connections panel — separate from configured Docker connections (they have no saved connection id) and no longer double-listed under Local Sessions.
- A confirmation toast fires on success; failures surface a recoverable error toast.

## Scope boundary (SI-2)

**Container spawns only.** Non-container spawns (local / WSL / SSH) are owned by SI-2 and are explicitly short-circuited here with a `frontend::spawn` log + `TODO(SI-2)` — not half-implemented. The container-vs-non-container decision is made frontend-side from the presence of `container_image` / `container_mount` (the CLI container path always passes `--container-image`).

## Follow-ups filed

- #1465 — add an explicit spawn-kind discriminator to the `SpawnRequest` payload before SI-2 lands (so both consumers switch on an authoritative field, not field presence).
- #1466 — mark the Docker *session* as spawned in the backend registry so the Spawned Containers grouping survives a closed tab (orphan case).
- #1467 — collapse `addTab`'s trailing positional params into an options object (the `spawned` flag makes it a 9-positional-param function).

## Test plan

**Automated (unit wiring — green):**
- `src/hooks/useSpawnRequests.test.ts` — container spawn → `resolveContainerSpawn` called with the request args → Docker tab opened with the returned settings/title, marked spawned → confirmation toast; error path toasts; non-container spawn ignored; unsubscribes on unmount.
- `src/components/Terminal/Tab.spawned-badge.test.tsx` — the "Spawned" badge renders only for spawned tabs.
- `src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx` — spawned container listed in its own section, not double-listed under Local Sessions, killable via `close_terminal`.
- Full suite: 2874 frontend tests pass; `tsc`, ESLint, Prettier, markdownlint clean.

**Manual (needs Docker + a built app — documented in `docs/testing.md`):**
`termiHub spawn --location <dir> --container-image <img>` → a Docker tab opens bind-mounted at the dir (`pwd` = `/workspace`, marker file visible), shows a "Spawned" badge, the confirmation toast appears, and the container is listed separately under Spawned Containers in Open Connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
