### PR TITLE
feat(sftp): support the file editor in session-layer file browsing (Closes #1557)

### DIFF
--- a/docs/changes/dev2/feature/1557-session-layer-editor.md
+++ b/docs/changes/dev2/feature/1557-session-layer-editor.md
@@ -1,0 +1,13 @@
+### Added
+
+- File editor support for session-layer file browsing: files opened from an FTP,
+  Docker, or agent-session file browser now open in the editor and can be saved
+  back over the session layer. Previously the Edit action (and double-click /
+  Enter on a file row) silently did nothing for these connection types, because
+  the editor tab could only reference an SSH `SftpManager` session. An editor tab
+  can now reference a session-layer browser instead, reading and writing through
+  `session_read_file` / `session_write_file`, and a session-backed editor tab no
+  longer puts the file browser into SFTP mode. The SFTP-specific affordances
+  (read-only detection, sudo/elevated writes, "save a copy", download) remain
+  exclusive to SSH, which the session layer does not expose. SFTP editing is
+  unchanged (#1557).

--- a/src/components/FileEditor/FileEditor.test.tsx
+++ b/src/components/FileEditor/FileEditor.test.tsx
@@ -814,3 +814,151 @@ describe("FileEditor — SFTP-only read-only fallback (#1330)", () => {
     expect(query("file-editor-download")).toBeNull();
   });
 });
+
+describe("FileEditor — session-layer backed tabs (#1557)", () => {
+  const SESSION_META: EditorTabMeta = {
+    filePath: "/srv/app/config.yml",
+    isRemote: true,
+    sessionBrowser: { sessionId: "sess-ftp-1", connectionType: "ftp" },
+  };
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  /** Encode text the way session_read_file returns it: a plain byte array. */
+  function bytes(text: string): number[] {
+    return Array.from(new TextEncoder().encode(text));
+  }
+
+  it("reads the file through session_read_file and never touches the SFTP path", async () => {
+    mockedInvoke.mockImplementation((cmd, args) => {
+      if (cmd === "session_read_file") {
+        expect(args).toMatchObject({ sessionId: "sess-ftp-1", path: "/srv/app/config.yml" });
+        return Promise.resolve(bytes("port: 8080\n"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render(SESSION_META);
+    await flush();
+
+    expect((query("mock-monaco") as HTMLTextAreaElement).value).toBe("port: 8080\n");
+    const commands = mockedInvoke.mock.calls.map((c) => c[0]);
+    expect(commands).toContain("session_read_file");
+    expect(commands.filter((c) => String(c).startsWith("sftp_"))).toEqual([]);
+  });
+
+  it("decodes non-ASCII content returned as bytes", async () => {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "session_read_file") return Promise.resolve(bytes("gruß: 🌍\n"));
+      return Promise.resolve(undefined);
+    });
+
+    render(SESSION_META);
+    await flush();
+
+    expect((query("mock-monaco") as HTMLTextAreaElement).value).toBe("gruß: 🌍\n");
+  });
+
+  it("saves the buffer back through session_write_file", async () => {
+    const writes: { sessionId: string; path: string; data: number[] }[] = [];
+    mockedInvoke.mockImplementation((cmd, args) => {
+      if (cmd === "session_read_file") return Promise.resolve(bytes("port: 8080\n"));
+      if (cmd === "session_write_file") {
+        writes.push(args as unknown as { sessionId: string; path: string; data: number[] });
+        return Promise.resolve(undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render(SESSION_META);
+    await flush();
+
+    editContent("port: 9090\n");
+    await flush();
+
+    const saveBtn = query("file-editor-save") as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(false);
+    await act(async () => {
+      saveBtn.click();
+    });
+    await flush();
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].sessionId).toBe("sess-ftp-1");
+    expect(writes[0].path).toBe("/srv/app/config.yml");
+    expect(new TextDecoder().decode(new Uint8Array(writes[0].data))).toBe("port: 9090\n");
+    // A successful save clears the dirty flag and raises no error banner.
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(false);
+    expect(query("file-editor-save-error")).toBeNull();
+  });
+
+  it("surfaces a failed session save and keeps the buffer dirty", async () => {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "session_read_file") return Promise.resolve(bytes("port: 8080\n"));
+      if (cmd === "session_write_file")
+        return Promise.reject(new Error("write config.yml: permission denied"));
+      return Promise.resolve(undefined);
+    });
+
+    render(SESSION_META);
+    await flush();
+
+    editContent("port: 9090\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-save") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(query("file-editor-save-error")?.textContent ?? "").toMatch(/permission denied/i);
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
+  });
+
+  it("marks the tab remote but offers no SFTP-only affordances", async () => {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "session_read_file") return Promise.resolve(bytes("body\n"));
+      // Were these ever reached, they would light up the sudo / fallback UI.
+      if (cmd === "sftp_has_exec_capability") return Promise.resolve(true);
+      if (cmd === "sftp_check_writable") return Promise.resolve("readOnly");
+      return Promise.resolve(undefined);
+    });
+
+    render(SESSION_META);
+    await flush();
+
+    // The session layer exposes read/write only: no writability probe, no sudo,
+    // no realpath-backed "save a copy", no SFTP download.
+    expect(query("file-editor-remote-badge")).not.toBeNull();
+    expect(query("file-editor-readonly-badge")).toBeNull();
+    expect(query("file-editor-edit-with-sudo")).toBeNull();
+    expect(query("file-editor-save-copy")).toBeNull();
+    expect(query("file-editor-download")).toBeNull();
+  });
+
+  it("surfaces a session read failure as a load error", async () => {
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "session_read_file") return Promise.reject(new Error("no such file"));
+      return Promise.resolve(undefined);
+    });
+
+    render(SESSION_META);
+    await flush();
+
+    expect(container.textContent ?? "").toMatch(/no such file/i);
+  });
+});

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -33,6 +33,8 @@ import {
   sftpCheckWritable,
   sftpDownload,
   sftpRealpath,
+  sessionReadFile,
+  sessionWriteFile,
   storeCredential,
   resolveCredential,
   removeCredential,
@@ -50,6 +52,27 @@ const MAX_SUDO_ATTEMPTS = 3;
 
 // Use local monaco-editor package instead of CDN (important for Tauri/offline)
 loader.config({ monaco });
+
+/**
+ * Read a file's text through the session layer (#1557).
+ *
+ * `session_read_file` is byte-oriented — it backs binary transfers too — so the
+ * editor decodes here. The SFTP path (`sftp_read_file_content`) decodes backend
+ * side and hands back a string already, which is why only this side needs it.
+ */
+async function sessionReadFileContent(sessionId: string, path: string): Promise<string> {
+  const bytes = await sessionReadFile(sessionId, path);
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+/** Write a file's text through the session layer, mirroring {@link sessionReadFileContent}. */
+async function sessionWriteFileContent(
+  sessionId: string,
+  path: string,
+  content: string
+): Promise<void> {
+  await sessionWriteFile(sessionId, path, Array.from(new TextEncoder().encode(content)));
+}
 
 /**
  * Read current editor status from a Monaco editor instance.
@@ -231,6 +254,8 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
         let text: string;
         if (meta.isRemote && meta.sftpSessionId) {
           text = await sftpReadFileContent(meta.sftpSessionId, meta.filePath);
+        } else if (meta.isRemote && meta.sessionBrowser) {
+          text = await sessionReadFileContent(meta.sessionBrowser.sessionId, meta.filePath);
         } else {
           text = await localReadFile(meta.filePath);
         }
@@ -251,7 +276,14 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     return () => {
       cancelled = true;
     };
-  }, [meta.filePath, meta.isRemote, meta.sftpSessionId, meta.scratch, meta.scratchContent]);
+  }, [
+    meta.filePath,
+    meta.isRemote,
+    meta.sftpSessionId,
+    meta.sessionBrowser,
+    meta.scratch,
+    meta.scratchContent,
+  ]);
 
   // Probe whether the remote connection can run remote commands (shell vs
   // SFTP-only). Determines whether privilege-elevated writes will be offered.
@@ -627,6 +659,8 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     try {
       if (meta.isRemote && meta.sftpSessionId) {
         await sftpWriteFileContent(meta.sftpSessionId, meta.filePath, content);
+      } else if (meta.isRemote && meta.sessionBrowser) {
+        await sessionWriteFileContent(meta.sessionBrowser.sessionId, meta.filePath, content);
       } else {
         await localWriteFile(targetPath, content);
       }
@@ -653,6 +687,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     meta.filePath,
     meta.isRemote,
     meta.sftpSessionId,
+    meta.sessionBrowser,
     tabId,
     renameTab,
     elevated,

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -2071,3 +2071,147 @@ describe("FileBrowser – symlinks (#1513)", () => {
     expect(useAppStore.getState().localCurrentPath).toBe("/etc/target");
   });
 });
+
+// --- Editor tabs backed by the session layer (#1557) ---
+describe("FileBrowser – session-layer editor tabs (#1557)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    mockedInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "local_list_dir") return Promise.resolve([]);
+      if (cmd === "session_list_files") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function renderBrowser() {
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <FileBrowser />
+        </TooltipProvider>
+      );
+    });
+  }
+
+  /** An editor tab carries a dummy local config; only its editorMeta matters here. */
+  function makeEditorTab(editorMeta: TerminalTab["editorMeta"]): TerminalTab {
+    return makeTab({
+      id: "tab-editor-1",
+      connectionType: "local",
+      contentType: "editor",
+      config: { type: "local", config: {} },
+      editorMeta,
+    });
+  }
+
+  it("puts a session-backed editor tab in 'session' mode, not 'sftp'", () => {
+    setActiveTab(
+      makeEditorTab({
+        filePath: "/srv/app/config.yml",
+        isRemote: true,
+        sessionBrowser: { sessionId: "ftp-sess-1", connectionType: "ftp" },
+      })
+    );
+
+    renderBrowser();
+
+    // Falling into "sftp" here would point the browser at an SftpManager
+    // session that does not exist for an FTP/Docker/agent-backed tab.
+    expect(useAppStore.getState().fileBrowserMode).toBe("session");
+    expect(useAppStore.getState().sessionFileBrowserId).toBe("ftp-sess-1");
+  });
+
+  it("keeps an SFTP-backed editor tab in 'sftp' mode", () => {
+    setActiveTab(
+      makeEditorTab({
+        filePath: "/etc/hosts",
+        isRemote: true,
+        sftpSessionId: "sftp-sess-1",
+      })
+    );
+
+    renderBrowser();
+
+    expect(useAppStore.getState().fileBrowserMode).toBe("sftp");
+  });
+
+  it("keeps a local editor tab in 'local' mode", () => {
+    setActiveTab(makeEditorTab({ filePath: "/home/me/notes.txt", isRemote: false }));
+
+    renderBrowser();
+
+    expect(useAppStore.getState().fileBrowserMode).toBe("local");
+  });
+
+  it("opens a session-backed editor tab when a file is activated in session mode", async () => {
+    const ftpTab = makeTab({
+      connectionType: "ftp",
+      sessionId: "ftp-sess-1",
+      config: { type: "ftp", config: { host: "ftp.example.com", port: 21 } },
+    });
+    setActiveTab(ftpTab);
+    useAppStore.setState({
+      connectionTypes: [
+        {
+          typeId: "ftp",
+          displayName: "FTP",
+          icon: "folder",
+          schema: { groups: [] },
+          capabilities: {
+            monitoring: false,
+            fileBrowser: true,
+            resize: false,
+            persistent: false,
+          },
+        },
+      ],
+    });
+
+    renderBrowser();
+    await flushAsync();
+    expect(useAppStore.getState().fileBrowserMode).toBe("session");
+
+    const entry: FileEntry = {
+      name: "config.yml",
+      path: "/srv/app/config.yml",
+      isDirectory: false,
+      size: 12,
+      modified: "2026-07-17T00:00:00Z",
+      permissions: "-rw-r--r--",
+      writable: true,
+    };
+    act(() => {
+      useAppStore.setState({ sessionFileEntries: [entry], sessionCurrentPath: "/srv/app" });
+    });
+
+    // Double-clicking a file is the same code path as the "Edit" context item.
+    const row = container.querySelector('[data-testid="file-row-config.yml"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    act(() => {
+      row.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+    });
+    await flushAsync();
+
+    const editorTab = (useAppStore.getState().rootPanel as LeafPanel).tabs.find(
+      (t) => t.contentType === "editor"
+    );
+    expect(editorTab).toBeDefined();
+    expect(editorTab?.editorMeta).toMatchObject({
+      filePath: "/srv/app/config.yml",
+      isRemote: true,
+      permissions: "-rw-r--r--",
+      sessionBrowser: { sessionId: "ftp-sess-1", connectionType: "ftp" },
+    });
+    // The session layer has no SftpManager session behind it.
+    expect(editorTab?.editorMeta?.sftpSessionId).toBeUndefined();
+  });
+});

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -1061,12 +1061,10 @@ export function FileBrowser() {
             // Session-layer browsing (FTP, Docker, agent sessions): the editor
             // reads and writes through session_read_file / session_write_file
             // rather than an SftpManager session. (#1557)
-            useAppStore
-              .getState()
-              .openEditorTab(entry.path, true, undefined, entry.permissions, {
-                sessionId: sessionFileBrowserId,
-                connectionType: activeTabConnectionType ?? "remote-session",
-              });
+            useAppStore.getState().openEditorTab(entry.path, true, undefined, entry.permissions, {
+              sessionId: sessionFileBrowserId,
+              connectionType: activeTabConnectionType ?? "remote-session",
+            });
           }
           break;
         case "download":

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -607,8 +607,13 @@ function useFileBrowserSync() {
       return;
     }
     if (activeTabContentType === "editor") {
-      // Editor tabs: derive mode from file location
-      if (activeTabEditorMeta?.isRemote) {
+      // Editor tabs: derive mode from the transport the tab was opened with.
+      // A session-backed tab must not fall into "sftp" mode — there is no
+      // SftpManager session behind it, so the browser would show nothing. (#1557)
+      if (activeTabEditorMeta?.sessionBrowser) {
+        setSessionFileBrowserId(activeTabEditorMeta.sessionBrowser.sessionId);
+        setFileBrowserMode("session");
+      } else if (activeTabEditorMeta?.isRemote) {
         setFileBrowserMode("sftp");
       } else {
         setFileBrowserMode("local");
@@ -1036,6 +1041,8 @@ export function FileBrowser() {
   }, []);
 
   const sftpSessionId = useAppStore((s) => s.sftpSessionId);
+  const sessionFileBrowserId = useAppStore((s) => s.sessionFileBrowserId);
+  const activeTabConnectionType = useAppStore((s) => getActiveTab(s)?.connectionType ?? null);
 
   const handleContextAction = useCallback(
     (entry: FileEntry, action: string) => {
@@ -1050,8 +1057,17 @@ export function FileBrowser() {
                 mode === "sftp" ? (sftpSessionId ?? undefined) : undefined,
                 mode === "sftp" ? entry.permissions : undefined
               );
+          } else if (mode === "session" && sessionFileBrowserId) {
+            // Session-layer browsing (FTP, Docker, agent sessions): the editor
+            // reads and writes through session_read_file / session_write_file
+            // rather than an SftpManager session. (#1557)
+            useAppStore
+              .getState()
+              .openEditorTab(entry.path, true, undefined, entry.permissions, {
+                sessionId: sessionFileBrowserId,
+                connectionType: activeTabConnectionType ?? "remote-session",
+              });
           }
-          // session mode: file editing via editor not yet supported for agent sessions
           break;
         case "download":
           // downloadFile surfaces its own success/error toast (see useFileSystem).
@@ -1103,7 +1119,17 @@ export function FileBrowser() {
         }
       }
     },
-    [mode, sftpSessionId, downloadFile, openInVscode, copyEntry, cutEntry, deleteEntry]
+    [
+      mode,
+      sftpSessionId,
+      sessionFileBrowserId,
+      activeTabConnectionType,
+      downloadFile,
+      openInVscode,
+      copyEntry,
+      cutEntry,
+      deleteEntry,
+    ]
   );
 
   const handleRenameSubmit = useCallback(

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -9,6 +9,7 @@ import {
   TabContentType,
   TerminalOptions,
   EditorTabMeta,
+  EditorSessionRef,
   ConnectionEditorMeta,
   TunnelEditorMeta,
   WorkspaceEditorMeta,
@@ -478,11 +479,19 @@ interface AppState {
   ) => void;
   httpMonitors: HttpMonitorState[];
   setHttpMonitors: (monitors: HttpMonitorState[]) => void;
+  /**
+   * Open (or focus) an editor tab for a file.
+   *
+   * A remote tab is backed by exactly one transport: pass `sftpSessionId` for
+   * the legacy SFTP path (SSH), or `sessionBrowser` for the protocol-agnostic
+   * session layer (FTP, Docker, agent sessions — #1557).
+   */
   openEditorTab: (
     filePath: string,
     isRemote: boolean,
     sftpSessionId?: string,
-    permissions?: string | null
+    permissions?: string | null,
+    sessionBrowser?: EditorSessionRef
   ) => void;
   /**
    * Open a new "scratch" editor tab seeded with in-memory content that is not
@@ -2329,7 +2338,7 @@ export const useAppStore = create<AppState>((set, get) => {
         return { rootPanel, activePanelId: targetPanelId };
       }),
 
-    openEditorTab: (filePath, isRemote, sftpSessionId, permissions) =>
+    openEditorTab: (filePath, isRemote, sftpSessionId, permissions, sessionBrowser) =>
       set((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
@@ -2346,11 +2355,19 @@ export const useAppStore = create<AppState>((set, get) => {
               ...l,
               tabs: l.tabs.map((t) => {
                 if (t.id !== existing.id) return { ...t, isActive: false };
-                // Refresh the SFTP session ID so a reconnected session works.
-                const updatedMeta =
-                  isRemote && sftpSessionId && t.editorMeta
-                    ? { ...t.editorMeta, sftpSessionId }
-                    : t.editorMeta;
+                // Refresh the backing session so a reconnected session works.
+                // Only the transport actually supplied is refreshed, and the
+                // other is cleared with it: a tab must never carry both an
+                // sftpSessionId and a sessionBrowser, or the editor's
+                // SFTP-first branch would shadow the session-layer one. (#1557)
+                let updatedMeta = t.editorMeta;
+                if (isRemote && t.editorMeta) {
+                  if (sftpSessionId) {
+                    updatedMeta = { ...t.editorMeta, sftpSessionId, sessionBrowser: undefined };
+                  } else if (sessionBrowser) {
+                    updatedMeta = { ...t.editorMeta, sessionBrowser, sftpSessionId: undefined };
+                  }
+                }
                 return { ...t, isActive: true, editorMeta: updatedMeta };
               }),
               activeTabId: existing.id,
@@ -2365,7 +2382,13 @@ export const useAppStore = create<AppState>((set, get) => {
 
         const fileName = filePath.split("/").pop() ?? filePath;
         const dummyConfig: ConnectionConfig = { type: "local", config: { shell: "zsh" } };
-        const editorMeta: EditorTabMeta = { filePath, isRemote, sftpSessionId, permissions };
+        const editorMeta: EditorTabMeta = {
+          filePath,
+          isRemote,
+          sftpSessionId,
+          permissions,
+          sessionBrowser,
+        };
         const newTab = createTab(fileName, "local", dummyConfig, targetPanelId, "editor");
         newTab.editorMeta = editorMeta;
 

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -32,10 +32,45 @@ export type TabContentType =
   | "workspace-editor"
   | "network-diagnostic";
 
+/**
+ * Reference to a session-layer file browser backing a remote editor tab (#1557).
+ *
+ * The session layer ({@link https://github.com/armaxri/termiHub/issues/1335})
+ * dispatches file reads/writes through `SessionManager` by session id, so any
+ * connection type whose backend implements the `FileBrowser` trait (FTP, Docker,
+ * agent sessions, ...) can back an editor tab. `connectionType` is carried for
+ * display/diagnostics; routing only needs `sessionId`.
+ */
+export interface EditorSessionRef {
+  sessionId: SessionId;
+  connectionType: ConnectionType;
+}
+
+/**
+ * Describes what an editor tab is editing.
+ *
+ * `isRemote` means "not on the local disk". Which remote transport backs the
+ * tab is then decided by exactly one of two mutually exclusive fields:
+ *
+ * - {@link sftpSessionId} — the legacy `SftpManager`/`sftp_*` path, used by SSH.
+ *   It is the only path that offers the SFTP-specific affordances (writability
+ *   probes, exec capability, elevated/sudo writes, realpath, download).
+ * - {@link sessionBrowser} — the protocol-agnostic session layer, used by every
+ *   other file-browser-capable type (#1557). It offers read and write only; the
+ *   SFTP-specific affordances above are gated on `sftpSessionId` and therefore
+ *   stay off for these tabs.
+ *
+ * A local tab (`isRemote: false`) carries neither.
+ */
 export interface EditorTabMeta {
   filePath: string;
   isRemote: boolean;
   sftpSessionId?: string;
+  /**
+   * Set when this remote editor tab is backed by the session layer rather than
+   * an `SftpManager` session. Mutually exclusive with {@link sftpSessionId}. (#1557)
+   */
+  sessionBrowser?: EditorSessionRef;
   /**
    * Unix permission string (e.g. `-rw-r--r--`) for a remote file, captured from
    * the file-browser listing when the editor was opened. Surfaced in the


### PR DESCRIPTION
Follow-up to #1335 (PR #1558). The editor did not work in `session` mode because the editor tab was SFTP-shaped: `EditorTabMeta` could only reference an `SftpManager` session. FTP, Docker and agent-session file browsers therefore had a dead Edit action — this is why #1335's "previews" acceptance criterion was never fully met.

## What changed

**`EditorTabMeta` gained a seam rather than being reshaped wholesale.** `isRemote` keeps meaning "not on the local disk"; which remote transport backs the tab is now decided by exactly one of two mutually exclusive fields:

- `sftpSessionId` — the legacy `SftpManager`/`sftp_*` path, used by SSH.
- `sessionBrowser: { sessionId, connectionType }` — the protocol-agnostic session layer, used by every other file-browser-capable type.

This turned out to be the cheap change, because the existing code was already written the right way. Every SFTP-specific affordance — writability probe, exec-capability probe, elevated/sudo writes, realpath, download, "save a copy" — already gates on `!!meta.sftpSessionId`, not on `isRemote`. So they stay off for session-backed tabs with **no new gating code**, and there was no need to duplicate a layer that exists: `sessionReadFile`/`sessionWriteFile` and the `session_*` command surface were already in place from #1335, so this PR adds no backend code at all.

Concretely:

- `src/types/terminal.ts` — new `EditorSessionRef`; `sessionBrowser` on `EditorTabMeta`, with the two-transport contract documented.
- `src/store/appStore.ts` — `openEditorTab` takes an optional `sessionBrowser`. On refresh of an existing tab, only the supplied transport is set and the other is cleared, so a tab can never carry both (which would let the SFTP-first branch shadow the session one).
- `src/components/FileEditor/FileEditor.tsx` — load and save branch to `session_read_file` / `session_write_file`. These are byte-oriented (they back binary transfers too), so the editor decodes/encodes UTF-8 at the boundary; the SFTP commands already hand back a string.
- `src/components/Sidebar/FileBrowser.tsx` — the `edit` action works in `session` mode, and the editor-tab branch of the mode effect routes a session-backed tab to `session` instead of falling into `sftp` (which would have pointed the browser at an `SftpManager` session that does not exist).

Worth noting: the Edit context item, double-click, and Enter were never mode-gated — they always called the action, which silently no-op'd in session mode. All three paths now work; no new testids, so the catalog is unchanged.

## Tests

`FileEditor.test.tsx` — reads via `session_read_file` and never touches `sftp_*`; decodes non-ASCII bytes; saves via `session_write_file` with the right session/path/bytes; surfaces a failed save and keeps the buffer dirty; surfaces a read failure as a load error; and a guard that a session tab is badged remote but offers **no** sudo / save-a-copy / download / read-only badge even when the SFTP probes would answer affirmatively.

`FileBrowser.test.tsx` — a session-backed editor tab lands in `session` mode with the right session id; SFTP and local editor tabs are unchanged; and activating a file in session mode opens an editor tab carrying `sessionBrowser` and no `sftpSessionId`.

**Verified red without the implementation**: 5 of 6 `FileEditor` cases and 2 of 4 `FileBrowser` cases fail on the pre-change code. The rest are deliberate regression guards for the SFTP/local paths, and I am not claiming they prove the new behavior.

## Test plan

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 3286 passed / 351 files.
- `./scripts/check.sh` — all checks pass (prettier caught one file; fixed in its own commit).
- `cargo test --workspace --all-features` — all pass except `termihub-core --test docker_spawn`, which **fails identically on clean `develop` (803ed117)** on this host and is unrelated: this PR is frontend-only and touches zero Rust.

Closes #1557