### PR TITLE
feat(agent): host-wide registry daemon for cross-worker client identity (Closes #1574)

### DIFF
--- a/agent/src/daemon/mod.rs
+++ b/agent/src/daemon/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
 pub mod process;
 pub mod protocol;
+pub mod spawn;
 pub mod transport;

--- a/agent/src/daemon/spawn.rs
+++ b/agent/src/daemon/spawn.rs
@@ -113,7 +113,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn configure_detached_stderr_redirects_into_the_supplied_log() {
-        let path = std::env::temp_dir().join(format!("termihub-spawn-test-{}.log", std::process::id()));
+        let path =
+            std::env::temp_dir().join(format!("termihub-spawn-test-{}.log", std::process::id()));
         let log = std::fs::File::create(&path).expect("create log");
 
         let mut command = std::process::Command::new("sh");

--- a/agent/src/daemon/spawn.rs
+++ b/agent/src/daemon/spawn.rs
@@ -1,0 +1,146 @@
+//! Detached-spawn helpers shared by every daemon **role**.
+//!
+//! Both daemon roles — the per-session daemon (`--daemon <id>`, spawned by
+//! [`crate::session::manager`]) and the host-wide registry daemon
+//! (`--registry-daemon`, spawned by [`crate::registry_daemon::client`]) — must
+//! outlive the agent worker that spawned them. The worker is typically running
+//! as `termihub-agent --stdio` inside an SSH exec channel, so "outlive" has two
+//! separate requirements, and both roles need both:
+//!
+//! 1. **Don't inherit the worker's stderr** ([`configure_detached_stderr`]) —
+//!    that stderr *is* the exec channel.
+//! 2. **Leave the worker's process session** ([`configure_detachment`]) — or
+//!    sshd's SIGHUP on disconnect takes the daemon with it.
+//!
+//! Keeping these in one place is what lets the registry inherit the
+//! survives-a-binary-swap property that ADR-11 leans on, rather than
+//! re-deriving it (see ADR-11's amendment in `docs/architecture.md`).
+
+/// Point a to-be-spawned daemon's stderr at `log`, or discard it.
+///
+/// The daemon must **not** inherit the agent's stderr: when the agent is reached
+/// over SSH that stderr is the exec channel of `termihub-agent --stdio`, and
+/// keeping it tethers the daemon's lifetime to the SSH connection — a disconnect
+/// tears the channel down and takes the daemon with it (so a reconnect finds
+/// nothing to re-attach). A detached daemon owns its own stderr on every
+/// platform: callers pass a log file in the per-user socket dir (diagnostics
+/// without the coupling) where one is available, and `None` falls back to a null
+/// stderr.
+pub fn configure_detached_stderr(command: &mut std::process::Command, log: Option<std::fs::File>) {
+    let stderr = match log {
+        Some(file) => std::process::Stdio::from(file),
+        None => std::process::Stdio::null(),
+    };
+    command.stderr(stderr);
+}
+
+/// Detach a to-be-spawned daemon so it outlives the agent that spawns it — the
+/// whole point of a *persistent* session, and of a registry that survives an
+/// agent binary swap.
+///
+/// On Windows: a new process group with no console window. On unix: a fresh
+/// session via `setsid`. Being merely orphaned (the agent never waits on the
+/// child) is **not** enough on unix, because the agent is typically launched
+/// over an SSH exec channel (`termihub-agent --stdio`); when that channel closes
+/// sshd sends SIGHUP to the whole session, killing any daemon still in it, so a
+/// reconnect would find no session to re-attach. `setsid` moves the daemon out
+/// of the SSH session's process group, immunising it against that hangup.
+/// (Detaching stderr from the same channel — see [`configure_detached_stderr`] —
+/// is the other half of surviving the disconnect.)
+pub fn configure_detachment(command: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::{
+            CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS,
+        };
+        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // Safety: `setsid` is async-signal-safe and touches no shared state of
+        // the (forked, not-yet-exec'd) child before the following `exec`.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── daemon detachment (issue #995) ───────────────────────────────
+
+    /// Moved here from `session::manager` with the helper itself (#1574): both
+    /// the session daemon and the registry daemon depend on this property, so
+    /// it is tested once, where the shared code lives.
+    #[cfg(unix)]
+    #[test]
+    fn configure_detachment_starts_a_new_session() {
+        // A detached daemon must survive the agent (and its SSH exec channel)
+        // going away. On unix that requires the spawned child to leave the SSH
+        // session via `setsid` — otherwise sshd's SIGHUP on disconnect kills it,
+        // and a reconnect finds no persistent session to re-attach and no
+        // registry to ask who is connected. Assert the child a
+        // detachment-configured Command spawns is a session leader (its session
+        // id equals its pid), which only holds after `setsid`.
+        let mut command = std::process::Command::new("sleep");
+        command.arg("30");
+        configure_detachment(&mut command);
+        let mut child = command.spawn().expect("spawn sleep");
+        let pid = child.id() as libc::pid_t;
+        // Safety: `getsid` merely reads the session id of an existing pid.
+        let sid = unsafe { libc::getsid(pid) };
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_eq!(
+            sid, pid,
+            "daemon child should be its own session leader (setsid)"
+        );
+    }
+
+    /// A daemon must never inherit the agent's stderr — over SSH that stderr is
+    /// the exec channel, and inheriting it ties the daemon's life to the SSH
+    /// connection. Assert the log file the caller supplies actually receives the
+    /// child's stderr.
+    #[cfg(unix)]
+    #[test]
+    fn configure_detached_stderr_redirects_into_the_supplied_log() {
+        let path = std::env::temp_dir().join(format!("termihub-spawn-test-{}.log", std::process::id()));
+        let log = std::fs::File::create(&path).expect("create log");
+
+        let mut command = std::process::Command::new("sh");
+        command.arg("-c").arg("echo daemon-diagnostics >&2");
+        configure_detached_stderr(&mut command, Some(log));
+        let status = command.status().expect("run child");
+        assert!(status.success());
+
+        let written = std::fs::read_to_string(&path).expect("read log");
+        assert!(
+            written.contains("daemon-diagnostics"),
+            "child stderr should land in the log file, got {written:?}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// With no log available (the non-unix path) stderr must be discarded, never
+    /// inherited.
+    #[cfg(unix)]
+    #[test]
+    fn configure_detached_stderr_falls_back_to_null() {
+        let mut command = std::process::Command::new("sh");
+        command.arg("-c").arg("echo noise >&2");
+        configure_detached_stderr(&mut command, None);
+        // Captured output would be non-empty if stderr were inherited or piped;
+        // a null stderr yields nothing.
+        let output = command.output().expect("run child");
+        assert!(output.stderr.is_empty(), "stderr should be discarded");
+    }
+}

--- a/agent/src/daemon/transport.rs
+++ b/agent/src/daemon/transport.rs
@@ -131,8 +131,9 @@ pub async fn connect(endpoint: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
 
 #[cfg(unix)]
 #[allow(unused_imports)]
-pub use unix_impl::{endpoint_alive, open_daemon_log, open_registry_log, registry_endpoint,
-                    session_endpoint};
+pub use unix_impl::{
+    endpoint_alive, open_daemon_log, open_registry_log, registry_endpoint, session_endpoint,
+};
 #[cfg(windows)]
 #[allow(unused_imports)]
 pub use windows_impl::{endpoint_alive, registry_endpoint, session_endpoint};

--- a/agent/src/daemon/transport.rs
+++ b/agent/src/daemon/transport.rs
@@ -28,6 +28,17 @@
 use std::io;
 use std::time::Duration;
 
+/// Env var overriding the host-wide registry endpoint.
+///
+/// The registry endpoint is otherwise a fixed per-user path, which is exactly
+/// what makes it a rendezvous — workers find it without being told. That also
+/// means every agent of one user on one machine shares it, so tests (and
+/// side-by-side development checkouts) need a way to opt into an isolated one
+/// rather than fighting over the live socket. Mirrors the session daemon's
+/// existing `TERMIHUB_SOCKET_PATH`. A worker that sets it also passes it to any
+/// registry it spawns, via the inherited environment.
+pub const REGISTRY_ENDPOINT_ENV: &str = "TERMIHUB_REGISTRY_ENDPOINT";
+
 use termihub_core::ipc::{
     self, ListenerOptions, ListenerSecurity, LocalSocketListener, StaleReclaim,
 };
@@ -148,8 +159,14 @@ mod unix_impl {
     /// `0o700` directory (ADR-11): one registry per user per host, which is what
     /// makes it a rendezvous every worker of that user can find without being
     /// told where it is. Because the dir is already per-user, the file name
-    /// needs no user component.
+    /// needs no user component. Overridable via
+    /// [`REGISTRY_ENDPOINT_ENV`](super::REGISTRY_ENDPOINT_ENV).
     pub fn registry_endpoint() -> String {
+        if let Ok(endpoint) = std::env::var(super::REGISTRY_ENDPOINT_ENV) {
+            if !endpoint.is_empty() {
+                return endpoint;
+            }
+        }
         socket_dir()
             .join("registry.sock")
             .to_string_lossy()
@@ -225,8 +242,14 @@ mod windows_impl {
     /// scoping for free from the `0o700` socket *directory* that has no windows
     /// analog. Two users on one host therefore get two distinct pipes — matching
     /// the "one registry per user per host" rule — on top of the per-user DACL
-    /// that keeps each one unreachable by the other.
+    /// that keeps each one unreachable by the other. Overridable via
+    /// [`REGISTRY_ENDPOINT_ENV`](super::REGISTRY_ENDPOINT_ENV).
     pub fn registry_endpoint() -> String {
+        if let Ok(endpoint) = std::env::var(super::REGISTRY_ENDPOINT_ENV) {
+            if !endpoint.is_empty() {
+                return endpoint;
+            }
+        }
         let user = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".to_string());
         format!(r"\\.\pipe\termihub-registry-{user}")
     }

--- a/agent/src/daemon/transport.rs
+++ b/agent/src/daemon/transport.rs
@@ -64,12 +64,36 @@ impl DaemonListener {
     /// (`0o700` socket dir + file on unix, per-user DACL on windows) and
     /// unconditionally reclaiming any stale endpoint left by a previous daemon.
     /// The endpoint appearing signals readiness to connecting clients.
+    ///
+    /// This is the **per-session** daemon policy: the endpoint path embeds a
+    /// unique session id, so exactly one daemon can ever want it and reclaiming
+    /// it unconditionally is safe. Roles whose endpoint is a *singleton*
+    /// rendezvous that several processes may race for must use
+    /// [`bind_singleton`](Self::bind_singleton) instead.
     pub async fn bind(endpoint: &str) -> io::Result<Self> {
+        Self::bind_with_reclaim(endpoint, StaleReclaim::Unconditional).await
+    }
+
+    /// Bind a listener at a **singleton** `endpoint` — one that any number of
+    /// processes may race to own (the host-wide registry daemon, ADR-11).
+    ///
+    /// Identical to [`bind`](Self::bind) but for the stale-reclaim policy:
+    /// [`StaleReclaim::IfProbeDead`] only clears the path when a connect probe
+    /// shows nothing is listening, so a **live** owner keeps it and this bind
+    /// fails with [`io::ErrorKind::AddrInUse`]. That is what makes a spawn race
+    /// safe: the loser sees `AddrInUse`, exits, and connects to the winner
+    /// instead of silently stealing the endpoint out from under it. On windows
+    /// `first_pipe_instance(true)` already rejects a live owner.
+    pub async fn bind_singleton(endpoint: &str) -> io::Result<Self> {
+        Self::bind_with_reclaim(endpoint, StaleReclaim::IfProbeDead).await
+    }
+
+    async fn bind_with_reclaim(endpoint: &str, stale_reclaim: StaleReclaim) -> io::Result<Self> {
         let inner = LocalSocketListener::bind_with_options(
             endpoint,
             ListenerOptions {
                 security: ListenerSecurity::CurrentUserOnly,
-                stale_reclaim: StaleReclaim::Unconditional,
+                stale_reclaim,
             },
         )
         .await?;
@@ -96,10 +120,11 @@ pub async fn connect(endpoint: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
 
 #[cfg(unix)]
 #[allow(unused_imports)]
-pub use unix_impl::{endpoint_alive, open_daemon_log, session_endpoint};
+pub use unix_impl::{endpoint_alive, open_daemon_log, open_registry_log, registry_endpoint,
+                    session_endpoint};
 #[cfg(windows)]
 #[allow(unused_imports)]
-pub use windows_impl::{endpoint_alive, session_endpoint};
+pub use windows_impl::{endpoint_alive, registry_endpoint, session_endpoint};
 
 // ── Unix session-path helpers ───────────────────────────────────────
 
@@ -113,6 +138,20 @@ mod unix_impl {
     pub fn session_endpoint(session_id: &str) -> String {
         socket_dir()
             .join(format!("session-{session_id}.sock"))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Compute the endpoint (socket path) for the host-wide registry daemon.
+    ///
+    /// A **singleton** sibling of the per-session sockets in the same per-user
+    /// `0o700` directory (ADR-11): one registry per user per host, which is what
+    /// makes it a rendezvous every worker of that user can find without being
+    /// told where it is. Because the dir is already per-user, the file name
+    /// needs no user component.
+    pub fn registry_endpoint() -> String {
+        socket_dir()
+            .join("registry.sock")
             .to_string_lossy()
             .into_owned()
     }
@@ -148,9 +187,22 @@ mod unix_impl {
     /// Best-effort: returns `None` if the dir or file can't be created, and the
     /// caller falls back to a null stderr.
     pub fn open_daemon_log(session_id: &str) -> Option<std::fs::File> {
+        open_log(&format!("session-{session_id}.log"))
+    }
+
+    /// Open (truncating) the registry daemon's log file in the socket dir.
+    ///
+    /// Same reasoning as [`open_daemon_log`]: the registry is spawned by a
+    /// worker that may itself be running over an SSH exec channel, so it must
+    /// never inherit that stderr. Logs beside its socket as `registry.log`.
+    pub fn open_registry_log() -> Option<std::fs::File> {
+        open_log("registry.log")
+    }
+
+    fn open_log(file_name: &str) -> Option<std::fs::File> {
         let dir = socket_dir();
         ensure_socket_dir(&dir).ok()?;
-        std::fs::File::create(dir.join(format!("session-{session_id}.log"))).ok()
+        std::fs::File::create(dir.join(file_name)).ok()
     }
 }
 
@@ -163,6 +215,20 @@ mod windows_impl {
     /// Pipe names live in the `\\.\pipe\` namespace and are unique per session.
     pub fn session_endpoint(session_id: &str) -> String {
         format!(r"\\.\pipe\termihub-session-{session_id}")
+    }
+
+    /// Compute the pipe name for the host-wide registry daemon (ADR-11).
+    ///
+    /// Unlike the per-session pipes, this name is a **singleton** rendezvous
+    /// with no unique component, so it must carry the user itself: the
+    /// `\\.\pipe\` namespace is machine-global, and unix gets its per-user
+    /// scoping for free from the `0o700` socket *directory* that has no windows
+    /// analog. Two users on one host therefore get two distinct pipes — matching
+    /// the "one registry per user per host" rule — on top of the per-user DACL
+    /// that keeps each one unreachable by the other.
+    pub fn registry_endpoint() -> String {
+        let user = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".to_string());
+        format!(r"\\.\pipe\termihub-registry-{user}")
     }
 
     /// Cheap liveness pre-check: whether a named-pipe instance exists.

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -24,6 +24,8 @@ use crate::files::{FileBackend, FileError};
 use crate::monitoring::MonitoringManagerApi;
 use crate::network;
 use crate::protocol::errors;
+use crate::registry_daemon::client::RegistryClient;
+use crate::registry_daemon::protocol::ClientRecord;
 use crate::protocol::methods::{
     AgentRequestDeferredUpdateParams, AgentRequestDeferredUpdateResult, AgentSettings,
     AgentSettingsUpdateParams, AgentShutdownParams, AgentShutdownResult, Capabilities,
@@ -74,6 +76,9 @@ struct HandlerState {
     /// Agent-assigned id for this connection's client, generated once in
     /// [`AgentHandler::new`] so `initialize` and disconnect agree on the key.
     client_id: String,
+    /// This worker's handle to the host-wide registry daemon, when the
+    /// transport loop wired one up. See [`AgentHandler::registry_client`].
+    registry_client: Arc<OnceLock<Arc<RegistryClient>>>,
     /// Shared with [`AgentHandler::shutdown_flag`] so the transport loop can
     /// detect shutdown without re-locking the mutex after every request.
     shutdown_flag: Arc<AtomicBool>,
@@ -99,6 +104,12 @@ pub struct AgentHandler {
     /// `initialize` so [`deregister_client`](Self::deregister_client) removes
     /// the right entry.
     client_id: String,
+    /// This worker's handle to the host-wide registry daemon (ADR-11), shared
+    /// with [`HandlerState`]. Set once by the transport loop via
+    /// [`with_registry_client`](Self::with_registry_client); left empty by unit
+    /// tests, which is also the honest representation of a host where the
+    /// registry could not be reached.
+    registry_client: Arc<OnceLock<Arc<RegistryClient>>>,
 }
 
 impl AgentHandler {
@@ -110,6 +121,7 @@ impl AgentHandler {
         let shutdown_flag = Arc::new(AtomicBool::new(false));
         let client_registry = Arc::new(ConnectionRegistry::new());
         let client_id = uuid::Uuid::new_v4().to_string();
+        let registry_client: Arc<OnceLock<Arc<RegistryClient>>> = Arc::new(OnceLock::new());
 
         let state = Mutex::new(HandlerState {
             session_manager,
@@ -120,6 +132,7 @@ impl AgentHandler {
             agent_settings: AgentSettings::default(),
             client_registry: client_registry.clone(),
             client_id: client_id.clone(),
+            registry_client: registry_client.clone(),
             shutdown_flag: shutdown_flag.clone(),
         });
 
@@ -132,7 +145,25 @@ impl AgentHandler {
             shutdown_flag,
             client_registry,
             client_id,
+            registry_client,
         })
+    }
+
+    /// Attach this worker's host-wide registry handle (ADR-11).
+    ///
+    /// Called by the transport loops right after construction. Kept out of
+    /// [`new`](Self::new) deliberately: the registry is **optional
+    /// infrastructure**, so a handler without one must remain a fully working
+    /// handler — which is both what a registry-less host gets and what every
+    /// unit test exercises.
+    pub fn with_registry_client(self, client: Arc<RegistryClient>) -> Self {
+        let _ = self.registry_client.set(client);
+        self
+    }
+
+    /// This worker's registry handle, if one was attached.
+    fn registry(&self) -> Option<&Arc<RegistryClient>> {
+        self.registry_client.get()
     }
 
     /// Shared registry of the clients connected to this agent process.
@@ -145,13 +176,23 @@ impl AgentHandler {
         self.client_registry.clone()
     }
 
-    /// Remove this handler's client from the registry.
+    /// Remove this handler's client from the per-process registry **and** from
+    /// the host-wide one.
     ///
     /// Called by the transport loops (`io/stdio.rs`, `io/tcp.rs`) once the
-    /// connection ends, so a disconnected client no longer appears as connected.
-    /// A no-op if `initialize` never populated the entry.
+    /// connection ends, so a disconnected client no longer appears as connected
+    /// — to this worker or to any other worker on the host. A no-op if
+    /// `initialize` never populated the entry.
+    ///
+    /// The host-wide withdrawal is only the *prompt* path. If this worker is
+    /// killed outright and never gets here, the registry still drops the record
+    /// when the socket closes (see `registry_daemon::process`), so a crash
+    /// cannot leave a phantom client behind.
     pub fn deregister_client(&self) {
         self.client_registry.remove(&self.client_id);
+        if let Some(registry) = self.registry() {
+            registry.deregister();
+        }
     }
 
     /// Process a raw JSON-RPC request string and return the response string.
@@ -357,11 +398,27 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
             // Record the connected client (additive to the single-client
             // settings above). One entry per agent process in `--stdio` mode.
             let client_id = s.client_id.clone();
-            s.client_registry.register(
+            let entry = s.client_registry.register(
                 client_id.clone(),
                 p.client.clone(),
                 p.client_version.clone(),
             );
+
+            // Announce the client host-wide too (ADR-11). This is bound to
+            // `initialize`, not to any session — which is exactly why a desktop
+            // holding **no sessions** is still visible and reachable, the case
+            // an agent binary swap would otherwise kill without warning.
+            // Fire-and-forget: a missing registry must never fail `initialize`.
+            if let Some(registry) = s.registry_client.get() {
+                registry.register(ClientRecord {
+                    client_id: entry.client_id.clone(),
+                    client: entry.client.clone(),
+                    client_version: entry.client_version.clone(),
+                    connected_since: entry.connected_since.to_rfc3339(),
+                    pid: std::process::id(),
+                });
+            }
+
             let buffer_size = mb_to_bytes(p.agent_settings.persistent_scrollback_buffer_size_mb);
             (
                 s.session_manager.clone(),
@@ -1337,33 +1394,56 @@ fn register_agent_list_connections(
     module: &mut RpcModule<Mutex<HandlerState>>,
 ) -> anyhow::Result<()> {
     module.register_async_method("agent.list_connections", |_params, ctx, _ext| async move {
-        // Read-only: snapshot the per-process client registry. Requires
-        // `initialize` first so the caller is already recorded.
-        let registry = {
+        // Read-only. Requires `initialize` first so the caller is already
+        // recorded in both registries.
+        let (local_registry, host_registry) = {
             let s = ctx.lock().await;
             if !s.initialized {
                 return Err(not_initialized());
             }
-            s.client_registry.clone()
+            (s.client_registry.clone(), s.registry_client.get().cloned())
         };
 
-        // Full snapshot including the caller. Because of the per-process
-        // topology (one agent process per `--stdio` channel), in production
-        // this holds exactly the requesting desktop; the desktop-side update
-        // guard excludes its own `client_id` (from `initialize`) so a lone
-        // client is not mistaken for an "other host". A shared `--listen`
-        // process, or a future daemon-coordination layer, would surface the
-        // additional clients here.
-        let connections: Vec<ConnectionInfo> = registry
-            .list()
-            .into_iter()
-            .map(|c| ConnectionInfo {
-                client_id: c.client_id,
-                client: c.client,
-                client_version: c.client_version,
-                connected_since: c.connected_since.to_rfc3339(),
-            })
-            .collect();
+        // The host-wide set, from the registry daemon (ADR-11): every client
+        // attached to this host, whether or not it holds any sessions, and
+        // whether or not it is served by *this* worker process. Includes the
+        // caller — the desktop-side update guard excludes its own `client_id`
+        // (from `initialize`) so it is not mistaken for an "other host".
+        let host_wide = match host_registry {
+            Some(registry) => registry.list().await,
+            None => None,
+        };
+
+        // The registry is optional infrastructure, so its absence must never
+        // turn into a wrong answer. `None` means "no host-wide view" — not "no
+        // clients" — and the honest fallback is this process's own client, the
+        // one thing we can still say for certain. That is the pre-registry
+        // behaviour, so a registry-less host degrades to exactly what it had
+        // before rather than to an empty set.
+        let connections: Vec<ConnectionInfo> = match host_wide {
+            Some(clients) => clients
+                .into_iter()
+                .map(|c| ConnectionInfo {
+                    client_id: c.client_id,
+                    client: c.client,
+                    client_version: c.client_version,
+                    connected_since: c.connected_since,
+                })
+                .collect(),
+            None => {
+                debug!("Registry unavailable; reporting this process's clients only");
+                local_registry
+                    .list()
+                    .into_iter()
+                    .map(|c| ConnectionInfo {
+                        client_id: c.client_id,
+                        client: c.client,
+                        client_version: c.client_version,
+                        connected_since: c.connected_since.to_rfc3339(),
+                    })
+                    .collect()
+            }
+        };
 
         Ok::<_, ErrorObjectOwned>(
             serde_json::to_value(ConnectionListResult { connections }).unwrap(),

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -24,8 +24,6 @@ use crate::files::{FileBackend, FileError};
 use crate::monitoring::MonitoringManagerApi;
 use crate::network;
 use crate::protocol::errors;
-use crate::registry_daemon::client::RegistryClient;
-use crate::registry_daemon::protocol::ClientRecord;
 use crate::protocol::methods::{
     AgentRequestDeferredUpdateParams, AgentRequestDeferredUpdateResult, AgentSettings,
     AgentSettingsUpdateParams, AgentShutdownParams, AgentShutdownResult, Capabilities,
@@ -40,6 +38,8 @@ use crate::protocol::methods::{
     SessionGetBufferResult, SessionInputParams, SessionListEntry, SessionListResult,
     SessionResizeParams,
 };
+use crate::registry_daemon::client::RegistryClient;
+use crate::registry_daemon::protocol::ClientRecord;
 use crate::session::definitions::{Connection, ConnectionStoreApi, Folder};
 use crate::session::manager::{
     DeferredUpdateError, DeferredUpdateOutcome, SessionCreateError, SessionManagerApi, MAX_SESSIONS,

--- a/agent/src/io/stdio.rs
+++ b/agent/src/io/stdio.rs
@@ -9,6 +9,7 @@ use crate::io::transport::run_transport_loop;
 use crate::monitoring::{MonitoringManager, MonitoringManagerApi};
 use crate::protocol::messages::JsonRpcNotification;
 use crate::registry::build_registry;
+use crate::registry_daemon::client::{RegistryClient, RegistryConfig};
 use crate::session::definitions::{ConnectionStore, ConnectionStoreApi};
 use crate::session::manager::SessionManager;
 
@@ -30,6 +31,7 @@ pub async fn run_stdio_loop(
     let connection_store = Arc::new(ConnectionStore::new(ConnectionStore::default_path()));
     let update_tx = notification_tx.clone();
     let test_update_tx = notification_tx.clone();
+    let registry_tx = notification_tx.clone();
     let monitoring_manager = Arc::new(MonitoringManager::new(
         notification_tx,
         connection_store.clone(),
@@ -64,11 +66,22 @@ pub async fn run_stdio_loop(
         test_update.notify_attached(&test_update_tx, env!("CARGO_PKG_VERSION"));
     }
 
+    // Join the host-wide registry (ADR-11) so this worker's client is visible to
+    // the host's other desktops, and cross-worker broadcasts reach ours. Started
+    // before the loop and connected in the background: the registry is optional
+    // infrastructure, so this must not delay serving the client.
+    let registry_client = Arc::new(RegistryClient::start(
+        RegistryConfig::default(),
+        registry_tx,
+        shutdown.child_token(),
+    ));
+
     let handler = AgentHandler::new(
         session_manager.clone(),
         connection_store.clone() as Arc<dyn ConnectionStoreApi>,
         monitoring_manager.clone() as Arc<dyn MonitoringManagerApi>,
-    )?;
+    )?
+    .with_registry_client(registry_client);
 
     let stdin = tokio::io::stdin();
     let mut stdout = tokio::io::stdout();

--- a/agent/src/io/tcp.rs
+++ b/agent/src/io/tcp.rs
@@ -10,6 +10,7 @@ use crate::io::transport::run_transport_loop;
 use crate::monitoring::{MonitoringManager, MonitoringManagerApi};
 use crate::protocol::messages::JsonRpcNotification;
 use crate::registry::build_registry;
+use crate::registry_daemon::client::{RegistryClient, RegistryConfig};
 use crate::session::definitions::{ConnectionStore, ConnectionStoreApi};
 use crate::session::manager::SessionManager;
 
@@ -37,9 +38,19 @@ pub async fn run_tcp_listener(
     let connection_store = Arc::new(ConnectionStore::new(ConnectionStore::default_path()));
     let update_tx = notification_tx.clone();
     let test_update_tx = notification_tx.clone();
+    let registry_tx = notification_tx.clone();
     let monitoring_manager = Arc::new(MonitoringManager::new(
         notification_tx,
         connection_store.clone(),
+    ));
+
+    // Join the host-wide registry (ADR-11). One per process, shared by every
+    // client this listener serves — the same lifetime as the `SessionManager`
+    // above, and for the same reason: it is host state, not client state.
+    let registry_client = Arc::new(RegistryClient::start(
+        RegistryConfig::default(),
+        registry_tx,
+        shutdown.child_token(),
     ));
 
     // Ensure default shell connection exists on first run
@@ -115,7 +126,7 @@ pub async fn run_tcp_listener(
                     connection_store.clone() as Arc<dyn ConnectionStoreApi>,
                     monitoring_manager.clone() as Arc<dyn MonitoringManagerApi>,
                 ) {
-                    Ok(handler) => handler,
+                    Ok(handler) => handler.with_registry_client(registry_client.clone()),
                     Err(e) => {
                         warn!("failed to build handler for {}, dropping client: {}", peer, e);
                         continue;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -140,7 +140,10 @@ async fn main() -> anyhow::Result<()> {
             // `registry_daemon::client`), never by a user. Exits on its own once
             // it has been idle, and exits immediately — successfully — if
             // another registry already owns the endpoint.
-            info!("termihub-agent {} starting as the host-wide registry", VERSION);
+            info!(
+                "termihub-agent {} starting as the host-wide registry",
+                VERSION
+            );
             registry_daemon::process::run_registry_daemon().await
         }
         other => {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -7,6 +7,7 @@ mod monitoring;
 mod network;
 mod protocol;
 mod registry;
+mod registry_daemon;
 mod session;
 mod state;
 mod transport;
@@ -27,6 +28,7 @@ fn print_usage() {
     eprintln!("  --stdio              Run in stdio mode (NDJSON over stdin/stdout)");
     eprintln!("  --listen [addr]      Run in TCP listener mode (default: {DEFAULT_LISTEN_ADDR})");
     eprintln!("  --daemon <id>        Run as a session daemon (internal use only)");
+    eprintln!("  --registry-daemon    Run as the host-wide client registry (internal use only)");
     eprintln!();
     eprintln!("Options:");
     eprintln!("  --version             Print version and exit");
@@ -130,6 +132,16 @@ async fn main() -> anyhow::Result<()> {
                 std::process::exit(1);
             });
             daemon::process::run_daemon(session_id).await
+        }
+        "--registry-daemon" => {
+            init_tracing();
+
+            // Spawned by a worker that could not find a registry (see
+            // `registry_daemon::client`), never by a user. Exits on its own once
+            // it has been idle, and exits immediately — successfully — if
+            // another registry already owns the endpoint.
+            info!("termihub-agent {} starting as the host-wide registry", VERSION);
+            registry_daemon::process::run_registry_daemon().await
         }
         other => {
             eprintln!("Unknown option: {}", other);

--- a/agent/src/registry_daemon/client.rs
+++ b/agent/src/registry_daemon/client.rs
@@ -102,6 +102,9 @@ enum Command {
     Register(Box<ClientRecord>),
     Deregister,
     List(oneshot::Sender<Vec<ClientRecord>>),
+    /// Constructed only by [`RegistryClient::broadcast`], whose production
+    /// caller lands with #1351 — see the note there.
+    #[allow(dead_code)]
     Broadcast(Box<BroadcastEnvelope>),
 }
 
@@ -167,9 +170,22 @@ impl RegistryClient {
     /// Fan a notification out to every *other* worker on this host.
     ///
     /// The cross-worker half of the notification path: the local per-process
-    /// channel can only reach this worker's own client, so anything that must
-    /// reach the host's other desktops goes through here.
-    #[cfg_attr(not(test), allow(dead_code))]
+    /// channel ([`io/tcp.rs`](crate::io::tcp)'s `mpsc`) is multi-producer but
+    /// **single-consumer**, so it can only ever reach this worker's own client.
+    /// Anything that must reach the host's *other* desktops goes through here.
+    ///
+    /// # No production caller yet
+    ///
+    /// #1574 deliberately ships the broadcast **substrate**; #1351 (coordinated
+    /// update notification) is the feature that sends one, and owns what gets
+    /// broadcast and when. So this is dead code on purpose until #1351 lands —
+    /// hence the `allow`, which should be removed with the first real caller.
+    ///
+    /// It is not untested: the registry's fan-out and this client's delivery are
+    /// unit-tested here and in [`super::process`], and
+    /// `agent/tests/registry_daemon_integration.rs` proves the round trip across
+    /// two processes on a real socket.
+    #[allow(dead_code)]
     pub fn broadcast(&self, envelope: BroadcastEnvelope) {
         let _ = self.cmd_tx.send(Command::Broadcast(Box::new(envelope)));
     }
@@ -249,7 +265,12 @@ async fn connect_or_spawn(config: &RegistryConfig) -> std::io::Result<(BoxedRead
     if let Err(e) = spawn_registry_daemon() {
         warn!("Failed to spawn registry daemon: {e}");
     }
-    ipc::connect_with_retry(&config.endpoint, SPAWN_CONNECT_TIMEOUT, CONNECT_POLL_INTERVAL).await
+    ipc::connect_with_retry(
+        &config.endpoint,
+        SPAWN_CONNECT_TIMEOUT,
+        CONNECT_POLL_INTERVAL,
+    )
+    .await
 }
 
 /// Spawn `termihub-agent --registry-daemon`, detached.
@@ -381,10 +402,9 @@ fn handle_frame(sup: &mut Supervisor, frame: crate::daemon::protocol::Frame) {
                 // Hand it to the worker's own notification channel — the last
                 // hop to this worker's client. A closed channel means the client
                 // is already gone; the event is simply not needed.
-                let _ = sup.notification_tx.send(JsonRpcNotification::new(
-                    envelope.method,
-                    envelope.params,
-                ));
+                let _ = sup
+                    .notification_tx
+                    .send(JsonRpcNotification::new(envelope.method, envelope.params));
             }
             Err(e) => warn!("Registry sent an undecodable event: {e}"),
         },
@@ -486,9 +506,13 @@ mod tests {
         let (mut sup, _rx) = supervisor();
         let mut sink: BoxedWriter = Box::new(tokio::io::sink());
 
-        handle_command(&mut sup, &mut sink, Command::Register(Box::new(record("a"))))
-            .await
-            .expect("register");
+        handle_command(
+            &mut sup,
+            &mut sink,
+            Command::Register(Box::new(record("a"))),
+        )
+        .await
+        .expect("register");
         assert_eq!(sup.desired, Some(record("a")));
 
         handle_command(&mut sup, &mut sink, Command::Deregister)

--- a/agent/src/registry_daemon/client.rs
+++ b/agent/src/registry_daemon/client.rs
@@ -1,0 +1,529 @@
+//! Worker-side client for the host-wide registry daemon (ADR-11).
+//!
+//! Every agent worker owns one [`RegistryClient`]. It announces the worker's
+//! client, answers "who else is attached to this host?", and carries
+//! cross-worker broadcasts.
+//!
+//! # The registry is optional, always
+//!
+//! The single hardest requirement here is that **a missing or restarting
+//! registry must never degrade a working agent**. A desktop's terminal must keep
+//! working on a host where the registry failed to spawn, crashed, or is mid
+//! restart. So every method on [`RegistryClient`] is infallible and
+//! non-blocking: they hand a command to a background supervisor task and return.
+//! The supervisor owns all the fallibility —
+//!
+//! - **Absent** → connecting fails, the supervisor spawns a registry and retries;
+//!   if that fails too it backs off and tries again, forever, silently.
+//! - **Restarting** → the connection drops, the supervisor reconnects and
+//!   **re-sends the registration it is holding**, which is what makes a restart
+//!   invisible to the worker and self-healing without any explicit resync.
+//! - **Never available** → [`list`](RegistryClient::list) times out and returns
+//!   `None`, and the caller falls back to its own per-process registry. A lone
+//!   worker still reports itself; it just cannot see peers, which is exactly the
+//!   pre-registry behaviour.
+//!
+//! Nothing here ever returns an error to the RPC layer, and nothing here is on
+//! a session's I/O path.
+//!
+//! ```text
+//!   RegistryClient::register/list/broadcast   (never blocks, never fails)
+//!            │ command channel
+//!            ▼
+//!    supervisor task ──connect or spawn──► registry daemon
+//!            │  ▲            reconnect + re-register on drop
+//!            ▼  │
+//!     MSG_EVENT │──► notification_tx ──► this worker's own client
+//! ```
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use termihub_core::ipc;
+use termihub_core::protocol::messages::JsonRpcNotification;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::daemon::protocol::{read_frame_async, write_frame_async};
+use crate::daemon::transport::{registry_endpoint, BoxedReader, BoxedWriter};
+use crate::io::transport::NotificationSender;
+use crate::registry_daemon::protocol::{
+    BroadcastEnvelope, ClientRecord, MSG_BROADCAST, MSG_CLIENTS, MSG_DEREGISTER, MSG_EVENT,
+    MSG_LIST, MSG_REGISTER,
+};
+
+/// How long [`RegistryClient::list`] waits for the registry to answer before
+/// giving up and letting the caller fall back to its per-process view.
+///
+/// A local socket round-trip to a process that holds everything in memory is
+/// sub-millisecond; this bound exists only so a wedged registry cannot stall an
+/// `agent.list_connections` RPC. It is deliberately far below any desktop-side
+/// RPC timeout, so the fallback answer arrives well before the caller gives up.
+const LIST_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How long to wait for a freshly spawned registry to bind its endpoint.
+///
+/// Much shorter than the session daemon's 30 s: a registry binds a socket and
+/// nothing else — no PTY, no shell, no ConPTY — so if it has not appeared in a
+/// few seconds it is not coming, and the worker is better off proceeding
+/// without it than blocking.
+const SPAWN_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// How often to retry while a freshly spawned registry binds its endpoint.
+const CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+/// How long the supervisor waits after a failed or dropped connection before
+/// trying again. Bounds the respawn rate when a registry cannot start at all.
+const RECONNECT_DELAY: Duration = Duration::from_secs(2);
+
+/// How the worker reaches its registry.
+#[derive(Debug, Clone)]
+pub struct RegistryConfig {
+    /// Endpoint to connect to (unix socket path / windows pipe name).
+    pub endpoint: String,
+    /// Whether a failed connect may spawn a registry daemon.
+    ///
+    /// Always `true` in production. Tests that run the registry in-process set
+    /// it to `false` so a failure surfaces as a failure rather than silently
+    /// spawning a real detached process from the test binary.
+    pub auto_spawn: bool,
+}
+
+impl Default for RegistryConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: registry_endpoint(),
+            auto_spawn: true,
+        }
+    }
+}
+
+/// A command from a [`RegistryClient`] handle to its supervisor task.
+enum Command {
+    Register(Box<ClientRecord>),
+    Deregister,
+    List(oneshot::Sender<Vec<ClientRecord>>),
+    Broadcast(Box<BroadcastEnvelope>),
+}
+
+/// Handle to this worker's registry connection.
+///
+/// Cheap to clone-by-`Arc` and safe to use from any task. Dropping the handle
+/// does not stop the supervisor; cancel the [`CancellationToken`] passed to
+/// [`start`](Self::start) for that (the transport loops pass their shutdown
+/// token, so the supervisor dies with the worker).
+pub struct RegistryClient {
+    cmd_tx: mpsc::UnboundedSender<Command>,
+}
+
+impl RegistryClient {
+    /// Start a registry client and its background supervisor.
+    ///
+    /// Returns immediately — the supervisor connects (spawning a registry if
+    /// needed) in the background, so a slow or missing registry never delays
+    /// worker startup. `notification_tx` is this worker's existing notification
+    /// channel: broadcasts from *other* workers are delivered into it, which is
+    /// how a cross-worker event reaches this worker's client.
+    pub fn start(
+        config: RegistryConfig,
+        notification_tx: NotificationSender,
+        shutdown: CancellationToken,
+    ) -> Self {
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        tokio::spawn(supervise(config, cmd_rx, notification_tx, shutdown));
+        Self { cmd_tx }
+    }
+
+    /// Announce this worker's client to the host.
+    ///
+    /// Called when `initialize` completes — never when a session is created —
+    /// which is precisely why a desktop **holding no sessions** is still
+    /// visible to its peers. Sent again automatically after any reconnect.
+    pub fn register(&self, record: ClientRecord) {
+        let _ = self.cmd_tx.send(Command::Register(Box::new(record)));
+    }
+
+    /// Withdraw this worker's client (its connection ended).
+    pub fn deregister(&self) {
+        let _ = self.cmd_tx.send(Command::Deregister);
+    }
+
+    /// Every client attached to this host, or `None` when the registry could not
+    /// answer in [`LIST_TIMEOUT`].
+    ///
+    /// `None` means "no host-wide view available", not "nobody is connected" —
+    /// callers must fall back to their per-process registry rather than report
+    /// an empty host.
+    pub async fn list(&self) -> Option<Vec<ClientRecord>> {
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx.send(Command::List(tx)).ok()?;
+        match tokio::time::timeout(LIST_TIMEOUT, rx).await {
+            Ok(Ok(clients)) => Some(clients),
+            // Timed out, or the supervisor dropped the responder because the
+            // connection died before it could answer.
+            _ => None,
+        }
+    }
+
+    /// Fan a notification out to every *other* worker on this host.
+    ///
+    /// The cross-worker half of the notification path: the local per-process
+    /// channel can only reach this worker's own client, so anything that must
+    /// reach the host's other desktops goes through here.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn broadcast(&self, envelope: BroadcastEnvelope) {
+        let _ = self.cmd_tx.send(Command::Broadcast(Box::new(envelope)));
+    }
+}
+
+/// State the supervisor keeps **across** reconnects.
+struct Supervisor {
+    /// The registration to (re-)send on every connection. Holding it here is
+    /// what makes a registry restart self-healing.
+    desired: Option<ClientRecord>,
+    /// `list` responders awaiting a `MSG_CLIENTS`, in send order.
+    ///
+    /// A single connection delivers frames in order, so the registry answers
+    /// `MSG_LIST`s in the order it received them and FIFO matching is exact —
+    /// no correlation ids needed on the wire.
+    pending_lists: VecDeque<oneshot::Sender<Vec<ClientRecord>>>,
+    notification_tx: NotificationSender,
+}
+
+/// Own the registry connection for the worker's whole life: connect, serve,
+/// reconnect, forever, until `shutdown`.
+async fn supervise(
+    config: RegistryConfig,
+    mut cmd_rx: mpsc::UnboundedReceiver<Command>,
+    notification_tx: NotificationSender,
+    shutdown: CancellationToken,
+) {
+    let mut sup = Supervisor {
+        desired: None,
+        pending_lists: VecDeque::new(),
+        notification_tx,
+    };
+
+    while !shutdown.is_cancelled() {
+        match connect_or_spawn(&config).await {
+            Ok((reader, writer)) => {
+                debug!("Registry client connected to {}", config.endpoint);
+                run_session(&mut sup, &mut cmd_rx, reader, writer, &shutdown).await;
+                debug!("Registry client session ended");
+            }
+            Err(e) => {
+                // Not an error the worker should care about — it just means no
+                // host-wide view for now. Everything else keeps working.
+                debug!("Registry unavailable at {}: {e}", config.endpoint);
+            }
+        }
+
+        // The connection is gone; nobody is going to answer these.
+        sup.pending_lists.clear();
+
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            _ = tokio::time::sleep(RECONNECT_DELAY) => {}
+        }
+    }
+    debug!("Registry client supervisor stopped");
+}
+
+/// Connect to the registry, spawning one if nothing is listening.
+///
+/// Probes with a fail-fast connect first: on the overwhelmingly common path a
+/// registry is already up and this is a single syscall with no process spawn.
+async fn connect_or_spawn(config: &RegistryConfig) -> std::io::Result<(BoxedReader, BoxedWriter)> {
+    if let Ok(halves) = ipc::connect(&config.endpoint).await {
+        return Ok(halves);
+    }
+    if !config.auto_spawn {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "registry not running and auto-spawn is disabled",
+        ));
+    }
+
+    // Nothing listening — start one. Several workers may reach this at once;
+    // the losers' daemons exit on `AddrInUse` and everyone connects to the
+    // winner, so no locking is needed (see `process::run_registry_daemon`).
+    if let Err(e) = spawn_registry_daemon() {
+        warn!("Failed to spawn registry daemon: {e}");
+    }
+    ipc::connect_with_retry(&config.endpoint, SPAWN_CONNECT_TIMEOUT, CONNECT_POLL_INTERVAL).await
+}
+
+/// Spawn `termihub-agent --registry-daemon`, detached.
+///
+/// Uses the **same** detachment path as the session daemons
+/// ([`crate::daemon::spawn`]) — that shared path is what gives the registry the
+/// survives-an-agent-binary-swap property ADR-11's deferred-update approach
+/// leans on, rather than a second, subtly different daemonization.
+fn spawn_registry_daemon() -> std::io::Result<()> {
+    let agent_exe = std::env::current_exe()?;
+    let mut command = std::process::Command::new(&agent_exe);
+    command
+        .arg("--registry-daemon")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null());
+
+    #[cfg(unix)]
+    let log = crate::daemon::transport::open_registry_log();
+    #[cfg(not(unix))]
+    let log = None;
+    crate::daemon::spawn::configure_detached_stderr(&mut command, log);
+    crate::daemon::spawn::configure_detachment(&mut command);
+
+    // Detached and never waited on: the child reparents to init and outlives us
+    // by design, so there is no zombie to reap.
+    command.spawn()?;
+    info!("Spawned registry daemon");
+    Ok(())
+}
+
+/// Drive one registry connection until it fails or the worker shuts down.
+async fn run_session(
+    sup: &mut Supervisor,
+    cmd_rx: &mut mpsc::UnboundedReceiver<Command>,
+    mut reader: BoxedReader,
+    mut writer: BoxedWriter,
+    shutdown: &CancellationToken,
+) {
+    // Re-announce whatever we are holding. On a first connection this is
+    // usually `None` (nobody has called `initialize` yet) and the register
+    // arrives as a command moments later; on a reconnect it is the whole point.
+    if let Some(record) = sup.desired.clone() {
+        if send_json(&mut writer, MSG_REGISTER, &record).await.is_err() {
+            return;
+        }
+    }
+
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                // Say goodbye so peers see us leave immediately rather than
+                // when the OS eventually tears the socket down.
+                let _ = write_frame_async(&mut writer, MSG_DEREGISTER, &[]).await;
+                return;
+            }
+
+            cmd = cmd_rx.recv() => {
+                let Some(cmd) = cmd else { return };
+                if handle_command(sup, &mut writer, cmd).await.is_err() {
+                    return;
+                }
+            }
+
+            frame = read_frame_async(&mut reader) => {
+                match frame {
+                    Ok(Some(frame)) => handle_frame(sup, frame),
+                    Ok(None) => {
+                        debug!("Registry closed the connection");
+                        return;
+                    }
+                    Err(e) => {
+                        debug!("Registry read error: {e}");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Apply one command, writing whatever it implies to the registry.
+///
+/// `Err` means the connection is unusable and the session must end (the
+/// supervisor then reconnects and replays `desired`).
+async fn handle_command(
+    sup: &mut Supervisor,
+    writer: &mut BoxedWriter,
+    cmd: Command,
+) -> std::io::Result<()> {
+    match cmd {
+        Command::Register(record) => {
+            // Remember before sending: if the write fails, the reconnect must
+            // still know what to announce.
+            sup.desired = Some(*record.clone());
+            send_json(writer, MSG_REGISTER, &*record).await
+        }
+        Command::Deregister => {
+            sup.desired = None;
+            write_frame_async(writer, MSG_DEREGISTER, &[]).await
+        }
+        Command::List(responder) => {
+            write_frame_async(writer, MSG_LIST, &[]).await?;
+            sup.pending_lists.push_back(responder);
+            Ok(())
+        }
+        Command::Broadcast(envelope) => send_json(writer, MSG_BROADCAST, &*envelope).await,
+    }
+}
+
+/// Apply one frame from the registry.
+fn handle_frame(sup: &mut Supervisor, frame: crate::daemon::protocol::Frame) {
+    match frame.msg_type {
+        MSG_CLIENTS => match serde_json::from_slice::<Vec<ClientRecord>>(&frame.payload) {
+            Ok(clients) => {
+                if let Some(responder) = sup.pending_lists.pop_front() {
+                    // `Err` just means the caller already timed out and walked
+                    // away — its fallback answer is already on its way back.
+                    let _ = responder.send(clients);
+                }
+            }
+            Err(e) => warn!("Registry sent an undecodable client list: {e}"),
+        },
+        MSG_EVENT => match serde_json::from_slice::<BroadcastEnvelope>(&frame.payload) {
+            Ok(envelope) => {
+                debug!(
+                    "Registry event {} from {}",
+                    envelope.method, envelope.origin_client_id
+                );
+                // Hand it to the worker's own notification channel — the last
+                // hop to this worker's client. A closed channel means the client
+                // is already gone; the event is simply not needed.
+                let _ = sup.notification_tx.send(JsonRpcNotification::new(
+                    envelope.method,
+                    envelope.params,
+                ));
+            }
+            Err(e) => warn!("Registry sent an undecodable event: {e}"),
+        },
+        // `MSG_ACK` needs no action — `register` is fire-and-forget by design.
+        // Unknown types are ignored: this worker may be older or newer than the
+        // registry it found, which is normal across a binary swap.
+        _ => {}
+    }
+}
+
+/// Write a JSON-payload frame.
+async fn send_json<T: serde::Serialize>(
+    writer: &mut BoxedWriter,
+    msg_type: u8,
+    value: &T,
+) -> std::io::Result<()> {
+    let payload = serde_json::to_vec(value).map_err(std::io::Error::other)?;
+    write_frame_async(writer, msg_type, &payload).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(client_id: &str) -> ClientRecord {
+        ClientRecord {
+            client_id: client_id.into(),
+            client: "termihub-desktop".into(),
+            client_version: "1.0.0".into(),
+            connected_since: "2026-07-17T10:00:00+00:00".into(),
+            pid: std::process::id(),
+        }
+    }
+
+    fn supervisor() -> (Supervisor, mpsc::UnboundedReceiver<JsonRpcNotification>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            Supervisor {
+                desired: None,
+                pending_lists: VecDeque::new(),
+                notification_tx: tx,
+            },
+            rx,
+        )
+    }
+
+    /// A broadcast from another worker must arrive on this worker's own
+    /// notification channel — that hop is what makes the registry a real
+    /// cross-worker notification path rather than just a directory.
+    #[test]
+    fn an_event_is_delivered_to_this_workers_notification_channel() {
+        let (mut sup, mut rx) = supervisor();
+        let envelope = BroadcastEnvelope {
+            origin_client_id: "other".into(),
+            method: "agent.update_pending".into(),
+            params: serde_json::json!({"version": "2.0.0"}),
+        };
+
+        handle_frame(
+            &mut sup,
+            crate::daemon::protocol::Frame {
+                msg_type: MSG_EVENT,
+                payload: serde_json::to_vec(&envelope).unwrap(),
+            },
+        );
+
+        let notification = rx.try_recv().expect("notification forwarded");
+        assert_eq!(notification.method, "agent.update_pending");
+        assert_eq!(notification.params, serde_json::json!({"version": "2.0.0"}));
+        assert_eq!(notification.jsonrpc, "2.0");
+    }
+
+    #[test]
+    fn client_lists_are_matched_to_waiters_in_order() {
+        let (mut sup, _rx) = supervisor();
+        let (tx1, rx1) = oneshot::channel();
+        let (tx2, rx2) = oneshot::channel();
+        sup.pending_lists.push_back(tx1);
+        sup.pending_lists.push_back(tx2);
+
+        for ids in [vec![record("a")], vec![record("b")]] {
+            handle_frame(
+                &mut sup,
+                crate::daemon::protocol::Frame {
+                    msg_type: MSG_CLIENTS,
+                    payload: serde_json::to_vec(&ids).unwrap(),
+                },
+            );
+        }
+
+        assert_eq!(rx1.blocking_recv().unwrap(), vec![record("a")]);
+        assert_eq!(rx2.blocking_recv().unwrap(), vec![record("b")]);
+    }
+
+    /// The registration must be remembered, not just sent — a reconnect replays
+    /// it, and that replay is the entire "survives a registry restart" story.
+    #[tokio::test]
+    async fn register_is_remembered_for_replay_and_deregister_forgets_it() {
+        let (mut sup, _rx) = supervisor();
+        let mut sink: BoxedWriter = Box::new(tokio::io::sink());
+
+        handle_command(&mut sup, &mut sink, Command::Register(Box::new(record("a"))))
+            .await
+            .expect("register");
+        assert_eq!(sup.desired, Some(record("a")));
+
+        handle_command(&mut sup, &mut sink, Command::Deregister)
+            .await
+            .expect("deregister");
+        assert_eq!(sup.desired, None, "a withdrawn client must not be replayed");
+    }
+
+    /// With no registry reachable and no spawning allowed, `list` must return
+    /// `None` — the signal that tells `agent.list_connections` to fall back to
+    /// its per-process view instead of reporting an empty host.
+    #[tokio::test]
+    async fn list_returns_none_when_the_registry_never_answers() {
+        let client = RegistryClient::start(
+            RegistryConfig {
+                endpoint: crate::daemon::transport::session_endpoint("nonexistent-registry-probe"),
+                auto_spawn: false,
+            },
+            mpsc::unbounded_channel().0,
+            CancellationToken::new(),
+        );
+
+        assert_eq!(client.list().await, None);
+    }
+
+    #[test]
+    fn unknown_frames_from_a_skewed_registry_are_ignored() {
+        let (mut sup, mut rx) = supervisor();
+        handle_frame(
+            &mut sup,
+            crate::daemon::protocol::Frame {
+                msg_type: 0xEE,
+                payload: b"from a newer registry".to_vec(),
+            },
+        );
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/agent/src/registry_daemon/mod.rs
+++ b/agent/src/registry_daemon/mod.rs
@@ -1,0 +1,32 @@
+//! The host-wide registry daemon: a new daemon **role** on the existing daemon
+//! substrate (ADR-11 in `docs/architecture.md`).
+//!
+//! The session daemons are shared across **time** — a restarted worker
+//! re-attaches to one and replays its ring buffer — but never across
+//! **workers**: their endpoints are per-session (`session-{id}.sock`), a second
+//! attach *evicts* the first, and a desktop holding no sessions has no daemon at
+//! all. So they cannot answer "who else is attached to this host?".
+//!
+//! The registry daemon can. It is one process per user per host that every
+//! worker registers its client with, keyed to `initialize` rather than to any
+//! session — which is what makes a **session-less desktop** visible and
+//! reachable, the case an agent binary swap would otherwise kill without
+//! warning.
+//!
+//! It is a new *role*, not a new *mechanism*: [`process`] listens on
+//! [`crate::daemon::transport::DaemonListener`], speaks
+//! [`crate::daemon::protocol`]'s framing, lives in the same per-user
+//! current-user-only socket dir, and is spawned through the same detached-spawn
+//! path ([`crate::daemon::spawn`]) as the session daemons. That reuse is what
+//! carries over the three properties the role must have: **no new network
+//! socket** (unix socket / windows named pipe, current-user-only), **survives an
+//! agent binary swap** (detached), and **all three platforms** (inherited from
+//! `termihub_core::ipc`).
+//!
+//! - [`protocol`] — the role's frame vocabulary and record types
+//! - [`process`] — the daemon itself (`termihub-agent --registry-daemon`)
+//! - [`client`] — the worker-side handle, which treats the registry as optional
+
+pub mod client;
+pub mod process;
+pub mod protocol;

--- a/agent/src/registry_daemon/process.rs
+++ b/agent/src/registry_daemon/process.rs
@@ -1,0 +1,424 @@
+//! The host-wide registry daemon process (`termihub-agent --registry-daemon`).
+//!
+//! One per user per host (ADR-11). Agent workers connect to it, announce the
+//! client they serve, ask it who else is connected, and fan notifications out
+//! through it. It is a **rendezvous**, not a proxy: it holds no sessions, no
+//! PTYs and no buffers, only the client set and the broadcast fan-out.
+//!
+//! Three things distinguish it from the per-session daemon role it shares its
+//! substrate with:
+//!
+//! - **Many concurrent connections.** A session daemon owns a PTY, so a second
+//!   attach *takes over* (`daemon/process.rs` evicts the previous worker on
+//!   every `accept`). A registry with takeover semantics would be pointless —
+//!   the whole job is holding several workers at once — so each connection gets
+//!   its own task and its own writer, and none evicts another.
+//! - **Singleton endpoint.** Its path has no unique component, so several
+//!   workers can race to spawn it. [`DaemonListener::bind_singleton`] makes the
+//!   race safe: the loser gets `AddrInUse` and exits quietly (see
+//!   [`run_registry_daemon`]).
+//! - **Idle exit.** A session daemon lives as long as its shell. The registry
+//!   has nothing of its own to keep alive, so it exits once it has been empty
+//!   for [`IDLE_TIMEOUT`] rather than lingering forever on a host whose desktops
+//!   have all gone home. A worker that needs it again just respawns it.
+//!
+//! Liveness is the connection itself. A worker that exits — cleanly, killed, or
+//! crashed — closes its socket, and the registry drops its record on EOF. There
+//! is no PID reaping and no heartbeat, because there is nothing a dead worker
+//! can leave behind.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use crate::daemon::protocol::{read_frame_async, write_frame_async};
+use crate::daemon::transport::{registry_endpoint, BoxedReader, BoxedWriter, DaemonListener};
+use crate::registry_daemon::protocol::{
+    BroadcastEnvelope, ClientRecord, MSG_ACK, MSG_BROADCAST, MSG_CLIENTS, MSG_DEREGISTER,
+    MSG_EVENT, MSG_LIST, MSG_REGISTER,
+};
+
+/// How long the registry stays up with no worker connected before exiting.
+///
+/// Long enough to ride out the gap while a host's last desktop reconnects (an
+/// agent binary swap, an SSH blip) without a respawn; short enough that a host
+/// nobody is using is not left with an idle process. Respawn is cheap and
+/// automatic, so erring low costs only a process start.
+pub const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// A single connected worker.
+struct WorkerConn {
+    /// The client this worker announced, once it has sent `MSG_REGISTER`.
+    ///
+    /// `None` between accept and register — and after a `MSG_DEREGISTER` from a
+    /// worker whose client disconnected but whose process is still up. Such a
+    /// worker still holds a live connection and still receives broadcasts; it
+    /// just is not part of the client set.
+    record: Option<ClientRecord>,
+    /// Outbound frames for this worker, drained by its writer task.
+    tx: mpsc::UnboundedSender<(u8, Vec<u8>)>,
+}
+
+/// The registry's whole state: who is connected, and how to reach them.
+#[derive(Default)]
+struct RegistryState {
+    workers: Mutex<HashMap<u64, WorkerConn>>,
+}
+
+impl RegistryState {
+    /// Snapshot of every registered client, host-wide.
+    fn clients(&self) -> Vec<ClientRecord> {
+        let guard = self.workers.lock().unwrap_or_else(|e| e.into_inner());
+        guard.values().filter_map(|w| w.record.clone()).collect()
+    }
+
+    /// Number of live worker connections (registered or not).
+    fn connection_count(&self) -> usize {
+        let guard = self.workers.lock().unwrap_or_else(|e| e.into_inner());
+        guard.len()
+    }
+
+    /// Fan `payload` out to every worker except `except_conn`.
+    ///
+    /// Send failures are ignored: an unbounded channel only fails when the
+    /// receiving task is gone, which means that worker is already tearing down
+    /// and its own reader loop will remove it. A broadcast must never fail
+    /// because one recipient died.
+    fn fan_out(&self, except_conn: u64, msg_type: u8, payload: Vec<u8>) {
+        let guard = self.workers.lock().unwrap_or_else(|e| e.into_inner());
+        for (conn_id, worker) in guard.iter() {
+            if *conn_id == except_conn {
+                continue;
+            }
+            let _ = worker.tx.send((msg_type, payload.clone()));
+        }
+    }
+}
+
+/// Run the registry daemon until it has been idle for [`IDLE_TIMEOUT`].
+///
+/// Binds the singleton endpoint first. If another registry already owns it the
+/// bind fails with [`io::ErrorKind::AddrInUse`](std::io::ErrorKind::AddrInUse)
+/// and this returns `Ok(())` — losing a spawn race is a **success**, not an
+/// error: the winner is serving, which is exactly what the loser's spawner
+/// wanted. Any other bind error is real and propagates.
+pub async fn run_registry_daemon() -> anyhow::Result<()> {
+    run_registry_daemon_at(&registry_endpoint(), IDLE_TIMEOUT).await
+}
+
+/// [`run_registry_daemon`] with the endpoint and idle timeout supplied.
+///
+/// Production always uses [`run_registry_daemon`]; this exists so tests can run
+/// the **real** registry — real socket, real frames, real concurrency — on a
+/// throwaway endpoint without racing the host's live one or waiting a minute to
+/// observe the idle exit.
+pub async fn run_registry_daemon_at(endpoint: &str, idle_timeout: Duration) -> anyhow::Result<()> {
+    let mut listener = match DaemonListener::bind_singleton(endpoint).await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            info!("Registry daemon already running at {endpoint}, exiting");
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "Failed to bind registry endpoint {endpoint}: {e}"
+            ))
+        }
+    };
+
+    info!("Registry daemon listening at {endpoint}");
+
+    let state = Arc::new(RegistryState::default());
+    let next_conn_id = AtomicU64::new(0);
+
+    loop {
+        match tokio::time::timeout(idle_timeout, listener.accept()).await {
+            Ok(Ok((reader, writer))) => {
+                let conn_id = next_conn_id.fetch_add(1, Ordering::Relaxed);
+                tokio::spawn(serve_worker(state.clone(), conn_id, reader, writer));
+            }
+            Ok(Err(e)) => {
+                // As in the TCP accept loop: a transient accept error must not
+                // tear the registry down and disconnect every other worker.
+                warn!("Registry accept() failed, continuing to listen: {e}");
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            Err(_elapsed) => {
+                if state.connection_count() == 0 {
+                    info!("Registry daemon idle for {idle_timeout:?}, exiting");
+                    break;
+                }
+            }
+        }
+    }
+
+    listener.cleanup();
+    Ok(())
+}
+
+/// Serve one worker connection for its whole life.
+///
+/// Splits into a writer task draining the worker's outbound queue and this
+/// reader loop. On any read error or EOF the worker is removed from the state —
+/// that removal is the registry's entire liveness story.
+async fn serve_worker(
+    state: Arc<RegistryState>,
+    conn_id: u64,
+    mut reader: BoxedReader,
+    mut writer: BoxedWriter,
+) {
+    let (tx, mut rx) = mpsc::unbounded_channel::<(u8, Vec<u8>)>();
+
+    {
+        let mut guard = state.workers.lock().unwrap_or_else(|e| e.into_inner());
+        guard.insert(conn_id, WorkerConn { record: None, tx });
+    }
+    debug!("Registry: worker {conn_id} connected");
+
+    let writer_task = tokio::spawn(async move {
+        while let Some((msg_type, payload)) = rx.recv().await {
+            if let Err(e) = write_frame_async(&mut writer, msg_type, &payload).await {
+                debug!("Registry: write to worker failed, dropping writer: {e}");
+                break;
+            }
+        }
+    });
+
+    loop {
+        match read_frame_async(&mut reader).await {
+            Ok(Some(frame)) => handle_frame(&state, conn_id, frame),
+            Ok(None) => {
+                debug!("Registry: worker {conn_id} disconnected (EOF)");
+                break;
+            }
+            Err(e) => {
+                debug!("Registry: worker {conn_id} read error: {e}");
+                break;
+            }
+        }
+    }
+
+    // The worker is gone — drop its record (and, by dropping its sender, stop
+    // its writer task). This is what garbage-collects a crashed worker.
+    {
+        let mut guard = state.workers.lock().unwrap_or_else(|e| e.into_inner());
+        guard.remove(&conn_id);
+    }
+    writer_task.abort();
+}
+
+/// Apply one frame from a worker to the registry state.
+///
+/// Never fails the connection on a bad frame: an unknown type or an undecodable
+/// payload is logged and skipped. A worker built against a newer or older
+/// vocabulary must degrade, not be disconnected — the registry outlives agent
+/// binary swaps by design, so version skew across the endpoint is the normal
+/// case, not an error.
+fn handle_frame(state: &Arc<RegistryState>, conn_id: u64, frame: crate::daemon::protocol::Frame) {
+    match frame.msg_type {
+        MSG_REGISTER => {
+            let record: ClientRecord = match serde_json::from_slice(&frame.payload) {
+                Ok(record) => record,
+                Err(e) => {
+                    warn!("Registry: undecodable REGISTER from worker {conn_id}: {e}");
+                    return;
+                }
+            };
+            info!(
+                "Registry: client {} ({} {}) registered from pid {}",
+                record.client_id, record.client, record.client_version, record.pid
+            );
+            let mut guard = state.workers.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(worker) = guard.get_mut(&conn_id) {
+                worker.record = Some(record);
+                let _ = worker.tx.send((MSG_ACK, Vec::new()));
+            }
+        }
+        MSG_DEREGISTER => {
+            let mut guard = state.workers.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(worker) = guard.get_mut(&conn_id) {
+                if let Some(record) = worker.record.take() {
+                    info!("Registry: client {} deregistered", record.client_id);
+                }
+            }
+        }
+        MSG_LIST => {
+            let clients = state.clients();
+            let payload = match serde_json::to_vec(&clients) {
+                Ok(payload) => payload,
+                Err(e) => {
+                    warn!("Registry: failed to encode client list: {e}");
+                    return;
+                }
+            };
+            let guard = state.workers.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(worker) = guard.get(&conn_id) {
+                let _ = worker.tx.send((MSG_CLIENTS, payload));
+            }
+        }
+        MSG_BROADCAST => {
+            // Decode only to validate and to log the origin — the payload is
+            // forwarded byte-for-byte, so the registry never needs to
+            // understand the notification it is carrying.
+            match serde_json::from_slice::<BroadcastEnvelope>(&frame.payload) {
+                Ok(envelope) => {
+                    debug!(
+                        "Registry: broadcasting {} from {}",
+                        envelope.method, envelope.origin_client_id
+                    );
+                    state.fan_out(conn_id, MSG_EVENT, frame.payload);
+                }
+                Err(e) => warn!("Registry: undecodable BROADCAST from worker {conn_id}: {e}"),
+            }
+        }
+        other => debug!("Registry: ignoring unknown frame type 0x{other:02x}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn record(client_id: &str) -> ClientRecord {
+        ClientRecord {
+            client_id: client_id.into(),
+            client: "termihub-desktop".into(),
+            client_version: "1.0.0".into(),
+            connected_since: "2026-07-17T10:00:00+00:00".into(),
+            pid: 1,
+        }
+    }
+
+    fn conn(state: &RegistryState, conn_id: u64) -> mpsc::UnboundedReceiver<(u8, Vec<u8>)> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        state
+            .workers
+            .lock()
+            .unwrap()
+            .insert(conn_id, WorkerConn { record: None, tx });
+        rx
+    }
+
+    fn frame(msg_type: u8, payload: Vec<u8>) -> crate::daemon::protocol::Frame {
+        crate::daemon::protocol::Frame { msg_type, payload }
+    }
+
+    #[test]
+    fn register_records_the_client_and_acks() {
+        let state = Arc::new(RegistryState::default());
+        let mut rx = conn(&state, 0);
+
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_REGISTER, serde_json::to_vec(&record("a")).unwrap()),
+        );
+
+        assert_eq!(state.clients(), vec![record("a")]);
+        assert_eq!(rx.try_recv().expect("ack").0, MSG_ACK);
+    }
+
+    /// The property the whole issue turns on: a worker holding **no sessions**
+    /// is still a registered, visible client. Registration is keyed to
+    /// `initialize`, never to session topology.
+    #[test]
+    fn a_session_less_worker_is_still_visible_to_others() {
+        let state = Arc::new(RegistryState::default());
+        // Two workers, neither of which has ever mentioned a session.
+        let _rx_a = conn(&state, 0);
+        let mut rx_b = conn(&state, 1);
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_REGISTER, serde_json::to_vec(&record("a")).unwrap()),
+        );
+        handle_frame(
+            &state,
+            1,
+            frame(MSG_REGISTER, serde_json::to_vec(&record("b")).unwrap()),
+        );
+
+        // Worker B asks who is connected and sees session-less worker A.
+        let _ = rx_b.try_recv(); // the ACK
+        handle_frame(&state, 1, frame(MSG_LIST, Vec::new()));
+        let (msg_type, payload) = rx_b.try_recv().expect("client list");
+        assert_eq!(msg_type, MSG_CLIENTS);
+        let clients: Vec<ClientRecord> = serde_json::from_slice(&payload).unwrap();
+
+        let mut ids: Vec<String> = clients.into_iter().map(|c| c.client_id).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn deregister_clears_the_record_but_keeps_the_connection() {
+        let state = Arc::new(RegistryState::default());
+        let _rx = conn(&state, 0);
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_REGISTER, serde_json::to_vec(&record("a")).unwrap()),
+        );
+        handle_frame(&state, 0, frame(MSG_DEREGISTER, Vec::new()));
+
+        assert!(state.clients().is_empty(), "record must be withdrawn");
+        assert_eq!(
+            state.connection_count(),
+            1,
+            "the worker is still connected and must keep receiving broadcasts"
+        );
+    }
+
+    #[test]
+    fn broadcast_reaches_every_other_worker_but_not_the_sender() {
+        let state = Arc::new(RegistryState::default());
+        let mut rx_a = conn(&state, 0);
+        let mut rx_b = conn(&state, 1);
+        let mut rx_c = conn(&state, 2);
+
+        let envelope = BroadcastEnvelope {
+            origin_client_id: "a".into(),
+            method: "agent.update_pending".into(),
+            params: json!({"version": "2.0.0"}),
+        };
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_BROADCAST, serde_json::to_vec(&envelope).unwrap()),
+        );
+
+        for rx in [&mut rx_b, &mut rx_c] {
+            let (msg_type, payload) = rx.try_recv().expect("event delivered");
+            assert_eq!(msg_type, MSG_EVENT);
+            let got: BroadcastEnvelope = serde_json::from_slice(&payload).unwrap();
+            assert_eq!(got, envelope);
+        }
+        assert!(
+            rx_a.try_recv().is_err(),
+            "a broadcast must not echo back to its sender"
+        );
+    }
+
+    #[test]
+    fn a_malformed_frame_is_skipped_rather_than_failing_the_worker() {
+        let state = Arc::new(RegistryState::default());
+        let mut rx = conn(&state, 0);
+
+        handle_frame(&state, 0, frame(MSG_REGISTER, b"not json".to_vec()));
+        handle_frame(&state, 0, frame(0xEE, b"from a newer agent".to_vec()));
+        // Still serving: a good REGISTER after the bad ones still works.
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_REGISTER, serde_json::to_vec(&record("a")).unwrap()),
+        );
+
+        assert_eq!(state.clients(), vec![record("a")]);
+        assert_eq!(rx.try_recv().expect("ack").0, MSG_ACK);
+    }
+}

--- a/agent/src/registry_daemon/protocol.rs
+++ b/agent/src/registry_daemon/protocol.rs
@@ -139,9 +139,13 @@ mod tests {
     async fn register_payload_survives_the_session_daemon_framing() {
         let record = sample_record();
         let mut buf: Vec<u8> = Vec::new();
-        frames::write_frame_async(&mut buf, MSG_REGISTER, &serde_json::to_vec(&record).unwrap())
-            .await
-            .expect("write frame");
+        frames::write_frame_async(
+            &mut buf,
+            MSG_REGISTER,
+            &serde_json::to_vec(&record).unwrap(),
+        )
+        .await
+        .expect("write frame");
 
         let mut cursor = std::io::Cursor::new(buf);
         let frame = frames::read_frame_async(&mut cursor)
@@ -158,8 +162,15 @@ mod tests {
     #[test]
     fn registry_types_do_not_collide_with_session_daemon_types() {
         use crate::daemon::protocol as session;
-        let registry = [MSG_REGISTER, MSG_DEREGISTER, MSG_LIST, MSG_BROADCAST, MSG_ACK,
-                        MSG_CLIENTS, MSG_EVENT];
+        let registry = [
+            MSG_REGISTER,
+            MSG_DEREGISTER,
+            MSG_LIST,
+            MSG_BROADCAST,
+            MSG_ACK,
+            MSG_CLIENTS,
+            MSG_EVENT,
+        ];
         let session = [
             session::MSG_INPUT,
             session::MSG_RESIZE,
@@ -173,7 +184,10 @@ mod tests {
             session::MSG_READY,
         ];
         for r in registry {
-            assert!(!session.contains(&r), "type 0x{r:02x} is used by both roles");
+            assert!(
+                !session.contains(&r),
+                "type 0x{r:02x} is used by both roles"
+            );
         }
     }
 }

--- a/agent/src/registry_daemon/protocol.rs
+++ b/agent/src/registry_daemon/protocol.rs
@@ -1,0 +1,179 @@
+//! Frame vocabulary for the host-wide registry daemon (ADR-11).
+//!
+//! This is a **new daemon role on the existing substrate**, not a new
+//! mechanism: the wire encoding is exactly [`crate::daemon::protocol`]'s
+//! `[type: 1][length: 4 BE][payload]` framing, read and written with the same
+//! [`read_frame_async`](crate::daemon::protocol::read_frame_async) /
+//! [`write_frame_async`](crate::daemon::protocol::write_frame_async). Only the
+//! message *types* and their payload meanings are new.
+//!
+//! The session-daemon vocabulary is a byte stream of PTY traffic, so its
+//! payloads are raw bytes. The registry's payloads are **structured records**
+//! (who is connected; what to tell everyone), so they are JSON — the same shape
+//! the `agent.list_connections` RPC and the JSON-RPC notifications already
+//! serialize. The volume is a handful of frames per client per session, not a
+//! keystroke stream, so the encoding cost that motivated the binary session
+//! protocol does not apply here.
+//!
+//! Type numbers deliberately do not overlap the session daemon's (`0x01..0x05`,
+//! `0x81..0x85`). The two roles listen on different endpoints and can never
+//! exchange frames, so a collision would be harmless — but a distinct range
+//! means a frame dump is never ambiguous about which role produced it.
+//!
+//! ```text
+//!  worker ──REGISTER (ClientRecord)──► registry ──ACK──► worker
+//!  worker ──LIST────────────────────► registry ──CLIENTS (Vec<ClientRecord>)──► worker
+//!  worker ──BROADCAST (Envelope)────► registry ──EVENT (Envelope)──► every *other* worker
+//!  worker ──DEREGISTER──────────────► registry
+//!  worker ──(disconnect / crash)────► registry drops the record implicitly
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+// ── Worker → Registry ───────────────────────────────────────────────
+
+/// Worker → Registry: announce this worker's client (payload: JSON
+/// [`ClientRecord`]). Re-sent verbatim after a reconnect, which is what makes a
+/// registry restart transparent to an already-running worker.
+pub const MSG_REGISTER: u8 = 0x10;
+/// Worker → Registry: withdraw this worker's client (empty payload). The
+/// connection stays open; used when a client disconnects but the worker lives
+/// on.
+pub const MSG_DEREGISTER: u8 = 0x11;
+/// Worker → Registry: request the current host-wide client set (empty payload).
+pub const MSG_LIST: u8 = 0x12;
+/// Worker → Registry: fan this notification out to every other worker (payload:
+/// JSON [`BroadcastEnvelope`]).
+pub const MSG_BROADCAST: u8 = 0x13;
+
+// ── Registry → Worker ───────────────────────────────────────────────
+
+/// Registry → Worker: a [`MSG_REGISTER`] was recorded (empty payload).
+pub const MSG_ACK: u8 = 0x90;
+/// Registry → Worker: the host-wide client set (payload: JSON
+/// `Vec<ClientRecord>`), answering a [`MSG_LIST`].
+pub const MSG_CLIENTS: u8 = 0x91;
+/// Registry → Worker: another worker broadcast this (payload: JSON
+/// [`BroadcastEnvelope`]).
+pub const MSG_EVENT: u8 = 0x92;
+
+// ── Payloads ────────────────────────────────────────────────────────
+
+/// One client, as seen host-wide.
+///
+/// Field-for-field the `ConnectionInfo` the `agent.list_connections` RPC returns
+/// (`connected_since` already RFC 3339), so a registry snapshot maps into an RPC
+/// response without a second representation. `pid` is the *worker* process's id
+/// — not part of the RPC shape, but the thing that makes a record attributable
+/// to an OS process when debugging a host with several desktops attached.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientRecord {
+    /// Agent-assigned unique id for the client connection (from `initialize`).
+    pub client_id: String,
+    /// Client name reported in `initialize` (e.g. `"termihub-desktop"`).
+    pub client: String,
+    /// Client version reported in `initialize`.
+    pub client_version: String,
+    /// RFC 3339 timestamp of when the client completed `initialize`.
+    pub connected_since: String,
+    /// OS process id of the agent worker serving this client.
+    pub pid: u32,
+}
+
+/// A notification one worker wants every other worker's client to receive.
+///
+/// Carries a JSON-RPC notification's `method` and `params` verbatim so a
+/// receiving worker can reconstruct it without interpreting it, plus the
+/// originating `client_id` — the registry uses it to avoid echoing a broadcast
+/// back to its sender, and a receiver can use it to attribute the event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BroadcastEnvelope {
+    /// `client_id` of the client whose worker originated this broadcast.
+    pub origin_client_id: String,
+    /// JSON-RPC notification method name.
+    pub method: String,
+    /// JSON-RPC notification params.
+    pub params: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::daemon::protocol as frames;
+    use serde_json::json;
+
+    fn sample_record() -> ClientRecord {
+        ClientRecord {
+            client_id: "abc".into(),
+            client: "termihub-desktop".into(),
+            client_version: "1.2.3".into(),
+            connected_since: "2026-07-17T10:00:00+00:00".into(),
+            pid: 4242,
+        }
+    }
+
+    #[test]
+    fn client_record_round_trips_as_json() {
+        let record = sample_record();
+        let bytes = serde_json::to_vec(&record).expect("serialize");
+        let back: ClientRecord = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(back, record);
+    }
+
+    #[test]
+    fn broadcast_envelope_round_trips_as_json() {
+        let envelope = BroadcastEnvelope {
+            origin_client_id: "abc".into(),
+            method: "agent.update_pending".into(),
+            params: json!({"version": "2.0.0"}),
+        };
+        let bytes = serde_json::to_vec(&envelope).expect("serialize");
+        let back: BroadcastEnvelope = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(back, envelope);
+    }
+
+    /// The registry's payloads must survive the *session daemon's* framing
+    /// untouched — that reuse is the whole premise of "a new role on the
+    /// existing substrate" (ADR-11).
+    #[tokio::test]
+    async fn register_payload_survives_the_session_daemon_framing() {
+        let record = sample_record();
+        let mut buf: Vec<u8> = Vec::new();
+        frames::write_frame_async(&mut buf, MSG_REGISTER, &serde_json::to_vec(&record).unwrap())
+            .await
+            .expect("write frame");
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let frame = frames::read_frame_async(&mut cursor)
+            .await
+            .expect("read frame")
+            .expect("frame present");
+
+        assert_eq!(frame.msg_type, MSG_REGISTER);
+        let back: ClientRecord = serde_json::from_slice(&frame.payload).expect("decode payload");
+        assert_eq!(back, record);
+    }
+
+    /// A frame dump must never be ambiguous about which daemon role wrote it.
+    #[test]
+    fn registry_types_do_not_collide_with_session_daemon_types() {
+        use crate::daemon::protocol as session;
+        let registry = [MSG_REGISTER, MSG_DEREGISTER, MSG_LIST, MSG_BROADCAST, MSG_ACK,
+                        MSG_CLIENTS, MSG_EVENT];
+        let session = [
+            session::MSG_INPUT,
+            session::MSG_RESIZE,
+            session::MSG_DETACH,
+            session::MSG_KILL,
+            session::MSG_QUERY_BUFFER,
+            session::MSG_OUTPUT,
+            session::MSG_BUFFER_REPLAY,
+            session::MSG_EXITED,
+            session::MSG_ERROR,
+            session::MSG_READY,
+        ];
+        for r in registry {
+            assert!(!session.contains(&r), "type 0x{r:02x} is used by both roles");
+        }
+    }
+}

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -183,64 +183,21 @@ pub trait DaemonLauncher: Send + Sync + 'static {
     ) -> Result<SessionBackend, anyhow::Error>;
 }
 
-/// Point a to-be-spawned daemon's stderr somewhere that outlives the agent.
+/// Open the per-session daemon log, where the platform provides one.
 ///
-/// The daemon must **not** inherit the agent's stderr: when the agent is reached
-/// over SSH that stderr is the exec channel of `termihub-agent --stdio`, and
-/// keeping it tethers the daemon's lifetime to the SSH connection — a disconnect
-/// tears the channel down and takes the persistent-session daemon with it (so a
-/// reconnect finds nothing to re-attach). A detached daemon owns its own stderr
-/// on every platform: on unix it logs to a per-session file in its socket dir
-/// (diagnostics without the coupling), falling back to null; elsewhere it is
-/// discarded to null (a Windows per-session log path is a future refinement).
-fn configure_daemon_stderr(command: &mut std::process::Command, session_id: &str) {
+/// On unix the daemon logs to a per-session file in its socket dir; elsewhere it
+/// is discarded to null (a Windows per-session log path is a future refinement).
+/// See [`crate::daemon::spawn::configure_detached_stderr`] for why it must never
+/// simply inherit the agent's stderr.
+fn daemon_log(session_id: &str) -> Option<std::fs::File> {
     #[cfg(unix)]
-    let stderr = match crate::daemon::transport::open_daemon_log(session_id) {
-        Some(file) => std::process::Stdio::from(file),
-        None => std::process::Stdio::null(),
-    };
-    #[cfg(not(unix))]
-    let stderr = {
-        let _ = session_id;
-        std::process::Stdio::null()
-    };
-    command.stderr(stderr);
-}
-
-/// Detach a to-be-spawned daemon so it outlives the agent that spawns it — the
-/// whole point of a *persistent* session.
-///
-/// On Windows: a new process group with no console window. On unix: a fresh
-/// session via `setsid`. Being merely orphaned (the agent never waits on the
-/// child) is **not** enough on unix, because the agent is typically launched
-/// over an SSH exec channel (`termihub-agent --stdio`); when that channel closes
-/// sshd sends SIGHUP to the whole session, killing any daemon still in it, so a
-/// reconnect would find no session to re-attach. `setsid` moves the daemon out
-/// of the SSH session's process group, immunising it against that hangup.
-/// (Detaching stderr from the same channel — see [`configure_daemon_stderr`] —
-/// is the other half of surviving the disconnect.)
-fn configure_daemon_detachment(command: &mut std::process::Command) {
-    #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt;
-        use windows_sys::Win32::System::Threading::{
-            CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS,
-        };
-        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+        crate::daemon::transport::open_daemon_log(session_id)
     }
-    #[cfg(unix)]
+    #[cfg(not(unix))]
     {
-        use std::os::unix::process::CommandExt;
-        // Safety: `setsid` is async-signal-safe and touches no shared state of
-        // the (forked, not-yet-exec'd) child before the following `exec`.
-        unsafe {
-            command.pre_exec(|| {
-                if libc::setsid() == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
+        let _ = session_id;
+        None
     }
 }
 
@@ -271,8 +228,8 @@ impl DaemonLauncher for SystemDaemonLauncher {
             .env("TERMIHUB_BUFFER_SIZE", buffer_size_bytes.to_string())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null());
-        configure_daemon_stderr(&mut command, session_id);
-        configure_daemon_detachment(&mut command);
+        crate::daemon::spawn::configure_detached_stderr(&mut command, daemon_log(session_id));
+        crate::daemon::spawn::configure_detachment(&mut command);
 
         let mut child = command
             .spawn()
@@ -1169,31 +1126,8 @@ mod tests {
         Arc::new(crate::registry::build_registry())
     }
 
-    // ── daemon detachment (issue #995) ───────────────────────────────
-
-    #[cfg(unix)]
-    #[test]
-    fn configure_daemon_detachment_starts_a_new_session() {
-        // A persistent-session daemon must survive the agent (and its SSH exec
-        // channel) going away. On unix that requires the spawned child to leave
-        // the SSH session via `setsid` — otherwise sshd's SIGHUP on disconnect
-        // kills it and a reconnect finds nothing to re-attach. Assert the child a
-        // detachment-configured Command spawns is a session leader (its session id
-        // equals its pid), which only holds after `setsid`.
-        let mut command = std::process::Command::new("sleep");
-        command.arg("30");
-        configure_daemon_detachment(&mut command);
-        let mut child = command.spawn().expect("spawn sleep");
-        let pid = child.id() as libc::pid_t;
-        // Safety: `getsid` merely reads the session id of an existing pid.
-        let sid = unsafe { libc::getsid(pid) };
-        let _ = child.kill();
-        let _ = child.wait();
-        assert_eq!(
-            sid, pid,
-            "daemon child should be its own session leader (setsid)"
-        );
-    }
+    // The daemon-detachment test (#995) moved to `daemon::spawn` along with the
+    // helper it covers, which both daemon roles now share.
 
     // ── connect_or_daemon_exit (issue #847) ──────────────────────────
 

--- a/agent/tests/registry_daemon_integration.rs
+++ b/agent/tests/registry_daemon_integration.rs
@@ -275,7 +275,10 @@ fn a_second_session_less_desktop_is_visible_to_the_first() {
     let dir = TempDir::new().expect("temp dir");
     let endpoint = unique_endpoint(&dir, "visible");
     let _registry = spawn_registry(&endpoint);
-    assert!(wait_for_endpoint(&endpoint), "registry never bound {endpoint}");
+    assert!(
+        wait_for_endpoint(&endpoint),
+        "registry never bound {endpoint}"
+    );
 
     // Two independent agent processes — the real topology: one agent process
     // per desktop, exactly as the SSH-exec transport produces.
@@ -604,9 +607,14 @@ fn a_broadcast_from_one_worker_reaches_another_workers_process() {
         "method": "agent.update_pending",
         "params": { "version": "9.9.9" },
     });
-    sender.send(MSG_BROADCAST, &serde_json::to_vec(&envelope).expect("encode"));
+    sender.send(
+        MSG_BROADCAST,
+        &serde_json::to_vec(&envelope).expect("encode"),
+    );
 
-    let (msg_type, payload) = receiver.recv().expect("the other worker must get the event");
+    let (msg_type, payload) = receiver
+        .recv()
+        .expect("the other worker must get the event");
     assert_eq!(msg_type, MSG_EVENT, "expected an EVENT frame");
     let got: Value = serde_json::from_slice(&payload).expect("decode envelope");
     assert_eq!(
@@ -643,7 +651,10 @@ fn a_broadcast_with_no_other_workers_is_harmless() {
         "method": "agent.update_pending",
         "params": {},
     });
-    lonely.send(MSG_BROADCAST, &serde_json::to_vec(&envelope).expect("encode"));
+    lonely.send(
+        MSG_BROADCAST,
+        &serde_json::to_vec(&envelope).expect("encode"),
+    );
 
     // The registry must still be serving: a later REGISTER on a fresh connection
     // proves the broadcast did not take it down.

--- a/agent/tests/registry_daemon_integration.rs
+++ b/agent/tests/registry_daemon_integration.rs
@@ -1,0 +1,511 @@
+//! End-to-end tests for the host-wide registry daemon (#1574, ADR-11).
+//!
+//! These spawn **real** `termihub-agent` processes — two `--listen` workers and
+//! a `--registry-daemon` — and drive them over real sockets. Nothing here is
+//! mocked, because the claim being tested is exactly the one a mock cannot
+//! support: that two *separate agent processes* on one host can see each other.
+//!
+//! # Isolation
+//!
+//! The registry endpoint is a fixed per-user path by design (that is what makes
+//! it findable). Tests must therefore never touch the live one: every test
+//! points its agents at a unique endpoint in a `TempDir` via
+//! `TERMIHUB_REGISTRY_ENDPOINT`, which the spawned agents pass on to any
+//! registry they spawn through the inherited environment. Without this, these
+//! tests would fight each other, the developer's own agents, and the parallel
+//! development checkouts, all over one socket.
+//!
+//! ```sh
+//! cargo test -p termihub-agent --test registry_daemon_integration
+//! ```
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn agent_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_termihub-agent")
+}
+
+/// Generous per-RPC read timeout: a cold-started agent's first response can be
+/// slow on a loaded runner, and a timeout here would read as a registry failure
+/// when it is really just a slow start.
+const RPC_TIMEOUT: Duration = Duration::from_secs(20);
+/// How long to wait for an agent's TCP port to accept connections.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ── Process handles ───────────────────────────────────────────────────────────
+
+/// A spawned agent process, killed on drop so a failing assertion never leaks it.
+struct AgentProcess {
+    child: Child,
+    addr: String,
+}
+
+impl Drop for AgentProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// A spawned registry daemon, killed on drop.
+struct RegistryProcess {
+    child: Child,
+}
+
+impl Drop for RegistryProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn an agent in `--listen` mode pointed at `registry_endpoint`, and learn
+/// the port it actually bound.
+///
+/// Asks the OS for a port via `:0` and reads the real one back off the agent's
+/// own startup log, rather than reserving a port in the test and handing it over
+/// to the agent. That handover looks harmless and is not: between the test
+/// releasing the port and the agent binding it, another concurrently running
+/// agent can take it — and then the test's readiness probe *succeeds against the
+/// wrong process* while its own agent has already died on `AddrInUse`. The
+/// symptom is a "Connection reset by peer" halfway through an unrelated
+/// assertion. Binding `:0` in the agent itself closes the window completely:
+/// the port cannot be taken because it is never free.
+fn spawn_agent(registry_endpoint: &str) -> AgentProcess {
+    let mut child = Command::new(agent_binary())
+        .arg("--listen")
+        .arg("127.0.0.1:0")
+        .env("TERMIHUB_REGISTRY_ENDPOINT", registry_endpoint)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn agent");
+
+    let stderr = child.stderr.take().expect("piped stderr");
+    let addr = read_listen_addr(stderr);
+    AgentProcess { child, addr }
+}
+
+/// Read the agent's `Listening on <addr>` startup line, then keep the pipe
+/// drained.
+///
+/// The log line is emitted immediately after a successful `bind`, so seeing it
+/// means the port is already accepting — no readiness polling needed. The
+/// draining thread matters: a piped stderr nobody reads eventually fills its
+/// buffer and blocks the agent mid-test.
+fn read_listen_addr(stderr: std::process::ChildStderr) -> String {
+    let mut reader = BufReader::new(stderr);
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    let mut addr = None;
+
+    while Instant::now() < deadline {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break, // agent exited before binding
+            Ok(_) => {
+                if let Some(rest) = line.split("Listening on ").nth(1) {
+                    addr = Some(rest.trim().to_string());
+                    break;
+                }
+            }
+            Err(e) => panic!("reading agent stderr: {e}"),
+        }
+    }
+
+    // Keep the pipe from filling for the rest of the agent's life.
+    std::thread::spawn(move || {
+        let mut sink = String::new();
+        while reader.read_line(&mut sink).unwrap_or(0) > 0 {
+            sink.clear();
+        }
+    });
+
+    addr.expect("agent never logged a `Listening on` address")
+}
+
+/// Spawn the registry daemon explicitly, so the test owns its lifetime.
+fn spawn_registry(registry_endpoint: &str) -> RegistryProcess {
+    let child = Command::new(agent_binary())
+        .arg("--registry-daemon")
+        .env("TERMIHUB_REGISTRY_ENDPOINT", registry_endpoint)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn registry daemon");
+    RegistryProcess { child }
+}
+
+/// Wait for the registry's endpoint to appear on disk.
+fn wait_for_endpoint(endpoint: &str) -> bool {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    while Instant::now() < deadline {
+        if std::path::Path::new(endpoint).exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+// ── JSON-RPC client ───────────────────────────────────────────────────────────
+
+/// A desktop client attached to one agent.
+struct Client {
+    reader: BufReader<TcpStream>,
+    writer: TcpStream,
+    next_id: i64,
+}
+
+impl Client {
+    fn connect(addr: &str) -> Self {
+        let stream = TcpStream::connect(addr).expect("connect to agent");
+        stream
+            .set_read_timeout(Some(RPC_TIMEOUT))
+            .expect("set read timeout");
+        let reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        Self {
+            reader,
+            writer: stream,
+            next_id: 1,
+        }
+    }
+
+    fn call(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let request = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        writeln!(self.writer, "{request}").expect("write request");
+        self.writer.flush().expect("flush request");
+
+        // Skip notifications (they carry no `id`) until the matching response.
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).expect("read response");
+            assert!(n > 0, "agent closed the connection during {method}");
+            let value: Value = match serde_json::from_str(&line) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            if value.get("id").and_then(Value::as_i64) == Some(id) {
+                return value;
+            }
+        }
+    }
+
+    /// Complete `initialize` as a named desktop, returning our `client_id`.
+    fn initialize(&mut self, client: &str) -> String {
+        let response = self.call(
+            "initialize",
+            json!({
+                "protocolVersion": "0.3.0",
+                "client": client,
+                "clientVersion": "1.0.0",
+                "agentSettings": {},
+            }),
+        );
+        // `InitializeResult` serializes snake_case (unlike `InitializeParams`,
+        // which is camelCase).
+        response["result"]["client_id"]
+            .as_str()
+            .unwrap_or_else(|| panic!("initialize returned no client_id: {response}"))
+            .to_string()
+    }
+
+    /// `agent.list_connections`, as `client` names.
+    fn list_connection_names(&mut self) -> Vec<String> {
+        let response = self.call("agent.list_connections", json!({}));
+        let connections = response["result"]["connections"]
+            .as_array()
+            .unwrap_or_else(|| panic!("list_connections returned no array: {response}"));
+        let mut names: Vec<String> = connections
+            .iter()
+            .map(|c| c["client"].as_str().expect("client name").to_string())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+/// Poll `list_connections` until it matches `expected` or the deadline passes.
+///
+/// Registration crosses a process boundary asynchronously — `initialize` never
+/// waits for the registry, by design — so the host-wide view becomes correct a
+/// moment after `initialize` returns, not during it. Polling asserts the
+/// eventual state without encoding a fixed sleep.
+fn wait_for_connections(client: &mut Client, expected: &[&str]) -> Vec<String> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut last = Vec::new();
+    while Instant::now() < deadline {
+        last = client.list_connection_names();
+        if last == expected {
+            return last;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    last
+}
+
+fn unique_endpoint(dir: &TempDir, tag: &str) -> String {
+    dir.path()
+        .join(format!("registry-{tag}.sock"))
+        .to_string_lossy()
+        .into_owned()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// The issue's "Done when", end to end: a second desktop attached to the same
+/// host is visible to the first, through the registry, **while neither holds any
+/// sessions**.
+///
+/// Before this change each agent process could only ever see its own client, so
+/// the two lists here would each have been `["desktop-a"]` and `["desktop-b"]`.
+#[test]
+fn a_second_session_less_desktop_is_visible_to_the_first() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "visible");
+    let _registry = spawn_registry(&endpoint);
+    assert!(wait_for_endpoint(&endpoint), "registry never bound {endpoint}");
+
+    // Two independent agent processes — the real topology: one agent process
+    // per desktop, exactly as the SSH-exec transport produces.
+    let agent_a = spawn_agent(&endpoint);
+    let agent_b = spawn_agent(&endpoint);
+
+    let mut desktop_a = Client::connect(&agent_a.addr);
+    let mut desktop_b = Client::connect(&agent_b.addr);
+    desktop_a.initialize("desktop-a");
+    desktop_b.initialize("desktop-b");
+
+    // Neither desktop has created a single session. Before the registry, a
+    // session-less desktop had no daemon at all and was invisible — which is
+    // the exact client an agent binary swap kills without warning.
+    let seen_by_a = wait_for_connections(&mut desktop_a, &["desktop-a", "desktop-b"]);
+    assert_eq!(
+        seen_by_a,
+        vec!["desktop-a", "desktop-b"],
+        "desktop A must see the session-less desktop B through the registry"
+    );
+
+    let seen_by_b = wait_for_connections(&mut desktop_b, &["desktop-a", "desktop-b"]);
+    assert_eq!(
+        seen_by_b,
+        vec!["desktop-a", "desktop-b"],
+        "visibility must be symmetric"
+    );
+}
+
+/// A worker that finds no registry must start one. Nothing else spawns it —
+/// there is no installer, no service, and no supervisor — so if this does not
+/// hold, the whole feature is dead on a fresh host.
+#[test]
+fn a_worker_spawns_the_registry_when_none_is_running() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "autospawn");
+    assert!(
+        !std::path::Path::new(&endpoint).exists(),
+        "test must start with no registry"
+    );
+
+    // No `spawn_registry` here — only agents.
+    let agent_a = spawn_agent(&endpoint);
+    let agent_b = spawn_agent(&endpoint);
+    let mut desktop_a = Client::connect(&agent_a.addr);
+    let mut desktop_b = Client::connect(&agent_b.addr);
+    desktop_a.initialize("desktop-a");
+    desktop_b.initialize("desktop-b");
+
+    assert_eq!(
+        wait_for_connections(&mut desktop_a, &["desktop-a", "desktop-b"]),
+        vec!["desktop-a", "desktop-b"],
+        "a worker should have spawned a registry and both should be visible"
+    );
+    assert!(
+        std::path::Path::new(&endpoint).exists(),
+        "the auto-spawned registry should own {endpoint}"
+    );
+    // The auto-spawned registry is not ours to kill — it exits on its own once
+    // idle. Its endpoint is unique to this test, so it can affect nothing else.
+}
+
+/// A desktop that disconnects must stop being reported host-wide — otherwise
+/// #1351 would broadcast to, and block an update on, desktops that left.
+#[test]
+fn a_disconnected_desktop_disappears_from_the_host_wide_view() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "disconnect");
+    let _registry = spawn_registry(&endpoint);
+    assert!(wait_for_endpoint(&endpoint), "registry never bound");
+
+    let agent_a = spawn_agent(&endpoint);
+    let agent_b = spawn_agent(&endpoint);
+    let mut desktop_a = Client::connect(&agent_a.addr);
+    let mut desktop_b = Client::connect(&agent_b.addr);
+    desktop_a.initialize("desktop-a");
+    desktop_b.initialize("desktop-b");
+    assert_eq!(
+        wait_for_connections(&mut desktop_a, &["desktop-a", "desktop-b"]),
+        vec!["desktop-a", "desktop-b"],
+        "both should be visible before the disconnect"
+    );
+
+    // B's desktop goes away.
+    drop(desktop_b);
+
+    assert_eq!(
+        wait_for_connections(&mut desktop_a, &["desktop-a"]),
+        vec!["desktop-a"],
+        "a disconnected desktop must be withdrawn from the host-wide view"
+    );
+}
+
+/// A worker whose process is killed outright never gets to say goodbye. The
+/// registry must still drop it — its record's liveness is the socket, not a
+/// polite deregister.
+#[test]
+fn a_killed_worker_is_garbage_collected_by_the_registry() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "killed");
+    let _registry = spawn_registry(&endpoint);
+    assert!(wait_for_endpoint(&endpoint), "registry never bound");
+
+    let agent_a = spawn_agent(&endpoint);
+    let mut desktop_a = Client::connect(&agent_a.addr);
+    desktop_a.initialize("desktop-a");
+
+    {
+        let agent_b = spawn_agent(&endpoint);
+        let mut desktop_b = Client::connect(&agent_b.addr);
+        desktop_b.initialize("desktop-b");
+        assert_eq!(
+            wait_for_connections(&mut desktop_a, &["desktop-a", "desktop-b"]),
+            vec!["desktop-a", "desktop-b"],
+            "both should be visible before the kill"
+        );
+        // `agent_b`'s Drop kills the process — no clean shutdown, no goodbye.
+    }
+
+    assert_eq!(
+        wait_for_connections(&mut desktop_a, &["desktop-a"]),
+        vec!["desktop-a"],
+        "a killed worker's record must be reaped when its socket closes"
+    );
+}
+
+/// The registry is **optional infrastructure**. With none reachable and none
+/// spawnable, an agent must still initialize, still answer, and still report
+/// its own client — never an empty host, and never an error.
+#[test]
+fn an_agent_works_and_reports_itself_when_the_registry_cannot_run() {
+    let dir = TempDir::new().expect("temp dir");
+    // A path inside a non-existent directory: unconnectable, and un-bindable by
+    // a spawned registry, so the worker's auto-spawn fails too.
+    let endpoint = dir
+        .path()
+        .join("no-such-dir")
+        .join("registry.sock")
+        .to_string_lossy()
+        .into_owned();
+
+    let agent = spawn_agent(&endpoint);
+    let mut desktop = Client::connect(&agent.addr);
+    desktop.initialize("desktop-a");
+
+    assert_eq!(
+        desktop.list_connection_names(),
+        vec!["desktop-a"],
+        "a registry-less agent must fall back to its own per-process view"
+    );
+
+    // And it is still a fully working agent, not a degraded one.
+    let health = desktop.call("health.check", json!({}));
+    assert!(
+        health.get("error").is_none(),
+        "a missing registry must not break unrelated RPCs: {health}"
+    );
+}
+
+/// A registry that dies must not take the host-wide view with it permanently:
+/// workers reconnect and **re-announce**, so the view heals with no action from
+/// any desktop. This is the property an agent binary swap depends on.
+#[test]
+fn the_host_wide_view_heals_after_the_registry_restarts() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "restart");
+    let registry = spawn_registry(&endpoint);
+    assert!(wait_for_endpoint(&endpoint), "registry never bound");
+
+    let agent_a = spawn_agent(&endpoint);
+    let agent_b = spawn_agent(&endpoint);
+    let mut desktop_a = Client::connect(&agent_a.addr);
+    let mut desktop_b = Client::connect(&agent_b.addr);
+    desktop_a.initialize("desktop-a");
+    desktop_b.initialize("desktop-b");
+    assert_eq!(
+        wait_for_connections(&mut desktop_a, &["desktop-a", "desktop-b"]),
+        vec!["desktop-a", "desktop-b"],
+        "both should be visible before the restart"
+    );
+
+    // Kill the registry outright and stand a fresh one up in its place.
+    drop(registry);
+    let _replacement = spawn_registry(&endpoint);
+    assert!(wait_for_endpoint(&endpoint), "replacement never bound");
+
+    // Nobody re-initializes; the workers must repair this themselves.
+    assert_eq!(
+        wait_for_connections(&mut desktop_a, &["desktop-a", "desktop-b"]),
+        vec!["desktop-a", "desktop-b"],
+        "workers must reconnect and re-announce after a registry restart"
+    );
+}
+
+/// A second registry must never displace a live one — if it could, a spawn race
+/// between two starting workers would split the host into two registries that
+/// cannot see each other, which is the failure this whole design exists to
+/// avoid.
+#[test]
+fn a_second_registry_exits_rather_than_stealing_a_live_endpoint() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "race");
+    let _registry = spawn_registry(&endpoint);
+    assert!(wait_for_endpoint(&endpoint), "registry never bound");
+
+    let agent = spawn_agent(&endpoint);
+    let mut desktop = Client::connect(&agent.addr);
+    desktop.initialize("desktop-a");
+    assert_eq!(
+        wait_for_connections(&mut desktop, &["desktop-a"]),
+        vec!["desktop-a"],
+        "the first registry should be serving"
+    );
+
+    // A second registry starts on the same endpoint — as a racing worker's
+    // spawn would. It must lose and exit cleanly.
+    let mut loser = spawn_registry(&endpoint);
+    let status = loser
+        .child
+        .wait()
+        .expect("second registry should exit on its own");
+    assert!(
+        status.success(),
+        "losing the bind race is a success, not a failure: {status}"
+    );
+
+    // The original is untouched and still serving the same client.
+    assert_eq!(
+        desktop.list_connection_names(),
+        vec!["desktop-a"],
+        "the live registry must keep its endpoint and its clients"
+    );
+}

--- a/agent/tests/registry_daemon_integration.rs
+++ b/agent/tests/registry_daemon_integration.rs
@@ -509,3 +509,144 @@ fn a_second_registry_exits_rather_than_stealing_a_live_endpoint() {
         "the live registry must keep its endpoint and its clients"
     );
 }
+
+// ── Raw registry-protocol worker ──────────────────────────────────────────────
+//
+// The broadcast fan-out has no production caller yet — #1351 owns the update
+// notification that will send one. Its unit tests cover the registry's routing
+// and the client's delivery, but neither crosses a process boundary, and the
+// issue's "Done when" is specifically that *#1351 could broadcast to a non-empty
+// set*. So these tests speak the registry's frame vocabulary directly over the
+// real socket: that is the substrate contract #1351 will build on, proven on the
+// wire rather than in a unit harness.
+
+/// Frame type/payload constants, duplicated rather than imported: `termihub-agent`
+/// is a binary crate, so an integration test cannot `use` its modules. Keeping
+/// them here also makes these tests a genuine *external* check of the wire
+/// format — if a refactor changes a type byte, this fails, which is the point.
+const MSG_REGISTER: u8 = 0x10;
+const MSG_BROADCAST: u8 = 0x13;
+const MSG_ACK: u8 = 0x90;
+const MSG_EVENT: u8 = 0x92;
+
+/// A worker speaking the registry protocol directly, standing in for the agent
+/// worker that #1351 will make broadcast.
+struct RawWorker {
+    stream: std::os::unix::net::UnixStream,
+}
+
+impl RawWorker {
+    fn connect(endpoint: &str) -> Self {
+        let stream = std::os::unix::net::UnixStream::connect(endpoint).expect("connect registry");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("set read timeout");
+        Self { stream }
+    }
+
+    /// `[type: 1][length: 4 BE][payload]` — the session daemons' framing.
+    fn send(&mut self, msg_type: u8, payload: &[u8]) {
+        let mut frame = Vec::with_capacity(5 + payload.len());
+        frame.push(msg_type);
+        frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        frame.extend_from_slice(payload);
+        self.stream.write_all(&frame).expect("write frame");
+        self.stream.flush().expect("flush frame");
+    }
+
+    fn recv(&mut self) -> Option<(u8, Vec<u8>)> {
+        use std::io::Read;
+        let mut header = [0u8; 5];
+        self.stream.read_exact(&mut header).ok()?;
+        let len = u32::from_be_bytes([header[1], header[2], header[3], header[4]]) as usize;
+        let mut payload = vec![0u8; len];
+        self.stream.read_exact(&mut payload).ok()?;
+        Some((header[0], payload))
+    }
+
+    /// Register and wait for the ACK, so the caller knows the registry has
+    /// recorded this worker before it asserts on fan-out.
+    fn register(&mut self, client_id: &str) {
+        let record = json!({
+            "client_id": client_id,
+            "client": "termihub-desktop",
+            "client_version": "1.2.3",
+            "connected_since": "2026-07-17T10:00:00+00:00",
+            "pid": std::process::id(),
+        });
+        self.send(MSG_REGISTER, &serde_json::to_vec(&record).expect("encode"));
+        let (msg_type, _) = self.recv().expect("registry must ACK a REGISTER");
+        assert_eq!(msg_type, MSG_ACK, "expected ACK for {client_id}");
+    }
+}
+
+/// The broadcast half of the "Done when": a notification from one worker reaches
+/// the *other* worker's process — across a real socket, not a channel — and is
+/// not echoed to its sender.
+///
+/// This is the set #1351 will broadcast an impending update to. Before the
+/// registry existed, `io/tcp.rs`'s `mpsc` was multi-producer/single-consumer, so
+/// a notification could not leave the process that raised it at all.
+#[test]
+fn a_broadcast_from_one_worker_reaches_another_workers_process() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "broadcast");
+    let _registry = spawn_registry(&endpoint);
+    assert!(wait_for_endpoint(&endpoint), "registry never bound");
+
+    let mut sender = RawWorker::connect(&endpoint);
+    let mut receiver = RawWorker::connect(&endpoint);
+    sender.register("desktop-a");
+    receiver.register("desktop-b");
+
+    let envelope = json!({
+        "origin_client_id": "desktop-a",
+        "method": "agent.update_pending",
+        "params": { "version": "9.9.9" },
+    });
+    sender.send(MSG_BROADCAST, &serde_json::to_vec(&envelope).expect("encode"));
+
+    let (msg_type, payload) = receiver.recv().expect("the other worker must get the event");
+    assert_eq!(msg_type, MSG_EVENT, "expected an EVENT frame");
+    let got: Value = serde_json::from_slice(&payload).expect("decode envelope");
+    assert_eq!(
+        got, envelope,
+        "the envelope must arrive byte-for-byte: the registry carries notifications, it does not interpret them"
+    );
+
+    // The sender must not receive its own broadcast. Its client already handled
+    // the event locally; echoing it back would double-deliver.
+    sender
+        .stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .expect("shorten timeout");
+    assert!(
+        sender.recv().is_none(),
+        "a broadcast must never be echoed to its origin"
+    );
+}
+
+/// A broadcast with no peers must not fail the sender — the registry has to
+/// tolerate a host holding exactly one desktop, which is the common case.
+#[test]
+fn a_broadcast_with_no_other_workers_is_harmless() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "broadcast-alone");
+    let _registry = spawn_registry(&endpoint);
+    assert!(wait_for_endpoint(&endpoint), "registry never bound");
+
+    let mut lonely = RawWorker::connect(&endpoint);
+    lonely.register("desktop-a");
+
+    let envelope = json!({
+        "origin_client_id": "desktop-a",
+        "method": "agent.update_pending",
+        "params": {},
+    });
+    lonely.send(MSG_BROADCAST, &serde_json::to_vec(&envelope).expect("encode"));
+
+    // The registry must still be serving: a later REGISTER on a fresh connection
+    // proves the broadcast did not take it down.
+    let mut peer = RawWorker::connect(&endpoint);
+    peer.register("desktop-b");
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1428,7 +1428,18 @@ A first-time, download-backed Windows provision is gated on a connect-time conse
 
 ### ADR-11: Per-Process Agent Connection Tracking (Multi-Host Model)
 
-**Context:** The remote-agent update strategy epic (#1345, concept `docs/concepts/backlog/remote-agent-update-strategy.html`) needs an agent to answer "who else is connected?" so a desktop can update a shared agent without silently killing another desktop's sessions. The concept assumed **one shared agent process that knows all connected clients**. The code does not work that way: `AgentConnectionManager::connect_agent` (`src-tauri/src/terminal/agent_manager.rs`) opens a **russh exec channel per desktop** and runs `termihub-agent --stdio` (`RemoteAgentConfig::agent_exec_command`), so there is **one agent OS process per desktop→agent channel**, and that process's `AgentHandler`/`HandlerState` serves exactly one client. The `--listen` TCP mode (`agent/src/io/tcp.rs`) shares a `SessionManager` across connections but still accepts **one client at a time**. The only host-side state shared across `--stdio` workers is the layer of detached session **daemons** (`termihub-agent --daemon <id>`, unix socket / Windows named pipe), which outlive the worker and replay a ring buffer on re-attach. This gap (SI-1, #1346) is the foundational risk for every cross-client feature in the epic.
+**Context:** The remote-agent update strategy epic (#1345, concept `docs/concepts/backlog/remote-agent-update-strategy.html`) needs an agent to answer "who else is connected?" so a desktop can update a shared agent without silently killing another desktop's sessions. The concept assumed **one shared agent process that knows all connected clients**. The code does not work that way: `AgentConnectionManager::connect_agent` (`src-tauri/src/terminal/agent_manager.rs`) opens a **russh exec channel per desktop** and runs `termihub-agent --stdio` (`RemoteAgentConfig::agent_exec_command`), so there is **one agent OS process per desktop→agent channel**, and that process's `AgentHandler`/`HandlerState` serves exactly one client. The `--listen` TCP mode (`agent/src/io/tcp.rs`) shares a `SessionManager` across connections but still accepts **one client at a time**. The layer of detached session **daemons** (`termihub-agent --daemon <id>`, unix socket / Windows named pipe) outlives the worker and replays a ring buffer on re-attach. This gap (SI-1, #1346) is the foundational risk for every cross-client feature in the epic.
+
+> **Correction (#1574).** As originally written, this ADR claimed the session daemons were host-side state *shared across workers*, and built its rationale on it. That is **factually wrong**, verified at `1c554c6e`. The session daemons are shared across **time**, not across **workers**:
+>
+> | Original claim | Reality |
+> | --- | --- |
+> | Daemons are shared across workers | **No — they are per-session.** `daemon/transport.rs::session_endpoint` → `session-{session_id}.sock` (Windows: `\\.\pipe\termihub-session-{id}`) |
+> | A daemon can serve as a rendezvous | **No — single-attach with takeover.** `daemon/process.rs` clears `agent_writer` and aborts the previous reader on every `accept()`, evicting the incumbent |
+> | A host-wide endpoint exists | **No.** No host-wide endpoint existed before #1574 |
+> | Every desktop has a daemon | **No** — daemons exist only where sessions exist; a session-less desktop has none |
+>
+> A restarted worker re-attaching to a surviving daemon is time-sharing. At any instant a daemon has exactly one attached worker, and a second connection hijacks the live session's I/O. The decision below still stands — per-process tracking remains the honest primitive — but the sentences supporting it have been corrected, and the deferred coordination work was **not implementable as described**, which is why it was never filed. See the amendment under ADR-11a.
 
 Three options were prototyped against the real code:
 
@@ -1440,12 +1451,39 @@ Three options were prototyped against the real code:
 
 **Rationale:**
 
-- **Topology reality.** One `--stdio` process per desktop is fixed by the SSH-exec transport; a process genuinely knows one client, so per-process tracking is the honest primitive. The daemons are the _only_ thing already shared across workers on a host, and the epic's deferred-update approach already "leans entirely on" them surviving a binary swap — so they are the natural coordination substrate.
+- **Topology reality.** One `--stdio` process per desktop is fixed by the SSH-exec transport; a process genuinely knows one client, so per-process tracking is the honest primitive. The daemon **layer** is the only host-side substrate that already survives an agent binary swap on all three platforms, and the epic's deferred-update approach "leans entirely on" that property — so it is the natural coordination substrate. (As corrected above, the individual session daemons are *not* themselves shared across workers; what #1574 reuses is the substrate — `DaemonListener`, the frame protocol, the per-user socket dir — not the session daemons.)
 - **Security.** `--stdio` runs inside the existing authenticated SSH channel and opens no new socket. Option (b) would require a listening TCP port on every remote host plus its own authentication and port management — a real attack-surface regression over SSH-tunneled stdio.
 - **Retry / streaming.** Daemons already persist across agent-worker restarts and replay their ring buffer on re-attach; extending them keeps cross-client visibility that survives an agent binary swap. A new coordinator (a) would have to re-implement that restart/streaming story from scratch.
 - **Platform coverage.** The daemon layer already works on all three platforms (unix domain socket / Windows named pipe; Windows agent parity landed in #771), so (c) inherits the 3-platform matrix. A new long-lived coordinator (a) would need fresh cross-platform daemonization, and (b)'s single-client-at-a-time accept loop does not even deliver concurrent multi-client visibility without further rework.
 
 **Trade-off:** The shipped registry does not yet give cross-agent visibility on its own — in `--stdio` it holds exactly one client — so the epic's `list_connections`/broadcast features still need the follow-up daemon-layer work chosen here. That is deliberate: SI-1 fixes the model and lands the queryable primitive; the coordination surface is built on top in later sub-issues. RPC methods, UI, and update logic are explicitly out of scope for #1346.
+
+### ADR-11a: "Extending the daemon layer" admits a new daemon _role_ (host-wide registry)
+
+**Context:** ADR-11 deferred cross-worker coordination to "extending the existing daemon layer" and rejected option (a), "a new host-side coordinator/supervisor process". When #1574 came to implement that deferred half, the two readings forked and **neither** satisfied the brief:
+
+- Extending the **per-session** daemons cannot work. Visibility would become a function of *session topology*, not host topology: a desktop holding **zero sessions** has no daemon, so it is invisible and unreachable — and under SI-5 that is exactly the client an agent binary swap kills without warning. It would also silently redefine `agent.list_connections` from "connected clients" to "clients holding ≥1 live session", and would require reworking the attach contract that persistent-session re-attach depends on.
+- A host-wide registry process reaches the goal but is, literally, ADR-11's rejected (a).
+
+The deferred work was never filed precisely because ADR-11 assumed a shared substrate the per-session daemon layer does not provide (see the correction under ADR-11).
+
+**Decision:** "Extending the daemon layer" is hereby read as admitting a **new daemon role on the existing substrate**. `termihub-agent --registry-daemon` is a host-wide registry that reuses `DaemonListener`, the existing `[type][length][payload]` frame protocol, the per-user `0o700` socket dir and `termihub_core::ipc`. Every worker registers its client with it, keyed to `initialize` and **never to sessions**, so a session-less desktop is visible and reachable.
+
+This **is** ADR-11's option (a), adopted deliberately. ADR-11 rejected (a) for two reasons — *fresh cross-platform daemonization* and *re-implementing the restart/streaming story from scratch* — and **both are mitigated by reuse**: the registry inherits daemonization, the 3-platform matrix and the detached-spawn path from the substrate the session daemons already use. The rejection was written against such a process *existing*; reusing the substrate was not the option on the table. Option **(b) (`--listen` TCP) stays rejected** — its security objection is unchanged and binding.
+
+**The three properties that constrain any implementation of this role:**
+
+- **No new network socket.** UDS / Windows named pipe, current-user-only. A TCP port would be option (b).
+- **Survives an agent binary swap.** Detached, exactly like the session daemons.
+- **All three platforms**, inherited via `termihub_core::ipc`.
+
+**Rationale:**
+
+- **It is the only route that reaches the goal.** The session-less desktop is not an edge case; it is the motivating case for SI-5.
+- **Reuse, not a new mechanism.** The registry is a *role* — a different frame vocabulary on the same listener, dir and spawn path — so it adds no second daemonization story to maintain.
+- **Optional by construction.** A missing or restarting registry is never fatal to a worker: registration is best-effort, the worker re-registers on reconnect, and a worker whose registry is unreachable still serves its own client and reports itself.
+
+**Trade-off:** A second long-lived process shape now exists on a host. It is bounded deliberately: it is spawned on demand by whichever worker finds no registry running (the loser of a spawn race sees `AddrInUse` and exits), it exits on an idle timeout when no worker is attached, it holds only in-memory records, and it garbage-collects a worker by dropping its record when the connection drops. It stores nothing on disk and is safe to kill.
 
 ### ADR-12: Connection-Type-Agnostic Transfer Queue
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1430,14 +1430,14 @@ A first-time, download-backed Windows provision is gated on a connect-time conse
 
 **Context:** The remote-agent update strategy epic (#1345, concept `docs/concepts/backlog/remote-agent-update-strategy.html`) needs an agent to answer "who else is connected?" so a desktop can update a shared agent without silently killing another desktop's sessions. The concept assumed **one shared agent process that knows all connected clients**. The code does not work that way: `AgentConnectionManager::connect_agent` (`src-tauri/src/terminal/agent_manager.rs`) opens a **russh exec channel per desktop** and runs `termihub-agent --stdio` (`RemoteAgentConfig::agent_exec_command`), so there is **one agent OS process per desktop→agent channel**, and that process's `AgentHandler`/`HandlerState` serves exactly one client. The `--listen` TCP mode (`agent/src/io/tcp.rs`) shares a `SessionManager` across connections but still accepts **one client at a time**. The layer of detached session **daemons** (`termihub-agent --daemon <id>`, unix socket / Windows named pipe) outlives the worker and replays a ring buffer on re-attach. This gap (SI-1, #1346) is the foundational risk for every cross-client feature in the epic.
 
-> **Correction (#1574).** As originally written, this ADR claimed the session daemons were host-side state *shared across workers*, and built its rationale on it. That is **factually wrong**, verified at `1c554c6e`. The session daemons are shared across **time**, not across **workers**:
+> **Correction (#1574).** As originally written, this ADR claimed the session daemons were host-side state _shared across workers_, and built its rationale on it. That is **factually wrong**, verified at `1c554c6e`. The session daemons are shared across **time**, not across **workers**:
 >
-> | Original claim | Reality |
-> | --- | --- |
-> | Daemons are shared across workers | **No — they are per-session.** `daemon/transport.rs::session_endpoint` → `session-{session_id}.sock` (Windows: `\\.\pipe\termihub-session-{id}`) |
+> | Original claim                     | Reality                                                                                                                                                    |
+> | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+> | Daemons are shared across workers  | **No — they are per-session.** `daemon/transport.rs::session_endpoint` → `session-{session_id}.sock` (Windows: `\\.\pipe\termihub-session-{id}`)           |
 > | A daemon can serve as a rendezvous | **No — single-attach with takeover.** `daemon/process.rs` clears `agent_writer` and aborts the previous reader on every `accept()`, evicting the incumbent |
-> | A host-wide endpoint exists | **No.** No host-wide endpoint existed before #1574 |
-> | Every desktop has a daemon | **No** — daemons exist only where sessions exist; a session-less desktop has none |
+> | A host-wide endpoint exists        | **No.** No host-wide endpoint existed before #1574                                                                                                         |
+> | Every desktop has a daemon         | **No** — daemons exist only where sessions exist; a session-less desktop has none                                                                          |
 >
 > A restarted worker re-attaching to a surviving daemon is time-sharing. At any instant a daemon has exactly one attached worker, and a second connection hijacks the live session's I/O. The decision below still stands — per-process tracking remains the honest primitive — but the sentences supporting it have been corrected, and the deferred coordination work was **not implementable as described**, which is why it was never filed. See the amendment under ADR-11a.
 
@@ -1451,7 +1451,7 @@ Three options were prototyped against the real code:
 
 **Rationale:**
 
-- **Topology reality.** One `--stdio` process per desktop is fixed by the SSH-exec transport; a process genuinely knows one client, so per-process tracking is the honest primitive. The daemon **layer** is the only host-side substrate that already survives an agent binary swap on all three platforms, and the epic's deferred-update approach "leans entirely on" that property — so it is the natural coordination substrate. (As corrected above, the individual session daemons are *not* themselves shared across workers; what #1574 reuses is the substrate — `DaemonListener`, the frame protocol, the per-user socket dir — not the session daemons.)
+- **Topology reality.** One `--stdio` process per desktop is fixed by the SSH-exec transport; a process genuinely knows one client, so per-process tracking is the honest primitive. The daemon **layer** is the only host-side substrate that already survives an agent binary swap on all three platforms, and the epic's deferred-update approach "leans entirely on" that property — so it is the natural coordination substrate. (As corrected above, the individual session daemons are _not_ themselves shared across workers; what #1574 reuses is the substrate — `DaemonListener`, the frame protocol, the per-user socket dir — not the session daemons.)
 - **Security.** `--stdio` runs inside the existing authenticated SSH channel and opens no new socket. Option (b) would require a listening TCP port on every remote host plus its own authentication and port management — a real attack-surface regression over SSH-tunneled stdio.
 - **Retry / streaming.** Daemons already persist across agent-worker restarts and replay their ring buffer on re-attach; extending them keeps cross-client visibility that survives an agent binary swap. A new coordinator (a) would have to re-implement that restart/streaming story from scratch.
 - **Platform coverage.** The daemon layer already works on all three platforms (unix domain socket / Windows named pipe; Windows agent parity landed in #771), so (c) inherits the 3-platform matrix. A new long-lived coordinator (a) would need fresh cross-platform daemonization, and (b)'s single-client-at-a-time accept loop does not even deliver concurrent multi-client visibility without further rework.
@@ -1462,14 +1462,14 @@ Three options were prototyped against the real code:
 
 **Context:** ADR-11 deferred cross-worker coordination to "extending the existing daemon layer" and rejected option (a), "a new host-side coordinator/supervisor process". When #1574 came to implement that deferred half, the two readings forked and **neither** satisfied the brief:
 
-- Extending the **per-session** daemons cannot work. Visibility would become a function of *session topology*, not host topology: a desktop holding **zero sessions** has no daemon, so it is invisible and unreachable — and under SI-5 that is exactly the client an agent binary swap kills without warning. It would also silently redefine `agent.list_connections` from "connected clients" to "clients holding ≥1 live session", and would require reworking the attach contract that persistent-session re-attach depends on.
+- Extending the **per-session** daemons cannot work. Visibility would become a function of _session topology_, not host topology: a desktop holding **zero sessions** has no daemon, so it is invisible and unreachable — and under SI-5 that is exactly the client an agent binary swap kills without warning. It would also silently redefine `agent.list_connections` from "connected clients" to "clients holding ≥1 live session", and would require reworking the attach contract that persistent-session re-attach depends on.
 - A host-wide registry process reaches the goal but is, literally, ADR-11's rejected (a).
 
 The deferred work was never filed precisely because ADR-11 assumed a shared substrate the per-session daemon layer does not provide (see the correction under ADR-11).
 
 **Decision:** "Extending the daemon layer" is hereby read as admitting a **new daemon role on the existing substrate**. `termihub-agent --registry-daemon` is a host-wide registry that reuses `DaemonListener`, the existing `[type][length][payload]` frame protocol, the per-user `0o700` socket dir and `termihub_core::ipc`. Every worker registers its client with it, keyed to `initialize` and **never to sessions**, so a session-less desktop is visible and reachable.
 
-This **is** ADR-11's option (a), adopted deliberately. ADR-11 rejected (a) for two reasons — *fresh cross-platform daemonization* and *re-implementing the restart/streaming story from scratch* — and **both are mitigated by reuse**: the registry inherits daemonization, the 3-platform matrix and the detached-spawn path from the substrate the session daemons already use. The rejection was written against such a process *existing*; reusing the substrate was not the option on the table. Option **(b) (`--listen` TCP) stays rejected** — its security objection is unchanged and binding.
+This **is** ADR-11's option (a), adopted deliberately. ADR-11 rejected (a) for two reasons — _fresh cross-platform daemonization_ and _re-implementing the restart/streaming story from scratch_ — and **both are mitigated by reuse**: the registry inherits daemonization, the 3-platform matrix and the detached-spawn path from the substrate the session daemons already use. The rejection was written against such a process _existing_; reusing the substrate was not the option on the table. Option **(b) (`--listen` TCP) stays rejected** — its security objection is unchanged and binding.
 
 **The three properties that constrain any implementation of this role:**
 
@@ -1480,7 +1480,7 @@ This **is** ADR-11's option (a), adopted deliberately. ADR-11 rejected (a) for t
 **Rationale:**
 
 - **It is the only route that reaches the goal.** The session-less desktop is not an edge case; it is the motivating case for SI-5.
-- **Reuse, not a new mechanism.** The registry is a *role* — a different frame vocabulary on the same listener, dir and spawn path — so it adds no second daemonization story to maintain.
+- **Reuse, not a new mechanism.** The registry is a _role_ — a different frame vocabulary on the same listener, dir and spawn path — so it adds no second daemonization story to maintain.
 - **Optional by construction.** A missing or restarting registry is never fatal to a worker: registration is best-effort, the worker re-registers on reconnect, and a worker whose registry is unreachable still serves its own client and reports itself.
 
 **Trade-off:** A second long-lived process shape now exists on a host. It is bounded deliberately: it is spawned on demand by whichever worker finds no registry running (the loser of a spawn race sees `AddrInUse` and exits), it exits on an idle timeout when no worker is attached, it holds only in-memory records, and it garbage-collects a worker by dropping its record when the connection drops. It stores nothing on disk and is safe to kill.

--- a/docs/changes/dev0/feature/1574-registry-daemon.md
+++ b/docs/changes/dev0/feature/1574-registry-daemon.md
@@ -1,0 +1,15 @@
+### Added
+
+- **Host-wide agent registry daemon.** An agent host now runs a single per-user registry
+  (`termihub-agent --registry-daemon`) that every agent worker registers its client with, so a
+  desktop can see the other desktops attached to the same host — including desktops that hold no
+  sessions at all. It is a new role on the existing daemon substrate, so it opens **no network
+  socket** (unix domain socket / Windows named pipe, current-user-only), survives an agent binary
+  swap, and works on all three platforms. The registry is optional infrastructure: if it is absent,
+  cannot start, or restarts, agents keep working and simply report what they can see themselves.
+
+### Changed
+
+- **`agent.list_connections` now returns the host-wide client set** rather than only the client of
+  the agent process that answered. When no registry is reachable it falls back to the answering
+  process's own clients — the previous behaviour — rather than reporting an empty host.


### PR DESCRIPTION
Implements the decision recorded on #1574: a **host-wide registry daemon** as a new daemon *role* on the existing substrate.

## Why the original scope could not be built

The issue's premise — and ADR-11's — was factually wrong, and correcting it is part of this PR. ADR-11 claimed the session daemons were *"the only thing already shared across workers on a host"*. Verified at `1c554c6e`:

| Claim | Reality |
| --- | --- |
| Daemons are shared across workers | **No — per-session.** `session-{id}.sock` |
| A daemon can be a rendezvous | **No — single-attach with takeover.** Every `accept()` evicts the incumbent |
| A host-wide endpoint exists | **No.** None existed |
| Every desktop has a daemon | **No** — only where sessions exist |

Daemons are shared across **time**, not across **workers**. That error is why the deferred half was never filed: it was never implementable as described.

## What this does

A new role — `termihub-agent --registry-daemon` — reusing `DaemonListener`, the frame protocol, the per-user socket dir and `termihub_core::ipc`.

The three required properties, and how reuse carries each:

- **No new network socket** — UDS / Windows named pipe, current-user-only, inherited from the existing `0o700` socket dir. Option (b) (`--listen` TCP) stays rejected.
- **Survives an agent binary swap** — detached, via the same spawn path as the session daemons.
- **All three platforms** — via `termihub_core::ipc`.

**A session-less desktop is visible** because registration is keyed to `initialize`, never to sessions — the case that rejected option (B), and exactly the client a binary swap would kill without warning.

**The registry is optional infrastructure.** Absent, unspawnable, or restarting, it never fails a worker: every `RegistryClient` method is infallible and non-blocking, the supervisor reconnects and re-sends the registration it holds, and `list` returning `None` means *"no host-wide view"* — so `agent.list_connections` falls back to the answering process's own clients (the pre-registry behaviour) rather than reporting an empty host.

Liveness is the connection itself: a worker that exits or crashes closes its socket and the registry drops its record. No heartbeat, no PID reaping. The singleton endpoint makes a spawn race safe — the loser gets `AddrInUse` and exits.

## Scope

- [x] **Amend ADR-11** — correct the shared-across-workers claim in place; add **ADR-11a** recording that "extending the daemon layer" admits a new daemon *role*, that this is ADR-11's option (a) adopted deliberately (its objections are mitigated by reuse), and that (b) stays rejected. #1351/#1354 rest on this ADR.
- [x] Host-wide registry daemon on the existing substrate
- [x] Workers register/deregister; tolerate the registry being absent or restarting
- [x] Cross-worker broadcast replacing the per-process `mpsc`'s single-consumer limit
- [x] `agent.list_connections` returns the true multi-client set; the *"in production this holds exactly the requesting desktop"* comment is retired
- [x] Session-less desktop visible and reachable

### Broadcast has no production caller yet — on purpose

#1574 ships the broadcast **substrate** (per its title); #1351 owns the update notification that sends one and decides what/when. The path is fully built and tested on both sides, so `broadcast` carries an `allow(dead_code)` naming #1351 as the issue that removes it.

## Testing

`agent/tests/registry_daemon_integration.rs` spawns **real** agent processes and drives them over real sockets — the claim under test (two separate processes see each other) is one no mock can support. Tests point at a unique `TERMIHUB_REGISTRY_ENDPOINT` in a `TempDir`, so they never touch the live per-user socket or fight the parallel checkouts.

9 integration tests: session-less visibility (the "Done when"), spawn-on-demand, disconnect, crash GC, registry-absent, registry-restart healing, singleton race, plus cross-process broadcast fan-out and no-peers.

**Verified red without the change** — not assumed:

| Break | Result |
| --- | --- |
| Remove the crashed-worker GC | `a_killed_worker_is_garbage_collected_by_the_registry` **fails** |
| Disable the fan-out | `a_broadcast_from_one_worker_reaches_another_workers_process` **fails**; the no-peers test correctly stays green |

**Concurrency** (this is IPC + concurrency code, where a first green run lies):

| Run | Result |
| --- | --- |
| Integration suite, 10× sequential | **10/10** |
| Integration suite, 4-way concurrent × 3 rounds | **12/12** (108 test executions) |
| Full `cargo test -p termihub-agent` | **394 passed, 0 failed** |

`./scripts/check.sh` passes.

## Test plan

- [x] `cargo test -p termihub-agent`
- [x] `./scripts/check.sh`
- [ ] CI green on all three platforms — the integration tests are `#![cfg(unix)]`; the Windows named-pipe path is covered by unit tests and the shared `termihub_core::ipc` layer

Closes #1574