### PR TITLE
fix(sftp): Name a paste-upload Transfer Queue row after the pasted file (Closes #1573)

### DIFF
--- a/docs/changes/dev1/fix/1573-paste-upload-display-name.md
+++ b/docs/changes/dev1/fix/1573-paste-upload-display-name.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The Transfer Queue row for a copy/paste between SFTP locations is now named
+  after the file you pasted, instead of the internal temp file termiHub copies
+  it through. Pasting `report.csv` showed an upload row named
+  `termihub-paste-1784278708447-report.csv` — a scratch name that never
+  belonged on screen — even though the row's path column already pointed at
+  `report.csv`. A transfer row's name is now always the base name of the remote
+  path shown beside it, so the two can no longer disagree. Ordinary uploads,
+  where the local and destination names already match, are unaffected.

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -204,7 +204,13 @@ pub async fn sftp_upload(
         transfer_id: transfer_id.clone(),
         session_id,
         direction: TransferDirection::Upload,
-        file_name: file_name_of(&local_path),
+        // Named for the *remote* path, not the local one, so the name always
+        // agrees with the `path` this row displays (#1573). Every honest
+        // upload caller builds `remote_path` as `<dir>/<basename of local>`,
+        // so this is unchanged for them — but an SFTP→SFTP paste uploads from
+        // a local temp copy (`/tmp/termihub-paste-<ts>-<name>`), and the
+        // destination name is the one the user actually knows the file by.
+        file_name: file_name_of(&remote_path),
         path: remote_path.clone(),
         total,
     };
@@ -535,4 +541,40 @@ pub fn write_cheatsheet(html: String, app: tauri::AppHandle) -> Result<String, S
         .to_str()
         .map(|s| s.to_string())
         .ok_or_else(|| "file path contains non-UTF-8 characters".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::file_name_of;
+
+    #[test]
+    fn names_a_file_by_its_basename() {
+        assert_eq!(file_name_of("/home/testuser/report.csv"), "report.csv");
+        assert_eq!(file_name_of("/report.csv"), "report.csv");
+        assert_eq!(file_name_of("report.csv"), "report.csv");
+    }
+
+    #[test]
+    fn falls_back_to_the_whole_path_when_there_is_no_basename() {
+        assert_eq!(file_name_of("/"), "/");
+        assert_eq!(file_name_of(""), "");
+        assert_eq!(file_name_of(".."), "..");
+    }
+
+    /// Both transfer directions name the row from the *remote* path, so the
+    /// name always agrees with the `path` cell beside it. Feeding an upload the
+    /// destination path — rather than the local temp copy an SFTP→SFTP paste
+    /// reads from — is what keeps the scratch name off the row (#1573).
+    #[test]
+    fn names_a_paste_upload_after_the_destination_not_the_temp_copy() {
+        let temp_local = "/tmp/termihub-paste-1784278708447-report.csv";
+        let remote_dest = "/home/testuser/dest/report.csv";
+
+        assert_eq!(file_name_of(remote_dest), "report.csv");
+        assert_eq!(
+            file_name_of(temp_local),
+            "termihub-paste-1784278708447-report.csv",
+            "the temp basename is what the row must NOT show",
+        );
+    }
 }

--- a/tests/system/tests/test_transfer_queue.py
+++ b/tests/system/tests/test_transfer_queue.py
@@ -162,6 +162,8 @@ class TestTransferQueueLiveTransfer(
         the source to a local temp file and an upload to the destination — so the
         queue ends with two rows. Both must carry the remote path (#1531): the
         download's is the source path, the upload's is the destination path.
+        Both must also be named for the file the user pasted, never for the
+        internal temp copy the upload actually reads from (#1573).
         """
         name = f"payload-{unique_name('tq')}.bin"
         dest = f"destdir-{unique_name('tq')}"
@@ -215,14 +217,15 @@ class TestTransferQueueLiveTransfer(
         # Every row reaches 100%.
         assert [e["percent"] for e in entries] == [100, 100]
 
-        # Each row names its transfer's *source* basename: the backend derives
-        # `file_name` from the remote path on download and the local path on
-        # upload (`commands/files.rs::file_name_of`). A paste uploads from the
-        # local temp copy, so that row is named for the temp file — see the
-        # follow-up filed from this PR.
+        # Both rows name the file the user knows (#1573). The backend derives
+        # `file_name` from the remote path in both directions
+        # (`commands/files.rs::file_name_of`), so the name always agrees with
+        # the `path` cell in the same row. A paste uploads from a local temp
+        # copy (`/tmp/termihub-paste-<ts>-<name>`), and that internal name must
+        # never surface.
         assert by_direction["download"]["name"] == name
-        assert by_direction["upload"]["name"].startswith("termihub-paste-")
-        assert by_direction["upload"]["name"].endswith(name)
+        assert by_direction["upload"]["name"] == name
+        assert not by_direction["upload"]["name"].startswith("termihub-paste-")
 
         # The remote path from #1531 (PR #1543) reaches both rows: the download
         # reports the source path, the upload the destination path. Without the


### PR DESCRIPTION
## What

A Transfer Queue row for an SFTP→SFTP copy/paste was named after termiHub's internal scratch file. Pasting `report.csv` produced an upload row named `termihub-paste-1784278708447-report.csv`, beside a `path` cell that already correctly read `/home/testuser/dest/report.csv`.

## Where the fix went, and why

**In `sftp_upload` (`src-tauri/src/commands/files.rs`), not in `pasteEntry`.**

The issue offered both. The deciding argument is that the bug is not really "paste passes the wrong name" — it is that **a row's `name` and its `path` described different files**. `path` is documented as "remote path of the transferred file" and is populated from `remote_path` in both directions; `file_name` was derived from `remote_path` on download but `local_path` on upload. Those agree for an honest upload and disagree for a paste, which is exactly the reported symptom.

So the rule is now: **a transfer row's name is the base name of the path it displays.** That is a property the two cells can't violate, rather than a fix applied at one call site.

### This does not break the honest local→remote upload

`sftp_upload` has exactly one invoke site (`api.ts` → `sftpUpload`), reached by six callers. Every genuine upload builds `remote_path` as `<dir>/<basename of local_path>`:

| caller | local | remote | name before | name after |
| --- | --- | --- | --- | --- |
| `uploadFile` | picked file | `<cwd>/<basename>` | `report.csv` | `report.csv` |
| `uploadFileFromPath` | dragged file | `<cwd>/<basename>` | `report.csv` | `report.csv` |
| `pasteEntry` local→sftp | `clipEntry.path` | `<dir>/<clipEntry.name>` | `report.csv` | `report.csv` |
| `pasteEntry` sftp→sftp (×2) | **temp copy** | `<dir>/<clipEntry.name>` | `termihub-paste-…` | **`report.csv`** |

The basenames are equal for every honest caller, so their rows are byte-for-byte unchanged. Only the paste case — where the two legitimately differ — moves. Threading a display-name override through `pasteEntry` would instead have changed the command's API and left the next caller that uploads from a path the user never named with the same bug.

`useSessionFileSystem.pasteEntry` uses the agent file API, not `sftp_upload`, and is unaffected.

## Verification

The system test that pinned this is `-m "not integration"`-excluded in CI (#1569), so **green CI is not evidence here**. Verified locally against the `ssh-password` fixture with a forced rebuild (`--rebuild`) on both sides:

- **With the fix:** `1 passed` — and the whole file, `9 passed`.
- **Without the fix** (one line reverted, rebuilt): `1 failed`, on precisely the new assertion —
  `AssertionError: assert 'termihub-pas...-d8eb1c77.bin' == 'payload-sys-tq-d8eb1c77.bin'`

The download-name assertion passed in the red run too, confirming that direction is untouched.

`#1532` (PR #1565) deliberately pinned the buggy name and flagged it for this PR; that assertion is updated here, in the test commit that precedes the fix.

Also added Rust unit tests for `file_name_of`, including the paste temp-name case — these **do** run in CI, unlike the system test.

`./scripts/check.sh`, `./scripts/test.sh` and `npx tsc --noEmit` are clean. One unrelated pre-existing failure: `core/tests/docker_spawn.rs::docker_spawn_mounts_directory_and_opens_cd_to_mount` ("found: []"), in a crate this PR does not touch, while local compose fixtures were up.

## Follow-ups

- #1593 — flaky `open_sftp_browser` password-prompt race, hit once during this work.
- FTP's `ftp_upload` has the same latent `local_path`-derived name, but no caller creates a mismatch (there is no FTP paste-to-temp), so it is not a live bug and is left alone — noted in #1594.

Closes #1573
