### PR TITLE
feat(sftp): route non-SSH file browsing through the shared session layer (Refs #1335)

### DIFF
--- a/docs/changes/dev5/feature/1335-file-browser-session-layer.md
+++ b/docs/changes/dev5/feature/1335-file-browser-session-layer.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- File browsing now works for FTP and Docker connections in the sidebar. Both
+  connection types advertise the file-browser capability and implement the
+  shared `FileBrowser` trait, but the sidebar routed every non-local capable
+  type to the SSH-only `SftpManager` path, which tried to open an SFTP session
+  from a config that has no SSH host — so the file browser stayed empty. These
+  tabs now dispatch through the protocol-agnostic session layer
+  (`session_*` commands on `SessionManager`), which routes file operations via
+  the connection type's `file_browser()` and therefore works for any backend
+  implementing the trait. SSH browsing is unchanged and keeps its existing
+  `sftp_*` path (#1335, epic #1331).

--- a/docs/concepts/partial/ftp-client.html
+++ b/docs/concepts/partial/ftp-client.html
@@ -1904,20 +1904,26 @@ registry.register(Box::new(FtpBackend::new()));
               <tr>
                 <td>1</td>
                 <td>
-                  FTP sessions open into the file-browser sidebar tree; browsing dispatches through
-                  the connection type's <code>file_browser()</code>.
+                  FTP sessions open <em>directly into the file browser view — no terminal tab is
+                  created</em>; the tab body shows a non-terminal placeholder ("FTP sessions open
+                  into the file browser; there is no terminal output").
                 </td>
                 <td>
-                  The <code>Ftp</code> backend implements <code>file_browser()</code>, but the
-                  sidebar still dispatches only via <code>SftpManager</code>/<code>sftp_*</code>
-                  commands (<code>src-tauri/src/commands/files.rs</code>), so an FTP session is not
-                  yet browsable in the sidebar.
+                  Browsing itself is now wired (#1335): an FTP tab dispatches through the session
+                  layer, so <code>session_*</code> commands route file operations via the connection
+                  type's <code>file_browser()</code>. But an FTP connection still opens a
+                  <em>terminal</em> tab whose body is a dead terminal: the tab is what mints the
+                  session (<code>Terminal.tsx</code> → <code>create_connection</code>), and
+                  <code>Capabilities</code> has no flag saying a type lacks a terminal, so the UI
+                  cannot tell which types should skip the terminal body.
                 </td>
                 <td>Missing</td>
                 <td>
-                  Tracked by open sub-issue
-                  <a href="https://github.com/armaxri/termiHub/issues/1335">#1335</a> (SI-4) —
-                  protocol-agnostic file-browser session layer. Fix code there, then re-sync.
+                  Needs a decision before implementing: either add a <code>terminal</code> flag to
+                  <code>Capabilities</code> (a core change that also crosses the agent protocol) and
+                  render a non-terminal tab body from it, or special-case the <code>ftp</code> type
+                  in the frontend (cheaper, but not protocol-agnostic). Tracked by
+                  <a href="https://github.com/armaxri/termiHub/issues/1335">#1335</a> (SI-4).
                 </td>
               </tr>
             </tbody>

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -221,6 +221,135 @@ describe("FileBrowser – useFileBrowserSync", () => {
     expect(useAppStore.getState().fileBrowserMode).toBe("none");
   });
 
+  // --- Protocol-agnostic (session-layer) browsing for non-SSH types (#1335) ---
+
+  /** Register a desktop connection type that advertises the file-browser capability. */
+  function setFileBrowserCapableType(typeId: string, displayName: string) {
+    useAppStore.setState({
+      connectionTypes: [
+        {
+          typeId,
+          displayName,
+          icon: "folder",
+          schema: { groups: [] },
+          capabilities: {
+            monitoring: false,
+            fileBrowser: true,
+            resize: false,
+            persistent: false,
+          },
+        },
+      ],
+    });
+  }
+
+  it("sets fileBrowserMode to 'session' for an FTP tab and targets the tab's session", () => {
+    const ftpTab = makeTab({
+      connectionType: "ftp",
+      sessionId: "ftp-sess-1",
+      config: { type: "ftp", config: { host: "ftp.example.com", port: 21 } },
+    });
+    setActiveTab(ftpTab);
+    setFileBrowserCapableType("ftp", "FTP");
+
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+
+    // FTP must browse through the shared session layer, not the SSH-only
+    // SftpManager path — an `sftp_open` with an FTP config could never connect.
+    expect(useAppStore.getState().fileBrowserMode).toBe("session");
+    expect(useAppStore.getState().sessionFileBrowserId).toBe("ftp-sess-1");
+  });
+
+  it("keeps fileBrowserMode on 'sftp' for an SSH tab (legacy SftpManager path)", () => {
+    const sshTab = makeTab({
+      connectionType: "ssh",
+      sessionId: "ssh-sess-1",
+      config: { type: "ssh", config: { host: "example.com", port: 22, username: "root" } },
+    });
+    setActiveTab(sshTab);
+    setFileBrowserCapableType("ssh", "SSH");
+
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+
+    expect(useAppStore.getState().fileBrowserMode).toBe("sftp");
+  });
+
+  it("sets fileBrowserMode to 'none' for an FTP tab that has no session yet", () => {
+    const ftpTab = makeTab({
+      connectionType: "ftp",
+      sessionId: null,
+      config: { type: "ftp", config: { host: "ftp.example.com", port: 21 } },
+    });
+    setActiveTab(ftpTab);
+    setFileBrowserCapableType("ftp", "FTP");
+
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+
+    expect(useAppStore.getState().fileBrowserMode).toBe("none");
+  });
+
+  it("sets fileBrowserMode to 'none' for an FTP tab when the file browser is disabled", () => {
+    const ftpTab = makeTab({
+      connectionType: "ftp",
+      sessionId: "ftp-sess-1",
+      config: { type: "ftp", config: { host: "ftp.example.com", port: 21 } },
+    });
+    setActiveTab(ftpTab);
+    setFileBrowserCapableType("ftp", "FTP");
+    useAppStore.setState((s) => ({
+      settings: { ...s.settings, fileBrowserEnabled: false },
+    }));
+
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+
+    expect(useAppStore.getState().fileBrowserMode).toBe("none");
+  });
+
+  it("sets fileBrowserMode to 'session' for a Docker tab (shared session layer)", () => {
+    const dockerTab = makeTab({
+      connectionType: "docker",
+      sessionId: "docker-sess-1",
+      config: { type: "docker", config: { container: "web" } },
+    });
+    setActiveTab(dockerTab);
+    setFileBrowserCapableType("docker", "Docker");
+
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+
+    expect(useAppStore.getState().fileBrowserMode).toBe("session");
+    expect(useAppStore.getState().sessionFileBrowserId).toBe("docker-sess-1");
+  });
+
   it("sets fileBrowserMode to 'session' for remote-session tab when agent supports file browser", () => {
     const remoteTab = makeTab({
       connectionType: "remote-session",

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -266,7 +266,16 @@ describe("FileBrowser – useFileBrowserSync", () => {
     expect(useAppStore.getState().sessionFileBrowserId).toBe("ftp-sess-1");
   });
 
-  it("keeps fileBrowserMode on 'sftp' for an SSH tab (legacy SftpManager path)", () => {
+  it("keeps fileBrowserMode on 'sftp' for an SSH tab (legacy SftpManager path)", async () => {
+    // 'sftp' mode auto-connects an SFTP session, so the SFTP command surface
+    // has to answer for real here rather than resolving undefined.
+    mockedInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "sftp_open") return Promise.resolve("sftp-sess-1");
+      if (cmd === "sftp_realpath") return Promise.resolve("/root");
+      if (cmd === "sftp_list_dir") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+
     const sshTab = makeTab({
       connectionType: "ssh",
       sessionId: "ssh-sess-1",
@@ -282,6 +291,7 @@ describe("FileBrowser – useFileBrowserSync", () => {
         </TooltipProvider>
       );
     });
+    await flushAsync();
 
     expect(useAppStore.getState().fileBrowserMode).toBe("sftp");
   });

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -643,7 +643,28 @@ function useFileBrowserSync() {
       activeTabConnectionType &&
       typeSupportsFileBrowser(activeTabConnectionType, connectionTypes)
     ) {
-      setFileBrowserMode(fileBrowserEnabled ? "sftp" : "none");
+      if (!fileBrowserEnabled) {
+        setSessionFileBrowserId(null);
+        setFileBrowserMode("none");
+      } else if (activeTabConnectionType === "ssh") {
+        // SSH keeps the legacy SftpManager/sftp_* path, which carries features
+        // the shared FileBrowser trait does not expose yet (realpath, writability
+        // probes, elevated writes, exec capability). Converging it onto the
+        // session layer is tracked as a follow-up to #1335.
+        setFileBrowserMode("sftp");
+      } else if (activeTab.sessionId) {
+        // Every other file-browser-capable type (FTP, Docker, ...) dispatches
+        // through the session layer: SessionManager already keys sessions by id
+        // and routes file ops via ConnectionType::file_browser(), so this works
+        // for any backend that implements the trait (#1335).
+        setSessionFileBrowserId(activeTab.sessionId);
+        setFileBrowserMode("session");
+      } else {
+        // Session not established yet (still connecting) — this effect re-runs
+        // once the tab receives its session id.
+        setSessionFileBrowserId(null);
+        setFileBrowserMode("none");
+      }
     } else {
       setFileBrowserMode("none");
     }


### PR DESCRIPTION
Refs #1335 (SI-4) · Part of epic #1331 · Concept `docs/concepts/partial/ftp-client.html`

> **Deliberately `Refs`, not `Closes`** — one item in #1335's stated scope ("FTP sessions open straight into the file browser (no terminal tab)") needs a design decision before it can be implemented. See **Open question** below. Whether the issue should be wrapped up once that item is settled is your call.

> _(Edited: this line originally said "Please cl0se #1335 manually", which tripped `auto-close-issues.yml` on merge — it matches GitHub's closing keywords anywhere in the body. The issue was reopened; the wording is fixed so a workflow re-run cannot re-close it.)_

## What this fixes

FTP sessions were not browsable in the sidebar. The interesting part is *why*: most of the protocol-agnostic layer #1335 asks for **already exists**.

- `FileBrowser` trait (`core/src/files/browser.rs`) — exists.
- `FtpFileBrowser` implementing it, and `Ftp::file_browser()` — exist.
- `SessionManager` — already keyed by `session_id`, already dispatches file ops via the connection type's `file_browser()`.
- `session_*` commands + `useSessionFileSystem` — already the generic surface.

The only thing missing was the routing. `FileBrowser.tsx` sent **every** file-browser-capable non-local type to `"sftp"` mode, which opens an `SftpManager` session from the tab's config via `sftp_open`. An FTP (or Docker) config has no SSH host, so that call could never succeed and the sidebar stayed empty.

This PR routes those tabs through the session layer instead. **SSH deliberately stays on the legacy `sftp_*` path**, which carries features the shared trait does not expose (realpath, writability probes, elevated writes, exec capability) — so SFTP browsing is unchanged.

Because the fix is capability-driven rather than FTP-specific, **Docker sidebar browsing starts working too** — it was broken in exactly the same way.

## Why not `FileBrowserManager` / `fs_*`?

#1335 recommends a new `FileBrowserManager` holding `Box<dyn FileBrowser>` keyed by `session_id` with `fs_*` commands. `SessionManager` **is** that manager already (keyed by session id, dispatching through `file_browser()`), and `session_*` **is** that command surface. Building `fs_*` alongside it would have duplicated the layer rather than generalized it, so this takes the issue's intent via the existing seam. No parallel `FtpManager`/`ftp_*` surface was needed either.

## Open question (blocking the last scope item)

The concept says FTP "sessions open directly into the file browser view — no terminal tab is created", and its mockup shows an FTP tab whose body is a placeholder rather than a terminal. Two things make this more than a mechanical change:

1. **The terminal tab is what mints the session.** `Terminal.tsx` calls `create_connection`; a tab with no terminal body would need its own session-creation path.
2. **Nothing tells the UI a type has no terminal.** `Capabilities` is `{ monitoring, file_browser, resize, persistent }` — in the code *and* in the concept. So the options are:
   - add a `terminal` flag to `Capabilities` — a core change that also crosses the agent protocol (`ConnectionTypeInfo` is serialized to agents); or
   - special-case `type === "ftp"` in the frontend — cheap, but contradicts the protocol-agnostic goal of this very issue.

That is a call for the repo owner, so it is left out rather than guessed. Open divergence #1 in the concept sync ledger has been **narrowed** to exactly this remaining gap instead of resolved.

## Follow-ups filed

- #1557 — support the file editor in session-layer browsing (the "previews" part of the AC). Pre-existing: `session` mode has never supported the editor (`remote-session` is affected too), because `EditorTabMeta` is SFTP-shaped (`sftpSessionId`). FTP/Docker now inherit that limitation.

## Test plan

TDD — tests committed before the implementation, and verified red first (`expected 'sftp' to be 'session'`).

- **Unit** (`FileBrowser.test.tsx`): FTP tab → `session` mode targeting the tab's session; Docker tab → `session` mode; SSH tab → stays `sftp` (regression guard); FTP with no session yet → `none`; FTP with the file browser disabled → `none`.
- `./scripts/test.sh` — 350 files / 3233 tests pass; `./scripts/check.sh` — all checks pass.
- `origin/develop` merged in (no conflicts) and re-verified green.

Integration against the ProFTPD fixture is not included: the sidebar wiring is frontend routing, and the FTP backend's `FileBrowser` impl already has Docker-fixture coverage in `core/tests/ftp_file_browser.rs`.

### Manual

- Connect to an FTP server → sidebar file list populates; navigate directories; context menu (mkdir / rename / delete / copy / cut / paste) works.
- Connect over SSH → SFTP browsing behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
