### PR TITLE
feat(backend): emit remote path in transfer-progress for Transfer Queue rows (Closes #1531)

### DIFF
--- a/docs/changes/dev3/feature/1531-transfer-progress-remote-path.md
+++ b/docs/changes/dev3/feature/1531-transfer-progress-remote-path.md
@@ -1,0 +1,7 @@
+### Added
+
+- Transfer Queue rows now show the remote path (e.g. `/uploads/data.csv`)
+  alongside the file name. The backend `transfer-progress` event payload (and the
+  `transfer_list` snapshot) now carries a `path` field, populated from both the
+  SFTP (#1245) and FTP (#1336) transfer paths, and the frontend maps it into the
+  Transfer Queue entry (#1531).

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -156,6 +156,7 @@ pub async fn sftp_download(
         session_id,
         direction: TransferDirection::Download,
         file_name: file_name_of(&remote_path),
+        path: remote_path.clone(),
         total,
     };
     let registry = (*registry).clone();
@@ -204,6 +205,7 @@ pub async fn sftp_upload(
         session_id,
         direction: TransferDirection::Upload,
         file_name: file_name_of(&local_path),
+        path: remote_path.clone(),
         total,
     };
     let registry = (*registry).clone();

--- a/src-tauri/src/commands/transfer.rs
+++ b/src-tauri/src/commands/transfer.rs
@@ -86,6 +86,7 @@ pub async fn ftp_download(
             &session_id,
             TransferDirection::Download,
             &file_name,
+            &remote_path,
             0,
         );
         let registry = (*registry).clone();
@@ -145,6 +146,7 @@ pub async fn ftp_upload(
             &session_id,
             TransferDirection::Upload,
             &file_name,
+            &remote_path,
             0,
         );
         let registry = (*registry).clone();

--- a/src-tauri/src/files/transfer/mod.rs
+++ b/src-tauri/src/files/transfer/mod.rs
@@ -109,6 +109,11 @@ pub struct TransferProgress {
     pub session_id: String,
     pub direction: TransferDirection,
     pub file_name: String,
+    /// Remote path of the transferred file (e.g. `/uploads/data.csv`), so the
+    /// Transfer Queue row can show it alongside the file name (#1531). Omitted
+    /// from the payload when empty.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub path: String,
     pub transferred: u64,
     pub total: u64,
     /// Legacy phase (#1245) — kept for backward compatibility.
@@ -146,6 +151,7 @@ impl TransferProgress {
             session_id: snap.session_id.clone(),
             direction: snap.direction,
             file_name: snap.file_name.clone(),
+            path: snap.path.clone(),
             transferred: snap.transferred,
             total: snap.total,
             phase,
@@ -183,6 +189,9 @@ pub struct TransferContext {
     pub session_id: String,
     pub direction: TransferDirection,
     pub file_name: String,
+    /// Remote path of the transferred file, surfaced in `transfer-progress`
+    /// so the Transfer Queue row can show it alongside the file name (#1531).
+    pub path: String,
     pub total: u64,
 }
 
@@ -198,6 +207,7 @@ impl TransferContext {
             session_id: self.session_id.clone(),
             direction: self.direction,
             file_name: self.file_name.clone(),
+            path: self.path.clone(),
             transferred,
             total: self.total,
             phase,

--- a/src-tauri/src/files/transfer/registry.rs
+++ b/src-tauri/src/files/transfer/registry.rs
@@ -33,6 +33,9 @@ pub struct TransferSnapshot {
     pub session_id: String,
     pub direction: TransferDirection,
     pub file_name: String,
+    /// Remote path of the transferred file (#1531), for the Transfer Queue row.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub path: String,
     pub state: TransferStateTag,
     pub transferred: u64,
     pub total: u64,
@@ -69,6 +72,9 @@ pub struct TransferHandle {
     pub session_id: String,
     pub direction: TransferDirection,
     pub file_name: String,
+    /// Remote path of the transferred file (#1531), surfaced in snapshots and
+    /// `transfer-progress` events.
+    pub path: String,
     /// Hard-cancel primitive checked by the copy loop at each boundary.
     pub token: CancellationToken,
     control: Mutex<HandleControl>,
@@ -152,6 +158,7 @@ impl TransferHandle {
             session_id: self.session_id.clone(),
             direction: self.direction,
             file_name: self.file_name.clone(),
+            path: self.path.clone(),
             state: c.state.tag(),
             transferred: c.transferred,
             total: c.total,
@@ -285,6 +292,7 @@ impl TransferRegistry {
         session_id: &str,
         direction: TransferDirection,
         file_name: &str,
+        path: &str,
         total: u64,
     ) -> Arc<TransferHandle> {
         let handle = Arc::new(TransferHandle {
@@ -292,6 +300,7 @@ impl TransferRegistry {
             session_id: session_id.to_string(),
             direction,
             file_name: file_name.to_string(),
+            path: path.to_string(),
             token: CancellationToken::new(),
             control: Mutex::new(HandleControl {
                 state: TransferState::Queued,
@@ -540,7 +549,14 @@ mod tests {
     // --- Rich queue model (#1336) ---
 
     fn enq(reg: &TransferRegistry, id: &str, session: &str) -> Arc<TransferHandle> {
-        reg.enqueue(id, session, TransferDirection::Download, id, 100)
+        reg.enqueue(
+            id,
+            session,
+            TransferDirection::Download,
+            id,
+            &format!("/remote/{id}"),
+            100,
+        )
     }
 
     #[test]
@@ -552,6 +568,10 @@ mod tests {
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].transfer_id, "a");
         assert_eq!(list[0].state, TransferStateTag::Queued);
+        assert_eq!(
+            list[0].path, "/remote/a",
+            "the remote path is carried into the snapshot (#1531)"
+        );
     }
 
     #[test]

--- a/src-tauri/tests/sftp_transfer.rs
+++ b/src-tauri/tests/sftp_transfer.rs
@@ -153,6 +153,7 @@ async fn cancel_mid_transfer_cleans_up_partial_file() {
         session_id: "s".to_string(),
         direction: TransferDirection::Download,
         file_name: "100mb.bin".to_string(),
+        path: "/home/testuser/sftp-test/large-files/100mb.bin".to_string(),
         total: 100 * 1024 * 1024,
     };
 
@@ -275,6 +276,7 @@ async fn browsing_stays_live_during_transfer() {
         session_id: "s".to_string(),
         direction: TransferDirection::Download,
         file_name: "100mb.bin".to_string(),
+        path: "/home/testuser/sftp-test/large-files/100mb.bin".to_string(),
         total: 100 * 1024 * 1024,
     };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -722,6 +722,9 @@ export interface TransferProgress {
   sessionId: string;
   direction: "download" | "upload";
   fileName: string;
+  /** Remote path of the transferred file (e.g. `/uploads/data.csv`), when the
+   * backend supplies one — shown in the Transfer Queue row (#1531). */
+  path?: string;
   transferred: number;
   total: number;
   phase: TransferPhase;
@@ -748,6 +751,8 @@ export interface TransferSnapshot {
   sessionId: string;
   direction: "download" | "upload";
   fileName: string;
+  /** Remote path of the transferred file, when the backend supplies one (#1531). */
+  path?: string;
   state: TransferQueueState;
   transferred: number;
   total: number;

--- a/src/types/transfer.test.ts
+++ b/src/types/transfer.test.ts
@@ -128,6 +128,27 @@ describe("transferEntryFromProgress", () => {
     expect(entry.attempt).toBe(2);
     expect(entry.maxAttempts).toBe(3);
   });
+
+  it("takes the remote path from the event payload (#1531)", () => {
+    const entry = transferEntryFromProgress(
+      progress({ path: "/uploads/data.csv", transferred: 10 }),
+      undefined,
+      0
+    );
+    expect(entry.path).toBe("/uploads/data.csv");
+  });
+
+  it("prefers the event's path over a stale previous entry path", () => {
+    const prev: TransferEntry = {
+      ...transferEntryFromProgress(progress({ path: "/old/path.txt" }), undefined, 0),
+    };
+    const entry = transferEntryFromProgress(
+      progress({ path: "/new/path.txt", transferred: 20 }),
+      prev,
+      0
+    );
+    expect(entry.path).toBe("/new/path.txt");
+  });
 });
 
 describe("formatThroughput", () => {

--- a/src/types/transfer.ts
+++ b/src/types/transfer.ts
@@ -44,7 +44,7 @@ export interface TransferEntry {
   direction: TransferDirection;
   /** Display name (file name). */
   name: string;
-  /** Remote path, when the backend supplies one (SFTP events currently do not). */
+  /** Remote path, when the backend supplies one (SFTP and FTP events now do, #1531). */
   path?: string;
   /** Derived lifecycle state. */
   state: TransferQueueState;
@@ -93,8 +93,9 @@ export function stateFromPhase(phase: TransferProgress["phase"]): TransferQueueS
  * byte/time delta against `prev` while the transfer is `active`.
  *
  * `prev` is the existing entry for this id (if any); it seeds the throughput
- * delta and preserves fields the event does not carry (`path`). `now` is the
- * current wall-clock ms (injected for deterministic tests).
+ * delta and preserves fields a given event may omit — the remote `path` is
+ * taken from the event when present (#1531) and otherwise carried over from
+ * `prev`. `now` is the current wall-clock ms (injected for deterministic tests).
  */
 export function transferEntryFromProgress(
   progress: TransferProgress,
@@ -134,7 +135,7 @@ export function transferEntryFromProgress(
     sessionId: progress.sessionId,
     direction: progress.direction,
     name: progress.fileName,
-    path: prev?.path,
+    path: progress.path ?? prev?.path,
     state,
     transferred: progress.transferred,
     totalBytes,


### PR DESCRIPTION
## Summary

The Transfer Queue panel (#1337) renders a remote-path cell per row, but the `transfer-progress` event payload carried no path field, so `TransferEntry.path` was always undefined and the cell was omitted. This adds the remote path to the payload and maps it through.

Follow-up to #1337 (PR #1530), part of Epic #1331.

## Changes

**Backend (Rust)**
- Added a `path` field to the `TransferProgress` payload and the `TransferSnapshot` (`transfer_list`), serialized as `path` and omitted when empty.
- Threaded the remote path through the SFTP path (`TransferContext`, #1245) and the FTP queue path (`TransferHandle` / `TransferSnapshot` / `enqueue`, #1336), populated from the command callers (`sftp_download`/`sftp_upload`, `ftp_download`/`ftp_upload`).

**Frontend (TypeScript)**
- Surfaced `path` on `TransferProgress` and `TransferSnapshot` in `src/services/api.ts`.
- Mapped it into `TransferEntry.path` in `transferEntryFromProgress` (`src/types/transfer.ts`), preferring the event's path and falling back to the previous entry. No UI change needed — the panel already renders `.transfer-row__path` when set.

## Tests
- Added mapper unit tests: event-supplied path populates the entry, and an event path overrides a stale previous path.
- Extended the registry unit test to assert the remote path is carried into the snapshot.
- Updated the SFTP integration test's `TransferContext` construction.

## Done when
A live transfer row shows the remote path (e.g. `/uploads/data.csv`) as in the `ftp-client.html` mockup, covered by the updated mapper unit test. ✅

Closes #1531

🤖 Generated with [Claude Code](https://claude.com/claude-code)