### PR TITLE
test(sftp): tolerate self-resolving password prompt (Closes #1593)

### DIFF
--- a/tests/system/termihub_harness/ui/passwordprompt.py
+++ b/tests/system/termihub_harness/ui/passwordprompt.py
@@ -8,6 +8,7 @@ password-auth suites drive it directly.
 
 from __future__ import annotations
 
+from ..bridge import BridgeError
 from ..fixtures import SSH_PASSWORD
 from .base import HarnessMixin
 
@@ -20,13 +21,48 @@ class PasswordPromptUi(HarnessMixin):
         return bool(self.driver.get_state("passwordPromptOpen"))
 
     def handle_password_prompt(self, password: str = SSH_PASSWORD) -> None:
-        """Wait for the password prompt, enter ``password``, and click Connect."""
-        self.wait(
-            lambda: self.driver.exists("password-prompt-input"),
-            what="the SSH password prompt",
-        )
-        self.driver.type("password-prompt-input", password)
-        self.driver.click("password-prompt-connect")
+        """Wait for the SSH password prompt, enter ``password``, and click Connect.
+
+        Tolerant of the prompt resolving on its own: an auto-connecting SFTP
+        browser can authenticate from a credential cached by an earlier connect
+        and unmount the modal between our checks, leaving nothing to click
+        (#1593). The answer is therefore driven from ``passwordPromptOpen`` — the
+        store's authoritative liveness signal — inside a single poll:
+
+        * while the prompt has not opened yet, keep waiting (callers connect first
+          and answer immediately, before the modal has mounted);
+        * once it is open, type the password and click Connect;
+        * a modal that closes on its own after we have seen it open — before or
+          during the answer gesture — counts as answered, not failed.
+
+        Only a prompt that is still open when the click errors is a real failure.
+        The caller then waits on the real connected signal, so a self-resolved
+        prompt lands in the same success state as one we answered.
+        """
+        seen_open = False
+
+        def answered() -> bool:
+            nonlocal seen_open
+            if not self.password_prompt_open():
+                # Not open: either not raised yet (keep waiting) or, once we have
+                # seen it, resolved on its own (#1593) — which is success.
+                return seen_open
+            seen_open = True
+            if not self.driver.exists("password-prompt-connect"):
+                return False  # modal still mounting; answer once its button is live
+            try:
+                self.driver.type("password-prompt-input", password)
+                self.driver.click("password-prompt-connect")
+            except BridgeError:
+                # The modal unmounted mid-answer as the session authenticated from
+                # a cached credential — success. A prompt that is still open when
+                # the gesture errors is a genuine failure, so re-raise.
+                if self.password_prompt_open():
+                    raise
+                return True
+            return True
+
+        self.wait(answered, what="the SSH password prompt")
 
     def cancel_password_prompt(self) -> None:
         """Dismiss the password prompt without connecting."""

--- a/tests/system/termihub_harness/ui/sftp.py
+++ b/tests/system/termihub_harness/ui/sftp.py
@@ -27,6 +27,7 @@ class SftpUi(FileBrowserPathReads):
     if TYPE_CHECKING:  # borrowed from the mixins suites combine this with
         def switch_to_files_sidebar(self) -> None: ...
         def handle_password_prompt(self, password: str = ...) -> None: ...
+        def password_prompt_open(self) -> bool: ...
 
     def connect_sftp_browser(self, password: str = SSH_PASSWORD) -> str:
         """Open the file browser for the active SSH tab and wait for its path.
@@ -42,7 +43,10 @@ class SftpUi(FileBrowserPathReads):
             or self.driver.exists(self.CURRENT_PATH),
             what="the SFTP browser or its password prompt",
         )
-        if self.driver.exists("password-prompt-input"):
+        # Gate on the store's liveness signal, not a stale DOM check: the prompt
+        # can auto-resolve from a cached credential, and ``handle_password_prompt``
+        # then tolerates it closing under us (#1593).
+        if self.password_prompt_open():
             self.handle_password_prompt(password)
         return self.wait(
             lambda: self.file_browser_path() or None,

--- a/tests/system/tests/test_password_prompt.py
+++ b/tests/system/tests/test_password_prompt.py
@@ -1,0 +1,166 @@
+"""Unit tests for the SSH password-prompt helper (issue #1593).
+
+Machinery group (no app): a stub driver models the password-prompt modal so
+these run anywhere without a build, like the ``test_ui_helpers`` lookups.
+
+The regression these lock down (#1593): an auto-connecting SFTP browser can
+authenticate from a credential cached by an earlier connect and unmount the
+modal *between* the harness's checks. The old ``handle_password_prompt`` waited
+for the input, then typed and clicked Connect unconditionally — so a modal that
+resolved itself mid-gesture died with ``no element with
+data-testid="password-prompt-connect"``. The helper must now treat a prompt that
+closes on its own as answered, while still waiting for a prompt that has not
+appeared yet (every SSH suite connects first and answers immediately).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from termihub_harness import PasswordPromptUi
+from termihub_harness.bridge import BridgeError
+
+PASSWORD = "hunter2"
+
+
+class PromptDriver:
+    """Driver stub modelling the SSH password-prompt modal for the helper.
+
+    ``passwordPromptOpen`` (served via ``get_state``) is the authoritative
+    liveness signal the helper drives from; the connect button and input mount
+    with it. Hooks let a test unmount the modal mid-answer to reproduce #1593:
+
+    * ``appear_after`` — polls the modal stays closed before it opens (a connect
+      that has not raised the prompt yet).
+    * ``connect_present`` — whether the Connect button is in the DOM while open.
+    * ``close_after_exists`` — close the modal once ``exists`` has been polled N
+      times (the prompt resolving after we saw it open, before we clicked).
+    * ``close_on_type`` / ``type_raises`` / ``close_on_click`` / ``click_raises``
+      — unmount and/or error during the answer gesture itself.
+    """
+
+    def __init__(
+        self,
+        *,
+        appear_after: int = 0,
+        connect_present: bool = True,
+        close_after_exists: int = 0,
+        close_on_type: bool = False,
+        type_raises: bool = False,
+        close_on_click: bool = False,
+        click_raises: bool = False,
+    ) -> None:
+        self.open = True
+        self._appear_after = appear_after
+        self.connect_present = connect_present
+        self._close_after_exists = close_after_exists
+        self.close_on_type = close_on_type
+        self.type_raises = type_raises
+        self.close_on_click = close_on_click
+        self.click_raises = click_raises
+        self._state_calls = 0
+        self._exists_calls = 0
+        self.typed: list[str] = []
+        self.clicks: list[str] = []
+
+    def get_state(self, path=None):
+        assert path == "passwordPromptOpen", path
+        self._state_calls += 1
+        if self._state_calls <= self._appear_after:
+            return False
+        return self.open
+
+    def exists(self, test_id: str) -> bool:
+        assert test_id == "password-prompt-connect", test_id
+        self._exists_calls += 1
+        present = self.open and self.connect_present
+        if self._close_after_exists and self._exists_calls >= self._close_after_exists:
+            self.open = False
+        return present
+
+    def type(self, test_id: str, text: str) -> None:
+        assert test_id == "password-prompt-input", test_id
+        if self.close_on_type:
+            self.open = False
+        if self.type_raises:
+            raise BridgeError("type", 'no element with data-testid="password-prompt-input"')
+        self.typed.append(text)
+
+    def click(self, test_id: str) -> None:
+        assert test_id == "password-prompt-connect", test_id
+        if self.close_on_click:
+            self.open = False
+        if self.click_raises:
+            raise BridgeError("click", 'no element with data-testid="password-prompt-connect"')
+        self.clicks.append(test_id)
+
+
+class FakePromptHarness(PasswordPromptUi):
+    """``PasswordPromptUi`` with an eager, synchronous ``wait`` (no app, no timing)."""
+
+    _MAX_POLLS = 100
+
+    def __init__(self, driver: PromptDriver) -> None:
+        self.driver = driver
+
+    def wait(self, predicate, *, timeout=0, interval=0, what=""):
+        for _ in range(self._MAX_POLLS):
+            result = predicate()
+            if result:
+                return result
+        raise AssertionError(f"timed out waiting for {what}")
+
+
+def test_answers_an_open_prompt():
+    # The ordinary path: the modal is open, so the helper types the password and
+    # clicks Connect exactly once.
+    driver = PromptDriver()
+    FakePromptHarness(driver).handle_password_prompt(PASSWORD)
+    assert driver.typed == [PASSWORD]
+    assert driver.clicks == ["password-prompt-connect"]
+
+
+def test_waits_for_a_prompt_that_has_not_appeared_yet():
+    # SSH suites connect and answer immediately, before the modal mounts. The
+    # helper must keep waiting (not early-return) and answer once it opens — the
+    # #1593 tolerance must never swallow a prompt that simply has not arrived.
+    driver = PromptDriver(appear_after=3)
+    FakePromptHarness(driver).handle_password_prompt(PASSWORD)
+    assert driver.typed == [PASSWORD]
+    assert driver.clicks == ["password-prompt-connect"]
+
+
+def test_tolerates_prompt_unmounting_when_the_connect_click_errors():
+    # The exact #1593 failure: the session authenticates from a cached credential
+    # and the modal unmounts as we click Connect, so the bridge cannot find the
+    # button. A prompt that has closed on its own is answered, not a failure.
+    driver = PromptDriver(close_on_click=True, click_raises=True)
+    # Must not raise BridgeError.
+    FakePromptHarness(driver).handle_password_prompt(PASSWORD)
+    assert driver.typed == [PASSWORD]
+    assert driver.clicks == []  # the click never landed — the modal was gone
+
+
+def test_tolerates_prompt_unmounting_when_the_password_type_errors():
+    # The same race one step earlier: the modal unmounts before we can even type.
+    driver = PromptDriver(close_on_type=True, type_raises=True)
+    FakePromptHarness(driver).handle_password_prompt(PASSWORD)
+    assert driver.typed == []
+    assert driver.clicks == []
+
+
+def test_treats_a_prompt_that_resolves_before_the_answer_as_success():
+    # Seen open, but the modal resolves (closes) before its button is answerable;
+    # once we have seen it open, a subsequent close is success, not a hang.
+    driver = PromptDriver(connect_present=False, close_after_exists=1)
+    FakePromptHarness(driver).handle_password_prompt(PASSWORD)
+    assert driver.typed == []
+    assert driver.clicks == []
+
+
+def test_reraises_when_the_click_errors_but_the_prompt_is_still_open():
+    # A genuinely broken answer — the click errors yet the modal is still open —
+    # must still surface, so the tolerance cannot mask a real regression.
+    driver = PromptDriver(click_raises=True)  # click raises but stays open
+    with pytest.raises(BridgeError):
+        FakePromptHarness(driver).handle_password_prompt(PASSWORD)

--- a/tests/system/tests/test_transfer_queue.py
+++ b/tests/system/tests/test_transfer_queue.py
@@ -147,7 +147,10 @@ class TestTransferQueueLiveTransfer(
             or self.driver.get_state("sftpStatus") == "connected",
             what="the SFTP browser or its password prompt",
         )
-        if self.driver.exists("password-prompt-input"):
+        # Gate on the store's liveness signal, not a stale DOM check: the SFTP
+        # session can auto-resolve the prompt from a cached credential, and
+        # ``handle_password_prompt`` then tolerates it closing under us (#1593).
+        if self.password_prompt_open():
             self.handle_password_prompt()
         self.wait(
             lambda: self.driver.get_state("sftpStatus") == "connected",


### PR DESCRIPTION
## What

`handle_password_prompt` used a check-then-act on the SSH password modal: it waited for `password-prompt-input`, then typed and clicked `password-prompt-connect` unconditionally. When an auto-connecting SFTP browser authenticates from a credential cached by an earlier connect, the modal unmounts **between** the check and the click, so `open_sftp_browser` / `connect_sftp_browser` died with:

```
BridgeError: no element with data-testid="password-prompt-connect"
```

This was a **test-harness synchronisation bug**, not an app TOCTOU — the app is behaving correctly (the SFTP session legitimately auto-connects and dismisses the transient prompt). The test was synchronising on the wrong signal (the modal's DOM) instead of the real liveness signal.

## Fix

- **`termihub_harness/ui/passwordprompt.py`** — drive `handle_password_prompt` from the `passwordPromptOpen` store field (the app's authoritative liveness signal) inside a single poll: keep waiting while the prompt has not opened yet (SSH suites connect first and answer immediately), answer it once it is open, and treat a modal that closes on its own after we have seen it — before or during the answer gesture — as answered rather than clicking a button that has unmounted. A prompt still open when the gesture errors is re-raised, so a genuine breakage is never masked.
- **`termihub_harness/ui/sftp.py`** and **`tests/system/tests/test_transfer_queue.py`** — gate the answer on `password_prompt_open()` (the same store signal) instead of a stale `exists("password-prompt-input")` DOM check.

The fix lives in the shared helper, so every password-auth suite benefits.

## Tests

New no-app regression suite `tests/system/tests/test_password_prompt.py` models the modal with a stub driver and locks down: the ordinary answer, waiting for a not-yet-mounted prompt, tolerance of the modal unmounting as the click/type errors (the exact #1593 failure), a prompt that resolves before the answer, and re-raising when the click errors while the prompt is still open. Red before the fix, green after.

## Validation (integration lane is CI-dark, #1569 — validated locally)

- Machinery suite (`pytest -m "not integration"`): **213 passed**.
- Live SFTP transfer test against a real `ssh-password` container, ~35 runs: **zero** `password-prompt-connect` errors (the race is gone).

Closes #1593

## Follow-up

Across the live runs a **separate, unrelated** flake surfaced — `wait(exists(QUEUE), what="the Transfer Queue panel")` timing out after a successful SFTP transfer (the panel does not render). Filed separately; it is not the password-prompt race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)