### PR TITLE
feat(ui): editor disk-change conflict actions — reload / keep my changes (Closes #1620)

### DIFF
--- a/docs/changes/dev5/feature/1620-editor-conflict-actions.md
+++ b/docs/changes/dev5/feature/1620-editor-conflict-actions.md
@@ -1,0 +1,9 @@
+### Added
+
+- The built-in editor's "file changed on disk" notice is now actionable when the
+  buffer has unsaved edits. The banner offers **Reload from disk** (discard your
+  unsaved edits and load the on-disk version) and **Keep my changes** (dismiss the
+  notice and keep your edits; your next save overwrites disk with your version).
+  Nothing is destructive without an explicit click — leaving both buttons keeps
+  your edits and leaves disk untouched, and if the file changes on disk again the
+  notice re-appears. (#1620)

--- a/src/components/FileEditor/FileEditor.external-change.test.tsx
+++ b/src/components/FileEditor/FileEditor.external-change.test.tsx
@@ -141,6 +141,14 @@ function query(testId: string): HTMLElement | null {
   return container.querySelector(`[data-testid="${testId}"]`);
 }
 
+function clickButton(testId: string): void {
+  const btn = query(testId) as HTMLButtonElement | null;
+  expect(btn, `${testId} should be present`).not.toBeNull();
+  act(() => {
+    btn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
 function editContent(value: string): void {
   const ta = query("mock-monaco") as HTMLTextAreaElement;
   const setter = Object.getOwnPropertyDescriptor(
@@ -252,5 +260,74 @@ describe("FileEditor — external on-disk change reload (#1620)", () => {
     expect(currentModelValue).toBe("line one\nmy local edit\n");
     expect(query("file-editor-disk-changed-banner")).not.toBeNull();
     expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("'Reload from disk' discards unsaved edits and loads the on-disk version", async () => {
+    render();
+    await flush();
+
+    editContent("line one\nmy local edit\n");
+    await flush();
+    await fireExternalChange("line one\nexternal edit\n");
+    // Precondition: conflict banner up, buffer dirty, disk version differs.
+    expect(query("file-editor-disk-changed-banner")).not.toBeNull();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(false);
+
+    clickButton("file-editor-disk-changed-reload");
+    await flush();
+
+    // Buffer now holds the disk content, is clean (matches disk), banner gone.
+    expect(currentModelValue).toBe("line one\nexternal edit\n");
+    expect(query("file-editor-disk-changed-banner")).toBeNull();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("'Keep my changes' dismisses the banner, keeps edits dirty, and a later save still writes", async () => {
+    render();
+    await flush();
+
+    editContent("line one\nmy local edit\n");
+    await flush();
+    await fireExternalChange("line one\nexternal edit\n");
+    expect(query("file-editor-disk-changed-banner")).not.toBeNull();
+
+    clickButton("file-editor-disk-changed-keep");
+    await flush();
+
+    // Banner dismissed, but the buffer keeps the local edits and stays dirty.
+    expect(query("file-editor-disk-changed-banner")).toBeNull();
+    expect(currentModelValue).toBe("line one\nmy local edit\n");
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(false);
+
+    // A subsequent save is not blocked and writes the user's version to disk.
+    mockedInvoke.mockClear();
+    clickButton("file-editor-save");
+    await flush();
+    const writeCall = mockedInvoke.mock.calls.find((c) => c[0] === "local_write_file");
+    expect(writeCall, "save should invoke local_write_file").toBeDefined();
+    expect((writeCall![1] as { content: string }).content).toBe("line one\nmy local edit\n");
+    // Buffer is now saved/clean.
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("re-surfaces the banner when the file changes on disk again after 'Keep my changes'", async () => {
+    render();
+    await flush();
+
+    editContent("line one\nmy local edit\n");
+    await flush();
+    await fireExternalChange("line one\nexternal edit\n");
+    expect(query("file-editor-disk-changed-banner")).not.toBeNull();
+
+    clickButton("file-editor-disk-changed-keep");
+    await flush();
+    expect(query("file-editor-disk-changed-banner")).toBeNull();
+
+    // A *new* on-disk change (not the one already dismissed) surfaces again —
+    // dismissing one change does not mute the file.
+    await fireExternalChange("line one\nanother external edit\n");
+    expect(query("file-editor-disk-changed-banner")).not.toBeNull();
+    // Edits still preserved.
+    expect(currentModelValue).toBe("line one\nmy local edit\n");
   });
 });

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -11,6 +11,7 @@ import {
   ShieldCheck,
   Copy,
   Download,
+  RotateCcw,
   X,
 } from "lucide-react";
 import { Button, toast } from "@/components/ui";
@@ -428,6 +429,26 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     if (!isDirty && diskChangedWhileDirty) setDiskChangedWhileDirty(false);
   }, [isDirty, diskChangedWhileDirty]);
 
+  // Adopt `disk` as the new buffer-and-saved content, discarding any local
+  // edits. Monaco is uncontrolled, so update its model directly (preserving
+  // cursor/scroll) when mounted; otherwise updating state is enough and the
+  // load path renders from it. Setting savedContent === the new content leaves
+  // the buffer clean (content === savedContent). (#1620)
+  const applyDiskContent = useCallback((disk: string) => {
+    const editor = editorRef.current;
+    const model = editor?.getModel();
+    if (editor && model) {
+      const view = editor.saveViewState();
+      setSavedContent(disk);
+      // Fires onChange -> setContent(disk); the buffer stays clean.
+      model.setValue(disk);
+      if (view) editor.restoreViewState(view);
+    } else {
+      setContent(disk);
+      setSavedContent(disk);
+    }
+  }, []);
+
   // Reflect the current on-disk contents of a locally-watched file (#1620).
   // Invoked (debounced) when the OS reports the open file changed underneath us.
   const reloadFromDisk = useCallback(async () => {
@@ -453,35 +474,56 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     const hasUnsavedEdits = content !== null && content !== savedContent;
     if (hasUnsavedEdits) {
       // Genuine conflict: the file changed on disk while the buffer has local
-      // edits. Detection only — do NOT clobber either side. The resolution
-      // policy (reload / keep / merge / prompt) is a deferred, user-visible
-      // decision, so we just surface a non-destructive notice.
+      // edits. Detection only — do NOT clobber either side. The user resolves
+      // it from the banner (Reload from disk / Keep my changes, #1620); until
+      // then edits are kept and disk is untouched. Re-surfaces on each new
+      // external change (savedContent is left untouched by "Keep my changes").
       frontendLog(
         "file_editor",
-        `external change detected for tab ${tabId} with unsaved edits — deferring (no reload)`
+        `external change detected for tab ${tabId} with unsaved edits — surfacing conflict banner`
       );
       setDiskChangedWhileDirty(true);
       return;
     }
 
-    // Happy path: the buffer is clean, so reflect the new content. Monaco is
-    // uncontrolled, so update its model directly; preserve cursor/scroll.
-    const editor = editorRef.current;
-    const model = editor?.getModel();
-    if (editor && model) {
-      const view = editor.saveViewState();
-      setSavedContent(disk);
-      // Fires onChange -> setContent(disk); the buffer stays clean.
-      model.setValue(disk);
-      if (view) editor.restoreViewState(view);
-    } else {
-      // Not mounted yet (still loading) — updating state is enough; the load
-      // path renders from it.
-      setContent(disk);
-      setSavedContent(disk);
-    }
+    // Happy path: the buffer is clean, so reflect the new content silently.
+    applyDiskContent(disk);
     frontendLog("file_editor", `reloaded tab ${tabId} from external on-disk change`);
-  }, [meta.isRemote, isUnsavedScratch, effectivePath, savedContent, content, tabId]);
+  }, [meta.isRemote, isUnsavedScratch, effectivePath, savedContent, content, tabId, applyDiskContent]);
+
+  // Banner action "Reload from disk" (#1620): discard the unsaved buffer edits
+  // and load the on-disk version. Reuses the clean-case reload path; the only
+  // difference is it proceeds despite a dirty buffer. Once applied, the buffer
+  // matches disk (clean), which also clears the conflict banner.
+  const handleReloadFromDisk = useCallback(async () => {
+    if (meta.isRemote || isUnsavedScratch) return;
+    let disk: string;
+    try {
+      disk = await localReadFile(effectivePath);
+    } catch (err) {
+      frontendLog(
+        "file_editor",
+        `conflict reload-from-disk read failed for tab ${tabId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return;
+    }
+    applyDiskContent(disk);
+    setDiskChangedWhileDirty(false);
+    frontendLog("file_editor", `reloaded tab ${tabId} from disk, discarding unsaved edits`);
+  }, [meta.isRemote, isUnsavedScratch, effectivePath, tabId, applyDiskContent]);
+
+  // Banner action "Keep my changes" (#1620): dismiss the conflict banner and
+  // ignore the on-disk change. Clears the pending-conflict state so a later
+  // save is not blocked, but deliberately does NOT touch savedContent — the
+  // buffer stays dirty (the user still has unsaved edits) and a subsequent
+  // save overwrites disk with their version, which is the existing behaviour.
+  // If the file changes on disk again, the watcher re-surfaces the banner.
+  const handleKeepMyChanges = useCallback(() => {
+    setDiskChangedWhileDirty(false);
+    frontendLog("file_editor", `kept unsaved edits for tab ${tabId}, ignoring on-disk change`);
+  }, [tabId]);
 
   // Keep a stable ref so the (path-scoped) watch effect's event handler always
   // calls the latest reload logic without re-subscribing on every keystroke.
@@ -1116,11 +1158,31 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
             nothing was overwritten.
           </span>
           <Button
+            variant="secondary"
+            size="sm"
+            icon={<RotateCcw size={14} />}
+            onClick={handleReloadFromDisk}
+            title="Discard your unsaved edits and load the version on disk"
+            data-testid="file-editor-disk-changed-reload"
+          >
+            Reload from disk
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<FileEdit size={14} />}
+            onClick={handleKeepMyChanges}
+            title="Keep your unsaved edits; ignore the on-disk change until you next save"
+            data-testid="file-editor-disk-changed-keep"
+          >
+            Keep my changes
+          </Button>
+          <Button
             variant="ghost"
             size="sm"
             iconOnly
             icon={<X size={14} />}
-            onClick={() => setDiskChangedWhileDirty(false)}
+            onClick={handleKeepMyChanges}
             title="Dismiss"
             aria-label="Dismiss on-disk change notice"
             data-testid="file-editor-disk-changed-dismiss"

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -489,7 +489,15 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     // Happy path: the buffer is clean, so reflect the new content silently.
     applyDiskContent(disk);
     frontendLog("file_editor", `reloaded tab ${tabId} from external on-disk change`);
-  }, [meta.isRemote, isUnsavedScratch, effectivePath, savedContent, content, tabId, applyDiskContent]);
+  }, [
+    meta.isRemote,
+    isUnsavedScratch,
+    effectivePath,
+    savedContent,
+    content,
+    tabId,
+    applyDiskContent,
+  ]);
 
   // Banner action "Reload from disk" (#1620): discard the unsaved buffer edits
   // and load the on-disk version. Reuses the clean-case reload path; the only


### PR DESCRIPTION
## Summary

Completes #1620 by making the "file changed on disk while you have unsaved edits" banner actionable. PR #1629 shipped the detection + happy path (clean buffer → silent reload) and left the conflict case as a passive banner. This implements the repo owner's decision (the DECISION comment on the issue): keep the passive banner as default, add two explicit actions.

- **Reload from disk** → discards the unsaved buffer edits and loads the on-disk version. Reuses the clean-case reload path (`applyDiskContent`), the only difference being it proceeds despite a dirty buffer. The buffer ends clean, matching disk.
- **Keep my changes** → dismisses the banner and ignores the on-disk change. Clears the pending-conflict state so a later save is not blocked, but deliberately does **not** touch `savedContent`, so the buffer stays dirty and a subsequent save overwrites disk with the user's version (existing save behaviour).

Nothing is destructive without an explicit click; the default of inaction keeps edits and leaves disk untouched. Because "Keep my changes" leaves `savedContent` untouched, a fresh on-disk change re-surfaces the banner (you dismissed one change, not muted the file). The `X` dismiss maps to "Keep my changes".

## Behaviour

- Happy path (clean buffer, from #1629) unchanged: silent reload, cursor/scroll preserved.
- Reload from disk: buffer replaced with disk content, dirty cleared → matches disk.
- Keep my changes: banner dismissed, buffer stays dirty, later save still writes.
- Re-fire: a new external change after "Keep my changes" re-shows the banner.

## Testing

- Extended `FileEditor.external-change.test.tsx` (functional Monaco mock) with three tests: Reload replaces the buffer and clears dirty; Keep-mine dismisses the banner, keeps the buffer dirty, and a subsequent save invokes `local_write_file` with the user's content; and the banner re-surfaces on a fresh on-disk change after Keep-mine.
- Verified all three **fail** when the two `onClick` handlers are stubbed to no-ops (they assert the real state transitions, not just a present button).
- `npx tsc --noEmit`, `pnpm run lint`, and `prettier --check` all clean.
- No new CSS (the banner shares the read-only banner's flex layout that already hosts buttons); no raw hex / new tokens. New testids (`file-editor-disk-changed-reload`, `file-editor-disk-changed-keep`) are plain literals the catalog scanner picks up automatically.

Note on live drive: per ADR-5 there is no macOS WKWebView `tauri-driver`, so the literal GUI click-through is not automatable on this host; the flow is exercised end to end via the functional Monaco-mock frontend tests (same approach the #1629 agent used), driving edit → external-change event → banner → each action → asserted outcome.

Closes #1620