### PR TITLE
fix(ui): surface recoverable errors for silent appStore mutating actions (Closes #1472)

### DIFF
--- a/docs/changes/dev1/bugfix/1472-appstore-silent-actions.md
+++ b/docs/changes/dev1/bugfix/1472-appstore-silent-actions.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Store-level mutating actions that previously failed silently now surface a
+  recoverable error toast, so a failed persist no longer leaves the UI quietly
+  out of sync with disk. Newly covered actions: connection bulk delete,
+  new/delete folder, folder expand/collapse persistence, duplicate,
+  move-to-file, move-to-folder and bulk move; remote-agent persist
+  (new/update/reorder/delete), disconnect, session refresh, and connection
+  definition save/update/delete plus folder delete; workspace duplicate; and
+  save/clear of the restored last session (#1472).

--- a/src/store/appStore.silentActions.test.ts
+++ b/src/store/appStore.silentActions.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/**
+ * Regression suite for #1472 — no user-initiated mutating action dispatched
+ * from appStore should resolve silently. Each test rejects the underlying
+ * persist/command and asserts a recoverable `toast.error` fires (rather than
+ * the failure being swallowed by a bare `console.error`).
+ */
+
+// Mock the toast hub so we can assert feedback without real DOM toasts.
+const toastSuccess = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+const toastError = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+const toastLoading = vi.fn((_message: unknown, _opts?: unknown) => "toast-id");
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastSuccess(message) : toastSuccess(message, opts),
+    error: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastError(message) : toastError(message, opts),
+    loading: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastLoading(message) : toastLoading(message, opts),
+    info: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve("persisted-id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  persistAgent: vi.fn(() => Promise.resolve()),
+  removeAgent: vi.fn(() => Promise.resolve()),
+  reorderAgents: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  disconnectAgent: vi.fn(() => Promise.resolve()),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(() => Promise.resolve({})),
+  updateAgentDefinition: vi.fn(() => Promise.resolve({})),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(() => Promise.resolve({})),
+  updateAgentFolder: vi.fn(() => Promise.resolve({})),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/workspaceApi", () => ({
+  getWorkspaces: vi.fn(() => Promise.resolve([])),
+  loadWorkspace: vi.fn(() => Promise.resolve({})),
+  saveWorkspace: vi.fn(() => Promise.resolve()),
+  deleteWorkspace: vi.fn(() => Promise.resolve()),
+  duplicateWorkspace: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/lastSessionApi", () => ({
+  saveLastSession: vi.fn(() => Promise.resolve()),
+  loadLastSession: vi.fn(() => Promise.resolve(null)),
+  clearLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore, _resetConnectionReloadSeq } from "./appStore";
+import {
+  persistConnection,
+  removeConnection,
+  persistFolder,
+  removeFolder,
+  persistAgent,
+  removeAgent,
+  reorderAgents,
+  moveConnectionToFile,
+} from "@/services/storage";
+import {
+  disconnectAgent,
+  listAgentSessions,
+  saveAgentDefinition,
+  updateAgentDefinition,
+  deleteAgentDefinition,
+  deleteAgentFolder,
+} from "@/services/api";
+import { duplicateWorkspace } from "@/services/workspaceApi";
+import { saveLastSession, clearLastSession } from "@/services/lastSessionApi";
+import type { SavedConnection, ConnectionFolder, RemoteAgentDefinition } from "@/types/connection";
+import { DEFAULT_AGENT_SETTINGS } from "@/types/connection";
+
+function makeConnection(overrides: Partial<SavedConnection> = {}): SavedConnection {
+  return {
+    id: `conn-${Math.random().toString(36).slice(2, 8)}`,
+    name: "prod-gateway",
+    config: { type: "local", config: { shell: "bash" } },
+    folderId: null,
+    ...overrides,
+  };
+}
+
+function makeFolder(overrides: Partial<ConnectionFolder> = {}): ConnectionFolder {
+  return {
+    id: `folder-${Math.random().toString(36).slice(2, 8)}`,
+    name: "Test Folder",
+    parentId: null,
+    isExpanded: false,
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: `agent-${Math.random().toString(36).slice(2, 8)}`,
+    name: "Test Agent",
+    config: { host: "test.local", port: 22, username: "user", authMethod: "password" },
+    isExpanded: false,
+    connectionState: "disconnected",
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    ...overrides,
+  };
+}
+
+/** Flush the fire-and-forget persist/remove promise chains. */
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const AGENT_ID = "agent-test-1";
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  _resetConnectionReloadSeq();
+  vi.clearAllMocks();
+});
+
+describe("#1472 — connection mutating actions surface errors", () => {
+  it("bulkDeleteConnections toasts on a rejected removal", async () => {
+    vi.mocked(removeConnection).mockRejectedValueOnce(new Error("locked"));
+    const conn = makeConnection();
+    useAppStore.setState({ connections: [conn] });
+    useAppStore.getState().bulkDeleteConnections([conn.id]);
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("locked"));
+  });
+
+  it("addFolder toasts on a rejected persist", async () => {
+    vi.mocked(persistFolder).mockRejectedValueOnce(new Error("disk full"));
+    useAppStore.getState().addFolder(makeFolder({ name: "Servers" }));
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("Servers"));
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("disk full"));
+  });
+
+  it("deleteFolder toasts on a rejected removal", async () => {
+    vi.mocked(removeFolder).mockRejectedValueOnce(new Error("nope"));
+    const folder = makeFolder();
+    useAppStore.setState({ folders: [folder] });
+    useAppStore.getState().deleteFolder(folder.id);
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("nope"));
+  });
+
+  it("toggleFolder toasts on a rejected persist", async () => {
+    vi.mocked(persistFolder).mockRejectedValueOnce(new Error("io"));
+    const folder = makeFolder();
+    useAppStore.setState({ folders: [folder] });
+    useAppStore.getState().toggleFolder(folder.id);
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("io"));
+  });
+
+  it("duplicateConnection toasts on a rejected persist", async () => {
+    vi.mocked(persistConnection).mockRejectedValueOnce(new Error("boom"));
+    const conn = makeConnection({ name: "orig" });
+    useAppStore.setState({ connections: [conn] });
+    useAppStore.getState().duplicateConnection(conn.id);
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("orig"));
+  });
+
+  it("moveConnectionToFile toasts on a rejected move", async () => {
+    vi.mocked(moveConnectionToFile).mockRejectedValueOnce(new Error("perm"));
+    const conn = makeConnection({ name: "mover", sourceFile: null });
+    useAppStore.setState({ connections: [conn] });
+    await useAppStore.getState().moveConnectionToFile(conn.id, "other.json");
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("perm"));
+  });
+
+  it("moveConnectionToFolder toasts on a rejected persist", async () => {
+    vi.mocked(persistConnection).mockRejectedValueOnce(new Error("bad"));
+    const conn = makeConnection({ name: "movee" });
+    useAppStore.setState({ connections: [conn] });
+    useAppStore.getState().moveConnectionToFolder(conn.id, "folder-1");
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("bad"));
+  });
+
+  it("bulkMoveConnectionsToFolder toasts on a rejected persist", async () => {
+    vi.mocked(persistConnection).mockRejectedValueOnce(new Error("nope"));
+    const conn = makeConnection();
+    useAppStore.setState({ connections: [conn] });
+    useAppStore.getState().bulkMoveConnectionsToFolder([conn.id], "folder-1");
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("nope"));
+  });
+});
+
+describe("#1472 — agent mutating actions surface errors", () => {
+  it("addRemoteAgent toasts on a rejected persist", async () => {
+    vi.mocked(persistAgent).mockRejectedValueOnce(new Error("disk"));
+    useAppStore.getState().addRemoteAgent(makeAgent({ name: "edge" }));
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("edge"));
+  });
+
+  it("updateRemoteAgent toasts on a rejected persist", async () => {
+    vi.mocked(persistAgent).mockRejectedValueOnce(new Error("disk"));
+    const agent = makeAgent({ name: "edge" });
+    useAppStore.setState({ remoteAgents: [agent] });
+    useAppStore.getState().updateRemoteAgent({ ...agent, name: "edge2" });
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("edge2"));
+  });
+
+  it("reorderRemoteAgents toasts on a rejected persist", async () => {
+    vi.mocked(reorderAgents).mockRejectedValueOnce(new Error("order fail"));
+    useAppStore.setState({ remoteAgents: [makeAgent(), makeAgent()] });
+    useAppStore.getState().reorderRemoteAgents(0, 1);
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("order fail"));
+  });
+
+  it("deleteRemoteAgent toasts on a rejected removal", async () => {
+    vi.mocked(removeAgent).mockRejectedValueOnce(new Error("busy"));
+    const agent = makeAgent({ name: "gone" });
+    useAppStore.setState({ remoteAgents: [agent] });
+    useAppStore.getState().deleteRemoteAgent(agent.id);
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("busy"));
+  });
+
+  it("disconnectRemoteAgent toasts on a rejected disconnect", async () => {
+    vi.mocked(disconnectAgent).mockRejectedValueOnce(new Error("hung"));
+    await useAppStore.getState().disconnectRemoteAgent(AGENT_ID);
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("hung"));
+  });
+
+  it("refreshAgentSessions toasts on a rejected list", async () => {
+    vi.mocked(listAgentSessions).mockRejectedValueOnce(new Error("no route"));
+    await useAppStore.getState().refreshAgentSessions(AGENT_ID);
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("no route"));
+  });
+
+  it("saveAgentDef toasts on a rejected save", async () => {
+    vi.mocked(saveAgentDefinition).mockRejectedValueOnce(new Error("denied"));
+    await useAppStore.getState().saveAgentDef(AGENT_ID, {
+      name: "x",
+      type: "shell",
+      config: {},
+      persistent: false,
+      folder_id: null,
+      terminal_options: null,
+      icon: null,
+    });
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("denied"));
+  });
+
+  it("deleteAgentDef toasts on a rejected delete", async () => {
+    vi.mocked(deleteAgentDefinition).mockRejectedValueOnce(new Error("missing"));
+    await useAppStore.getState().deleteAgentDef(AGENT_ID, "def-1");
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("missing"));
+  });
+
+  it("updateAgentDef toasts on a rejected update", async () => {
+    vi.mocked(updateAgentDefinition).mockRejectedValueOnce(new Error("stale"));
+    await useAppStore.getState().updateAgentDef(AGENT_ID, { id: "def-1", name: "y" });
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("stale"));
+  });
+
+  it("deleteAgentFolder toasts on a rejected delete", async () => {
+    vi.mocked(deleteAgentFolder).mockRejectedValueOnce(new Error("locked"));
+    await useAppStore.getState().deleteAgentFolder(AGENT_ID, "folder-1");
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("locked"));
+  });
+});
+
+describe("#1472 — workspace and session mutating actions surface errors", () => {
+  it("duplicateWorkspaceInBackend toasts on a rejected duplicate", async () => {
+    vi.mocked(duplicateWorkspace).mockRejectedValueOnce(new Error("copy fail"));
+    await useAppStore.getState().duplicateWorkspaceInBackend("ws-1");
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("copy fail"));
+  });
+
+  it("saveLastSession toasts on a rejected save", async () => {
+    vi.mocked(saveLastSession).mockRejectedValueOnce(new Error("write fail"));
+    await useAppStore.getState().saveLastSession();
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("write fail"),
+      expect.objectContaining({ id: "last-session-save-error" })
+    );
+  });
+
+  it("clearLastSession toasts on a rejected clear", async () => {
+    vi.mocked(clearLastSession).mockRejectedValueOnce(new Error("clear fail"));
+    await useAppStore.getState().clearLastSession();
+    await flush();
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("clear fail"));
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3045,9 +3045,12 @@ export const useAppStore = create<AppState>((set, get) => {
         // Persist the toggled folder
         const toggled = folders.find((f) => f.id === folderId);
         if (toggled) {
-          persistFolder(toggled).catch((err) =>
-            console.error("Failed to persist folder toggle:", err)
-          );
+          persistFolder(toggled).catch((err) => {
+            console.error("Failed to persist folder toggle:", err);
+            toast.error(
+              `Failed to save folder state: ${err instanceof Error ? err.message : String(err)}`
+            );
+          });
         }
         return { folders };
       });
@@ -3129,9 +3132,17 @@ export const useAppStore = create<AppState>((set, get) => {
       Promise.all(toDelete.map((c) => removeConnection(c.id, c.sourceFile)))
         .then(() => {
           frontendLog("connection_sync", `bulkDeleteConnections: backend confirmed, reloading`);
+          toast.success(
+            `Deleted ${toDelete.length} ${toDelete.length === 1 ? "connection" : "connections"}`
+          );
           return applyConnectionReload();
         })
-        .catch((err) => console.error("Failed to persist bulk connection deletion:", err));
+        .catch((err) => {
+          console.error("Failed to persist bulk connection deletion:", err);
+          toast.error(
+            `Failed to delete connections: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
     },
 
     addFolder: (folder) => {
@@ -3139,7 +3150,12 @@ export const useAppStore = create<AppState>((set, get) => {
       frontendLog("connection_sync", `addFolder: persisting ${folder.id}`);
       persistFolder(folder)
         .then(() => applyConnectionReload())
-        .catch((err) => console.error("Failed to persist new folder:", err));
+        .catch((err) => {
+          console.error("Failed to persist new folder:", err);
+          toast.error(
+            `Failed to create folder ${folder.name}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
     },
 
     deleteFolder: (folderId) => {
@@ -3160,7 +3176,12 @@ export const useAppStore = create<AppState>((set, get) => {
       frontendLog("connection_sync", `deleteFolder: removing ${folderId}`);
       removeFolder(folderId)
         .then(() => applyConnectionReload())
-        .catch((err) => console.error("Failed to persist folder deletion:", err));
+        .catch((err) => {
+          console.error("Failed to persist folder deletion:", err);
+          toast.error(
+            `Failed to delete folder: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
     },
 
     duplicateConnection: (connectionId) => {
@@ -3176,7 +3197,12 @@ export const useAppStore = create<AppState>((set, get) => {
       frontendLog("connection_sync", `duplicateConnection: persisting copy of ${connectionId}`);
       persistConnection(stripPassword(duplicate))
         .then(() => applyConnectionReload())
-        .catch((err) => console.error("Failed to persist duplicated connection:", err));
+        .catch((err) => {
+          console.error("Failed to persist duplicated connection:", err);
+          toast.error(
+            `Failed to duplicate ${original.name}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
     },
 
     moveConnectionToFile: async (connectionId, targetSource) => {
@@ -3191,6 +3217,9 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
       } catch (err) {
         console.error("Failed to move connection to file:", err);
+        toast.error(
+          `Failed to move ${conn.name}: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -3207,7 +3236,12 @@ export const useAppStore = create<AppState>((set, get) => {
         frontendLog("connection_sync", `moveConnectionToFolder: persisting ${connectionId}`);
         persistConnection(stripPassword(moved))
           .then(() => applyConnectionReload())
-          .catch((err) => console.error("Failed to persist connection move:", err));
+          .catch((err) => {
+            console.error("Failed to persist connection move:", err);
+            toast.error(
+              `Failed to move ${moved.name}: ${err instanceof Error ? err.message : String(err)}`
+            );
+          });
       }
     },
 
@@ -3227,7 +3261,12 @@ export const useAppStore = create<AppState>((set, get) => {
       );
       Promise.all(moved.map((conn) => persistConnection(stripPassword(conn))))
         .then(() => applyConnectionReload())
-        .catch((err) => console.error("Failed to persist bulk connection move:", err));
+        .catch((err) => {
+          console.error("Failed to persist bulk connection move:", err);
+          toast.error(
+            `Failed to move connections: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
     },
 
     // File browser / SFTP
@@ -3895,7 +3934,12 @@ export const useAppStore = create<AppState>((set, get) => {
         name: agent.name,
         config: agent.config,
         agentSettings: agent.agentSettings,
-      }).catch((err) => console.error("Failed to persist new agent:", err));
+      }).catch((err) => {
+        console.error("Failed to persist new agent:", err);
+        toast.error(
+          `Failed to save agent ${agent.name}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
     },
 
     updateRemoteAgent: (agent) => {
@@ -3907,7 +3951,12 @@ export const useAppStore = create<AppState>((set, get) => {
         name: agent.name,
         config: agent.config,
         agentSettings: agent.agentSettings,
-      }).catch((err) => console.error("Failed to persist agent update:", err));
+      }).catch((err) => {
+        console.error("Failed to persist agent update:", err);
+        toast.error(
+          `Failed to save agent ${agent.name}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
     },
 
     reorderRemoteAgents: (oldIndex, newIndex) => {
@@ -3918,9 +3967,12 @@ export const useAppStore = create<AppState>((set, get) => {
         return { remoteAgents: agents };
       });
       const agentIds = get().remoteAgents.map((a) => a.id);
-      persistAgentOrder(agentIds).catch((err) =>
-        console.error("Failed to persist agent reorder:", err)
-      );
+      persistAgentOrder(agentIds).catch((err) => {
+        console.error("Failed to persist agent reorder:", err);
+        toast.error(
+          `Failed to save agent order: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
     },
 
     deleteRemoteAgent: (agentId) => {
@@ -3942,7 +3994,12 @@ export const useAppStore = create<AppState>((set, get) => {
           Object.entries(s.agentFolders).filter(([k]) => k !== agentId)
         ),
       }));
-      removeAgent(agentId).catch((err) => console.error("Failed to persist agent deletion:", err));
+      removeAgent(agentId).catch((err) => {
+        console.error("Failed to persist agent deletion:", err);
+        toast.error(
+          `Failed to delete agent ${agent?.name ?? ""}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
     },
 
     toggleRemoteAgent: (agentId) => {
@@ -3997,6 +4054,9 @@ export const useAppStore = create<AppState>((set, get) => {
         await apiDisconnectAgent(agentId);
       } catch (err) {
         console.error(`Failed to disconnect agent ${agentId}:`, err);
+        toast.error(
+          `Failed to disconnect agent: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
       set((s) => ({
         remoteAgents: s.remoteAgents.map((a) =>
@@ -4088,6 +4148,9 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
       } catch (err) {
         console.error(`Failed to refresh agent sessions for ${agentId}:`, err);
+        toast.error(
+          `Failed to load agent sessions: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -4105,6 +4168,9 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
       } catch (err) {
         console.error(`Failed to save agent definition on ${agentId}:`, err);
+        toast.error(
+          `Failed to save connection: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -4135,6 +4201,9 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
       } catch (err) {
         console.error(`Failed to delete agent definition on ${agentId}:`, err);
+        toast.error(
+          `Failed to delete connection: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -4151,6 +4220,9 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
       } catch (err) {
         console.error(`Failed to update agent definition on ${agentId}:`, err);
+        toast.error(
+          `Failed to update connection: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -4223,6 +4295,7 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
       } catch (err) {
         console.error(`Failed to delete agent folder on ${agentId}:`, err);
+        toast.error(`Failed to delete folder: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
 
@@ -4890,8 +4963,12 @@ export const useAppStore = create<AppState>((set, get) => {
       try {
         await apiDuplicateWorkspace(workspaceId);
         await get().loadWorkspaces();
+        toast.success("Duplicated workspace");
       } catch (err) {
         console.error("Failed to duplicate workspace:", err);
+        toast.error(
+          `Failed to duplicate workspace: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -5188,6 +5265,11 @@ export const useAppStore = create<AppState>((set, get) => {
         });
       } catch (err) {
         console.error("Failed to save last session:", err);
+        // Auto-save fires on every layout change (debounced); use a stable id so
+        // repeated failures collapse into a single, replaceable toast.
+        toast.error(`Failed to save session: ${err instanceof Error ? err.message : String(err)}`, {
+          id: "last-session-save-error",
+        });
       }
     },
 
@@ -5283,6 +5365,9 @@ export const useAppStore = create<AppState>((set, get) => {
         await apiClearLastSession();
       } catch (err) {
         console.error("Failed to clear last session:", err);
+        toast.error(
+          `Failed to clear saved session: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 


### PR DESCRIPTION
## Summary

Follow-up to #1342. That PR fixed component-level silent failures; this one closes the remaining **store-level** surface in `src/store/appStore.ts` where a mutating action swallowed a persist/command rejection at a bare `console.error`, violating the design-system rule "every action gives feedback". Each affected handler now also raises a recoverable `toast.error` (keeping the optimistic UI update recoverable), reusing the same `toast` API and message style established in #1342.

## Actions given failure feedback

- **Connections** — bulk delete (also adds a success toast, matching single delete), new folder, delete folder, folder expand/collapse persistence, duplicate, move-to-file, move-to-folder, bulk move.
- **Agents** — persist new/update/reorder/delete; disconnect; refresh sessions; save/update/delete connection definition; delete folder. (create/update agent folder already toasted.)
- **Workspaces** — duplicate (silent — its caller does not catch), plus a success confirmation.
- **Session** — save last session (stable toast id so the debounced auto-save can't stack repeats) and clear last session.

## Left intentionally untouched (already surfaced — avoids double-toasting)

The **rethrowing** save actions do not swallow: they `throw` and their component callers already show error toasts (from #1342), so adding a store toast would double up:

- Tunnels: `saveTunnel` (caller toasts); `startTunnel`/`stopTunnel`/`reconnectTunnel`/`deleteTunnel` already toast in the store.
- Embedded servers: `saveEmbeddedServer` / `deleteEmbeddedServer` (callers toast).
- Workspaces: `saveWorkspaceToBackend` / `saveCurrentAsWorkspace` (callers toast).
- Agents: `connectRemoteAgent` (rethrows; surfaced by the agent header/AgentErrorTab).

## Out of scope (unchanged)

Pure load/detect/reload background reads and layout config/preset persistence (internal, high-frequency), as specified in the issue.

## Test plan

- New regression suite `src/store/appStore.silentActions.test.ts` (21 cases) mocks each underlying persist/command to reject and asserts a `toast.error` fires. Verified **red** against the unfixed store (21/21 fail) and **green** with the fix.
- Full frontend suite: 2966 passing.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check`: clean.
- testid catalog: up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)