### PR TITLE
fix(agent): settle registry fan-out vs unregistered connections (Closes #1608)

### DIFF
--- a/agent/src/registry_daemon/process.rs
+++ b/agent/src/registry_daemon/process.rs
@@ -404,6 +404,100 @@ mod tests {
         );
     }
 
+    /// A connection that has opened but never sent `MSG_REGISTER` still receives
+    /// broadcasts — and this is deliberate, not the oversight #1608 asked us to
+    /// check. The fan-out targets **connections**, while `agent.list_connections`
+    /// (via [`RegistryState::clients`]) targets registered **clients**: the two
+    /// answer different questions and are meant to differ, not to agree.
+    ///
+    /// Why a not-yet-registered connection must still be reached: a worker mid
+    /// `initialize` handshake is *racing to become a client*, and the one
+    /// production broadcast — `agent.update_pending` (#1351) — is exactly the
+    /// signal it must not miss, or it will spin up sessions the imminent binary
+    /// swap is about to tear down. Delivery is harmless before registration: the
+    /// worker dispatches on frame type (never on ACK ordering, see #1610) and a
+    /// client that is not there yet simply drops the event on a closed channel.
+    ///
+    /// This test pins that behaviour so a later "tidy up the fan-out" change
+    /// cannot silently drop the racing-registration case.
+    #[test]
+    fn an_unregistered_connection_still_receives_broadcasts() {
+        let state = Arc::new(RegistryState::default());
+        let _rx_sender = conn(&state, 0);
+        let mut rx_unregistered = conn(&state, 1);
+        // The sender registers; the recipient never does.
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_REGISTER, serde_json::to_vec(&record("a")).unwrap()),
+        );
+
+        let envelope = BroadcastEnvelope {
+            origin_client_id: "a".into(),
+            method: "agent.update_pending".into(),
+            params: json!({"version": "2.0.0"}),
+        };
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_BROADCAST, serde_json::to_vec(&envelope).unwrap()),
+        );
+
+        // The unregistered connection is invisible to `list`...
+        assert_eq!(state.clients(), vec![record("a")]);
+        // ...yet still receives the broadcast.
+        let (msg_type, payload) = rx_unregistered
+            .try_recv()
+            .expect("event must reach an unregistered connection");
+        assert_eq!(msg_type, MSG_EVENT);
+        let got: BroadcastEnvelope = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(got, envelope);
+    }
+
+    /// A worker that registered and then sent `MSG_DEREGISTER` — its client
+    /// disconnected but its process is still up and its socket still open — keeps
+    /// receiving broadcasts, matching the invariant documented on [`WorkerConn`].
+    /// Its record is gone from `list`, but the connection is live, so the fan-out
+    /// still reaches it; with no client behind it the event harmlessly drops.
+    #[test]
+    fn a_deregistered_but_connected_worker_still_receives_broadcasts() {
+        let state = Arc::new(RegistryState::default());
+        let _rx_sender = conn(&state, 0);
+        let mut rx_gone = conn(&state, 1);
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_REGISTER, serde_json::to_vec(&record("a")).unwrap()),
+        );
+        handle_frame(
+            &state,
+            1,
+            frame(MSG_REGISTER, serde_json::to_vec(&record("b")).unwrap()),
+        );
+        handle_frame(&state, 1, frame(MSG_DEREGISTER, Vec::new()));
+        let _ = rx_gone.try_recv(); // drain b's ACK
+
+        // b is no longer a client, but its connection is still live.
+        assert_eq!(state.clients(), vec![record("a")]);
+        assert_eq!(state.connection_count(), 2);
+
+        let envelope = BroadcastEnvelope {
+            origin_client_id: "a".into(),
+            method: "agent.update_pending".into(),
+            params: json!({"version": "2.0.0"}),
+        };
+        handle_frame(
+            &state,
+            0,
+            frame(MSG_BROADCAST, serde_json::to_vec(&envelope).unwrap()),
+        );
+
+        let (msg_type, _) = rx_gone
+            .try_recv()
+            .expect("event must reach a deregistered-but-connected worker");
+        assert_eq!(msg_type, MSG_EVENT);
+    }
+
     #[test]
     fn a_malformed_frame_is_skipped_rather_than_failing_the_worker() {
         let state = Arc::new(RegistryState::default());

--- a/agent/src/registry_daemon/process.rs
+++ b/agent/src/registry_daemon/process.rs
@@ -82,7 +82,22 @@ impl RegistryState {
         guard.len()
     }
 
-    /// Fan `payload` out to every worker except `except_conn`.
+    /// Fan `payload` out to every worker **connection** except `except_conn`.
+    ///
+    /// Deliberately keyed to the connection, not the client: an unregistered
+    /// connection (mid `initialize`, or a client that deregistered but whose
+    /// process is still up) is reached too. This is the intentional resolution
+    /// of #1608, not an oversight — the fan-out targets connections while
+    /// [`clients`](Self::clients) / `agent.list_connections` targets registered
+    /// clients, and the two are meant to answer different questions:
+    ///
+    /// - A connection racing to register is *about to become a client*, and the
+    ///   one production broadcast — `agent.update_pending` (#1351) — is precisely
+    ///   the signal it must not miss, or it will spin up sessions the imminent
+    ///   binary swap is about to tear down. Skipping it would open that race.
+    /// - Reaching a connection with no client behind it is harmless: the worker
+    ///   dispatches on frame type, never on ACK ordering (#1610), and a departed
+    ///   client just drops the event on a closed channel (`client.rs`).
     ///
     /// Send failures are ignored: an unbounded channel only fails when the
     /// receiving task is gone, which means that worker is already tearing down


### PR DESCRIPTION
## What

Settles the self-consistency question in #1608: `RegistryState::fan_out` reaches **every live connection** except the sender, including connections that have not yet registered a client (`record: None`), while `agent.list_connections` (`RegistryState::clients`) reports only registered clients. Are those two supposed to agree?

## Decision: keep the current behaviour — no behaviour change

After tracing both sides (`registry_daemon/process.rs` fan-out and `registry_daemon/client.rs` delivery), the current behaviour is correct and deliberate. The fan-out targets **connections**; `list_connections` targets registered **clients**; the two answer different questions and are meant to differ.

Why fanning to an unregistered connection is right, not a bug:

- A connection mid `initialize` is **racing to become a client**. The one production broadcast is `agent.update_pending` (#1351, coordinated update) — precisely the signal such a connection must not miss, or it will spin up sessions the imminent binary swap is about to tear down. Skipping unregistered connections would *open* that race.
- Reaching a connection with no client behind it is harmless: the worker dispatches on frame type, never on ACK ordering (established by #1610), and a departed client drops the event on a closed channel (`client.rs`).

So this is a **pinned-invariant + documentation** change, not a code-path change. `fan_out` is untouched functionally.

## Changes

- **Tests** (`registry_daemon::process`): `an_unregistered_connection_still_receives_broadcasts` and `a_deregistered_but_connected_worker_still_receives_broadcasts` pin both `record: None` cases. Verified load-bearing: applying the hypothetical `record.is_none() → skip` change makes both (and the pre-existing `broadcast_reaches_every_other_worker_but_not_the_sender`) fail.
- **Docs**: `RegistryState::fan_out` now states the connection-vs-client invariant and cites #1608/#1351/#1610 so the next reader does not re-open the question.

## Testing

- `cargo test -p termihub-agent` process unit tests: 7 passed.
- Registry integration suite on macOS: 12 passed.
- Hammered on Linux (`rust:1-bookworm`, `--cpus=4`, Docker-volume target dir to avoid the bind-mount fake-`E0463` trap): 10× sequential + 4-way concurrent × 5 rounds = **30 suite executions (360 test-executions), 0 failures**.
- `cargo fmt` / `cargo clippy` on the agent: clean.

Closes #1608