### PR TITLE
test(agent): serialise fork against binary copy in live-agent harnesses (Closes #1597)

### DIFF
--- a/agent/tests/common/mod.rs
+++ b/agent/tests/common/mod.rs
@@ -1,0 +1,65 @@
+//! Shared helpers for the live-agent test harnesses.
+//!
+//! Cargo does not build `tests/common/mod.rs` as a test binary of its own, so
+//! this is a plain module each suite pulls in with `mod common;`.
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+static FORK_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Serialises **every `fork`** in this test binary against **every write to a
+/// binary this suite is about to `execve`** (#1597).
+///
+/// ## The race
+///
+/// A harness that copies the agent binary into a temp dir and runs it does:
+///
+/// 1. Thread **A** calls `fs::copy`, which holds a **write fd** on `binA`.
+/// 2. Thread **B** calls `Command::spawn`, which **forks**. The child inherits
+///    *every* fd in the process — including A's write fd on `binA`. `O_CLOEXEC`
+///    does not save you: it closes the fd at `execve`, and B's child is sitting
+///    between `fork` and `exec`.
+/// 3. A finishes its copy and closes its own fd, then `execve`s `binA`.
+/// 4. Linux fails that `execve` with **`ETXTBSY`** ("Text file busy") because
+///    B's not-yet-exec'd child *still* holds a write fd on the file.
+///
+/// Linux-only (macOS does not enforce `ETXTBSY` this way), and intermittent —
+/// it needs a fork to land inside another thread's copy window. See
+/// rust-lang/rust#3352.
+///
+/// ## Why this works
+///
+/// `Command::spawn` does not return until the child has `exec`'d (std blocks on
+/// a `CLOEXEC` pipe to report exec failures). So holding this lock across
+/// `copy` → `chmod` → `spawn` guarantees no fd is inherited that outlives the
+/// critical section: by the time the lock drops, every child has already exec'd
+/// and closed what it inherited.
+///
+/// ## Two things that look sufficient and are not
+///
+/// - **Copying to a temp path and renaming into place.** `rename` does not
+///   change the inode, and `ETXTBSY` is enforced per *inode* — an inherited
+///   write fd on the temp path still refers to the very inode being exec'd.
+///   Measured on Linux, 6 threads × 200 spawns: 119/1200 failures, versus
+///   220/1200 with no mitigation at all. It does not fix it.
+/// - **Locking only the harness's own copy+spawn.** *Any* fork in the process
+///   inherits the fd, including unrelated ones like a `docker` probe. With one
+///   such fork site left unlocked: 47/1200 failures. With every fork site
+///   taking this lock: 0/1200.
+///
+/// So the rule is not "lock the spawn" but **lock the fork** — if you add a
+/// `Command` that forks anywhere in one of these suites, it takes this guard,
+/// however unrelated it looks.
+///
+/// Hold it for the copy and the spawn only. Drop it before anything that waits
+/// on the child (reading its log, polling its port), or the suite serialises
+/// wholesale instead of just at the hazard.
+pub fn fork_guard() -> MutexGuard<'static, ()> {
+    FORK_LOCK
+        .get_or_init(|| Mutex::new(()))
+        // A test that panics while holding this must not cascade into every
+        // sibling: the guard protects fd timing, not data, so there is no
+        // invariant for a panic to have broken.
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/agent/tests/deferred_update_hook_integration.rs
+++ b/agent/tests/deferred_update_hook_integration.rs
@@ -62,6 +62,8 @@ use std::time::{Duration, Instant};
 use serde_json::{json, Value};
 use tempfile::TempDir;
 
+mod common;
+
 /// The hook's gate and its binary override — mirrored from
 /// `agent/src/update/test_hook.rs`.
 const HOOK_ENV: &str = "TERMIHUB_AGENT_TEST_PENDING_UPDATE";
@@ -128,15 +130,19 @@ impl LiveAgent {
     fn spawn(gate: Option<&str>) -> Self {
         let install_dir = TempDir::new().expect("install dir");
         let bin_path = install_dir.path().join("termihub-agent");
-        std::fs::copy(agent_binary(), &bin_path).expect("copy agent binary");
-        std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755))
-            .expect("chmod agent copy");
-
         let config_home = TempDir::new().expect("config home");
 
         let stderr_file = tempfile::NamedTempFile::new().expect("stderr file");
         let stderr_path = stderr_file.path().to_path_buf();
         let (stderr_handle, _keep) = stderr_file.keep().expect("persist stderr file");
+
+        // Everything from the copy to the spawn runs under the fork lock: a
+        // sibling thread forking mid-copy inherits our write fd and makes our
+        // own execve fail with ETXTBSY (#1597). See `common::fork_guard`.
+        let fork_guard = common::fork_guard();
+        std::fs::copy(agent_binary(), &bin_path).expect("copy agent binary");
+        std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod agent copy");
 
         let mut cmd = Command::new(&bin_path);
         cmd.arg("--listen")
@@ -160,6 +166,12 @@ impl LiveAgent {
         }
 
         let child = cmd.spawn().expect("spawn agent process");
+        // `spawn` returns only once the child has exec'd, so the inherited-fd
+        // window is closed here. Release before the log wait below, which blocks
+        // for as long as the agent takes to bind — holding it there would
+        // serialise the whole suite rather than just the hazard.
+        drop(fork_guard);
+
         let addr = read_listen_addr(&stderr_path);
         LiveAgent {
             child,

--- a/agent/tests/self_update_integration.rs
+++ b/agent/tests/self_update_integration.rs
@@ -58,6 +58,8 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+mod common;
+
 /// Published asset suffix the mock release advertises. Forced via
 /// `TERMIHUB_AGENT_UPDATE_ASSET_SUFFIX` so the test is independent of the host
 /// architecture (the real `current_asset_suffix()` only resolves on Linux).
@@ -188,9 +190,6 @@ impl LiveAgent {
     fn spawn(server: &MockServer, strategy: &str, initial_delay: Duration) -> Self {
         let install_dir = TempDir::new().expect("install dir");
         let bin_path = install_dir.path().join("termihub-agent");
-        std::fs::copy(agent_binary(), &bin_path).expect("copy agent binary");
-        std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755))
-            .expect("chmod agent copy");
 
         let config_home = TempDir::new().expect("config home");
         let port = reserve_port();
@@ -199,6 +198,14 @@ impl LiveAgent {
         let stderr_file = tempfile::NamedTempFile::new().expect("stderr file");
         let stderr_path = stderr_file.path().to_path_buf();
         let (stderr_handle, _keep) = stderr_file.keep().expect("persist stderr file");
+
+        // Everything from the copy to the spawn runs under the fork lock: a
+        // sibling thread forking mid-copy inherits our write fd and makes our
+        // own execve fail with ETXTBSY (#1597). See `common::fork_guard`.
+        let fork_guard = common::fork_guard();
+        std::fs::copy(agent_binary(), &bin_path).expect("copy agent binary");
+        std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod agent copy");
 
         let child = Command::new(&bin_path)
             .arg("--listen")
@@ -221,6 +228,9 @@ impl LiveAgent {
             .stderr(Stdio::from(stderr_handle))
             .spawn()
             .expect("spawn agent process");
+        // `spawn` returns only once the child has exec'd, so the inherited-fd
+        // window is closed here.
+        drop(fork_guard);
 
         LiveAgent {
             child,
@@ -420,12 +430,28 @@ impl Client {
 
 // ── Docker availability ─────────────────────────────────────────────────────
 
+/// Takes the fork lock even though it has nothing to do with the agent binary:
+/// this `fork` inherits any write fd a sibling thread's `fs::copy` currently
+/// holds, and that is enough to make *that* thread's `execve` fail with
+/// ETXTBSY. The hazard is the fork, not the binary (#1597).
+/// Forks under the fork lock even though it has nothing to do with the agent
+/// binary: this `fork` inherits any write fd a sibling thread's `fs::copy`
+/// currently holds, which is enough to make *that* thread's `execve` fail with
+/// ETXTBSY. The hazard is the fork, not the binary (#1597).
+///
+/// `spawn` + `wait` rather than `status()` so the lock covers only the
+/// fork-to-exec window, not the wait for `docker info` to finish.
 fn docker_available() -> bool {
-    Command::new("docker")
-        .arg("info")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+    let child = {
+        let _fork_guard = common::fork_guard();
+        Command::new("docker")
+            .arg("info")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+    };
+    child
+        .and_then(|mut c| c.wait())
         .map(|s| s.success())
         .unwrap_or(false)
 }
@@ -676,11 +702,17 @@ async fn active_docker_session_is_never_interrupted() {
     }
     // Pre-pull so container start (and thus session activation) is fast enough to
     // beat the gated first poll deterministically.
-    let _ = Command::new("docker")
-        .args(["pull", "alpine:latest"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
+    // Fork under the lock, wait outside it — an image pull is far too long to
+    // hold the fork lock for. See `common::fork_guard` (#1597).
+    let pull = {
+        let _fork_guard = common::fork_guard();
+        Command::new("docker")
+            .args(["pull", "alpine:latest"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+    };
+    let _ = pull.and_then(|mut c| c.wait());
     assert_never_interrupts("docker", json!({"image": "alpine:latest"}), Some(60)).await;
 }
 


### PR DESCRIPTION
## Problem

Both live-agent harnesses copy the agent binary into a private temp dir and immediately exec it, from ~6 parallel test threads:

1. Thread **A** calls `fs::copy`, holding a **write fd** on `binA`.
2. Thread **B** calls `Command::spawn`, which **forks**. The child inherits *every* fd — including A's write fd on `binA`. `O_CLOEXEC` does not help: it closes the fd at `execve`, and B's child sits between `fork` and `exec`.
3. A closes its own fd and `execve`s `binA` → Linux returns **`ETXTBSY`**, because B's not-yet-exec'd child still holds a write fd on it.

Linux-only, intermittent, and fires on PRs touching zero Rust (it hit #1575, a two-Python-file diff). See rust-lang/rust#3352.

## Verifying the diagnosis

Reproduced in `rust:1-bookworm` (rustc 1.96.1), non-root, CPU-limited to 4 cores. **The real harness, unmodified, at 6 test threads — 8 runs: 7 `ExecutableFileBusy` failures across 4 of 8 runs.** With this PR: **0 across 8 runs**, and `self_update_integration` goes 6/6 green.

A standalone reproducer (6 threads x 200 copy+spawn cycles) isolates the mechanism and tests the candidate fixes:

| Mitigation | ETXTBSY / 1200 spawns |
| --- | --- |
| None | 220 |
| Copy to temp path + `rename` into place | **119** |
| Mutex over copy+spawn only, one unrelated fork site left unlocked | **47** |
| Mutex taken at **every** fork site | **0** |

Two results shaped the fix, and both contradict an approach that looks right:

- **`rename` does not work.** `rename` does not change the inode, and `ETXTBSY` is enforced per *inode* — an inherited write fd on the temp path still refers to the very inode being exec'd. It halves the rate and fixes nothing.
- **Guarding only the harness's own copy+spawn is not enough.** *Any* fork inherits the fd. `self_update_integration.rs` has two unrelated fork sites — `docker_available()` and the `docker pull` pre-warm — that the issue's suggested scope would have left open, and one such site is worth 47/1200.

So the rule is **lock the fork, not the spawn**.

## Change

- New `agent/tests/common/mod.rs` — a `fork_guard()` over a per-binary `Mutex`, documenting the race and both dead ends above. Poisoning is ignored deliberately: it guards fd timing, not data, so a panicking test must not cascade into its siblings.
- `deferred_update_hook_integration.rs` / `self_update_integration.rs` — hold the guard across `copy` -> `chmod` -> `spawn`, and release it immediately after. `spawn` returns only once the child has exec'd, so the window is closed at that point; the log/port waits stay outside the lock, so the suites still run parallel everywhere except the hazard.
- The two docker fork sites use `spawn` + `wait` instead of `status()`, so the lock covers the fork-to-exec window rather than a whole image pull.

Test-only; no change fragment (non-user-facing).

## Not #1559

#1559 (`applied_update_does_not_re_exec_on_the_next_idle`) is a different bug and this does not claim to fix it. It did not fire in 6 fixed runs, so there is no evidence either way about its rate — too rare to measure at this sample size.

Closes #1597
