### PR TITLE
fix(config): resolve the dev port from dev.local.json so a bare tauri dev stays isolated (Closes #1588)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -411,8 +411,14 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features
 
 # Dev server
-pnpm tauri dev
+./scripts/dev.sh         # preferred — also starts this checkout's dev agent
+pnpm tauri dev           # app only; same dev port, no dev agent
 ```
+
+Both honour this checkout's `dev_port` from `dev.local.json`, so neither collides
+with another parallel checkout. Only `./scripts/dev.sh` starts the `dev_agent_port`
+`sshd` and registers the dev-agent connection — see
+[docs/testing.md](../docs/testing.md) → "Parallel test isolation".
 
 ---
 

--- a/docs/changes/dev3/fix/1588-dev-local-isolation-bypass.md
+++ b/docs/changes/dev3/fix/1588-dev-local-isolation-bypass.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- `pnpm tauri dev` now starts on the Vite dev port from this checkout's
+  `dev.local.json` (`dev_port`) instead of always binding the default `1420`.
+  Only `./scripts/dev.sh` / `scripts/dev.cmd` read the file before, so launching
+  the app directly silently squatted on checkout 0's dev server and dev agent —
+  a collision that surfaced as cross-checkout flakiness rather than a clean
+  error. Both halves of the launch now resolve the port from the same place:
+  `vite.config.ts` (which binds it) and Tauri's `build.devUrl` (which loads it,
+  via the new `pnpm tauri` wrapper). A checkout with no `dev.local.json` — a
+  fresh clone, or CI — still uses `1420`, and `TERMIHUB_DEV_PORT` still
+  overrides both (#1588).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -166,6 +166,12 @@ This starts:
 - The Vite development server for the frontend (with hot module replacement)
 - The Rust backend compiled in debug mode
 
+Both read the Vite dev port from the gitignored `dev.local.json` (`dev_port`,
+default `1420`), so several checkouts can run the app at once without competing
+for the port. `./scripts/dev.sh` is the fuller path: it additionally starts this
+checkout's dev-agent `sshd`, frees a stale port, and accepts a one-off override
+(`./scripts/dev.sh 1499`). See [testing.md](testing.md) → "Parallel test isolation".
+
 Frontend changes appear instantly. Rust backend changes trigger a recompile and restart.
 
 ### Individual Commands

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -664,8 +664,8 @@ cp default.dev.local.json dev.local.json
 
 | Key                | Default    | Purpose                                                                                                                                                       |
 | ------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dev_port`         | `1420`     | Vite dev-server port for `./scripts/dev.sh` (HMR uses `dev_port + 1`).                                                                                        |
-| `dev_agent_port`   | `2222`     | Local `sshd` port `./scripts/dev.sh` starts for the dev agent (Unix only).                                                                                    |
+| `dev_port`         | `1420`     | Vite dev-server port (HMR uses `dev_port + 1`). Honoured by `./scripts/dev.sh` **and** by a bare `pnpm tauri dev`.                                            |
+| `dev_agent_port`   | `2222`     | Local `sshd` port `./scripts/dev.sh` starts for the dev agent (Unix only). **Only `dev.sh` starts it** — `pnpm tauri dev` does not.                           |
 | `dev_name`         | —          | Label for the dev-agent connection entry in the termiHub sidebar (optional).                                                                                  |
 | `compose_project`  | `termihub` | Docker Compose project name for the test containers. Namespaces every **container, network and volume**, so parallel checkouts never share a container.       |
 | `test_port_offset` | `0`        | Integer added to **every** published / looked-up test infrastructure port. Keep it a multiple of `1000` and unique per checkout so port ranges never overlap. |
@@ -705,10 +705,33 @@ examples — one fully-filled, non-colliding file per checkout:
 cp examples/dev0.dev.local.json dev.local.json   # or dev1 / dev2 / dev3
 ```
 
+#### Running the app in a parallel checkout
+
+Both launch paths honour this checkout's `dev_port`, so neither one collides
+with checkout 0's dev server:
+
+```bash
+./scripts/dev.sh     # preferred
+pnpm tauri dev       # same dev port, but no dev agent
+```
+
+Prefer **`./scripts/dev.sh`**. It is the only one that also starts this
+checkout's `dev_agent_port` `sshd` and registers the dev-agent connection, frees
+a stale `dev_port`, and takes a one-off port override (`./scripts/dev.sh 1499`).
+
+`pnpm tauri dev` is isolated by construction rather than by convention
+([#1588](https://github.com/armaxri/termiHub/issues/1588)): it routes through
+`scripts/internal/tauri.mjs`, which resolves `dev_port` and merges a matching
+`build.devUrl` over the static `http://localhost:1420` in `tauri.conf.json`.
+Both halves have to agree — Vite binds the port, Tauri loads the URL — so the
+wrapper and `vite.config.ts` read the same resolver. Before that, `pnpm tauri dev`
+bound **1420 in every checkout**, silently squatting on checkout 0's dev server;
+it only ever failed loudly when something already held the port.
+
 #### What is isolated, and how
 
 `dev.local.json` resolves into a canonical set of environment variables that
-every entry point honours. The resolver lives in two mirrored forms:
+every entry point honours. The resolver lives in three mirrored forms:
 
 - **Shell:** `scripts/internal/dev-local-env.sh` — sourced by `test.sh`,
   `test-system*.sh`, and the E2E runner; exports `COMPOSE_PROJECT_NAME`,
@@ -717,6 +740,13 @@ every entry point honours. The resolver lives in two mirrored forms:
 - **Python:** `termihub_harness.dev_local` — read by the bridge-harness Docker
   fixtures so the harness publishes/looks up the same offset ports and runs
   `compose` under the same project name.
+- **Node:** `scripts/internal/dev-local.mjs` — read by `vite.config.ts` and the
+  `pnpm tauri` wrapper to resolve `dev_port`.
+
+All three apply the same precedence: an explicit **environment variable** wins,
+then the `dev.local.json` key, then the built-in default. So `dev.sh` keeps
+overriding via `TERMIHUB_DEV_PORT`, and a checkout with no `dev.local.json` — a
+fresh clone, or CI — behaves exactly as it always did.
 
 | Resource                         | Base (offset 0)                    | Derivation                                                                    |
 | -------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------- |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri",
+    "tauri": "node scripts/internal/tauri.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -103,3 +103,5 @@ The `internal/` subdirectory contains scripts that are **not** intended for dire
 | `internal/autoformat.sh`            | `.claude/settings.json` PostToolUse hook | Auto-format a single edited file (Prettier / rustfmt) and refresh the `data-testid` catalog    |
 | `internal/regen-testid-catalog.mjs` | `internal/autoformat.sh`                 | Regenerate the `data-testid` catalog when a source `.tsx` with a `data-testid` changes (#1084) |
 | `internal/kill-port.cjs`            | `dev.sh` / `dev.cmd`                     | Kill any process occupying the Vite dev server port                                            |
+| `internal/dev-local.mjs`            | `vite.config.ts` / `internal/tauri.mjs`  | Resolve this checkout's `dev_port` from `dev.local.json` (Node half of the resolver) (#1588)   |
+| `internal/tauri.mjs`                | `pnpm tauri`                             | Point `tauri dev` at this checkout's `dev_port`; pass every other subcommand through (#1588)   |

--- a/scripts/internal/README.md
+++ b/scripts/internal/README.md
@@ -7,5 +7,7 @@ Internal helper scripts used by other scripts or tooling. These are **not** inte
 | `autoformat.sh`            | `.claude/settings.json` PostToolUse hook | Auto-format a single edited file (Prettier / rustfmt) and refresh the `data-testid` catalog when a source `.tsx` changes     |
 | `regen-testid-catalog.mjs` | `autoformat.sh`                          | Regenerate `tests/system/testid-catalog.md` when the edited file is a source `.ts`/`.tsx` containing a `data-testid` (#1084) |
 | `kill-port.cjs`            | `dev.sh` / `dev.cmd`                     | Kill any process occupying the Vite dev server port                                                                          |
+| `dev-local.mjs`            | `vite.config.ts` / `tauri.mjs`           | Resolve this checkout's `dev_port` from `dev.local.json` — Node half of the resolver (#1588)                                 |
+| `tauri.mjs`                | `pnpm tauri`                             | Merge this checkout's `dev_port` into `tauri dev`'s `build.devUrl`; every other subcommand passes through (#1588)            |
 | `package-vcxsrv.ps1`       | release process (operator, Windows)      | Build the pinned minimal VcXsrv `.zip` for SSH X11 forwarding from an installed VcXsrv, print/patch its SHA-256 (#1076)      |
 | `package-vcxsrv.sh`        | `package-vcxsrv.ps1`                     | Git-Bash wrapper that forwards long flags to `package-vcxsrv.ps1`                                                            |

--- a/scripts/internal/dev-local.mjs
+++ b/scripts/internal/dev-local.mjs
@@ -1,0 +1,69 @@
+/**
+ * Per-checkout dev settings resolved from `dev.local.json` (parallel isolation).
+ *
+ * This is the **Node** third of the resolver trio; the other two are
+ * `scripts/internal/dev-local-env.sh` (shell) and
+ * `tests/system/termihub_harness/dev_local.py` (Python). All three read the same
+ * gitignored `dev.local.json` and apply the same precedence, so several
+ * checkouts can run their dev servers and test environments at once without
+ * contending. See docs/testing.md → "Parallel test isolation".
+ *
+ * Precedence for every value: an explicit **environment variable** wins (so
+ * `scripts/dev.sh` and CI keep overriding), then the `dev.local.json` key, then
+ * a built-in default that reproduces the historical single-checkout behaviour
+ * exactly. A missing or malformed file is therefore never an error — it just
+ * means "use the defaults", which is the fresh-clone / CI case.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Vite dev-server port when nothing else says otherwise (checkout 0). */
+export const DEFAULT_DEV_PORT = 1420;
+
+/** Repo root: `scripts/internal/dev-local.mjs` → up two. */
+export const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * Parse a port from a JSON value or env string.
+ *
+ * @param {unknown} value
+ * @returns {number | null} the port, or `null` if absent/unusable.
+ */
+function parsePort(value) {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  const port = typeof value === "number" ? value : Number(value.trim());
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return port;
+}
+
+/**
+ * Parse `dev.local.json` from `repoRoot`; `{}` when absent or invalid.
+ *
+ * @param {string} [repoRoot]
+ * @returns {Record<string, unknown>}
+ */
+export function readDevLocal(repoRoot = REPO_ROOT) {
+  let data;
+  try {
+    data = JSON.parse(readFileSync(join(repoRoot, "dev.local.json"), "utf8"));
+  } catch {
+    return {};
+  }
+  return data !== null && typeof data === "object" && !Array.isArray(data) ? data : {};
+}
+
+/**
+ * The Vite dev-server port: `TERMIHUB_DEV_PORT` > `dev.local.json` > 1420.
+ *
+ * @param {{ repoRoot?: string, env?: Record<string, string | undefined> }} [options]
+ * @returns {number}
+ */
+export function resolveDevPort({ repoRoot = REPO_ROOT, env = process.env } = {}) {
+  return (
+    parsePort(env.TERMIHUB_DEV_PORT) ??
+    parsePort(readDevLocal(repoRoot).dev_port) ??
+    DEFAULT_DEV_PORT
+  );
+}

--- a/scripts/internal/dev-local.test.mjs
+++ b/scripts/internal/dev-local.test.mjs
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_DEV_PORT, readDevLocal, resolveDevPort } from "./dev-local.mjs";
+
+/**
+ * Every case runs against a throwaway repo root. The real checkouts' own
+ * dev.local.json is read-only infrastructure — never write to or remove it.
+ */
+let root;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "termihub-dev-local-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Write a dev.local.json into the temp root. */
+function writeDevLocal(contents) {
+  writeFileSync(
+    join(root, "dev.local.json"),
+    typeof contents === "string" ? contents : JSON.stringify(contents)
+  );
+}
+
+describe("resolveDevPort", () => {
+  it("falls back to 1420 with no dev.local.json (fresh clone / CI)", () => {
+    expect(resolveDevPort({ repoRoot: root, env: {} })).toBe(DEFAULT_DEV_PORT);
+    expect(DEFAULT_DEV_PORT).toBe(1420);
+  });
+
+  it("reads dev_port from dev.local.json when the env var is unset", () => {
+    // The #1588 regression: this returned 1420 — checkout 0's port — in every
+    // checkout, because only scripts/dev.sh ever read the file.
+    writeDevLocal({ dev_port: 1450, dev_name: "dev3" });
+    expect(resolveDevPort({ repoRoot: root, env: {} })).toBe(1450);
+  });
+
+  it("lets TERMIHUB_DEV_PORT win over dev.local.json", () => {
+    // scripts/dev.sh exports the var (honouring its own CLI port argument);
+    // that override must keep winning.
+    writeDevLocal({ dev_port: 1450 });
+    expect(resolveDevPort({ repoRoot: root, env: { TERMIHUB_DEV_PORT: "1499" } })).toBe(1499);
+  });
+
+  it("uses TERMIHUB_DEV_PORT with no dev.local.json present", () => {
+    expect(resolveDevPort({ repoRoot: root, env: { TERMIHUB_DEV_PORT: "1499" } })).toBe(1499);
+  });
+
+  it("ignores an unusable env value and falls through to the file", () => {
+    writeDevLocal({ dev_port: 1450 });
+    for (const bad of ["", "   ", "not-a-port", "0", "70000", "14.5"]) {
+      expect(resolveDevPort({ repoRoot: root, env: { TERMIHUB_DEV_PORT: bad } })).toBe(1450);
+    }
+  });
+
+  it("ignores an unusable dev_port and falls through to the default", () => {
+    for (const bad of [0, 70000, "nope", null, true, 14.5]) {
+      writeDevLocal({ dev_port: bad });
+      expect(resolveDevPort({ repoRoot: root, env: {} })).toBe(DEFAULT_DEV_PORT);
+    }
+  });
+
+  it("accepts a numeric string dev_port", () => {
+    writeDevLocal({ dev_port: "1450" });
+    expect(resolveDevPort({ repoRoot: root, env: {} })).toBe(1450);
+  });
+
+  it("treats a malformed dev.local.json as absent rather than throwing", () => {
+    writeDevLocal("{ this is not json");
+    expect(resolveDevPort({ repoRoot: root, env: {} })).toBe(DEFAULT_DEV_PORT);
+  });
+});
+
+describe("readDevLocal", () => {
+  it("returns {} when the file is missing", () => {
+    expect(readDevLocal(root)).toEqual({});
+  });
+
+  it("returns the parsed object", () => {
+    writeDevLocal({ dev_port: 1450, dev_name: "dev3", compose_project: "termihub-test-3" });
+    expect(readDevLocal(root)).toEqual({
+      dev_port: 1450,
+      dev_name: "dev3",
+      compose_project: "termihub-test-3",
+    });
+  });
+
+  it("returns {} for valid JSON that is not an object", () => {
+    for (const contents of ["[1, 2]", '"string"', "null", "42"]) {
+      writeDevLocal(contents);
+      expect(readDevLocal(root)).toEqual({});
+    }
+  });
+});

--- a/scripts/internal/tauri.mjs
+++ b/scripts/internal/tauri.mjs
@@ -2,50 +2,75 @@
 /**
  * `pnpm tauri` wrapper that keeps `tauri dev` inside this checkout's isolation.
  *
- * Why this exists (#1588): the dev server's port lives in the gitignored
+ * Why this exists (#1588): the dev-server port lives in the gitignored
  * `dev.local.json`, but two separate places have to agree on it — Vite (which
  * binds the port) and Tauri's `build.devUrl` (which loads it). `devUrl` is a
  * static `http://localhost:1420` in `src-tauri/tauri.conf.json`, so a bare
  * `pnpm tauri dev` used to bind **1420 in every checkout** regardless of
- * `dev.local.json` — silently squatting on checkout 0's port and dev agent, and
- * producing cross-checkout flakiness that looks like a real bug. Only
- * `scripts/dev.sh` / `scripts/dev.cmd` resolved the port, so isolation held by
- * convention rather than by construction.
+ * `dev.local.json` — silently squatting on checkout 0's dev server and dev
+ * agent, and producing cross-checkout flakiness that looks like a real bug.
+ * Only `scripts/dev.sh` / `scripts/dev.cmd` resolved the port, so isolation held
+ * by convention rather than by construction.
  *
- * This wrapper closes that gap for `tauri dev`:
- *   - exports `TERMIHUB_DEV_PORT` so the `beforeDevCommand` Vite child agrees,
- *   - merges in a `build.devUrl` pointing at the same port.
- *
- * Everything else is a strict pass-through — `tauri build`, `tauri info`, etc.
- * behave exactly as before, which matters because CI builds run through here.
- *
- * The injected `--config` is placed **before** the caller's arguments, and Tauri
- * merges configs left to right with later values winning. So an explicit
- * `--config` (as `scripts/dev.sh` passes, carrying its CLI port override) still
- * takes precedence, and `scripts/dev.sh` keeps working unchanged.
+ * This wrapper closes that gap for `tauri dev` by merging in a `build.devUrl`
+ * pointing at the resolved port. Everything else is a strict pass-through —
+ * `tauri build`, `tauri info`, etc. behave exactly as before, which matters
+ * because CI builds run through here.
  */
 
 import { createRequire } from "node:module";
+import { argv, env, exit } from "node:process";
+import { fileURLToPath } from "node:url";
 
 import { resolveDevPort } from "./dev-local.mjs";
 
-const require = createRequire(import.meta.url);
-const cli = require("@tauri-apps/cli/main");
-
-const args = process.argv.slice(2);
-
-if (args[0] === "dev") {
-  const devPort = resolveDevPort();
-  // Exported for the `beforeDevCommand` (`pnpm dev` → vite.config.ts). Vite
-  // resolves the port itself via the same resolver, so this only pins the value
-  // both sides already agree on — and keeps `TERMIHUB_DEV_PORT` visible to any
-  // other child process, exactly as scripts/dev.sh sets it.
-  process.env.TERMIHUB_DEV_PORT = String(devPort);
-  const devUrl = `http://localhost:${devPort}`;
-  args.splice(1, 0, "--config", JSON.stringify({ build: { devUrl } }));
+/**
+ * Apply this checkout's dev port to a `tauri` argument list.
+ *
+ * Only `dev` is touched; every other subcommand passes through untouched.
+ *
+ * The injected `--config` is placed **before** the caller's arguments because
+ * Tauri merges configs left to right, with later values winning. So an explicit
+ * `--config` (as `scripts/dev.sh` passes, carrying its CLI port override) still
+ * takes precedence — `scripts/dev.sh` keeps working unchanged — while a config
+ * that sets other keys but not `devUrl` still gets the isolated port. Inserting
+ * at index 1 also keeps it ahead of any `--` runner/app argument separator.
+ *
+ * @param {string[]} args - arguments after `tauri` (e.g. `["dev"]`).
+ * @param {number} devPort - the resolved Vite dev-server port.
+ * @returns {string[]} the arguments to hand to the real Tauri CLI.
+ */
+export function applyDevPort(args, devPort) {
+  if (args[0] !== "dev") return [...args];
+  const config = JSON.stringify({ build: { devUrl: `http://localhost:${devPort}` } });
+  return [args[0], "--config", config, ...args.slice(1)];
 }
 
-cli.run(args, "pnpm tauri").catch((err) => {
-  cli.logError(err.message);
-  process.exit(1);
-});
+/** Run the real Tauri CLI, isolating `dev` to this checkout's port. */
+function main() {
+  const require = createRequire(import.meta.url);
+  const cli = require("@tauri-apps/cli/main");
+
+  const args = argv.slice(2);
+  let effective = args;
+
+  if (args[0] === "dev") {
+    const devPort = resolveDevPort();
+    // Exported for the `beforeDevCommand` (`pnpm dev` → vite.config.ts). Vite
+    // resolves the port itself through the same resolver, so this only pins the
+    // value both sides already agree on — and keeps `TERMIHUB_DEV_PORT` visible
+    // to child processes, exactly as scripts/dev.sh sets it.
+    env.TERMIHUB_DEV_PORT = String(devPort);
+    effective = applyDevPort(args, devPort);
+  }
+
+  cli.run(effective, "pnpm tauri").catch((err) => {
+    cli.logError(err.message);
+    exit(1);
+  });
+}
+
+// Importable for tests; only the real invocation runs the CLI.
+if (argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/internal/tauri.mjs
+++ b/scripts/internal/tauri.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * `pnpm tauri` wrapper that keeps `tauri dev` inside this checkout's isolation.
+ *
+ * Why this exists (#1588): the dev server's port lives in the gitignored
+ * `dev.local.json`, but two separate places have to agree on it — Vite (which
+ * binds the port) and Tauri's `build.devUrl` (which loads it). `devUrl` is a
+ * static `http://localhost:1420` in `src-tauri/tauri.conf.json`, so a bare
+ * `pnpm tauri dev` used to bind **1420 in every checkout** regardless of
+ * `dev.local.json` — silently squatting on checkout 0's port and dev agent, and
+ * producing cross-checkout flakiness that looks like a real bug. Only
+ * `scripts/dev.sh` / `scripts/dev.cmd` resolved the port, so isolation held by
+ * convention rather than by construction.
+ *
+ * This wrapper closes that gap for `tauri dev`:
+ *   - exports `TERMIHUB_DEV_PORT` so the `beforeDevCommand` Vite child agrees,
+ *   - merges in a `build.devUrl` pointing at the same port.
+ *
+ * Everything else is a strict pass-through — `tauri build`, `tauri info`, etc.
+ * behave exactly as before, which matters because CI builds run through here.
+ *
+ * The injected `--config` is placed **before** the caller's arguments, and Tauri
+ * merges configs left to right with later values winning. So an explicit
+ * `--config` (as `scripts/dev.sh` passes, carrying its CLI port override) still
+ * takes precedence, and `scripts/dev.sh` keeps working unchanged.
+ */
+
+import { createRequire } from "node:module";
+
+import { resolveDevPort } from "./dev-local.mjs";
+
+const require = createRequire(import.meta.url);
+const cli = require("@tauri-apps/cli/main");
+
+const args = process.argv.slice(2);
+
+if (args[0] === "dev") {
+  const devPort = resolveDevPort();
+  // Exported for the `beforeDevCommand` (`pnpm dev` → vite.config.ts). Vite
+  // resolves the port itself via the same resolver, so this only pins the value
+  // both sides already agree on — and keeps `TERMIHUB_DEV_PORT` visible to any
+  // other child process, exactly as scripts/dev.sh sets it.
+  process.env.TERMIHUB_DEV_PORT = String(devPort);
+  const devUrl = `http://localhost:${devPort}`;
+  args.splice(1, 0, "--config", JSON.stringify({ build: { devUrl } }));
+}
+
+cli.run(args, "pnpm tauri").catch((err) => {
+  cli.logError(err.message);
+  process.exit(1);
+});

--- a/scripts/internal/tauri.test.mjs
+++ b/scripts/internal/tauri.test.mjs
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { applyDevPort } from "./tauri.mjs";
+
+const configFor = (port) => JSON.stringify({ build: { devUrl: `http://localhost:${port}` } });
+
+describe("applyDevPort", () => {
+  it("merges the resolved devUrl into `tauri dev`", () => {
+    // The #1588 fix: without this, tauri.conf.json's static
+    // http://localhost:1420 wins and every checkout loads checkout 0's URL.
+    expect(applyDevPort(["dev"], 1450)).toEqual(["dev", "--config", configFor(1450)]);
+  });
+
+  it("keeps the caller's own --config winning (scripts/dev.sh)", () => {
+    // Tauri merges configs left to right, later wins — so dev.sh's --config,
+    // which carries its CLI port override, must come after the injected one.
+    const own = JSON.stringify({ build: { devUrl: "http://localhost:1499" } });
+    expect(applyDevPort(["dev", "--config", own], 1450)).toEqual([
+      "dev",
+      "--config",
+      configFor(1450),
+      "--config",
+      own,
+    ]);
+  });
+
+  it("stays ahead of a `--` runner/app argument separator", () => {
+    expect(applyDevPort(["dev", "--", "-q"], 1450)).toEqual([
+      "dev",
+      "--config",
+      configFor(1450),
+      "--",
+      "-q",
+    ]);
+  });
+
+  it("preserves other dev flags", () => {
+    expect(applyDevPort(["dev", "--exit-on-panic", "-f", "custom"], 1450)).toEqual([
+      "dev",
+      "--config",
+      configFor(1450),
+      "--exit-on-panic",
+      "-f",
+      "custom",
+    ]);
+  });
+
+  it("passes every other subcommand through untouched", () => {
+    // CI runs `pnpm tauri build` — this must stay byte-for-byte identical.
+    for (const args of [
+      ["build"],
+      ["build", "--no-bundle", "--target", "x86_64-unknown-linux-gnu"],
+      ["build", "--debug"],
+      ["info"],
+      ["--help"],
+      [],
+    ]) {
+      expect(applyDevPort(args, 1450)).toEqual(args);
+    }
+  });
+
+  it("does not mutate the caller's array", () => {
+    const args = ["dev"];
+    applyDevPort(args, 1450);
+    expect(args).toEqual(["dev"]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,17 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { fileURLToPath } from "url";
 
+import { resolveDevPort } from "./scripts/internal/dev-local.mjs";
+
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
-// Allow running multiple dev instances in parallel by setting TERMIHUB_DEV_PORT.
-// The HMR websocket uses devPort + 1. See scripts/dev.sh for how to configure this.
-// @ts-expect-error process is a nodejs global
-const devPort = parseInt(process.env.TERMIHUB_DEV_PORT ?? "1420", 10);
+// Per-checkout dev port: TERMIHUB_DEV_PORT > dev.local.json's dev_port > 1420.
+// Reading dev.local.json here (not just the env var) is what stops a bare
+// `pnpm tauri dev` from silently binding checkout 0's 1420 in every parallel
+// checkout (#1588). With no dev.local.json — a fresh clone, or CI — this is
+// still plain 1420. The HMR websocket uses devPort + 1.
+// See docs/testing.md → "Parallel test isolation".
+const devPort = resolveDevPort();
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({


### PR DESCRIPTION
## The bug

`vite.config.ts` read the dev port from `TERMIHUB_DEV_PORT` and defaulted to `1420`. Only `scripts/dev.sh` / `scripts/dev.cmd` ever exported that variable from `dev.local.json`. So a bare `pnpm tauri dev` bound **1420 in every checkout** regardless of what that checkout's `dev.local.json` said — and `.claude/CLAUDE.md` listed `pnpm tauri dev` as *the* way to run the app, so the instructions led straight into it.

It failed the way a missing `dev.local.json` fails: **by colliding, not by erroring**. #1588 only surfaced because something already held 1420. With the port free it would have quietly squatted on checkout 0's dev server and dev agent, and the resulting cross-checkout flakiness would have looked like a real bug in whatever was being tested.

## Why not documentation only

The issue is filed as `docs(config)`, and the docs fixes are here — but a silent-collision bug fixed only by documentation is still a silent-collision bug for anyone who doesn't read the docs. The failure is silent, so the cost of not reading is paid by someone else, later, as a flaky test. That is worth fixing by construction, and the issue's own third bullet asks for exactly that.

## Why the fix is not just `vite.config.ts`

The obvious fix — have `vite.config.ts` read `dev.local.json` — is a **half fix**, and worth spelling out because it looks complete:

**Two places have to agree on the port.** Vite *binds* it; Tauri's `build.devUrl` *loads* it. `devUrl` is a static `http://localhost:1420` in `src-tauri/tauri.conf.json` — that's why `dev.sh` passes `--config` on top of exporting the env var. Fix only Vite and `pnpm tauri dev` stops colliding but starts loading the wrong URL: no longer silent, but broken.

So both halves now resolve from one place:

- **`scripts/internal/dev-local.mjs`** — the **Node** third of the resolver trio, alongside `dev-local-env.sh` (shell) and `dev_local.py` (Python), with the same `env > file > default` precedence.
- **`scripts/internal/tauri.mjs`** — `pnpm tauri` routes through it; it merges a matching `build.devUrl` into `tauri dev`.

## Not breaking the single-checkout case

This was the real constraint — `vite.config.ts` runs where `dev.local.json` legitimately doesn't exist.

- **No `dev.local.json` → still plain `1420`.** Missing *or malformed* is never an error; it means "use the defaults", matching the other two resolvers. Fresh clone and CI are unchanged.
- **`TERMIHUB_DEV_PORT` still wins**, so `scripts/dev.sh` is **unchanged** and keeps its CLI override (`./scripts/dev.sh 1499`).
- **`tauri build` is a strict pass-through** — byte-for-byte identical args, pinned by a test. CI's `pnpm tauri build --no-bundle` runs through this wrapper, so it mattered.
- The injected `--config` goes **before** the caller's args; Tauri merges configs left to right with later winning, so `dev.sh`'s own `--config` still takes precedence.

## Verification

Both cases exercised with **real Vite**, not just unit tests:

| Checkout | Command | Vite binds |
| --- | --- | --- |
| `dev3` (`dev_port: 1450`) | bare `pnpm dev`, no env var | **1450** ✅ (1420 untouched) |
| temp root, **no** `dev.local.json` | bare `vite` | **1420** ✅ |

And the wrapper, in `dev3` with no env var:

```
resolved dev port : 1450
tauri dev args    : ["dev","--config","{\"build\":{\"devUrl\":\"http://localhost:1450\"}}"]
tauri build args  : ["build","--no-bundle"]        # untouched
```

**The tests fail without the fix.** Ran the new suite against the pre-fix resolver: 4 of 11 fail, including "reads dev_port from dev.local.json when the env var is unset".

- `pnpm test` — 3306 passed / 354 files
- `npx tsc --noEmit`, `pnpm lint`, `pnpm format:check`, `pnpm markdownlint` — clean

Every test runs against a **temp repo root**; no checkout's real `dev.local.json` was written to or removed.

## Docs

`.claude/CLAUDE.md`, `docs/testing.md` → *Parallel test isolation*, `docs/contributing.md`, and both `scripts` READMEs. Since the bare command is now correct, these say so rather than warning it bypasses — and name the one thing only `./scripts/dev.sh` does (start the `dev_agent_port` sshd), so preferring it has a stated reason.

Closes #1588
