### PR TITLE
feat(ui): reuse tree search + keyboard-nav across tunnel/workspace/agent sidebars (Closes #1379)

### DIFF
--- a/docs/changes/dev1/refactor/1379-sidebar-nav-reuse.md
+++ b/docs/changes/dev1/refactor/1379-sidebar-nav-reuse.md
@@ -1,0 +1,11 @@
+### Added
+
+- Keyboard navigation and ARIA tree semantics for the Tunnels, Workspaces, and
+  Remote Agents sidebars, matching the Connections tree (#1356). Each list is now
+  a `role="tree"` with `role="treeitem"` rows and roving-tabindex focus: arrow
+  keys move between rows, Home/End jump to the ends, type-ahead jumps by name,
+  and Enter activates the focused row (edit a tunnel, launch a workspace, or open
+  the focused agent connection). Mouse behavior is unchanged.
+- A search filter in the Remote Agents section header that narrows each agent's
+  saved connections by name and auto-expands matching folders, mirroring the
+  Connections filter (Escape clears it).

--- a/src/components/Sidebar/AgentNode.keyboard.test.tsx
+++ b/src/components/Sidebar/AgentNode.keyboard.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Keyboard-navigation + ARIA tree semantics + search filter for the Remote
+ * Agents tree (#1379).
+ *
+ * The agent tree adopts the same roving-tabindex arrow-key model + tree ARIA
+ * roles as the Connections tree: one row is tabbable at a time, arrows move the
+ * roving focus, Enter activates the focused row, and a header filter narrows the
+ * saved definitions (auto-expanding matching folders).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { AgentNode } from "./AgentNode";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+import type { AgentDefinitionInfo, AgentFolderInfo } from "@/services/api";
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({ attributes: {}, listeners: {}, setNodeRef: vi.fn(), isDragging: false }),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  useDndContext: () => ({ active: null }),
+  useDndMonitor: () => {},
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({ CSS: { Transform: { toString: () => "" } } }));
+
+vi.mock("@/services/api", () => ({
+  removeCredential: vi.fn(() => Promise.resolve()),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  cancelConnectAgent: vi.fn(() => Promise.resolve()),
+}));
+
+const addTabMock = vi.fn();
+
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return {
+    ...actual,
+    Tooltip: ({ children }: { children: React.ReactNode }) => children,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+      promise: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("./AgentSetupDialog", () => ({ AgentSetupDialog: () => null }));
+vi.mock("./ConnectionErrorDialog", () => ({ ConnectionErrorDialog: () => null }));
+vi.mock("./InlineFolderInput", () => ({ InlineFolderInput: () => null }));
+
+const AGENT_ID = "agent-kbd-test";
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: AGENT_ID,
+    name: "Test Agent",
+    config: { host: "host.example.com", port: 22, username: "user", authMethod: "password" },
+    connectionState: "connected",
+    isExpanded: true,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    capabilities: {
+      connectionTypes: [],
+      maxSessions: 10,
+      availableShells: ["bash"],
+      availableSerialPorts: [],
+      availableDockerImages: [],
+    },
+    ...overrides,
+  };
+}
+
+function def(id: string, name: string, folderId: string | null = null): AgentDefinitionInfo {
+  return { id, name, sessionType: "shell", config: {}, persistent: false, folderId };
+}
+
+function folder(id: string, name: string, isExpanded = true): AgentFolderInfo {
+  return { id, name, parentId: null, isExpanded };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(sel: string): HTMLElement | null {
+  return container.querySelector(sel);
+}
+
+function seed(definitions: AgentDefinitionInfo[], folders: AgentFolderInfo[] = []) {
+  useAppStore.setState(useAppStore.getInitialState());
+  useAppStore.setState({
+    remoteAgents: [makeAgent()],
+    agentDefinitions: { [AGENT_ID]: definitions },
+    agentFolders: { [AGENT_ID]: folders },
+    agentSessions: {},
+    addTab: addTabMock,
+  });
+}
+
+function render(filterQuery?: string) {
+  act(() => {
+    root.render(React.createElement(AgentNode, { agent: makeAgent(), filterQuery }));
+  });
+}
+
+function press(row: HTMLElement, key: string) {
+  act(() => {
+    row.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+describe("AgentNode — keyboard navigation + filter (#1379)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("marks the agent tree as a tree with treeitem rows", () => {
+    seed([def("d1", "alpha"), def("d2", "bravo")]);
+    render();
+    const tree = query('[role="tree"]');
+    expect(tree).not.toBeNull();
+    const rows = container.querySelectorAll('[role="treeitem"]');
+    expect(rows.length).toBe(2);
+    expect(rows[0].getAttribute("aria-level")).toBe("1");
+  });
+
+  it("keeps a single roving-tabindex row and moves it with ArrowDown", () => {
+    seed([def("d1", "alpha"), def("d2", "bravo")]);
+    render();
+    const rows = Array.from(container.querySelectorAll<HTMLElement>('[role="treeitem"]'));
+    expect(rows[0].getAttribute("tabindex")).toBe("0");
+    expect(rows[1].getAttribute("tabindex")).toBe("-1");
+    press(rows[0], "ArrowDown");
+    expect(document.activeElement).toBe(rows[1]);
+    expect(rows[1].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("opens the focused definition on Enter", () => {
+    seed([def("d1", "alpha"), def("d2", "bravo")]);
+    render();
+    const rows = Array.from(container.querySelectorAll<HTMLElement>('[role="treeitem"]'));
+    press(rows[0], "ArrowDown");
+    press(rows[1], "Enter");
+    expect(addTabMock).toHaveBeenCalledTimes(1);
+    // The opened definition is the second row (bravo).
+    expect(addTabMock.mock.calls[0][0]).toBe("bravo");
+  });
+
+  it("marks folder rows with aria-expanded", () => {
+    seed([def("d1", "alpha", "f1")], [folder("f1", "Prod")]);
+    render();
+    const folderRow = container.querySelector("[aria-expanded]");
+    expect(folderRow).not.toBeNull();
+    expect(folderRow!.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("filters the tree to matching definitions", () => {
+    seed([def("d1", "web-server"), def("d2", "database")]);
+    render("web");
+    const rows = Array.from(container.querySelectorAll<HTMLElement>('[role="treeitem"]'));
+    const labels = rows.map((r) => r.textContent);
+    expect(labels.some((l) => l?.includes("web-server"))).toBe(true);
+    expect(labels.some((l) => l?.includes("database"))).toBe(false);
+  });
+});

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -56,7 +56,9 @@ import { AgentVersionBadge } from "@/components/AgentVersionBadge/AgentVersionBa
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
 import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
-import { computeFlatVisibleIds } from "@/utils/computeFlatVisibleIds";
+import { useRovingListNav } from "@/hooks/useRovingListNav";
+import { AgentTreeFilter, filterAgentTree } from "@/utils/agentTreeSearch";
+import { computeAgentTreeNodes, type AgentVisibleNode } from "@/utils/computeAgentTreeNodes";
 import { AgentSetupDialog } from "./AgentSetupDialog";
 import { ConnectionErrorDialog } from "./ConnectionErrorDialog";
 import { InlineFolderInput } from "./InlineFolderInput";
@@ -72,6 +74,35 @@ const STATE_DOT_CLASSES: Record<string, string> = {
   reconnecting: "agent-node__state-dot--reconnecting",
   disconnected: "agent-node__state-dot--disconnected",
 };
+
+/**
+ * Shared roving-tabindex / filter plumbing threaded through the agent tree so
+ * every row participates in keyboard navigation and search filtering (#1379),
+ * mirroring the Connections tree. Roving focus + type-ahead are driven by the
+ * shared {@link useRovingListNav} hook over the flattened visible node list.
+ */
+interface AgentTreeNavProps {
+  /** Active search filter, or `null` when no query is entered. */
+  filter: AgentTreeFilter | null;
+  /** Roving-tabindex active index into the flattened visible node list. */
+  activeIndex: number;
+  /** Flattened-list index of a node by id (`-1` when not currently visible). */
+  getNodeIndex: (id: string) => number;
+  /** Stable per-index ref callback wiring a row into the roving-nav hook. */
+  getRowRef: (index: number) => (el: HTMLButtonElement | null) => void;
+  /** Keyboard handler for a tree row, keyed by its node id. */
+  onTreeKeyDown: (event: React.KeyboardEvent, nodeId: string) => void;
+  /** Sync the roving active index when a row gains DOM focus. */
+  onRowFocus: (index: number) => void;
+  /** Toggle a folder's expansion (suppressed while a filter is active). */
+  onToggleFolder: (folderId: string) => void;
+}
+
+/** Roving-nav props needed by a leaf (definition) row. */
+type AgentItemNavProps = Pick<
+  AgentTreeNavProps,
+  "activeIndex" | "getNodeIndex" | "getRowRef" | "onTreeKeyDown" | "onRowFocus"
+>;
 
 /** Icon for a session/connection type string. */
 function SessionTypeIcon({ type, size = 14 }: { type: string; size?: number }) {
@@ -91,7 +122,7 @@ function SessionTypeIcon({ type, size = 14 }: { type: string; size?: number }) {
 
 // ── Agent connection item ────────────────────────────────────────────
 
-interface AgentConnectionItemProps {
+interface AgentConnectionItemProps extends AgentItemNavProps {
   agentId: string;
   definition: AgentDefinitionInfo;
   depth: number;
@@ -119,6 +150,11 @@ function AgentConnectionItem({
   onStartPersistent,
   onAttachPersistent,
   onStopPersistent,
+  activeIndex,
+  getNodeIndex,
+  getRowRef,
+  onTreeKeyDown,
+  onRowFocus,
 }: AgentConnectionItemProps) {
   const deleteAgentDef = useAppStore((s) => s.deleteAgentDef);
   const persistentEntry = useAppStore((s) => s.persistentSessions[`${agentId}:${definition.id}`]);
@@ -143,6 +179,18 @@ function AgentConnectionItem({
     },
   });
 
+  const rowIndex = getNodeIndex(definition.id);
+  const rowRef = getRowRef(rowIndex);
+  // Merge the draggable ref with the roving-nav row ref so the definition button
+  // is both draggable and a focusable roving-tabindex row.
+  const setRowNode = useCallback(
+    (el: HTMLButtonElement | null) => {
+      setDragRef(el);
+      rowRef(el);
+    },
+    [setDragRef, rowRef]
+  );
+
   let className = "connection-tree__item";
   if (isDragging) className += " connection-tree__item--dragging";
   if (isSelected) className += " connection-tree__item--selected";
@@ -164,7 +212,7 @@ function AgentConnectionItem({
     <ContextMenu.Root>
       <ContextMenu.Trigger asChild>
         <button
-          ref={setDragRef}
+          ref={setRowNode}
           className={className}
           style={{ paddingLeft: `${depth * 16 + 8}px` }}
           onClick={(e) => onConnectionClick(definition.id, e)}
@@ -182,6 +230,12 @@ function AgentConnectionItem({
           title={`${definition.name} (${definition.sessionType}${definition.persistent ? ", persistent" : ""})`}
           {...attributes}
           {...listeners}
+          role="treeitem"
+          aria-level={depth}
+          aria-selected={isSelected}
+          tabIndex={rowIndex === activeIndex ? 0 : -1}
+          onKeyDown={(e) => onTreeKeyDown(e, definition.id)}
+          onFocus={() => onRowFocus(rowIndex)}
         >
           <ConnectionIcon
             config={{
@@ -332,7 +386,7 @@ function AgentConnectionItem({
 
 // ── Agent folder node (recursive) ───────────────────────────────────
 
-interface AgentFolderNodeProps {
+interface AgentFolderNodeProps extends AgentTreeNavProps {
   agentId: string;
   folder: AgentFolderInfo;
   allFolders: AgentFolderInfo[];
@@ -366,14 +420,23 @@ function AgentFolderNode({
   onStartPersistent,
   onAttachPersistent,
   onStopPersistent,
+  filter,
+  activeIndex,
+  getNodeIndex,
+  getRowRef,
+  onTreeKeyDown,
+  onRowFocus,
+  onToggleFolder,
 }: AgentFolderNodeProps) {
-  const toggleAgentFolder = useAppStore((s) => s.toggleAgentFolder);
   const createAgentFolder = useAppStore((s) => s.createAgentFolder);
   const deleteAgentFolder = useAppStore((s) => s.deleteAgentFolder);
 
   const [creatingSubfolder, setCreatingSubfolder] = useState(false);
 
-  const Chevron = folder.isExpanded ? ChevronDown : ChevronRight;
+  // Under an active filter, matched folders are force-expanded regardless of
+  // their stored state (auto-expand matches).
+  const expanded = filter ? filter.visibleFolderIds.has(folder.id) : folder.isExpanded;
+  const Chevron = expanded ? ChevronDown : ChevronRight;
 
   const childFolders = useMemo(
     () => allFolders.filter((f) => f.parentId === folder.id),
@@ -383,11 +446,28 @@ function AgentFolderNode({
     () => allDefinitions.filter((d) => d.folderId === folder.id),
     [allDefinitions, folder.id]
   );
+  const visibleChildFolders = filter
+    ? childFolders.filter((f) => filter.visibleFolderIds.has(f.id))
+    : childFolders;
+  const visibleChildDefinitions = filter
+    ? childDefinitions.filter((d) => filter.matchingDefinitionIds.has(d.id))
+    : childDefinitions;
 
   const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: `agent-folder:${agentId}:${folder.id}`,
     data: { type: "agent-folder", agentId, folderId: folder.id },
   });
+  const rowIndex = getNodeIndex(folder.id);
+  const rowRef = getRowRef(rowIndex);
+  // Merge the droppable ref with the roving-nav row ref so the folder button is
+  // both a drop target and a focusable roving-tabindex row.
+  const setRowNode = useCallback(
+    (el: HTMLButtonElement | null) => {
+      setDropRef(el);
+      rowRef(el);
+    },
+    [setDropRef, rowRef]
+  );
   const { active } = useDndContext();
   const isAgentConnectionOver =
     isOver &&
@@ -399,10 +479,16 @@ function AgentFolderNode({
       <ContextMenu.Root>
         <ContextMenu.Trigger asChild>
           <button
-            ref={setDropRef}
+            ref={setRowNode}
             className={`connection-tree__folder${isAgentConnectionOver ? " connection-tree__folder--drop-over" : ""}`}
             style={{ paddingLeft: `${depth * 16 + 8}px` }}
-            onClick={() => toggleAgentFolder(agentId, folder.id)}
+            onClick={() => onToggleFolder(folder.id)}
+            role="treeitem"
+            aria-expanded={expanded}
+            aria-level={depth}
+            tabIndex={rowIndex === activeIndex ? 0 : -1}
+            onKeyDown={(e) => onTreeKeyDown(e, folder.id)}
+            onFocus={() => onRowFocus(rowIndex)}
           >
             <Folder size={16} />
             <span className="connection-tree__label">{folder.name}</span>
@@ -437,8 +523,8 @@ function AgentFolderNode({
         </ContextMenu.Portal>
       </ContextMenu.Root>
 
-      {folder.isExpanded && (
-        <div className="connection-tree__children">
+      {expanded && (
+        <div className="connection-tree__children" role="group">
           {creatingSubfolder && (
             <InlineFolderInput
               depth={depth + 1}
@@ -449,7 +535,7 @@ function AgentFolderNode({
               onCancel={() => setCreatingSubfolder(false)}
             />
           )}
-          {childFolders.map((f) => (
+          {visibleChildFolders.map((f) => (
             <AgentFolderNode
               key={f.id}
               agentId={agentId}
@@ -467,9 +553,16 @@ function AgentFolderNode({
               onStartPersistent={onStartPersistent}
               onAttachPersistent={onAttachPersistent}
               onStopPersistent={onStopPersistent}
+              filter={filter}
+              activeIndex={activeIndex}
+              getNodeIndex={getNodeIndex}
+              getRowRef={getRowRef}
+              onTreeKeyDown={onTreeKeyDown}
+              onRowFocus={onRowFocus}
+              onToggleFolder={onToggleFolder}
             />
           ))}
-          {childDefinitions.map((def) => (
+          {visibleChildDefinitions.map((def) => (
             <AgentConnectionItem
               key={def.id}
               agentId={agentId}
@@ -484,6 +577,11 @@ function AgentFolderNode({
               onStartPersistent={onStartPersistent}
               onAttachPersistent={onAttachPersistent}
               onStopPersistent={onStopPersistent}
+              activeIndex={activeIndex}
+              getNodeIndex={getNodeIndex}
+              getRowRef={getRowRef}
+              onTreeKeyDown={onTreeKeyDown}
+              onRowFocus={onRowFocus}
             />
           ))}
         </div>
@@ -498,9 +596,19 @@ interface AgentRootDropZoneProps {
   agentId: string;
   children: ReactNode;
   onAreaClick?: (event: React.MouseEvent) => void;
+  /** Accessible label for the tree (the agent name). */
+  ariaLabel: string;
+  /** Roving-nav keyboard handler is per-row, but the tree owns the ARIA role. */
+  onKeyDown?: (event: React.KeyboardEvent) => void;
 }
 
-function AgentRootDropZone({ agentId, children, onAreaClick }: AgentRootDropZoneProps) {
+function AgentRootDropZone({
+  agentId,
+  children,
+  onAreaClick,
+  ariaLabel,
+  onKeyDown,
+}: AgentRootDropZoneProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: `agent-root:${agentId}`,
     data: { type: "agent-root", agentId },
@@ -516,6 +624,9 @@ function AgentRootDropZone({ agentId, children, onAreaClick }: AgentRootDropZone
       ref={setNodeRef}
       className={`connection-list__tree${isAgentConnectionOver ? " connection-tree__root-drop--over" : ""}`}
       onClick={onAreaClick}
+      onKeyDown={onKeyDown}
+      role="tree"
+      aria-label={ariaLabel}
     >
       {children}
     </div>
@@ -528,9 +639,11 @@ interface AgentNodeProps {
   agent: RemoteAgentDefinition;
   style?: React.CSSProperties;
   sectionRef?: (el: HTMLDivElement | null) => void;
+  /** Active search query for the Remote Agents section (empty = no filter). */
+  filterQuery?: string;
 }
 
-export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
+export function AgentNode({ agent, style, sectionRef, filterQuery = "" }: AgentNodeProps) {
   const {
     attributes,
     listeners,
@@ -596,9 +709,33 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
     [agentDefinitions]
   );
 
+  const toggleAgentFolder = useAppStore((s) => s.toggleAgentFolder);
+
+  // Live search filter over this agent's saved definitions (auto-expands
+  // matching folders). `null` when the query is empty. Sessions are live, not
+  // saved entries, so they are never filtered out.
+  const filter = useMemo(
+    () => filterAgentTree(filterQuery, agentFolders, agentDefinitions),
+    [filterQuery, agentFolders, agentDefinitions]
+  );
+
+  // Only a connected/reconnecting agent renders its tree, so the roving-nav
+  // node list is empty otherwise (keeps activeIndex clamped to nothing).
+  const treeActive = isConnected || isReconnecting;
+
+  // Flattened, in-order list of the interactive rows actually rendered — drives
+  // both roving-tabindex keyboard navigation and Shift+Click range selection.
+  const visibleNodes = useMemo(
+    () =>
+      treeActive
+        ? computeAgentTreeNodes(agentSessions, agentFolders, agentDefinitions, filter)
+        : [],
+    [treeActive, agentSessions, agentFolders, agentDefinitions, filter]
+  );
+
   const flatVisibleDefIds = useMemo(
-    () => computeFlatVisibleIds(rootFolders, rootDefinitions, agentFolders, agentDefinitions),
-    [rootFolders, rootDefinitions, agentFolders, agentDefinitions]
+    () => visibleNodes.filter((n) => n.kind === "definition").map((n) => n.id),
+    [visibleNodes]
   );
 
   const {
@@ -609,6 +746,45 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
   } = useTreeSelection(flatVisibleDefIds);
 
   const allSelectedDefIds = useMemo(() => [...selectedDefIds], [selectedDefIds]);
+
+  // Flat-list index lookup by node id so each row can resolve its position in
+  // the roving-nav item array (`visibleNodes`) for tabindex and ref wiring.
+  const nodeIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    visibleNodes.forEach((node, index) => map.set(node.id, index));
+    return map;
+  }, [visibleNodes]);
+  const getNodeIndex = useCallback((id: string) => nodeIndexById.get(id) ?? -1, [nodeIndexById]);
+
+  // Type-ahead label for a node: a session's title, a definition's name, or a
+  // folder's name.
+  const folderNameById = useMemo(
+    () => new Map(agentFolders.map((f) => [f.id, f.name])),
+    [agentFolders]
+  );
+  const getNodeLabel = useCallback(
+    (node: AgentVisibleNode) => {
+      if (node.kind === "session") return node.session?.title ?? "";
+      if (node.kind === "definition") return node.definition?.name ?? "";
+      return folderNameById.get(node.id) ?? "";
+    },
+    [folderNameById]
+  );
+
+  const { activeIndex, setActiveIndex, getRowRef, focusRow, makeKeyDownHandler } = useRovingListNav<
+    AgentVisibleNode,
+    HTMLButtonElement
+  >(visibleNodes, getNodeLabel);
+
+  // While a search filter is active, folders are force-expanded by the render
+  // logic; suppress toggles so clearing the filter restores the prior state.
+  const handleToggleFolder = useCallback(
+    (folderId: string) => {
+      if (filter) return;
+      toggleAgentFolder(agent.id, folderId);
+    },
+    [filter, toggleAgentFolder, agent.id]
+  );
 
   useDndMonitor({
     onDragEnd(event) {
@@ -874,6 +1050,112 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
     [agent.id, stopPersistentSession]
   );
 
+  // Activate a row: folders toggle, sessions attach, definitions open — shared
+  // by Enter (via the roving-nav handler) and Space (tree-specific handler).
+  const activateNode = useCallback(
+    (node: AgentVisibleNode) => {
+      if (node.kind === "folder") {
+        handleToggleFolder(node.id);
+      } else if (node.kind === "session" && node.session) {
+        handleAttachSession(node.session);
+      } else if (node.kind === "definition" && node.definition) {
+        // Persistent shells go through the persistent-session machinery so the
+        // sidebar dot reflects real state (matching the double-click path).
+        if (node.definition.persistent) handleAttachPersistent(agent.id, node.definition);
+        else handleOpenDefinition(node.definition);
+      }
+    },
+    [
+      handleToggleFolder,
+      handleAttachSession,
+      handleAttachPersistent,
+      handleOpenDefinition,
+      agent.id,
+    ]
+  );
+
+  // Shared roving-nav keydown handler (Up/Down, Home/End, Enter, type-ahead,
+  // Escape). Focus navigation does not mutate the multi-selection, so the
+  // selection callbacks are intentionally inert (mouse drives selection).
+  const rovingKeyDown = useMemo(
+    () =>
+      makeKeyDownHandler({
+        onActivate: activateNode,
+        onNavigateUp: () => {},
+        onRename: () => {},
+        onSelectAll: () => {},
+        onClearSelection: clearDefSelection,
+        getAnchorIndex: () => -1,
+        onSelectRange: () => {},
+        onSelectSingle: () => {},
+      }),
+    [makeKeyDownHandler, activateNode, clearDefSelection]
+  );
+
+  // Per-row keydown: tree-specific keys (expand/collapse, move to parent/child,
+  // Space to activate) are handled here; everything else delegates to the
+  // shared roving-nav handler.
+  const handleTreeKeyDown = useCallback(
+    (event: React.KeyboardEvent, nodeId: string) => {
+      const index = getNodeIndex(nodeId);
+      const node = visibleNodes[index];
+      if (!node) return;
+      switch (event.key) {
+        case "ArrowRight": {
+          if (node.kind !== "folder") return;
+          event.preventDefault();
+          if (!node.isExpanded && node.hasChildren) {
+            handleToggleFolder(node.id);
+          } else if (node.isExpanded) {
+            const child = visibleNodes[index + 1];
+            if (child && child.depth > node.depth) focusRow(index + 1);
+          }
+          return;
+        }
+        case "ArrowLeft": {
+          event.preventDefault();
+          if (node.kind === "folder" && node.isExpanded) {
+            handleToggleFolder(node.id);
+          } else if (node.parentId) {
+            const parentIndex = getNodeIndex(node.parentId);
+            if (parentIndex >= 0) focusRow(parentIndex);
+          }
+          return;
+        }
+        case " ": {
+          event.preventDefault();
+          activateNode(node);
+          return;
+        }
+        default:
+          rovingKeyDown(event);
+      }
+    },
+    [visibleNodes, getNodeIndex, focusRow, activateNode, rovingKeyDown, handleToggleFolder]
+  );
+
+  // Sync the roving active index when a row gains DOM focus (Tab, click).
+  const handleRowFocus = useCallback((index: number) => setActiveIndex(index), [setActiveIndex]);
+
+  // Root-level rows filtered to the active search (folders auto-expand matches).
+  const visibleRootFolders = filter
+    ? rootFolders.filter((f) => filter.visibleFolderIds.has(f.id))
+    : rootFolders;
+  const visibleRootDefinitions = filter
+    ? rootDefinitions.filter((d) => filter.matchingDefinitionIds.has(d.id))
+    : rootDefinitions;
+  const hasFilterMatches = visibleRootFolders.length + visibleRootDefinitions.length > 0;
+
+  const treeNav: AgentTreeNavProps = {
+    filter,
+    activeIndex,
+    getNodeIndex,
+    getRowRef,
+    onTreeKeyDown: handleTreeKeyDown,
+    onRowFocus: handleRowFocus,
+    onToggleFolder: handleToggleFolder,
+  };
+
   const hasContent =
     agentSessions.length > 0 || agentDefinitions.length > 0 || agentFolders.length > 0;
 
@@ -1132,7 +1414,11 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
       />
 
       {agent.isExpanded && (
-        <AgentRootDropZone agentId={agent.id} onAreaClick={handleTreeAreaClick}>
+        <AgentRootDropZone
+          agentId={agent.id}
+          onAreaClick={handleTreeAreaClick}
+          ariaLabel={`${agent.name} connections`}
+        >
           {isConnected || isReconnecting ? (
             <>
               {/* Reconnecting banner */}
@@ -1153,19 +1439,28 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                     <Zap size={12} />
                     Active Sessions
                   </div>
-                  {agentSessions.map((session) => (
-                    <button
-                      key={session.sessionId}
-                      className="connection-tree__item"
-                      style={{ paddingLeft: 32 }}
-                      onDoubleClick={() => handleAttachSession(session)}
-                      title={`${session.title} (${session.status})`}
-                    >
-                      <SessionTypeIcon type={session.type} />
-                      <span className="connection-tree__label">{session.title}</span>
-                      <span className="connection-tree__type">{session.status}</span>
-                    </button>
-                  ))}
+                  {agentSessions.map((session) => {
+                    const rowIndex = getNodeIndex(session.sessionId);
+                    return (
+                      <button
+                        key={session.sessionId}
+                        ref={getRowRef(rowIndex)}
+                        className="connection-tree__item"
+                        style={{ paddingLeft: 32 }}
+                        onDoubleClick={() => handleAttachSession(session)}
+                        title={`${session.title} (${session.status})`}
+                        role="treeitem"
+                        aria-level={1}
+                        tabIndex={rowIndex === activeIndex ? 0 : -1}
+                        onKeyDown={(e) => handleTreeKeyDown(e, session.sessionId)}
+                        onFocus={() => handleRowFocus(rowIndex)}
+                      >
+                        <SessionTypeIcon type={session.type} />
+                        <span className="connection-tree__label">{session.title}</span>
+                        <span className="connection-tree__type">{session.status}</span>
+                      </button>
+                    );
+                  })}
                 </>
               )}
 
@@ -1190,7 +1485,7 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
               )}
 
               {/* Root folders */}
-              {rootFolders.map((folder) => (
+              {visibleRootFolders.map((folder) => (
                 <AgentFolderNode
                   key={folder.id}
                   agentId={agent.id}
@@ -1208,11 +1503,12 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                   onStartPersistent={handleStartPersistent}
                   onAttachPersistent={handleAttachPersistent}
                   onStopPersistent={handleStopPersistent}
+                  {...treeNav}
                 />
               ))}
 
               {/* Root connections (no folder) */}
-              {rootDefinitions.map((def) => (
+              {visibleRootDefinitions.map((def) => (
                 <AgentConnectionItem
                   key={def.id}
                   agentId={agent.id}
@@ -1227,11 +1523,23 @@ export function AgentNode({ agent, style, sectionRef }: AgentNodeProps) {
                   onStartPersistent={handleStartPersistent}
                   onAttachPersistent={handleAttachPersistent}
                   onStopPersistent={handleStopPersistent}
+                  activeIndex={activeIndex}
+                  getNodeIndex={getNodeIndex}
+                  getRowRef={getRowRef}
+                  onTreeKeyDown={handleTreeKeyDown}
+                  onRowFocus={handleRowFocus}
                 />
               ))}
 
+              {/* No-match state while filtering */}
+              {filter && !hasFilterMatches && agentSessions.length === 0 && (
+                <p className="agent-node__hint" role="status" style={{ paddingLeft: 32 }}>
+                  No connections match “{filter.query}”.
+                </p>
+              )}
+
               {/* Empty state */}
-              {!hasContent && (
+              {!hasContent && !filter && (
                 <div className="agent-node__hint" style={{ paddingLeft: 32 }}>
                   No sessions. Right-click to create one.
                 </div>

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -482,6 +482,7 @@ function buildExpandedIndexMap(sectionsExpanded: boolean[]): { map: number[]; co
 export function ConnectionList() {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
+  const [agentFilterQuery, setAgentFilterQuery] = useState("");
   const [draggingConnection, setDraggingConnection] = useState<SavedConnection | null>(null);
   const [draggingAgentName, setDraggingAgentName] = useState<string | null>(null);
   const [draggingAgentDef, setDraggingAgentDef] = useState<AgentDefinitionInfo | null>(null);
@@ -1291,6 +1292,38 @@ export function ConnectionList() {
                 </div>
               </div>
               {!remoteAgentsCollapsed && (
+                <div className="connection-list__filter">
+                  <Search size={14} className="connection-list__filter-icon" aria-hidden="true" />
+                  <Input
+                    className="connection-list__filter-input"
+                    value={agentFilterQuery}
+                    onChange={(e) => setAgentFilterQuery(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape") {
+                        e.preventDefault();
+                        setAgentFilterQuery("");
+                      }
+                    }}
+                    placeholder="Filter agent connections…"
+                    aria-label="Filter agent connections"
+                    data-testid="agent-filter-input"
+                  />
+                  {agentFilterQuery && (
+                    <Tooltip content="Clear filter" side="top">
+                      <button
+                        type="button"
+                        className="connection-list__filter-clear"
+                        onClick={() => setAgentFilterQuery("")}
+                        aria-label="Clear agent filter"
+                        data-testid="agent-filter-clear"
+                      >
+                        <X size={14} />
+                      </button>
+                    </Tooltip>
+                  )}
+                </div>
+              )}
+              {!remoteAgentsCollapsed && (
                 <SortableContext
                   items={remoteAgents.map((a) => a.id)}
                   strategy={verticalListSortingStrategy}
@@ -1310,6 +1343,7 @@ export function ConnectionList() {
                         )}
                         <AgentNode
                           agent={agent}
+                          filterQuery={agentFilterQuery}
                           style={innerIdx >= 0 ? { flex: innerFlexValues[innerIdx] } : undefined}
                           sectionRef={(el) => {
                             if (innerIdx >= 0) innerSectionRefs.current[innerIdx] = el;

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { Play, Square, Pencil, Copy, Trash2, RotateCw, Info, AlertTriangle } from "lucide-react";
 import { Button, Tooltip, toast } from "@/components/ui";
 import { SidebarListItem, SidebarStatusDot } from "@/components/SidebarListItem";
@@ -23,6 +24,10 @@ interface TunnelListItemProps {
   onEdit: (tunnelId: string) => void;
   onDuplicate: (tunnelId: string) => void;
   onDelete: (tunnelId: string) => void;
+  /** Roving-tabindex ref wiring the row into the sidebar's keyboard navigation. */
+  rowRef?: (el: HTMLDivElement | null) => void;
+  /** Roving-tabindex row props (role, tabIndex, aria-level, onFocus) for keyboard nav. */
+  rowProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 /** Get the port mapping display string for a tunnel. */
@@ -69,6 +74,8 @@ export function TunnelListItem({
   onEdit,
   onDuplicate,
   onDelete,
+  rowRef,
+  rowProps,
 }: TunnelListItemProps) {
   const status = state?.status ?? "disconnected";
   const isActive = status === "connected" || status === "connecting" || status === "reconnecting";
@@ -88,6 +95,8 @@ export function TunnelListItem({
 
   return (
     <SidebarListItem
+      ref={rowRef}
+      {...rowProps}
       testId={`tunnel-item-${tunnel.id}`}
       nameTestId={`tunnel-name-${tunnel.id}`}
       name={tunnel.name}

--- a/src/components/TunnelSidebar/TunnelSidebar.keyboard.test.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.keyboard.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Keyboard-navigation + ARIA tree semantics for the Tunnels sidebar (#1379).
+ *
+ * The Tunnels list adopts the same roving-tabindex arrow-key model + tree ARIA
+ * roles as the Connections tree: one row is tabbable at a time, arrows move the
+ * roving focus, and Enter activates (edits) the focused tunnel.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { TunnelConfig } from "@/types/tunnel";
+import { TooltipProvider } from "@/components/ui";
+import { TunnelSidebar } from "./TunnelSidebar";
+
+vi.mock("@/store/appStore", () => {
+  const state: Record<string, unknown> = {};
+  const useAppStore = (selector: (s: Record<string, unknown>) => unknown) => selector(state);
+  useAppStore.setState = (patch: Record<string, unknown>) => Object.assign(state, patch);
+  return { useAppStore };
+});
+
+function makeTunnel(id: string, name: string): TunnelConfig {
+  return {
+    id,
+    name,
+    sshConnectionId: "conn-1",
+    tunnelType: {
+      type: "local",
+      config: { localHost: "127.0.0.1", localPort: 8080, remoteHost: "127.0.0.1", remotePort: 80 },
+    },
+    autoStart: false,
+    reconnectOnDisconnect: false,
+  };
+}
+
+const openTunnelEditorTab = vi.fn();
+
+function seedStore() {
+  (useAppStore as unknown as { setState: (p: Record<string, unknown>) => void }).setState({
+    tunnels: [makeTunnel("tun-1", "Alpha"), makeTunnel("tun-2", "Bravo")],
+    tunnelStates: {},
+    connections: [],
+    startTunnel: vi.fn(),
+    stopTunnel: vi.fn(),
+    reconnectTunnel: vi.fn(),
+    saveTunnel: vi.fn(),
+    deleteTunnel: vi.fn(),
+    openTunnelEditorTab,
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+function press(key: string) {
+  const list = query("tunnel-list")!;
+  act(() => {
+    list.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+function renderSidebar() {
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <TunnelSidebar />
+      </TooltipProvider>
+    );
+  });
+}
+
+describe("TunnelSidebar — keyboard navigation (#1379)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+    seedStore();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("marks the list as a tree and rows as treeitems", () => {
+    renderSidebar();
+    expect(query("tunnel-list")!.getAttribute("role")).toBe("tree");
+    const first = query("tunnel-item-tun-1")!;
+    expect(first.getAttribute("role")).toBe("treeitem");
+    expect(first.getAttribute("aria-level")).toBe("1");
+  });
+
+  it("keeps a single roving-tabindex row (first row tabbable)", () => {
+    renderSidebar();
+    expect(query("tunnel-item-tun-1")!.getAttribute("tabindex")).toBe("0");
+    expect(query("tunnel-item-tun-2")!.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("moves the roving focus down with ArrowDown", () => {
+    renderSidebar();
+    press("ArrowDown");
+    expect(document.activeElement).toBe(query("tunnel-item-tun-2"));
+    expect(query("tunnel-item-tun-2")!.getAttribute("tabindex")).toBe("0");
+    expect(query("tunnel-item-tun-1")!.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("activates (edits) the focused tunnel on Enter", () => {
+    renderSidebar();
+    press("ArrowDown");
+    press("Enter");
+    expect(openTunnelEditorTab).toHaveBeenCalledWith("tun-2");
+  });
+});

--- a/src/components/TunnelSidebar/TunnelSidebar.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.tsx
@@ -131,7 +131,7 @@ export function TunnelSidebar() {
                 onDuplicate={handleDuplicate}
                 onDelete={handleDelete}
                 rowRef={ref}
-                rowProps={{ ...itemProps, role: "treeitem", "aria-level": 1 }}
+                rowProps={itemProps}
               />
             );
           })}

--- a/src/components/TunnelSidebar/TunnelSidebar.tsx
+++ b/src/components/TunnelSidebar/TunnelSidebar.tsx
@@ -3,7 +3,8 @@ import { Plus } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { toast } from "@/components/ui";
 import { ConfirmDeleteDialog } from "@/components/Sidebar/ConfirmDeleteDialog";
-import type { TunnelStatus } from "@/types/tunnel";
+import { useFlatRovingNav } from "@/hooks/useFlatRovingNav";
+import type { TunnelConfig, TunnelStatus } from "@/types/tunnel";
 import { TunnelListItem } from "./TunnelListItem";
 import "./TunnelSidebar.css";
 
@@ -79,6 +80,16 @@ export function TunnelSidebar() {
 
   const cancelDelete = useCallback(() => setPendingDelete(null), []);
 
+  // Roving-tabindex keyboard navigation over the flat tunnel list, matching the
+  // Connections tree's arrow-key + Enter model. Enter edits the focused tunnel
+  // (the same action as double-click).
+  const handleActivate = useCallback((tunnel: TunnelConfig) => handleEdit(tunnel.id), [handleEdit]);
+  const nav = useFlatRovingNav<TunnelConfig, HTMLDivElement>(
+    tunnels,
+    (tunnel) => tunnel.name,
+    handleActivate
+  );
+
   return (
     <div className="tunnel-sidebar" data-testid="tunnel-sidebar">
       <div className="tunnel-sidebar__actions">
@@ -98,21 +109,32 @@ export function TunnelSidebar() {
           <span>Click &quot;+ New Tunnel&quot; to create one.</span>
         </div>
       ) : (
-        <div className="tunnel-sidebar__list" data-testid="tunnel-list">
-          {tunnels.map((tunnel) => (
-            <TunnelListItem
-              key={tunnel.id}
-              tunnel={tunnel}
-              state={tunnelStates[tunnel.id]}
-              connections={connections}
-              onStart={startTunnel}
-              onStop={stopTunnel}
-              onReconnect={reconnectTunnel}
-              onEdit={handleEdit}
-              onDuplicate={handleDuplicate}
-              onDelete={handleDelete}
-            />
-          ))}
+        <div
+          className="tunnel-sidebar__list"
+          data-testid="tunnel-list"
+          role="tree"
+          aria-label="SSH tunnels"
+          onKeyDown={nav.onKeyDown}
+        >
+          {tunnels.map((tunnel, index) => {
+            const { ref, ...itemProps } = nav.getItemProps(index);
+            return (
+              <TunnelListItem
+                key={tunnel.id}
+                tunnel={tunnel}
+                state={tunnelStates[tunnel.id]}
+                connections={connections}
+                onStart={startTunnel}
+                onStop={stopTunnel}
+                onReconnect={reconnectTunnel}
+                onEdit={handleEdit}
+                onDuplicate={handleDuplicate}
+                onDelete={handleDelete}
+                rowRef={ref}
+                rowProps={{ ...itemProps, role: "treeitem", "aria-level": 1 }}
+              />
+            );
+          })}
         </div>
       )}
       <ConfirmDeleteDialog

--- a/src/components/WorkspaceSidebar/WorkspaceListItem.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceListItem.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { Play, Loader2, Pencil, Copy, Trash2 } from "lucide-react";
 import { Button, Tooltip } from "@/components/ui";
 import { SidebarListItem } from "@/components/SidebarListItem";
@@ -15,6 +16,10 @@ interface WorkspaceListItemProps {
    * launch (GAP G6, #1146).
    */
   launchDisabled?: boolean;
+  /** Roving-tabindex ref wiring the row into the sidebar's keyboard navigation. */
+  rowRef?: (el: HTMLDivElement | null) => void;
+  /** Roving-tabindex row props (role, tabIndex, aria-level, onFocus) for keyboard nav. */
+  rowProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 export function WorkspaceListItem({
@@ -24,9 +29,13 @@ export function WorkspaceListItem({
   onDuplicate,
   onDelete,
   launchDisabled = false,
+  rowRef,
+  rowProps,
 }: WorkspaceListItemProps) {
   return (
     <SidebarListItem
+      ref={rowRef}
+      {...rowProps}
       testId={`workspace-item-${workspace.id}`}
       nameTestId={`workspace-name-${workspace.id}`}
       name={workspace.name}

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.keyboard.test.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.keyboard.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Keyboard-navigation + ARIA tree semantics for the Workspaces sidebar (#1379).
+ *
+ * The Workspaces list adopts the same roving-tabindex arrow-key model + tree
+ * ARIA roles as the Connections tree: one row is tabbable at a time, arrows move
+ * the roving focus, and Enter activates (launches) the focused workspace.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { WorkspaceSidebar } from "./WorkspaceSidebar";
+import { withTooltip } from "@/test/tooltip";
+import { WorkspaceSummary } from "@/types/workspace";
+import { useAppStore } from "@/store/appStore";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn().mockResolvedValue(vi.fn()) }));
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn() }));
+
+const sampleWorkspaces: WorkspaceSummary[] = [
+  { id: "ws-1", name: "Alpha", connectionCount: 3 },
+  { id: "ws-2", name: "Bravo", connectionCount: 1 },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+function press(key: string) {
+  const list = query("workspace-list")!;
+  act(() => {
+    list.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+describe("WorkspaceSidebar — keyboard navigation (#1379)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("marks the list as a tree and rows as treeitems", () => {
+    useAppStore.setState({ workspaces: sampleWorkspaces });
+    act(() => root.render(withTooltip(<WorkspaceSidebar />)));
+
+    expect(query("workspace-list")!.getAttribute("role")).toBe("tree");
+    const first = query("workspace-item-ws-1")!;
+    expect(first.getAttribute("role")).toBe("treeitem");
+    expect(first.getAttribute("aria-level")).toBe("1");
+  });
+
+  it("keeps a single roving-tabindex row (first row tabbable)", () => {
+    useAppStore.setState({ workspaces: sampleWorkspaces });
+    act(() => root.render(withTooltip(<WorkspaceSidebar />)));
+
+    expect(query("workspace-item-ws-1")!.getAttribute("tabindex")).toBe("0");
+    expect(query("workspace-item-ws-2")!.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("moves the roving focus down with ArrowDown", () => {
+    useAppStore.setState({ workspaces: sampleWorkspaces });
+    act(() => root.render(withTooltip(<WorkspaceSidebar />)));
+
+    press("ArrowDown");
+    expect(document.activeElement).toBe(query("workspace-item-ws-2"));
+    expect(query("workspace-item-ws-2")!.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("activates (launches) the focused workspace on Enter", () => {
+    const launchWorkspace = vi.fn();
+    useAppStore.setState({
+      workspaces: sampleWorkspaces,
+      launchWorkspace,
+      launchingWorkspaceId: null,
+    });
+    act(() => root.render(withTooltip(<WorkspaceSidebar />)));
+
+    press("ArrowDown");
+    press("Enter");
+    expect(launchWorkspace).toHaveBeenCalledWith("ws-2");
+  });
+});

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -230,7 +230,7 @@ export function WorkspaceSidebar() {
                 onDelete={handleDelete}
                 launchDisabled={launchingWorkspaceId !== null}
                 rowRef={ref}
-                rowProps={{ ...itemProps, role: "treeitem", "aria-level": 1 }}
+                rowProps={itemProps}
               />
             );
           })}

--- a/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
+++ b/src/components/WorkspaceSidebar/WorkspaceSidebar.tsx
@@ -6,6 +6,8 @@ import { useAppStore } from "@/store/appStore";
 import { Button, toast, Tooltip } from "@/components/ui";
 import { frontendLog } from "@/utils/frontendLog";
 import { exportWorkspaces, importWorkspaces } from "@/services/workspaceApi";
+import { useFlatRovingNav } from "@/hooks/useFlatRovingNav";
+import type { WorkspaceSummary } from "@/types/workspace";
 import { WorkspaceListItem } from "./WorkspaceListItem";
 import { SaveWorkspaceDialog, SaveWorkspaceScope } from "./SaveWorkspaceDialog";
 import { ConfirmDeleteDialog } from "@/components/Sidebar/ConfirmDeleteDialog";
@@ -138,6 +140,21 @@ export function WorkspaceSidebar() {
   const activeGroup = tabGroups.find((g) => g.id === activeTabGroupId);
   const activeGroupName = activeGroup?.name ?? "Main";
 
+  // Roving-tabindex keyboard navigation over the flat workspace list, matching
+  // the Connections tree's arrow-key + Enter model. Enter launches the focused
+  // workspace (the same action as double-click), unless a launch is in flight.
+  const handleActivate = useCallback(
+    (workspace: WorkspaceSummary) => {
+      if (launchingWorkspaceId === null) handleLaunch(workspace.id);
+    },
+    [launchingWorkspaceId, handleLaunch]
+  );
+  const nav = useFlatRovingNav<WorkspaceSummary, HTMLDivElement>(
+    workspaces,
+    (workspace) => workspace.name,
+    handleActivate
+  );
+
   return (
     <div className="workspace-sidebar" data-testid="workspace-sidebar">
       <div className="workspace-sidebar__actions">
@@ -194,18 +211,29 @@ export function WorkspaceSidebar() {
           <span>Click &quot;+ New Workspace&quot; to create one.</span>
         </div>
       ) : (
-        <div className="workspace-sidebar__list" data-testid="workspace-list">
-          {workspaces.map((workspace) => (
-            <WorkspaceListItem
-              key={workspace.id}
-              workspace={workspace}
-              onLaunch={handleLaunch}
-              onEdit={handleEdit}
-              onDuplicate={handleDuplicate}
-              onDelete={handleDelete}
-              launchDisabled={launchingWorkspaceId !== null}
-            />
-          ))}
+        <div
+          className="workspace-sidebar__list"
+          data-testid="workspace-list"
+          role="tree"
+          aria-label="Workspaces"
+          onKeyDown={nav.onKeyDown}
+        >
+          {workspaces.map((workspace, index) => {
+            const { ref, ...itemProps } = nav.getItemProps(index);
+            return (
+              <WorkspaceListItem
+                key={workspace.id}
+                workspace={workspace}
+                onLaunch={handleLaunch}
+                onEdit={handleEdit}
+                onDuplicate={handleDuplicate}
+                onDelete={handleDelete}
+                launchDisabled={launchingWorkspaceId !== null}
+                rowRef={ref}
+                rowProps={{ ...itemProps, role: "treeitem", "aria-level": 1 }}
+              />
+            );
+          })}
         </div>
       )}
       {showSaveDialog && (

--- a/src/hooks/useFlatRovingNav.test.tsx
+++ b/src/hooks/useFlatRovingNav.test.tsx
@@ -26,14 +26,7 @@ function Harness({ items, onActivate }: { items: Item[]; onActivate: (item: Item
       {items.map((item, index) => {
         const { ref, ...props } = nav.getItemProps(index);
         return (
-          <button
-            key={item.name}
-            ref={ref}
-            role="treeitem"
-            aria-level={1}
-            data-testid={`row-${item.name}`}
-            {...props}
-          >
+          <button key={item.name} ref={ref} data-testid={`row-${item.name}`} {...props}>
             {item.name}
           </button>
         );

--- a/src/hooks/useFlatRovingNav.test.tsx
+++ b/src/hooks/useFlatRovingNav.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useFlatRovingNav, FlatRovingNav } from "./useFlatRovingNav";
+
+interface Item {
+  name: string;
+}
+
+const ITEMS: Item[] = [
+  { name: "alpha" },
+  { name: "apple" },
+  { name: "banana" },
+  { name: "cherry" },
+];
+
+/**
+ * Minimal list harness mirroring how a flat sidebar wires the hook: a keydown
+ * container plus roving-tabindex rows whose props flow through getItemProps.
+ */
+function Harness({ items, onActivate }: { items: Item[]; onActivate: (item: Item) => void }) {
+  const nav = useFlatRovingNav<Item, HTMLButtonElement>(items, (i) => i.name, onActivate);
+  navRef = nav;
+  return (
+    <div data-testid="list" role="tree" onKeyDown={nav.onKeyDown}>
+      {items.map((item, index) => {
+        const { ref, ...props } = nav.getItemProps(index);
+        return (
+          <button
+            key={item.name}
+            ref={ref}
+            role="treeitem"
+            aria-level={1}
+            data-testid={`row-${item.name}`}
+            {...props}
+          >
+            {item.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+let navRef: FlatRovingNav<HTMLButtonElement>;
+
+describe("useFlatRovingNav", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  function press(key: string, opts: Partial<KeyboardEventInit> = {}) {
+    const list = container.querySelector('[data-testid="list"]') as HTMLElement;
+    act(() => {
+      list.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...opts }));
+    });
+  }
+
+  function render(items: Item[], onActivate: (item: Item) => void) {
+    act(() => {
+      root.render(<Harness items={items} onActivate={onActivate} />);
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("starts with the first row active (tabIndex 0)", () => {
+    render(ITEMS, vi.fn());
+    expect(navRef.activeIndex).toBe(0);
+    expect(navRef.getItemProps(0).tabIndex).toBe(0);
+    expect(navRef.getItemProps(1).tabIndex).toBe(-1);
+  });
+
+  it("moves the active row with ArrowDown/ArrowUp and focuses it", () => {
+    render(ITEMS, vi.fn());
+    press("ArrowDown");
+    expect(navRef.activeIndex).toBe(1);
+    expect(document.activeElement).toBe(container.querySelector('[data-testid="row-apple"]'));
+    press("ArrowUp");
+    expect(navRef.activeIndex).toBe(0);
+  });
+
+  it("jumps to the ends with Home/End", () => {
+    render(ITEMS, vi.fn());
+    press("End");
+    expect(navRef.activeIndex).toBe(ITEMS.length - 1);
+    press("Home");
+    expect(navRef.activeIndex).toBe(0);
+  });
+
+  it("activates the focused row on Enter", () => {
+    const onActivate = vi.fn();
+    render(ITEMS, onActivate);
+    press("ArrowDown");
+    press("Enter");
+    expect(onActivate).toHaveBeenCalledWith(ITEMS[1], 1);
+  });
+
+  it("type-ahead jumps to a label starting with the typed key", () => {
+    render(ITEMS, vi.fn());
+    press("b");
+    expect(navRef.activeIndex).toBe(2);
+  });
+
+  it("onFocus syncs the active index to the focused row", () => {
+    render(ITEMS, vi.fn());
+    act(() => navRef.getItemProps(2).onFocus());
+    expect(navRef.activeIndex).toBe(2);
+  });
+});

--- a/src/hooks/useFlatRovingNav.ts
+++ b/src/hooks/useFlatRovingNav.ts
@@ -1,0 +1,83 @@
+import { useCallback, useMemo } from "react";
+import { useRovingListNav } from "./useRovingListNav";
+
+/**
+ * Roving-tabindex props for a single row, spread-friendly for the row element.
+ * The `ref` is passed separately (React reserves `ref`); everything else can be
+ * spread onto the row.
+ */
+export interface FlatRovingItemProps<E extends HTMLElement> {
+  /** Wires the row into the roving-nav focus tracking. */
+  ref: (el: E | null) => void;
+  /** `0` for the active row, `-1` for the rest (roving-tabindex). */
+  tabIndex: number;
+  /** Sync the roving active index when the row gains DOM focus (Tab/click). */
+  onFocus: () => void;
+}
+
+/** Public surface of {@link useFlatRovingNav}. */
+export interface FlatRovingNav<E extends HTMLElement> {
+  /** Roving-tabindex active index into the items array. */
+  activeIndex: number;
+  /**
+   * Keyboard handler for the list container that wraps the roving rows. Covers
+   * arrow/Home/End movement, Enter to activate, and type-ahead jumping.
+   */
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  /** Roving-tabindex props (ref, tabIndex, onFocus) for the row at `index`. */
+  getItemProps: (index: number) => FlatRovingItemProps<E>;
+}
+
+/**
+ * Roving-tabindex keyboard navigation for a **flat, single-select** sidebar
+ * list (Tunnels, Workspaces, …). A thin adapter over {@link useRovingListNav}
+ * that fills in the multi-select/tree callbacks with no-ops so the caller only
+ * has to supply an `onActivate` (Enter / activation) handler.
+ *
+ * Wire it up by spreading {@link FlatRovingNav.getItemProps} onto each row and
+ * attaching {@link FlatRovingNav.onKeyDown} to the row container. Arrow keys move
+ * focus, Enter activates, and printable characters type-ahead by label.
+ *
+ * @param items - Rows in display order (the single source of order for both the
+ *   rendered rows and keyboard navigation).
+ * @param getLabel - Extracts the type-ahead label (usually the display name).
+ * @param onActivate - Invoked for Enter on the focused row.
+ */
+export function useFlatRovingNav<T, E extends HTMLElement = HTMLElement>(
+  items: T[],
+  getLabel: (item: T) => string,
+  onActivate: (item: T, index: number) => void
+): FlatRovingNav<E> {
+  const { activeIndex, setActiveIndex, getRowRef, makeKeyDownHandler } = useRovingListNav<T, E>(
+    items,
+    getLabel
+  );
+
+  // A flat single-select list uses none of the tree/multi-select callbacks;
+  // only Enter activation is meaningful here.
+  const onKeyDown = useMemo(
+    () =>
+      makeKeyDownHandler({
+        onActivate,
+        onNavigateUp: () => {},
+        onRename: () => {},
+        onSelectAll: () => {},
+        onClearSelection: () => {},
+        getAnchorIndex: () => -1,
+        onSelectRange: () => {},
+        onSelectSingle: () => {},
+      }),
+    [makeKeyDownHandler, onActivate]
+  );
+
+  const getItemProps = useCallback(
+    (index: number): FlatRovingItemProps<E> => ({
+      ref: getRowRef(index),
+      tabIndex: index === activeIndex ? 0 : -1,
+      onFocus: () => setActiveIndex(index),
+    }),
+    [getRowRef, activeIndex, setActiveIndex]
+  );
+
+  return { activeIndex, onKeyDown, getItemProps };
+}

--- a/src/hooks/useFlatRovingNav.ts
+++ b/src/hooks/useFlatRovingNav.ts
@@ -13,6 +13,10 @@ export interface FlatRovingItemProps<E extends HTMLElement> {
   tabIndex: number;
   /** Sync the roving active index when the row gains DOM focus (Tab/click). */
   onFocus: () => void;
+  /** Tree row semantics — the list container carries `role="tree"`. */
+  role: "treeitem";
+  /** Flat list, so every row is a top-level tree node. */
+  "aria-level": number;
 }
 
 /** Public surface of {@link useFlatRovingNav}. */
@@ -75,6 +79,8 @@ export function useFlatRovingNav<T, E extends HTMLElement = HTMLElement>(
       ref: getRowRef(index),
       tabIndex: index === activeIndex ? 0 : -1,
       onFocus: () => setActiveIndex(index),
+      role: "treeitem",
+      "aria-level": 1,
     }),
     [getRowRef, activeIndex, setActiveIndex]
   );

--- a/src/utils/agentTreeSearch.test.ts
+++ b/src/utils/agentTreeSearch.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { filterAgentTree, agentDefinitionMatchesQuery } from "./agentTreeSearch";
+import type { AgentDefinitionInfo, AgentFolderInfo } from "@/services/api";
+
+function def(id: string, name: string, folderId: string | null = null): AgentDefinitionInfo {
+  return { id, name, sessionType: "shell", config: {}, persistent: false, folderId };
+}
+
+function folder(id: string, name: string, parentId: string | null = null): AgentFolderInfo {
+  return { id, name, parentId, isExpanded: false };
+}
+
+describe("agentDefinitionMatchesQuery", () => {
+  it("matches everything on an empty query", () => {
+    expect(agentDefinitionMatchesQuery(def("d1", "Anything"), "")).toBe(true);
+  });
+
+  it("matches by (case-insensitive) name substring", () => {
+    expect(agentDefinitionMatchesQuery(def("d1", "Web Server"), "web")).toBe(true);
+    expect(agentDefinitionMatchesQuery(def("d1", "Web Server"), "db")).toBe(false);
+  });
+});
+
+describe("filterAgentTree", () => {
+  it("returns null for an empty query", () => {
+    expect(filterAgentTree("  ", [], [])).toBeNull();
+  });
+
+  it("keeps only matching definitions and their ancestor folders", () => {
+    const folders = [folder("f1", "Prod"), folder("f2", "Nested", "f1")];
+    const definitions = [
+      def("d1", "web-01", "f2"),
+      def("d2", "db-01", "f2"),
+      def("d3", "root-web", null),
+    ];
+    const result = filterAgentTree("web", folders, definitions);
+    expect(result).not.toBeNull();
+    expect([...result!.matchingDefinitionIds].sort()).toEqual(["d1", "d3"]);
+    // f2 holds a match, f1 is its ancestor — both visible; no unrelated folders.
+    expect([...result!.visibleFolderIds].sort()).toEqual(["f1", "f2"]);
+  });
+
+  it("marks no folders visible when only a root definition matches", () => {
+    const folders = [folder("f1", "Prod")];
+    const definitions = [def("d1", "web-01", null), def("d2", "db-01", "f1")];
+    const result = filterAgentTree("web", folders, definitions);
+    expect([...result!.matchingDefinitionIds]).toEqual(["d1"]);
+    expect(result!.visibleFolderIds.size).toBe(0);
+  });
+});

--- a/src/utils/agentTreeSearch.ts
+++ b/src/utils/agentTreeSearch.ts
@@ -1,0 +1,74 @@
+import { AgentDefinitionInfo, AgentFolderInfo } from "@/services/api";
+
+/**
+ * Result of filtering a remote-agent connection tree by a search query.
+ *
+ * Mirrors {@link import("./connectionSearch").ConnectionTreeFilter} for the
+ * agent domain: when a query is active, only definitions whose name matches are
+ * kept, along with every ancestor folder needed to reveal them. Folders in
+ * {@link AgentTreeFilter.visibleFolderIds} are always shown expanded (the
+ * "auto-expand matches" behaviour), regardless of their stored `isExpanded`.
+ */
+export interface AgentTreeFilter {
+  /** Normalized (trimmed, lower-cased) query the filter was built from. */
+  query: string;
+  /** Saved definitions that match the query and should be rendered. */
+  matchingDefinitionIds: Set<string>;
+  /** Folders that contain a match (transitively) and should be rendered + expanded. */
+  visibleFolderIds: Set<string>;
+}
+
+/** Normalize a folder/definition parent reference (`undefined` → `null`). */
+function parentOf(value: string | null | undefined): string | null {
+  return value ?? null;
+}
+
+/**
+ * Whether an agent definition matches the (already normalized) query by name.
+ * An empty query matches everything.
+ */
+export function agentDefinitionMatchesQuery(
+  definition: AgentDefinitionInfo,
+  normalizedQuery: string
+): boolean {
+  if (!normalizedQuery) return true;
+  return definition.name.toLowerCase().includes(normalizedQuery);
+}
+
+/**
+ * Build an {@link AgentTreeFilter} for the given query, or `null` when the query
+ * is empty (meaning: no filtering, render the full tree with stored expansion
+ * state).
+ */
+export function filterAgentTree(
+  query: string,
+  folders: AgentFolderInfo[],
+  definitions: AgentDefinitionInfo[]
+): AgentTreeFilter | null {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return null;
+
+  const matchingDefinitionIds = new Set<string>();
+  for (const d of definitions) {
+    if (agentDefinitionMatchesQuery(d, normalizedQuery)) matchingDefinitionIds.add(d.id);
+  }
+
+  const childFolders = (parentId: string | null) =>
+    folders.filter((f) => parentOf(f.parentId) === parentId);
+  const folderDefinitions = (folderId: string | null) =>
+    definitions.filter((d) => parentOf(d.folderId) === folderId);
+
+  // Post-order pass: a folder is visible when any descendant definition matches.
+  const visibleFolderIds = new Set<string>();
+  function markVisible(folder: AgentFolderInfo): boolean {
+    let hasMatch = folderDefinitions(folder.id).some((d) => matchingDefinitionIds.has(d.id));
+    for (const child of childFolders(folder.id)) {
+      if (markVisible(child)) hasMatch = true;
+    }
+    if (hasMatch) visibleFolderIds.add(folder.id);
+    return hasMatch;
+  }
+  childFolders(null).forEach(markVisible);
+
+  return { query: normalizedQuery, matchingDefinitionIds, visibleFolderIds };
+}

--- a/src/utils/computeAgentTreeNodes.test.ts
+++ b/src/utils/computeAgentTreeNodes.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { computeAgentTreeNodes } from "./computeAgentTreeNodes";
+import { filterAgentTree } from "./agentTreeSearch";
+import type { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
+
+function def(id: string, name: string, folderId: string | null = null): AgentDefinitionInfo {
+  return { id, name, sessionType: "shell", config: {}, persistent: false, folderId };
+}
+
+function folder(
+  id: string,
+  name: string,
+  parentId: string | null = null,
+  isExpanded = true
+): AgentFolderInfo {
+  return { id, name, parentId, isExpanded };
+}
+
+function session(id: string, title: string): AgentSessionInfo {
+  return { sessionId: id, title, type: "shell", status: "running", attached: false };
+}
+
+describe("computeAgentTreeNodes", () => {
+  it("lists sessions first, then folders (with children), then root definitions", () => {
+    const sessions = [session("s1", "Live")];
+    const folders = [folder("f1", "Prod")];
+    const definitions = [def("d1", "web", "f1"), def("d2", "root-conn", null)];
+
+    const nodes = computeAgentTreeNodes(sessions, folders, definitions, null);
+    expect(nodes.map((n) => `${n.kind}:${n.id}`)).toEqual([
+      "session:s1",
+      "folder:f1",
+      "definition:d1",
+      "definition:d2",
+    ]);
+    const f1 = nodes.find((n) => n.id === "f1")!;
+    expect(f1.hasChildren).toBe(true);
+    expect(f1.isExpanded).toBe(true);
+    // Nested definition is one level deeper than its folder.
+    const d1 = nodes.find((n) => n.id === "d1")!;
+    expect(d1.depth).toBe(nodes.find((n) => n.id === "f1")!.depth + 1);
+    expect(d1.parentId).toBe("f1");
+  });
+
+  it("omits children of collapsed folders", () => {
+    const folders = [folder("f1", "Prod", null, false)];
+    const definitions = [def("d1", "web", "f1")];
+    const nodes = computeAgentTreeNodes([], folders, definitions, null);
+    expect(nodes.map((n) => n.id)).toEqual(["f1"]);
+    expect(nodes[0].isExpanded).toBe(false);
+  });
+
+  it("under an active filter, includes only matches + ancestors and force-expands them", () => {
+    // Folder stored collapsed, but the filter force-expands it to reveal a match.
+    const folders = [folder("f1", "Prod", null, false), folder("f2", "Other", null, false)];
+    const definitions = [def("d1", "web", "f1"), def("d2", "db", "f1"), def("d3", "cache", "f2")];
+    const filter = filterAgentTree("web", folders, definitions);
+
+    const nodes = computeAgentTreeNodes([], folders, definitions, filter);
+    expect(nodes.map((n) => `${n.kind}:${n.id}`)).toEqual(["folder:f1", "definition:d1"]);
+    expect(nodes.find((n) => n.id === "f1")!.isExpanded).toBe(true);
+  });
+
+  it("keeps sessions visible even under an active filter", () => {
+    const sessions = [session("s1", "Live")];
+    const definitions = [def("d1", "web", null), def("d2", "db", null)];
+    const filter = filterAgentTree("web", [], definitions);
+    const nodes = computeAgentTreeNodes(sessions, [], definitions, filter);
+    expect(nodes.map((n) => `${n.kind}:${n.id}`)).toEqual(["session:s1", "definition:d1"]);
+  });
+});

--- a/src/utils/computeAgentTreeNodes.ts
+++ b/src/utils/computeAgentTreeNodes.ts
@@ -1,0 +1,124 @@
+import { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
+import { AgentTreeFilter } from "./agentTreeSearch";
+
+/**
+ * A single rendered row of a remote agent's tree, flattened into visual order.
+ * Drives roving-tabindex keyboard navigation: the array index is the row's
+ * position, `depth` its indent level, and `parentId` the row to jump to on
+ * ArrowLeft.
+ *
+ * Sibling of {@link import("./computeVisibleTreeNodes").VisibleTreeNode} for the
+ * agent domain, which additionally carries live sessions as leaf rows.
+ */
+export interface AgentVisibleNode {
+  /** Session `sessionId`, folder `id`, or definition `id`. */
+  id: string;
+  kind: "session" | "folder" | "definition";
+  depth: number;
+  /** Folders: effective expansion state. Sessions/definitions: always `false`. */
+  isExpanded: boolean;
+  /** Folders: whether any child folder/definition is currently rendered. */
+  hasChildren: boolean;
+  /** Folder's `parentId` or definition's `folderId` (`null` at the root; sessions are always root leaves). */
+  parentId: string | null;
+  /** Present for session rows only. */
+  session?: AgentSessionInfo;
+  /** Present for definition rows only. */
+  definition?: AgentDefinitionInfo;
+}
+
+/** Normalize a folder/definition parent reference (`undefined` → `null`). */
+function parentOf(value: string | null | undefined): string | null {
+  return value ?? null;
+}
+
+/**
+ * Flatten a remote agent's tree into the exact list of interactive rows that
+ * are rendered, in top-to-bottom visual order: live sessions first, then the
+ * saved-connection folder tree, then root-level definitions.
+ *
+ * When `filter` is provided (an active search), only matching definitions and
+ * their ancestor folders are included, and those folders are treated as
+ * expanded regardless of stored state. Sessions are live connections rather
+ * than saved entries, so they are not affected by the filter. When `filter` is
+ * `null`, the full tree is walked honoring each folder's `isExpanded`.
+ *
+ * @param baseDepth - Indent level of the root rows (the agent header sits above
+ *   the tree, so root rows start at depth 1).
+ */
+export function computeAgentTreeNodes(
+  sessions: AgentSessionInfo[],
+  folders: AgentFolderInfo[],
+  definitions: AgentDefinitionInfo[],
+  filter: AgentTreeFilter | null,
+  baseDepth = 1
+): AgentVisibleNode[] {
+  const nodes: AgentVisibleNode[] = [];
+
+  // Live sessions render first as root leaves; the search filter only narrows
+  // saved definitions/folders, so sessions are always included.
+  for (const session of sessions) {
+    nodes.push({
+      id: session.sessionId,
+      kind: "session",
+      depth: baseDepth,
+      isExpanded: false,
+      hasChildren: false,
+      parentId: null,
+      session,
+    });
+  }
+
+  const isFolderRendered = (folder: AgentFolderInfo) =>
+    filter ? filter.visibleFolderIds.has(folder.id) : true;
+  const isFolderExpanded = (folder: AgentFolderInfo) => (filter ? true : folder.isExpanded);
+  const isDefRendered = (def: AgentDefinitionInfo) =>
+    filter ? filter.matchingDefinitionIds.has(def.id) : true;
+
+  const childFolders = (parentId: string | null) =>
+    folders.filter((f) => parentOf(f.parentId) === parentId && isFolderRendered(f));
+  const folderDefinitions = (folderId: string | null) =>
+    definitions.filter((d) => parentOf(d.folderId) === folderId && isDefRendered(d));
+
+  function pushFolder(folder: AgentFolderInfo, depth: number): void {
+    const kids = childFolders(folder.id);
+    const defs = folderDefinitions(folder.id);
+    const expanded = isFolderExpanded(folder);
+    nodes.push({
+      id: folder.id,
+      kind: "folder",
+      depth,
+      isExpanded: expanded,
+      hasChildren: kids.length + defs.length > 0,
+      parentId: parentOf(folder.parentId),
+    });
+    if (!expanded) return;
+    kids.forEach((k) => pushFolder(k, depth + 1));
+    defs.forEach((d) =>
+      nodes.push({
+        id: d.id,
+        kind: "definition",
+        depth: depth + 1,
+        isExpanded: false,
+        hasChildren: false,
+        parentId: folder.id,
+        definition: d,
+      })
+    );
+  }
+
+  childFolders(null).forEach((f) => pushFolder(f, baseDepth));
+  folderDefinitions(null).forEach((d) =>
+    nodes.push({
+      id: d.id,
+      kind: "definition",
+      depth: baseDepth,
+      isExpanded: false,
+      hasChildren: false,
+      parentId: null,
+      definition: d,
+    })
+  );
+
+  return nodes;
+}

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -33,6 +33,8 @@ Fixed strings — match exactly.
 | `agent-external-file-row` | `src/components/ConnectionEditor/AgentExternalFilesSettings.tsx` |
 | `agent-external-file-toggle` | `src/components/ConnectionEditor/AgentExternalFilesSettings.tsx` |
 | `agent-external-files` | `src/components/ConnectionEditor/AgentExternalFilesSettings.tsx` |
+| `agent-filter-clear` | `src/components/Sidebar/ConnectionList.tsx` |
+| `agent-filter-input` | `src/components/Sidebar/ConnectionList.tsx` |
 | `agent-setup-arch-select` | `src/components/Sidebar/AgentSetupDialog.tsx` |
 | `agent-setup-binary-path` | `src/components/Sidebar/AgentSetupDialog.tsx` |
 | `agent-setup-branch-name` | `src/components/Sidebar/AgentSetupDialog.tsx` |


### PR DESCRIPTION
## Summary

Reuses the Connections tree's search + keyboard-navigation pattern (#1356) across the other tree/list sidebars, so keyboard users get the same arrow-key + Enter model and correct ARIA tree semantics everywhere. Closes #1379.

### Nav hook adopted
The canonical roving-nav hook after #1375/#1461 is **`src/hooks/useRovingListNav.ts`** (the older `useTreeKeyboardNav` was retired). This PR builds on it:
- **`useFlatRovingNav`** (new) — a thin adapter over `useRovingListNav` for flat, single-select lists. Fills in the tree/multi-select callbacks with no-ops so a caller only supplies `onActivate`, and its `getItemProps(i)` returns roving-tabindex row props (ref, tabIndex, onFocus, `role="treeitem"`, `aria-level`).
- The **Remote Agents tree** reuses `useRovingListNav` directly (like the Connections tree) since it needs tree-specific keys.

### Per-sidebar changes
- **Tunnels** (`TunnelSidebar` / `TunnelListItem`): list is now `role="tree"`, rows `role="treeitem"` with roving tabindex; arrows move focus, Enter edits the focused tunnel (same as double-click). Mouse behavior unchanged.
- **Workspaces** (`WorkspaceSidebar` / `WorkspaceListItem`): same treatment; Enter launches the focused workspace (respects the in-flight `launchDisabled` guard).
- **Remote Agents** (`AgentNode`): roving-tabindex nav + full tree ARIA over the flattened visible rows (sessions → folders → definitions), Enter/Space activation (folder toggle / session attach / definition open), ArrowLeft/Right collapse-expand + parent/child jump — mirroring the Connections tree. A **filter input** in the Remote Agents section header (`ConnectionList`) narrows each agent's saved connections by name and auto-expands matching folders (Escape clears).

### Generalized utils (not duplicated per sidebar)
- `src/utils/agentTreeSearch.ts` — `filterAgentTree` (sibling of `connectionSearch`).
- `src/utils/computeAgentTreeNodes.ts` — flattens an agent's tree into ordered visible rows (sibling of `computeVisibleTreeNodes`), sessions kept visible under an active filter.

### ARIA notes
- Containers use `role="tree"` + `aria-label`; rows use `role="treeitem"`; folders add `aria-expanded`; definitions add `aria-selected`; `aria-level` reflects tree depth (root = 1). Flat lists are single-level trees (every row `aria-level=1`). Inline action buttons remain Tab-reachable, matching the existing Connections tree.

## Test plan
- New unit tests (TDD, test commits precede impl): `useFlatRovingNav`, `agentTreeSearch`, `computeAgentTreeNodes`, and keyboard-nav/ARIA/filter tests for the Tunnels, Workspaces, and Remote Agents sidebars (arrow move, Enter activate, roving tabindex, tree roles, filter narrows the list).
- Full suite: `pnpm test` → 328 files / 3009 tests pass. `pnpm build`, `pnpm run lint`, `pnpm run format:check` all clean. testid catalog regenerated via the Python gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
