### PR TITLE
test(system): deterministically shut down pyftpdlib FTP server to fix flaky teardown race (Closes #1477)

### DIFF
--- a/tests/system/tests/test_transfer_checkers.py
+++ b/tests/system/tests/test_transfer_checkers.py
@@ -82,7 +82,23 @@ def test_tftp_download_missing_file_raises(tmp_path: Path):
 
 @contextlib.contextmanager
 def _ftp_server(root: Path):
-    """Run a pyftpdlib FTP server (anonymous read) in a background thread."""
+    """Run a pyftpdlib FTP server (anonymous read) in a background thread.
+
+    The server thread must shut down **deterministically**, otherwise the run
+    intermittently fails with ``OSError: [Errno 9] Bad file descriptor`` — a
+    thread exception pytest surfaces as ``PytestUnhandledThreadExceptionWarning``
+    (see issue #1477). The race is calling :meth:`FTPServer.close_all` from the
+    main thread while the server thread is still inside ``ioloop.poll`` on the
+    same sockets: closing the fds out from under ``kqueue``/``epoll`` yields
+    ``EBADF``.
+
+    To avoid it we mirror pyftpdlib's own threaded test helper: the thread runs
+    ``serve_forever(blocking=False)`` in a loop gated by a stop event, and it is
+    the *thread itself* that calls ``close_all`` once the loop exits — so the
+    poll and the socket close never overlap. The main thread only sets the event
+    and :meth:`~threading.Thread.join`\\ s, guaranteeing the loop has returned
+    before the context exits.
+    """
     pyftpdlib = pytest.importorskip(
         "pyftpdlib", reason="pyftpdlib (test-only) not installed; ftp_download uses stdlib"
     )
@@ -96,14 +112,27 @@ def _ftp_server(root: Path):
     handler.authorizer = authorizer
     port = _free_port()
     server = FTPServer(("127.0.0.1", port), handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
+
+    stop = threading.Event()
+
+    def _run() -> None:
+        # Single-shot polling (blocking=False) lets us re-check the stop event
+        # each iteration; close_all() runs here, in the polling thread, so it can
+        # never race an in-flight poll on the just-closed sockets.
+        try:
+            while not stop.is_set():
+                server.serve_forever(timeout=0.1, blocking=False)
+        finally:
+            server.close_all()
+
+    thread = threading.Thread(target=_run, daemon=True)
     thread.start()
     time.sleep(0.3)
     try:
         yield port
     finally:
-        with contextlib.suppress(Exception):
-            server.close_all()
+        stop.set()
+        thread.join(timeout=5.0)
 
 
 def test_ftp_download_returns_file_bytes(tmp_path: Path):


### PR DESCRIPTION
## Problem

The machinery suite (`tests/system/pytest.sh -m "not integration"`) intermittently failed in `tests/system/tests/test_transfer_checkers.py::test_ftp_list_includes_file`. The `_ftp_server` helper started a `pyftpdlib` `FTPServer` in a daemon thread via `threading.Thread(target=server.serve_forever, ...)` and tore it down by calling `server.close_all()` **from the main thread** while the server thread was still inside `ioloop.poll` on the same sockets.

Closing the file descriptors out from under `kqueue`/`epoll` yields `OSError: [Errno 9] Bad file descriptor` inside the server thread. pytest surfaces the escaped thread exception as `PytestUnhandledThreadExceptionWarning` — benign on macOS/kqueue (test passes) but nondeterministically hard-fails on Linux CI. It flaked on unrelated PRs (e.g. #1475, which touches zero `tests/system/` files); a classic pre-existing flaky test on `develop`.

## Fix

Mirror pyftpdlib's own threaded test helper — eliminate the race rather than mute the warning:

- The server thread runs `serve_forever(timeout=0.1, blocking=False)` in a loop gated by a `threading.Event`.
- The thread **itself** calls `close_all()` once the loop exits (in a `finally`), so the poll and the socket close can never overlap.
- The main thread only sets the event and `thread.join(timeout=5.0)`s, guaranteeing `serve_forever` has returned before the context manager exits.

No poll ever runs against a closed socket, so no unhandled thread exception escapes. Test assertions are unchanged; no blanket warnings filter was added.

## Verification (all foreground, local macOS)

- **Reproduced first**: `pytest.sh -m "not integration" -k transfer_checkers -W error::pytest.PytestUnhandledThreadExceptionWarning` failed **15/15** times before the fix (`Exception in thread ... (serve_forever)`), with `test_ftp_list_includes_file` erroring.
- **After the fix**: the same warnings-as-errors loop passed **15/15** (now `5 passed`, previously `4 passed, 1 error`).
- **Full machinery suite** (`-m "not integration"`) run **5×**: all `190 passed`, **0** `PytestUnhandledThreadExceptionWarning` in every run.

This unblocks the flaky machinery failures seen across unrelated PRs (e.g. #1475).

🤖 Generated with [Claude Code](https://claude.com/claude-code)