### PR TITLE
docs(config): document the enforced lowercase commit-subject rule (Closes #1609)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -320,7 +320,7 @@ Use these skills with `/skill-name` during development:
 - **Never commit directly to `main` or `develop`**
 - **Never push directly to `main` or `develop`**: all changes must be submitted via pull request — no exceptions, even for documentation-only changes
 - **Every change requires a PR targeting `develop`**: create a feature or bugfix branch, push it to `origin`, and open a pull request against `develop`. Only target `main` when the user explicitly requests it.
-- **Conventional Commits**: `type(scope): subject` — types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `chore`, `ci`, `revert` (enforced by `commitlint.config.js`)
+- **Conventional Commits**: `type(scope): subject` — types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `chore`, `ci`, `revert` (enforced by `commitlint.config.js`). The subject must be **lowercase**: `subject-case` (from `@commitlint/config-conventional`) rejects sentence-case/start-case/PascalCase/UPPER-CASE, so start it with a lowercase word — `fix(config): resolve …`, not `fix(config): Resolve …`.
 - **Scopes**: `terminal`, `ssh`, `serial`, `ui`, `backend`, `sftp`, `config`, `agent`, `credential`, `tunnel`, `workspace`, `network`, `embedded-servers`
 - **Always merge with a merge commit** (`gh pr merge --merge`) — never squash or rebase, never rebase branches
 - **Commit early and often** — commit as soon as a single logical topic is complete (a single topic = a single commit). Do not batch multiple topics into one commit. Each logical step gets its own commit:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,9 @@
 export default {
   extends: ["@commitlint/config-conventional"],
+  // Inherited rules from config-conventional are intentionally left in force. In
+  // particular `subject-case` requires a lowercase subject (it rejects sentence-case,
+  // start-case, pascal-case and upper-case) — see the commit-format notes in
+  // docs/contributing.md and .claude/CLAUDE.md. Only the type list is overridden below.
   rules: {
     // Keep in sync with the type lists in docs/contributing.md and .claude/CLAUDE.md.
     // `build` is part of the Conventional Commits spec and is already used in this

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -288,6 +288,12 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 This list is enforced by `commitlint.config.js` — a subject using any other type fails the
 Lint Commit Messages check.
 
+**Subject**: must be **lowercase**. The `subject-case` rule inherited from
+`@commitlint/config-conventional` rejects sentence-case, start-case, PascalCase and
+UPPER-CASE subjects, so start the `<subject>` with a lowercase word — otherwise Lint Commit
+Messages fails. Use `fix(config): resolve the dev port collision`, not
+`fix(config): Resolve the dev port collision`.
+
 **Scopes**: `terminal`, `ssh`, `serial`, `ui`, `backend`, `sftp`, `config`, etc.
 
 **Examples:**


### PR DESCRIPTION
## What

Document the enforced lowercase commit-subject rule so contributors satisfy `Lint Commit Messages` without discovering it from a red check (follow-up to #1588 / PR #1604).

`commitlint.config.js` extends `@commitlint/config-conventional`, whose `subject-case` rule rejects sentence-case, start-case, PascalCase and UPPER-CASE subjects at error level — but only the `type-enum` override was documented. Verified locally against real commitlint: `feat: Foo bar` fails, `feat: add iOS support` passes; the effective requirement is that the subject start with a lowercase word.

## Changes

- `docs/contributing.md` → *Conventional Commits*: added a **Subject** note beside the type-list note.
- `.claude/CLAUDE.md`: extended the Conventional Commits bullet with the same rule.
- `commitlint.config.js`: comment noting the inherited `subject-case` rule is deliberately not relaxed.

Docs-only; markdownlint passes locally.

Closes #1609