### PR TITLE
feat(ui): add close button to bottom-right toasts (Closes #1504)

### DIFF
--- a/docs/changes/dev1/feature/1504-toast-close-button.md
+++ b/docs/changes/dev1/feature/1504-toast-close-button.md
@@ -1,0 +1,9 @@
+### Added
+
+- Toast notifications (bottom-right) now have a discoverable, keyboard-accessible
+  close (**X**) button that dismisses the toast immediately, instead of waiting
+  for auto-dismiss. It uses the design-system lucide `X` icon, is fully
+  token-styled (hover, focus ring) in both light and dark themes, and appears on
+  all non-loading variants — success, error, info, and default. Loading toasts
+  omit it by sonner's design; they resolve in place into a closable
+  success/error toast (#1504).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -813,6 +813,24 @@ and the TLS-mode → port auto-adjust. See PR #1338.
 5. Connect an **FTPS** (explicit or implicit) connection → the modal is **never**
    shown.
 
+### Toast close button — light/dark rendering (#1504)
+
+Verifies the bottom-right toast close (X) button renders and is styled
+correctly in both themes. See PR #1504.
+
+1. Trigger any toast (e.g. save a connection to get a success toast, or perform
+   an action that fails to get a persistent error toast).
+2. Confirm a close (**X**) button appears in the top-right of the toast, using
+   the lucide `X` icon, not overlapping the message or action button.
+3. Hover the button → it shows a subtle background; **Tab** to it → a visible
+   focus ring appears; press **Enter/Space** or click → the toast dismisses
+   immediately.
+4. Switch between **light** and **dark** themes (Settings → Appearance) and
+   repeat: the icon, hover, and focus ring must remain legible in both.
+5. Repeat across variants (success, error, info). Loading toasts intentionally
+   have no close button; confirm the toast they resolve into (success/error)
+   does.
+
 ### Agent binary SHA-256 checksums (release dry-run, #1350)
 
 Verifies that every published agent binary has a matching `*.sha256` asset and

--- a/src/components/ui/Toast/ToastProvider.test.tsx
+++ b/src/components/ui/Toast/ToastProvider.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { ToastProvider } from "./ToastProvider";
+import { toast } from "./toast";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+/** Advance a real macrotask tick inside act so sonner can flush its subscription. */
+async function tick(ms = 25) {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+}
+
+/** Poll the DOM until `predicate` holds or the attempt budget is exhausted. */
+async function waitFor(predicate: () => boolean, attempts = 60) {
+  for (let i = 0; i < attempts; i++) {
+    if (predicate()) return;
+    await tick();
+  }
+  throw new Error("waitFor: condition not met within budget");
+}
+
+describe("ToastProvider close button", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    toast.dismiss();
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders a keyboard-accessible close button with a lucide icon on a toast", async () => {
+    render(<ToastProvider />);
+    act(() => {
+      toast.success("Saved");
+    });
+    await waitFor(() => document.querySelector("[data-close-button]") !== null);
+
+    const close = document.querySelector("[data-close-button]") as HTMLButtonElement;
+    expect(close).toBeTruthy();
+    // Native <button> is keyboard-focusable by default.
+    expect(close.tagName).toBe("BUTTON");
+    // Has an accessible name for screen-reader / keyboard users.
+    expect(close.getAttribute("aria-label")).toBeTruthy();
+    // Renders a real lucide SVG icon, not a unicode glyph.
+    expect(close.querySelector("svg")).toBeTruthy();
+    expect(close.textContent?.trim()).toBe("");
+  });
+
+  it("dismisses the toast immediately when the close button is clicked", async () => {
+    render(<ToastProvider />);
+    act(() => {
+      toast.success("Dismiss me");
+    });
+    await waitFor(() => (document.body.textContent ?? "").includes("Dismiss me"));
+
+    const close = document.querySelector("[data-close-button]") as HTMLButtonElement;
+    act(() => close.click());
+
+    await waitFor(() => !(document.body.textContent ?? "").includes("Dismiss me"));
+    expect(document.body.textContent).not.toContain("Dismiss me");
+  });
+});

--- a/src/components/ui/Toast/ToastProvider.tsx
+++ b/src/components/ui/Toast/ToastProvider.tsx
@@ -1,5 +1,5 @@
 import { Toaster } from "sonner";
-import { CheckCircle2, XCircle, Info, Loader2 } from "lucide-react";
+import { CheckCircle2, XCircle, Info, Loader2, X } from "lucide-react";
 import "./toast.css";
 
 /**
@@ -9,6 +9,13 @@ import "./toast.css";
  * `--shadow-dropdown`, token radii/spacing, and intent colors from
  * `--color-success/-error/-info` / `--accent-color`.
  *
+ * Every toast carries a discoverable, keyboard-focusable close (X) button so it
+ * can be dismissed manually rather than only auto-dismissing (`closeButton`).
+ * The close icon overrides sonner's default with the design-system lucide `X`;
+ * it is token-styled in `toast.css`. Note sonner omits the close button on
+ * `loading` toasts by design — those resolve in place into a closable
+ * success/error toast.
+ *
  * Motion is left to the global reduced-motion rules in `toast.css`.
  */
 export function ToastProvider() {
@@ -17,12 +24,14 @@ export function ToastProvider() {
       position="bottom-right"
       gap={8}
       offset={16}
-      toastOptions={{ className: "th-toast", unstyled: true }}
+      closeButton
+      toastOptions={{ className: "th-toast", unstyled: true, closeButtonAriaLabel: "Close" }}
       icons={{
         success: <CheckCircle2 className="th-toast__icon-svg" aria-hidden />,
         error: <XCircle className="th-toast__icon-svg" aria-hidden />,
         info: <Info className="th-toast__icon-svg" aria-hidden />,
         loading: <Loader2 className="th-toast__icon-svg th-toast__icon-svg--spin" aria-hidden />,
+        close: <X className="th-toast__close-icon" aria-hidden />,
       }}
     />
   );

--- a/src/components/ui/Toast/toast.css
+++ b/src/components/ui/Toast/toast.css
@@ -62,23 +62,42 @@
   color: var(--text-secondary);
 }
 
+/*
+ * sonner renders the close button as the toast's first child; `order` moves it
+ * to the visual end and `margin-left: auto` pins it to the top-right corner
+ * (align-items: flex-start), clear of the icon, message, and action button.
+ * Sizing/hover/focus mirror the shared modal close button (.ui-modal__close).
+ */
 .th-toast [data-close-button] {
+  order: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
   margin-left: auto;
-  width: 18px;
-  height: 18px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
 }
 .th-toast [data-close-button]:hover {
+  background: var(--bg-hover);
   color: var(--text-primary);
+}
+.th-toast [data-close-button]:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+.th-toast__close-icon {
+  width: 15px;
+  height: 15px;
 }
 
 /* ── Intent accents ─────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Bottom-right toast notifications previously had **no way to be dismissed manually** — only auto-dismiss (and error/loading toasts persist indefinitely). This adds a discoverable, keyboard-accessible close (**X**) button to every toast.

## Changes

- **Enable sonner's close affordance** — `ToastProvider` now passes `closeButton` to `<Toaster>`, and overrides sonner's default close glyph with the design-system lucide `X` via `icons={{ close: <X .../> }}`. The accessible label is set to `Close` (`toastOptions.closeButtonAriaLabel`).
- **Token-only styling** in `toast.css` — because sonner is mounted with `unstyled: true`, the `[data-close-button]` rules fully own the control. Styling mirrors the shared modal close button (`.ui-modal__close`): 24×24 hit target, `--radius-sm`, transparent surface, `--text-secondary` → `--text-primary`/`--bg-hover` on hover, `--shadow-focus` focus-visible ring, `--transition-fast`. sonner renders the close button as the toast's first DOM child, so `order` + `margin-left: auto` pin it to the top-right corner, clear of the icon, message, and action button. No raw hex/rgba/pixel-radii.
- Reduced-motion already disables the button's transition.

## Accessibility

- Native `<button>` — keyboard-focusable, Enter/Space activatable.
- `aria-label="Close"` for screen readers.
- Visible `--shadow-focus` ring on `:focus-visible`.

## Light / dark themes

All values are per-theme tokens, so hover, focus ring, and icon color stay legible in both themes.

## Note on loading toasts

sonner intentionally omits the close button on `loading` toasts (they are meant to resolve programmatically). termiHub loading toasts resolve in place into a closable success/error toast, so this is not a gap.

## Test plan

- **Automated** — `src/components/ui/Toast/ToastProvider.test.tsx` renders `<ToastProvider/>`, fires a toast, and asserts the close button renders as a focusable `<button>` with an accessible name and a lucide `<svg>` icon, then that clicking it dismisses the toast. Added test-first (red → green).
- **Manual (light/dark visual)** — see `docs/testing.md` → "Toast close button — light/dark rendering (#1504)": trigger toasts across variants, hover/Tab/click the X, and confirm rendering in both themes.

Closes #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)