### PR TITLE
ci: build and clippy the ftp cargo feature to catch feature-gated breakage

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -55,19 +55,39 @@ jobs:
       - name: Run Clippy (linter)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-      # Guards #868: the Docker-dependent integration tests in core/tests/ are
+      # Guards #868 + #1499: builds termihub-core with individual opt-in features
+      # *in isolation*, which the --all-features jobs above cannot do because
+      # feature unification always compiles everything together.
+      #
+      # #868: the Docker-dependent integration tests in core/tests/ are
       # feature-gated (#![cfg(feature = "ssh")], etc.) so a plain
-      # `cargo test -p termihub-core` compiles to a no-op instead of erroring.
-      # Every other Rust job runs --all-features, where cargo feature unification
-      # would hide a newly-added un-gated test file — this check would not. The
-      # ssh / telnet partial builds also verify the gates resolve correctly
-      # (telnet.rs needs both ssh and telnet). Compile-only (--no-run): the tests
-      # themselves need Docker fixtures and run in the integration lane.
-      - name: Core compiles without --all-features (guards #868)
+      # `cargo test -p termihub-core` compiles to a no-op instead of erroring; a
+      # newly-added un-gated test file would be hidden under --all-features but
+      # caught here. The per-feature builds also verify the gates resolve
+      # correctly (telnet.rs needs both ssh and telnet).
+      #
+      # #1499: opt-in feature code (e.g. `ftp`, which gates core/src/backends/ftp/)
+      # must compile on the offending PR. This isolation build additionally catches
+      # gate bugs that --all-features masks — code reachable under `ftp` that
+      # accidentally leans on a symbol only present when another feature is on.
+      # (The #1324/#1456 regression — an MLSD FileEntry construction missing the
+      # new `writable` field, E0063 — fails here.)
+      #
+      # Compile-only (--no-run): these tests need Docker fixtures and run in the
+      # integration lane.
+      - name: Core compiles with each opt-in feature in isolation (guards #868, #1499)
         run: |
           cargo test -p termihub-core --no-run
           cargo test -p termihub-core --no-run --features ssh
           cargo test -p termihub-core --no-run --features telnet
+          cargo test -p termihub-core --no-run --features ftp
+
+      # Clippy the opt-in `ftp` feature in isolation. The --all-features clippy
+      # above lints ftp code with every other feature also on; this lints the
+      # ftp-only feature set so a lint (or compile) break specific to that path
+      # can't merge undetected (#1499).
+      - name: Clippy ftp feature in isolation (guards #1499)
+        run: cargo clippy -p termihub-core --features ftp --all-targets -- -D warnings
 
       # Prebuilt binary download (~seconds) instead of `cargo install cargo-audit`,
       # which compiles from source (~3 min) on a cold cache.


### PR DESCRIPTION
Closes #1499
Follow-up to the #1324/#1456 ftp-build regression (fixed by #1485).

## Problem

`termihub-core`'s backend features are all opt-in (`default = []`): `ftp`, `ssh`, `telnet`, `docker`, `serial`, `local-shell`, `wsl`. The #1324/#1456 regression — an MLSD `FileEntry` construction in `core/src/backends/ftp/listing_parser.rs` that missed the newly-added `writable` field (E0063) — reached `develop` as a **semantic merge conflict**: #1324 added the field and #1456 added the construction site on separate branches, each green in isolation, and the break only materialized once both merged.

Investigation finding: the existing `code-quality.yml` clippy (`cargo clippy --workspace --all-targets --all-features`) and test (`cargo test --workspace --all-features`) jobs **do** already compile the `ftp` code (I confirmed the reintroduced bug fails both). The genuine residual gap is that `--all-features` only ever compiles every feature **together**, so cargo feature unification can mask a break that appears only when a single opt-in feature is built **in isolation** — and the existing per-feature isolation guard step built `ssh` and `telnet` alone but omitted `ftp`.

## Change

Job changed: **Rust Code Quality** (`.github/workflows/code-quality.yml`), no new job.

- Extended the existing per-feature isolation guard step (renamed to `Core compiles with each opt-in feature in isolation (guards #868, #1499)`) to also run `cargo test -p termihub-core --no-run --features ftp`. This mirrors the existing `ssh`/`telnet` lines and matches `ftp`'s own feature-gated integration test file `core/tests/ftp_file_browser.rs` (`#![cfg(feature = "ftp")]`), so an un-gated ftp test file would also be caught (the #868 concern).
- Added a dedicated `Clippy ftp feature in isolation (guards #1499)` step: `cargo clippy -p termihub-core --features ftp --all-targets -- -D warnings`, linting the ftp-only feature set.

Both are compile-cheap (`cargo check`/`--no-run` altitude, no Docker) and reuse the job's warm `rust-cache`.

### Cheap-check vs full-build tradeoff

No full app build was added. `--all-features` already gives the "everything on" coverage; the only missing dimension was the isolated `ftp` feature set, so the additions are a compile-only `--no-run` build plus a clippy pass, not another `tauri build`.

### CI-time impact

Small. Two extra core compilations under the `ftp`-only feature set (a distinct feature-unification fingerprint from `--all-features`, so not cache-shared): ~30–60 s on a warm cache in the already-existing `rust-quality` job. No new runner/OS matrix entry.

## Proof it catches the regression

Reintroduced the exact bug by removing the `writable` field from the MLSD `FileEntry` construction in `core/src/backends/ftp/listing_parser.rs`, then ran the new commands:

- `cargo test -p termihub-core --no-run --features ftp` → **fails** `error[E0063]: missing field 'writable' in initializer of 'FileEntry'`
- `cargo clippy -p termihub-core --features ftp --all-targets -- -D warnings` → **fails** with the same E0063

Reverted the breakage; both commands pass clean on the fixed tree. (For reference the existing `--all-features` clippy also fails on the reintroduced bug — the new steps make the opt-in-feature coverage explicit and add isolated-feature-set coverage that `--all-features` cannot provide.)

## Test plan

- [x] `cargo test -p termihub-core --no-run --features ftp` passes on the clean tree
- [x] `cargo clippy -p termihub-core --features ftp --all-targets -- -D warnings` passes on the clean tree
- [x] Both fail with E0063 when the `writable` field is temporarily removed from the MLSD construction (regression proof), then pass again after revert
- [x] Workflow YAML validated (parses cleanly; structure/indentation matches sibling steps)
- [x] Commit passes `commitlint --strict` (`ci` type, header 74 chars, body lines ≤ 100, footer format)

No change fragment (`docs/changes/`) added: this is a CI/infra-only change with no user-facing effect (per CLAUDE.md). `CHANGELOG.md` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)