### PR TITLE
feat(ui): command palette — cover context-bound commands (Closes #1527)

### DIFF
--- a/docs/changes/dev1/feature/1527-command-palette-context-commands.md
+++ b/docs/changes/dev1/feature/1527-command-palette-context-commands.md
@@ -1,0 +1,10 @@
+### Added
+
+- Command palette (Cmd/Ctrl+P) now covers context-bound commands that act on the
+  focused panel/terminal: **Close Tab**, **Next Tab**, **Previous Tab**, **Focus
+  Panel Above/Below/Left/Right**, **Find in Terminal**, and **Clear Terminal**.
+  Running one from the palette resolves the active panel/terminal at run time and
+  behaves exactly like the matching keyboard shortcut (accelerators still come
+  from the single keybinding source). Commands with no applicable target — e.g.
+  Focus Panel Left with a single pane, or Find in Terminal on a non-terminal tab
+  — appear disabled with a clear affordance and are inert on Enter/click (#1527).

--- a/src/components/CommandPalette/CommandPalette.css
+++ b/src/components/CommandPalette/CommandPalette.css
@@ -32,6 +32,18 @@
   border-left-color: var(--accent-color);
 }
 
+/* Context-bound command with no applicable target: shown for discoverability
+   but visibly inert (it does nothing on Enter/click). */
+.command-palette__item--disabled {
+  color: var(--text-disabled);
+  cursor: default;
+}
+
+.command-palette__item--disabled .command-palette__icon,
+.command-palette__item--disabled .command-palette__accelerator {
+  color: var(--text-disabled);
+}
+
 .command-palette__icon {
   display: inline-flex;
   flex-shrink: 0;

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
+import { getAllLeaves } from "@/utils/panelTree";
 import { CommandPalette } from "./CommandPalette";
 import type { SavedConnection } from "@/types/connection";
 
@@ -139,5 +140,41 @@ describe("CommandPalette", () => {
   it("shows an empty state when nothing matches", () => {
     typeInto("zzzznomatch");
     expect(document.querySelector(".command-palette__empty")).not.toBeNull();
+  });
+
+  it("surfaces a context-bound command disabled when no target applies", () => {
+    // The initial state has an empty active panel, so Close Tab has no target.
+    typeInto("close tab");
+    expect(activeLabel()).toBe("Close Tab");
+    const active = document.querySelector('[role="option"][aria-selected="true"]');
+    expect(active?.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("does not run a disabled context command on Enter and keeps the palette open", () => {
+    typeInto("close tab");
+    keydown("Enter");
+    expect(useAppStore.getState().commandPaletteOpen).toBe(true);
+  });
+
+  it("runs an available context command on Enter and closes", () => {
+    // Give the active panel a focused terminal so Find in Terminal has a target.
+    act(() => {
+      const id = useAppStore
+        .getState()
+        .addTab("Shell", "local", undefined, { contentType: "terminal" });
+      const panel = getAllLeaves(useAppStore.getState().rootPanel).find((p) =>
+        p.tabs.some((t) => t.id === id)
+      )!;
+      useAppStore.getState().setActivePanel(panel.id);
+      useAppStore.getState().setActiveTab(id, panel.id);
+    });
+    const toggleSpy = vi.spyOn(useAppStore.getState(), "toggleTerminalSearch");
+
+    typeInto("find in terminal");
+    expect(activeLabel()).toBe("Find in Terminal");
+    keydown("Enter");
+
+    expect(toggleSpy).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().commandPaletteOpen).toBe(false);
   });
 });

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -19,6 +19,12 @@ type PaletteEntry =
       label: string;
       /** Effective accelerator string, or null. */
       accelerator: string | null;
+      /**
+       * Whether the command has an applicable target in the current context.
+       * Context-bound commands (focus-panel, tab close/next/prev, terminal
+       * find/clear) are disabled and non-activatable when false.
+       */
+      available: boolean;
       /** Activate the entry. */
       run: () => void;
     }
@@ -45,6 +51,11 @@ export function CommandPalette(): React.ReactElement {
   const open = useAppStore((s) => s.commandPaletteOpen);
   const setOpen = useAppStore((s) => s.setCommandPaletteOpen);
   const connections = useAppStore((s) => s.connections);
+  // Context-bound command availability depends on live panel/terminal state;
+  // subscribe so the entry list (and its disabled affordances) recompute when
+  // the focused panel, its tabs, or the active panel change.
+  const rootPanel = useAppStore((s) => s.rootPanel);
+  const activePanelId = useAppStore((s) => s.activePanelId);
   const { connect } = useConnectSavedConnection();
 
   const [query, setQuery] = useState("");
@@ -59,6 +70,7 @@ export function CommandPalette(): React.ReactElement {
       key: `command:${cmd.id}`,
       label: cmd.label,
       accelerator: cmd.accelerator,
+      available: cmd.available,
       run: cmd.run,
     }));
     const connectionEntries: PaletteEntry[] = connections.map((conn) => ({
@@ -69,7 +81,12 @@ export function CommandPalette(): React.ReactElement {
       connection: conn,
     }));
     return [...commandEntries, ...connectionEntries];
-  }, [connections]);
+    // buildCommands() reads live panel/terminal state via the store to compute
+    // each context command's availability; rootPanel and activePanelId are listed
+    // so the entries (and their disabled affordances) recompute when focus moves,
+    // even though they are not referenced directly in this closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connections, rootPanel, activePanelId]);
 
   // Ranked results. An empty query returns every entry in declaration order.
   const results = useMemo<PaletteEntry[]>(() => {
@@ -103,6 +120,10 @@ export function CommandPalette(): React.ReactElement {
   const activate = useCallback(
     (entry: PaletteEntry | undefined) => {
       if (!entry) return;
+      // A context-bound command with no applicable target is inert: leave the
+      // palette open so the user sees it did nothing (and why, via the disabled
+      // affordance) rather than silently dismissing.
+      if (entry.kind === "command" && !entry.available) return;
       // Close first so the palette never stacks over a follow-on dialog (e.g.
       // the password prompt a connect may trigger).
       setOpen(false);
@@ -174,40 +195,45 @@ export function CommandPalette(): React.ReactElement {
             aria-label="Commands and connections"
             ref={listRef}
           >
-            {results.map((entry, index) => (
-              <li
-                key={entry.key}
-                data-index={index}
-                role="option"
-                aria-selected={index === activeIndex}
-                className={`command-palette__item${
-                  index === activeIndex ? " command-palette__item--active" : ""
-                }`}
-                onMouseMove={() => setActiveIndex(index)}
-                onClick={() => activate(entry)}
-                data-testid={`command-palette-item-${entry.key}`}
-              >
-                <span className="command-palette__icon" aria-hidden="true">
+            {results.map((entry, index) => {
+              const disabled = entry.kind === "command" && !entry.available;
+              return (
+                <li
+                  key={entry.key}
+                  data-index={index}
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  aria-disabled={disabled || undefined}
+                  className={`command-palette__item${
+                    index === activeIndex ? " command-palette__item--active" : ""
+                  }${disabled ? " command-palette__item--disabled" : ""}`}
+                  title={disabled ? "Unavailable in the current context" : undefined}
+                  onMouseMove={() => setActiveIndex(index)}
+                  onClick={() => activate(entry)}
+                  data-testid={`command-palette-item-${entry.key}`}
+                >
+                  <span className="command-palette__icon" aria-hidden="true">
+                    {entry.kind === "command" ? (
+                      <TerminalSquare size={16} />
+                    ) : (
+                      <ConnectionIcon
+                        config={entry.connection.config}
+                        customIcon={entry.connection.icon}
+                        size={16}
+                      />
+                    )}
+                  </span>
+                  <span className="command-palette__label">{entry.label}</span>
                   {entry.kind === "command" ? (
-                    <TerminalSquare size={16} />
+                    entry.accelerator ? (
+                      <span className="command-palette__accelerator">{entry.accelerator}</span>
+                    ) : null
                   ) : (
-                    <ConnectionIcon
-                      config={entry.connection.config}
-                      customIcon={entry.connection.icon}
-                      size={16}
-                    />
+                    <span className="command-palette__type">{entry.connection.config.type}</span>
                   )}
-                </span>
-                <span className="command-palette__label">{entry.label}</span>
-                {entry.kind === "command" ? (
-                  entry.accelerator ? (
-                    <span className="command-palette__accelerator">{entry.accelerator}</span>
-                  ) : null
-                ) : (
-                  <span className="command-palette__type">{entry.connection.config.type}</span>
-                )}
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
-import { getAllLeaves, findAdjacentLeaf, FocusDirection } from "@/utils/panelTree";
 import {
   processKeyEvent,
   onChordStateChange,
@@ -9,6 +8,7 @@ import {
   isEventFromTerminal,
   getActionScope,
 } from "@/services/keybindings";
+import { CONTEXT_COMMANDS } from "@/services/contextCommands";
 import {
   activeContextFromTab,
   isEventFromTextInput,
@@ -18,6 +18,11 @@ import {
 /**
  * Global keyboard shortcuts for the application.
  * Uses the KeybindingService's chord-aware processKeyEvent() for matching.
+ *
+ * Context-bound actions (focus-panel, tab close/next/prev, terminal find/clear)
+ * are executed via the shared {@link CONTEXT_COMMANDS} registry so the keyboard
+ * handler and the command palette run identical logic against the focused
+ * panel/terminal.
  */
 export function useKeyboardShortcuts() {
   // Capture-phase interception for zoom-panel: must fire before Monaco (and other
@@ -35,13 +40,6 @@ export function useKeyboardShortcuts() {
     window.addEventListener("keydown", handleZoomCapture, { capture: true });
     return () => window.removeEventListener("keydown", handleZoomCapture, { capture: true });
   }, []);
-
-  const addTab = useAppStore((s) => s.addTab);
-  const rootPanel = useAppStore((s) => s.rootPanel);
-  const activePanelId = useAppStore((s) => s.activePanelId);
-  const closeTab = useAppStore((s) => s.closeTab);
-  const setActiveTab = useAppStore((s) => s.setActiveTab);
-  const toggleSidebar = useAppStore((s) => s.toggleSidebar);
 
   useEffect(() => {
     // Wire chord state changes to the store for StatusBar display
@@ -67,8 +65,6 @@ export function useKeyboardShortcuts() {
         return;
       }
 
-      const allLeaves = getAllLeaves(rootPanel);
-
       // Context-aware routing: when an editor or input surface owns this combo,
       // step aside (no preventDefault) so the focused widget handles it. The
       // setting lets users restore the old global-first behavior. Global-scoped
@@ -82,56 +78,25 @@ export function useKeyboardShortcuts() {
         }
       }
 
+      // Context-bound actions (focus-panel, tab close/next/prev, terminal
+      // find/clear) run through the shared registry so palette and keyboard
+      // behaviour stay identical. Availability is resolved inside run().
+      if (action in CONTEXT_COMMANDS) {
+        e.preventDefault();
+        CONTEXT_COMMANDS[action].run();
+        return;
+      }
+
       switch (action) {
         case "toggle-sidebar":
           e.preventDefault();
-          toggleSidebar();
+          useAppStore.getState().toggleSidebar();
           break;
 
         case "new-terminal":
           e.preventDefault();
-          addTab("Terminal", "local");
+          useAppStore.getState().addTab("Terminal", "local");
           break;
-
-        case "close-tab": {
-          e.preventDefault();
-          const panel = allLeaves.find((p) => p.id === activePanelId);
-          if (!panel?.activeTabId) break;
-          const tabId = panel.activeTabId;
-          const confirmEnabled = useAppStore.getState().settings.confirmCloseTabOnShortcut ?? true;
-          if (confirmEnabled) {
-            const activeTab = panel.tabs.find((t) => t.id === tabId);
-            useAppStore.getState().setPendingShortcutCloseConfirm({
-              kind: "tab",
-              tabId,
-              panelId: panel.id,
-              label: activeTab?.title ?? "this tab",
-            });
-          } else {
-            closeTab(tabId, panel.id);
-          }
-          break;
-        }
-
-        case "next-tab": {
-          e.preventDefault();
-          const panel = allLeaves.find((p) => p.id === activePanelId);
-          if (!panel || panel.tabs.length < 2) break;
-          const currentIdx = panel.tabs.findIndex((t) => t.id === panel.activeTabId);
-          const nextIdx = (currentIdx + 1) % panel.tabs.length;
-          setActiveTab(panel.tabs[nextIdx].id, panel.id);
-          break;
-        }
-
-        case "prev-tab": {
-          e.preventDefault();
-          const panel = allLeaves.find((p) => p.id === activePanelId);
-          if (!panel || panel.tabs.length < 2) break;
-          const currentIdx = panel.tabs.findIndex((t) => t.id === panel.activeTabId);
-          const prevIdx = (currentIdx - 1 + panel.tabs.length) % panel.tabs.length;
-          setActiveTab(panel.tabs[prevIdx].id, panel.id);
-          break;
-        }
 
         case "show-shortcuts":
           e.preventDefault();
@@ -147,16 +112,6 @@ export function useKeyboardShortcuts() {
           e.preventDefault();
           useAppStore.getState().setCommandPaletteOpen(true);
           break;
-
-        case "clear-terminal": {
-          e.preventDefault();
-          const panel = allLeaves.find((p) => p.id === activePanelId);
-          const tabId = panel?.activeTabId;
-          if (tabId) {
-            window.dispatchEvent(new CustomEvent("termihub:clear-terminal", { detail: { tabId } }));
-          }
-          break;
-        }
 
         case "split-right":
           e.preventDefault();
@@ -187,38 +142,6 @@ export function useKeyboardShortcuts() {
           e.preventDefault();
           useAppStore.getState().zoomReset();
           break;
-
-        case "focus-up":
-        case "focus-down":
-        case "focus-left":
-        case "focus-right": {
-          e.preventDefault();
-          const dir = action.replace("focus-", "") as FocusDirection;
-          const currentPanel = allLeaves.find((p) => p.id === activePanelId);
-          if (!currentPanel) break;
-          const target = findAdjacentLeaf(rootPanel, currentPanel.id, dir);
-          if (target) {
-            useAppStore.getState().setActivePanel(target.id);
-            if (target.activeTabId) {
-              window.dispatchEvent(
-                new CustomEvent("termihub:focus-terminal", {
-                  detail: { tabId: target.activeTabId },
-                })
-              );
-            }
-          }
-          break;
-        }
-
-        case "find-in-terminal": {
-          e.preventDefault();
-          const panel = allLeaves.find((p) => p.id === activePanelId);
-          const activeTab = panel?.tabs.find((t) => t.id === panel.activeTabId);
-          if (activeTab?.contentType === "terminal") {
-            useAppStore.getState().toggleTerminalSearch(activeTab.id);
-          }
-          break;
-        }
 
         case "new-tab-group":
           e.preventDefault();
@@ -270,5 +193,5 @@ export function useKeyboardShortcuts() {
       window.removeEventListener("keydown", handleKeyDown);
       cancelChord();
     };
-  }, [addTab, rootPanel, activePanelId, closeTab, setActiveTab, toggleSidebar]);
+  }, []);
 }

--- a/src/services/commands.test.ts
+++ b/src/services/commands.test.ts
@@ -31,10 +31,15 @@ describe("buildCommands", () => {
     expect(ids).toContain("toggle-sidebar");
     expect(ids).toContain("open-settings");
     expect(ids).toContain("zoom-in");
-    // …while the palette's own shortcut and context-bound actions are not.
+    // …as are the context-bound commands added in #1527…
+    expect(ids).toContain("close-tab");
+    expect(ids).toContain("next-tab");
+    expect(ids).toContain("prev-tab");
+    expect(ids).toContain("focus-up");
+    expect(ids).toContain("clear-terminal");
+    expect(ids).toContain("find-in-terminal");
+    // …while the palette's own shortcut has no runner and stays out.
     expect(ids).not.toContain("command-palette");
-    expect(ids).not.toContain("close-tab");
-    expect(ids).not.toContain("focus-up");
   });
 
   it("runs the matching store action", () => {
@@ -43,5 +48,25 @@ describe("buildCommands", () => {
     const cmd = buildCommands().find((c) => c.id === "toggle-sidebar");
     cmd!.run();
     expect(toggleSidebar).toHaveBeenCalledOnce();
+  });
+
+  it("marks store-only commands as always available", () => {
+    const cmd = buildCommands().find((c) => c.id === "toggle-sidebar");
+    expect(cmd!.available).toBe(true);
+  });
+
+  it("marks context-bound commands unavailable when no target applies", () => {
+    // Fresh state: empty active panel, single leaf, no terminal — every
+    // context-bound command is a no-op and reports itself unavailable.
+    const commands = buildCommands();
+    for (const id of ["close-tab", "next-tab", "focus-up", "clear-terminal", "find-in-terminal"]) {
+      expect(commands.find((c) => c.id === id)!.available).toBe(false);
+    }
+  });
+
+  it("marks a context-bound command available once its target exists", () => {
+    useAppStore.getState().addTab("Shell", "local");
+    const available = buildCommands().find((c) => c.id === "close-tab")!.available;
+    expect(available).toBe(true);
   });
 });

--- a/src/services/commands.ts
+++ b/src/services/commands.ts
@@ -1,8 +1,9 @@
 import { getDefaultBindings, getActionAccelerator } from "@/services/keybindings";
 import { useAppStore } from "@/store/appStore";
+import { CONTEXT_COMMANDS, ContextCommand } from "@/services/contextCommands";
 
 /**
- * A runnable application command surfaced in the command palette (#1484).
+ * A runnable application command surfaced in the command palette (#1484, #1527).
  *
  * Commands are sourced from the existing keybinding actions
  * ({@link getDefaultBindings}) so their label and accelerator have a single
@@ -15,18 +16,24 @@ export interface PaletteCommand {
   label: string;
   /** Effective accelerator string (user override or platform default), or null. */
   accelerator: string | null;
+  /**
+   * Whether the command can run against the current context. Store-only
+   * commands are always available; context-bound commands (focus-panel, tab
+   * close/next/prev, terminal find/clear) are unavailable when there is no
+   * applicable target, and the palette disables them with a clear affordance.
+   */
+  available: boolean;
   /** Execute the command. */
   run: () => void;
 }
 
 /**
- * Runner for each palette-runnable action. An action is surfaced in the palette
- * only when it has an entry here, so context-bound actions that need live panel
- * state (focus-panel, close-tab, next/prev-tab, terminal find/clear) are
- * intentionally omitted — they stay keyboard-only until they can run without a
- * DOM/panel lookup. Everything here operates purely on store state.
+ * Store-only runners: actions that operate purely on global store state and are
+ * always available. Context-bound actions (which need live panel/terminal
+ * resolution) live in {@link CONTEXT_COMMANDS} instead, so the palette and the
+ * keyboard handler share one implementation and one availability check.
  */
-const COMMAND_RUNNERS: Record<string, () => void> = {
+const STORE_RUNNERS: Record<string, () => void> = {
   "toggle-sidebar": () => useAppStore.getState().toggleSidebar(),
   "open-settings": () => useAppStore.getState().openSettingsTab(),
   "show-shortcuts": () => useAppStore.getState().setShortcutsOverlayOpen(true),
@@ -45,18 +52,35 @@ const COMMAND_RUNNERS: Record<string, () => void> = {
 };
 
 /**
+ * Resolve the runner for a keybinding action, or `undefined` when the action is
+ * not surfaced in the palette. Store-only runners are wrapped so every runner
+ * exposes the same `{ run, isAvailable? }` shape.
+ */
+function getRunner(action: string): ContextCommand | undefined {
+  if (action in CONTEXT_COMMANDS) return CONTEXT_COMMANDS[action];
+  if (action in STORE_RUNNERS) return { run: STORE_RUNNERS[action], isAvailable: () => true };
+  return undefined;
+}
+
+/**
  * Build the list of runnable commands for the command palette, in the order
  * their bindings are declared. Labels and accelerators come from the keybinding
  * service so the palette stays in sync with the shortcuts overlay and any user
- * overrides.
+ * overrides. Availability is resolved against live context at call time, so
+ * callers rebuild whenever the focused panel/terminal changes.
  */
 export function buildCommands(): PaletteCommand[] {
-  return getDefaultBindings()
-    .filter((binding) => binding.action in COMMAND_RUNNERS)
-    .map((binding) => ({
+  const commands: PaletteCommand[] = [];
+  for (const binding of getDefaultBindings()) {
+    const runner = getRunner(binding.action);
+    if (!runner) continue;
+    commands.push({
       id: binding.action,
       label: binding.label,
       accelerator: getActionAccelerator(binding.action),
-      run: COMMAND_RUNNERS[binding.action],
-    }));
+      available: runner.isAvailable(),
+      run: runner.run,
+    });
+  }
+  return commands;
 }

--- a/src/services/contextCommands.test.ts
+++ b/src/services/contextCommands.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the context-bound command registry (#1527).
+ *
+ * These commands act on the currently-focused panel/terminal, so each is
+ * covered on two axes: `isAvailable()` reports whether a target applies in the
+ * current context, and `run()` acts on that target (and is inert when none
+ * applies). The same registry backs both the keyboard handler and the palette.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CONTEXT_COMMANDS } from "./contextCommands";
+import { useAppStore, getActiveTab } from "@/store/appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+
+/** Add a tab of the given content type and make it the active tab/panel. */
+function addActiveTab(contentType: "terminal" | "editor" = "terminal"): string {
+  const id = useAppStore.getState().addTab("Tab", "local", undefined, { contentType });
+  const panel = getAllLeaves(useAppStore.getState().rootPanel).find((p) =>
+    p.tabs.some((t) => t.id === id)
+  )!;
+  useAppStore.getState().setActivePanel(panel.id);
+  useAppStore.getState().setActiveTab(id, panel.id);
+  return id;
+}
+
+/** The active leaf panel resolved from live store state. */
+function activeLeaf() {
+  const { rootPanel, activePanelId } = useAppStore.getState();
+  return getAllLeaves(rootPanel).find((p) => p.id === activePanelId) ?? null;
+}
+
+beforeEach(() => {
+  useAppStore.setState({ ...useAppStore.getInitialState() });
+});
+
+describe("CONTEXT_COMMANDS registry", () => {
+  it("registers exactly the context-bound actions from the issue", () => {
+    expect(Object.keys(CONTEXT_COMMANDS).sort()).toEqual(
+      [
+        "clear-terminal",
+        "close-tab",
+        "find-in-terminal",
+        "focus-down",
+        "focus-left",
+        "focus-right",
+        "focus-up",
+        "next-tab",
+        "prev-tab",
+      ].sort()
+    );
+  });
+});
+
+describe("close-tab", () => {
+  const cmd = CONTEXT_COMMANDS["close-tab"];
+
+  it("is unavailable when the active panel has no tab", () => {
+    // Fresh state: the initial panel is empty.
+    expect(cmd.isAvailable()).toBe(false);
+  });
+
+  it("is available once a tab is focused", () => {
+    addActiveTab();
+    expect(cmd.isAvailable()).toBe(true);
+  });
+
+  it("closes the active tab immediately when the confirm setting is disabled", () => {
+    addActiveTab();
+    useAppStore.setState((s) => ({
+      settings: { ...s.settings, confirmCloseTabOnShortcut: false },
+    }));
+    cmd.run();
+    expect(activeLeaf()!.tabs).toHaveLength(0);
+    expect(useAppStore.getState().pendingShortcutCloseConfirm).toBeNull();
+  });
+
+  it("opens the confirm dialog when the confirm setting is enabled (default)", () => {
+    const tabId = addActiveTab();
+    cmd.run();
+    expect(activeLeaf()!.tabs).toHaveLength(1);
+    const confirm = useAppStore.getState().pendingShortcutCloseConfirm;
+    expect(confirm?.kind).toBe("tab");
+    if (confirm?.kind === "tab") expect(confirm.tabId).toBe(tabId);
+  });
+
+  it("run() is inert when there is no target", () => {
+    cmd.run();
+    expect(useAppStore.getState().pendingShortcutCloseConfirm).toBeNull();
+  });
+});
+
+describe("next-tab / prev-tab", () => {
+  it("are unavailable with fewer than two tabs", () => {
+    expect(CONTEXT_COMMANDS["next-tab"].isAvailable()).toBe(false);
+    addActiveTab();
+    expect(CONTEXT_COMMANDS["next-tab"].isAvailable()).toBe(false);
+    expect(CONTEXT_COMMANDS["prev-tab"].isAvailable()).toBe(false);
+  });
+
+  it("cycle the active panel's selection", () => {
+    const first = addActiveTab();
+    const second = addActiveTab();
+    const panel = activeLeaf()!;
+    useAppStore.getState().setActiveTab(first, panel.id);
+
+    expect(CONTEXT_COMMANDS["next-tab"].isAvailable()).toBe(true);
+    CONTEXT_COMMANDS["next-tab"].run();
+    expect(activeLeaf()!.activeTabId).toBe(second);
+
+    CONTEXT_COMMANDS["prev-tab"].run();
+    expect(activeLeaf()!.activeTabId).toBe(first);
+  });
+});
+
+describe("focus-panel", () => {
+  it("all directions are unavailable with a single panel", () => {
+    addActiveTab();
+    for (const dir of ["focus-up", "focus-down", "focus-left", "focus-right"]) {
+      expect(CONTEXT_COMMANDS[dir].isAvailable()).toBe(false);
+    }
+  });
+
+  it("resolves the adjacent panel and moves focus to it", () => {
+    addActiveTab();
+    // Split horizontally: the new (right) panel becomes active, so the original
+    // panel sits to its left.
+    useAppStore.getState().splitPanel("horizontal");
+    const rightPanelId = useAppStore.getState().activePanelId;
+
+    expect(CONTEXT_COMMANDS["focus-left"].isAvailable()).toBe(true);
+    expect(CONTEXT_COMMANDS["focus-right"].isAvailable()).toBe(false);
+
+    CONTEXT_COMMANDS["focus-left"].run();
+    expect(useAppStore.getState().activePanelId).not.toBe(rightPanelId);
+  });
+});
+
+describe("clear-terminal / find-in-terminal", () => {
+  it("are available only when the active tab is a terminal", () => {
+    expect(CONTEXT_COMMANDS["clear-terminal"].isAvailable()).toBe(false);
+    addActiveTab("editor");
+    expect(CONTEXT_COMMANDS["clear-terminal"].isAvailable()).toBe(false);
+    expect(CONTEXT_COMMANDS["find-in-terminal"].isAvailable()).toBe(false);
+    addActiveTab("terminal");
+    expect(CONTEXT_COMMANDS["clear-terminal"].isAvailable()).toBe(true);
+    expect(CONTEXT_COMMANDS["find-in-terminal"].isAvailable()).toBe(true);
+  });
+
+  it("clear-terminal dispatches a clear event for the focused terminal", () => {
+    const tabId = addActiveTab("terminal");
+    const events: CustomEvent[] = [];
+    const listener = (e: Event) => events.push(e as CustomEvent);
+    window.addEventListener("termihub:clear-terminal", listener);
+    CONTEXT_COMMANDS["clear-terminal"].run();
+    window.removeEventListener("termihub:clear-terminal", listener);
+    expect(events).toHaveLength(1);
+    expect(events[0].detail.tabId).toBe(tabId);
+  });
+
+  it("find-in-terminal toggles the terminal search for the focused terminal", () => {
+    const tabId = addActiveTab("terminal");
+    const toggleSpy = vi.spyOn(useAppStore.getState(), "toggleTerminalSearch");
+    CONTEXT_COMMANDS["find-in-terminal"].run();
+    expect(toggleSpy).toHaveBeenCalledWith(tabId);
+  });
+
+  it("run() is inert on a non-terminal tab", () => {
+    addActiveTab("editor");
+    const toggleSpy = vi.spyOn(useAppStore.getState(), "toggleTerminalSearch");
+    const events: CustomEvent[] = [];
+    const listener = (e: Event) => events.push(e as CustomEvent);
+    window.addEventListener("termihub:clear-terminal", listener);
+    CONTEXT_COMMANDS["clear-terminal"].run();
+    CONTEXT_COMMANDS["find-in-terminal"].run();
+    window.removeEventListener("termihub:clear-terminal", listener);
+    expect(events).toHaveLength(0);
+    expect(toggleSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("getActiveTab integration", () => {
+  // Guards the assumption find/clear availability relies on.
+  it("returns the focused terminal tab", () => {
+    const id = addActiveTab("terminal");
+    expect(getActiveTab(useAppStore.getState())?.id).toBe(id);
+  });
+});

--- a/src/services/contextCommands.ts
+++ b/src/services/contextCommands.ts
@@ -1,0 +1,132 @@
+import { useAppStore, getActiveTab } from "@/store/appStore";
+import { getAllLeaves, findAdjacentLeaf, FocusDirection } from "@/utils/panelTree";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
+
+/**
+ * A context-bound application command — one that acts on the currently-focused
+ * panel or terminal rather than on global store state.
+ *
+ * Unlike the store-only commands surfaced directly in the command palette,
+ * these need live context resolution (which panel is active, whether it holds a
+ * terminal, how many tabs it has). Each command therefore reports whether it
+ * has an applicable target right now via {@link ContextCommand.isAvailable} and
+ * resolves that target at run time in {@link ContextCommand.run}.
+ *
+ * This registry is the single source of truth for the behaviour of these
+ * actions: both the global keyboard handler ({@link useKeyboardShortcuts}) and
+ * the command palette ({@link buildCommands}) run them from here, so a shortcut
+ * and its palette entry can never drift apart.
+ */
+export interface ContextCommand {
+  /**
+   * Whether the command has an applicable target in the current context (e.g.
+   * an adjacent panel to focus, a second tab to switch to, a focused terminal).
+   * The palette uses this to disable the entry when it would be a no-op.
+   */
+  isAvailable: () => boolean;
+  /** Execute the command against the currently-focused panel/terminal. */
+  run: () => void;
+}
+
+/** Resolve the active leaf panel from live store state, or null when none. */
+function activeLeaf(): LeafPanel | null {
+  const { rootPanel, activePanelId } = useAppStore.getState();
+  if (!activePanelId) return null;
+  return getAllLeaves(rootPanel).find((p) => p.id === activePanelId) ?? null;
+}
+
+/** The active tab, but only when it is a terminal (find/clear apply). */
+function activeTerminalTab(): TerminalTab | null {
+  const tab = getActiveTab(useAppStore.getState());
+  return tab && tab.contentType === "terminal" ? tab : null;
+}
+
+/** Close the active tab, honouring the confirm-on-shortcut setting. */
+function closeActiveTab(): void {
+  const panel = activeLeaf();
+  if (!panel?.activeTabId) return;
+  const tabId = panel.activeTabId;
+  const state = useAppStore.getState();
+  const confirmEnabled = state.settings.confirmCloseTabOnShortcut ?? true;
+  if (confirmEnabled) {
+    const activeTab = panel.tabs.find((t) => t.id === tabId);
+    state.setPendingShortcutCloseConfirm({
+      kind: "tab",
+      tabId,
+      panelId: panel.id,
+      label: activeTab?.title ?? "this tab",
+    });
+  } else {
+    state.closeTab(tabId, panel.id);
+  }
+}
+
+/** Whether the active panel has more than one tab to cycle between. */
+function hasMultipleTabs(): boolean {
+  const panel = activeLeaf();
+  return !!panel && panel.tabs.length >= 2;
+}
+
+/** Cycle the active panel's selection by `delta` tabs, wrapping around. */
+function cycleTab(delta: 1 | -1): void {
+  const panel = activeLeaf();
+  if (!panel || panel.tabs.length < 2) return;
+  const currentIdx = panel.tabs.findIndex((t) => t.id === panel.activeTabId);
+  const nextIdx = (currentIdx + delta + panel.tabs.length) % panel.tabs.length;
+  useAppStore.getState().setActiveTab(panel.tabs[nextIdx].id, panel.id);
+}
+
+/** Whether there is a panel adjacent to the active one in `dir`. */
+function canFocusPanel(dir: FocusDirection): boolean {
+  const panel = activeLeaf();
+  if (!panel) return false;
+  return findAdjacentLeaf(useAppStore.getState().rootPanel, panel.id, dir) !== null;
+}
+
+/** Move focus to the panel adjacent to the active one in `dir`. */
+function focusPanel(dir: FocusDirection): void {
+  const state = useAppStore.getState();
+  const panel = activeLeaf();
+  if (!panel) return;
+  const target = findAdjacentLeaf(state.rootPanel, panel.id, dir);
+  if (!target) return;
+  state.setActivePanel(target.id);
+  if (target.activeTabId) {
+    window.dispatchEvent(
+      new CustomEvent("termihub:focus-terminal", { detail: { tabId: target.activeTabId } })
+    );
+  }
+}
+
+/** Clear the focused terminal (no-op when the active tab is not a terminal). */
+function clearActiveTerminal(): void {
+  const tab = activeTerminalTab();
+  if (!tab) return;
+  window.dispatchEvent(new CustomEvent("termihub:clear-terminal", { detail: { tabId: tab.id } }));
+}
+
+/** Toggle the search bar of the focused terminal. */
+function findInActiveTerminal(): void {
+  const tab = activeTerminalTab();
+  if (!tab) return;
+  useAppStore.getState().toggleTerminalSearch(tab.id);
+}
+
+/**
+ * Registry of context-bound commands, keyed by keybinding action id. Consumed by
+ * both the keyboard handler and the command palette so the two never diverge.
+ */
+export const CONTEXT_COMMANDS: Record<string, ContextCommand> = {
+  "close-tab": { isAvailable: () => !!activeLeaf()?.activeTabId, run: closeActiveTab },
+  "next-tab": { isAvailable: hasMultipleTabs, run: () => cycleTab(1) },
+  "prev-tab": { isAvailable: hasMultipleTabs, run: () => cycleTab(-1) },
+  "focus-up": { isAvailable: () => canFocusPanel("up"), run: () => focusPanel("up") },
+  "focus-down": { isAvailable: () => canFocusPanel("down"), run: () => focusPanel("down") },
+  "focus-left": { isAvailable: () => canFocusPanel("left"), run: () => focusPanel("left") },
+  "focus-right": { isAvailable: () => canFocusPanel("right"), run: () => focusPanel("right") },
+  "clear-terminal": { isAvailable: () => activeTerminalTab() !== null, run: clearActiveTerminal },
+  "find-in-terminal": {
+    isAvailable: () => activeTerminalTab() !== null,
+    run: findInActiveTerminal,
+  },
+};


### PR DESCRIPTION
Follow-up to #1484 (PR #1510). Extends the command palette to cover the context-bound commands that were deliberately omitted because they need live panel/terminal resolution.

## What changed

- **Shared registry.** Extracted the focus-panel, tab close/next/prev, and terminal find/clear logic out of the global keyboard handler into `src/services/contextCommands.ts` (`CONTEXT_COMMANDS`). Each command exposes `run()` and an `isAvailable()` that resolve the focused panel/terminal from live store state. `useKeyboardShortcuts` now dispatches these actions through the registry — one implementation, so the shortcut and its palette entry can never drift apart.
- **Palette coverage.** The palette now lists **Close Tab**, **Next Tab**, **Previous Tab**, **Focus Panel Above/Below/Left/Right**, **Find in Terminal**, and **Clear Terminal**. Enter runs the highlighted command against the active context, matching the keyboard behaviour (including the confirm-on-close flow).
- **Single accelerator source.** Labels and accelerators still come from `getActionAccelerator` / `DEFAULT_BINDINGS`; no keybinding strings are duplicated.
- **Availability affordance.** A command with no applicable target (e.g. Focus Panel Left with a single pane, or Find in Terminal on a non-terminal tab) renders disabled (`--text-disabled`, `aria-disabled`, tooltip) and is inert on Enter/click. Availability recomputes as the focused panel/terminal changes.

## Scope check (from #1527)

- [x] Command registry can express/resolve context-bound actions against the focused panel/terminal.
- [x] Actions registered so Enter runs them against the active context; disabled with a clear affordance when no target applies.
- [x] Single source of truth for accelerators preserved.
- [x] Tests: a context-bound command runs against the focused panel/terminal, and is unavailable/disabled when no target applies.

## Testing

- `pnpm test` — full frontend suite green (3208 tests). New/updated: `src/services/contextCommands.test.ts`, `src/services/commands.test.ts`, `src/components/CommandPalette/CommandPalette.test.tsx`.
- `pnpm build` (tsc + vite), `pnpm run lint`, `pnpm run format:check`, `python3 scripts/build-testid-catalog.py --check` — all clean (palette items keep the existing dynamic `command-palette-item-*` testid, so the catalog is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)