### PR TITLE
chore(config): shrink dev target dir via [profile.dev] debug = 0 (Closes #1537)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,22 @@
 members = ["core", "src-tauri", "agent"]
 resolver = "2"
 
+# Dev/test builds keep file:line backtraces but drop full DWARF. A clean
+# `cargo build --workspace` target/debug measures 6.7 GB with Cargo's default
+# `debug = true` and 4.5 GB here (9.4 GB -> 6.5 GB once test binaries are built),
+# which is what makes several parallel checkouts fit on one disk — see
+# docs/testing.md -> "Parallel test isolation". Release builds are unaffected:
+# every shipping artifact is built with `--release`.
+#
+# `line-tables-only` keeps symbolised file/line backtraces across the whole
+# stack, dependencies included, which is the debugging story this repo actually
+# documents (docs/contributing.md -> "Process exit codes": RUST_BACKTRACE=1).
+# Step-debugging through dependency code degrades; override locally with
+# `RUSTFLAGS="-C debuginfo=2"` or a `[profile.dev]` in `.cargo/config.toml` if
+# you need it. See https://github.com/armaxri/termiHub/issues/1537.
+[profile.dev]
+debug = "line-tables-only"
+
 [workspace.dependencies]
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,21 +2,32 @@
 members = ["core", "src-tauri", "agent"]
 resolver = "2"
 
-# Dev/test builds keep file:line backtraces but drop full DWARF. A clean
-# `cargo build --workspace` target/debug measures 6.7 GB with Cargo's default
-# `debug = true` and 4.5 GB here (9.4 GB -> 6.5 GB once test binaries are built),
-# which is what makes several parallel checkouts fit on one disk — see
-# docs/testing.md -> "Parallel test isolation". Release builds are unaffected:
-# every shipping artifact is built with `--release`.
+# Dev/test builds emit no debug info at all. The workspace declared no
+# [profile.dev], so it ran on Cargo's default `debug = true` — full DWARF for
+# every crate in the dependency graph, which was the bulk of the debug target.
+# Release builds are unaffected: every shipping artifact is built with
+# `--release`.
 #
-# `line-tables-only` keeps symbolised file/line backtraces across the whole
-# stack, dependencies included, which is the debugging story this repo actually
-# documents (docs/contributing.md -> "Process exit codes": RUST_BACKTRACE=1).
-# Step-debugging through dependency code degrades; override locally with
-# `RUSTFLAGS="-C debuginfo=2"` or a `[profile.dev]` in `.cargo/config.toml` if
-# you need it. See https://github.com/armaxri/termiHub/issues/1537.
+# Measured, clean `du -sh target/debug` (macOS aarch64, rustc 1.93):
+#
+#   debug = true (Cargo default)  6.7 GB   9.4 GB with test binaries
+#   debug = "line-tables-only"    4.5 GB   6.5 GB
+#   debug = 0 (this)              3.3 GB   5.0 GB
+#
+# That is what makes several parallel checkouts fit on one disk — see
+# docs/testing.md -> "Parallel test isolation".
+#
+# TRADE-OFF, deliberate: this strips file/line from panic backtraces. A
+# backtrace still names the function symbols but reports no source location,
+# and `RUST_BACKTRACE=1` (docs/contributing.md -> "Process exit codes") is
+# correspondingly coarser. termiHub is not step-debugged in practice, so the
+# debug info was not earning its disk. To get it back for a debugging session,
+# build with `RUSTFLAGS="-C debuginfo=2"` (full DWARF) or
+# `RUSTFLAGS="-C debuginfo=1"` (file/line only), or set a [profile.dev] in a
+# local, uncommitted .cargo/config.toml. See
+# https://github.com/armaxri/termiHub/issues/1537.
 [profile.dev]
-debug = "line-tables-only"
+debug = 0
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -563,6 +563,40 @@ names, published ports, Docker networks, the `tauri-driver` port, the virtual
 serial device paths) is derived from a single per-checkout config file so two
 checkouts never contend for the same resource.
 
+#### Disk cost per checkout
+
+Ports and container names are isolated, but **disk is shared** — it is what
+actually caps how many checkouts fit on one machine. Each checkout carries its
+own `target/`, and nothing is shared between them. Measured on macOS
+(aarch64, rustc 1.93) with the workspace `[profile.dev] debug =
+"line-tables-only"` set in the root `Cargo.toml`:
+
+| Checkout state                                   | `target/debug` |
+| ------------------------------------------------ | -------------- |
+| Cold (never built)                               | 0              |
+| After `cargo build --workspace` (or `setup.sh`)  | **4.5 GB**     |
+| After the test binaries are built (`cargo test`) | **6.5 GB**     |
+
+So budget **~6.5 GB per checkout** — a primed-but-untested checkout starts at
+4.5 GB and grows toward 6.5 GB as soon as its suites run. Five parallel
+checkouts need ~33 GB of free disk, ten need ~65 GB.
+
+> Without the `[profile.dev]` setting these were **6.7 GB / 9.4 GB** — Cargo's
+> default `debug = true` emits full DWARF for every crate in the dependency
+> graph ([#1537](https://github.com/armaxri/termiHub/issues/1537)). Backtraces
+> still carry file/line; only step-debugging through dependency code degrades.
+
+Two things worth knowing before provisioning N checkouts:
+
+- **A cold checkout pulls its whole `target/` the first time anything builds
+  it** — including the first time a test run builds it. Several cold checkouts
+  can therefore exhaust the disk mid-run and fail builds in **every** checkout
+  at once, including ones that were already working. If builds start failing
+  across unrelated checkouts, check free space before reading any diff.
+- **Reclaim with `cargo clean`** in an idle checkout (at the cost of a full
+  rebuild). Never `git clean -xfd` — `dev.local.json` is gitignored, so that
+  would delete this checkout's isolation config (see below).
+
 #### Setup
 
 Each checkout owns a gitignored `dev.local.json`. Create it from the committed

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -568,23 +568,30 @@ checkouts never contend for the same resource.
 Ports and container names are isolated, but **disk is shared** — it is what
 actually caps how many checkouts fit on one machine. Each checkout carries its
 own `target/`, and nothing is shared between them. Measured on macOS
-(aarch64, rustc 1.93) with the workspace `[profile.dev] debug =
-"line-tables-only"` set in the root `Cargo.toml`:
+(aarch64, rustc 1.93) with the workspace `[profile.dev] debug = 0` set in the
+root `Cargo.toml`:
 
 | Checkout state                                   | `target/debug` |
 | ------------------------------------------------ | -------------- |
 | Cold (never built)                               | 0              |
-| After `cargo build --workspace` (or `setup.sh`)  | **4.5 GB**     |
-| After the test binaries are built (`cargo test`) | **6.5 GB**     |
+| After `cargo build --workspace` (or `setup.sh`)  | **3.3 GB**     |
+| After the test binaries are built (`cargo test`) | **5.0 GB**     |
 
-So budget **~6.5 GB per checkout** — a primed-but-untested checkout starts at
-4.5 GB and grows toward 6.5 GB as soon as its suites run. Five parallel
-checkouts need ~33 GB of free disk, ten need ~65 GB.
+So budget **~5 GB per checkout** — a primed-but-untested checkout starts at
+3.3 GB and grows toward 5 GB as soon as its suites run. Five parallel checkouts
+need ~25 GB of free disk, ten need ~50 GB.
 
 > Without the `[profile.dev]` setting these were **6.7 GB / 9.4 GB** — Cargo's
 > default `debug = true` emits full DWARF for every crate in the dependency
-> graph ([#1537](https://github.com/armaxri/termiHub/issues/1537)). Backtraces
-> still carry file/line; only step-debugging through dependency code degrades.
+> graph ([#1537](https://github.com/armaxri/termiHub/issues/1537)).
+>
+> `debug = 0` is a deliberate trade: dev/test builds emit **no debug info**, so
+> a panic backtrace names its frames but gives **no file/line for them**. The
+> panic site itself is still reported with file and line — that comes from
+> `#[track_caller]`, not from debug info — so a failing test still points at
+> where it blew up. If you need full backtraces or a step-debugger for a
+> session, build with `RUSTFLAGS="-C debuginfo=2"` (or `=1` for file/line
+> only); the disk cost above then reverts for that checkout.
 
 Two things worth knowing before provisioning N checkouts:
 


### PR DESCRIPTION
Closes #1537

The workspace `Cargo.toml` declared no `[profile.dev]`, so dev and test builds ran on Cargo's default `debug = true` — full DWARF debug info for every crate in the dependency graph, which was the bulk of the debug target. This adds:

```toml
[profile.dev]
debug = 0
```

Release builds are unaffected: every shipping artifact (`release.yml`, `agent.yml`, `dev-build.yml`) is built with `--release`.

## Measured — clean builds, four ways

Not estimated. Every row is a `cargo clean` followed by a full build, `du -sh target/debug`, on macOS aarch64 / rustc 1.93.0. All builds exited 0.

| `[profile.dev] debug` | `cargo build --workspace` | + `cargo test --workspace --no-run` |
| --- | --- | --- |
| `true` — **Cargo default, the "before"** | **6.7 GB** | **9.4 GB** |
| `"line-tables-only"` | 4.5 GB (−33%) | 6.5 GB (−31%) |
| `"line-tables-only"` + deps `debug = 0` | 3.7 GB (−45%) | 5.6 GB (−40%) |
| **`0` — this PR, the "after"** | **3.3 GB (−51%)** | **5.0 GB (−47%)** |

The 6.7 GB baseline reproduces the primed-checkout figure exactly. The issue's 11 GB came from a checkout that had also *run* its suites with `--all-features`; 9.4 GB here is `--no-run` with default features, so the two are consistent — the ratio is what transfers.

`debug = 0` is the only level that delivers the **"roughly halves"** #1537 predicted; `line-tables-only` gets a third.

## The dropped acceptance criterion — read this

**#1537's criterion "confirm a failing test still reports a file:line backtrace" is void, by repo owner decision, and this PR does not satisfy it.** `debug = 0` strips exactly that information. The owner's reasoning: this app is not step-debugged in practice, so the debug info is not earning its disk, and maximum savings wins.

This is recorded here so that the file:line loss reads six months from now as **a deliberate trade, not an oversight**. The earlier revision of this branch used `line-tables-only` specifically to preserve that criterion; it was superseded.

I ran the check anyway, to document the regression rather than hide it. Same failing test, `RUST_BACKTRACE=1`, on `debug = 0`:

```
thread 'backtrace_probe_reports_file_and_line' panicked at core/tests/zz_backtrace_probe.rs:5:5:
deliberate probe panic for #1537
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: zz_backtrace_probe::inner_frame
   3: zz_backtrace_probe::middle_frame
   4: zz_backtrace_probe::backtrace_probe_reports_file_and_line
   5: zz_backtrace_probe::backtrace_probe_reports_file_and_line::{{closure}}
   6: core::ops::function::FnOnce::call_once
```

Against the same probe on `line-tables-only`, which carried `at ./tests/zz_backtrace_probe.rs:5:5` under each frame. So, precisely:

- **Lost** — the `at <file>:<line>:<col>` source location under every backtrace frame. Frames still name their symbols (`zz_backtrace_probe::inner_frame`), so the call path stays readable; you cannot jump to a line for the intermediate frames.
- **Kept** — the panic site's own file:line (`panicked at core/tests/zz_backtrace_probe.rs:5:5`). That comes from `#[track_caller]`, not from debug info, so **a failing test still points at where it blew up**. This is why the practical loss is narrower than "no file:line at all".

Restore per-session with `RUSTFLAGS="-C debuginfo=2"` (full DWARF) or `=1` (file/line only).

**Nothing breaks structurally.** I grepped `core/`, `src-tauri/`, `agent/`, `.github/`, `scripts/` and `tests/` for anything asserting on backtrace contents, installing a panic hook, or parsing symbols — zero hits. No test asserts on a backtrace, no CI check parses symbols. The cost is diagnostic quality, nothing more.

## docs/testing.md

"Parallel test isolation" documents port/container isolation but never the disk cost — which is what actually caps the number of checkouts, and whose failure mode is nasty (a cold checkout pulls its whole `target/` on first build, so several can exhaust the volume mid-run and fail builds in *every* checkout at once, including working ones). Added a "Disk cost per checkout" subsection with the measured figures, the N-checkout arithmetic (**5 checkouts ≈ 25 GB, was ~47 GB**; 10 ≈ 50 GB), the backtrace trade above, that failure mode, and the `cargo clean`-yes / `git clean -xfd`-never distinction.

## Test plan

- [x] `cargo clean` + full clean build measured for all four profiles; all exit 0, figures above
- [x] Backtrace regression characterised on `debug = 0` and recorded above (criterion dropped by owner decision — not satisfied, deliberately)
- [x] Grepped for backtrace/symbol-dependent code and CI — zero hits
- [x] `cargo metadata` parses; `cargo build -p termihub-core` succeeds
- [x] `pnpm run markdownlint` — 0 errors
- [x] `pnpm run format:check` + `cargo fmt --all -- --check` — clean

No Rust source changed, so clippy cannot regress; CI confirms.

No change fragment: this is a build-profile change for developers with no user-facing effect (release artifacts are byte-for-byte unaffected), which `CLAUDE.md` puts in the skip list.

#1538 was filed earlier in this PR's life to revisit stripping dependency debug info, back when this branch kept `line-tables-only`. The owner's decision goes further than that issue proposed and lands it here, so #1538 is closed as superseded rather than left contradicting the merged setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
