### PR TITLE
refactor(ui): collapse addTab trailing params into an options object (Closes #1467)

### DIFF
--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -861,9 +861,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
             title: name.trim(),
           },
         },
-        undefined,
-        undefined,
-        terminalOptions
+        { terminalOptions }
       );
       closeThisTab();
       return;
@@ -974,7 +972,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
       }
     }
 
-    addTab(saved.name, saved.config.type, config, undefined, undefined, saved.terminalOptions);
+    addTab(saved.name, saved.config.type, config, { terminalOptions: saved.terminalOptions });
     closeThisTab();
   }, [
     isAgentDefinitionMode,

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -987,9 +987,7 @@ export function AgentNode({ agent, style, sectionRef, filterQuery = "" }: AgentN
             definitionId: def.id,
           },
         },
-        undefined,
-        undefined,
-        def.terminalOptions
+        { terminalOptions: def.terminalOptions }
       );
     },
     [agent.id, addTab]

--- a/src/components/Sidebar/AgentSetupDialog.tsx
+++ b/src/components/Sidebar/AgentSetupDialog.tsx
@@ -247,10 +247,7 @@ export function AgentSetupDialog({ open: isOpen, onOpenChange, agent }: AgentSet
             enableX11Forwarding: false,
           },
         },
-        undefined,
-        "terminal",
-        undefined,
-        result.sessionId
+        { contentType: "terminal", sessionId: result.sessionId }
       );
 
       setPhase({ kind: "running", step: "connect", message: "Setup started…" });

--- a/src/components/Sidebar/ConnectionList.filter.test.tsx
+++ b/src/components/Sidebar/ConnectionList.filter.test.tsx
@@ -156,14 +156,9 @@ describe("ConnectionList — filter/search", () => {
     typeInto(input, "web");
     keydown(input, "Enter");
 
-    expect(addTab).toHaveBeenCalledWith(
-      "web-server",
-      "local",
-      expect.anything(),
-      undefined,
-      undefined,
-      undefined
-    );
+    expect(addTab).toHaveBeenCalledWith("web-server", "local", expect.anything(), {
+      terminalOptions: undefined,
+    });
   });
 
   it("Escape clears the query and restores all connections", () => {

--- a/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
+++ b/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
@@ -140,14 +140,9 @@ describe("ConnectionList — keyboard navigation & ARIA", () => {
     act(() => item1.focus());
     keydown(item1, "Enter");
 
-    expect(addTab).toHaveBeenCalledWith(
-      "Connection conn-1",
-      "local",
-      expect.anything(),
-      undefined,
-      undefined,
-      undefined
-    );
+    expect(addTab).toHaveBeenCalledWith("Connection conn-1", "local", expect.anything(), {
+      terminalOptions: undefined,
+    });
   });
 
   it("folder rows expose aria-expanded and ArrowRight expands a collapsed folder", () => {

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -601,14 +601,9 @@ export function ConnectionList() {
         // Password auth always needs a credential; key auth only when encrypted.
         const needsCredential = authMethod === "password" || (authMethod === "key" && keyEncrypted);
         if (!needsCredential) {
-          addTab(
-            connection.name,
-            connection.config.type,
-            config,
-            undefined,
-            undefined,
-            connection.terminalOptions
-          );
+          addTab(connection.name, connection.config.type, config, {
+            terminalOptions: connection.terminalOptions,
+          });
           return;
         }
 
@@ -619,14 +614,9 @@ export function ConnectionList() {
         // synthetic) connection id and would miss, forcing a redundant prompt
         // even though the password is already known.
         if (typeof cfg.password === "string" && cfg.password.length > 0) {
-          addTab(
-            connection.name,
-            connection.config.type,
-            config,
-            undefined,
-            undefined,
-            connection.terminalOptions
-          );
+          addTab(connection.name, connection.config.type, config, {
+            terminalOptions: connection.terminalOptions,
+          });
           return;
         }
 
@@ -653,15 +643,10 @@ export function ConnectionList() {
           try {
             const sessionId = await createTerminal(preConfig);
             // Stored credential worked — open tab with existing session
-            addTab(
-              connection.name,
-              connection.config.type,
-              preConfig,
-              undefined,
-              undefined,
-              connection.terminalOptions,
-              sessionId
-            );
+            addTab(connection.name, connection.config.type, preConfig, {
+              terminalOptions: connection.terminalOptions,
+              sessionId,
+            });
             return;
           } catch (err) {
             const errStr = String(err);
@@ -673,14 +658,9 @@ export function ConnectionList() {
               await removeCredential(connection.id, resolution.credentialType).catch(() => {});
             } else {
               // Non-auth failure — let the Terminal component handle the error
-              addTab(
-                connection.name,
-                connection.config.type,
-                config,
-                undefined,
-                undefined,
-                connection.terminalOptions
-              );
+              addTab(connection.name, connection.config.type, config, {
+                terminalOptions: connection.terminalOptions,
+              });
               return;
             }
           }
@@ -717,14 +697,9 @@ export function ConnectionList() {
         }
       }
 
-      addTab(
-        connection.name,
-        connection.config.type,
-        config,
-        undefined,
-        undefined,
-        connection.terminalOptions
-      );
+      addTab(connection.name, connection.config.type, config, {
+        terminalOptions: connection.terminalOptions,
+      });
     },
     [addTab, requestPassword]
   );

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -447,7 +447,7 @@ describe("useKeyboardShortcuts", () => {
   describe("context-aware routing (scope gate)", () => {
     /** Add a tab of the given content type and make it the active tab/panel. */
     function addActiveTab(contentType: "terminal" | "editor"): void {
-      const id = useAppStore.getState().addTab("Tab", "local", undefined, undefined, contentType);
+      const id = useAppStore.getState().addTab("Tab", "local", undefined, { contentType });
       const panel = getAllLeaves(useAppStore.getState().rootPanel).find((p) =>
         p.tabs.some((t) => t.id === id)
       )!;

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -17,7 +17,7 @@ export function useTerminal() {
       config?: ConnectionConfig,
       panelId?: string
     ) => {
-      addTab(title, connectionType, config, panelId);
+      addTab(title, connectionType, config, { panelId });
     },
     [addTab]
   );

--- a/src/store/appStore.terminalReconnect.test.ts
+++ b/src/store/appStore.terminalReconnect.test.ts
@@ -92,11 +92,11 @@ function makePersistentTab(oldSessionId: string | null): string {
         title: "Persistent Shell",
       },
     },
-    undefined,
-    "terminal",
-    undefined,
-    oldSessionId,
-    CONNECTION_ID
+    {
+      contentType: "terminal",
+      sessionId: oldSessionId,
+      persistentConnectionId: CONNECTION_ID,
+    }
   );
 }
 

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -117,6 +117,48 @@ describe("appStore", () => {
     });
   });
 
+  describe("addTab with options object", () => {
+    it("applies contentType, sessionId and persistentConnectionId from the options object", () => {
+      const { addTab, activePanelId } = useAppStore.getState();
+      addTab(
+        "Persistent Shell",
+        "ssh",
+        { type: "ssh", config: { host: "pi.local" } },
+        {
+          contentType: "terminal",
+          sessionId: "session-abc",
+          persistentConnectionId: "conn-42",
+        }
+      );
+
+      const state = useAppStore.getState();
+      const leaf = findLeaf(state.rootPanel, activePanelId!) as LeafPanel;
+      expect(leaf.tabs).toHaveLength(1);
+      expect(leaf.tabs[0].contentType).toBe("terminal");
+      expect(leaf.tabs[0].sessionId).toBe("session-abc");
+      expect(leaf.tabs[0].persistentConnectionId).toBe("conn-42");
+    });
+
+    it("marks the tab spawned when options.spawned is true", () => {
+      const { addTab, activePanelId } = useAppStore.getState();
+      addTab("Spawned", "docker", { type: "docker", config: {} }, { spawned: true });
+
+      const state = useAppStore.getState();
+      const leaf = findLeaf(state.rootPanel, activePanelId!) as LeafPanel;
+      expect(leaf.tabs[0].spawned).toBe(true);
+    });
+
+    it("defaults spawned to falsy and sessionId to null when options are omitted", () => {
+      const { addTab, activePanelId } = useAppStore.getState();
+      addTab("Plain", "local");
+
+      const state = useAppStore.getState();
+      const leaf = findLeaf(state.rootPanel, activePanelId!) as LeafPanel;
+      expect(leaf.tabs[0].spawned).toBeFalsy();
+      expect(leaf.tabs[0].sessionId).toBeNull();
+    });
+  });
+
   describe("closeTab", () => {
     it("removes tab and selects next tab", () => {
       const { addTab } = useAppStore.getState();

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -94,10 +94,7 @@ describe("appStore", () => {
             enableX11Forwarding: false,
           },
         },
-        undefined,
-        "terminal",
-        undefined,
-        "existing-session-123"
+        { contentType: "terminal", sessionId: "existing-session-123" }
       );
 
       const state = useAppStore.getState();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -195,6 +195,30 @@ export interface FileClipboard {
   terminalSessionId?: string | null;
 }
 
+/**
+ * Optional settings for {@link AppState.addTab}. Every field is optional — omit
+ * the whole object (or any individual field) to accept the documented defaults.
+ * Collapsing these trailing flags into one object keeps call sites from having
+ * to thread placeholder `undefined`s to reach a later argument (#1467).
+ */
+export interface AddTabOptions {
+  /** Panel to add the tab to. Defaults to the active panel (or first leaf). */
+  panelId?: string;
+  /** Tab content kind. Defaults to `"terminal"`. */
+  contentType?: TabContentType;
+  /** Per-tab terminal appearance/behavior overrides. */
+  terminalOptions?: TerminalOptions;
+  /** Pre-existing backend session id to attach to. Defaults to `null`. */
+  sessionId?: string | null;
+  /** Persistent-connection id this tab is attached to, if any. */
+  persistentConnectionId?: string;
+  /**
+   * Marks the tab as an externally spawned session with no saved connection
+   * (#1446). Defaults to `false`.
+   */
+  spawned?: boolean;
+}
+
 /** Return a new Record with `key` removed. */
 function omitKey<V>(rec: Record<string, V>, key: string): Record<string, V> {
   const { [key]: _, ...rest } = rec;
@@ -307,16 +331,19 @@ interface AppState {
   // Panels & Tabs
   rootPanel: PanelNode;
   activePanelId: string | null;
+  /**
+   * Open a new tab and make it active.
+   * @param title Tab title.
+   * @param connectionType Connection type key (e.g. `"local"`, `"ssh"`, `"remote-session"`).
+   * @param config Connection config; defaults to a local shell when omitted.
+   * @param options Optional tab settings — see {@link AddTabOptions}.
+   * @returns The id of the created tab.
+   */
   addTab: (
     title: string,
     connectionType: string,
     config?: ConnectionConfig,
-    panelId?: string,
-    contentType?: TabContentType,
-    terminalOptions?: TerminalOptions,
-    sessionId?: string | null,
-    persistentConnectionId?: string,
-    spawned?: boolean
+    options?: AddTabOptions
   ) => string;
   /**
    * Open a Docker session tab for a resolved external container spawn (#1446).
@@ -1665,16 +1692,13 @@ export const useAppStore = create<AppState>((set, get) => {
       const entry = get().persistentSessions[connectionId];
       const conn = get().connections.find((c) => c.id === connectionId);
       if (!conn || !entry?.sessionId) return;
-      const tabId = get().addTab(
-        conn.name,
-        conn.config.type,
-        conn.config,
+      const tabId = get().addTab(conn.name, conn.config.type, conn.config, {
         panelId,
-        "terminal",
-        conn.terminalOptions,
-        entry.sessionId,
-        connectionId
-      );
+        contentType: "terminal",
+        terminalOptions: conn.terminalOptions,
+        sessionId: entry.sessionId,
+        persistentConnectionId: connectionId,
+      });
       try {
         await apiAttachPersistentTab(connectionId, tabId);
         set((state) => {
@@ -1809,11 +1833,13 @@ export const useAppStore = create<AppState>((set, get) => {
             title: def.name,
           },
         },
-        panelId,
-        "terminal",
-        def.terminalOptions,
-        entry.sessionId,
-        connectionId
+        {
+          panelId,
+          contentType: "terminal",
+          terminalOptions: def.terminalOptions,
+          sessionId: entry.sessionId,
+          persistentConnectionId: connectionId,
+        }
       );
       // Resolve the actual panel the tab landed in so we can close it on failure.
       const actualPanelId = findLeafByTab(get().rootPanel, tabId)?.id;
@@ -2019,17 +2045,9 @@ export const useAppStore = create<AppState>((set, get) => {
       if (sessionId) get().settleRestoreTab(tabId, "connected");
     },
 
-    addTab: (
-      title,
-      connectionType,
-      config,
-      panelId,
-      contentType,
-      terminalOptions,
-      sessionId,
-      persistentConnectionId,
-      spawned
-    ) => {
+    addTab: (title, connectionType, config, options) => {
+      const { panelId, contentType, terminalOptions, sessionId, persistentConnectionId, spawned } =
+        options ?? {};
       let createdTabId = "";
       set((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
@@ -2088,12 +2106,7 @@ export const useAppStore = create<AppState>((set, get) => {
         spawn.title,
         "docker",
         { type: "docker", config: spawn.settings },
-        undefined,
-        "terminal",
-        undefined,
-        undefined,
-        undefined,
-        true
+        { contentType: "terminal", spawned: true }
       ),
 
     openSettingsTab: () =>

--- a/src/utils/reopenTab.ts
+++ b/src/utils/reopenTab.ts
@@ -29,9 +29,9 @@ export function showReopenToast(payload: ReopenTabPayload | null): void {
     action: {
       label: "Reopen",
       onClick: () =>
-        useAppStore
-          .getState()
-          .addTab(payload.title, payload.connectionType, payload.config, undefined, "terminal"),
+        useAppStore.getState().addTab(payload.title, payload.connectionType, payload.config, {
+          contentType: "terminal",
+        }),
     },
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #1446. `useAppStore().addTab` had grown to a 9-positional-parameter function, and `openSpawnedContainer` had to pass five placeholder `undefined`s just to reach the trailing `spawned` boolean. This collapses the trailing optional flags into a single named options object.

### New signature

```ts
addTab(
  title: string,
  connectionType: string,
  config?: ConnectionConfig,
  options?: AddTabOptions
) => string
```

`title`, `connectionType`, and `config` stay positional — `config` is passed on its own at ~40 call sites and never needs skipping. Everything previously trailing moves into the new exported `AddTabOptions` interface:

```ts
interface AddTabOptions {
  panelId?: string;
  contentType?: TabContentType;
  terminalOptions?: TerminalOptions;
  sessionId?: string | null;
  persistentConnectionId?: string;
  spawned?: boolean;
}
```

`panelId` is included in the options object (not left positional) precisely because callers set `contentType`/`spawned` without a `panelId` — keeping it positional would have re-introduced placeholder `undefined`s.

### Call sites migrated

All `addTab` invocations across `src/` and tests:
- Store internals: `attachPersistentSession`, `attachAgentPersistentSession`, `openSpawnedContainer` (now `{ contentType: "terminal", spawned: true }` — the five placeholder `undefined`s are gone).
- Components: `ConnectionList` (5 calls), `AgentNode`, `AgentSetupDialog`, `ConnectionEditor` (2 calls).
- Hooks/utils: `useTerminal`, `reopenTab`.
- Tests: `appStore.test.ts`, `appStore.terminalReconnect.test.ts`, `useKeyboardShortcuts.test.ts`, plus two `toHaveBeenCalledWith` assertions (`ConnectionList.filter`, `ConnectionList.keyboard-nav`).

### No behavior change

Pure signature refactor — the implementation destructures the options object at the top and the body is byte-for-byte identical. No user-facing change, so no `docs/changes/` fragment.

## Test plan

- `pnpm build` (tsc) — passes; the typechecker confirms every call site was migrated (no positional leftovers).
- `pnpm test` — full suite green (331 files, 3039 tests).
- `pnpm run lint` + `pnpm run format:check` — clean.
- Added focused tests asserting the options-object shape applies `contentType`/`sessionId`/`persistentConnectionId`, that `spawned: true` marks the tab, and that omitting options defaults `spawned` falsy and `sessionId` null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)