### PR TITLE
feat(ftp): keep-alive, auto-reconnect, encoding + protocol-quirk robustness (Closes #1339)

### DIFF
--- a/core/src/backends/ftp/file_browser.rs
+++ b/core/src/backends/ftp/file_browser.rs
@@ -8,11 +8,22 @@
 //! Directory listings prefer the machine-readable `MLSD` command and fall back
 //! to `LIST` (parsed by [`listing_parser`](super::listing_parser)) when the
 //! server does not support it.
+//!
+//! ## Robustness (issue #1339)
+//!
+//! Every operation runs through [`reconnect::run_with_reconnect`]: a transport
+//! failure (a dropped idle control connection, a transient network fault)
+//! transparently re-establishes the connection and retries, up to
+//! [`reconnect::MAX_RECONNECT_RETRIES`] times. Each reconnect also advances the
+//! data-channel fallback one step (extended passive → passive), so a server that
+//! rejects `EPSV` degrades gracefully to classic `PASV`.
 
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use futures_util::io::{AsyncReadExt, Cursor};
-use suppaftp::{AsyncRustlsFtpStream, FtpError};
+use suppaftp::{AsyncRustlsFtpStream, FtpError, Mode};
 use tokio::sync::Mutex;
 
 use crate::config::FtpConfig;
@@ -20,6 +31,7 @@ use crate::errors::FileError;
 use crate::files::{FileBrowser, FileEntry};
 
 use super::listing_parser::{parse_list, parse_mlsd, parse_mlsd_line};
+use super::reconnect;
 
 /// FTP-backed file browser for a single FTP/FTPS connection.
 ///
@@ -28,6 +40,12 @@ use super::listing_parser::{parse_list, parse_mlsd, parse_mlsd_line};
 pub(crate) struct FtpFileBrowser {
     config: FtpConfig,
     client: Arc<Mutex<Option<AsyncRustlsFtpStream>>>,
+    /// Ordered data-channel modes to try (`EPSV`→`PASV` for passive). The index
+    /// advances on each reconnect, so a passive-mode data failure degrades to
+    /// the more widely supported classic `PASV`.
+    data_modes: Vec<Mode>,
+    /// Current index into [`data_modes`](Self::data_modes).
+    mode_index: AtomicUsize,
 }
 
 /// Map a [`suppaftp`] error to a [`FileError`], tagging it with the operation.
@@ -38,23 +56,101 @@ fn map_err(op: &str, err: FtpError) -> FileError {
 impl FtpFileBrowser {
     /// Create a browser for `config`; no connection is opened until first use.
     pub(crate) fn new(config: FtpConfig) -> Self {
+        let data_modes = super::data_mode_chain(config.mode);
         Self {
             config,
             client: Arc::new(Mutex::new(None)),
+            data_modes,
+            mode_index: AtomicUsize::new(0),
         }
     }
 
-    /// Ensure the browsing control connection is established.
+    /// A clone of the shared control-connection handle, for the keep-alive task.
+    pub(crate) fn shared_client(&self) -> Arc<Mutex<Option<AsyncRustlsFtpStream>>> {
+        self.client.clone()
+    }
+
+    /// Test-only: forcibly shut the live control socket down to simulate a
+    /// mid-session control-connection drop. Returns `true` if a connection was
+    /// open and closed.
+    #[doc(hidden)]
+    pub(crate) async fn debug_drop_connection(&self) -> bool {
+        let guard = self.client.lock().await;
+        match guard.as_ref() {
+            Some(stream) => {
+                let _ = stream.get_ref().shutdown(std::net::Shutdown::Both);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// The data-channel mode currently in effect (the reconnect fallback point).
+    fn current_mode(&self) -> Mode {
+        let last = self.data_modes.len().saturating_sub(1);
+        let idx = self.mode_index.load(Ordering::Relaxed).min(last);
+        self.data_modes.get(idx).copied().unwrap_or(Mode::Passive)
+    }
+
+    /// Ensure the browsing control connection is established (using the current
+    /// data-channel mode).
     async fn ensure_connected(&self) -> Result<(), FileError> {
         let mut guard = self.client.lock().await;
         if guard.is_some() {
             return Ok(());
         }
-        let stream = super::establish(&self.config)
+        let stream = super::establish_with_mode(&self.config, self.current_mode())
             .await
             .map_err(|e| FileError::OperationFailed(format!("FTP connection failed: {e}")))?;
         *guard = Some(stream);
         Ok(())
+    }
+
+    /// Re-establish the control connection after a drop, advancing the
+    /// data-channel fallback one step (`EPSV`→`PASV`) so a passive failure
+    /// degrades gracefully.
+    async fn reconnect(&self) -> Result<(), FtpError> {
+        let last = self.data_modes.len().saturating_sub(1);
+        let prev = self.mode_index.load(Ordering::Relaxed);
+        if prev < last {
+            self.mode_index.store(prev + 1, Ordering::Relaxed);
+        }
+        let mut guard = self.client.lock().await;
+        *guard = None;
+        let stream = super::establish_with_mode(&self.config, self.current_mode())
+            .await
+            .map_err(|e| {
+                FtpError::ConnectionError(std::io::Error::other(format!(
+                    "FTP reconnect failed: {e}"
+                )))
+            })?;
+        *guard = Some(stream);
+        Ok(())
+    }
+
+    /// Run `op` with the auto-reconnect retry policy, mapping the final error to
+    /// a [`FileError`] tagged with `op_name`.
+    async fn with_reconnect<T, Op, OpFut>(&self, op_name: &str, op: Op) -> Result<T, FileError>
+    where
+        Op: FnMut() -> OpFut,
+        OpFut: Future<Output = Result<T, FtpError>>,
+    {
+        self.ensure_connected().await?;
+        reconnect::run_with_reconnect(
+            reconnect::MAX_RECONNECT_RETRIES,
+            reconnect::is_connection_error,
+            reconnect::reconnect_backoff,
+            op,
+            || self.reconnect(),
+        )
+        .await
+        .map_err(|e| map_err(op_name, e))
+    }
+
+    /// Lock the shared stream, returning a retryable "not connected" error when
+    /// the slot is empty (so the retry driver reconnects).
+    async fn locked_stream(&self) -> tokio::sync::MutexGuard<'_, Option<AsyncRustlsFtpStream>> {
+        self.client.lock().await
     }
 }
 
@@ -74,94 +170,75 @@ fn split_parent(path: &str) -> (String, String) {
 #[async_trait::async_trait]
 impl FileBrowser for FtpFileBrowser {
     async fn list_dir(&self, path: &str) -> Result<Vec<FileEntry>, FileError> {
-        self.ensure_connected().await?;
-        let mut guard = self.client.lock().await;
-        let stream = guard
-            .as_mut()
-            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
-
-        // Prefer MLSD (machine-readable); fall back to LIST when unsupported.
-        match stream.mlsd(Some(path)).await {
-            Ok(lines) => Ok(parse_mlsd(&lines, path)),
-            Err(_) => {
-                let lines = stream
-                    .list(Some(path))
-                    .await
-                    .map_err(|e| map_err("LIST", e))?;
-                Ok(parse_list(&lines, path))
+        self.with_reconnect("LIST", || async {
+            let mut guard = self.locked_stream().await;
+            let stream = guard.as_mut().ok_or_else(reconnect::not_connected_err)?;
+            // Prefer MLSD (machine-readable). A connection error propagates so the
+            // driver reconnects; a protocol error means MLSD is unsupported, so we
+            // fall back to LIST on the (still-live) connection.
+            match stream.mlsd(Some(path)).await {
+                Ok(lines) => Ok(parse_mlsd(&lines, path)),
+                Err(FtpError::ConnectionError(e)) => Err(FtpError::ConnectionError(e)),
+                Err(_) => {
+                    let lines = stream.list(Some(path)).await?;
+                    Ok(parse_list(&lines, path))
+                }
             }
-        }
+        })
+        .await
     }
 
     async fn read_file(&self, path: &str) -> Result<Vec<u8>, FileError> {
-        self.ensure_connected().await?;
-        let mut guard = self.client.lock().await;
-        let stream = guard
-            .as_mut()
-            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
-
-        let mut data_stream = stream
-            .retr_as_stream(path)
-            .await
-            .map_err(|e| map_err("RETR", e))?;
-        let mut buf = Vec::new();
-        data_stream
-            .read_to_end(&mut buf)
-            .await
-            .map_err(|e| FileError::OperationFailed(format!("FTP read failed: {e}")))?;
-        stream
-            .finalize_retr_stream(data_stream)
-            .await
-            .map_err(|e| map_err("RETR", e))?;
-        Ok(buf)
+        self.with_reconnect("RETR", || async {
+            let mut guard = self.locked_stream().await;
+            let stream = guard.as_mut().ok_or_else(reconnect::not_connected_err)?;
+            let mut data_stream = stream.retr_as_stream(path).await?;
+            let mut buf = Vec::new();
+            data_stream
+                .read_to_end(&mut buf)
+                .await
+                .map_err(FtpError::ConnectionError)?;
+            stream.finalize_retr_stream(data_stream).await?;
+            Ok(buf)
+        })
+        .await
     }
 
     async fn write_file(&self, path: &str, data: &[u8]) -> Result<(), FileError> {
-        self.ensure_connected().await?;
-        let mut guard = self.client.lock().await;
-        let stream = guard
-            .as_mut()
-            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
-
-        let mut cursor = Cursor::new(data);
-        stream
-            .put_file(path, &mut cursor)
-            .await
-            .map_err(|e| map_err("STOR", e))?;
-        Ok(())
+        self.with_reconnect("STOR", || async {
+            let mut guard = self.locked_stream().await;
+            let stream = guard.as_mut().ok_or_else(reconnect::not_connected_err)?;
+            let mut cursor = Cursor::new(data);
+            stream.put_file(path, &mut cursor).await?;
+            Ok(())
+        })
+        .await
     }
 
     async fn delete(&self, path: &str) -> Result<(), FileError> {
-        self.ensure_connected().await?;
-        let mut guard = self.client.lock().await;
-        let stream = guard
-            .as_mut()
-            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
-
         // FTP deletes files with DELE and directories with RMD, and the trait
-        // does not tell us which. Try DELE first; on failure, treat it as a
-        // directory and try RMD.
-        match stream.rm(path).await {
-            Ok(()) => Ok(()),
-            Err(file_err) => stream.rmdir(path).await.map_err(|dir_err| {
-                FileError::OperationFailed(format!(
-                    "FTP delete failed (DELE: {file_err}; RMD: {dir_err})"
-                ))
-            }),
-        }
+        // does not tell us which. Try DELE first; on a *protocol* failure, treat
+        // it as a directory and try RMD. A connection error propagates so the
+        // retry driver reconnects rather than misfiring RMD on a dead stream.
+        self.with_reconnect("delete", || async {
+            let mut guard = self.locked_stream().await;
+            let stream = guard.as_mut().ok_or_else(reconnect::not_connected_err)?;
+            match stream.rm(path).await {
+                Ok(()) => Ok(()),
+                Err(FtpError::ConnectionError(e)) => Err(FtpError::ConnectionError(e)),
+                Err(_) => stream.rmdir(path).await,
+            }
+        })
+        .await
     }
 
     async fn rename(&self, from: &str, to: &str) -> Result<(), FileError> {
-        self.ensure_connected().await?;
-        let mut guard = self.client.lock().await;
-        let stream = guard
-            .as_mut()
-            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
-
-        stream
-            .rename(from, to)
-            .await
-            .map_err(|e| map_err("RNFR/RNTO", e))
+        self.with_reconnect("RNFR/RNTO", || async {
+            let mut guard = self.locked_stream().await;
+            let stream = guard.as_mut().ok_or_else(reconnect::not_connected_err)?;
+            stream.rename(from, to).await
+        })
+        .await
     }
 
     async fn stat(&self, path: &str) -> Result<FileEntry, FileError> {
@@ -178,47 +255,43 @@ impl FileBrowser for FtpFileBrowser {
             });
         }
 
-        self.ensure_connected().await?;
         let (parent, base) = split_parent(path);
 
-        let mut guard = self.client.lock().await;
-        let stream = guard
-            .as_mut()
-            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
+        let found = self
+            .with_reconnect("stat", || async {
+                let mut guard = self.locked_stream().await;
+                let stream = guard.as_mut().ok_or_else(reconnect::not_connected_err)?;
 
-        // Prefer MLST (single-entry machine listing).
-        if let Ok(line) = stream.mlst(Some(path)).await {
-            if let Some(entry) = parse_mlsd_line(line.as_bytes(), &parent) {
-                return Ok(entry);
-            }
-        }
+                // Prefer MLST (single-entry machine listing).
+                if let Ok(line) = stream.mlst(Some(path)).await {
+                    if let Some(entry) = parse_mlsd_line(line.as_bytes(), &parent) {
+                        return Ok(Some(entry));
+                    }
+                }
 
-        // Fall back to listing the parent and matching by name.
-        let entries = match stream.mlsd(Some(&parent)).await {
-            Ok(lines) => parse_mlsd(&lines, &parent),
-            Err(_) => {
-                let lines = stream
-                    .list(Some(&parent))
-                    .await
-                    .map_err(|e| map_err("LIST", e))?;
-                parse_list(&lines, &parent)
-            }
-        };
+                // Fall back to listing the parent and matching by name.
+                let entries = match stream.mlsd(Some(&parent)).await {
+                    Ok(lines) => parse_mlsd(&lines, &parent),
+                    Err(FtpError::ConnectionError(e)) => return Err(FtpError::ConnectionError(e)),
+                    Err(_) => {
+                        let lines = stream.list(Some(&parent)).await?;
+                        parse_list(&lines, &parent)
+                    }
+                };
+                Ok(entries.into_iter().find(|e| e.name == base))
+            })
+            .await?;
 
-        entries
-            .into_iter()
-            .find(|e| e.name == base)
-            .ok_or_else(|| FileError::NotFound(path.to_string()))
+        found.ok_or_else(|| FileError::NotFound(path.to_string()))
     }
 
     async fn mkdir(&self, path: &str) -> Result<(), FileError> {
-        self.ensure_connected().await?;
-        let mut guard = self.client.lock().await;
-        let stream = guard
-            .as_mut()
-            .ok_or_else(|| FileError::OperationFailed("FTP not connected".to_string()))?;
-
-        stream.mkdir(path).await.map_err(|e| map_err("MKD", e))
+        self.with_reconnect("MKD", || async {
+            let mut guard = self.locked_stream().await;
+            let stream = guard.as_mut().ok_or_else(reconnect::not_connected_err)?;
+            stream.mkdir(path).await
+        })
+        .await
     }
 }
 
@@ -246,5 +319,34 @@ mod tests {
         fn assert_send<T: Send>() {}
         assert_send::<FtpFileBrowser>();
         assert_send::<Box<dyn FileBrowser>>();
+    }
+
+    #[test]
+    fn passive_browser_starts_on_extended_passive_then_falls_back() {
+        // A passive-mode browser begins on EPSV; after a reconnect the fallback
+        // advances one step to classic PASV, and stays there.
+        let browser = FtpFileBrowser::new(FtpConfig::default());
+        assert_eq!(browser.current_mode(), Mode::ExtendedPassive);
+
+        // Simulate the reconnect fallback advance (without a live server).
+        browser.mode_index.store(1, Ordering::Relaxed);
+        assert_eq!(browser.current_mode(), Mode::Passive);
+
+        // Never advances past the last entry.
+        browser.mode_index.store(99, Ordering::Relaxed);
+        assert_eq!(browser.current_mode(), Mode::Passive);
+    }
+
+    #[test]
+    fn active_browser_has_single_mode() {
+        let cfg = FtpConfig {
+            mode: crate::config::FtpDataMode::Active,
+            ..FtpConfig::default()
+        };
+        let browser = FtpFileBrowser::new(cfg);
+        assert_eq!(browser.current_mode(), Mode::Active);
+        // No fallback exists; the mode is stable even if the index is bumped.
+        browser.mode_index.store(5, Ordering::Relaxed);
+        assert_eq!(browser.current_mode(), Mode::Active);
     }
 }

--- a/core/src/backends/ftp/mod.rs
+++ b/core/src/backends/ftp/mod.rs
@@ -11,8 +11,10 @@
 
 mod file_browser;
 mod listing_parser;
+pub(crate) mod reconnect;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use file_browser::FtpFileBrowser;
 
@@ -21,6 +23,8 @@ use futures_rustls::rustls::{ClientConfig, RootCertStore};
 use futures_rustls::TlsConnector;
 use suppaftp::types::{FileType, FormatControl};
 use suppaftp::{AsyncRustlsConnector, AsyncRustlsFtpStream, FtpError, Mode};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 use tracing::{debug, info};
 
 use crate::config::{FtpConfig, FtpDataMode, FtpTlsMode, FtpTransferType};
@@ -50,6 +54,10 @@ pub struct Ftp {
     /// own control connection (opened lazily) so it can offer the `&self`-based
     /// [`FileBrowser`] API independently of this session's mutable stream.
     browser: Option<FtpFileBrowser>,
+    /// Background keep-alive task sending periodic `NOOP`s on the browsing
+    /// connection; aborted on [`disconnect`](ConnectionType::disconnect) and on
+    /// drop so no task outlives the session.
+    keep_alive: Option<JoinHandle<()>>,
 }
 
 impl Ftp {
@@ -58,6 +66,82 @@ impl Ftp {
         Self {
             client: None,
             browser: None,
+            keep_alive: None,
+        }
+    }
+
+    /// Test-only hook: forcibly close the file browser's control socket to
+    /// simulate a mid-session control-connection drop, so integration tests can
+    /// assert the auto-reconnect path recovers. Returns `true` when a live
+    /// connection was closed.
+    #[doc(hidden)]
+    pub async fn debug_drop_browsing_connection(&self) -> bool {
+        match &self.browser {
+            Some(browser) => browser.debug_drop_connection().await,
+            None => false,
+        }
+    }
+}
+
+impl Drop for Ftp {
+    fn drop(&mut self) {
+        if let Some(handle) = self.keep_alive.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Build the actionable connect-timeout error message for `host:port`.
+///
+/// A bare "timed out" is unhelpful; this names the endpoint and suggests the
+/// common causes (wrong host/port, server down, firewall) so the user has
+/// something to check (concept: "surface a clear error with suggestions").
+fn connection_timeout_message(host: &str, port: u16, secs: u64) -> String {
+    format!(
+        "FTP connection to {host}:{port} timed out after {secs}s. Check that the host \
+         and port are correct, the server is running, and no firewall is blocking the \
+         connection."
+    )
+}
+
+/// Ordered list of suppaftp data-channel [`Mode`]s to attempt for `mode`.
+///
+/// For passive connections we prefer **extended passive** (`EPSV`, RFC 2428):
+/// it is the modern command, works over IPv6, and returns only a port (no
+/// address), sidestepping the NAT address-rewriting pitfalls of classic `PASV`.
+/// Servers that predate or disable `EPSV` reject it, so classic `PASV` follows
+/// as the graceful fallback. Active mode has no alternate.
+pub(crate) fn data_mode_chain(mode: FtpDataMode) -> Vec<Mode> {
+    match mode {
+        FtpDataMode::Passive => vec![Mode::ExtendedPassive, Mode::Passive],
+        FtpDataMode::Active => vec![Mode::Active],
+    }
+}
+
+/// Periodic `NOOP` keep-alive for the browsing control connection.
+///
+/// Every `interval`, when the connection is idle (the lock is free) and
+/// established, a `NOOP` is sent to stop the server dropping it. A failed `NOOP`
+/// means the connection is already dead, so the stream is dropped and the next
+/// file operation re-establishes it via the reconnect path. The task runs until
+/// the [`Ftp`] backend aborts its handle.
+async fn keep_alive_loop(client: Arc<Mutex<Option<AsyncRustlsFtpStream>>>, interval: Duration) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // The first tick fires immediately; consume it so the first NOOP waits a
+    // full interval rather than firing right after connect.
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        // `try_lock` so keep-alive never contends with an in-flight operation.
+        let Ok(mut guard) = client.try_lock() else {
+            continue;
+        };
+        if let Some(stream) = guard.as_mut() {
+            if let Err(e) = stream.noop().await {
+                debug!("FTP keep-alive NOOP failed; dropping idle connection: {e}");
+                *guard = None;
+            }
         }
     }
 }
@@ -93,9 +177,27 @@ fn build_tls_connector() -> Result<AsyncRustlsConnector, SessionError> {
     ))))
 }
 
-/// Establish the control connection: TCP → optional TLS → auth → mode →
-/// transfer type → initial `CWD`.
+/// Establish the control connection using the preferred data-channel mode for
+/// `config` (the first entry of [`data_mode_chain`] — extended passive for
+/// passive connections).
 async fn establish(config: &FtpConfig) -> Result<AsyncRustlsFtpStream, SessionError> {
+    let mode = data_mode_chain(config.mode)
+        .into_iter()
+        .next()
+        .unwrap_or(Mode::Passive);
+    establish_with_mode(config, mode).await
+}
+
+/// Establish the control connection with an explicit data-channel `mode`: TCP →
+/// optional TLS → auth → mode → transfer type → initial `CWD`.
+///
+/// Taking the mode explicitly lets the reconnect path downgrade extended passive
+/// (`EPSV`) to classic passive (`PASV`) on a re-establish without re-reading the
+/// config.
+async fn establish_with_mode(
+    config: &FtpConfig,
+    mode: Mode,
+) -> Result<AsyncRustlsFtpStream, SessionError> {
     let addr = format!("{}:{}", config.host, config.port);
 
     // TCP connect + optional TLS negotiation.
@@ -121,11 +223,8 @@ async fn establish(config: &FtpConfig) -> Result<AsyncRustlsFtpStream, SessionEr
             .map_err(map_ftp_err)?,
     };
 
-    // Data-channel mode (passive/active).
-    stream.set_mode(match config.mode {
-        FtpDataMode::Passive => Mode::Passive,
-        FtpDataMode::Active => Mode::Active,
-    });
+    // Data-channel mode (passive/extended-passive/active).
+    stream.set_mode(mode);
 
     // Authenticate.
     if config.anonymous {
@@ -326,6 +425,21 @@ fn transfer_group() -> SettingsGroup {
                     },
                 )
             },
+            SettingsField {
+                default: Some(serde_json::json!(60)),
+                description: Some(
+                    "Send a periodic NOOP to keep an idle connection alive (0 disables it)"
+                        .to_string(),
+                ),
+                ..base_field(
+                    "keepAliveSecs",
+                    "Keep-alive (s)",
+                    FieldType::Number {
+                        min: Some(0.0),
+                        max: None,
+                    },
+                )
+            },
         ],
     }
 }
@@ -390,18 +504,32 @@ impl ConnectionType for Ftp {
         let stream = tokio::time::timeout(config.timeout(), establish(&config))
             .await
             .map_err(|_| {
-                SessionError::SpawnFailed(format!(
-                    "FTP connect timed out after {}s",
-                    config.timeout_secs
+                SessionError::SpawnFailed(connection_timeout_message(
+                    &config.host,
+                    config.port,
+                    config.timeout_secs,
                 ))
             })??;
 
+        // Bind the browser and start the idle keep-alive task (if enabled) on its
+        // shared control connection.
+        let keep_alive_interval = config.keep_alive_interval();
+        let browser = FtpFileBrowser::new(config);
+        if let Some(interval) = keep_alive_interval {
+            let shared = browser.shared_client();
+            self.keep_alive = Some(tokio::spawn(keep_alive_loop(shared, interval)));
+        }
+
         self.client = Some(stream);
-        self.browser = Some(FtpFileBrowser::new(config));
+        self.browser = Some(browser);
         Ok(())
     }
 
     async fn disconnect(&mut self) -> Result<(), SessionError> {
+        // Stop the keep-alive task first so it never touches a closing stream.
+        if let Some(handle) = self.keep_alive.take() {
+            handle.abort();
+        }
         // Drop the browser (closing its own control connection, if opened).
         self.browser = None;
         if let Some(mut client) = self.client.take() {
@@ -630,6 +758,45 @@ mod tests {
         let ftp = Ftp::new();
         assert!(ftp.write(b"ignored").is_ok());
         assert!(ftp.resize(80, 24).is_ok());
+    }
+
+    #[test]
+    fn data_mode_chain_prefers_epsv_then_pasv_for_passive() {
+        // Passive connections try EPSV first, then fall back to classic PASV.
+        assert_eq!(
+            data_mode_chain(FtpDataMode::Passive),
+            vec![Mode::ExtendedPassive, Mode::Passive]
+        );
+    }
+
+    #[test]
+    fn data_mode_chain_active_has_no_fallback() {
+        assert_eq!(data_mode_chain(FtpDataMode::Active), vec![Mode::Active]);
+    }
+
+    #[test]
+    fn establish_uses_extended_passive_as_first_choice() {
+        // `establish` selects the head of the chain; for the default (passive)
+        // config that is extended passive (EPSV).
+        let first = data_mode_chain(FtpConfig::default().mode)
+            .into_iter()
+            .next()
+            .unwrap();
+        assert_eq!(first, Mode::ExtendedPassive);
+    }
+
+    #[test]
+    fn connect_timeout_message_is_actionable() {
+        // The connect-timeout message names the endpoint and suggests remedies.
+        let msg = connection_timeout_message("ftp.example.com", 21, 30);
+        assert!(msg.contains("ftp.example.com:21"), "names host:port: {msg}");
+        assert!(msg.contains("30s"), "names the timeout: {msg}");
+        let lower = msg.to_lowercase();
+        assert!(lower.contains("firewall"), "suggests firewall check: {msg}");
+        assert!(
+            lower.contains("server is running"),
+            "suggests server check: {msg}"
+        );
     }
 
     #[test]

--- a/core/src/backends/ftp/reconnect.rs
+++ b/core/src/backends/ftp/reconnect.rs
@@ -1,0 +1,256 @@
+//! Auto-reconnect policy for the FTP backend (issue #1339).
+//!
+//! FTP control connections are long-lived and idle between user actions, so
+//! servers frequently drop them (idle timeout, NAT eviction, transient network
+//! faults). This module provides a small, backend-agnostic retry driver plus the
+//! FTP-specific error classification used to decide when a failed operation is
+//! worth reconnecting and retrying.
+//!
+//! The [`run_with_reconnect`] driver is deliberately generic over the operation,
+//! the reconnect step and the error type so its retry/backoff behaviour can be
+//! unit-tested without a live server (see the tests below); the FTP browser
+//! wires it up with [`is_connection_error`] and a real re-establish closure.
+
+use std::future::Future;
+use std::time::Duration;
+
+use suppaftp::FtpError;
+
+/// Maximum number of reconnect attempts before giving up (concept: "up to 3
+/// retries"). The initial attempt is not counted, so an operation is tried at
+/// most `1 + MAX_RECONNECT_RETRIES` times.
+pub(crate) const MAX_RECONNECT_RETRIES: usize = 3;
+
+/// Backoff before the `attempt`-th reconnect (0-based): an exponential ramp
+/// (100ms, 200ms, 400ms, …) capped at 2s to bound worst-case latency.
+pub(crate) fn reconnect_backoff(attempt: usize) -> Duration {
+    let shift = attempt.min(4) as u32;
+    let ms = 100u64.saturating_mul(1u64 << shift);
+    Duration::from_millis(ms.min(2000))
+}
+
+/// Whether a [`FtpError`] indicates a broken control connection that a
+/// reconnect could plausibly recover.
+///
+/// Only transport-level failures ([`FtpError::ConnectionError`]) are treated as
+/// reconnectable; protocol-level refusals (`550 No such file`, a `530`
+/// permission denial, etc.) are surfaced to the caller unchanged so a bad path
+/// or permission error is never masked by a pointless reconnect loop.
+pub(crate) fn is_connection_error(err: &FtpError) -> bool {
+    matches!(err, FtpError::ConnectionError(_))
+}
+
+/// A synthetic connection error used when the control stream is absent (the
+/// slot is `None`), so the retry driver treats "not connected" as reconnectable.
+pub(crate) fn not_connected_err() -> FtpError {
+    FtpError::ConnectionError(std::io::Error::new(
+        std::io::ErrorKind::NotConnected,
+        "FTP control connection not established",
+    ))
+}
+
+/// Run `op`, retrying on reconnectable errors after invoking `reconnect`.
+///
+/// * `op` is (re)invoked for each attempt; it must (re)acquire whatever shared
+///   state it needs so a fresh connection established by `reconnect` is picked
+///   up on the next try.
+/// * A failure is retried only when `is_retryable` returns `true` and the
+///   attempt budget (`max_retries`) is not yet exhausted; otherwise the error is
+///   returned as-is.
+/// * Between attempts the driver sleeps for `backoff(attempt)` and then calls
+///   `reconnect`. If `reconnect` itself fails, that error is returned
+///   immediately (no point retrying an operation we could not reconnect for).
+///
+/// Returns the first `Ok`, or the last error once retries are exhausted.
+pub(crate) async fn run_with_reconnect<T, E, Op, OpFut, Rc, RcFut>(
+    max_retries: usize,
+    is_retryable: impl Fn(&E) -> bool,
+    backoff: impl Fn(usize) -> Duration,
+    mut op: Op,
+    mut reconnect: Rc,
+) -> Result<T, E>
+where
+    Op: FnMut() -> OpFut,
+    OpFut: Future<Output = Result<T, E>>,
+    Rc: FnMut() -> RcFut,
+    RcFut: Future<Output = Result<(), E>>,
+{
+    let mut attempt = 0;
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if attempt >= max_retries || !is_retryable(&err) {
+                    return Err(err);
+                }
+                let delay = backoff(attempt);
+                if !delay.is_zero() {
+                    tokio::time::sleep(delay).await;
+                }
+                reconnect().await?;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    /// A `Response`-free retryable error for tests.
+    fn conn_err() -> FtpError {
+        not_connected_err()
+    }
+
+    /// A non-reconnectable protocol error for tests.
+    fn proto_err() -> FtpError {
+        FtpError::BadResponse
+    }
+
+    #[test]
+    fn backoff_is_monotonic_and_capped() {
+        let d0 = reconnect_backoff(0);
+        let d1 = reconnect_backoff(1);
+        let d2 = reconnect_backoff(2);
+        assert_eq!(d0, Duration::from_millis(100));
+        assert_eq!(d1, Duration::from_millis(200));
+        assert_eq!(d2, Duration::from_millis(400));
+        assert!(d1 > d0 && d2 > d1, "backoff must grow");
+        // Far-out attempts plateau (shift is capped) and never exceed 2s.
+        let far = reconnect_backoff(100);
+        assert_eq!(
+            far,
+            reconnect_backoff(4),
+            "backoff plateaus once shift caps"
+        );
+        assert!(
+            far <= Duration::from_millis(2000),
+            "backoff is bounded at 2s"
+        );
+    }
+
+    #[test]
+    fn classifies_connection_vs_protocol_errors() {
+        assert!(is_connection_error(&conn_err()));
+        assert!(!is_connection_error(&proto_err()));
+    }
+
+    #[tokio::test]
+    async fn returns_immediately_on_first_success() {
+        let calls = Cell::new(0);
+        let reconnects = Cell::new(0);
+        let result: Result<u8, FtpError> = run_with_reconnect(
+            MAX_RECONNECT_RETRIES,
+            is_connection_error,
+            |_| Duration::ZERO,
+            || async {
+                calls.set(calls.get() + 1);
+                Ok(7)
+            },
+            || async {
+                reconnects.set(reconnects.get() + 1);
+                Ok(())
+            },
+        )
+        .await;
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(calls.get(), 1, "op runs exactly once on success");
+        assert_eq!(reconnects.get(), 0, "no reconnect when the first try works");
+    }
+
+    #[tokio::test]
+    async fn retries_then_succeeds_and_reconnects_between_attempts() {
+        let calls = Cell::new(0);
+        let reconnects = Cell::new(0);
+        let result: Result<&str, FtpError> = run_with_reconnect(
+            MAX_RECONNECT_RETRIES,
+            is_connection_error,
+            |_| Duration::ZERO,
+            || async {
+                let n = calls.get() + 1;
+                calls.set(n);
+                // Fail the first two attempts with a connection error, then succeed.
+                if n <= 2 {
+                    Err(conn_err())
+                } else {
+                    Ok("ok")
+                }
+            },
+            || async {
+                reconnects.set(reconnects.get() + 1);
+                Ok(())
+            },
+        )
+        .await;
+        assert_eq!(result.unwrap(), "ok");
+        assert_eq!(calls.get(), 3, "op tried 3 times (2 failures + success)");
+        assert_eq!(reconnects.get(), 2, "reconnect once per failure");
+    }
+
+    #[tokio::test]
+    async fn gives_up_after_max_retries_returning_last_error() {
+        let calls = Cell::new(0);
+        let reconnects = Cell::new(0);
+        let result: Result<(), FtpError> = run_with_reconnect(
+            MAX_RECONNECT_RETRIES,
+            is_connection_error,
+            |_| Duration::ZERO,
+            || async {
+                calls.set(calls.get() + 1);
+                Err(conn_err())
+            },
+            || async {
+                reconnects.set(reconnects.get() + 1);
+                Ok(())
+            },
+        )
+        .await;
+        assert!(result.is_err(), "exhausted retries surface the error");
+        // 1 initial + MAX_RECONNECT_RETRIES retries.
+        assert_eq!(calls.get(), 1 + MAX_RECONNECT_RETRIES);
+        assert_eq!(reconnects.get(), MAX_RECONNECT_RETRIES);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_non_reconnectable_errors() {
+        let calls = Cell::new(0);
+        let reconnects = Cell::new(0);
+        let result: Result<(), FtpError> = run_with_reconnect(
+            MAX_RECONNECT_RETRIES,
+            is_connection_error,
+            |_| Duration::ZERO,
+            || async {
+                calls.set(calls.get() + 1);
+                Err(proto_err())
+            },
+            || async {
+                reconnects.set(reconnects.get() + 1);
+                Ok(())
+            },
+        )
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 1, "protocol errors are not retried");
+        assert_eq!(reconnects.get(), 0, "no reconnect for protocol errors");
+    }
+
+    #[tokio::test]
+    async fn propagates_reconnect_failure() {
+        let calls = Cell::new(0);
+        let result: Result<(), FtpError> = run_with_reconnect(
+            MAX_RECONNECT_RETRIES,
+            is_connection_error,
+            |_| Duration::ZERO,
+            || async {
+                calls.set(calls.get() + 1);
+                Err(conn_err())
+            },
+            || async { Err(FtpError::BadResponse) },
+        )
+        .await;
+        assert!(matches!(result, Err(FtpError::BadResponse)));
+        assert_eq!(calls.get(), 1, "op stops once reconnect fails");
+    }
+}

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -508,6 +508,11 @@ pub struct FtpConfig {
     /// Connect timeout in seconds.
     #[serde(default = "default_ftp_timeout_secs")]
     pub timeout_secs: u64,
+    /// Idle keep-alive interval in seconds. A periodic `NOOP` is sent on the
+    /// browsing control connection every `keep_alive_secs` seconds to stop
+    /// servers dropping an idle connection. `0` disables keep-alive.
+    #[serde(default = "default_ftp_keep_alive_secs")]
+    pub keep_alive_secs: u64,
     /// When set, the plain-FTP insecure-connection warning is suppressed for
     /// this connection (the user checked "Don't warn again for this
     /// connection"). Set implicitly by the connect-time warning modal, not by
@@ -529,6 +534,7 @@ impl Default for FtpConfig {
             transfer_type: FtpTransferType::default(),
             initial_directory: None,
             timeout_secs: default_ftp_timeout_secs(),
+            keep_alive_secs: default_ftp_keep_alive_secs(),
             suppress_security_warning: false,
         }
     }
@@ -538,6 +544,14 @@ impl FtpConfig {
     /// Connect timeout as a [`Duration`].
     pub fn timeout(&self) -> Duration {
         Duration::from_secs(self.timeout_secs)
+    }
+
+    /// Keep-alive interval as a [`Duration`], or `None` when disabled (`0`).
+    ///
+    /// Backends spawn a periodic `NOOP` task on this interval; returning `None`
+    /// means no keep-alive task should be started.
+    pub fn keep_alive_interval(&self) -> Option<Duration> {
+        (self.keep_alive_secs > 0).then(|| Duration::from_secs(self.keep_alive_secs))
     }
 }
 
@@ -668,6 +682,10 @@ fn default_ftp_port() -> u16 {
 
 fn default_ftp_timeout_secs() -> u64 {
     30
+}
+
+fn default_ftp_keep_alive_secs() -> u64 {
+    60
 }
 
 #[cfg(test)]
@@ -1414,6 +1432,30 @@ mod tests {
         assert!(cfg.initial_directory.is_none());
         assert_eq!(cfg.timeout_secs, 30);
         assert_eq!(cfg.timeout(), Duration::from_secs(30));
+        // Keep-alive defaults to 60s (concept: periodic NOOP, default 60s).
+        assert_eq!(cfg.keep_alive_secs, 60);
+        assert_eq!(cfg.keep_alive_interval(), Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn ftp_config_keep_alive_interval_disabled_when_zero() {
+        let cfg = FtpConfig {
+            keep_alive_secs: 0,
+            ..FtpConfig::default()
+        };
+        assert_eq!(
+            cfg.keep_alive_interval(),
+            None,
+            "keep-alive of 0 must disable the NOOP task"
+        );
+    }
+
+    #[test]
+    fn ftp_config_keep_alive_secs_camel_case() {
+        let json = r#"{"host": "ftp.example.com", "keepAliveSecs": 15}"#;
+        let cfg: FtpConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.keep_alive_secs, 15);
+        assert_eq!(cfg.keep_alive_interval(), Some(Duration::from_secs(15)));
     }
 
     #[test]
@@ -1490,6 +1532,7 @@ mod tests {
             transfer_type: FtpTransferType::Binary,
             initial_directory: Some("/pub".into()),
             timeout_secs: 30,
+            keep_alive_secs: 60,
             suppress_security_warning: false,
         };
         let json = serde_json::to_string(&cfg).unwrap();

--- a/core/tests/ftp_reconnect.rs
+++ b/core/tests/ftp_reconnect.rs
@@ -1,0 +1,164 @@
+#![cfg(feature = "ftp")]
+//! FTP auto-reconnect integration tests (issue #1339).
+//!
+//! Exercises the [`FtpFileBrowser`] auto-reconnect path against the live FTP
+//! Docker fixture (`tests/docker/ftp-server/`): a browsing operation succeeds,
+//! the underlying control socket is forcibly dropped mid-session (simulating an
+//! idle-timeout / NAT eviction / transient fault), and the next operation must
+//! transparently re-establish the connection and return correct results.
+//!
+//! ## Fixture
+//!
+//! Container `ftp-server` (vsftpd), plain FTP on host port **2401** → container
+//! `:21`. Login `ftpuser` / `ftppass` (read everything, write into `/uploads`).
+//!
+//! ## Running
+//!
+//! ```bash
+//! docker compose -f tests/docker/docker-compose.yml --profile ftp up -d --wait ftp-server
+//! cargo test -p termihub-core --features ftp --test ftp_reconnect -- --nocapture
+//! docker compose -f tests/docker/docker-compose.yml --profile ftp down -v
+//! ```
+//!
+//! Without the fixture up, every test **skips cleanly** via `require_docker!`
+//! (a runtime port-reachability check), so a plain `cargo test` never fails
+//! here. Auto-reconnect *policy* (retry count, backoff, error classification,
+//! EPSV→PASV selection) is covered by fast unit tests in
+//! `core/src/backends/ftp/reconnect.rs` and `.../mod.rs`; this file verifies the
+//! end-to-end recovery against a real server.
+
+mod common;
+
+use common::{port_ftp, require_docker};
+
+use termihub_core::backends::ftp::Ftp;
+use termihub_core::connection::ConnectionType;
+use termihub_core::files::FileBrowser;
+
+/// Settings JSON for the `ftpuser` account.
+fn ftpuser_settings() -> serde_json::Value {
+    serde_json::json!({
+        "host": "127.0.0.1",
+        "port": port_ftp(),
+        "tlsMode": "none",
+        "username": "ftpuser",
+        "password": "ftppass",
+        // Keep-alive is irrelevant to these tests (they force the drop directly);
+        // disable it so no background NOOP interferes with the poisoned socket.
+        "keepAliveSecs": 0,
+    })
+}
+
+/// Connect an [`Ftp`] session with the ftpuser account.
+async fn connect() -> Ftp {
+    let mut ftp = Ftp::new();
+    ftp.connect(ftpuser_settings())
+        .await
+        .expect("FTP connect failed");
+    assert!(ftp.is_connected(), "FTP should report connected");
+    ftp
+}
+
+/// List `/pub` and return the sorted entry names.
+async fn list_pub_names(browser: &dyn FileBrowser) -> Vec<String> {
+    let mut names: Vec<String> = browser
+        .list_dir("/pub")
+        .await
+        .expect("list_dir(/pub) failed")
+        .into_iter()
+        .map(|e| e.name)
+        .collect();
+    names.sort();
+    names
+}
+
+// ── RECONNECT-01: a listing recovers after a mid-session control drop ─────────
+
+#[tokio::test]
+async fn ftp_reconnect_01_recovers_after_control_drop() {
+    require_docker!(port_ftp());
+
+    let mut ftp = connect().await;
+
+    // Baseline listing establishes the browsing control connection.
+    let before = {
+        let browser = ftp.file_browser().expect("FTP exposes a file browser");
+        list_pub_names(browser).await
+    };
+    assert!(!before.is_empty(), "baseline /pub listing is non-empty");
+
+    // Forcibly drop the live control socket, simulating an idle-timeout / fault.
+    assert!(
+        ftp.debug_drop_browsing_connection().await,
+        "a live browsing connection should have been dropped"
+    );
+
+    // The next listing must transparently reconnect and return the same tree.
+    let after = {
+        let browser = ftp.file_browser().expect("FTP exposes a file browser");
+        list_pub_names(browser).await
+    };
+    assert_eq!(
+        before, after,
+        "listing after auto-reconnect matches the pre-drop listing"
+    );
+
+    ftp.disconnect().await.expect("disconnect should succeed");
+}
+
+// ── RECONNECT-02: repeated drops each recover (retry budget re-arms) ──────────
+
+#[tokio::test]
+async fn ftp_reconnect_02_survives_repeated_drops() {
+    require_docker!(port_ftp());
+
+    let mut ftp = connect().await;
+    let expected = {
+        let browser = ftp.file_browser().expect("FTP exposes a file browser");
+        list_pub_names(browser).await
+    };
+
+    // Drop-then-list several times; each cycle must recover independently.
+    for cycle in 0..3 {
+        assert!(
+            ftp.debug_drop_browsing_connection().await,
+            "cycle {cycle}: expected a live connection to drop"
+        );
+        let names = {
+            let browser = ftp.file_browser().expect("FTP exposes a file browser");
+            list_pub_names(browser).await
+        };
+        assert_eq!(names, expected, "cycle {cycle}: listing recovered");
+    }
+
+    ftp.disconnect().await.expect("disconnect should succeed");
+}
+
+// ── RECONNECT-03: a read (RETR) recovers after a control drop ─────────────────
+
+#[tokio::test]
+async fn ftp_reconnect_03_read_recovers_after_drop() {
+    require_docker!(port_ftp());
+
+    let mut ftp = connect().await;
+
+    // Prime the connection, then drop it.
+    {
+        let browser = ftp.file_browser().expect("FTP exposes a file browser");
+        let _ = list_pub_names(browser).await;
+    }
+    assert!(ftp.debug_drop_browsing_connection().await);
+
+    // A RETR after the drop must reconnect and return exact bytes.
+    let browser = ftp.file_browser().expect("FTP exposes a file browser");
+    let readme = browser
+        .read_file("/pub/readme.txt")
+        .await
+        .expect("read readme.txt after reconnect");
+    assert_eq!(
+        readme, b"termiHub FTP test server. See pub/docs for more information.\n",
+        "readme.txt content after reconnect"
+    );
+
+    ftp.disconnect().await.expect("disconnect should succeed");
+}

--- a/docs/changes/dev1/feature/1339-ftp-robustness.md
+++ b/docs/changes/dev1/feature/1339-ftp-robustness.md
@@ -1,0 +1,9 @@
+## Added
+
+- FTP connections now send periodic `NOOP` keep-alives (default every 60 seconds, configurable via the new "Keep-alive (s)" setting; set to `0` to disable) so idle sessions are not dropped by server idle-timeouts or NAT eviction.
+- FTP file operations (listing, download, upload, rename, delete, mkdir) now auto-reconnect after a dropped control connection — up to 3 retries with exponential backoff — and retry the operation transparently, so a transient network blip no longer surfaces as a hard failure.
+
+## Changed
+
+- FTP passive-mode transfers now prefer extended passive (`EPSV`) and fall back automatically to classic passive (`PASV`) on servers that reject it, improving compatibility (including IPv6) without configuration.
+- A failed FTP connect now reports an actionable timeout error that names the host and port and suggests what to check (host/port correctness, server status, firewall), instead of a bare "timed out".


### PR DESCRIPTION
Production robustness for the merged `FtpBackend` (Epic #1331 · concept `docs/concepts/backlog/ftp-client.html`). Backend-only for v1 (agent-side FTP is an explicit non-goal).

## What shipped (backend Rust robustness)

- **Keep-alive** — `Ftp::connect` spawns a tokio task that sends a periodic `NOOP` on the browsing control connection (interval from the new `keepAliveSecs` config, default 60s, `0` disables). The `JoinHandle` is aborted on `disconnect` and on `Drop`, so no task leaks.
- **Auto-reconnect** — every file-browser operation runs through a generic retry driver (`core/src/backends/ftp/reconnect.rs`): on a transport-level failure it re-establishes the control connection and retries the operation, up to 3 times with exponential backoff. Protocol-level refusals (550/530/…) are surfaced unchanged so a bad path or permission error is never masked.
- **EPSV→PASV fallback** — passive connections now prefer extended passive (`EPSV`); each reconnect advances the data-channel fallback one step to classic `PASV`, so servers that reject `EPSV` degrade gracefully (also fixes IPv6).
- **Actionable connect-timeout** — the timeout error now names `host:port` and suggests what to check (host/port, server status, firewall).
- **Already present, preserved:** UTF-8→Latin-1 filename decoding (`listing_parser::decode_bytes`) and the MLSD→LIST fallback (`file_browser`) were merged earlier; the new retry path preserves both (MLSD connection-drops trigger reconnect; MLSD-unsupported still falls back to LIST).

## Deferred to follow-ups (frontend, out of scope for a clean backend PR)

- **#1513** — FTP symlink icon / navigation / target-in-properties. Needs cross-cutting `FileEntry` symlink metadata shared by all backends.
- **#1514** — Virtual scrolling for large directories in `FileBrowser.tsx`. The sidebar has no existing windowing mechanism and `package.json` ships none, so it requires a new dependency + changes to the large shared component — larger than a clean addition here.

## Test plan

- **Unit (run, green):** retry driver (success / retry-then-success / retry-cap / non-retryable passthrough / reconnect-failure propagation), backoff bounds, error classification, EPSV→PASV mode selection, keep-alive interval (default 60 / disabled at 0 / camelCase parse), and the actionable timeout message. `cargo test -p termihub-core --all-features` → 742 lib tests pass; `cargo clippy --workspace --all-targets --all-features -D warnings` clean; `cargo fmt --check` clean.
- **Docker integration (`core/tests/ftp_reconnect.rs`, gated):** connects to the live `ftp-server` fixture, forcibly drops the control socket mid-session, and asserts listing/read recovery (plus repeated-drop and RETR-after-drop variants). Docker was **unavailable on the dev host**, so these were **compiled and confirmed to skip cleanly** via `require_docker!` but not executed against a live server locally — they run in CI's fixtures job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
