### PR TITLE
fix(backend): honour docker cli context so "docker" runtime cannot silently be podman (#1600)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7423,6 +7423,7 @@ dependencies = [
  "serial2",
  "serial2-tokio",
  "serial_test",
+ "sha2 0.10.9",
  "shellexpand",
  "socket2 0.5.10",
  "suppaftp",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,6 +36,10 @@ p384 = { version = "=0.14.0-rc.9", optional = true }
 p521 = { version = "=0.14.0-rc.9", optional = true }
 bollard = { workspace = true, optional = true }
 futures-util = { version = "0.3", optional = true }
+# Hashing the Docker CLI context name to locate its `contexts/meta/<id>` entry
+# (the id is the lowercase hex SHA-256 of the context name) — see
+# backends/docker/runtime.rs.
+sha2 = { version = "0.10", optional = true }
 # FTP / FTPS client. `async-rustls` aligns with termiHub's rustls stack
 # (the concept originally proposed `async-native-tls`; deviation flagged in the PR).
 # `deprecated` is required for implicit FTPS (`connect_secure_implicit`).
@@ -93,7 +97,13 @@ ssh = [
     "dep:p384",
     "dep:p521",
 ]
-docker = ["dep:bollard", "dep:futures-util", "dep:tracing"]
+docker = [
+    "dep:bollard",
+    "dep:futures-util",
+    "dep:tracing",
+    "dep:sha2",
+    "dep:hex",
+]
 wsl = ["dep:portable-pty", "dep:tracing"]
 ftp = [
     "dep:suppaftp",

--- a/core/src/backends/docker/mod.rs
+++ b/core/src/backends/docker/mod.rs
@@ -1423,4 +1423,69 @@ mod tests {
         let result = docker.connect(settings).await;
         assert!(result.is_err());
     }
+
+    /// Manual, host-dependent diagnostic for #1600. Requires a live host where
+    /// Docker Desktop and Podman both run and `/var/run/docker.sock` points at
+    /// Podman (the exact misconfiguration the bug describes). Run with:
+    /// `cargo test -p termihub-core --features docker -- --ignored --nocapture
+    ///  connect_to_runtime_honours_docker_context`.
+    #[cfg(unix)]
+    #[tokio::test]
+    #[ignore = "requires a live Docker+Podman host with docker.sock -> Podman"]
+    async fn connect_to_runtime_honours_docker_context() {
+        // BEFORE: the platform default socket (what the old `Docker` path used
+        // via connect_with_local_defaults) — on this host it is Podman.
+        let default = bollard::Docker::connect_with_local_defaults().unwrap();
+        let default_ver = default.version().await.unwrap();
+        println!(
+            "default socket -> podman={} server={:?}",
+            runtime::version_is_podman(&default_ver),
+            default_ver.version
+        );
+
+        // AFTER: explicit Docker must reach a real Docker daemon (or fail loud),
+        // never silently Podman.
+        let docker = connect_to_runtime(&ContainerRuntime::Docker)
+            .await
+            .expect("explicit Docker should reach a Docker daemon on this host");
+        let docker_ver = docker.version().await.unwrap();
+        println!(
+            "runtime=Docker -> podman={} server={:?}",
+            runtime::version_is_podman(&docker_ver),
+            docker_ver.version
+        );
+        assert!(
+            !runtime::version_is_podman(&docker_ver),
+            "explicit Docker must not land on Podman"
+        );
+
+        // Podman must still reach Podman when a socket is discoverable.
+        // (On macOS `podman_socket_uri()` may not locate the machine socket —
+        // a pre-existing gap tracked separately — so this step is best-effort.)
+        match connect_to_runtime(&ContainerRuntime::Podman).await {
+            Ok(podman) => {
+                let podman_ver = podman.version().await.unwrap();
+                println!(
+                    "runtime=Podman -> podman={} server={:?}",
+                    runtime::version_is_podman(&podman_ver),
+                    podman_ver.version
+                );
+                assert!(runtime::version_is_podman(&podman_ver));
+            }
+            Err(e) => println!("runtime=Podman -> socket not discovered: {e}"),
+        }
+
+        // Auto prefers the real Docker endpoint (via context), not Podman.
+        let auto = connect_to_runtime(&ContainerRuntime::Auto).await.unwrap();
+        let auto_ver = auto.version().await.unwrap();
+        println!(
+            "runtime=Auto -> podman={} server={:?}",
+            runtime::version_is_podman(&auto_ver),
+            auto_ver.version
+        );
+        assert!(
+            !runtime::version_is_podman(&auto_ver),
+            "Auto must prefer real Docker over Podman-behind-docker.sock"
+        );
+    }
 }

--- a/core/src/backends/docker/mod.rs
+++ b/core/src/backends/docker/mod.rs
@@ -5,6 +5,7 @@
 //! Docker API access instead of shelling out to the Docker CLI.
 
 mod file_browser;
+mod runtime;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -133,48 +134,124 @@ fn podman_socket_uri() -> Option<String> {
 
 /// Connect to the appropriate container runtime based on the config.
 ///
-/// - `Auto`: tries `connect_with_local_defaults()` first (which already handles
-///   `DOCKER_HOST`/`CONTAINER_HOST`); if the ping fails, falls back to the Podman socket.
-/// - `Docker`: uses `connect_with_local_defaults()` only.
-/// - `Podman`: connects directly to the Podman socket.
-fn connect_to_runtime(runtime: &ContainerRuntime) -> Result<bollard::Docker, SessionError> {
+/// Unlike a bare `connect_with_local_defaults()`, this honours the **Docker
+/// CLI context** for the `Docker`/`Auto` paths and verifies the daemon
+/// identity, so an explicit `Docker` selection can never silently land on a
+/// Podman daemon behind a hijacked `/var/run/docker.sock` (issue #1600):
+///
+/// - `Docker`: resolves the endpoint the Docker CLI would use (`DOCKER_HOST`,
+///   else the active `docker context`), else the platform default socket. It
+///   then queries `/version` and **fails loudly** if the daemon is Podman.
+/// - `Auto`: prefers that same Docker endpoint, verified by an actual
+///   `/version` round-trip; if it is unreachable, falls back to the Podman
+///   socket. (The old check only fired when the client failed to *construct*,
+///   which never happened in practice.)
+/// - `Podman`: connects directly to the Podman socket and verifies it is
+///   reachable.
+async fn connect_to_runtime(runtime: &ContainerRuntime) -> Result<bollard::Docker, SessionError> {
     match runtime {
-        ContainerRuntime::Docker => bollard::Docker::connect_with_local_defaults().map_err(|e| {
-            SessionError::SpawnFailed(format!("Failed to connect to Docker daemon: {e}"))
-        }),
+        ContainerRuntime::Docker => connect_docker().await,
+        ContainerRuntime::Auto => connect_auto().await,
         ContainerRuntime::Podman => {
             let uri = podman_socket_uri().ok_or_else(|| {
                 SessionError::SpawnFailed("Could not determine Podman socket path".to_string())
             })?;
-            connect_podman(&uri)
-        }
-        ContainerRuntime::Auto => {
-            // Try Docker/default first.
-            match bollard::Docker::connect_with_local_defaults() {
-                Ok(client) => Ok(client),
-                Err(_) => {
-                    // Fall back to Podman socket.
-                    let uri = podman_socket_uri().ok_or_else(|| {
-                        SessionError::SpawnFailed(
-                            "Failed to connect to Docker daemon and no Podman socket found"
-                                .to_string(),
-                        )
-                    })?;
-                    connect_podman(&uri)
-                }
-            }
+            let client = connect_via_uri(&uri)?;
+            client.version().await.map_err(|e| {
+                SessionError::SpawnFailed(format!(
+                    "Selected runtime is Podman but the socket at {uri} is unreachable: {e}"
+                ))
+            })?;
+            info!(endpoint = %uri, runtime = "podman", "Connected to Podman runtime");
+            Ok(client)
         }
     }
 }
 
+/// Construct a client for the Docker CLI's active endpoint, returning the
+/// client together with a human-readable label of the endpoint used.
+fn connect_docker_endpoint() -> Result<(bollard::Docker, String), SessionError> {
+    match runtime::resolve_docker_endpoint() {
+        Some(uri) => {
+            let client = connect_via_uri(&uri)?;
+            Ok((client, uri))
+        }
+        None => {
+            let client = bollard::Docker::connect_with_local_defaults().map_err(|e| {
+                SessionError::SpawnFailed(format!("Failed to connect to Docker daemon: {e}"))
+            })?;
+            Ok((client, "platform default socket".to_string()))
+        }
+    }
+}
+
+/// Explicit-`Docker` path: connect to the Docker CLI endpoint and reject a
+/// Podman daemon rather than silently using it.
+async fn connect_docker() -> Result<bollard::Docker, SessionError> {
+    let (client, endpoint) = connect_docker_endpoint()?;
+    let version = client.version().await.map_err(|e| {
+        SessionError::SpawnFailed(format!(
+            "Selected runtime is Docker but the daemon at {endpoint} is unreachable: {e}"
+        ))
+    })?;
+    if runtime::version_is_podman(&version) {
+        let server = version.version.as_deref().unwrap_or("unknown");
+        return Err(SessionError::SpawnFailed(format!(
+            "Selected runtime is Docker but the daemon at {endpoint} is Podman (server {server}). \
+             Check your Docker CLI context (`docker context ls`) or set DOCKER_HOST to a Docker endpoint."
+        )));
+    }
+    info!(endpoint = %endpoint, runtime = "docker", "Connected to Docker runtime");
+    Ok(client)
+}
+
+/// `Auto` path: prefer the real Docker endpoint (verified by a `/version`
+/// round-trip), falling back to the Podman socket only when Docker is
+/// genuinely unreachable.
+async fn connect_auto() -> Result<bollard::Docker, SessionError> {
+    match connect_docker_endpoint() {
+        Ok((client, endpoint)) => match client.version().await {
+            Ok(version) => {
+                let detected = if runtime::version_is_podman(&version) {
+                    "podman"
+                } else {
+                    "docker"
+                };
+                info!(endpoint = %endpoint, runtime = detected, "Auto-selected container runtime");
+                return Ok(client);
+            }
+            Err(e) => {
+                debug!(endpoint = %endpoint, error = %e, "Default Docker endpoint unreachable; trying Podman");
+            }
+        },
+        Err(e) => {
+            debug!(error = %e, "Could not construct default Docker client; trying Podman");
+        }
+    }
+
+    let uri = podman_socket_uri().ok_or_else(|| {
+        SessionError::SpawnFailed(
+            "Failed to reach Docker daemon and no Podman socket found".to_string(),
+        )
+    })?;
+    let client = connect_via_uri(&uri)?;
+    client.version().await.map_err(|e| {
+        SessionError::SpawnFailed(format!(
+            "Failed to reach Docker daemon; Podman socket at {uri} is also unreachable: {e}"
+        ))
+    })?;
+    info!(endpoint = %uri, runtime = "podman", "Auto-selected Podman runtime (Docker unavailable)");
+    Ok(client)
+}
+
 /// Connect to a container runtime via an explicit URI string.
-fn connect_podman(uri: &str) -> Result<bollard::Docker, SessionError> {
+fn connect_via_uri(uri: &str) -> Result<bollard::Docker, SessionError> {
     #[cfg(unix)]
     if uri.starts_with("unix://") {
         return bollard::Docker::connect_with_unix(uri, 120, bollard::API_DEFAULT_VERSION).map_err(
             |e| {
                 SessionError::SpawnFailed(format!(
-                    "Failed to connect to Podman socket at {uri}: {e}"
+                    "Failed to connect to container socket at {uri}: {e}"
                 ))
             },
         );
@@ -192,7 +269,7 @@ fn connect_podman(uri: &str) -> Result<bollard::Docker, SessionError> {
         )
         .map_err(|e| {
             SessionError::SpawnFailed(format!(
-                "Failed to connect to Podman named pipe at {pipe_name}: {e}"
+                "Failed to connect to container named pipe at {pipe_name}: {e}"
             ))
         });
         #[cfg(not(windows))]
@@ -538,7 +615,7 @@ impl ConnectionType for Docker {
         info!(image = %config.image, "Connecting Docker session");
 
         // Connect to the container runtime (Docker or Podman).
-        let client = connect_to_runtime(&config.runtime)?;
+        let client = connect_to_runtime(&config.runtime).await?;
 
         // Pull the image if it's not already available locally.
         info!(image = %config.image, "Pulling Docker image");

--- a/core/src/backends/docker/runtime.rs
+++ b/core/src/backends/docker/runtime.rs
@@ -1,0 +1,263 @@
+//! Container-runtime endpoint resolution and daemon identification.
+//!
+//! `bollard::Docker::connect_with_local_defaults()` only ever looks at
+//! `DOCKER_HOST` and then the platform default socket (`/var/run/docker.sock`
+//! on Unix). It never reads the **Docker CLI contexts**
+//! (`~/.docker/config.json` → `currentContext` → `~/.docker/contexts/meta/`),
+//! which is where the real Docker Desktop endpoint lives on macOS and Windows.
+//!
+//! On a host that also runs Podman, `podman-mac-helper` symlinks
+//! `/var/run/docker.sock` at the Podman machine socket, so
+//! `connect_with_local_defaults()` silently targets Podman even though the
+//! Docker CLI (and the user) are on the `desktop-linux` Docker context. This
+//! module resolves the endpoint the Docker CLI itself would use, and
+//! identifies whether a connected daemon is actually Podman, so the backend
+//! can honour an explicit `Docker` selection instead of silently running
+//! Podman. See issue #1600.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// The endpoint the Docker CLI would use for the active context, resolved
+/// **without** falling back to the platform default socket.
+///
+/// Resolution order mirrors the Docker CLI:
+/// 1. `DOCKER_HOST` — an explicit override always wins.
+/// 2. The active Docker CLI context (`DOCKER_CONTEXT` env, otherwise
+///    `config.json` → `currentContext`) endpoint from
+///    `contexts/meta/<id>/meta.json`.
+///
+/// Returns `None` when neither is set (or the active context is `default`),
+/// meaning the caller should fall back to bollard's platform default socket.
+pub(super) fn resolve_docker_endpoint() -> Option<String> {
+    if let Some(host) = non_empty_env("DOCKER_HOST") {
+        return Some(host);
+    }
+    let docker_dir = docker_config_dir()?;
+    docker_endpoint_from_dir(&docker_dir)
+}
+
+/// Read an environment variable, treating empty as unset.
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+/// Locate the Docker CLI config directory (`$DOCKER_CONFIG` or `~/.docker`).
+fn docker_config_dir() -> Option<PathBuf> {
+    if let Some(dir) = non_empty_env("DOCKER_CONFIG") {
+        return Some(PathBuf::from(dir));
+    }
+    // `HOME` on Unix; `USERPROFILE` on Windows.
+    let home = non_empty_env("HOME").or_else(|| non_empty_env("USERPROFILE"))?;
+    Some(PathBuf::from(home).join(".docker"))
+}
+
+/// Resolve the active context's Docker endpoint from a Docker config directory.
+///
+/// Split out from [`resolve_docker_endpoint`] so it can be unit-tested against
+/// a fixture directory tree without touching real environment or `$HOME`.
+fn docker_endpoint_from_dir(docker_dir: &Path) -> Option<String> {
+    let context = active_context(docker_dir)?;
+    // The `default` context always maps to the platform default socket, which
+    // bollard already handles — signal a fall-through with `None`.
+    if context.is_empty() || context == "default" {
+        return None;
+    }
+    let meta_path = docker_dir
+        .join("contexts")
+        .join("meta")
+        .join(context_id(&context))
+        .join("meta.json");
+    let data = std::fs::read_to_string(meta_path).ok()?;
+    let meta: ContextMeta = serde_json::from_str(&data).ok()?;
+    meta.endpoints
+        .get("docker")
+        .map(|e| e.host.clone())
+        .filter(|h| !h.is_empty())
+}
+
+/// Determine the active context name (`DOCKER_CONTEXT` env, else
+/// `config.json` → `currentContext`).
+fn active_context(docker_dir: &Path) -> Option<String> {
+    if let Some(ctx) = non_empty_env("DOCKER_CONTEXT") {
+        return Some(ctx);
+    }
+    let data = std::fs::read_to_string(docker_dir.join("config.json")).ok()?;
+    let config: DockerConfigFile = serde_json::from_str(&data).ok()?;
+    config.current_context.filter(|c| !c.is_empty())
+}
+
+/// The Docker CLI stores each context under a directory named after the
+/// lowercase hex SHA-256 digest of the context name.
+fn context_id(name: &str) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(name.as_bytes()))
+}
+
+/// Relevant subset of `~/.docker/config.json`.
+#[derive(Debug, Deserialize)]
+struct DockerConfigFile {
+    #[serde(rename = "currentContext")]
+    current_context: Option<String>,
+}
+
+/// Relevant subset of `contexts/meta/<id>/meta.json`.
+#[derive(Debug, Deserialize)]
+struct ContextMeta {
+    #[serde(rename = "Endpoints", default)]
+    endpoints: HashMap<String, ContextEndpoint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContextEndpoint {
+    #[serde(rename = "Host", default)]
+    host: String,
+}
+
+/// Whether a daemon `/version` response identifies the daemon as Podman.
+///
+/// Podman's Docker-compatible API reports a component named `Podman Engine`
+/// (and a platform like `linux/arm64/fedora-43`), whereas Docker reports an
+/// `Engine` component and a `Docker Desktop …` / `Docker Engine …` platform.
+/// Matching `podman` (case-insensitively) in either field is a stable signal
+/// across Podman versions.
+pub(super) fn version_is_podman(version: &bollard::system::Version) -> bool {
+    let component_hit = version
+        .components
+        .as_ref()
+        .map(|comps| comps.iter().any(|c| contains_podman(&c.name)))
+        .unwrap_or(false);
+    let platform_hit = version
+        .platform
+        .as_ref()
+        .map(|p| contains_podman(&p.name))
+        .unwrap_or(false);
+    component_hit || platform_hit
+}
+
+fn contains_podman(s: &str) -> bool {
+    s.to_ascii_lowercase().contains("podman")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bollard::models::SystemVersionPlatform;
+    use bollard::system::{Version, VersionComponents};
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Build a fixture `.docker` directory with the given `currentContext` and
+    /// a single named context whose Docker endpoint is `host`.
+    fn write_context_fixture(dir: &Path, current: &str, name: &str, host: &str) {
+        fs::write(
+            dir.join("config.json"),
+            format!(r#"{{"currentContext":"{current}"}}"#),
+        )
+        .unwrap();
+        let meta_dir = dir.join("contexts").join("meta").join(context_id(name));
+        fs::create_dir_all(&meta_dir).unwrap();
+        fs::write(
+            meta_dir.join("meta.json"),
+            format!(r#"{{"Name":"{name}","Endpoints":{{"docker":{{"Host":"{host}"}}}}}}"#),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn resolves_active_context_endpoint() {
+        // Regression for #1600: the desktop-linux context endpoint must be
+        // resolved rather than the platform default socket (which a Podman
+        // install may have hijacked).
+        let tmp = TempDir::new().unwrap();
+        let host = "unix:///Users/arne/.docker/run/docker.sock";
+        write_context_fixture(tmp.path(), "desktop-linux", "desktop-linux", host);
+
+        assert_eq!(docker_endpoint_from_dir(tmp.path()), Some(host.to_string()));
+    }
+
+    #[test]
+    fn default_context_falls_through_to_none() {
+        // The `default` context is the platform default socket, which bollard
+        // already handles — resolution must defer to it.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("config.json"),
+            r#"{"currentContext":"default"}"#,
+        )
+        .unwrap();
+        assert_eq!(docker_endpoint_from_dir(tmp.path()), None);
+    }
+
+    #[test]
+    fn missing_config_falls_through_to_none() {
+        // A host with no Docker CLI config (common Linux Docker install) must
+        // keep working via the default socket.
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(docker_endpoint_from_dir(tmp.path()), None);
+    }
+
+    #[test]
+    fn missing_context_meta_falls_through_to_none() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("config.json"),
+            r#"{"currentContext":"desktop-linux"}"#,
+        )
+        .unwrap();
+        // No contexts/meta tree written.
+        assert_eq!(docker_endpoint_from_dir(tmp.path()), None);
+    }
+
+    #[test]
+    fn context_id_is_sha256_hex_of_name() {
+        // Matches `printf desktop-linux | shasum -a 256`.
+        assert_eq!(
+            context_id("desktop-linux"),
+            "fe9c6bd7a66301f49ca9b6a70b217107cd1284598bfc254700c989b916da791e"
+        );
+    }
+
+    #[test]
+    fn empty_endpoint_host_is_ignored() {
+        let tmp = TempDir::new().unwrap();
+        write_context_fixture(tmp.path(), "ctx", "ctx", "");
+        assert_eq!(docker_endpoint_from_dir(tmp.path()), None);
+    }
+
+    fn version_with(component: Option<&str>, platform: Option<&str>) -> Version {
+        Version {
+            components: component.map(|name| {
+                vec![VersionComponents {
+                    name: name.to_string(),
+                    version: "1.0".to_string(),
+                    details: None,
+                }]
+            }),
+            platform: platform.map(|name| SystemVersionPlatform {
+                name: name.to_string(),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn detects_podman_from_component_name() {
+        let v = version_with(Some("Podman Engine"), Some("linux/arm64/fedora-43"));
+        assert!(version_is_podman(&v));
+    }
+
+    #[test]
+    fn does_not_flag_docker_engine_as_podman() {
+        let v = version_with(Some("Engine"), Some("Docker Desktop 4.78.0 (229452)"));
+        assert!(!version_is_podman(&v));
+    }
+
+    #[test]
+    fn detects_podman_from_platform_when_components_absent() {
+        let v = version_with(None, Some("linux/amd64/podman"));
+        assert!(version_is_podman(&v));
+    }
+}

--- a/docs/changes/dev2/fix/1600-docker-context-selection.md
+++ b/docs/changes/dev2/fix/1600-docker-context-selection.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- Docker/Podman container sessions now honour the Docker CLI's active context
+  when selecting the runtime. Previously the backend connected via
+  `/var/run/docker.sock` only, so on a host where a Podman install has
+  symlinked that socket at its own daemon (e.g. `podman-mac-helper`), selecting
+  **Docker** silently ran Podman. The backend now resolves the endpoint the
+  Docker CLI would use (`DOCKER_HOST`, then the active `docker context`
+  endpoint) before the default socket, verifies the daemon with a `/version`
+  round-trip, and **fails loudly** with an explicit message if an explicit
+  Docker selection reaches a Podman daemon. `Auto` now prefers the real Docker
+  endpoint (verified by ping) and falls back to Podman only when Docker is
+  genuinely unreachable, and the resolved endpoint and detected runtime are
+  logged so a mismatch is diagnosable (#1600).


### PR DESCRIPTION
## What

`connect_to_runtime` resolved the container daemon via bollard's
`connect_with_local_defaults()`, which only consults `DOCKER_HOST` and then
the platform default socket (`/var/run/docker.sock`). It **never** read the
Docker CLI contexts (`~/.docker/config.json` → `currentContext` →
`contexts/meta/<id>/meta.json`), which is where the real Docker Desktop
endpoint lives on macOS and Windows.

On a host running both Docker Desktop and Podman, `podman-mac-helper`
symlinks `/var/run/docker.sock` at the Podman machine socket, so selecting
**Docker** silently connected to **Podman** — the picker's contract violated
without any signal.

## Change

New `core/src/backends/docker/runtime.rs`:

- `resolve_docker_endpoint()` — resolves the endpoint the Docker CLI itself
  would use: `DOCKER_HOST`, then the active `docker context`
  (`DOCKER_CONTEXT` env or `config.json` `currentContext`, whose endpoint is
  read from `contexts/meta/<sha256(name)>/meta.json`). Returns `None` (defer
  to the platform default socket) for the `default` context or when no config
  exists, so plain single-daemon hosts keep working with zero config.
- `version_is_podman()` — identifies a Podman daemon from its `/version`
  response (a `Podman Engine` component / a `podman` platform string).

`connect_to_runtime` now:

- **Docker**: connects to the resolved Docker endpoint, does a `/version`
  round-trip, and **fails loudly** ("the daemon at <endpoint> is Podman …")
  instead of silently operating Podman.
- **Auto**: prefers the resolved Docker endpoint verified by an actual ping,
  and falls back to the Podman socket only when Docker is genuinely
  unreachable (the old fallback only fired when the client failed to
  *construct*, which never happened). This also fixes the #1366-shaped
  "Auto silently prefers Podman-behind-docker.sock".
- **Podman**: unchanged target, now verified reachable.

The resolved endpoint and detected runtime are logged on connect so a
mismatch is diagnosable without a debugger.

## Verified on the affected host

macOS with Docker Desktop + Podman, `/var/run/docker.sock` -> Podman. The
`#[ignore]`d diagnostic `connect_to_runtime_honours_docker_context` prints:

```
default socket -> podman=true  server=Some("5.7.1")   # what old Docker path reached
runtime=Docker -> podman=false server=Some("29.5.3")  # now the real Docker Desktop
runtime=Auto   -> podman=false server=Some("29.5.3")  # prefers real Docker
```

## Tests

- Unit tests over fixture `config.json` / `meta.json` trees (context
  resolution, `default`/missing fall-through, empty host, SHA-256 context id)
  and over `/version` payloads (Podman vs Docker detection). These run in CI.
- An `#[ignore]`d unix-only host diagnostic that exercises the live path
  (above).

## Follow-ups

- macOS explicit **Podman** selection is a pre-existing gap unrelated to this
  fix: `podman_socket_uri()` checks Linux well-known paths only and does not
  find the macOS Podman machine socket (`/var/folders/.../T/podman/...`). Filed
  as a follow-up.

Closes #1600