### PR TITLE
refactor(ui): draw ConfirmDialog's don't-ask-again as a checkbox (Closes #1590)

### DIFF
--- a/docs/changes/dev1/refactor/1590-confirmdialog-checkbox.md
+++ b/docs/changes/dev1/refactor/1590-confirmdialog-checkbox.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Confirmation dialogs** now draw their "Don't ask again" opt-out as a
+  checkbox instead of a switch, following the distinction established in
+  #1562: a checkbox means "takes effect when you confirm", a switch means
+  "applies immediately". The opt-out is scoped to the confirmation, so a
+  switch overstated its immediacy. This affects the "Insecure Connection"
+  FTP warning and the close-tab/close-panel confirmation. Behavior,
+  keyboard handling and persistence are unchanged (#1590).

--- a/src/components/ui/ConfirmDialog.test.tsx
+++ b/src/components/ui/ConfirmDialog.test.tsx
@@ -12,6 +12,13 @@ function render(ui: React.ReactElement) {
   });
 }
 
+/** The "don't ask again" control rendered in the dialog body. */
+function dontAskAgain(): HTMLButtonElement {
+  return document.querySelector(
+    '[data-testid="confirm-dialog-dont-ask-again"]'
+  ) as HTMLButtonElement;
+}
+
 describe("ConfirmDialog", () => {
   beforeEach(() => {
     container = document.createElement("div");
@@ -70,7 +77,7 @@ describe("ConfirmDialog", () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  it("renders the don't-ask-again toggle and reports changes", () => {
+  it("renders the don't-ask-again checkbox and reports changes", () => {
     const onChange = vi.fn();
     render(
       <ConfirmDialog
@@ -82,11 +89,104 @@ describe("ConfirmDialog", () => {
         onCancel={vi.fn()}
       />
     );
-    const toggle = document.querySelector(
-      '[data-testid="confirm-dialog-dont-ask-again"]'
-    ) as HTMLElement;
-    expect(toggle).toBeTruthy();
-    act(() => toggle.click());
+    const box = dontAskAgain();
+    expect(box).toBeTruthy();
+    act(() => box.click());
     expect(onChange).toHaveBeenCalledWith(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  // The opt-out takes effect on Confirm, so it must read as a checkbox and not
+  // as a switch — a switch tells the user it applied the moment it was flipped.
+  it("exposes the don't-ask-again opt-out as a checkbox, not a switch", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="T"
+        message="M"
+        dontAskAgain={{ checked: false, onChange: vi.fn() }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    const box = dontAskAgain();
+    expect(box.getAttribute("role")).toBe("checkbox");
+    expect(box.getAttribute("role")).not.toBe("switch");
+    expect(box.classList.contains("ui-checkbox")).toBe(true);
+    expect(box.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("reflects the checked state of the don't-ask-again opt-out", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="T"
+        message="M"
+        dontAskAgain={{ checked: true, onChange: vi.fn() }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(dontAskAgain().getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("labels the don't-ask-again opt-out with the custom label", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="T"
+        message="M"
+        dontAskAgain={{ checked: false, onChange: vi.fn(), label: "Don't warn again" }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(dontAskAgain().getAttribute("aria-label")).toBe("Don't warn again");
+    expect(document.querySelector(".ui-confirm__ask-again")?.textContent).toContain(
+      "Don't warn again"
+    );
+  });
+
+  // Clicking the wrapping <label> must reach the control exactly once: a label
+  // around a button can forward the click and re-toggle it straight back.
+  it("toggles once when the don't-ask-again label text is clicked", () => {
+    const onChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="T"
+        message="M"
+        dontAskAgain={{ checked: false, onChange }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    act(() => (document.querySelector(".ui-confirm__ask-again span") as HTMLElement).click());
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  // WAI-ARIA: Space activates a checkbox, Enter does not. Enter inside the
+  // dialog stays the confirm shortcut rather than ticking the opt-out.
+  it("confirms rather than ticking the opt-out when Enter is pressed on it", () => {
+    const onConfirm = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="T"
+        message="M"
+        dontAskAgain={{ checked: false, onChange }}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+    const box = dontAskAgain();
+    act(() => box.focus());
+    act(() => {
+      box.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,18 +1,26 @@
 import React, { useEffect, useRef } from "react";
 import { Modal } from "./Modal";
 import { Button, ButtonVariant } from "./Button";
-import { Toggle } from "./Toggle";
+import { Checkbox } from "./Checkbox";
 import "./ui.css";
 
-/** Optional "don't ask again" opt-out rendered below a confirmation message. */
+/**
+ * Optional "don't ask again" opt-out rendered below a confirmation message.
+ *
+ * Drawn as a {@link Checkbox} rather than a {@link Toggle}: the opt-out is
+ * scoped to the confirmation, so it reads as "apply this when I press Confirm"
+ * — a switch would promise that it applied the moment it was flipped.
+ * Consumers are expected to honour that contract and defer the write to their
+ * `onConfirm`.
+ */
 export interface ConfirmDontAskAgain {
   /** Current checked state. */
   checked: boolean;
-  /** Called with the next value when the user flips the toggle. */
+  /** Called with the next value when the user ticks the checkbox. */
   onChange: (checked: boolean) => void;
   /** Visible label (defaults to "Don't ask again"). */
   label?: string;
-  /** Test hook forwarded to the toggle. */
+  /** Test hook forwarded to the checkbox. */
   "data-testid"?: string;
 }
 
@@ -30,7 +38,7 @@ export interface ConfirmDialogProps {
   cancelLabel?: string;
   /** Confirm button variant (defaults to "danger" for destructive actions). */
   confirmVariant?: ButtonVariant;
-  /** When provided, renders a "don't ask again" opt-out toggle. */
+  /** When provided, renders a "don't ask again" opt-out checkbox. */
   dontAskAgain?: ConfirmDontAskAgain;
   /** Invoked when the user confirms. */
   onConfirm: () => void;
@@ -42,7 +50,7 @@ export interface ConfirmDialogProps {
 
 /**
  * The single shared confirmation dialog for destructive/irreversible actions.
- * Composes {@link Modal} + {@link Button} (+ optional {@link Toggle}) so every
+ * Composes {@link Modal} + {@link Button} (+ optional {@link Checkbox}) so every
  * confirm surface shares one look, motion, and safe-default behavior: the
  * Cancel button is focused on open, and Enter confirms only when Cancel does
  * not hold focus. Prefer this over hand-rolling a per-feature confirm shell.
@@ -101,7 +109,7 @@ export function ConfirmDialog({
       {message}
       {dontAskAgain && (
         <label className="ui-confirm__ask-again">
-          <Toggle
+          <Checkbox
             checked={dontAskAgain.checked}
             onCheckedChange={dontAskAgain.onChange}
             aria-label={dontAskAgain.label ?? "Don't ask again"}


### PR DESCRIPTION
Follow-up to #1562 (PR #1589), which added the `Checkbox` primitive and deliberately left this shared surface for its own review.

`ConfirmDialog`'s "don't ask again" opt-out is scoped to the confirmation, so it now renders a `Checkbox` rather than a `Toggle` (a Radix `Switch`) — per the distinction #1562 established: a checkbox means "takes effect when you confirm", a switch means "applies immediately".

## What changed

- `ConfirmDialog.tsx` — `Toggle` → `Checkbox`. The wrapping `<label>`, the `aria-label`, and the `confirm-dialog-dont-ask-again` testid are all unchanged.
- Tests asserting checkbox semantics so the control cannot silently regress to a switch.
- No CSS change needed: `.ui-confirm__ask-again` is pure flex with `align-items: center` and no fixed dimensions, and `.ui-checkbox` is 14x14 with `flex-shrink: 0`, so the 34x20 → 14x14 swap re-aligns on its own.

## Visual change, per consumer

Six components render `ConfirmDialog`, but only **two** pass `dontAskAgain` — so only two change at all:

| Consumer | Visual change |
| --- | --- |
| `ConnectionList` — "Insecure Connection" FTP warning | "Don't warn again for this connection" switch → checkbox |
| `ConfirmSessionCloseDialog` — close tab / close panel | "Don't ask again" switch → checkbox |
| `EmbeddedServerSidebar`, `OpenConnectionsModal`, `TabBar`, `UnlockDialog` | **None** — no `dontAskAgain` prop |

Settings toggles are untouched and correctly remain switches; the only `role="switch"` assertion in the suite is `TerminalSettings.test.tsx`, which is a Settings toggle.

## Persistence is unchanged

The primitive only forwards `onChange`; it does not decide when the write happens. Both consumers' persistence tests pass untouched, including the one asserting the session-close write fires on click.

## Verification

- Mutation-tested: reverting to `Toggle` turns the role assertion red (`expected 'switch' to be 'checkbox'`). The other new tests stay green by design — they assert behaviour that is *intentionally identical* across both controls, which is the point of a behaviour-preserving migration.
- `npx tsc --noEmit` clean; `pnpm test` 3304/3304 across 352 files; lint + prettier clean.
- Testid catalog regenerates to a zero diff.

## Follow-up filed

#1606 — `ConfirmSessionCloseDialog` writes its opt-out immediately on tick rather than on confirm, so cancelling still persists it. Pre-existing since the original feature commit, and it contradicts the checkbox contract this PR documents. Fixing it changes behaviour, so it is deliberately out of scope here.

Note: the `ui-modernization` concept's primitive inventory is stale (it does not list `Checkbox`), unchanged from #1562. Flagged, not synced — concept reconciliation is human-triggered via `/sync-concept`.
