### PR TITLE
feat(backend): write a rotating application log file (Closes #1570)

### DIFF
--- a/docs/changes/dev2/feature/1570-application-log.md
+++ b/docs/changes/dev2/feature/1570-application-log.md
@@ -22,4 +22,6 @@
   files — so it cannot grow without bound. It records INFO and above (the LogViewer
   keeps its more detailed DEBUG view), and never contains passwords, key material,
   or terminal contents. Set `TERMIHUB_FILE_LOG` (e.g. `TERMIHUB_FILE_LOG=debug`) to
-  raise the file's detail when diagnosing a problem.
+  raise the file's detail when diagnosing a problem — SSH packet-level logging stays
+  clamped even then, so raising verbosity cannot accidentally put transport internals
+  into a file you are about to share.

--- a/docs/changes/dev2/feature/1570-application-log.md
+++ b/docs/changes/dev2/feature/1570-application-log.md
@@ -1,0 +1,25 @@
+### Added
+
+- **termiHub now writes an application log file** (#1570). Previously the log
+  existed only in memory — the in-app LogViewer's ring buffer — and vanished with
+  the process, so a post-mortem of an unexpected exit had to be reconstructed
+  entirely from the OS log with no contribution from termiHub itself. The app now
+  writes to the platform's conventional log location:
+
+  | Platform | Path                                                |
+  | -------- | --------------------------------------------------- |
+  | macOS    | `~/Library/Logs/com.termihub.app/termihub.log`      |
+  | Windows  | `%LOCALAPPDATA%\com.termihub.app\logs\termihub.log` |
+  | Linux    | `~/.local/share/com.termihub.app/logs/termihub.log` |
+
+  The file records the startup banner (version, PID) and the shutdown path, ending
+  in `termiHub exited cleanly`, so a clean exit is now visible as such in termiHub's
+  own log rather than only in the OS log — and a run that ends without that line is
+  recognisable as a kill or a crash. Older runs are kept as `termihub.1.log` /
+  `termihub.2.log`.
+
+  The log is **hard-capped at 15 MiB total** — it rotates at 5 MiB and keeps three
+  files — so it cannot grow without bound. It records INFO and above (the LogViewer
+  keeps its more detailed DEBUG view), and never contains passwords, key material,
+  or terminal contents. Set `TERMIHUB_FILE_LOG` (e.g. `TERMIHUB_FILE_LOG=debug`) to
+  raise the file's detail when diagnosing a problem.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2411,3 +2411,53 @@ On a real host where your SSH user has `sudo` rights (e.g. a Raspberry Pi):
    unchanged, and no temp file remains.
 5. Inspect the LogViewer / backend logs during all of the above and confirm the
    **sudo password never appears** in any log line.
+
+### Application log file (#1570)
+
+Rotation, capping, the platform log-directory resolution, and the INFO-level file
+filter are covered by unit tests (`src-tauri/src/utils/file_log.rs`). The steps
+below are manual because they need a **bundled** app: only a real install exercises
+the launch path a post-mortem cares about, and the point of the feature is that the
+evidence exists on disk after the process is gone. Referenced by PR #1578.
+
+**A run leaves a log behind, on every platform.**
+
+1. Launch the installed app and open a session, then locate the log file:
+   - macOS: `~/Library/Logs/com.termihub.app/termihub.log`
+   - Windows: `%LOCALAPPDATA%\com.termihub.app\logs\termihub.log`
+   - Linux: `~/.local/share/com.termihub.app/logs/termihub.log`
+2. Confirm the file exists and its first line of the run is the
+   `termiHub starting` banner carrying the **version** and **pid**.
+3. Confirm entries are timestamped, carry a level and a target, and contain **no
+   ANSI escape sequences** (the file is read in a plain editor, not a terminal).
+
+**A clean exit is visible as a clean exit.**
+
+1. Close the app via the **window close button**. Re-open the log and confirm it
+   ends with the full breadcrumb sequence: `Window close requested`,
+   `Exit requested, shutting down`, then `termiHub exited cleanly` — whose absence
+   in the 2026-07-17 investigation forced the reconstruction from Apple's unified
+   log.
+2. Relaunch and quit via the **app menu / Cmd+Q** instead. Confirm the log ends with
+   `termiHub exited cleanly`. Note that this path emits **only** that line — Tauri
+   raises neither `CloseRequested` nor `ExitRequested` for a menu quit, so
+   `termiHub exited cleanly` is the one marker common to every clean exit and the
+   line to look for. Do not treat a missing `Exit requested` as evidence of a crash.
+3. Relaunch, then **kill** the app (`kill -9`, or Force Quit). Confirm the log ends
+   _without_ `termiHub exited cleanly` — a killed run is distinguishable from a clean
+   one by inspection alone, which is the whole point.
+4. Relaunch once more and confirm the new run **appends** below the previous one
+   rather than truncating it, so the run before an incident survives the restart.
+
+**The cap holds and secrets stay out.**
+
+1. Connect to an SSH host using a password and/or unlock the credential store.
+   Confirm the log records the _actions_ ("Unlocking credential store") but that
+   the password, passphrase, and private-key material appear **nowhere** in the
+   file. Confirm terminal contents are not logged.
+2. To exercise rotation without waiting for 5 MiB, relaunch with
+   `TERMIHUB_FILE_LOG=trace` and drive the app (open sessions, browse SFTP) until
+   the log passes 5 MiB. Confirm `termihub.log` starts fresh, the previous content
+   moved to `termihub.1.log`, and that after enough churn `termihub.2.log` is the
+   oldest kept — `termihub.3.log` must **never** appear and the directory must
+   stay under ~15 MiB.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2455,9 +2455,13 @@ evidence exists on disk after the process is gone. Referenced by PR #1578.
    Confirm the log records the _actions_ ("Unlocking credential store") but that
    the password, passphrase, and private-key material appear **nowhere** in the
    file. Confirm terminal contents are not logged.
-2. To exercise rotation without waiting for 5 MiB, relaunch with
-   `TERMIHUB_FILE_LOG=trace` and drive the app (open sessions, browse SFTP) until
-   the log passes 5 MiB. Confirm `termihub.log` starts fresh, the previous content
-   moved to `termihub.1.log`, and that after enough churn `termihub.2.log` is the
-   oldest kept — `termihub.3.log` must **never** appear and the directory must
-   stay under ~15 MiB.
+2. Relaunch with `TERMIHUB_FILE_LOG=debug` and open an SSH session. Confirm the
+   file gains termiHub's own DEBUG detail but still contains **no `russh` packet
+   logging** — raising termiHub's verbosity must never unclamp SSH internals into
+   a file users paste into issues (`russh` is held at WARN on top of any override).
+3. To exercise rotation without waiting for 5 MiB, append filler to the live file
+   (`python3 -c "open('termihub.log','a').write('x'*(5*1024*1024))"`) and relaunch:
+   the startup banner alone then trips the cap. Confirm `termihub.log` starts fresh
+   with the banner, the previous content moved to `termihub.1.log`, and that after
+   enough churn `termihub.2.log` is the oldest kept — `termihub.3.log` must
+   **never** appear and the directory must stay under ~15 MiB.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,9 +21,10 @@ mod workspace;
 use std::sync::{Arc, Mutex};
 
 use tauri::{Emitter, Manager, RunEvent, WindowEvent};
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Layer;
 
 use connection::manager::ConnectionManager;
 use connection::recovery::RecoveryWarning;
@@ -35,6 +36,7 @@ use network::NetworkManager;
 use session::manager::SessionManager;
 use session::registry::build_desktop_registry;
 use terminal::agent_manager::{AgentConnectionManager, AgentRpcClient};
+use utils::file_log;
 use utils::log_capture::{create_log_buffer, default_env_filter, LogCaptureLayer};
 
 /// Build the shared X server lifecycle manager (issue #1049).
@@ -144,11 +146,52 @@ pub fn run() {
     let capture_layer = LogCaptureLayer::new(log_buffer.clone());
     let app_handle_slot = capture_layer.app_handle_slot();
 
+    // Durable application log (#1570). A bundled desktop app has nowhere for the
+    // `fmt` layer's stdout to go and the ring buffer dies with the process, so
+    // without this sink the app leaves no evidence of what it was doing. Kept
+    // best-effort: an unwritable log directory must never stop the app booting,
+    // so the failure is recorded and startup continues.
+    let (file_layer, file_log_status) = match file_log::RotatingLogFile::with_defaults() {
+        Ok(writer) => (
+            Some(
+                tracing_subscriber::fmt::layer()
+                    // No terminal on the other end of a file: escape codes would
+                    // just make it unreadable.
+                    .with_ansi(false)
+                    .with_writer(writer)
+                    .with_filter(file_log::file_env_filter()),
+            ),
+            Ok(()),
+        ),
+        Err(e) => (None, Err(e)),
+    };
+
     tracing_subscriber::registry()
         .with(default_env_filter())
         .with(tracing_subscriber::fmt::layer())
         .with(capture_layer)
+        .with(file_layer)
         .init();
+
+    // The first lines of every run: they mark the run boundary in an appended
+    // file and record the version a later post-mortem will need.
+    match (&file_log_status, file_log::log_file_path()) {
+        (Ok(()), Some(path)) => info!(
+            version = env!("CARGO_PKG_VERSION"),
+            pid = std::process::id(),
+            log_file = %path.display(),
+            "termiHub starting"
+        ),
+        (Err(e), _) => {
+            info!(
+                version = env!("CARGO_PKG_VERSION"),
+                pid = std::process::id(),
+                "termiHub starting"
+            );
+            warn!("Application log file unavailable, logging to memory only: {e}");
+        }
+        (Ok(()), None) => unreachable!("the writer opened, so a log path resolves"),
+    }
 
     // Shared X server manager (#1049), held as an `Arc` so the provisioner
     // (#1052) and the Tauri commands can both reference the same instance.
@@ -801,6 +844,23 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
+            // Shutdown breadcrumbs (#1570). The 2026-07-17 post-mortem could only
+            // establish that termiHub had exited *cleanly* by reading Apple's
+            // unified log — the app itself recorded nothing on the way out. These
+            // three events make the clean-exit path self-evident from termiHub's
+            // own log, and their *absence* before a restart is what distinguishes
+            // a clean shutdown from a kill or a crash.
+            match &event {
+                RunEvent::WindowEvent {
+                    label,
+                    event: WindowEvent::CloseRequested { .. },
+                    ..
+                } => info!(window = %label, "Window close requested"),
+                RunEvent::ExitRequested { .. } => info!("Exit requested, shutting down"),
+                RunEvent::Exit => info!("termiHub exited cleanly"),
+                _ => {}
+            }
+
             if let RunEvent::WindowEvent {
                 event: WindowEvent::Destroyed,
                 ..

--- a/src-tauri/src/utils/file_log.rs
+++ b/src-tauri/src/utils/file_log.rs
@@ -72,15 +72,35 @@ const MAX_FILES: usize = 3;
 /// depend on how the app happened to be launched.
 ///
 /// `TERMIHUB_FILE_LOG` overrides this when a support case needs more detail.
-const FILE_LOG_DIRECTIVE: &str = "info";
+///
+/// `russh` is clamped for the same reason the ring buffer clamps it — it emits
+/// per-packet cipher logs below WARN — but here the clamp is also a *safety*
+/// property, not just a noise one: this file is written to disk and pasted into
+/// issues, so packet-level SSH internals must not reach it. See
+/// [`RUSSH_CLAMP`], which keeps that true even when the override lowers the level.
+const FILE_LOG_DIRECTIVE: &str = "info,russh=warn";
+
+/// Floor applied to `russh` on top of *any* file directive, including a
+/// `TERMIHUB_FILE_LOG` override.
+///
+/// Without this, `TERMIHUB_FILE_LOG=debug` would silently unclamp russh's
+/// per-packet cipher logging into a durable, user-shared file. A support case
+/// that genuinely needs russh internals can still ask for them explicitly
+/// (`TERMIHUB_FILE_LOG="debug,russh=debug"`) — the point is that it cannot
+/// happen by accident while someone is only trying to raise termiHub's own detail.
+const RUSSH_CLAMP: &str = "russh=warn";
 
 /// Build the [`EnvFilter`] for the file sink.
 ///
-/// Honors `TERMIHUB_FILE_LOG` when set, else [`FILE_LOG_DIRECTIVE`].
+/// Honors `TERMIHUB_FILE_LOG` when set, else [`FILE_LOG_DIRECTIVE`]. An override
+/// gets [`RUSSH_CLAMP`] prepended, so a directive that names `russh` explicitly
+/// still wins (later directives take precedence in an `EnvFilter`) while one that
+/// does not stays clamped.
 pub fn file_env_filter() -> EnvFilter {
     match std::env::var("TERMIHUB_FILE_LOG") {
         Ok(directive) if !directive.trim().is_empty() => {
-            EnvFilter::try_new(&directive).unwrap_or_else(|_| EnvFilter::new(FILE_LOG_DIRECTIVE))
+            EnvFilter::try_new(format!("{RUSSH_CLAMP},{directive}"))
+                .unwrap_or_else(|_| EnvFilter::new(FILE_LOG_DIRECTIVE))
         }
         _ => EnvFilter::new(FILE_LOG_DIRECTIVE),
     }
@@ -401,6 +421,58 @@ mod tests {
 
         assert_eq!(read(&dir.path().join("termihub.log")), "bbbbb\n");
         assert!(!dir.path().join("termihub.1.log").exists());
+    }
+
+    /// Render what `directive` admits for `russh` at DEBUG, without touching the
+    /// process environment (which is global and would race other tests).
+    fn russh_debug_reaches_file(directive: &str) -> bool {
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::Layer as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = RotatingLogFile::new(dir.path(), 1 << 20, 3).unwrap();
+        let filter = EnvFilter::try_new(directive).unwrap();
+
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(log.clone())
+                .with_filter(filter),
+        );
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug!(target: "russh", "packet cipher internals");
+        });
+
+        read(&dir.path().join("termihub.log")).contains("packet cipher internals")
+    }
+
+    #[test]
+    fn the_default_file_directive_clamps_russh() {
+        assert!(
+            !russh_debug_reaches_file(FILE_LOG_DIRECTIVE),
+            "russh DEBUG is per-packet cipher logging and must never reach a file \
+             users paste into issues"
+        );
+    }
+
+    #[test]
+    fn raising_file_detail_does_not_unclamp_russh() {
+        // The realistic support instruction: "set TERMIHUB_FILE_LOG=debug". It must
+        // raise termiHub's own detail without dragging SSH packet internals along.
+        assert!(
+            !russh_debug_reaches_file(&format!("{RUSSH_CLAMP},debug")),
+            "TERMIHUB_FILE_LOG=debug must not silently enable russh packet logging"
+        );
+    }
+
+    #[test]
+    fn an_explicit_russh_directive_still_wins() {
+        // Escape hatch: a support case that truly needs russh internals can ask.
+        assert!(
+            russh_debug_reaches_file(&format!("{RUSSH_CLAMP},debug,russh=debug")),
+            "an explicit russh=debug must still be honored — the clamp is a default, \
+             not a prohibition"
+        );
     }
 
     #[test]

--- a/src-tauri/src/utils/file_log.rs
+++ b/src-tauri/src/utils/file_log.rs
@@ -1,0 +1,464 @@
+//! Persistent application log file (#1570).
+//!
+//! termiHub historically kept its log only in memory: the [`LogCaptureLayer`]
+//! ring buffer feeds the in-app LogViewer, and the `fmt` layer writes to stdout
+//! — which is discarded for a bundled desktop app. The moment the process was
+//! gone, so was every trace of what it had been doing. A post-mortem of the
+//! 2026-07-17 shutdown had to be reconstructed entirely from Apple's unified
+//! log and jetsam snapshots because termiHub itself left nothing behind.
+//!
+//! This module adds the missing durable sink: a rotating, hard-capped log file
+//! in the platform's conventional location.
+//!
+//! # Design notes
+//!
+//! **Why not `tauri-plugin-log`?** The issue suggested it, but the app already
+//! owns a full `tracing` pipeline (filter + fmt + ring buffer). The plugin
+//! builds a second, parallel logging system on the `log` crate; every event
+//! would need bridging and the two would drift. Adding one more `Layer` to the
+//! registry that already exists is both smaller and keeps a single source of
+//! truth.
+//!
+//! **Why synchronous writes, not `tracing_appender::non_blocking`?** The
+//! non-blocking writer hands events to a background thread over a channel. When
+//! the process dies abruptly — SIGKILL, jetsam, panic — whatever is still in
+//! that channel is lost. The lost tail is exactly the part a post-mortem needs.
+//! At INFO volume the cost of writing straight through is irrelevant, so this
+//! writer trades throughput we do not need for the durability that is the whole
+//! point of the feature.
+//!
+//! **Why a custom rotator?** `tracing-appender`'s rotation is time-based
+//! (`max_log_files` bounds the file *count*, not their size), so a single
+//! runaway day — a reconnect loop, say — could still write an unbounded file.
+//! Size-based rotation gives a hard ceiling that does not depend on how the app
+//! behaves: at most [`MAX_FILE_BYTES`] × [`MAX_FILES`] on disk, always.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::EnvFilter;
+
+/// The app's bundle identifier, matching `tauri.conf.json`.
+///
+/// Used to build the platform log directory. Kept in sync with the bundle id by
+/// [`tests::log_dir_matches_platform_convention`].
+const BUNDLE_ID: &str = "com.termihub.app";
+
+/// Base name of the current log file (`termihub.log`).
+const LOG_STEM: &str = "termihub";
+
+/// Extension of the log files.
+const LOG_EXT: &str = "log";
+
+/// Size at which the current log file is rotated away.
+const MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// Total number of log files kept: the current one plus `MAX_FILES - 1`
+/// archives. Together with [`MAX_FILE_BYTES`] this bounds on-disk usage at
+/// 15 MiB.
+const MAX_FILES: usize = 3;
+
+/// Filter directive for the *file* sink.
+///
+/// Deliberately stricter than the ring buffer's directive (which keeps
+/// termiHub's crates at DEBUG so the in-app LogViewer stays useful). A file a
+/// user is expected to read — and paste into an issue — must not drown in
+/// per-keystroke debug spam, so the file keeps INFO and above. `RUST_LOG` is
+/// intentionally *not* honored here: it tunes the interactive LogViewer, and
+/// having it silently change what lands on disk would make the file's contents
+/// depend on how the app happened to be launched.
+///
+/// `TERMIHUB_FILE_LOG` overrides this when a support case needs more detail.
+const FILE_LOG_DIRECTIVE: &str = "info";
+
+/// Build the [`EnvFilter`] for the file sink.
+///
+/// Honors `TERMIHUB_FILE_LOG` when set, else [`FILE_LOG_DIRECTIVE`].
+pub fn file_env_filter() -> EnvFilter {
+    match std::env::var("TERMIHUB_FILE_LOG") {
+        Ok(directive) if !directive.trim().is_empty() => {
+            EnvFilter::try_new(&directive).unwrap_or_else(|_| EnvFilter::new(FILE_LOG_DIRECTIVE))
+        }
+        _ => EnvFilter::new(FILE_LOG_DIRECTIVE),
+    }
+}
+
+/// Resolve the directory the application log is written to.
+///
+/// Follows each platform's own convention rather than inventing one — notably
+/// on macOS this is `~/Library/Logs/<bundle-id>/`, which is where the #1570
+/// investigator looked and found nothing. These paths match Tauri's own
+/// `app_log_dir()` resolution, but are computed here because the subscriber is
+/// initialized before the Tauri app exists.
+///
+/// - macOS: `~/Library/Logs/com.termihub.app`
+/// - Windows: `%LOCALAPPDATA%\com.termihub.app\logs`
+/// - Linux: `$XDG_DATA_HOME/com.termihub.app/logs` (i.e. `~/.local/share/...`)
+///
+/// Returns `None` when the platform base directory cannot be resolved, in which
+/// case file logging is skipped rather than guessed at.
+pub fn log_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        dirs::home_dir().map(|h| h.join("Library").join("Logs").join(BUNDLE_ID))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        dirs::data_local_dir().map(|d| d.join(BUNDLE_ID).join("logs"))
+    }
+}
+
+/// Full path of the current (un-rotated) log file, for reporting to the user.
+pub fn log_file_path() -> Option<PathBuf> {
+    log_dir().map(|d| d.join(format!("{LOG_STEM}.{LOG_EXT}")))
+}
+
+/// A size-rotating, count-capped log file.
+///
+/// Cloneable and cheap to clone: clones share one file handle and one lock, so
+/// interleaved writes from many threads stay whole.
+#[derive(Clone)]
+pub struct RotatingLogFile {
+    inner: Arc<Mutex<Rotator>>,
+}
+
+impl RotatingLogFile {
+    /// Open (or create) the log file in `dir`, rotating at `max_bytes` and
+    /// keeping at most `max_files` files in total.
+    ///
+    /// Appends to an existing file so a restart does not discard the previous
+    /// run — the run boundary is marked by the startup banner instead.
+    pub fn new(dir: impl AsRef<Path>, max_bytes: u64, max_files: usize) -> io::Result<Self> {
+        let rotator = Rotator::open(dir.as_ref().to_path_buf(), max_bytes, max_files.max(1))?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(rotator)),
+        })
+    }
+
+    /// Open the log file at the platform's conventional location with the
+    /// default size and count caps.
+    pub fn with_defaults() -> io::Result<Self> {
+        let dir = log_dir().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "could not resolve a platform log directory",
+            )
+        })?;
+        Self::new(dir, MAX_FILE_BYTES, MAX_FILES)
+    }
+}
+
+impl<'a> MakeWriter<'a> for RotatingLogFile {
+    type Writer = LockedRotator<'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        // A poisoned lock means some other thread panicked mid-write. Losing
+        // the log at exactly that moment is the opposite of what this module is
+        // for, so recover the guard and keep writing.
+        LockedRotator(self.inner.lock().unwrap_or_else(|e| e.into_inner()))
+    }
+}
+
+/// Write guard handed to the `fmt` layer for the duration of one event.
+pub struct LockedRotator<'a>(MutexGuard<'a, Rotator>);
+
+impl Write for LockedRotator<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+/// The rotation state machine. Not public: all access goes through the lock.
+struct Rotator {
+    dir: PathBuf,
+    file: File,
+    /// Bytes in the *current* file, tracked rather than `stat`-ed per write.
+    written: u64,
+    max_bytes: u64,
+    max_files: usize,
+}
+
+impl Rotator {
+    fn open(dir: PathBuf, max_bytes: u64, max_files: usize) -> io::Result<Self> {
+        fs::create_dir_all(&dir)?;
+        let path = Self::path_in(&dir, 0);
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let written = file.metadata().map(|m| m.len()).unwrap_or(0);
+        Ok(Self {
+            dir,
+            file,
+            written,
+            max_bytes,
+            max_files,
+        })
+    }
+
+    /// Path of log generation `gen`: 0 is the live file, 1..n the archives.
+    fn path_in(dir: &Path, generation: usize) -> PathBuf {
+        if generation == 0 {
+            dir.join(format!("{LOG_STEM}.{LOG_EXT}"))
+        } else {
+            dir.join(format!("{LOG_STEM}.{generation}.{LOG_EXT}"))
+        }
+    }
+
+    fn path(&self, generation: usize) -> PathBuf {
+        Self::path_in(&self.dir, generation)
+    }
+
+    /// Shift every generation one older, dropping the oldest, and start a fresh
+    /// live file.
+    fn rotate(&mut self) -> io::Result<()> {
+        let archives = self.max_files - 1;
+        if archives == 0 {
+            // Degenerate cap of one file: truncate in place.
+            self.file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(self.path(0))?;
+            self.written = 0;
+            return Ok(());
+        }
+
+        // Drop the oldest, then walk backwards so nothing overwrites a file we
+        // still need.
+        let _ = fs::remove_file(self.path(archives));
+        for generation in (1..archives).rev() {
+            let _ = fs::rename(self.path(generation), self.path(generation + 1));
+        }
+        let _ = fs::rename(self.path(0), self.path(1));
+
+        self.file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.path(0))?;
+        self.written = 0;
+        Ok(())
+    }
+}
+
+impl Write for Rotator {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Rotate *before* writing so a single event is never split across two
+        // files. `written > 0` keeps an event larger than the cap from spinning
+        // the rotation on an already-empty file.
+        if self.written > 0 && self.written + buf.len() as u64 > self.max_bytes {
+            self.rotate()?;
+        }
+        let n = self.file.write(buf)?;
+        self.written += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read(path: &Path) -> String {
+        fs::read_to_string(path).unwrap_or_default()
+    }
+
+    #[test]
+    fn writes_land_in_the_live_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = RotatingLogFile::new(dir.path(), 1024, 3).unwrap();
+
+        log.make_writer().write_all(b"hello\n").unwrap();
+
+        assert_eq!(read(&dir.path().join("termihub.log")), "hello\n");
+    }
+
+    #[test]
+    fn creates_the_log_directory_if_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("deep").join("nested");
+
+        RotatingLogFile::new(&nested, 1024, 3).unwrap();
+
+        assert!(nested.join("termihub.log").exists());
+    }
+
+    #[test]
+    fn reopening_appends_rather_than_truncating() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let first = RotatingLogFile::new(dir.path(), 1024, 3).unwrap();
+        first.make_writer().write_all(b"run one\n").unwrap();
+        drop(first);
+
+        let second = RotatingLogFile::new(dir.path(), 1024, 3).unwrap();
+        second.make_writer().write_all(b"run two\n").unwrap();
+
+        assert_eq!(read(&dir.path().join("termihub.log")), "run one\nrun two\n");
+    }
+
+    #[test]
+    fn rotates_once_the_size_cap_is_exceeded() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = RotatingLogFile::new(dir.path(), 10, 3).unwrap();
+
+        log.make_writer().write_all(b"aaaaa\n").unwrap(); // 6 bytes, fits
+        log.make_writer().write_all(b"bbbbb\n").unwrap(); // would be 12 > 10
+
+        assert_eq!(
+            read(&dir.path().join("termihub.log")),
+            "bbbbb\n",
+            "the live file should hold only the post-rotation write"
+        );
+        assert_eq!(
+            read(&dir.path().join("termihub.1.log")),
+            "aaaaa\n",
+            "the pre-rotation content should have moved to generation 1"
+        );
+    }
+
+    #[test]
+    fn rotation_never_splits_a_single_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = RotatingLogFile::new(dir.path(), 10, 3).unwrap();
+
+        log.make_writer().write_all(b"aaaaa\n").unwrap();
+        // An event larger than the whole cap must still be written whole.
+        log.make_writer().write_all(b"a-very-long-event\n").unwrap();
+
+        assert_eq!(
+            read(&dir.path().join("termihub.log")),
+            "a-very-long-event\n",
+            "an oversized event must land intact in the fresh file"
+        );
+    }
+
+    #[test]
+    fn generations_shift_and_the_oldest_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = RotatingLogFile::new(dir.path(), 10, 3).unwrap();
+
+        for line in ["one\n", "two\n", "three\n", "four\n"] {
+            // Each write is 4-6 bytes; pad past the cap to force a rotation per line.
+            log.make_writer().write_all(line.as_bytes()).unwrap();
+            log.make_writer().write_all(b"pad-to-force\n").unwrap();
+        }
+
+        // Only MAX_FILES generations may ever exist.
+        assert!(dir.path().join("termihub.log").exists());
+        assert!(dir.path().join("termihub.1.log").exists());
+        assert!(dir.path().join("termihub.2.log").exists());
+        assert!(
+            !dir.path().join("termihub.3.log").exists(),
+            "generation 3 exceeds the cap and must never be created"
+        );
+    }
+
+    #[test]
+    fn total_disk_usage_stays_bounded_under_sustained_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let max_bytes = 256;
+        let max_files = 3;
+        let log = RotatingLogFile::new(dir.path(), max_bytes, max_files).unwrap();
+
+        // Write far more than the cap: 2000 * ~32B ≈ 64 KB against a 768 B cap.
+        for i in 0..2000 {
+            log.make_writer()
+                .write_all(format!("event number {i} padding\n").as_bytes())
+                .unwrap();
+        }
+
+        let total: u64 = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.metadata().ok())
+            .map(|m| m.len())
+            .sum();
+
+        // Each file may overshoot by at most one event, hence the slack.
+        let ceiling = max_bytes * max_files as u64 + 1024;
+        assert!(
+            total <= ceiling,
+            "log grew to {total} B, above the {ceiling} B ceiling — the cap is not holding"
+        );
+    }
+
+    #[test]
+    fn a_cap_of_one_file_truncates_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = RotatingLogFile::new(dir.path(), 10, 1).unwrap();
+
+        log.make_writer().write_all(b"aaaaa\n").unwrap();
+        log.make_writer().write_all(b"bbbbb\n").unwrap();
+
+        assert_eq!(read(&dir.path().join("termihub.log")), "bbbbb\n");
+        assert!(!dir.path().join("termihub.1.log").exists());
+    }
+
+    #[test]
+    fn log_dir_matches_platform_convention() {
+        let dir = log_dir().expect("a platform log directory should resolve on test hosts");
+
+        assert!(
+            dir.ends_with(BUNDLE_ID) || dir.ends_with(Path::new(BUNDLE_ID).join("logs")),
+            "log dir {dir:?} must be namespaced by the bundle id"
+        );
+
+        #[cfg(target_os = "macos")]
+        assert!(
+            dir.ends_with(Path::new("Library").join("Logs").join(BUNDLE_ID)),
+            "macOS must use ~/Library/Logs/<bundle-id>, got {dir:?}"
+        );
+
+        #[cfg(not(target_os = "macos"))]
+        assert!(
+            dir.ends_with(Path::new(BUNDLE_ID).join("logs")),
+            "non-macOS platforms must use <local-data>/<bundle-id>/logs, got {dir:?}"
+        );
+    }
+
+    #[test]
+    fn log_file_path_sits_inside_the_log_dir() {
+        let path = log_file_path().unwrap();
+        assert_eq!(path.file_name().unwrap(), "termihub.log");
+        assert_eq!(path.parent().unwrap(), log_dir().unwrap());
+    }
+
+    #[test]
+    fn file_filter_keeps_info_and_drops_debug() {
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::Layer as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let log = RotatingLogFile::new(dir.path(), 1 << 20, 3).unwrap();
+
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(log.clone())
+                .with_filter(file_env_filter()),
+        );
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: "termihub_lib::session", "session opened");
+            tracing::debug!(target: "termihub_lib::session", "per-keystroke noise");
+        });
+
+        let contents = read(&dir.path().join("termihub.log"));
+        assert!(
+            contents.contains("session opened"),
+            "INFO must reach the file, got: {contents:?}"
+        );
+        assert!(
+            !contents.contains("per-keystroke noise"),
+            "DEBUG must not reach the file — it is what drowns a readable log; got: {contents:?}"
+        );
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -3,6 +3,9 @@ pub mod docker_detect;
 pub mod download;
 pub mod errors;
 pub mod expand;
+/// Rotating, size-capped application log file written to the platform's
+/// conventional log directory (#1570).
+pub mod file_log;
 pub mod fs;
 pub mod log_capture;
 pub mod portable;


### PR DESCRIPTION
termiHub kept its log only in memory: the ring buffer feeds the in-app LogViewer and the `fmt` layer writes to stdout, which a bundled desktop app discards. Once the process was gone, so was every trace of what it had been doing — the 2026-07-17 post-mortem had to be reconstructed entirely from Apple's unified log and jetsam snapshots, with no contribution from termiHub itself.

This adds the missing durable sink to the `tracing` registry that already exists.

## Where the log lands

Platform convention per platform — on macOS, exactly where the investigator looked and found nothing:

| Platform | Path |
| --- | --- |
| macOS | `~/Library/Logs/com.termihub.app/termihub.log` |
| Windows | `%LOCALAPPDATA%\com.termihub.app\logs\termihub.log` |
| Linux | `~/.local/share/com.termihub.app/logs/termihub.log` |

## The clean-exit path

The reason this issue exists is that termiHub exited *cleanly* and left no trace of having done so — a log that only captured crashes would not have answered the question that prompted it. The run now brackets itself: a startup banner (version, PID) and shutdown breadcrumbs ending in `termiHub exited cleanly`. A run that ends without that line is recognisable as a kill or a crash by inspection alone.

## Rotation and cap

Size-based rotation, hard-capped: 5 MiB per file x 3 files = **15 MiB maximum**, always. `tracing-appender`'s rotation is time-based and bounds file *count*, not size, so a reconnect loop could still write an unbounded file — hence the custom rotator. Writes are synchronous rather than `non_blocking`, because the tail buffered in a background channel is exactly the part a post-mortem needs when the process dies abruptly.

## Not logging secrets

The file keeps INFO and above, and `russh` is clamped to WARN — **including on top of any `TERMIHUB_FILE_LOG` override**. The app's ring-buffer directive already clamped russh because it emits per-packet cipher logs; the file sink initially inherited no such clamp, so the documented support instruction `TERMIHUB_FILE_LOG=debug` would have unclamped SSH transport internals into precisely the file users paste into issues. An explicit `russh=debug` still wins for a support case that needs it. Audited the INFO-level call sites: the only credential-adjacent lines log the *action* ("Setting up master password"), never the value.

## Verified by running it

Not just tests — observed on a real run:

- Deleted `~/Library/Logs/com.termihub.app/` entirely; the app **recreated the directory and file** from nothing.
- File carried the banner with version and PID, **no ANSI escapes** (stdout had them), and **zero DEBUG lines** while stdout had many — the filter separation holds live.
- **Rotation observed live**: seeded the file past 5 MiB, relaunched; the seed moved to `termihub.1.log` and `termihub.log` restarted fresh with the banner.
- **Append across runs** confirmed: the previous run's lines stayed intact with the new run below.
- **Clean exit** logged on both quit paths; **`kill -9`** left the log ending mid-stream with no `exited cleanly` line.
- `TERMIHUB_FILE_LOG=debug` raised detail with **zero russh lines**.

## A correction to the docs

Observed while verifying: a **menu quit (Cmd+Q) emits neither `CloseRequested` nor `ExitRequested`** — it logs only `termiHub exited cleanly`, while the window-close path logs the full sequence. The manual test steps now look for that one line, which is the marker common to every clean exit, rather than for `Exit requested`.

## Test plan

- 14 unit tests in `src-tauri/src/utils/file_log.rs` covering rotation, the disk cap under sustained writes, oversized events, generation shifting, the platform path resolution, and the russh clamp. Verified red without the change: removing the rotation call fails 5; removing the clamp fails `raising_file_detail_does_not_unclamp_russh`.
- Manual steps added to `docs/testing.md` (bundled-app paths, clean-exit breadcrumbs, rotation, secrets).
- `./scripts/check.sh` passes; `npx tsc --noEmit` clean.

Closes #1570

## Follow-ups

- #1588 — `pnpm tauri dev` silently bypasses `dev.local.json` port isolation (found while verifying this change on a running app; the documented dev command defaults to port 1420 and ignores the checkout's configured port).
