### PR TITLE
fix(ui): type webview zoom access to clear tsc --noEmit errors

### DIFF
--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Ambient augmentation for the non-standard CSS `zoom` property.
+ *
+ * `zoom` is widely supported by browsers (and used by {@link useWebviewZoom} to
+ * scale the whole webview) but is not part of the standard `CSSStyleDeclaration`
+ * type shipped with TypeScript's DOM lib. Declaring it here keeps
+ * `document.documentElement.style.zoom` typed without per-site casts.
+ */
+interface CSSStyleDeclaration {
+  zoom: string;
+}


### PR DESCRIPTION
Closes #1498

## Summary

`pnpm exec tsc --noEmit` reported ~10 `TS2339: Property 'zoom' does not exist on type 'CSSStyleDeclaration'` errors in `src/hooks/useWebviewZoom.ts` and `useWebviewZoom.test.ts`. The non-standard CSS `zoom` property (used to scale the whole webview) isn't part of TypeScript's DOM `CSSStyleDeclaration` type.

### Approach

Added a minimal ambient augmentation at `src/types/css.d.ts` declaring `zoom: string` on the global `CSSStyleDeclaration` interface. This types every `document.documentElement.style.zoom` access across the codebase without per-site casts and without any `any`. No changes to `useWebviewZoom.ts` or its test were needed — the augmentation alone clears all errors, so it's the least-invasive fix.

This is a types-only change; runtime behavior is byte-for-byte unchanged.

Note: the Frontend Code Quality CI job already runs `pnpm exec tsc --noEmit` (code-quality.yml line 106-107), so this fix is what makes that step green and the regression guard is already in place — no CI change needed.

## Test plan

- `pnpm exec tsc --noEmit` → zero errors (was ~10)
- `pnpm exec vitest run src/hooks/useWebviewZoom` → 5/5 pass
- `pnpm run lint` → clean
- `pnpm run format:check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)