### PR TITLE
fix(ui): filter the file browser to find rows outside the virtual window (Closes #1582)

### DIFF
--- a/tests/system/termihub_harness/ui/files.py
+++ b/tests/system/termihub_harness/ui/files.py
@@ -23,7 +23,12 @@ from .base import HarnessMixin
 
 
 def file_row_testid(name: str) -> str:
-    """The ``data-testid`` of the file-browser row for an entry ``name``."""
+    """The ``data-testid`` of the file-browser row for an entry ``name``.
+
+    Present in the DOM only while the row is inside the virtualizer's mounted
+    window — see :meth:`FilesUi.wait_for_file_row`, which filters to the entry
+    rather than assuming every listed entry has a node.
+    """
     return f"file-row-{name}"
 
 
@@ -70,6 +75,8 @@ class FilesUi(FileBrowserPathReads):
     # Stable file-browser toolbar / inline-input testids (entry-name-free).
     UP = "file-browser-up"
     REFRESH = "file-browser-refresh"
+    FILTER = "file-browser-filter"
+    FILTER_CLEAR = "file-browser-filter-clear"
     NEW_FILE = "file-browser-new-file"
     NEW_FILE_INPUT = "file-browser-new-file-input"
     NEW_FILE_CONFIRM = "file-browser-new-file-confirm"
@@ -101,16 +108,36 @@ class FilesUi(FileBrowserPathReads):
     def wait_for_file_row(
         self, name: str, *, timeout: float = DEFAULT_WAIT_TIMEOUT, refresh_every: float = 2.0
     ) -> None:
-        """Poll until entry ``name`` lists, refreshing the directory periodically.
+        """Poll until entry ``name`` lists, filtering to it and refreshing as needed.
 
-        The browser only re-reads the directory on navigation/refresh, so a file
-        created from the terminal (or while the Files sidebar was hidden) is not
-        in the cached listing — and a terminal ``touch``/``printf`` runs async, so
-        a single up-front refresh can fire before the file even exists. This
-        refreshes every ``refresh_every`` seconds while polling, which reliably
-        reveals the entry without the per-tick refresh storm that overwhelmed the
-        WebKit renderer. Set ``refresh_every`` to 0 to never refresh (the entry is
+        Two app behaviors make the naive "refresh and look for the row" wait wrong,
+        and this handles both:
+
+        **The listing is virtualized** (``@tanstack/react-virtual``), so only the
+        visible window of rows (+ ``ROW_OVERSCAN``) is ever mounted — roughly the
+        first ~33 of them at the default sidebar height. An entry further down the
+        sort order has **no DOM node at all**, so ``file-row-<name>`` would never
+        appear no matter how long or how often we refreshed. A real home directory
+        blows past that window easily (#1582: the sentinel sorted to index 80 of
+        104), which is why every case that waits on a *newly created* entry failed
+        while the ones that only read the path passed. So this types ``name`` into
+        the browser's filter box — the same affordance a user reaches for — which
+        narrows ``displayEntries`` until the row is inside the mounted window.
+
+        **The directory is only re-read on navigation/refresh**, so a file created
+        from the terminal (or while the Files sidebar was hidden) is not in the
+        cached listing — and a terminal ``touch``/``printf`` runs async, so a
+        single up-front refresh can fire before the file even exists. This
+        refreshes every ``refresh_every`` seconds while polling, which reveals the
+        entry without the per-tick refresh storm that overwhelmed the WebKit
+        renderer. Set ``refresh_every`` to 0 to never refresh (the entry is
         expected to already be in the current listing).
+
+        The filter is **left applied** on return: the row's DOM node exists only
+        because of it, so clearing it here would unmount the very row the caller
+        is about to click or assert on. Refreshing keeps the filter (only
+        navigation resets it), so the two mechanisms compose. Call
+        :meth:`clear_entry_filter` when a test needs the whole listing back.
         """
         deadline = time.monotonic() + timeout
         next_refresh = 0.0  # refresh immediately on the first tick
@@ -119,10 +146,28 @@ class FilesUi(FileBrowserPathReads):
             if refresh_every and now >= next_refresh and self.driver.exists(self.REFRESH):
                 self.refresh_file_browser()
                 next_refresh = now + refresh_every
+            # Re-applied every tick, not once up front: navigating (which some
+            # callers do between ticks) clears the filter, and re-typing the same
+            # value is a no-op for React's controlled input.
+            if self.driver.exists(self.FILTER):
+                self.filter_entries(name)
             if self.file_row_exists(name):
                 return
             time.sleep(0.5)  # the directory only changes on a refresh, so poll gently
         raise AssertionError(f"timed out waiting for file row {name!r}")
+
+    # -- filter ------------------------------------------------------------------
+    def filter_entries(self, query: str) -> None:
+        """Narrow the listing to entries whose name contains ``query``.
+
+        Matching is case-insensitive and substring-based (``filterEntries`` in
+        ``src/utils/fileBrowserNav.ts``). Passing ``""`` clears the filter.
+        """
+        self.driver.type(self.FILTER, query)
+
+    def clear_entry_filter(self) -> None:
+        """Drop any active filter so the full listing shows again."""
+        self.filter_entries("")
 
     def refresh_file_browser(self) -> None:
         """Re-list the current directory via the toolbar refresh button."""

--- a/tests/system/tests/test_files_ui.py
+++ b/tests/system/tests/test_files_ui.py
@@ -1,0 +1,149 @@
+"""Unit tests for FilesUi's row wait against a virtualized listing (#1582).
+
+Machinery group (no app): drives :class:`~termihub_harness.ui.FilesUi` against a
+fake driver that reproduces the two app behaviors the real wait must survive —
+the row list is **virtualized** (only a small window of rows is mounted) and the
+toolbar **filter** narrows that list.
+
+This is the regression guard for #1582: `wait_for_file_row` used to assume every
+listed entry had a DOM node, so any entry sorting past the mounted window could
+never be found — the row simply did not exist to wait for. These tests fail
+against that version and run in the machinery lane, which (unlike the integration
+lane, #1569) actually executes in CI.
+"""
+
+import pytest
+
+from termihub_harness.ui import FilesUi, file_row_testid
+
+
+class FakeVirtualizedBrowser:
+    """A driver double: a filterable listing that mounts only its first rows.
+
+    Mirrors ``FileBrowser.tsx`` — entries are filtered (case-insensitive
+    substring, per ``filterEntries``) and only the first ``WINDOW`` of the
+    survivors get a ``file-row-<name>`` node, as ``@tanstack/react-virtual``
+    mounts just the visible window plus overscan.
+    """
+
+    # Literal testids on purpose: the double must describe the *app's* DOM, not
+    # borrow the constants from the class under test (which would turn a missing
+    # constant into an import-time error instead of the behavioral failure).
+    REFRESH = "file-browser-refresh"
+    FILTER = "file-browser-filter"
+
+    WINDOW = 5
+
+    def __init__(self, names):
+        self.names = list(names)
+        self.filter_query = ""
+        self.refreshes = 0
+
+    def _displayed(self):
+        query = self.filter_query.strip().lower()
+        if not query:
+            return list(self.names)
+        return [n for n in self.names if query in n.lower()]
+
+    def _mounted(self):
+        return self._displayed()[: self.WINDOW]
+
+    def exists(self, test_id):
+        if test_id in (self.REFRESH, self.FILTER):
+            return True
+        if test_id.startswith("file-row-"):
+            return test_id[len("file-row-") :] in self._mounted()
+        return False
+
+    def type(self, test_id, text):
+        if test_id == self.FILTER:
+            self.filter_query = text
+
+    def click(self, test_id):
+        if test_id == self.REFRESH:
+            self.refreshes += 1
+
+
+class _Files(FilesUi):
+    """FilesUi bound to a fake driver (SystemTest supplies the real one)."""
+
+    def __init__(self, driver):
+        self.driver = driver
+
+
+# A listing far longer than the mounted window, with the target near the end —
+# the shape of a real home directory (#1582 saw index 80 of 104).
+LISTING = [f"entry-{i:03d}.txt" for i in range(60)] + ["target.txt"]
+
+
+def test_finds_a_row_that_sorts_past_the_mounted_window():
+    """The regression: the target has no DOM node until the filter narrows to it."""
+    driver = FakeVirtualizedBrowser(LISTING)
+    files = _Files(driver)
+
+    # Precondition: the row genuinely is not mounted, so a naive wait cannot see it.
+    assert not driver.exists(file_row_testid("target.txt"))
+
+    files.wait_for_file_row("target.txt", timeout=5)
+
+    assert driver.exists(file_row_testid("target.txt"))
+
+
+def test_leaves_the_filter_applied_so_the_row_stays_mounted():
+    """Callers click/assert on the row right after, so it must not unmount."""
+    driver = FakeVirtualizedBrowser(LISTING)
+    files = _Files(driver)
+
+    files.wait_for_file_row("target.txt", timeout=5)
+
+    assert driver.filter_query == "target.txt"
+    assert files.file_row_exists("target.txt")
+
+
+def test_finds_a_row_already_inside_the_window():
+    """An entry at the top still resolves (and needs no refresh)."""
+    driver = FakeVirtualizedBrowser(LISTING)
+    files = _Files(driver)
+
+    files.wait_for_file_row("entry-000.txt", timeout=5, refresh_every=0)
+
+    assert driver.refreshes == 0
+
+
+def test_refreshes_while_polling_for_an_entry_that_appears_late():
+    """A file created from the terminal only lands in the listing on a refresh."""
+    driver = FakeVirtualizedBrowser(LISTING)
+    files = _Files(driver)
+    original_click = driver.click
+
+    def click(test_id):
+        original_click(test_id)
+        if test_id == driver.REFRESH and driver.refreshes == 2:
+            driver.names.append("late.txt")  # the terminal's touch finally lands
+
+    driver.click = click
+
+    files.wait_for_file_row("late.txt", timeout=15)
+
+    assert driver.refreshes >= 2
+    assert files.file_row_exists("late.txt")
+
+
+def test_clear_entry_filter_restores_the_full_listing():
+    driver = FakeVirtualizedBrowser(LISTING)
+    files = _Files(driver)
+    files.wait_for_file_row("target.txt", timeout=5)
+
+    files.clear_entry_filter()
+
+    assert driver.filter_query == ""
+    assert files.file_row_exists("entry-000.txt")
+
+
+def test_times_out_for_an_entry_that_never_exists():
+    """The wait still fails loudly — filtering must not mask a missing entry."""
+    driver = FakeVirtualizedBrowser(LISTING)
+    files = _Files(driver)
+
+    with pytest.raises(AssertionError, match="timed out waiting for file row 'ghost.txt'"):
+        files.wait_for_file_row("ghost.txt", timeout=1)


### PR DESCRIPTION
## Root cause — a harness bug, not an app bug

The file-browser row list is **virtualized** (`@tanstack/react-virtual`): only the visible window of rows plus `ROW_OVERSCAN` is mounted — roughly the first ~33 at the default sidebar height (`ROW_HEIGHT = 24`, `ROW_OVERSCAN = 8`). `wait_for_file_row` assumed every listed entry had a DOM node. An entry sorting past that window has **no node at all**, so no amount of waiting or refreshing could ever reveal it.

Measured from the failing run's own `state.json`: the store held **104 entries** for `/Users/arne` and the sentinel sorted to **index 80**. The data layer was correct the whole time — `localCurrentPath` was right and `localFileEntries` *contained the file*. Only the DOM lacked the row.

That is exactly why the six failures were the six cases waiting on a **newly created** entry, while every case that only reads the path passed.

## The issue's prime suspect was wrong

#1582 suspected `ShellFsUi.touch_home`'s relative `touch` landing outside the browsed directory. It isn't:

- The captured `terminal.txt` shows the command already absolute and succeeding at `~`: `touch "$HOME/e2e_fb_sys-entry-5e010bec.txt"`.
- **Four of the six failures never touch the terminal at all** — `test_create_file_via_inline_input`, `test_create_folder_via_toolbar` and both context-menu cases create their entry through the browser's *own* New File/Folder input and fail identically. The creation route was never the variable; list position was.

## The fix

Type the entry name into the browser's **filter** box — the affordance a real user reaches for to find a file in a long listing — which narrows `displayEntries` until the row falls inside the mounted window. No sleeps, no bumped timeouts, no retry wrapper.

The filter survives a refresh (only navigation calls `resetNavState`), so it composes with the existing refresh polling, and it is deliberately **left applied** on return: the row's node exists only because of it, so clearing it would unmount the very row the caller is about to click. `clear_entry_filter()` is exposed for tests that need the full listing.

Fixed centrally in `wait_for_file_row`, so the SFTP, transfer-queue, editor and external-app suites that share it get the same robustness.

## Verification — local, against a forced rebuild

CI cannot validate this (`-m "not integration"`, #1569), so it was proven locally.

```
before:  6 failed, 10 passed   (-k file_browser_local, --rebuild)
after:  16 passed, 0 failed
```

No regressions in the other consumers of the shared wait:

```
-k "sftp_infra or transfer_queue" --fixtures ssh-password  →  16 passed
```

## Regression test

`tests/system/tests/test_files_ui.py` drives `FilesUi` against a fake driver modelling the virtual window + filter. It fails against the old wait with the production symptom (`timed out waiting for file row 'target.txt'`) and passes with the fix.

It sits in the **machinery lane**, so — unlike the integration lane (#1569) — it actually runs in CI.

## Follow-up filed

- #1591 — two `test_editor.py` status-bar cases fail on a clean `develop` (`editorStatus` never clears on a terminal tab). Verified pre-existing by re-running against `f4ae55ce` with this fix reverted; unrelated to this work.

Also seen once and not reproduced in two further runs: `test_connection_editor.py::test_new_connection_in_folder_via_context_menu` — noted as a possible flake, not filed.

## Test plan

- [x] `./scripts/test-system-py.sh --debug -m integration -k file_browser_local` → 16 passed
- [x] `./scripts/test-system-py.sh --debug --fixtures "ssh-password" -m integration -k "sftp_infra or transfer_queue"` → 16 passed
- [x] `cd tests/system && ./pytest.sh -k files_ui` → 6 passed (and red without the fix)
- [x] `./scripts/check.sh` → ALL CHECKS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)