### PR TITLE
ci: pin uv version in System-Test Harness setup-uv step (Closes #1552)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -205,6 +205,12 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6
         with:
+          # Pin uv itself (issue #1552). Without an explicit version the action
+          # resolves "latest" through the GitHub Releases API, which flakes and
+          # fast-fails the whole job on transient API errors — unrelated to the
+          # PR under test. A fixed version skips that lookup entirely and also
+          # makes the toolchain reproducible; bump it deliberately.
+          version: '0.11.29'
           # Pin the interpreter for reproducibility; dependencies are resolved
           # from the committed tests/system/uv.lock (the wrapper uses --frozen).
           python-version: '3.12'


### PR DESCRIPTION
Follow-up to #1340 (PR #1547).

## Problem

The **System-Test Harness (machinery)** check has been failing intermittently at the **Setup uv** step across unrelated PRs. With no version specified, `astral-sh/setup-uv@v6` resolves "latest" through the GitHub Releases API, which flakes:

```
Getting latest version from GitHub API...
##[error]Github API request failed while getting latest release. Check the GitHub status page for outages. Try again later.
```

Each failure is a ~4-8s fast-fail with the machinery suite never running — pure CI infrastructure noise. PR #1547 (docs-only) hit it three times in a row.

## Change

Pin an explicit uv version in the `setup-uv` step:

```yaml
- name: Setup uv
  uses: astral-sh/setup-uv@v6
  with:
    version: "0.11.29"
    python-version: "3.12"
    ...
```

`0.11.29` is the current uv release — i.e. what the action would have resolved to anyway, now without the API round-trip.

This also completes the pinning story for the job: the interpreter was already pinned (`python-version: 3.12`) and the dependencies come from the committed `tests/system/uv.lock` (`--frozen`); uv itself was the last floating piece.

## Scope check

- [x] Pin an explicit uv version so the action does not query the GitHub API for "latest"
- [x] Consider the same pin for any other workflow using `astral-sh/setup-uv` — `grep -rn setup-uv .github/` confirms this is the **only** usage in the repo, workflows and composite actions alike

## Test plan

- No product code touched; the workflow is the change. Verification is the check itself: the **System-Test Harness (machinery)** job on this PR must show **Setup uv** installing the pinned `0.11.29` with no `Getting latest version from GitHub API...` line, and the machinery suite must actually run.
- No change fragment: CI-only, not user-facing (per `docs/changes/README.md`).
- No follow-up issues filed — the issue scope is fully covered.

## Maintenance note

Pinning trades flake for a manual bump. The version carries an inline comment marking it as a deliberate pin; Dependabot does not track `with:` inputs, so the bump is intentional and on the maintainer.

Closes #1552