### PR TITLE
refactor(backend): share one file_name_of helper between transfer commands (Closes #1612)

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -8,6 +8,7 @@ use crate::files::sftp::{lock_session, ElevatedWriteResult, SftpManager, Writabi
 use crate::files::transfer::{self, TransferContext, TransferDirection, TransferRegistry};
 use crate::files::FileEntry;
 use crate::utils::errors::TerminalError;
+use crate::utils::fs::file_name_of;
 use crate::utils::vscode;
 
 /// Open a new SFTP session. Returns the session ID.
@@ -94,14 +95,6 @@ pub async fn sftp_check_writable(
     tokio::task::spawn_blocking(move || lock_session(&session)?.check_writable(&remote_path))
         .await
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
-}
-
-/// Extract the display file name from a path (falls back to the whole path).
-fn file_name_of(path: &str) -> String {
-    std::path::Path::new(path)
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| path.to_string())
 }
 
 /// Open a dedicated SFTP channel off `session` and (for downloads) stat the
@@ -541,40 +534,4 @@ pub fn write_cheatsheet(html: String, app: tauri::AppHandle) -> Result<String, S
         .to_str()
         .map(|s| s.to_string())
         .ok_or_else(|| "file path contains non-UTF-8 characters".to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::file_name_of;
-
-    #[test]
-    fn names_a_file_by_its_basename() {
-        assert_eq!(file_name_of("/home/testuser/report.csv"), "report.csv");
-        assert_eq!(file_name_of("/report.csv"), "report.csv");
-        assert_eq!(file_name_of("report.csv"), "report.csv");
-    }
-
-    #[test]
-    fn falls_back_to_the_whole_path_when_there_is_no_basename() {
-        assert_eq!(file_name_of("/"), "/");
-        assert_eq!(file_name_of(""), "");
-        assert_eq!(file_name_of(".."), "..");
-    }
-
-    /// Both transfer directions name the row from the *remote* path, so the
-    /// name always agrees with the `path` cell beside it. Feeding an upload the
-    /// destination path — rather than the local temp copy an SFTP→SFTP paste
-    /// reads from — is what keeps the scratch name off the row (#1573).
-    #[test]
-    fn names_a_paste_upload_after_the_destination_not_the_temp_copy() {
-        let temp_local = "/tmp/termihub-paste-1784278708447-report.csv";
-        let remote_dest = "/home/testuser/dest/report.csv";
-
-        assert_eq!(file_name_of(remote_dest), "report.csv");
-        assert_eq!(
-            file_name_of(temp_local),
-            "termihub-paste-1784278708447-report.csv",
-            "the temp basename is what the row must NOT show",
-        );
-    }
 }

--- a/src-tauri/src/commands/transfer.rs
+++ b/src-tauri/src/commands/transfer.rs
@@ -11,6 +11,8 @@ use tracing::debug;
 
 use crate::files::transfer::{TransferRegistry, TransferSnapshot};
 use crate::utils::errors::TerminalError;
+#[cfg(feature = "ftp")]
+use crate::utils::fs::file_name_of;
 
 /// Pause an in-flight transfer. Unknown ids are a no-op.
 #[tauri::command]
@@ -184,52 +186,5 @@ pub async fn ftp_upload(
         Err(TerminalError::ConnectionFailed(
             "FTP support is not built into this binary".to_string(),
         ))
-    }
-}
-
-/// Extract the display file name from a path (falls back to the whole path).
-#[cfg(feature = "ftp")]
-fn file_name_of(path: &str) -> String {
-    std::path::Path::new(path)
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| path.to_string())
-}
-
-#[cfg(all(test, feature = "ftp"))]
-mod tests {
-    use super::file_name_of;
-
-    #[test]
-    fn names_a_file_by_its_basename() {
-        assert_eq!(file_name_of("/home/testuser/report.csv"), "report.csv");
-        assert_eq!(file_name_of("/report.csv"), "report.csv");
-        assert_eq!(file_name_of("report.csv"), "report.csv");
-    }
-
-    #[test]
-    fn falls_back_to_the_whole_path_when_there_is_no_basename() {
-        assert_eq!(file_name_of("/"), "/");
-        assert_eq!(file_name_of(""), "");
-        assert_eq!(file_name_of(".."), "..");
-    }
-
-    /// `ftp_upload` and `ftp_download` both name the row from the *remote* path,
-    /// so a row's name always agrees with the `path` cell beside it (#1594,
-    /// mirroring #1573 for SFTP). An honest local→remote upload has equal local
-    /// and remote basenames, so the row is unchanged; only a caller uploading
-    /// from a scratch/temp local copy the user never named would differ, and
-    /// naming from the remote path keeps that scratch name off the row.
-    #[test]
-    fn names_an_upload_after_the_remote_destination_not_the_local_source() {
-        let temp_local = "/tmp/termihub-paste-1784278708447-report.csv";
-        let remote_dest = "/home/testuser/dest/report.csv";
-
-        assert_eq!(file_name_of(remote_dest), "report.csv");
-        assert_eq!(
-            file_name_of(temp_local),
-            "termihub-paste-1784278708447-report.csv",
-            "the local scratch basename is what the row must NOT show",
-        );
     }
 }

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -12,6 +12,19 @@ pub fn is_nonempty_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Extract the display file name from a path (falls back to the whole path).
+///
+/// Shared by the SFTP (`commands/files.rs`) and FTP (`commands/transfer.rs`)
+/// transfer commands, which name a Transfer Queue row from the basename of the
+/// path it displays so the name always agrees with the `path` cell beside it
+/// (#1573, #1594).
+pub fn file_name_of(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -42,5 +55,37 @@ mod tests {
     fn false_for_directory() {
         let tmp = tempfile::tempdir().unwrap();
         assert!(!is_nonempty_file(tmp.path()));
+    }
+
+    #[test]
+    fn file_name_of_names_a_file_by_its_basename() {
+        assert_eq!(file_name_of("/home/testuser/report.csv"), "report.csv");
+        assert_eq!(file_name_of("/report.csv"), "report.csv");
+        assert_eq!(file_name_of("report.csv"), "report.csv");
+    }
+
+    #[test]
+    fn file_name_of_falls_back_to_the_whole_path_when_there_is_no_basename() {
+        assert_eq!(file_name_of("/"), "/");
+        assert_eq!(file_name_of(""), "");
+        assert_eq!(file_name_of(".."), "..");
+    }
+
+    /// Both SFTP (#1573) and FTP (#1594) transfer directions name a row from the
+    /// *remote* path, so the name always agrees with the `path` cell beside it.
+    /// Feeding an upload the destination path — rather than the local temp copy
+    /// an SFTP→SFTP paste reads from — is what keeps the scratch name off the
+    /// row.
+    #[test]
+    fn file_name_of_names_a_paste_upload_after_the_destination_not_the_temp_copy() {
+        let temp_local = "/tmp/termihub-paste-1784278708447-report.csv";
+        let remote_dest = "/home/testuser/dest/report.csv";
+
+        assert_eq!(file_name_of(remote_dest), "report.csv");
+        assert_eq!(
+            file_name_of(temp_local),
+            "termihub-paste-1784278708447-report.csv",
+            "the temp basename is what the row must NOT show",
+        );
     }
 }


### PR DESCRIPTION
## What

`commands/files.rs` (SFTP) and `commands/transfer.rs` (FTP) each carried a **byte-for-byte identical** private `file_name_of(&str) -> String` helper. They converged only just now: #1573 (PR #1595) fixed `sftp_upload` and #1594 (PR #1611) fixed `ftp_upload`, both landing on the same rule — a transfer row's name is the basename of the path it displays. #1594 filed #1612 to dedupe once that happened.

## Change (pure refactor — no behaviour change)

- Extract a single `pub fn file_name_of` into `src-tauri/src/utils/fs.rs`, the existing home for small filesystem predicates shared across modules (alongside `is_nonempty_file`). Both command modules were already reaching into other things there, so neither reaches into the other.
- `files.rs` imports it unconditionally (SFTP call sites keep it live); `transfer.rs` imports it under `#[cfg(feature = "ftp")]` so the shared helper does not warn as dead code / unused import when `ftp` is off.
- The two identical `#[cfg(test)]` modules are folded into one set of unit tests against the shared helper in `fs.rs`.

The two helper bodies were confirmed identical before merging; the extracted function is the same code verbatim.

## Verification

- `cargo clippy -p termihub --all-targets` (default, ftp off) — clean, no unused-import warning.
- `cargo clippy -p termihub --all-targets --features ftp` — clean.
- `cargo test -p termihub --features ftp fs::` — all 7 tests pass (the 3 folded `file_name_of` cases plus the 4 pre-existing `is_nonempty_file` cases).
- `cargo fmt --check` — clean.

Closes #1612