### PR TITLE
feat(agent): auto-apply staged self-update on idle (Closes #1401)

### DIFF
--- a/agent/src/io/stdio.rs
+++ b/agent/src/io/stdio.rs
@@ -20,6 +20,7 @@ use crate::session::manager::SessionManager;
 pub async fn run_stdio_loop(
     shutdown: CancellationToken,
     allow_self_update: bool,
+    update_strategy: crate::update::UpdateStrategy,
 ) -> anyhow::Result<()> {
     let (notification_tx, mut notification_rx) =
         tokio::sync::mpsc::unbounded_channel::<JsonRpcNotification>();
@@ -41,7 +42,11 @@ pub async fn run_stdio_loop(
 
     // Optional background GitHub self-update check (off unless opted in).
     crate::update::spawn_self_update_task(
-        crate::update::UpdateConfig::from_env(allow_self_update, env!("CARGO_PKG_VERSION")),
+        crate::update::UpdateConfig::from_env(
+            allow_self_update,
+            update_strategy,
+            env!("CARGO_PKG_VERSION"),
+        ),
         session_manager.clone(),
         update_tx,
         shutdown.child_token(),

--- a/agent/src/io/tcp.rs
+++ b/agent/src/io/tcp.rs
@@ -25,6 +25,7 @@ pub async fn run_tcp_listener(
     addr: &str,
     shutdown: CancellationToken,
     allow_self_update: bool,
+    update_strategy: crate::update::UpdateStrategy,
 ) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr).await?;
     info!("Listening on {}", listener.local_addr()?);
@@ -48,7 +49,11 @@ pub async fn run_tcp_listener(
 
     // Optional background GitHub self-update check (off unless opted in).
     crate::update::spawn_self_update_task(
-        crate::update::UpdateConfig::from_env(allow_self_update, env!("CARGO_PKG_VERSION")),
+        crate::update::UpdateConfig::from_env(
+            allow_self_update,
+            update_strategy,
+            env!("CARGO_PKG_VERSION"),
+        ),
         session_manager.clone(),
         update_tx,
         shutdown.child_token(),

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -198,4 +198,46 @@ mod tests {
         // No flag, and the env var is not set in this test process.
         assert!(!self_update_enabled(&args(&["termihub-agent", "--stdio"])));
     }
+
+    #[test]
+    fn update_strategy_parses_from_flag() {
+        use update::UpdateStrategy;
+        assert_eq!(
+            update_strategy_from_args(&args(&[
+                "termihub-agent",
+                "--stdio",
+                "--allow-self-update",
+                "--update-strategy",
+                "deferred",
+            ])),
+            UpdateStrategy::Deferred
+        );
+        assert_eq!(
+            update_strategy_from_args(&args(&[
+                "termihub-agent",
+                "--stdio",
+                "--update-strategy",
+                "coordinated",
+            ])),
+            UpdateStrategy::Coordinated
+        );
+    }
+
+    #[test]
+    fn update_strategy_defaults_to_immediate_when_absent_or_unknown() {
+        use update::UpdateStrategy;
+        assert_eq!(
+            update_strategy_from_args(&args(&["termihub-agent", "--stdio"])),
+            UpdateStrategy::Immediate
+        );
+        assert_eq!(
+            update_strategy_from_args(&args(&[
+                "termihub-agent",
+                "--stdio",
+                "--update-strategy",
+                "bogus",
+            ])),
+            UpdateStrategy::Immediate
+        );
+    }
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -34,11 +34,14 @@ fn print_usage() {
     eprintln!(
         "  --allow-self-update   Enable the background GitHub self-update check (off by default)"
     );
+    eprintln!("  --update-strategy <s> Self-update apply strategy: immediate|coordinated|deferred");
 }
 
 /// CLI flag / env var that opts the agent into the background self-update check.
 const SELF_UPDATE_FLAG: &str = "--allow-self-update";
 const SELF_UPDATE_ENV: &str = "TERMIHUB_AGENT_ALLOW_SELF_UPDATE";
+/// CLI flag carrying the connection's configured self-update apply strategy.
+const UPDATE_STRATEGY_FLAG: &str = "--update-strategy";
 
 /// Determine whether the agent should run the optional self-update check.
 ///
@@ -53,6 +56,19 @@ fn self_update_enabled(args: &[String]) -> bool {
         std::env::var(SELF_UPDATE_ENV).ok().as_deref(),
         Some("1") | Some("true") | Some("yes")
     )
+}
+
+/// Parse the `--update-strategy <value>` CLI flag (#1401).
+///
+/// The desktop appends it alongside `--allow-self-update` so the agent knows
+/// whether a self-downloaded update may auto-apply on idle. Absent or unknown
+/// values default to [`UpdateStrategy::Immediate`].
+fn update_strategy_from_args(args: &[String]) -> update::UpdateStrategy {
+    args.iter()
+        .position(|a| a == UPDATE_STRATEGY_FLAG)
+        .and_then(|i| args.get(i + 1))
+        .map(|v| update::UpdateStrategy::from_cli(v))
+        .unwrap_or_default()
 }
 
 #[tokio::main]
@@ -83,8 +99,9 @@ async fn main() -> anyhow::Result<()> {
 
             let shutdown = setup_shutdown_signal();
             let allow_self_update = self_update_enabled(&args);
+            let update_strategy = update_strategy_from_args(&args);
             info!("termihub-agent {} starting in stdio mode", VERSION);
-            io::stdio::run_stdio_loop(shutdown, allow_self_update).await
+            io::stdio::run_stdio_loop(shutdown, allow_self_update, update_strategy).await
         }
         "--listen" => {
             init_tracing();
@@ -98,11 +115,12 @@ async fn main() -> anyhow::Result<()> {
                 .unwrap_or(DEFAULT_LISTEN_ADDR);
             let shutdown = setup_shutdown_signal();
             let allow_self_update = self_update_enabled(&args);
+            let update_strategy = update_strategy_from_args(&args);
             info!(
                 "termihub-agent {} starting in TCP listener mode on {}",
                 VERSION, addr
             );
-            io::tcp::run_tcp_listener(addr, shutdown, allow_self_update).await
+            io::tcp::run_tcp_listener(addr, shutdown, allow_self_update, update_strategy).await
         }
         "--daemon" => {
             init_tracing();

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -1282,6 +1282,37 @@ mod tests {
             }
         }
 
+        /// [`UpdateApplier`] that always fails, to exercise retain-on-failure.
+        struct FailingApplier {
+            attempts: Arc<StdMutex<Vec<PendingUpdate>>>,
+        }
+
+        impl UpdateApplier for FailingApplier {
+            fn apply(&self, pending: &PendingUpdate) -> anyhow::Result<()> {
+                self.attempts
+                    .lock()
+                    .expect("attempts lock")
+                    .push(pending.clone());
+                anyhow::bail!("simulated apply failure")
+            }
+        }
+
+        fn manager_with_failing_applier() -> (SessionManager, AppliedLog, tempfile::TempDir) {
+            let tmp = tempfile::tempdir().unwrap();
+            let state_path = tmp.path().join("state.json");
+            let attempts: AppliedLog = Arc::new(StdMutex::new(Vec::new()));
+            let mgr = SessionManager::with_test_deps(
+                test_notification_tx(),
+                test_registry(),
+                Arc::new(SystemDaemonLauncher),
+                state_path,
+                Arc::new(FailingApplier {
+                    attempts: attempts.clone(),
+                }),
+            );
+            (mgr, attempts, tmp)
+        }
+
         type AppliedLog = Arc<StdMutex<Vec<PendingUpdate>>>;
 
         fn manager_with_recording_applier() -> (SessionManager, AppliedLog, tempfile::TempDir) {
@@ -1331,9 +1362,37 @@ mod tests {
 
             // Closing the last session applies it exactly once.
             mgr.close(&ids[1]).await;
-            let log = applied.lock().unwrap();
-            assert_eq!(log.len(), 1, "update applies exactly on last disconnect");
-            assert_eq!(log[0].binary_path, "/tmp/new-agent");
+            {
+                let log = applied.lock().unwrap();
+                assert_eq!(log.len(), 1, "update applies exactly on last disconnect");
+                assert_eq!(log[0].binary_path, "/tmp/new-agent");
+            }
+            // A successful apply clears the pending update.
+            assert!(
+                mgr.pending_update_for_test().await.is_none(),
+                "successful apply on last disconnect clears pending_update"
+            );
+        }
+
+        #[tokio::test]
+        async fn failed_apply_on_last_disconnect_keeps_pending() {
+            // Retain-on-failure (#1401): if the apply fails on the last
+            // disconnect, the pending update is KEPT so a later cycle can retry.
+            let (mgr, attempts, _tmp) = manager_with_failing_applier();
+            mgr.create_stub_session("stub", "A".to_string(), serde_json::json!({}))
+                .await
+                .unwrap();
+            mgr.seed_pending_update_for_test(fake_pending("/tmp/new-agent"))
+                .await;
+            let ids: Vec<String> = mgr.list().await.into_iter().map(|s| s.id).collect();
+
+            mgr.close(&ids[0]).await;
+
+            assert_eq!(attempts.lock().unwrap().len(), 1, "apply was attempted");
+            assert!(
+                mgr.pending_update_for_test().await.is_some(),
+                "a failed apply must keep pending_update for retry"
+            );
         }
 
         #[tokio::test]

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -835,32 +835,58 @@ impl SessionManager {
         }
     }
 
-    /// Consume the pending update (clearing it from persisted state) and apply
-    /// it. A no-op when nothing is pending.
+    /// Record the timestamp of the most recent self-update poll (#1401).
     ///
-    /// The pending update is cleared **before** the apply so a failed or
-    /// re-execed apply can never trigger an apply loop. On a successful Unix
-    /// apply the process re-execs and this never returns.
-    async fn apply_pending_update(&self) -> anyhow::Result<()> {
-        let pending = {
-            let mut state = self.state.lock().await;
-            let taken = state.update.pending_update.take();
-            if taken.is_some() {
-                state.save_to(&self.state_path);
-            }
-            taken
-        };
+    /// Owned here so the self-update timer and the deferred-apply path share a
+    /// single in-memory + persisted `update` state; a direct write from the
+    /// timer would be clobbered by the next session-close persist.
+    pub async fn record_update_check_time(&self, timestamp: String) {
+        let mut state = self.state.lock().await;
+        state.update.last_check_time = Some(timestamp);
+        state.save_to(&self.state_path);
+    }
 
-        match pending {
-            Some(pending) => {
-                info!(
-                    "Applying deferred agent update (version {:?}) from {}",
-                    pending.version, pending.binary_path
-                );
-                self.update_applier.apply(&pending)
-            }
-            None => Ok(()),
-        }
+    /// Record a staged pending update in the shared agent state **without**
+    /// applying it (#1401).
+    ///
+    /// Used by the self-update timer when the connection's update strategy does
+    /// not auto-apply on idle (coordinated), so a later coordinated apply — or
+    /// an explicit `agent.request_deferred_update` — can consume it.
+    pub async fn stage_pending_update(&self, binary_path: String, version: String) {
+        let mut state = self.state.lock().await;
+        state.update.pending_update = Some(PendingUpdate {
+            version,
+            binary_path,
+            staged_at: Utc::now().to_rfc3339(),
+        });
+        state.save_to(&self.state_path);
+    }
+
+    /// Apply the pending update, clearing it from persisted state **only on
+    /// success**. A no-op when nothing is pending.
+    ///
+    /// The update is applied first and the pending record is cleared afterwards,
+    /// so a failed apply KEEPS the pending update and a later cycle (the next
+    /// last-disconnect, or the next self-update poll) can retry (#1401). On a
+    /// successful Unix apply the process re-execs and this never returns, so the
+    /// clear only runs in tests / on the non-Unix path. Retaining on failure
+    /// cannot cause a tight apply loop: applies fire only on discrete
+    /// transitions (a session closing to zero, or a 24h poll), never in a spin.
+    async fn apply_pending_update(&self) -> anyhow::Result<()> {
+        let pending = { self.state.lock().await.update.pending_update.clone() };
+        let Some(pending) = pending else {
+            return Ok(());
+        };
+        info!(
+            "Applying deferred agent update (version {:?}) from {}",
+            pending.version, pending.binary_path
+        );
+        self.update_applier.apply(&pending)?;
+        // Success (test / non-unix path): consume the pending update.
+        let mut state = self.state.lock().await;
+        state.update.pending_update = None;
+        state.save_to(&self.state_path);
+        Ok(())
     }
 }
 

--- a/agent/src/state/persistence.rs
+++ b/agent/src/state/persistence.rs
@@ -39,9 +39,9 @@ pub struct UpdateState {
 /// The deferred apply (SI-6, #1352) is wired: the agent applies this when its
 /// last session disconnects, or immediately via `agent.request_deferred_update`
 /// when it is idle — see [`crate::session::manager::SessionManager`] and the
-/// `crate::update::apply` module. (Auto-applying a *self-update* staged by the
-/// background timer on idle is still staging-only; that wiring is tracked
-/// separately.)
+/// `crate::update::apply` module. A *self-update* staged by the background timer
+/// now flows through the same path and auto-applies on idle (#1401), gated on
+/// the connection's update strategy; a failed apply keeps this record for retry.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PendingUpdate {
     /// Target version (release tag semver, e.g. `"0.3.0"`).

--- a/agent/src/update/mod.rs
+++ b/agent/src/update/mod.rs
@@ -310,13 +310,53 @@ fn now_rfc3339() -> String {
 mod tests {
     use super::*;
     use crate::protocol::messages::JsonRpcNotification;
+    use crate::session::manager::{SessionManager, SystemDaemonLauncher};
+    use crate::state::persistence::PendingUpdate;
+    use std::sync::Mutex as StdMutex;
     use tokio::sync::mpsc;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     const SHA256_OF_ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
 
-    fn test_config(api_url: String, state_path: PathBuf, staging_dir: PathBuf) -> UpdateConfig {
+    /// [`UpdateApplier`] that records apply calls (returning success) instead of
+    /// swapping the binary + re-execing, so the auto-apply path can be tested
+    /// without replacing the test process.
+    struct RecordingApplier {
+        applied: Arc<StdMutex<Vec<PendingUpdate>>>,
+    }
+
+    impl UpdateApplier for RecordingApplier {
+        fn apply(&self, pending: &PendingUpdate) -> anyhow::Result<()> {
+            self.applied
+                .lock()
+                .expect("recording lock")
+                .push(pending.clone());
+            Ok(())
+        }
+    }
+
+    /// [`UpdateApplier`] that always fails, to exercise the retain-on-failure
+    /// path (the pending update must survive so a later cycle can retry).
+    struct FailingApplier {
+        attempts: Arc<StdMutex<Vec<PendingUpdate>>>,
+    }
+
+    impl UpdateApplier for FailingApplier {
+        fn apply(&self, pending: &PendingUpdate) -> anyhow::Result<()> {
+            self.attempts
+                .lock()
+                .expect("attempts lock")
+                .push(pending.clone());
+            anyhow::bail!("simulated apply failure")
+        }
+    }
+
+    fn test_config(
+        api_url: String,
+        staging_dir: PathBuf,
+        update_strategy: UpdateStrategy,
+    ) -> UpdateConfig {
         UpdateConfig {
             allow_self_update: true,
             check_interval: DEFAULT_CHECK_INTERVAL,
@@ -324,15 +364,76 @@ mod tests {
             current_version: "0.2.1".to_string(),
             asset_suffix: Some("linux-x64".to_string()),
             staging_dir,
-            state_path,
             user_agent: "termihub-agent/test".to_string(),
+            update_strategy,
         }
+    }
+
+    /// Build a session manager over an isolated `state.json` and injected
+    /// [`UpdateApplier`], so the self-update timer's state writes and apply calls
+    /// are observable without touching the real state or re-execing.
+    fn test_session_manager(
+        state_path: PathBuf,
+        applier: Arc<dyn UpdateApplier>,
+    ) -> Arc<SessionManager> {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(crate::registry::build_registry());
+        Arc::new(SessionManager::with_test_deps(
+            tx,
+            registry,
+            Arc::new(SystemDaemonLauncher),
+            state_path,
+            applier,
+        ))
+    }
+
+    fn recording_manager(
+        state_path: PathBuf,
+    ) -> (Arc<SessionManager>, Arc<StdMutex<Vec<PendingUpdate>>>) {
+        let applied = Arc::new(StdMutex::new(Vec::new()));
+        let mgr = test_session_manager(
+            state_path,
+            Arc::new(RecordingApplier {
+                applied: applied.clone(),
+            }),
+        );
+        (mgr, applied)
     }
 
     fn try_recv(
         rx: &mut mpsc::UnboundedReceiver<JsonRpcNotification>,
     ) -> Option<JsonRpcNotification> {
         rx.try_recv().ok()
+    }
+
+    /// Mount a `releases/latest` response advertising v0.3.0 with a binary +
+    /// checksum asset served by the same mock server (SHA-256 of `b"abc"`).
+    async fn mount_update_release(server: &MockServer) {
+        let body = format!(
+            r#"{{"tag_name":"v0.3.0","assets":[
+                {{"name":"termihub-agent-linux-x64","browser_download_url":"{base}/bin"}},
+                {{"name":"termihub-agent-linux-x64.sha256","browser_download_url":"{base}/bin.sha256"}}
+            ]}}"#,
+            base = server.uri()
+        );
+        Mock::given(method("GET"))
+            .and(path("/releases/latest"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/bin"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"abc".to_vec()))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/bin.sha256"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n")),
+            )
+            .mount(server)
+            .await;
     }
 
     #[tokio::test]
@@ -342,9 +443,10 @@ mod tests {
         let state_path = tmp.path().join("state.json");
         let config = test_config(
             "http://127.0.0.1:1/repos/x/y/releases/latest".to_string(),
-            state_path.clone(),
             tmp.path().join("updates"),
+            UpdateStrategy::Immediate,
         );
+        let (mgr, applied) = recording_manager(state_path.clone());
         let client = reqwest::Client::builder()
             .timeout(Duration::from_millis(500))
             .build()
@@ -352,10 +454,11 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         // Must not error despite the network being unreachable.
-        run_check_once(&config, &client, 0, &tx).await.unwrap();
+        run_check_once(&config, &client, &mgr, &tx).await.unwrap();
 
-        // No notification emitted, but the attempt was recorded.
+        // No notification emitted, but the attempt was recorded and nothing applied.
         assert!(try_recv(&mut rx).is_none());
+        assert!(applied.lock().unwrap().is_empty());
         let state = AgentState::load_from(&state_path);
         assert!(state.update.last_check_time.is_some());
         assert!(state.update.pending_update.is_none());
@@ -375,16 +478,17 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let config = test_config(
             format!("{}/releases/latest", server.uri()),
-            tmp.path().join("state.json"),
             tmp.path().join("updates"),
+            UpdateStrategy::Immediate,
         );
+        let (mgr, _applied) = recording_manager(tmp.path().join("state.json"));
         let (tx, mut rx) = mpsc::unbounded_channel();
 
-        run_check_once(&config, &reqwest::Client::new(), 0, &tx)
+        run_check_once(&config, &reqwest::Client::new(), &mgr, &tx)
             .await
             .unwrap();
 
-        assert!(try_recv(&mut rx).is_none(), "no update → no notification");
+        assert!(try_recv(&mut rx).is_none(), "no update -> no notification");
     }
 
     #[tokio::test]
@@ -404,13 +508,20 @@ mod tests {
         let state_path = tmp.path().join("state.json");
         let config = test_config(
             format!("{}/releases/latest", server.uri()),
-            state_path.clone(),
             tmp.path().join("updates"),
+            UpdateStrategy::Immediate,
         );
+        let (mgr, applied) = recording_manager(state_path.clone());
+        // Two active sessions -> notify only, never download or apply.
+        mgr.create_stub_session("stub", "A".to_string(), serde_json::json!({}))
+            .await
+            .unwrap();
+        mgr.create_stub_session("stub", "B".to_string(), serde_json::json!({}))
+            .await
+            .unwrap();
         let (tx, mut rx) = mpsc::unbounded_channel();
 
-        // 2 active sessions → notify only, never download.
-        run_check_once(&config, &reqwest::Client::new(), 2, &tx)
+        run_check_once(&config, &reqwest::Client::new(), &mgr, &tx)
             .await
             .unwrap();
 
@@ -418,70 +529,137 @@ mod tests {
         assert_eq!(notif.method, AGENT_UPDATE_AVAILABLE);
         assert_eq!(notif.params["availableVersion"], "0.3.0");
         assert_eq!(notif.params["staged"], false);
-        // Nothing staged with sessions active.
+        // Nothing staged or applied with sessions active.
+        assert!(applied.lock().unwrap().is_empty());
         let state = AgentState::load_from(&state_path);
         assert!(state.update.pending_update.is_none());
     }
 
     #[tokio::test]
-    async fn newer_when_idle_downloads_verifies_and_stages() {
+    async fn newer_when_idle_stages_and_auto_applies() {
+        // apply-on-idle transition: idle + eligible strategy -> the staged,
+        // verified binary is applied and the pending update is cleared (#1401).
         let server = MockServer::start().await;
-        // Release JSON points binary + checksum assets back at this mock server.
-        let body = format!(
-            r#"{{"tag_name":"v0.3.0","assets":[
-                {{"name":"termihub-agent-linux-x64","browser_download_url":"{base}/bin"}},
-                {{"name":"termihub-agent-linux-x64.sha256","browser_download_url":"{base}/bin.sha256"}}
-            ]}}"#,
-            base = server.uri()
-        );
-        Mock::given(method("GET"))
-            .and(path("/releases/latest"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(body))
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path("/bin"))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"abc".to_vec()))
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path("/bin.sha256"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_string(format!("{SHA256_OF_ABC}  termihub-agent-linux-x64\n")),
-            )
-            .mount(&server)
-            .await;
+        mount_update_release(&server).await;
 
         let tmp = tempfile::tempdir().unwrap();
         let state_path = tmp.path().join("state.json");
         let staging_dir = tmp.path().join("updates");
         let config = test_config(
             format!("{}/releases/latest", server.uri()),
-            state_path.clone(),
             staging_dir.clone(),
+            UpdateStrategy::Deferred,
         );
+        let (mgr, applied) = recording_manager(state_path.clone());
         let (tx, mut rx) = mpsc::unbounded_channel();
 
-        // 0 active sessions → download + verify + stage.
-        run_check_once(&config, &reqwest::Client::new(), 0, &tx)
+        run_check_once(&config, &reqwest::Client::new(), &mgr, &tx)
             .await
             .unwrap();
 
         let staged_path = staging_dir.join("termihub-agent-linux-x64");
         assert_eq!(std::fs::read(&staged_path).unwrap(), b"abc");
 
+        // Notification emitted before the apply so desktops see the lifecycle.
         let notif = try_recv(&mut rx).expect("update notification emitted");
         assert_eq!(notif.params["availableVersion"], "0.3.0");
         assert_eq!(notif.params["staged"], true);
 
-        let state = AgentState::load_from(&state_path);
-        let pending = state
+        // The staged binary was applied (idle) and the pending update cleared.
+        {
+            let log = applied.lock().unwrap();
+            assert_eq!(log.len(), 1, "staged self-update applied exactly once");
+            assert_eq!(log[0].version, "0.3.0");
+            assert_eq!(log[0].binary_path, staged_path.to_string_lossy());
+        }
+        assert!(
+            mgr.pending_update_for_test().await.is_none(),
+            "successful apply clears pending_update"
+        );
+    }
+
+    #[tokio::test]
+    async fn newer_when_idle_coordinated_stages_without_applying() {
+        // A coordinated strategy stages + notifies but must NOT auto-apply; the
+        // pending update is recorded for a later coordinated apply (#1401).
+        let server = MockServer::start().await;
+        mount_update_release(&server).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let state_path = tmp.path().join("state.json");
+        let staging_dir = tmp.path().join("updates");
+        let config = test_config(
+            format!("{}/releases/latest", server.uri()),
+            staging_dir.clone(),
+            UpdateStrategy::Coordinated,
+        );
+        let (mgr, applied) = recording_manager(state_path.clone());
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        run_check_once(&config, &reqwest::Client::new(), &mgr, &tx)
+            .await
+            .unwrap();
+
+        let notif = try_recv(&mut rx).expect("update notification emitted");
+        assert_eq!(notif.params["staged"], true);
+        // Never applied under a coordinated strategy...
+        assert!(
+            applied.lock().unwrap().is_empty(),
+            "coordinated strategy must not auto-apply on idle"
+        );
+        // ...but the staged update is recorded for a later coordinated apply.
+        let pending = mgr
+            .pending_update_for_test()
+            .await
+            .expect("coordinated strategy records the staged update");
+        assert_eq!(pending.version, "0.3.0");
+        assert_eq!(
+            pending.binary_path,
+            staging_dir
+                .join("termihub-agent-linux-x64")
+                .to_string_lossy()
+        );
+    }
+
+    #[tokio::test]
+    async fn newer_when_idle_failed_apply_keeps_pending() {
+        // state-clearing: a FAILED apply must KEEP the pending update so a later
+        // cycle can retry (#1401).
+        let server = MockServer::start().await;
+        mount_update_release(&server).await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let state_path = tmp.path().join("state.json");
+        let staging_dir = tmp.path().join("updates");
+        let config = test_config(
+            format!("{}/releases/latest", server.uri()),
+            staging_dir.clone(),
+            UpdateStrategy::Immediate,
+        );
+        let attempts = Arc::new(StdMutex::new(Vec::new()));
+        let mgr = test_session_manager(
+            state_path.clone(),
+            Arc::new(FailingApplier {
+                attempts: attempts.clone(),
+            }),
+        );
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        run_check_once(&config, &reqwest::Client::new(), &mgr, &tx)
+            .await
+            .unwrap();
+
+        assert_eq!(attempts.lock().unwrap().len(), 1, "apply was attempted");
+        let pending = mgr
+            .pending_update_for_test()
+            .await
+            .expect("failed apply keeps pending_update for retry");
+        assert_eq!(pending.version, "0.3.0");
+        // Persisted too, so a later agent run still sees it.
+        assert!(AgentState::load_from(&state_path)
             .update
             .pending_update
-            .expect("pending update recorded");
-        assert_eq!(pending.version, "0.3.0");
-        assert_eq!(pending.binary_path, staged_path.to_string_lossy());
+            .is_some());
     }
 
     #[test]
@@ -491,8 +669,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let mut config = test_config(
             "http://127.0.0.1:1/".to_string(),
-            tmp.path().join("state.json"),
             tmp.path().join("updates"),
+            UpdateStrategy::Immediate,
         );
         config.allow_self_update = false;
         // Build the pieces spawn needs without a running check.

--- a/agent/src/update/mod.rs
+++ b/agent/src/update/mod.rs
@@ -14,14 +14,19 @@
 //! Every failure path (no internet, GitHub error, bad checksum) logs a warning
 //! and skips the cycle — the agent never crashes because of a self-update check.
 //!
-//! # Partial implementation (#1355)
+//! # Auto-apply on idle (#1401)
 //!
-//! This lands the poll → semver → verified-download → notify/stage pipeline. The
-//! deferred-apply mechanism itself now exists (SI-6, #1352 — see the `apply`
-//! submodule and [`crate::session::manager::SessionManager`]), but the
-//! *background self-update timer* still stops after staging the verified binary
-//! and recording it in `state.json`; auto-triggering the apply from this timer
-//! on idle is tracked as a follow-up.
+//! Once a verified binary is staged, this timer hands it to the shared
+//! deferred-apply mechanism (SI-6, #1352) via
+//! [`SessionManager::request_deferred_update`]. Because staging only happens
+//! when the agent is already idle, the update is applied immediately
+//! (exec-replace via the daemon survive-restart model) — but strictly gated on
+//! the connection's [`UpdateStrategy`]: `immediate`/`deferred` auto-apply on
+//! idle, whereas `coordinated` stages only and waits for an explicit
+//! coordinated apply. Active sessions are never interrupted: if a session
+//! opened between the idle check and the apply, `request_deferred_update`
+//! re-checks and defers to the last-disconnect hook. A failed apply keeps the
+//! pending update so a later cycle can retry.
 
 mod apply;
 mod checksum;
@@ -40,7 +45,7 @@ use crate::io::transport::NotificationSender;
 use crate::protocol::messages::JsonRpcNotification;
 use crate::protocol::methods::{UpdateAvailableNotification, AGENT_UPDATE_AVAILABLE};
 use crate::session::manager::SessionManager;
-use crate::state::persistence::{AgentState, PendingUpdate};
+use crate::state::persistence::AgentState;
 
 pub use apply::{should_apply_deferred_update, SystemUpdateApplier, UpdateApplier};
 pub use github::{current_asset_suffix, DEFAULT_REPO};
@@ -51,12 +56,53 @@ pub const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 /// Timeout for a single GitHub API / download request.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How a staged agent self-update is applied once the agent goes idle (#1401).
+///
+/// Mirrors the desktop-side `RemoteAgentConfig.update_strategy` (#1354). The
+/// agent receives its configured value via the `--update-strategy` CLI flag and
+/// uses it purely to gate whether a *self-downloaded* update may auto-apply when
+/// the last session disconnects. It does not affect desktop-driven redeploys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpdateStrategy {
+    /// Apply as soon as the agent is idle (the default).
+    #[default]
+    Immediate,
+    /// Broadcast to connected hosts and wait for an explicit coordinated apply
+    /// (SI-5). A staged self-update is recorded but never auto-applied on idle.
+    Coordinated,
+    /// Apply when the last session disconnects.
+    Deferred,
+}
+
+impl UpdateStrategy {
+    /// Parse the value passed on the `--update-strategy` CLI flag. Unknown or
+    /// missing values fall back to [`UpdateStrategy::Immediate`].
+    pub fn from_cli(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "coordinated" => Self::Coordinated,
+            "deferred" => Self::Deferred,
+            _ => Self::Immediate,
+        }
+    }
+
+    /// Whether a staged self-update may be auto-applied once the agent is idle.
+    ///
+    /// `immediate` and `deferred` both converge to "apply when no sessions are
+    /// active"; `coordinated` waits for an explicit coordinated apply (SI-5) and
+    /// must never auto-apply.
+    pub fn auto_applies_when_idle(self) -> bool {
+        matches!(self, Self::Immediate | Self::Deferred)
+    }
+}
+
 /// Configuration for the self-update background task.
 ///
-/// Field-level overrides (`api_url`, `asset_suffix`, `staging_dir`,
-/// `state_path`) exist so the check cycle can be unit tested against a mock HTTP
-/// server and a temporary state file. Production callers build defaults via
-/// [`UpdateConfig::from_env`].
+/// Field-level overrides (`api_url`, `asset_suffix`, `staging_dir`) exist so
+/// the check cycle can be unit tested against a mock HTTP server and a
+/// temporary staging dir. All persisted `update` state (last-check time, staged
+/// pending update) is owned by the [`SessionManager`] so the self-update timer
+/// and the #1352 deferred-apply path share a single source of truth. Production
+/// callers build defaults via [`UpdateConfig::from_env`].
 #[derive(Debug, Clone)]
 pub struct UpdateConfig {
     /// Master gate — when `false` the background task is never spawned.
@@ -72,15 +118,20 @@ pub struct UpdateConfig {
     pub asset_suffix: Option<String>,
     /// Directory a verified update binary is staged into.
     pub staging_dir: PathBuf,
-    /// Path to the agent's `state.json`.
-    pub state_path: PathBuf,
     /// `User-Agent` header sent to the GitHub API (GitHub requires one).
     pub user_agent: String,
+    /// Configured update strategy — gates whether a staged self-update
+    /// auto-applies on idle (#1401).
+    pub update_strategy: UpdateStrategy,
 }
 
 impl UpdateConfig {
     /// Build the production configuration for the current agent process.
-    pub fn from_env(allow_self_update: bool, current_version: &str) -> Self {
+    pub fn from_env(
+        allow_self_update: bool,
+        update_strategy: UpdateStrategy,
+        current_version: &str,
+    ) -> Self {
         Self {
             allow_self_update,
             check_interval: DEFAULT_CHECK_INTERVAL,
@@ -88,8 +139,8 @@ impl UpdateConfig {
             current_version: current_version.to_string(),
             asset_suffix: current_asset_suffix().map(str::to_string),
             staging_dir: AgentState::config_dir().join("updates"),
-            state_path: AgentState::default_path(),
             user_agent: format!("termihub-agent/{current_version}"),
+            update_strategy,
         }
     }
 
@@ -143,8 +194,7 @@ pub fn spawn_self_update_task(
                     break;
                 }
                 _ = interval.tick() => {
-                    let active = session_manager.active_count().await;
-                    if let Err(e) = run_check_once(&config, &client, active, &notification_tx).await {
+                    if let Err(e) = run_check_once(&config, &client, &session_manager, &notification_tx).await {
                         // run_check_once already logs its own warnings; this is a
                         // defensive backstop so an unexpected error never leaks.
                         warn!("Self-update check failed: {e}");
@@ -164,14 +214,17 @@ pub fn spawn_self_update_task(
 async fn run_check_once(
     config: &UpdateConfig,
     client: &reqwest::Client,
-    active_sessions: u32,
+    session_manager: &Arc<SessionManager>,
     notification_tx: &NotificationSender,
 ) -> anyhow::Result<()> {
     // Record the attempt up-front so `last_check_time` reflects reality even if
-    // the network call below fails.
-    let mut state = AgentState::load_from(&config.state_path);
-    state.update.last_check_time = Some(now_rfc3339());
-    state.save_to(&config.state_path);
+    // the network call below fails. Routed through the SessionManager so the
+    // agent's persisted `update` state has a single owner shared with the #1352
+    // deferred-apply path (a direct write here would be clobbered by the next
+    // session-close persist).
+    session_manager
+        .record_update_check_time(now_rfc3339())
+        .await;
 
     let release = match github::fetch_latest_release(client, &config.api_url).await {
         Ok(release) => release,
@@ -213,33 +266,18 @@ async fn run_check_once(
         .and_then(|suffix| release.asset_urls_for(suffix));
 
     // When idle and we have a downloadable asset, stage a verified binary.
-    let mut staged = false;
+    let active_sessions = session_manager.active_count().await;
+    let mut staged_binary: Option<String> = None;
     if active_sessions == 0 {
         if let (Some(suffix), Some(urls)) = (config.asset_suffix.as_deref(), asset_urls.as_ref()) {
             let dest = config.staged_binary_path(suffix);
             match download::download_and_verify(client, urls, &dest).await {
                 Ok(()) => {
-                    state.update.pending_update = Some(PendingUpdate {
-                        version: available_version.clone(),
-                        binary_path: dest.to_string_lossy().into_owned(),
-                        staged_at: now_rfc3339(),
-                    });
-                    state.save_to(&config.state_path);
-                    staged = true;
+                    staged_binary = Some(dest.to_string_lossy().into_owned());
                     info!(
                         "Self-update: staged verified agent {} at {}",
                         available_version,
                         dest.display()
-                    );
-                    // The deferred-apply mechanism (SI-6 / #1352) now exists, but
-                    // this background timer intentionally stops after staging —
-                    // auto-triggering the apply from the timer on idle is a
-                    // separate follow-up. The staged update will still be applied
-                    // when the last session disconnects or via
-                    // `agent.request_deferred_update`.
-                    debug!(
-                        "Self-update: binary staged and recorded in state.json; \
-                         apply happens on last disconnect or via request_deferred_update"
                     );
                 }
                 Err(e) => {
@@ -260,13 +298,54 @@ async fn run_check_once(
         );
     }
 
+    // Notify BEFORE applying: a successful Unix apply re-execs the process and
+    // never returns, so connected desktops must be told about the update
+    // lifecycle first.
     notify_update_available(
         notification_tx,
         &config.current_version,
         &available_version,
         asset_urls.map(|u| u.binary_url),
-        staged,
+        staged_binary.is_some(),
     );
+
+    // Hand a freshly staged binary to the shared #1352 deferred-apply mechanism
+    // (#1401). `allow_self_update` is already implied — this task is never
+    // spawned when it is off. The update strategy decides whether to auto-apply
+    // on idle now, or merely record the staged update for a later coordinated
+    // apply. Because we are idle, an eligible strategy applies immediately via
+    // exec-replace; if a session raced in, `request_deferred_update` re-checks
+    // and defers to the last-disconnect hook so active sessions are never cut.
+    if let Some(binary_path) = staged_binary {
+        if config.update_strategy.auto_applies_when_idle() {
+            match session_manager
+                .request_deferred_update(Some(binary_path), Some(available_version.clone()))
+                .await
+            {
+                Ok(outcome) => info!(
+                    "Self-update: staged agent {} handed to deferred-apply ({outcome:?})",
+                    available_version
+                ),
+                // The pending update is retained on failure (see
+                // `SessionManager::apply_pending_update`) so a later idle cycle
+                // can retry.
+                Err(e) => warn!(
+                    "Self-update: applying staged agent {} failed, keeping it staged for \
+                     retry: {e}",
+                    available_version
+                ),
+            }
+        } else {
+            session_manager
+                .stage_pending_update(binary_path, available_version.clone())
+                .await;
+            info!(
+                "Self-update: staged agent {} recorded; awaiting coordinated apply \
+                 (update_strategy = coordinated)",
+                available_version
+            );
+        }
+    }
 
     Ok(())
 }

--- a/docs/changes/dev0/feature/1401-auto-apply-self-update-idle.md
+++ b/docs/changes/dev0/feature/1401-auto-apply-self-update-idle.md
@@ -1,0 +1,11 @@
+### Changed
+
+- Remote agents with **Allow agent self-update** enabled now automatically apply
+  a staged, SHA-256-verified update once they become idle (their last session
+  closes), instead of only staging it and waiting for a manual apply. The apply
+  reuses the deferred exec-replace mechanism, so it never interrupts active
+  sessions and persistent daemon sessions survive the restart. The connection's
+  **Update Strategy** is honored: `immediate`/`deferred` auto-apply on idle,
+  while `coordinated` stages and notifies only. A failed apply keeps the staged
+  update so a later cycle retries; a successful apply clears it and the agent
+  comes back on the new version.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1386,8 +1386,36 @@ See PR #1389.
    (`could not reach GitHub, skipping this cycle`) and keeps serving sessions —
    it must not crash. `last_check_time` in `state.json` still updates.
 
-> Note: automatic apply-on-idle of a staged update is deferred to #1352; this PR
-> stops after staging and notifying.
+### Agent self-update auto-apply on idle (#1401)
+
+Verifies that an agent with self-update enabled automatically applies a staged,
+verified update once its last session closes — respecting the connection's
+update strategy and never interrupting active sessions. Requires a Linux remote
+host. See PR for #1401. (End-to-end apply across a real restart is covered by the
+deferred Docker integration follow-up #1519.)
+
+1. **Strategy reaches the agent.** Edit the agent, turn **Allow agent self-update**
+   on, set **Update Strategy** to **Deferred** (or **Immediate**), save, and
+   reconnect. Confirm the SSH exec command now ends with
+   `--stdio --allow-self-update --update-strategy deferred` (inspect the app log
+   or `agent_exec_command`).
+2. **Active session blocks apply.** With a newer release published and a staged
+   `pending_update` in the host's `state.json`, keep at least one session open on
+   that agent. Wait for (or force) a self-update cycle. Confirm the agent does
+   **not** swap its binary while a session is active (the session keeps running;
+   `pending_update` remains in `state.json`).
+3. **Applies on last disconnect.** Close the last session on that agent. Confirm
+   the agent applies the staged binary (exec-replace), comes back on the new
+   version, and clears `pending_update` from `state.json`. Persistent daemon
+   sessions (if any were re-opened) survive the restart and re-attach.
+4. **Coordinated does not auto-apply.** Repeat step 1 with **Update Strategy** set
+   to **Coordinated**. Confirm that on idle the agent stages and notifies but does
+   **not** auto-apply — `pending_update` stays recorded for a later coordinated
+   apply.
+5. **Retry on failure.** Make the staged binary unusable (e.g. corrupt the staged
+   file after staging) and trigger an apply on last disconnect. Confirm the apply
+   fails, the agent keeps running the old version, logs the failure, and retains
+   `pending_update` so the next cycle retries.
 
 ### Agent version + update-state badge — light/dark colors (#1347)
 

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -51,6 +51,18 @@ pub enum UpdateStrategy {
     Deferred,
 }
 
+impl UpdateStrategy {
+    /// Lowercase CLI token passed to the agent via `--update-strategy` (#1401),
+    /// matching the agent-side `UpdateStrategy::from_cli` parser.
+    pub fn as_cli_str(self) -> &'static str {
+        match self {
+            Self::Immediate => "immediate",
+            Self::Coordinated => "coordinated",
+            Self::Deferred => "deferred",
+        }
+    }
+}
+
 /// SSH transport configuration for a remote agent (no session details).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -78,8 +90,10 @@ pub struct RemoteAgentConfig {
     pub external_connection_files: Vec<ExternalAgentFile>,
     /// Whether the agent may check GitHub and update itself in the background.
     ///
-    /// Opt-in (`false` by default). The self-update mechanism (SI-8) is not yet
-    /// implemented; this flag persists the user's preference until it lands.
+    /// Opt-in (`false` by default). When enabled the agent polls for a newer
+    /// release, stages a SHA-256-verified binary while idle (#1355) and
+    /// auto-applies it once its last session disconnects (#1401), honoring
+    /// [`Self::update_strategy`].
     #[serde(default)]
     pub allow_self_update: bool,
     /// How this agent's binary is updated when a newer desktop version deploys.
@@ -143,12 +157,18 @@ impl RemoteAgentConfig {
     pub fn agent_exec_command(&self) -> String {
         let path = self.agent_path();
         // Opt the agent into its background GitHub self-update check only when
-        // the connection enables it (#1355); off by default.
+        // the connection enables it (#1355); off by default. When enabled, also
+        // pass the configured update strategy so the agent knows whether a
+        // staged self-update may auto-apply on idle (#1401).
         let args = if self.allow_self_update {
-            "--stdio --allow-self-update"
+            format!(
+                "--stdio --allow-self-update --update-strategy {}",
+                self.update_strategy.as_cli_str()
+            )
         } else {
-            "--stdio"
+            "--stdio".to_string()
         };
+        let args = args.as_str();
         if crate::terminal::agent_install::is_windows_path(path) {
             return windows_agent_command(path, args);
         }

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -508,10 +508,38 @@ mod tests {
             allow_self_update: true,
             ..Default::default()
         };
+        // Self-update on with the default (immediate) strategy.
         assert_eq!(
             config.agent_exec_command(),
-            "$HOME/.local/bin/termihub-agent --stdio --allow-self-update"
+            "$HOME/.local/bin/termihub-agent --stdio --allow-self-update --update-strategy immediate"
         );
+    }
+
+    #[test]
+    fn agent_exec_command_passes_configured_update_strategy() {
+        let config = RemoteAgentConfig {
+            host: "pi.local".to_string(),
+            username: "pi".to_string(),
+            allow_self_update: true,
+            update_strategy: UpdateStrategy::Deferred,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.agent_exec_command(),
+            "$HOME/.local/bin/termihub-agent --stdio --allow-self-update --update-strategy deferred"
+        );
+    }
+
+    #[test]
+    fn agent_exec_command_omits_update_strategy_when_self_update_off() {
+        let config = RemoteAgentConfig {
+            host: "pi.local".to_string(),
+            username: "pi".to_string(),
+            update_strategy: UpdateStrategy::Deferred,
+            ..Default::default()
+        };
+        // Strategy is only meaningful for self-update; omit it when off.
+        assert!(!config.agent_exec_command().contains("--update-strategy"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1401
Part of Epic #1345
Follow-up to #1355 (PR #1402) + #1352 (PR #1518)

## Summary

Wires the agent-side self-update **staging** pipeline (#1355) through the **deferred-apply / exec-replace** mechanism (#1352) so a staged, verified update actually applies once the agent goes idle — without ever interrupting active sessions.

### What was already wired (by #1352)
- The zero-session `SessionManager::close()` hook already applied *any* recorded `pending_update` on last disconnect via `apply_pending_update` → `UpdateApplier` (unix exec-replace), plus the pure `should_apply_deferred_update` gate and `agent.request_deferred_update`.

### What this PR adds
- **Bridged the two mechanisms (single source of truth).** The #1355 timer wrote `pending_update` directly to `state.json`, while `SessionManager` owns a *cached* in-memory `AgentState` — so a staged self-update was invisible to the apply path and got clobbered on the next `close()`. All `update` state (last-check time + staged pending update) now flows through `SessionManager` (`record_update_check_time`, `stage_pending_update`, `request_deferred_update`), so both paths share one state.
- **Auto-apply on idle.** After staging while idle, the timer hands the verified binary to `request_deferred_update`, which applies immediately (exec-replace) — or, if a session raced in, re-checks and defers to the last-disconnect hook. Active sessions are never cut.
- **`update_strategy` gate.** The agent now receives the connection's configured strategy via a new `--update-strategy` CLI flag. `immediate`/`deferred` auto-apply on idle; `coordinated` stages + notifies only.
- **`allow_self_update` gate.** Implied — the self-update task is never spawned when off.
- **Retain-on-failure.** `apply_pending_update` now applies **first** and clears the pending update only on **success**; a failed apply keeps it (and logs) so a later cycle retries. (Previously it cleared before applying, losing the update on failure.)
- **Notification re-emit.** `agent.update_available` is emitted **before** the apply so connected desktops observe the lifecycle even though a successful unix apply re-execs and never returns.

### Never-interrupt guarantee
Auto-apply fires strictly at `active_count() == 0` (reusing #1352's `should_apply_deferred_update`); persistent daemon sessions survive the exec-replace and re-attach.

## Testing
Unit tests (macOS-runnable):
- `agent/src/update/mod.rs`: apply-on-idle for eligible strategy (applies + clears pending); coordinated stages without applying; failed apply keeps pending; active-sessions notify-only; offline/up-to-date.
- `agent/src/session/manager.rs`: successful apply on last disconnect clears pending; failed apply retains it.
- `agent/src/main.rs`: `--update-strategy` parsing.
- `src-tauri/src/terminal/backend.rs`: desktop exec command carries `--update-strategy`.

Deferred: Docker (#995) end-to-end apply-across-restart integration is tracked by the existing deferred-update Docker follow-up **#1519** (stage → close last session → assert new version on reconnect). Manual steps added to `docs/testing.md`.

## Test plan
- [x] `cargo test -p termihub-agent` (317 unit + integration pass)
- [x] `cargo test -p termihub` backend tests
- [x] `cargo clippy -p termihub-agent -p termihub --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- Manual: enable self-update on a Linux host, publish a newer tag, keep a session open → no apply; close last session → applies; reconnect → new version; `pending_update` cleared (see docs/testing.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)