### PR TITLE
feat(backend): persist per-entry container-image preference for spawn entries (Closes #1447)

### DIFF
--- a/docs/changes/dev1/feature/1447-container-image-preference.md
+++ b/docs/changes/dev1/feature/1447-container-image-preference.md
@@ -1,0 +1,9 @@
+### Added
+
+- Shell-integration quick-access entries can now carry a saved **container
+  image** and **mount-target** preference. When an entry opens a "new container"
+  spawn and no explicit `--container-image` / `--container-mount` is given on the
+  command line, the saved preference is used before the built-in defaults
+  (`ubuntu:22.04` / `/workspace`). The fields are edited in the entry dialog
+  (Settings → Shell Integration) and persist across restarts. Existing
+  `settings.json` files without the fields are unaffected.

--- a/src-tauri/src/commands/shell_integration.rs
+++ b/src-tauri/src/commands/shell_integration.rs
@@ -123,6 +123,8 @@ mod tests {
             connection_id: None,
             visibility: ShellEntryVisibility::Always,
             show_for: ShowForTargets::default(),
+            container_image: None,
+            container_mount: None,
         }
     }
 

--- a/src-tauri/src/commands/spawn.rs
+++ b/src-tauri/src/commands/spawn.rs
@@ -6,52 +6,182 @@
 //! the target directory bind-mounted. The interactive picker that chooses "new
 //! container" (SI-3) and the frontend session/tab wiring are out of scope here.
 
+use tauri::State;
+
+use crate::connection::manager::ConnectionManager;
+use crate::connection::shell_integration::ShellIntegrationSettings;
 use crate::spawn::container::{self, ContainerSpawn};
 use crate::spawn::SpawnRequest;
 
-/// Resolve a directory-mount container spawn into Docker session settings.
+/// The saved per-entry container preferences (image + mount target) looked up
+/// for a spawn's `--entry-id`, if any.
+type SavedContainerPrefs = (Option<String>, Option<String>);
+
+/// Look up the saved per-entry container image / mount preferences for the entry
+/// addressed by `entry_id`. An absent or unknown id yields no preference, so the
+/// spawn falls through to the request value and then the built-in defaults.
+fn saved_container_prefs(
+    settings: &ShellIntegrationSettings,
+    entry_id: Option<&str>,
+) -> SavedContainerPrefs {
+    entry_id
+        .and_then(|id| settings.entries.iter().find(|e| e.id == id))
+        .map(|e| (e.container_image.clone(), e.container_mount.clone()))
+        .unwrap_or((None, None))
+}
+
+/// Resolve a directory-mount container spawn into Docker session settings,
+/// honoring any saved per-entry image / mount preference (#1447).
 ///
-/// Mirrors the CLI `termiHub spawn --location … [--container-image …]
-/// [--container-mount …]` inputs. The returned [`ContainerSpawn`] carries the
-/// camelCase Docker settings JSON (single bind of the resolved host directory →
-/// mount, working directory set to the mount, `removeOnExit: false` so the
-/// container is stopped-not-removed on close), a `"… (Spawned)"` tab title, and
-/// `spawned: true` so the frontend can badge and track it separately from
-/// configured Docker connections.
+/// Mirrors the CLI `termiHub spawn --entry-id … --location … [--container-image
+/// …] [--container-mount …]` inputs. Image and mount are each resolved in strict
+/// priority order: explicit request value > the saved per-entry preference (the
+/// entry addressed by `entry_id`) > the built-in default. The returned
+/// [`ContainerSpawn`] carries the camelCase Docker settings JSON (single bind of
+/// the resolved host directory to the mount, working directory set to the mount,
+/// `removeOnExit: false` so the container is stopped-not-removed on close), a
+/// `"… (Spawned)"` tab title, and `spawned: true` so the frontend can badge and
+/// track them separately from configured Docker connections.
 #[tauri::command]
 pub fn resolve_container_spawn(
+    manager: State<'_, ConnectionManager>,
     location: Option<String>,
+    entry_id: Option<String>,
+    container_image: Option<String>,
+    container_mount: Option<String>,
+) -> Result<ContainerSpawn, String> {
+    let settings = manager.get_settings();
+    resolve_container_spawn_with(
+        &settings.shell_integration,
+        location,
+        entry_id,
+        container_image,
+        container_mount,
+    )
+}
+
+/// Pure resolution shared by the Tauri command and its tests: validate the
+/// location, look up the saved per-entry preferences, and build the spawn.
+fn resolve_container_spawn_with(
+    settings: &ShellIntegrationSettings,
+    location: Option<String>,
+    entry_id: Option<String>,
     container_image: Option<String>,
     container_mount: Option<String>,
 ) -> Result<ContainerSpawn, String> {
     if location.as_deref().map(str::trim).unwrap_or("").is_empty() {
         return Err("a spawn location is required for a container spawn".to_string());
     }
+    let (saved_image, saved_mount) = saved_container_prefs(settings, entry_id.as_deref());
     let request = SpawnRequest {
         location,
+        entry_id,
         container_image,
         container_mount,
         ..SpawnRequest::default()
     };
-    Ok(container::build_container_spawn(&request, None))
+    Ok(container::build_container_spawn(
+        &request,
+        saved_image.as_deref(),
+        saved_mount.as_deref(),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::connection::shell_integration::{ShellEntry, ShellEntryVisibility, ShowForTargets};
+
+    fn settings_with_entry(
+        id: &str,
+        image: Option<&str>,
+        mount: Option<&str>,
+    ) -> ShellIntegrationSettings {
+        ShellIntegrationSettings {
+            entries: vec![ShellEntry {
+                id: id.to_string(),
+                name: "Open in termiHub".to_string(),
+                connection_id: None,
+                visibility: ShellEntryVisibility::Always,
+                show_for: ShowForTargets::default(),
+                container_image: image.map(str::to_string),
+                container_mount: mount.map(str::to_string),
+            }],
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn requires_a_location() {
-        assert!(resolve_container_spawn(None, None, None).is_err());
-        assert!(resolve_container_spawn(Some("  ".into()), None, None).is_err());
+        let settings = ShellIntegrationSettings::default();
+        assert!(resolve_container_spawn_with(&settings, None, None, None, None).is_err());
+        assert!(
+            resolve_container_spawn_with(&settings, Some("  ".into()), None, None, None).is_err()
+        );
     }
 
     #[test]
     fn resolves_settings_for_a_location() {
-        let spawn = resolve_container_spawn(Some("/proj".into()), Some("alpine".into()), None)
-            .expect("resolves");
+        let settings = ShellIntegrationSettings::default();
+        let spawn = resolve_container_spawn_with(
+            &settings,
+            Some("/proj".into()),
+            None,
+            Some("alpine".into()),
+            None,
+        )
+        .expect("resolves");
         assert!(spawn.spawned);
         assert_eq!(spawn.settings["image"], "alpine");
         assert_eq!(spawn.settings["removeOnExit"], false);
+    }
+
+    #[test]
+    fn saved_entry_preference_is_honored_when_no_explicit_value() {
+        // The entry's saved image/mount are used when the request omits them.
+        let settings = settings_with_entry("e1", Some("saved:9"), Some("/saved"));
+        let spawn = resolve_container_spawn_with(
+            &settings,
+            Some("/proj".into()),
+            Some("e1".into()),
+            None,
+            None,
+        )
+        .expect("resolves");
+        assert_eq!(spawn.settings["image"], "saved:9");
+        assert_eq!(spawn.settings["workingDirectory"], "/saved");
+    }
+
+    #[test]
+    fn explicit_request_value_beats_saved_entry_preference() {
+        let settings = settings_with_entry("e1", Some("saved:9"), Some("/saved"));
+        let spawn = resolve_container_spawn_with(
+            &settings,
+            Some("/proj".into()),
+            Some("e1".into()),
+            Some("node:20".into()),
+            Some("/srv".into()),
+        )
+        .expect("resolves");
+        assert_eq!(spawn.settings["image"], "node:20");
+        assert_eq!(spawn.settings["workingDirectory"], "/srv");
+    }
+
+    #[test]
+    fn unknown_entry_id_falls_back_to_defaults() {
+        let settings = settings_with_entry("e1", Some("saved:9"), Some("/saved"));
+        let spawn = resolve_container_spawn_with(
+            &settings,
+            Some("/proj".into()),
+            Some("does-not-exist".into()),
+            None,
+            None,
+        )
+        .expect("resolves");
+        assert_eq!(spawn.settings["image"], container::DEFAULT_CONTAINER_IMAGE);
+        assert_eq!(
+            spawn.settings["workingDirectory"],
+            container::DEFAULT_MOUNT_TARGET
+        );
     }
 }

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -939,6 +939,8 @@ mod tests {
                     connection_id: Some("saved-a".to_string()),
                     visibility: ShellEntryVisibility::Always,
                     show_for: ShowForTargets::default(),
+                    container_image: Some("alpine:3".to_string()),
+                    container_mount: Some("/src".to_string()),
                 }],
                 fallback: ShellIntegrationFallback::SystemDefaultShell,
                 open_in_new_window: true,

--- a/src-tauri/src/connection/shell_integration.rs
+++ b/src-tauri/src/connection/shell_integration.rs
@@ -66,6 +66,18 @@ pub struct ShellEntry {
     /// Which right-click targets this entry is registered for.
     #[serde(default)]
     pub show_for: ShowForTargets,
+    /// Saved per-entry container-image preference (e.g. `"alpine:3"`). When this
+    /// entry opens a "new container" spawn and no explicit `--container-image` is
+    /// given, this image is used before the built-in default. `None` → no saved
+    /// preference. Optional + `#[serde(default)]` so pre-#1447 `settings.json`
+    /// files round-trip unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_image: Option<String>,
+    /// Saved per-entry in-container mount-target preference (e.g. `"/src"`). Same
+    /// priority + forward-compat semantics as [`container_image`](Self::container_image):
+    /// honored for a container spawn when no explicit `--container-mount` is given.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_mount: Option<String>,
 }
 
 /// Fallback behaviour when no entry resolves a spawn request.
@@ -301,6 +313,8 @@ mod tests {
             connection_id: connection.map(str::to_string),
             visibility,
             show_for: ShowForTargets::default(),
+            container_image: None,
+            container_mount: None,
         }
     }
 
@@ -550,9 +564,12 @@ mod tests {
 
     #[test]
     fn settings_round_trip() {
+        let mut container_entry = entry("open", Some("saved-a"), ShellEntryVisibility::Always);
+        container_entry.container_image = Some("alpine:3".to_string());
+        container_entry.container_mount = Some("/src".to_string());
         let settings = ShellIntegrationSettings {
             entries: vec![
-                entry("open", Some("saved-a"), ShellEntryVisibility::Always),
+                container_entry,
                 entry("pick", None, ShellEntryVisibility::Extended),
             ],
             fallback: ShellIntegrationFallback::SystemDefaultShell,
@@ -584,7 +601,9 @@ mod tests {
 
     #[test]
     fn entry_defaults_applied_for_partial_json() {
-        // An entry with only id + name gets default visibility / show_for.
+        // An entry with only id + name gets default visibility / show_for, and no
+        // saved container preference — critical forward-compat: a pre-#1447
+        // settings.json entry (no container fields) deserializes with `None`.
         let json = r#"{"entries":[{"id":"e1","name":"Open in termiHub"}]}"#;
         let settings: ShellIntegrationSettings = serde_json::from_str(json).unwrap();
         assert_eq!(settings.entries.len(), 1);
@@ -594,6 +613,33 @@ mod tests {
         assert!(e.show_for.folders);
         assert!(!e.show_for.files);
         assert!(!e.show_for.folder_background);
+        assert!(e.container_image.is_none());
+        assert!(e.container_mount.is_none());
+    }
+
+    #[test]
+    fn entry_container_preference_round_trips_and_is_camel_case() {
+        // A saved per-entry container image/mount preference survives a JSON
+        // round-trip and serializes with camelCase keys.
+        let mut e = entry("open", Some("saved-a"), ShellEntryVisibility::Always);
+        e.container_image = Some("node:20".to_string());
+        e.container_mount = Some("/srv".to_string());
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("containerImage"), "json: {json}");
+        assert!(json.contains("containerMount"), "json: {json}");
+        let back: ShellEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.container_image.as_deref(), Some("node:20"));
+        assert_eq!(back.container_mount.as_deref(), Some("/srv"));
+    }
+
+    #[test]
+    fn entry_without_container_preference_omits_fields_in_json() {
+        // No saved preference → the keys are omitted entirely, so existing
+        // settings.json files keep their exact byte shape (skip_serializing_if).
+        let e = entry("open", Some("saved-a"), ShellEntryVisibility::Always);
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(!json.contains("containerImage"), "json: {json}");
+        assert!(!json.contains("containerMount"), "json: {json}");
     }
 
     #[test]

--- a/src-tauri/src/spawn/container.rs
+++ b/src-tauri/src/spawn/container.rs
@@ -50,10 +50,12 @@ pub fn resolve_container_image(explicit: Option<&str>, saved_pref: Option<&str>)
         .to_string()
 }
 
-/// Resolve the in-container mount target, defaulting to
-/// [`DEFAULT_MOUNT_TARGET`] when the request does not specify one.
-pub fn resolve_mount_target(explicit: Option<&str>) -> String {
+/// Resolve the in-container mount target in priority order: an explicit
+/// `--container-mount` value from the request, then a saved per-entry
+/// preference, then [`DEFAULT_MOUNT_TARGET`]. Blank values are ignored.
+pub fn resolve_mount_target(explicit: Option<&str>, saved_pref: Option<&str>) -> String {
     non_blank(explicit)
+        .or(non_blank(saved_pref))
         .unwrap_or(DEFAULT_MOUNT_TARGET)
         .to_string()
 }
@@ -93,11 +95,16 @@ pub fn build_spawn_docker_config(host_dir: &str, image: &str, mount: &str) -> Do
     }
 }
 
-/// Resolve a full [`ContainerSpawn`] from a spawn request and an optional saved
-/// per-entry image preference.
-pub fn build_container_spawn(req: &SpawnRequest, saved_image_pref: Option<&str>) -> ContainerSpawn {
+/// Resolve a full [`ContainerSpawn`] from a spawn request and the optional saved
+/// per-entry image / mount preferences. For each, the explicit request value
+/// wins, then the saved preference, then the built-in default.
+pub fn build_container_spawn(
+    req: &SpawnRequest,
+    saved_image_pref: Option<&str>,
+    saved_mount_pref: Option<&str>,
+) -> ContainerSpawn {
     let image = resolve_container_image(req.container_image.as_deref(), saved_image_pref);
-    let mount = resolve_mount_target(req.container_mount.as_deref());
+    let mount = resolve_mount_target(req.container_mount.as_deref(), saved_mount_pref);
     let host_dir = resolve_host_directory(req.location.as_deref().unwrap_or("."));
 
     let config = build_spawn_docker_config(&host_dir, &image, &mount);
@@ -164,13 +171,22 @@ mod tests {
 
     #[test]
     fn mount_defaults_to_workspace() {
-        assert_eq!(resolve_mount_target(None), DEFAULT_MOUNT_TARGET);
-        assert_eq!(resolve_mount_target(Some("  ")), DEFAULT_MOUNT_TARGET);
+        assert_eq!(resolve_mount_target(None, None), DEFAULT_MOUNT_TARGET);
+        assert_eq!(resolve_mount_target(Some("  "), None), DEFAULT_MOUNT_TARGET);
     }
 
     #[test]
     fn mount_honours_explicit_value() {
-        assert_eq!(resolve_mount_target(Some("/src")), "/src");
+        assert_eq!(resolve_mount_target(Some("/src"), None), "/src");
+    }
+
+    #[test]
+    fn mount_prefers_explicit_then_saved_then_default() {
+        // explicit > saved > default, mirroring image resolution.
+        assert_eq!(resolve_mount_target(Some("/src"), Some("/saved")), "/src");
+        assert_eq!(resolve_mount_target(None, Some("/saved")), "/saved");
+        assert_eq!(resolve_mount_target(Some("  "), Some("/saved")), "/saved");
+        assert_eq!(resolve_mount_target(None, None), DEFAULT_MOUNT_TARGET);
     }
 
     // ── host directory resolution ─────────────────────────────────────────
@@ -229,7 +245,7 @@ mod tests {
     #[test]
     fn build_container_spawn_defaults_mount_and_image() {
         let req = req_with(Some("/home/user/app"), None, None);
-        let spawn = build_container_spawn(&req, None);
+        let spawn = build_container_spawn(&req, None, None);
         assert!(spawn.spawned);
         assert!(spawn.title.contains("Spawned"), "title: {}", spawn.title);
         let vols = spawn
@@ -248,7 +264,7 @@ mod tests {
     #[test]
     fn build_container_spawn_honours_explicit_image_and_mount() {
         let req = req_with(Some("/data"), Some("node:20"), Some("/srv"));
-        let spawn = build_container_spawn(&req, None);
+        let spawn = build_container_spawn(&req, None, None);
         assert_eq!(spawn.settings["image"], "node:20");
         assert_eq!(spawn.settings["workingDirectory"], "/srv");
         let vols = spawn
@@ -261,11 +277,36 @@ mod tests {
     }
 
     #[test]
+    fn build_container_spawn_honours_saved_prefs_when_request_is_blank() {
+        // No explicit request image/mount → the saved per-entry preferences are
+        // used (the #1447 wiring), ahead of the built-in defaults.
+        let req = req_with(Some("/data"), None, None);
+        let spawn = build_container_spawn(&req, Some("saved:9"), Some("/saved"));
+        assert_eq!(spawn.settings["image"], "saved:9");
+        assert_eq!(spawn.settings["workingDirectory"], "/saved");
+        let vols = spawn
+            .settings
+            .get("volumes")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(vols[0]["containerPath"], "/saved");
+    }
+
+    #[test]
+    fn build_container_spawn_explicit_beats_saved_prefs() {
+        // Explicit request values win over the saved per-entry preferences.
+        let req = req_with(Some("/data"), Some("node:20"), Some("/srv"));
+        let spawn = build_container_spawn(&req, Some("saved:9"), Some("/saved"));
+        assert_eq!(spawn.settings["image"], "node:20");
+        assert_eq!(spawn.settings["workingDirectory"], "/srv");
+    }
+
+    #[test]
     fn build_container_spawn_settings_roundtrip_to_docker_config() {
         // The produced settings must parse back into a DockerConfig cleanly so
         // the Docker backend's `parse_docker_settings` accepts them verbatim.
         let req = req_with(Some("/proj"), Some("alpine"), Some("/workspace"));
-        let spawn = build_container_spawn(&req, None);
+        let spawn = build_container_spawn(&req, None, None);
         let parsed: DockerConfig =
             serde_json::from_value(spawn.settings).expect("settings parse as DockerConfig");
         assert_eq!(parsed.image, "alpine");

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -838,6 +838,8 @@ mod macos {
                 connection_id: None,
                 visibility: ShellEntryVisibility::Always,
                 show_for,
+                container_image: None,
+                container_mount: None,
             }
         }
 
@@ -1328,6 +1330,8 @@ mod imp {
                 connection_id: None,
                 visibility,
                 show_for,
+                container_image: None,
+                container_mount: None,
             }
         }
 
@@ -2303,6 +2307,8 @@ mod linux {
                 connection_id: None,
                 visibility: ShellEntryVisibility::Always,
                 show_for,
+                container_image: None,
+                container_mount: None,
             }
         }
 

--- a/src/components/Settings/ShellIntegrationEntryEditor.test.tsx
+++ b/src/components/Settings/ShellIntegrationEntryEditor.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { TooltipProvider } from "@/components/ui";
+import type { ShellEntry } from "@/types/connection";
+import { ShellIntegrationEntryEditor } from "./ShellIntegrationEntryEditor";
+import { createEntry } from "./shellIntegrationEntries";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function byTestId(id: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${id}"]`);
+}
+
+async function renderEditor(entry: ShellEntry, onSave: (e: ShellEntry) => void): Promise<void> {
+  await act(async () => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <ShellIntegrationEntryEditor
+          open
+          onOpenChange={() => {}}
+          entry={entry}
+          isNew
+          connections={[]}
+          onSave={onSave}
+        />
+      </TooltipProvider>
+    );
+  });
+}
+
+/** Fire a controlled-input change the way React's synthetic event expects. */
+function setInputValue(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("ShellIntegrationEntryEditor — container preference fields (#1447)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the container image and mount-target inputs", async () => {
+    await renderEditor(createEntry(), () => {});
+    expect(byTestId("shell-integration-entry-container-image")).not.toBeNull();
+    expect(byTestId("shell-integration-entry-container-mount")).not.toBeNull();
+  });
+
+  it("seeds the inputs from an entry's saved preferences", async () => {
+    const entry: ShellEntry = {
+      ...createEntry(),
+      containerImage: "alpine:3",
+      containerMount: "/src",
+    };
+    await renderEditor(entry, () => {});
+    expect((byTestId("shell-integration-entry-container-image") as HTMLInputElement).value).toBe(
+      "alpine:3"
+    );
+    expect((byTestId("shell-integration-entry-container-mount") as HTMLInputElement).value).toBe(
+      "/src"
+    );
+  });
+
+  it("persists edited container image and mount through onSave", async () => {
+    const onSave = vi.fn();
+    await renderEditor(createEntry(), onSave);
+
+    await act(async () => {
+      setInputValue(
+        byTestId("shell-integration-entry-container-image") as HTMLInputElement,
+        "node:20"
+      );
+    });
+    await act(async () => {
+      setInputValue(
+        byTestId("shell-integration-entry-container-mount") as HTMLInputElement,
+        "/srv"
+      );
+    });
+    await act(async () => {
+      byTestId("shell-integration-entry-save")?.click();
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0] as ShellEntry;
+    expect(saved.containerImage).toBe("node:20");
+    expect(saved.containerMount).toBe("/srv");
+  });
+
+  it("omits blank container fields (persists undefined, not empty strings)", async () => {
+    const onSave = vi.fn();
+    await renderEditor(createEntry(), onSave);
+
+    await act(async () => {
+      setInputValue(byTestId("shell-integration-entry-container-image") as HTMLInputElement, "   ");
+    });
+    await act(async () => {
+      byTestId("shell-integration-entry-save")?.click();
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0] as ShellEntry;
+    expect(saved.containerImage).toBeUndefined();
+    expect(saved.containerMount).toBeUndefined();
+  });
+});

--- a/src/components/Settings/ShellIntegrationEntryEditor.tsx
+++ b/src/components/Settings/ShellIntegrationEntryEditor.tsx
@@ -7,6 +7,21 @@ import { getPlatform } from "@/utils/platform";
 /** Sentinel Select value for the "show the session picker" (no fixed connection) choice. */
 const PICKER_VALUE = "__picker__";
 
+/**
+ * Built-in container spawn defaults, shown as placeholders so the user sees what
+ * a blank field falls back to. Mirror the Rust constants in
+ * `src-tauri/src/spawn/container.rs` (`DEFAULT_CONTAINER_IMAGE` /
+ * `DEFAULT_MOUNT_TARGET`).
+ */
+const DEFAULT_CONTAINER_IMAGE = "ubuntu:22.04";
+const DEFAULT_MOUNT_TARGET = "/workspace";
+
+/** Normalize a text input to `undefined` when blank so no empty string persists. */
+function emptyToUndefined(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
 interface ShellIntegrationEntryEditorProps {
   /** Whether the editor modal is open. */
   open: boolean;
@@ -55,7 +70,14 @@ export function ShellIntegrationEntryEditor({
 
   const handleSave = () => {
     if (nameError) return;
-    onSave({ ...draft, name: draft.name.trim() });
+    onSave({
+      ...draft,
+      name: draft.name.trim(),
+      // Persist blank container fields as omitted rather than empty strings so
+      // the entry round-trips to the same shape as one that never set them.
+      containerImage: emptyToUndefined(draft.containerImage ?? ""),
+      containerMount: emptyToUndefined(draft.containerMount ?? ""),
+    });
   };
 
   const setShowFor = (key: keyof ShellEntry["showFor"], value: boolean) =>
@@ -124,6 +146,37 @@ export function ShellIntegrationEntryEditor({
             data-testid="shell-integration-entry-visibility"
           />
         </Field>
+
+        <div
+          className="shell-integration-editor__group"
+          role="group"
+          aria-label="Container spawn defaults"
+        >
+          <span className="shell-integration-editor__group-label">Container spawn defaults</span>
+          <span className="shell-integration-editor__meta">
+            Used when this entry opens a new container. Leave blank to use the built-in defaults
+            (image {DEFAULT_CONTAINER_IMAGE}, mount {DEFAULT_MOUNT_TARGET}). An explicit
+            command-line image/mount always takes precedence.
+          </span>
+          <Field label="Container image" htmlFor="si-entry-container-image">
+            <Input
+              id="si-entry-container-image"
+              value={draft.containerImage ?? ""}
+              placeholder={DEFAULT_CONTAINER_IMAGE}
+              data-testid="shell-integration-entry-container-image"
+              onChange={(e) => setDraft((d) => ({ ...d, containerImage: e.target.value }))}
+            />
+          </Field>
+          <Field label="Mount target" htmlFor="si-entry-container-mount">
+            <Input
+              id="si-entry-container-mount"
+              value={draft.containerMount ?? ""}
+              placeholder={DEFAULT_MOUNT_TARGET}
+              data-testid="shell-integration-entry-container-mount"
+              onChange={(e) => setDraft((d) => ({ ...d, containerMount: e.target.value }))}
+            />
+          </Field>
+        </div>
 
         <div className="shell-integration-editor__group" role="group" aria-label="Show for">
           <span className="shell-integration-editor__group-label">Show for</span>

--- a/src/hooks/useSpawnRequests.test.ts
+++ b/src/hooks/useSpawnRequests.test.ts
@@ -14,8 +14,8 @@ vi.mock("@/services/events", () => ({
 
 const resolveContainerSpawn = vi.fn();
 vi.mock("@/services/api", () => ({
-  resolveContainerSpawn: (location: string, image?: string, mount?: string) =>
-    resolveContainerSpawn(location, image, mount),
+  resolveContainerSpawn: (location: string, entryId?: string, image?: string, mount?: string) =>
+    resolveContainerSpawn(location, entryId, image, mount),
 }));
 
 vi.mock("@/components/ui", () => ({
@@ -105,7 +105,28 @@ describe("useSpawnRequests — container spawn wiring (#1446)", () => {
       await Promise.resolve();
     });
 
-    expect(resolveContainerSpawn).toHaveBeenCalledWith("/home/user/app", "alpine:3", "/workspace");
+    expect(resolveContainerSpawn).toHaveBeenCalledWith(
+      "/home/user/app",
+      undefined,
+      "alpine:3",
+      "/workspace"
+    );
+  });
+
+  it("forwards the triggering entry_id so a saved preference can be honored (#1447)", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!(containerRequest({ entry_id: "entry-1", container_image: undefined }));
+      await Promise.resolve();
+    });
+
+    expect(resolveContainerSpawn).toHaveBeenCalledWith(
+      "/home/user/app",
+      "entry-1",
+      undefined,
+      "/workspace"
+    );
   });
 
   it("opens a Docker tab with the resolved settings and title, marked spawned", async () => {
@@ -216,7 +237,12 @@ describe("useSpawnRequests — kind discriminator (#1465)", () => {
       await Promise.resolve();
     });
 
-    expect(resolveContainerSpawn).toHaveBeenCalledWith("/home/user/app", "alpine:3", "/workspace");
+    expect(resolveContainerSpawn).toHaveBeenCalledWith(
+      "/home/user/app",
+      undefined,
+      "alpine:3",
+      "/workspace"
+    );
   });
 
   it("ignores an explicit local/WSL/SSH kind even when container fields are present", async () => {
@@ -241,7 +267,12 @@ describe("useSpawnRequests — kind discriminator (#1465)", () => {
       await Promise.resolve();
     });
 
-    expect(resolveContainerSpawn).toHaveBeenCalledWith("/home/user/app", "alpine:3", "/workspace");
+    expect(resolveContainerSpawn).toHaveBeenCalledWith(
+      "/home/user/app",
+      undefined,
+      "alpine:3",
+      "/workspace"
+    );
   });
 
   it("falls back to presence inference for an auto kind (non-container)", async () => {

--- a/src/hooks/useSpawnRequests.ts
+++ b/src/hooks/useSpawnRequests.ts
@@ -63,6 +63,7 @@ export function useSpawnRequests(): void {
         try {
           const spawn = await resolveContainerSpawn(
             location,
+            req.entry_id,
             req.container_image,
             req.container_mount
           );

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -136,17 +136,21 @@ export interface ContainerSpawn {
 
 /**
  * Resolve a directory-mount container spawn into Docker session settings
- * (#1446). Given a spawn `location` (and optional image / mount overrides),
- * returns the Docker settings + tab title used to open a "new container" tab
- * with the target directory bind-mounted.
+ * (#1446/#1447). Given a spawn `location` (and optional triggering `entryId` +
+ * image / mount overrides), returns the Docker settings + tab title used to open
+ * a "new container" tab with the target directory bind-mounted. When no explicit
+ * image / mount is given, the backend honors the saved per-entry preference of
+ * the entry addressed by `entryId` before falling back to the built-in defaults.
  */
 export async function resolveContainerSpawn(
   location: string,
+  entryId?: string,
   containerImage?: string,
   containerMount?: string
 ): Promise<ContainerSpawn> {
   return await invoke<ContainerSpawn>("resolve_container_spawn", {
     location,
+    entryId,
     containerImage,
     containerMount,
   });

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -294,6 +294,18 @@ export interface ShellEntry {
   visibility: ShellEntryVisibility;
   /** Which right-click targets this entry is registered for. */
   showFor: ShowForTargets;
+  /**
+   * Saved per-entry container-image preference (e.g. `"alpine:3"`). Used when
+   * this entry opens a "new container" spawn and no explicit `--container-image`
+   * is given, ahead of the built-in default. Omitted → no saved preference.
+   */
+  containerImage?: string;
+  /**
+   * Saved per-entry in-container mount-target preference (e.g. `"/src"`). Same
+   * priority as {@link containerImage}: honored for a container spawn when no
+   * explicit `--container-mount` is given.
+   */
+  containerMount?: string;
 }
 
 /** Linux per-file-manager install toggles (Linux-only in effect). */

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -408,6 +408,8 @@ Fixed strings — match exactly.
 | `shell-integration-banner-not-now` | `src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx` |
 | `shell-integration-entries-empty` | `src/components/Settings/ShellIntegrationSettings.tsx` |
 | `shell-integration-entry-connection` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
+| `shell-integration-entry-container-image` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
+| `shell-integration-entry-container-mount` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
 | `shell-integration-entry-editor` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |
 | `shell-integration-entry-list` | `src/components/Settings/ShellIntegrationSettings.tsx` |
 | `shell-integration-entry-name` | `src/components/Settings/ShellIntegrationEntryEditor.tsx` |


### PR DESCRIPTION
## Summary

Follow-up to #1372 (epic #1363). `spawn::container::resolve_container_image` already resolved the container image in priority order **explicit `--container-image` > saved per-entry preference > default**, but `ShellEntry` had nowhere to store that preference, so `resolve_container_spawn` always passed `None`. This wires the saved preference end-to-end (and extends the same treatment to the mount target).

## Changes

### Backend (`feat(backend)`)
- **`ShellEntry` model** (`src-tauri/src/connection/shell_integration.rs`): added optional `container_image` and `container_mount` fields, both `Option<String>` + `#[serde(default, skip_serializing_if = "Option::is_none")]`. Pre-#1447 `settings.json` files round-trip **unchanged** — absent keys deserialize to `None`, and unset fields are omitted on write.
- **Mount preference** (`src-tauri/src/spawn/container.rs`): `resolve_mount_target` now takes a saved-pref tier (explicit > saved > default), matching `resolve_container_image`; `build_container_spawn` accepts a saved mount pref alongside the saved image pref.
- **Spawn wiring** (`src-tauri/src/commands/spawn.rs`): `resolve_container_spawn` now resolves the triggering entry by `entry_id` from the persisted shell-integration settings and passes its saved image/mount into `build_container_spawn` (previously hardcoded `None`).

### Frontend (`feat(ui)`)
- **Types** (`src/types/connection.ts`): `ShellEntry` gains optional `containerImage` / `containerMount`.
- **Entry editor** (`src/components/Settings/ShellIntegrationEntryEditor.tsx`): a "Container spawn defaults" group with shared `Field` + `Input` primitives (tokens only), placeholders showing the built-in defaults, and blank-normalization so empty fields persist as omitted.
- **Spawn hook + api** (`src/hooks/useSpawnRequests.ts`, `src/services/api.ts`): forward the triggering `entry_id` through `resolveContainerSpawn` so the backend can look up the saved preference.

## Not in scope
The interactive picker's **"Remember choice"** (SI-3, #1366) that would *write* this preference is **not built yet**. This PR only adds the field, the editor, and the spawn resolution so a saved preference is **honored**; the picker writing it remains future work.

## Test plan
- Rust unit tests (47 in the touched modules pass):
  - `ShellEntry` with the new fields round-trips through serde; camelCase keys; unset fields omitted.
  - A pre-#1447 partial-JSON entry (no container fields) deserializes with `None` (forward-compat).
  - `resolve_container_spawn_with` honors a saved entry pref when the request omits image/mount, explicit request value beats the saved pref, and an unknown `entry_id` falls back to defaults.
  - `resolve_mount_target` / `build_container_spawn` priority: explicit > saved > default.
- Frontend (vitest, all pass): editor renders + seeds + persists the image/mount fields and omits blanks; the spawn hook forwards `entry_id` through `resolveContainerSpawn`.
- `./scripts/check.sh` (fmt, clippy `-D warnings`, lint) and `pnpm build` pass; testid catalog regenerated via the Python gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)