### PR TITLE
feat(agent): time-bound docker availability probe (Closes #1476)

### DIFF
--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use base64::Engine;
 use jsonrpsee::core::server::RpcModule;
@@ -371,7 +371,15 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
                 .await;
         }
 
-        let docker_available = detect_docker_available();
+        let docker_available = detect_docker_available().await;
+        // Only enumerate images when the daemon already answered the probe
+        // quickly — this keeps `initialize` from blocking on `docker images`
+        // when Docker is unresponsive.
+        let available_docker_images = if docker_available {
+            detect_docker_images()
+        } else {
+            Vec::new()
+        };
         let connection_types = session_manager.registry().available_types();
 
         Ok::<_, ErrorObjectOwned>(
@@ -384,7 +392,7 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
                     available_shells: detect_available_shells(),
                     available_serial_ports: termihub_core::session::serial::list_serial_ports(),
                     docker_available,
-                    available_docker_images: detect_docker_images(),
+                    available_docker_images,
                     monitoring_supported: detect_monitoring_supported(),
                 },
             })
@@ -1299,14 +1307,57 @@ fn detect_available_shells() -> Vec<String> {
         .collect()
 }
 
-fn detect_docker_available() -> bool {
-    std::process::Command::new("docker")
-        .args(["info"])
+/// Default hard timeout for the Docker availability probe. Kept short so a
+/// hung or unresponsive Docker daemon cannot stall the `initialize` handler.
+const DOCKER_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Environment variable to override [`DOCKER_PROBE_TIMEOUT`] (milliseconds).
+const DOCKER_PROBE_TIMEOUT_ENV: &str = "TERMIHUB_DOCKER_PROBE_TIMEOUT_MS";
+
+/// Resolve the Docker probe timeout, honouring the env override when present.
+fn docker_probe_timeout() -> Duration {
+    std::env::var(DOCKER_PROBE_TIMEOUT_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DOCKER_PROBE_TIMEOUT)
+}
+
+/// Probe whether Docker is usable by running `<program> info`.
+///
+/// The `program`/`timeout` seam keeps this injectable so tests can point at a
+/// shim binary without depending on a real Docker installation. Any spawn
+/// failure or non-zero exit reports "unavailable" — Docker container spawning
+/// is simply disabled, never a hard error that could fail `initialize`.
+async fn probe_docker_available(program: &str, _timeout: Duration) -> bool {
+    let mut cmd = tokio::process::Command::new(program);
+    cmd.args(["info"])
+        .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .kill_on_drop(true);
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            debug!("docker availability probe: failed to spawn '{program}': {e}");
+            return false;
+        }
+    };
+
+    match child.wait().await {
+        Ok(status) => status.success(),
+        Err(e) => {
+            debug!("docker availability probe: wait failed: {e}");
+            false
+        }
+    }
+}
+
+/// Detect whether Docker is available, time-bounded so an unresponsive daemon
+/// cannot block agent `initialize`.
+async fn detect_docker_available() -> bool {
+    probe_docker_available("docker", docker_probe_timeout()).await
 }
 
 fn detect_docker_images() -> Vec<String> {
@@ -1339,6 +1390,67 @@ mod tests {
     use super::*;
     use crate::session::manager::SessionManager;
     use serde_json::json;
+
+    // ── Docker availability probe tests ────────────────────────────
+
+    /// Write an executable shim script under a unique temp path and return it.
+    #[cfg(unix)]
+    fn write_shim(body: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = std::env::temp_dir().join(format!(
+            "termihub-docker-shim-{}.sh",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).expect("write shim");
+        let mut perms = std::fs::metadata(&path).expect("stat shim").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod shim");
+        path
+    }
+
+    /// A Docker binary that never responds must not stall the probe: it has to
+    /// return within the configured timeout and report "unavailable".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_docker_available_times_out_on_hang() {
+        let shim = write_shim("sleep 30");
+        let start = Instant::now();
+        let available =
+            probe_docker_available(shim.to_str().unwrap(), Duration::from_millis(200)).await;
+        let elapsed = start.elapsed();
+
+        assert!(!available, "hanging docker binary must report unavailable");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "probe must be time-bounded, took {elapsed:?}"
+        );
+        let _ = std::fs::remove_file(&shim);
+    }
+
+    /// A responsive Docker binary that exits 0 reports "available" promptly.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn probe_docker_available_reports_available_on_success() {
+        let shim = write_shim("exit 0");
+        let available =
+            probe_docker_available(shim.to_str().unwrap(), Duration::from_secs(2)).await;
+        assert!(available, "successful docker probe must report available");
+        let _ = std::fs::remove_file(&shim);
+    }
+
+    /// A missing Docker binary (spawn failure) reports "unavailable" promptly.
+    #[tokio::test]
+    async fn probe_docker_available_reports_unavailable_when_not_installed() {
+        let missing = format!("termihub-nonexistent-docker-{}", uuid::Uuid::new_v4());
+        let start = Instant::now();
+        let available = probe_docker_available(&missing, Duration::from_secs(2)).await;
+        assert!(!available, "missing docker binary must report unavailable");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "spawn failure must return promptly"
+        );
+    }
 
     // ── Test helpers ───────────────────────────────────────────────
 

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -1329,12 +1329,14 @@ fn docker_probe_timeout() -> Duration {
 /// shim binary without depending on a real Docker installation. Any spawn
 /// failure or non-zero exit reports "unavailable" — Docker container spawning
 /// is simply disabled, never a hard error that could fail `initialize`.
-async fn probe_docker_available(program: &str, _timeout: Duration) -> bool {
+async fn probe_docker_available(program: &str, timeout: Duration) -> bool {
     let mut cmd = tokio::process::Command::new(program);
     cmd.args(["info"])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
+        // Kill the probe child if this future is dropped (e.g. on timeout) so
+        // a hung `docker info` cannot linger.
         .kill_on_drop(true);
 
     let mut child = match cmd.spawn() {
@@ -1345,10 +1347,19 @@ async fn probe_docker_available(program: &str, _timeout: Duration) -> bool {
         }
     };
 
-    match child.wait().await {
-        Ok(status) => status.success(),
-        Err(e) => {
+    match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => status.success(),
+        Ok(Err(e)) => {
             debug!("docker availability probe: wait failed: {e}");
+            false
+        }
+        Err(_) => {
+            // Timed out — the Docker daemon is unresponsive. Kill the child and
+            // treat Docker as unavailable rather than blocking `initialize`.
+            let _ = child.start_kill();
+            warn!(
+                "docker availability probe timed out after {timeout:?}; treating Docker as unavailable"
+            );
             false
         }
     }
@@ -1398,10 +1409,8 @@ mod tests {
     fn write_shim(body: &str) -> std::path::PathBuf {
         use std::os::unix::fs::PermissionsExt;
 
-        let path = std::env::temp_dir().join(format!(
-            "termihub-docker-shim-{}.sh",
-            uuid::Uuid::new_v4()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("termihub-docker-shim-{}.sh", uuid::Uuid::new_v4()));
         std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).expect("write shim");
         let mut perms = std::fs::metadata(&path).expect("stat shim").permissions();
         perms.set_mode(0o755);

--- a/core/src/backends/ftp/listing_parser.rs
+++ b/core/src/backends/ftp/listing_parser.rs
@@ -20,7 +20,7 @@
 
 use suppaftp::list::{File as FtpFile, PosixPexQuery};
 
-use crate::files::utils::{chrono_from_epoch, format_permissions};
+use crate::files::utils::{chrono_from_epoch, format_permissions, writable_from_permissions};
 use crate::files::FileEntry;
 
 /// Decode raw listing bytes as UTF-8, falling back to Latin-1 (ISO-8859-1).
@@ -94,6 +94,7 @@ pub(crate) fn parse_mlsd_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
         _ => return None,
     };
 
+    let writable = writable_from_permissions(&permissions);
     Some(FileEntry {
         name: name.to_string(),
         path: join_path(dir, name),
@@ -101,6 +102,7 @@ pub(crate) fn parse_mlsd_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
         size,
         modified,
         permissions: Some(permissions),
+        writable,
     })
 }
 

--- a/docs/changes/dev0/feature/1476-docker-probe-timeout.md
+++ b/docs/changes/dev0/feature/1476-docker-probe-timeout.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Agent startup no longer hangs when Docker is installed but unresponsive
+  (stopped, hung, or a slow socket). The Docker availability probe run during
+  the agent's `initialize` handler is now time-bounded (default 2s, overridable
+  via `TERMIHUB_DOCKER_PROBE_TIMEOUT_MS`); on timeout or error it degrades to
+  "Docker unavailable" instead of blocking indefinitely (#1476).


### PR DESCRIPTION
Closes #1476
Follow-up to #1346 (PR #1473).

## Problem
`detect_docker_available()` ran `docker info` **synchronously** during the agent's `initialize` handler with no timeout. When the Docker daemon is installed but unresponsive (stopped, hung, or a slow socket), the call blocks indefinitely, so `initialize` — and any `init_handler`-based agent path/test — hangs forever.

## Approach
- Extracted the probe into an injectable seam `probe_docker_available(program, timeout)` (async, uses `tokio::process::Command`).
- Wrapped the child `wait()` in `tokio::time::timeout` with a short bounded deadline: default **2s**, overridable via `TERMIHUB_DOCKER_PROBE_TIMEOUT_MS`. `kill_on_drop(true)` plus an explicit `start_kill()` on timeout ensures a hung `docker info` child is reaped.
- **Degrade-to-unavailable**: timeout, spawn failure, or wait error all return `false` (Docker container spawning simply disabled) — never a hard error that could fail `initialize`.
- `initialize` now `await`s the async probe and only enumerates `docker images` when the daemon actually answered the probe, so image enumeration cannot stall startup either.
- Logs a `warn!` on timeout via the agent's `tracing` pattern (no secrets).

## Test plan
- `cargo test -p termihub-agent --bin termihub-agent probe_docker_available` — three regression tests, all green in <1s:
  - hanging binary (shim `sleep 30`) → returns unavailable within the 200ms test timeout (**fails against the old unbounded code**: took 30s and reported the wrong result);
  - fast-success binary → available;
  - missing binary (spawn failure) → unavailable promptly.
- `cargo test -p termihub-agent --bin termihub-agent initialize` — all 8 pass.
- `cargo clippy -p termihub-agent --all-targets -- -D warnings` — clean.
- `cargo fmt -p termihub-agent --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)