### PR TITLE
fix(agent): bind and log readiness only after the agent can accept (Closes #1579)

### DIFF
--- a/agent/src/io/tcp.rs
+++ b/agent/src/io/tcp.rs
@@ -80,6 +80,13 @@ pub async fn run_tcp_listener(
         test_update.seed(&session_manager).await;
     }
 
+    // Test-only (#1579): stretch the startup window so a regression test can
+    // observe the bind/accept ordering deterministically. `None` — and so a
+    // zero-cost no-op — in production. Runs BEFORE the bind below so that the
+    // simulated slow init happens while the port is still un-connectable,
+    // exactly as the real #1551 startup work now does.
+    startup_test_delay().await;
+
     loop {
         tokio::select! {
             _ = shutdown.cancelled() => {
@@ -166,4 +173,22 @@ pub async fn run_tcp_listener(
     session_manager.close_all().await;
 
     Ok(())
+}
+
+/// Test-only startup delay gate (#1579).
+///
+/// When `TERMIHUB_TEST_STARTUP_DELAY_MS` is set to a positive integer, sleep
+/// that many milliseconds on the startup path just before the listener binds.
+/// This lets `agent/tests/tcp_listener_readiness.rs` reproduce the class of slow
+/// init (`SessionManager::new`'s #1551 binary byte-compare, session recovery)
+/// that made the accept-before-ready race observable, without depending on real
+/// machine load. Unset in production, so this is a single failed env lookup.
+async fn startup_test_delay() {
+    if let Some(ms) = std::env::var("TERMIHUB_TEST_STARTUP_DELAY_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+    {
+        tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+    }
 }

--- a/agent/src/io/tcp.rs
+++ b/agent/src/io/tcp.rs
@@ -28,9 +28,6 @@ pub async fn run_tcp_listener(
     allow_self_update: bool,
     update_strategy: crate::update::UpdateStrategy,
 ) -> anyhow::Result<()> {
-    let listener = TcpListener::bind(addr).await?;
-    info!("Listening on {}", listener.local_addr()?);
-
     let (notification_tx, mut notification_rx) =
         tokio::sync::mpsc::unbounded_channel::<JsonRpcNotification>();
     let registry = Arc::new(build_registry());
@@ -86,6 +83,18 @@ pub async fn run_tcp_listener(
     // simulated slow init happens while the port is still un-connectable,
     // exactly as the real #1551 startup work now does.
     startup_test_delay().await;
+
+    // Bind and announce readiness only now, after all the startup work above
+    // has finished (#1579). Binding earlier makes `Listening on …` a lie: the
+    // kernel accepts connections into the listen backlog the instant the socket
+    // is bound, so a client's `connect` succeeds while this task is still deep
+    // in `SessionManager::new`'s #1551 binary byte-compare, `ensure_default_shell`
+    // and `recover_sessions` — and then the client's `initialize` stalls with no
+    // reader until the accept loop below is finally reached. By binding last, the
+    // log line is a true readiness signal and an early client is cleanly refused
+    // (the desktop retries with backoff) instead of accepted-then-stalled.
+    let listener = TcpListener::bind(addr).await?;
+    info!("Listening on {}", listener.local_addr()?);
 
     loop {
         tokio::select! {

--- a/agent/tests/self_update_integration.rs
+++ b/agent/tests/self_update_integration.rs
@@ -296,10 +296,16 @@ impl Client {
     /// is listening (it may still be mid-restart after a self-apply).
     fn connect(addr: &str, timeout: Duration) -> Option<Self> {
         let deadline = Instant::now() + timeout;
+        // Bound each handshake read to a fraction of the overall budget (#1579).
+        // A single stalled `initialize` read must not consume the entire
+        // `timeout` and leave no retry — the old flat 15s read matched the 15s
+        // caller budget exactly, so one stall was fatal. A third of the budget
+        // (capped at 5s) leaves several fresh-socket retries.
+        let handshake_read = (timeout / 3).min(Duration::from_secs(5));
         while Instant::now() < deadline {
             if let Ok(stream) = TcpStream::connect(addr) {
                 stream
-                    .set_read_timeout(Some(Duration::from_secs(15)))
+                    .set_read_timeout(Some(handshake_read))
                     .expect("set read timeout");
                 let writer = stream.try_clone().expect("clone stream");
                 let mut client = Client {
@@ -312,6 +318,15 @@ impl Client {
                     json!({"protocolVersion": "0.3.0", "client": "self-update-it", "clientVersion": "0.1.0"}),
                 );
                 if resp.get("result").is_some() {
+                    // Handshake done: restore a generous read timeout for the
+                    // normal RPCs this client goes on to make, which can be
+                    // legitimately slow under load. Only the retry-until-ready
+                    // handshake above needed the tight bound.
+                    client
+                        .reader
+                        .get_ref()
+                        .set_read_timeout(Some(Duration::from_secs(15)))
+                        .expect("restore read timeout");
                     return Some(client);
                 }
             }

--- a/agent/tests/tcp_listener_readiness.rs
+++ b/agent/tests/tcp_listener_readiness.rs
@@ -1,0 +1,157 @@
+//! Regression test for #1579: the TCP listener must not advertise readiness
+//! (`Listening on …`) before it can actually accept and answer a client.
+//!
+//! Before the fix, `run_tcp_listener` bound the socket and logged `Listening
+//! on …` *first*, then did the expensive startup work (`SessionManager::new`'s
+//! #1551 binary byte-compare, `ensure_default_shell`, `recover_sessions`) before
+//! reaching its `accept()` loop. The kernel accepts connections into the listen
+//! backlog the instant the socket is bound, so a client's `connect` succeeded
+//! immediately — and then its `initialize` stalled with no reader until the
+//! accept loop was finally reached. The bind log looked like a readiness signal
+//! but was not one.
+//!
+//! This test makes that window deterministic with the `TERMIHUB_TEST_STARTUP_DELAY_MS`
+//! gate, which stretches the startup path just before the bind in the fixed code.
+//! With the fix, `Listening on …` only appears *after* the delay, so by the time
+//! a client can read the address and connect, the accept loop is running and
+//! `initialize` answers promptly. Reverting the ordering (bind before the delay)
+//! makes this test fail: the log appears immediately but `initialize` blocks for
+//! the whole delay.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn agent_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_termihub-agent")
+}
+
+/// How long the agent's startup path is stretched before it binds.
+const STARTUP_DELAY: Duration = Duration::from_millis(3000);
+/// Time allowed to observe the `Listening on …` line.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+/// Read budget for `initialize` once we have connected. Deliberately shorter
+/// than `STARTUP_DELAY`: if the agent were still in its startup delay when we
+/// connected (the #1579 bug), the reply could not arrive inside this window.
+const INITIALIZE_READ_TIMEOUT: Duration = Duration::from_millis(1500);
+
+/// A spawned agent process, killed on drop so a failing assertion never leaks it.
+struct AgentProcess {
+    child: Child,
+}
+
+impl Drop for AgentProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// The agent does not advertise `Listening on …` until it is genuinely ready to
+/// accept, and a client that connects on the strength of that log gets a timely
+/// `initialize` response rather than an accepted-then-stalled socket.
+#[test]
+fn listening_log_is_a_true_readiness_signal() {
+    let spawned_at = Instant::now();
+    let mut child = Command::new(agent_binary())
+        .arg("--listen")
+        .arg("127.0.0.1:0")
+        .env(
+            "TERMIHUB_TEST_STARTUP_DELAY_MS",
+            STARTUP_DELAY.as_millis().to_string(),
+        )
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn agent");
+
+    let stderr = child.stderr.take().expect("piped stderr");
+    let agent = AgentProcess { child };
+
+    // Block until the agent announces its bound address, exactly as the desktop
+    // and the other integration tests key off this line.
+    let (addr, listening_at) = read_listen_addr(stderr);
+
+    // The bind must have been deferred until after the (simulated) slow init:
+    // the log cannot appear before the startup delay has elapsed. With the old
+    // ordering the log fires at ~0ms, far below this bound.
+    let elapsed = listening_at.duration_since(spawned_at);
+    assert!(
+        elapsed >= STARTUP_DELAY / 2,
+        "`Listening on` appeared after {elapsed:?}, before the {STARTUP_DELAY:?} startup delay \
+         — the listener bound before it was ready (#1579)"
+    );
+
+    // Connect the instant we see the readiness signal and send `initialize`.
+    let stream = TcpStream::connect(&addr).expect("connect to agent");
+    stream
+        .set_read_timeout(Some(INITIALIZE_READ_TIMEOUT))
+        .expect("set read timeout");
+    let mut writer = stream.try_clone().expect("clone stream");
+    let mut reader = BufReader::new(stream);
+
+    let request = concat!(
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":"#,
+        r#"{"protocolVersion":"0.3.0","client":"readiness-probe",""#,
+        r#"clientVersion":"1.0.0","agentSettings":{}}}"#,
+        "\n"
+    );
+    writer.write_all(request.as_bytes()).expect("write request");
+    writer.flush().expect("flush request");
+
+    // A readiness signal that is honest means this reply arrives well inside the
+    // short read budget. Under the #1579 bug the socket is connected but has no
+    // reader, so this read hits its timeout instead.
+    let mut line = String::new();
+    match reader.read_line(&mut line) {
+        Ok(0) => panic!("agent closed the connection before answering initialize"),
+        Ok(_) => {}
+        Err(e) => panic!(
+            "no initialize response within {INITIALIZE_READ_TIMEOUT:?} after `Listening on` \
+             — the agent accepted the connection but could not answer (#1579): {e}"
+        ),
+    }
+
+    let value: serde_json::Value = serde_json::from_str(&line)
+        .unwrap_or_else(|e| panic!("initialize reply not JSON: {e}: {line}"));
+    assert_eq!(value["id"].as_i64(), Some(1), "unexpected reply: {line}");
+    assert!(
+        value["result"]["client_id"].is_string(),
+        "initialize returned no client_id: {line}"
+    );
+
+    drop(agent);
+}
+
+/// Wait for the agent's `Listening on <addr>` line, returning the address and
+/// the instant it was observed. Drains the rest of the pipe afterwards so a
+/// full stderr buffer never blocks the agent mid-test.
+fn read_listen_addr(stderr: std::process::ChildStderr) -> (String, Instant) {
+    let mut reader = BufReader::new(stderr);
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    let mut found = None;
+
+    while Instant::now() < deadline {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break, // agent exited before binding
+            Ok(_) => {
+                if let Some(rest) = line.split("Listening on ").nth(1) {
+                    found = Some((rest.trim().to_string(), Instant::now()));
+                    break;
+                }
+            }
+            Err(e) => panic!("reading agent stderr: {e}"),
+        }
+    }
+
+    // Keep the pipe from filling for the rest of the agent's life.
+    std::thread::spawn(move || {
+        let mut sink = Vec::new();
+        let _ = reader.read_to_end(&mut sink);
+    });
+
+    found.expect("agent never logged a `Listening on` address")
+}

--- a/docs/changes/dev0/fix/1579-agent-accept-before-ready.md
+++ b/docs/changes/dev0/fix/1579-agent-accept-before-ready.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Agent: a listening agent no longer logs `Listening on …` and accepts TCP
+  connections before it can answer them. The listener previously bound the
+  socket (and logged readiness) up front, then did its expensive startup work
+  (`SessionManager` init including the #1551 binary byte-compare, default-shell
+  seeding, session recovery) before reaching its accept loop. Because the kernel
+  accepts connections into the listen backlog the moment the socket is bound, a
+  desktop that connected during startup got an accepted-but-unread socket and
+  its `initialize` stalled with no response. The bind now happens only after
+  startup finishes, so the readiness log is truthful and an early client is
+  cleanly refused (the desktop retries with backoff) rather than
+  accepted-then-stalled (#1579).


### PR DESCRIPTION
## Summary

The TCP listener bound its socket and logged `Listening on …` **before** doing its expensive startup work — `SessionManager::new` (including the #1551 multi-MB binary byte-compare), `ensure_default_shell`, `recover_sessions` — and only then reached its `accept()` loop. Because the kernel accepts connections into the listen backlog the instant the socket is bound, a desktop that connected during startup got an accepted-but-unread socket: its `TcpStream::connect` succeeded immediately, but `initialize` stalled with no reader until the accept loop was finally reached. The bind log read like a readiness signal but was not one.

This fixes the ordering: the bind and the `Listening on …` log now happen **after** all startup work, immediately before the accept loop. The readiness log is now truthful, and a client that connects too early is cleanly refused (the desktop reconnects with backoff) instead of accepted-then-stalled.

`stdio` needs no equivalent change — it has no bind/accept split, so a client's bytes simply buffer in the pipe and are read once the transport loop starts.

## What consumes the `Listening on …` signal

- The desktop connects over SSH with retry/backoff (`reconnect_agent` in `agent_manager.rs`), so connection-refused-until-ready is safe.
- The integration tests (`registry_daemon_integration.rs`, `deferred_update_hook_integration.rs`, `self_update_integration.rs`) parse the line to discover the ephemeral `:0` address — and `registry_daemon_integration.rs` explicitly (and wrongly) documented "seeing it means the port is already accepting." Binding last makes that assumption true.

## Proof

- **Deterministic regression test** (`agent/tests/tcp_listener_readiness.rs`): a new `TERMIHUB_TEST_STARTUP_DELAY_MS` gate stretches the startup path. With the bind placed first (reverted ordering) the test fails — the log fires before the delay and `initialize` cannot be answered within its short read budget. With the fix it passes. Committed test-first (red) then fix (green).
- **Load A/B** on the reachability-sensitive `active_shell_session_is_never_interrupted` test, identical CPU load (6 hogs, 12 concurrent copies): bind-early **1/12 reachability failures**, bind-late (this PR) **0/12**.

## Also in scope (#1579 checklist)

- Hardened `Client::connect` in `self_update_integration.rs`: each handshake read is now bounded to a third of the overall budget (capped 5s) so a single stalled read leaves retries, with a generous read timeout restored after the handshake so later RPCs are not shortened.

Not changed: making the #1551 startup byte-compare cheaper — left as the follow-up below.

## Test plan

- `cargo test -p termihub-agent --test tcp_listener_readiness` (new)
- `cargo test -p termihub-agent --test self_update_integration` (6/6)
- `cargo test -p termihub-agent --test registry_daemon_integration` (12/12)
- `cargo clippy -p termihub-agent --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`

Closes #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)