### PR TITLE
feat(agent): multi-host connection tracking model (spike + decision + ConnectionRegistry)

### DIFF
--- a/agent/src/client_registry.rs
+++ b/agent/src/client_registry.rs
@@ -1,0 +1,187 @@
+//! Per-process registry of clients connected to this agent.
+//!
+//! The desktop opens **one agent process per `--stdio` channel**
+//! (`src-tauri/src/terminal/agent_manager.rs` execs `termihub-agent --stdio`
+//! over a russh exec channel), so a single agent process serves exactly one
+//! desktop client. The [`ConnectionRegistry`] records that client — its
+//! agent-assigned id, the reported client name/version, and when it completed
+//! `initialize` — so the process can answer "who is connected" without guessing.
+//!
+//! The container is shaped to hold *many* clients (add / remove / list / get)
+//! even though the `--stdio` path only ever holds one: the TCP `--listen` mode
+//! (`agent/src/io/tcp.rs`) serves clients sequentially over a shared
+//! [`crate::session::manager::SessionManager`], and any future coordination
+//! layer (see the multi-host topology ADR in `docs/architecture.md`) builds on
+//! the same generic API.
+//!
+//! Concurrency follows the agent's existing state-sharing pattern
+//! (`Arc<Mutex<HashMap<..>>>`, as in `agent_manager.rs`): a `std::sync::Mutex`
+//! guarding a `HashMap`, held only for the duration of each map operation and
+//! never across an `.await`. Poisoned locks are recovered (`into_inner`) rather
+//! than panicking, matching `AgentConnectionManager::is_connected`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+
+/// A single client currently connected to this agent process.
+///
+/// Populated from the `initialize` request: `client` and `client_version` are
+/// the values the client reported, `client_id` is an agent-assigned identifier
+/// for this connection, and `connected_since` is stamped when `initialize`
+/// completed. Uses [`chrono::DateTime<Utc>`] to match both the concept's
+/// `ConnectedClient` shape (source of truth) and the wire format the future
+/// `agent.list_connections` RPC will serialize — the same time type the agent's
+/// session snapshots already use (`created_at`).
+#[derive(Debug, Clone)]
+pub struct ConnectedClient {
+    /// Agent-assigned unique id for this client connection.
+    pub client_id: String,
+    /// Client name reported in `initialize` (e.g. `"termihub-desktop"`).
+    pub client: String,
+    /// Client version reported in `initialize`.
+    pub client_version: String,
+    /// Wall-clock timestamp of when the client completed `initialize`.
+    pub connected_since: DateTime<Utc>,
+}
+
+/// Thread-safe registry of the clients connected to this agent process.
+#[derive(Debug, Default)]
+pub struct ConnectionRegistry {
+    clients: Mutex<HashMap<String, ConnectedClient>>,
+}
+
+impl ConnectionRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a client that has completed `initialize`, returning the stored
+    /// entry. Re-registering an existing `client_id` replaces the previous
+    /// entry (e.g. a re-`initialize` on the same connection).
+    pub fn register(
+        &self,
+        client_id: impl Into<String>,
+        client: impl Into<String>,
+        client_version: impl Into<String>,
+    ) -> ConnectedClient {
+        let entry = ConnectedClient {
+            client_id: client_id.into(),
+            client: client.into(),
+            client_version: client_version.into(),
+            connected_since: Utc::now(),
+        };
+        // TODO(#1346): insert `entry` into the map (implemented in the feat commit).
+        entry
+    }
+
+    /// Remove a client from the registry (called when its connection drops),
+    /// returning the removed entry if it was present.
+    pub fn remove(&self, client_id: &str) -> Option<ConnectedClient> {
+        let mut guard = self.clients.lock().unwrap_or_else(|e| e.into_inner());
+        guard.remove(client_id)
+    }
+
+    /// Look up a single connected client by id.
+    pub fn get(&self, client_id: &str) -> Option<ConnectedClient> {
+        let guard = self.clients.lock().unwrap_or_else(|e| e.into_inner());
+        guard.get(client_id).cloned()
+    }
+
+    /// Snapshot of every currently connected client.
+    pub fn list(&self) -> Vec<ConnectedClient> {
+        let guard = self.clients.lock().unwrap_or_else(|e| e.into_inner());
+        guard.values().cloned().collect()
+    }
+
+    /// Number of currently connected clients.
+    pub fn len(&self) -> usize {
+        let guard = self.clients.lock().unwrap_or_else(|e| e.into_inner());
+        guard.len()
+    }
+
+    /// Whether no clients are currently connected.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_adds_client() {
+        let reg = ConnectionRegistry::new();
+        let c = reg.register("id-1", "termihub-desktop", "1.2.3");
+
+        assert_eq!(c.client_id, "id-1");
+        assert_eq!(c.client, "termihub-desktop");
+        assert_eq!(c.client_version, "1.2.3");
+        assert_eq!(reg.len(), 1);
+        assert!(!reg.is_empty());
+    }
+
+    #[test]
+    fn get_returns_registered_metadata() {
+        let reg = ConnectionRegistry::new();
+        reg.register("id-1", "desktop", "0.1.0");
+
+        let got = reg.get("id-1").expect("client should be present");
+        assert_eq!(got.client, "desktop");
+        assert_eq!(got.client_version, "0.1.0");
+        assert!(reg.get("missing").is_none());
+    }
+
+    #[test]
+    fn connected_since_is_recent() {
+        let reg = ConnectionRegistry::new();
+        let before = Utc::now();
+        let c = reg.register("id-1", "desktop", "0.1.0");
+        let after = Utc::now();
+        assert!(
+            c.connected_since >= before && c.connected_since <= after,
+            "connected_since must be stamped at registration time"
+        );
+    }
+
+    #[test]
+    fn add_then_remove_leaves_registry_empty() {
+        let reg = ConnectionRegistry::new();
+        reg.register("id-1", "desktop", "0.1.0");
+
+        let removed = reg.remove("id-1").expect("remove should return the client");
+        assert_eq!(removed.client_id, "id-1");
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert!(reg.remove("id-1").is_none());
+    }
+
+    #[test]
+    fn multiple_clients_list_correctly() {
+        let reg = ConnectionRegistry::new();
+        reg.register("id-1", "desktop-a", "1.0.0");
+        reg.register("id-2", "desktop-b", "2.0.0");
+        reg.register("id-3", "desktop-c", "3.0.0");
+
+        assert_eq!(reg.len(), 3);
+        let mut ids: Vec<String> = reg.list().into_iter().map(|c| c.client_id).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["id-1", "id-2", "id-3"]);
+    }
+
+    #[test]
+    fn re_register_same_id_replaces_entry() {
+        let reg = ConnectionRegistry::new();
+        reg.register("id-1", "desktop", "1.0.0");
+        reg.register("id-1", "desktop", "1.1.0");
+
+        assert_eq!(reg.len(), 1);
+        assert_eq!(
+            reg.get("id-1").expect("client present").client_version,
+            "1.1.0"
+        );
+    }
+}

--- a/agent/src/client_registry.rs
+++ b/agent/src/client_registry.rs
@@ -34,6 +34,11 @@ use chrono::{DateTime, Utc};
 /// `ConnectedClient` shape (source of truth) and the wire format the future
 /// `agent.list_connections` RPC will serialize — the same time type the agent's
 /// session snapshots already use (`created_at`).
+///
+/// The metadata fields are the deliberate public shape for the upcoming
+/// `agent.list_connections` RPC (#1349); until it lands they are read only by
+/// tests, hence the `dead_code` allow in non-test builds.
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub struct ConnectedClient {
     /// Agent-assigned unique id for this client connection.
@@ -73,7 +78,8 @@ impl ConnectionRegistry {
             client_version: client_version.into(),
             connected_since: Utc::now(),
         };
-        // TODO(#1346): insert `entry` into the map (implemented in the feat commit).
+        let mut guard = self.clients.lock().unwrap_or_else(|e| e.into_inner());
+        guard.insert(entry.client_id.clone(), entry.clone());
         entry
     }
 
@@ -85,24 +91,28 @@ impl ConnectionRegistry {
     }
 
     /// Look up a single connected client by id.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn get(&self, client_id: &str) -> Option<ConnectedClient> {
         let guard = self.clients.lock().unwrap_or_else(|e| e.into_inner());
         guard.get(client_id).cloned()
     }
 
     /// Snapshot of every currently connected client.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn list(&self) -> Vec<ConnectedClient> {
         let guard = self.clients.lock().unwrap_or_else(|e| e.into_inner());
         guard.values().cloned().collect()
     }
 
     /// Number of currently connected clients.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn len(&self) -> usize {
         let guard = self.clients.lock().unwrap_or_else(|e| e.into_inner());
         guard.len()
     }
 
     /// Whether no clients are currently connected.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -348,8 +348,11 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
             s.agent_settings = p.agent_settings.clone();
             // Record the connected client (additive to the single-client
             // settings above). One entry per agent process in `--stdio` mode.
-            s.client_registry
-                .register(s.client_id.clone(), p.client.clone(), p.client_version.clone());
+            s.client_registry.register(
+                s.client_id.clone(),
+                p.client.clone(),
+                p.client_version.clone(),
+            );
             let buffer_size = mb_to_bytes(p.agent_settings.persistent_scrollback_buffer_size_mb);
             (
                 s.session_manager.clone(),

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -18,6 +18,7 @@ use serde_json::{json, Value};
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
+use crate::client_registry::ConnectionRegistry;
 use crate::files::local::LocalFileBackend;
 use crate::files::{FileBackend, FileError};
 use crate::monitoring::MonitoringManagerApi;
@@ -59,6 +60,14 @@ struct HandlerState {
     initialized: bool,
     start_time: Instant,
     agent_settings: AgentSettings,
+    /// Registry of clients connected to this agent process. Shared with
+    /// [`AgentHandler::client_registry`]; populated on `initialize`, cleared on
+    /// disconnect via [`AgentHandler::deregister_client`]. Additive to the
+    /// existing single-client `agent_settings` behavior.
+    client_registry: Arc<ConnectionRegistry>,
+    /// Agent-assigned id for this connection's client, generated once in
+    /// [`AgentHandler::new`] so `initialize` and disconnect agree on the key.
+    client_id: String,
     /// Shared with [`AgentHandler::shutdown_flag`] so the transport loop can
     /// detect shutdown without re-locking the mutex after every request.
     shutdown_flag: Arc<AtomicBool>,
@@ -75,6 +84,15 @@ struct HandlerState {
 pub struct AgentHandler {
     module: RpcModule<Mutex<HandlerState>>,
     pub shutdown_flag: Arc<AtomicBool>,
+    /// Registry of clients connected to this agent process (one per `--stdio`
+    /// worker; sequential clients per `--listen` connection). Shared with
+    /// [`HandlerState`] so `initialize` populates it and the transport loop can
+    /// query / clear it on disconnect.
+    client_registry: Arc<ConnectionRegistry>,
+    /// Agent-assigned id for this connection's client, matching the key used in
+    /// `initialize` so [`deregister_client`](Self::deregister_client) removes
+    /// the right entry.
+    client_id: String,
 }
 
 impl AgentHandler {
@@ -84,6 +102,8 @@ impl AgentHandler {
         monitoring_manager: Arc<dyn MonitoringManagerApi>,
     ) -> anyhow::Result<Self> {
         let shutdown_flag = Arc::new(AtomicBool::new(false));
+        let client_registry = Arc::new(ConnectionRegistry::new());
+        let client_id = uuid::Uuid::new_v4().to_string();
 
         let state = Mutex::new(HandlerState {
             session_manager,
@@ -92,6 +112,8 @@ impl AgentHandler {
             initialized: false,
             start_time: Instant::now(),
             agent_settings: AgentSettings::default(),
+            client_registry: client_registry.clone(),
+            client_id: client_id.clone(),
             shutdown_flag: shutdown_flag.clone(),
         });
 
@@ -102,7 +124,28 @@ impl AgentHandler {
         Ok(AgentHandler {
             module,
             shutdown_flag,
+            client_registry,
+            client_id,
         })
+    }
+
+    /// Shared registry of the clients connected to this agent process.
+    ///
+    /// In `--stdio` mode there is one [`AgentHandler`] per process, so this is
+    /// the process-wide view; in `--listen` mode each connection has its own
+    /// handler and registry.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn client_registry(&self) -> Arc<ConnectionRegistry> {
+        self.client_registry.clone()
+    }
+
+    /// Remove this handler's client from the registry.
+    ///
+    /// Called by the transport loops (`io/stdio.rs`, `io/tcp.rs`) once the
+    /// connection ends, so a disconnected client no longer appears as connected.
+    /// A no-op if `initialize` never populated the entry.
+    pub fn deregister_client(&self) {
+        self.client_registry.remove(&self.client_id);
     }
 
     /// Process a raw JSON-RPC request string and return the response string.
@@ -303,6 +346,10 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
             let mut s = ctx.lock().await;
             s.initialized = true;
             s.agent_settings = p.agent_settings.clone();
+            // Record the connected client (additive to the single-client
+            // settings above). One entry per agent process in `--stdio` mode.
+            s.client_registry
+                .register(s.client_id.clone(), p.client.clone(), p.client_version.clone());
             let buffer_size = mb_to_bytes(p.agent_settings.persistent_scrollback_buffer_size_mb);
             (
                 s.session_manager.clone(),
@@ -1388,6 +1435,54 @@ mod tests {
         let handler = make_handler();
         let result = dispatch(&handler, "initialize", json!({}), 1).await;
         assert_eq!(result["error"]["code"], errors::INVALID_PARAMS);
+    }
+
+    // ── ConnectionRegistry integration ─────────────────────────────
+    //
+    // Proves a client appears in / disappears from the per-process registry
+    // across the real `initialize` (connect) and `deregister_client`
+    // (disconnect) paths. The agent is a binary crate with no `[lib]` target,
+    // so `tests/` integration tests can only spawn the process; this handler-
+    // level test is the in-crate integration proof (a `--stdio` process is one
+    // client).
+
+    #[tokio::test]
+    async fn registry_empty_before_initialize() {
+        let handler = make_handler();
+        assert!(
+            handler.client_registry().is_empty(),
+            "registry must be empty before initialize"
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_registers_client_in_registry() {
+        let handler = make_handler();
+        assert!(handler.client_registry().is_empty());
+
+        init_handler(&handler).await;
+
+        let clients = handler.client_registry().list();
+        assert_eq!(clients.len(), 1, "one client after initialize");
+        // Metadata is parsed from the `initialize` payload (see `init_params`).
+        assert_eq!(clients[0].client, "test");
+        assert_eq!(clients[0].client_version, "0.1.0");
+        assert!(!clients[0].client_id.is_empty(), "client_id assigned");
+    }
+
+    #[tokio::test]
+    async fn deregister_client_removes_from_registry_on_disconnect() {
+        let handler = make_handler();
+        init_handler(&handler).await;
+        assert_eq!(handler.client_registry().len(), 1);
+
+        // Simulates the transport loop calling deregister on disconnect.
+        handler.deregister_client();
+
+        assert!(
+            handler.client_registry().is_empty(),
+            "registry must be empty after the client disconnects"
+        );
     }
 
     // ── Not-initialized gate ───────────────────────────────────────

--- a/agent/src/io/stdio.rs
+++ b/agent/src/io/stdio.rs
@@ -59,14 +59,19 @@ pub async fn run_stdio_loop(
 
     info!("Stdio transport loop started, waiting for input");
 
-    run_transport_loop(
+    let loop_result = run_transport_loop(
         &mut reader,
         &mut stdout,
         &handler,
         &mut notification_rx,
         shutdown,
     )
-    .await?;
+    .await;
+
+    // The single client for this process has disconnected — clear it from the
+    // registry before propagating any transport error.
+    handler.deregister_client();
+    loop_result?;
 
     // Graceful shutdown: stop monitoring and close all sessions
     info!("Shutting down — stopping monitoring and closing all sessions");

--- a/agent/src/io/tcp.rs
+++ b/agent/src/io/tcp.rs
@@ -115,6 +115,10 @@ pub async fn run_tcp_listener(
                     Err(e) => warn!("Client {} error: {}", peer, e),
                 }
 
+                // Clear this client from the registry now that its connection
+                // has ended (the handler is per-connection in listen mode).
+                handler.deregister_client();
+
                 // Detach all sessions so they remain alive for the next client
                 session_manager.detach_all().await;
             }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,3 +1,4 @@
+mod client_registry;
 mod daemon;
 mod files;
 mod handler;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1319,6 +1319,27 @@ A first-time, download-backed Windows provision is gated on a connect-time conse
 
 **Trade-off:** Three code paths instead of one. The Windows path installs VcXsrv via **winget** and the macOS path installs XQuartz via **Homebrew** (#1318) — termiHub runs each as a separate process but does not host/redistribute them, so neither carries a redistribution obligation (the earlier GPL-3.0 pinned-artifact concern, #1076, was dropped with that approach). Full E2E rendering cannot be automated in CI, so the cross-platform release matrix is a documented human step.
 
+### ADR-11: Per-Process Agent Connection Tracking (Multi-Host Model)
+
+**Context:** The remote-agent update strategy epic (#1345, concept `docs/concepts/backlog/remote-agent-update-strategy.html`) needs an agent to answer "who else is connected?" so a desktop can update a shared agent without silently killing another desktop's sessions. The concept assumed **one shared agent process that knows all connected clients**. The code does not work that way: `AgentConnectionManager::connect_agent` (`src-tauri/src/terminal/agent_manager.rs`) opens a **russh exec channel per desktop** and runs `termihub-agent --stdio` (`RemoteAgentConfig::agent_exec_command`), so there is **one agent OS process per desktop→agent channel**, and that process's `AgentHandler`/`HandlerState` serves exactly one client. The `--listen` TCP mode (`agent/src/io/tcp.rs`) shares a `SessionManager` across connections but still accepts **one client at a time**. The only host-side state shared across `--stdio` workers is the layer of detached session **daemons** (`termihub-agent --daemon <id>`, unix socket / Windows named pipe), which outlive the worker and replay a ring buffer on re-attach. This gap (SI-1, #1346) is the foundational risk for every cross-client feature in the epic.
+
+Three options were prototyped against the real code:
+
+- **(a) A new host-side coordinator/supervisor process** that all `--stdio` workers and daemons register with.
+- **(b) Switch the desktop→agent transport to the existing `--listen` TCP shared server** (one agent, many clients).
+- **(c) Build cross-client awareness on the already-shared persistent-daemon layer**, and keep a per-process registry of the one client each worker serves.
+
+**Decision:** Adopt **(c)**. Each agent process owns a `ConnectionRegistry` (`agent/src/client_registry.rs`) that records its single connected client — `ConnectedClient { client_id, client, client_version, connected_since }` — populated from `initialize` (`handler/dispatch.rs::register_initialize`) and cleared on disconnect by the transport loops (`io/stdio.rs`, `io/tcp.rs`). Cross-client/cross-worker coordination for later epic phases (`list_connections`, coordinated update broadcast) will be built by **extending the existing daemon layer** to carry client identity, **not** by introducing a new coordinator process (a) or changing the transport (b). The registry is the within-process building block that ships now; it is shaped for many clients (add/remove/list/get) so the same API serves the `--listen` path and any future coordination layer. Reject (a) and (b).
+
+**Rationale:**
+
+- **Topology reality.** One `--stdio` process per desktop is fixed by the SSH-exec transport; a process genuinely knows one client, so per-process tracking is the honest primitive. The daemons are the _only_ thing already shared across workers on a host, and the epic's deferred-update approach already "leans entirely on" them surviving a binary swap — so they are the natural coordination substrate.
+- **Security.** `--stdio` runs inside the existing authenticated SSH channel and opens no new socket. Option (b) would require a listening TCP port on every remote host plus its own authentication and port management — a real attack-surface regression over SSH-tunneled stdio.
+- **Retry / streaming.** Daemons already persist across agent-worker restarts and replay their ring buffer on re-attach; extending them keeps cross-client visibility that survives an agent binary swap. A new coordinator (a) would have to re-implement that restart/streaming story from scratch.
+- **Platform coverage.** The daemon layer already works on all three platforms (unix domain socket / Windows named pipe; Windows agent parity landed in #771), so (c) inherits the 3-platform matrix. A new long-lived coordinator (a) would need fresh cross-platform daemonization, and (b)'s single-client-at-a-time accept loop does not even deliver concurrent multi-client visibility without further rework.
+
+**Trade-off:** The shipped registry does not yet give cross-agent visibility on its own — in `--stdio` it holds exactly one client — so the epic's `list_connections`/broadcast features still need the follow-up daemon-layer work chosen here. That is deliberate: SI-1 fixes the model and lands the queryable primitive; the coordination surface is built on top in later sub-issues. RPC methods, UI, and update logic are explicitly out of scope for #1346.
+
 ---
 
 ## 10. Quality Requirements

--- a/docs/concepts/backlog/remote-agent-update-strategy.html
+++ b/docs/concepts/backlog/remote-agent-update-strategy.html
@@ -367,6 +367,34 @@
           If Host A updates the agent, Host B's active sessions are silently killed mid-use.
         </p>
 
+        <h3>Topology reality (corrected)</h3>
+        <p>
+          An earlier draft of this concept assumed
+          <em>one shared agent process that knows all connected clients</em>. That is not how the
+          code works, and the correction is load-bearing for every coordination feature below. The
+          desktop opens a <strong>russh exec channel per desktop</strong> and runs
+          <code>termihub-agent --stdio</code>
+          (<code>src-tauri/src/terminal/agent_manager.rs</code>), so there is
+          <strong>one agent OS process per desktop→agent channel</strong>, and that process serves
+          <strong>exactly one client</strong>. Two desktops connecting to the same host do not share
+          a running agent process — they share only the deployed binary on disk and the layer of
+          detached session <strong>daemons</strong> (<code>termihub-agent --daemon &lt;id&gt;</code
+          >) that outlive each agent worker and replay a ring buffer on re-attach.
+        </p>
+        <p>
+          The topology decision (spike SI-1, resolved in
+          <a href="../../architecture.md">ADR-11</a>) is therefore: each agent process owns a
+          <strong>per-process <code>ConnectionRegistry</code></strong>
+          (<code>agent/src/client_registry.rs</code>) recording its single client, and cross-client
+          coordination (<code>agent.list_connections</code>, the update broadcast) is built on the
+          already-shared <strong>daemon layer</strong> — <em>not</em> by adding a new host-side
+          coordinator process, and <em>not</em> by switching the transport to the
+          <code>--listen</code> TCP shared server (which would open a network port on every host and
+          still serve one client at a time). Where the approaches below say "broadcast to all
+          connected clients" or "the agent tracks connected client identities", read that as the
+          daemon-layer coordination substrate rather than a single all-knowing process.
+        </p>
+
         <h3>Goals</h3>
         <ul>
           <li>Prevent silent session termination when one host updates a shared agent</li>
@@ -381,9 +409,17 @@
             Side-by-side versioned agents running on the same host (see trade-off analysis below)
           </li>
           <li>Automatic rollback after a bad update</li>
-          <li>Windows or macOS agent targets (currently Linux-only)</li>
           <li>Enterprise MDM / centralised fleet management</li>
         </ul>
+        <p>
+          <strong>Platform matrix (corrected):</strong> an earlier draft listed Windows and macOS
+          agents as a non-goal ("currently Linux-only"). That is out of date — Windows agent parity
+          shipped in epic #771 and CI builds and publishes macOS and Windows agent binaries
+          alongside Linux. This feature therefore targets the real
+          <strong>3-platform matrix (Linux · macOS · Windows)</strong>; the coordination substrate
+          it builds on (detached daemons over a unix domain socket / Windows named pipe) already
+          works on all three.
+        </p>
       </section>
 
       <!-- ── UI Interface ───────────────────────────────────────────── -->
@@ -1419,11 +1455,18 @@ flowchart TD
     Ok(ListConnectionsResult { connections: clients })
 }</code></pre>
         <p>
-          <code>SessionRegistry</code> (or a new <code>ConnectionRegistry</code>) tracks each
-          connected client's metadata received during <code>initialize</code>:
+          The <code>ConnectionRegistry</code> (shipped in <code>agent/src/client_registry.rs</code>,
+          SI-1 / #1346) tracks the connected client's metadata received during
+          <code>initialize</code>. It is populated in
+          <code>handler/dispatch.rs::register_initialize</code> and cleared on disconnect by the
+          transport loops (<code>io/stdio.rs</code>, <code>io/tcp.rs</code>). Because of the
+          per-process topology (see <a href="#overview">Topology reality</a>), the registry holds
+          exactly one client in <code>--stdio</code> mode; the type is nonetheless shaped for many
+          clients so the same API serves the <code>--listen</code> path and the daemon-layer
+          coordination that <code>agent.list_connections</code> will build on:
         </p>
         <pre><code>pub struct ConnectedClient {
-    pub client_id: String,
+    pub client_id: String,       // agent-assigned per connection
     pub client: String,          // "termihub-desktop"
     pub client_version: String,
     pub connected_since: DateTime&lt;Utc&gt;,
@@ -1542,14 +1585,14 @@ pub struct UpdatePendingNotification {
           </li>
         </ul>
         <p>
-          Binary integrity verification (implemented in #1350): a SHA-256 checksum is published
-          as a release asset next to <em>every</em> agent artifact on all three platforms
+          Binary integrity verification (implemented in #1350): a SHA-256 checksum is published as a
+          release asset next to <em>every</em> agent artifact on all three platforms
           (<code>termihub-agent-linux-x64.sha256</code>,
           <code>termihub-agent-macos-arm64.sha256</code>,
           <code>termihub-agent-windows-x64.exe.sha256</code>, …). The desktop verifies the binary
           against its sidecar on the resolve chain (cache → bundled → download) before deploy,
-          redeploy, or exec-replace — a mismatched or tampered binary is rejected with a clear
-          error and never installed or executed.
+          redeploy, or exec-replace — a mismatched or tampered binary is rejected with a clear error
+          and never installed or executed.
         </p>
 
         <h3>Config / State Schema</h3>
@@ -1590,8 +1633,11 @@ pub struct UpdatePendingNotification {
           </p>
         </blockquote>
         <p>
-          <strong>Last synced:</strong> never (concept not yet implemented) ·
-          <strong>Status:</strong> diverged (not implemented — backlog feature)
+          <strong>Last synced:</strong> 2026-07-12 (SI-1 / #1346) ·
+          <strong>Status:</strong> partially implemented — the topology model and per-process
+          <code>ConnectionRegistry</code> are in code; the update RPCs, UI, and update logic remain
+          backlog. A full <code>/sync-concept remote-agent-update-strategy</code> pass is warranted
+          as later sub-issues land.
         </p>
 
         <h3>Open divergences</h3>
@@ -1609,8 +1655,11 @@ pub struct UpdatePendingNotification {
             <tbody>
               <tr>
                 <td>1</td>
-                <td>Entire feature (per concept)</td>
-                <td>Not implemented — backlog</td>
+                <td>
+                  Update RPCs / notifications, sidebar badge + chip, update dialogs, deferred-update
+                  daemon flow, SHA-256 integrity (Approaches 1–4, Phases 1–3)
+                </td>
+                <td>Not implemented — backlog (sub-issues #1347, #1349, #1350)</td>
                 <td>Missing</td>
                 <td>Implement per <code>concept</code> order, then re-sync</td>
               </tr>
@@ -1630,9 +1679,14 @@ pub struct UpdatePendingNotification {
             </thead>
             <tbody>
               <tr>
+                <td>2026-07-12</td>
                 <td>—</td>
-                <td>—</td>
-                <td>—</td>
+                <td>
+                  Topology corrected to the real one-process-per-<code>--stdio</code>-channel model
+                  and the 3-platform matrix; per-process <code>ConnectionRegistry</code> shipped in
+                  <code>agent/src/client_registry.rs</code> (SI-1, #1346). Decision recorded in
+                  <a href="../../architecture.md">ADR-11</a>.
+                </td>
               </tr>
             </tbody>
           </table>

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -95,6 +95,14 @@ The remote session management protocol enables the termiHub desktop app to manag
 | **Session Manager**  | Creates/destroys PTY and serial sessions, manages attach/detach                                  |
 | **SQLite DB**        | Persists session metadata so sessions survive agent restarts                                     |
 
+### Connection Topology & Client Tracking
+
+The desktop opens **one SSH exec channel per connection** and runs `termihub-agent --stdio`, so there is **one agent process per desktop→agent channel**, and that process serves **exactly one client**. Two desktops connecting to the same host do **not** share a running agent process — they run independent `--stdio` workers and share only the deployed binary on disk and the layer of detached **session daemons** (`termihub-agent --daemon <id>`) that outlive each worker. (The alternative `--listen` TCP mode shares a `SessionManager` across connections but still serves one client at a time; the desktop does not use it.)
+
+Because a process knows exactly one client, each agent process keeps a **per-process `ConnectionRegistry`** (`agent/src/client_registry.rs`) that records the connected client from the `initialize` request — its `client`, `client_version`, an agent-assigned `client_id`, and `connected_since`. The entry is added on `initialize` and removed when the transport connection drops. This is the in-process foundation for the coordinated remote-agent update strategy (epic #1345); cross-client coordination is built on the shared daemon layer rather than a single all-knowing process (see [ADR-11](architecture.md#adr-11-per-process-agent-connection-tracking-multi-host-model)).
+
+This topology and the tracking model are identical across the **3-platform agent matrix (Linux · macOS · Windows)**; only the daemon's internal transport differs (unix domain socket vs Windows named pipe, see [Platform Notes](#platform-notes-windows)).
+
 ---
 
 ## Transport Layer
@@ -325,6 +333,8 @@ Handshake that establishes the protocol version and exchanges capabilities.
 | `protocol_version` | `string` | Requested protocol version |
 | `client`           | `string` | Client identifier          |
 | `client_version`   | `string` | Client application version |
+
+On a successful `initialize`, the agent records the client (`client`, `client_version`, an agent-assigned `client_id`, and a `connected_since` timestamp) in its per-process `ConnectionRegistry` and clears it when the connection drops (see [Connection Topology & Client Tracking](#connection-topology--client-tracking)). Because each `--stdio` process serves one client, the registry holds exactly one entry in the SSH-tunnelled deployment.
 
 | Result Field                           | Type                   | Description                                  |
 | -------------------------------------- | ---------------------- | -------------------------------------------- |


### PR DESCRIPTION
Closes #1346
Part of Epic #1345

## Summary

Foundational spike (SI-1) for the remote-agent update epic: resolve the topology gap that gates every multi-host feature, record the decision, and ship the per-process `ConnectionRegistry` building block. **No RPC methods, UI, or update logic** — those are explicitly out of scope and land in later sub-issues (#1347, #1349, #1350).

## The decision (spike outcome)

The concept assumed **one shared agent process that knows all connected clients**. The code does not work that way: `AgentConnectionManager::connect_agent` opens a russh exec channel per desktop and runs `termihub-agent --stdio`, so there is **one agent OS process per desktop→agent channel**, each serving exactly one client. `--listen` shares a `SessionManager` but still serves one client at a time. The only host-side state shared across `--stdio` workers is the layer of detached session **daemons**.

Three options were weighed against the real code:

- **(a)** a new host-side coordinator/supervisor process
- **(b)** switch the transport to the `--listen` TCP shared server
- **(c)** keep a per-process registry and build cross-client coordination on the already-shared persistent-daemon layer

**Chosen: (c).** Each agent process owns a `ConnectionRegistry` recording its one client; cross-client coordination (future `list_connections`/broadcast) is built by extending the daemon layer, **not** by adding a coordinator process (a) or opening a TCP port (b). Rationale: topology reality (a process genuinely knows one client), security (`--stdio` reuses the authenticated SSH channel; (b) would open a network port on every host), retry/streaming (daemons already survive an agent binary swap and replay their ring buffer — the epic's deferred-update approach leans on this), and 3-platform coverage (the daemon layer already works on Linux/macOS/Windows; a new coordinator would need fresh cross-platform daemonization). Recorded as **ADR-11** in `docs/architecture.md`.

## What the `ConnectionRegistry` provides

`agent/src/client_registry.rs` — a thread-safe (`Mutex<HashMap>`, matching the agent's existing state-sharing pattern) registry of `ConnectedClient { client_id, client, client_version, connected_since }` with `register` / `remove` / `get` / `list` / `len` / `is_empty`. `connected_since` uses `chrono::DateTime<Utc>` to match the concept's shape and the future RPC's wire format. It is populated in `handler/dispatch.rs::register_initialize` from the `initialize` payload and cleared on disconnect by the transport loops (`io/stdio.rs`, `io/tcp.rs`). Additive to `HandlerState`'s existing single-client settings; shaped for many clients so the same API serves `--listen` and the future daemon-layer coordination.

## Docs

- `docs/architecture.md` — ADR-11 (decision, alternatives, rationale).
- `docs/remote-protocol.md` — new "Connection Topology & Client Tracking" section, an `initialize` client-tracking note, and the corrected 3-platform matrix.
- Concept HTML (`docs/concepts/backlog/remote-agent-update-strategy.html`) — "Topology reality (corrected)" note, dropped the stale Linux-only non-goal for the real 3-platform matrix, pointed Phase 1 impl at the shipped registry, and updated the sync ledger. A `/sync-concept remote-agent-update-strategy` pass is warranted as later sub-issues land.

No `docs/changes/` fragment: this is an internal-architecture spike with no user-facing behavior change.

## Test plan (TDD — test commit precedes feat commit)

- **Unit** (`client_registry.rs`): register/get/list/remove, `connected_since` stamping, add-then-remove empties, multiple clients list, re-register replaces. ✅
- **Integration** (handler-level, in-crate — the agent is a binary crate with no lib target so `tests/` can only spawn the process): a client appears in the registry after the real `initialize` dispatch and disappears after `deregister_client`. ✅
- Results on macOS: registry-scoped tests **12/12 pass**; full agent bin unit suite **294/294 pass**; `cargo build --workspace`, `cargo fmt --all -- --check`, `cargo clippy -p termihub-agent --all-targets -- -D warnings` all clean.

### Pre-existing, unrelated note

On a machine where the Docker daemon is not responding, `detect_docker_available()` (`docker info`, called during `initialize`) blocks, so any `init_handler`-based agent test hangs — this reproduces identically on `develop` and is an environment issue, not from this change. Verified green by shimming `docker` to fail fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)