### PR TITLE
feat(backend): add explicit spawn-kind discriminator to SpawnRequest

### DIFF
--- a/core/src/backends/ftp/listing_parser.rs
+++ b/core/src/backends/ftp/listing_parser.rs
@@ -101,6 +101,8 @@ pub(crate) fn parse_mlsd_line(raw: &[u8], dir: &str) -> Option<FileEntry> {
         size,
         modified,
         permissions: Some(permissions),
+        // Writability is derived only for the desktop SFTP browser (#1324).
+        writable: None,
     })
 }
 

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -31,12 +31,53 @@ mod tests;
 /// (#1409). Centralised so every producer stays in sync.
 pub const SPAWN_REQUEST_EVENT: &str = "spawn-request";
 
+/// Explicit discriminator for the kind of session a [`SpawnRequest`] targets
+/// (#1465).
+///
+/// Consumers branch on this authoritative field instead of inferring intent
+/// from which optional fields happen to be set. Pre-#1465 payloads carry no
+/// `kind`; serde fills [`SpawnKind::Auto`], which downstream consumers resolve
+/// by falling back to the legacy presence-based inference (a spawn is a
+/// container iff it carries a `container_image`/`container_mount`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpawnKind {
+    /// A "new container" spawn (Docker/Podman image + optional mount).
+    Container,
+    /// A local-shell spawn (owned by the SI-2 open path).
+    Local,
+    /// A WSL spawn (owned by the SI-2 open path).
+    Wsl,
+    /// An SSH spawn (owned by the SI-2 open path).
+    Ssh,
+    /// Kind not explicitly stated — resolve via presence-based inference. The
+    /// default for older payloads and for CLI invocations that carry no
+    /// discriminating flags.
+    #[default]
+    Auto,
+}
+
+impl SpawnKind {
+    /// Parse a wire/CLI token (`container|local|wsl|ssh|auto`) into a kind.
+    /// Returns `None` for unrecognised tokens so callers can degrade gracefully.
+    fn from_wire(token: &str) -> Option<Self> {
+        match token {
+            "container" => Some(Self::Container),
+            "local" => Some(Self::Local),
+            "wsl" => Some(Self::Wsl),
+            "ssh" => Some(Self::Ssh),
+            "auto" => Some(Self::Auto),
+            _ => None,
+        }
+    }
+}
+
 /// A request to open a new session, originating from an external
 /// `termiHub spawn` invocation.
 ///
-/// All fields are optional so partially-specified requests round-trip cleanly;
-/// resolution of the effective connection type happens downstream (out of scope
-/// for #1364).
+/// Aside from [`SpawnRequest::kind`], all fields are optional so
+/// partially-specified requests round-trip cleanly; resolution of the effective
+/// connection type happens downstream (out of scope for #1364).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SpawnRequest {
     /// Filesystem path (folder or file) the session should open at.
@@ -60,6 +101,12 @@ pub struct SpawnRequest {
     /// Mount target path inside the container (default resolved downstream).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container_mount: Option<String>,
+    /// Explicit spawn-kind discriminator (#1465). Defaults to
+    /// [`SpawnKind::Auto`] so pre-#1465 payloads (which omit the field)
+    /// round-trip and downstream consumers can fall back to presence-based
+    /// inference.
+    #[serde(default)]
+    pub kind: SpawnKind,
 }
 
 /// Outcome status returned by the running instance for a [`SpawnRequest`].
@@ -153,6 +200,18 @@ pub fn parse_spawn_args(args: &[String]) -> SpawnRequest {
                 req.pick = true;
                 None
             }
+            "--kind" => {
+                // Consume the value here (inline `--kind=x` or the next arg) and
+                // classify it; unknown tokens leave the default (`Auto`) intact.
+                let value = inline.clone().or_else(|| {
+                    i += 1;
+                    args.get(i).cloned()
+                });
+                if let Some(kind) = value.as_deref().and_then(SpawnKind::from_wire) {
+                    req.kind = kind;
+                }
+                None
+            }
             "--location" => Some(&mut req.location),
             "--entry-id" => Some(&mut req.entry_id),
             "--connection" => Some(&mut req.connection),
@@ -168,6 +227,13 @@ pub fn parse_spawn_args(args: &[String]) -> SpawnRequest {
             });
         }
         i += 1;
+    }
+    // With no explicit `--kind`, a container image/mount authoritatively marks a
+    // container spawn; everything else stays `Auto` for downstream resolution.
+    if matches!(req.kind, SpawnKind::Auto)
+        && (req.container_image.is_some() || req.container_mount.is_some())
+    {
+        req.kind = SpawnKind::Container;
     }
     req
 }

--- a/src-tauri/src/spawn/tests.rs
+++ b/src-tauri/src/spawn/tests.rs
@@ -8,8 +8,8 @@
 use std::sync::{Arc, Mutex};
 
 use super::{
-    classify_command, parse_spawn_args, Command, SpawnEndpoint, SpawnHandler, SpawnRequest,
-    SpawnResponse, SpawnStatus,
+    classify_command, parse_spawn_args, Command, SpawnEndpoint, SpawnHandler, SpawnKind,
+    SpawnRequest, SpawnResponse, SpawnStatus,
 };
 use super::{ipc_client, ipc_server};
 
@@ -22,6 +22,7 @@ fn full_request() -> SpawnRequest {
         pick: true,
         container_image: Some("ubuntu:22.04".to_string()),
         container_mount: Some("/workspace".to_string()),
+        kind: SpawnKind::Container,
     }
 }
 
@@ -65,6 +66,56 @@ fn spawn_response_round_trip() {
     assert_eq!(back.message.as_deref(), Some("boom"));
 }
 
+// ── spawn-kind discriminator (#1465) ─────────────────────────────────────
+
+#[test]
+fn spawn_kind_serializes_snake_case() {
+    let cases = [
+        (SpawnKind::Container, "\"container\""),
+        (SpawnKind::Local, "\"local\""),
+        (SpawnKind::Wsl, "\"wsl\""),
+        (SpawnKind::Ssh, "\"ssh\""),
+        (SpawnKind::Auto, "\"auto\""),
+    ];
+    for (kind, wire) in cases {
+        assert_eq!(serde_json::to_string(&kind).expect("serialize"), wire);
+        let back: SpawnKind = serde_json::from_str(wire).expect("deserialize");
+        assert_eq!(back, kind);
+    }
+}
+
+#[test]
+fn spawn_kind_defaults_to_auto() {
+    assert_eq!(SpawnKind::default(), SpawnKind::Auto);
+}
+
+#[test]
+fn spawn_request_round_trips_kind() {
+    let req = SpawnRequest {
+        location: Some("/p".to_string()),
+        kind: SpawnKind::Container,
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&req).expect("serialize");
+    assert!(
+        json.contains("\"kind\":\"container\""),
+        "kind on the wire: {json}"
+    );
+    let back: SpawnRequest = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.kind, SpawnKind::Container);
+    assert_eq!(req, back);
+}
+
+#[test]
+fn old_payload_without_kind_deserializes_to_auto() {
+    // Pre-#1465 payloads carry no `kind` field; serde default must fill Auto so
+    // downstream consumers can fall back to presence-based inference.
+    let back: SpawnRequest =
+        serde_json::from_str(r#"{"location":"/p","container_image":"img"}"#).expect("deserialize");
+    assert_eq!(back.kind, SpawnKind::Auto);
+    assert_eq!(back.container_image.as_deref(), Some("img"));
+}
+
 // ── CLI parsing ──────────────────────────────────────────────────────────
 
 fn to_args(parts: &[&str]) -> Vec<String> {
@@ -95,6 +146,48 @@ fn parse_spawn_args_full() {
     assert!(req.pick);
     assert_eq!(req.container_image.as_deref(), Some("img"));
     assert_eq!(req.container_mount.as_deref(), Some("/mnt"));
+    // Image/mount present → authoritatively a container spawn.
+    assert_eq!(req.kind, SpawnKind::Container);
+}
+
+#[test]
+fn parse_spawn_args_container_image_infers_container_kind() {
+    let req = parse_spawn_args(&to_args(&["--location", "/p", "--container-image", "img"]));
+    assert_eq!(req.kind, SpawnKind::Container);
+}
+
+#[test]
+fn parse_spawn_args_container_mount_only_infers_container_kind() {
+    let req = parse_spawn_args(&to_args(&["--container-mount", "/mnt"]));
+    assert_eq!(req.kind, SpawnKind::Container);
+}
+
+#[test]
+fn parse_spawn_args_location_only_defaults_to_auto() {
+    let req = parse_spawn_args(&to_args(&["--location", "/p"]));
+    assert_eq!(req.kind, SpawnKind::Auto);
+}
+
+#[test]
+fn parse_spawn_args_explicit_kind_flag() {
+    let req = parse_spawn_args(&to_args(&["--location", "/p", "--kind", "local"]));
+    assert_eq!(req.kind, SpawnKind::Local);
+
+    let req = parse_spawn_args(&to_args(&["--kind=ssh", "--location", "/p"]));
+    assert_eq!(req.kind, SpawnKind::Ssh);
+}
+
+#[test]
+fn parse_spawn_args_explicit_kind_wins_over_container_presence() {
+    // An explicit non-auto kind must not be overridden by presence inference.
+    let req = parse_spawn_args(&to_args(&["--kind", "local", "--container-image", "img"]));
+    assert_eq!(req.kind, SpawnKind::Local);
+}
+
+#[test]
+fn parse_spawn_args_unknown_kind_stays_auto() {
+    let req = parse_spawn_args(&to_args(&["--kind", "bogus", "--location", "/p"]));
+    assert_eq!(req.kind, SpawnKind::Auto);
 }
 
 #[test]

--- a/src/hooks/useSpawnRequests.test.ts
+++ b/src/hooks/useSpawnRequests.test.ts
@@ -174,3 +174,93 @@ describe("useSpawnRequests — container spawn wiring (#1446)", () => {
     expect(unlisten).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("useSpawnRequests — kind discriminator (#1465)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    emit = undefined;
+    resolveContainerSpawn.mockReset();
+    resolveContainerSpawn.mockResolvedValue(SAMPLE_SPAWN);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function mountHook(): Promise<void> {
+    function Harness() {
+      useSpawnRequests();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  it("routes an explicit container kind to the resolver", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!(containerRequest({ kind: "container" }));
+      await Promise.resolve();
+    });
+
+    expect(resolveContainerSpawn).toHaveBeenCalledWith("/home/user/app", "alpine:3", "/workspace");
+  });
+
+  it("ignores an explicit local/WSL/SSH kind even when container fields are present", async () => {
+    await mountHook();
+
+    // Container fields present but the authoritative kind says local → SI-2's
+    // job, not ours. The explicit discriminator wins over field presence.
+    await act(async () => {
+      emit!(containerRequest({ kind: "local" }));
+      await Promise.resolve();
+    });
+
+    expect(resolveContainerSpawn).not.toHaveBeenCalled();
+    expect(allTabs().some((t) => t.spawned)).toBe(false);
+  });
+
+  it("falls back to presence inference for an auto kind (container)", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!(containerRequest({ kind: "auto" }));
+      await Promise.resolve();
+    });
+
+    expect(resolveContainerSpawn).toHaveBeenCalledWith("/home/user/app", "alpine:3", "/workspace");
+  });
+
+  it("falls back to presence inference for an auto kind (non-container)", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!({ location: "/home/user/app", kind: "auto" });
+      await Promise.resolve();
+    });
+
+    expect(resolveContainerSpawn).not.toHaveBeenCalled();
+    expect(allTabs().some((t) => t.spawned)).toBe(false);
+  });
+
+  it("unsubscribes on unmount", async () => {
+    await mountHook();
+    act(() => root.unmount());
+    // Re-create the root so afterEach's unmount is a no-op.
+    root = createRoot(container);
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useSpawnRequests.ts
+++ b/src/hooks/useSpawnRequests.ts
@@ -6,13 +6,28 @@ import { resolveContainerSpawn } from "@/services/api";
 import { frontendLog } from "@/utils/frontendLog";
 
 /**
- * Whether a spawn request targets a "new container" spawn (#1446). The CLI
- * container path (`termiHub spawn --location … --container-image …`) always
- * carries an image; a mount override alone also signals container intent. All
- * other spawns (local / WSL / SSH) are owned by SI-2 and ignored here.
+ * Whether a spawn request targets a "new container" spawn (#1446/#1465).
+ *
+ * The authoritative signal is the explicit `kind` discriminator: `"container"`
+ * is ours, and the SI-2-owned kinds (`"local"`/`"wsl"`/`"ssh"`) are not. Older
+ * payloads (and CLI invocations with no discriminating flags) carry `"auto"`
+ * (or no `kind`); for those we fall back to the legacy presence-based inference
+ * — a container iff a `container_image`/`container_mount` is set — so behaviour
+ * is byte-for-byte identical during the SI-2 transition.
  */
 function isContainerSpawn(req: SpawnRequestPayload): boolean {
-  return !!req.container_image?.trim() || !!req.container_mount?.trim();
+  switch (req.kind) {
+    case "container":
+      return true;
+    case "local":
+    case "wsl":
+    case "ssh":
+      return false;
+    case "auto":
+    case undefined:
+    default:
+      return !!req.container_image?.trim() || !!req.container_mount?.trim();
+  }
 }
 
 /**

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -567,9 +567,19 @@ export async function onXServerProgress(
 }
 
 /**
+ * Explicit spawn-kind discriminator (#1465). Mirrors the Rust `SpawnKind`
+ * (snake_case wire tokens). Consumers branch on this authoritative field rather
+ * than inferring intent from which optional fields are set. Pre-#1465 payloads
+ * omit it and are treated as `"auto"`, resolved by falling back to
+ * presence-based inference.
+ */
+export type SpawnKind = "container" | "local" | "wsl" | "ssh" | "auto";
+
+/**
  * Payload of a `spawn-request` event (#1364). Emitted by the backend IPC
  * rendezvous when an external `termiHub spawn …` invocation reaches the running
- * instance. Fields mirror the Rust `SpawnRequest` (snake_case, all optional).
+ * instance. Fields mirror the Rust `SpawnRequest` (snake_case; all optional
+ * except `kind`, which defaults to `"auto"` on the wire).
  */
 export interface SpawnRequestPayload {
   /** Filesystem path (folder or file) the session should open at. */
@@ -586,6 +596,11 @@ export interface SpawnRequestPayload {
   container_image?: string;
   /** Mount target path inside the container. */
   container_mount?: string;
+  /**
+   * Explicit spawn-kind discriminator (#1465). Absent on pre-#1465 payloads,
+   * where it is treated as `"auto"` and resolved by presence-based inference.
+   */
+  kind?: SpawnKind;
 }
 
 /**


### PR DESCRIPTION
Closes #1465
Follow-up to #1446 (PR #1464), part of epic #1363.

## Summary

The frontend previously decided whether a `spawn-request` was a "new container" spawn by inspecting the presence of `container_image` / `container_mount`. Once the SI-2 local/WSL/SSH open path lands as a separate consumer, inferring kind from field presence is ambiguous. This adds an authoritative discriminator both consumers read.

- **`SpawnKind` enum** (Rust `src-tauri/src/spawn/mod.rs`) — variants `Container | Local | Wsl | Ssh | Auto`, serialized `#[serde(rename_all = "snake_case")]` so the wire tokens are `"container" | "local" | "wsl" | "ssh" | "auto"`.
- **`SpawnRequest.kind`** field with `#[serde(default)]` → `Auto`. Backward compatible: pre-#1465 payloads that omit `kind` deserialize to `Auto`.
- **CLI parser** accepts an explicit `--kind <token>` (`--kind=token` too); with no `--kind`, a container image/mount authoritatively marks a `Container` spawn, everything else stays `Auto`. Unknown tokens degrade to `Auto`.
- **Event round-trip** — `kind` rides through the `spawn-request` event payload unchanged (no change needed at the emit sites in `lib.rs` / `macos_services.rs`; the field just serializes).
- **Frontend** (`src/services/events.ts`, `src/hooks/useSpawnRequests.ts`) — `SpawnRequestPayload` mirrors `kind: SpawnKind`; `useSpawnRequests` branches on it: `container` resolves + opens, SI-2-owned `local`/`wsl`/`ssh` are ignored, and `auto` (or a missing `kind`) falls back to the previous presence-based inference.

### Backward compatibility

`auto` (the serde/CLI default and what every older payload deserializes to) is resolved by the exact legacy presence-based rule — container iff a `container_image`/`container_mount` is set — so **container-spawn behaviour is byte-for-byte unchanged** and the future SI-2 consumer reads the same authoritative field.

No user-visible behaviour change → no change fragment per CLAUDE.md.

## Test plan

- `cargo test -p termihub spawn::` — serde snake_case casing per variant, `kind` round-trips through `SpawnRequest`, old payload without `kind` → `Auto`, CLI inference (image/mount → container, location-only → auto, explicit `--kind` wins over presence, unknown token → auto).
- `npx vitest run src/hooks/useSpawnRequests.test.ts` — 11 pass: explicit container routes, `local`/`wsl`/`ssh` ignored even with container fields, `auto` falls back to presence inference (both container and non-container).
- `cargo clippy -p termihub --all-targets -- -D warnings`, `cargo fmt --check`, `eslint`, `tsc --noEmit`, `prettier --check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)