### PR TITLE
fix(config): move quick-start E2E SSH port off 2222 (Closes #1536)

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ pnpm tauri build
 
 ```bash
 cd examples
-./start-test-environment.sh   # Start SSH (port 2222) + Telnet (port 2323) servers
+./start-test-environment.sh   # Start SSH (port 2214) + Telnet (port 2323) servers
 ./stop-test-environment.sh    # Stop servers
 ```
 

--- a/docs/changes/dev4/fix/1536-dev-agent-port-collision.md
+++ b/docs/changes/dev4/fix/1536-dev-agent-port-collision.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Quick-start test environment: the example Docker SSH target now listens on host
+  port **2214** instead of 2222. At the default checkout (`test_port_offset` 0)
+  the old 2222 collided with the dev agent's `sshd` (`dev_agent_port`, also 2222),
+  so running `./scripts/dev.sh` and the E2E/quick-start SSH server at the same time
+  failed with "address already in use". The SSH port now sits just past the SSH
+  test cluster (2201-2213), leaving the conventional 2222 to the dev agent. The
+  `examples/config` "Docker SSH" connections and the `start-test-environment.sh`
+  output are updated to match (#1536).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -638,8 +638,11 @@ Give each parallel checkout a distinct row:
 | dev3     | `1450`     | `2252`           | `termihub-test-3` | `3000`             |
 
 Note the different step per key: `test_port_offset` jumps by **1000** (it is
-added to _every_ base test port, and the base ports span `2201…8080`, so the step
-must exceed that whole span or ranges would overlap); `dev_port` and
+added to _every_ base test port; the scheme is collision-free **not** because
+`1000` exceeds the `2201…8080` base-port span — it does not — but because no two
+base ports differ by an exact multiple of `1000`, so no checkout's offset port
+ever lands on another checkout's. Keep that invariant in mind when adding a base
+port); `dev_port` and
 `dev_agent_port` step by **10** (`dev_port` reserves `dev_port + 1` for Vite HMR);
 and `compose_project` just increments its numeric suffix (a name, not a port
 range). With offset `1000` the SSH containers move to `3201…3211`, telnet to
@@ -666,13 +669,15 @@ every entry point honours. The resolver lives in two mirrored forms:
   fixtures so the harness publishes/looks up the same offset ports and runs
   `compose` under the same project name.
 
-| Resource                         | Base (offset 0)                 | Derivation                                                                 |
-| -------------------------------- | ------------------------------- | -------------------------------------------------------------------------- |
-| Docker container / network names | `termihub-*` / `termihub-*-net` | Prefixed with `compose_project` (`COMPOSE_PROJECT_NAME`).                  |
-| SSH / telnet / HTTP host ports   | `2201–2211`, `2301`, `8080`     | `base + test_port_offset`, published by `tests/docker/docker-compose.yml`. |
-| SSH-tunnel test ports            | `18081–18088`                   | `base + test_port_offset`.                                                 |
-| Virtual serial device paths      | `/tmp/termihub-serial-{a,b}`    | Suffixed with `compose_project`.                                           |
-| `tauri-driver` (E2E) port        | `4444`                          | `4444 + test_port_offset`.                                                 |
+| Resource                         | Base (offset 0)                    | Derivation                                                                    |
+| -------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------- |
+| Docker container / network names | `termihub-*` / `termihub-*-net`    | Prefixed with `compose_project` (`COMPOSE_PROJECT_NAME`).                     |
+| SSH / telnet / HTTP host ports   | `2201–2213`, `2301`, `8080`        | `base + test_port_offset`, published by `tests/docker/docker-compose.yml`.    |
+| FTP / FTPS host ports            | `2401`, `2402`, PASV `30000–30019` | `base + test_port_offset`, published by `tests/docker/docker-compose.yml`.    |
+| Quick-start (E2E) host ports     | `2214` (SSH), `2323` (telnet)      | `base + test_port_offset`, published by `examples/docker/docker-compose.yml`. |
+| SSH-tunnel test ports            | `18081–18088`                      | `base + test_port_offset`.                                                    |
+| Virtual serial device paths      | `/tmp/termihub-serial-{a,b}`       | Suffixed with `compose_project`.                                              |
+| `tauri-driver` (E2E) port        | `4444`                             | `4444 + test_port_offset`.                                                    |
 
 The Rust integration tests reach the jump-host target through its **Compose
 service-name network alias** (`ssh-jumphost-target`, `ssh-jumphost-bastion`),

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,8 +34,8 @@ The example config (`config/connections.json`) includes pre-configured connectio
 
 | Connection       | Type   | Host      | Port | Credentials             | Notes                  |
 | ---------------- | ------ | --------- | ---- | ----------------------- | ---------------------- |
-| Docker SSH       | SSH    | 127.0.0.1 | 2222 | `testuser` / `testpass` |                        |
-| Docker SSH + X11 | SSH    | 127.0.0.1 | 2222 | `testuser` / `testpass` | X11 forwarding enabled |
+| Docker SSH       | SSH    | 127.0.0.1 | 2214 | `testuser` / `testpass` |                        |
+| Docker SSH + X11 | SSH    | 127.0.0.1 | 2214 | `testuser` / `testpass` | X11 forwarding enabled |
 | Docker Telnet    | Telnet | 127.0.0.1 | 2323 | `testuser` / `testpass` |                        |
 
 SSH connections prompt for the password at connect time.
@@ -108,7 +108,7 @@ examples/
 │   └── connections.json               # Pre-configured test connections
 ├── docker/
 │   ├── Dockerfile                     # Ubuntu + SSH + Telnet + X11
-│   ├── docker-compose.yml             # Port mappings (2222, 2323)
+│   ├── docker-compose.yml             # Port mappings (2214, 2323)
 │   └── entrypoint.sh                  # Starts sshd + telnetd
 ├── scripts/
 │   ├── start-test-environment.sh      # Build, start, and launch app
@@ -123,7 +123,7 @@ examples/
 
 ### Port conflicts
 
-If ports 2222 or 2323 are already in use, edit `docker/docker-compose.yml` to change the host port mappings (left side of the colon).
+If ports 2214 or 2323 are already in use, edit `docker/docker-compose.yml` to change the host port mappings (left side of the colon).
 
 ### Docker not running
 
@@ -141,7 +141,7 @@ Start Docker Desktop or the Docker service:
 If the start script reports that SSH didn't start in time:
 
 1. Check Docker logs: `docker compose -f examples/docker/docker-compose.yml logs`
-2. Ensure no other service is using port 2222
+2. Ensure no other service is using port 2214
 
 ### socat not found
 

--- a/examples/config/connections.json
+++ b/examples/config/connections.json
@@ -11,12 +11,12 @@
   "connections": [
     {
       "id": "conn-docker-ssh",
-      "name": "Docker SSH (port 2222)",
+      "name": "Docker SSH (port 2214)",
       "config": {
         "type": "ssh",
         "config": {
           "host": "127.0.0.1",
-          "port": 2222,
+          "port": 2214,
           "username": "testuser",
           "authMethod": "password",
           "password": null,
@@ -28,12 +28,12 @@
     },
     {
       "id": "conn-docker-ssh-x11",
-      "name": "Docker SSH + X11 (port 2222)",
+      "name": "Docker SSH + X11 (port 2214)",
       "config": {
         "type": "ssh",
         "config": {
           "host": "127.0.0.1",
-          "port": 2222,
+          "port": 2214,
           "username": "testuser",
           "authMethod": "password",
           "password": null,

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -3,7 +3,8 @@ services:
     build: .
     ports:
       # Offset per checkout (docs/testing.md "Parallel test isolation"); a bare
-      # `docker compose up` keeps the historical 2222/2323.
-      - "${TERMIHUB_TEST_E2E_SSH_PORT:-2222}:22" # SSH
+      # `docker compose up` uses 2214/2323. SSH is 2214 (not 2222) so it does not
+      # clash with the dev agent's 2222 at test_port_offset 0 (#1536).
+      - "${TERMIHUB_TEST_E2E_SSH_PORT:-2214}:22" # SSH
       - "${TERMIHUB_TEST_E2E_TELNET_PORT:-2323}:23" # Telnet
     restart: unless-stopped

--- a/examples/scripts/start-test-environment.sh
+++ b/examples/scripts/start-test-environment.sh
@@ -31,10 +31,10 @@ echo "Building and starting test containers..."
 docker compose -f "$DOCKER_DIR/docker-compose.yml" up -d --build
 
 # --- Wait for SSH to be ready ---
-echo "Waiting for SSH server on port 2222..."
+echo "Waiting for SSH server on port 2214..."
 MAX_WAIT=30
 WAITED=0
-while ! nc -z 127.0.0.1 2222 2>/dev/null; do
+while ! nc -z 127.0.0.1 2214 2>/dev/null; do
     sleep 1
     WAITED=$((WAITED + 1))
     if [ "$WAITED" -ge "$MAX_WAIT" ]; then
@@ -50,7 +50,7 @@ echo "==========================================="
 echo "  Test Environment Running"
 echo "==========================================="
 echo ""
-echo "  SSH:    127.0.0.1:2222"
+echo "  SSH:    127.0.0.1:2214"
 echo "  Telnet: 127.0.0.1:2323"
 echo ""
 echo "  Username: testuser"

--- a/scripts/internal/dev-local-env.sh
+++ b/scripts/internal/dev-local-env.sh
@@ -75,7 +75,10 @@ _thdl_port TERMIHUB_TEST_FTP_PASV_MAX              30009
 _thdl_port TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MIN    30010
 _thdl_port TERMIHUB_TEST_FTPS_IMPLICIT_PASV_MAX    30019
 # examples/docker quick-start dev target (examples/docker/docker-compose.yml).
-_thdl_port TERMIHUB_TEST_E2E_SSH_PORT        2222
+# SSH sits at 2214 — just past the SSH cluster (2201-2213) — so it never
+# collides with the dev agent's conventional 2222 (`dev_agent_port`), which at
+# test_port_offset 0 would otherwise want the same host port (#1536).
+_thdl_port TERMIHUB_TEST_E2E_SSH_PORT        2214
 _thdl_port TERMIHUB_TEST_E2E_TELNET_PORT     2323
 
 # Virtual serial device paths — suffixed with the project so two checkouts'

--- a/tests/system/tests/test_dev_local.py
+++ b/tests/system/tests/test_dev_local.py
@@ -5,6 +5,7 @@ project / offset / ports, including env-var precedence. Runs anywhere.
 """
 
 import json
+import re
 
 import pytest
 
@@ -14,6 +15,22 @@ from termihub_harness import dev_local
 def _write(tmp_path, data):
     (tmp_path / "dev.local.json").write_text(json.dumps(data), encoding="utf-8")
     return tmp_path
+
+
+def _committed_dev_agent_port() -> int:
+    """`dev_agent_port` from the committed template (`default.dev.local.json`)."""
+    text = (dev_local.REPO_ROOT / "default.dev.local.json").read_text(encoding="utf-8")
+    return int(json.loads(text)["dev_agent_port"])
+
+
+def _committed_e2e_ssh_base() -> int:
+    """`TERMIHUB_TEST_E2E_SSH_PORT` base from the shell resolver."""
+    text = (
+        dev_local.REPO_ROOT / "scripts" / "internal" / "dev-local-env.sh"
+    ).read_text(encoding="utf-8")
+    match = re.search(r"TERMIHUB_TEST_E2E_SSH_PORT\s+(\d+)", text)
+    assert match, "TERMIHUB_TEST_E2E_SSH_PORT not found in dev-local-env.sh"
+    return int(match.group(1))
 
 
 @pytest.fixture(autouse=True)
@@ -75,3 +92,16 @@ def test_compose_env_covers_project_and_every_service(tmp_path):
     assert env["TERMIHUB_TEST_NETWORK_TARGET_PORT"] == "10080"
     assert set(dev_local.BASE_PORTS).issubset(env)
     assert all(isinstance(v, str) for v in env.values())
+
+
+def test_dev_agent_port_does_not_collide_with_e2e_ssh_port():
+    """Regression for #1536.
+
+    At ``test_port_offset`` 0 a fresh checkout starts both the dev agent's local
+    ``sshd`` (``dev_agent_port``) and the quick-start E2E SSH container
+    (``TERMIHUB_TEST_E2E_SSH_PORT``). Both bind a host port, so their committed
+    defaults must differ — otherwise the second to start fails with "address
+    already in use". Historically both defaulted to 2222; the E2E port now sits
+    at 2214, just past the SSH cluster (2201-2213).
+    """
+    assert _committed_dev_agent_port() != _committed_e2e_ssh_base()


### PR DESCRIPTION
## What & why

The committed defaults gave **both** the dev agent's local `sshd` (`dev_agent_port`) and the quick-start/E2E SSH container (`TERMIHUB_TEST_E2E_SSH_PORT`) host port **2222** at `test_port_offset` 0. Running `./scripts/dev.sh` and the E2E/quick-start SSH server at the same time in the same checkout failed with "address already in use" — the isolation docs promise every checkout can run all its environments at once, and `dev0` (the lone-developer default) could not.

This implements the issue's **recommended Option 1**: keep the conventional **2222** for the dev agent and move the E2E SSH port to **2214**, just past the SSH test cluster (`2201-2213`).

## Changes

- **Resolver** (`scripts/internal/dev-local-env.sh`) and **compose default** (`examples/docker/docker-compose.yml`): `TERMIHUB_TEST_E2E_SSH_PORT` `2222` → `2214`.
- **Quick-start surfaces that hardcode the host port** (these weren't covered by the resolver, so they'd otherwise drift): `examples/scripts/start-test-environment.sh`, the two `examples/config/connections.json` "Docker SSH" connections, `README.md`, and `examples/README.md`.
  - The E2E telnet port (`2323`) is unchanged — no collision.
  - The `e2e-runner`'s internal socat forward (container-internal `127.0.0.1:2222`) is deliberately left alone; it is not a host port and is unrelated to the collision.
- **Regression test** (`tests/system/tests/test_dev_local.py`): asserts the committed `dev_agent_port` default and the resolver's E2E SSH base differ, so neither can be silently reverted onto the same port. Fails on the pre-fix tree (both 2222), passes now.

## Docs corrections (the issue's "also worth fixing while here")

- The `docs/testing.md` base-port table listed only `2201-2211`, `2301`, `8080` — completed it with the SSH sudo/nosudo ports (`2212-2213`), the FTP/FTPS ports + PASV range, and the quick-start E2E ports.
- Corrected the stated rationale for the `1000` offset step: `1000` does **not** exceed the `2201-8080` span; the scheme is collision-free because no two base ports differ by an exact multiple of `1000`.

The third "worth fixing" note (dev-agent series headroom near telnet `2301`) is tied to Option 2 (moving the dev-agent series) and does not apply under Option 1; there is no collision today, so it is left as-is.

## Note on option choice

The issue offered two options and recommended Option 1 (move the E2E port, keep the dev agent on 2222); this PR follows that recommendation. Its real surface was a bit larger than the "one line each plus docs" estimate because `start-test-environment.sh`, `examples/config`, and the READMEs also hardcode the quick-start SSH port — all updated here so the quick-start stays consistent.

## Test plan

- `cd tests/system && ./pytest.sh -m "not integration" -k dev_local` → 6 passed.
- `source scripts/internal/dev-local-env.sh` resolves `TERMIHUB_TEST_E2E_SSH_PORT` to `2214 + offset`.
- Prettier + markdownlint clean on changed files.

Closes #1536