### PR TITLE
feat(sftp): derive FileEntry.writable in SSH and FTP browsers

### DIFF
--- a/core/src/backends/ftp/listing_parser.rs
+++ b/core/src/backends/ftp/listing_parser.rs
@@ -20,7 +20,7 @@
 
 use suppaftp::list::{File as FtpFile, PosixPexQuery};
 
-use crate::files::utils::{chrono_from_epoch, format_permissions};
+use crate::files::utils::{chrono_from_epoch, format_permissions, writable_from_permissions};
 use crate::files::FileEntry;
 
 /// Decode raw listing bytes as UTF-8, falling back to Latin-1 (ISO-8859-1).
@@ -94,6 +94,7 @@ pub(crate) fn parse_mlsd_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
         _ => return None,
     };
 
+    let writable = writable_from_permissions(&permissions);
     Some(FileEntry {
         name: name.to_string(),
         path: join_path(dir, name),
@@ -101,6 +102,7 @@ pub(crate) fn parse_mlsd_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
         size,
         modified,
         permissions: Some(permissions),
+        writable,
     })
 }
 
@@ -206,15 +208,18 @@ fn join_path(dir: &str, name: &str) -> String {
 /// `with_perms` controls whether a permission string is attached: POSIX and
 /// MLSD lines carry meaningful permissions, whereas DOS listings do not.
 fn entry_from_file(file: &FtpFile, dir: &str, with_perms: bool) -> FileEntry {
+    // POSIX/MLSD lines carry a permission string we can derive writability from;
+    // DOS lines carry none, so `writable` stays `None` there.
+    let permissions = with_perms.then(|| perms_string(file));
+    let writable = permissions.as_deref().and_then(writable_from_permissions);
     FileEntry {
         name: file.name().to_string(),
         path: join_path(dir, file.name()),
         is_directory: file.is_directory(),
         size: file.size() as u64,
         modified: modified_iso(file),
-        permissions: with_perms.then(|| perms_string(file)),
-        // Writability is derived only for the desktop SFTP browser (#1324).
-        writable: None,
+        permissions,
+        writable,
     }
 }
 

--- a/core/src/backends/ftp/listing_parser.rs
+++ b/core/src/backends/ftp/listing_parser.rs
@@ -234,6 +234,8 @@ mod tests {
         modified: &'static str,
         /// Expected permission string, or `None`.
         perms: Option<&'static str>,
+        /// Expected writability hint derived from `perms`.
+        writable: Option<bool>,
     }
 
     const DIR: &str = "/pub";
@@ -256,6 +258,7 @@ mod tests {
                     case.perms,
                     "permissions for {expected}"
                 );
+                assert_eq!(e.writable, case.writable, "writable for {expected}");
             }
         }
     }
@@ -271,6 +274,7 @@ mod tests {
                 size: 4096,
                 modified: "2018-11-05T00:00:00Z",
                 perms: Some("rwxrwxr-x"),
+                writable: Some(true),
             },
             // Regular file.
             Case {
@@ -280,6 +284,7 @@ mod tests {
                 size: 1337,
                 modified: "2018-03-18T00:00:00Z",
                 perms: Some("rw-r--r--"),
+                writable: Some(true),
             },
             // Name containing spaces.
             Case {
@@ -289,6 +294,7 @@ mod tests {
                 size: 1234567,
                 modified: "2000-01-01T00:00:00Z",
                 perms: Some("r--r--r--"),
+                writable: Some(false),
             },
             // Symlink: the "-> target" suffix is stripped from the name and the
             // entry is not a directory.
@@ -299,6 +305,7 @@ mod tests {
                 size: 7,
                 modified: "2018-11-05T00:00:00Z",
                 perms: Some("rwxrwxrwx"),
+                writable: Some(true),
             },
             // "total" summary line and junk are skipped.
             Case {
@@ -308,6 +315,7 @@ mod tests {
                 size: 0,
                 modified: "",
                 perms: None,
+                writable: None,
             },
             Case {
                 line: b"this is not a listing line",
@@ -316,6 +324,7 @@ mod tests {
                 size: 0,
                 modified: "",
                 perms: None,
+                writable: None,
             },
         ];
         for case in &cases {
@@ -334,6 +343,7 @@ mod tests {
                 size: 0,
                 modified: "2014-04-08T15:09:00Z",
                 perms: None,
+                writable: None,
             },
             // Regular file with a size.
             Case {
@@ -343,6 +353,7 @@ mod tests {
                 size: 8192,
                 modified: "2014-04-08T15:09:00Z",
                 perms: None,
+                writable: None,
             },
             // Malformed date → skipped.
             Case {
@@ -352,6 +363,7 @@ mod tests {
                 size: 0,
                 modified: "",
                 perms: None,
+                writable: None,
             },
         ];
         for case in &cases {
@@ -370,6 +382,7 @@ mod tests {
                 size: 8192,
                 modified: "2018-11-05T16:32:48Z",
                 perms: Some("rwxrwxrwx"),
+                writable: Some(true),
             },
             // Directory.
             Case {
@@ -379,6 +392,7 @@ mod tests {
                 size: 4096,
                 modified: "2018-11-05T16:32:48Z",
                 perms: Some("rwxrwxrwx"),
+                writable: Some(true),
             },
             // File carrying an explicit unix.mode fact.
             Case {
@@ -388,6 +402,17 @@ mod tests {
                 size: 4096,
                 modified: "2018-11-05T16:32:48Z",
                 perms: Some("rw-r--r--"),
+                writable: Some(true),
+            },
+            // Read-only file (unix.mode=444) → no class may write.
+            Case {
+                line: b"type=file;size=4096;modify=20181105163248;unix.mode=444; readonly.bin",
+                name: Some("readonly.bin"),
+                is_dir: false,
+                size: 4096,
+                modified: "2018-11-05T16:32:48Z",
+                perms: Some("r--r--r--"),
+                writable: Some(false),
             },
             // Symlink (type=link) → not a directory.
             Case {
@@ -397,6 +422,7 @@ mod tests {
                 size: 0,
                 modified: "2018-11-05T16:32:48Z",
                 perms: Some("rwxrwxrwx"),
+                writable: Some(true),
             },
             // Unknown type → malformed, skipped.
             Case {
@@ -406,6 +432,7 @@ mod tests {
                 size: 0,
                 modified: "",
                 perms: None,
+                writable: None,
             },
             // Empty line → skipped.
             Case {
@@ -415,6 +442,7 @@ mod tests {
                 size: 0,
                 modified: "",
                 perms: None,
+                writable: None,
             },
         ];
         for case in &cases {
@@ -437,6 +465,7 @@ mod tests {
                 size: 0,
                 modified: "",
                 perms: None,
+                writable: None,
             },
             // Parent entry (pdir) → skipped like `..`.
             Case {
@@ -446,6 +475,7 @@ mod tests {
                 size: 0,
                 modified: "",
                 perms: None,
+                writable: None,
             },
             // Directory with a four-digit UNIX.mode.
             Case {
@@ -455,6 +485,7 @@ mod tests {
                 size: 0,
                 modified: "2026-07-12T22:07:26Z",
                 perms: Some("rwxr-xr-x"),
+                writable: Some(true),
             },
             // Regular file with size + four-digit UNIX.mode.
             Case {
@@ -464,6 +495,7 @@ mod tests {
                 size: 61,
                 modified: "2026-07-12T22:07:26Z",
                 perms: Some("rw-r--r--"),
+                writable: Some(true),
             },
             // MLST (single-entry) echoes the full pathname as the name; it must
             // be reduced to the base name (DIR here is the entry's parent).
@@ -474,6 +506,7 @@ mod tests {
                 size: 61,
                 modified: "2026-07-12T22:07:26Z",
                 perms: Some("rw-r--r--"),
+                writable: Some(true),
             },
         ];
         for case in &cases {

--- a/core/src/backends/ssh/file_browser.rs
+++ b/core/src/backends/ssh/file_browser.rs
@@ -11,11 +11,20 @@ use tokio::sync::Mutex;
 
 use crate::config::SshConfig;
 use crate::errors::FileError;
-use crate::files::utils::{chrono_from_epoch, format_permissions};
+use crate::files::utils::{chrono_from_epoch, format_permissions, writable_from_permissions};
 use crate::files::{FileBrowser, FileEntry};
 
 use super::handler::SshSession;
 use super::jump_host::{connect_target, GatewayHold};
+
+/// Derive the [`FileEntry::writable`] hint from an optional 9-char permission
+/// string, mirroring the desktop SFTP browser (#1324, #1482).
+///
+/// Returns `None` when no permission string is available; otherwise defers to
+/// [`writable_from_permissions`] (the cheap, conservative layer).
+fn writable_hint(permissions: Option<&str>) -> Option<bool> {
+    permissions.and_then(writable_from_permissions)
+}
 
 /// State of a connected SFTP session.
 struct SftpState {
@@ -105,6 +114,8 @@ impl FileBrowser for SftpFileBrowser {
             }
             let meta = entry.metadata();
             let full_path = format!("{}/{}", path.trim_end_matches('/'), name);
+            let permissions = meta.permissions.map(format_permissions);
+            let writable = writable_hint(permissions.as_deref());
             result.push(FileEntry {
                 name,
                 path: full_path,
@@ -114,9 +125,8 @@ impl FileBrowser for SftpFileBrowser {
                     .mtime
                     .map(|t| chrono_from_epoch(t as u64))
                     .unwrap_or_default(),
-                permissions: meta.permissions.map(format_permissions),
-                // Writability is derived only for the desktop SFTP browser (#1324).
-                writable: None,
+                permissions,
+                writable,
             });
         }
         Ok(result)
@@ -244,6 +254,8 @@ impl FileBrowser for SftpFileBrowser {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
 
+        let permissions = meta.permissions.map(format_permissions);
+        let writable = writable_hint(permissions.as_deref());
         Ok(FileEntry {
             name,
             path: path.to_string(),
@@ -253,9 +265,8 @@ impl FileBrowser for SftpFileBrowser {
                 .mtime
                 .map(|t| chrono_from_epoch(t as u64))
                 .unwrap_or_default(),
-            permissions: meta.permissions.map(format_permissions),
-            // Writability is derived only for the desktop SFTP browser (#1324).
-            writable: None,
+            permissions,
+            writable,
         })
     }
 }

--- a/core/src/backends/ssh/file_browser.rs
+++ b/core/src/backends/ssh/file_browser.rs
@@ -259,3 +259,26 @@ impl FileBrowser for SftpFileBrowser {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::writable_hint;
+
+    #[test]
+    fn writable_hint_none_without_permissions() {
+        assert_eq!(writable_hint(None), None);
+    }
+
+    #[test]
+    fn writable_hint_true_when_any_class_writable() {
+        // Owner-only write (typical `rw-r--r--`) still counts as writable.
+        assert_eq!(writable_hint(Some("rw-r--r--")), Some(true));
+        assert_eq!(writable_hint(Some("rwxr-xr-x")), Some(true));
+    }
+
+    #[test]
+    fn writable_hint_false_when_no_class_writable() {
+        assert_eq!(writable_hint(Some("r--r--r--")), Some(false));
+        assert_eq!(writable_hint(Some("r-xr-xr-x")), Some(false));
+    }
+}


### PR DESCRIPTION
Closes #1482
Follow-up to #1324 (PR #1478).

## Summary

#1324 added `FileEntry.writable: Option<bool>` and `writable_from_permissions()` but only populated a real value in the desktop SFTP browser. This wires the same cheap derivation into the remaining browsers that already carry a permission string:

- **SSH file browser** (`core/src/backends/ssh/file_browser.rs`, `list_dir` + `stat`): the SFTP 9-char permission string is run through `writable_from_permissions()` via a small, testable `writable_hint()` helper.
- **FTP listing parser** (`core/src/backends/ftp/listing_parser.rs`): `parse_mlsd_line` and `entry_from_file` derive `writable` for Unix `ls -l` and MLSD entries. **DOS listings carry no permission string, so `writable` stays `None`**; the synthesized FTP root `stat` (no perms) likewise keeps `None`.

An **authoritative write-probe** for SSH/FTP (analogous to SFTP's `check_writable`) is intentionally **deferred** — out of scope here; this is the cheap permission-string layer only. No behavior change to the direct-write path.

### Incidental fix

The `ftp` feature no longer builds on `develop`: #1324 added the `writable` field but missed the ProFTPD MLSD construction site introduced in #1456, so `parse_mlsd_line` was missing the field. This PR completes that site, restoring `cargo build -p termihub-core --features ftp`.

## Test plan

- `cargo test -p termihub-core --features ssh,ftp --lib` — 578 passed. New/extended coverage:
  - FTP listing-parser table tests assert `writable` = `Some(true)`/`Some(false)` for Unix & MLSD entries (incl. a new `unix.mode=444` read-only MLSD case) and `None` for DOS listings.
  - SSH `writable_hint` unit tests (`None` without perms, `Some(true)`/`Some(false)` by class).
- `cargo build -p termihub-core` (default) and `--features ssh,ftp` — both clean.
- `cargo clippy -p termihub-core --all-targets -- -D warnings` and `--features ssh,ftp` — both clean.
- `cargo fmt` clean.

No change fragment: backend-only refinement with no user-visible surface yet (the badge/banner lands via #1325).

🤖 Generated with [Claude Code](https://claude.com/claude-code)