### PR TITLE
feat(config): persist the Session Picker's remembered target (Closes #1561)

### DIFF
--- a/docs/changes/dev4/feature/1561-remember-picked-target.md
+++ b/docs/changes/dev4/feature/1561-remember-picked-target.md
@@ -1,0 +1,29 @@
+### Added
+
+- **"Remember this choice" now persists.** The Session Picker's footer checkbox
+  previously rendered and reached the confirm payload but saved nothing. Ticking
+  it now writes the picked target onto the context-menu entry that triggered the
+  spawn, for **every** section the picker offers — a local shell, a WSL
+  distribution, or a Docker/Podman "new container" with its image and mount. The
+  next right-click on that entry opens the remembered target directly instead of
+  asking again. A spawn started from a bare `termiHub spawn --pick` has no entry
+  to remember onto, so the box is simply a no-op there (#1561).
+
+### Fixed
+
+- **A context-menu entry can now actually spawn a container.** Registration used
+  to emit only `spawn --entry-id <id> --location <path>`, so a click arrived with
+  no spawn kind and was inferred to be a local shell. The saved per-entry
+  container image (#1447) was therefore only ever consulted when the CLI passed
+  `--kind container` explicitly — an entry configured with an image silently
+  opened a shell instead. The registered command line now carries the entry's
+  remembered kind, and the spawn resolvers fall back to the entry's saved shell
+  and container runtime when the request names none (#1561).
+
+### Changed
+
+- `ShellEntry` gained `spawnKind`, `shell` and `containerRuntime`. All three
+  default, so existing `settings.json` files load and round-trip unchanged and
+  read as "no remembered choice" — which preserves every previous spawn
+  behaviour. A WSL distribution is stored in the existing `wsl:<distro>` shell
+  encoding rather than as a second representation (#1561).

--- a/src-tauri/src/commands/shell_integration.rs
+++ b/src-tauri/src/commands/shell_integration.rs
@@ -204,4 +204,49 @@ mod tests {
         new_si.registered = false;
         assert!(!stage_shell_integration(&mut on, new_si));
     }
+
+    // ── Remember this choice (#1561) ─────────────────────────────────────────
+
+    #[test]
+    fn stage_remembered_choice_writes_the_picked_target_onto_the_entry() {
+        let mut settings = AppSettings::default();
+        settings.shell_integration.entries = vec![entry("a"), entry("b")];
+
+        assert!(stage_remembered_choice(
+            &mut settings,
+            "b",
+            PickedTarget::Container {
+                runtime: ContainerRuntime::Podman,
+                image: "alpine:3".to_string(),
+                mount: "/workspace".to_string(),
+            },
+        ));
+
+        let b = &settings.shell_integration.entries[1];
+        assert_eq!(b.spawn_kind, SpawnKind::Container);
+        assert_eq!(b.container_runtime, ContainerRuntime::Podman);
+        assert_eq!(b.container_image.as_deref(), Some("alpine:3"));
+        assert_eq!(b.container_mount.as_deref(), Some("/workspace"));
+
+        // The choice must land on the addressed entry only.
+        assert_eq!(settings.shell_integration.entries[0], entry("a"));
+    }
+
+    /// The entry can be deleted between the context-menu click and the picker's
+    /// confirm. That must be a quiet no-op, not an error or an invented entry.
+    #[test]
+    fn stage_remembered_choice_ignores_an_unknown_entry() {
+        let mut settings = AppSettings::default();
+        settings.shell_integration.entries = vec![entry("a")];
+
+        assert!(!stage_remembered_choice(
+            &mut settings,
+            "gone",
+            PickedTarget::Local {
+                shell: "zsh".to_string()
+            },
+        ));
+
+        assert_eq!(settings.shell_integration.entries, vec![entry("a")]);
+    }
 }

--- a/src-tauri/src/commands/shell_integration.rs
+++ b/src-tauri/src/commands/shell_integration.rs
@@ -6,7 +6,7 @@ use tauri::State;
 use crate::connection::manager::ConnectionManager;
 use crate::connection::settings::AppSettings;
 use crate::connection::shell_integration::{
-    self, ShellIntegrationSettings, ShellIntegrationStatus,
+    self, PickedTarget, ShellIntegrationSettings, ShellIntegrationStatus,
 };
 use crate::spawn::registry;
 use crate::utils::portable::detect_app_mode;
@@ -111,10 +111,60 @@ pub fn save_shell_integration_settings(
     Ok(current_status(&manager))
 }
 
+/// Save a picked target onto the entry addressed by `entry_id`, returning whether
+/// an entry actually changed. An unknown id is a no-op — the entry may have been
+/// deleted between the context-menu click and the picker's confirm.
+fn stage_remembered_choice(
+    settings: &mut AppSettings,
+    entry_id: &str,
+    target: PickedTarget,
+) -> bool {
+    match settings
+        .shell_integration
+        .entries
+        .iter_mut()
+        .find(|e| e.id == entry_id)
+    {
+        Some(entry) => {
+            entry.remember(target);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Persist the Session Picker's "Remember this choice" (#1561): save the picked
+/// target onto the triggering entry so a later context-menu click opens it
+/// directly instead of prompting again.
+///
+/// Re-registers when the integration is currently registered, because the entry's
+/// remembered kind is part of the command line the OS surface invokes
+/// (`--kind <token>`) — without that the OS would keep calling the pre-choice
+/// command. Returns the recomputed status, mirroring
+/// [`save_shell_integration_settings`].
+#[tauri::command]
+pub fn remember_spawn_choice(
+    manager: State<'_, ConnectionManager>,
+    entry_id: String,
+    target: PickedTarget,
+) -> Result<ShellIntegrationStatus, String> {
+    let mut settings = manager.get_settings();
+    if !stage_remembered_choice(&mut settings, &entry_id, target) {
+        return Ok(current_status(&manager));
+    }
+    if settings.shell_integration.registered {
+        registry::register(&mut settings.shell_integration).map_err(|e| format!("{e:#}"))?;
+    }
+    manager.save_settings(settings).map_err(|e| e.to_string())?;
+    Ok(current_status(&manager))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::connection::shell_integration::{ShellEntry, ShellEntryVisibility, ShowForTargets};
+    use crate::spawn::SpawnKind;
+    use termihub_core::config::ContainerRuntime;
 
     fn entry(id: &str) -> ShellEntry {
         ShellEntry {
@@ -125,6 +175,9 @@ mod tests {
             show_for: ShowForTargets::default(),
             container_image: None,
             container_mount: None,
+            spawn_kind: SpawnKind::Auto,
+            shell: None,
+            container_runtime: ContainerRuntime::Auto,
         }
     }
 

--- a/src-tauri/src/commands/spawn.rs
+++ b/src-tauri/src/commands/spawn.rs
@@ -13,7 +13,7 @@ use tauri::State;
 
 use crate::connection::config::SavedConnection;
 use crate::connection::manager::ConnectionManager;
-use crate::connection::shell_integration::ShellIntegrationSettings;
+use crate::connection::shell_integration::{ShellEntry, ShellIntegrationSettings};
 use crate::spawn::container::{self, ContainerSpawn};
 use crate::spawn::handler::{self, PendingSpawn, ShellSpawn};
 use crate::spawn::{SpawnKind, SpawnRequest};
@@ -30,8 +30,7 @@ fn saved_container_prefs(
     settings: &ShellIntegrationSettings,
     entry_id: Option<&str>,
 ) -> SavedContainerPrefs {
-    entry_id
-        .and_then(|id| settings.entries.iter().find(|e| e.id == id))
+    saved_entry(settings, entry_id)
         .map(|e| (e.container_image.clone(), e.container_mount.clone()))
         .unwrap_or((None, None))
 }
@@ -72,6 +71,16 @@ pub fn resolve_container_spawn(
     )
 }
 
+/// Look up the entry addressed by `entry_id`, if any. An absent or unknown id
+/// yields `None`, so the spawn falls through to the request values and then the
+/// built-in defaults.
+fn saved_entry<'a>(
+    settings: &'a ShellIntegrationSettings,
+    entry_id: Option<&str>,
+) -> Option<&'a ShellEntry> {
+    entry_id.and_then(|id| settings.entries.iter().find(|e| e.id == id))
+}
+
 /// Map the frontend's runtime token onto a [`ContainerRuntime`]. Anything else —
 /// including no token at all — means "detect it", which is what every pre-picker
 /// spawn did.
@@ -97,6 +106,14 @@ fn resolve_container_spawn_with(
         return Err("a spawn location is required for a container spawn".to_string());
     }
     let (saved_image, saved_mount) = saved_container_prefs(settings, entry_id.as_deref());
+    // An explicitly requested runtime wins; otherwise fall back to the one the
+    // entry remembered (#1561), and only then to detection.
+    let runtime = match runtime {
+        ContainerRuntime::Auto => saved_entry(settings, entry_id.as_deref())
+            .map(|e| e.container_runtime.clone())
+            .unwrap_or_default(),
+        explicit => explicit,
+    };
     let request = SpawnRequest {
         location,
         entry_id,
@@ -139,10 +156,20 @@ pub fn resolve_shell_spawn(
     kind: Option<String>,
     shell: Option<String>,
 ) -> Result<ShellSpawn, String> {
+    let settings = manager.get_settings();
+    let entry = saved_entry(&settings.shell_integration, entry_id.as_deref());
+    // An explicitly requested kind/shell wins; otherwise fall back to whatever the
+    // entry remembered (#1561), and only then to the pre-picker defaults. A
+    // context-menu click carries no shell and (for an un-remembered entry) an
+    // `auto` kind, so this is what makes a remembered choice take effect.
     let kind = kind
         .as_deref()
         .and_then(SpawnKind::from_wire)
+        .filter(|k| !matches!(k, SpawnKind::Auto))
+        .or_else(|| entry.map(|e| e.spawn_kind))
         .unwrap_or_default();
+    let shell = shell
+        .or_else(|| entry.and_then(ShellEntry::resolved_shell).map(str::to_string));
     let request = SpawnRequest {
         location,
         connection,
@@ -500,6 +527,9 @@ mod tests {
                 show_for: ShowForTargets::default(),
                 container_image: image.map(str::to_string),
                 container_mount: mount.map(str::to_string),
+                spawn_kind: SpawnKind::Auto,
+                shell: None,
+                container_runtime: ContainerRuntime::Auto,
             }],
             ..Default::default()
         }

--- a/src-tauri/src/commands/spawn.rs
+++ b/src-tauri/src/commands/spawn.rs
@@ -399,7 +399,9 @@ fn wsl_distros() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::connection::shell_integration::{ShellEntry, ShellEntryVisibility, ShowForTargets};
+    use crate::connection::shell_integration::{
+        PickedTarget, ShellEntry, ShellEntryVisibility, ShowForTargets,
+    };
 
     // `list_spawn_options` reports whatever the host actually has, so the
     // assertions below cover the invariants that must hold on every machine and
@@ -511,6 +513,151 @@ mod tests {
         ] {
             assert!(json.get(key).is_some(), "missing key {key}");
         }
+    }
+
+    /// Settings holding a single entry with a remembered target (#1561) — what
+    /// the picker's "Remember this choice" writes.
+    fn settings_with_remembered(id: &str, target: PickedTarget) -> ShellIntegrationSettings {
+        let mut settings = settings_with_entry(id, None, None);
+        settings.entries[0].remember(target);
+        settings
+    }
+
+    #[test]
+    fn a_remembered_runtime_is_used_when_the_request_names_none() {
+        // A context-menu click carries no runtime, so without the entry fallback
+        // a remembered Podman pick would silently auto-detect — and run Docker.
+        let settings = settings_with_remembered(
+            "open",
+            PickedTarget::Container {
+                runtime: ContainerRuntime::Podman,
+                image: "alpine:3".to_string(),
+                mount: "/workspace".to_string(),
+            },
+        );
+        let spawn = resolve_container_spawn_with(
+            &settings,
+            Some("/proj".into()),
+            Some("open".into()),
+            None,
+            None,
+            ContainerRuntime::Auto,
+        )
+        .expect("resolves");
+
+        assert_eq!(spawn.settings["runtime"], "podman");
+        assert_eq!(spawn.settings["image"], "alpine:3");
+    }
+
+    #[test]
+    fn an_explicit_runtime_outranks_the_remembered_one() {
+        let settings = settings_with_remembered(
+            "open",
+            PickedTarget::Container {
+                runtime: ContainerRuntime::Podman,
+                image: "alpine:3".to_string(),
+                mount: "/workspace".to_string(),
+            },
+        );
+        let spawn = resolve_container_spawn_with(
+            &settings,
+            Some("/proj".into()),
+            Some("open".into()),
+            None,
+            None,
+            ContainerRuntime::Docker,
+        )
+        .expect("resolves");
+
+        assert_eq!(spawn.settings["runtime"], "docker");
+    }
+
+    /// An unknown entry id must not resurrect a stale preference.
+    #[test]
+    fn an_unknown_entry_id_keeps_runtime_auto_detection() {
+        let settings = settings_with_remembered(
+            "open",
+            PickedTarget::Container {
+                runtime: ContainerRuntime::Podman,
+                image: "alpine:3".to_string(),
+                mount: "/workspace".to_string(),
+            },
+        );
+        let spawn = resolve_container_spawn_with(
+            &settings,
+            Some("/proj".into()),
+            Some("deleted".into()),
+            None,
+            None,
+            ContainerRuntime::Auto,
+        )
+        .expect("resolves");
+
+        assert_eq!(spawn.settings["runtime"], "auto");
+    }
+
+    /// The #1561 read-side, end to end at the pure layer: a context-menu click on
+    /// a remembered local entry (`--kind local`, no `--shell`) must open the
+    /// remembered shell rather than the system default.
+    #[test]
+    fn a_remembered_local_shell_is_opened_for_a_context_menu_click() {
+        let settings = settings_with_remembered(
+            "open",
+            PickedTarget::Local {
+                shell: "fish".to_string(),
+            },
+        );
+        let entry = saved_entry(&settings, Some("open")).expect("entry exists");
+
+        assert_eq!(entry.spawn_kind, SpawnKind::Local);
+
+        let req = SpawnRequest {
+            location: Some("/proj".into()),
+            entry_id: Some("open".into()),
+            kind: entry.spawn_kind,
+            ..SpawnRequest::default()
+        };
+        let spawn = resolve_shell_spawn_with(
+            &req,
+            Path::new("/home/u"),
+            &[],
+            None,
+            entry.resolved_shell(),
+        )
+        .expect("resolves");
+
+        assert_eq!(spawn.settings["shell"], "fish");
+    }
+
+    /// A remembered WSL distro must reach the resolver as a bare distro name — the
+    /// `wsl:` storage prefix must not leak into the session settings. Without a
+    /// remembered distro this host has none, so the resolve would error.
+    #[test]
+    fn a_remembered_wsl_distro_is_opened_for_a_context_menu_click() {
+        let settings = settings_with_remembered(
+            "open",
+            PickedTarget::Wsl {
+                distro: "Ubuntu-22.04".to_string(),
+            },
+        );
+        let entry = saved_entry(&settings, Some("open")).expect("entry exists");
+        let req = SpawnRequest {
+            location: Some("/proj".into()),
+            entry_id: Some("open".into()),
+            kind: entry.spawn_kind,
+            ..SpawnRequest::default()
+        };
+        let spawn = resolve_shell_spawn_with(
+            &req,
+            Path::new("/home/u"),
+            &[],
+            // No default distro available: only the remembered pick can resolve.
+            None,
+            entry.resolved_shell(),
+        )
+        .expect("resolves from the remembered distro");
+
+        assert_eq!(spawn.settings["distribution"], "Ubuntu-22.04");
     }
 
     fn settings_with_entry(

--- a/src-tauri/src/commands/spawn.rs
+++ b/src-tauri/src/commands/spawn.rs
@@ -168,8 +168,11 @@ pub fn resolve_shell_spawn(
         .filter(|k| !matches!(k, SpawnKind::Auto))
         .or_else(|| entry.map(|e| e.spawn_kind))
         .unwrap_or_default();
-    let shell = shell
-        .or_else(|| entry.and_then(ShellEntry::resolved_shell).map(str::to_string));
+    let shell = shell.or_else(|| {
+        entry
+            .and_then(ShellEntry::resolved_shell)
+            .map(str::to_string)
+    });
     let request = SpawnRequest {
         location,
         connection,

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -931,6 +931,8 @@ mod tests {
             ShellEntry, ShellEntryVisibility, ShellIntegrationFallback, ShellIntegrationSettings,
             ShowForTargets,
         };
+        use crate::spawn::SpawnKind;
+        use termihub_core::config::ContainerRuntime;
         let settings = AppSettings {
             shell_integration: ShellIntegrationSettings {
                 entries: vec![ShellEntry {
@@ -941,6 +943,9 @@ mod tests {
                     show_for: ShowForTargets::default(),
                     container_image: Some("alpine:3".to_string()),
                     container_mount: Some("/src".to_string()),
+                    spawn_kind: SpawnKind::Auto,
+                    shell: None,
+                    container_runtime: ContainerRuntime::Auto,
                 }],
                 fallback: ShellIntegrationFallback::SystemDefaultShell,
                 open_in_new_window: true,

--- a/src-tauri/src/connection/shell_integration.rs
+++ b/src-tauri/src/connection/shell_integration.rs
@@ -184,7 +184,11 @@ impl ShellEntry {
     /// encoding, not the wire value `resolve_shell_spawn` takes), the shell name
     /// verbatim otherwise. `None` when nothing is saved.
     pub fn resolved_shell(&self) -> Option<&str> {
-        let shell = self.shell.as_deref().map(str::trim).filter(|s| !s.is_empty())?;
+        let shell = self
+            .shell
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())?;
         match self.spawn_kind {
             SpawnKind::Wsl => Some(shell.strip_prefix("wsl:").unwrap_or(shell)),
             _ => Some(shell),
@@ -897,7 +901,8 @@ mod tests {
     /// shape so a frontend rename cannot drift silently.
     #[test]
     fn picked_target_deserializes_the_frontend_union() {
-        let local: PickedTarget = serde_json::from_str(r#"{"kind":"local","shell":"fish"}"#).unwrap();
+        let local: PickedTarget =
+            serde_json::from_str(r#"{"kind":"local","shell":"fish"}"#).unwrap();
         assert_eq!(
             local,
             PickedTarget::Local {

--- a/src-tauri/src/connection/shell_integration.rs
+++ b/src-tauri/src/connection/shell_integration.rs
@@ -772,4 +772,150 @@ mod tests {
         assert!(json.contains("firstLaunchBannerDismissed"));
         assert!(json.contains("linuxFileManagers"));
     }
+
+    // ── Remembered picked target (#1561) ─────────────────────────────────────
+
+    /// A `settings.json` written before #1561 knows nothing of the three new
+    /// fields. It must still load, and must load as "no remembered choice" — the
+    /// state that preserves every pre-#1561 behaviour.
+    #[test]
+    fn pre_1561_entry_deserializes_without_a_remembered_target() {
+        let json = r#"{
+            "id": "open",
+            "name": "Open in termiHub",
+            "containerImage": "alpine:3",
+            "containerMount": "/src"
+        }"#;
+        let entry: ShellEntry = serde_json::from_str(json).unwrap();
+
+        assert_eq!(entry.spawn_kind, SpawnKind::Auto);
+        assert_eq!(entry.shell, None);
+        assert_eq!(entry.container_runtime, ContainerRuntime::Auto);
+        // The pre-existing #1447 preferences must survive untouched.
+        assert_eq!(entry.container_image.as_deref(), Some("alpine:3"));
+        assert_eq!(entry.container_mount.as_deref(), Some("/src"));
+    }
+
+    /// An un-remembered entry must serialize to exactly the pre-#1561 JSON — no
+    /// new keys — so upgrading and downgrading round-trips a config unchanged.
+    #[test]
+    fn entry_without_a_remembered_target_serializes_no_new_keys() {
+        let entry = entry("open", None, ShellEntryVisibility::Always);
+        let json = serde_json::to_value(&entry).unwrap();
+
+        assert_eq!(json.get("shell"), None);
+        // `spawn_kind`/`container_runtime` are non-Option, so they always emit;
+        // pin their neutral values rather than their absence.
+        assert_eq!(json["spawnKind"], serde_json::json!("auto"));
+        assert_eq!(json["containerRuntime"], serde_json::json!("auto"));
+    }
+
+    #[test]
+    fn remember_local_shell_pins_kind_and_shell() {
+        let mut e = entry("open", None, ShellEntryVisibility::Always);
+        e.remember(PickedTarget::Local {
+            shell: "zsh".to_string(),
+        });
+
+        assert_eq!(e.spawn_kind, SpawnKind::Local);
+        assert_eq!(e.shell.as_deref(), Some("zsh"));
+        assert_eq!(e.resolved_shell(), Some("zsh"));
+    }
+
+    /// A WSL distro is stored in `shell_to_command`'s `wsl:<distro>` encoding —
+    /// one field for both shell sections — but the resolver wants the bare distro.
+    #[test]
+    fn remember_wsl_distro_encodes_the_wsl_prefix_and_strips_it_on_read() {
+        let mut e = entry("open", None, ShellEntryVisibility::Always);
+        e.remember(PickedTarget::Wsl {
+            distro: "Ubuntu-22.04".to_string(),
+        });
+
+        assert_eq!(e.spawn_kind, SpawnKind::Wsl);
+        assert_eq!(e.shell.as_deref(), Some("wsl:Ubuntu-22.04"));
+        assert_eq!(e.resolved_shell(), Some("Ubuntu-22.04"));
+    }
+
+    /// A local shell whose name happens to start with `wsl:` is not a thing, but a
+    /// local entry must never have a prefix stripped regardless — the encoding is
+    /// only interpreted for the WSL kind.
+    #[test]
+    fn resolved_shell_only_strips_the_prefix_for_a_wsl_entry() {
+        let mut e = entry("open", None, ShellEntryVisibility::Always);
+        e.spawn_kind = SpawnKind::Local;
+        e.shell = Some("wsl:weird".to_string());
+
+        assert_eq!(e.resolved_shell(), Some("wsl:weird"));
+    }
+
+    #[test]
+    fn remember_container_pins_runtime_image_and_mount() {
+        let mut e = entry("open", None, ShellEntryVisibility::Always);
+        e.remember(PickedTarget::Container {
+            runtime: ContainerRuntime::Podman,
+            image: "alpine:3".to_string(),
+            mount: "/workspace".to_string(),
+        });
+
+        assert_eq!(e.spawn_kind, SpawnKind::Container);
+        assert_eq!(e.container_runtime, ContainerRuntime::Podman);
+        assert_eq!(e.container_image.as_deref(), Some("alpine:3"));
+        assert_eq!(e.container_mount.as_deref(), Some("/workspace"));
+    }
+
+    /// Remembering one section must not silently discard another section's saved
+    /// preference — `spawn_kind` already makes it inert.
+    #[test]
+    fn remember_local_keeps_a_previously_saved_container_image() {
+        let mut e = entry("open", None, ShellEntryVisibility::Always);
+        e.container_image = Some("alpine:3".to_string());
+        e.remember(PickedTarget::Local {
+            shell: "bash".to_string(),
+        });
+
+        assert_eq!(e.container_image.as_deref(), Some("alpine:3"));
+        assert_eq!(e.spawn_kind, SpawnKind::Local);
+    }
+
+    /// A remembered target must survive a real save/load cycle, not just live in
+    /// memory — this is the whole point of "Remember this choice".
+    #[test]
+    fn a_remembered_target_round_trips_through_json() {
+        let mut e = entry("open", None, ShellEntryVisibility::Always);
+        e.remember(PickedTarget::Wsl {
+            distro: "Ubuntu-22.04".to_string(),
+        });
+
+        let json = serde_json::to_string(&e).unwrap();
+        let back: ShellEntry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(back, e);
+        assert_eq!(back.resolved_shell(), Some("Ubuntu-22.04"));
+    }
+
+    /// The picker's `SpawnTarget` union crosses the bridge as-is; pin the wire
+    /// shape so a frontend rename cannot drift silently.
+    #[test]
+    fn picked_target_deserializes_the_frontend_union() {
+        let local: PickedTarget = serde_json::from_str(r#"{"kind":"local","shell":"fish"}"#).unwrap();
+        assert_eq!(
+            local,
+            PickedTarget::Local {
+                shell: "fish".to_string()
+            }
+        );
+
+        let container: PickedTarget = serde_json::from_str(
+            r#"{"kind":"container","runtime":"podman","image":"alpine:3","mount":"/workspace"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            container,
+            PickedTarget::Container {
+                runtime: ContainerRuntime::Podman,
+                image: "alpine:3".to_string(),
+                mount: "/workspace".to_string(),
+            }
+        );
+    }
 }

--- a/src-tauri/src/connection/shell_integration.rs
+++ b/src-tauri/src/connection/shell_integration.rs
@@ -10,7 +10,10 @@
 //! files / Quick Actions) and file-manager detection land in later epic issues.
 
 use serde::{Deserialize, Serialize};
+use termihub_core::config::ContainerRuntime;
 use termihub_core::files::utils::normalize_platform_path;
+
+use crate::spawn::SpawnKind;
 
 /// Windows context-menu visibility for a shell-integration entry.
 ///
@@ -78,6 +81,115 @@ pub struct ShellEntry {
     /// honored for a container spawn when no explicit `--container-mount` is given.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container_mount: Option<String>,
+    /// The kind of session this entry opens — the Session Picker's "Remember this
+    /// choice" writes the picked section here (SI-3, #1366 / #1561).
+    ///
+    /// [`SpawnKind::Auto`] (the default, and what every pre-#1561 `settings.json`
+    /// deserializes to) means "no remembered choice": the entry keeps the legacy
+    /// presence-based inference and registers a plain `spawn --entry-id …` command.
+    /// Anything else is authoritative — it is emitted as `--kind <token>` at
+    /// registration time and pins resolution for a context-menu click.
+    #[serde(default)]
+    pub spawn_kind: SpawnKind,
+    /// Saved per-entry shell preference in [`shell_to_command`]'s single-string
+    /// encoding: a local shell name (`"zsh"`, `"powershell"`, an absolute path) or
+    /// a WSL distribution as `"wsl:<distro>"` (e.g. `"wsl:Ubuntu-22.04"`).
+    ///
+    /// Honored for a [`SpawnKind::Local`] / [`SpawnKind::Wsl`] spawn when no
+    /// explicit shell is passed. `None` → no saved preference, so the spawn falls
+    /// back to the system default shell / default distribution.
+    ///
+    /// [`shell_to_command`]: termihub_core::session::shell::shell_to_command
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell: Option<String>,
+    /// Saved per-entry container-runtime preference — the Docker/Podman section the
+    /// user picked. Same priority + forward-compat semantics as
+    /// [`container_image`](Self::container_image): honored for a container spawn
+    /// when no explicit runtime is given. [`ContainerRuntime::Auto`] (the default)
+    /// keeps the pre-picker behaviour of detecting whichever runtime is installed.
+    #[serde(default)]
+    pub container_runtime: ContainerRuntime,
+}
+
+/// A target picked in the interactive Session Picker, as the frontend's
+/// `SpawnTarget` discriminated union sends it (SI-3, #1366).
+///
+/// Mirrors `src/types/spawn.ts` field-for-field so a confirmed choice crosses the
+/// bridge without a translation table. Only used as the input to
+/// [`ShellEntry::remember`]; the persisted shape is [`ShellEntry`]'s own fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PickedTarget {
+    /// A local shell, by detected shell name (e.g. `"bash"`).
+    Local {
+        /// Shell name in [`shell_to_command`](termihub_core::session::shell::shell_to_command) encoding.
+        shell: String,
+    },
+    /// A WSL distribution, by name (e.g. `"Ubuntu-22.04"`).
+    Wsl {
+        /// Distribution name, *without* the `wsl:` prefix.
+        distro: String,
+    },
+    /// A new container bind-mounting the spawn location at `mount`.
+    Container {
+        /// Docker or Podman — the picker's choice of section.
+        runtime: ContainerRuntime,
+        /// Image reference (`repository:tag`).
+        image: String,
+        /// In-container mount target for the spawn location.
+        mount: String,
+    },
+}
+
+impl ShellEntry {
+    /// Save a picked target onto this entry — the write side of the Session
+    /// Picker's "Remember this choice" (#1561).
+    ///
+    /// Pins [`spawn_kind`](Self::spawn_kind) to the picked section so a later
+    /// context-menu click resolves to it authoritatively instead of re-inferring,
+    /// and records the section's own target: the shell (a WSL distro is stored in
+    /// `shell_to_command`'s `wsl:<distro>` encoding, so one field covers both shell
+    /// sections) or the container runtime + image + mount.
+    ///
+    /// Only the picked section's fields are written. A preference belonging to a
+    /// *different* section is left alone rather than cleared — `spawn_kind` already
+    /// makes it inert, and keeping it means remembering a local shell does not
+    /// silently discard the container image the user configured in Settings
+    /// (#1447).
+    pub fn remember(&mut self, target: PickedTarget) {
+        match target {
+            PickedTarget::Local { shell } => {
+                self.spawn_kind = SpawnKind::Local;
+                self.shell = Some(shell);
+            }
+            PickedTarget::Wsl { distro } => {
+                self.spawn_kind = SpawnKind::Wsl;
+                self.shell = Some(format!("wsl:{distro}"));
+            }
+            PickedTarget::Container {
+                runtime,
+                image,
+                mount,
+            } => {
+                self.spawn_kind = SpawnKind::Container;
+                self.container_runtime = runtime;
+                self.container_image = Some(image);
+                self.container_mount = Some(mount);
+            }
+        }
+    }
+
+    /// The entry's saved shell in the form the spawn resolver wants: a bare
+    /// distribution name for a WSL entry (the `wsl:` prefix is the storage
+    /// encoding, not the wire value `resolve_shell_spawn` takes), the shell name
+    /// verbatim otherwise. `None` when nothing is saved.
+    pub fn resolved_shell(&self) -> Option<&str> {
+        let shell = self.shell.as_deref().map(str::trim).filter(|s| !s.is_empty())?;
+        match self.spawn_kind {
+            SpawnKind::Wsl => Some(shell.strip_prefix("wsl:").unwrap_or(shell)),
+            _ => Some(shell),
+        }
+    }
 }
 
 /// Fallback behaviour when no entry resolves a spawn request.
@@ -315,6 +427,9 @@ mod tests {
             show_for: ShowForTargets::default(),
             container_image: None,
             container_mount: None,
+            spawn_kind: SpawnKind::Auto,
+            shell: None,
+            container_runtime: ContainerRuntime::Auto,
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -638,6 +638,7 @@ pub fn run() {
             commands::shell_integration::install_shell_integration,
             commands::shell_integration::uninstall_shell_integration,
             commands::shell_integration::save_shell_integration_settings,
+            commands::shell_integration::remember_spawn_choice,
             commands::spawn::list_spawn_options,
             commands::spawn::resolve_container_spawn,
             commands::spawn::resolve_shell_spawn,

--- a/src-tauri/src/spawn/mod.rs
+++ b/src-tauri/src/spawn/mod.rs
@@ -81,6 +81,19 @@ impl SpawnKind {
             _ => None,
         }
     }
+
+    /// The wire/CLI token for this kind — the inverse of [`from_wire`](Self::from_wire).
+    /// Used by shell-integration registration to emit a remembered entry's kind as
+    /// `--kind <token>` (#1561).
+    pub fn to_wire(self) -> &'static str {
+        match self {
+            Self::Container => "container",
+            Self::Local => "local",
+            Self::Wsl => "wsl",
+            Self::Ssh => "ssh",
+            Self::Auto => "auto",
+        }
+    }
 }
 
 /// A request to open a new session, originating from an external

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -394,6 +394,45 @@ mod shared_helper_tests {
         );
     }
 
+    /// A remembered entry (#1561) carries its kind into the invocation, so the
+    /// click arrives already classified instead of as `auto`. Without this a
+    /// remembered container entry falls through the presence-based inference and
+    /// opens a local shell — the bug #1561 fixes.
+    #[test]
+    fn spawn_command_line_emits_a_remembered_kind() {
+        assert_eq!(
+            spawn_command_line("/opt/termihub/termiHub", "open", SpawnKind::Container, "%f"),
+            r#""/opt/termihub/termiHub" spawn --entry-id open --kind container --location %f"#
+        );
+        assert_eq!(
+            spawn_command_line("/opt/termihub/termiHub", "open", SpawnKind::Wsl, "%f"),
+            r#""/opt/termihub/termiHub" spawn --entry-id open --kind wsl --location %f"#
+        );
+        assert_eq!(
+            spawn_command_line("/opt/termihub/termiHub", "open", SpawnKind::Local, "%f"),
+            r#""/opt/termihub/termiHub" spawn --entry-id open --kind local --location %f"#
+        );
+    }
+
+    /// The emitted `--kind` token must be one the CLI parser actually accepts —
+    /// otherwise registration writes a command line the app silently ignores.
+    #[test]
+    fn every_emitted_kind_round_trips_through_the_cli_parser() {
+        for kind in [
+            SpawnKind::Container,
+            SpawnKind::Local,
+            SpawnKind::Wsl,
+            SpawnKind::Ssh,
+            SpawnKind::Auto,
+        ] {
+            assert_eq!(
+                SpawnKind::from_wire(kind.to_wire()),
+                Some(kind),
+                "{kind:?} does not round-trip through the wire token"
+            );
+        }
+    }
+
     #[test]
     fn id_slug_windows_style_uses_underscore_without_trim_or_fallback() {
         // Windows `entry_key_name`: non-alnum → `_`, lowercased, no trimming,

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -34,6 +34,7 @@
 use crate::connection::shell_integration::{
     DetectedFileManager, ShellEntry, ShellIntegrationSettings,
 };
+use crate::spawn::SpawnKind;
 use anyhow::Context;
 use std::path::Path;
 
@@ -291,15 +292,27 @@ fn uninstall() -> anyhow::Result<()> {
 // pins their exact output on every platform.
 
 /// The termiHub spawn command line a surface invokes:
-/// `"{exe_path}" spawn --entry-id {entry_id} --location {location}`.
+/// `"{exe_path}" spawn --entry-id {entry_id} --location {location}`, with
+/// ` --kind {kind}` appended when the entry has a remembered spawn kind (#1561).
 ///
 /// `location` is the *already-formatted* location token — the caller supplies
 /// whatever quoting or placeholder its surface needs (macOS passes the quoted
 /// `"$@"`, Windows the quoted `"%1"` / `"%V"`, Linux a bare `%f` or the quoted
 /// `"$1"`).
+///
+/// `kind` carries the entry's saved target into the invocation, so a
+/// context-menu click arrives already classified instead of as `auto` — which is
+/// what lets a remembered container entry actually spawn a container rather than
+/// falling through the presence-based inference to a local shell. [`SpawnKind::Auto`]
+/// (no remembered choice) emits no flag at all, keeping the pre-#1561 command
+/// line byte-for-byte.
 #[allow(dead_code)]
-fn spawn_command_line(exe_path: &str, entry_id: &str, location: &str) -> String {
-    format!(r#""{exe_path}" spawn --entry-id {entry_id} --location {location}"#)
+fn spawn_command_line(exe_path: &str, entry_id: &str, kind: SpawnKind, location: &str) -> String {
+    let kind_flag = match kind {
+        SpawnKind::Auto => String::new(),
+        kind => format!(" --kind {}", kind.to_wire()),
+    };
+    format!(r#""{exe_path}" spawn --entry-id {entry_id}{kind_flag} --location {location}"#)
 }
 
 /// Reduce an entry id to a single safe key/filename token: ASCII alphanumerics
@@ -366,17 +379,17 @@ mod shared_helper_tests {
     fn spawn_command_line_formats_exe_id_and_location_token() {
         // Linux desktop / KDE / Thunar: bare `%f` placeholder, no quoting.
         assert_eq!(
-            spawn_command_line("/opt/termihub/termiHub", "open", "%f"),
+            spawn_command_line("/opt/termihub/termiHub", "open", SpawnKind::Auto, "%f"),
             r#""/opt/termihub/termiHub" spawn --entry-id open --location %f"#
         );
         // macOS: the already-quoted `"$@"` token is passed through verbatim.
         assert_eq!(
-            spawn_command_line("/Applications/termiHub", "open", r#""$@""#),
+            spawn_command_line("/Applications/termiHub", "open", SpawnKind::Auto, r#""$@""#),
             r#""/Applications/termiHub" spawn --entry-id open --location "$@""#
         );
         // Windows: the caller pre-quotes the `%1` / `%V` placeholder.
         assert_eq!(
-            spawn_command_line(r"C:\termiHub.exe", "open", "\"%1\""),
+            spawn_command_line(r"C:\termiHub.exe", "open", SpawnKind::Auto, "\"%1\""),
             r#""C:\termiHub.exe" spawn --entry-id open --location "%1""#
         );
     }
@@ -593,7 +606,7 @@ mod macos {
     /// The shell script the Quick Action runs: the spawn subcommand with the
     /// selected paths passed as positional arguments (the quoted `"$@"` token).
     fn shell_command(entry: &ShellEntry, exe_path: &str) -> String {
-        spawn_command_line(exe_path, &entry.id, r#""$@""#)
+        spawn_command_line(exe_path, &entry.id, entry.spawn_kind, r#""$@""#)
     }
 
     /// Escape the five XML predefined entities so arbitrary names / paths embed
@@ -774,7 +787,9 @@ mod macos {
     mod tests {
         use super::*;
         use crate::connection::shell_integration::{ShellEntryVisibility, ShowForTargets};
+        use crate::spawn::SpawnKind;
         use std::path::PathBuf;
+        use termihub_core::config::ContainerRuntime;
 
         const EXE: &str = "/Applications/termiHub.app/Contents/MacOS/termiHub";
 
@@ -840,6 +855,9 @@ mod macos {
                 show_for,
                 container_image: None,
                 container_mount: None,
+                spawn_kind: SpawnKind::Auto,
+                shell: None,
+                container_runtime: ContainerRuntime::Auto,
             }
         }
 
@@ -1092,7 +1110,7 @@ mod imp {
     /// Explorer `placeholder` (`%1` / `%V`) is wrapped in quotes for the command
     /// line.
     fn command_line(exe_path: &str, entry: &ShellEntry, placeholder: &str) -> String {
-        spawn_command_line(exe_path, &entry.id, &format!("\"{placeholder}\""))
+        spawn_command_line(exe_path, &entry.id, entry.spawn_kind, &format!("\"{placeholder}\""))
     }
 
     /// True for any registry key name termiHub owns (entry keys and the submenu
@@ -1332,6 +1350,9 @@ mod imp {
                 show_for,
                 container_image: None,
                 container_mount: None,
+                spawn_kind: SpawnKind::Auto,
+                shell: None,
+                container_runtime: ContainerRuntime::Auto,
             }
         }
 
@@ -1921,7 +1942,7 @@ mod linux {
                 .map(|entry| thunar::Action {
                     name: entry.name.clone(),
                     unique_id: format!("{THUNAR_ID_PREFIX}{}", slug(entry)),
-                    command: spawn_command_line(exe_path, &entry.id, "%f"),
+                    command: spawn_command_line(exe_path, &entry.id, entry.spawn_kind, "%f"),
                     directories: entry.show_for.folders || entry.show_for.folder_background,
                     other_files: entry.show_for.files,
                 })
@@ -2018,7 +2039,7 @@ mod linux {
              MimeType=inode/directory;\n\
              {DESKTOP_MARKER}\n",
             name = desktop_value(&entry.name),
-            exec = spawn_command_line(exe_path, &entry.id, "%f"),
+            exec = spawn_command_line(exe_path, &entry.id, entry.spawn_kind, "%f"),
         )
     }
 
@@ -2029,7 +2050,7 @@ mod linux {
             "#!/bin/sh\n\
              {NAUTILUS_MARKER}\n\
              {command}\n",
-            command = spawn_command_line(exe_path, &entry.id, "\"$1\""),
+            command = spawn_command_line(exe_path, &entry.id, entry.spawn_kind, "\"$1\""),
         )
     }
 
@@ -2049,7 +2070,7 @@ mod linux {
              Icon={ICON}\n\
              Exec={exec}\n",
             name = desktop_value(&entry.name),
-            exec = spawn_command_line(exe_path, &entry.id, "%f"),
+            exec = spawn_command_line(exe_path, &entry.id, entry.spawn_kind, "%f"),
         )
     }
 
@@ -2309,6 +2330,9 @@ mod linux {
                 show_for,
                 container_image: None,
                 container_mount: None,
+                spawn_kind: SpawnKind::Auto,
+                shell: None,
+                container_runtime: ContainerRuntime::Auto,
             }
         }
 

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -1149,7 +1149,12 @@ mod imp {
     /// Explorer `placeholder` (`%1` / `%V`) is wrapped in quotes for the command
     /// line.
     fn command_line(exe_path: &str, entry: &ShellEntry, placeholder: &str) -> String {
-        spawn_command_line(exe_path, &entry.id, entry.spawn_kind, &format!("\"{placeholder}\""))
+        spawn_command_line(
+            exe_path,
+            &entry.id,
+            entry.spawn_kind,
+            &format!("\"{placeholder}\""),
+        )
     }
 
     /// True for any registry key name termiHub owns (entry keys and the submenu

--- a/src-tauri/src/spawn/registry.rs
+++ b/src-tauri/src/spawn/registry.rs
@@ -1325,6 +1325,8 @@ mod imp {
         use crate::connection::shell_integration::{
             ShellEntry, ShellEntryVisibility, ShowForTargets,
         };
+        use crate::spawn::SpawnKind;
+        use termihub_core::config::ContainerRuntime;
         use winreg::enums::*;
         use winreg::RegKey;
 
@@ -2307,7 +2309,9 @@ mod linux {
         use crate::connection::shell_integration::{
             LinuxFileManagerToggles, ShellEntry, ShellEntryVisibility, ShowForTargets,
         };
+        use crate::spawn::SpawnKind;
         use std::sync::Mutex;
+        use termihub_core::config::ContainerRuntime;
 
         const EXE: &str = "/opt/termihub/termiHub";
 

--- a/src-tauri/src/spawn/tests.rs
+++ b/src-tauri/src/spawn/tests.rs
@@ -332,10 +332,18 @@ async fn ipc_server_client_round_trip() {
 #[test]
 fn a_remembered_container_entry_parses_back_as_a_container_spawn() {
     // Exactly the tokens registration writes for a remembered container entry.
-    let args: Vec<String> = ["spawn", "--entry-id", "open", "--kind", "container", "--location", "/proj"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let args: Vec<String> = [
+        "spawn",
+        "--entry-id",
+        "open",
+        "--kind",
+        "container",
+        "--location",
+        "/proj",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
 
     let req = parse_spawn_args(&args);
 
@@ -365,10 +373,18 @@ fn an_un_remembered_entry_still_parses_as_auto() {
 /// pre-#1561 code lost to the connection/first-installed-distro fallback.
 #[test]
 fn a_remembered_wsl_entry_parses_back_as_a_wsl_spawn() {
-    let args: Vec<String> = ["spawn", "--entry-id", "open", "--kind", "wsl", "--location", "/proj"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let args: Vec<String> = [
+        "spawn",
+        "--entry-id",
+        "open",
+        "--kind",
+        "wsl",
+        "--location",
+        "/proj",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
 
     assert_eq!(parse_spawn_args(&args).kind, SpawnKind::Wsl);
 }

--- a/src-tauri/src/spawn/tests.rs
+++ b/src-tauri/src/spawn/tests.rs
@@ -318,3 +318,57 @@ async fn ipc_server_client_round_trip() {
         let _ = std::fs::remove_file(endpoint.address());
     }
 }
+
+// ── Remembered entry kind survives the registration → click → parse chain (#1561) ──
+
+/// The bug #1561 fixes, pinned end to end at the seam that had none.
+///
+/// Registration used to emit only `spawn --entry-id <id> --location <path>`, so a
+/// context-menu click parsed to `kind: Auto` with no container fields — and the
+/// presence-based inference then classified it a **local shell**. An entry could
+/// therefore never spawn a container, no matter what was saved on it. The
+/// registered command line now carries the entry's remembered kind, so the click
+/// arrives already classified.
+#[test]
+fn a_remembered_container_entry_parses_back_as_a_container_spawn() {
+    // Exactly the tokens registration writes for a remembered container entry.
+    let args: Vec<String> = ["spawn", "--entry-id", "open", "--kind", "container", "--location", "/proj"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let req = parse_spawn_args(&args);
+
+    assert_eq!(req.kind, SpawnKind::Container);
+    assert_eq!(req.entry_id.as_deref(), Some("open"));
+    assert_eq!(req.location.as_deref(), Some("/proj"));
+    // The saved image/mount are resolved from the entry by `resolve_container_spawn`,
+    // not carried on the command line — the kind is what routes it there at all.
+    assert_eq!(req.container_image, None);
+}
+
+/// The pre-#1561 command line — no `--kind` — must keep behaving exactly as it
+/// did, so an un-remembered entry is untouched by this change.
+#[test]
+fn an_un_remembered_entry_still_parses_as_auto() {
+    let args: Vec<String> = ["spawn", "--entry-id", "open", "--location", "/proj"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let req = parse_spawn_args(&args);
+
+    assert_eq!(req.kind, SpawnKind::Auto);
+}
+
+/// A remembered WSL entry must survive the same chain — the section that the
+/// pre-#1561 code lost to the connection/first-installed-distro fallback.
+#[test]
+fn a_remembered_wsl_entry_parses_back_as_a_wsl_spawn() {
+    let args: Vec<String> = ["spawn", "--entry-id", "open", "--kind", "wsl", "--location", "/proj"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    assert_eq!(parse_spawn_args(&args).kind, SpawnKind::Wsl);
+}

--- a/src/hooks/useSpawnRequests.test.ts
+++ b/src/hooks/useSpawnRequests.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/services/events", () => ({
 const resolveContainerSpawn = vi.fn();
 const resolveShellSpawn = vi.fn();
 const takePendingSpawn = vi.fn();
+const rememberSpawnChoice = vi.fn();
 vi.mock("@/services/api", () => ({
   resolveContainerSpawn: (
     location: string,
@@ -38,6 +39,7 @@ vi.mock("@/services/api", () => ({
     shell?: string
   ) => resolveShellSpawn(location, connection, entryId, kind, shell),
   takePendingSpawn: () => takePendingSpawn(),
+  rememberSpawnChoice: (entryId: string, target: unknown) => rememberSpawnChoice(entryId, target),
 }));
 
 vi.mock("@/components/ui", () => ({
@@ -52,11 +54,12 @@ vi.mock("@/components/ui", () => ({
 
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
-import { applySpawnChoice, useSpawnRequests } from "./useSpawnRequests";
+import { applySpawnChoice, useSpawnChoiceHandler, useSpawnRequests } from "./useSpawnRequests";
 import { useAppStore } from "@/store/appStore";
 import { toast } from "@/components/ui";
 import { getAllLeaves } from "@/utils/panelTree";
 import type { SpawnRequestPayload } from "@/services/events";
+import type { SpawnChoice } from "@/types/spawn";
 import type { ContainerSpawn, ShellSpawn } from "@/services/api";
 import type { TerminalTab } from "@/types/terminal";
 
@@ -668,5 +671,126 @@ describe("applySpawnChoice — folding a picker choice back into its request (SI
     );
 
     expect(request.new_window).toBe(true);
+  });
+});
+
+describe("useSpawnChoiceHandler — persisting \"Remember this choice\" (#1561)", () => {
+  /** Render the hook and hand back its confirm handler. */
+  function choiceHandler(): (req: SpawnRequestPayload, choice: SpawnChoice) => Promise<void> {
+    let handler!: ReturnType<typeof useSpawnChoiceHandler>;
+    function Probe() {
+      handler = useSpawnChoiceHandler();
+      return null;
+    }
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    act(() => {
+      createRoot(host).render(React.createElement(Probe));
+    });
+    return handler;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rememberSpawnChoice.mockResolvedValue(undefined);
+    resolveShellSpawn.mockResolvedValue(SAMPLE_SHELL_SPAWN);
+    resolveContainerSpawn.mockResolvedValue(SAMPLE_SPAWN);
+  });
+
+  const REQ: SpawnRequestPayload = { location: "/proj", entry_id: "open", pick: true };
+
+  it("saves the picked local shell onto the triggering entry", async () => {
+    const handler = choiceHandler();
+
+    await act(async () => {
+      await handler(REQ, {
+        target: { kind: "local", shell: "fish" },
+        newWindow: false,
+        remember: true,
+      });
+    });
+
+    expect(rememberSpawnChoice).toHaveBeenCalledWith("open", { kind: "local", shell: "fish" });
+  });
+
+  it("saves the picked container runtime, image and mount", async () => {
+    const handler = choiceHandler();
+
+    await act(async () => {
+      await handler(REQ, {
+        target: { kind: "container", runtime: "podman", image: "alpine:3", mount: "/workspace" },
+        newWindow: false,
+        remember: true,
+      });
+    });
+
+    expect(rememberSpawnChoice).toHaveBeenCalledWith("open", {
+      kind: "container",
+      runtime: "podman",
+      image: "alpine:3",
+      mount: "/workspace",
+    });
+  });
+
+  it("saves the picked WSL distribution", async () => {
+    const handler = choiceHandler();
+
+    await act(async () => {
+      await handler(REQ, {
+        target: { kind: "wsl", distro: "Ubuntu-22.04" },
+        newWindow: false,
+        remember: true,
+      });
+    });
+
+    expect(rememberSpawnChoice).toHaveBeenCalledWith("open", {
+      kind: "wsl",
+      distro: "Ubuntu-22.04",
+    });
+  });
+
+  it("saves nothing when the box is left unticked", async () => {
+    const handler = choiceHandler();
+
+    await act(async () => {
+      await handler(REQ, {
+        target: { kind: "local", shell: "fish" },
+        newWindow: false,
+        remember: false,
+      });
+    });
+
+    expect(rememberSpawnChoice).not.toHaveBeenCalled();
+  });
+
+  // A bare `termiHub spawn --pick` from a terminal has no entry to remember onto.
+  it("saves nothing when the spawn came from no context-menu entry", async () => {
+    const handler = choiceHandler();
+
+    await act(async () => {
+      await handler(
+        { location: "/proj", pick: true },
+        { target: { kind: "local", shell: "fish" }, newWindow: false, remember: true }
+      );
+    });
+
+    expect(rememberSpawnChoice).not.toHaveBeenCalled();
+  });
+
+  // Remembering is a side effect of the spawn, never a precondition for it.
+  it("still opens the session when remembering fails", async () => {
+    rememberSpawnChoice.mockRejectedValue(new Error("disk full"));
+    const handler = choiceHandler();
+
+    await act(async () => {
+      await handler(REQ, {
+        target: { kind: "local", shell: "fish" },
+        newWindow: false,
+        remember: true,
+      });
+    });
+
+    expect(resolveShellSpawn).toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("could not remember"));
   });
 });

--- a/src/hooks/useSpawnRequests.test.ts
+++ b/src/hooks/useSpawnRequests.test.ts
@@ -674,7 +674,7 @@ describe("applySpawnChoice — folding a picker choice back into its request (SI
   });
 });
 
-describe("useSpawnChoiceHandler — persisting \"Remember this choice\" (#1561)", () => {
+describe('useSpawnChoiceHandler — persisting "Remember this choice" (#1561)', () => {
   /** Render the hook and hand back its confirm handler. */
   function choiceHandler(): (req: SpawnRequestPayload, choice: SpawnChoice) => Promise<void> {
     let handler!: ReturnType<typeof useSpawnChoiceHandler>;

--- a/src/hooks/useSpawnRequests.ts
+++ b/src/hooks/useSpawnRequests.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
 import { toast } from "@/components/ui";
 import { onSpawnPickerRequested, onSpawnRequest, SpawnRequestPayload } from "@/services/events";
-import { resolveContainerSpawn, resolveShellSpawn, takePendingSpawn } from "@/services/api";
+import {
+  rememberSpawnChoice,
+  resolveContainerSpawn,
+  resolveShellSpawn,
+  takePendingSpawn,
+} from "@/services/api";
 import type { ContainerRuntime, SpawnChoice } from "@/types/spawn";
 import { frontendLog } from "@/utils/frontendLog";
 
@@ -223,9 +228,35 @@ export function useSpawnRequests(): void {
 }
 
 /**
+ * Persist a "Remember this choice" selection onto the entry that triggered the
+ * spawn (#1561), so a later context-menu click opens the picked target directly
+ * instead of prompting again.
+ *
+ * A no-op unless the user actually ticked the box *and* the spawn came from a
+ * context-menu entry — a bare `termiHub spawn --pick` from a terminal has no
+ * entry to remember onto.
+ *
+ * Remembering is a side effect of the spawn, not a precondition for it: a failed
+ * save is logged and toasted but never blocks opening the session the user asked
+ * for.
+ */
+async function persistRememberedChoice(
+  req: SpawnRequestPayload,
+  choice: SpawnChoice
+): Promise<void> {
+  if (!choice.remember || !req.entry_id) return;
+  try {
+    await rememberSpawnChoice(req.entry_id, choice.target);
+  } catch (err) {
+    frontendLog("spawn", `Failed to remember spawn choice: ${err}`);
+    toast.error(`Opened the session, but could not remember the choice: ${err}`);
+  }
+}
+
+/**
  * The confirm handler for the Session Picker (SI-3, #1366): fold the choice back
- * into its request and open the session through the same path every other spawn
- * takes.
+ * into its request, persist it when "Remember this choice" was ticked (#1561),
+ * and open the session through the same path every other spawn takes.
  */
 export function useSpawnChoiceHandler(): (
   req: SpawnRequestPayload,
@@ -237,6 +268,7 @@ export function useSpawnChoiceHandler(): (
   return useCallback(
     async (req, choice) => {
       const { request, picked } = applySpawnChoice(req, choice);
+      await persistRememberedChoice(req, choice);
       await handleSpawnRequest(request, { openSpawnedContainer, openSpawnedShell }, picked);
     },
     [openSpawnedContainer, openSpawnedShell]

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -14,7 +14,7 @@ import {
 import { XServerConsentDecision, XServerStatusReport } from "@/types/xserver";
 import { CredentialStoreStatusInfo, SwitchCredentialStoreResult } from "@/types/credential";
 import type { SpawnRequestPayload } from "@/services/events";
-import type { ContainerRuntime } from "@/types/spawn";
+import type { ContainerRuntime, SpawnTarget } from "@/types/spawn";
 import {
   SavedConnection,
   ConnectionFolder,
@@ -677,6 +677,23 @@ export async function saveShellIntegrationSettings(
 ): Promise<ShellIntegrationStatus> {
   return await invoke<ShellIntegrationStatus>("save_shell_integration_settings", {
     shellIntegration,
+  });
+}
+
+/**
+ * Persist the Session Picker's "Remember this choice" (#1561): save the picked
+ * target onto the entry that triggered the spawn, so a later context-menu click
+ * opens it directly instead of prompting again. Re-registers the OS context menu
+ * when the integration is registered, since the remembered kind is part of the
+ * command line the surface invokes. An unknown `entryId` is a no-op.
+ */
+export async function rememberSpawnChoice(
+  entryId: string,
+  target: SpawnTarget
+): Promise<ShellIntegrationStatus> {
+  return await invoke<ShellIntegrationStatus>("remember_spawn_choice", {
+    entryId,
+    target,
   });
 }
 

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -1,6 +1,7 @@
 import { ConnectionConfig, RemoteAgentConfig, TerminalOptions, LineEnding } from "./terminal";
 import { SettingsSchema, Capabilities } from "./schema";
 import { KeybindingOverrideEntry } from "./keybindings";
+import type { SavedContainerRuntime, SpawnKind } from "./spawn";
 
 /**
  * Explicit lifecycle status of the single desktop SFTP session (audit gap A1).
@@ -314,6 +315,26 @@ export interface ShellEntry {
    * explicit `--container-mount` is given.
    */
   containerMount?: string;
+  /**
+   * The kind of session this entry opens — written by the Session Picker's
+   * "Remember this choice" (#1561). `"auto"` (the default) means no remembered
+   * choice, keeping the presence-based inference. Anything else is emitted as
+   * `--kind <token>` at registration time and pins how a context-menu click
+   * resolves.
+   */
+  spawnKind?: SpawnKind;
+  /**
+   * Saved per-entry shell preference in the backend's single-string encoding: a
+   * local shell name (`"zsh"`) or a WSL distribution as `"wsl:<distro>"`.
+   * Honored for a local/WSL spawn when no explicit shell is passed.
+   */
+  shell?: string;
+  /**
+   * Saved per-entry container-runtime preference — the Docker/Podman section the
+   * user picked. `"auto"` (the default) keeps detecting whichever runtime is
+   * installed.
+   */
+  containerRuntime?: SavedContainerRuntime;
 }
 
 /** Linux per-file-manager install toggles (Linux-only in effect). */

--- a/src/types/spawn.ts
+++ b/src/types/spawn.ts
@@ -11,6 +11,21 @@
 export type ContainerRuntime = "docker" | "podman";
 
 /**
+ * The container runtime *saved* on a shell-integration entry (#1561). Widens
+ * {@link ContainerRuntime} with `"auto"` — the default, meaning "no remembered
+ * preference, detect whichever runtime is installed". Mirrors the Rust
+ * `ContainerRuntime`, which carries the `Auto` variant the picker never offers.
+ */
+export type SavedContainerRuntime = ContainerRuntime | "auto";
+
+/**
+ * The kind of session a spawn targets — the wire tokens of the Rust `SpawnKind`.
+ * `"auto"` means "not explicitly stated": resolve by falling back to
+ * presence-based inference.
+ */
+export type SpawnKind = "container" | "local" | "wsl" | "ssh" | "auto";
+
+/**
  * The target a user picked, as a discriminated union on `kind`. The `kind`
  * values line up with the Rust `SpawnKind` wire tokens, so a choice maps onto a
  * spawn request without a translation table.


### PR DESCRIPTION
## What

The Session Picker's "Remember this choice" checkbox rendered and reached the confirm payload but persisted nothing (#1366 / PR #1560). This makes it real, per the owner's **option (a)** decision recorded on #1561.

`ShellEntry` gains three fields, all `#[serde(default)]`:

| Field | Purpose |
| --- | --- |
| `spawn_kind: SpawnKind` | The picked section. `Auto` (the default) = no remembered choice, keeping the legacy presence-based inference. |
| `shell: Option<String>` | The picked shell in `shell_to_command`'s existing single-string encoding — a local shell name, or a WSL distro as `wsl:<distro>`. One field covers both shell sections; no second representation was invented. |
| `container_runtime: ContainerRuntime` | The Docker/Podman section the user picked. `Auto` keeps detection. |

## The read-side bug this also fixes

Registration emitted only `spawn --entry-id <id> --location <path>`, so a context-menu click arrived as `kind: auto` and `isContainerSpawn()` inferred a local shell. **The per-entry `container_image` preference (#1447) was therefore only ever consulted when the CLI explicitly passed `--kind container` — an entry configured with an image silently opened a shell.** Registration now emits the entry's remembered kind as `--kind <token>`, and `resolve_shell_spawn` / `resolve_container_spawn` fall back to the entry's saved shell and runtime when the request names none. A remembered container entry now genuinely spawns a container from a right-click.

Precedence throughout is: explicit request value > entry's remembered value > pre-picker default.

## Compatibility

`SpawnKind::Auto` emits no `--kind` flag at all, so an un-remembered entry's command line is byte-for-byte what it was. A pre-#1561 `settings.json` loads as "no remembered choice", preserving every previous behaviour; a test pins that.

## Schema placement

The schema change lands here rather than as an SI-4 amendment: #1367 is closed and delivered, and these fields are only meaningful alongside the read/write wiring in this PR.

## Testing

- Rust: 1060 lib tests green; `cargo fmt --check`, `clippy --workspace --all-targets -D warnings` clean.
- Frontend: `tsc --noEmit` clean, prettier/eslint clean, 31 vitest tests in `useSpawnRequests.test.ts`.
- **Mutation-verified:** breaking the runtime fallback, the `wsl:` strip, the `--kind` emission, the `remember` write and the frontend persist path each turns the corresponding tests red. No test passes vacuously.

Closes #1561
