### PR TITLE
fix(config): ignore auto-close keywords in code, quotes and negations (Closes #1566)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -325,6 +325,30 @@ handling. The keyword parser lives in
 (unit-tested in `parse-issue-refs.test.mjs`). Just keep using `Closes #N` in your
 PR descriptions — no manual close needed.
 
+The workflow runs on the `pull_request: closed` event, so it fires **a short
+while after** the merge, not instantly. An issue still showing as open seconds
+after you merge is normal — give it a minute before assuming the workflow failed.
+
+#### Mentioning an issue you do **not** want closed
+
+The parser only counts a keyword that is genuinely instructing a close. It
+ignores keywords that appear:
+
+- inside an inline code span (`` `Closes #123` ``) or a fenced code block;
+- inside a blockquote line (`> Closes #123`), e.g. when quoting another PR;
+- directly negated by the words in front of them ("this PR does not close #123").
+
+**Wrap the reference in backticks whenever a PR body needs to discuss a
+reference rather than act on it.** That is the reliable escape hatch. The
+negation handling is a convenience for the obvious phrasings — a regex cannot
+truly parse English negation, so it only looks a few words back and stops at the
+nearest sentence or line boundary. Do not lean on it for anything subtler than
+"does not close #N"; reach for backticks instead.
+
+To link an issue without closing it at all, use a non-keyword phrasing such as
+"Part of #123", "Follow-up to #123", or "See #123" — these have never closed
+anything.
+
 ---
 
 ## Coding Standards

--- a/scripts/internal/parse-issue-refs.mjs
+++ b/scripts/internal/parse-issue-refs.mjs
@@ -17,8 +17,89 @@
  */
 const CLOSING_KEYWORD = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]*#(\d+)/gi;
 
+/** A fenced code block delimiter: three or more backticks/tildes, up to 3 leading spaces. */
+const FENCE_LINE = /^ {0,3}(?:`{3,}|~{3,})/;
+
+/** A blockquote line: `>` after up to 3 leading spaces. */
+const BLOCKQUOTE_LINE = /^ {0,3}>/;
+
+/**
+ * An inline code span: a run of backticks, then the shortest stretch that does
+ * not contain that same run, then the matching run. Mirrors CommonMark closely
+ * enough for PR prose; an unpaired backtick simply never matches.
+ */
+const CODE_SPAN = /(`+)(?:(?!\1)[\s\S])*\1/g;
+
+/** Words that negate a following closing keyword ("does not close #N"). */
+const NEGATION = /\b(?:not|never|neither|nor|cannot|without|unless)\b|\w+n['’]t\b/i;
+
+/**
+ * How many words before the keyword are searched for a negation. Deliberately
+ * short: English negation scope is not something a regex can truly resolve, so
+ * we only claim the immediate, unambiguous cases ("does not close #N").
+ */
+const NEGATION_WINDOW_WORDS = 5;
+
+/**
+ * Blank out a stretch of text while preserving its length and line structure,
+ * so masking never joins words across a removed region or shifts offsets.
+ *
+ * @param {string} chunk - Text to blank.
+ * @returns {string} The same length, with everything but newlines replaced by spaces.
+ */
+function blank(chunk) {
+  return chunk.replace(/[^\n]/g, " ");
+}
+
+/**
+ * Mask the regions where a closing keyword is being *shown* rather than *used*:
+ * fenced code blocks, blockquotes, and inline code spans.
+ *
+ * @param {string} text - Raw PR title/body.
+ * @returns {string} Same-length text with those regions blanked out.
+ */
+function maskNonProse(text) {
+  let inFence = false;
+  const lines = text.split("\n").map((line) => {
+    if (FENCE_LINE.test(line)) {
+      inFence = !inFence;
+      return blank(line);
+    }
+    if (inFence || BLOCKQUOTE_LINE.test(line)) {
+      return blank(line);
+    }
+    return line;
+  });
+
+  // Code spans are resolved after fences so a fenced block's backticks cannot
+  // pair up with prose backticks elsewhere in the body.
+  return lines.join("\n").replace(CODE_SPAN, blank);
+}
+
+/**
+ * Is the keyword at `index` directly negated by the words just before it?
+ *
+ * The lookback stops at the nearest sentence or line boundary, so a negation in
+ * a previous sentence cannot suppress a later, genuine `Closes #N`.
+ *
+ * @param {string} text - Masked text being scanned.
+ * @param {number} index - Start offset of the keyword match.
+ * @returns {boolean} True when a negation sits within the preceding few words.
+ */
+function isNegated(text, index) {
+  const sentence = text.slice(0, index).split(/[.!?;:\n]/).pop() ?? "";
+  const words = sentence.trim().split(/\s+/).filter(Boolean);
+  return NEGATION.test(words.slice(-NEGATION_WINDOW_WORDS).join(" "));
+}
+
 /**
  * Extract the issue numbers a piece of text marks for closing.
+ *
+ * A keyword only counts when it is genuinely instructing a close. References
+ * inside inline code spans, fenced code blocks, or blockquotes are ignored, as
+ * is a keyword directly negated by the words in front of it. Backticks are the
+ * reliable escape hatch when a PR body needs to *discuss* a reference —
+ * negation handling is a best-effort convenience, not a guarantee.
  *
  * @param {string | null | undefined} text - PR title or body to scan.
  * @returns {number[]} Sorted, de-duplicated issue numbers (empty if none/invalid input).
@@ -28,8 +109,12 @@ export function parseIssueRefs(text) {
     return [];
   }
 
+  const prose = maskNonProse(text);
   const numbers = new Set();
-  for (const match of text.matchAll(CLOSING_KEYWORD)) {
+  for (const match of prose.matchAll(CLOSING_KEYWORD)) {
+    if (isNegated(prose, match.index)) {
+      continue;
+    }
     numbers.add(Number.parseInt(match[1], 10));
   }
 

--- a/scripts/internal/parse-issue-refs.test.mjs
+++ b/scripts/internal/parse-issue-refs.test.mjs
@@ -56,4 +56,89 @@ describe("parseIssueRefs", () => {
     const body = ["Implements the feature.", "", "Closes #80", "Fixes #81"].join("\n");
     expect(parseIssueRefs(body)).toEqual([80, 81]);
   });
+
+  describe("inline code spans", () => {
+    it("ignores a keyword inside a single-backtick span", () => {
+      expect(parseIssueRefs("The template line is `Closes #901` in the body.")).toEqual([]);
+    });
+
+    it("ignores a keyword inside a multi-backtick span", () => {
+      expect(parseIssueRefs("Write ``Closes #902`` verbatim.")).toEqual([]);
+    });
+
+    it("still parses a keyword outside the span on the same line", () => {
+      expect(parseIssueRefs("Unlike `Closes #903`, this one really does. Closes #904")).toEqual([
+        904,
+      ]);
+    });
+
+    it("does not treat an unpaired backtick as opening a span", () => {
+      expect(parseIssueRefs("A stray ` tick. Closes #905")).toEqual([905]);
+    });
+  });
+
+  describe("fenced code blocks", () => {
+    it("ignores keywords inside a backtick fence", () => {
+      const body = ["Example PR body:", "", "```markdown", "Closes #906", "```", ""].join("\n");
+      expect(parseIssueRefs(body)).toEqual([]);
+    });
+
+    it("ignores keywords inside a tilde fence", () => {
+      const body = ["Example:", "", "~~~", "Fixes #907", "~~~"].join("\n");
+      expect(parseIssueRefs(body)).toEqual([]);
+    });
+
+    it("resumes parsing after the fence closes", () => {
+      const body = ["```", "Closes #908", "```", "", "Closes #909"].join("\n");
+      expect(parseIssueRefs(body)).toEqual([909]);
+    });
+  });
+
+  describe("blockquotes", () => {
+    it("ignores keywords on quoted lines", () => {
+      const body = ["Quoting the other PR:", "", "> Closes #910", "", "This PR does not."].join("\n");
+      expect(parseIssueRefs(body)).toEqual([]);
+    });
+
+    it("ignores keywords in a nested blockquote", () => {
+      expect(parseIssueRefs(">> Resolves #911")).toEqual([]);
+    });
+  });
+
+  describe("negated keywords", () => {
+    it("ignores a directly negated keyword", () => {
+      expect(parseIssueRefs("This PR does not close #912.")).toEqual([]);
+      expect(parseIssueRefs("It doesn't fix #913.")).toEqual([]);
+      expect(parseIssueRefs("This will never resolve #914.")).toEqual([]);
+    });
+
+    it("does not let a negation leak across a sentence boundary", () => {
+      expect(parseIssueRefs("This is not a refactor. Closes #915")).toEqual([915]);
+    });
+
+    it("does not let a negation leak across a line break", () => {
+      expect(parseIssueRefs("The parser is not clever\nCloses #916")).toEqual([916]);
+    });
+  });
+
+  describe("the bodies that caused the real incidents", () => {
+    // PR #1564: the body explained that the PR deliberately left work behind, and
+    // the bot closed the issue anyway.
+    it("does not close an issue the body says it leaves open", () => {
+      const body = [
+        "Implements the first half of the migration.",
+        "",
+        "This PR does not close #917 — the remainder is blocked on another issue.",
+        "",
+        "Closes #918",
+      ].join("\n");
+      expect(parseIssueRefs(body)).toEqual([918]);
+    });
+
+    // The other incident: a body asking a human to close an issue by hand.
+    // Backticks are the documented escape hatch for this shape.
+    it("respects backticks as the escape hatch for meta-discussion", () => {
+      expect(parseIssueRefs("Please `close #919` manually once the release ships.")).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`scripts/internal/parse-issue-refs.mjs` matched a closing keyword **anywhere** in the PR
title/body, with no notion of context. Prose that merely *mentioned* a reference closed the
issue on merge. This is not hypothetical — it has now bitten two separate PRs, and both had to
be reopened by hand. The failure is silent and lands **after** the merge, when nobody is
watching.

## What changed

Before scanning, the parser masks the regions where a keyword is being *shown* rather than
*used*, then skips keywords that are directly negated.

Handled (all illustrations below use issue numbers that do not exist):

| Shape | Before | Now |
| --- | --- | --- |
| `Closes #99991` (plain prose) | closes | closes — unchanged |
| Inline code span: `` `Closes #99992` `` | closes | ignored |
| Fenced code block containing a keyword | closes | ignored |
| Blockquote: `> Closes #99993` | closes | ignored |
| `this PR does not close #99994` | closes | ignored |

Masking preserves length and line structure, so blanked regions never join words across the
gap and an earlier negation cannot leak past a sentence or line boundary.

## Honest scope

**The negation handling is deliberately narrow, and the docs say so.** A regex cannot parse
English negation, so it only looks a few words back and stops at the nearest sentence or line
break — it claims the unambiguous shapes ("does not close #N", "doesn't fix #N") and nothing
subtler. The robust, guaranteed escape hatch is **backticks**, and `docs/contributing.md` now
points readers at that rather than at the negation heuristic.

The context masking (code spans, fences, blockquotes) is the load-bearing part; the negation
check is a convenience that fails in the safe direction — an issue lingering open is noticed by
a human, an issue wrongly closed is not.

Also documented: the workflow fires on `pull_request: closed` and so runs a short while after
the merge. An issue still open seconds later is normal, not a failed workflow — this had been
misread as a broken workflow.

## Tests

TDD: `test(config)` commit lands the 11 new cases red, `fix(config)` turns them green.
`scripts/internal/parse-issue-refs.test.mjs` now covers a plain keyword (control — must still
close), inline code spans (single and multi-backtick, plus an unpaired stray tick), backtick and
tilde fences, resumption after a fence, blockquotes (incl. nested), negations, negations
correctly *not* leaking across sentence/line boundaries, and the two real-world body shapes that
caused the incidents.

22/22 pass; `format:check`, `lint` and `markdownlint` are clean.

Verified beyond the unit tests: ran the CLI entry point the workflow actually invokes against a
body containing four decoy references plus one genuine one, and it emitted only the genuine one.

No change fragment — CI/internal tooling, not user-facing.

Closes #1566
