### PR TITLE
chore(config): allow the build commit type in commitlint (Closes #1571)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -320,7 +320,7 @@ Use these skills with `/skill-name` during development:
 - **Never commit directly to `main` or `develop`**
 - **Never push directly to `main` or `develop`**: all changes must be submitted via pull request — no exceptions, even for documentation-only changes
 - **Every change requires a PR targeting `develop`**: create a feature or bugfix branch, push it to `origin`, and open a pull request against `develop`. Only target `main` when the user explicitly requests it.
-- **Conventional Commits**: `type(scope): subject` — types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
+- **Conventional Commits**: `type(scope): subject` — types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `chore`, `ci`, `revert` (enforced by `commitlint.config.js`)
 - **Scopes**: `terminal`, `ssh`, `serial`, `ui`, `backend`, `sftp`, `config`, `agent`, `credential`, `tunnel`, `workspace`, `network`, `embedded-servers`
 - **Always merge with a merge commit** (`gh pr merge --merge`) — never squash or rebase, never rebase branches
 - **Commit early and often** — commit as soon as a single logical topic is complete (a single topic = a single commit). Do not batch multiple topics into one commit. Each logical step gets its own commit:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,10 +1,14 @@
 export default {
   extends: ["@commitlint/config-conventional"],
   rules: {
+    // Keep in sync with the type lists in docs/contributing.md and .claude/CLAUDE.md.
+    // `build` is part of the Conventional Commits spec and is already used in this
+    // repo's issue titles (e.g. #1537, #1538), so copying an issue title into a commit
+    // subject must not fail the lint (#1571).
     "type-enum": [
       2,
       "always",
-      ["feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "ci", "revert"],
+      ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "chore", "ci", "revert"],
     ],
   },
   ignores: [

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -277,7 +277,10 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 <footer>
 ```
 
-**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`
+**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `chore`, `ci`, `revert`
+
+This list is enforced by `commitlint.config.js` — a subject using any other type fails the
+Lint Commit Messages check.
 
 **Scopes**: `terminal`, `ssh`, `serial`, `ui`, `backend`, `sftp`, `config`, etc.
 


### PR DESCRIPTION
Adds `build` to the commitlint `type-enum`, taking **option 1** from the issue.

## Why option 1

The issue offered adding `build` to the enum, or dropping `build:` from issue titles. Option 1 is the one the issue itself recommends ("fewer moving parts"), it matches the Conventional Commits spec, and it leaves the existing issue titles valid rather than requiring a retroactive retitling pass. Option 2 would also have to be enforced by convention alone — nothing checks issue titles — so the trap would come straight back the next time someone wrote a natural `build:` title.

## What changed

- `commitlint.config.js` — `build` added to the type-enum, with a comment recording why and pointing at the sibling doc lists.
- `docs/contributing.md` and `.claude/CLAUDE.md` — the documented type lists were **already stale before this change**: both omitted `ci` and `revert`, which the enum has always allowed. Aligned all three lists so the documented set matches the enforced one; otherwise the same "the docs say one thing, CI says another" trap just moves next door.

## Verification

Piped the literal title of the issue that triggered this through the linter:

```
$ echo "build: shrink the dev target directory" | pnpm exec commitlint   # exit 0
$ echo "bogus: something" | pnpm exec commitlint
type must be one of [feat, fix, docs, style, refactor, perf, test, build, chore, ci, revert]
```

So the case from the report passes and the enum still rejects everything outside the list.

## Note

This commit deliberately uses `chore(config):` rather than `build:` — the change enabling `build` cannot rely on itself having landed.