### PR TITLE
feat(backend): symlink metadata for Docker, WSL, and SFTP link targets (Closes #1523)

### DIFF
--- a/core/src/backends/docker/file_browser.rs
+++ b/core/src/backends/docker/file_browser.rs
@@ -191,7 +191,10 @@ impl FileBrowser for DockerFileBrowser {
                 "-path",
                 path,
                 "-printf",
-                "%f\t%y\t%s\t%T@\t%m\n",
+                // `%y` is the entry's own type (`l` for a symlink); `%Y` is the
+                // type after following the link (so a symlink-to-dir still lists
+                // as a directory); `%l` is the link target (empty for non-links).
+                "%f\t%y\t%s\t%T@\t%m\t%Y\t%l\n",
             ],
         )
         .await?;
@@ -258,7 +261,11 @@ impl FileBrowser for DockerFileBrowser {
 
 // --- Parsing helpers (ported from agent/src/files/docker.rs) ---
 
-/// Parse the output of `find -printf '%f\t%y\t%s\t%T@\t%m\n'`.
+/// Parse the output of `find -printf '%f\t%y\t%s\t%T@\t%m\t%Y\t%l\n'`.
+///
+/// The trailing `%Y` (type after following links) and `%l` (link target) fields
+/// let the browser distinguish symlinks from the `%y` own-type field and report
+/// the link target, matching the FTP/local behavior (#1513, #1523).
 fn parse_find_output(output: &str, parent_path: &str) -> Result<Vec<FileEntry>, FileError> {
     let mut entries = Vec::new();
     let parent = if parent_path.ends_with('/') {
@@ -271,16 +278,31 @@ fn parse_find_output(output: &str, parent_path: &str) -> Result<Vec<FileEntry>, 
         if line.is_empty() {
             continue;
         }
-        let fields: Vec<&str> = line.splitn(5, '\t').collect();
-        if fields.len() < 5 {
+        // The final `%l` field is empty for non-links, so a non-symlink row ends
+        // in a trailing tab; `splitn(7, …)` still yields 7 fields (last empty).
+        let fields: Vec<&str> = line.splitn(7, '\t').collect();
+        if fields.len() < 7 {
             continue;
         }
 
         let name = fields[0].to_string();
-        let is_directory = fields[1] == "d";
+        let own_type = fields[1];
         let size: u64 = fields[2].parse().unwrap_or(0);
         let mtime_float: f64 = fields[3].parse().unwrap_or(0.0);
         let mode: u32 = u32::from_str_radix(fields[4].trim(), 8).unwrap_or(0);
+        // `%Y` follows the link, so a symlink-to-dir still lists as a directory
+        // (matching the local browser); it falls back to the own type otherwise.
+        let is_directory = fields[5] == "d";
+        // `%y` reports the entry's own type; `l` marks a symbolic link.
+        let is_symlink = own_type == "l";
+        // `%l` carries the target only for links; map the empty non-link value
+        // (and a link whose target could not be read) to `None`.
+        let symlink_target = if is_symlink {
+            let target = fields[6];
+            (!target.is_empty()).then(|| target.to_string())
+        } else {
+            None
+        };
 
         let path = format!("{parent}{name}");
         let modified = chrono_from_epoch(mtime_float as u64);
@@ -295,9 +317,8 @@ fn parse_find_output(output: &str, parent_path: &str) -> Result<Vec<FileEntry>, 
             permissions,
             // Writability is derived only for the desktop SFTP browser (#1324).
             writable: None,
-            // The `ls` capture does not distinguish links cheaply (see #1513).
-            is_symlink: false,
-            symlink_target: None,
+            is_symlink,
+            symlink_target,
         });
     }
 
@@ -318,7 +339,8 @@ fn parse_stat_output(output: &str, path: &str) -> Result<FileEntry, FileError> {
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| fields[0].to_string());
-    let is_directory = fields[1].contains("directory");
+    let file_type = fields[1];
+    let is_directory = file_type.contains("directory");
     let size: u64 = fields[2].parse().unwrap_or(0);
     let mtime: u64 = fields[3].parse().unwrap_or(0);
     let mode: u32 = u32::from_str_radix(fields[4].trim(), 8).unwrap_or(0);
@@ -332,8 +354,9 @@ fn parse_stat_output(output: &str, path: &str) -> Result<FileEntry, FileError> {
         permissions: Some(format_permissions(mode)),
         // Writability is derived only for the desktop SFTP browser (#1324).
         writable: None,
-        // `stat -c` capture does not surface link status cheaply (see #1513).
-        is_symlink: false,
+        // `stat` does not dereference by default, so `%F` reports "symbolic
+        // link" for a link itself; the target is not carried by this capture.
+        is_symlink: file_type.contains("symbolic link"),
         symlink_target: None,
     })
 }
@@ -471,8 +494,10 @@ mod tests {
 
     #[test]
     fn parse_find_output_basic() {
-        let output = "readme.md\tf\t1024\t1705321845.0\t644\n\
-                       src\td\t4096\t1705321845.0\t755\n";
+        // Columns: %f %y %s %T@ %m %Y %l — a plain file/dir has an empty %l
+        // (trailing tab) and %Y == %y.
+        let output = "readme.md\tf\t1024\t1705321845.0\t644\tf\t\n\
+                       src\td\t4096\t1705321845.0\t755\td\t\n";
         let entries = parse_find_output(output, "/project").unwrap();
         assert_eq!(entries.len(), 2);
 
@@ -482,11 +507,14 @@ mod tests {
         assert!(!file.is_directory);
         assert_eq!(file.size, 1024);
         assert_eq!(file.permissions.as_deref(), Some("rw-r--r--"));
+        assert!(!file.is_symlink);
+        assert_eq!(file.symlink_target, None);
 
         let dir = &entries[1];
         assert_eq!(dir.name, "src");
         assert!(dir.is_directory);
         assert_eq!(dir.permissions.as_deref(), Some("rwxr-xr-x"));
+        assert!(!dir.is_symlink);
     }
 
     #[test]
@@ -497,9 +525,51 @@ mod tests {
 
     #[test]
     fn parse_find_output_trailing_slash() {
-        let output = "file.txt\tf\t100\t1000000.0\t644\n";
+        let output = "file.txt\tf\t100\t1000000.0\t644\tf\t\n";
         let entries = parse_find_output(output, "/dir/").unwrap();
         assert_eq!(entries[0].path, "/dir/file.txt");
+    }
+
+    #[test]
+    fn parse_find_output_symlink_with_target() {
+        // A symlink: own type %y == `l`, followed type %Y resolves to the target
+        // kind, and %l carries the link target.
+        let output = "link\tl\t7\t1705321845.0\t777\tf\t/etc/target\n";
+        let entries = parse_find_output(output, "/project").unwrap();
+        assert_eq!(entries.len(), 1);
+
+        let link = &entries[0];
+        assert_eq!(link.name, "link");
+        assert!(link.is_symlink, "is_symlink");
+        assert_eq!(link.symlink_target.as_deref(), Some("/etc/target"));
+        // %Y == `f` (target is a regular file), so it does not list as a dir.
+        assert!(!link.is_directory);
+    }
+
+    #[test]
+    fn parse_find_output_symlink_to_directory_lists_as_dir() {
+        // A symlink-to-dir: %y == `l` but %Y == `d`, so it stays navigable as a
+        // directory while still being flagged a symlink.
+        let output = "linkdir\tl\t7\t1705321845.0\t777\td\t/var/data\n";
+        let entries = parse_find_output(output, "/project").unwrap();
+        let link = &entries[0];
+        assert!(link.is_symlink);
+        assert!(
+            link.is_directory,
+            "symlink-to-dir should list as a directory"
+        );
+        assert_eq!(link.symlink_target.as_deref(), Some("/var/data"));
+    }
+
+    #[test]
+    fn parse_find_output_broken_symlink_has_no_target() {
+        // A symlink whose target find could not resolve: %l may still carry the
+        // raw target, but an empty %l maps to None rather than an empty string.
+        let output = "broken\tl\t7\t1705321845.0\t777\tN\t\n";
+        let entries = parse_find_output(output, "/project").unwrap();
+        let link = &entries[0];
+        assert!(link.is_symlink);
+        assert_eq!(link.symlink_target, None);
     }
 
     // --- parse_stat_output tests ---
@@ -521,6 +591,17 @@ mod tests {
         assert_eq!(result.name, "log");
         assert!(result.is_directory);
         assert_eq!(result.permissions.as_deref(), Some("rwxr-xr-x"));
+        assert!(!result.is_symlink);
+    }
+
+    #[test]
+    fn parse_stat_output_symlink() {
+        // `stat -c %F` reports "symbolic link" for a link without dereferencing.
+        let output = "/project/link\tsymbolic link\t7\t1705321845\t777\n";
+        let result = parse_stat_output(output, "/project/link").unwrap();
+        assert_eq!(result.name, "link");
+        assert!(result.is_symlink, "is_symlink");
+        assert!(!result.is_directory);
     }
 
     #[test]

--- a/core/src/backends/ssh/file_browser.rs
+++ b/core/src/backends/ssh/file_browser.rs
@@ -116,6 +116,15 @@ impl FileBrowser for SftpFileBrowser {
             let full_path = format!("{}/{}", path.trim_end_matches('/'), name);
             let permissions = meta.permissions.map(format_permissions);
             let writable = writable_hint(permissions.as_deref());
+            // `read_dir` returns lstat-style attributes, so this flags the link
+            // itself. Resolve the target with a best-effort `readlink` only for
+            // link rows — a plain file never triggers the extra round-trip.
+            let is_symlink = meta.is_symlink();
+            let symlink_target = if is_symlink {
+                state.sftp.read_link(full_path.clone()).await.ok()
+            } else {
+                None
+            };
             result.push(FileEntry {
                 name,
                 path: full_path,
@@ -127,10 +136,8 @@ impl FileBrowser for SftpFileBrowser {
                     .unwrap_or_default(),
                 permissions,
                 writable,
-                // `read_dir` returns lstat-style attributes, so this flags the
-                // link itself; SFTP carries no cheap target.
-                is_symlink: meta.is_symlink(),
-                symlink_target: None,
+                is_symlink,
+                symlink_target,
             });
         }
         Ok(result)

--- a/core/src/backends/wsl.rs
+++ b/core/src/backends/wsl.rs
@@ -127,8 +127,38 @@ fn map_io_error(e: std::io::Error, path: &str) -> FileError {
     }
 }
 
+/// Derive `(is_symlink, symlink_target)` for a UNC path.
+///
+/// `symlink_metadata` does not follow the link, so it reveals whether the path
+/// itself is a symbolic link (a WSL symlink surfaces as a reparse point over
+/// the UNC mount); `read_link` then reads the target best-effort. Any failure
+/// degrades to `(false, None)` / `None` so a broken or unreadable link still
+/// lists (#1523).
+fn read_symlink_unc(unc_path: &str) -> (bool, Option<String>) {
+    let is_symlink = std::fs::symlink_metadata(unc_path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
+    if is_symlink {
+        let target = std::fs::read_link(unc_path)
+            .ok()
+            .map(|t| t.to_string_lossy().into_owned());
+        (true, target)
+    } else {
+        (false, None)
+    }
+}
+
 /// Build a `FileEntry` from filesystem metadata.
-fn entry_from_metadata(name: String, path: String, metadata: &std::fs::Metadata) -> FileEntry {
+///
+/// `unc_path` is the Windows UNC path backing this entry; it is used to detect
+/// symlink status and read the link target (the `metadata` argument follows the
+/// link, so it cannot report link status on its own).
+fn entry_from_metadata(
+    name: String,
+    path: String,
+    metadata: &std::fs::Metadata,
+    unc_path: &str,
+) -> FileEntry {
     use crate::files::utils::chrono_from_epoch;
 
     let modified = metadata
@@ -141,6 +171,8 @@ fn entry_from_metadata(name: String, path: String, metadata: &std::fs::Metadata)
         })
         .unwrap_or_default();
 
+    let (is_symlink, symlink_target) = read_symlink_unc(unc_path);
+
     FileEntry {
         name,
         path,
@@ -151,9 +183,8 @@ fn entry_from_metadata(name: String, path: String, metadata: &std::fs::Metadata)
         permissions: None,
         // No permission info over UNC → writability is unknown.
         writable: None,
-        // Link status over UNC is not resolved here (see #1513).
-        is_symlink: false,
-        symlink_target: None,
+        is_symlink,
+        symlink_target,
     }
 }
 
@@ -179,7 +210,9 @@ impl FileBrowser for WslFileBrowser {
                     .metadata()
                     .map_err(|e| map_io_error(e, &linux_parent))?;
                 let full_path = WslFileBrowser::join_linux_path(&linux_parent, &name);
-                result.push(entry_from_metadata(name, full_path, &metadata));
+                let entry_unc = entry.path();
+                let entry_unc = entry_unc.to_string_lossy();
+                result.push(entry_from_metadata(name, full_path, &metadata, &entry_unc));
             }
 
             result.sort_by(|a, b| {
@@ -252,7 +285,7 @@ impl FileBrowser for WslFileBrowser {
                 .file_name()
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_else(|| linux_path.clone());
-            Ok(entry_from_metadata(name, linux_path, &metadata))
+            Ok(entry_from_metadata(name, linux_path, &metadata, &unc_path))
         })
         .await
         .map_err(|e| FileError::OperationFailed(e.to_string()))?
@@ -1193,6 +1226,7 @@ mod tests {
             "test.txt".to_string(),
             "/home/user/test.txt".to_string(),
             &metadata,
+            &file_path.to_string_lossy(),
         );
 
         assert_eq!(entry.name, "test.txt");
@@ -1202,6 +1236,9 @@ mod tests {
         assert!(!entry.modified.is_empty());
         // Permissions are None (UNC paths don't expose Unix permissions)
         assert!(entry.permissions.is_none());
+        // A regular file is not a symlink and carries no target.
+        assert!(!entry.is_symlink);
+        assert_eq!(entry.symlink_target, None);
     }
 
     #[test]
@@ -1215,10 +1252,53 @@ mod tests {
             "subdir".to_string(),
             "/home/user/subdir".to_string(),
             &metadata,
+            &sub.to_string_lossy(),
         );
 
         assert_eq!(entry.name, "subdir");
         assert!(entry.is_directory);
+        assert!(!entry.is_symlink);
+    }
+
+    /// `read_symlink_unc` reports a regular file as a non-link with no target.
+    #[test]
+    fn read_symlink_unc_regular_file_is_not_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("real.txt");
+        std::fs::write(&file_path, "hi").unwrap();
+
+        let (is_symlink, target) = super::read_symlink_unc(&file_path.to_string_lossy());
+        assert!(!is_symlink);
+        assert_eq!(target, None);
+    }
+
+    /// `read_symlink_unc` flags a symlink and reads its target. WSL symlinks
+    /// surface as reparse points over the UNC mount; here a real filesystem
+    /// symlink stands in. Creating a symlink on Windows needs privilege, so the
+    /// test degrades to a no-op if creation is not permitted.
+    #[test]
+    fn read_symlink_unc_flags_symlink_with_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.txt");
+        std::fs::write(&real, "hi").unwrap();
+        let link = dir.path().join("link.txt");
+
+        #[cfg(windows)]
+        let created = std::os::windows::fs::symlink_file(&real, &link).is_ok();
+        #[cfg(unix)]
+        let created = std::os::unix::fs::symlink(&real, &link).is_ok();
+
+        if !created {
+            eprintln!("symlink creation not permitted — skipping");
+            return;
+        }
+
+        let (is_symlink, target) = super::read_symlink_unc(&link.to_string_lossy());
+        assert!(is_symlink, "link.txt should be flagged as a symlink");
+        assert!(
+            target.as_deref().unwrap_or_default().ends_with("real.txt"),
+            "target should point at real.txt, got {target:?}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/docs/changes/dev5/feature/1523-symlink-metadata-link-targets.md
+++ b/docs/changes/dev5/feature/1523-symlink-metadata-link-targets.md
@@ -1,0 +1,9 @@
+### Added
+
+- File browser symbolic-link support now extends to the Docker, WSL, and SFTP
+  backends (follow-up to #1513). Docker link rows are detected via the `find`
+  `%y`/`%Y` type fields and carry their `%l` target; the SFTP browsers resolve a
+  best-effort `readlink` target for link rows only; and the WSL browser flags
+  links via `symlink_metadata` over the UNC path and reads their target. These
+  rows now show the distinct link-badge icon and, where the protocol carries it,
+  the `→ target` hint — matching the FTP/local behavior. Closes #1523.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1904,6 +1904,25 @@ tree contains a symlink (create one on the host, e.g. `ln -s data linkdir` and
    browser must **follow** it and list the target directory's contents.
 3. Confirm a non-symlink file shows no link icon and no `→ target` hint.
 
+### Docker, WSL, and SFTP symlink icon and target (#1523)
+
+Extends the #1513 symlink handling to the Docker, WSL, and SFTP browsers. The
+Docker `find`/`stat` parsers are covered by unit tests
+(`cargo test -p termihub-core --all-features --lib backends::docker`); the SFTP
+`readlink` and WSL `symlink_metadata` paths need a live server/distribution, so
+confirm them manually. In each case, on the host create a symlink to a file and
+one to a directory (e.g. `ln -s data linkdir` and `ln -s data/file.bin linkfile`).
+
+1. **Docker** — connect to a running container, browse to a directory holding
+   symlinks. Each link row shows the distinct **link-badge icon** and an inline
+   `→ target` hint; a directory symlink follows into the target on double-click.
+2. **SFTP (SSH)** — browse an SSH connection's directory containing symlinks.
+   Each link row shows the link-badge icon and the `→ target` hint (resolved via
+   a best-effort `readlink`); a plain file shows neither.
+3. **WSL** (Windows only) — browse a WSL distribution's directory containing
+   symlinks. Each link row shows the link-badge icon and, where the target could
+   be read, the `→ target` hint.
+
 ### FTP transfer queue: concurrency, pause/resume, retry, resume (#1336)
 
 Verifies the shared transfer-queue model (queue / bounded concurrency /

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -313,6 +313,16 @@ impl SftpSession {
                     let full_path = format!("{}/{}", path.trim_end_matches('/'), name);
                     let permissions = meta.permissions.map(format_permissions);
                     let writable = permissions.as_deref().and_then(writable_from_permissions);
+                    // `read_dir` returns lstat-style attributes, so this flags
+                    // the link itself. Resolve the target with a best-effort
+                    // `readlink` only for link rows — a plain file never
+                    // triggers the extra round-trip.
+                    let is_symlink = meta.is_symlink();
+                    let symlink_target = if is_symlink {
+                        self.sftp.read_link(full_path.clone()).await.ok()
+                    } else {
+                        None
+                    };
                     result.push(FileEntry {
                         name,
                         path: full_path,
@@ -324,10 +334,8 @@ impl SftpSession {
                             .unwrap_or_default(),
                         permissions,
                         writable,
-                        // `read_dir` returns lstat-style attributes, so this
-                        // flags the link itself; SFTP carries no cheap target.
-                        is_symlink: meta.is_symlink(),
-                        symlink_target: None,
+                        is_symlink,
+                        symlink_target,
                     });
                 }
                 Ok::<Vec<FileEntry>, TerminalError>(result)


### PR DESCRIPTION
## Summary

Follow-up to #1513 (PR #1522). #1513 added the shared `FileEntry` `is_symlink` / `symlinkTarget` fields and populated them for FTP and the local browsers, but the Docker, WSL, and SFTP backends still reported `is_symlink: false` / no target because the information was not cheaply available with the previous command shapes. This wires up all three.

### Docker (`core/src/backends/docker/file_browser.rs`)
- Extend the `find -printf` format from `%f\t%y\t%s\t%T@\t%m\n` to `%f\t%y\t%s\t%T@\t%m\t%Y\t%l\n`:
  - `%y` (own type) `== l` flags the symlink.
  - `%Y` (type **after** following the link) drives `is_directory`, so a symlink-to-dir still lists as a directory and stays navigable — matching the local browser.
  - `%l` supplies the link target (empty for non-links → `None`).
- `parse_stat_output` flags links from `%F` ("symbolic link"), which `stat` reports without dereferencing.

### SFTP (`core/src/backends/ssh/file_browser.rs`, `src-tauri/src/files/sftp.rs`)
- `read_dir` already returns lstat-style attributes (the `is_symlink` flag). Add a **best-effort `readlink`** (`SftpSession::read_link`) to populate `symlink_target` — but **only for link rows**, so a plain file never adds a round-trip (bounded, as the issue requires). A failed readlink degrades to `None`.

### WSL (`core/src/backends/wsl.rs`)
- New `read_symlink_unc` helper uses `symlink_metadata` over the UNC path (which does not follow the link) to detect the symlink, then `read_link` for the target. Wired into `entry_from_metadata` at both the `list_dir` and `stat` call sites. Windows-only module, so tests are inherently `#[cfg(windows)]`-gated.

No frontend changes are needed: #1513 renders `isSymlink` / `symlinkTarget` generically in `FileBrowser.tsx`, so populating the fields in these backends is sufficient for the icon and `→ target` hint to appear.

## Tests
- Docker parser unit tests: symlink with target, symlink-to-dir listing as a directory, broken symlink → no target, and `stat` "symbolic link" detection; existing tests updated to the new 7-field format.
- WSL: `read_symlink_unc` unit tests (regular file → not a link; symlink → flagged with target, skipping gracefully when symlink creation is not permitted).
- SFTP `readlink` and WSL UNC paths need a live server / distribution, so they are covered by documented manual steps.
- `cargo test -p termihub-core --all-features` green; `./scripts/check.sh` green (fmt, clippy `-D warnings`, ESLint, markdownlint, prettier). WSL code additionally verified with `cargo check --target x86_64-pc-windows-msvc`.
- One pre-existing environment-dependent integration test (`core/tests/docker_spawn.rs`, container spawn / bind-mount, "found: []") fails locally without a Docker daemon + fixtures; it does not touch this change.

## Manual test plan
Documented in `docs/testing.md` under "Docker, WSL, and SFTP symlink icon and target (#1523)": create a file symlink and a directory symlink on the host, then confirm each backend's link rows show the link-badge icon and (where the protocol carries it) the `→ target` hint, and that a directory symlink follows into its target.

Closes #1523

🤖 Generated with [Claude Code](https://claude.com/claude-code)