### PR TITLE
fix(backend): name ftp_upload's transfer row from the remote path (Closes #1594)

### DIFF
--- a/src-tauri/src/commands/transfer.rs
+++ b/src-tauri/src/commands/transfer.rs
@@ -140,7 +140,13 @@ pub async fn ftp_upload(
         debug!(session_id, local_path, remote_path, "FTP upload");
         let config = parse_ftp_config(config)?;
         let transfer_id = uuid::Uuid::new_v4().to_string();
-        let file_name = file_name_of(&local_path);
+        // Named for the *remote* path, not the local one, so the name always
+        // agrees with the `path` this row displays (#1594, mirroring the SFTP
+        // fix in #1573). Every honest local→remote upload builds `remote_path`
+        // as `<dir>/<basename of local>`, so this is byte-for-byte unchanged
+        // for them; it only differs for a future caller that uploads from a
+        // scratch/temp path the user never named (as SFTP→SFTP paste does).
+        let file_name = file_name_of(&remote_path);
         let handle = registry.enqueue(
             &transfer_id,
             &session_id,
@@ -188,4 +194,42 @@ fn file_name_of(path: &str) -> String {
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| path.to_string())
+}
+
+#[cfg(all(test, feature = "ftp"))]
+mod tests {
+    use super::file_name_of;
+
+    #[test]
+    fn names_a_file_by_its_basename() {
+        assert_eq!(file_name_of("/home/testuser/report.csv"), "report.csv");
+        assert_eq!(file_name_of("/report.csv"), "report.csv");
+        assert_eq!(file_name_of("report.csv"), "report.csv");
+    }
+
+    #[test]
+    fn falls_back_to_the_whole_path_when_there_is_no_basename() {
+        assert_eq!(file_name_of("/"), "/");
+        assert_eq!(file_name_of(""), "");
+        assert_eq!(file_name_of(".."), "..");
+    }
+
+    /// `ftp_upload` and `ftp_download` both name the row from the *remote* path,
+    /// so a row's name always agrees with the `path` cell beside it (#1594,
+    /// mirroring #1573 for SFTP). An honest local→remote upload has equal local
+    /// and remote basenames, so the row is unchanged; only a caller uploading
+    /// from a scratch/temp local copy the user never named would differ, and
+    /// naming from the remote path keeps that scratch name off the row.
+    #[test]
+    fn names_an_upload_after_the_remote_destination_not_the_local_source() {
+        let temp_local = "/tmp/termihub-paste-1784278708447-report.csv";
+        let remote_dest = "/home/testuser/dest/report.csv";
+
+        assert_eq!(file_name_of(remote_dest), "report.csv");
+        assert_eq!(
+            file_name_of(temp_local),
+            "termihub-paste-1784278708447-report.csv",
+            "the local scratch basename is what the row must NOT show",
+        );
+    }
 }


### PR DESCRIPTION
## What

`ftp_upload` (`src-tauri/src/commands/transfer.rs`) derived the Transfer Queue row's `file_name` from the **local** path, while its `path` cell comes from the **remote** path — so the two cells could describe different files. This is the same defect that #1573 (PR #1595) fixed for `sftp_upload`.

The rule #1573 established: **a transfer row's name is the base name of the path it displays.** This PR applies that invariant to `ftp_upload` — a one-line change at the single `enqueue` site, `file_name_of(&local_path)` → `file_name_of(&remote_path)`, exactly mirroring the SFTP fix.

## Latent, not live — the honest case stays a no-op

This was deliberately left out of #1573 because it is **latent**: no FTP caller does download-to-temp-then-reupload today (unlike `useFileSystem.pasteEntry` for SFTP), so no current FTP path produces a mismatched name. For a genuine local→remote FTP upload the local and remote basenames are equal, so naming from either is identical — this change is **byte-for-byte unchanged** for every honest upload. It only differs where a future caller uploads from a scratch/temp local file the user never named, which is precisely the case where naming from the remote path keeps the scratch name off the row.

## Tests

Added `ftp`-gated Rust unit tests for `file_name_of` in `transfer.rs`, mirroring #1573's unit tests. These **do** run in CI under `cargo test --workspace --all-features`, unlike the system suite which is `-m "not integration"`-excluded (#1569).

## Verification — and its limit (stated plainly)

- `cargo test -p termihub --features ftp` — the 3 new tests pass.
- `cargo fmt --all --check` and `cargo clippy -p termihub --features ftp --all-targets -- -D warnings` are clean.

**What I could not verify:** there is no FTP fixture that drives `ftp_upload`'s transfer-row naming end-to-end. The FTP system tests (`test_transfer_checkers.py`) exercise the harness-side `ftp_download` checker via `pyftpdlib`, not the Rust command's `enqueue` naming. This is the same gap #1573's author flagged as the reason they deferred this. Consequently the added unit tests guard the `file_name_of` invariant but — because the helper itself is unchanged — do not by themselves fail on a regression of the call site; the call-site change is verified by code review against the identical, already-merged SFTP fix, not by a red test run. No live FTP verification is claimed.

Refs the SFTP precedent: #1573 / PR #1595 (merge `65c8a3b2`).

Closes #1594