### PR TITLE
feat(sftp): read-only badge + banner in FileEditor

### DIFF
--- a/docs/changes/dev0/feature/1325-fileeditor-readonly-badge.md
+++ b/docs/changes/dev0/feature/1325-fileeditor-readonly-badge.md
@@ -1,0 +1,10 @@
+### Added
+
+- File editor now surfaces when a remote (SFTP) file is read-only: opening a
+  file you have no write access to shows a **Read-only** lock badge next to the
+  Remote badge (its tooltip shows the file's permission string) plus a
+  dismissible info banner above the editor. Detection is driven by a
+  non-destructive SFTP write-open probe, so it catches the owner-mismatch case
+  the cheap permission hint cannot. This is detection only — direct save
+  behaviour for writable files is unchanged; an elevated "save a copy" fallback
+  lands in a later update (#1325, epic #1323).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1171,7 +1171,7 @@ incompatible = error/red, updating = accent/blue.
 ### File editor read-only badge + banner (#1325)
 
 Verifies a read-only remote (SFTP) file surfaces its state in the editor.
-Detection only — no elevated save is offered. See PR for #1325.
+Detection only — no elevated save is offered. See PR #1486 (#1325).
 
 1. On a remote (SSH/SFTP) connection, browse to a file the connecting user
    **cannot** write (e.g. a root-owned `/etc/…` file, or `chmod 400`/`chown` a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1168,6 +1168,27 @@ incompatible = error/red, updating = accent/blue.
    amber `· M updates available` count shows and clicking the item opens the
    Connections sidebar.
 
+### File editor read-only badge + banner (#1325)
+
+Verifies a read-only remote (SFTP) file surfaces its state in the editor.
+Detection only — no elevated save is offered. See PR for #1325.
+
+1. On a remote (SSH/SFTP) connection, browse to a file the connecting user
+   **cannot** write (e.g. a root-owned `/etc/…` file, or `chmod 400`/`chown` a
+   file to another user). Right-click → **Edit** to open it in the editor.
+2. Confirm a **Read-only** lock badge appears in the toolbar next to the
+   **Remote** badge, and a warning-colored info banner appears above the editor
+   explaining the file is read-only. Hover the badge — the tooltip shows the
+   file's permission string (e.g. `-rw-r--r--`).
+3. Click the banner's dismiss (×) control → the banner disappears while the
+   Read-only badge **remains** (the badge is a persistent state indicator).
+4. Open a **writable** remote file (one you own with write permission) → neither
+   the badge nor the banner appears, and Save works as before.
+5. Open a **local** file → neither the badge nor the banner appears (no probe is
+   performed for local files).
+6. Toggle light/dark themes (Settings → Appearance) with a read-only file open →
+   the badge and banner stay legible in both themes.
+
 ### Guided-Manual Tests in the Python Harness (preferred)
 
 Guided-manual tests are **first-class `pytest` tests** in the Python system-test harness (`tests/system/`). Each one does all the automatable setup through the existing mixins — launch the app, build connections/state — and then prompts the operator for only the irreducibly-manual step (a native OS dialog, xterm-canvas color fidelity, cursor blink). This is the key difference from the legacy YAML runner: the operator does just the un-automatable bit, and the test shares the harness's app/agent orchestration, fixtures, and reporting.

--- a/src/components/FileEditor/FileEditor.css
+++ b/src/components/FileEditor/FileEditor.css
@@ -40,6 +40,16 @@
   border-radius: var(--radius-sm);
 }
 
+/*
+ * Read-only badge: shares the remote-badge box (see composed class list in the
+ * markup) and only recolors it to the warning token. Signals that the
+ * connecting user has no write access to the remote file. (issue 1325)
+ */
+.file-editor__readonly-badge {
+  color: var(--color-warning);
+  border-color: var(--color-warning);
+}
+
 .file-editor__filepath {
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
@@ -84,6 +94,27 @@
 }
 
 .file-editor__save-error-text {
+  flex: 1;
+  min-width: 0;
+}
+
+/*
+ * Dismissible read-only notice banner. Mirrors the save-error banner structure
+ * but is warning-colored (informational, not a failure). Tokens only; the tint
+ * is derived from the warning token via color-mix rather than a raw rgba. (issue 1325)
+ */
+.file-editor__readonly-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background-color: color-mix(in srgb, var(--color-warning) 12%, var(--bg-secondary));
+  border-bottom: 1px solid var(--color-warning);
+  color: var(--color-warning);
+  font-size: var(--font-size-sm);
+}
+
+.file-editor__readonly-banner-text {
   flex: 1;
   min-width: 0;
 }

--- a/src/components/FileEditor/FileEditor.test.tsx
+++ b/src/components/FileEditor/FileEditor.test.tsx
@@ -239,6 +239,100 @@ describe("FileEditor — close while in error state (#971)", () => {
   });
 });
 
+describe("FileEditor — read-only badge + banner (#1325)", () => {
+  const REMOTE_RO_META: EditorTabMeta = {
+    filePath: "/etc/hosts",
+    isRemote: true,
+    sftpSessionId: "sftp-sess-1",
+    permissions: "-rw-r--r--",
+  };
+  const LOCAL_META: EditorTabMeta = {
+    filePath: "/tmp/local.txt",
+    isRemote: false,
+  };
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  function mockWritability(result: "writable" | "readOnly" | "unknown"): void {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "sftp_read_file_content") return Promise.resolve("127.0.0.1 localhost\n");
+      if (cmd === "local_read_file") return Promise.resolve("local body\n");
+      if (cmd === "sftp_check_writable") return Promise.resolve(result);
+      return Promise.resolve(undefined);
+    });
+  }
+
+  it("renders the badge + banner and shows the parsed permissions in the tooltip", async () => {
+    mockWritability("readOnly");
+    render(REMOTE_RO_META);
+    await flush();
+
+    const badge = query("file-editor-readonly-badge");
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute("title") ?? "").toContain("rw-r--r--");
+    expect(query("file-editor-readonly-banner")).not.toBeNull();
+  });
+
+  it("dismisses the banner while keeping the badge", async () => {
+    mockWritability("readOnly");
+    render(REMOTE_RO_META);
+    await flush();
+
+    expect(query("file-editor-readonly-banner")).not.toBeNull();
+    await act(async () => {
+      (query("file-editor-readonly-banner-dismiss") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(query("file-editor-readonly-banner")).toBeNull();
+    // The badge is a persistent state indicator and stays after dismissal.
+    expect(query("file-editor-readonly-badge")).not.toBeNull();
+  });
+
+  it("shows neither badge nor banner for a writable remote file", async () => {
+    mockWritability("writable");
+    render(REMOTE_RO_META);
+    await flush();
+
+    expect(query("file-editor-readonly-badge")).toBeNull();
+    expect(query("file-editor-readonly-banner")).toBeNull();
+  });
+
+  it("shows neither badge nor banner when writability is unknown", async () => {
+    mockWritability("unknown");
+    render(REMOTE_RO_META);
+    await flush();
+
+    expect(query("file-editor-readonly-badge")).toBeNull();
+    expect(query("file-editor-readonly-banner")).toBeNull();
+  });
+
+  it("does not probe writability for a local file and renders no badge/banner", async () => {
+    mockWritability("readOnly");
+    render(LOCAL_META);
+    await flush();
+
+    const probed = mockedInvoke.mock.calls.some(([cmd]) => cmd === "sftp_check_writable");
+    expect(probed).toBe(false);
+    expect(query("file-editor-readonly-badge")).toBeNull();
+    expect(query("file-editor-readonly-banner")).toBeNull();
+  });
+});
+
 describe("FileEditor — toolbar composes shared UI primitives (#1358)", () => {
   beforeEach(() => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
-import { Save, Loader2, AlertCircle, Globe, FileEdit, X } from "lucide-react";
+import { Save, Loader2, AlertCircle, Globe, FileEdit, Lock, X } from "lucide-react";
 import { Button } from "@/components/ui";
 import { save } from "@tauri-apps/plugin-dialog";
 import { EditorTabMeta, EditorStatus } from "@/types/terminal";
@@ -17,6 +17,7 @@ import {
   sftpReadFileContent,
   sftpWriteFileContent,
   sftpHasExecCapability,
+  sftpCheckWritable,
 } from "@/services/api";
 import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
 import { frontendLog } from "@/utils/frontendLog";
@@ -106,6 +107,16 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // future privilege-elevated ("save with sudo") writes, which need a shell to
   // run `sudo`. `false` for local files and SFTP-only connections.
   const [execCapable, setExecCapable] = useState(false);
+
+  // Authoritative writability of the remote file, from a non-destructive SFTP
+  // write-open probe (#1324/#1325): `false` = read-only (server denied the
+  // write-open), `true` = writable, `"unknown"` = probe inconclusive. Only
+  // `false` surfaces the read-only badge/banner; `true`/`"unknown"` leave the
+  // direct-save path untouched. Local files stay `"unknown"` (never probed).
+  const [writable, setWritable] = useState<boolean | "unknown">("unknown");
+  // Whether the user has dismissed the read-only notice banner. The badge is a
+  // persistent state indicator; only the banner is dismissible.
+  const [readonlyBannerDismissed, setReadonlyBannerDismissed] = useState(false);
 
   const saveRef = useRef<() => void>(() => {});
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
@@ -208,6 +219,41 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       cancelled = true;
     };
   }, [meta.isRemote, meta.sftpSessionId]);
+
+  // Probe the connecting user's actual write access to this remote file, in
+  // parallel with the content read (it never blocks the load; a failure just
+  // degrades to "unknown" so no badge is shown). Only a definitive read-only
+  // result surfaces the badge/banner — detection only, no elevated save. (#1325)
+  useEffect(() => {
+    let cancelled = false;
+    setReadonlyBannerDismissed(false);
+    if (!meta.isRemote || !meta.sftpSessionId || meta.scratch) {
+      setWritable("unknown");
+      return;
+    }
+    const sessionId = meta.sftpSessionId;
+    const filePath = meta.filePath;
+    sftpCheckWritable(sessionId, filePath)
+      .then((result) => {
+        if (cancelled) return;
+        const mapped = result === "readOnly" ? false : result === "writable" ? true : "unknown";
+        setWritable(mapped);
+        frontendLog("file_editor", `writability for ${filePath}: ${result}`);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setWritable("unknown");
+        frontendLog(
+          "file_editor",
+          `writability probe failed for ${filePath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [meta.isRemote, meta.sftpSessionId, meta.filePath, meta.scratch]);
 
   // An unsaved scratch buffer has no on-disk copy, so it is always considered
   // dirty (closing it would lose the captured content) until saved via Save As.
@@ -443,6 +489,20 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
               Remote
             </span>
           )}
+          {writable === false && (
+            <span
+              className="file-editor__remote-badge file-editor__readonly-badge"
+              data-testid="file-editor-readonly-badge"
+              title={
+                meta.permissions
+                  ? `Read-only (${meta.permissions})`
+                  : "Read-only — you don't have write access to this file"
+              }
+            >
+              <Lock size={12} />
+              Read-only
+            </span>
+          )}
           {isUnsavedScratch && (
             <span className="file-editor__remote-badge" data-testid="file-editor-scratch-badge">
               <FileEdit size={12} />
@@ -467,6 +527,29 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
           {isUnsavedScratch ? "Save As..." : "Save"}
         </Button>
       </div>
+      {writable === false && !readonlyBannerDismissed && (
+        <div
+          className="file-editor__readonly-banner"
+          role="status"
+          data-testid="file-editor-readonly-banner"
+        >
+          <Lock size={14} />
+          <span className="file-editor__readonly-banner-text">
+            This file is read-only — you don&apos;t have permission to write to it. Saving directly
+            will fail; a read-only fallback (save a copy) will be offered in a later update.
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            icon={<X size={14} />}
+            onClick={() => setReadonlyBannerDismissed(true)}
+            title="Dismiss"
+            aria-label="Dismiss read-only notice"
+            data-testid="file-editor-readonly-banner-dismiss"
+          />
+        </div>
+      )}
       {saveError && (
         <div className="file-editor__save-error" role="alert" data-testid="file-editor-save-error">
           <AlertCircle size={14} />

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -943,7 +943,8 @@ export function FileBrowser() {
               .openEditorTab(
                 entry.path,
                 mode === "sftp",
-                mode === "sftp" ? (sftpSessionId ?? undefined) : undefined
+                mode === "sftp" ? (sftpSessionId ?? undefined) : undefined,
+                mode === "sftp" ? entry.permissions : undefined
               );
           }
           // session mode: file editing via editor not yet supported for agent sessions

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -18,6 +18,7 @@ import {
   ConnectionFolder,
   ConnectionTypeInfo,
   FileEntry,
+  Writability,
   ExternalFileError,
   AppSettings,
   ShellIntegrationStatus,
@@ -804,6 +805,23 @@ export async function sftpWriteFileContent(
  */
 export async function sftpHasExecCapability(sessionId: string): Promise<boolean> {
   return await invoke<boolean>("sftp_has_exec_capability", { sessionId });
+}
+
+/**
+ * Probe whether the connecting user can actually open a specific remote file
+ * for writing, via a non-destructive SFTP write-open probe (issue #1324).
+ *
+ * Returns `"writable"` / `"readOnly"` / `"unknown"`; the probe never modifies
+ * the file. `"unknown"` means the check was inconclusive — the caller treats it
+ * as writable and attempts the save so a false negative never blocks editing.
+ * This catches the owner-mismatch case the cheap `FileEntry.writable` hint
+ * cannot detect.
+ */
+export async function sftpCheckWritable(
+  sessionId: string,
+  remotePath: string
+): Promise<Writability> {
+  return await invoke<Writability>("sftp_check_writable", { sessionId, remotePath });
 }
 
 // --- Session-based file browsing commands ---

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -398,7 +398,12 @@ interface AppState {
   ) => void;
   httpMonitors: HttpMonitorState[];
   setHttpMonitors: (monitors: HttpMonitorState[]) => void;
-  openEditorTab: (filePath: string, isRemote: boolean, sftpSessionId?: string) => void;
+  openEditorTab: (
+    filePath: string,
+    isRemote: boolean,
+    sftpSessionId?: string,
+    permissions?: string | null
+  ) => void;
   /**
    * Open a new "scratch" editor tab seeded with in-memory content that is not
    * backed by a file on disk (e.g. captured terminal output). The tab is
@@ -2189,7 +2194,7 @@ export const useAppStore = create<AppState>((set, get) => {
         return { rootPanel, activePanelId: targetPanelId };
       }),
 
-    openEditorTab: (filePath, isRemote, sftpSessionId) =>
+    openEditorTab: (filePath, isRemote, sftpSessionId, permissions) =>
       set((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
@@ -2225,7 +2230,7 @@ export const useAppStore = create<AppState>((set, get) => {
 
         const fileName = filePath.split("/").pop() ?? filePath;
         const dummyConfig: ConnectionConfig = { type: "local", config: { shell: "zsh" } };
-        const editorMeta: EditorTabMeta = { filePath, isRemote, sftpSessionId };
+        const editorMeta: EditorTabMeta = { filePath, isRemote, sftpSessionId, permissions };
         const newTab = createTab(fileName, "local", dummyConfig, targetPanelId, "editor");
         newTab.editorMeta = editorMeta;
 

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -521,3 +521,14 @@ export interface FileEntry {
    */
   writable: boolean | null;
 }
+
+/**
+ * Authoritative writability of a specific remote file, decided by a
+ * non-destructive SFTP write-open probe (`sftp_check_writable`, #1324).
+ *
+ * - `"writable"` — the file could be opened for writing.
+ * - `"readOnly"` — the server denied the write-open with `PERMISSION_DENIED`.
+ * - `"unknown"` — the probe was inconclusive; callers treat it as writable and
+ *   attempt the save so a false negative never blocks editing.
+ */
+export type Writability = "writable" | "readOnly" | "unknown";

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -37,6 +37,13 @@ export interface EditorTabMeta {
   isRemote: boolean;
   sftpSessionId?: string;
   /**
+   * Unix permission string (e.g. `-rw-r--r--`) for a remote file, captured from
+   * the file-browser listing when the editor was opened. Surfaced in the
+   * read-only badge tooltip; `null`/absent when unknown (local files or a
+   * backend that does not report permissions). (#1325)
+   */
+  permissions?: string | null;
+  /**
    * When true, the editor is a "scratch" buffer seeded from in-memory content
    * ({@link scratchContent}) instead of being read from disk. Used e.g. to open
    * captured terminal output in an editor that is not yet saved to a file.

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -195,6 +195,9 @@ Fixed strings — match exactly.
 | `file-browser-up` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-upload` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-editor-error` | `src/components/FileEditor/FileEditor.tsx` |
+| `file-editor-readonly-badge` | `src/components/FileEditor/FileEditor.tsx` |
+| `file-editor-readonly-banner` | `src/components/FileEditor/FileEditor.tsx` |
+| `file-editor-readonly-banner-dismiss` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-remote-badge` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-save` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-save-error` | `src/components/FileEditor/FileEditor.tsx` |


### PR DESCRIPTION
Closes #1325
Part of Epic #1323 · Concept #970 (`docs/concepts/backlog/elevated-sftp-editing.html`)

## Summary

Surfaces read-only state for remote (SFTP) files in the built-in file editor.
On load, the editor probes the connecting user's *actual* write access via the
non-destructive `sftp_check_writable` command (added in SI-1 / #1324), running
in parallel with the content read. A definitive read-only result renders:

- a warning-colored **Read-only** lock badge beside the Remote badge, whose
  tooltip shows the file's permission string (e.g. `-rw-r--r--`), and
- a dismissible warning-colored info banner above the editor (mirrors the
  existing `.file-editor__save-error` structure). Dismissing the banner keeps
  the badge — the badge is a persistent state indicator.

The permission string is threaded from the file-browser listing into
`EditorTabMeta`, so no extra round-trip is needed for the tooltip. New
`sftpCheckWritable` wrapper in `api.ts` and a `Writability` type. New CSS uses
design tokens only (`--color-warning` + a `color-mix` tint — no raw hex/rgba).

## Out of scope (detection only)

No "Edit with sudo" affordance, no elevated save, no SFTP-only "Save a copy"
action wiring (SI-6/SI-7). The banner copy *mentions* the future fallback but
wires no action. **Direct-save behaviour for writable/unknown files is
byte-for-byte unchanged**, and the probe never blocks the content load — a
probe failure degrades to "unknown" (no badge/banner).

## Test plan

- **Unit (Vitest):** `FileEditor` renders badge+banner when the probe returns
  `readOnly` (tooltip shows the permission string), dismiss hides the banner
  while the badge persists, and `writable`/`unknown` remote files plus local
  files render neither and skip the probe (`sftp_check_writable` not invoked).
  Full suite green (2986 tests); token-discipline guard green.
- **Manual (macOS):** documented in `docs/testing.md` — open a read-only remote
  file → badge + banner + permission tooltip; dismiss the banner; a writable
  file and a local file show neither; legible in light/dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)