### PR TITLE
feat(backend): external-trigger session opening + focus + spawn toast (#1365)

### DIFF
--- a/docs/changes/dev0/feature/1365-external-trigger-session.md
+++ b/docs/changes/dev0/feature/1365-external-trigger-session.md
@@ -1,0 +1,12 @@
+### Added
+
+- CLI/context-menu spawn: an external `termiHub spawn` for a local/WSL/SSH
+  target now opens a session inside the running app. The window is focused, a
+  shell tab opens `cd`'d to the target directory, and a toast confirms the
+  action. The target path is resolved sensibly — a folder opens in itself, a
+  file opens in its parent directory, and a missing path opens your home
+  directory with a warning toast (symlinks are resolved; a WSL target is mapped
+  to its `/mnt/` path). Spawns that arrive on a cold start (before the UI is
+  ready) are queued and processed once the app finishes loading. Complements the
+  already-shipped "new container" spawn path. Part of the Shell Context Menu &
+  CLI Spawn Integration epic (#1363, #1365).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -913,8 +913,37 @@ manual.
    is **not** also listed under **Local Sessions**. Its **Kill** action stops the
    backend session.
 7. (Boundary) Run `termiHub spawn --location ~/tmp/spawn` with **no**
-   `--container-image`. Confirm no tab opens (non-container spawns are SI-2; the
-   request is ignored, logged in the LogViewer under `frontend::spawn`).
+   `--container-image`. Confirm this now opens a **local shell tab** `cd`'d to the
+   directory (the SI-2 path below), not a container.
+
+### External local/WSL/SSH spawn opens a shell tab (frontend consumption, #1365)
+
+The wiring (spawn event / cold-start drain → `resolve_shell_spawn` → focus window
+→ open local shell tab `cd`'d to the target → confirmation toast) is covered by
+unit tests (`src-tauri/src/spawn/handler.rs`, `src/hooks/useSpawnRequests.test.ts`).
+A live end-to-end run needs a built app, so the path below is manual (window focus
+per-OS, especially Wayland, is manual-only). Referenced by PR #1508.
+
+**Spawn a local shell at a directory / file / missing path.**
+
+1. With the built app already running, create a scratch directory with a file
+   (e.g. `mkdir -p ~/tmp/spawn && echo hi > ~/tmp/spawn/hi.txt`).
+2. From another terminal run `termiHub spawn --location ~/tmp/spawn`.
+3. Confirm the termiHub **window comes to the foreground**, a **new local shell
+   tab** opens titled `spawn (Spawned)` with a **"Spawned"** badge, and a brief
+   **confirmation toast** reports the shell was opened (mentions the location).
+4. In the terminal, `pwd` prints the target directory — proving the shell opened
+   `cd`'d there.
+5. (File) Run `termiHub spawn --location ~/tmp/spawn/hi.txt`. Confirm the shell
+   opens in the **parent directory** (`~/tmp/spawn`).
+6. (Missing) Run `termiHub spawn --location ~/tmp/does-not-exist`. Confirm the
+   shell opens in your **home directory** and an **info toast** warns the path was
+   not found.
+7. (Windows/WSL) With `--kind wsl`, confirm the WSL shell opens at the target
+   converted to its `/mnt/<drive>/…` path.
+8. (Cold start) Quit the app, then run `termiHub spawn --location ~/tmp/spawn`.
+   Confirm the app launches and, once loaded, focuses and opens the shell tab at
+   the target (the queued cold-start spawn is processed post-UI-ready).
 
 ### Spawned container grouping survives tab close (#1466)
 

--- a/src-tauri/src/commands/spawn.rs
+++ b/src-tauri/src/commands/spawn.rs
@@ -11,7 +11,8 @@ use tauri::State;
 use crate::connection::manager::ConnectionManager;
 use crate::connection::shell_integration::ShellIntegrationSettings;
 use crate::spawn::container::{self, ContainerSpawn};
-use crate::spawn::SpawnRequest;
+use crate::spawn::handler::{self, PendingSpawn, ShellSpawn};
+use crate::spawn::{SpawnKind, SpawnRequest};
 
 /// The saved per-entry container preferences (image + mount target) looked up
 /// for a spawn's `--entry-id`, if any.
@@ -85,6 +86,48 @@ fn resolve_container_spawn_with(
         saved_image.as_deref(),
         saved_mount.as_deref(),
     ))
+}
+
+/// Resolve a local/WSL/SSH spawn into local-shell session settings (#1365, SI-2).
+///
+/// The parallel of [`resolve_container_spawn`] for the "open a shell at the
+/// target directory" path. The requested `location` is resolved to a working
+/// directory (folder → itself, file → parent, missing → the home directory,
+/// symlinks resolved) which becomes the shell's `startingDirectory`; a WSL-kind
+/// spawn converts that directory to its `/mnt/` path. The returned [`ShellSpawn`]
+/// carries the camelCase local-shell settings, a `"… (Spawned)"` tab title,
+/// `spawned: true`, and a `missing` flag the frontend surfaces as a warning.
+#[tauri::command]
+pub fn resolve_shell_spawn(
+    location: Option<String>,
+    connection: Option<String>,
+    entry_id: Option<String>,
+    kind: Option<String>,
+) -> ShellSpawn {
+    let kind = kind
+        .as_deref()
+        .and_then(SpawnKind::from_wire)
+        .unwrap_or_default();
+    let request = SpawnRequest {
+        location,
+        connection,
+        entry_id,
+        kind,
+        ..SpawnRequest::default()
+    };
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    handler::build_shell_spawn(&request, &home)
+}
+
+/// Drain the cold-start pending spawn, if any (#1365).
+///
+/// A spawn handed to a freshly-launched instance before the UI is ready is
+/// parked in [`PendingSpawn`] (no event listener exists yet); the frontend calls
+/// this once its `spawn-request` subscription is registered to pick it up and
+/// process it through the same path as a live event.
+#[tauri::command]
+pub fn take_pending_spawn(pending: State<'_, PendingSpawn>) -> Option<SpawnRequest> {
+    handler::take_pending_spawn(&pending)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,6 +170,7 @@ pub fn run() {
         .manage(NetworkManager::new())
         .manage(x_server_manager.clone())
         .manage(x_server_consent_registry.clone())
+        .manage(spawn::handler::PendingSpawn::default())
         .manage(commands::connection_path::ProbeRegistry::default())
         .manage(crate::terminal::agent_cancel::AgentDeployCancellation::default())
         .manage(log_buffer);
@@ -512,16 +513,18 @@ pub fn run() {
             match spawn::SpawnEndpoint::for_current_user() {
                 Ok(endpoint) => {
                     let emit_handle = app.handle().clone();
-                    let handler: spawn::SpawnHandler =
-                        Arc::new(move |req: spawn::SpawnRequest| match emit_handle
-                            .emit(spawn::SPAWN_REQUEST_EVENT, &req)
-                        {
+                    let handler: spawn::SpawnHandler = Arc::new(move |req: spawn::SpawnRequest| {
+                        // Focus the window and forward the request to the
+                        // frontend (#1365 adds the focus so an external spawn
+                        // raises the running instance, for every spawn kind).
+                        match spawn::handler::emit_spawn_request(&emit_handle, &req) {
                             Ok(()) => spawn::SpawnResponse::accepted(),
                             Err(e) => {
                                 tracing::warn!("failed to emit spawn-request event: {e}");
                                 spawn::SpawnResponse::error(format!("emit failed: {e}"))
                             }
-                        });
+                        }
+                    });
                     tauri::async_runtime::spawn(async move {
                         if let Err(e) = spawn::ipc_server::serve(&endpoint, handler).await {
                             tracing::warn!("spawn IPC server stopped: {e}");
@@ -532,11 +535,16 @@ pub fn run() {
             }
 
             // Process a spawn request this instance launched to handle itself
-            // (no running instance accepted the pre-init forward).
-            if let Some(req) = &pending_spawn {
-                if let Err(e) = app.handle().emit(spawn::SPAWN_REQUEST_EVENT, req) {
-                    tracing::warn!("failed to emit pending spawn-request: {e}");
-                }
+            // (no running instance accepted the pre-init forward). On cold start
+            // the frontend listener is not registered yet, so an event would be
+            // lost — park the request and focus the window; the frontend drains
+            // it via `take_pending_spawn` once its subscription is ready (#1365).
+            if let Some(req) = pending_spawn {
+                spawn::handler::store_pending_spawn(
+                    app.handle(),
+                    &app.state::<spawn::handler::PendingSpawn>(),
+                    req,
+                );
             }
 
             // Store recovery warnings so the frontend can retrieve them
@@ -631,6 +639,8 @@ pub fn run() {
             commands::shell_integration::uninstall_shell_integration,
             commands::shell_integration::save_shell_integration_settings,
             commands::spawn::resolve_container_spawn,
+            commands::spawn::resolve_shell_spawn,
+            commands::spawn::take_pending_spawn,
             commands::connection::move_connection_to_file,
             commands::connection::save_external_file,
             commands::connection::reload_external_connections,

--- a/src-tauri/src/macos_services.rs
+++ b/src-tauri/src/macos_services.rs
@@ -13,7 +13,7 @@
 //! `openInTermiHub:userData:error:` on our provider with the selected
 //! file-system objects on an [`NSPasteboard`]. We read the selected paths and
 //! forward each into the **same** spawn flow the Quick Action bundles use: a
-//! [`SpawnRequest`] re-emitted as the [`SPAWN_REQUEST_EVENT`] Tauri event, which
+//! [`SpawnRequest`] re-emitted as the [`crate::spawn::SPAWN_REQUEST_EVENT`] Tauri event, which
 //! the running instance already handles (see `lib.rs`). This is the internal
 //! equivalent of the bundles' `termiHub spawn --location <path>` invocation — no
 //! separate spawn mechanism is introduced.
@@ -26,7 +26,7 @@
 //!
 //! [`NSServices`]: https://developer.apple.com/documentation/bundleresources/information_property_list/nsservices
 
-use crate::spawn::{SpawnRequest, SPAWN_REQUEST_EVENT};
+use crate::spawn::SpawnRequest;
 use anyhow::{Context, Result};
 use objc2::rc::Retained;
 use objc2::runtime::NSObject;
@@ -38,7 +38,7 @@ use objc2_app_kit::{NSApplication, NSPasteboard, NSUpdateDynamicServices};
 #[allow(deprecated)]
 use objc2_app_kit::NSFilenamesPboardType;
 use objc2_foundation::{NSArray, NSString};
-use tauri::{AppHandle, Emitter};
+use tauri::AppHandle;
 
 /// Map the file-system paths carried by a Services invocation into the spawn
 /// requests forwarded to the running instance.
@@ -106,12 +106,14 @@ impl ServicesProvider {
         unsafe { msg_send![super(this), init] }
     }
 
-    /// Emit one [`SPAWN_REQUEST_EVENT`] per selected path, reusing the running
+    /// Emit one [`crate::spawn::SPAWN_REQUEST_EVENT`] per selected path, reusing the running
     /// instance's existing spawn handling.
     fn forward_spawn_requests(&self, paths: &[String]) {
         let handle = &self.ivars().app_handle;
         for request in spawn_requests_from_paths(paths) {
-            if let Err(e) = handle.emit(SPAWN_REQUEST_EVENT, &request) {
+            // Focus the window and forward the request (#1365), reusing the
+            // shared spawn emit so Services-triggered spawns behave like IPC ones.
+            if let Err(e) = crate::spawn::handler::emit_spawn_request(handle, &request) {
                 tracing::warn!("failed to emit spawn-request from Services provider: {e}");
             }
         }

--- a/src-tauri/src/spawn/handler.rs
+++ b/src-tauri/src/spawn/handler.rs
@@ -1,0 +1,269 @@
+//! External-trigger session opening for local/WSL/SSH spawns (#1365, SI-2).
+//!
+//! The parallel of [`container`](super::container) for the "open a shell at the
+//! target directory" path. A `termiHub spawn` that reaches the running instance
+//! is turned into a session the frontend opens:
+//!
+//! 1. the target `location` is resolved to a working directory — a folder is
+//!    used as-is, a file resolves to its parent, and a missing path falls back
+//!    to the home directory (flagged so the frontend can warn), with symlinks
+//!    resolved,
+//! 2. the resolved directory becomes the shell's starting directory (the
+//!    `core/src/backends/local_shell.rs` `cwd` path — so the session opens
+//!    `cd`'d to the target without a fragile post-start `cd`), and
+//! 3. the main window is focused and the request is delivered to the frontend
+//!    over the shared `spawn-request` event so it opens the tab and confirms
+//!    with a toast.
+//!
+//! The path-resolution and Windows→WSL conversion helpers are pure so they are
+//! unit-testable without a Tauri `AppHandle` (the high-value, macOS-runnable
+//! coverage for this feature).
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::Serialize;
+use serde_json::json;
+use tauri::{AppHandle, Emitter, Manager, Runtime};
+
+use super::{SpawnKind, SpawnRequest, SPAWN_REQUEST_EVENT};
+
+/// A spawn target resolved to a concrete working directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedLocation {
+    /// Directory the session should open in (`cd` target).
+    pub cwd: PathBuf,
+    /// `true` when the requested path did not exist and `cwd` fell back to home.
+    pub missing: bool,
+}
+
+/// A resolved shell spawn: the local-shell settings JSON to hand to
+/// `create_connection("local", …)` plus a display title carrying the "Spawned"
+/// marker for the tab badge. Mirrors [`ContainerSpawn`](super::container::ContainerSpawn).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShellSpawn {
+    /// Local-shell backend settings (camelCase JSON) for the spawned session.
+    pub settings: serde_json::Value,
+    /// Human-readable tab title, e.g. `"Shell: project (Spawned)"`.
+    pub title: String,
+    /// Always `true` — distinguishes spawned shells from configured connections
+    /// so the frontend can badge and track them separately.
+    pub spawned: bool,
+    /// `true` when the requested path was missing and home was substituted, so
+    /// the frontend can surface a warning.
+    pub missing: bool,
+}
+
+/// Cold-start pending spawn slot.
+///
+/// A spawn handed to this instance before the UI is ready cannot be delivered by
+/// an event (no frontend listener yet), so it is parked here and drained by the
+/// frontend via `take_pending_spawn` once its listener is registered.
+#[derive(Default)]
+pub struct PendingSpawn(pub Mutex<Option<SpawnRequest>>);
+
+/// Resolve a spawn target `location` into a working directory.
+///
+/// - `None`/empty → `home` (not treated as "missing").
+/// - Existing directory → that directory, with symlinks resolved.
+/// - Existing file → the file's parent directory, with symlinks resolved.
+/// - Missing path → `home`, flagged `missing = true`.
+pub fn resolve_spawn_location(location: Option<&str>, home: &Path) -> ResolvedLocation {
+    todo!("resolve_spawn_location")
+}
+
+/// Convert a Windows absolute path to its WSL `/mnt/` equivalent.
+///
+/// `C:\Users\foo\bar.sh` → `/mnt/c/Users/foo/bar.sh`. Returns `None` when the
+/// path does not start with a drive-letter prefix. Mirrors
+/// `core/src/backends/wsl.rs::windows_path_to_wsl_path` so WSL spawns land in the
+/// distribution-visible mount path.
+pub fn windows_path_to_wsl_path(win_path: &str) -> Option<String> {
+    todo!("windows_path_to_wsl_path")
+}
+
+/// Build the resolved [`ShellSpawn`] for a spawn request, resolving its target
+/// against `home`. For a WSL-kind spawn the resolved directory is converted to
+/// its `/mnt/` path so the distribution opens in the right place.
+pub fn build_shell_spawn(req: &SpawnRequest, home: &Path) -> ShellSpawn {
+    todo!("build_shell_spawn")
+}
+
+/// The home directory, falling back to `.` when it cannot be determined.
+fn home_dir() -> PathBuf {
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Focus the main window, best-effort. Logged (not fatal) on failure so a spawn
+/// still opens its tab even when the platform refuses the focus (e.g. Wayland).
+pub fn focus_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        if let Err(e) = window.set_focus() {
+            tracing::warn!("failed to focus window for spawn: {e}");
+        }
+    }
+}
+
+/// Focus the main window and deliver a spawn request to the frontend over the
+/// shared [`SPAWN_REQUEST_EVENT`]. Used for warm spawns (a running instance
+/// reached over IPC or the macOS Services provider).
+pub fn emit_spawn_request<R: Runtime>(app: &AppHandle<R>, req: &SpawnRequest) -> tauri::Result<()> {
+    focus_main_window(app);
+    app.emit(SPAWN_REQUEST_EVENT, req)
+}
+
+/// Park a cold-start spawn request so the frontend drains it once ready, and
+/// focus the window so the launched instance surfaces immediately.
+pub fn store_pending_spawn<R: Runtime>(
+    app: &AppHandle<R>,
+    pending: &PendingSpawn,
+    req: SpawnRequest,
+) {
+    focus_main_window(app);
+    if let Ok(mut slot) = pending.0.lock() {
+        *slot = Some(req);
+    }
+}
+
+/// Drain the parked cold-start spawn request, if any.
+pub fn take_pending_spawn(pending: &PendingSpawn) -> Option<SpawnRequest> {
+    pending.0.lock().ok().and_then(|mut slot| slot.take())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn none_location_resolves_to_home_not_missing() {
+        let home = PathBuf::from("/home/user");
+        let resolved = resolve_spawn_location(None, &home);
+        assert_eq!(resolved.cwd, home);
+        assert!(!resolved.missing);
+    }
+
+    #[test]
+    fn empty_location_resolves_to_home_not_missing() {
+        let home = PathBuf::from("/home/user");
+        let resolved = resolve_spawn_location(Some("   "), &home);
+        assert_eq!(resolved.cwd, home);
+        assert!(!resolved.missing);
+    }
+
+    #[test]
+    fn existing_directory_resolves_to_itself() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let home = PathBuf::from("/home/user");
+        let resolved = resolve_spawn_location(Some(dir.path().to_str().unwrap()), &home);
+        // Canonicalize the expectation too, to tolerate /var → /private/var on macOS.
+        assert_eq!(resolved.cwd, fs::canonicalize(dir.path()).unwrap());
+        assert!(!resolved.missing);
+    }
+
+    #[test]
+    fn existing_file_resolves_to_parent_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("script.sh");
+        fs::write(&file, b"echo hi").expect("write file");
+        let home = PathBuf::from("/home/user");
+        let resolved = resolve_spawn_location(Some(file.to_str().unwrap()), &home);
+        assert_eq!(resolved.cwd, fs::canonicalize(dir.path()).unwrap());
+        assert!(!resolved.missing);
+    }
+
+    #[test]
+    fn missing_path_falls_back_to_home_and_flags_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+        let home = PathBuf::from("/home/user");
+        let resolved = resolve_spawn_location(Some(missing.to_str().unwrap()), &home);
+        assert_eq!(resolved.cwd, home);
+        assert!(resolved.missing);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_directory_resolves_to_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real = dir.path().join("real-dir");
+        fs::create_dir(&real).expect("create real dir");
+        let link = dir.path().join("link-dir");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+        let home = PathBuf::from("/home/user");
+        let resolved = resolve_spawn_location(Some(link.to_str().unwrap()), &home);
+        assert_eq!(resolved.cwd, fs::canonicalize(&real).unwrap());
+        assert!(!resolved.missing);
+    }
+
+    #[test]
+    fn windows_path_converts_to_wsl_mount() {
+        assert_eq!(
+            windows_path_to_wsl_path(r"C:\Users\foo\bar.sh").as_deref(),
+            Some("/mnt/c/Users/foo/bar.sh")
+        );
+        assert_eq!(windows_path_to_wsl_path(r"D:\").as_deref(), Some("/mnt/d"));
+    }
+
+    #[test]
+    fn non_drive_path_has_no_wsl_conversion() {
+        assert_eq!(windows_path_to_wsl_path("/already/unix"), None);
+        assert_eq!(windows_path_to_wsl_path("relative/path"), None);
+    }
+
+    #[test]
+    fn build_shell_spawn_sets_starting_directory_and_spawned_flag() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let home = PathBuf::from("/home/user");
+        let req = SpawnRequest {
+            location: Some(dir.path().to_str().unwrap().to_string()),
+            kind: SpawnKind::Local,
+            ..SpawnRequest::default()
+        };
+        let spawn = build_shell_spawn(&req, &home);
+        assert!(spawn.spawned);
+        assert!(!spawn.missing);
+        assert!(spawn.title.contains("Spawned"), "title: {}", spawn.title);
+        let cwd = fs::canonicalize(dir.path()).unwrap();
+        assert_eq!(
+            spawn.settings["startingDirectory"],
+            json!(cwd.to_string_lossy())
+        );
+    }
+
+    #[test]
+    fn build_shell_spawn_missing_target_uses_home_and_flags_missing() {
+        let home = PathBuf::from("/home/user");
+        let req = SpawnRequest {
+            location: Some("/no/such/path/here".to_string()),
+            kind: SpawnKind::Local,
+            ..SpawnRequest::default()
+        };
+        let spawn = build_shell_spawn(&req, &home);
+        assert!(spawn.missing);
+        assert_eq!(
+            spawn.settings["startingDirectory"],
+            json!(home.to_string_lossy())
+        );
+    }
+
+    #[test]
+    fn build_shell_spawn_wsl_kind_converts_windows_path() {
+        // A WSL spawn's resolved Windows directory is converted to its /mnt path
+        // so the distribution opens in the right place. Use a path that does not
+        // exist so resolution falls back to `home` deterministically, then the
+        // WSL conversion applies to that Windows-style home.
+        let home = PathBuf::from(r"C:\Users\foo");
+        let req = SpawnRequest {
+            location: None,
+            kind: SpawnKind::Wsl,
+            ..SpawnRequest::default()
+        };
+        let spawn = build_shell_spawn(&req, &home);
+        assert_eq!(
+            spawn.settings["startingDirectory"],
+            json!("/mnt/c/Users/foo")
+        );
+    }
+}

--- a/src-tauri/src/spawn/handler.rs
+++ b/src-tauri/src/spawn/handler.rs
@@ -70,7 +70,37 @@ pub struct PendingSpawn(pub Mutex<Option<SpawnRequest>>);
 /// - Existing file → the file's parent directory, with symlinks resolved.
 /// - Missing path → `home`, flagged `missing = true`.
 pub fn resolve_spawn_location(location: Option<&str>, home: &Path) -> ResolvedLocation {
-    todo!("resolve_spawn_location")
+    let trimmed = location.map(str::trim).filter(|s| !s.is_empty());
+    let Some(loc) = trimmed else {
+        return ResolvedLocation {
+            cwd: home.to_path_buf(),
+            missing: false,
+        };
+    };
+
+    // `canonicalize` both resolves symlinks and requires the target to exist, so
+    // a missing path surfaces as an error and falls back to home.
+    match std::fs::canonicalize(loc) {
+        Ok(canon) => {
+            let cwd = if canon.is_dir() {
+                canon
+            } else {
+                // A file resolves to its parent directory.
+                canon
+                    .parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| home.to_path_buf())
+            };
+            ResolvedLocation {
+                cwd,
+                missing: false,
+            }
+        }
+        Err(_) => ResolvedLocation {
+            cwd: home.to_path_buf(),
+            missing: true,
+        },
+    }
 }
 
 /// Convert a Windows absolute path to its WSL `/mnt/` equivalent.
@@ -80,19 +110,70 @@ pub fn resolve_spawn_location(location: Option<&str>, home: &Path) -> ResolvedLo
 /// `core/src/backends/wsl.rs::windows_path_to_wsl_path` so WSL spawns land in the
 /// distribution-visible mount path.
 pub fn windows_path_to_wsl_path(win_path: &str) -> Option<String> {
-    todo!("windows_path_to_wsl_path")
+    // Parsed from the raw string (not `std::path::Component`) so the conversion
+    // is host-independent — `Path::components` only recognises a drive `Prefix`
+    // on Windows targets, which would make this untestable on macOS/Linux.
+    let bytes = win_path.as_bytes();
+    let drive = match bytes.first() {
+        Some(c) if c.is_ascii_alphabetic() => (*c as char).to_ascii_lowercase(),
+        _ => return None,
+    };
+    if bytes.get(1) != Some(&b':') {
+        return None;
+    }
+    // Strip the `C:` prefix, normalise separators, and trim leading/trailing
+    // slashes so the join below never produces `//` or a trailing `/`.
+    let rest = win_path[2..].replace('\\', "/");
+    let rest = rest.trim_matches('/');
+    if rest.is_empty() {
+        Some(format!("/mnt/{drive}"))
+    } else {
+        Some(format!("/mnt/{drive}/{rest}"))
+    }
 }
 
 /// Build the resolved [`ShellSpawn`] for a spawn request, resolving its target
 /// against `home`. For a WSL-kind spawn the resolved directory is converted to
 /// its `/mnt/` path so the distribution opens in the right place.
 pub fn build_shell_spawn(req: &SpawnRequest, home: &Path) -> ShellSpawn {
-    todo!("build_shell_spawn")
-}
+    let resolved = resolve_spawn_location(req.location.as_deref(), home);
+    if resolved.missing {
+        tracing::warn!(
+            requested = ?req.location,
+            "spawn target not found; opening the home directory"
+        );
+    }
 
-/// The home directory, falling back to `.` when it cannot be determined.
-fn home_dir() -> PathBuf {
-    dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))
+    let native = resolved.cwd.to_string_lossy().into_owned();
+    // A WSL spawn lands in the distribution's `/mnt/<drive>` view of the Windows
+    // directory; a non-convertible path is used unchanged.
+    let starting_directory = match req.kind {
+        SpawnKind::Wsl => windows_path_to_wsl_path(&native).unwrap_or(native),
+        _ => native,
+    };
+
+    // Serialised into the exact camelCase keys the local-shell backend parses
+    // (`startingDirectory`, `shellIntegration`); the shell itself is left to the
+    // system default. This is the `core/src/backends/local_shell.rs` `cwd` path,
+    // so the session opens `cd`'d to the target without a post-start `cd`.
+    let settings = json!({
+        "startingDirectory": starting_directory,
+        "shellIntegration": true,
+    });
+
+    let name = resolved
+        .cwd
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "Shell".to_string());
+
+    ShellSpawn {
+        settings,
+        title: format!("{name} (Spawned)"),
+        spawned: true,
+        missing: resolved.missing,
+    }
 }
 
 /// Focus the main window, best-effort. Logged (not fatal) on failure so a spawn

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -61,7 +61,7 @@ pub enum SpawnKind {
 impl SpawnKind {
     /// Parse a wire/CLI token (`container|local|wsl|ssh|auto`) into a kind.
     /// Returns `None` for unrecognised tokens so callers can degrade gracefully.
-    fn from_wire(token: &str) -> Option<Self> {
+    pub fn from_wire(token: &str) -> Option<Self> {
         match token {
             "container" => Some(Self::Container),
             "local" => Some(Self::Local),

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 compile_error!("spawn IPC requires a Unix or Windows target");
 
 pub mod container;
+pub mod handler;
 pub mod ipc_client;
 pub mod ipc_server;
 pub mod registry;

--- a/src/hooks/useSpawnRequests.test.ts
+++ b/src/hooks/useSpawnRequests.test.ts
@@ -13,9 +13,14 @@ vi.mock("@/services/events", () => ({
 }));
 
 const resolveContainerSpawn = vi.fn();
+const resolveShellSpawn = vi.fn();
+const takePendingSpawn = vi.fn();
 vi.mock("@/services/api", () => ({
   resolveContainerSpawn: (location: string, entryId?: string, image?: string, mount?: string) =>
     resolveContainerSpawn(location, entryId, image, mount),
+  resolveShellSpawn: (location?: string, connection?: string, entryId?: string, kind?: string) =>
+    resolveShellSpawn(location, connection, entryId, kind),
+  takePendingSpawn: () => takePendingSpawn(),
 }));
 
 vi.mock("@/components/ui", () => ({
@@ -35,7 +40,7 @@ import { useAppStore } from "@/store/appStore";
 import { toast } from "@/components/ui";
 import { getAllLeaves } from "@/utils/panelTree";
 import type { SpawnRequestPayload } from "@/services/events";
-import type { ContainerSpawn } from "@/services/api";
+import type { ContainerSpawn, ShellSpawn } from "@/services/api";
 import type { TerminalTab } from "@/types/terminal";
 
 const SAMPLE_SPAWN: ContainerSpawn = {
@@ -58,6 +63,13 @@ function containerRequest(overrides: Partial<SpawnRequestPayload> = {}): SpawnRe
   };
 }
 
+const SAMPLE_SHELL_SPAWN: ShellSpawn = {
+  settings: { startingDirectory: "/home/user/app", shellIntegration: true },
+  title: "app (Spawned)",
+  spawned: true,
+  missing: false,
+};
+
 /** Collect every terminal tab across the live root panel. */
 function allTabs(): TerminalTab[] {
   return getAllLeaves(useAppStore.getState().rootPanel).flatMap((leaf) => leaf.tabs);
@@ -75,6 +87,10 @@ describe("useSpawnRequests — container spawn wiring (#1446)", () => {
     emit = undefined;
     resolveContainerSpawn.mockReset();
     resolveContainerSpawn.mockResolvedValue(SAMPLE_SPAWN);
+    resolveShellSpawn.mockReset();
+    resolveShellSpawn.mockResolvedValue(SAMPLE_SHELL_SPAWN);
+    takePendingSpawn.mockReset();
+    takePendingSpawn.mockResolvedValue(null);
     vi.clearAllMocks();
   });
 
@@ -174,7 +190,7 @@ describe("useSpawnRequests — container spawn wiring (#1446)", () => {
     expect(allTabs().some((t) => t.spawned)).toBe(false);
   });
 
-  it("ignores a non-container spawn (SI-2 owns local/WSL/SSH)", async () => {
+  it("opens a shell tab for a non-container spawn (SI-2 local/WSL/SSH)", async () => {
     await mountHook();
 
     await act(async () => {
@@ -182,9 +198,19 @@ describe("useSpawnRequests — container spawn wiring (#1446)", () => {
       await Promise.resolve();
     });
 
+    // A non-container spawn is routed to the shell resolver, not the container one.
     expect(resolveContainerSpawn).not.toHaveBeenCalled();
-    expect(allTabs().some((t) => t.spawned)).toBe(false);
-    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+    expect(resolveShellSpawn).toHaveBeenCalledWith(
+      "/home/user/app",
+      undefined,
+      undefined,
+      undefined
+    );
+    const tab = allTabs().find((t) => t.spawned);
+    expect(tab?.connectionType).toBe("local");
+    expect(tab?.config.type).toBe("local");
+    expect(tab?.config.config).toEqual(SAMPLE_SHELL_SPAWN.settings);
+    expect(vi.mocked(toast.success)).toHaveBeenCalledTimes(1);
   });
 
   it("unsubscribes on unmount", async () => {
@@ -208,6 +234,10 @@ describe("useSpawnRequests — kind discriminator (#1465)", () => {
     emit = undefined;
     resolveContainerSpawn.mockReset();
     resolveContainerSpawn.mockResolvedValue(SAMPLE_SPAWN);
+    resolveShellSpawn.mockReset();
+    resolveShellSpawn.mockResolvedValue(SAMPLE_SHELL_SPAWN);
+    takePendingSpawn.mockReset();
+    takePendingSpawn.mockResolvedValue(null);
     vi.clearAllMocks();
   });
 
@@ -245,18 +275,20 @@ describe("useSpawnRequests — kind discriminator (#1465)", () => {
     );
   });
 
-  it("ignores an explicit local/WSL/SSH kind even when container fields are present", async () => {
+  it("routes an explicit local kind to the shell resolver even when container fields are present", async () => {
     await mountHook();
 
     // Container fields present but the authoritative kind says local → SI-2's
-    // job, not ours. The explicit discriminator wins over field presence.
+    // shell open path, not the container one. The discriminator wins over
+    // field presence.
     await act(async () => {
       emit!(containerRequest({ kind: "local" }));
       await Promise.resolve();
     });
 
     expect(resolveContainerSpawn).not.toHaveBeenCalled();
-    expect(allTabs().some((t) => t.spawned)).toBe(false);
+    expect(resolveShellSpawn).toHaveBeenCalledWith("/home/user/app", undefined, undefined, "local");
+    expect(allTabs().find((t) => t.spawned)?.connectionType).toBe("local");
   });
 
   it("falls back to presence inference for an auto kind (container)", async () => {
@@ -275,7 +307,7 @@ describe("useSpawnRequests — kind discriminator (#1465)", () => {
     );
   });
 
-  it("falls back to presence inference for an auto kind (non-container)", async () => {
+  it("falls back to presence inference for an auto kind (non-container → shell)", async () => {
     await mountHook();
 
     await act(async () => {
@@ -284,7 +316,8 @@ describe("useSpawnRequests — kind discriminator (#1465)", () => {
     });
 
     expect(resolveContainerSpawn).not.toHaveBeenCalled();
-    expect(allTabs().some((t) => t.spawned)).toBe(false);
+    expect(resolveShellSpawn).toHaveBeenCalledWith("/home/user/app", undefined, undefined, "auto");
+    expect(allTabs().find((t) => t.spawned)?.connectionType).toBe("local");
   });
 
   it("unsubscribes on unmount", async () => {
@@ -293,5 +326,105 @@ describe("useSpawnRequests — kind discriminator (#1465)", () => {
     // Re-create the root so afterEach's unmount is a no-op.
     root = createRoot(container);
     expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useSpawnRequests — shell spawn wiring (#1365, SI-2)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    emit = undefined;
+    resolveContainerSpawn.mockReset();
+    resolveContainerSpawn.mockResolvedValue(SAMPLE_SPAWN);
+    resolveShellSpawn.mockReset();
+    resolveShellSpawn.mockResolvedValue(SAMPLE_SHELL_SPAWN);
+    takePendingSpawn.mockReset();
+    takePendingSpawn.mockResolvedValue(null);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function mountHook(): Promise<void> {
+    function Harness() {
+      useSpawnRequests();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    // Two microtask flushes: subscribe, then drain the pending spawn.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("opens a shell tab at the resolved directory and confirms with a toast", async () => {
+    await mountHook();
+
+    await act(async () => {
+      emit!({ location: "/home/user/app", kind: "local" });
+      await Promise.resolve();
+    });
+
+    const tab = allTabs().find((t) => t.spawned);
+    expect(tab?.connectionType).toBe("local");
+    expect(tab?.config.config).toEqual(SAMPLE_SHELL_SPAWN.settings);
+    expect(tab?.title).toBe(SAMPLE_SHELL_SPAWN.title);
+    expect(vi.mocked(toast.success)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it("warns with an info toast when the target path was missing", async () => {
+    resolveShellSpawn.mockResolvedValue({
+      ...SAMPLE_SHELL_SPAWN,
+      settings: { startingDirectory: "/home/user", shellIntegration: true },
+      missing: true,
+    });
+    await mountHook();
+
+    await act(async () => {
+      emit!({ location: "/no/such/dir", kind: "local" });
+      await Promise.resolve();
+    });
+
+    expect(allTabs().some((t) => t.spawned)).toBe(true);
+    expect(vi.mocked(toast.info)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a recoverable error toast when shell resolution fails", async () => {
+    resolveShellSpawn.mockRejectedValue("boom");
+    await mountHook();
+
+    await act(async () => {
+      emit!({ location: "/home/user/app", kind: "local" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(toast.error).mock.calls[0][0])).toContain("boom");
+    expect(allTabs().some((t) => t.spawned)).toBe(false);
+  });
+
+  it("drains and opens a cold-start pending spawn once subscribed", async () => {
+    // A spawn parked before the UI was ready is picked up via take_pending_spawn.
+    takePendingSpawn.mockResolvedValue({ location: "/home/user/app", kind: "local" });
+    await mountHook();
+
+    expect(takePendingSpawn).toHaveBeenCalledTimes(1);
+    const tab = allTabs().find((t) => t.spawned);
+    expect(tab?.connectionType).toBe("local");
+    expect(tab?.config.config).toEqual(SAMPLE_SHELL_SPAWN.settings);
   });
 });

--- a/src/hooks/useSpawnRequests.ts
+++ b/src/hooks/useSpawnRequests.ts
@@ -2,8 +2,11 @@ import { useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
 import { toast } from "@/components/ui";
 import { onSpawnRequest, SpawnRequestPayload } from "@/services/events";
-import { resolveContainerSpawn } from "@/services/api";
+import { resolveContainerSpawn, resolveShellSpawn, takePendingSpawn } from "@/services/api";
 import { frontendLog } from "@/utils/frontendLog";
+
+/** Auto-dismiss duration (ms) for the spawn confirmation toast (#1365). */
+const SPAWN_TOAST_DURATION_MS = 3000;
 
 /**
  * Whether a spawn request targets a "new container" spawn (#1446/#1465).
@@ -31,48 +34,83 @@ function isContainerSpawn(req: SpawnRequestPayload): boolean {
 }
 
 /**
- * App-scoped hook that consumes `spawn-request` events (#1364/#1446). For a
- * container spawn it resolves the Docker settings via `resolve_container_spawn`
- * and opens a Docker session tab (badged "Spawned" and tracked separately from
- * configured connections), confirming with a toast. Non-container spawns are
- * short-circuited with a log — the local/WSL/SSH open path is SI-2's scope.
+ * Handle a single resolved spawn request, whether it arrived over the live
+ * `spawn-request` event or was drained from the cold-start pending slot.
+ *
+ * A container spawn resolves Docker settings via `resolve_container_spawn` and
+ * opens a Docker session tab (#1446). A local/WSL/SSH spawn resolves the target
+ * directory via `resolve_shell_spawn` and opens a shell tab `cd`'d there (#1365,
+ * SI-2). Either way a toast confirms the action; a missing path warns.
+ */
+async function handleSpawnRequest(
+  req: SpawnRequestPayload,
+  open: {
+    openSpawnedContainer: ReturnType<typeof useAppStore.getState>["openSpawnedContainer"];
+    openSpawnedShell: ReturnType<typeof useAppStore.getState>["openSpawnedShell"];
+  }
+): Promise<void> {
+  if (isContainerSpawn(req)) {
+    const location = req.location ?? "";
+    try {
+      const spawn = await resolveContainerSpawn(
+        location,
+        req.entry_id,
+        req.container_image,
+        req.container_mount
+      );
+      open.openSpawnedContainer(spawn);
+      toast.success(`Spawned container at ${location || "."}`, {
+        duration: SPAWN_TOAST_DURATION_MS,
+      });
+    } catch (err) {
+      frontendLog("spawn", `Failed to resolve container spawn: ${err}`);
+      toast.error(`Failed to open spawned container: ${err}`);
+    }
+    return;
+  }
+
+  // Local / WSL / SSH spawn: open a shell tab at the resolved target (SI-2).
+  try {
+    const spawn = await resolveShellSpawn(req.location, req.connection, req.entry_id, req.kind);
+    open.openSpawnedShell(spawn);
+    if (spawn.missing) {
+      toast.info(`Path not found — opened a shell in your home directory instead`, {
+        duration: SPAWN_TOAST_DURATION_MS,
+      });
+    } else {
+      toast.success(`Opened a shell at ${req.location || "."}`, {
+        duration: SPAWN_TOAST_DURATION_MS,
+      });
+    }
+  } catch (err) {
+    frontendLog("spawn", `Failed to resolve shell spawn: ${err}`);
+    toast.error(`Failed to open spawned shell: ${err}`);
+  }
+}
+
+/**
+ * App-scoped hook that consumes spawn requests (#1364/#1446/#1465/#1365).
+ *
+ * Subscribes to the live `spawn-request` event and, once subscribed, drains any
+ * cold-start pending spawn (parked by a freshly-launched instance before the UI
+ * was ready) via `take_pending_spawn`. Both feed the same {@link
+ * handleSpawnRequest} routing so container and local/WSL/SSH spawns behave
+ * identically no matter how they arrive.
  *
  * Registered once at app scope; the subscription is torn down on unmount.
  */
 export function useSpawnRequests(): void {
   const openSpawnedContainer = useAppStore((s) => s.openSpawnedContainer);
+  const openSpawnedShell = useAppStore((s) => s.openSpawnedShell);
 
   useEffect(() => {
     let unlisten: (() => void) | null = null;
     let disposed = false;
+    const open = { openSpawnedContainer, openSpawnedShell };
 
     const setup = async () => {
-      const off = await onSpawnRequest(async (req) => {
-        if (!isContainerSpawn(req)) {
-          // TODO(SI-2): local / WSL / SSH spawns are resolved and opened by a
-          // separate work item. Ignore them here rather than half-opening a
-          // session with the wrong backend.
-          frontendLog(
-            "spawn",
-            `Ignoring non-container spawn-request (SI-2 owns local/WSL/SSH): ${JSON.stringify(req)}`
-          );
-          return;
-        }
-
-        const location = req.location ?? "";
-        try {
-          const spawn = await resolveContainerSpawn(
-            location,
-            req.entry_id,
-            req.container_image,
-            req.container_mount
-          );
-          openSpawnedContainer(spawn);
-          toast.success(`Spawned container at ${location || "."}`);
-        } catch (err) {
-          frontendLog("spawn", `Failed to resolve container spawn: ${err}`);
-          toast.error(`Failed to open spawned container: ${err}`);
-        }
+      const off = await onSpawnRequest((req) => {
+        void handleSpawnRequest(req, open);
       });
       // If the effect was cleaned up before the async listen() resolved, tear
       // the listener down immediately so it does not leak.
@@ -81,6 +119,19 @@ export function useSpawnRequests(): void {
         return;
       }
       unlisten = off;
+
+      // The subscription is live — safe to drain a cold-start pending spawn now
+      // without racing the event. `take_pending_spawn` removes it from the
+      // backend, so once drained it must be processed even if this effect was
+      // torn down meanwhile (e.g. StrictMode remount) — otherwise it is lost.
+      try {
+        const pending = await takePendingSpawn();
+        if (pending) {
+          void handleSpawnRequest(pending, open);
+        }
+      } catch (err) {
+        frontendLog("spawn", `Failed to drain pending spawn: ${err}`);
+      }
     };
 
     void setup();
@@ -89,5 +140,5 @@ export function useSpawnRequests(): void {
       disposed = true;
       unlisten?.();
     };
-  }, [openSpawnedContainer]);
+  }, [openSpawnedContainer, openSpawnedShell]);
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -13,6 +13,7 @@ import {
 } from "@/types/terminal";
 import { XServerConsentDecision, XServerStatusReport } from "@/types/xserver";
 import { CredentialStoreStatusInfo, SwitchCredentialStoreResult } from "@/types/credential";
+import type { SpawnRequestPayload } from "@/services/events";
 import {
   SavedConnection,
   ConnectionFolder,
@@ -169,6 +170,57 @@ export async function resolveContainerSpawn(
     containerImage,
     containerMount,
   });
+}
+
+/**
+ * A resolved local/WSL/SSH shell spawn (#1365, SI-2). Mirrors the Rust
+ * `ShellSpawn`: the camelCase local-shell backend `settings` (with the resolved
+ * target as `startingDirectory`) to open the session with, a `"… (Spawned)"` tab
+ * `title`, `spawned: true` so it is tracked separately from saved connections,
+ * and `missing: true` when the requested path did not exist and the home
+ * directory was substituted.
+ */
+export interface ShellSpawn {
+  /** Local-shell backend settings (camelCase) for the spawned session. */
+  settings: Record<string, unknown>;
+  /** Display title carrying the "Spawned" marker for the tab badge. */
+  title: string;
+  /** Always `true` — distinguishes spawned shells from saved connections. */
+  spawned: boolean;
+  /** `true` when the requested path was missing and home was substituted. */
+  missing: boolean;
+}
+
+/**
+ * Resolve an external local/WSL/SSH spawn into local-shell session settings
+ * (#1365). Given the spawn `location` (folder, file, or missing path) and its
+ * `kind`, the backend resolves the working directory (folder → itself, file →
+ * parent, missing → home, symlinks resolved; a WSL spawn is converted to its
+ * `/mnt/` path) and returns the settings + title used to open a shell tab `cd`'d
+ * to the target.
+ */
+export async function resolveShellSpawn(
+  location?: string,
+  connection?: string,
+  entryId?: string,
+  kind?: string
+): Promise<ShellSpawn> {
+  return await invoke<ShellSpawn>("resolve_shell_spawn", {
+    location,
+    connection,
+    entryId,
+    kind,
+  });
+}
+
+/**
+ * Drain the cold-start pending spawn, if any (#1365). A freshly-launched
+ * instance parks a spawn handed to it before the UI was ready; the frontend
+ * calls this once its `spawn-request` subscription is registered to pick it up.
+ * Returns `null` when nothing is pending.
+ */
+export async function takePendingSpawn(): Promise<SpawnRequestPayload | null> {
+  return await invoke<SpawnRequestPayload | null>("take_pending_spawn");
 }
 
 /** Send input data to a terminal session */

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -103,7 +103,7 @@ import {
   detachPersistentTab as apiDetachPersistentTab,
   saveShellIntegrationSettings,
 } from "@/services/api";
-import type { ConnectionTypeInfo, ContainerSpawn } from "@/services/api";
+import type { ConnectionTypeInfo, ContainerSpawn, ShellSpawn } from "@/services/api";
 import { RemoteAgentConfig } from "@/types/terminal";
 import { TunnelConfig, TunnelState } from "@/types/tunnel";
 import { EmbeddedServerConfig, ServerState as EmbeddedServerState } from "@/types/embeddedServer";
@@ -352,6 +352,13 @@ interface AppState {
    * Returns the created tab id.
    */
   openSpawnedContainer: (spawn: ContainerSpawn) => string;
+  /**
+   * Open a local-shell session tab for a resolved external local/WSL/SSH spawn
+   * (#1365, SI-2). Reuses the standard {@link addTab} open path with the spawn's
+   * shell settings (the resolved target as `startingDirectory`) + tab title and
+   * marks the tab `spawned` (no saved connection id). Returns the created tab id.
+   */
+  openSpawnedShell: (spawn: ShellSpawn) => string;
 
   // Persistent connection sessions
   /** Live state of all persistent connection sessions, keyed by connectionId. */
@@ -2111,6 +2118,14 @@ export const useAppStore = create<AppState>((set, get) => {
         spawn.title,
         "docker",
         { type: "docker", config: spawn.settings },
+        { contentType: "terminal", spawned: true }
+      ),
+
+    openSpawnedShell: (spawn) =>
+      get().addTab(
+        spawn.title,
+        "local",
+        { type: "local", config: spawn.settings },
         { contentType: "terminal", spawned: true }
       ),
 


### PR DESCRIPTION
Closes #1365
Part of Epic #1363

## Summary

Processes a resolved `SpawnRequest` for a **local/WSL/SSH** target inside the running app (SI-2): the window is focused, a shell tab opens `cd`'d to the target directory, and a toast confirms the action. This is the parallel of the already-merged container-spawn path (#1446/#1465).

## Wiring approach (deviation from the issue's proposed new event)

The issue proposed a **new** `spawn-open-session` event + a new `pendingSpawnRequest` store slot. In this codebase the container path (#1446/#1465) already established a single consumer — the `spawn-request` event routed through `useSpawnRequests` and branching on the `kind` discriminator, with the local/WSL/SSH branch left as a `TODO(SI-2)`. **Adding a second event + consumer would duplicate that machinery**, so instead this PR **extends the existing consumer**: the `TODO(SI-2)` branch now resolves the target via a new `resolve_shell_spawn` command (mirroring `resolve_container_spawn`) and opens a spawned local-shell tab. No competing consumer is introduced.

Two smaller deviations, both noted for reviewers:
- **`cd` via the shell's `startingDirectory`, not a post-start `send_input`.** The resolved directory is passed as the local-shell `startingDirectory` (the `core/src/backends/local_shell.rs` `cwd` path the issue references), so the shell opens `cd`'d there without racing the prompt.
- **Toast uses the shared bottom-right toaster (3 s auto-dismiss), not a new top toast.** Repositioning is a global `<Toaster/>` concern (design system: one motion language) and out of scope for a single feature.

## What changed

- **`spawn/handler.rs`** (new): pure `resolve_spawn_location` (folder → itself, file → parent, missing → home + warn flag, symlinks resolved) + `windows_path_to_wsl_path` (host-independent so it is testable on macOS) + `build_shell_spawn`. Plus `emit_spawn_request` (focus + emit) and a `PendingSpawn` cold-start slot with `store`/`take`.
- **`commands/spawn.rs`**: `resolve_shell_spawn` and `take_pending_spawn` commands.
- **`lib.rs` / `macos_services.rs`**: every warm spawn now **focuses the window** at the shared emit sites; the cold-start pending spawn is **parked** (not emitted into the void) and drained by the frontend once its subscription is live.
- **Frontend**: `resolveShellSpawn` / `takePendingSpawn` API, `openSpawnedShell` store action, and the extended `useSpawnRequests` hook (routes non-container spawns, drains the cold-start pending, toasts success / info-on-missing / error).

## SI scope boundary

In: local/WSL/SSH open path, path resolution, window focus, cold-start handling, confirmation toast. Out: the interactive picker (SI-3), container spawn (SI-9, #1446), registration (SI-5/6/7). WSL/SSH currently open a local shell at the resolved (WSL-converted) path rather than a real WSL-distro/SSH session — proper backend selection needs connection resolution and is tracked as follow-up **#1511**.

## Test plan

- **Unit (backend, TDD):** `resolve_spawn_location` — dir → dir, file → parent, missing → home (flagged), symlink → target; `windows_path_to_wsl_path` — `C:\…` → `/mnt/c/…`, non-drive → none; `build_shell_spawn` wiring + WSL conversion. `cargo test -p termihub spawn::handler` (11 tests, committed failing first).
- **Unit (frontend):** `useSpawnRequests.test.ts` — shell open, entry/kind routing, missing → info toast, error toast, cold-start pending drain. Full `pnpm test` suite green (3074).
- **System (Python bridge):** not run here (bridge not runnable in this environment); the local/WSL/missing/cold-start flows are captured as **manual steps** in `docs/testing.md`.
- **Manual:** focus + open behavior per-OS (esp. Wayland) — see `docs/testing.md`.

Checks: `cargo build/clippy/fmt -p termihub`, `tsc --noEmit`, `eslint`, `prettier --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)