### PR TITLE
fix(ui): persist don't-ask-again only on confirm (Closes #1606)

### DIFF
--- a/docs/changes/dev2/fix/1606-confirm-dialog-persist-on-confirm.md
+++ b/docs/changes/dev2/fix/1606-confirm-dialog-persist-on-confirm.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Close-session confirmation dialog: ticking **"Don't ask again"** and then
+  **cancelling** no longer disables the confirmation. The preference is now
+  saved only when you confirm the close (close the tab/panel) with the box
+  ticked; cancelling discards the tick and leaves the setting untouched. This
+  matches the checkbox contract used elsewhere (a checkbox applies on confirm,
+  not the moment it is ticked) (#1606).

--- a/src/components/Terminal/ConfirmSessionCloseDialog.test.tsx
+++ b/src/components/Terminal/ConfirmSessionCloseDialog.test.tsx
@@ -119,7 +119,7 @@ describe("ConfirmSessionCloseDialog", () => {
     expect(useAppStore.getState().pendingSessionCloseConfirm).toBeNull();
   });
 
-  it("Don't ask again persists confirmCloseLiveSession=false", () => {
+  it("Don't ask again then Confirm persists confirmCloseLiveSession=false", () => {
     const updateSettings = vi.fn(() => Promise.resolve());
     useAppStore.setState({ updateSettings });
     useAppStore.getState().addTab("x", "local");
@@ -136,10 +136,59 @@ describe("ConfirmSessionCloseDialog", () => {
       })
     );
 
+    // Ticking alone must not write — the preference is deferred to confirm.
     act(() => q("confirm-dialog-dont-ask-again").click());
+    expect(updateSettings).not.toHaveBeenCalled();
 
+    // Confirming commits the deferred preference.
+    act(() => q("confirm-dialog-confirm").click());
     expect(updateSettings).toHaveBeenCalledWith(
       expect.objectContaining({ confirmCloseLiveSession: false })
     );
+  });
+
+  it("Don't ask again then Cancel does NOT persist the preference", () => {
+    const updateSettings = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ updateSettings });
+    useAppStore.getState().addTab("y", "local");
+    const panel = getAllLeaves(useAppStore.getState().rootPanel)[0];
+    render();
+
+    act(() =>
+      useAppStore.getState().setPendingSessionCloseConfirm({
+        kind: "tab",
+        tabId: panel.tabs[0].id,
+        panelId: panel.id,
+        label: "y",
+        reopen: null,
+      })
+    );
+
+    act(() => q("confirm-dialog-dont-ask-again").click());
+    act(() => q("confirm-dialog-cancel").click());
+
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("Confirm without ticking leaves the preference untouched", () => {
+    const updateSettings = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ updateSettings });
+    useAppStore.getState().addTab("z", "local");
+    const panel = getAllLeaves(useAppStore.getState().rootPanel)[0];
+    render();
+
+    act(() =>
+      useAppStore.getState().setPendingSessionCloseConfirm({
+        kind: "tab",
+        tabId: panel.tabs[0].id,
+        panelId: panel.id,
+        label: "z",
+        reopen: null,
+      })
+    );
+
+    act(() => q("confirm-dialog-confirm").click());
+
+    expect(updateSettings).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/ConfirmSessionCloseDialog.tsx
+++ b/src/components/Terminal/ConfirmSessionCloseDialog.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ConfirmDialog } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { showReopenToast } from "@/utils/reopenTab";
@@ -9,8 +10,12 @@ import { showReopenToast } from "@/utils/reopenTab";
  *
  * Reads `pendingSessionCloseConfirm` from the store; renders nothing when no
  * request is pending. Confirming performs the close (and, for a tab with a known
- * connection, fires an Undo/Reopen toast). The dialog's "Don't ask again" toggle
- * persists `confirmCloseLiveSession: false` so future closes skip the prompt.
+ * connection, fires an Undo/Reopen toast). The dialog's "Don't ask again"
+ * checkbox is local state that only takes effect on confirm: confirming with it
+ * ticked persists `confirmCloseLiveSession: false` so future closes skip the
+ * prompt, while cancelling discards the tick and leaves the setting untouched.
+ * This honours the checkbox contract from {@link ConfirmDialog} (a checkbox
+ * applies on confirm, not the moment it is ticked).
  */
 export function ConfirmSessionCloseDialog() {
   const request = useAppStore((s) => s.pendingSessionCloseConfirm);
@@ -19,24 +24,28 @@ export function ConfirmSessionCloseDialog() {
   const removePanel = useAppStore((s) => s.removePanel);
   const settings = useAppStore((s) => s.settings);
   const updateSettings = useAppStore((s) => s.updateSettings);
-  const dontAsk = settings.confirmCloseLiveSession === false;
+  // Local, deferred checkbox state — committed only on confirm, discarded on cancel.
+  const [dontAsk, setDontAsk] = useState(false);
 
   if (!request) return null;
 
-  const handleCancel = () => setRequest(null);
+  const handleCancel = () => {
+    setDontAsk(false);
+    setRequest(null);
+  };
 
   const handleConfirm = () => {
+    if (dontAsk) {
+      void updateSettings({ ...settings, confirmCloseLiveSession: false });
+    }
     if (request.kind === "tab") {
       closeTab(request.tabId, request.panelId);
       showReopenToast(request.reopen);
     } else {
       removePanel(request.panelId);
     }
+    setDontAsk(false);
     setRequest(null);
-  };
-
-  const handleDontAskChange = (checked: boolean) => {
-    void updateSettings({ ...settings, confirmCloseLiveSession: !checked });
   };
 
   const isTab = request.kind === "tab";
@@ -56,7 +65,7 @@ export function ConfirmSessionCloseDialog() {
       onCancel={handleCancel}
       dontAskAgain={{
         checked: dontAsk,
-        onChange: handleDontAskChange,
+        onChange: setDontAsk,
         label: "Don't ask again",
       }}
       data-testid="confirm-session-close-dialog"


### PR DESCRIPTION
## Summary

`ConfirmSessionCloseDialog`'s "Don't ask again" checkbox wrote `confirmCloseLiveSession=false` immediately on the checkbox `onChange` (pre-existing since the original feature commit `ddc84679`, flagged in #1590). That meant ticking the box and then **cancelling** wrongly disabled the confirmation for future closes.

Per the owner's decision on the issue, the preference must persist **only when the user confirms** the dialog:

- Tick then **Cancel** → preference NOT saved; the dialog still appears next time.
- Tick then **Confirm** (close the tab/panel) → preference IS saved; dialog suppressed next time.
- Untouched checkbox → no change.

## Changes

- The "Don't ask again" checkbox is now local component state (`useState`), committed only inside the confirm handler and discarded on cancel. This honours the checkbox contract already documented on the shared `ConfirmDialog` (a checkbox applies on confirm, not the moment it is ticked; #1562 / #1590).
- The persistence storage is unchanged — only *when* it is written moved.

## Not affected

The FTP "Insecure Connection" consumer (`ConnectionList`) was already correct — it holds `insecureFtpDontWarn` in local state and only persists in `handleInsecureFtpConfirm`. This change is confined to `ConfirmSessionCloseDialog`, and its test (`ConnectionList.ftp-warning.test.tsx`) still passes.

## Tests

Three regression tests, committed before the fix (TDD):
- tick then **Cancel** asserts `updateSettings` was NOT called.
- tick then **Confirm** asserts the tick did not write on its own, then that confirm DID write `confirmCloseLiveSession: false`.
- confirm without ticking asserts no write.

The two directional tests were confirmed red against the unpatched code and green after the fix. `npx tsc --noEmit`, eslint, and the `ConfirmDialog`/FTP-warning suites all pass.

Closes #1606