### PR TITLE
test(ftp): Python-bridge E2E for the insecure-FTP warning modal

### DIFF
--- a/tests/system/termihub_harness/ui/connections.py
+++ b/tests/system/termihub_harness/ui/connections.py
@@ -307,6 +307,42 @@ class ConnectionsUi(HarnessMixin):
             "connection-editor-save-connect" if connect else "connection-editor-save"
         )
 
+    def create_ftp_connection(
+        self,
+        name: str,
+        *,
+        host: str = "ftp.example.com",
+        port: int = 21,
+        tls_mode: str = "none",
+        connect: bool = False,
+    ) -> None:
+        """Fill the editor for an FTP connection and save (or Save & Connect).
+
+        ``tls_mode`` selects the native ``field-tlsMode`` dropdown: ``"none"`` for
+        plain FTP (the schema default), ``"explicit"`` / ``"implicit"`` for FTPS.
+        Only host/port/tlsMode are required by the backend schema, so
+        username/password are left empty — enough to save a connection and drive
+        the pre-connect insecure-FTP warning flow (#1338). That warning modal is
+        raised on the sidebar connect path (double-click) for plain FTP, so tests
+        save here (``connect=False``) and connect via :meth:`connect_connection`.
+        """
+        self.open_new_connection_editor()
+        self.driver.type("connection-editor-name-input", name)
+        self.select_connection_type("ftp")
+        self.wait(
+            lambda: self.driver.exists("field-host"), what="the FTP connection fields"
+        )
+        self.driver.type("field-host", str(host))
+        self.driver.type("field-port", str(port))
+        if tls_mode:
+            self._select_when_available(
+                "field-tlsMode", tls_mode, what=f"the {tls_mode!r} TLS-mode option"
+            )
+        self.driver.click(
+            "connection-editor-save-connect" if connect else "connection-editor-save"
+        )
+        self.require_connection(name)
+
     def open_serial_editor(self) -> None:
         """Open the editor and switch it to the Serial type, awaiting its fields.
 

--- a/tests/system/tests/test_ftp_insecure_warning.py
+++ b/tests/system/tests/test_ftp_insecure_warning.py
@@ -1,0 +1,122 @@
+"""Insecure-FTP pre-connect warning modal — Python-bridge E2E (issue #1493).
+
+Drives the real app over the test bridge to cover the plaintext-FTP warning
+modal shipped in #1338 (PR #1492). When a plain-FTP connection (``tlsMode ==
+"none"``) whose per-connection ``suppressSecurityWarning`` flag is unset is
+connected from the sidebar, the app must raise the ``insecure-ftp-warning``
+modal *before* any control connection opens (before a tab is created). FTPS
+connections, and plain-FTP connections whose warning has been suppressed via
+"Don't warn again", connect without the modal.
+
+No live FTP server is needed: the whole flow under test — modal appears, Cancel
+aborts, Connect Anyway proceeds, "Don't warn again" persists — happens on the
+frontend before the control connection opens, and ``addTab`` creates the tab
+synchronously regardless of whether the subsequent connect succeeds. So a tab
+appearing (or not) is a server-independent signal that the connect was (or was
+not) initiated. The connect-through happy path against a real FTP endpoint is
+therefore out of scope here (see the PR notes).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from termihub_harness import (
+    ConnectionsUi,
+    SystemTest,
+    TabsUi,
+    unique_name,
+)
+
+pytestmark = pytest.mark.integration
+
+WARNING_MODAL = "insecure-ftp-warning"
+CONFIRM = "confirm-dialog-confirm"
+CANCEL = "confirm-dialog-cancel"
+DONT_WARN = "confirm-dialog-dont-ask-again"
+
+
+class TestInsecureFtpWarning(ConnectionsUi, TabsUi, SystemTest):
+    """FTP-SEC-01: the plaintext-FTP warning modal gates the sidebar connect."""
+
+    def _warning_open(self) -> bool:
+        """Whether the insecure-FTP warning modal is currently mounted."""
+        return self.driver.exists(WARNING_MODAL)
+
+    def _suppress_flag(self, name: str) -> object:
+        """The persisted ``suppressSecurityWarning`` value for ``name`` (or None)."""
+        conn = self.find_connection(name)
+        if conn is None:
+            return None
+        return conn.get("config", {}).get("config", {}).get("suppressSecurityWarning")
+
+    def test_plain_ftp_warns_and_cancel_aborts(self):
+        """Plain FTP raises the modal before any tab; Cancel closes it and aborts."""
+        name = unique_name("ftp-plain")
+        self.create_ftp_connection(name, tls_mode="none")
+        before = self.tab_count()
+
+        self.connect_connection(name)
+        self.wait(self._warning_open, what="the insecure-FTP warning modal")
+        # The control connection must not have opened yet — no tab created.
+        assert self.find_tab(name) is None
+        assert self.tab_count() == before
+
+        self.driver.click(CANCEL)
+        self.wait(lambda: not self._warning_open(), what="the modal to close")
+        # Cancel aborts: still no tab for this connection.
+        assert self.find_tab(name) is None
+        assert self.tab_count() == before
+
+    def test_connect_anyway_proceeds(self):
+        """Connect Anyway (toggle off) dismisses the modal and opens the tab."""
+        name = unique_name("ftp-anyway")
+        self.create_ftp_connection(name, tls_mode="none")
+
+        self.connect_connection(name)
+        self.wait(self._warning_open, what="the insecure-FTP warning modal")
+
+        self.driver.click(CONFIRM)
+        self.wait(lambda: not self._warning_open(), what="the modal to close")
+        # The connect proceeds — a tab is created for the connection.
+        self.wait(lambda: self.find_tab(name), what="the FTP tab to open")
+        # With the toggle off, no per-connection suppression is persisted.
+        assert self._suppress_flag(name) is not True
+
+    def test_dont_warn_again_persists_and_skips_modal(self):
+        """"Don't warn again" persists suppression so the next connect skips the modal."""
+        name = unique_name("ftp-suppress")
+        self.create_ftp_connection(name, tls_mode="none")
+
+        # First connect: raise the modal, tick "Don't warn again", Connect Anyway.
+        self.connect_connection(name)
+        self.wait(self._warning_open, what="the insecure-FTP warning modal")
+        self.driver.click(DONT_WARN)
+        self.driver.click(CONFIRM)
+        self.wait(lambda: not self._warning_open(), what="the modal to close")
+        self.wait(lambda: self.find_tab(name), what="the first FTP tab")
+
+        # The suppression flag is persisted onto the connection.
+        self.wait(
+            lambda: self._suppress_flag(name) is True,
+            what="suppressSecurityWarning to persist",
+        )
+
+        # Second connect: the modal is skipped and a second tab opens directly.
+        before = self.tab_count()
+        self.connect_connection(name)
+        self.wait(lambda: self.tab_count() > before, what="a second FTP tab to open")
+        assert not self._warning_open()
+
+
+class TestFtpsNoWarning(ConnectionsUi, TabsUi, SystemTest):
+    """FTP-SEC-02: an FTPS connection connects without the insecure-FTP modal."""
+
+    def test_ftps_connects_without_warning(self):
+        name = unique_name("ftps-explicit")
+        self.create_ftp_connection(name, tls_mode="explicit")
+
+        self.connect_connection(name)
+        # FTPS never raises the warning — the connect proceeds straight to a tab.
+        self.wait(lambda: self.find_tab(name), what="the FTPS tab to open")
+        assert not self.driver.exists(WARNING_MODAL)


### PR DESCRIPTION
Closes #1493
Follow-up to #1338 (PR #1492).

## Summary

Adds a Python-bridge system test that drives the **real built app** over the WebSocket test bridge to cover the plaintext-FTP pre-connect warning modal shipped in #1338. The suite (`tests/system/tests/test_ftp_insecure_warning.py`) asserts, end-to-end:

- **Plain FTP warns + Cancel aborts** — connecting a `tlsMode: "none"` FTP connection from the sidebar raises the `insecure-ftp-warning` modal *before* any control connection opens (no tab created yet); **Cancel** closes the modal and no tab is opened.
- **Connect Anyway proceeds** — with the toggle off, confirming dismisses the modal and opens the tab, and no per-connection suppression is persisted.
- **"Don't warn again" persists + skips** — ticking the toggle and confirming persists `suppressSecurityWarning` onto the connection, so a **second** connect opens a tab directly with no modal.
- **FTPS shows no modal** — an `explicit` FTPS connection connects straight to a tab with the warning modal never appearing.

A small `create_ftp_connection` helper was added to the `ConnectionsUi` harness mixin, mirroring the existing `create_ssh_connection` / `create_telnet_connection` idioms (type select + `field-host` / `field-port` / `field-tlsMode`).

## How it was run

Built a debug app and ran the suite through the harness on macOS:

```
./scripts/test-system-py.sh --debug -k "InsecureFtp or FtpsNoWarning" -x -v
# → 4 passed, 537 deselected
```

`uvx ruff check` on the changed files passes.

## Why no live FTP server / deferred connect-through

The entire flow under test happens on the frontend *before* the control connection opens, and `addTab` creates the tab synchronously regardless of whether the subsequent connect succeeds — so a tab appearing (or not) is a server-independent signal that the connect was (or was not) initiated. The **connect-through happy path against a real FTP endpoint** (asserting a live file-browser session) is therefore out of scope here and left as manual/deferred coverage; the modal, cancel, suppression, and FTPS-no-modal behaviors are all fully exercised without a server.

## Docs

Test-only change — no change fragment per CLAUDE.md; no new manual test steps, so `docs/testing.md` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)