### PR TITLE
feat(ui): discoverable keyboard-shortcuts menu + command palette (Closes #1353)

### DIFF
--- a/docs/changes/dev1/feature/1353-command-palette-discoverability.md
+++ b/docs/changes/dev1/feature/1353-command-palette-discoverability.md
@@ -1,0 +1,9 @@
+### Added
+
+- The keyboard-shortcuts reference is now discoverable from a visible menu: the
+  Settings wheel dropdown (Activity Bar) has a **Keyboard Shortcuts** item that
+  opens the shortcuts overlay, so it no longer requires knowing the F1 /
+  Cmd+K Cmd+S shortcut up front. The Settings-menu rows that have a binding now
+  show their accelerator inline (e.g. "Settings Cmd+,", "Keyboard Shortcuts
+  Cmd+K Cmd+S"), reflecting the effective binding including any user override
+  (#1353). The command palette portion of the issue is tracked as a follow-up.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -814,6 +814,21 @@ that the desktop rejects a tampered binary before install. See PR #1350.
 4. Delete the tampered cache entry; the next deploy re-downloads, re-verifies,
    and succeeds.
 
+### Keyboard-shortcuts menu discoverability (#1353)
+
+Verifies the shortcuts reference is reachable from a visible menu and that
+Settings-menu rows show their accelerators. The menu item and accelerator
+rendering are covered by unit tests; this manual check confirms the accelerator
+strings render correctly per platform and reflect a user rebinding. See PR #1487.
+
+1. Open the Settings wheel menu in the Activity Bar.
+2. Confirm a **Keyboard Shortcuts** row appears with its accelerator on the
+   right (`Cmd+K Cmd+S` on macOS, `F1` on Windows/Linux), and the **Settings**
+   row shows `Cmd+,` / `Ctrl+,`.
+3. Click **Keyboard Shortcuts** → the keyboard-shortcuts overlay opens.
+4. In Settings, rebind "Open Settings" to a different combo, then reopen the
+   Settings menu → the Settings row accelerator reflects the new binding.
+
 ### Docker/Podman directory-mount container spawn — Podman variant (#1372)
 
 The Docker path is covered by the `docker_spawn` integration test

--- a/src/components/ActivityBar/ActivityBar.css
+++ b/src/components/ActivityBar/ActivityBar.css
@@ -185,3 +185,12 @@
   color: var(--text-secondary);
   white-space: nowrap;
 }
+
+.settings-menu__item-accelerator {
+  margin-left: auto;
+  padding-left: var(--spacing-md);
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}

--- a/src/components/ActivityBar/ActivityBar.shortcuts.test.tsx
+++ b/src/components/ActivityBar/ActivityBar.shortcuts.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * The keyboard-shortcuts reference must be discoverable from a visible menu, not
+ * only via a shortcut the user has to already know (#1353). These tests pin:
+ *
+ *  - a "Keyboard Shortcuts" item in the Settings wheel dropdown that opens the
+ *    shortcuts overlay, and
+ *  - inline accelerators rendered on the Settings-menu rows that have a binding
+ *    (Settings, Keyboard Shortcuts), using the same effective binding the
+ *    overlay shows.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { getActionAccelerator } from "@/services/keybindings";
+import { withTooltip } from "@/test/tooltip";
+import { ActivityBar } from "./ActivityBar";
+
+vi.mock("@/components/OpenConnections/OpenConnectionsModal", () => ({
+  OpenConnectionsModal: () => null,
+}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-fs", () => ({ readTextFile: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useAppStore.setState(useAppStore.getInitialState());
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+/** Open the Settings dropdown via keyboard and wait for the portalled content. */
+async function openSettingsMenu(): Promise<void> {
+  const trigger = container.querySelector<HTMLButtonElement>(
+    '[data-testid="activity-bar-settings"]'
+  )!;
+  await act(async () => {
+    trigger.focus();
+    trigger.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", code: "Enter", keyCode: 13, bubbles: true })
+    );
+  });
+  for (
+    let i = 0;
+    i < 20 && !document.querySelector('[data-testid="settings-menu-shortcuts"]');
+    i++
+  ) {
+    await act(async () => {
+      await nextFrame();
+    });
+  }
+}
+
+function render(): void {
+  act(() => {
+    root.render(withTooltip(<ActivityBar />));
+  });
+}
+
+describe("ActivityBar Settings menu — shortcuts discoverability (#1353)", () => {
+  it("offers a Keyboard Shortcuts item that opens the shortcuts overlay", async () => {
+    render();
+    await openSettingsMenu();
+
+    const item = document.querySelector<HTMLElement>('[data-testid="settings-menu-shortcuts"]');
+    expect(item).not.toBeNull();
+    expect(useAppStore.getState().shortcutsOverlayOpen).toBe(false);
+
+    await act(async () => {
+      item!.click();
+    });
+    expect(useAppStore.getState().shortcutsOverlayOpen).toBe(true);
+  });
+
+  it("renders the show-shortcuts accelerator on the Keyboard Shortcuts row", async () => {
+    render();
+    await openSettingsMenu();
+
+    const item = document.querySelector<HTMLElement>('[data-testid="settings-menu-shortcuts"]')!;
+    const accel = getActionAccelerator("show-shortcuts")!;
+    expect(accel).toBeTruthy();
+    expect(item.textContent).toContain(accel);
+  });
+
+  it("renders the open-settings accelerator on the Settings row", async () => {
+    render();
+    await openSettingsMenu();
+
+    const item = document.querySelector<HTMLElement>('[data-testid="settings-menu-open"]')!;
+    const accel = getActionAccelerator("open-settings")!;
+    expect(accel).toBeTruthy();
+    expect(item.textContent).toContain(accel);
+  });
+});

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -14,6 +14,7 @@ import {
   Activity,
   RefreshCw,
   Info,
+  Keyboard,
 } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as ContextMenu from "@radix-ui/react-context-menu";
@@ -23,6 +24,7 @@ import { useAppStore, SidebarView } from "@/store/appStore";
 import { useExperimentalFeatures } from "@/hooks/useExperimentalFeatures";
 import { OpenConnectionsModal } from "@/components/OpenConnections/OpenConnectionsModal";
 import { Tooltip } from "@/components/ui";
+import { getActionAccelerator } from "@/services/keybindings";
 import { ActivityBarItem } from "./ActivityBarItem";
 import "./ActivityBar.css";
 
@@ -31,6 +33,23 @@ interface ActivityBarItemDef {
   icon: typeof Network;
   label: string;
   experimental?: boolean;
+}
+
+interface MenuAcceleratorProps {
+  /** Keybinding action id whose effective accelerator should be shown. */
+  action: string;
+}
+
+/**
+ * Renders an action's effective accelerator, right-aligned within a settings
+ * menu row (e.g. "Settings  ⌘,"). Renders nothing when the action has no
+ * binding. Uses {@link getActionAccelerator} so the label stays in sync with
+ * the shortcuts overlay and any user override.
+ */
+function MenuAccelerator({ action }: MenuAcceleratorProps) {
+  const accelerator = getActionAccelerator(action);
+  if (!accelerator) return null;
+  return <span className="settings-menu__item-accelerator">{accelerator}</span>;
 }
 
 const REQUIRED_ITEMS: ActivityBarItemDef[] = [
@@ -59,6 +78,7 @@ export function ActivityBar({ horizontal }: ActivityBarProps) {
   const openSettingsTab = useAppStore((s) => s.openSettingsTab);
   const openLogViewerTab = useAppStore((s) => s.openLogViewerTab);
   const openOverlayView = useAppStore((s) => s.openOverlayView);
+  const setShortcutsOverlayOpen = useAppStore((s) => s.setShortcutsOverlayOpen);
   const activityBarPosition = useAppStore((s) => s.layoutConfig.activityBarPosition);
   const hiddenActivityBarViews = useAppStore(
     (s) => s.layoutConfig.hiddenActivityBarViews ?? EMPTY_HIDDEN_VIEWS
@@ -148,6 +168,16 @@ export function ActivityBar({ horizontal }: ActivityBarProps) {
                   >
                     <Settings size={14} />
                     Settings
+                    <MenuAccelerator action="open-settings" />
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    className="settings-menu__item"
+                    onSelect={() => setShortcutsOverlayOpen(true)}
+                    data-testid="settings-menu-shortcuts"
+                  >
+                    <Keyboard size={14} />
+                    Keyboard Shortcuts
+                    <MenuAccelerator action="show-shortcuts" />
                   </DropdownMenu.Item>
                   <DropdownMenu.Item
                     className="settings-menu__item"

--- a/src/services/keybindings.accelerator.test.ts
+++ b/src/services/keybindings.accelerator.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getActionAccelerator, clearOverrides, setOverride } from "./keybindings";
+
+/**
+ * `getActionAccelerator` is the single source of truth for rendering an action's
+ * accelerator inline (e.g. on Settings-menu rows), so it must reflect the same
+ * effective binding — user override or platform default — that the shortcuts
+ * overlay shows (#1353).
+ */
+describe("getActionAccelerator", () => {
+  afterEach(() => {
+    clearOverrides();
+  });
+
+  it("returns a serialized accelerator for a known single-combo action", () => {
+    const accel = getActionAccelerator("open-settings");
+    expect(accel).toBeTruthy();
+    // "Open Settings" is bound to <mod>+, on every platform.
+    expect(accel).toContain(",");
+  });
+
+  it("returns the chord form for the shortcuts action", () => {
+    const accel = getActionAccelerator("show-shortcuts");
+    expect(accel).toBeTruthy();
+  });
+
+  it("reflects a user override rather than the platform default", () => {
+    setOverride("open-settings", { key: "P", ctrl: true, shift: true });
+    expect(getActionAccelerator("open-settings")).toBe("Ctrl+Shift+P");
+  });
+
+  it("returns null for an unknown action", () => {
+    expect(getActionAccelerator("does-not-exist")).toBeNull();
+  });
+});

--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -452,6 +452,18 @@ export function getDefaultBindings(): KeyBinding[] {
 }
 
 /**
+ * Get the human-readable accelerator string for an action (e.g. `"Cmd+,"` or
+ * `"F1"`), reflecting the effective binding — user override or platform default.
+ * Returns `null` when the action has no binding. This is the single source of
+ * truth for rendering accelerators inline (e.g. on menu rows), so it stays in
+ * sync with what the shortcuts overlay displays.
+ */
+export function getActionAccelerator(action: string): string | null {
+  const combo = getEffectiveCombo(action);
+  return combo ? serializeBinding(combo) : null;
+}
+
+/**
  * Get the scope of an action — where it is allowed to fire relative to the
  * active tab. Unknown or unannotated actions default to `"global"` so existing
  * behavior is preserved.

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -391,6 +391,7 @@ Fixed strings — match exactly.
 | `settings-menu-import` | `src/components/ActivityBar/ActivityBar.tsx` |
 | `settings-menu-open` | `src/components/ActivityBar/ActivityBar.tsx` |
 | `settings-menu-open-connections` | `src/components/ActivityBar/ActivityBar.tsx` |
+| `settings-menu-shortcuts` | `src/components/ActivityBar/ActivityBar.tsx` |
 | `settings-menu-updates` | `src/components/ActivityBar/ActivityBar.tsx` |
 | `settings-provide-x-server` | `src/components/Settings/GeneralSettings.tsx` |
 | `settings-restore-last-session` | `src/components/Settings/GeneralSettings.tsx` |


### PR DESCRIPTION
## What shipped

Fixes the discoverability gap from #1353: the keyboard-shortcuts reference was only reachable via a shortcut you had to already know (F1 / Cmd+K Cmd+S), and the Settings wheel menu rows showed no accelerators.

**Discoverability quick-win (fully delivered here):**
- New **Keyboard Shortcuts** item in the Settings wheel dropdown (Activity Bar) that opens the shortcuts overlay — the reference is now reachable from a visible menu.
- Inline accelerators on the Settings-menu rows that have a binding (Settings `Cmd+,`, Keyboard Shortcuts `Cmd+K Cmd+S`), rendered via a new `getActionAccelerator` helper in `src/services/keybindings.ts` — a single source of truth that reflects the effective binding (including any user override), so the menu can never drift from the shortcuts overlay.

**Command palette — deferred to a follow-up.** Implemented cleanly would require first extracting the saved-connection connect flow (credential-store resolution, password/passphrase prompts, unlock, stale-credential handling — ~150 lines currently inline in `ConnectionList.tsx`) into a reusable hook, so the palette can connect without duplicating delicate credential logic. Per the issue's explicit sanction to split the palette into its own scope, this is tracked as **#1484** (Ready2Implement) rather than half-shipped. This PR still `Closes #1353` — the committed deliverable is the discoverability quick-win.

## Test plan

Automated (all green):
- `src/services/keybindings.accelerator.test.ts` — `getActionAccelerator` returns the serialized effective accelerator, honors a user override, and returns null for unknown actions.
- `src/components/ActivityBar/ActivityBar.shortcuts.test.tsx` — the Settings menu exposes a Keyboard Shortcuts item that opens the overlay, and the Settings / Keyboard Shortcuts rows render their accelerators.
- Full suite: 2988 tests pass; `pnpm build`, `pnpm run lint`, `pnpm run format:check` all clean.

Manual:
1. Open the Settings wheel menu in the Activity Bar.
2. Confirm a **Keyboard Shortcuts** row appears, showing its accelerator (`Cmd+K Cmd+S` on macOS, `F1` on Win/Linux), and the **Settings** row shows `Cmd+,` / `Ctrl+,`.
3. Click **Keyboard Shortcuts** → the shortcuts overlay opens.
4. Rebind "Open Settings" in settings → reopen the menu → the Settings row accelerator reflects the new binding.

Follow-up: #1484 (command palette).

🤖 Generated with [Claude Code](https://claude.com/claude-code)