### PR TITLE
feat(ui): reflect external on-disk changes to open local editor files (Refs #1620)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,6 +2105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2216,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -3229,6 +3247,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3602,6 +3640,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3878,6 +3936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -4053,6 +4112,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -7320,6 +7419,7 @@ dependencies = [
  "keyring",
  "libc",
  "libunftp",
+ "notify-debouncer-full",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/docs/changes/dev5/feature/1620-editor-external-change-reload.md
+++ b/docs/changes/dev5/feature/1620-editor-external-change-reload.md
@@ -1,0 +1,11 @@
+### Added
+
+- Local files open in the built-in editor now reflect external on-disk changes.
+  When another process rewrites a local file that is open in the editor and the
+  editor buffer has no unsaved edits, the editor reloads the new content
+  automatically (cursor and scroll position preserved). Detection uses OS file
+  watching (FSEvents / inotify / ReadDirectoryChangesW) with debouncing, and the
+  watcher is torn down when the tab closes. If the file changes on disk while the
+  buffer has unsaved edits, the change is detected and a non-destructive notice is
+  shown — your edits are kept and nothing is overwritten. Remote (SFTP / session)
+  files are unaffected. (#1620)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,10 @@ tauri = { version = "2", default-features = false, features = ["wry", "compressi
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+# Cross-platform filesystem watching (FSEvents / inotify / ReadDirectoryChangesW)
+# for reflecting external on-disk changes to open local editor files (#1620).
+# The debouncer coalesces the multiple syscalls a single external save emits.
+notify-debouncer-full = "0.7"
 serde = { workspace = true }
 hex = "0.4"
 # SHA-256 hashing: agent-binary integrity verification (all platforms) and

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -334,6 +334,32 @@ pub fn local_write_file(path: String, content: String) -> Result<(), TerminalErr
     crate::files::local::write_file_content(&path, &content)
 }
 
+/// Start watching a local file for external on-disk changes (#1620).
+///
+/// `watch_id` is an opaque per-editor-instance key the frontend also matches the
+/// resulting `local-file-changed` events against; re-watching the same id
+/// replaces the previous watch. Only local editor files are watched — remote
+/// (SFTP / session) files never call this.
+#[tauri::command]
+pub fn watch_local_file(
+    watch_id: String,
+    path: String,
+    manager: State<'_, crate::files::watcher::FileWatchManager>,
+    app_handle: tauri::AppHandle,
+) -> Result<(), TerminalError> {
+    manager.watch(app_handle, watch_id, path)
+}
+
+/// Stop watching a local file previously registered with [`watch_local_file`].
+/// Unknown ids are a harmless no-op.
+#[tauri::command]
+pub fn unwatch_local_file(
+    watch_id: String,
+    manager: State<'_, crate::files::watcher::FileWatchManager>,
+) {
+    manager.unwatch(&watch_id);
+}
+
 /// Read a remote file's contents as a UTF-8 string via SFTP.
 #[tauri::command]
 pub async fn sftp_read_file_content(

--- a/src-tauri/src/files/mod.rs
+++ b/src-tauri/src/files/mod.rs
@@ -1,5 +1,6 @@
 pub mod local;
 pub mod sftp;
 pub mod transfer;
+pub mod watcher;
 
 pub use termihub_core::files::FileEntry;

--- a/src-tauri/src/files/watcher.rs
+++ b/src-tauri/src/files/watcher.rs
@@ -68,6 +68,26 @@ impl FileWatchManager {
         watch_id: String,
         path: String,
     ) -> Result<(), TerminalError> {
+        // The path is echoed back so the frontend can confirm it matches the tab;
+        // contents are never read or logged here.
+        self.watch_with_sink(watch_id, path, move |watch_id, path| {
+            let _ = app.emit("local-file-changed", FileChangedPayload { watch_id, path });
+        })
+    }
+
+    /// Core of [`Self::watch`], parameterised by the notification `sink` so the
+    /// OS-watch pipeline can be exercised against a real file without a Tauri
+    /// `AppHandle`. The sink is called with `(watch_id, path)` on each debounced
+    /// change to the target file.
+    fn watch_with_sink<F>(
+        &self,
+        watch_id: String,
+        path: String,
+        sink: F,
+    ) -> Result<(), TerminalError>
+    where
+        F: Fn(String, String) + Send + 'static,
+    {
         let target = PathBuf::from(&path);
         // Watch the containing directory so atomic rename-replace writes (which
         // swap the inode) are still observed; events are filtered to the target
@@ -92,15 +112,7 @@ impl FileWatchManager {
                         .flat_map(|ev| ev.paths.iter())
                         .any(|p| paths_match(p, &target_for_cb));
                     if touched {
-                        // The path is echoed back so the frontend can confirm it
-                        // matches the tab; contents are never read or logged here.
-                        let _ = app.emit(
-                            "local-file-changed",
-                            FileChangedPayload {
-                                watch_id: watch_id_cb.clone(),
-                                path: emit_path.clone(),
-                            },
-                        );
+                        sink(watch_id_cb.clone(), emit_path.clone());
                     }
                 }
                 Err(errors) => {
@@ -183,5 +195,75 @@ mod tests {
             Path::new("/home/u"),
             Path::new("/home/u/notes.txt")
         ));
+    }
+
+    /// End-to-end against a real file: an external write to a watched file must
+    /// drive the sink with the file's `watch_id`. Exercises the actual OS watcher
+    /// (FSEvents / inotify / ReadDirectoryChangesW), not a mock.
+    #[test]
+    fn sink_fires_on_real_external_write() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let file = dir.path().join("notes.txt");
+        std::fs::write(&file, "before").expect("seed file");
+
+        let manager = FileWatchManager::new();
+        let (tx, rx) = mpsc::channel();
+        manager
+            .watch_with_sink(
+                "w1".to_string(),
+                file.to_string_lossy().to_string(),
+                move |watch_id, _path| {
+                    let _ = tx.send(watch_id);
+                },
+            )
+            .expect("watch starts");
+
+        // Let the OS watch arm before writing (FSEvents in particular is lazy).
+        std::thread::sleep(Duration::from_millis(400));
+        std::fs::write(&file, "after external change").expect("external write");
+
+        let got = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("a change event should arrive");
+        assert_eq!(got, "w1");
+
+        manager.unwatch("w1");
+    }
+
+    /// Dropping the watch (via `unwatch`) stops delivery: writes after teardown
+    /// must not reach the sink — the resource-cleanup guarantee.
+    #[test]
+    fn sink_stops_after_unwatch() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let file = dir.path().join("notes.txt");
+        std::fs::write(&file, "before").expect("seed file");
+
+        let manager = FileWatchManager::new();
+        let (tx, rx) = mpsc::channel();
+        manager
+            .watch_with_sink(
+                "w1".to_string(),
+                file.to_string_lossy().to_string(),
+                move |watch_id, _path| {
+                    let _ = tx.send(watch_id);
+                },
+            )
+            .expect("watch starts");
+
+        manager.unwatch("w1");
+        // Drain any event that may have been queued before teardown.
+        while rx.try_recv().is_ok() {}
+
+        std::thread::sleep(Duration::from_millis(400));
+        std::fs::write(&file, "after teardown").expect("external write");
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(800)).is_err(),
+            "no event should arrive after unwatch"
+        );
     }
 }

--- a/src-tauri/src/files/watcher.rs
+++ b/src-tauri/src/files/watcher.rs
@@ -1,0 +1,187 @@
+//! Watch open local editor files for external on-disk changes (#1620).
+//!
+//! When a local file is open in the built-in editor and another process
+//! rewrites it on disk, the editor should be able to reflect the new content.
+//! This module owns the OS-level file watchers (FSEvents / inotify /
+//! ReadDirectoryChangesW via the `notify` crate) and emits a `local-file-changed`
+//! event to the frontend, which decides whether to reload (only remote/SFTP
+//! files are excluded — those never reach this module).
+//!
+//! Design notes:
+//! - **Watch the parent directory, not the file.** Many tools save via
+//!   write-to-temp-then-rename, which swaps in a fresh inode; a watch on the
+//!   original file would go deaf after the first such write. Watching the parent
+//!   directory (non-recursively) and filtering events to the target name catches
+//!   both in-place writes and atomic-rename replacements.
+//! - **Debounced.** A single logical save can fire several filesystem events;
+//!   the debouncer coalesces them so the editor is not reload-stormed.
+//! - **One watcher per editor instance**, keyed by an opaque `watch_id` supplied
+//!   by the frontend. Re-watching the same id replaces the previous watcher, and
+//!   dropping it stops the underlying OS watch — so a closed tab leaks nothing.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use notify_debouncer_full::notify::{RecommendedWatcher, RecursiveMode};
+use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
+use tauri::{AppHandle, Emitter};
+use tracing::{debug, warn};
+
+use crate::utils::errors::TerminalError;
+
+/// How long to wait for filesystem events to settle before notifying the
+/// frontend. A single external save often emits several syscalls; coalescing
+/// them here avoids reloading the editor multiple times for one logical change.
+const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(300);
+
+/// Emitted to the frontend when a watched local file changes on disk. The
+/// `watch_id` routes the event back to the exact editor instance that
+/// registered the watch.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FileChangedPayload {
+    watch_id: String,
+    path: String,
+}
+
+type FileDebouncer = Debouncer<RecommendedWatcher, RecommendedCache>;
+
+/// Tracks one active watcher per `watch_id` (an opaque per-editor-instance key).
+#[derive(Default)]
+pub struct FileWatchManager {
+    watchers: Mutex<HashMap<String, FileDebouncer>>,
+}
+
+impl FileWatchManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start (or replace) a watch on `path` for `watch_id`. On any change to the
+    /// file, a `local-file-changed` event carrying `watch_id` and `path` is
+    /// emitted to the frontend.
+    pub fn watch(
+        &self,
+        app: AppHandle,
+        watch_id: String,
+        path: String,
+    ) -> Result<(), TerminalError> {
+        let target = PathBuf::from(&path);
+        // Watch the containing directory so atomic rename-replace writes (which
+        // swap the inode) are still observed; events are filtered to the target
+        // file name in the callback below.
+        let watch_dir = target
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let target_for_cb = target.clone();
+        let watch_id_cb = watch_id.clone();
+        let emit_path = path.clone();
+
+        let mut debouncer = new_debouncer(
+            DEBOUNCE_TIMEOUT,
+            None,
+            move |result: DebounceEventResult| match result {
+                Ok(events) => {
+                    let touched = events
+                        .iter()
+                        .flat_map(|ev| ev.paths.iter())
+                        .any(|p| paths_match(p, &target_for_cb));
+                    if touched {
+                        // The path is echoed back so the frontend can confirm it
+                        // matches the tab; contents are never read or logged here.
+                        let _ = app.emit(
+                            "local-file-changed",
+                            FileChangedPayload {
+                                watch_id: watch_id_cb.clone(),
+                                path: emit_path.clone(),
+                            },
+                        );
+                    }
+                }
+                Err(errors) => {
+                    for e in errors {
+                        warn!("local file watch error: {e}");
+                    }
+                }
+            },
+        )
+        .map_err(|e| TerminalError::EditorError(format!("failed to create file watcher: {e}")))?;
+
+        debouncer
+            .watch(&watch_dir, RecursiveMode::NonRecursive)
+            .map_err(|e| {
+                TerminalError::EditorError(format!("failed to watch {}: {e}", watch_dir.display()))
+            })?;
+
+        // Inserting over an existing id drops the previous debouncer, which stops
+        // its OS watch and background thread.
+        let mut guard = self.watchers.lock().unwrap_or_else(|e| e.into_inner());
+        guard.insert(watch_id.clone(), debouncer);
+        debug!(watch_id, "watching local file for external changes");
+        Ok(())
+    }
+
+    /// Stop watching for `watch_id`. Unknown ids are a harmless no-op.
+    pub fn unwatch(&self, watch_id: &str) {
+        let mut guard = self.watchers.lock().unwrap_or_else(|e| e.into_inner());
+        if guard.remove(watch_id).is_some() {
+            debug!(watch_id, "stopped watching local file");
+        }
+    }
+}
+
+/// Whether a filesystem event path refers to the watched target file. Because
+/// the watch is scoped to the target's own directory (non-recursive), a matching
+/// final path component uniquely identifies the file and also matches the
+/// rename-destination event of an atomic replace.
+fn paths_match(event_path: &Path, target: &Path) -> bool {
+    match (event_path.file_name(), target.file_name()) {
+        (Some(a), Some(b)) => a == b,
+        _ => event_path == target,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_same_file_name_in_dir() {
+        assert!(paths_match(
+            Path::new("/home/u/notes.txt"),
+            Path::new("/home/u/notes.txt")
+        ));
+    }
+
+    #[test]
+    fn ignores_staged_temp_file_of_atomic_replace() {
+        // Atomic replace stages a differently-named temp file, then renames it
+        // onto the target. The temp write must not be mistaken for the target;
+        // only the rename-to-target event (matched above) counts.
+        assert!(!paths_match(
+            Path::new("/home/u/.notes.txt.tmp1234"),
+            Path::new("/home/u/notes.txt")
+        ));
+    }
+
+    #[test]
+    fn ignores_other_files_in_dir() {
+        assert!(!paths_match(
+            Path::new("/home/u/other.txt"),
+            Path::new("/home/u/notes.txt")
+        ));
+    }
+
+    #[test]
+    fn ignores_the_directory_itself() {
+        assert!(!paths_match(
+            Path::new("/home/u"),
+            Path::new("/home/u/notes.txt")
+        ));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,6 +210,7 @@ pub fn run() {
         .plugin(tauri_plugin_cli::init())
         .manage(SftpManager::new())
         .manage(TransferRegistry::new())
+        .manage(files::watcher::FileWatchManager::new())
         .manage(NetworkManager::new())
         .manage(x_server_manager.clone())
         .manage(x_server_consent_registry.clone())
@@ -724,6 +725,8 @@ pub fn run() {
             commands::files::local_rename,
             commands::files::local_read_file,
             commands::files::local_write_file,
+            commands::files::watch_local_file,
+            commands::files::unwatch_local_file,
             commands::files::sftp_read_file_content,
             commands::files::sftp_write_file_content,
             commands::files::sftp_write_file_content_elevated,

--- a/src/components/FileEditor/FileEditor.css
+++ b/src/components/FileEditor/FileEditor.css
@@ -130,6 +130,28 @@
   min-width: 0;
 }
 
+/*
+ * Dismissible notice shown when the file changed on disk while the buffer had
+ * unsaved edits (#1620). Warning-toned like the read-only banner (informational,
+ * not a failure); tokens only. The clean-buffer case reloads silently and shows
+ * no banner.
+ */
+.file-editor__disk-changed-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background-color: color-mix(in srgb, var(--color-warning) 12%, var(--bg-secondary));
+  border-bottom: 1px solid var(--color-warning);
+  color: var(--color-warning);
+  font-size: var(--font-size-sm);
+}
+
+.file-editor__disk-changed-banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
 @keyframes file-editor-spin {
   from {
     transform: rotate(0deg);

--- a/src/components/FileEditor/FileEditor.external-change.test.tsx
+++ b/src/components/FileEditor/FileEditor.external-change.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import React from "react";
+import { createRoot, Root } from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import { useAppStore } from "@/store/appStore";
+import { FileEditor } from "./FileEditor";
+import type { EditorTabMeta } from "@/types/terminal";
+
+// Capture the external-change event callback the editor registers so the test
+// can fire a simulated `local-file-changed` event at it.
+let fileChangeCb: ((watchId: string, path: string) => void) | null = null;
+vi.mock("@/services/events", () => ({
+  onLocalFileChanged: vi.fn((cb: (watchId: string, path: string) => void) => {
+    fileChangeCb = cb;
+    return Promise.resolve(() => {
+      fileChangeCb = null;
+    });
+  }),
+}));
+
+// Functional Monaco mock: renders a textarea, calls onMount with a small fake
+// editor backed by a mutable model string, and reflects model.setValue back
+// into the textarea. This lets the reload path (which drives the Monaco model
+// directly, since the real editor is uncontrolled) be observed end to end.
+let currentModelValue = "";
+vi.mock("@monaco-editor/react", () => {
+  const MockEditor = ({
+    defaultValue,
+    onChange,
+    onMount,
+  }: {
+    defaultValue?: string;
+    onChange?: (value: string | undefined) => void;
+    onMount?: (editor: unknown) => void;
+  }) => {
+    const ref = React.useRef<HTMLTextAreaElement | null>(null);
+    React.useEffect(() => {
+      currentModelValue = defaultValue ?? "";
+      const ta = ref.current;
+      const fakeModel = {
+        getValue: () => currentModelValue,
+        setValue: (v: string) => {
+          currentModelValue = v;
+          if (ta) ta.value = v;
+          onChange?.(v);
+        },
+        getOptions: () => ({ tabSize: 4, insertSpaces: true }),
+        getLanguageId: () => "plaintext",
+        getEOL: () => "\n",
+        updateOptions: () => {},
+        setEOL: () => {},
+      };
+      const fakeEditor = {
+        getModel: () => fakeModel,
+        getPosition: () => ({ lineNumber: 1, column: 1 }),
+        getDomNode: () => document.createElement("div"),
+        addAction: () => {},
+        onDidChangeCursorPosition: () => {},
+        saveViewState: () => ({}),
+        restoreViewState: () => {},
+        setValue: (v: string) => fakeModel.setValue(v),
+      };
+      onMount?.(fakeEditor);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return React.createElement("textarea", {
+      ref,
+      "data-testid": "mock-monaco",
+      defaultValue,
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        currentModelValue = e.target.value;
+        onChange?.(e.target.value);
+      },
+    });
+  };
+  return { default: MockEditor, loader: { config: vi.fn() } };
+});
+
+// This suite mounts the editor (calls onMount), unlike the sibling suite, so the
+// monaco mock must carry the keybinding/EOL constants handleEditorMount reads.
+vi.mock("monaco-editor", () => ({
+  KeyMod: { CtrlCmd: 2048 },
+  KeyCode: { KeyS: 49 },
+  editor: {
+    setTheme: vi.fn(),
+    setModelLanguage: vi.fn(),
+    EndOfLineSequence: { LF: 0, CRLF: 1 },
+  },
+  languages: {
+    getLanguages: vi.fn(() => [{ id: "plaintext", aliases: ["Plain Text"] }]),
+    register: vi.fn(),
+    setMonarchTokensProvider: vi.fn(),
+    setLanguageConfiguration: vi.fn(),
+  },
+}));
+
+vi.mock("@/themes", () => ({
+  getCurrentTheme: () => ({ id: "dark" }),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+const mockedInvoke = vi.mocked(invoke);
+
+const TAB_ID = "tab-fe-ext-1";
+const LOCAL_META: EditorTabMeta = {
+  filePath: "/home/user/notes.txt",
+  isRemote: false,
+};
+const REMOTE_META: EditorTabMeta = {
+  filePath: "/etc/hosts",
+  isRemote: true,
+  sftpSessionId: "sftp-sess-1",
+};
+
+const INITIAL = "line one\n";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(meta: EditorTabMeta = LOCAL_META) {
+  act(() => {
+    root.render(<FileEditor tabId={TAB_ID} meta={meta} isVisible={true} />);
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function query(testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+function editContent(value: string): void {
+  const ta = query("mock-monaco") as HTMLTextAreaElement;
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value"
+  )!.set!;
+  act(() => {
+    setter.call(ta, value);
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+/** Read the watchId the editor registered via the watch_local_file invoke. */
+function registeredWatchId(): string {
+  const call = mockedInvoke.mock.calls.find((c) => c[0] === "watch_local_file");
+  expect(call, "watch_local_file should have been invoked").toBeDefined();
+  return (call![1] as { watchId: string }).watchId;
+}
+
+async function fireExternalChange(diskContent: string): Promise<void> {
+  // The next local_read_file resolves with the new on-disk content.
+  mockedInvoke.mockImplementation((cmd) => {
+    if (cmd === "local_read_file") return Promise.resolve(diskContent);
+    return Promise.resolve(undefined);
+  });
+  const watchId = registeredWatchId();
+  await act(async () => {
+    fileChangeCb?.(watchId, LOCAL_META.filePath);
+  });
+  // Frontend debounce is 150ms; advance past it, then flush the async reload.
+  await act(async () => {
+    vi.advanceTimersByTime(200);
+  });
+  await flush();
+}
+
+describe("FileEditor — external on-disk change reload (#1620)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+    fileChangeCb = null;
+    currentModelValue = "";
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "local_read_file") return Promise.resolve(INITIAL);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("registers a watch for a local file on mount and tears it down on unmount", async () => {
+    render();
+    await flush();
+
+    const watchCall = mockedInvoke.mock.calls.find((c) => c[0] === "watch_local_file");
+    expect(watchCall).toBeDefined();
+    expect((watchCall![1] as { path: string }).path).toBe(LOCAL_META.filePath);
+
+    act(() => root.unmount());
+    // Re-create a root so afterEach's unmount is a harmless no-op.
+    root = createRoot(container);
+
+    const unwatchCall = mockedInvoke.mock.calls.find((c) => c[0] === "unwatch_local_file");
+    expect(unwatchCall).toBeDefined();
+  });
+
+  it("does not watch a remote file", async () => {
+    render(REMOTE_META);
+    await flush();
+    const watchCall = mockedInvoke.mock.calls.find((c) => c[0] === "watch_local_file");
+    expect(watchCall).toBeUndefined();
+  });
+
+  it("reflects the new on-disk content when the buffer has no unsaved edits", async () => {
+    render();
+    await flush();
+    expect(currentModelValue).toBe(INITIAL);
+
+    await fireExternalChange("line one\nline two (external)\n");
+
+    expect(currentModelValue).toBe("line one\nline two (external)\n");
+    // Clean reload: no conflict notice, buffer not marked dirty.
+    expect(query("file-editor-disk-changed-banner")).toBeNull();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("does not clobber unsaved edits, and surfaces a conflict notice instead", async () => {
+    render();
+    await flush();
+
+    // Local edit → buffer dirty.
+    editContent("line one\nmy local edit\n");
+    await flush();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(false);
+
+    await fireExternalChange("line one\nexternal edit\n");
+
+    // Edits preserved (not overwritten by disk), and the conflict is surfaced.
+    expect(currentModelValue).toBe("line one\nmy local edit\n");
+    expect(query("file-editor-disk-changed-banner")).not.toBeNull();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useId } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
 import {
@@ -26,6 +26,8 @@ import { getCurrentTheme, onThemeChange } from "@/themes";
 import {
   localReadFile,
   localWriteFile,
+  watchLocalFile,
+  unwatchLocalFile,
   sftpReadFileContent,
   sftpWriteFileContent,
   sftpWriteFileContentElevated,
@@ -41,6 +43,7 @@ import {
   TransferTerminalError,
   type ElevatedWriteResult,
 } from "@/services/api";
+import { onLocalFileChanged } from "@/services/events";
 import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
 import { SudoPromptDialog, type SudoAuthorizeOptions } from "./SudoPromptDialog";
 import { SaveCopyDialog } from "./SaveCopyDialog";
@@ -178,6 +181,13 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // persistent state indicator; only the banner is dismissible.
   const [readonlyBannerDismissed, setReadonlyBannerDismissed] = useState(false);
 
+  // Set when the file changed on disk while the buffer had unsaved edits (#1620).
+  // This is the genuine-conflict case: we detect it and surface a non-destructive
+  // notice, but deliberately do NOT auto-reload (which would clobber the user's
+  // edits) — the resolution policy is a deferred decision. The clean case (no
+  // unsaved edits) reloads silently instead and never sets this.
+  const [diskChangedWhileDirty, setDiskChangedWhileDirty] = useState(false);
+
   // Elevated ("sudo") edit mode. Once a save is authorized with sudo, the tab
   // stays in elevated mode for the rest of the session: a persistent `sudo`
   // marker is shown and subsequent saves route through the elevated path.
@@ -211,6 +221,11 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   const isUnsavedScratch = meta.scratch === true && scratchSavedPath === null;
   // The effective path used for display, language detection and saving.
   const effectivePath = scratchSavedPath ?? meta.filePath;
+  // Stable, per-editor-instance key for the local file watch (#1620). Keyed off
+  // React's useId rather than the tab id so a second instance for the same tab
+  // (e.g. the zoom overlay, `keepModel`) gets its own watch and its own cleanup,
+  // and never tears down the other instance's watcher.
+  const watchId = useId();
   const fileName = getBasename(effectivePath);
   const detectedLanguage = resolveLanguage(fileName, fileLanguageMappings);
   // Scratch buffers share the synthetic file name, so key the Monaco model on
@@ -406,6 +421,121 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     if (content === null || savedContent === null) return;
     setEditorDirty(tabId, isDirty);
   }, [isDirty, content, savedContent, tabId, setEditorDirty]);
+
+  // Once the buffer is clean again (saved, or edits reverted), a pending
+  // disk-changed conflict notice no longer applies (#1620).
+  useEffect(() => {
+    if (!isDirty && diskChangedWhileDirty) setDiskChangedWhileDirty(false);
+  }, [isDirty, diskChangedWhileDirty]);
+
+  // Reflect the current on-disk contents of a locally-watched file (#1620).
+  // Invoked (debounced) when the OS reports the open file changed underneath us.
+  const reloadFromDisk = useCallback(async () => {
+    // Only local, on-disk editor buffers are watched.
+    if (meta.isRemote || isUnsavedScratch) return;
+    let disk: string;
+    try {
+      disk = await localReadFile(effectivePath);
+    } catch (err) {
+      frontendLog(
+        "file_editor",
+        `external-change reload read failed for tab ${tabId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return;
+    }
+    // Nothing new relative to what we last loaded/saved. This also silently
+    // absorbs the watcher event fired by our own save (disk === savedContent
+    // afterwards), so saving never triggers a spurious reload.
+    if (disk === savedContent) return;
+
+    const hasUnsavedEdits = content !== null && content !== savedContent;
+    if (hasUnsavedEdits) {
+      // Genuine conflict: the file changed on disk while the buffer has local
+      // edits. Detection only — do NOT clobber either side. The resolution
+      // policy (reload / keep / merge / prompt) is a deferred, user-visible
+      // decision, so we just surface a non-destructive notice.
+      frontendLog(
+        "file_editor",
+        `external change detected for tab ${tabId} with unsaved edits — deferring (no reload)`
+      );
+      setDiskChangedWhileDirty(true);
+      return;
+    }
+
+    // Happy path: the buffer is clean, so reflect the new content. Monaco is
+    // uncontrolled, so update its model directly; preserve cursor/scroll.
+    const editor = editorRef.current;
+    const model = editor?.getModel();
+    if (editor && model) {
+      const view = editor.saveViewState();
+      setSavedContent(disk);
+      // Fires onChange -> setContent(disk); the buffer stays clean.
+      model.setValue(disk);
+      if (view) editor.restoreViewState(view);
+    } else {
+      // Not mounted yet (still loading) — updating state is enough; the load
+      // path renders from it.
+      setContent(disk);
+      setSavedContent(disk);
+    }
+    frontendLog("file_editor", `reloaded tab ${tabId} from external on-disk change`);
+  }, [meta.isRemote, isUnsavedScratch, effectivePath, savedContent, content, tabId]);
+
+  // Keep a stable ref so the (path-scoped) watch effect's event handler always
+  // calls the latest reload logic without re-subscribing on every keystroke.
+  const reloadFromDiskRef = useRef(reloadFromDisk);
+  reloadFromDiskRef.current = reloadFromDisk;
+
+  // Watch the open local file for external on-disk changes and reflect them
+  // (#1620). Remote (SFTP / session) files use their own transports and are not
+  // watched here; an unsaved scratch buffer has no on-disk file yet.
+  useEffect(() => {
+    if (meta.isRemote || isUnsavedScratch) return;
+    const filePath = effectivePath;
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const start = async () => {
+      try {
+        await watchLocalFile(watchId, filePath);
+      } catch (err) {
+        frontendLog(
+          "file_editor",
+          `failed to start local file watch for tab ${tabId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+      const off = await onLocalFileChanged((changedWatchId) => {
+        if (changedWatchId !== watchId) return;
+        // Coalesce bursts on the frontend too — belt-and-braces over the
+        // backend debounce.
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          void reloadFromDiskRef.current();
+        }, 150);
+      });
+      // The effect may have been torn down while awaiting; drop the listener.
+      if (disposed) {
+        off();
+      } else {
+        unlisten = off;
+      }
+    };
+    void start();
+
+    return () => {
+      disposed = true;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      unlisten?.();
+      void unwatchLocalFile(watchId).catch(() => {
+        // best-effort teardown
+      });
+    };
+  }, [meta.isRemote, isUnsavedScratch, effectivePath, watchId, tabId]);
 
   // A file that failed to load (e.g. the connection dropped) shows the
   // error-only view, which doesn't render the UnsavedChangesDialog. If such a
@@ -971,6 +1101,29 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
             title="Dismiss"
             aria-label="Dismiss read-only notice"
             data-testid="file-editor-readonly-banner-dismiss"
+          />
+        </div>
+      )}
+      {diskChangedWhileDirty && (
+        <div
+          className="file-editor__disk-changed-banner"
+          role="status"
+          data-testid="file-editor-disk-changed-banner"
+        >
+          <AlertCircle size={14} />
+          <span className="file-editor__disk-changed-banner-text">
+            This file changed on disk while you have unsaved changes. Your edits are kept and
+            nothing was overwritten.
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            icon={<X size={14} />}
+            onClick={() => setDiskChangedWhileDirty(false)}
+            title="Dismiss"
+            aria-label="Dismiss on-disk change notice"
+            data-testid="file-editor-disk-changed-dismiss"
           />
         </div>
       )}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1053,6 +1053,22 @@ export async function localWriteFile(path: string, content: string): Promise<voi
   await invoke("local_write_file", { path, content });
 }
 
+/**
+ * Start watching a local file for external on-disk changes (#1620).
+ *
+ * `watchId` is an opaque per-editor-instance key; the resulting
+ * `local-file-changed` events carry it back so the right editor reloads.
+ * Re-watching the same id replaces the previous watch.
+ */
+export async function watchLocalFile(watchId: string, path: string): Promise<void> {
+  await invoke("watch_local_file", { watchId, path });
+}
+
+/** Stop watching a local file previously registered with {@link watchLocalFile}. */
+export async function unwatchLocalFile(watchId: string): Promise<void> {
+  await invoke("unwatch_local_file", { watchId });
+}
+
 /** Read a remote file's contents as a UTF-8 string via SFTP. */
 export async function sftpReadFileContent(sessionId: string, remotePath: string): Promise<string> {
   return await invoke<string>("sftp_read_file_content", { sessionId, remotePath });

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -378,6 +378,24 @@ export async function onVscodeEditComplete(
   });
 }
 
+interface LocalFileChangedPayload {
+  watchId: string;
+  path: string;
+}
+
+/**
+ * Subscribe to external on-disk change events for watched local editor files
+ * (#1620). The `watchId` identifies which editor instance registered the watch;
+ * callers filter to their own id.
+ */
+export async function onLocalFileChanged(
+  callback: (watchId: string, path: string) => void
+): Promise<UnlistenFn> {
+  return await listen<LocalFileChangedPayload>("local-file-changed", (event) => {
+    callback(event.payload.watchId, event.payload.path);
+  });
+}
+
 /** Subscribe to real-time log entry events from the backend. */
 export async function onLogEntry(callback: (entry: LogEntry) => void): Promise<UnlistenFn> {
   return await listen<LogEntry>("log-entry", (event) => {


### PR DESCRIPTION
## What & why

The built-in editor did not reflect external on-disk changes to an open **local** file: when another process (e.g. Claude Code) rewrote a file open in the editor, termiHub kept showing the stale buffer. Reported from real usage and confirmed by the owner in #1620.

This delivers the **happy path** and wires up **detection** for the conflict case.

## Behaviour

- **Local file open, no unsaved edits, changes on disk → reload automatically.** The new content is loaded into Monaco with cursor/scroll preserved. The buffer stays clean.
- **Local file with unsaved edits, changes on disk → detected, never clobbered.** A non-destructive notice is shown; the user's edits are kept and the disk is untouched.
- **Remote (SFTP / session) files are not watched** — out of scope, they use their own transports.

## How it works

- New Rust `FileWatchManager` (`notify-debouncer-full`: FSEvents / inotify / ReadDirectoryChangesW) with `watch_local_file` / `unwatch_local_file` commands, emitting a debounced `local-file-changed` event.
- Watches the **parent directory** and filters to the target file name, so atomic write-to-temp-then-rename saves are still seen (a plain file watch would go deaf after the first such save).
- Debounced backend-side (300 ms) and frontend-side (150 ms) so one logical save is not a reload-storm. A reload that reads back identical content is a no-op, which also prevents our own save from self-triggering.
- One OS watch **per editor instance** (keyed off `useId`), torn down on unmount / path change — no watcher leak.
- No file contents are read into any log; paths are kept out of the file log.

## Deferred — conflict-resolution policy (open decision)

The policy for **unsaved-edits + on-disk-change** (silent-reload-only-when-clean + prompt-on-conflict, vs. always-prompt, vs. keep-both) is a user-visible decision reserved by the owner. This PR **detects** that case and surfaces a passive, non-destructive notice, but does not implement a resolution flow. That is why this uses `Refs` and leaves the issue open. Follow-up: a dedicated decision + implementation for the conflict branch.

## Tests

- Rust: unit tests for the event/target matching, plus **real-filesystem** integration tests that watch a temp file, assert an external write reaches the watcher, and that `unwatch` stops delivery (exercises the real OS watcher, not a mock).
- Frontend: regression tests (functional Monaco mock) covering clean-buffer reload applies new content, unsaved-edit conflict is detected without clobbering, watch registration/teardown, and that remote files are not watched. Verified red without the reload logic.

## Verification

Drove the real OS-watch path against a real file on macOS (the integration test above, stable across repeated runs) — a genuine external write fires the watcher end to end. The full GUI click-through on macOS is not automatable (no WKWebView `tauri-driver`, ADR-5).

Refs #1620

## Follow-up issues

- #1626 — sidebar file-browser listing refresh on external change
- #1627 — external-change detection for remote transports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
