### PR TITLE
test(system): Python-bridge integration test for the Transfer Queue panel (Closes #1532)

### DIFF
--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -223,6 +223,17 @@ def ssh_fixtures():
 
 
 @pytest.fixture(scope="session")
+def ssh_password_fixtures():
+    """Password-auth SSH container only (port 2201).
+
+    ``ssh_fixtures`` also brings up ``ssh-keys``; suites that never authenticate
+    with a key should ask for this instead, so they neither wait for that image
+    to build nor skip when only *it* fails to.
+    """
+    return _ensure_ssh_services([(SSH_PASSWORD_SERVICE, SSH_PASSWORD_PORT)])
+
+
+@pytest.fixture(scope="session")
 def ssh_x11_fixtures():
     """X11-forwarding SSH container (port 2208).
 

--- a/tests/system/tests/test_transfer_queue.py
+++ b/tests/system/tests/test_transfer_queue.py
@@ -1,0 +1,494 @@
+"""Transfer Queue panel integration tests (issue #1532).
+
+The Vitest suite from #1337 (PR #1530) covers the mapper, the store slice and
+every row/control permutation in isolation. What it cannot cover is the wiring:
+that a **real backend transfer** reaches the panel at all — the
+``transfer-progress`` event → ``onTransferProgress`` ``listen`` subscription →
+``useTransferEvents`` → ``applyTransferProgressToQueue`` → ``TransferQueue``
+render chain, running inside the real app. That is what this suite adds.
+
+Two suites, split by what each can assert *deterministically*:
+
+``TestTransferQueueLiveTransfer``
+    Drives a **real SFTP transfer** over the Docker ``ssh-password`` fixture and
+    asserts the panel populates from it. The entry point is the file browser's
+    **copy → paste**: an SFTP→SFTP copy is implemented as "download to a local
+    temp file, re-upload to the destination" (``useFileSystem.pasteEntry``), so a
+    single paste drives two real ``sftp_download`` / ``sftp_upload`` transfers
+    and emits real ``transfer-progress`` events — including the remote ``path``
+    added by #1531 (PR #1543), which this suite asserts reaches the row.
+
+    Copy/paste is used deliberately: it is the **only** transfer entry point the
+    bridge can drive. Every other one (file-browser Download/Upload, the
+    editor's "Download a copy") opens a native OS file dialog first, which the
+    in-webview bridge cannot reach — the same constraint documented in
+    ``test_sftp_infra.py`` and handled as guided-manual in ``test_native_dialogs.py``.
+
+``TestTransferQueuePanel``
+    Drives the panel through ``emitEvent`` (#1545, PR #1556), injecting
+    ``transfer-progress`` on the real Tauri event bus. The app's own ``listen``
+    subscription and store fold run untouched — only the byte-moving backend is
+    substituted. This buys **determinism** for the states a real localhost
+    transfer cannot be held in long enough to assert: rising percent, ``paused``,
+    ``failed``, and the exact control set per state. It needs no container.
+
+Together: the live suite proves the real pipeline carries a real transfer to the
+panel; the injected suite pins the per-state behaviour the issue enumerates.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from termihub_harness import (
+    ConnectionsUi,
+    FilesUi,
+    PasswordPromptUi,
+    SidebarUi,
+    SshUi,
+    SystemTest,
+    TabsUi,
+    TerminalUi,
+    unique_name,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ── testids (tests/system/testid-catalog.md) ────────────────────────────────
+QUEUE = "transfer-queue"
+QUEUE_SUMMARY = "transfer-queue-summary"
+QUEUE_INDICATOR = "transfer-queue-indicator"
+ROW = "transfer-row"
+ROW_NAME = "transfer-row-name"
+ROW_STATUS = "transfer-row-status"
+PAUSE = "transfer-pause"
+RESUME = "transfer-resume"
+CANCEL = "transfer-cancel"
+RETRY = "transfer-retry"
+REMOVE = "transfer-remove"
+CLEAR_COMPLETED = "transfer-clear-completed"
+CANCEL_ALL = "transfer-cancel-all"
+MINIMIZE = "transfer-minimize"
+
+
+def progress(**overrides) -> dict:
+    """A ``transfer-progress`` payload, keyed as the backend serializes it.
+
+    ``TransferProgress`` is ``#[serde(rename_all = "camelCase")]``
+    (``src-tauri/src/files/transfer/mod.rs``), so every key here is camelCase —
+    copied from the emitter, as ``docs/test-bridge.md`` requires for ``emitEvent``.
+    """
+    payload = {
+        "transferId": "t-1",
+        "sessionId": "s-1",
+        "direction": "download",
+        "fileName": "data.csv",
+        "path": "/uploads/data.csv",
+        "transferred": 0,
+        "total": 1000,
+        "phase": "transferring",
+        "state": "active",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TransferQueueReads:
+    """Shared readers over the Transfer Queue store slice and panel."""
+
+    def queue_entries(self) -> list[dict]:
+        """The `transferQueue` slice as a list (the panel renders its values)."""
+        queue = self.driver.get_state("transferQueue") or {}
+        return list(queue.values())
+
+    def entry_states(self) -> list[str]:
+        return [e["state"] for e in self.queue_entries()]
+
+    def wait_for_queue_size(self, size: int, *, timeout: float = 30.0) -> list[dict]:
+        return self.wait(
+            lambda: (
+                self.queue_entries() if len(self.queue_entries()) == size else False
+            ),
+            what=f"the transfer queue to hold {size} row(s)",
+            timeout=timeout,
+        )
+
+
+@pytest.mark.usefixtures("ssh_password_fixtures")
+class TestTransferQueueLiveTransfer(
+    TerminalUi,
+    TabsUi,
+    SidebarUi,
+    ConnectionsUi,
+    PasswordPromptUi,
+    SshUi,
+    FilesUi,
+    TransferQueueReads,
+    SystemTest,
+):
+    """The panel populated by a **real** SFTP transfer over the SSH fixture.
+
+    Password auth only (``ssh_password_fixtures``) — this suite never uses a key,
+    so it does not pull in the ``ssh-keys`` image the broader ``ssh_fixtures``
+    would build.
+    """
+
+    # A size that is big enough for the 256 KiB chunk loop to emit several
+    # throttled (~10 Hz) progress updates, but small enough that the paste
+    # settles well inside the wait budget on a localhost container.
+    FILE_MB = 8
+
+    def sftp_path(self) -> str:
+        """The browser's current remote directory, read from the store.
+
+        Deliberately not ``FilesUi.file_browser_path()``: that helper still reads
+        a ``file-browser-current-path`` testid which no longer exists — the path
+        bar became the breadcrumb ``FileBrowserPathBar`` (see the follow-up filed
+        from this PR). The store's ``currentPath`` is what the bar renders from,
+        so it is both current and the thing under test here.
+        """
+        return self.driver.get_state("currentPath") or ""
+
+    def open_sftp_browser(self) -> str:
+        """Show the Files sidebar, clear any password prompt, await the listing."""
+        self.switch_to_files_sidebar()
+        self.wait(
+            lambda: self.driver.exists("password-prompt-input")
+            or self.driver.get_state("sftpStatus") == "connected",
+            what="the SFTP browser or its password prompt",
+        )
+        if self.driver.exists("password-prompt-input"):
+            self.handle_password_prompt()
+        self.wait(
+            lambda: self.driver.get_state("sftpStatus") == "connected",
+            what="the SFTP session to connect",
+        )
+        return self.wait(lambda: self.sftp_path() or False, what="the remote path")
+
+    def test_real_sftp_paste_populates_the_transfer_queue(self):
+        """A real copy/paste drives rows to `completed`, carrying the remote path.
+
+        The paste is one user action but two backend transfers — a download of
+        the source to a local temp file and an upload to the destination — so the
+        queue ends with two rows. Both must carry the remote path (#1531): the
+        download's is the source path, the upload's is the destination path.
+        """
+        name = f"payload-{unique_name('tq')}.bin"
+        dest = f"destdir-{unique_name('tq')}"
+
+        self.connect_ssh_password(unique_name("transfer-queue"))
+        source_dir = self.open_sftp_browser()
+
+        # Seed a source file and an empty destination directory.
+        self.run_command(f"dd if=/dev/zero of={name} bs=1M count={self.FILE_MB} 2>/dev/null")
+        self.run_command(f"mkdir -p {dest}")
+        self.run_command("sync")
+        self.wait_for_file_row(name)
+
+        # Copy the source file, then paste it inside the destination directory.
+        # Paste is driven from the toolbar button rather than the row context
+        # menu, so the destination does not need an entry to right-click.
+        self.open_file_menu(name)
+        self.driver.click("context-file-copy")
+
+        self.wait_for_file_row(dest)
+        self.driver.double_click(f"file-row-{dest}")
+        self.wait(
+            lambda: self.sftp_path() == f"{source_dir.rstrip('/')}/{dest}",
+            what=f"the browser to enter {dest!r}",
+        )
+
+        self.wait(
+            lambda: self.driver.get_attribute("file-browser-paste", "disabled") is None,
+            what="Paste to enable once the clipboard holds the copied file",
+        )
+        self.driver.click("file-browser-paste")
+
+        # The panel appears as soon as the first transfer registers.
+        self.wait(lambda: self.driver.exists(QUEUE), what="the Transfer Queue panel")
+
+        # Download + upload = two rows, both settling at `completed`.
+        entries = self.wait(
+            lambda: (
+                self.queue_entries()
+                if len(self.queue_entries()) == 2
+                and all(e["state"] == "completed" for e in self.queue_entries())
+                else False
+            ),
+            what="both paste transfers to complete",
+            timeout=120.0,
+        )
+
+        by_direction = {e["direction"]: e for e in entries}
+        assert set(by_direction) == {"download", "upload"}, entries
+
+        # Every row reaches 100%.
+        assert [e["percent"] for e in entries] == [100, 100]
+
+        # Each row names its transfer's *source* basename: the backend derives
+        # `file_name` from the remote path on download and the local path on
+        # upload (`commands/files.rs::file_name_of`). A paste uploads from the
+        # local temp copy, so that row is named for the temp file — see the
+        # follow-up filed from this PR.
+        assert by_direction["download"]["name"] == name
+        assert by_direction["upload"]["name"].startswith("termihub-paste-")
+        assert by_direction["upload"]["name"].endswith(name)
+
+        # The remote path from #1531 (PR #1543) reaches both rows: the download
+        # reports the source path, the upload the destination path. Without the
+        # backend emitting `path`, the entries carry no path at all and this
+        # fails (`.get` so that reads as an assertion, not a KeyError).
+        base = source_dir.rstrip("/")
+        assert by_direction["download"].get("path") == f"{base}/{name}"
+        assert by_direction["upload"].get("path") == f"{base}/{dest}/{name}"
+
+        # The panel renders the completed rows and summarises them.
+        assert self.driver.exists(ROW)
+        assert self.driver.get_text(ROW_STATUS) == "done"
+        assert "2 done" in self.driver.get_text(QUEUE_SUMMARY)
+
+        # A completed row offers Remove only — no pause/cancel/retry.
+        assert self.driver.exists(REMOVE)
+        assert not self.driver.exists(PAUSE)
+        assert not self.driver.exists(CANCEL)
+
+        # The pasted file really landed in the destination directory at full
+        # size: the transfer moved bytes, it did not merely emit events.
+        self.wait_for_file_row(name)
+        entry = self.wait(
+            lambda: next(
+                (
+                    f
+                    for f in (self.driver.get_state("fileEntries") or [])
+                    if f["name"] == name
+                ),
+                False,
+            ),
+            what="the pasted file to list in the destination",
+        )
+        assert entry["size"] == self.FILE_MB * 1024 * 1024
+
+    def test_clear_completed_empties_the_panel_after_a_real_transfer(self):
+        """Clear Completed drops the settled rows, and the panel unmounts."""
+        # Runs after the paste test in the same suite (one app per class), so the
+        # queue still holds its two completed rows.
+        self.wait_for_queue_size(2)
+
+        self.driver.click(CLEAR_COMPLETED)
+
+        self.wait(
+            lambda: self.queue_entries() == [],
+            what="the queue to be cleared of completed rows",
+        )
+        # Empty queue ⇒ the panel renders nothing at all.
+        self.wait(lambda: not self.driver.exists(QUEUE), what="the panel to unmount")
+
+
+class TestTransferQueuePanel(TransferQueueReads, SystemTest):
+    """Per-state panel behaviour, driven deterministically through ``emitEvent``.
+
+    Every event here goes over the **real** Tauri bus, so the app's real
+    ``listen`` subscription, ``useTransferEvents`` hook and store fold run — only
+    the byte-moving backend is substituted (see the module docstring).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_queue_between_tests(self):
+        """Reset the panel to empty + expanded so each test starts clean.
+
+        The suite shares one app across its tests, and the Transfer Queue
+        deliberately *retains* terminal rows, so leftovers would leak between
+        tests. `clearCompleted` only drops `completed` rows, so drive every
+        leftover row to `completed` first, then clear them in one click.
+        """
+        yield
+        self.restore_panel()
+        for entry in self.queue_entries():
+            self.emit_progress(
+                transferId=entry["id"], phase="done", state="completed", transferred=1000
+            )
+        if self.queue_entries():
+            self.wait(
+                lambda: all(e["state"] == "completed" for e in self.queue_entries()),
+                what="leftover rows to settle as completed",
+            )
+            self.driver.click(CLEAR_COMPLETED)
+            self.wait(lambda: self.queue_entries() == [], what="the queue to empty")
+
+    # -- helpers ---------------------------------------------------------------
+    def emit_progress(self, **overrides) -> None:
+        """Inject one ``transfer-progress`` event on the real Tauri bus."""
+        self.driver.emit_event("transfer-progress", progress(**overrides))
+
+    def restore_panel(self) -> None:
+        """Un-minimize the panel via its indicator (the store has no direct setter)."""
+        if self.driver.exists(QUEUE_INDICATOR):
+            self.driver.click(QUEUE_INDICATOR)
+            self.wait(
+                lambda: not self.driver.exists(QUEUE_INDICATOR),
+                what="the panel to restore",
+            )
+
+    def wait_for_row_state(self, state: str, *, transfer_id: str = "t-1") -> dict:
+        return self.wait(
+            lambda: next(
+                (
+                    e
+                    for e in self.queue_entries()
+                    if e["id"] == transfer_id and e["state"] == state
+                ),
+                False,
+            ),
+            what=f"transfer {transfer_id} to be {state}",
+        )
+
+    # -- tests -----------------------------------------------------------------
+    def test_active_row_shows_rising_percent_and_active_controls(self):
+        """A row appears with rising percent and offers Pause + Cancel."""
+        assert not self.driver.exists(QUEUE), "suite must start with an empty queue"
+
+        self.emit_progress(transferred=100)  # 10%
+        self.wait(lambda: self.driver.exists(ROW), what="the transfer row")
+
+        assert self.driver.exists(QUEUE)
+        assert self.driver.get_text(ROW_NAME) == "data.csv"
+        assert self.wait_for_row_state("active")["percent"] == 10
+
+        # An active row offers Pause and Cancel — not Resume/Retry/Remove.
+        assert self.driver.exists(PAUSE)
+        assert self.driver.exists(CANCEL)
+        assert not self.driver.exists(RESUME)
+        assert not self.driver.exists(RETRY)
+        assert not self.driver.exists(REMOVE)
+
+        # Percent rises as the backend reports more bytes.
+        self.emit_progress(transferred=550)
+        assert self.wait_for_row_state("active")["percent"] == 55
+        self.emit_progress(transferred=900)
+        self.wait(
+            lambda: self.queue_entries()[0]["percent"] == 90,
+            what="the row to reach 90%",
+        )
+        assert "1 active" in self.driver.get_text(QUEUE_SUMMARY)
+
+    def test_paused_row_swaps_pause_for_resume(self):
+        """`paused` swaps Pause → Resume, keeps Cancel, and Resume goes back."""
+        self.emit_progress(transferred=300)
+        self.wait_for_row_state("active")
+
+        self.emit_progress(transferred=300, state="paused")
+        self.wait_for_row_state("paused")
+
+        assert self.driver.exists(RESUME)
+        assert self.driver.exists(CANCEL)
+        assert not self.driver.exists(PAUSE)
+        assert self.driver.get_text(ROW_STATUS) == "paused"
+
+        # Resume clicks through to the backend (`transfer_resume`), which no-ops
+        # for an id it never registered; the row follows the next event.
+        self.driver.click(RESUME)
+        self.emit_progress(transferred=400, state="active")
+        self.wait_for_row_state("active")
+        assert self.driver.exists(PAUSE)
+
+    def test_failed_row_offers_retry_and_remove(self):
+        """A `failed` row surfaces its attempt counter, Retry and Remove."""
+        self.emit_progress(
+            phase="error",
+            state="failed",
+            message="connection reset",
+            attempt=2,
+            maxAttempts=3,
+        )
+        entry = self.wait_for_row_state("failed")
+
+        assert entry["error"] == "connection reset"
+        assert self.driver.get_text(ROW_STATUS) == "failed (2/3)"
+        assert self.driver.exists(RETRY)
+        assert self.driver.exists(REMOVE)
+        assert not self.driver.exists(PAUSE)
+        assert not self.driver.exists(CANCEL)
+
+    def test_cancel_removes_the_row_when_the_backend_confirms(self):
+        """Cancel drives the backend; the row settles on the `cancelled` event."""
+        self.emit_progress(transferred=200)
+        self.wait_for_row_state("active")
+
+        self.driver.click(CANCEL)
+
+        # The click reaches `transfer_cancel`; the row's state change is owned by
+        # the backend's terminal event, exactly as in a real transfer.
+        self.emit_progress(transferred=200, phase="cancelled", state="cancelled")
+        self.wait_for_row_state("cancelled")
+
+        assert self.driver.get_text(ROW_STATUS) == "cancelled"
+        assert self.driver.exists(RETRY)
+        assert self.driver.exists(REMOVE)
+        # A settled row is retained, not dropped — that is the panel's contract.
+        assert self.driver.exists(QUEUE)
+
+    def test_cancel_all_is_enabled_only_while_a_row_is_pending(self):
+        """Cancel All targets every non-terminal row and disables when none are."""
+        self.emit_progress(transferId="t-1", transferred=100)
+        self.emit_progress(transferId="t-2", fileName="b.bin", transferred=200)
+        self.wait_for_queue_size(2)
+
+        # Two pending rows ⇒ Cancel All is enabled (no `disabled` attribute).
+        assert self.driver.get_attribute(CANCEL_ALL, "disabled") is None
+
+        self.driver.click(CANCEL_ALL)
+        for tid in ("t-1", "t-2"):
+            self.emit_progress(transferId=tid, phase="cancelled", state="cancelled")
+        self.wait(
+            lambda: self.entry_states() == ["cancelled", "cancelled"],
+            what="both rows to be cancelled",
+        )
+
+        # Nothing pending ⇒ Cancel All disables itself.
+        self.wait(
+            lambda: self.driver.get_attribute(CANCEL_ALL, "disabled") is not None,
+            what="Cancel All to disable",
+        )
+
+    def test_clear_completed_keeps_unfinished_rows(self):
+        """Clear Completed drops only `completed` rows, keeping an active one."""
+        self.emit_progress(transferId="t-1", phase="done", state="completed", transferred=1000)
+        self.emit_progress(transferId="t-2", fileName="b.bin", transferred=100)
+        self.wait_for_queue_size(2)
+
+        self.driver.click(CLEAR_COMPLETED)
+
+        remaining = self.wait(
+            lambda: self.queue_entries() if len(self.queue_entries()) == 1 else False,
+            what="the completed row to be cleared",
+        )
+        assert remaining[0]["id"] == "t-2"
+        assert remaining[0]["state"] == "active"
+        assert self.driver.exists(QUEUE)
+
+    def test_minimize_collapses_to_the_indicator_and_restores(self):
+        """Minimize hides the panel behind the status-bar indicator, which restores it."""
+        self.emit_progress(transferred=100)
+        self.wait(lambda: self.driver.exists(QUEUE), what="the panel")
+        assert not self.driver.exists(QUEUE_INDICATOR)
+
+        self.driver.click(MINIMIZE)
+
+        # Panel gone, indicator up and counting the in-progress transfer.
+        self.wait(lambda: self.driver.exists(QUEUE_INDICATOR), what="the minimized indicator")
+        assert not self.driver.exists(QUEUE)
+        assert "1 transferring" in self.driver.get_text(QUEUE_INDICATOR)
+
+        # The queue keeps folding events while minimized.
+        self.emit_progress(phase="done", state="completed", transferred=1000)
+        self.wait(
+            lambda: "1 finished" in self.driver.get_text(QUEUE_INDICATOR),
+            what="the indicator to report the finished transfer",
+        )
+
+        # Clicking the indicator restores the panel.
+        self.driver.click(QUEUE_INDICATOR)
+        self.wait(lambda: self.driver.exists(QUEUE), what="the panel to restore")
+        assert not self.driver.exists(QUEUE_INDICATOR)
+        assert self.driver.get_text(ROW_STATUS) == "done"


### PR DESCRIPTION
## Summary

Adds the Python-bridge system test named in #1337's test plan (follow-up to PR #1530, part of Epic #1331). `tests/system/tests/test_transfer_queue.py` covers the Transfer Queue panel and its minimized indicator, in two suites split by what each can assert *deterministically*.

### `TestTransferQueueLiveTransfer` — a real SFTP transfer

Drives a **real transfer** over the `ssh-password` container and asserts the panel populates from it, exercising the whole chain inside the real app: backend `transfer-progress` emit → `listen` subscription → `useTransferEvents` → `applyTransferProgressToQueue` → render.

The entry point is the file browser's **copy → paste**. An SFTP→SFTP copy is implemented as "download to a local temp file, re-upload to the destination" (`useFileSystem.pasteEntry`), so one paste drives two real `sftp_download`/`sftp_upload` transfers.

**Why copy/paste and not Download/Upload:** it is the only transfer entry point the bridge can drive. Every other one (file-browser Download/Upload, the editor's "Download a copy") opens a native OS file dialog first, which the in-webview bridge cannot reach — the constraint already documented in `test_sftp_infra.py` and handled as guided-manual in `test_native_dialogs.py`.

Asserts: both rows reach `completed` at 100%, the row renders with Remove (and no pause/cancel/retry), the summary reads `2 done`, the remote **`path` from #1531 (PR #1543)** lands on both rows (source path on the download, destination path on the upload), and the pasted file really lands at full size — bytes moved, not just events emitted.

### `TestTransferQueuePanel` — deterministic per-state coverage

Drives the panel via `emitEvent` (#1545, PR #1556), injecting `transfer-progress` on the **real Tauri bus** — the app's own `listen` subscription and store fold run untouched; only the byte-moving backend is substituted. This buys determinism for the states a localhost transfer cannot be held in long enough to assert: rising percent (10% → 55% → 90%), `paused` ↔ `active`, `failed` with its `failed (2/3)` attempt counter, the exact control set per state, Cancel, Cancel All's enable/disable, Clear Completed keeping unfinished rows, and Minimize → `transfer-queue-indicator` → restore.

Needs no container, so it runs anywhere the app is built.

## Also

- **`ssh_password_fixtures`** (new, `conftest.py`): brings up the password-auth container *only*. `ssh_fixtures` also builds `ssh-keys`, which this suite never uses.
- The suite reads the browser's remote path from the store rather than `FilesUi.file_browser_path()` — see the follow-up note below.

## Verification

- `./tests/system/pytest.sh tests/test_transfer_queue.py` → **9 passed** against a real `pnpm tauri build --debug`, with the `ssh-password` container live.
- Machinery lane (`-m "not integration"`, what PR CI runs) → 193 passed; these 9 are correctly deselected as `integration`.
- `npx tsc --noEmit` clean.
- **Confirmed the tests fail without the behaviour they cover** — each sabotage was rebuilt and run, then reverted:
  - reverting #1543's mapper line (`path: progress.path ?? prev?.path` → `prev?.path`) turns the live suite red: `assert None == '/home/testuser/payload-….bin'`.
  - gating off the `paused` branch of `TransferControls` turns the panel suite red: `assert False = exists('transfer-resume')`.

## Note for reviewers

These suites are `integration`-marked, so **PR CI does not run them** — the machinery lane only checks that they collect. They were verified locally as above.

## Done when

A `tests/system/` test drives a transfer end-to-end and asserts the Transfer Queue panel + minimized indicator behavior, passing via the harness. ✅

Closes #1532

🤖 Generated with [Claude Code](https://claude.com/claude-code)