### PR TITLE
fix(ui): Network Tools correctness & live-feedback polish (Closes #1359)

### DIFF
--- a/docs/changes/dev1/bugfix/1359-networktools-correctness.md
+++ b/docs/changes/dev1/bugfix/1359-networktools-correctness.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- Network Tools › Traceroute no longer shows `avg NaNms` (or a misleading
+  `0ms`) in the completed footer when the final hop never answered — the
+  average is omitted when there is no valid round-trip to average. (#1359)
+
+### Changed
+
+- Network Tools › Traceroute now appends a "Trace canceled" footer after Stop
+  instead of silently freezing the results table. (#1359)
+- Network Tools › Ping surfaces running loss %, RTT min/avg/max and jitter live
+  from the streamed replies while the ping is in progress, rather than hiding
+  all statistics until Stop. (#1359)
+- Network Tools › Port Scanner's running footer now shows a live open-port count
+  alongside the number of ports checked. (#1359)
+- Network Tools › DNS Lookup bounds each query with a visible timeout and offers
+  a Cancel button while the lookup is in flight, so a hung resolver can no
+  longer leave the panel spinning. (#1359)
+- Network Tools › Open Ports auto-loads the listening ports on mount; Refresh
+  remains for an explicit re-fetch. (#1359)

--- a/src/components/NetworkTools/DnsLookupPanel.timeout.test.tsx
+++ b/src/components/NetworkTools/DnsLookupPanel.timeout.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Regression tests for the DNS Lookup timeout / cancel affordance (#1359).
+ *
+ * A one-shot DNS query with no cancel would hang the panel on a stuck resolver.
+ * The panel now bounds the query with a visible timeout and offers a Cancel
+ * button while the lookup is in flight.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { networkDnsLookup } from "@/services/networkApi";
+import { DnsLookupPanel } from "./DnsLookupPanel";
+
+vi.mock("@/services/networkApi", () => ({
+  networkDnsLookup: vi.fn(),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function run() {
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('[data-testid="dns-run"]')!.click();
+  });
+  await flush();
+}
+
+describe("DnsLookupPanel — timeout / cancel", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("offers a Cancel button while the lookup is in flight and reports the cancel", async () => {
+    // Never resolves — simulates a hung resolver.
+    vi.mocked(networkDnsLookup).mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      root.render(<DnsLookupPanel prefillHost="example.com" />);
+    });
+    await run();
+
+    const cancelBtn = container.querySelector<HTMLButtonElement>('[data-testid="dns-cancel"]');
+    expect(cancelBtn).not.toBeNull();
+
+    await act(async () => {
+      cancelBtn!.click();
+    });
+    await flush();
+
+    expect(container.textContent?.toLowerCase()).toContain("cancel");
+    // The Cancel affordance is gone once the lookup ends.
+    expect(container.querySelector('[data-testid="dns-cancel"]')).toBeNull();
+  });
+
+  it("times out a hung query with a visible error", async () => {
+    vi.useFakeTimers();
+    vi.mocked(networkDnsLookup).mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      root.render(<DnsLookupPanel prefillHost="example.com" />);
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="dns-run"]')!.click();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(11_000);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent?.toLowerCase()).toContain("timed out");
+  });
+});

--- a/src/components/NetworkTools/DnsLookupPanel.tsx
+++ b/src/components/NetworkTools/DnsLookupPanel.tsx
@@ -1,8 +1,8 @@
-import { useState, useCallback } from "react";
-import { Play } from "lucide-react";
+import { useState, useCallback, useRef } from "react";
+import { Play, StopCircle } from "lucide-react";
 import { Button, Field, Input, Select } from "@/components/ui";
 import { networkDnsLookup } from "@/services/networkApi";
-import type { DnsRecord, DnsRecordType } from "@/types/network";
+import type { DnsRecord, DnsRecordType, DnsResult } from "@/types/network";
 import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
 import { validateHost } from "@/utils/fieldValidation";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
@@ -25,6 +25,9 @@ const RECORD_TYPES: DnsRecordType[] = [
 /** Record-type dropdown options (value === label), derived once. */
 const RECORD_TYPE_OPTIONS = RECORD_TYPES.map((t) => ({ value: t, label: t }));
 
+/** Bound a hung resolver so the lookup can never hang the panel indefinitely. */
+const DNS_TIMEOUT_MS = 10_000;
+
 interface DnsLookupPanelProps {
   prefillHost?: string;
 }
@@ -37,8 +40,12 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
   const [records, setRecords] = useState<DnsRecord[]>([]);
   const [queryMs, setQueryMs] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
 
   const hostnameRef = useAutofocusSelect<HTMLInputElement>();
+
+  // Rejects the in-flight lookup when the user cancels; null while idle.
+  const cancelRef = useRef<(() => void) | null>(null);
 
   const hostnameError = validateHost(hostname, "Hostname");
 
@@ -47,17 +54,47 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
     setRecords([]);
     setQueryMs(null);
     setError(null);
+    setRunning(true);
 
     try {
-      const result = await networkDnsLookup(hostname, recordType, server.trim() || undefined);
+      // Race the lookup against a bounded timeout and a user Cancel so a hung
+      // resolver can never leave the panel spinning forever.
+      const result = await new Promise<DnsResult>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          cancelRef.current = null;
+          reject(new Error(`DNS lookup timed out after ${DNS_TIMEOUT_MS / 1000}s`));
+        }, DNS_TIMEOUT_MS);
+        cancelRef.current = () => {
+          clearTimeout(timer);
+          cancelRef.current = null;
+          reject(new Error("DNS lookup canceled"));
+        };
+        networkDnsLookup(hostname, recordType, server.trim() || undefined)
+          .then((r) => {
+            clearTimeout(timer);
+            cancelRef.current = null;
+            resolve(r);
+          })
+          .catch((e) => {
+            clearTimeout(timer);
+            cancelRef.current = null;
+            reject(e instanceof Error ? e : new Error(String(e)));
+          });
+      });
       setRecords(result.records);
       setQueryMs(result.queryMs);
     } catch (err) {
       setError(String(err));
       frontendLog("dns_lookup", `DNS lookup failed: ${err}`);
       throw err; // keep the async Button in its error path (no false success flash)
+    } finally {
+      setRunning(false);
     }
   }, [hostname, recordType, server]);
+
+  const handleCancel = useCallback(() => {
+    cancelRef.current?.();
+  }, []);
 
   // Enter and click share one gate and one async Button lifecycle (#1414).
   const { formProps, submitProps } = useSubmitButton(!hostnameError, handleRun);
@@ -81,6 +118,17 @@ export function DnsLookupPanel({ prefillHost }: DnsLookupPanelProps) {
       <div className="network-panel__header">
         <span className="network-panel__title">DNS Lookup</span>
         <div className="network-panel__actions">
+          {running && (
+            <Button
+              variant="danger"
+              size="sm"
+              icon={<StopCircle size={14} />}
+              onClick={handleCancel}
+              data-testid="dns-cancel"
+            >
+              Cancel
+            </Button>
+          )}
           <Button
             variant="primary"
             size="sm"

--- a/src/components/NetworkTools/OpenPortsPanel.autoload.test.tsx
+++ b/src/components/NetworkTools/OpenPortsPanel.autoload.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Regression test for Open Ports auto-load on mount (#1359).
+ *
+ * The panel used to open empty and required a manual Refresh. It now lists the
+ * listening ports automatically when mounted (Refresh remains for re-fetch).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { networkOpenPorts } from "@/services/networkApi";
+import { OpenPortsPanel } from "./OpenPortsPanel";
+
+vi.mock("@/services/networkApi", () => ({
+  networkOpenPorts: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("OpenPortsPanel — auto-load", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("lists ports automatically on mount without a manual Refresh", async () => {
+    vi.mocked(networkOpenPorts).mockResolvedValueOnce([
+      { protocol: "TCP", localAddr: "0.0.0.0:22", pid: 100, process: "sshd" },
+    ]);
+
+    await act(async () => {
+      root.render(<OpenPortsPanel />);
+    });
+    await flush();
+
+    expect(networkOpenPorts).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("sshd");
+    // The click-to-refresh placeholder is gone once auto-loaded.
+    expect(container.textContent).not.toContain("Click Refresh");
+  });
+
+  it("Refresh re-fetches after the initial auto-load", async () => {
+    await act(async () => {
+      root.render(<OpenPortsPanel />);
+    });
+    await flush();
+    expect(networkOpenPorts).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="open-ports-refresh"]')!.click();
+    });
+    await flush();
+
+    expect(networkOpenPorts).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/NetworkTools/OpenPortsPanel.test.tsx
+++ b/src/components/NetworkTools/OpenPortsPanel.test.tsx
@@ -48,33 +48,33 @@ describe("OpenPortsPanel — Button migration", () => {
   });
 
   it("lists open ports when Refresh is clicked", async () => {
-    vi.mocked(networkOpenPorts).mockResolvedValueOnce([
+    // The panel auto-loads on mount (#1359); Refresh re-fetches the same list.
+    vi.mocked(networkOpenPorts).mockResolvedValue([
       { protocol: "TCP", localAddr: "0.0.0.0:22", pid: 100, process: "sshd" },
     ]);
     await act(async () => {
       root.render(<OpenPortsPanel />);
     });
+    await flush();
 
     await act(async () => {
       container.querySelector<HTMLButtonElement>('[data-testid="open-ports-refresh"]')!.click();
     });
     await flush();
 
-    expect(networkOpenPorts).toHaveBeenCalledTimes(1);
+    // Once on mount (auto-load) plus once for the click.
+    expect(networkOpenPorts).toHaveBeenCalledTimes(2);
     expect(container.textContent).toContain("sshd");
   });
 
   it("shows the error inline when listing fails", async () => {
-    vi.mocked(networkOpenPorts).mockRejectedValueOnce(new Error("permission denied"));
+    vi.mocked(networkOpenPorts).mockRejectedValue(new Error("permission denied"));
     await act(async () => {
       root.render(<OpenPortsPanel />);
     });
-
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="open-ports-refresh"]')!.click();
-    });
     await flush();
 
+    // The auto-load surfaces the failure without needing a manual Refresh.
     expect(container.textContent).toContain("permission denied");
   });
 });

--- a/src/components/NetworkTools/OpenPortsPanel.tsx
+++ b/src/components/NetworkTools/OpenPortsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { RefreshCw } from "lucide-react";
 import { Button, Field, Input, Select } from "@/components/ui";
 import { networkOpenPorts } from "@/services/networkApi";
@@ -33,6 +33,14 @@ export function OpenPortsPanel() {
       throw err; // keep the async Button in its error path (no false success flash)
     }
   }, []);
+
+  // Auto-load listening ports on mount so the panel opens populated; Refresh
+  // remains for an explicit re-fetch. The handler throws to keep the Refresh
+  // Button's error path, so swallow that here (the error is already surfaced
+  // inline via setError).
+  useEffect(() => {
+    void handleRefresh().catch(() => {});
+  }, [handleRefresh]);
 
   const filtered = ports.filter((p) => {
     if (protocolFilter !== "All" && p.protocol !== protocolFilter) return false;

--- a/src/components/NetworkTools/PingPanel.live-stats.test.tsx
+++ b/src/components/NetworkTools/PingPanel.live-stats.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Regression test for live ping statistics (#1359).
+ *
+ * The panel used to hide loss % / avg-min-max RTT until the backend's closing
+ * stats arrived on Stop. It must now surface running stats derived from the
+ * streamed replies while the ping is still running.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { onPingResult } from "@/services/networkApi";
+import { PingPanel } from "./PingPanel";
+import type { PingResult } from "@/types/network";
+
+vi.mock("@/services/networkApi", () => ({
+  networkPingStart: vi.fn(() => Promise.resolve("task-1")),
+  networkPingStop: vi.fn(() => Promise.resolve()),
+  onPingResult: vi.fn(() => Promise.resolve(() => {})),
+  onPingComplete: vi.fn(() => Promise.resolve(() => {})),
+  onPingError: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("./LatencyChart", () => ({ LatencyChart: () => null }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function emitResult(result: PingResult) {
+  const cb = vi.mocked(onPingResult).mock.calls[0][0];
+  await act(async () => {
+    cb({ taskId: "task-1", result });
+  });
+  await flush();
+}
+
+function statsText(): string {
+  return container.querySelector('[data-testid="ping-stats"]')?.textContent ?? "";
+}
+
+describe("PingPanel — live stats", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows running loss % and RTT stats derived from streamed replies", async () => {
+    await act(async () => {
+      root.render(<PingPanel prefillHost="example.com" />);
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="ping-start"]')!.click();
+    });
+    await flush();
+
+    await emitResult({ seq: 1, latencyMs: 10, timedOut: false, tcpFallback: false });
+    await emitResult({ seq: 2, timedOut: true, tcpFallback: false });
+    await emitResult({ seq: 3, latencyMs: 30, timedOut: false, tcpFallback: false });
+
+    const text = statsText();
+    // 3 sent, 2 received → 33.3% loss; avg (10+30)/2 = 20ms.
+    expect(text).toContain("Sent: 3");
+    expect(text).toContain("Received: 2");
+    expect(text).toContain("Loss: 33.3%");
+    expect(text).toContain("avg=20ms");
+    expect(text).not.toContain("NaN");
+  });
+});

--- a/src/components/NetworkTools/PingPanel.tsx
+++ b/src/components/NetworkTools/PingPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/services/networkApi";
 import type { PingResult, PingStats, DiagnosticStatus } from "@/types/network";
 import { LatencyChart } from "./LatencyChart";
+import { deriveLivePingStats } from "./pingStats";
 import { validateHost, validateIntRange } from "@/utils/fieldValidation";
 import { frontendLog } from "@/utils/frontendLog";
 
@@ -161,6 +162,11 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
 
   const latencyPoints = results.map((r) => r.latencyMs ?? null);
 
+  // While running, show stats derived live from the replies received so far; on
+  // completion the backend's authoritative closing stats take over.
+  const liveStats = status === "running" ? deriveLivePingStats(results) : null;
+  const displayStats = stats ?? liveStats;
+
   return (
     <form className="network-panel" data-testid="ping-panel" {...formProps}>
       <div className="network-panel__header">
@@ -259,21 +265,21 @@ export function PingPanel({ prefillHost }: PingPanelProps) {
         </div>
       )}
 
-      {(stats || status === "running") && (
+      {displayStats && (
         <div className="network-panel__stats" data-testid="ping-stats">
-          {stats && (
-            <>
-              <span>
-                Sent: {stats.sent} · Received: {stats.received} · Loss:{" "}
-                {stats.lossPercent.toFixed(1)}%
-              </span>
-              <span>
-                RTT: min={stats.minMs.toFixed(0)}ms avg={stats.avgMs.toFixed(0)}ms max=
-                {stats.maxMs.toFixed(0)}ms jitter={stats.jitterMs.toFixed(0)}ms
-              </span>
-            </>
-          )}
-          {status === "running" && <span>{results.length} replies received…</span>}
+          <span>
+            Sent: {displayStats.sent} · Received: {displayStats.received} · Loss:{" "}
+            {displayStats.lossPercent.toFixed(1)}%
+          </span>
+          <span>
+            RTT: min={displayStats.minMs.toFixed(0)}ms avg={displayStats.avgMs.toFixed(0)}ms max=
+            {displayStats.maxMs.toFixed(0)}ms jitter={displayStats.jitterMs.toFixed(0)}ms
+          </span>
+        </div>
+      )}
+      {status === "running" && !displayStats && (
+        <div className="network-panel__stats" data-testid="ping-stats">
+          <span>Waiting for first reply…</span>
         </div>
       )}
     </form>

--- a/src/components/NetworkTools/PortScannerPanel.live-open.test.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.live-open.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Regression test for the Port Scanner live open-count (#1359).
+ *
+ * The running footer showed only "ports checked". It must also surface a live
+ * count of open ports found so far, so progress is visible before completion.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { onScanResult } from "@/services/networkApi";
+import { PortScannerPanel } from "./PortScannerPanel";
+import type { PortState } from "@/types/network";
+
+vi.mock("@/services/networkApi", () => ({
+  networkPortScan: vi.fn(() => Promise.resolve("task-1")),
+  networkPortScanCancel: vi.fn(() => Promise.resolve()),
+  onScanResult: vi.fn(() => Promise.resolve(() => {})),
+  onScanComplete: vi.fn(() => Promise.resolve(() => {})),
+  onScanError: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function emitResult(port: number, state: PortState) {
+  const cb = vi.mocked(onScanResult).mock.calls[0][0];
+  await act(async () => {
+    cb({ taskId: "task-1", host: "10.0.0.1", port, state });
+  });
+  await flush();
+}
+
+function footerText(): string {
+  return container.querySelector('[data-testid="port-scanner-footer"]')?.textContent ?? "";
+}
+
+describe("PortScannerPanel — live open-count", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows a running open-count while scanning", async () => {
+    await act(async () => {
+      root.render(<PortScannerPanel prefillHost="10.0.0.1" />);
+    });
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="port-scanner-run"]')!.click();
+    });
+    await flush();
+
+    await emitResult(22, "open");
+    await emitResult(80, "closed");
+    await emitResult(443, "open");
+
+    const text = footerText();
+    expect(text).toContain("3 checked");
+    expect(text).toContain("2 open");
+  });
+});

--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -139,6 +139,10 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
     latencyMs: r.latencyMs != null ? `${r.latencyMs}ms` : "—",
   }));
 
+  // Live open-port tally so the running footer surfaces progress, not just the
+  // number of ports checked.
+  const liveOpen = useMemo(() => results.filter((r) => r.state === "open").length, [results]);
+
   return (
     <form className="network-panel" data-testid="port-scanner-panel" {...formProps}>
       <div className="network-panel__header">
@@ -244,7 +248,7 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
           summary
             ? `Scanned ${summary.total} ports in ${(summary.elapsedMs / 1000).toFixed(1)}s — ${summary.open} open, ${summary.closed} closed, ${summary.filtered} filtered${status === "canceled" ? " (scan canceled)" : ""}`
             : status === "running"
-              ? `Scanning… ${results.length} ports checked`
+              ? `Scanning… ${results.length} checked, ${liveOpen} open`
               : null
         }
       />

--- a/src/components/NetworkTools/TraceroutePanel.footer.test.tsx
+++ b/src/components/NetworkTools/TraceroutePanel.footer.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Regression tests for the Traceroute footer (#1359):
+ *  - the completed footer never renders "NaN"/a misleading "avg 0ms" when the
+ *    last hop had no valid RTT, and
+ *  - a "canceled" footer appears after Stop (previously the table just froze).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { networkTraceroute, onTracerouteHop, onTracerouteComplete } from "@/services/networkApi";
+import { TraceroutePanel } from "./TraceroutePanel";
+import type { TracerouteHop } from "@/types/network";
+
+vi.mock("@/services/networkApi", () => ({
+  networkTraceroute: vi.fn(() => Promise.resolve("task-1")),
+  networkTracerouteCancel: vi.fn(() => Promise.resolve()),
+  onTracerouteHop: vi.fn(() => Promise.resolve(() => {})),
+  onTracerouteComplete: vi.fn(() => Promise.resolve(() => {})),
+  onTracerouteError: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function start() {
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('[data-testid="traceroute-run"]')!.click();
+  });
+  await flush();
+}
+
+async function emitHop(hop: TracerouteHop) {
+  const cb = vi.mocked(onTracerouteHop).mock.calls[0][0];
+  await act(async () => {
+    cb({ taskId: "task-1", hop });
+  });
+  await flush();
+}
+
+async function emitComplete() {
+  const cb = vi.mocked(onTracerouteComplete).mock.calls[0][0];
+  await act(async () => {
+    cb({ taskId: "task-1" });
+  });
+  await flush();
+}
+
+function footerText(): string {
+  return container.querySelector('[data-testid="traceroute-footer"]')?.textContent ?? "";
+}
+
+describe("TraceroutePanel — footer", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("omits the average (no NaN, no misleading 0ms) when the last hop has no valid RTT", async () => {
+    await act(async () => {
+      root.render(<TraceroutePanel prefillHost="example.com" />);
+    });
+    await start();
+    await emitHop({ hop: 1, ip: undefined, rttMs: [null, null, null] });
+    await emitComplete();
+
+    const text = footerText();
+    expect(text).toContain("Trace complete");
+    expect(text).not.toContain("NaN");
+    expect(text).not.toContain("avg");
+  });
+
+  it("shows the average when the last hop has valid RTTs", async () => {
+    await act(async () => {
+      root.render(<TraceroutePanel prefillHost="example.com" />);
+    });
+    await start();
+    await emitHop({ hop: 1, ip: "1.1.1.1", rttMs: [10, 20, 30] });
+    await emitComplete();
+
+    expect(footerText()).toContain("avg 20ms");
+  });
+
+  it("never renders NaN when the trace completes with zero hops", async () => {
+    await act(async () => {
+      root.render(<TraceroutePanel prefillHost="example.com" />);
+    });
+    await start();
+    await emitComplete();
+
+    expect(footerText()).not.toContain("NaN");
+  });
+
+  it("appends a canceled footer after Stop", async () => {
+    await act(async () => {
+      root.render(<TraceroutePanel prefillHost="example.com" />);
+    });
+    await start();
+    await emitHop({ hop: 1, ip: "1.1.1.1", rttMs: [10, 20, 30] });
+
+    // Stop is the danger-variant button shown while running.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>(".ui-btn--danger")!.click();
+    });
+    await flush();
+
+    expect(footerText().toLowerCase()).toContain("canceled");
+    expect(networkTraceroute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/NetworkTools/TraceroutePanel.tsx
+++ b/src/components/NetworkTools/TraceroutePanel.tsx
@@ -79,10 +79,15 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
     rtt3: h.rttMs[2] != null ? `${h.rttMs[2].toFixed(1)}ms` : "—",
   }));
 
+  // Average the last hop's *valid* round-trips only. When the final hop never
+  // answered (all `null`) there is no meaningful average — keep it `null` so the
+  // footer omits it rather than rendering "avg NaNms" (or a misleading 0ms).
   const lastHop = hops[hops.length - 1];
+  const lastValidRtts = lastHop?.rttMs.filter((r): r is number => r != null) ?? [];
   const avgRtt =
-    lastHop?.rttMs.filter((r): r is number => r != null).reduce((a, b) => a + b, 0) /
-    (lastHop?.rttMs.filter((r): r is number => r != null).length || 1);
+    lastValidRtts.length > 0
+      ? lastValidRtts.reduce((a, b) => a + b, 0) / lastValidRtts.length
+      : null;
 
   return (
     <form className="network-panel" data-testid="traceroute-panel" {...formProps}>
@@ -154,12 +159,15 @@ export function TraceroutePanel({ prefillHost }: TraceroutePanelProps) {
       <DiagnosticResultsTable
         columns={columns}
         rows={formattedRows}
+        footerTestId="traceroute-footer"
         footer={
           status === "completed"
-            ? `Trace complete: ${hops.length} hops, avg ${avgRtt.toFixed(0)}ms`
-            : status === "running"
-              ? `Tracing… hop ${hops.length}`
-              : null
+            ? `Trace complete: ${hops.length} hops${avgRtt != null ? `, avg ${avgRtt.toFixed(0)}ms` : ""}`
+            : status === "canceled"
+              ? `Trace canceled: ${hops.length} hops`
+              : status === "running"
+                ? `Tracing… hop ${hops.length}`
+                : null
         }
       />
     </form>

--- a/src/components/NetworkTools/pingStats.test.ts
+++ b/src/components/NetworkTools/pingStats.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import type { PingResult } from "@/types/network";
+import { deriveLivePingStats } from "./pingStats";
+
+function reply(seq: number, latencyMs: number | undefined, timedOut = false): PingResult {
+  return { seq, latencyMs, timedOut, tcpFallback: false };
+}
+
+describe("deriveLivePingStats", () => {
+  it("returns null with no replies", () => {
+    expect(deriveLivePingStats([])).toBeNull();
+  });
+
+  it("computes loss %, min/avg/max RTT from streamed replies", () => {
+    const stats = deriveLivePingStats([reply(1, 10), reply(2, 20), reply(3, 30)]);
+    expect(stats).not.toBeNull();
+    expect(stats!.sent).toBe(3);
+    expect(stats!.received).toBe(3);
+    expect(stats!.lossPercent).toBe(0);
+    expect(stats!.minMs).toBe(10);
+    expect(stats!.maxMs).toBe(30);
+    expect(stats!.avgMs).toBe(20);
+  });
+
+  it("counts timed-out replies as loss but not received", () => {
+    const stats = deriveLivePingStats([
+      reply(1, 10),
+      reply(2, undefined, true),
+      reply(3, 30),
+      reply(4, undefined, true),
+    ]);
+    expect(stats!.sent).toBe(4);
+    expect(stats!.received).toBe(2);
+    expect(stats!.lossPercent).toBe(50);
+    expect(stats!.minMs).toBe(10);
+    expect(stats!.maxMs).toBe(30);
+    expect(stats!.avgMs).toBe(20);
+  });
+
+  it("reports 100% loss without dividing by zero when all replies time out", () => {
+    const stats = deriveLivePingStats([reply(1, undefined, true), reply(2, undefined, true)]);
+    expect(stats!.sent).toBe(2);
+    expect(stats!.received).toBe(0);
+    expect(stats!.lossPercent).toBe(100);
+    expect(stats!.avgMs).toBe(0);
+    expect(Number.isNaN(stats!.avgMs)).toBe(false);
+  });
+
+  it("computes jitter as the mean absolute consecutive RTT difference", () => {
+    // diffs: |20-10|=10, |15-20|=5 → mean 7.5
+    const stats = deriveLivePingStats([reply(1, 10), reply(2, 20), reply(3, 15)]);
+    expect(stats!.jitterMs).toBeCloseTo(7.5);
+  });
+});

--- a/src/components/NetworkTools/pingStats.ts
+++ b/src/components/NetworkTools/pingStats.ts
@@ -1,0 +1,45 @@
+import type { PingResult, PingStats } from "@/types/network";
+
+/**
+ * Derive live ping statistics from the streamed replies received so far.
+ *
+ * The backend emits an authoritative {@link PingStats} in its closing
+ * `network-ping-complete` event, but until then the panel would otherwise show
+ * nothing. This computes the same shape from the replies streamed so far so the
+ * loss %, RTT min/avg/max and jitter can update live while the ping is running.
+ *
+ * A timed-out reply counts towards `sent` but not `received`. `jitterMs` is the
+ * mean absolute difference between consecutive successful round-trip times.
+ *
+ * @param results the replies streamed so far.
+ * @returns live stats, or `null` when no replies have arrived yet.
+ */
+export function deriveLivePingStats(results: PingResult[]): PingStats | null {
+  if (results.length === 0) return null;
+
+  const sent = results.length;
+  const latencies = results
+    .filter((r) => !r.timedOut && r.latencyMs != null)
+    .map((r) => r.latencyMs as number);
+  const received = latencies.length;
+  const lossPercent = ((sent - received) / sent) * 100;
+
+  if (received === 0) {
+    return { sent, received, lossPercent, minMs: 0, avgMs: 0, maxMs: 0, jitterMs: 0 };
+  }
+
+  const minMs = Math.min(...latencies);
+  const maxMs = Math.max(...latencies);
+  const avgMs = latencies.reduce((a, b) => a + b, 0) / received;
+
+  let jitterMs = 0;
+  if (latencies.length > 1) {
+    let diffSum = 0;
+    for (let i = 1; i < latencies.length; i++) {
+      diffSum += Math.abs(latencies[i] - latencies[i - 1]);
+    }
+    jitterMs = diffSum / (latencies.length - 1);
+  }
+
+  return { sent, received, lossPercent, minMs, avgMs, maxMs, jitterMs };
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -149,6 +149,7 @@ Fixed strings — match exactly.
 | `custom-grammar-register-error` | `src/components/Settings/CustomGrammarsSettings.tsx` |
 | `custom-grammars-settings` | `src/components/Settings/CustomGrammarsSettings.tsx` |
 | `develop-branch-badge` | `src/components/StatusBar/UpdateIndicator.tsx` |
+| `dns-cancel` | `src/components/NetworkTools/DnsLookupPanel.tsx` |
 | `dns-hostname` | `src/components/NetworkTools/DnsLookupPanel.tsx` |
 | `dns-lookup-panel` | `src/components/NetworkTools/DnsLookupPanel.tsx` |
 | `dns-record-type` | `src/components/NetworkTools/DnsLookupPanel.tsx` |


### PR DESCRIPTION
Fixes the distinct correctness and live-feedback defects in `src/components/NetworkTools/` tracked by #1359. Builds on the recently-merged NetworkTools primitive refactor (#1435) and the unified submit-button lifecycle (#1414).

## Bugs fixed (correctness)

- **Traceroute `avg NaNms`** — the completed footer averaged the *last hop's* round-trips with no guard, so an unreachable final hop (all `null` RTTs, or a zero-hop completion) rendered `avg NaNms` or a misleading `avg 0ms`. The average is now computed only over the last hop's valid RTTs and omitted entirely when there is nothing to average.
- **Traceroute has no "canceled" footer** — Stop used to just freeze the table (unlike Port Scanner, which appends "scan canceled"). It now shows a `Trace canceled: N hops` footer.

> Note: the two other items the issue lists — the Port Scanner CIDR-aware large-scan estimate and its "scan canceled" footer — are already present on `develop` (landed with #1348), so no change was needed there.

## Live-feedback polish

- **Ping** now derives running loss %, RTT min/avg/max and jitter live from the streamed replies (via a new pure `deriveLivePingStats` helper) instead of hiding all statistics until Stop. The backend's authoritative closing stats still take over on completion.
- **Port Scanner** running footer now shows a live open-count (`N checked, M open`) alongside the checked count.
- **DNS Lookup** bounds each query with a visible 10s timeout and offers a **Cancel** button while the lookup is in flight, so a hung resolver can no longer leave the panel spinning. (Fully frontend — no backend change needed.)
- **Open Ports** auto-loads the listening ports on mount; **Refresh** remains for an explicit re-fetch.

## Test plan

TDD — regression tests were committed before the implementation:

- `pingStats.test.ts` — loss/avg/min/max/jitter derivation incl. all-timeout (no div-by-zero) and jitter.
- `TraceroutePanel.footer.test.tsx` — no `NaN`/misleading `avg` on an unreachable last hop or zero-hop completion; average shown for valid RTTs; canceled footer after Stop.
- `PingPanel.live-stats.test.tsx` — running loss %/avg surfaced from streamed replies.
- `PortScannerPanel.live-open.test.tsx` — live open-count in the running footer.
- `DnsLookupPanel.timeout.test.tsx` — Cancel affordance while in flight; bounded timeout produces a visible error (fake timers).
- `OpenPortsPanel.autoload.test.tsx` (+ updated `OpenPortsPanel.test.tsx`) — auto-load on mount; Refresh re-fetches.

`pnpm test` (2945 passed), `pnpm build`, `pnpm run lint`, `pnpm run format:check` all green. `python3 scripts/build-testid-catalog.py --check` up to date (registers the new `dns-cancel` test-id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)