### PR TITLE
feat(agent): deferred update (apply on last disconnect)

### DIFF
--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -25,20 +25,23 @@ use crate::monitoring::MonitoringManagerApi;
 use crate::network;
 use crate::protocol::errors;
 use crate::protocol::methods::{
-    AgentSettings, AgentSettingsUpdateParams, AgentShutdownParams, AgentShutdownResult,
-    Capabilities, ConnectionCreateParams, ConnectionDeleteParams, ConnectionInfo,
-    ConnectionListResult, ConnectionTypesResult, ConnectionUpdateParams, FilesDeleteParams,
-    FilesListParams, FilesListResult, FilesMkdirParams, FilesReadParams, FilesReadResult,
-    FilesRenameParams, FilesStatParams, FilesWriteParams, FolderCreateParams, FolderDeleteParams,
-    FolderUpdateParams, HealthCheckResult, InitializeParams, InitializeResult,
-    MonitoringSubscribeParams, MonitoringUnsubscribeParams, NetworkDnsLookupParams,
-    NetworkPingParams, NetworkPortScanParams, NetworkTracerouteParams, NetworkWolParams,
-    SessionAttachParams, SessionCloseParams, SessionCreateParams, SessionCreateResult,
-    SessionDetachParams, SessionGetBufferParams, SessionGetBufferResult, SessionInputParams,
-    SessionListEntry, SessionListResult, SessionResizeParams,
+    AgentRequestDeferredUpdateParams, AgentRequestDeferredUpdateResult, AgentSettings,
+    AgentSettingsUpdateParams, AgentShutdownParams, AgentShutdownResult, Capabilities,
+    ConnectionCreateParams, ConnectionDeleteParams, ConnectionInfo, ConnectionListResult,
+    ConnectionTypesResult, ConnectionUpdateParams, FilesDeleteParams, FilesListParams,
+    FilesListResult, FilesMkdirParams, FilesReadParams, FilesReadResult, FilesRenameParams,
+    FilesStatParams, FilesWriteParams, FolderCreateParams, FolderDeleteParams, FolderUpdateParams,
+    HealthCheckResult, InitializeParams, InitializeResult, MonitoringSubscribeParams,
+    MonitoringUnsubscribeParams, NetworkDnsLookupParams, NetworkPingParams, NetworkPortScanParams,
+    NetworkTracerouteParams, NetworkWolParams, SessionAttachParams, SessionCloseParams,
+    SessionCreateParams, SessionCreateResult, SessionDetachParams, SessionGetBufferParams,
+    SessionGetBufferResult, SessionInputParams, SessionListEntry, SessionListResult,
+    SessionResizeParams,
 };
 use crate::session::definitions::{Connection, ConnectionStoreApi, Folder};
-use crate::session::manager::{SessionCreateError, SessionManagerApi, MAX_SESSIONS};
+use crate::session::manager::{
+    DeferredUpdateError, DeferredUpdateOutcome, SessionCreateError, SessionManagerApi, MAX_SESSIONS,
+};
 
 /// The agent's protocol version.
 ///
@@ -318,6 +321,7 @@ fn register_all(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<(
     register_health_check(module)?;
     register_agent_shutdown(module)?;
     register_agent_settings_update(module)?;
+    register_agent_request_deferred_update(module)?;
     register_agent_list_connections(module)?;
     Ok(())
 }
@@ -1271,6 +1275,59 @@ fn register_agent_settings_update(
 
         Ok::<_, ErrorObjectOwned>(json!({"applied": true}))
     })?;
+    Ok(())
+}
+
+/// `agent.request_deferred_update` — stage/apply a deferred agent update (#1352).
+///
+/// Records the update and applies it immediately when the agent is idle (0
+/// sessions); otherwise it is deferred until the last session disconnects.
+/// Active sessions are never interrupted.
+fn register_agent_request_deferred_update(
+    module: &mut RpcModule<Mutex<HandlerState>>,
+) -> anyhow::Result<()> {
+    module.register_async_method(
+        "agent.request_deferred_update",
+        |params, ctx, _ext| async move {
+            let session_manager = get_session_manager(&ctx).await?;
+
+            let p: AgentRequestDeferredUpdateParams = params
+                .parse()
+                .map_err(|e| invalid_params("agent.request_deferred_update", e))?;
+
+            let outcome = session_manager
+                .request_deferred_update(p.binary_path, p.version)
+                .await
+                .map_err(|e| match e {
+                    DeferredUpdateError::BinaryNotFound(path) => rpc_err(
+                        errors::INVALID_PARAMS,
+                        format!("Update binary not found: {path}"),
+                    ),
+                    DeferredUpdateError::NoPendingUpdate => {
+                        rpc_err(errors::INVALID_PARAMS, "No pending update to apply")
+                    }
+                    DeferredUpdateError::ApplyFailed(err) => rpc_err(
+                        errors::DEFERRED_UPDATE_FAILED,
+                        format!("Failed to apply update: {err:#}"),
+                    ),
+                })?;
+
+            let result = match outcome {
+                DeferredUpdateOutcome::Applying => AgentRequestDeferredUpdateResult {
+                    applied: true,
+                    active_sessions: 0,
+                },
+                DeferredUpdateOutcome::Deferred { active_sessions } => {
+                    AgentRequestDeferredUpdateResult {
+                        applied: false,
+                        active_sessions,
+                    }
+                }
+            };
+
+            serde_json::to_value(result).map_err(|e| rpc_err(errors::INTERNAL_ERROR, e.to_string()))
+        },
+    )?;
     Ok(())
 }
 
@@ -3110,6 +3167,21 @@ mod tests {
 
         async fn active_count(&self) -> u32 {
             self.sessions.lock().await.len() as u32
+        }
+
+        async fn request_deferred_update(
+            &self,
+            _binary_path: Option<String>,
+            _version: Option<String>,
+        ) -> Result<DeferredUpdateOutcome, DeferredUpdateError> {
+            let active = self.sessions.lock().await.len() as u32;
+            if active == 0 {
+                Ok(DeferredUpdateOutcome::Applying)
+            } else {
+                Ok(DeferredUpdateOutcome::Deferred {
+                    active_sessions: active,
+                })
+            }
         }
 
         async fn attach(&self, session_id: &str) -> Result<(), String> {

--- a/agent/src/protocol/errors.rs
+++ b/agent/src/protocol/errors.rs
@@ -29,6 +29,7 @@ mod tests {
             FILE_BROWSING_NOT_SUPPORTED,
             MONITORING_ERROR,
             SHUTDOWN_ERROR,
+            DEFERRED_UPDATE_FAILED,
         ];
         for code in codes {
             assert!(code < 0, "Error code {code} should be negative");
@@ -71,6 +72,7 @@ mod tests {
             FILE_BROWSING_NOT_SUPPORTED,
             MONITORING_ERROR,
             SHUTDOWN_ERROR,
+            DEFERRED_UPDATE_FAILED,
         ];
         for code in app_codes {
             assert!(

--- a/agent/src/protocol/methods.rs
+++ b/agent/src/protocol/methods.rs
@@ -411,6 +411,30 @@ pub struct AgentShutdownResult {
     pub detached_sessions: u32,
 }
 
+// ── agent.request_deferred_update ───────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRequestDeferredUpdateParams {
+    /// Absolute path (on the agent host) to the new agent binary to stage.
+    /// Omit to apply an update the agent already staged itself (self-update).
+    #[serde(default)]
+    pub binary_path: Option<String>,
+    /// Optional target version label (bookkeeping only).
+    #[serde(default)]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRequestDeferredUpdateResult {
+    /// `true` if the update was applied immediately (agent was idle); `false`
+    /// if it was deferred until the last session disconnects.
+    pub applied: bool,
+    /// Number of sessions still active (0 when applied immediately).
+    pub active_sessions: u32,
+}
+
 // ── network.port_scan ───────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize)]

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,7 +25,8 @@ use termihub_core::session::traits::OutputSink;
 
 use crate::daemon::client::{DaemonClient, DaemonWriterHandle};
 use crate::daemon::transport::{endpoint_alive, session_endpoint};
-use crate::state::persistence::{AgentState, PersistedSession};
+use crate::state::persistence::{AgentState, PendingUpdate, PersistedSession};
+use crate::update::{should_apply_deferred_update, SystemUpdateApplier, UpdateApplier};
 
 /// Maximum number of concurrent sessions the agent supports.
 pub const MAX_SESSIONS: u32 = 20;
@@ -77,6 +79,13 @@ pub trait SessionManagerApi: Send + Sync + 'static {
     /// Return the number of sessions with status `Running`.
     async fn active_count(&self) -> u32;
 
+    /// Record a deferred agent update, applying it immediately when idle.
+    async fn request_deferred_update(
+        &self,
+        binary_path: Option<String>,
+        version: Option<String>,
+    ) -> Result<DeferredUpdateOutcome, DeferredUpdateError>;
+
     /// Attach a client to an existing session.
     async fn attach(&self, session_id: &str) -> Result<(), String>;
 
@@ -113,6 +122,40 @@ impl fmt::Display for SessionCreateError {
             Self::LimitReached => write!(f, "Session limit reached (max {MAX_SESSIONS})"),
             Self::InvalidConfig(msg) => write!(f, "Invalid configuration: {msg}"),
             Self::BackendFailed(msg) => write!(f, "Backend failed: {msg}"),
+        }
+    }
+}
+
+/// Result of a deferred-update request (`agent.request_deferred_update`).
+#[derive(Debug)]
+pub enum DeferredUpdateOutcome {
+    /// The agent was idle (0 active sessions) so the update is being applied
+    /// immediately. On Unix the process re-execs and this variant is only
+    /// observed in tests / on the non-Unix path.
+    Applying,
+    /// The update was recorded and will apply when the last of `active_sessions`
+    /// sessions disconnects. Active sessions are never interrupted.
+    Deferred { active_sessions: u32 },
+}
+
+/// Errors from requesting a deferred update.
+#[derive(Debug)]
+pub enum DeferredUpdateError {
+    /// The provided binary path does not point to an existing file.
+    BinaryNotFound(String),
+    /// No `binary_path` was given and no update is currently staged/pending.
+    NoPendingUpdate,
+    /// Applying the update failed (binary swap or re-exec error, or an
+    /// unsupported platform).
+    ApplyFailed(anyhow::Error),
+}
+
+impl fmt::Display for DeferredUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BinaryNotFound(path) => write!(f, "Update binary not found: {path}"),
+            Self::NoPendingUpdate => write!(f, "No pending update to apply"),
+            Self::ApplyFailed(e) => write!(f, "Failed to apply update: {e:#}"),
         }
     }
 }
@@ -311,20 +354,25 @@ pub struct SessionManager {
     registry: Arc<ConnectionTypeRegistry>,
     launcher: Arc<dyn DaemonLauncher>,
     state: Mutex<AgentState>,
+    /// Path the persisted [`AgentState`] is read from / written to. Configurable
+    /// so tests get an isolated `state.json` instead of touching the real one.
+    state_path: PathBuf,
+    /// Applies a deferred update by swapping the agent binary. Injected so tests
+    /// can record apply requests without replacing the test process.
+    update_applier: Arc<dyn UpdateApplier>,
     /// Configurable ring-buffer size for daemon-backed persistent sessions.
     persistent_buffer_size: Arc<AtomicUsize>,
 }
 
 impl SessionManager {
     pub fn new(notification_tx: NotificationSender, registry: Arc<ConnectionTypeRegistry>) -> Self {
-        Self {
-            sessions: Mutex::new(HashMap::new()),
+        Self::with_deps(
             notification_tx,
             registry,
-            launcher: Arc::new(SystemDaemonLauncher),
-            state: Mutex::new(AgentState::load()),
-            persistent_buffer_size: Arc::new(AtomicUsize::new(DEFAULT_PERSISTENT_BUFFER_SIZE)),
-        }
+            Arc::new(SystemDaemonLauncher),
+            AgentState::default_path(),
+            Arc::new(SystemUpdateApplier),
+        )
     }
 
     /// Create a session manager with a custom daemon launcher (for testing).
@@ -334,12 +382,52 @@ impl SessionManager {
         registry: Arc<ConnectionTypeRegistry>,
         launcher: Arc<dyn DaemonLauncher>,
     ) -> Self {
+        Self::with_deps(
+            notification_tx,
+            registry,
+            launcher,
+            AgentState::default_path(),
+            Arc::new(SystemUpdateApplier),
+        )
+    }
+
+    /// Create a session manager with a fully injected set of dependencies,
+    /// including an isolated state path and a custom [`UpdateApplier`] (used by
+    /// the deferred-update tests so they never touch the real `state.json` or
+    /// re-exec the test process).
+    #[cfg(test)]
+    pub fn with_test_deps(
+        notification_tx: NotificationSender,
+        registry: Arc<ConnectionTypeRegistry>,
+        launcher: Arc<dyn DaemonLauncher>,
+        state_path: PathBuf,
+        update_applier: Arc<dyn UpdateApplier>,
+    ) -> Self {
+        Self::with_deps(
+            notification_tx,
+            registry,
+            launcher,
+            state_path,
+            update_applier,
+        )
+    }
+
+    fn with_deps(
+        notification_tx: NotificationSender,
+        registry: Arc<ConnectionTypeRegistry>,
+        launcher: Arc<dyn DaemonLauncher>,
+        state_path: PathBuf,
+        update_applier: Arc<dyn UpdateApplier>,
+    ) -> Self {
+        let state = AgentState::load_from(&state_path);
         Self {
             sessions: Mutex::new(HashMap::new()),
             notification_tx,
             registry,
             launcher,
-            state: Mutex::new(AgentState::load()),
+            state: Mutex::new(state),
+            state_path,
+            update_applier,
             persistent_buffer_size: Arc::new(AtomicUsize::new(DEFAULT_PERSISTENT_BUFFER_SIZE)),
         }
     }
@@ -383,7 +471,7 @@ impl SessionManager {
         if capabilities.persistent {
             if let SessionBackend::Daemon(ref client) = backend {
                 let mut state = self.state.lock().await;
-                state.add_session(
+                state.sessions.insert(
                     id.clone(),
                     PersistedSession {
                         type_id: type_id.to_string(),
@@ -394,6 +482,7 @@ impl SessionManager {
                         definition_id: definition_id.clone(),
                     },
                 );
+                state.save_to(&self.state_path);
             }
         }
 
@@ -520,19 +609,40 @@ impl SessionManager {
     /// Disconnects the backend before removing the session.
     /// Returns `true` if the session was found and removed.
     pub async fn close(&self, session_id: &str) -> bool {
-        let mut sessions = self.sessions.lock().await;
-        if let Some(mut info) = sessions.remove(session_id) {
-            close_backend(&mut info.backend).await;
-
-            {
-                let mut state = self.state.lock().await;
-                state.remove_session(session_id);
+        let reached_zero = {
+            let mut sessions = self.sessions.lock().await;
+            match sessions.remove(session_id) {
+                Some(mut info) => {
+                    close_backend(&mut info.backend).await;
+                    // Compute the remaining running count while we still hold the
+                    // lock so the "reached zero" decision can't race a concurrent
+                    // create/close.
+                    sessions
+                        .values()
+                        .filter(|s| s.status == SessionStatus::Running)
+                        .count()
+                        == 0
+                }
+                None => return false,
             }
+        };
 
-            true
-        } else {
-            false
+        {
+            let mut state = self.state.lock().await;
+            state.sessions.remove(session_id);
+            state.save_to(&self.state_path);
         }
+
+        // Deferred-update hook: when the last session disconnects and an update
+        // is pending, apply it now (persistent daemon sessions are unaffected —
+        // there are none left running here).
+        if reached_zero {
+            if let Err(e) = self.apply_pending_update().await {
+                warn!("Deferred agent update failed to apply on last disconnect: {e:#}");
+            }
+        }
+
+        true
     }
 
     /// Detach all sessions without closing them.
@@ -609,7 +719,8 @@ impl SessionManager {
                 None => {
                     warn!("Session {id} has no daemon endpoint, removing");
                     let mut state = self.state.lock().await;
-                    state.remove_session(id);
+                    state.sessions.remove(id);
+                    state.save_to(&self.state_path);
                     continue;
                 }
             };
@@ -617,7 +728,8 @@ impl SessionManager {
             if !endpoint_alive(&endpoint) {
                 info!("Daemon endpoint gone for session {id}, removing from state");
                 let mut state = self.state.lock().await;
-                state.remove_session(id);
+                state.sessions.remove(id);
+                state.save_to(&self.state_path);
                 continue;
             }
 
@@ -648,7 +760,8 @@ impl SessionManager {
                 Err(e) => {
                     warn!("Failed to recover session {id}: {e}");
                     let mut state = self.state.lock().await;
-                    state.remove_session(id);
+                    state.sessions.remove(id);
+                    state.save_to(&self.state_path);
                 }
             }
         }
@@ -667,6 +780,87 @@ impl SessionManager {
             .values()
             .filter(|s| s.status == SessionStatus::Running)
             .count() as u32
+    }
+
+    /// Record a deferred agent update and apply it immediately if the agent is
+    /// already idle (#1352).
+    ///
+    /// When `binary_path` is `Some`, that binary is staged as the pending update
+    /// (persisted to `state.json`). When it is `None`, the already-staged pending
+    /// update is used — this is the "Apply Now" path for a self-update binary the
+    /// agent downloaded earlier.
+    ///
+    /// The update is applied immediately **only** when there are zero active
+    /// sessions; otherwise it is deferred until the last session disconnects
+    /// (see [`SessionManager::close`]). Active sessions are never interrupted.
+    pub async fn request_deferred_update(
+        &self,
+        binary_path: Option<String>,
+        version: Option<String>,
+    ) -> Result<DeferredUpdateOutcome, DeferredUpdateError> {
+        // Stage a caller-supplied binary, or fall back to an existing pending
+        // update.
+        if let Some(path) = binary_path {
+            if !Path::new(&path).is_file() {
+                return Err(DeferredUpdateError::BinaryNotFound(path));
+            }
+            let mut state = self.state.lock().await;
+            state.update.pending_update = Some(PendingUpdate {
+                version: version.unwrap_or_default(),
+                binary_path: path,
+                staged_at: Utc::now().to_rfc3339(),
+            });
+            state.save_to(&self.state_path);
+        }
+
+        let has_pending = self.state.lock().await.update.pending_update.is_some();
+        if !has_pending {
+            return Err(DeferredUpdateError::NoPendingUpdate);
+        }
+
+        let active = self.active_count().await;
+        if should_apply_deferred_update(active, true) {
+            self.apply_pending_update()
+                .await
+                .map_err(DeferredUpdateError::ApplyFailed)?;
+            Ok(DeferredUpdateOutcome::Applying)
+        } else {
+            info!(
+                "Deferred agent update recorded — will apply when the last of {active} \
+                 active session(s) disconnects"
+            );
+            Ok(DeferredUpdateOutcome::Deferred {
+                active_sessions: active,
+            })
+        }
+    }
+
+    /// Consume the pending update (clearing it from persisted state) and apply
+    /// it. A no-op when nothing is pending.
+    ///
+    /// The pending update is cleared **before** the apply so a failed or
+    /// re-execed apply can never trigger an apply loop. On a successful Unix
+    /// apply the process re-execs and this never returns.
+    async fn apply_pending_update(&self) -> anyhow::Result<()> {
+        let pending = {
+            let mut state = self.state.lock().await;
+            let taken = state.update.pending_update.take();
+            if taken.is_some() {
+                state.save_to(&self.state_path);
+            }
+            taken
+        };
+
+        match pending {
+            Some(pending) => {
+                info!(
+                    "Applying deferred agent update (version {:?}) from {}",
+                    pending.version, pending.binary_path
+                );
+                self.update_applier.apply(&pending)
+            }
+            None => Ok(()),
+        }
     }
 }
 
@@ -813,6 +1007,14 @@ impl SessionManagerApi for SessionManager {
 
     async fn active_count(&self) -> u32 {
         SessionManager::active_count(self).await
+    }
+
+    async fn request_deferred_update(
+        &self,
+        binary_path: Option<String>,
+        version: Option<String>,
+    ) -> Result<DeferredUpdateOutcome, DeferredUpdateError> {
+        SessionManager::request_deferred_update(self, binary_path, version).await
     }
 
     async fn attach(&self, session_id: &str) -> Result<(), String> {
@@ -1032,6 +1234,207 @@ mod tests {
             let snapshot = info.snapshot();
             sessions.insert(id, info);
             Ok(snapshot)
+        }
+
+        /// Seed a pending update directly into the in-memory + persisted state
+        /// (test-only), so the zero-session hook has something to apply.
+        #[cfg(test)]
+        pub async fn seed_pending_update_for_test(
+            &self,
+            pending: crate::state::persistence::PendingUpdate,
+        ) {
+            let mut state = self.state.lock().await;
+            state.update.pending_update = Some(pending);
+            state.save_to(&self.state_path);
+        }
+
+        /// Read the current pending update (test-only).
+        #[cfg(test)]
+        pub async fn pending_update_for_test(
+            &self,
+        ) -> Option<crate::state::persistence::PendingUpdate> {
+            self.state.lock().await.update.pending_update.clone()
+        }
+    }
+
+    // ── Deferred update (issue #1352) ────────────────────────────────
+
+    mod deferred_update_tests {
+        use super::*;
+        use crate::state::persistence::PendingUpdate;
+        use crate::update::UpdateApplier;
+        use std::sync::Mutex as StdMutex;
+
+        /// [`UpdateApplier`] that records apply calls instead of swapping the
+        /// binary + re-execing, so the zero-session hook can be tested without
+        /// replacing the test process.
+        struct RecordingApplier {
+            applied: Arc<StdMutex<Vec<PendingUpdate>>>,
+        }
+
+        impl UpdateApplier for RecordingApplier {
+            fn apply(&self, pending: &PendingUpdate) -> anyhow::Result<()> {
+                self.applied
+                    .lock()
+                    .expect("recording lock")
+                    .push(pending.clone());
+                Ok(())
+            }
+        }
+
+        type AppliedLog = Arc<StdMutex<Vec<PendingUpdate>>>;
+
+        fn manager_with_recording_applier() -> (SessionManager, AppliedLog, tempfile::TempDir) {
+            let tmp = tempfile::tempdir().unwrap();
+            let state_path = tmp.path().join("state.json");
+            let applied: AppliedLog = Arc::new(StdMutex::new(Vec::new()));
+            let mgr = SessionManager::with_test_deps(
+                test_notification_tx(),
+                test_registry(),
+                Arc::new(SystemDaemonLauncher),
+                state_path,
+                Arc::new(RecordingApplier {
+                    applied: applied.clone(),
+                }),
+            );
+            (mgr, applied, tmp)
+        }
+
+        fn fake_pending(path: &str) -> PendingUpdate {
+            PendingUpdate {
+                version: "0.9.0".to_string(),
+                binary_path: path.to_string(),
+                staged_at: "2026-07-14T09:00:00Z".to_string(),
+            }
+        }
+
+        #[tokio::test]
+        async fn applies_only_on_last_disconnect() {
+            let (mgr, applied, _tmp) = manager_with_recording_applier();
+            mgr.create_stub_session("stub", "A".to_string(), serde_json::json!({}))
+                .await
+                .unwrap();
+            mgr.create_stub_session("stub", "B".to_string(), serde_json::json!({}))
+                .await
+                .unwrap();
+            mgr.seed_pending_update_for_test(fake_pending("/tmp/new-agent"))
+                .await;
+
+            let ids: Vec<String> = mgr.list().await.into_iter().map(|s| s.id).collect();
+
+            // Closing the first of two sessions must NOT apply the update.
+            mgr.close(&ids[0]).await;
+            assert!(
+                applied.lock().unwrap().is_empty(),
+                "update must not apply while a session is still running"
+            );
+
+            // Closing the last session applies it exactly once.
+            mgr.close(&ids[1]).await;
+            let log = applied.lock().unwrap();
+            assert_eq!(log.len(), 1, "update applies exactly on last disconnect");
+            assert_eq!(log[0].binary_path, "/tmp/new-agent");
+        }
+
+        #[tokio::test]
+        async fn last_disconnect_without_pending_does_not_apply() {
+            let (mgr, applied, _tmp) = manager_with_recording_applier();
+            mgr.create_stub_session("stub", "A".to_string(), serde_json::json!({}))
+                .await
+                .unwrap();
+            let ids: Vec<String> = mgr.list().await.into_iter().map(|s| s.id).collect();
+            mgr.close(&ids[0]).await;
+            assert!(
+                applied.lock().unwrap().is_empty(),
+                "no pending update → nothing applied on last disconnect"
+            );
+        }
+
+        #[tokio::test]
+        async fn request_with_active_sessions_defers_without_applying() {
+            let (mgr, applied, tmp) = manager_with_recording_applier();
+            mgr.create_stub_session("stub", "A".to_string(), serde_json::json!({}))
+                .await
+                .unwrap();
+            // A real file so path validation passes.
+            let bin = tmp.path().join("staged-agent");
+            std::fs::write(&bin, b"BIN").unwrap();
+
+            let outcome = mgr
+                .request_deferred_update(
+                    Some(bin.to_string_lossy().into_owned()),
+                    Some("1.0.0".to_string()),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                matches!(
+                    outcome,
+                    DeferredUpdateOutcome::Deferred { active_sessions: 1 }
+                ),
+                "must defer with an active session, got {outcome:?}"
+            );
+            assert!(
+                applied.lock().unwrap().is_empty(),
+                "must not apply while a session is active"
+            );
+            assert!(
+                mgr.pending_update_for_test().await.is_some(),
+                "the pending update must be persisted for the last-disconnect apply"
+            );
+        }
+
+        #[tokio::test]
+        async fn request_when_idle_applies_immediately() {
+            let (mgr, applied, tmp) = manager_with_recording_applier();
+            let bin = tmp.path().join("staged-agent");
+            std::fs::write(&bin, b"BIN").unwrap();
+
+            let outcome = mgr
+                .request_deferred_update(Some(bin.to_string_lossy().into_owned()), None)
+                .await
+                .unwrap();
+
+            assert!(
+                matches!(outcome, DeferredUpdateOutcome::Applying),
+                "idle agent applies immediately, got {outcome:?}"
+            );
+            assert_eq!(applied.lock().unwrap().len(), 1);
+            // Consumed on apply.
+            assert!(mgr.pending_update_for_test().await.is_none());
+        }
+
+        #[tokio::test]
+        async fn request_without_path_applies_existing_pending_when_idle() {
+            // The "Apply Now" path for an already-staged self-update: no binary
+            // path is supplied, the agent uses its recorded pending update.
+            let (mgr, applied, _tmp) = manager_with_recording_applier();
+            mgr.seed_pending_update_for_test(fake_pending("/tmp/staged-agent"))
+                .await;
+
+            let outcome = mgr.request_deferred_update(None, None).await.unwrap();
+            assert!(matches!(outcome, DeferredUpdateOutcome::Applying));
+            let log = applied.lock().unwrap();
+            assert_eq!(log.len(), 1);
+            assert_eq!(log[0].binary_path, "/tmp/staged-agent");
+        }
+
+        #[tokio::test]
+        async fn request_without_path_and_no_pending_errors() {
+            let (mgr, _applied, _tmp) = manager_with_recording_applier();
+            let err = mgr.request_deferred_update(None, None).await.unwrap_err();
+            assert!(matches!(err, DeferredUpdateError::NoPendingUpdate));
+        }
+
+        #[tokio::test]
+        async fn request_with_missing_binary_errors() {
+            let (mgr, _applied, _tmp) = manager_with_recording_applier();
+            let err = mgr
+                .request_deferred_update(Some("/no/such/binary".to_string()), None)
+                .await
+                .unwrap_err();
+            assert!(matches!(err, DeferredUpdateError::BinaryNotFound(_)));
         }
     }
 

--- a/agent/src/state/persistence.rs
+++ b/agent/src/state/persistence.rs
@@ -124,30 +124,6 @@ impl AgentState {
         }
     }
 
-    /// Load state from the default state file.
-    pub fn load() -> Self {
-        let path = Self::default_path();
-        Self::load_from(&path)
-    }
-
-    /// Save state to the default state file.
-    pub fn save(&self) {
-        let path = Self::default_path();
-        self.save_to(&path);
-    }
-
-    /// Add a session and persist.
-    pub fn add_session(&mut self, id: String, session: PersistedSession) {
-        self.sessions.insert(id, session);
-        self.save();
-    }
-
-    /// Remove a session and persist.
-    pub fn remove_session(&mut self, id: &str) {
-        self.sessions.remove(id);
-        self.save();
-    }
-
     /// The default `state.json` path under the platform config dir.
     ///
     /// Resolves to `$XDG_CONFIG_HOME/termihub-agent/state.json` on Linux,

--- a/agent/src/state/persistence.rs
+++ b/agent/src/state/persistence.rs
@@ -33,12 +33,15 @@ pub struct UpdateState {
     pub pending_update: Option<PendingUpdate>,
 }
 
-/// A self-update binary that has been downloaded and SHA-256-verified but not
-/// yet applied.
+/// An agent binary that has been staged (downloaded + SHA-256-verified, or
+/// pushed via `agent.request_deferred_update`) but not yet applied.
 ///
-/// Applying it on idle (deferred apply) depends on SI-6 (#1352) and is
-/// intentionally not wired up yet — until then the agent only stages the binary
-/// and records it here so a later change can pick it up.
+/// The deferred apply (SI-6, #1352) is wired: the agent applies this when its
+/// last session disconnects, or immediately via `agent.request_deferred_update`
+/// when it is idle — see [`crate::session::manager::SessionManager`] and the
+/// `crate::update::apply` module. (Auto-applying a *self-update* staged by the
+/// background timer on idle is still staging-only; that wiring is tracked
+/// separately.)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PendingUpdate {
     /// Target version (release tag semver, e.g. `"0.3.0"`).
@@ -71,15 +74,9 @@ pub struct PersistedSession {
 }
 
 impl AgentState {
-    /// Load state from the default state file.
+    /// Load state from a specific path.
     ///
     /// Returns an empty state if the file is missing or corrupt.
-    pub fn load() -> Self {
-        let path = Self::default_path();
-        Self::load_from(&path)
-    }
-
-    /// Load state from a specific path (for testing).
     pub fn load_from(path: &PathBuf) -> Self {
         match std::fs::read_to_string(path) {
             Ok(contents) => match serde_json::from_str::<AgentState>(&contents) {
@@ -103,13 +100,7 @@ impl AgentState {
         }
     }
 
-    /// Save state to the default state file.
-    pub fn save(&self) {
-        let path = Self::default_path();
-        self.save_to(&path);
-    }
-
-    /// Save state to a specific path (for testing).
+    /// Save state to a specific path.
     pub fn save_to(&self, path: &PathBuf) {
         if let Some(parent) = path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
@@ -131,6 +122,18 @@ impl AgentState {
                 warn!("Failed to serialize agent state: {}", e);
             }
         }
+    }
+
+    /// Load state from the default state file.
+    pub fn load() -> Self {
+        let path = Self::default_path();
+        Self::load_from(&path)
+    }
+
+    /// Save state to the default state file.
+    pub fn save(&self) {
+        let path = Self::default_path();
+        self.save_to(&path);
     }
 
     /// Add a session and persist.
@@ -378,6 +381,40 @@ mod tests {
             .expect("pending update present");
         assert_eq!(pending.version, "0.3.0");
         assert_eq!(pending.binary_path, "/tmp/updates/termihub-agent-linux-x64");
+    }
+
+    #[test]
+    fn deferred_update_request_round_trips_and_consumes() {
+        // A deferred update requested via `agent.request_deferred_update` records
+        // a PendingUpdate (version may be empty when only a path is supplied). It
+        // must survive a restart and clear cleanly once consumed on apply.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.json");
+
+        let mut state = AgentState::default();
+        state.update.pending_update = Some(PendingUpdate {
+            version: String::new(),
+            binary_path: "/opt/updates/termihub-agent".to_string(),
+            staged_at: "2026-07-14T09:00:00Z".to_string(),
+        });
+        state.save_to(&path);
+
+        // Survives a restart.
+        let mut reloaded = AgentState::load_from(&path);
+        let pending = reloaded
+            .update
+            .pending_update
+            .clone()
+            .expect("pending update present after reload");
+        assert_eq!(pending.binary_path, "/opt/updates/termihub-agent");
+        assert!(pending.version.is_empty());
+
+        // Consuming it (apply) clears it and persists the cleared state.
+        let taken = reloaded.update.pending_update.take();
+        assert!(taken.is_some());
+        reloaded.save_to(&path);
+        let after = AgentState::load_from(&path);
+        assert!(after.update.pending_update.is_none());
     }
 
     #[test]

--- a/agent/src/update/apply.rs
+++ b/agent/src/update/apply.rs
@@ -1,0 +1,168 @@
+//! Applying a deferred agent update (#1352, SI-6).
+//!
+//! The deferred-update contract: a staged/pending update is applied **strictly**
+//! when the agent has zero active sessions, so swapping the running binary never
+//! interrupts a live session. Persistent sessions live in detached daemon
+//! processes ([`crate::daemon`]) that are decoupled from the agent's lifetime, so
+//! replacing (and re-execing) the agent binary leaves them running — they are
+//! re-attached by [`crate::session::manager::SessionManager::recover_sessions`]
+//! once the new agent starts.
+//!
+//! The actual binary swap + re-exec is Unix-only (see [`apply_update_binary`]);
+//! on other platforms it returns an error so the caller can surface it, keeping
+//! the whole crate compiling everywhere.
+
+#[cfg(unix)]
+use std::path::Path;
+
+use crate::state::persistence::PendingUpdate;
+
+/// Decide whether a pending update should be applied right now.
+///
+/// Returns `true` only when the agent is idle (`active_count == 0`) **and** an
+/// update is actually pending. This is the single source of truth for the
+/// "apply on last disconnect" gate: it must never return `true` while a session
+/// is still running.
+pub fn should_apply_deferred_update(active_count: u32, has_pending: bool) -> bool {
+    active_count == 0 && has_pending
+}
+
+/// Applies a staged agent update by swapping the running binary and re-execing.
+///
+/// Injected into [`crate::session::manager::SessionManager`] so tests can record
+/// apply calls without replacing the test process.
+pub trait UpdateApplier: Send + Sync + 'static {
+    /// Apply `pending`.
+    ///
+    /// On a successful Unix apply the process image is replaced by the new
+    /// binary and this call **never returns**. An `Err` means the swap or
+    /// re-exec failed (or the platform is unsupported) and the agent keeps
+    /// running with the update unapplied.
+    fn apply(&self, pending: &PendingUpdate) -> anyhow::Result<()>;
+}
+
+/// Production [`UpdateApplier`] that swaps the on-disk binary and re-execs.
+pub struct SystemUpdateApplier;
+
+impl UpdateApplier for SystemUpdateApplier {
+    fn apply(&self, pending: &PendingUpdate) -> anyhow::Result<()> {
+        apply_update_binary(&pending.binary_path)
+    }
+}
+
+/// Swap the running agent binary with the staged one and re-exec (Unix).
+///
+/// The staged binary is copied over the current executable atomically (via a
+/// temp file + `rename` in the same directory) and then the process re-execs
+/// itself with the same CLI arguments so the new code takes over immediately.
+#[cfg(unix)]
+fn apply_update_binary(binary_path: &str) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    let current = std::env::current_exe().context("resolve current agent executable")?;
+    replace_binary(Path::new(binary_path), &current)
+        .with_context(|| format!("replace agent binary at {}", current.display()))?;
+    reexec(&current)
+}
+
+/// Non-Unix stub: applying a deferred update is only supported on Unix, where a
+/// running executable can be replaced in place. Returns an error so the caller
+/// surfaces it; keeps Windows/other builds compiling.
+#[cfg(not(unix))]
+fn apply_update_binary(_binary_path: &str) -> anyhow::Result<()> {
+    anyhow::bail!("deferred agent update apply is only supported on Unix platforms")
+}
+
+/// Atomically replace the executable at `dst` with the file at `src`, marking it
+/// executable. Copies to a sibling temp file first so a crash mid-copy can never
+/// leave a truncated agent binary in place.
+#[cfg(unix)]
+fn replace_binary(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    use anyhow::Context;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = dst.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = dir.join(".termihub-agent.update.tmp");
+
+    std::fs::copy(src, &tmp)
+        .with_context(|| format!("copy staged binary {} -> {}", src.display(), tmp.display()))?;
+
+    let mut perms = std::fs::metadata(&tmp)
+        .with_context(|| format!("stat staged binary {}", tmp.display()))?
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&tmp, perms)
+        .with_context(|| format!("chmod staged binary {}", tmp.display()))?;
+
+    std::fs::rename(&tmp, dst).with_context(|| format!("atomically replace {}", dst.display()))?;
+
+    Ok(())
+}
+
+/// Re-exec `exe` with the current process's CLI arguments. On success this
+/// replaces the process image and never returns; it only returns on failure.
+#[cfg(unix)]
+fn reexec(exe: &Path) -> anyhow::Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    // `exec` replaces the current image with `exe`; control only returns here if
+    // the exec itself failed.
+    let err = std::process::Command::new(exe).args(&args).exec();
+    Err(anyhow::anyhow!(
+        "re-exec of {} failed: {err}",
+        exe.display()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applies_only_when_idle_and_pending() {
+        // The core "apply on last disconnect" gate.
+        assert!(
+            should_apply_deferred_update(0, true),
+            "idle + pending → apply"
+        );
+        assert!(
+            !should_apply_deferred_update(0, false),
+            "idle but nothing pending → no apply"
+        );
+        assert!(
+            !should_apply_deferred_update(1, true),
+            "one active session → never apply"
+        );
+        assert!(
+            !should_apply_deferred_update(5, true),
+            "several active sessions → never apply"
+        );
+        assert!(
+            !should_apply_deferred_update(1, false),
+            "active + nothing pending → no apply"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replace_binary_swaps_contents_and_marks_executable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let staged = tmp.path().join("staged-agent");
+        let current = tmp.path().join("running-agent");
+        std::fs::write(&staged, b"NEW-BINARY").unwrap();
+        std::fs::write(&current, b"OLD-BINARY").unwrap();
+        // Start the "running" binary non-executable to prove replace fixes perms.
+        std::fs::set_permissions(&current, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        replace_binary(&staged, &current).unwrap();
+
+        assert_eq!(std::fs::read(&current).unwrap(), b"NEW-BINARY");
+        let mode = std::fs::metadata(&current).unwrap().permissions().mode();
+        assert_ne!(mode & 0o111, 0, "replaced binary must be executable");
+        // The temp file must not linger next to the binary.
+        assert!(!tmp.path().join(".termihub-agent.update.tmp").exists());
+    }
+}

--- a/agent/src/update/mod.rs
+++ b/agent/src/update/mod.rs
@@ -17,10 +17,13 @@
 //! # Partial implementation (#1355)
 //!
 //! This lands the poll → semver → verified-download → notify/stage pipeline. The
-//! deferred **auto-apply on idle** step depends on SI-6 (#1352, not yet built);
-//! until it lands the agent stops after staging the verified binary and
-//! recording it in `state.json`. Wiring auto-apply is tracked as a follow-up.
+//! deferred-apply mechanism itself now exists (SI-6, #1352 — see the `apply`
+//! submodule and [`crate::session::manager::SessionManager`]), but the
+//! *background self-update timer* still stops after staging the verified binary
+//! and recording it in `state.json`; auto-triggering the apply from this timer
+//! on idle is tracked as a follow-up.
 
+mod apply;
 mod checksum;
 mod download;
 mod github;
@@ -39,6 +42,7 @@ use crate::protocol::methods::{UpdateAvailableNotification, AGENT_UPDATE_AVAILAB
 use crate::session::manager::SessionManager;
 use crate::state::persistence::{AgentState, PendingUpdate};
 
+pub use apply::{should_apply_deferred_update, SystemUpdateApplier, UpdateApplier};
 pub use github::{current_asset_suffix, DEFAULT_REPO};
 
 /// Default interval between self-update checks (24 hours).
@@ -227,12 +231,15 @@ async fn run_check_once(
                         available_version,
                         dest.display()
                     );
-                    // Deferred auto-apply on idle depends on SI-6 (#1352), which
-                    // is not implemented yet — stop after staging. A follow-up
-                    // wires the apply step once SI-6 lands.
+                    // The deferred-apply mechanism (SI-6 / #1352) now exists, but
+                    // this background timer intentionally stops after staging —
+                    // auto-triggering the apply from the timer on idle is a
+                    // separate follow-up. The staged update will still be applied
+                    // when the last session disconnects or via
+                    // `agent.request_deferred_update`.
                     debug!(
-                        "Self-update: auto-apply deferred (SI-6 / #1352 not implemented); \
-                         binary staged and recorded in state.json"
+                        "Self-update: binary staged and recorded in state.json; \
+                         apply happens on last disconnect or via request_deferred_update"
                     );
                 }
                 Err(e) => {

--- a/core/src/protocol/errors.rs
+++ b/core/src/protocol/errors.rs
@@ -62,6 +62,9 @@ pub const MONITORING_ERROR: i64 = -32014;
 /// An error occurred during agent shutdown.
 pub const SHUTDOWN_ERROR: i64 = -32015;
 
+/// A deferred agent update failed to apply (binary swap / re-exec error).
+pub const DEFERRED_UPDATE_FAILED: i64 = -32016;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -89,6 +92,7 @@ mod tests {
             FILE_BROWSING_NOT_SUPPORTED,
             MONITORING_ERROR,
             SHUTDOWN_ERROR,
+            DEFERRED_UPDATE_FAILED,
         ];
         for code in codes {
             assert!(code < 0, "Error code {code} should be negative");
@@ -131,6 +135,7 @@ mod tests {
             FILE_BROWSING_NOT_SUPPORTED,
             MONITORING_ERROR,
             SHUTDOWN_ERROR,
+            DEFERRED_UPDATE_FAILED,
         ];
         for code in app_codes {
             assert!(

--- a/docs/changes/dev0/feature/1352-agent-deferred-update.md
+++ b/docs/changes/dev0/feature/1352-agent-deferred-update.md
@@ -1,0 +1,13 @@
+### Added
+
+- Deferred agent updates: a remote agent can now be told to update without
+  interrupting active sessions. The update is recorded and applied strictly when
+  the agent's last session disconnects, leaning on the detached-daemon model so
+  persistent sessions survive the binary swap; the next connection reports the
+  new version. When a connected agent reports a staged update
+  (`agent.update_available`), a banner appears near the agent's header in the
+  sidebar. "Apply Now" forces the update — an idle agent swaps immediately and
+  reconnects, while a busy agent defers the swap until its last active session
+  disconnects (the banner reports how many sessions it will wait on). A dropped
+  connection right after an immediate apply is treated as the expected binary
+  swap, not a failure. "Dismiss" hides the banner for the session (#1352).

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -831,6 +831,59 @@ Gracefully shut down the agent process. Active sessions are detached (left runni
 
 ---
 
+### `agent.request_deferred_update`
+
+Request a **deferred agent update** (#1352). The agent records a pending update in `state.json` and applies it **only** when it has zero active sessions — so active sessions are never interrupted. When the agent is already idle it applies immediately (this is the "Apply Now" path); otherwise the update is deferred until the last session disconnects (the agent also emits an `agent.update_available` notification when it stages a self-update, which drives the desktop's "Apply Now" banner).
+
+Applying swaps the on-disk agent binary with the staged one and re-execs it (Unix only). The detached-daemon model means persistent sessions survive the swap and are recovered on the next connect, which reports the new version. Because the agent re-execs on a successful immediate apply, the current connection is torn down — the desktop should treat a subsequent disconnect as expected and reconnect.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "agent.request_deferred_update",
+  "params": {
+    "binaryPath": "/opt/updates/termihub-agent",
+    "version": "0.3.0"
+  },
+  "id": 11
+}
+```
+
+| Param        | Type     | Required | Description                                                                                                                  |
+| ------------ | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `binaryPath` | `string` | No       | Absolute path (on the agent host) to the new agent binary to stage. Omit to apply an update the agent already staged itself. |
+| `version`    | `string` | No       | Target version label (bookkeeping only)                                                                                      |
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "applied": false,
+    "activeSessions": 2
+  },
+  "id": 11
+}
+```
+
+| Result Field     | Type      | Description                                                         |
+| ---------------- | --------- | ------------------------------------------------------------------- |
+| `applied`        | `boolean` | `true` if applied immediately (agent idle); `false` if deferred     |
+| `activeSessions` | `integer` | Sessions still active (the update applies when they all disconnect) |
+
+**Errors:**
+
+| Code     | When                                                            |
+| -------- | --------------------------------------------------------------- |
+| `-32007` | Agent not initialized                                           |
+| `-32602` | `binaryPath` does not exist, or no update is staged to apply    |
+| `-32016` | The update failed to apply (binary swap / re-exec, or non-Unix) |
+
+---
+
 ### `connections.list`
 
 List all saved connections and folders.
@@ -1706,6 +1759,7 @@ For serial sessions:
 | `-32013` | File browsing not supported | File browsing is not supported for this connection type (e.g., serial)               |
 | `-32014` | Monitoring error            | A monitoring operation failed (collection error, SSH failure, etc.)                  |
 | `-32015` | Shutdown error              | An error occurred during agent shutdown                                              |
+| `-32016` | Deferred update failed      | A deferred agent update failed to apply (binary swap / re-exec, or non-Unix)         |
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -778,6 +778,30 @@ E2E test coverage: all WebdriverIO specs have been ported to the cross-platform 
 - For serial port tests: host-side virtual serial ports via `socat` + echo server, set up by `scripts/test-system-linux.sh` (see also `examples/serial/`)
 - Test on each target OS (macOS, Linux, Windows) for cross-platform items
 
+### Deferred agent update (apply on last disconnect) (#1352)
+
+Verifies that a deferred agent update never interrupts active sessions and
+applies strictly when the last session disconnects, and that "Apply Now" forces
+it. Requires a real remote agent (SSH) whose staged binary can be swapped — use
+a Unix agent host (the exec-replace is Unix-only). See PR #1352.
+
+1. **No interruption while busy.** Connect to a remote agent and open at least one
+   long-running session (e.g. `tail -f` or `top`). Stage/deploy a newer agent
+   binary and request a deferred update (or trigger the staged-update banner and
+   press **Apply Now**). Expect: the session keeps running uninterrupted, and the
+   banner/toast reports the update is deferred until the last session disconnects
+   (naming the active-session count).
+2. **Applies on last disconnect.** Close the session(s) one by one. Expect: nothing
+   happens until the **last** session closes; when it does, the agent swaps its
+   binary and re-execs (the connection drops).
+3. **New version on reconnect.** Reconnect to the agent. Expect: the agent version
+   badge reports the new version, and any persistent daemon sessions are recovered.
+4. **Apply Now when idle.** With a staged-update banner shown and no active
+   sessions on the agent, press **Apply Now**. Expect: the update applies
+   immediately, the connection drops, and reconnecting shows the new version.
+5. **Dismiss.** Press **Dismiss** on the banner. Expect: the banner hides for the
+   session and no update is requested.
+
 ### FTP insecure-connection warning & editor behaviors (#1338)
 
 Verifies the plaintext-FTP warning modal, the schema-conditional editor fields,

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -140,6 +140,65 @@ pub async fn apply_agent_settings(
     .unwrap_or_else(|e| Err(e.to_string()))
 }
 
+/// Response to a deferred-update request (`request_agent_deferred_update`).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeferredUpdateResponse {
+    /// `true` if the agent was idle and applied the update immediately.
+    pub applied: bool,
+    /// Sessions still active on the agent (0 when applied immediately).
+    pub active_sessions: u32,
+}
+
+/// Request a deferred agent update (#1352).
+///
+/// Sends `agent.request_deferred_update` over JSON-RPC. When `binary_path` is
+/// omitted the agent applies an update it already staged itself ("Apply Now").
+/// The agent applies immediately only when idle; otherwise it defers until the
+/// last session disconnects, never interrupting active sessions.
+///
+/// Note: when the agent applies immediately it re-execs the new binary, which
+/// tears down the current connection — the caller should treat a subsequent
+/// disconnect as expected and reconnect to observe the new version.
+#[tauri::command]
+pub async fn request_agent_deferred_update(
+    agent_id: String,
+    binary_path: Option<String>,
+    version: Option<String>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
+) -> Result<DeferredUpdateResponse, String> {
+    info!(agent_id, "Requesting deferred agent update");
+    let manager = agent_manager.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut params = serde_json::Map::new();
+        if let Some(path) = binary_path {
+            params.insert("binaryPath".to_string(), Value::String(path));
+        }
+        if let Some(v) = version {
+            params.insert("version".to_string(), Value::String(v));
+        }
+        let result = manager
+            .send_request(
+                &agent_id,
+                "agent.request_deferred_update",
+                Value::Object(params),
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(DeferredUpdateResponse {
+            applied: result
+                .get("applied")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            active_sessions: result
+                .get("activeSessions")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+        })
+    })
+    .await
+    .unwrap_or_else(|e| Err(e.to_string()))
+}
+
 /// Close a session on a remote agent.
 ///
 /// Sends `connection.close` over JSON-RPC to the agent, then the agent

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -677,6 +677,7 @@ pub fn run() {
             commands::agent::shutdown_agent,
             commands::agent::get_agent_capabilities,
             commands::agent::apply_agent_settings,
+            commands::agent::request_agent_deferred_update,
             commands::agent::list_agent_sessions,
             commands::agent::close_agent_session,
             commands::agent::list_agent_definitions,

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -1587,6 +1587,21 @@ fn emit_agent_state(app_handle: &AppHandle, agent_id: &str, state: &str) {
     emit_agent_state_with_error(app_handle, agent_id, state, None);
 }
 
+/// Forward an agent's `agent.update_available` notification to the frontend as
+/// the `agent-update-available` Tauri event (#1352). Tags it with the desktop's
+/// `agent_id` so the per-agent deferred-update banner can key off it.
+fn emit_agent_update_available(app_handle: &AppHandle, agent_id: &str, params: &Value) {
+    let _ = app_handle.emit(
+        "agent-update-available",
+        serde_json::json!({
+            "agent_id": agent_id,
+            "currentVersion": params.get("currentVersion").and_then(Value::as_str).unwrap_or(""),
+            "availableVersion": params.get("availableVersion").and_then(Value::as_str).unwrap_or(""),
+            "staged": params.get("staged").and_then(Value::as_bool).unwrap_or(false),
+        }),
+    );
+}
+
 // ── Async I/O task ───────────────────────────────────────────────────
 
 /// Main async I/O task for an agent connection.
@@ -1731,6 +1746,13 @@ async fn agent_io_task(
                                         }
                                     }
                                     Ok(jsonrpc::JsonRpcMessage::Notification { method, params }) => {
+                                        if method == "agent.update_available" {
+                                            emit_agent_update_available(
+                                                &app_handle,
+                                                &agent_id,
+                                                &params,
+                                            );
+                                        }
                                         handle_notification(
                                             &method,
                                             &params,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { useTunnelEvents } from "@/hooks/useTunnelEvents";
 import { useTransferEvents } from "@/hooks/useTransferEvents";
 import { useEmbeddedServerEvents } from "@/hooks/useEmbeddedServerEvents";
 import { useCredentialStoreEvents } from "@/hooks/useCredentialStoreEvents";
+import { useAgentUpdateEvents } from "@/hooks/useAgentUpdateEvents";
 import { useSpawnRequests } from "@/hooks/useSpawnRequests";
 import { useHttpMonitorNotifications } from "@/hooks/useHttpMonitorNotifications";
 import { useWebviewZoom } from "@/hooks/useWebviewZoom";
@@ -105,6 +106,7 @@ function App() {
   useTransferEvents();
   useEmbeddedServerEvents();
   useCredentialStoreEvents();
+  useAgentUpdateEvents();
   useSpawnRequests();
   useHttpMonitorNotifications();
   useWebviewZoom();

--- a/src/components/AgentUpdateBanner/AgentUpdateBanner.css
+++ b/src/components/AgentUpdateBanner/AgentUpdateBanner.css
@@ -1,0 +1,44 @@
+/* Per-agent deferred-update banner (issue 1352). Tokens only. */
+
+.agent-update-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: color-mix(in srgb, var(--accent-color) 10%, var(--bg-secondary));
+  border-top: 1px solid var(--border-primary);
+  border-bottom: 1px solid var(--border-primary);
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+}
+
+.agent-update-banner__icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--accent-color);
+  flex-shrink: 0;
+}
+
+.agent-update-banner__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.agent-update-banner__text strong {
+  font-weight: var(--font-weight-semibold);
+}
+
+.agent-update-banner__text span {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.agent-update-banner__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-shrink: 0;
+}

--- a/src/components/AgentUpdateBanner/AgentUpdateBanner.test.tsx
+++ b/src/components/AgentUpdateBanner/AgentUpdateBanner.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { AgentPendingUpdate } from "@/store/appStore";
+import * as api from "@/services/api";
+import { AgentUpdateBanner } from "./AgentUpdateBanner";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/api")>();
+  return {
+    ...actual,
+    requestAgentDeferredUpdate: vi.fn(),
+  };
+});
+
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return {
+    ...actual,
+    toast: toastMocks,
+  };
+});
+
+const mockedApi = vi.mocked(api);
+
+const AGENT_ID = "agent-1";
+const AGENT_NAME = "prod-box";
+
+function stagedUpdate(overrides: Partial<AgentPendingUpdate> = {}): AgentPendingUpdate {
+  return { currentVersion: "0.1.0", availableVersion: "0.2.0", staged: true, ...overrides };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render() {
+  await act(async () => {
+    root.render(<AgentUpdateBanner agentId={AGENT_ID} agentName={AGENT_NAME} />);
+  });
+}
+
+function byTestId(id: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${id}"]`);
+}
+
+const bannerId = `agent-update-banner-${AGENT_ID}`;
+const applyId = `agent-update-banner-apply-${AGENT_ID}`;
+const dismissId = `agent-update-banner-dismiss-${AGENT_ID}`;
+
+describe("AgentUpdateBanner", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({
+      agentUpdates: { [AGENT_ID]: stagedUpdate() },
+      agentUpdatesDismissed: {},
+    });
+    mockedApi.requestAgentDeferredUpdate.mockResolvedValue({ applied: true, activeSessions: 0 });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders when a staged update exists", async () => {
+    await render();
+    expect(byTestId(bannerId)).not.toBeNull();
+    expect(byTestId(bannerId)?.textContent).toContain("0.2.0");
+    expect(byTestId(bannerId)?.textContent).toContain(AGENT_NAME);
+  });
+
+  it("does not render when no update is recorded", async () => {
+    useAppStore.setState({ agentUpdates: {} });
+    await render();
+    expect(byTestId(bannerId)).toBeNull();
+  });
+
+  it("does not render when the update is not staged", async () => {
+    useAppStore.setState({ agentUpdates: { [AGENT_ID]: stagedUpdate({ staged: false }) } });
+    await render();
+    expect(byTestId(bannerId)).toBeNull();
+  });
+
+  it("applies immediately and shows success when applied=true", async () => {
+    await render();
+    await act(async () => {
+      byTestId(applyId)?.click();
+    });
+    expect(mockedApi.requestAgentDeferredUpdate).toHaveBeenCalledWith(AGENT_ID);
+    expect(toastMocks.success).toHaveBeenCalledTimes(1);
+    // Banner hides once the update has been triggered.
+    expect(byTestId(bannerId)).toBeNull();
+  });
+
+  it("shows the deferred message when applied=false", async () => {
+    mockedApi.requestAgentDeferredUpdate.mockResolvedValue({ applied: false, activeSessions: 3 });
+    await render();
+    await act(async () => {
+      byTestId(applyId)?.click();
+    });
+    expect(toastMocks.info).toHaveBeenCalledTimes(1);
+    expect(toastMocks.info.mock.calls[0][0]).toContain("3");
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("treats a post-apply connection drop as instructional, not an error", async () => {
+    mockedApi.requestAgentDeferredUpdate.mockRejectedValue(new Error("connection closed"));
+    await render();
+    await act(async () => {
+      byTestId(applyId)?.click();
+    });
+    expect(toastMocks.info).toHaveBeenCalledTimes(1);
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+
+  it("hides the banner on Dismiss without calling the update API", async () => {
+    await render();
+    await act(async () => {
+      byTestId(dismissId)?.click();
+    });
+    expect(byTestId(bannerId)).toBeNull();
+    expect(mockedApi.requestAgentDeferredUpdate).not.toHaveBeenCalled();
+    expect(useAppStore.getState().agentUpdatesDismissed[AGENT_ID]).toBe(true);
+  });
+});

--- a/src/components/AgentUpdateBanner/AgentUpdateBanner.tsx
+++ b/src/components/AgentUpdateBanner/AgentUpdateBanner.tsx
@@ -1,0 +1,119 @@
+import { useCallback } from "react";
+import { ArrowUpCircle } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { Button, toast } from "@/components/ui";
+import { requestAgentDeferredUpdate } from "@/services/api";
+import "./AgentUpdateBanner.css";
+
+/** Props for {@link AgentUpdateBanner}. */
+export interface AgentUpdateBannerProps {
+  /** Id of the agent this banner belongs to. */
+  agentId: string;
+  /** Display name of the agent, shown in the banner copy. */
+  agentName: string;
+}
+
+/**
+ * Connection-drop errors are expected while the agent swaps its own binary on
+ * an immediate ("applied") update — the transport goes away as the process
+ * restarts. Treat those as instructional success rather than a hard failure.
+ */
+function isExpectedApplyDisconnect(error: unknown): boolean {
+  const raw = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return (
+    raw.includes("disconnect") ||
+    raw.includes("connection") ||
+    raw.includes("closed") ||
+    raw.includes("timeout") ||
+    raw.includes("reset") ||
+    raw.includes("eof") ||
+    raw.includes("not connected") ||
+    raw.includes("broken pipe")
+  );
+}
+
+/**
+ * Per-agent banner offering to apply a staged deferred update (#1352). Shown
+ * near a connected agent's header when the agent has reported a staged update
+ * (`agent.update_available`, `staged: true`) that the user has not dismissed.
+ *
+ * "Apply Now" requests the deferred update: when the agent is idle it swaps
+ * immediately (`applied: true`); otherwise it defers until the last active
+ * session disconnects (`applied: false`, `activeSessions: N`). The staged
+ * binary is applied automatically on that last disconnect regardless — the
+ * banner just lets the user trigger it sooner. Every outcome resolves with a
+ * toast; a post-apply connection drop is treated as expected.
+ */
+export function AgentUpdateBanner({ agentId, agentName }: AgentUpdateBannerProps) {
+  const update = useAppStore((s) => s.agentUpdates[agentId]);
+  const dismissed = useAppStore((s) => s.agentUpdatesDismissed[agentId] ?? false);
+  const dismissAgentUpdate = useAppStore((s) => s.dismissAgentUpdate);
+
+  const handleApply = useCallback(async () => {
+    try {
+      const result = await requestAgentDeferredUpdate(agentId);
+      if (result.applied) {
+        toast.success("Agent updated — reconnecting…");
+      } else {
+        const n = result.activeSessions;
+        toast.info(
+          `Update deferred — it will be applied automatically when the last of ${n} active ` +
+            `session${n === 1 ? "" : "s"} disconnects.`
+        );
+      }
+      dismissAgentUpdate(agentId);
+    } catch (err) {
+      // A dropped connection right after triggering an immediate apply is the
+      // binary swap in progress, not a real failure — report it as instructional.
+      if (isExpectedApplyDisconnect(err)) {
+        toast.info("Agent is updating — it will reconnect automatically once the swap completes.");
+        dismissAgentUpdate(agentId);
+        return;
+      }
+      // Genuine failure: rethrow so the async Button surfaces a recoverable
+      // error toast and returns to idle.
+      throw err;
+    }
+  }, [agentId, dismissAgentUpdate]);
+
+  const handleDismiss = useCallback(() => {
+    dismissAgentUpdate(agentId);
+  }, [agentId, dismissAgentUpdate]);
+
+  // Only surface a staged, undismissed update.
+  if (!update || !update.staged || dismissed) {
+    return null;
+  }
+
+  return (
+    <div className="agent-update-banner" data-testid={`agent-update-banner-${agentId}`}>
+      <span className="agent-update-banner__icon">
+        <ArrowUpCircle size={16} />
+      </span>
+      <div className="agent-update-banner__text">
+        <strong>
+          {agentName}: update available (v{update.availableVersion})
+        </strong>
+        <span>It will be applied automatically when the last session disconnects.</span>
+      </div>
+      <div className="agent-update-banner__actions">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleDismiss}
+          data-testid={`agent-update-banner-dismiss-${agentId}`}
+        >
+          Dismiss
+        </Button>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleApply}
+          data-testid={`agent-update-banner-apply-${agentId}`}
+        >
+          Apply Now
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AgentUpdateBanner/index.ts
+++ b/src/components/AgentUpdateBanner/index.ts
@@ -1,0 +1,2 @@
+export { AgentUpdateBanner } from "./AgentUpdateBanner";
+export type { AgentUpdateBannerProps } from "./AgentUpdateBanner";

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -53,6 +53,7 @@ import { classifyAgentError, ClassifiedAgentError } from "@/utils/classifyAgentE
 import { resolveAgentUpdateState } from "@/utils/agentVersion";
 import { useDesktopVersion } from "@/hooks/useDesktopVersion";
 import { AgentVersionBadge } from "@/components/AgentVersionBadge/AgentVersionBadge";
+import { AgentUpdateBanner } from "@/components/AgentUpdateBanner";
 import { resolveConnectionCredential } from "@/utils/resolveConnectionCredential";
 import { ensureCredentialStoreUnlocked } from "@/utils/ensureCredentialStoreUnlocked";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
@@ -1401,6 +1402,10 @@ export function AgentNode({ agent, style, sectionRef, filterQuery = "" }: AgentN
           </ContextMenu.Content>
         </ContextMenu.Portal>
       </ContextMenu.Root>
+
+      {/* Deferred-update banner: only for a connected agent with a staged update
+          (the banner self-gates on the store's staged/dismissed state, #1352). */}
+      {isConnected && <AgentUpdateBanner agentId={agent.id} agentName={agent.name} />}
 
       <AgentSetupDialog open={setupDialogOpen} onOpenChange={setSetupDialogOpen} agent={agent} />
       <ConnectionErrorDialog

--- a/src/hooks/useAgentUpdateEvents.ts
+++ b/src/hooks/useAgentUpdateEvents.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useAppStore } from "@/store/appStore";
+import { onAgentUpdateAvailable } from "@/services/events";
+
+/**
+ * Hook that folds backend `agent-update-available` events (#1352) into the
+ * store's `agentUpdates` map. Each event is an agent's `agent.update_available`
+ * notification forwarded by the desktop backend; recording it lets the
+ * per-agent deferred-update banner offer "Apply Now".
+ */
+export function useAgentUpdateEvents(): void {
+  const setAgentUpdateAvailable = useAppStore((s) => s.setAgentUpdateAvailable);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+
+    const setup = async () => {
+      unlisten = await onAgentUpdateAvailable((update) => {
+        setAgentUpdateAvailable(update.agentId, {
+          currentVersion: update.currentVersion,
+          availableVersion: update.availableVersion,
+          staged: update.staged,
+        });
+      });
+    };
+
+    void setup();
+
+    return () => {
+      unlisten?.();
+    };
+  }, [setAgentUpdateAvailable]);
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1017,6 +1017,36 @@ export async function applyAgentSettings(agentId: string, settings: AgentSetting
   await invoke("apply_agent_settings", { agentId, settings });
 }
 
+/** Outcome of a deferred agent-update request (#1352). */
+export interface AgentDeferredUpdateResult {
+  /**
+   * `true` when the agent was idle and applied the update immediately (the
+   * connection is expected to drop as the binary swaps); `false` when the
+   * update was deferred until the last of `activeSessions` disconnects.
+   */
+  applied: boolean;
+  /** Number of active sessions the update will wait on when `applied` is false. */
+  activeSessions: number;
+}
+
+/**
+ * Request a deferred agent update. Omit `binaryPath` to apply the agent's
+ * already-staged pending update (the banner case). When the agent is idle it
+ * applies immediately (`applied: true`); otherwise it defers until the last of
+ * `activeSessions` sessions disconnects (`applied: false`).
+ */
+export async function requestAgentDeferredUpdate(
+  agentId: string,
+  binaryPath?: string,
+  version?: string
+): Promise<AgentDeferredUpdateResult> {
+  return await invoke<AgentDeferredUpdateResult>("request_agent_deferred_update", {
+    agentId,
+    binaryPath,
+    version,
+  });
+}
+
 /** Disconnect from a remote agent. */
 export async function disconnectAgent(agentId: string): Promise<void> {
   await invoke("disconnect_agent", { agentId });

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -325,6 +325,44 @@ export async function onAgentDeployProgress(
   });
 }
 
+/**
+ * Payload of an `agent-update-available` event (#1352). The desktop backend
+ * forwards the agent's `agent.update_available` JSON-RPC notification, tagging
+ * it with the originating `agent_id`. `staged: true` means a verified new binary
+ * is staged on the agent and ready to apply (idle) or defer (busy).
+ */
+interface AgentUpdateAvailablePayload {
+  agent_id: string;
+  currentVersion: string;
+  availableVersion: string;
+  staged: boolean;
+}
+
+/** A staged/available agent update, keyed to its originating agent. */
+export interface AgentUpdateAvailable {
+  agentId: string;
+  currentVersion: string;
+  availableVersion: string;
+  staged: boolean;
+}
+
+/**
+ * Subscribe to `agent.update_available` notifications forwarded by the backend
+ * as `agent-update-available` Tauri events (#1352). Returns the unlisten handle.
+ */
+export async function onAgentUpdateAvailable(
+  callback: (update: AgentUpdateAvailable) => void
+): Promise<UnlistenFn> {
+  return await listen<AgentUpdateAvailablePayload>("agent-update-available", (event) => {
+    callback({
+      agentId: event.payload.agent_id,
+      currentVersion: event.payload.currentVersion,
+      availableVersion: event.payload.availableVersion,
+      staged: event.payload.staged,
+    });
+  });
+}
+
 interface VscodeEditCompletePayload {
   remotePath: string;
   success: boolean;

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -283,6 +283,18 @@ function stripPassword(connection: SavedConnection): SavedConnection {
   return connection;
 }
 
+/**
+ * A staged/available update reported by a connected agent via its
+ * `agent.update_available` notification (#1352). Recorded per agent id so the
+ * deferred-update banner can offer "Apply Now".
+ */
+export interface AgentPendingUpdate {
+  currentVersion: string;
+  availableVersion: string;
+  /** `true` when a verified new binary is staged and ready to apply/defer. */
+  staged: boolean;
+}
+
 interface AppState {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
@@ -807,6 +819,14 @@ interface AppState {
   agentSessions: Record<string, AgentSessionInfo[]>;
   agentDefinitions: Record<string, AgentDefinitionInfo[]>;
   agentFolders: Record<string, AgentFolderInfo[]>;
+  /** Staged/available agent updates by agent id, from `agent.update_available` (#1352). */
+  agentUpdates: Record<string, AgentPendingUpdate>;
+  /** Per-agent dismissal of the deferred-update banner (#1352). */
+  agentUpdatesDismissed: Record<string, boolean>;
+  /** Record (or clear) a staged/available update for an agent. */
+  setAgentUpdateAvailable: (agentId: string, update: AgentPendingUpdate) => void;
+  /** Hide the deferred-update banner for an agent for this session. */
+  dismissAgentUpdate: (agentId: string) => void;
   addRemoteAgent: (agent: RemoteAgentDefinition) => void;
   updateRemoteAgent: (agent: RemoteAgentDefinition) => void;
   deleteRemoteAgent: (agentId: string) => void;
@@ -3944,6 +3964,23 @@ export const useAppStore = create<AppState>((set, get) => {
     agentSessions: {},
     agentDefinitions: {},
     agentFolders: {},
+    agentUpdates: {},
+    agentUpdatesDismissed: {},
+
+    setAgentUpdateAvailable: (agentId, update) => {
+      set((s) => ({
+        agentUpdates: { ...s.agentUpdates, [agentId]: update },
+        // A freshly reported update re-arms the banner even if a prior one was
+        // dismissed this session.
+        agentUpdatesDismissed: { ...s.agentUpdatesDismissed, [agentId]: false },
+      }));
+    },
+
+    dismissAgentUpdate: (agentId) => {
+      set((s) => ({
+        agentUpdatesDismissed: { ...s.agentUpdatesDismissed, [agentId]: true },
+      }));
+    },
 
     addRemoteAgent: (agent) => {
       set((state) => ({ remoteAgents: [...state.remoteAgents, agent] }));

--- a/tests/system/testid-catalog.md
+++ b/tests/system/testid-catalog.md
@@ -636,6 +636,9 @@ static prefix/suffix (e.g. a row keyed by name renders `file-row-<name>`).
 | `agent-reconnect-*` | `agent-reconnect-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-shutdown-*` | `agent-shutdown-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `agent-state-*` | `agent-state-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
+| `agent-update-banner-*` | `agent-update-banner-${agentId}` | `src/components/AgentUpdateBanner/AgentUpdateBanner.tsx` |
+| `agent-update-banner-apply-*` | `agent-update-banner-apply-${agentId}` | `src/components/AgentUpdateBanner/AgentUpdateBanner.tsx` |
+| `agent-update-banner-dismiss-*` | `agent-update-banner-dismiss-${agentId}` | `src/components/AgentUpdateBanner/AgentUpdateBanner.tsx` |
 | `agent-version-badge-*` | `agent-version-badge-${agent.id}` | `src/components/Sidebar/AgentNode.tsx` |
 | `color-picker-swatch-*` | `color-picker-swatch-${color.replace("#", "")}` | `src/components/Terminal/ColorPickerDialog.tsx` |
 | `connection-connect-*` | `connection-connect-${connection.id}` | `src/components/Sidebar/ConnectionList.tsx` |


### PR DESCRIPTION
Closes #1352
Part of Epic #1345

## Summary

Phase 3 / Approach 4: a **deferred agent update** that leaves active sessions untouched and applies only when the **last session disconnects**, leaning on the detached-daemon model so persistent sessions survive the binary swap and report the new version on the next connect.

- **RPC `agent.request_deferred_update { binaryPath?, version? }`** — records a `pending_update` in `state.json`. Omit `binaryPath` to apply an already-staged self-update ("Apply Now"). Applies **immediately only when idle** (0 active sessions); otherwise defers.
- **State persistence** — reuses the existing `UpdateState.pending_update` in `state.json` (from #1355); `SessionManager` now routes state through a configurable path.
- **Zero-session hook** — `SessionManager::close` computes the remaining running count and, on reaching zero with a pending update, applies it. A pure `should_apply_deferred_update(active, has_pending)` gate is the single source of truth (true only at 0 sessions + pending).
- **Exec-replace via daemon detach** — apply swaps the on-disk agent binary with the staged one (atomic temp-file + rename, marked executable) and re-execs with the same args. Gated `#[cfg(unix)]`; non-Unix returns an error and keeps compiling.
- **Desktop banner** — a per-agent sidebar banner with **Apply Now** (idle → applies + reconnects; busy → defers, naming the active-session count) and **Dismiss**, composed from the shared `Button` primitive with toast feedback. The desktop backend forwards the agent's `agent.update_available` notification as an `agent-update-available` event.

## How the zero-session apply works

`request_deferred_update` persists the pending update, then checks `active_count()`. If **0**, it consumes the pending update (clearing it from `state.json` first, so a re-exec can never loop) and calls the injected `UpdateApplier`. If **> 0**, it returns `Deferred { activeSessions }` and does nothing to running sessions. On each `close`, when the last running session is removed the same apply path fires. On Unix a successful apply re-execs (the connection drops — the desktop treats that as expected and reconnects to see the new version).

## Exec-replace gating

`apply_update_binary` is `#[cfg(unix)]` (copy staged → temp in the target dir, `chmod 0755`, atomic `rename`, then `CommandExt::exec`). `#[cfg(not(unix))]` returns an error (`-32016`), so Windows/other builds compile — CI validates the non-Unix build.

## Constraint honored

Active sessions are **never** interrupted: apply is strictly gated on `active_count == 0`. "Apply Now" with active sessions defers rather than forcing (the banner reports the count).

## Documented caveat

With a long-running persistent session the update may be delayed **indefinitely** — it only applies once the last session disconnects. This is by design.

## Tested vs deferred

**Unit-tested (runnable on macOS):**
- `should_apply_deferred_update` gate — applies only at 0 sessions with a pending update.
- Unix binary-swap helper — replaces contents + marks executable, no temp left behind.
- `state.json` round-trip for a staged pending update (and legacy state without the field → `None`).
- Zero-session hook via an injected recording `UpdateApplier` + isolated state path: applies exactly on last disconnect; not before; not without a pending update.
- `request_deferred_update`: applies when idle, defers with active sessions, applies existing pending when no path given, and errors on missing binary / no pending.
- Frontend: `AgentUpdateBanner` Vitest suite (renders, Apply Now applied/deferred, Dismiss).

**Deferred (not runnable here):**
- Docker integration test (#995): open a session → request deferred → close → assert new version on reconnect. Follow-up filed.
- Python-bridge banner E2E. Follow-up filed.

## Out of scope

Self-update and GitHub polling (from #1355) are untouched; auto-triggering the background self-update timer's apply-on-idle onto this mechanism is left as a tracked follow-up.

## Test plan

- `cargo test -p termihub-agent` (311 unit + integration green), `cargo clippy -p termihub-agent --all-targets -- -D warnings` clean.
- `cargo build -p termihub` + `cargo clippy -p termihub` clean.
- `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm run format:check`, `pnpm exec vitest run src/components/AgentUpdateBanner` green; `pnpm run markdownlint` clean.
- Manual steps added to `docs/testing.md` (deferred update: long-running session → request → no interruption; close last session → applies; reconnect → new version; Apply Now forces it when idle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
