### PR TITLE
feat(sftp): smarter default path for the Save-a-copy dialog (Closes #1535)

### DIFF
--- a/docs/changes/dev0/feature/1535-sftp-save-copy-path.md
+++ b/docs/changes/dev0/feature/1535-sftp-save-copy-path.md
@@ -1,0 +1,8 @@
+### Changed
+
+- SFTP "Save a copy…" (for read-only remote files on connections with no shell)
+  now pre-fills a likely-writable destination instead of the read-only original
+  path: the file's name under the connecting user's remote home
+  (`<home>/<name>`) when it can be resolved, or a same-directory `<name>.copy`
+  sibling otherwise. The field stays fully editable — this only sets a smarter
+  initial value so the copy usually saves without manual editing (#1535).

--- a/src/components/FileEditor/FileEditor.test.tsx
+++ b/src/components/FileEditor/FileEditor.test.tsx
@@ -673,7 +673,7 @@ describe("FileEditor — SFTP-only read-only fallback (#1330)", () => {
    * Mock a read-only remote file on a connection with **no** exec channel
    * (SFTP-only / relayed), recording any Save-a-copy / Download backend calls.
    */
-  function mockSftpOnlyReadonly(): {
+  function mockSftpOnlyReadonly(home?: string): {
     writeCalls: Array<Record<string, unknown>>;
     downloadCalls: Array<Record<string, unknown>>;
   } {
@@ -683,6 +683,11 @@ describe("FileEditor — SFTP-only read-only fallback (#1330)", () => {
       if (cmd === "sftp_read_file_content") return Promise.resolve("127.0.0.1 localhost\n");
       if (cmd === "sftp_has_exec_capability") return Promise.resolve(false);
       if (cmd === "sftp_check_writable") return Promise.resolve("readOnly");
+      if (cmd === "sftp_realpath") {
+        return home !== undefined
+          ? Promise.resolve(home)
+          : Promise.reject(new Error("no realpath"));
+      }
       if (cmd === "sftp_write_file_content") {
         writeCalls.push((args ?? {}) as Record<string, unknown>);
         return Promise.resolve(undefined);
@@ -720,6 +725,36 @@ describe("FileEditor — SFTP-only read-only fallback (#1330)", () => {
     // The fallback actions are offered instead.
     expect(query("file-editor-save-copy")).not.toBeNull();
     expect(query("file-editor-download")).not.toBeNull();
+  });
+
+  it("pre-fills Save a copy with the file's basename under the remote home (#1535)", async () => {
+    mockSftpOnlyReadonly("/home/user");
+    render(REMOTE_RO_META);
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-save-copy") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    // The read-only original is /etc/hosts; the default should point at the
+    // writable home, not the original path the save would fail on.
+    const input = docQuery("save-copy-input") as HTMLInputElement;
+    expect(input.value).toBe("/home/user/hosts");
+  });
+
+  it("falls back to a .copy sibling when the remote home can't be resolved (#1535)", async () => {
+    mockSftpOnlyReadonly(); // realpath rejects
+    render(REMOTE_RO_META);
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-save-copy") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const input = docQuery("save-copy-input") as HTMLInputElement;
+    expect(input.value).toBe("/etc/hosts.copy");
   });
 
   it("writes the buffer to the chosen writable remote path via Save a copy", async () => {

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -19,6 +19,7 @@ import { EditorTabMeta, EditorStatus } from "@/types/terminal";
 import { useAppStore } from "@/store/appStore";
 import { resolveLanguage } from "@/utils/languageMapping";
 import { getBasename } from "@/utils/formatters";
+import { suggestedSaveCopyPath } from "@/utils/saveCopyPath";
 import { getAvailableLanguages } from "@/utils/monacoLanguages";
 import { getMonacoTheme } from "@/utils/monacoCustomLanguages";
 import { getCurrentTheme, onThemeChange } from "@/themes";
@@ -31,6 +32,7 @@ import {
   sftpHasExecCapability,
   sftpCheckWritable,
   sftpDownload,
+  sftpRealpath,
   storeCredential,
   resolveCredential,
   removeCredential,
@@ -170,6 +172,10 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // it locally.
   const [saveCopyDialogOpen, setSaveCopyDialogOpen] = useState(false);
   const [saveCopyBusy, setSaveCopyBusy] = useState(false);
+  // Connecting user's resolved remote home directory, used to pre-fill the
+  // "Save a copy…" dialog with a likely-writable destination (#1535). Null
+  // until resolved (or if resolution fails / the file is local).
+  const [remoteHome, setRemoteHome] = useState<string | null>(null);
 
   const saveRef = useRef<() => void>(() => {});
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
@@ -276,6 +282,38 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       cancelled = true;
     };
   }, [meta.isRemote, meta.sftpSessionId]);
+
+  // Resolve the connecting user's remote home directory so the "Save a copy…"
+  // dialog can default to a likely-writable destination there (#1535). Passing
+  // "." to realpath yields the session's home. Best-effort: a failure just
+  // leaves home null and the dialog falls back to a same-directory sibling.
+  useEffect(() => {
+    let cancelled = false;
+    if (!meta.isRemote || !meta.sftpSessionId || meta.scratch) {
+      setRemoteHome(null);
+      return;
+    }
+    const sessionId = meta.sftpSessionId;
+    sftpRealpath(sessionId, ".")
+      .then((home) => {
+        if (cancelled) return;
+        setRemoteHome(home);
+        frontendLog("file_editor", `resolved remote home for sftp session ${sessionId}: ${home}`);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setRemoteHome(null);
+        frontendLog(
+          "file_editor",
+          `remote home resolution failed for sftp session ${sessionId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [meta.isRemote, meta.sftpSessionId, meta.scratch]);
 
   // Probe the connecting user's actual write access to this remote file, in
   // parallel with the content read (it never blocks the load; a failure just
@@ -945,7 +983,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       />
       <SaveCopyDialog
         open={saveCopyDialogOpen}
-        defaultPath={effectivePath}
+        defaultPath={suggestedSaveCopyPath(effectivePath, remoteHome)}
         busy={saveCopyBusy}
         onSubmit={handleSaveCopySubmit}
         onCancel={() => setSaveCopyDialogOpen(false)}

--- a/src/components/FileEditor/SaveCopyDialog.tsx
+++ b/src/components/FileEditor/SaveCopyDialog.tsx
@@ -6,8 +6,9 @@ export interface SaveCopyDialogProps {
   /** Whether the dialog is open (controlled). */
   open: boolean;
   /**
-   * Suggested initial remote path. The user edits it to point at a writable
-   * location — the original file is read-only, so saving over it would fail.
+   * Suggested initial remote path, pre-filled to a likely-writable destination
+   * (the remote home, or a `.copy` sibling — see {@link suggestedSaveCopyPath})
+   * so the user can usually save without editing. Stays fully editable (#1535).
    */
   defaultPath: string;
   /** True while the parent writes the copy (drives the pending state). */

--- a/src/utils/saveCopyPath.test.ts
+++ b/src/utils/saveCopyPath.test.ts
@@ -18,9 +18,7 @@ describe("suggestedSaveCopyPath", () => {
 
   it("falls back to a same-directory .copy sibling when home is unknown", () => {
     expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf")).toBe("/etc/nginx/nginx.conf.copy");
-    expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf", null)).toBe(
-      "/etc/nginx/nginx.conf.copy"
-    );
+    expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf", null)).toBe("/etc/nginx/nginx.conf.copy");
     expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf", "")).toBe("/etc/nginx/nginx.conf.copy");
     expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf", "   ")).toBe(
       "/etc/nginx/nginx.conf.copy"

--- a/src/utils/saveCopyPath.test.ts
+++ b/src/utils/saveCopyPath.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { suggestedSaveCopyPath } from "./saveCopyPath";
+
+describe("suggestedSaveCopyPath", () => {
+  it("places the file's basename in the remote home directory", () => {
+    expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf", "/home/alice")).toBe(
+      "/home/alice/nginx.conf"
+    );
+  });
+
+  it("normalizes a trailing slash on the home directory", () => {
+    expect(suggestedSaveCopyPath("/etc/hosts", "/home/alice/")).toBe("/home/alice/hosts");
+  });
+
+  it("handles the root directory as home without doubling the slash", () => {
+    expect(suggestedSaveCopyPath("/etc/hosts", "/")).toBe("/hosts");
+  });
+
+  it("falls back to a same-directory .copy sibling when home is unknown", () => {
+    expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf")).toBe("/etc/nginx/nginx.conf.copy");
+    expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf", null)).toBe(
+      "/etc/nginx/nginx.conf.copy"
+    );
+    expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf", "")).toBe("/etc/nginx/nginx.conf.copy");
+    expect(suggestedSaveCopyPath("/etc/nginx/nginx.conf", "   ")).toBe(
+      "/etc/nginx/nginx.conf.copy"
+    );
+  });
+
+  it("never returns the original read-only path unchanged", () => {
+    const original = "/etc/nginx/nginx.conf";
+    expect(suggestedSaveCopyPath(original, "/home/alice")).not.toBe(original);
+    expect(suggestedSaveCopyPath(original)).not.toBe(original);
+  });
+
+  it("keeps a file already in home from colliding with itself via the sibling fallback", () => {
+    // Original lives in home: home-join yields the identical path, so we must
+    // fall back to the .copy sibling rather than suggest the read-only original.
+    expect(suggestedSaveCopyPath("/home/alice/notes.txt", "/home/alice")).toBe(
+      "/home/alice/notes.txt.copy"
+    );
+  });
+});

--- a/src/utils/saveCopyPath.ts
+++ b/src/utils/saveCopyPath.ts
@@ -1,0 +1,33 @@
+import { getBasename } from "@/utils/formatters";
+
+/**
+ * Suggest a likely-writable default destination for the SFTP "Save a copy…"
+ * dialog (#1535).
+ *
+ * The dialog opens on a read-only remote file, so pre-filling the original path
+ * only guarantees another failed save. Instead we aim at a path the user can
+ * typically write without editing:
+ *
+ * 1. If the connecting user's remote home directory is known, drop the file's
+ *    basename there (`<home>/<name>`) — home is almost always writable.
+ * 2. Otherwise (home unresolved, or home would reproduce the original path),
+ *    fall back to a same-directory sibling `<originalPath>.copy`, which at least
+ *    never re-suggests the exact read-only path the save just failed on.
+ *
+ * Remote paths are POSIX, so joining uses `/`.
+ *
+ * @param originalPath the read-only remote path the editor is showing.
+ * @param remoteHome the connecting user's resolved home directory, if known.
+ * @returns a destination path to pre-fill; always editable by the user.
+ */
+export function suggestedSaveCopyPath(originalPath: string, remoteHome?: string | null): string {
+  const home = remoteHome?.trim();
+  if (home) {
+    const base = getBasename(originalPath);
+    const homePath = `${home.replace(/\/+$/, "")}/${base}`;
+    // Guard against the file already living in home: home-join would reproduce
+    // the read-only original, so keep the sibling fallback instead.
+    if (homePath !== originalPath) return homePath;
+  }
+  return `${originalPath}.copy`;
+}


### PR DESCRIPTION
## Summary

Follow-up to #1330 / #1525. The SFTP **"Save a copy…"** dialog (shown for read-only remote files on connections with no exec channel) used to pre-fill the **original read-only path** as the destination, so the user always had to edit it before the save could succeed — saving to the read-only path just fails again.

It now pre-fills a **likely-writable** destination:

- **The file's basename under the connecting user's remote home** (`<home>/<name>`), resolving home via the existing `sftpRealpath(session, ".")`.
- **Fallback:** a same-directory `<name>.copy` sibling when home can't be resolved (non-remote, no session, or realpath error) — which still never re-suggests the exact read-only path the save just failed on.
- The field stays **fully editable**; this only sets a smarter initial value.

## Changes

- New pure helper `src/utils/saveCopyPath.ts` (`suggestedSaveCopyPath`) with unit tests.
- `FileEditor` resolves the remote home once per SFTP session (best-effort) and feeds the suggested path into `SaveCopyDialog`'s `defaultPath`.
- Updated `SaveCopyDialog` `defaultPath` JSDoc.
- Changelog fragment.

## Test plan

- `src/utils/saveCopyPath.test.ts` — 6 cases: home-join, trailing-slash normalization, root home, sibling fallback (undefined/null/empty/whitespace home), never returns the original unchanged, and the in-home self-collision → sibling case.
- `FileEditor.test.tsx` — 2 new cases: dialog pre-fills `/home/user/hosts` when realpath resolves home; falls back to `/etc/hosts.copy` when realpath rejects.
- `pnpm build`, `pnpm run lint`, `pnpm run format:check`, `pnpm run markdownlint` all clean.

Closes #1535