### PR TITLE
test(ftp): live Docker transfer integration test (byte-exact + REST kill/resume) (Closes #1507)

### DIFF
--- a/core/tests/ftp_transfer.rs
+++ b/core/tests/ftp_transfer.rs
@@ -1,0 +1,530 @@
+#![cfg(feature = "ftp")]
+//! FTP live transfer integration tests (issue #1507).
+//!
+//! Exercises the streaming data-plane primitive
+//! [`termihub_core::backends::ftp::run_attempt`] (issue #1336) against the seeded
+//! FTP Docker fixture. Where the unit tests in
+//! `core/src/backends/ftp/transfer.rs` only cover the value types, these tests
+//! drive real bytes over a real ProFTPD server and assert:
+//!
+//!   * **byte-exact download** of a known 1 MiB fixture file (RETR),
+//!   * **byte-exact upload** of a deterministic payload (STOR) verified by a
+//!     download round-trip,
+//!   * **`REST`-based resume** in both directions — a transfer is interrupted
+//!     mid-flight via the `should_stop` probe, then resumed from the partial
+//!     offset, and the final file is byte-identical to a full transfer,
+//!   * **concurrent transfers use separate data connections** — two downloads
+//!     and a live directory listing all run at once, because every
+//!     `run_attempt` (and the browser) opens its own control+data connection.
+//!
+//! ## Fixture
+//!
+//! Container `ftp-server` (ProFTPD), plain FTP on host port **2401** → container
+//! `:21`. Login `ftpuser` / `ftppass` reads the whole tree and writes into
+//! `/uploads`. The read-only `/pub` tree has fixed sizes + fixed content; keep
+//! the constants below in sync with
+//! `tests/docker/ftp-server/generate-test-data.sh`. `REST`-based upload resume
+//! additionally requires `AllowStoreRestart on` in
+//! `tests/docker/ftp-server/proftpd.conf.tmpl` (RETR restart is on by default).
+//!
+//! ## Running
+//!
+//! ```bash
+//! # Bring the fixture up (waits for the port-21 healthcheck):
+//! docker compose -f tests/docker/docker-compose.yml --profile ftp up -d --wait ftp-server
+//!
+//! # Run this suite (the `ftp` feature gates the whole file):
+//! cargo test -p termihub-core --features ftp --test ftp_transfer -- --nocapture
+//!
+//! # Tear down when done:
+//! docker compose -f tests/docker/docker-compose.yml --profile ftp down -v
+//! ```
+//!
+//! Without the fixture up, every test **skips cleanly** via `require_docker!`
+//! (a runtime port-reachability check), so a plain `cargo test` never fails
+//! here.
+
+mod common;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use common::{port_ftp, require_docker};
+
+use termihub_core::backends::ftp::{
+    probe_remote_size, run_attempt, AttemptOutcome, Ftp, FtpDirection, StopReason,
+};
+use termihub_core::config::FtpConfig;
+use termihub_core::connection::ConnectionType;
+
+// ── Known seeded fixture facts (must match generate-test-data.sh) ────────────
+
+/// `/pub/data/dataset-1m.bin` — 1 MiB, zero-filled.
+const DATASET_1M: &str = "/pub/data/dataset-1m.bin";
+const DATASET_1M_SIZE: u64 = 1_048_576;
+
+/// `/pub/data/dataset-64k.bin` — 64 KiB, zero-filled.
+const DATASET_64K: &str = "/pub/data/dataset-64k.bin";
+const DATASET_64K_SIZE: u64 = 65_536;
+
+/// `/pub/readme.txt` — fixed text content (61 bytes incl. trailing newline).
+const README_PATH: &str = "/pub/readme.txt";
+const README_BYTES: &[u8] = b"termiHub FTP test server. See pub/docs for more information.\n";
+
+/// Number of entries at the top of `/pub` (2 files + 3 directories).
+const PUB_TOP_COUNT: usize = 5;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// `FtpConfig` for the `ftpuser` account (plain FTP, passive, binary).
+fn ftpuser_config() -> FtpConfig {
+    FtpConfig {
+        host: "127.0.0.1".to_string(),
+        port: port_ftp(),
+        username: "ftpuser".to_string(),
+        password: Some("ftppass".to_string()),
+        ..Default::default()
+    }
+}
+
+/// Settings JSON for the `ftpuser` account (for the browser session).
+fn ftpuser_settings() -> serde_json::Value {
+    serde_json::json!({
+        "host": "127.0.0.1",
+        "port": port_ftp(),
+        "tlsMode": "none",
+        "username": "ftpuser",
+        "password": "ftppass",
+    })
+}
+
+/// A deterministic, non-trivial payload of `len` bytes (so a byte-exact
+/// comparison is meaningful — unlike the zero-filled fixture binaries).
+fn payload(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+/// A per-process remote path under `/uploads` so reruns never collide.
+fn upload_path(tag: &str) -> String {
+    format!("/uploads/th_xfer_{}_{tag}.bin", std::process::id())
+}
+
+/// Best-effort remote cleanup via a browser session.
+async fn cleanup_remote(path: &str) {
+    let mut ftp = Ftp::new();
+    if ftp.connect(ftpuser_settings()).await.is_ok() {
+        if let Some(browser) = ftp.file_browser() {
+            let _ = browser.delete(path).await;
+        }
+        let _ = ftp.disconnect().await;
+    }
+}
+
+/// A no-op progress callback.
+fn no_progress(_transferred: u64) {}
+
+/// A `should_stop` probe that never stops.
+fn never_stop() -> Option<StopReason> {
+    None
+}
+
+// ── FTP-XFER-01: byte-exact download (RETR) ──────────────────────────────────
+
+#[tokio::test]
+async fn ftp_transfer_01_download_byte_exact() {
+    require_docker!(port_ftp());
+
+    let cfg = ftpuser_config();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let local = tmp.path().join("dataset-1m.bin");
+    let local_str = local.to_str().expect("utf8 path");
+
+    let mut last_progress = 0u64;
+    let outcome = run_attempt(
+        &cfg,
+        FtpDirection::Download,
+        DATASET_1M,
+        local_str,
+        0,
+        |t| last_progress = t,
+        never_stop,
+    )
+    .await
+    .expect("download attempt");
+
+    assert_eq!(
+        outcome,
+        AttemptOutcome::Completed {
+            transferred: DATASET_1M_SIZE
+        },
+        "download should complete with the full byte count"
+    );
+    assert_eq!(
+        last_progress, DATASET_1M_SIZE,
+        "progress must reach EOF byte count"
+    );
+
+    let bytes = tokio::fs::read(&local).await.expect("read downloaded file");
+    assert_eq!(bytes.len() as u64, DATASET_1M_SIZE, "downloaded size");
+    assert!(
+        bytes.iter().all(|&b| b == 0),
+        "dataset-1m.bin is zero-filled"
+    );
+
+    // A text file must round-trip byte-for-byte too.
+    let readme = tmp.path().join("readme.txt");
+    run_attempt(
+        &cfg,
+        FtpDirection::Download,
+        README_PATH,
+        readme.to_str().expect("utf8 path"),
+        0,
+        no_progress,
+        never_stop,
+    )
+    .await
+    .expect("download readme");
+    let content = tokio::fs::read(&readme).await.expect("read readme");
+    assert_eq!(content, README_BYTES, "readme.txt content byte-exact");
+}
+
+// ── FTP-XFER-02: byte-exact upload (STOR), verified by download round-trip ───
+
+#[tokio::test]
+async fn ftp_transfer_02_upload_byte_exact() {
+    require_docker!(port_ftp());
+
+    let cfg = ftpuser_config();
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Deterministic, non-trivial payload (~300 KiB spans multiple chunks).
+    let data = payload(307_200);
+    let src = tmp.path().join("upload_src.bin");
+    tokio::fs::write(&src, &data).await.expect("write src");
+
+    let remote = upload_path("simple");
+    cleanup_remote(&remote).await;
+
+    let outcome = run_attempt(
+        &cfg,
+        FtpDirection::Upload,
+        &remote,
+        src.to_str().expect("utf8 path"),
+        0,
+        no_progress,
+        never_stop,
+    )
+    .await
+    .expect("upload attempt");
+    assert_eq!(
+        outcome,
+        AttemptOutcome::Completed {
+            transferred: data.len() as u64
+        },
+        "upload should complete with the full byte count"
+    );
+
+    // Download it back and compare byte-for-byte.
+    let verify = tmp.path().join("upload_verify.bin");
+    run_attempt(
+        &cfg,
+        FtpDirection::Download,
+        &remote,
+        verify.to_str().expect("utf8 path"),
+        0,
+        no_progress,
+        never_stop,
+    )
+    .await
+    .expect("download-back attempt");
+    let got = tokio::fs::read(&verify).await.expect("read verify");
+    assert_eq!(got, data, "uploaded bytes round-trip exactly");
+
+    cleanup_remote(&remote).await;
+}
+
+// ── FTP-XFER-03: REST-based download resume ──────────────────────────────────
+
+#[tokio::test]
+async fn ftp_transfer_03_download_rest_resume() {
+    require_docker!(port_ftp());
+
+    let cfg = ftpuser_config();
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Reference: a full, uninterrupted download of the same file.
+    let full = tmp.path().join("full.bin");
+    run_attempt(
+        &cfg,
+        FtpDirection::Download,
+        DATASET_1M,
+        full.to_str().expect("utf8 path"),
+        0,
+        no_progress,
+        never_stop,
+    )
+    .await
+    .expect("full download");
+    let reference = tokio::fs::read(&full).await.expect("read reference");
+    assert_eq!(reference.len() as u64, DATASET_1M_SIZE);
+
+    // Interrupted download: stop after the first chunk lands.
+    let partial = tmp.path().join("partial.bin");
+    let partial_str = partial.to_str().expect("utf8 path");
+    let seen = Arc::new(AtomicU64::new(0));
+    let stop_after: u64 = 200_000;
+
+    let outcome = {
+        let progress_seen = seen.clone();
+        let stop_seen = seen.clone();
+        run_attempt(
+            &cfg,
+            FtpDirection::Download,
+            DATASET_1M,
+            partial_str,
+            0,
+            move |t| progress_seen.store(t, Ordering::SeqCst),
+            move || {
+                if stop_seen.load(Ordering::SeqCst) >= stop_after {
+                    Some(StopReason::Pause)
+                } else {
+                    None
+                }
+            },
+        )
+        .await
+        .expect("interrupted download")
+    };
+
+    let transferred = match outcome {
+        AttemptOutcome::Stopped {
+            transferred,
+            reason,
+        } => {
+            assert_eq!(reason, StopReason::Pause, "stop reason is Pause");
+            transferred
+        }
+        AttemptOutcome::Completed { .. } => panic!("expected a mid-flight stop, got Completed"),
+    };
+    assert!(
+        transferred >= stop_after && transferred < DATASET_1M_SIZE,
+        "partial offset {transferred} should be mid-flight (>= {stop_after}, < {DATASET_1M_SIZE})"
+    );
+    let partial_len = tokio::fs::metadata(&partial)
+        .await
+        .expect("stat partial")
+        .len();
+    assert_eq!(
+        partial_len, transferred,
+        "partial file on disk holds exactly the reported offset"
+    );
+
+    // Resume from the partial offset via REST; the result must be complete and
+    // byte-identical to the full download.
+    let outcome2 = run_attempt(
+        &cfg,
+        FtpDirection::Download,
+        DATASET_1M,
+        partial_str,
+        transferred,
+        no_progress,
+        never_stop,
+    )
+    .await
+    .expect("resumed download");
+    assert_eq!(
+        outcome2,
+        AttemptOutcome::Completed {
+            transferred: DATASET_1M_SIZE
+        },
+        "resume should complete to EOF"
+    );
+
+    let resumed = tokio::fs::read(&partial).await.expect("read resumed");
+    assert_eq!(
+        resumed, reference,
+        "REST-resumed file is byte-identical to a full download"
+    );
+}
+
+// ── FTP-XFER-04: REST-based upload resume ────────────────────────────────────
+
+#[tokio::test]
+async fn ftp_transfer_04_upload_rest_resume() {
+    require_docker!(port_ftp());
+
+    let cfg = ftpuser_config();
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let data = payload(800_000);
+    let src = tmp.path().join("resume_src.bin");
+    tokio::fs::write(&src, &data).await.expect("write src");
+    let src_str = src.to_str().expect("utf8 path");
+
+    let remote = upload_path("resume");
+    cleanup_remote(&remote).await;
+
+    // Interrupted upload: stop after the first chunk is written.
+    let seen = Arc::new(AtomicU64::new(0));
+    let stop_after: u64 = 200_000;
+    let outcome = {
+        let progress_seen = seen.clone();
+        let stop_seen = seen.clone();
+        run_attempt(
+            &cfg,
+            FtpDirection::Upload,
+            &remote,
+            src_str,
+            0,
+            move |t| progress_seen.store(t, Ordering::SeqCst),
+            move || {
+                if stop_seen.load(Ordering::SeqCst) >= stop_after {
+                    Some(StopReason::Pause)
+                } else {
+                    None
+                }
+            },
+        )
+        .await
+        .expect("interrupted upload")
+    };
+    let transferred = match outcome {
+        AttemptOutcome::Stopped {
+            transferred,
+            reason,
+        } => {
+            assert_eq!(reason, StopReason::Pause);
+            transferred
+        }
+        AttemptOutcome::Completed { .. } => panic!("expected a mid-flight stop, got Completed"),
+    };
+    assert!(transferred >= stop_after, "upload stopped mid-flight");
+
+    // The server retained the partial STOR; resume from its actual size (this is
+    // what a real queue does — REST from the server-reported offset).
+    let remote_size = probe_remote_size(&cfg, &remote)
+        .await
+        .expect("SIZE of partial upload");
+    assert!(
+        remote_size > 0 && remote_size <= transferred,
+        "server retained a partial upload ({remote_size} bytes, <= reported {transferred})"
+    );
+
+    let outcome2 = run_attempt(
+        &cfg,
+        FtpDirection::Upload,
+        &remote,
+        src_str,
+        remote_size,
+        no_progress,
+        never_stop,
+    )
+    .await
+    .expect("resumed upload");
+    assert_eq!(
+        outcome2,
+        AttemptOutcome::Completed {
+            transferred: data.len() as u64
+        },
+        "resumed upload completes to the full size"
+    );
+
+    // Download the resumed remote file and confirm it matches the source.
+    let verify = tmp.path().join("resume_verify.bin");
+    run_attempt(
+        &cfg,
+        FtpDirection::Download,
+        &remote,
+        verify.to_str().expect("utf8 path"),
+        0,
+        no_progress,
+        never_stop,
+    )
+    .await
+    .expect("download resumed upload");
+    let got = tokio::fs::read(&verify).await.expect("read verify");
+    assert_eq!(
+        got, data,
+        "REST-resumed upload is byte-identical to the source"
+    );
+
+    cleanup_remote(&remote).await;
+}
+
+// ── FTP-XFER-05: concurrent transfers + live browsing ────────────────────────
+//
+// Two downloads and a directory listing run at once. Each `run_attempt` and the
+// browser open their own control+data connection, so browsing stays responsive
+// while transfers are in flight. If transfers shared one data connection this
+// would deadlock or serialize; instead all three complete together.
+
+#[tokio::test]
+async fn ftp_transfer_05_concurrent_separate_connections() {
+    require_docker!(port_ftp());
+
+    let cfg = ftpuser_config();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let a = tmp.path().join("concurrent_1m.bin");
+    let b = tmp.path().join("concurrent_64k.bin");
+
+    let mut ftp = Ftp::new();
+    ftp.connect(ftpuser_settings())
+        .await
+        .expect("browser connect");
+
+    let dl_a = run_attempt(
+        &cfg,
+        FtpDirection::Download,
+        DATASET_1M,
+        a.to_str().expect("utf8 path"),
+        0,
+        no_progress,
+        never_stop,
+    );
+    let dl_b = run_attempt(
+        &cfg,
+        FtpDirection::Download,
+        DATASET_64K,
+        b.to_str().expect("utf8 path"),
+        0,
+        no_progress,
+        never_stop,
+    );
+    let browse = async {
+        let browser = ftp.file_browser().expect("FTP exposes a browser");
+        browser.list_dir("/pub").await
+    };
+
+    let (res_a, res_b, res_listing) = tokio::join!(dl_a, dl_b, browse);
+
+    assert_eq!(
+        res_a.expect("concurrent download A"),
+        AttemptOutcome::Completed {
+            transferred: DATASET_1M_SIZE
+        },
+    );
+    assert_eq!(
+        res_b.expect("concurrent download B"),
+        AttemptOutcome::Completed {
+            transferred: DATASET_64K_SIZE
+        },
+    );
+
+    // Browsing stayed live and returned the seeded tree during the transfers.
+    let listing = res_listing.expect("concurrent list_dir");
+    assert_eq!(
+        listing.len(),
+        PUB_TOP_COUNT,
+        "live listing sees the full /pub tree while transfers run"
+    );
+
+    // Both downloads are byte-exact.
+    let bytes_a = tokio::fs::read(&a).await.expect("read A");
+    assert_eq!(bytes_a.len() as u64, DATASET_1M_SIZE);
+    assert!(bytes_a.iter().all(|&x| x == 0), "A zero-filled");
+    let bytes_b = tokio::fs::read(&b).await.expect("read B");
+    assert_eq!(bytes_b.len() as u64, DATASET_64K_SIZE);
+    assert!(bytes_b.iter().all(|&x| x == 0), "B zero-filled");
+
+    ftp.disconnect().await.expect("disconnect");
+}

--- a/scripts/test-system-linux.sh
+++ b/scripts/test-system-linux.sh
@@ -438,6 +438,13 @@ if [ "$WITH_FTP" -eq 1 ]; then
         echo "FTP FILE-BROWSER TESTS FAILED."
         TEST_EXIT=1
     fi
+
+    echo ""
+    echo "--- FTP transfer tests (ftp profile) ---"
+    if ! cargo test -p termihub-core --all-features --test ftp_transfer -- --nocapture; then
+        echo "FTP TRANSFER TESTS FAILED."
+        TEST_EXIT=1
+    fi
 fi
 
 # ─── Summary ────────────────────────────────────────────────────────────────

--- a/scripts/test-system-windows.sh
+++ b/scripts/test-system-windows.sh
@@ -522,6 +522,13 @@ if [ "$SKIP_INTEGRATION" -eq 0 ]; then
             echo "FTP FILE-BROWSER TESTS FAILED."
             TEST_EXIT=1
         fi
+
+        echo ""
+        echo "--- FTP transfer tests (ftp profile) ---"
+        if ! cargo test -p termihub-core --all-features --test ftp_transfer -- --nocapture; then
+            echo "FTP TRANSFER TESTS FAILED."
+            TEST_EXIT=1
+        fi
     fi
 else
     echo ""

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -211,14 +211,20 @@ curl -k --ssl-reqd ftp://ftpuser:ftppass@127.0.0.1:2401/pub/  # explicit FTPS
 curl -k ftps://ftpuser:ftppass@127.0.0.1:2402/pub/            # implicit FTPS
 ```
 
-The app-level Rust integration test for the FTP file browser lives at
-[`core/tests/ftp_file_browser.rs`](../../core/tests/ftp_file_browser.rs) (gated
-behind the `ftp` feature; skips cleanly when the fixture is not up). Run it
-directly against the fixture with:
+The app-level Rust integration tests for the FTP backend live at
+[`core/tests/ftp_file_browser.rs`](../../core/tests/ftp_file_browser.rs) (listing
+
+- CRUD) and [`core/tests/ftp_transfer.rs`](../../core/tests/ftp_transfer.rs)
+  (byte-exact up/download + `REST` kill/resume + concurrent transfers) — both gated
+  behind the `ftp` feature and skipping cleanly when the fixture is not up. The
+  `REST`-based upload-resume path relies on `AllowStoreRestart on` in
+  [`ftp-server/proftpd.conf.tmpl`](ftp-server/proftpd.conf.tmpl). Run them directly
+  against the fixture with:
 
 ```bash
 docker compose -f tests/docker/docker-compose.yml --profile ftp up -d --wait ftp-server
 cargo test -p termihub-core --features ftp --test ftp_file_browser -- --nocapture
+cargo test -p termihub-core --features ftp --test ftp_transfer -- --nocapture
 ```
 
 Or via the orchestration scripts, which start the `ftp` profile and run the

--- a/tests/docker/ftp-server/proftpd.conf.tmpl
+++ b/tests/docker/ftp-server/proftpd.conf.tmpl
@@ -26,6 +26,15 @@ MaxInstances          30
 User                  proftpd
 Group                 nogroup
 
+# Allow REST-based resume for BOTH directions so the transfer integration test
+# (#1507) can interrupt a RETR/STOR mid-flight and resume from the partial
+# offset. RetrieveRestart defaults on; StoreRestart defaults off, so enable it
+# explicitly for the upload-resume path. AllowOverwrite lets the resumed STOR
+# write over the partial file (anonymous stays read-only via its Limit WRITE).
+AllowRetrieveRestart  on
+AllowStoreRestart     on
+AllowOverwrite        on
+
 # Chroot every login to its landing directory; the fixture never needs a shell.
 DefaultRoot           ~
 RequireValidShell     off


### PR DESCRIPTION
## What

Follow-up to #1336 (transfer-queue model + FTP up/download, unit-covered only). Adds `core/tests/ftp_transfer.rs` — a `#[cfg(feature = "ftp")]`, runtime-skip integration suite that drives the live data-plane primitive `termihub_core::backends::ftp::run_attempt` against the seeded FTP Docker fixture. This is the automated coverage the live byte-exact + `REST` resume behavior previously lacked.

## Fixture

Container `ftp-server` (ProFTPD), plain FTP at `127.0.0.1:2401`, login `ftpuser`/`ftppass`, seeded `/pub` tree from #1333 (`generate-test-data.sh`). The suite skips cleanly (`require_docker!` port probe) when the fixture is not up, so a plain `cargo test` never fails.

## What it asserts

- **Byte-exact download (RETR)** — `/pub/data/dataset-1m.bin` (1048576 bytes, zero-filled) plus a fixed-content text file, byte-for-byte.
- **Byte-exact upload (STOR)** — a deterministic non-trivial payload, verified by a download round-trip comparing bytes.
- **`REST`-based resume, download** — interrupt mid-flight via the `should_stop` probe (`AttemptOutcome::Stopped`), assert the partial local file holds exactly the reported offset, resume from that offset, and assert the final file is byte-identical to a full download.
- **`REST`-based resume, upload** — interrupt mid-flight, `REST` from the server-reported partial size (`probe_remote_size`), resume, and confirm the resumed remote file is byte-identical to the source.
- **Concurrent transfers use separate data connections** — two downloads and a live `/pub` listing run at once via `tokio::join!`; each `run_attempt` (and the browser) opens its own control+data connection, so browsing stays live during transfers.

## Fixture change

Enabled `AllowRetrieveRestart` / `AllowStoreRestart` / `AllowOverwrite` in `tests/docker/ftp-server/proftpd.conf.tmpl` so the upload-resume path (`REST` before `STOR`, overwriting the partial) is permitted. ProFTPD's `AllowStoreRestart` defaults off; `AllowRetrieveRestart` is on by default. Anonymous logins stay read-only via their existing `<Limit WRITE> DenyAll`.

## Orchestration wiring

Runs under `--with-ftp` in both `scripts/test-system-linux.sh` and `scripts/test-system-windows.sh`, immediately after the existing `ftp_file_browser` suite. Documented in `tests/docker/README.md`.

## How verified

Ran locally against the real fixture on macOS + Docker Desktop 29.5.3:

```
docker compose -f tests/docker/docker-compose.yml --profile ftp up -d --build --wait ftp-server
cargo test -p termihub-core --features ftp --test ftp_transfer -- --nocapture
# running 5 tests ... test result: ok. 5 passed; 0 failed
```

Also confirmed the skip path (`TERMIHUB_TEST_FTP_PORT=59999` → all 5 SKIPPED, result ok), and that `cargo clippy -p termihub-core --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, and `./scripts/check.sh` all pass. Re-ran the suite green after merging `origin/develop`.

Test-infra only, non-user-facing → no `docs/changes/` fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)