### PR TITLE
fix(backend): resolve macOS Podman machine socket for explicit runtime: Podman (Closes #1622)

### DIFF
--- a/core/src/backends/docker/mod.rs
+++ b/core/src/backends/docker/mod.rs
@@ -124,6 +124,12 @@ fn podman_socket_uri() -> Option<String> {
             return Some(format!("unix://{path}"));
         }
     }
+    // macOS: Podman runs in a VM whose Docker-compatible API socket lives under
+    // the per-user `$TMPDIR` (none of the paths above exist on macOS). See #1622.
+    #[cfg(target_os = "macos")]
+    if let Some(uri) = runtime::podman_machine_socket() {
+        return Some(uri);
+    }
     None
 }
 
@@ -154,7 +160,11 @@ async fn connect_to_runtime(runtime: &ContainerRuntime) -> Result<bollard::Docke
         ContainerRuntime::Auto => connect_auto().await,
         ContainerRuntime::Podman => {
             let uri = podman_socket_uri().ok_or_else(|| {
-                SessionError::SpawnFailed("Could not determine Podman socket path".to_string())
+                SessionError::SpawnFailed(
+                    "Could not determine Podman socket path. Ensure a Podman machine is \
+                     running (`podman machine start`) or set CONTAINER_HOST to the socket."
+                        .to_string(),
+                )
             })?;
             let client = connect_via_uri(&uri)?;
             client.version().await.map_err(|e| {
@@ -1459,9 +1469,9 @@ mod tests {
             "explicit Docker must not land on Podman"
         );
 
-        // Podman must still reach Podman when a socket is discoverable.
-        // (On macOS `podman_socket_uri()` may not locate the machine socket —
-        // a pre-existing gap tracked separately — so this step is best-effort.)
+        // Podman must still reach Podman when a socket is discoverable. On
+        // macOS the machine API socket is now located via #1622; this step
+        // stays best-effort so the test also runs on Docker-only hosts.
         match connect_to_runtime(&ContainerRuntime::Podman).await {
             Ok(podman) => {
                 let podman_ver = podman.version().await.unwrap();
@@ -1486,6 +1496,40 @@ mod tests {
         assert!(
             !runtime::version_is_podman(&auto_ver),
             "Auto must prefer real Docker over Podman-behind-docker.sock"
+        );
+    }
+
+    /// Manual, host-dependent diagnostic for #1622. Requires a macOS host with
+    /// a **running Podman machine** (`podman machine start`). Proves that
+    /// explicit `runtime: Podman` resolves the machine's API socket and reaches
+    /// the Podman daemon, where before this fix `podman_socket_uri()` returned
+    /// `None`. Run with:
+    /// `cargo test -p termihub-core --features docker -- --ignored --nocapture
+    ///  connect_to_runtime_reaches_macos_podman_machine`.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    #[ignore = "requires a macOS host with a running Podman machine"]
+    async fn connect_to_runtime_reaches_macos_podman_machine() {
+        let uri = podman_socket_uri()
+            .expect("a running Podman machine's API socket must be resolvable on macOS");
+        println!("runtime=Podman -> resolved socket {uri}");
+        assert!(
+            uri.contains("-api.sock"),
+            "expected the machine API socket, got: {uri}"
+        );
+
+        let client = connect_to_runtime(&ContainerRuntime::Podman)
+            .await
+            .expect("explicit Podman should reach the machine daemon on this host");
+        let version = client.version().await.unwrap();
+        println!(
+            "runtime=Podman -> podman={} server={:?}",
+            runtime::version_is_podman(&version),
+            version.version
+        );
+        assert!(
+            runtime::version_is_podman(&version),
+            "explicit Podman must reach a Podman daemon"
         );
     }
 }

--- a/core/src/backends/docker/runtime.rs
+++ b/core/src/backends/docker/runtime.rs
@@ -141,6 +141,72 @@ fn contains_podman(s: &str) -> bool {
     s.to_ascii_lowercase().contains("podman")
 }
 
+/// Resolve the local API socket of the running Podman **machine** on macOS.
+///
+/// On macOS (and Windows) Podman runs inside a VM, so there is no native
+/// `/run/.../podman.sock`; the machine instead exposes a Docker-compatible API
+/// on a per-user Unix socket under the user's private temp directory:
+///
+/// ```text
+/// $TMPDIR/podman/<machine>-api.sock
+/// ```
+///
+/// e.g. `/var/folders/…/T/podman/podman-machine-default-api.sock`. This is the
+/// same endpoint the `podman` Docker CLI context points at, and the one
+/// reported by `podman machine inspect` → `ConnectionInfo.PodmanSocket.Path`.
+/// The path is per-user and non-deterministic (macOS randomises `$TMPDIR`), so
+/// it cannot be a fixed constant — we read `$TMPDIR` and look for the socket.
+///
+/// Returns `None` when `$TMPDIR` is unset or no machine API socket is present
+/// (typically: no Podman machine has been started). Reading the socket rather
+/// than shelling out to `podman machine inspect` keeps resolution fast and
+/// dependency-free, mirroring the config-based Docker context resolution added
+/// for #1600.
+#[cfg(target_os = "macos")]
+pub(super) fn podman_machine_socket() -> Option<String> {
+    let tmpdir = non_empty_env("TMPDIR")?;
+    podman_machine_socket_in(Path::new(&tmpdir))
+}
+
+/// Pure helper for [`podman_machine_socket`]: find a Podman machine API socket
+/// under `<tmpdir>/podman/`. Split out so it can be unit-tested against a
+/// fixture directory without depending on the real `$TMPDIR` or a running
+/// Podman machine.
+///
+/// Prefers the default machine's socket (`podman-machine-default-api.sock`);
+/// otherwise falls back to any single `*-api.sock` present (covering a
+/// non-default machine name), picking the lexicographically first for
+/// determinism.
+///
+/// Compiled on macOS (where it is used) and in test builds on every platform,
+/// so the resolution logic is covered by the cross-platform CI test lane.
+#[cfg(any(target_os = "macos", test))]
+fn podman_machine_socket_in(tmpdir: &Path) -> Option<String> {
+    let dir = tmpdir.join("podman");
+
+    // Prefer the default machine's API socket when it exists.
+    let default = dir.join("podman-machine-default-api.sock");
+    if default.exists() {
+        return Some(format!("unix://{}", default.display()));
+    }
+
+    // Otherwise fall back to any single machine API socket (non-default name).
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .ok()?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with("-api.sock"))
+        })
+        .collect();
+    candidates.sort();
+    candidates
+        .into_iter()
+        .next()
+        .map(|path| format!("unix://{}", path.display()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -259,5 +325,91 @@ mod tests {
     fn detects_podman_from_platform_when_components_absent() {
         let v = version_with(None, Some("linux/amd64/podman"));
         assert!(version_is_podman(&v));
+    }
+
+    /// Create an empty file at `path`, making parent directories as needed.
+    /// Stands in for the machine API socket (a Unix socket is also a file entry
+    /// on disk, so `Path::exists()` and `read_dir` treat our fixture the same).
+    fn touch(path: &Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"").unwrap();
+    }
+
+    #[test]
+    fn resolves_default_podman_machine_socket() {
+        // Regression for #1622: on macOS the machine API socket lives at
+        // `$TMPDIR/podman/podman-machine-default-api.sock`; it must be resolved
+        // rather than returning `None` (which fails explicit runtime: Podman).
+        let tmp = TempDir::new().unwrap();
+        let sock = tmp
+            .path()
+            .join("podman")
+            .join("podman-machine-default-api.sock");
+        touch(&sock);
+
+        assert_eq!(
+            podman_machine_socket_in(tmp.path()),
+            Some(format!("unix://{}", sock.display()))
+        );
+    }
+
+    #[test]
+    fn resolves_non_default_machine_socket() {
+        // A user with a custom-named machine still resolves via the single
+        // `*-api.sock` fallback.
+        let tmp = TempDir::new().unwrap();
+        let sock = tmp
+            .path()
+            .join("podman")
+            .join("podman-machine-work-api.sock");
+        touch(&sock);
+
+        assert_eq!(
+            podman_machine_socket_in(tmp.path()),
+            Some(format!("unix://{}", sock.display()))
+        );
+    }
+
+    #[test]
+    fn prefers_default_machine_socket_over_others() {
+        let tmp = TempDir::new().unwrap();
+        let default = tmp
+            .path()
+            .join("podman")
+            .join("podman-machine-default-api.sock");
+        touch(&default);
+        touch(
+            &tmp.path()
+                .join("podman")
+                .join("podman-machine-work-api.sock"),
+        );
+
+        assert_eq!(
+            podman_machine_socket_in(tmp.path()),
+            Some(format!("unix://{}", default.display()))
+        );
+    }
+
+    #[test]
+    fn no_socket_when_machine_dir_absent() {
+        // No Podman machine started (or no Podman installed): no `podman/` dir,
+        // so resolution yields `None` and the caller reports the machine as
+        // unavailable rather than picking a wrong socket.
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(podman_machine_socket_in(tmp.path()), None);
+    }
+
+    #[test]
+    fn no_socket_when_dir_has_no_api_sock() {
+        // The machine dir exists (gvproxy sockets, logs) but no API socket —
+        // e.g. a stopped machine. Must not match a non-API socket.
+        let tmp = TempDir::new().unwrap();
+        touch(
+            &tmp.path()
+                .join("podman")
+                .join("podman-machine-default-gvproxy.sock"),
+        );
+        touch(&tmp.path().join("podman").join("gvproxy.log"));
+        assert_eq!(podman_machine_socket_in(tmp.path()), None);
     }
 }

--- a/docs/changes/dev3/fix/1622-podman-machine-socket-macos.md
+++ b/docs/changes/dev3/fix/1622-podman-machine-socket-macos.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Docker/Podman: selecting **runtime: Podman** on macOS now connects to the running
+  Podman machine instead of failing with "Could not determine Podman socket path". On
+  macOS Podman runs in a VM whose Docker-compatible API socket lives at a per-user path
+  under `$TMPDIR` (`…/T/podman/podman-machine-default-api.sock`), which none of the
+  previously checked locations matched. The socket is now resolved there (preferring the
+  default machine, falling back to any single machine socket). The Linux/rootless native
+  socket paths are unchanged, and when no machine is running the error now points to
+  `podman machine start` (#1622).


### PR DESCRIPTION
## Summary

Fixes #1622. On macOS, selecting **runtime: Podman** failed with `Could not determine Podman socket path` because Podman runs inside a VM whose Docker-compatible API socket lives at a per-user path under `$TMPDIR` — e.g. `/var/folders/…/T/podman/podman-machine-default-api.sock` — which none of the paths `podman_socket_uri()` checked (`CONTAINER_HOST`/`DOCKER_HOST`, `$XDG_RUNTIME_DIR`, the Linux `~/.local/share` machine socket) matched. This was pre-existing (surfaced while fixing #1600, not a regression).

## What changed

- `core/src/backends/docker/runtime.rs`: new `podman_machine_socket()` resolving the macOS machine API socket under `$TMPDIR/podman/`, preferring `podman-machine-default-api.sock` and falling back to any single `*-api.sock` (covers a non-default machine name). This mirrors #1600's config-based, non-shelling endpoint resolution — the same socket the `podman` Docker CLI context and `podman machine inspect` report.
- `core/src/backends/docker/mod.rs`: `podman_socket_uri()` consults the machine socket on macOS (gated `#[cfg(target_os = "macos")]`), so the **Linux rootless/native socket paths are unchanged**. The Podman-runtime error now points to `podman machine start`.

## Where the socket path comes from & why

Podman's macOS machine creates its API socket at `$TMPDIR/podman/<machine>-api.sock`. It is per-user and non-deterministic (macOS randomises `$TMPDIR`), so it can't be a constant; reading it from the well-known `$TMPDIR/podman/` directory is fast, dependency-free, and avoids shelling out to `podman machine inspect`, in the same spirit as the Docker context resolution from #1600. The exact same path is what the auto-created `podman` Docker CLI context points at and what `podman machine inspect` → `ConnectionInfo.PodmanSocket.Path` reports.

## Tests

- Five cross-platform unit tests for the resolver against fixture directories (default socket, non-default machine, default-preferred, no `podman/` dir, dir with only non-API sockets). These run in the `Run Tests` lane on ubuntu/windows/macOS via `cargo test --workspace --all-features`.
- A macOS host diagnostic (`#[ignore]`) that pings Podman `/version` through the resolved socket.
- Verified red→green locally: stubbing the resolver makes both the unit test and the host diagnostic fail.

## Manual verification on a macOS host (Podman 5.7.1 machine running)

```
runtime=Podman -> resolved socket unix:///var/folders/…/T/podman/podman-machine-default-api.sock
runtime=Podman -> podman=true server=Some("5.7.1")
```

Before the fix the same diagnostic panics with "a running Podman machine's API socket must be resolvable on macOS".