### PR TITLE
feat(sftp): elevated edit mode — sudo prompt dialog, marker, retry, caching

### DIFF
--- a/docs/changes/dev0/feature/1329-elevated-edit-mode.md
+++ b/docs/changes/dev0/feature/1329-elevated-edit-mode.md
@@ -1,0 +1,18 @@
+### Added
+
+- **Elevated (sudo) edit mode** in the file editor: a read-only remote file on an
+  exec-capable (SSH shell) connection now shows an **Edit with sudo** action in
+  place of Save. Authorizing opens a password prompt that names the host, user,
+  and target file, masks the password, and offers **Remember for this session**
+  (default on) plus **Save in credential store** (shown only when the credential
+  store is unlocked). A correct password writes the file with root privileges via
+  the elevated backend path, confirms with a success toast, and pins a persistent
+  accent **sudo** marker in the toolbar for the rest of the session — subsequent
+  saves reuse the cached (or stored) password without re-prompting. A wrong
+  password re-prompts with an attempt counter up to three times, then falls back
+  to the existing save-error banner with the edited buffer preserved; a
+  non-password failure (sudo missing / not in sudoers) surfaces the same banner.
+  The banner also gains a **Retry with sudo** action for a direct save that failed
+  on an unknown-writability file. The sudo password lives only in in-memory
+  session state and, opt-in, the credential store — it is never written to tab or
+  workspace state, and never logged. (#1329, epic #1323, concept #970)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1295,7 +1295,7 @@ Detection only — no elevated save is offered. See PR #1486 (#1325).
 
 Verifies read-only remote files can be saved with `sudo` via the in-app prompt.
 Requires an SSH/SFTP connection whose user has `sudo` rights on the host (e.g. a
-Raspberry Pi). See PR #<PR> (#1329).
+Raspberry Pi). See PR #1508 (#1329).
 
 1. On a remote SSH/SFTP connection, open a **root-owned** file the user cannot
    write directly (e.g. `/etc/hosts`). Confirm the read-only badge/banner appear

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1261,6 +1261,38 @@ Detection only — no elevated save is offered. See PR #1486 (#1325).
 6. Toggle light/dark themes (Settings → Appearance) with a read-only file open →
    the badge and banner stay legible in both themes.
 
+### File editor elevated (sudo) edit mode (#1329)
+
+Verifies read-only remote files can be saved with `sudo` via the in-app prompt.
+Requires an SSH/SFTP connection whose user has `sudo` rights on the host (e.g. a
+Raspberry Pi). See PR #<PR> (#1329).
+
+1. On a remote SSH/SFTP connection, open a **root-owned** file the user cannot
+   write directly (e.g. `/etc/hosts`). Confirm the read-only badge/banner appear
+   and the toolbar action is **Edit with sudo** (not **Save**).
+2. Make an edit, then click **Edit with sudo**. In the prompt confirm the **host**,
+   **user**, and **file** are named and the password field is masked. Leave
+   **Remember for this session** on (default). Enter the correct password →
+   **Authorize**.
+3. The save succeeds (success toast), a persistent accent **sudo** marker appears
+   in the toolbar, and the buffer is clean. Verify the file was actually changed
+   on the host (`cat` it in a shell).
+4. Edit again and press **Save** / `Ctrl+S` → it saves elevated **without**
+   re-prompting (the session password is cached). The `sudo` marker stays.
+5. Open another root-owned file, click **Edit with sudo**, and enter a **wrong**
+   password three times → the prompt shows an "Incorrect password. Attempt N of 3"
+   counter, then after the 3rd failure the dialog closes and the #969 save-error
+   banner appears with the buffer **intact** (still dirty; nothing lost).
+6. With the credential store **locked** (or in `none` mode), open the sudo prompt →
+   the **Save in credential store** option is **hidden**. Unlock the store and
+   reopen the prompt → the option appears; enabling it and authorizing persists
+   the sudo password (a later session reuses it silently).
+7. On a file whose writability was **unknown**, press **Save**, let the direct save
+   fail with a permission error → the #969 banner shows a **Retry with sudo**
+   action; click it to open the prompt and save elevated.
+8. Confirm the sudo password is never visible in the LogViewer (elevated-save DEBUG
+   lines name the host/path only) and never written to workspace/tab state.
+
 ### Guided-Manual Tests in the Python Harness (preferred)
 
 Guided-manual tests are **first-class `pytest` tests** in the Python system-test harness (`tests/system/`). Each one does all the automatable setup through the existing mixins — launch the app, build connections/state — and then prompts the operator for only the irreducibly-manual step (a native OS dialog, xterm-canvas color fidelity, cursor blink). This is the key difference from the legacy YAML runner: the operator does just the un-automatable bit, and the test shares the harness's app/agent orchestration, fixtures, and reporting.

--- a/src-tauri/src/commands/credential.rs
+++ b/src-tauri/src/commands/credential.rs
@@ -348,6 +348,7 @@ fn parse_credential_type(s: &str) -> Result<CredentialType, String> {
     match s {
         "password" => Ok(CredentialType::Password),
         "key_passphrase" => Ok(CredentialType::KeyPassphrase),
+        "sudo_password" => Ok(CredentialType::SudoPassword),
         _ => Err(format!("Unknown credential type: {s}")),
     }
 }
@@ -437,6 +438,14 @@ mod tests {
         assert_eq!(
             parse_credential_type("key_passphrase").unwrap(),
             CredentialType::KeyPassphrase
+        );
+    }
+
+    #[test]
+    fn parse_credential_type_sudo_password() {
+        assert_eq!(
+            parse_credential_type("sudo_password").unwrap(),
+            CredentialType::SudoPassword
         );
     }
 

--- a/src/components/FileEditor/FileEditor.css
+++ b/src/components/FileEditor/FileEditor.css
@@ -50,6 +50,17 @@
   border-color: var(--color-warning);
 }
 
+/*
+ * Elevated ("sudo") edit-mode marker: a filled accent chip (not just an accent
+ * outline like the remote badge) so the persistent elevated state reads clearly
+ * against the toolbar. (issue 1329)
+ */
+.file-editor__sudo-badge {
+  color: var(--text-on-accent);
+  background-color: var(--accent-color);
+  border-color: var(--accent-color);
+}
+
 .file-editor__filepath {
   font-size: var(--font-size-sm);
   color: var(--text-secondary);

--- a/src/components/FileEditor/FileEditor.test.tsx
+++ b/src/components/FileEditor/FileEditor.test.tsx
@@ -333,6 +333,250 @@ describe("FileEditor — read-only badge + banner (#1325)", () => {
   });
 });
 
+describe("FileEditor — elevated (sudo) edit mode (#1329)", () => {
+  const REMOTE_RO_META: EditorTabMeta = {
+    filePath: "/etc/hosts",
+    isRemote: true,
+    sftpSessionId: "sftp-sess-1",
+    permissions: "-rw-r--r--",
+  };
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+    // A host label so the dialog can name the target and derive a credential key.
+    useAppStore.setState({
+      sftpSessions: { "sftp-sess-1": { hostLabel: "pi@raspberrypi:22", owningTabId: TAB_ID } },
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  /** Query portalled (Radix) dialog content from the whole document. */
+  function docQuery(testId: string): HTMLElement | null {
+    return document.querySelector(`[data-testid="${testId}"]`);
+  }
+
+  function typeInto(el: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value"
+    )!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  /**
+   * Mock the backend for elevated flows. `elevatedResults` is consumed one entry
+   * per `sftp_write_file_content_elevated` call so a test can script
+   * incorrect→incorrect→success sequences.
+   */
+  function mockBackend(opts: {
+    readOnly?: boolean;
+    execCapable?: boolean;
+    elevatedResults?: unknown[];
+    storeStatus?: "unlocked" | "locked" | "unavailable";
+  }): { elevatedCalls: Array<Record<string, unknown>> } {
+    const { readOnly = true, execCapable = true, elevatedResults = [] } = opts;
+    const elevatedCalls: Array<Record<string, unknown>> = [];
+    const queue = [...elevatedResults];
+    mockedInvoke.mockImplementation((cmd, args) => {
+      if (cmd === "sftp_read_file_content") return Promise.resolve("127.0.0.1 localhost\n");
+      if (cmd === "sftp_has_exec_capability") return Promise.resolve(execCapable);
+      if (cmd === "sftp_check_writable") return Promise.resolve(readOnly ? "readOnly" : "writable");
+      if (cmd === "sftp_write_file_content_elevated") {
+        elevatedCalls.push((args ?? {}) as Record<string, unknown>);
+        return Promise.resolve(queue.shift() ?? { kind: "success" });
+      }
+      if (cmd === "store_credential") return Promise.resolve(undefined);
+      if (cmd === "resolve_credential") return Promise.resolve(null);
+      return Promise.resolve(undefined);
+    });
+    return { elevatedCalls };
+  }
+
+  it("offers 'Edit with sudo' only when the file is read-only and exec-capable", async () => {
+    mockBackend({ readOnly: true, execCapable: true });
+    render(REMOTE_RO_META);
+    await flush();
+
+    expect(query("file-editor-edit-with-sudo")).not.toBeNull();
+    // The plain Save button is replaced by the sudo entry point.
+    expect(query("file-editor-save")).toBeNull();
+  });
+
+  it("does not offer 'Edit with sudo' when the connection is not exec-capable", async () => {
+    mockBackend({ readOnly: true, execCapable: false });
+    render(REMOTE_RO_META);
+    await flush();
+
+    expect(query("file-editor-edit-with-sudo")).toBeNull();
+    expect(query("file-editor-save")).not.toBeNull();
+  });
+
+  it("routes an authorized save through the elevated command and shows the sudo marker", async () => {
+    const { elevatedCalls } = mockBackend({
+      readOnly: true,
+      execCapable: true,
+      elevatedResults: [{ kind: "success" }],
+    });
+    render(REMOTE_RO_META);
+    await flush();
+
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    // The sudo prompt appears; authorize it.
+    typeInto(docQuery("sudo-prompt-input") as HTMLInputElement, "sudo-pw");
+    await act(async () => {
+      (docQuery("sudo-prompt-submit") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(elevatedCalls).toHaveLength(1);
+    expect(elevatedCalls[0].sudoPassword).toBe("sudo-pw");
+    // Success: buffer is clean and the persistent sudo marker is shown.
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(false);
+    expect(query("file-editor-sudo-badge")).not.toBeNull();
+  });
+
+  it("re-prompts on an incorrect password up to 3 times, then falls to the #969 banner", async () => {
+    const { elevatedCalls } = mockBackend({
+      readOnly: true,
+      execCapable: true,
+      elevatedResults: [
+        { kind: "incorrectPassword" },
+        { kind: "incorrectPassword" },
+        { kind: "incorrectPassword" },
+      ],
+    });
+    render(REMOTE_RO_META);
+    await flush();
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    // Three wrong attempts.
+    for (let i = 0; i < 3; i++) {
+      typeInto(docQuery("sudo-prompt-input") as HTMLInputElement, `wrong-${i}`);
+      await act(async () => {
+        (docQuery("sudo-prompt-submit") as HTMLButtonElement).click();
+      });
+      await flush();
+    }
+
+    expect(elevatedCalls).toHaveLength(3);
+    // Dialog is dismissed and the #969 save-error banner is shown with the buffer intact.
+    expect(docQuery("sudo-prompt-dialog")).toBeNull();
+    expect(query("file-editor-save-error")).not.toBeNull();
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
+  });
+
+  it("surfaces a non-password failure ('other') in the #969 banner with the buffer intact", async () => {
+    mockBackend({
+      readOnly: true,
+      execCapable: true,
+      elevatedResults: [{ kind: "other", message: "sudo: command not found" }],
+    });
+    render(REMOTE_RO_META);
+    await flush();
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+    typeInto(docQuery("sudo-prompt-input") as HTMLInputElement, "pw");
+    await act(async () => {
+      (docQuery("sudo-prompt-submit") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const banner = query("file-editor-save-error");
+    expect(banner?.textContent ?? "").toMatch(/command not found/i);
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
+  });
+
+  it("caches the session password so a second elevated save does not re-prompt", async () => {
+    const { elevatedCalls } = mockBackend({
+      readOnly: true,
+      execCapable: true,
+      elevatedResults: [{ kind: "success" }, { kind: "success" }],
+    });
+    render(REMOTE_RO_META);
+    await flush();
+    editContent("127.0.0.1 localhost\nedit1\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+    typeInto(docQuery("sudo-prompt-input") as HTMLInputElement, "cached-pw");
+    await act(async () => {
+      (docQuery("sudo-prompt-submit") as HTMLButtonElement).click();
+    });
+    await flush();
+    expect(elevatedCalls).toHaveLength(1);
+
+    // Edit again and save via the (now elevated) Save button — no dialog.
+    editContent("127.0.0.1 localhost\nedit2\n");
+    await flush();
+    await act(async () => {
+      (query("file-editor-save") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(docQuery("sudo-prompt-dialog")).toBeNull();
+    expect(elevatedCalls).toHaveLength(2);
+    expect(elevatedCalls[1].sudoPassword).toBe("cached-pw");
+  });
+
+  it("adds a 'Retry with sudo' action to the #969 banner after a failed direct save", async () => {
+    // Writability unknown → direct save attempted → permission denied → banner.
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "sftp_read_file_content") return Promise.resolve("body\n");
+      if (cmd === "sftp_has_exec_capability") return Promise.resolve(true);
+      if (cmd === "sftp_check_writable") return Promise.resolve("unknown");
+      if (cmd === "sftp_write_file_content") return Promise.reject(new Error("permission denied"));
+      return Promise.resolve(undefined);
+    });
+    render(REMOTE_RO_META);
+    await flush();
+    editContent("body\nmore\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-save") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(query("file-editor-save-error")).not.toBeNull();
+    expect(query("file-editor-save-error-retry-sudo")).not.toBeNull();
+  });
+});
+
 describe("FileEditor — toolbar composes shared UI primitives (#1358)", () => {
   beforeEach(() => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
-import { Save, Loader2, AlertCircle, Globe, FileEdit, Lock, X } from "lucide-react";
-import { Button } from "@/components/ui";
+import { Save, Loader2, AlertCircle, Globe, FileEdit, Lock, ShieldCheck, X } from "lucide-react";
+import { Button, toast } from "@/components/ui";
 import { save } from "@tauri-apps/plugin-dialog";
 import { EditorTabMeta, EditorStatus } from "@/types/terminal";
 import { useAppStore } from "@/store/appStore";
@@ -16,12 +16,21 @@ import {
   localWriteFile,
   sftpReadFileContent,
   sftpWriteFileContent,
+  sftpWriteFileContentElevated,
   sftpHasExecCapability,
   sftpCheckWritable,
+  storeCredential,
+  resolveCredential,
+  removeCredential,
+  type ElevatedWriteResult,
 } from "@/services/api";
 import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
+import { SudoPromptDialog, type SudoAuthorizeOptions } from "./SudoPromptDialog";
 import { frontendLog } from "@/utils/frontendLog";
 import "./FileEditor.css";
+
+/** Maximum number of sudo-password attempts before falling back to the error banner. */
+const MAX_SUDO_ATTEMPTS = 3;
 
 // Use local monaco-editor package instead of CDN (important for Tauri/offline)
 loader.config({ monaco });
@@ -82,6 +91,18 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // Subscribe to the theme setting so we re-derive the Monaco theme when the
   // user explicitly switches between dark / light / system in the settings.
   const themeSetting = useAppStore((s) => s.settings.theme);
+  // Host label (`user@host:port`) of the editor's SFTP session — names the host
+  // in the sudo prompt and keys the (optional) credential-store entry. The
+  // credential store treats this string as an opaque namespace, and a sudo
+  // password belongs to the remote user@host rather than any UI connection id.
+  const hostLabel = useAppStore((s) =>
+    meta.sftpSessionId ? (s.sftpSessions[meta.sftpSessionId]?.hostLabel ?? null) : null
+  );
+  // Live credential-store status — the "save in credential store" option only
+  // appears when it is unlocked.
+  const credentialStoreUnlocked = useAppStore(
+    (s) => s.credentialStoreStatus?.status === "unlocked"
+  );
 
   const [content, setContent] = useState<string | null>(null);
   const [savedContent, setSavedContent] = useState<string | null>(null);
@@ -118,8 +139,23 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // persistent state indicator; only the banner is dismissible.
   const [readonlyBannerDismissed, setReadonlyBannerDismissed] = useState(false);
 
+  // Elevated ("sudo") edit mode. Once a save is authorized with sudo, the tab
+  // stays in elevated mode for the rest of the session: a persistent `sudo`
+  // marker is shown and subsequent saves route through the elevated path.
+  const [elevated, setElevated] = useState(false);
+  // Sudo prompt dialog state. `sudoAttempt` is 1-based; a rejected password
+  // bumps it (up to MAX_SUDO_ATTEMPTS) while the dialog stays open. `sudoBusy`
+  // drives the dialog's pending state while the backend verifies.
+  const [sudoDialogOpen, setSudoDialogOpen] = useState(false);
+  const [sudoAttempt, setSudoAttempt] = useState(1);
+  const [sudoBusy, setSudoBusy] = useState(false);
+
   const saveRef = useRef<() => void>(() => {});
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  // In-memory session password cache ("Remember for this session"). Held in a
+  // ref — never React/store state and never {@link EditorTabMeta} — so it is
+  // impossible for it to be serialized into persisted tab/workspace state.
+  const sudoPasswordRef = useRef<string | null>(null);
 
   // A scratch buffer has no on-disk counterpart until the user saves it.
   const isUnsavedScratch = meta.scratch === true && scratchSavedPath === null;
@@ -260,6 +296,15 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   const isDirty =
     content !== null && savedContent !== null && (isUnsavedScratch || content !== savedContent);
 
+  // Whether the primary toolbar action should be "Edit with sudo" instead of
+  // "Save": a remote file the probe reported read-only, on an exec-capable
+  // (shell) connection, before the session has been elevated. Once elevated the
+  // normal Save button returns (it routes through the sudo path).
+  const offerEditWithSudo =
+    meta.isRemote && !!meta.sftpSessionId && writable === false && execCapable && !elevated;
+  // Whether a failed direct save can be retried with sudo (a shell exists).
+  const canRetryWithSudo = meta.isRemote && !!meta.sftpSessionId && execCapable && !elevated;
+
   // Sync dirty state to the store (drives the tab dirty dot and close prompt).
   useEffect(() => {
     if (content === null || savedContent === null) return;
@@ -282,8 +327,178 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     }
   }, [error, tabId, pendingCloseRequest, setEditorDirty, setPendingCloseRequest, closeTab]);
 
+  // Apply the effects of a successful elevated write: mark the buffer saved,
+  // enter (persistent) elevated mode, optionally cache the password for the
+  // session, and confirm with a success toast.
+  const applyElevatedSuccess = useCallback(
+    (bufferContent: string, password: string, remember: boolean) => {
+      setSavedContent(bufferContent);
+      setElevated(true);
+      if (remember) sudoPasswordRef.current = password;
+      frontendLog("file_editor", `elevated save succeeded for ${meta.filePath}`);
+      toast.success(`Saved ${getBasename(meta.filePath)} with sudo`);
+    },
+    [meta.filePath]
+  );
+
+  // Attempt a single elevated write with a candidate password. Returns a small
+  // discriminated outcome so the two call sites (silent cache/credential path
+  // and the interactive dialog) can react. Non-password failures are surfaced
+  // in the #969 banner here; the password is never logged.
+  const attemptElevatedWrite = useCallback(
+    async (password: string, bufferContent: string): Promise<"success" | "wrong" | "error"> => {
+      const sessionId = meta.sftpSessionId;
+      if (!sessionId) return "error";
+      frontendLog(
+        "file_editor",
+        `elevated save attempt for ${meta.filePath} on ${hostLabel ?? "unknown host"}`
+      );
+      let result: ElevatedWriteResult;
+      try {
+        result = await sftpWriteFileContentElevated(
+          sessionId,
+          meta.filePath,
+          bufferContent,
+          password
+        );
+      } catch (err) {
+        frontendLog(
+          "file_editor",
+          `elevated save threw for ${meta.filePath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        setSaveError(formatSaveError(err));
+        return "error";
+      }
+      if (result.kind === "success") return "success";
+      if (result.kind === "incorrectPassword") return "wrong";
+      frontendLog("file_editor", `elevated save failed for ${meta.filePath}: ${result.message}`);
+      setSaveError(`Save failed: ${result.message}`);
+      return "error";
+    },
+    [meta.sftpSessionId, meta.filePath, hostLabel]
+  );
+
+  // Save via the elevated (sudo) path, prompting only when needed. Tries the
+  // in-memory session cache first, then an opt-in persisted credential (when the
+  // store is unlocked); a hit saves silently, a miss or a stale/rejected
+  // password opens the interactive prompt.
+  const saveElevated = useCallback(async () => {
+    if (content === null || saving) return;
+    const bufferContent = content;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      let password = sudoPasswordRef.current;
+      let fromStore = false;
+      if (!password && credentialStoreUnlocked && hostLabel) {
+        try {
+          password = await resolveCredential(hostLabel, "sudo_password");
+          fromStore = password != null;
+        } catch {
+          password = null;
+        }
+      }
+      if (password) {
+        const outcome = await attemptElevatedWrite(password, bufferContent);
+        if (outcome === "success") {
+          applyElevatedSuccess(bufferContent, password, true);
+          return;
+        }
+        if (outcome === "error") return;
+        // Stale cache / rejected stored password — discard it and prompt.
+        sudoPasswordRef.current = null;
+        if (fromStore && hostLabel) {
+          try {
+            await removeCredential(hostLabel, "sudo_password");
+          } catch {
+            // best-effort cleanup
+          }
+        }
+      }
+    } finally {
+      setSaving(false);
+    }
+    setSudoAttempt(1);
+    setSudoDialogOpen(true);
+  }, [
+    content,
+    saving,
+    credentialStoreUnlocked,
+    hostLabel,
+    attemptElevatedWrite,
+    applyElevatedSuccess,
+  ]);
+
+  // Handle a password submitted from the sudo prompt: verify it, then persist /
+  // cache / re-prompt / give up per the outcome and the 3-attempt limit.
+  const handleSudoSubmit = useCallback(
+    async (password: string, opts: SudoAuthorizeOptions) => {
+      if (content === null) return;
+      const bufferContent = content;
+      setSudoBusy(true);
+      setSaveError(null);
+      const outcome = await attemptElevatedWrite(password, bufferContent);
+      setSudoBusy(false);
+
+      if (outcome === "success") {
+        applyElevatedSuccess(bufferContent, password, opts.rememberForSession);
+        if (opts.persistToStore && credentialStoreUnlocked && hostLabel) {
+          try {
+            await storeCredential(hostLabel, "sudo_password", password);
+          } catch (err) {
+            frontendLog(
+              "file_editor",
+              `failed to persist sudo password: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
+        setSudoDialogOpen(false);
+        setSudoAttempt(1);
+        return;
+      }
+      if (outcome === "error") {
+        // Non-password failure: dismiss the prompt, keep the buffer, show banner.
+        setSudoDialogOpen(false);
+        setSudoAttempt(1);
+        return;
+      }
+      // Wrong password: re-prompt until the attempt limit, then fall to #969.
+      if (sudoAttempt >= MAX_SUDO_ATTEMPTS) {
+        setSudoDialogOpen(false);
+        setSudoAttempt(1);
+        setSaveError(
+          `Incorrect sudo password — ${MAX_SUDO_ATTEMPTS} attempts failed. The file was not saved.`
+        );
+        return;
+      }
+      setSudoAttempt((n) => n + 1);
+    },
+    [
+      content,
+      attemptElevatedWrite,
+      applyElevatedSuccess,
+      credentialStoreUnlocked,
+      hostLabel,
+      sudoAttempt,
+    ]
+  );
+
+  const handleSudoCancel = useCallback(() => {
+    setSudoDialogOpen(false);
+    setSudoAttempt(1);
+  }, []);
+
   const handleSave = useCallback(async () => {
     if (content === null || saving) return;
+
+    // Read-only remote file that has a shell, or an already-elevated session:
+    // route through the sudo path instead of the direct SFTP write.
+    if (meta.isRemote && meta.sftpSessionId && (elevated || (writable === false && execCapable))) {
+      await saveElevated();
+      return;
+    }
 
     // First save of a scratch buffer: ask the user where to write it (Save As).
     // Until a destination is chosen there is nothing to write to disk.
@@ -327,6 +542,10 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     meta.sftpSessionId,
     tabId,
     renameTab,
+    elevated,
+    writable,
+    execCapable,
+    saveElevated,
   ]);
 
   // Keep saveRef up to date for Monaco keybinding
@@ -503,6 +722,16 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
               Read-only
             </span>
           )}
+          {elevated && (
+            <span
+              className="file-editor__remote-badge file-editor__sudo-badge"
+              data-testid="file-editor-sudo-badge"
+              title="Elevated (sudo) edit mode — saves are written with root privileges"
+            >
+              <ShieldCheck size={12} />
+              sudo
+            </span>
+          )}
           {isUnsavedScratch && (
             <span className="file-editor__remote-badge" data-testid="file-editor-scratch-badge">
               <FileEdit size={12} />
@@ -513,19 +742,35 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
             {effectivePath}
           </span>
         </div>
-        <Button
-          variant="secondary"
-          size="sm"
-          icon={<Save size={14} />}
-          onClick={handleSave}
-          disabled={!isDirty}
-          pendingLabel="Saving..."
-          errorToast={false}
-          title={isUnsavedScratch ? "Save As... (Ctrl+S)" : "Save (Ctrl+S)"}
-          data-testid="file-editor-save"
-        >
-          {isUnsavedScratch ? "Save As..." : "Save"}
-        </Button>
+        {offerEditWithSudo ? (
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<ShieldCheck size={14} />}
+            onClick={handleSave}
+            disabled={!isDirty}
+            pendingLabel="Saving..."
+            errorToast={false}
+            title="Save this read-only file with sudo"
+            data-testid="file-editor-edit-with-sudo"
+          >
+            Edit with sudo
+          </Button>
+        ) : (
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<Save size={14} />}
+            onClick={handleSave}
+            disabled={!isDirty}
+            pendingLabel="Saving..."
+            errorToast={false}
+            title={isUnsavedScratch ? "Save As... (Ctrl+S)" : "Save (Ctrl+S)"}
+            data-testid="file-editor-save"
+          >
+            {isUnsavedScratch ? "Save As..." : "Save"}
+          </Button>
+        )}
       </div>
       {writable === false && !readonlyBannerDismissed && (
         <div
@@ -554,6 +799,21 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
         <div className="file-editor__save-error" role="alert" data-testid="file-editor-save-error">
           <AlertCircle size={14} />
           <span className="file-editor__save-error-text">{saveError}</span>
+          {canRetryWithSudo && (
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<ShieldCheck size={14} />}
+              onClick={() => {
+                setSaveError(null);
+                void saveElevated();
+              }}
+              title="Retry this save with sudo"
+              data-testid="file-editor-save-error-retry-sudo"
+            >
+              Retry with sudo
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="sm"
@@ -566,6 +826,17 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
           />
         </div>
       )}
+      <SudoPromptDialog
+        open={sudoDialogOpen}
+        hostLabel={hostLabel ?? meta.filePath}
+        targetPath={meta.filePath}
+        attempt={sudoAttempt}
+        maxAttempts={MAX_SUDO_ATTEMPTS}
+        credentialStoreUnlocked={credentialStoreUnlocked}
+        busy={sudoBusy}
+        onSubmit={handleSudoSubmit}
+        onCancel={handleSudoCancel}
+      />
       <div className="file-editor__editor-container">
         <Editor
           defaultValue={content ?? ""}

--- a/src/components/FileEditor/SudoPromptDialog.css
+++ b/src/components/FileEditor/SudoPromptDialog.css
@@ -1,0 +1,66 @@
+.sudo-prompt__lead {
+  margin: 0 0 var(--spacing-md);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.sudo-prompt__lead code {
+  font-family: var(--font-mono);
+}
+
+.sudo-prompt__facts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin: 0 0 var(--spacing-md);
+  padding: var(--spacing-sm);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-sm);
+}
+
+.sudo-prompt__fact {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-sm);
+  min-width: 0;
+}
+
+.sudo-prompt__fact dt {
+  flex-shrink: 0;
+  width: 44px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sudo-prompt__fact dd {
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.sudo-prompt__error {
+  margin: var(--spacing-sm) 0 0;
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+}
+
+.sudo-prompt__option {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+.sudo-prompt__option-label {
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}

--- a/src/components/FileEditor/SudoPromptDialog.test.tsx
+++ b/src/components/FileEditor/SudoPromptDialog.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { SudoPromptDialog } from "./SudoPromptDialog";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function query(testId: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+/** Drive a controlled input the way React expects (native setter + input event). */
+function typeInto(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+const BASE_PROPS = {
+  open: true,
+  hostLabel: "pi@raspberrypi:22",
+  targetPath: "/etc/hosts",
+  attempt: 1,
+  maxAttempts: 3,
+  credentialStoreUnlocked: true,
+  onSubmit: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe("SudoPromptDialog", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<SudoPromptDialog {...BASE_PROPS} open={false} />);
+    expect(query("sudo-prompt-dialog")).toBeNull();
+  });
+
+  it("names the host, user, and target file", () => {
+    render(<SudoPromptDialog {...BASE_PROPS} />);
+    expect(query("sudo-prompt-host")?.textContent).toContain("raspberrypi");
+    expect(query("sudo-prompt-user")?.textContent).toContain("pi");
+    expect(query("sudo-prompt-target")?.textContent).toContain("/etc/hosts");
+  });
+
+  it("masks the password field by default", () => {
+    render(<SudoPromptDialog {...BASE_PROPS} />);
+    const input = query("sudo-prompt-input") as HTMLInputElement;
+    expect(input.getAttribute("type")).toBe("password");
+  });
+
+  it("disables Authorize until a non-empty password is entered", () => {
+    render(<SudoPromptDialog {...BASE_PROPS} />);
+    const submit = query("sudo-prompt-submit") as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    typeInto(query("sudo-prompt-input") as HTMLInputElement, "hunter2");
+    expect(submit.disabled).toBe(false);
+  });
+
+  it("shows the 'Save in credential store' option only when the store is unlocked", () => {
+    render(<SudoPromptDialog {...BASE_PROPS} credentialStoreUnlocked={true} />);
+    expect(query("sudo-prompt-persist")).not.toBeNull();
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    render(<SudoPromptDialog {...BASE_PROPS} credentialStoreUnlocked={false} />);
+    expect(query("sudo-prompt-persist")).toBeNull();
+  });
+
+  it("surfaces the attempt counter when re-prompting after a rejected password", () => {
+    render(<SudoPromptDialog {...BASE_PROPS} attempt={2} />);
+    const err = query("sudo-prompt-error");
+    expect(err).not.toBeNull();
+    expect(err?.textContent ?? "").toMatch(/attempt\s*2\s*of\s*3/i);
+  });
+
+  it("shows no attempt error on the first prompt", () => {
+    render(<SudoPromptDialog {...BASE_PROPS} attempt={1} />);
+    expect(query("sudo-prompt-error")).toBeNull();
+  });
+
+  it("submits the password with the caching choices (remember on by default)", () => {
+    const onSubmit = vi.fn();
+    render(<SudoPromptDialog {...BASE_PROPS} onSubmit={onSubmit} />);
+    typeInto(query("sudo-prompt-input") as HTMLInputElement, "s3cret");
+    act(() => {
+      (query("sudo-prompt-submit") as HTMLButtonElement).click();
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("s3cret", {
+      rememberForSession: true,
+      persistToStore: false,
+    });
+  });
+
+  it("fires onCancel from the Cancel button", () => {
+    const onCancel = vi.fn();
+    render(<SudoPromptDialog {...BASE_PROPS} onCancel={onCancel} />);
+    act(() => {
+      (query("sudo-prompt-cancel") as HTMLButtonElement).click();
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/FileEditor/SudoPromptDialog.tsx
+++ b/src/components/FileEditor/SudoPromptDialog.tsx
@@ -1,0 +1,190 @@
+import { useState, useEffect, useCallback } from "react";
+import { ShieldCheck } from "lucide-react";
+import { Modal, Button, Field, Toggle } from "@/components/ui";
+import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
+import "./SudoPromptDialog.css";
+
+/** Caching choices returned alongside the entered password. */
+export interface SudoAuthorizeOptions {
+  /** Keep the password in memory for the rest of this editor session. */
+  rememberForSession: boolean;
+  /** Persist the password in the (unlocked) credential store. */
+  persistToStore: boolean;
+}
+
+export interface SudoPromptDialogProps {
+  /** Whether the dialog is open (controlled). */
+  open: boolean;
+  /** Host label (`user@host:port`) of the remote connection, for context. */
+  hostLabel: string;
+  /** Absolute remote path of the file being saved. */
+  targetPath: string;
+  /** 1-based attempt number; when > 1 the previous password was rejected. */
+  attempt: number;
+  /** Maximum number of attempts allowed (drives the "attempt X of N" counter). */
+  maxAttempts: number;
+  /** Whether the credential store is unlocked — gates the persist option. */
+  credentialStoreUnlocked: boolean;
+  /** True while the parent verifies the submitted password (pending state). */
+  busy?: boolean;
+  /** Submit the entered password plus the caching choices. */
+  onSubmit: (password: string, options: SudoAuthorizeOptions) => void;
+  /** Cancel / dismiss without authorizing. */
+  onCancel: () => void;
+}
+
+/** Split a `user@host:port` label into its user and host parts for display. */
+function splitHostLabel(hostLabel: string): { user: string; host: string } {
+  const at = hostLabel.indexOf("@");
+  if (at < 0) return { user: "", host: hostLabel };
+  return { user: hostLabel.slice(0, at), host: hostLabel.slice(at + 1) };
+}
+
+/**
+ * Password prompt for a privilege-elevated (`sudo`) remote save.
+ *
+ * Composed entirely from shared UI primitives (Modal / Field / Toggle / Button)
+ * plus the masked {@link PasswordInput}. The password is handed straight back to
+ * the caller via {@link onSubmit}; this component never stores or logs it beyond
+ * the controlled input, and clears it whenever the attempt changes (re-prompt).
+ */
+export function SudoPromptDialog({
+  open,
+  hostLabel,
+  targetPath,
+  attempt,
+  maxAttempts,
+  credentialStoreUnlocked,
+  busy = false,
+  onSubmit,
+  onCancel,
+}: SudoPromptDialogProps) {
+  const [password, setPassword] = useState("");
+  const [rememberForSession, setRememberForSession] = useState(true);
+  const [persistToStore, setPersistToStore] = useState(false);
+
+  // Reset all fields when the dialog (re)opens.
+  useEffect(() => {
+    if (open) {
+      setPassword("");
+      setRememberForSession(true);
+      setPersistToStore(false);
+    }
+  }, [open]);
+
+  // On a re-prompt (attempt bumped while the dialog stays open) clear only the
+  // rejected password, preserving the user's caching choices.
+  useEffect(() => {
+    setPassword("");
+  }, [attempt]);
+
+  const { user, host } = splitHostLabel(hostLabel);
+
+  const handleSubmit = useCallback(() => {
+    if (!password || busy) return;
+    onSubmit(password, {
+      rememberForSession,
+      persistToStore: credentialStoreUnlocked && persistToStore,
+    });
+  }, [password, busy, onSubmit, rememberForSession, persistToStore, credentialStoreUnlocked]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") handleSubmit();
+    },
+    [handleSubmit]
+  );
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+      title="Save with sudo"
+      description="Authenticate to write this read-only file with elevated privileges."
+      onKeyDown={handleKeyDown}
+      data-testid="sudo-prompt-dialog"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onCancel} data-testid="sudo-prompt-cancel">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            icon={<ShieldCheck size={14} />}
+            onClick={handleSubmit}
+            disabled={!password || busy}
+            data-testid="sudo-prompt-submit"
+          >
+            {busy ? "Authorizing…" : "Authorize"}
+          </Button>
+        </>
+      }
+    >
+      <p className="sudo-prompt__lead">
+        Saving requires administrator (<code>sudo</code>) privileges on the remote host.
+      </p>
+      <dl className="sudo-prompt__facts">
+        <div className="sudo-prompt__fact">
+          <dt>Host</dt>
+          <dd data-testid="sudo-prompt-host">{host}</dd>
+        </div>
+        <div className="sudo-prompt__fact">
+          <dt>User</dt>
+          <dd data-testid="sudo-prompt-user">{user || "(default)"}</dd>
+        </div>
+        <div className="sudo-prompt__fact">
+          <dt>File</dt>
+          <dd data-testid="sudo-prompt-target" title={targetPath}>
+            {targetPath}
+          </dd>
+        </div>
+      </dl>
+      <Field label="sudo password" htmlFor="sudo-prompt-password">
+        <PasswordInput
+          id="sudo-prompt-password"
+          className="ui-input"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Password for sudo"
+          autoFocus
+          disabled={busy}
+          data-testid="sudo-prompt-input"
+        />
+      </Field>
+      {attempt > 1 && (
+        <p className="sudo-prompt__error" role="alert" data-testid="sudo-prompt-error">
+          Incorrect password. Attempt {attempt} of {maxAttempts}.
+        </p>
+      )}
+      <div className="sudo-prompt__option">
+        <Toggle
+          id="sudo-prompt-remember"
+          checked={rememberForSession}
+          onCheckedChange={setRememberForSession}
+          disabled={busy}
+          data-testid="sudo-prompt-remember"
+        />
+        <label htmlFor="sudo-prompt-remember" className="sudo-prompt__option-label">
+          Remember for this session
+        </label>
+      </div>
+      {credentialStoreUnlocked && (
+        <div className="sudo-prompt__option">
+          <Toggle
+            id="sudo-prompt-persist"
+            checked={persistToStore}
+            onCheckedChange={setPersistToStore}
+            disabled={busy}
+            data-testid="sudo-prompt-persist"
+          />
+          <label htmlFor="sudo-prompt-persist" className="sudo-prompt__option-label">
+            Save in credential store
+          </label>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/FileEditor/index.ts
+++ b/src/components/FileEditor/index.ts
@@ -1,1 +1,3 @@
 export { FileEditor } from "./FileEditor";
+export { SudoPromptDialog } from "./SudoPromptDialog";
+export type { SudoPromptDialogProps, SudoAuthorizeOptions } from "./SudoPromptDialog";

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1390,10 +1390,17 @@ export async function setAutoLockTimeout(minutes: number | null): Promise<void> 
   await invoke("set_auto_lock_timeout", { minutes });
 }
 
+/**
+ * A credential kind the frontend can store/resolve/remove. Mirrors the backend
+ * `CredentialType` string forms. `sudo_password` (#1327) backs the elevated
+ * edit mode's opt-in persistence (#1329).
+ */
+export type CredentialType = "password" | "key_passphrase" | "sudo_password";
+
 /** Store a credential for a connection (e.g., after entering it via the password prompt). */
 export async function storeCredential(
   connectionId: string,
-  credentialType: "password" | "key_passphrase",
+  credentialType: CredentialType,
   value: string
 ): Promise<void> {
   await invoke("store_credential", { connectionId, credentialType, value });
@@ -1402,7 +1409,7 @@ export async function storeCredential(
 /** Resolve a stored credential for a connection. Returns the value or null if not found. */
 export async function resolveCredential(
   connectionId: string,
-  credentialType: "password" | "key_passphrase"
+  credentialType: CredentialType
 ): Promise<string | null> {
   return await invoke<string | null>("resolve_credential", { connectionId, credentialType });
 }
@@ -1410,7 +1417,7 @@ export async function resolveCredential(
 /** Remove a stored credential for a connection (e.g., after auth failure). */
 export async function removeCredential(
   connectionId: string,
-  credentialType: "password" | "key_passphrase"
+  credentialType: CredentialType
 ): Promise<void> {
   await invoke("remove_credential", { connectionId, credentialType });
 }

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -196,6 +196,7 @@ Fixed strings — match exactly.
 | `file-browser-transfers` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-up` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-browser-upload` | `src/components/Sidebar/FileBrowser.tsx` |
+| `file-editor-edit-with-sudo` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-error` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-readonly-badge` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-readonly-banner` | `src/components/FileEditor/FileEditor.tsx` |
@@ -204,7 +205,9 @@ Fixed strings — match exactly.
 | `file-editor-save` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-save-error` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-save-error-dismiss` | `src/components/FileEditor/FileEditor.tsx` |
+| `file-editor-save-error-retry-sudo` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-editor-scratch-badge` | `src/components/FileEditor/FileEditor.tsx` |
+| `file-editor-sudo-badge` | `src/components/FileEditor/FileEditor.tsx` |
 | `file-row-rename-input` | `src/components/Sidebar/FileBrowser.tsx` |
 | `file-type-add-btn` | `src/components/Settings/FileTypeSettings.tsx` |
 | `file-type-add-error` | `src/components/Settings/FileTypeSettings.tsx` |
@@ -445,6 +448,16 @@ Fixed strings — match exactly.
 | `status-bar-language` | `src/components/StatusBar/StatusBar.tsx` |
 | `status-bar-tab-size` | `src/components/StatusBar/StatusBar.tsx` |
 | `status-bar-transfers` | `src/components/StatusBar/StatusBar.tsx` |
+| `sudo-prompt-cancel` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-dialog` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-error` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-host` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-input` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-persist` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-remember` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-submit` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-target` | `src/components/FileEditor/SudoPromptDialog.tsx` |
+| `sudo-prompt-user` | `src/components/FileEditor/SudoPromptDialog.tsx` |
 | `tab-context-clear` | `src/components/Terminal/Tab.tsx` |
 | `tab-context-copy` | `src/components/Terminal/Tab.tsx` |
 | `tab-context-horizontal-scroll` | `src/components/Terminal/Tab.tsx` |


### PR DESCRIPTION
Closes #1329

**Part of Epic #1323 · Concept #970** (`docs/concepts/backlog/elevated-sftp-editing.html`)

## Summary

The convergence point of the elevated-SFTP-editing epic: a user-facing **elevated (sudo) edit mode** in the file editor.

- **`SudoPromptDialog`** (new, composed from the shared `ui/` primitives — Modal, Field, Toggle, Button + `PasswordInput`): names host / user / target, masks the password, offers **Remember for this session** (default on) and **Save in credential store** (shown only when the store is **unlocked**), and surfaces an attempt counter on re-prompt.
- **`FileEditor`**: when a remote file is read-only (`writable===false`) **and** the connection is exec-capable, the toolbar swaps **Save** for **Edit with sudo**. Authorizing routes the write through `sftpWriteFileContentElevated` (#1328), shows a success toast, and pins a persistent accent **sudo** marker for the session. Wrong password re-prompts up to **3** times (with the counter), then falls back to the existing **#969 save-error banner** with the buffer intact; a non-password (`other`) failure surfaces the same banner. The session password is cached in memory (so a second elevated save doesn't re-prompt) and, opt-in, persisted as a `CredentialType::SudoPassword` credential.
- The **#969 banner** gains a **Retry with sudo** action for the unknown→failed direct-save path when a shell exists.
- Widened the credential command/type mapping to accept `sudo_password` (the #1327 enum wasn't yet reachable from the Tauri command layer).
- LogViewer DEBUG per elevated save (host/path only — **never** the password). New `data-testid`s → full `tests/system/testid-catalog.md` regenerated.

## Password safety

The sudo password lives **only** in a component `useRef` (session cache) and, opt-in, the credential store. It is never placed in `EditorTabMeta`, the Zustand store, or any serialized tab/workspace state, and is never logged.

## Out of scope

The SFTP-only **"Save a copy"** fallback (SI-7 / #1330) — the read-only banner still points to it as future work.

## Test plan

- **Unit (Vitest):** `SudoPromptDialog.test.tsx` (9) + new `FileEditor` elevated block (7) — dialog render/validate/gating/counter; Edit-with-sudo gating; elevated routing; `IncorrectPassword` ×3 → banner with buffer intact; `Other` → banner; success → toast + marker; session cache avoids re-prompt; Retry-with-sudo. Full suite: **3093 passing**. `tsc --noEmit`, `eslint`, `prettier --check`, `markdownlint`, token-discipline all green.
- **Rust:** `parse_credential_type_sudo_password` (credential command mapping).
- **System (Python bridge):** open→edit→elevate with a stubbed sudo result, asserting the marker + success-toast testids — **documented as manual** here (bridge not runnable in this environment).
- **Manual:** full round-trip + retry + persist against a real Pi — steps added to `docs/testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
