### PR TITLE
feat(ui): command palette fuzzy-matching commands + saved connections (Closes #1484)

### DIFF
--- a/docs/changes/dev1/feature/1484-command-palette.md
+++ b/docs/changes/dev1/feature/1484-command-palette.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Command palette (Cmd/Ctrl+P)** — a keyboard-first palette that fuzzy-matches
+  both application commands and saved connections in one ranked list. Press
+  Cmd+P (macOS) or Ctrl+Shift+P (Windows/Linux) to open it, type to filter, use
+  the arrow keys to move, and press Enter to run the highlighted command or
+  connect to the highlighted connection (Esc closes). Connecting reuses the
+  sidebar's exact credential flow, so stored-credential resolution and
+  password/passphrase prompts behave identically. (#1484)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -778,6 +778,24 @@ E2E test coverage: all WebdriverIO specs have been ported to the cross-platform 
 - For serial port tests: host-side virtual serial ports via `socat` + echo server, set up by `scripts/test-system-linux.sh` (see also `examples/serial/`)
 - Test on each target OS (macOS, Linux, Windows) for cross-platform items
 
+### Command palette (#1484)
+
+Verifies the Cmd/Ctrl+P command palette that fuzzy-matches application commands
+and saved connections. Introduced in PR #1484.
+
+1. Press the palette shortcut (macOS **Cmd+P**, Windows/Linux **Ctrl+Shift+P**) →
+   a modal opens with an empty search box focused, listing commands first, then
+   saved connections.
+2. Type part of a command name (e.g. `new term`) → **New Terminal** ranks to the
+   top with its accelerator shown on the right. Press **Enter** → a new terminal
+   tab opens and the palette closes.
+3. Reopen the palette and type part of a saved connection's name or host → the
+   matching connection ranks to the top with its connection-type badge. Press
+   **Enter** → it connects exactly as a sidebar double-click would (including any
+   password/passphrase or credential-store-unlock prompt).
+4. With the palette open, use **Arrow Up/Down** to move the highlight and
+   **Esc** to close without running anything.
+
 ### FTP insecure-connection warning & editor behaviors (#1338)
 
 Verifies the plaintext-FTP warning modal, the schema-conditional editor fields,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@xterm/xterm": "^6.0.0",
     "html-to-image": "^1.11.13",
     "lucide-react": "^0.563.0",
+    "match-sorter": "^8.3.0",
     "monaco-editor": "^0.55.1",
     "react": "^18.3.1",
     "react-colorful": "^5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@18.3.1)
+      match-sorter:
+        specifier: ^8.3.0
+        version: 8.3.0
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -288,6 +291,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -2611,6 +2618,9 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  match-sorter@8.3.0:
+    resolution: {integrity: sha512-8Py1GbZi5zsclYSFcPAH4H5xfTbeD0bOREA7qP/t8bW4MbOSlPl8sbqHOedEV7O+Bxyvxm6xs/v6BXJGe+JDNA==}
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
@@ -2893,6 +2903,9 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  remove-accents@0.5.0:
+    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3448,6 +3461,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5637,6 +5652,11 @@ snapshots:
 
   marked@14.0.0: {}
 
+  match-sorter@8.3.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      remove-accents: 0.5.0
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -6006,6 +6026,8 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  remove-accents@0.5.0: {}
 
   require-directory@2.1.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { ExportDialog, ImportDialog } from "@/components/ExportImport";
 import { UnlockDialog } from "@/components/UnlockDialog";
 import { RecoveryDialog } from "@/components/Settings/RecoveryDialog";
 import { ShortcutsOverlay } from "@/components/KeyboardShortcuts/ShortcutsOverlay";
+import { CommandPalette } from "@/components/CommandPalette/CommandPalette";
 import { OverlayViewPanel } from "@/components/Settings/OverlayViewPanel";
 import { LargePasteDialog } from "@/components/Terminal/LargePasteDialog";
 import { OpenSavedFileDialog } from "@/components/Terminal/OpenSavedFileDialog";
@@ -283,6 +284,7 @@ function App() {
             warnings={recoveryWarnings}
           />
           <ShortcutsOverlay open={shortcutsOverlayOpen} onOpenChange={setShortcutsOverlayOpen} />
+          <CommandPalette />
           <OverlayViewPanel />
           <LargePasteDialog
             open={largePasteDialog.open}

--- a/src/components/CommandPalette/CommandPalette.css
+++ b/src/components/CommandPalette/CommandPalette.css
@@ -1,0 +1,69 @@
+.command-palette {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.command-palette__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 360px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.command-palette__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  transition: background-color var(--transition-fast);
+}
+
+.command-palette__item--active {
+  background-color: var(--bg-active);
+  border-left-color: var(--accent-color);
+}
+
+.command-palette__icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.command-palette__label {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.command-palette__accelerator {
+  flex-shrink: 0;
+  padding-left: var(--spacing-md);
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.command-palette__type {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.command-palette__empty {
+  margin: 0;
+  padding: var(--spacing-md);
+  color: var(--text-secondary);
+  text-align: center;
+}

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Tests for the command palette (#1484): fuzzy matching across commands and
+ * saved connections, Enter to run/connect, and keyboard navigation.
+ *
+ * The connect flow itself is covered by useConnectSavedConnection's own tests;
+ * here it is mocked so the palette's wiring (which entry, closing on activate)
+ * is verified in isolation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { CommandPalette } from "./CommandPalette";
+import type { SavedConnection } from "@/types/connection";
+
+const { connectSpy } = vi.hoisted(() => ({
+  connectSpy: vi.fn((_connection: unknown) => Promise.resolve()),
+}));
+
+vi.mock("@/hooks/useConnectSavedConnection", () => ({
+  useConnectSavedConnection: () => ({ connect: connectSpy }),
+}));
+
+function sshConn(id: string, name: string, host: string): SavedConnection {
+  return {
+    id,
+    name,
+    folderId: null,
+    config: { type: "ssh", config: { host, username: "user", authMethod: "agent" } },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(React.createElement(CommandPalette));
+  });
+}
+
+function getInput(): HTMLInputElement {
+  const el = document.querySelector<HTMLInputElement>('[data-testid="command-palette-input"]');
+  if (!el) throw new Error("command palette input not found");
+  return el;
+}
+
+function typeInto(value: string) {
+  const input = getInput();
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function keydown(key: string) {
+  act(() => {
+    getInput().dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  });
+}
+
+function activeLabel(): string | null {
+  return (
+    document.querySelector('[role="option"][aria-selected="true"] .command-palette__label')
+      ?.textContent ?? null
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+  useAppStore.setState({
+    ...useAppStore.getInitialState(),
+    commandPaletteOpen: true,
+    connections: [
+      sshConn("c1", "Production Server", "prod.example.com"),
+      sshConn("c2", "Staging Box", "staging.example.com"),
+    ],
+  });
+  render();
+}, 10000);
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("CommandPalette", () => {
+  it("ranks a fuzzy-matched command to the top", () => {
+    typeInto("new term");
+    expect(activeLabel()).toBe("New Terminal");
+  });
+
+  it("ranks a fuzzy-matched connection to the top", () => {
+    typeInto("production");
+    expect(activeLabel()).toBe("Production Server");
+  });
+
+  it("matches a connection by host", () => {
+    typeInto("staging.example");
+    expect(activeLabel()).toBe("Staging Box");
+  });
+
+  it("runs the highlighted command on Enter and closes", () => {
+    const addTab = vi.fn(() => "tab-1");
+    useAppStore.setState({ addTab });
+    typeInto("new terminal");
+    keydown("Enter");
+    expect(addTab).toHaveBeenCalledWith("Terminal", "local");
+    expect(useAppStore.getState().commandPaletteOpen).toBe(false);
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
+  it("connects the highlighted connection on Enter and closes", () => {
+    typeInto("production");
+    keydown("Enter");
+    expect(connectSpy).toHaveBeenCalledOnce();
+    expect(connectSpy.mock.calls[0][0]).toMatchObject({ id: "c1", name: "Production Server" });
+    expect(useAppStore.getState().commandPaletteOpen).toBe(false);
+  });
+
+  it("moves the selection with the arrow keys", () => {
+    // Empty query lists commands first; the first command is initially active.
+    const firstActive = activeLabel();
+    keydown("ArrowDown");
+    expect(activeLabel()).not.toBe(firstActive);
+  });
+
+  it("closes on Escape", () => {
+    keydown("Escape");
+    expect(useAppStore.getState().commandPaletteOpen).toBe(false);
+  });
+
+  it("shows an empty state when nothing matches", () => {
+    typeInto("zzzznomatch");
+    expect(document.querySelector(".command-palette__empty")).not.toBeNull();
+  });
+});

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { matchSorter } from "match-sorter";
+import { TerminalSquare } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { buildCommands } from "@/services/commands";
+import { useConnectSavedConnection } from "@/hooks/useConnectSavedConnection";
+import { ConnectionIcon } from "@/utils/connectionIcons";
+import { Modal, Input } from "@/components/ui";
+import type { SavedConnection } from "@/types/connection";
+import "./CommandPalette.css";
+
+/** A single fuzzy-matchable palette entry — either a command or a saved connection. */
+type PaletteEntry =
+  | {
+      kind: "command";
+      /** Stable React/list key. */
+      key: string;
+      /** Primary text shown and matched against. */
+      label: string;
+      /** Effective accelerator string, or null. */
+      accelerator: string | null;
+      /** Activate the entry. */
+      run: () => void;
+    }
+  | {
+      kind: "connection";
+      key: string;
+      label: string;
+      /** Host used as a secondary match key, if any. */
+      host: string;
+      connection: SavedConnection;
+    };
+
+/**
+ * Command palette (Cmd/Ctrl+P): a keyboard-first modal that fuzzy-matches both
+ * application commands and saved connections in one ranked list. Enter runs the
+ * highlighted command or connects the highlighted connection; Arrow keys move
+ * the selection and Esc closes (via the shared Modal).
+ *
+ * Composed from the shared {@link Modal} + {@link Input} primitives; matching is
+ * delegated to `match-sorter`. Connecting reuses {@link useConnectSavedConnection}
+ * so the palette shares the sidebar's exact credential flow.
+ */
+export function CommandPalette(): React.ReactElement {
+  const open = useAppStore((s) => s.commandPaletteOpen);
+  const setOpen = useAppStore((s) => s.setCommandPaletteOpen);
+  const connections = useAppStore((s) => s.connections);
+  const { connect } = useConnectSavedConnection();
+
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // All entries (commands first, then connections) in declaration order — the
+  // order shown when the query is empty.
+  const entries = useMemo<PaletteEntry[]>(() => {
+    const commandEntries: PaletteEntry[] = buildCommands().map((cmd) => ({
+      kind: "command",
+      key: `command:${cmd.id}`,
+      label: cmd.label,
+      accelerator: cmd.accelerator,
+      run: cmd.run,
+    }));
+    const connectionEntries: PaletteEntry[] = connections.map((conn) => ({
+      kind: "connection",
+      key: `connection:${conn.id}`,
+      label: conn.name,
+      host: String((conn.config.config as Record<string, unknown>).host ?? ""),
+      connection: conn,
+    }));
+    return [...commandEntries, ...connectionEntries];
+  }, [connections]);
+
+  // Ranked results. An empty query returns every entry in declaration order.
+  const results = useMemo<PaletteEntry[]>(() => {
+    if (query.trim() === "") return entries;
+    return matchSorter(entries, query, {
+      keys: ["label", (entry) => (entry.kind === "connection" ? entry.host : "")],
+    });
+  }, [entries, query]);
+
+  // Reset the query and selection each time the palette opens.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  // Keep the selection in range and pointed at the top hit as results change.
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  // Keep the highlighted row scrolled into view.
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const row = list.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`);
+    row?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, results]);
+
+  const activate = useCallback(
+    (entry: PaletteEntry | undefined) => {
+      if (!entry) return;
+      // Close first so the palette never stacks over a follow-on dialog (e.g.
+      // the password prompt a connect may trigger).
+      setOpen(false);
+      if (entry.kind === "command") {
+        entry.run();
+      } else {
+        void connect(entry.connection);
+      }
+    },
+    [connect, setOpen]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((i) => (results.length === 0 ? 0 : (i + 1) % results.length));
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((i) =>
+          results.length === 0 ? 0 : (i - 1 + results.length) % results.length
+        );
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        setActiveIndex(0);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        setActiveIndex(Math.max(0, results.length - 1));
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        activate(results[activeIndex]);
+      }
+    },
+    [results, activeIndex, activate]
+  );
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={setOpen}
+      title="Command Palette"
+      description="Fuzzy-find and run a command or connect to a saved connection"
+      size="lg"
+      hideClose
+      data-testid="command-palette"
+    >
+      <div className="command-palette">
+        <Input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a command or connection…"
+          aria-label="Command or connection search"
+          role="combobox"
+          aria-expanded
+          aria-controls="command-palette-list"
+          data-testid="command-palette-input"
+        />
+        {results.length === 0 ? (
+          <p className="command-palette__empty" role="status">
+            No matching commands or connections.
+          </p>
+        ) : (
+          <ul
+            id="command-palette-list"
+            className="command-palette__list"
+            role="listbox"
+            aria-label="Commands and connections"
+            ref={listRef}
+          >
+            {results.map((entry, index) => (
+              <li
+                key={entry.key}
+                data-index={index}
+                role="option"
+                aria-selected={index === activeIndex}
+                className={`command-palette__item${
+                  index === activeIndex ? " command-palette__item--active" : ""
+                }`}
+                onMouseMove={() => setActiveIndex(index)}
+                onClick={() => activate(entry)}
+                data-testid={`command-palette-item-${entry.key}`}
+              >
+                <span className="command-palette__icon" aria-hidden="true">
+                  {entry.kind === "command" ? (
+                    <TerminalSquare size={16} />
+                  ) : (
+                    <ConnectionIcon
+                      config={entry.connection.config}
+                      customIcon={entry.connection.icon}
+                      size={16}
+                    />
+                  )}
+                </span>
+                <span className="command-palette__label">{entry.label}</span>
+                {entry.kind === "command" ? (
+                  entry.accelerator ? (
+                    <span className="command-palette__accelerator">{entry.accelerator}</span>
+                  ) : null
+                ) : (
+                  <span className="command-palette__type">{entry.connection.config.type}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -33,20 +33,12 @@ import {
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { SavedConnection, ConnectionFolder } from "@/types/connection";
-import {
-  createTerminal,
-  removeCredential,
-  storeCredential,
-  isSshKeyEncrypted,
-  type AgentDefinitionInfo,
-} from "@/services/api";
-import { frontendLog } from "@/utils/frontendLog";
+import { type AgentDefinitionInfo } from "@/services/api";
 import { openLocalCommandTab } from "@/utils/openLocalCommandTab";
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { Tooltip, Input, ConfirmDialog } from "@/components/ui";
 import { shouldShowInsecureFtpWarning } from "@/utils/ftpSecurity";
-import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
-import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
+import { useConnectSavedConnection } from "@/hooks/useConnectSavedConnection";
 import { useSectionResize } from "@/hooks/useSectionResize";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
 import { useRovingListNav } from "@/hooks/useRovingListNav";
@@ -498,7 +490,6 @@ export function ConnectionList() {
   const remoteAgents = useAppStore((s) => s.remoteAgents);
   const experimental = useExperimentalFeatures();
   const toggleFolder = useAppStore((s) => s.toggleFolder);
-  const addTab = useAppStore((s) => s.addTab);
   const updateConnection = useAppStore((s) => s.updateConnection);
   const openConnectionEditorTab = useAppStore((s) => s.openConnectionEditorTab);
   const deleteConnection = useAppStore((s) => s.deleteConnection);
@@ -517,8 +508,6 @@ export function ConnectionList() {
     activationConstraint: { distance: 8 },
   });
   const sensors = useSensors(pointerSensor);
-
-  const requestPassword = useAppStore((s) => s.requestPassword);
 
   const rootFolders = useMemo(() => folders.filter((f) => f.parentId === null), [folders]);
   const rootConnections = useMemo(
@@ -587,130 +576,7 @@ export function ConnectionList() {
   const [insecureFtpConnection, setInsecureFtpConnection] = useState<SavedConnection | null>(null);
   const [insecureFtpDontWarn, setInsecureFtpDontWarn] = useState(false);
 
-  const performConnect = useCallback(
-    async (connection: SavedConnection) => {
-      let config = connection.config;
-      const cfg = config.config as unknown as Record<string, unknown>;
-
-      // Connections with authMethod and password support credential store resolution
-      if (cfg.authMethod && cfg.host) {
-        const authMethod = cfg.authMethod as string;
-        const savePassword = cfg.savePassword as boolean | undefined;
-
-        // For key auth, decide whether a passphrase is needed from the key's
-        // actual encryption rather than the savePassword flag (#885): a
-        // passphrase-protected key must be unlocked even when savePassword is
-        // off, and an unencrypted key must never prompt. If the file can't be
-        // read, default to "encrypted" so an encrypted key never fails silently.
-        let keyEncrypted = false;
-        if (authMethod === "key") {
-          keyEncrypted = await isSshKeyEncrypted((cfg.keyPath as string) ?? "").catch(() => true);
-        }
-        // Password auth always needs a credential; key auth only when encrypted.
-        const needsCredential = authMethod === "password" || (authMethod === "key" && keyEncrypted);
-        if (!needsCredential) {
-          addTab(connection.name, connection.config.type, config, {
-            terminalOptions: connection.terminalOptions,
-          });
-          return;
-        }
-
-        // An inline, non-empty password on the config is itself the credential —
-        // e.g. an "Open Jump Host Terminal" gateway synthesized from an inline
-        // hop, whose password lives on the hop, not in the store (#963). Use it
-        // directly: a credential-store lookup here is keyed by this (possibly
-        // synthetic) connection id and would miss, forcing a redundant prompt
-        // even though the password is already known.
-        if (typeof cfg.password === "string" && cfg.password.length > 0) {
-          addTab(connection.name, connection.config.type, config, {
-            terminalOptions: connection.terminalOptions,
-          });
-          return;
-        }
-
-        // Before attempting credential resolution, check whether the credential store
-        // is locked. If it is, we can't read the stored credential and SSH would fall
-        // back to interactive password prompts. Prompt for unlock first and wait —
-        // on success the code continues and the credential resolves automatically.
-        const proceed = await ensureCredentialStoreUnlocked({ authMethod, savePassword });
-        if (!proceed) return;
-
-        // Try to resolve credential from the store first
-        const resolution = await resolveConnectionCredential(
-          connection.id,
-          authMethod,
-          savePassword
-        );
-
-        if (resolution.usedStoredCredential && resolution.password) {
-          // Pre-connect with stored credential to validate it
-          const preConfig = {
-            ...config,
-            config: { ...cfg, password: resolution.password },
-          } as typeof config;
-          try {
-            const sessionId = await createTerminal(preConfig);
-            // Stored credential worked — open tab with existing session
-            addTab(connection.name, connection.config.type, preConfig, {
-              terminalOptions: connection.terminalOptions,
-              sessionId,
-            });
-            return;
-          } catch (err) {
-            const errStr = String(err);
-            if (
-              errStr.toLowerCase().includes("auth failed") ||
-              errStr.includes("Authentication failed")
-            ) {
-              // Stale credential — remove it and fall through to prompt
-              await removeCredential(connection.id, resolution.credentialType).catch(() => {});
-            } else {
-              // Non-auth failure — let the Terminal component handle the error
-              addTab(connection.name, connection.config.type, config, {
-                terminalOptions: connection.terminalOptions,
-              });
-              return;
-            }
-          }
-        }
-
-        // No stored credential or stale credential was cleared — prompt the user
-        if (authMethod === "password") {
-          const host = cfg.host as string;
-          const username = (cfg.username as string) ?? "";
-          const password = await requestPassword(host, username);
-          if (password === null) return;
-          config = { ...config, config: { ...cfg, password } } as typeof config;
-          // Persist the entered password if the user opted in via the prompt checkbox
-          if (useAppStore.getState().passwordPromptShouldSave) {
-            await storeCredential(connection.id, "password", password).catch((err) => {
-              frontendLog("connection_list", `Failed to store credential: ${err}`);
-            });
-          }
-        } else if (authMethod === "key") {
-          // Key auth with an encrypted key (guaranteed by the needsCredential
-          // gate above) and no stored passphrase yet — prompt so the backend can
-          // unlock the key, regardless of savePassword (#885). Whether the
-          // passphrase is then stored still follows the prompt's Save box.
-          const host = cfg.host as string;
-          const username = (cfg.username as string) ?? "";
-          const passphrase = await requestPassword(host, username);
-          if (passphrase === null) return;
-          config = { ...config, config: { ...cfg, password: passphrase } } as typeof config;
-          if (useAppStore.getState().passwordPromptShouldSave) {
-            await storeCredential(connection.id, "key_passphrase", passphrase).catch((err) => {
-              frontendLog("connection_list", `Failed to store key passphrase: ${err}`);
-            });
-          }
-        }
-      }
-
-      addTab(connection.name, connection.config.type, config, {
-        terminalOptions: connection.terminalOptions,
-      });
-    },
-    [addTab, requestPassword]
-  );
+  const { connect: performConnect } = useConnectSavedConnection();
 
   // Connect entry point: for a plain-FTP connection that has not been suppressed,
   // surface the insecure-connection warning modal *before* the control

--- a/src/hooks/useConnectSavedConnection.test.tsx
+++ b/src/hooks/useConnectSavedConnection.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Regression tests for {@link useConnectSavedConnection}.
+ *
+ * This hook is the extracted saved-connection connect flow that previously
+ * lived inline in `ConnectionList` (#1484). These tests pin the credential
+ * behavior — password/passphrase prompting (#885), inline-password shortcut
+ * (#963), stale-credential clearing, and store opt-in — so the extraction and
+ * any future refactor stay behavior-identical to the sidebar's connect path.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { useConnectSavedConnection } from "./useConnectSavedConnection";
+import type { SavedConnection } from "@/types/connection";
+import {
+  resolveCredential,
+  createTerminal,
+  removeCredential,
+  storeCredential,
+  isSshKeyEncrypted,
+} from "@/services/api";
+
+vi.mock("@/services/api", () => ({
+  createTerminal: vi.fn(() => Promise.resolve("session-1")),
+  removeCredential: vi.fn(() => Promise.resolve()),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+  // Default: key files are encrypted. Tests override per-case.
+  isSshKeyEncrypted: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+const mockedResolveCredential = vi.mocked(resolveCredential);
+const mockedCreateTerminal = vi.mocked(createTerminal);
+const mockedRemoveCredential = vi.mocked(removeCredential);
+const mockedStoreCredential = vi.mocked(storeCredential);
+const mockedIsSshKeyEncrypted = vi.mocked(isSshKeyEncrypted);
+
+function makeSshConn(id: string, authMethod: string, savePassword?: boolean): SavedConnection {
+  return {
+    id,
+    name: `SSH ${id}`,
+    folderId: null,
+    config: {
+      type: "ssh",
+      config: {
+        host: "host.example.com",
+        username: "user",
+        authMethod,
+        ...(savePassword !== undefined ? { savePassword } : {}),
+      },
+    },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let addTabSpy: ReturnType<typeof vi.fn>;
+
+async function renderHook(): Promise<ReturnType<typeof useConnectSavedConnection>> {
+  let api: ReturnType<typeof useConnectSavedConnection> | undefined;
+  function Harness() {
+    api = useConnectSavedConnection();
+    return null;
+  }
+  await act(async () => {
+    root.render(React.createElement(Harness));
+  });
+  return api!;
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+  mockedResolveCredential.mockResolvedValue(null);
+  mockedCreateTerminal.mockResolvedValue("session-1");
+  mockedIsSshKeyEncrypted.mockResolvedValue(true);
+  addTabSpy = vi.fn(() => "tab-1");
+  useAppStore.setState({
+    ...useAppStore.getInitialState(),
+    addTab: addTabSpy as unknown as (typeof useAppStore.getState)["addTab"],
+    credentialStoreStatus: { mode: "master_password", status: "unlocked" },
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("useConnectSavedConnection", () => {
+  it("prompts for password auth when no credential is stored", async () => {
+    const { connect } = await renderHook();
+    await act(async () => {
+      void connect(makeSshConn("pw-no-cred", "password"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+    expect(addTabSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not prompt for password auth when a stored credential exists", async () => {
+    mockedResolveCredential.mockResolvedValue("stored-secret");
+    const { connect } = await renderHook();
+    await act(async () => {
+      await connect(makeSshConn("pw-with-cred", "password"));
+    });
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+    expect(mockedCreateTerminal).toHaveBeenCalledOnce();
+    // Opened against the pre-validated session id.
+    expect(addTabSpy).toHaveBeenCalledWith(
+      "SSH pw-with-cred",
+      "ssh",
+      expect.anything(),
+      expect.objectContaining({ sessionId: "session-1" })
+    );
+  });
+
+  it("prompts for an encrypted key when no passphrase is stored", async () => {
+    const { connect } = await renderHook();
+    await act(async () => {
+      void connect(makeSshConn("key-no-pass", "key", true));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+  });
+
+  it("prompts for an encrypted key even when savePassword is off (#885)", async () => {
+    const { connect } = await renderHook();
+    await act(async () => {
+      void connect(makeSshConn("key-enc-no-save", "key", false));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+  });
+
+  it("does not prompt for an unencrypted key even with savePassword on (#885)", async () => {
+    mockedIsSshKeyEncrypted.mockResolvedValue(false);
+    const { connect } = await renderHook();
+    await act(async () => {
+      await connect(makeSshConn("key-unencrypted", "key", true));
+    });
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+    expect(addTabSpy).toHaveBeenCalledOnce();
+  });
+
+  it("uses an inline password directly without consulting the store (#963)", async () => {
+    const conn = makeSshConn("pw-inline", "password");
+    (conn.config.config as Record<string, unknown>).password = "inline-secret";
+    const { connect } = await renderHook();
+    await act(async () => {
+      await connect(conn);
+    });
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+    expect(mockedResolveCredential).not.toHaveBeenCalled();
+    expect(addTabSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does not prompt for agent auth", async () => {
+    const { connect } = await renderHook();
+    await act(async () => {
+      await connect(makeSshConn("agent-auth", "agent"));
+    });
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+    expect(addTabSpy).toHaveBeenCalledOnce();
+  });
+
+  it("opens a local (non-SSH) connection directly", async () => {
+    const conn: SavedConnection = {
+      id: "local-conn",
+      name: "Local Shell",
+      folderId: null,
+      config: { type: "local", config: { shell: "bash" } },
+    };
+    const { connect } = await renderHook();
+    await act(async () => {
+      await connect(conn);
+    });
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+    expect(addTabSpy).toHaveBeenCalledOnce();
+  });
+
+  it("clears a stale credential and prompts when the pre-connect auth fails", async () => {
+    mockedResolveCredential.mockResolvedValue("stale-secret");
+    mockedCreateTerminal.mockRejectedValue(new Error("Authentication failed"));
+    const { connect } = await renderHook();
+    await act(async () => {
+      void connect(makeSshConn("pw-stale", "password"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mockedRemoveCredential).toHaveBeenCalledWith("pw-stale", "password");
+    expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+  });
+
+  it("stores the passphrase as key_passphrase when the user opts in for key auth", async () => {
+    const { connect } = await renderHook();
+    await act(async () => {
+      void connect(makeSshConn("key-store", "key", true));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      useAppStore.getState().submitPassword("my-passphrase", true);
+      await Promise.resolve();
+    });
+    expect(mockedStoreCredential).toHaveBeenCalledWith(
+      "key-store",
+      "key_passphrase",
+      "my-passphrase"
+    );
+  });
+});

--- a/src/hooks/useConnectSavedConnection.test.tsx
+++ b/src/hooks/useConnectSavedConnection.test.tsx
@@ -84,7 +84,7 @@ beforeEach(() => {
   addTabSpy = vi.fn(() => "tab-1");
   useAppStore.setState({
     ...useAppStore.getInitialState(),
-    addTab: addTabSpy as unknown as (typeof useAppStore.getState)["addTab"],
+    addTab: addTabSpy as unknown as ReturnType<typeof useAppStore.getState>["addTab"],
     credentialStoreStatus: { mode: "master_password", status: "unlocked" },
   });
 });

--- a/src/hooks/useConnectSavedConnection.ts
+++ b/src/hooks/useConnectSavedConnection.ts
@@ -1,0 +1,173 @@
+import { useCallback } from "react";
+import { useAppStore } from "@/store/appStore";
+import { SavedConnection } from "@/types/connection";
+import {
+  createTerminal,
+  removeCredential,
+  storeCredential,
+  isSshKeyEncrypted,
+} from "@/services/api";
+import { frontendLog } from "@/utils/frontendLog";
+import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
+import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
+
+/** Return value of {@link useConnectSavedConnection}. */
+export interface UseConnectSavedConnection {
+  /**
+   * Open a terminal tab for a saved connection, resolving credentials from the
+   * credential store (and prompting when needed) exactly as the sidebar does.
+   */
+  connect: (connection: SavedConnection) => Promise<void>;
+}
+
+/**
+ * Shared saved-connection connect flow.
+ *
+ * Encapsulates the credential-aware connect path used by the sidebar
+ * {@link ConnectionList} — and now the command palette — so the credential
+ * logic lives in exactly one place:
+ *
+ * - Skips credential handling for connections without `authMethod`/`host`
+ *   (e.g. local shells) and for non-password/unencrypted-key auth.
+ * - For key auth, prompts based on the key's *actual* encryption rather than
+ *   the `savePassword` flag (#885).
+ * - Treats a non-empty inline password as the credential itself (#963).
+ * - Unlocks the credential store before resolving a stored secret (#1144).
+ * - Validates a stored credential with a pre-connect and clears it if stale
+ *   (#885/#963), otherwise prompts and optionally persists the entered secret.
+ *
+ * This hook intentionally contains no UI: callers own any surrounding
+ * confirmation (e.g. the sidebar's insecure-FTP warning) and render the shared
+ * `PasswordPrompt` / `UnlockDialog` that this flow drives through the store.
+ */
+export function useConnectSavedConnection(): UseConnectSavedConnection {
+  const addTab = useAppStore((s) => s.addTab);
+  const requestPassword = useAppStore((s) => s.requestPassword);
+
+  const connect = useCallback(
+    async (connection: SavedConnection) => {
+      let config = connection.config;
+      const cfg = config.config as unknown as Record<string, unknown>;
+
+      // Connections with authMethod and password support credential store resolution
+      if (cfg.authMethod && cfg.host) {
+        const authMethod = cfg.authMethod as string;
+        const savePassword = cfg.savePassword as boolean | undefined;
+
+        // For key auth, decide whether a passphrase is needed from the key's
+        // actual encryption rather than the savePassword flag (#885): a
+        // passphrase-protected key must be unlocked even when savePassword is
+        // off, and an unencrypted key must never prompt. If the file can't be
+        // read, default to "encrypted" so an encrypted key never fails silently.
+        let keyEncrypted = false;
+        if (authMethod === "key") {
+          keyEncrypted = await isSshKeyEncrypted((cfg.keyPath as string) ?? "").catch(() => true);
+        }
+        // Password auth always needs a credential; key auth only when encrypted.
+        const needsCredential = authMethod === "password" || (authMethod === "key" && keyEncrypted);
+        if (!needsCredential) {
+          addTab(connection.name, connection.config.type, config, {
+            terminalOptions: connection.terminalOptions,
+          });
+          return;
+        }
+
+        // An inline, non-empty password on the config is itself the credential —
+        // e.g. an "Open Jump Host Terminal" gateway synthesized from an inline
+        // hop, whose password lives on the hop, not in the store (#963). Use it
+        // directly: a credential-store lookup here is keyed by this (possibly
+        // synthetic) connection id and would miss, forcing a redundant prompt
+        // even though the password is already known.
+        if (typeof cfg.password === "string" && cfg.password.length > 0) {
+          addTab(connection.name, connection.config.type, config, {
+            terminalOptions: connection.terminalOptions,
+          });
+          return;
+        }
+
+        // Before attempting credential resolution, check whether the credential store
+        // is locked. If it is, we can't read the stored credential and SSH would fall
+        // back to interactive password prompts. Prompt for unlock first and wait —
+        // on success the code continues and the credential resolves automatically.
+        const proceed = await ensureCredentialStoreUnlocked({ authMethod, savePassword });
+        if (!proceed) return;
+
+        // Try to resolve credential from the store first
+        const resolution = await resolveConnectionCredential(
+          connection.id,
+          authMethod,
+          savePassword
+        );
+
+        if (resolution.usedStoredCredential && resolution.password) {
+          // Pre-connect with stored credential to validate it
+          const preConfig = {
+            ...config,
+            config: { ...cfg, password: resolution.password },
+          } as typeof config;
+          try {
+            const sessionId = await createTerminal(preConfig);
+            // Stored credential worked — open tab with existing session
+            addTab(connection.name, connection.config.type, preConfig, {
+              terminalOptions: connection.terminalOptions,
+              sessionId,
+            });
+            return;
+          } catch (err) {
+            const errStr = String(err);
+            if (
+              errStr.toLowerCase().includes("auth failed") ||
+              errStr.includes("Authentication failed")
+            ) {
+              // Stale credential — remove it and fall through to prompt
+              await removeCredential(connection.id, resolution.credentialType).catch(() => {});
+            } else {
+              // Non-auth failure — let the Terminal component handle the error
+              addTab(connection.name, connection.config.type, config, {
+                terminalOptions: connection.terminalOptions,
+              });
+              return;
+            }
+          }
+        }
+
+        // No stored credential or stale credential was cleared — prompt the user
+        if (authMethod === "password") {
+          const host = cfg.host as string;
+          const username = (cfg.username as string) ?? "";
+          const password = await requestPassword(host, username);
+          if (password === null) return;
+          config = { ...config, config: { ...cfg, password } } as typeof config;
+          // Persist the entered password if the user opted in via the prompt checkbox
+          if (useAppStore.getState().passwordPromptShouldSave) {
+            await storeCredential(connection.id, "password", password).catch((err) => {
+              frontendLog("connection_list", `Failed to store credential: ${err}`);
+            });
+          }
+        } else if (authMethod === "key") {
+          // Key auth with an encrypted key (guaranteed by the needsCredential
+          // gate above) and no stored passphrase yet — prompt so the backend can
+          // unlock the key, regardless of savePassword (#885). Whether the
+          // passphrase is then stored still follows the prompt's Save box.
+          const host = cfg.host as string;
+          const username = (cfg.username as string) ?? "";
+          const passphrase = await requestPassword(host, username);
+          if (passphrase === null) return;
+          config = { ...config, config: { ...cfg, password: passphrase } } as typeof config;
+          if (useAppStore.getState().passwordPromptShouldSave) {
+            await storeCredential(connection.id, "key_passphrase", passphrase).catch((err) => {
+              frontendLog("connection_list", `Failed to store key passphrase: ${err}`);
+            });
+          }
+        }
+      }
+
+      addTab(connection.name, connection.config.type, config, {
+        terminalOptions: connection.terminalOptions,
+      });
+    },
+    [addTab, requestPassword]
+  );
+
+  return { connect };
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -143,6 +143,11 @@ export function useKeyboardShortcuts() {
           useAppStore.getState().openSettingsTab();
           break;
 
+        case "command-palette":
+          e.preventDefault();
+          useAppStore.getState().setCommandPaletteOpen(true);
+          break;
+
         case "clear-terminal": {
           e.preventDefault();
           const panel = allLeaves.find((p) => p.id === activePanelId);

--- a/src/services/commands.test.ts
+++ b/src/services/commands.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for the command palette's command registry (#1484).
+ *
+ * The registry is sourced from the keybinding actions so labels and
+ * accelerators have a single source of truth; only actions with a runner are
+ * surfaced, and running a command invokes the matching store action.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildCommands } from "./commands";
+import { getActionAccelerator, clearOverrides } from "./keybindings";
+import { useAppStore } from "@/store/appStore";
+
+describe("buildCommands", () => {
+  beforeEach(() => {
+    clearOverrides();
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+  });
+
+  it("sources label and accelerator from the keybinding action", () => {
+    const commands = buildCommands();
+    const newTerminal = commands.find((c) => c.id === "new-terminal");
+    expect(newTerminal).toBeDefined();
+    expect(newTerminal!.label).toBe("New Terminal");
+    // Accelerator comes straight from the keybinding service — no duplication.
+    expect(newTerminal!.accelerator).toBe(getActionAccelerator("new-terminal"));
+  });
+
+  it("only surfaces actions that have a runner", () => {
+    const ids = buildCommands().map((c) => c.id);
+    // Runnable, store-only commands are present…
+    expect(ids).toContain("toggle-sidebar");
+    expect(ids).toContain("open-settings");
+    expect(ids).toContain("zoom-in");
+    // …while the palette's own shortcut and context-bound actions are not.
+    expect(ids).not.toContain("command-palette");
+    expect(ids).not.toContain("close-tab");
+    expect(ids).not.toContain("focus-up");
+  });
+
+  it("runs the matching store action", () => {
+    const toggleSidebar = vi.fn();
+    useAppStore.setState({ toggleSidebar });
+    const cmd = buildCommands().find((c) => c.id === "toggle-sidebar");
+    cmd!.run();
+    expect(toggleSidebar).toHaveBeenCalledOnce();
+  });
+});

--- a/src/services/commands.ts
+++ b/src/services/commands.ts
@@ -1,0 +1,62 @@
+import { getDefaultBindings, getActionAccelerator } from "@/services/keybindings";
+import { useAppStore } from "@/store/appStore";
+
+/**
+ * A runnable application command surfaced in the command palette (#1484).
+ *
+ * Commands are sourced from the existing keybinding actions
+ * ({@link getDefaultBindings}) so their label and accelerator have a single
+ * source of truth — the palette never duplicates accelerator strings.
+ */
+export interface PaletteCommand {
+  /** The keybinding action id (e.g. `"new-terminal"`). */
+  id: string;
+  /** Human-readable label from the action's binding. */
+  label: string;
+  /** Effective accelerator string (user override or platform default), or null. */
+  accelerator: string | null;
+  /** Execute the command. */
+  run: () => void;
+}
+
+/**
+ * Runner for each palette-runnable action. An action is surfaced in the palette
+ * only when it has an entry here, so context-bound actions that need live panel
+ * state (focus-panel, close-tab, next/prev-tab, terminal find/clear) are
+ * intentionally omitted — they stay keyboard-only until they can run without a
+ * DOM/panel lookup. Everything here operates purely on store state.
+ */
+const COMMAND_RUNNERS: Record<string, () => void> = {
+  "toggle-sidebar": () => useAppStore.getState().toggleSidebar(),
+  "open-settings": () => useAppStore.getState().openSettingsTab(),
+  "show-shortcuts": () => useAppStore.getState().setShortcutsOverlayOpen(true),
+  "new-terminal": () => {
+    useAppStore.getState().addTab("Terminal", "local");
+  },
+  "split-right": () => useAppStore.getState().splitPanel("horizontal"),
+  "split-down": () => useAppStore.getState().splitPanel("vertical"),
+  "zoom-panel": () => useAppStore.getState().toggleZoomActiveTab(),
+  "zoom-in": () => useAppStore.getState().zoomIn(),
+  "zoom-out": () => useAppStore.getState().zoomOut(),
+  "zoom-reset": () => useAppStore.getState().zoomReset(),
+  "new-tab-group": () => {
+    useAppStore.getState().addTabGroup();
+  },
+};
+
+/**
+ * Build the list of runnable commands for the command palette, in the order
+ * their bindings are declared. Labels and accelerators come from the keybinding
+ * service so the palette stays in sync with the shortcuts overlay and any user
+ * overrides.
+ */
+export function buildCommands(): PaletteCommand[] {
+  return getDefaultBindings()
+    .filter((binding) => binding.action in COMMAND_RUNNERS)
+    .map((binding) => ({
+      id: binding.action,
+      label: binding.label,
+      accelerator: getActionAccelerator(binding.action),
+      run: COMMAND_RUNNERS[binding.action],
+    }));
+}

--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -36,6 +36,17 @@ export const DEFAULT_BINDINGS: KeyBinding[] = [
     configurable: true,
   },
   {
+    action: "command-palette",
+    label: "Command Palette",
+    category: "general",
+    macDefault: { key: "p", meta: true },
+    // Avoid bare Ctrl+P: readline "previous-history". Ctrl+Shift+P matches the
+    // familiar VS Code command-palette shortcut and does not collide with the
+    // shell key map.
+    winLinuxDefault: { key: "P", ctrl: true, shift: true },
+    configurable: true,
+  },
+  {
     action: "show-shortcuts",
     label: "Keyboard Shortcuts",
     category: "general",

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -508,6 +508,10 @@ interface AppState {
   shortcutsOverlayOpen: boolean;
   setShortcutsOverlayOpen: (open: boolean) => void;
 
+  // Command palette (Cmd/Ctrl+P) — fuzzy-find commands + saved connections
+  commandPaletteOpen: boolean;
+  setCommandPaletteOpen: (open: boolean) => void;
+
   // Standalone overlay views (updates, about) — opened from the settings menu
   overlayView: "updates" | "about" | null;
   openOverlayView: (view: "updates" | "about") => void;
@@ -2741,6 +2745,9 @@ export const useAppStore = create<AppState>((set, get) => {
     // Shortcuts overlay
     shortcutsOverlayOpen: false,
     setShortcutsOverlayOpen: (open) => set({ shortcutsOverlayOpen: open }),
+
+    commandPaletteOpen: false,
+    setCommandPaletteOpen: (open) => set({ commandPaletteOpen: open }),
 
     // Standalone overlay views
     overlayView: null,

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -63,6 +63,8 @@ Fixed strings — match exactly.
 | `color-picker-apply` | `src/components/Terminal/ColorPickerDialog.tsx` |
 | `color-picker-clear` | `src/components/Terminal/ColorPickerDialog.tsx` |
 | `color-picker-hex-input` | `src/components/Terminal/ColorPickerDialog.tsx` |
+| `command-palette` | `src/components/CommandPalette/CommandPalette.tsx` |
+| `command-palette-input` | `src/components/CommandPalette/CommandPalette.tsx` |
 | `confirm-close-tab-cancel` | `src/components/Terminal/ConfirmCloseTabDialog.tsx` |
 | `confirm-close-tab-dialog` | `src/components/Terminal/ConfirmCloseTabDialog.tsx` |
 | `confirm-delete-cancel` | `src/components/Sidebar/ConfirmDeleteDialog.tsx` |
@@ -621,6 +623,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `agent-state-*` | `agent-state-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-version-badge-*` | `agent-version-badge-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `color-picker-swatch-*` | `color-picker-swatch-${color.replace("#", "")}` | `src/components/Terminal/ColorPickerDialog.tsx` |
+| `command-palette-item-*` | `command-palette-item-${entry.key}` | `src/components/CommandPalette/CommandPalette.tsx` |
 | `connection-connect-*` | `connection-connect-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-item-*` | `connection-item-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |
 | `connection-jump-badge-*` | `connection-jump-badge-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |
@@ -696,12 +699,8 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `server-dialog-proto-*` | `server-dialog-proto-${type}` | `src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx` |
 | `server-duplicate-*` | `server-duplicate-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `server-edit-*` | `server-edit-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
-| `server-item-*` | `server-item-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
-| `server-name-*` | `server-name-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `server-start-*` | `server-start-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
-| `server-status-*` | `server-status-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `server-stop-*` | `server-stop-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
-| `server-type-*` | `server-type-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `settings-nav-*` | `settings-nav-${cat.id}` | `src/components/Settings/SettingsNav.tsx` |
 | `shell-integration-entry-*` | `shell-integration-entry-${entry.id}` | `src/components/Settings/ShellIntegrationSettings.tsx` |
 | `shell-integration-entry-delete-*` | `shell-integration-entry-delete-${entry.id}` | `src/components/Settings/ShellIntegrationSettings.tsx` |
@@ -717,14 +716,10 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `tunnel-delete-*` | `tunnel-delete-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-duplicate-*` | `tunnel-duplicate-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-edit-*` | `tunnel-edit-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
-| `tunnel-item-*` | `tunnel-item-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
-| `tunnel-name-*` | `tunnel-name-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-reconnect-*` | `tunnel-reconnect-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-retry-*` | `tunnel-retry-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-start-*` | `tunnel-start-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
-| `tunnel-status-*` | `tunnel-status-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-stop-*` | `tunnel-stop-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
-| `tunnel-type-*` | `tunnel-type-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-view-error-*` | `tunnel-view-error-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `workspace-delete-*` | `workspace-delete-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 | `workspace-duplicate-*` | `workspace-duplicate-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
@@ -732,9 +727,7 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `workspace-group-chip-*` | `workspace-group-chip-${index}` | `src/components/WorkspaceEditor/WorkspaceEditor.tsx` |
 | `workspace-group-close-*` | `workspace-group-close-${index}` | `src/components/WorkspaceEditor/WorkspaceEditor.tsx` |
 | `workspace-group-rename-input-*` | `workspace-group-rename-input-${index}` | `src/components/WorkspaceEditor/WorkspaceEditor.tsx` |
-| `workspace-item-*` | `workspace-item-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 | `workspace-launch-*` | `workspace-launch-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
-| `workspace-name-*` | `workspace-name-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 
 ## Indirect test IDs
 

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -703,8 +703,12 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `server-dialog-proto-*` | `server-dialog-proto-${type}` | `src/components/EmbeddedServerSidebar/EmbeddedServerDialog.tsx` |
 | `server-duplicate-*` | `server-duplicate-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `server-edit-*` | `server-edit-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
+| `server-item-*` | `server-item-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
+| `server-name-*` | `server-name-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `server-start-*` | `server-start-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
+| `server-status-*` | `server-status-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `server-stop-*` | `server-stop-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
+| `server-type-*` | `server-type-${config.id}` | `src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx` |
 | `settings-nav-*` | `settings-nav-${cat.id}` | `src/components/Settings/SettingsNav.tsx` |
 | `shell-integration-entry-*` | `shell-integration-entry-${entry.id}` | `src/components/Settings/ShellIntegrationSettings.tsx` |
 | `shell-integration-entry-delete-*` | `shell-integration-entry-delete-${entry.id}` | `src/components/Settings/ShellIntegrationSettings.tsx` |
@@ -720,10 +724,14 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `tunnel-delete-*` | `tunnel-delete-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-duplicate-*` | `tunnel-duplicate-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-edit-*` | `tunnel-edit-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
+| `tunnel-item-*` | `tunnel-item-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
+| `tunnel-name-*` | `tunnel-name-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-reconnect-*` | `tunnel-reconnect-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-retry-*` | `tunnel-retry-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-start-*` | `tunnel-start-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
+| `tunnel-status-*` | `tunnel-status-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-stop-*` | `tunnel-stop-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
+| `tunnel-type-*` | `tunnel-type-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `tunnel-view-error-*` | `tunnel-view-error-${tunnel.id}` | `src/components/TunnelSidebar/TunnelListItem.tsx` |
 | `workspace-delete-*` | `workspace-delete-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 | `workspace-duplicate-*` | `workspace-duplicate-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
@@ -731,7 +739,9 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `workspace-group-chip-*` | `workspace-group-chip-${index}` | `src/components/WorkspaceEditor/WorkspaceEditor.tsx` |
 | `workspace-group-close-*` | `workspace-group-close-${index}` | `src/components/WorkspaceEditor/WorkspaceEditor.tsx` |
 | `workspace-group-rename-input-*` | `workspace-group-rename-input-${index}` | `src/components/WorkspaceEditor/WorkspaceEditor.tsx` |
+| `workspace-item-*` | `workspace-item-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 | `workspace-launch-*` | `workspace-launch-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
+| `workspace-name-*` | `workspace-name-${workspace.id}` | `src/components/WorkspaceSidebar/WorkspaceListItem.tsx` |
 
 ## Indirect test IDs
 


### PR DESCRIPTION
## Summary

Adds a keyboard-first **command palette** (Cmd/Ctrl+P) that fuzzy-matches **both application commands and saved connections** in one ranked list. Press the shortcut, type to filter, use the arrow keys to move, and press **Enter** to run the highlighted command or connect to the highlighted connection (**Esc** closes). Follow-up to #1353.

## What changed

### 1. Connect-flow extraction (`refactor(ui)`), done first as the riskiest part
- Extracted the ~150-line saved-connection connect flow out of `ConnectionList` into a reusable **`useConnectSavedConnection`** hook — **no behavior change**. This is the credential-store resolution, password/passphrase prompting (#885), inline-password shortcut (#963), credential-store unlock (#1144), and stale-credential clearing.
- `ConnectionList` now calls the hook; its insecure-FTP warning wrapper is unchanged.
- **Parity proof:** the existing `ConnectionList.credential.test.tsx` matrix continues to pass through the hook, plus a new hook-level regression test (`useConnectSavedConnection.test.tsx`) pins the same behavior at the hook boundary.

### 2. Command palette (`feat(ui)`)
- New **`command-palette`** keybinding action — defaults **Cmd+P** (macOS) / **Ctrl+Shift+P** (Win/Linux), chosen to avoid shell/tmux/readline collisions per the existing convention. Wired through the keybindings service + `useKeyboardShortcuts`.
- **Command registry** (`src/services/commands.ts`) sourced from the keybinding actions, reusing `getActionAccelerator` so accelerators have a **single source of truth** (no second copy). Only actions with a store-only runner are surfaced; context-bound actions (focus-panel, close/next/prev-tab, terminal find/clear) are intentionally omitted for now.
- **`CommandPalette`** composed from the shared `Modal` + `Input` primitives; keyboard-first (arrows, Enter, Home/End, Esc); each command shows its accelerator inline, each connection its type badge + real `ConnectionIcon`.
- **Matcher library:** `match-sorter` (added dep) — maintained, ranked matching well-suited to a command palette; matches connections by name **and** host.
- Connecting reuses `useConnectSavedConnection`, so the palette shares the sidebar's exact credential flow (including any password/unlock prompt).

## Matcher library
Chose **`match-sorter` 8.3.0** over a custom scorer (per CLAUDE.md "prefer libraries"): maintained, small, and its ranking (exact → starts-with → word-starts-with → contains → acronym) matches command-palette expectations.

## Test plan
Automated: full `pnpm test` (3098 passing), `pnpm build`, `pnpm run lint`, `pnpm run format:check`, `pnpm run markdownlint` all green. New tests cover the hook parity matrix, the command registry, and the palette (fuzzy ranking of a command + a connection + host match, Enter runs/connects, arrow navigation, Esc close, empty state).

Manual (also added to `docs/testing.md`):
1. Press the palette shortcut (macOS Cmd+P, Win/Linux Ctrl+Shift+P) → modal opens with focused search, commands first then connections.
2. Type `new term` → **New Terminal** ranks top with its accelerator; Enter opens a terminal and closes the palette.
3. Reopen, type part of a saved connection's name/host → it ranks top with its type badge; Enter connects exactly as a sidebar double-click (incl. any credential prompt).
4. Arrow Up/Down move the highlight; Esc closes without running anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
