### PR TITLE
feat(ui): add Checkbox primitive and adopt it in the session picker (Closes #1562)

### DIFF
--- a/docs/changes/dev4/feature/1562-checkbox-primitive.md
+++ b/docs/changes/dev4/feature/1562-checkbox-primitive.md
@@ -1,0 +1,16 @@
+### Added
+
+- **`Checkbox` UI primitive** in `src/components/ui/`, a token-styled skin over
+  `@radix-ui/react-checkbox`. It complements the existing `Toggle` (a Radix
+  `Switch`) rather than replacing it: a checkbox means "takes effect when you
+  confirm", a switch means "applies immediately". Real `role="checkbox"`,
+  `aria-checked` (including `mixed`), Space activation and focus-visible
+  styling come from Radix; the indeterminate state is supported for mixed
+  parent/child selections (#1562).
+
+### Changed
+
+- The **Session Picker** footer now draws "Open in new window" and "Remember
+  choice" as checkboxes instead of switches, matching the concept mockup. Both
+  options only take effect when **Open** is pressed, so a switch overstated
+  their immediacy. Behavior is unchanged (#1562).

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@hookform/resolvers": "^5.4.0",
     "@lucide/lab": "^0.1.2",
     "@monaco-editor/react": "^4.7.0",
+    "@radix-ui/react-checkbox": "^1.3.7",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.7
+        version: 1.3.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-context-menu':
         specifier: ^2.2.16
         version: 2.2.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -904,6 +907,9 @@ packages:
   '@radix-ui/primitive@1.1.4':
     resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
 
+  '@radix-ui/primitive@1.1.5':
+    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
+
   '@radix-ui/react-arrow@1.1.11':
     resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
     peerDependencies:
@@ -919,6 +925,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.7':
+    resolution: {integrity: sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -985,6 +1004,15 @@ packages:
 
   '@radix-ui/react-context@1.1.4':
     resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1173,6 +1201,19 @@ packages:
 
   '@radix-ui/react-presence@1.1.6':
     resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.7':
+    resolution: {integrity: sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3956,6 +3997,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.4': {}
 
+  '@radix-ui/primitive@1.1.5': {}
+
   '@radix-ui/react-arrow@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3968,6 +4011,22 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-checkbox@1.3.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.5
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -4019,6 +4078,12 @@ snapshots:
       '@types/react': 18.3.28
 
   '@radix-ui/react-context@1.1.4(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-context@1.2.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -4217,6 +4282,15 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
   '@radix-ui/react-presence@1.1.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-presence@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1

--- a/src/components/Spawn/SpawnPicker.test.tsx
+++ b/src/components/Spawn/SpawnPicker.test.tsx
@@ -146,6 +146,18 @@ describe("SpawnPicker", () => {
     );
   });
 
+  it("renders the footer options as checkboxes, not switches", async () => {
+    await renderPicker();
+
+    // Both options only take effect when Open is pressed, so the design draws
+    // checkboxes (#1562). A switch would imply they apply immediately.
+    for (const id of ["spawn-picker-new-window", "spawn-picker-remember"]) {
+      const control = query(id) as HTMLElement;
+      expect(control.getAttribute("role")).toBe("checkbox");
+      expect(control.classList.contains("ui-checkbox")).toBe(true);
+    }
+  });
+
   it("cancels without confirming", async () => {
     const onConfirm = vi.fn();
     const onCancel = vi.fn();

--- a/src/components/Spawn/SpawnPicker.tsx
+++ b/src/components/Spawn/SpawnPicker.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Container, Folder, Terminal } from "lucide-react";
-import { Button, Input, Modal, Select, Toggle } from "@/components/ui";
+import { Button, Checkbox, Input, Modal, Select } from "@/components/ui";
 import { listSpawnOptions, type SpawnOptions } from "@/services/api";
 import type { ContainerRuntime, SpawnChoice, SpawnTarget } from "@/types/spawn";
 import { frontendLog } from "@/utils/frontendLog";
@@ -228,7 +228,7 @@ export function SpawnPicker({
         <div className="spawn-picker__footer">
           <div className="spawn-picker__footer-checks">
             <label className="spawn-picker__check">
-              <Toggle
+              <Checkbox
                 checked={newWindow}
                 onCheckedChange={setNewWindow}
                 aria-label="Open in new window"
@@ -237,7 +237,7 @@ export function SpawnPicker({
               Open in new window
             </label>
             <label className="spawn-picker__check">
-              <Toggle
+              <Checkbox
                 checked={remember}
                 onCheckedChange={setRemember}
                 aria-label="Remember choice"

--- a/src/components/ui/Checkbox.test.tsx
+++ b/src/components/ui/Checkbox.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Checkbox } from "./Checkbox";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function checkbox(testid = "cb"): HTMLButtonElement {
+  return document.querySelector(`[data-testid="${testid}"]`) as HTMLButtonElement;
+}
+
+describe("Checkbox", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a checkbox with the base class and reflects the checked state", () => {
+    render(<Checkbox data-testid="cb" checked onCheckedChange={() => {}} />);
+    const cb = checkbox();
+    expect(cb).toBeTruthy();
+    expect(cb.classList.contains("ui-checkbox")).toBe(true);
+    // Radix Checkbox exposes role="checkbox" + aria-checked for accessibility —
+    // the semantics a div-with-onClick would not have.
+    expect(cb.getAttribute("role")).toBe("checkbox");
+    expect(cb.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("reflects the unchecked state", () => {
+    render(<Checkbox data-testid="cb" checked={false} onCheckedChange={() => {}} />);
+    expect(checkbox().getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("exposes the indeterminate state as aria-checked=mixed", () => {
+    render(<Checkbox data-testid="cb" checked="indeterminate" onCheckedChange={() => {}} />);
+    expect(checkbox().getAttribute("aria-checked")).toBe("mixed");
+    expect(checkbox().getAttribute("data-state")).toBe("indeterminate");
+  });
+
+  it("renders the indicator when checked and hides it when unchecked", () => {
+    render(<Checkbox data-testid="cb" checked onCheckedChange={() => {}} />);
+    expect(document.querySelector(".ui-checkbox__indicator")).toBeTruthy();
+
+    render(<Checkbox data-testid="cb" checked={false} onCheckedChange={() => {}} />);
+    expect(document.querySelector(".ui-checkbox__indicator")).toBeNull();
+  });
+
+  it("renders the indicator in the indeterminate state", () => {
+    render(<Checkbox data-testid="cb" checked="indeterminate" onCheckedChange={() => {}} />);
+    expect(document.querySelector(".ui-checkbox__indicator")).toBeTruthy();
+  });
+
+  it("calls onCheckedChange with the new value when clicked", () => {
+    const onCheckedChange = vi.fn();
+    render(<Checkbox data-testid="cb" checked={false} onCheckedChange={onCheckedChange} />);
+    act(() => checkbox().click());
+    expect(onCheckedChange).toHaveBeenCalledTimes(1);
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("reports a boolean when toggled out of the indeterminate state", () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <Checkbox data-testid="cb" checked="indeterminate" onCheckedChange={onCheckedChange} />
+    );
+    act(() => checkbox().click());
+    // The consumer's state is boolean; "indeterminate" must never be echoed back.
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("is a natively focusable button, so it is keyboard operable", () => {
+    render(<Checkbox data-testid="cb" checked={false} onCheckedChange={() => {}} />);
+    const cb = checkbox();
+    expect(cb.tagName).toBe("BUTTON");
+    // type=button keeps it from submitting a surrounding form.
+    expect(cb.getAttribute("type")).toBe("button");
+    act(() => cb.focus());
+    expect(document.activeElement).toBe(cb);
+  });
+
+  it("does not activate on Enter, per the WAI-ARIA checkbox pattern", () => {
+    const onCheckedChange = vi.fn();
+    render(<Checkbox data-testid="cb" checked={false} onCheckedChange={onCheckedChange} />);
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    act(() => {
+      checkbox().dispatchEvent(event);
+    });
+    // Radix prevents Enter: a checkbox toggles with Space, unlike a button.
+    expect(event.defaultPrevented).toBe(true);
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+
+  it("is labelled by an associated <label htmlFor>", () => {
+    render(
+      <>
+        <label htmlFor="cb-id">Remember choice</label>
+        <Checkbox data-testid="cb" id="cb-id" checked={false} onCheckedChange={() => {}} />
+      </>
+    );
+    expect(checkbox().id).toBe("cb-id");
+    expect((document.querySelector("label") as HTMLLabelElement).htmlFor).toBe("cb-id");
+  });
+
+  it("forwards an aria-label when there is no visible label", () => {
+    render(
+      <Checkbox data-testid="cb" aria-label="Remember choice" checked onCheckedChange={() => {}} />
+    );
+    expect(checkbox().getAttribute("aria-label")).toBe("Remember choice");
+  });
+
+  it("is disabled and does not fire onCheckedChange when disabled", () => {
+    const onCheckedChange = vi.fn();
+    render(<Checkbox data-testid="cb" checked={false} disabled onCheckedChange={onCheckedChange} />);
+    const cb = checkbox();
+    expect(cb.hasAttribute("disabled")).toBe(true);
+    act(() => cb.click());
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/Checkbox.test.tsx
+++ b/src/components/ui/Checkbox.test.tsx
@@ -74,9 +74,7 @@ describe("Checkbox", () => {
 
   it("reports a boolean when toggled out of the indeterminate state", () => {
     const onCheckedChange = vi.fn();
-    render(
-      <Checkbox data-testid="cb" checked="indeterminate" onCheckedChange={onCheckedChange} />
-    );
+    render(<Checkbox data-testid="cb" checked="indeterminate" onCheckedChange={onCheckedChange} />);
     act(() => checkbox().click());
     // The consumer's state is boolean; "indeterminate" must never be echoed back.
     expect(onCheckedChange).toHaveBeenCalledWith(true);
@@ -124,7 +122,9 @@ describe("Checkbox", () => {
 
   it("is disabled and does not fire onCheckedChange when disabled", () => {
     const onCheckedChange = vi.fn();
-    render(<Checkbox data-testid="cb" checked={false} disabled onCheckedChange={onCheckedChange} />);
+    render(
+      <Checkbox data-testid="cb" checked={false} disabled onCheckedChange={onCheckedChange} />
+    );
     const cb = checkbox();
     expect(cb.hasAttribute("disabled")).toBe(true);
     act(() => cb.click());

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check, Minus } from "lucide-react";
+import "./ui.css";
+
+/**
+ * The state a {@link Checkbox} can display. `"indeterminate"` is the mixed
+ * state of a parent whose children are only partly checked; it is a state the
+ * consumer sets, never one the user can select.
+ */
+export type CheckboxChecked = boolean | "indeterminate";
+
+/**
+ * Props for the shared {@link Checkbox} primitive — a token-styled skin over
+ * `@radix-ui/react-checkbox`, so real `role="checkbox"`, `aria-checked`
+ * (including `mixed`), Space activation, and focus handling come from Radix
+ * rather than a hand-rolled control.
+ */
+export interface CheckboxProps {
+  /** Controlled state. Pass `"indeterminate"` for the mixed state. */
+  checked: CheckboxChecked;
+  /**
+   * Called with the next value when the user toggles the box. Always a
+   * boolean: activating an indeterminate checkbox resolves it to `true`, so
+   * `"indeterminate"` is never echoed back to the consumer.
+   */
+  onCheckedChange: (checked: boolean) => void;
+  /** Disable interaction. */
+  disabled?: boolean;
+  /** Accessible label (use when there is no associated visible `<label>`). */
+  "aria-label"?: string;
+  /** Associates the checkbox with a `<label htmlFor>`. */
+  id?: string;
+  /** Test hook forwarded to the checkbox root. */
+  "data-testid"?: string;
+}
+
+/**
+ * The single shared checkbox primitive.
+ *
+ * Prefer this over {@link Toggle} for booleans that take effect on confirm —
+ * a checkbox conventionally means "applies when you press OK", where a switch
+ * means "applies immediately". Checked = `--accent-color` with a tick;
+ * indeterminate shows a dash.
+ */
+export function Checkbox({
+  checked,
+  onCheckedChange,
+  disabled,
+  id,
+  ...rest
+}: CheckboxProps): React.ReactElement {
+  return (
+    <CheckboxPrimitive.Root
+      id={id}
+      className="ui-checkbox"
+      checked={checked}
+      onCheckedChange={(next) => onCheckedChange(next === true)}
+      disabled={disabled}
+      {...rest}
+    >
+      <CheckboxPrimitive.Indicator className="ui-checkbox__indicator">
+        {checked === "indeterminate" ? (
+          <Minus size={10} strokeWidth={3} aria-hidden="true" />
+        ) : (
+          <Check size={10} strokeWidth={3} aria-hidden="true" />
+        )}
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -29,6 +29,9 @@ export type { ConfirmDialogProps, ConfirmDontAskAgain } from "./ConfirmDialog";
 export { Toggle } from "./Toggle";
 export type { ToggleProps } from "./Toggle";
 
+export { Checkbox } from "./Checkbox";
+export type { CheckboxProps, CheckboxChecked } from "./Checkbox";
+
 export { Tooltip, TooltipProvider } from "./Tooltip";
 export type { TooltipProps, TooltipProviderProps } from "./Tooltip";
 

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -371,6 +371,46 @@
   background: var(--text-on-accent);
 }
 
+/* ── Checkbox (Radix skin) ──────────────────────────────────────────── */
+.ui-checkbox {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  padding: 0;
+  display: inline-grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--bg-active);
+  border: 1px solid var(--text-secondary);
+  color: var(--text-on-accent);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.ui-checkbox:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+.ui-checkbox[data-state="checked"],
+.ui-checkbox[data-state="indeterminate"] {
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+}
+
+.ui-checkbox:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ui-checkbox__indicator {
+  display: grid;
+  place-items: center;
+  line-height: 0;
+}
+
 /* ── Progress (accessible div) ──────────────────────────────────────── */
 .ui-progress {
   position: relative;


### PR DESCRIPTION
Follow-up to #1366 (PR #1560), which used `Toggle` where the concept mockup draws a checkbox and flagged the divergence rather than silently shipping the wrong control. This closes it.

## The decision: wrap Radix, do not hand-roll

The issue left the approach open. I wrapped `@radix-ui/react-checkbox`.

Consistency with the existing system decided it: **every** primitive in `src/components/ui/` is already a thin token'd skin over a Radix dep — Modal→`react-dialog`, Select→`react-select`, Toggle→`react-switch`, Tooltip→`react-tooltip`. A hand-rolled checkbox would have been the only primitive that was not, and CLAUDE.md rule 2 ("primitives are thin token'd skins over deps already in `package.json`") plus the Prefer-Libraries-Over-Custom-Code rule both point the same way. `@radix-ui/react-checkbox` is a first-party sibling of five deps already installed, so the dependency is additive, not a new vendor.

The argument against — "it is only a box with a tick" — is exactly the "I could write this in 50 lines" reasoning CLAUDE.md names as *not* a valid reason to skip a library. The 50 lines that matter are the accessibility ones.

## Checkbox is not a restyled Toggle

`Toggle` stays. The two now mean different things, which is the point:

| | Means |
| --- | --- |
| `Toggle` (switch) | applies **immediately** — Settings |
| `Checkbox` | takes effect **on confirm** — dialog footers |

## Accessibility — the actual deliverable

From Radix, and each one asserted in `Checkbox.test.tsx`:

- `role="checkbox"` and `aria-checked` — `true` / `false` / **`mixed`** for indeterminate
- a native `<button type="button">`: focusable, Space-activated, and it does **not** submit a surrounding form
- **Enter does not toggle it**, per the WAI-ARIA checkbox pattern (Radix `preventDefault`s it) — the concrete behavioural difference from a button
- `focus-visible` ring via `--shadow-focus`; labelling by both `<label htmlFor>` and `aria-label`

**These tests were verified to fail without the change.** Replacing the Radix root with the `div`-and-onClick anti-pattern turns **7 of the 12 red** — including every semantics, focus and Enter assertion. They are not decoration and would not pass either way.

Indeterminate is supported for mixed parent/child selections; `onCheckedChange` always reports a **boolean**, so `"indeterminate"` is never echoed back into consumer state.

## Adoption

The picker footer's **"Remember choice"** and **"Open in new window"** both migrate — the mockup draws both with `.check`, and both only take effect when **Open** is pressed. A picker test now asserts `role="checkbox"`, so the divergence cannot silently return. Behavior is unchanged; testids are unchanged, so the testid catalog needs no update.

**Audit of other confirm-scoped booleans** (issue scope): the Settings toggles are all apply-immediately and correctly stay `Toggle`. The one real candidate is `ConfirmDialog`'s "don't ask again", which *is* confirm-scoped — but it is a shared primitive whose migration is a visual change across many dialogs, so it gets its own PR rather than growing this one: **#1590**.

Styling follows the mockup's `.check` (14px, tick on `--accent-color`) using tokens only — no raw values, no change to `tokenDiscipline` (#1563 is a separate agent's).

## Test plan

- `npx vitest run` — 3289 passed (352 files), incl. 12 new Checkbox tests + 1 new picker test
- `npx tsc --noEmit` — clean (run explicitly; vitest does not typecheck)
- `pnpm run lint`, `./scripts/format.sh`, `tokenDiscipline` — clean
- Mutation check as described above

No manual test steps — behavior is unchanged and the states are covered by unit tests.
