### PR TITLE
test(sftp): point the file-browser path helpers at the real path bar (Closes #1568)

### DIFF
--- a/src/components/Sidebar/FileBrowserPathBar.tsx
+++ b/src/components/Sidebar/FileBrowserPathBar.tsx
@@ -74,7 +74,12 @@ export function FileBrowserPathBar({ currentPath, onNavigate }: FileBrowserPathB
 
   return (
     <div className="file-browser__path-bar">
-      <nav className="file-browser__breadcrumbs" aria-label="Path" title={currentPath}>
+      <nav
+        className="file-browser__breadcrumbs"
+        aria-label="Path"
+        title={currentPath}
+        data-testid="file-browser-current-path"
+      >
         {crumbs.map((crumb, i) => (
           <span className="file-browser__crumb-group" key={crumb.path}>
             {i > 0 && <ChevronRight size={11} className="file-browser__crumb-sep" aria-hidden />}

--- a/tests/system/termihub_harness/ui/files.py
+++ b/tests/system/termihub_harness/ui/files.py
@@ -7,8 +7,9 @@ and create files/folders via the inline toolbar inputs. It builds on
 both alongside :class:`~termihub_harness.SystemTest`.
 
 This is the local counterpart to :class:`~termihub_harness.ui.SftpUi` (remote SFTP
-browsing): both read ``file-browser-current-path`` and ``file-row-<name>``, but a
-local browser needs no password prompt and follows the terminal's CWD.
+browsing): both read ``file-browser-current-path`` and ``file-row-<name>`` — via
+the shared :class:`FileBrowserPathReads` — but a local browser needs no password
+prompt and follows the terminal's CWD.
 """
 
 from __future__ import annotations
@@ -26,11 +27,47 @@ def file_row_testid(name: str) -> str:
     return f"file-row-{name}"
 
 
-class FilesUi(HarnessMixin):
+class FileBrowserPathReads(HarnessMixin):
+    """Read the path the file browser currently shows.
+
+    Shared by :class:`FilesUi` (local) and :class:`~termihub_harness.ui.SftpUi`
+    (remote): the two drive different backends but render the **same**
+    ``FileBrowserPathBar``, so the read belongs in one place. It used to be
+    copy-pasted into both, which is how it went stale in both at once (#1568).
+
+    The bar is a breadcrumb: its text is the path *segmented* into per-crumb
+    buttons, so ``get_text`` would yield the labels run together rather than a
+    path. The nav's ``title`` — the tooltip the user sees — is the full path
+    verbatim, so that is what these read.
+
+    Deliberately **not** the store's ``currentPath``: that field is the SFTP
+    browser's path only. ``useFileBrowser`` picks currentPath from one of three
+    sub-hooks (local / sftp / session) by mode, so reading the store would
+    silently return the wrong path for a local browser. The bar renders whichever
+    mode is active, so reading the bar is correct for every mode.
+    """
+
+    CURRENT_PATH = "file-browser-current-path"
+
+    def file_browser_path(self) -> str:
+        """The path currently shown in the file browser (empty if none)."""
+        if not self.driver.exists(self.CURRENT_PATH):
+            return ""
+        return self.driver.get_attribute(self.CURRENT_PATH, "title") or ""
+
+    def wait_for_path_contains(self, needle: str, *, timeout: float = DEFAULT_WAIT_TIMEOUT) -> str:
+        """Poll until the displayed path contains ``needle``; return the full path."""
+        return self.wait(
+            lambda: (lambda p: p if needle in p else None)(self.file_browser_path()),
+            timeout=timeout,
+            what=f"{needle!r} in the file-browser path",
+        )
+
+
+class FilesUi(FileBrowserPathReads):
     """Drive and read the local file browser for the active terminal."""
 
     # Stable file-browser toolbar / inline-input testids (entry-name-free).
-    CURRENT_PATH = "file-browser-current-path"
     UP = "file-browser-up"
     REFRESH = "file-browser-refresh"
     NEW_FILE = "file-browser-new-file"
@@ -48,26 +85,12 @@ class FilesUi(HarnessMixin):
         """Show the Files sidebar for the active local terminal; return its path.
 
         The local browser follows the terminal's CWD and needs no password, so it
-        is ready once ``file-browser-current-path`` renders a non-empty path.
+        is ready once the path bar renders a non-empty path.
         """
         self.switch_to_files_sidebar()
         return self.wait(
-            lambda: self.driver.get_text(self.CURRENT_PATH) or None,
+            lambda: self.file_browser_path() or None,
             what="the local file-browser path",
-        )
-
-    def file_browser_path(self) -> str:
-        """The path currently shown in the file browser (empty if none)."""
-        if not self.driver.exists(self.CURRENT_PATH):
-            return ""
-        return self.driver.get_text(self.CURRENT_PATH)
-
-    def wait_for_path_contains(self, needle: str, *, timeout: float = DEFAULT_WAIT_TIMEOUT) -> str:
-        """Poll until the displayed path contains ``needle``; return the full path."""
-        return self.wait(
-            lambda: (lambda p: p if needle in p else None)(self.file_browser_path()),
-            timeout=timeout,
-            what=f"{needle!r} in the file-browser path",
         )
 
     # -- entries -----------------------------------------------------------------

--- a/tests/system/termihub_harness/ui/sftp.py
+++ b/tests/system/termihub_harness/ui/sftp.py
@@ -11,11 +11,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ..fixtures import SSH_PASSWORD
-from .base import HarnessMixin
+from .files import FileBrowserPathReads
 
 
-class SftpUi(HarnessMixin):
-    """Open the SFTP browser for the active tab and read its current path."""
+class SftpUi(FileBrowserPathReads):
+    """Open the SFTP browser for the active tab and read its current path.
+
+    The path read (``file_browser_path``) comes from
+    :class:`~termihub_harness.ui.files.FileBrowserPathReads`: the remote browser
+    renders the same ``FileBrowserPathBar`` as the local one, so suites that mix
+    this with :class:`~termihub_harness.ui.FilesUi` get one implementation rather
+    than two that can drift apart (#1568).
+    """
 
     if TYPE_CHECKING:  # borrowed from the mixins suites combine this with
         def switch_to_files_sidebar(self) -> None: ...
@@ -32,18 +39,12 @@ class SftpUi(HarnessMixin):
         # wait() returns truthy or raises, so no outer guard is needed.
         self.wait(
             lambda: self.driver.exists("password-prompt-input")
-            or self.driver.exists("file-browser-current-path"),
+            or self.driver.exists(self.CURRENT_PATH),
             what="the SFTP browser or its password prompt",
         )
         if self.driver.exists("password-prompt-input"):
             self.handle_password_prompt(password)
         return self.wait(
-            lambda: self.driver.get_text("file-browser-current-path"),
+            lambda: self.file_browser_path() or None,
             what="the file-browser path",
         )
-
-    def file_browser_path(self) -> str:
-        """The path currently shown in the file browser (empty if none)."""
-        if not self.driver.exists("file-browser-current-path"):
-            return ""
-        return self.driver.get_text("file-browser-current-path")

--- a/tests/system/tests/test_file_browser_local.py
+++ b/tests/system/tests/test_file_browser_local.py
@@ -4,8 +4,8 @@ Ported from ``tests/e2e/file-browser-local.test.js`` and
 ``file-browser-extended.test.js`` onto the Python bridge harness (#809).
 
 The browser is driven through its real toolbar/row testids and asserted against
-what the user sees — ``file-browser-current-path`` for the path and
-``file-row-<name>`` for entries. Known entries are created in the browser's
+what the user sees — ``file-browser-current-path`` (the breadcrumb path bar,
+read via its ``title``) for the path and ``file-row-<name>`` for entries. Known entries are created in the browser's
 **current** directory (the home dir a fresh shell shows) or via the browser's own
 New File/Folder inputs, so a test never depends on OSC 7 cwd-following timing for
 its fixtures. The dedicated CWD-aware tests below *do* exercise cwd-following and

--- a/tests/system/tests/test_ssh_password_extended.py
+++ b/tests/system/tests/test_ssh_password_extended.py
@@ -15,6 +15,7 @@ from termihub_harness import (
     SSH_KEY_PATH,
     SSH_PASSWORD_PORT,
     SSH_USERNAME,
+    SftpUi,
     SidebarUi,
     SystemTest,
     TabsUi,
@@ -28,7 +29,9 @@ HOST = "127.0.0.1"
 
 
 @pytest.mark.usefixtures("ssh_fixtures")
-class TestSshPasswordExtended(TerminalUi, TabsUi, SidebarUi, ConnectionsUi, PasswordPromptUi, SystemTest):
+class TestSshPasswordExtended(
+    TerminalUi, TabsUi, SidebarUi, ConnectionsUi, PasswordPromptUi, SftpUi, SystemTest
+):
     def test_key_auth_shows_no_password_dialog(self):
         name = unique_name("ssh-key-nopass")
         self.create_ssh_connection(
@@ -56,13 +59,13 @@ class TestSshPasswordExtended(TerminalUi, TabsUi, SidebarUi, ConnectionsUi, Pass
         self.switch_to_files_sidebar()
         prompted = self.wait(
             lambda: self.driver.exists("password-prompt-input")
-            or self.driver.exists("file-browser-current-path"),
+            or self.driver.exists(self.CURRENT_PATH),
             what="the SFTP browser or its password prompt",
         )
         assert prompted
         if self.driver.exists("password-prompt-input"):
             self.handle_password_prompt()
             assert self.wait(
-                lambda: self.driver.get_text("file-browser-current-path"),
+                lambda: self.file_browser_path() or None,
                 what="the SFTP browser to load",
             )

--- a/tests/system/tests/test_transfer_queue.py
+++ b/tests/system/tests/test_transfer_queue.py
@@ -139,17 +139,6 @@ class TestTransferQueueLiveTransfer(
     # settles well inside the wait budget on a localhost container.
     FILE_MB = 8
 
-    def sftp_path(self) -> str:
-        """The browser's current remote directory, read from the store.
-
-        Deliberately not ``FilesUi.file_browser_path()``: that helper still reads
-        a ``file-browser-current-path`` testid which no longer exists — the path
-        bar became the breadcrumb ``FileBrowserPathBar`` (see the follow-up filed
-        from this PR). The store's ``currentPath`` is what the bar renders from,
-        so it is both current and the thing under test here.
-        """
-        return self.driver.get_state("currentPath") or ""
-
     def open_sftp_browser(self) -> str:
         """Show the Files sidebar, clear any password prompt, await the listing."""
         self.switch_to_files_sidebar()
@@ -164,7 +153,7 @@ class TestTransferQueueLiveTransfer(
             lambda: self.driver.get_state("sftpStatus") == "connected",
             what="the SFTP session to connect",
         )
-        return self.wait(lambda: self.sftp_path() or False, what="the remote path")
+        return self.wait(lambda: self.file_browser_path() or False, what="the remote path")
 
     def test_real_sftp_paste_populates_the_transfer_queue(self):
         """A real copy/paste drives rows to `completed`, carrying the remote path.
@@ -195,7 +184,7 @@ class TestTransferQueueLiveTransfer(
         self.wait_for_file_row(dest)
         self.driver.double_click(f"file-row-{dest}")
         self.wait(
-            lambda: self.sftp_path() == f"{source_dir.rstrip('/')}/{dest}",
+            lambda: self.file_browser_path() == f"{source_dir.rstrip('/')}/{dest}",
             what=f"the browser to enter {dest!r}",
         )
 


### PR DESCRIPTION
The `FilesUi` / `SftpUi` helpers target a `file-browser-current-path` testid that no longer exists anywhere in `src/`. The path bar became the breadcrumb `FileBrowserPathBar` and the id went with the old markup.

It fails **silently**: `exists()` returns False and `get_text()` returns `""`, so `connect_sftp_browser()`, `open_file_browser()`, `file_browser_path()`, `enter_directory()` and `navigate_up()` simply time out rather than erroring usefully. PR CI only ever runs `-m "not integration"`, so integration tests are checked to *collect*, never to *run* — the rot was invisible. That dark lane is #1569 and is out of scope here.

## The fix

**Restore the id on the breadcrumb `<nav>`, read its `title`.** The nav already carries `title={currentPath}` — the full path verbatim, and what the user sees on hover. `get_text()` is not usable here: the crumbs render the path as separate labelled buttons, so it would return the labels run together rather than a path.

**Read the bar, not the store.** The alternative was the store's `currentPath`. That would be wrong: `useFileBrowser` selects `currentPath` from one of three sub-hooks (local / sftp / session) by mode, and the store field is the **SFTP** one only — a store read returns the wrong path for a local browser, silently. The bar renders whichever mode is active, so reading it is correct for all three.

**One implementation, not two.** The read was copy-pasted into both mixins, which is precisely why a single markup change rotted both at once. It now lives in a shared `FileBrowserPathReads` that `FilesUi` and `SftpUi` inherit — the two suites that mix both get one implementation instead of two that can drift.

Also folds in two further copies of the same rot:
- `test_ssh_password_extended.py` hand-rolled the same flow inline with the dead literal; it now mixes `SftpUi` and uses the shared read (kept explicit rather than calling `connect_sftp_browser()`, which would swallow the prompt assertion the test exists to make).
- `test_transfer_queue.py` (#1532, PR #1565) worked around the broken helper by reading the store. With the helper fixed the workaround is unnecessary and is removed — its 9 tests still pass.

The testid catalog is generated and gitignored (#1528); regenerating picks the id up under `FileBrowserPathBar.tsx`.

## Test plan

CI cannot validate this fix (#1569), so it was run locally against a real build with the Docker SSH fixtures live:

- `test_sftp_infra.py` — the bar for this work
- `test_transfer_queue.py` — confirms the removed workaround
- `test_file_browser_local.py` — the local browser path
- `test_ssh_password_extended.py`, `test_ssh_sftp_cwd.py`
- Frontend unit: 226 passed / 33 files
- Python non-integration: 193 passed

Results are reported in the PR thread.

Closes #1568