### PR TITLE
fix(testing): report an explicit per-suite verdict in test.sh (Closes #1572)

### DIFF
--- a/scripts/test.cmd
+++ b/scripts/test.cmd
@@ -13,19 +13,37 @@ if not exist node_modules (
 
 set FAILED=0
 
+REM A runner's own summary is not the verdict. Vitest exits non-zero when the run
+REM hit an unhandled error even though every test passed, so its summary can read
+REM "3223 passed" on a run that failed (#1572): the count describes the tests, the
+REM exit code describes the run. Only the exit code decides here, and the verdict
+REM is printed right after it so the two cannot be read apart. Mirrors test.sh.
 echo === Frontend: Vitest ===
 call pnpm test
-if errorlevel 1 set FAILED=1
+set FRONTEND_STATUS=%errorlevel%
+call :verdict %FRONTEND_STATUS% "Frontend: Vitest"
 
 echo.
 echo === Rust workspace: cargo test ===
 cargo test --workspace --all-features
-if errorlevel 1 set FAILED=1
+set RUST_STATUS=%errorlevel%
+call :verdict %RUST_STATUS% "Rust workspace: cargo test"
 
 echo.
 if %FAILED%==1 (
-    echo SOME TESTS FAILED.
+    echo SOME TESTS FAILED:
+    if not "%FRONTEND_STATUS%"=="0" echo   - Frontend: Vitest ^(exit %FRONTEND_STATUS%^)
+    if not "%RUST_STATUS%"=="0" echo   - Rust workspace: cargo test ^(exit %RUST_STATUS%^)
     exit /b 1
-) else (
-    echo ALL TESTS PASSED.
 )
+echo ALL TESTS PASSED.
+exit /b 0
+
+:verdict
+if "%~1"=="0" (
+    echo PASS: %~2
+) else (
+    echo FAIL: %~2 ^(exit %~1^)
+    set FAILED=1
+)
+goto :eof

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,25 +17,45 @@ if [ ! -d node_modules ]; then
 fi
 
 FAILED=0
+FAILED_SUITES=""
 
+# Print the verdict for a suite that has just run, and remember any failure.
+#
+# A runner's own summary is not the verdict. vitest exits non-zero when the run
+# hit an unhandled error even though every test passed, so its summary can read
+# "3223 passed" on a run that failed (#1572): the count describes the tests, the
+# exit code describes the run. Only the exit code decides here, and the verdict
+# is printed right after it so the two can't be read apart -- otherwise a failed
+# suite's last word is a pass count, minutes of later output scroll it away, and
+# the reader scrolling back finds only the reassuring number.
+verdict() {
+    local name="$1" status="$2"
+    if [ "$status" -eq 0 ]; then
+        echo "PASS: $name"
+    else
+        echo "FAIL: $name (exit $status)"
+        FAILED=1
+        FAILED_SUITES="${FAILED_SUITES}  - ${name} (exit ${status})"$'\n'
+    fi
+}
+
+# Each suite runs under `|| status=$?` so a failure records a verdict instead of
+# aborting the script under `set -e`: one red suite must not hide the other's result.
 echo "=== Frontend: Vitest ==="
-if pnpm test; then
-    echo "PASS"
-else
-    FAILED=1
-fi
+status=0
+pnpm test || status=$?
+verdict "Frontend: Vitest" "$status"
 
 echo ""
 echo "=== Rust workspace: cargo test ==="
-if cargo test --workspace --all-features; then
-    echo "PASS"
-else
-    FAILED=1
-fi
+status=0
+cargo test --workspace --all-features || status=$?
+verdict "Rust workspace: cargo test" "$status"
 
 echo ""
 if [ "$FAILED" -ne 0 ]; then
-    echo "SOME TESTS FAILED."
+    echo "SOME TESTS FAILED:"
+    printf "%s" "$FAILED_SUITES"
     exit 1
 else
     echo "ALL TESTS PASSED."

--- a/tests/system/tests/test_test_script.py
+++ b/tests/system/tests/test_test_script.py
@@ -1,0 +1,145 @@
+"""Unit tests for the verdict reporting of ``scripts/test.sh`` (#1572).
+
+The script's job is to turn two runners' exit codes into one unambiguous
+verdict. That is worth testing precisely because a runner's *own* summary can
+contradict its exit code: vitest exits non-zero when the run hit an unhandled
+error even though every test passed, so the output reads ``3223 passed``
+alongside pnpm's ``ELIFECYCLE`` (#1572, found via #1335 / PR #1558).
+
+``pnpm`` and ``cargo`` are stubbed on ``PATH`` so the suites' exit codes can be
+driven directly — no real test run, no build. The stub reproduces the
+contradicting-summary shape so the guard covers the actual bug, not a
+simplification of it.
+
+Skipped when no POSIX ``bash`` is available (e.g. native Windows without Git
+Bash); the script itself is exercised through its ``.cmd`` twin there.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "test.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="POSIX bash unavailable"
+)
+
+# What vitest prints on a run where every test passed but an unhandled error
+# failed the run. The pass line is the trap: it is accurate and it is not the
+# verdict.
+VITEST_CONTRADICTING_SUMMARY = """\
+ Test Files  1 passed (1)
+      Tests  3223 passed (3223)
+     Errors  1 error
+ ELIFECYCLE  Test failed. See above for more details.
+"""
+
+
+def _stub_bin(tmp_path: Path, pnpm_exit: int, cargo_exit: int) -> Path:
+    """Create a bin dir with fake ``pnpm``/``cargo`` that exit as instructed."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    # `pnpm install` must stay successful: test.sh runs it when node_modules is
+    # absent (as on the machinery CI runner), and that is not what we are testing.
+    pnpm = bin_dir / "pnpm"
+    pnpm.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "install" ]; then exit 0; fi\n'
+        f"cat <<'EOF'\n{VITEST_CONTRADICTING_SUMMARY}EOF\n"
+        f"exit {pnpm_exit}\n"
+    )
+
+    cargo = bin_dir / "cargo"
+    cargo.write_text(f"#!/usr/bin/env bash\necho 'test result: ok'\nexit {cargo_exit}\n")
+
+    for stub in (pnpm, cargo):
+        stub.chmod(0o755)
+    return bin_dir
+
+
+def _run(tmp_path: Path, pnpm_exit: int, cargo_exit: int) -> subprocess.CompletedProcess[str]:
+    bin_dir = _stub_bin(tmp_path, pnpm_exit, cargo_exit)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+
+def test_script_exists_and_is_executable():
+    assert SCRIPT.is_file(), f"test script missing at {SCRIPT}"
+
+
+def test_all_passing_reports_success_and_exits_zero(tmp_path: Path):
+    result = _run(tmp_path, pnpm_exit=0, cargo_exit=0)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALL TESTS PASSED." in result.stdout
+    assert "FAIL" not in result.stdout
+
+
+def test_failing_frontend_exits_non_zero(tmp_path: Path):
+    result = _run(tmp_path, pnpm_exit=1, cargo_exit=0)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "ALL TESTS PASSED." not in result.stdout
+
+
+def test_failing_frontend_prints_a_verdict_beside_the_passing_summary(tmp_path: Path):
+    """The bug: a passing count and a failing run, with no verdict between them.
+
+    vitest's own summary says "3223 passed" on this run. Without an explicit
+    per-suite verdict the next thing printed is the *next section header*, so
+    the failure scrolls away under minutes of cargo output and a reader
+    scrolling back lands on the pass line.
+    """
+    result = _run(tmp_path, pnpm_exit=1, cargo_exit=0)
+
+    assert "3223 passed" in result.stdout, "stub should reproduce the contradicting summary"
+    # The verdict must appear, name the suite, and carry the exit code.
+    assert "FAIL: Frontend: Vitest (exit 1)" in result.stdout
+
+    # ...and it must come *after* the misleading pass line, so the last word on
+    # that suite is the verdict rather than the count.
+    assert result.stdout.index("FAIL: Frontend: Vitest") > result.stdout.index("3223 passed")
+
+
+def test_summary_names_which_suite_failed(tmp_path: Path):
+    """"SOME TESTS FAILED." alone does not say which — so the reader goes hunting."""
+    result = _run(tmp_path, pnpm_exit=1, cargo_exit=0)
+    tail = result.stdout[result.stdout.index("SOME TESTS FAILED") :]
+    assert "Frontend: Vitest (exit 1)" in tail
+    assert "Rust workspace" not in tail, "a passing suite must not be listed as failed"
+
+
+def test_summary_names_only_the_failing_rust_suite(tmp_path: Path):
+    result = _run(tmp_path, pnpm_exit=0, cargo_exit=101)
+    assert result.returncode == 1
+    tail = result.stdout[result.stdout.index("SOME TESTS FAILED") :]
+    assert "Rust workspace: cargo test (exit 101)" in tail
+    assert "Frontend" not in tail
+
+
+def test_summary_names_every_failing_suite(tmp_path: Path):
+    result = _run(tmp_path, pnpm_exit=1, cargo_exit=101)
+    assert result.returncode == 1
+    tail = result.stdout[result.stdout.index("SOME TESTS FAILED") :]
+    assert "Frontend: Vitest (exit 1)" in tail
+    assert "Rust workspace: cargo test (exit 101)" in tail
+
+
+def test_a_failing_suite_does_not_stop_the_next_one(tmp_path: Path):
+    """set -e must not abort the run: both suites report even when the first fails."""
+    result = _run(tmp_path, pnpm_exit=1, cargo_exit=0)
+    assert "=== Rust workspace: cargo test ===" in result.stdout
+    assert "PASS: Rust workspace: cargo test" in result.stdout


### PR DESCRIPTION
## The decision

The issue offers two options. Only one of them is `test.sh`'s to take.

**Rejected — "suppress the pass summary".** That line is vitest's, not the script's. Suppressing it would mean owning a custom reporter, and it would be wrong regardless: the 3223 tests genuinely *did* pass, and vitest already prints `Errors  1 error` in that same summary block. Deleting accurate output to fix a reading problem is the wrong trade. **The fix is to answer the pass line, not to hide it.**

**Taken — "carry the non-zero exit explicitly".** This is squarely `test.sh`'s job, and it is where the defect actually is.

## The defect is sharper than the issue states

`test.sh` already got the *exit code* right (`FAILED=1`, `exit 1`) — that part was never broken and is now covered by tests so it stays that way. The real problem is the **verdict**: success printed `PASS`, failure printed **nothing at all**. So a failing suite's last word was the runner's own contradicting summary, and then `cargo test` ran for minutes and scrolled it away. The final `SOME TESTS FAILED.` never said *which* suite.

Reproduced with stubbed runners on the parent commit:

```
=== Frontend: Vitest ===
      Tests  3223 passed (3223)
 ELIFECYCLE  Test failed. See above for more details.
                                        <- frontend failure ends here, unmarked
=== Rust workspace: cargo test ===
test result: ok
PASS                                    <- the only verdict on screen
SOME TESTS FAILED.                      <- which one?
```

A reader scrolling back to find the failure lands on `3223 passed` beside the frontend section and reasonably concludes the frontend was fine and Rust broke. That is the mixed signal.

## After

```
=== Frontend: Vitest ===
      Tests  3223 passed (3223)
 ELIFECYCLE  Test failed. See above for more details.
FAIL: Frontend: Vitest (exit 1)

=== Rust workspace: cargo test ===
PASS: Rust workspace: cargo test

SOME TESTS FAILED:
  - Frontend: Vitest (exit 1)
```

The count describes the tests; the exit code describes the run. Only the exit code decides, and the verdict now sits immediately after it so the two cannot be read apart.

## Notes

- **Phrasing follows existing precedent** — `test-system-{linux,mac,windows}.sh` already print `SOME TESTS FAILED (exit code: $TEST_EXIT)`. This aligns `test.sh` with its own siblings rather than inventing a style.
- **`set -e` safety**: each suite runs under `|| status=$?` so a red suite records a verdict instead of aborting the script — one failing suite must not hide the other's result. Covered by a test.
- **`test.cmd`** is kept in step with the same verdict format.
- **No change fragment**: `scripts/test.sh` is a dev helper, not user-facing app behaviour.

## Verification

TDD — the five bug-describing tests fail on the parent commit and pass after the fix (3 baseline tests pass on both, pinning the already-correct exit-code behaviour). Tests live in `tests/system/tests/test_test_script.py`, following the `test_runner_script.py` precedent, and run in the **machinery** CI lane (no app build, no Docker). `pnpm`/`cargo` are stubbed on `PATH` and the stub reproduces the real contradicting-summary shape, so the guard covers the actual bug rather than a simplification of it.

Also ran the real `./scripts/test.sh` end-to-end: frontend `3270 passed` -> `PASS: Frontend: Vitest`. The run also surfaced an unrelated pre-existing failure, which the new output attributed correctly on the first read — `FAIL: Rust workspace: cargo test (exit 101)`. Filed as a follow-up; this branch changes no Rust (see below).

## Follow-ups filed

- **#1585** — `docker_spawn` integration test fails reproducibly against Docker Desktop on macOS (Docker up, `alpine` present, 3/3 runs). Unrelated to this branch, which changes no Rust. Found by running the real `./scripts/test.sh` while verifying this fix — and it was this PR's new output that named the culprit suite on the first read.
