### PR TITLE
test(ui): clear editor status bar by switching to a terminal tab (Closes #1591)

### DIFF
--- a/tests/system/termihub_harness/ui/tabs.py
+++ b/tests/system/termihub_harness/ui/tabs.py
@@ -64,6 +64,27 @@ class TabsUi(HarnessMixin):
         """Click the tab with the given id to make it active."""
         self.driver.click(f"tab-{tab_id}")
 
+    def switch_to_terminal_tab(self) -> dict[str, Any]:
+        """Activate the first open terminal tab and wait for it to focus.
+
+        ``ensure_terminal`` only *creates* a terminal when none exists — when one
+        is already open (the fresh app spawns one) it neither switches to it nor
+        changes the active tab. Tests that need a terminal tab to become the
+        *active* one (so an editor's status-bar items clear) must switch to it
+        explicitly; this walks the panel tree for a ``contentType == "terminal"``
+        tab, clicks it, and waits until it is the active tab.
+        """
+        term = next(
+            (t for t in self._all_tabs() if t.get("contentType") == "terminal"), None
+        )
+        assert term is not None, "expected an open terminal tab to switch to"
+        self.switch_to_tab(term["id"])
+        self.wait(
+            lambda: (self.active_tab() or {}).get("id") == term["id"],
+            what="the terminal tab to become active",
+        )
+        return term
+
     def close_tab(self, tab_id: str) -> None:
         """Close the tab with the given id, confirming any close dialog.
 

--- a/tests/system/tests/test_editor.py
+++ b/tests/system/tests/test_editor.py
@@ -181,9 +181,10 @@ class TestEditor(TerminalUi, TabsUi, SidebarUi, FilesUi, EditorUi, ShellFsUi, Sy
     def test_status_bar_items_hide_on_a_terminal_tab(self):
         self._open_editor()
         assert self.editor_status_present() is True
-        # A terminal tab has no editor status.
-        self.switch_to_connections_sidebar()
-        self.ensure_terminal()
+        # Activating a terminal tab must clear the editor status-bar items.
+        # ``ensure_terminal`` alone does not switch tabs when a terminal already
+        # exists, so switch to the terminal tab explicitly.
+        self.switch_to_terminal_tab()
         self.wait(
             lambda: self.editor_status() is None,
             what="the editor status to clear on the terminal tab",
@@ -193,8 +194,7 @@ class TestEditor(TerminalUi, TabsUi, SidebarUi, FilesUi, EditorUi, ShellFsUi, Sy
     def test_status_bar_items_return_when_switching_back_to_the_editor(self):
         name = self._open_editor()
         editor_tab = self.find_tab(name)
-        self.switch_to_connections_sidebar()
-        self.ensure_terminal()
+        self.switch_to_terminal_tab()
         self.wait(lambda: self.editor_status() is None, what="status to clear")
         self.switch_to_tab(editor_tab["id"])
         self.wait(lambda: self.editor_status() is not None, what="status to return")

--- a/tests/system/tests/test_ui_helpers.py
+++ b/tests/system/tests/test_ui_helpers.py
@@ -10,6 +10,7 @@ from termihub_harness import find_connection, find_folder
 from termihub_harness.bridge import BridgeError
 from termihub_harness.ui import connection_item_testid, folder_toggle_testid, iter_tabs
 from termihub_harness.ui.base import HarnessMixin
+from termihub_harness.ui.tabs import TabsUi
 
 
 class StubDriver:
@@ -139,6 +140,94 @@ def test_open_named_context_menu_waits_for_resolve_then_a_mounted_trigger():
         what="the menu",
     )
     assert driver.context_menu_calls == ["trigger-9"]
+
+
+class TabDriver:
+    """Driver stub for tab switching: serves ``get_state`` for the panel tree and
+    ``activePanelId``, and flips a leaf's ``activeTabId`` when its tab is clicked.
+
+    Clicking ``tab-<id>`` mirrors the real app: the clicked tab becomes the active
+    tab of whichever leaf contains it, so ``active_tab()`` then reflects it.
+    """
+
+    def __init__(self, root: dict, active_panel_id: str):
+        self._root = root
+        self._active_panel_id = active_panel_id
+        self.clicks: list[str] = []
+
+    def get_state(self, path=None):
+        if path == "rootPanel":
+            return self._root
+        if path == "activePanelId":
+            return self._active_panel_id
+        raise BridgeError("getState", f'state path "{path}" does not resolve')
+
+    def click(self, test_id: str) -> None:
+        self.clicks.append(test_id)
+        if not test_id.startswith("tab-"):
+            return
+        tab_id = test_id[len("tab-") :]
+
+        def activate(node):
+            if not isinstance(node, dict):
+                return
+            if node.get("type") == "leaf":
+                if any(t.get("id") == tab_id for t in node.get("tabs") or []):
+                    node["activeTabId"] = tab_id
+                return
+            for child in node.get("children") or []:
+                activate(child)
+
+        activate(self._root)
+
+
+class FakeTabs(TabsUi):
+    """``TabsUi`` with an eager, app-free ``wait`` (same pattern as FakeHarness)."""
+
+    _MAX_POLLS = 50
+
+    def __init__(self, driver):
+        self.driver = driver
+
+    def wait(self, predicate, *, timeout=0, interval=0, what=""):
+        for _ in range(self._MAX_POLLS):
+            result = predicate()
+            if result:
+                return result
+        raise AssertionError(f"timed out waiting for {what}")
+
+
+def test_switch_to_terminal_tab_activates_the_open_terminal():
+    # An editor tab is active alongside an open terminal tab. Switching must
+    # click the *terminal* tab (by contentType) and leave it the active tab —
+    # ``ensure_terminal`` would not have changed the active tab at all.
+    root = {
+        "type": "leaf",
+        "id": "p1",
+        "activeTabId": "ed",
+        "tabs": [
+            {"id": "ed", "contentType": "editor"},
+            {"id": "term", "contentType": "terminal"},
+        ],
+    }
+    driver = TabDriver(root, "p1")
+    tabs = FakeTabs(driver)
+    result = tabs.switch_to_terminal_tab()
+    assert result["id"] == "term"
+    assert driver.clicks == ["tab-term"]
+    assert tabs.active_tab()["id"] == "term"
+
+
+def test_switch_to_terminal_tab_raises_when_no_terminal_is_open():
+    root = {
+        "type": "leaf",
+        "id": "p1",
+        "activeTabId": "ed",
+        "tabs": [{"id": "ed", "contentType": "editor"}],
+    }
+    tabs = FakeTabs(TabDriver(root, "p1"))
+    with pytest.raises(AssertionError):
+        tabs.switch_to_terminal_tab()
 
 
 def test_iter_tabs_flattens_a_split_tree_in_order():


### PR DESCRIPTION
## Summary

The two `test_editor.py` status-bar cases

- `test_status_bar_items_hide_on_a_terminal_tab`
- `test_status_bar_items_return_when_switching_back_to_the_editor`

fail on clean `develop` under `-m integration`. Found while verifying #1582, confirmed pre-existing there.

## Verdict: test bug, not an app bug

Both tests used `ensure_terminal()` to "switch to a terminal tab", but `ensure_terminal()` only **creates** a terminal when none exists — it does **not** change the active tab when a terminal is already open (the fresh app spawns one). So after opening the editor the editor tab stayed active, `editorStatus` **correctly** stayed populated, and the `editor_status() is None` waits timed out against a working app.

The app is correct: `FileEditor`'s `isVisible` effect already calls `setEditorStatus(null)` when the editor tab is no longer the active tab. Verified locally by driving the real flow — with a genuine terminal-tab switch the status bar clears and returns as expected.

## Fix

- Add a `switch_to_terminal_tab()` harness helper (`tabs.py`) that finds the `contentType == "terminal"` tab, clicks it, and waits for it to become active.
- Use it in both status-bar tests instead of `ensure_terminal()`.
- Add app-free unit tests for the helper (run in the non-integration CI lane).

No production/app code changed.

## Verification (local, macOS debug build — the integration lane is dark in CI, #1569)

- Before: `test_status_bar_items_hide_on_a_terminal_tab` and `test_status_bar_items_return_when_switching_back_to_the_editor` **FAILED** (timeout), the other editor status cases passed.
- After: full `-m integration -k editor` → all 8 `test_editor.py` cases **pass**.
- `-m "not integration" -k ui_helpers` → 11 passed (incl. the 2 new helper tests).

Closes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)