### PR TITLE
feat(agent): surface the coordinated-update notice on other hosts (Closes #1602)

### DIFF
--- a/docs/changes/dev1/feature/1602-coordinated-update-notice.md
+++ b/docs/changes/dev1/feature/1602-coordinated-update-notice.md
@@ -1,7 +1,7 @@
 ## Added
 
 - **Coordinated agent updates:** when one host updates a remote agent configured
-  with the *Coordinated* strategy, every other connected host now sees a "being
+  with the _Coordinated_ strategy, every other connected host now sees a "being
   updated by another host" notice instead of an unexplained disconnect. The
   affected connection is suspended (the clean disconnect is the acknowledgement
   the updating host waits for) and automatically reconnects to the new version

--- a/docs/changes/dev1/feature/1602-coordinated-update-notice.md
+++ b/docs/changes/dev1/feature/1602-coordinated-update-notice.md
@@ -1,0 +1,11 @@
+## Added
+
+- **Coordinated agent updates:** when one host updates a remote agent configured
+  with the *Coordinated* strategy, every other connected host now sees a "being
+  updated by another host" notice instead of an unexplained disconnect. The
+  affected connection is suspended (the clean disconnect is the acknowledgement
+  the updating host waits for) and automatically reconnects to the new version
+  once the agent has restarted; sessions survive in detached daemons and resume
+  on reconnect. Applying a coordinated agent's staged self-update from the
+  update banner now routes through the coordinated path so other hosts are warned
+  first rather than hard-cut. (#1602)

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -199,6 +199,93 @@ pub async fn request_agent_deferred_update(
     .unwrap_or_else(|e| Err(e.to_string()))
 }
 
+/// Response to a coordinated-update request (`request_agent_update`, #1602).
+///
+/// Mirrors the agent's `agent.request_update` result (#1351): the apply outcome
+/// (`applied` / `active_sessions`) plus the coordination outcome (`notified_clients`
+/// / `all_acked` / `remaining_clients`), so the desktop can report *"3 hosts were
+/// notified, 1 was still connected"* rather than only "done".
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoordinatedUpdateResponse {
+    /// `true` if the agent was idle and applied the update immediately.
+    pub applied: bool,
+    /// Sessions still active on the agent (0 when applied immediately).
+    pub active_sessions: u32,
+    /// How many *other* hosts were sent the `agent.update_pending` notice.
+    pub notified_clients: u32,
+    /// `true` when every notified host disconnected inside the window (or there
+    /// was nobody to notify); `false` when the window closed with hosts still
+    /// attached, or when no host-wide view was available.
+    pub all_acked: bool,
+    /// `client_id`s still attached when the window closed. Empty on the happy path.
+    pub remaining_clients: Vec<String>,
+}
+
+/// Request a coordinated agent update (#1602, SI-5).
+///
+/// Sends `agent.request_update` over JSON-RPC (#1351). The agent broadcasts an
+/// `agent.update_pending` notice to every *other* connected host, gives them a
+/// window to disconnect cleanly, then applies the update through the same
+/// deferred-apply path as [`request_agent_deferred_update`] — never interrupting
+/// active sessions. When `binary_path` is omitted the agent applies an update it
+/// already staged itself (the coordinated self-update "Apply Now" path).
+///
+/// Note: when the agent applies immediately it re-execs the new binary, which
+/// tears down this connection — the caller should treat a subsequent disconnect
+/// as expected and reconnect to observe the new version.
+#[tauri::command]
+pub async fn request_agent_update(
+    agent_id: String,
+    binary_path: Option<String>,
+    version: Option<String>,
+    agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
+) -> Result<CoordinatedUpdateResponse, String> {
+    info!(agent_id, "Requesting coordinated agent update");
+    let manager = agent_manager.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut params = serde_json::Map::new();
+        if let Some(path) = binary_path {
+            params.insert("binaryPath".to_string(), Value::String(path));
+        }
+        if let Some(v) = version {
+            params.insert("version".to_string(), Value::String(v));
+        }
+        let result = manager
+            .send_request(&agent_id, "agent.request_update", Value::Object(params))
+            .map_err(|e| e.to_string())?;
+        Ok(CoordinatedUpdateResponse {
+            applied: result
+                .get("applied")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            active_sessions: result
+                .get("activeSessions")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+            notified_clients: result
+                .get("notifiedClients")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32,
+            all_acked: result
+                .get("allAcked")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            remaining_clients: result
+                .get("remainingClients")
+                .and_then(Value::as_array)
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        })
+    })
+    .await
+    .unwrap_or_else(|e| Err(e.to_string()))
+}
+
 /// Close a session on a remote agent.
 ///
 /// Sends `connection.close` over JSON-RPC to the agent, then the agent

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -741,6 +741,7 @@ pub fn run() {
             commands::agent::get_agent_capabilities,
             commands::agent::apply_agent_settings,
             commands::agent::request_agent_deferred_update,
+            commands::agent::request_agent_update,
             commands::agent::list_agent_sessions,
             commands::agent::close_agent_session,
             commands::agent::list_agent_definitions,

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -1602,6 +1602,30 @@ fn emit_agent_update_available(app_handle: &AppHandle, agent_id: &str, params: &
     );
 }
 
+/// Forward an agent's `agent.update_pending` notification to the frontend as the
+/// `remote-agent-update-pending` Tauri event (#1602). Broadcast by the agent to
+/// every *other* connected host when one host initiates a coordinated update
+/// (#1351): this desktop is being cut over, so the frontend surfaces the "being
+/// updated by another host" notice, suspends the affected session and queues an
+/// auto-reconnect. Tagged with the `agent_id` so the notice keys off it exactly
+/// like the deferred-update banner.
+fn emit_remote_agent_update_pending(app_handle: &AppHandle, agent_id: &str, params: &Value) {
+    let _ = app_handle.emit(
+        "remote-agent-update-pending",
+        serde_json::json!({
+            "agent_id": agent_id,
+            "requestedByVersion": params
+                .get("requestedByVersion")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown"),
+            "estimatedRestartSecs": params
+                .get("estimatedRestartSecs")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+        }),
+    );
+}
+
 // ── Async I/O task ───────────────────────────────────────────────────
 
 /// Main async I/O task for an agent connection.
@@ -1748,6 +1772,13 @@ async fn agent_io_task(
                                     Ok(jsonrpc::JsonRpcMessage::Notification { method, params }) => {
                                         if method == "agent.update_available" {
                                             emit_agent_update_available(
+                                                &app_handle,
+                                                &agent_id,
+                                                &params,
+                                            );
+                                        }
+                                        if method == "agent.update_pending" {
+                                            emit_remote_agent_update_pending(
                                                 &app_handle,
                                                 &agent_id,
                                                 &params,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { useTransferEvents } from "@/hooks/useTransferEvents";
 import { useEmbeddedServerEvents } from "@/hooks/useEmbeddedServerEvents";
 import { useCredentialStoreEvents } from "@/hooks/useCredentialStoreEvents";
 import { useAgentUpdateEvents } from "@/hooks/useAgentUpdateEvents";
+import { useAgentUpdatePendingEvents } from "@/hooks/useAgentUpdatePendingEvents";
 import { useSpawnChoiceHandler, useSpawnRequests } from "@/hooks/useSpawnRequests";
 import { useHttpMonitorNotifications } from "@/hooks/useHttpMonitorNotifications";
 import { useWebviewZoom } from "@/hooks/useWebviewZoom";
@@ -110,6 +111,7 @@ function App() {
   useEmbeddedServerEvents();
   useCredentialStoreEvents();
   useAgentUpdateEvents();
+  useAgentUpdatePendingEvents();
   useSpawnRequests();
   useHttpMonitorNotifications();
   useWebviewZoom();

--- a/src/components/AgentUpdateBanner/AgentUpdateBanner.test.tsx
+++ b/src/components/AgentUpdateBanner/AgentUpdateBanner.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/services/api", async (importOriginal) => {
   return {
     ...actual,
     requestAgentDeferredUpdate: vi.fn(),
+    requestAgentUpdate: vi.fn(),
   };
 });
 
@@ -137,5 +138,57 @@ describe("AgentUpdateBanner", () => {
     expect(byTestId(bannerId)).toBeNull();
     expect(mockedApi.requestAgentDeferredUpdate).not.toHaveBeenCalled();
     expect(useAppStore.getState().agentUpdatesDismissed[AGENT_ID]).toBe(true);
+  });
+
+  describe("coordinated strategy (#1602)", () => {
+    function seedCoordinatedAgent(): void {
+      useAppStore.setState({
+        remoteAgents: [
+          {
+            id: AGENT_ID,
+            name: AGENT_NAME,
+            config: { updateStrategy: "coordinated" },
+          },
+        ] as unknown as ReturnType<typeof useAppStore.getState>["remoteAgents"],
+      });
+    }
+
+    it("routes Apply Now through agent.request_update, not the deferred RPC", async () => {
+      seedCoordinatedAgent();
+      mockedApi.requestAgentUpdate.mockResolvedValue({
+        applied: true,
+        activeSessions: 0,
+        notifiedClients: 2,
+        allAcked: true,
+        remainingClients: [],
+      });
+      await render();
+      await act(async () => {
+        byTestId(applyId)?.click();
+      });
+      expect(mockedApi.requestAgentUpdate).toHaveBeenCalledWith(AGENT_ID);
+      expect(mockedApi.requestAgentDeferredUpdate).not.toHaveBeenCalled();
+      // The success notice mentions the hosts that were warned.
+      expect(toastMocks.success).toHaveBeenCalledTimes(1);
+      expect(toastMocks.success.mock.calls[0][0]).toContain("2");
+    });
+
+    it("shows the deferred message when the coordinated apply is deferred", async () => {
+      seedCoordinatedAgent();
+      mockedApi.requestAgentUpdate.mockResolvedValue({
+        applied: false,
+        activeSessions: 4,
+        notifiedClients: 1,
+        allAcked: true,
+        remainingClients: [],
+      });
+      await render();
+      await act(async () => {
+        byTestId(applyId)?.click();
+      });
+      expect(toastMocks.info).toHaveBeenCalledTimes(1);
+      expect(toastMocks.info.mock.calls[0][0]).toContain("4");
+      expect(toastMocks.success).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/AgentUpdateBanner/AgentUpdateBanner.tsx
+++ b/src/components/AgentUpdateBanner/AgentUpdateBanner.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { ArrowUpCircle } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { Button, toast } from "@/components/ui";
-import { requestAgentDeferredUpdate } from "@/services/api";
+import { requestAgentDeferredUpdate, requestAgentUpdate } from "@/services/api";
 import "./AgentUpdateBanner.css";
 
 /** Props for {@link AgentUpdateBanner}. */
@@ -48,9 +48,35 @@ export function AgentUpdateBanner({ agentId, agentName }: AgentUpdateBannerProps
   const update = useAppStore((s) => s.agentUpdates[agentId]);
   const dismissed = useAppStore((s) => s.agentUpdatesDismissed[agentId] ?? false);
   const dismissAgentUpdate = useAppStore((s) => s.dismissAgentUpdate);
+  // A coordinated-strategy agent stages its self-update and waits for a
+  // coordinated apply (#1351): "Apply Now" must go through `agent.request_update`
+  // so every *other* connected host is warned and given a clean disconnect
+  // window, rather than hard-cut by the plain deferred apply (#1602).
+  const isCoordinated = useAppStore(
+    (s) => s.remoteAgents.find((a) => a.id === agentId)?.config.updateStrategy === "coordinated"
+  );
 
   const handleApply = useCallback(async () => {
     try {
+      if (isCoordinated) {
+        const result = await requestAgentUpdate(agentId);
+        if (result.applied) {
+          const n = result.notifiedClients;
+          toast.success(
+            n > 0
+              ? `Agent updating — ${n} other host${n === 1 ? "" : "s"} notified. Reconnecting…`
+              : "Agent updated — reconnecting…"
+          );
+        } else {
+          const n = result.activeSessions;
+          toast.info(
+            `Update deferred — it will be applied automatically when the last of ${n} active ` +
+              `session${n === 1 ? "" : "s"} disconnects.`
+          );
+        }
+        dismissAgentUpdate(agentId);
+        return;
+      }
       const result = await requestAgentDeferredUpdate(agentId);
       if (result.applied) {
         toast.success("Agent updated — reconnecting…");
@@ -74,7 +100,7 @@ export function AgentUpdateBanner({ agentId, agentName }: AgentUpdateBannerProps
       // error toast and returns to idle.
       throw err;
     }
-  }, [agentId, dismissAgentUpdate]);
+  }, [agentId, dismissAgentUpdate, isCoordinated]);
 
   const handleDismiss = useCallback(() => {
     dismissAgentUpdate(agentId);

--- a/src/hooks/useAgentUpdatePendingEvents.ts
+++ b/src/hooks/useAgentUpdatePendingEvents.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useAppStore } from "@/store/appStore";
+import { onRemoteAgentUpdatePending } from "@/services/events";
+
+/**
+ * Hook that bridges backend `remote-agent-update-pending` events (#1602) to the
+ * store's coordinated-update handling. Each event is an agent's
+ * `agent.update_pending` notification — broadcast when *another* host initiates
+ * a coordinated update (#1351) — forwarded by the desktop backend. Handling it
+ * shows the "being updated by another host" notice, suspends the affected agent
+ * connection (the disconnect is the ack) and queues an auto-reconnect to the new
+ * version.
+ */
+export function useAgentUpdatePendingEvents(): void {
+  const handleAgentUpdatePending = useAppStore((s) => s.handleAgentUpdatePending);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+
+    const setup = async () => {
+      unlisten = await onRemoteAgentUpdatePending((pending) => {
+        handleAgentUpdatePending(
+          pending.agentId,
+          pending.requestedByVersion,
+          pending.estimatedRestartSecs
+        );
+      });
+    };
+
+    void setup();
+
+    return () => {
+      unlisten?.();
+    };
+  }, [handleAgentUpdatePending]);
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1292,6 +1292,46 @@ export async function requestAgentDeferredUpdate(
   });
 }
 
+/** Outcome of a coordinated agent-update request (#1602 / #1351, SI-5). */
+export interface AgentCoordinatedUpdateResult {
+  /**
+   * `true` when the agent was idle and applied the update immediately (the
+   * connection is expected to drop as the binary swaps); `false` when the update
+   * was deferred until the last of `activeSessions` disconnects.
+   */
+  applied: boolean;
+  /** Number of active sessions the update will wait on when `applied` is false. */
+  activeSessions: number;
+  /** How many *other* connected hosts were sent the `agent.update_pending` notice. */
+  notifiedClients: number;
+  /**
+   * `true` when every notified host disconnected inside the window (or there was
+   * nobody to notify); `false` when the window closed with hosts still attached.
+   */
+  allAcked: boolean;
+  /** Hosts still attached when the coordination window closed. Empty on success. */
+  remainingClients: string[];
+}
+
+/**
+ * Request a coordinated agent update (#1602 / #1351, SI-5). The agent broadcasts
+ * an `agent.update_pending` notice to every *other* connected host, gives them a
+ * window to disconnect cleanly, then applies through the deferred-apply path —
+ * never interrupting active sessions. Omit `binaryPath` to apply the agent's
+ * already-staged pending update (the coordinated "Apply Now" path).
+ */
+export async function requestAgentUpdate(
+  agentId: string,
+  binaryPath?: string,
+  version?: string
+): Promise<AgentCoordinatedUpdateResult> {
+  return await invoke<AgentCoordinatedUpdateResult>("request_agent_update", {
+    agentId,
+    binaryPath,
+    version,
+  });
+}
+
 /** Disconnect from a remote agent. */
 export async function disconnectAgent(agentId: string): Promise<void> {
   await invoke("disconnect_agent", { agentId });

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -396,16 +396,13 @@ export interface RemoteAgentUpdatePending {
 export async function onRemoteAgentUpdatePending(
   callback: (pending: RemoteAgentUpdatePending) => void
 ): Promise<UnlistenFn> {
-  return await listen<RemoteAgentUpdatePendingPayload>(
-    "remote-agent-update-pending",
-    (event) => {
-      callback({
-        agentId: event.payload.agent_id,
-        requestedByVersion: event.payload.requestedByVersion,
-        estimatedRestartSecs: event.payload.estimatedRestartSecs,
-      });
-    }
-  );
+  return await listen<RemoteAgentUpdatePendingPayload>("remote-agent-update-pending", (event) => {
+    callback({
+      agentId: event.payload.agent_id,
+      requestedByVersion: event.payload.requestedByVersion,
+      estimatedRestartSecs: event.payload.estimatedRestartSecs,
+    });
+  });
 }
 
 interface VscodeEditCompletePayload {

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -363,6 +363,51 @@ export async function onAgentUpdateAvailable(
   });
 }
 
+/**
+ * Payload of a `remote-agent-update-pending` event (#1602). The desktop backend
+ * forwards the agent's `agent.update_pending` JSON-RPC notification — broadcast
+ * by the agent to every *other* connected host when one host initiates a
+ * coordinated update (#1351) — tagged with the originating `agent_id`.
+ */
+interface RemoteAgentUpdatePendingPayload {
+  agent_id: string;
+  requestedByVersion: string;
+  estimatedRestartSecs: number;
+}
+
+/**
+ * A coordinated update in progress on an agent, initiated by another host,
+ * keyed to the agent whose connection is being cut over.
+ */
+export interface RemoteAgentUpdatePending {
+  agentId: string;
+  /** Version of the desktop that requested the update (`"unknown"` if unread). */
+  requestedByVersion: string;
+  /** How long the agent expects to be unavailable, for the restart progress. */
+  estimatedRestartSecs: number;
+}
+
+/**
+ * Subscribe to `agent.update_pending` notifications forwarded by the backend as
+ * `remote-agent-update-pending` Tauri events (#1602). Fires on a host *other*
+ * than the one initiating a coordinated update; the frontend suspends the
+ * affected session and queues an auto-reconnect. Returns the unlisten handle.
+ */
+export async function onRemoteAgentUpdatePending(
+  callback: (pending: RemoteAgentUpdatePending) => void
+): Promise<UnlistenFn> {
+  return await listen<RemoteAgentUpdatePendingPayload>(
+    "remote-agent-update-pending",
+    (event) => {
+      callback({
+        agentId: event.payload.agent_id,
+        requestedByVersion: event.payload.requestedByVersion,
+        estimatedRestartSecs: event.payload.estimatedRestartSecs,
+      });
+    }
+  );
+}
+
 interface VscodeEditCompletePayload {
   remotePath: string;
   success: boolean;

--- a/src/services/events.updatePending.test.ts
+++ b/src/services/events.updatePending.test.ts
@@ -19,10 +19,7 @@ describe("onRemoteAgentUpdatePending (#1602)", () => {
 
     const result = await onRemoteAgentUpdatePending(vi.fn());
 
-    expect(mockedListen).toHaveBeenCalledWith(
-      "remote-agent-update-pending",
-      expect.any(Function)
-    );
+    expect(mockedListen).toHaveBeenCalledWith("remote-agent-update-pending", expect.any(Function));
     expect(result).toBe(unlisten);
   });
 

--- a/src/services/events.updatePending.test.ts
+++ b/src/services/events.updatePending.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { listen } from "@tauri-apps/api/event";
+import { onRemoteAgentUpdatePending } from "./events";
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}));
+
+const mockedListen = vi.mocked(listen);
+
+describe("onRemoteAgentUpdatePending (#1602)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers a listener on the remote-agent-update-pending event", async () => {
+    const unlisten = vi.fn();
+    mockedListen.mockResolvedValue(unlisten);
+
+    const result = await onRemoteAgentUpdatePending(vi.fn());
+
+    expect(mockedListen).toHaveBeenCalledWith(
+      "remote-agent-update-pending",
+      expect.any(Function)
+    );
+    expect(result).toBe(unlisten);
+  });
+
+  it("maps the snake_case agent id and camelCase payload fields", async () => {
+    let captured: ((event: unknown) => void) | undefined;
+    mockedListen.mockImplementation((_event, handler) => {
+      captured = handler as (event: unknown) => void;
+      return Promise.resolve(vi.fn());
+    });
+
+    const callback = vi.fn();
+    await onRemoteAgentUpdatePending(callback);
+
+    captured!({
+      payload: {
+        agent_id: "agent-7",
+        requestedByVersion: "1.4.0",
+        estimatedRestartSecs: 5,
+      },
+    });
+
+    expect(callback).toHaveBeenCalledWith({
+      agentId: "agent-7",
+      requestedByVersion: "1.4.0",
+      estimatedRestartSecs: 5,
+    });
+  });
+});

--- a/src/store/appStore.agentUpdatePending.test.ts
+++ b/src/store/appStore.agentUpdatePending.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useAppStore } from "@/store/appStore";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  loading: vi.fn(),
+  dismiss: vi.fn(),
+  promise: vi.fn(),
+}));
+
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return { ...actual, toast: toastMocks };
+});
+
+const AGENT_ID = "agent-1";
+
+function seedAgent(): void {
+  const agent = {
+    id: AGENT_ID,
+    name: "prod-box",
+    config: { host: "h", port: 22, username: "u", authMethod: "key" },
+  } as unknown as RemoteAgentDefinition;
+  useAppStore.setState({ remoteAgents: [agent] });
+}
+
+describe("handleAgentUpdatePending (coordinated-update notice, #1602)", () => {
+  let disconnect: ReturnType<typeof vi.fn>;
+  let connect: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useAppStore.setState(useAppStore.getInitialState());
+    seedAgent();
+    // Isolate the orchestration from the real connect/disconnect (which hit the
+    // Tauri API) by overriding them with spies on the store instance.
+    disconnect = vi.fn().mockResolvedValue(undefined);
+    connect = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({
+      disconnectRemoteAgent: disconnect as unknown as (agentId: string) => Promise<void>,
+      connectRemoteAgent: connect as unknown as (
+        agentId: string,
+        password?: string
+      ) => Promise<void>,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("records the pending notice, suspends the connection, and shows the notice", () => {
+    useAppStore.getState().handleAgentUpdatePending(AGENT_ID, "1.4.0", 5);
+
+    const pending = useAppStore.getState().agentUpdatePending[AGENT_ID];
+    expect(pending).toBeDefined();
+    expect(pending.requestedByVersion).toBe("1.4.0");
+    expect(pending.estimatedRestartSecs).toBe(5);
+
+    // Disconnecting is the ack the updating host waits for.
+    expect(disconnect).toHaveBeenCalledWith(AGENT_ID);
+    // A loading toast surfaces the in-progress suspend.
+    expect(toastMocks.loading).toHaveBeenCalledTimes(1);
+    // The reconnect has not fired yet.
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("queues an auto-reconnect after the restart window (estimate + buffer)", async () => {
+    useAppStore.getState().handleAgentUpdatePending(AGENT_ID, "1.4.0", 5);
+
+    // estimate 5s + 3s buffer = 8s. Just before the window, nothing reconnects.
+    await vi.advanceTimersByTimeAsync(7000);
+    expect(connect).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(connect).toHaveBeenCalledWith(AGENT_ID);
+    // The notice clears once the reconnect is initiated.
+    expect(useAppStore.getState().agentUpdatePending[AGENT_ID]).toBeUndefined();
+  });
+
+  it("resolves the notice to success once the reconnect settles", async () => {
+    useAppStore.getState().handleAgentUpdatePending(AGENT_ID, "1.4.0", 5);
+    await vi.advanceTimersByTimeAsync(8000);
+    // Let the connect promise resolve.
+    await vi.runAllTimersAsync();
+    expect(toastMocks.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an error toast when the reconnect fails", async () => {
+    connect.mockRejectedValueOnce(new Error("host down"));
+    useAppStore.getState().handleAgentUpdatePending(AGENT_ID, "1.4.0", 5);
+    await vi.advanceTimersByTimeAsync(8000);
+    await vi.runAllTimersAsync();
+    expect(toastMocks.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a duplicate notice while an agent is already suspended", () => {
+    useAppStore.getState().handleAgentUpdatePending(AGENT_ID, "1.4.0", 5);
+    useAppStore.getState().handleAgentUpdatePending(AGENT_ID, "1.4.0", 5);
+    // Only the first notice suspends + toasts.
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(toastMocks.loading).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconnect if the notice was cleared before the window elapsed", async () => {
+    useAppStore.getState().handleAgentUpdatePending(AGENT_ID, "1.4.0", 5);
+    useAppStore.getState().clearAgentUpdatePending(AGENT_ID);
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("floors a zero restart estimate so the reconnect still queues", async () => {
+    useAppStore.getState().handleAgentUpdatePending(AGENT_ID, "unknown", 0);
+    // max(0,1) + 3 = 4s.
+    await vi.advanceTimersByTimeAsync(3999);
+    expect(connect).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(connect).toHaveBeenCalledWith(AGENT_ID);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -310,6 +310,30 @@ export interface AgentPendingUpdate {
   staged: boolean;
 }
 
+/**
+ * A coordinated update in progress on an agent, initiated by *another* host
+ * (#1602). Recorded per agent id from the `agent.update_pending` notification so
+ * the "being updated by another host" notice can show restart progress while the
+ * connection is suspended and a reconnect is queued.
+ */
+export interface AgentUpdatePending {
+  /** Version of the desktop that requested the update (`"unknown"` if unread). */
+  requestedByVersion: string;
+  /** The agent's estimate of how long it will be unavailable, in seconds. */
+  estimatedRestartSecs: number;
+  /** `Date.now()` when the notice arrived — drives the restart progress bar. */
+  since: number;
+}
+
+/**
+ * Extra seconds added to the agent's own restart estimate before the queued
+ * auto-reconnect fires (#1602). The agent only begins its restart once every
+ * host has disconnected (or a 10 s window closes), so reconnecting exactly at
+ * the estimate would race the process still coming up; a small buffer avoids a
+ * wasted failing attempt.
+ */
+const AGENT_UPDATE_RECONNECT_BUFFER_SECS = 3;
+
 interface AppState {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
@@ -905,6 +929,21 @@ interface AppState {
   setAgentUpdateAvailable: (agentId: string, update: AgentPendingUpdate) => void;
   /** Hide the deferred-update banner for an agent for this session. */
   dismissAgentUpdate: (agentId: string) => void;
+  /**
+   * Coordinated updates in progress on an agent, initiated by another host,
+   * from `agent.update_pending` (#1602). Keyed by agent id.
+   */
+  agentUpdatePending: Record<string, AgentUpdatePending>;
+  /**
+   * Handle an incoming `agent.update_pending` (#1602): record the notice,
+   * suspend the affected agent connection (the disconnect *is* the ack the
+   * updating host waits for), and queue an auto-reconnect to the new version
+   * once the agent's restart window has elapsed. Sessions survive in detached
+   * daemons and are recovered on reconnect, so only the connection is suspended.
+   */
+  handleAgentUpdatePending: (agentId: string, requestedByVersion: string, estimatedRestartSecs: number) => void;
+  /** Clear a recorded coordinated-update-pending notice for an agent. */
+  clearAgentUpdatePending: (agentId: string) => void;
   addRemoteAgent: (agent: RemoteAgentDefinition) => void;
   updateRemoteAgent: (agent: RemoteAgentDefinition) => void;
   deleteRemoteAgent: (agentId: string) => void;
@@ -4144,6 +4183,70 @@ export const useAppStore = create<AppState>((set, get) => {
       set((s) => ({
         agentUpdatesDismissed: { ...s.agentUpdatesDismissed, [agentId]: true },
       }));
+    },
+
+    agentUpdatePending: {},
+
+    handleAgentUpdatePending: (agentId, requestedByVersion, estimatedRestartSecs) => {
+      // Ignore a duplicate notice for an agent already suspended for this
+      // coordinated update — its reconnect is already queued.
+      if (get().agentUpdatePending[agentId]) return;
+
+      const agentName =
+        get().remoteAgents.find((a) => a.id === agentId)?.name ?? "Agent";
+      const toastId = `agent-update-pending-${agentId}`;
+
+      set((s) => ({
+        agentUpdatePending: {
+          ...s.agentUpdatePending,
+          [agentId]: { requestedByVersion, estimatedRestartSecs, since: Date.now() },
+        },
+      }));
+
+      // Surface the "being updated by another host" notice. A loading toast is
+      // the design system's long-running-work affordance (the "reactive"
+      // pillar): it shows the suspend/restart is in progress and resolves in
+      // place to success/error when the reconnect settles.
+      toast.loading(`${agentName} is being updated by another host…`, {
+        id: toastId,
+        description: "Sessions are paused briefly and reconnect automatically.",
+      });
+
+      // Suspend the connection: disconnecting is the ack the updating host waits
+      // for (there is no reply frame — see docs/remote-protocol.md
+      // `agent.update_pending`). Sessions live on in detached daemons and are
+      // recovered on reconnect, so only the transport goes away here.
+      void get().disconnectRemoteAgent(agentId);
+
+      // Queue the auto-reconnect once the agent has had its restart window.
+      const delayMs =
+        (Math.max(estimatedRestartSecs, 1) + AGENT_UPDATE_RECONNECT_BUFFER_SECS) * 1000;
+      setTimeout(() => {
+        // Skip if the notice was cleared meanwhile (e.g. a manual reconnect).
+        if (!get().agentUpdatePending[agentId]) return;
+        get().clearAgentUpdatePending(agentId);
+        get()
+          .connectRemoteAgent(agentId)
+          .then(() => {
+            toast.success(`${agentName} reconnected to the updated version.`, {
+              id: toastId,
+            });
+          })
+          .catch(() => {
+            toast.error(`Couldn't reconnect to ${agentName} after the update.`, {
+              id: toastId,
+            });
+          });
+      }, delayMs);
+    },
+
+    clearAgentUpdatePending: (agentId) => {
+      set((s) => {
+        if (!(agentId in s.agentUpdatePending)) return {};
+        const next = { ...s.agentUpdatePending };
+        delete next[agentId];
+        return { agentUpdatePending: next };
+      });
     },
 
     addRemoteAgent: (agent) => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -941,7 +941,11 @@ interface AppState {
    * once the agent's restart window has elapsed. Sessions survive in detached
    * daemons and are recovered on reconnect, so only the connection is suspended.
    */
-  handleAgentUpdatePending: (agentId: string, requestedByVersion: string, estimatedRestartSecs: number) => void;
+  handleAgentUpdatePending: (
+    agentId: string,
+    requestedByVersion: string,
+    estimatedRestartSecs: number
+  ) => void;
   /** Clear a recorded coordinated-update-pending notice for an agent. */
   clearAgentUpdatePending: (agentId: string) => void;
   addRemoteAgent: (agent: RemoteAgentDefinition) => void;
@@ -4192,8 +4196,7 @@ export const useAppStore = create<AppState>((set, get) => {
       // coordinated update — its reconnect is already queued.
       if (get().agentUpdatePending[agentId]) return;
 
-      const agentName =
-        get().remoteAgents.find((a) => a.id === agentId)?.name ?? "Agent";
+      const agentName = get().remoteAgents.find((a) => a.id === agentId)?.name ?? "Agent";
       const toastId = `agent-update-pending-${agentId}`;
 
       set((s) => ({


### PR DESCRIPTION
Completes the desktop/UI half of SI-5 (Approach 3), building on the agent half that #1351 (PR #1603) landed. When one host initiates a coordinated update, the agent broadcasts `agent.update_pending` to every other connected host through the registry daemon; before this PR the desktop dropped that notification on the floor, so other hosts still saw an unexplained disconnect.

## What landed

**Receiver side (the notice)** — mirrors the existing `agent.update_available` -> `agent-update-available` -> banner path (#1352):

- `agent_manager.rs` bridges `agent.update_pending` to a new `remote-agent-update-pending` Tauri event (next to `emit_agent_update_available`).
- `services/events.ts` subscribes via `onRemoteAgentUpdatePending`, mirroring `onAgentUpdateAvailable`.
- A new `agentUpdatePending` store slice + `handleAgentUpdatePending` action **suspends** the affected agent connection (the clean disconnect **is** the ack the updating host waits for — there is no reply frame) and **queues an auto-reconnect** once the restart window (estimate + a small buffer) elapses. Sessions survive in detached daemons and resume on reconnect, so only the transport goes away.
- Feedback follows the design system: a `toast.loading` for the in-progress suspend that resolves in place to success/error when the reconnect settles, rather than a bespoke progress component.

**Initiation (routing coordinated to the new RPC)**:

- New `request_agent_update` Tauri command + `requestAgentUpdate` API wrapper over the `agent.request_update` RPC (#1351), surfacing the coordination outcome (`notifiedClients` / `allAcked` / `remainingClients`).
- The `AgentUpdateBanner`'s **Apply Now** now routes a *coordinated*-strategy agent's staged self-update through `agent.request_update` instead of the plain deferred apply, so every other host is warned and given a clean disconnect window rather than hard-cut. This is the production trigger that makes the notice fire, following the agent's actual coordinated architecture (`agent/src/update/mod.rs` stages a coordinated self-update and awaits `agent.request_update`).

## Scope split — the desktop-push deploy routing is deferred to #1616

This issue's checklist also lists flipping `RemoteAgentConfig::effective_update_strategy` and routing the **desktop-push** Update deploy (`run_update_agent`) through the RPC. That is a genuinely separate, cross-platform change, not a match-arm flip: the deploy order is shutdown -> upload -> install, but `agent.request_update` fuses coordinate + apply and needs the binary staged **first** (upload -> `request_update{binaryPath}`), and the agent's apply-from-path swap + re-exec is **Unix-only** (`agent/src/update/apply.rs`), so Windows must fall back to immediate. Bundling that here would risk the deploy path and the review. It is filed as #1616 (Ready2Implement) with the full design. The coordinated **notice** — this issue's primary deliverable and acceptance criterion — is complete end to end via the self-update path.

## Tests

Vitest, verified **red under mutation** (neutered reconnect; forced non-coordinated routing):

- Event payload mapping (`onRemoteAgentUpdatePending`).
- Store orchestration: records the notice, suspends, queues the reconnect at estimate + buffer, resolves the toast to success/error, the duplicate-notice guard, the cleared-before-window case, and the zero-estimate floor.
- Banner routes a coordinated agent through `agent.request_update` (not the deferred RPC) with the right notices.

`npx tsc --noEmit`, `pnpm lint`, `pnpm format:check`, `cargo fmt --check`, and `cargo clippy -p termihub --all-targets` all clean. The Rust diff is additive (event bridge + command) and does not touch the intermittently-red agent integration tests.

Closes #1602