### PR TITLE
feat(agent): route the desktop-push Update deploy through the coordinated RPC (Closes #1616)

### DIFF
--- a/docs/changes/dev4/feature/1616-coordinated-deploy-routing.md
+++ b/docs/changes/dev4/feature/1616-coordinated-deploy-routing.md
@@ -1,0 +1,19 @@
+### Added
+
+- Remote agents set to the **Coordinated** update strategy now route the
+  desktop-push **Update** (deploy) through the coordinated path, not just the
+  agent's "Apply Now" self-update banner (#1602). On a **Unix** agent the new
+  binary is staged (uploaded without installing) and handed to
+  `agent.request_update`, which broadcasts `agent.update_pending` to every other
+  connected host, gives them a clean disconnect + auto-reconnect window, and
+  self-applies — no more hard-cutting other hosts on an Update. The Update dialog
+  reports how many hosts were notified and whether the apply was immediate or
+  deferred until the agent's last session disconnects (#1616).
+
+### Changed
+
+- `Coordinated` is now an active update strategy (previously saved-only). A
+  coordinated Update on a **Windows** agent falls back cleanly to the existing
+  immediate deploy (shutdown + redeploy, connected-host guard intact), because
+  the agent's apply-from-path self-swap is Unix-only. Non-coordinated
+  (Immediate / Deferred) updates are unchanged (#1616).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -929,6 +929,31 @@ a Unix agent host (the exec-replace is Unix-only). See PR #1352.
 5. **Dismiss.** Press **Dismiss** on the banner. Expect: the banner hides for the
    session and no update is requested.
 
+### Coordinated desktop-push Update deploy (#1616)
+
+Verifies that triggering an **Update** (the desktop-push deploy, not just the
+self-update banner) on a **Coordinated**-strategy agent notifies the other hosts
+and lets them reconnect cleanly, on Unix, with a documented Windows fallback.
+Requires three desktops (A, B, C) and one **Unix** agent host, plus a Windows
+agent host for step 4. See PR #1636.
+
+1. **Coordinated Unix deploy notifies others.** Set the agent's update strategy to
+   **Coordinated**. Connect desktops A, B, C to the same Unix agent and open a
+   persistent session on B. From A, open the agent's **Update** dialog and confirm.
+   Expect: A stages the binary and reports how many other hosts were notified; B
+   and C show the "being updated by another host" notice, suspend, and
+   auto-reconnect; B's persistent session survives (detached daemon) and resumes.
+2. **Applies after the window.** The agent applies once B and C disconnect or the
+   10s coordination window closes; A's connection drops as the agent re-execs.
+   Reconnect from A → the agent version badge shows the new version.
+3. **No hard cut.** Confirm B and C never saw an unexplained disconnect — only the
+   coordinated notice + reconnect.
+4. **Windows fallback.** Repeat step 1 against a **Windows** agent host. Expect: the
+   Update falls back to the immediate deploy (shutdown + redeploy); other connected
+   hosts are surfaced by the connected-host guard warning ("Notify Others &
+   Update") exactly as today — the coordinated self-swap is not attempted on
+   Windows, and the update path is not regressed.
+
 ### Command palette (#1484)
 
 Verifies the Cmd/Ctrl+P command palette that fuzzy-matches application commands

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -14,7 +14,7 @@ use crate::terminal::agent_manager::{
     AgentFolderInfo, AgentRpcClient, AgentSessionInfo,
 };
 use crate::terminal::agent_setup::{AgentSetupConfig, AgentSetupResult, RemoteArchInfo};
-use crate::terminal::backend::RemoteAgentConfig;
+use crate::terminal::backend::{RemoteAgentConfig, UpdateStrategy};
 
 /// Connect to a remote agent via SSH.
 ///
@@ -658,6 +658,13 @@ pub async fn update_agent_force(
 
 /// Shared body for [`update_agent`] / [`update_agent_force`]. `force` skips the
 /// connected-host guard.
+///
+/// Routes to the update path for the configured strategy:
+/// - `Coordinated` → stage the binary, then dispatch `agent.request_update` so
+///   the agent notifies other hosts and self-applies (Unix); Windows falls back
+///   to the immediate path because the agent's self-swap is Unix-only (#1616).
+/// - `Immediate` (and `Deferred`, which has no desktop-push dispatch path yet) →
+///   the hard shutdown + redeploy path.
 async fn run_update_agent(
     force: bool,
     agent_id: String,
@@ -667,9 +674,6 @@ async fn run_update_agent(
     manager: Arc<dyn AgentRpcClient>,
     cancellation: State<'_, AgentDeployCancellation>,
 ) -> Result<AgentDeployResult, String> {
-    // Route to the update path for the configured strategy. Only the immediate
-    // path (hard shutdown + redeploy) exists today; coordinated/deferred fall
-    // back to it until SI-5/SI-6 land (see #1354 and its follow-ups).
     let requested = config.update_strategy;
     let effective = config.effective_update_strategy();
     if requested != effective {
@@ -677,15 +681,49 @@ async fn run_update_agent(
             agent_id,
             ?requested,
             ?effective,
-            "Update strategy not yet implemented; falling back to immediate update"
+            "Update strategy has no desktop-push dispatch path; falling back to immediate update"
         );
     }
+    if effective == UpdateStrategy::Coordinated {
+        return run_coordinated_update(
+            force,
+            agent_id,
+            config,
+            deploy_config,
+            app_handle,
+            manager,
+            cancellation,
+        )
+        .await;
+    }
+    run_immediate_update(
+        force,
+        agent_id,
+        config,
+        deploy_config,
+        app_handle,
+        manager,
+        cancellation,
+    )
+    .await
+}
+
+/// The immediate desktop-push update: hard shutdown + redeploy. Also the
+/// Windows fallback for a `Coordinated` strategy (#1616).
+async fn run_immediate_update(
+    force: bool,
+    agent_id: String,
+    config: RemoteAgentConfig,
+    deploy_config: AgentDeployConfig,
+    app_handle: tauri::AppHandle,
+    manager: Arc<dyn AgentRpcClient>,
+    cancellation: State<'_, AgentDeployCancellation>,
+) -> Result<AgentDeployResult, String> {
     info!(
         agent_id,
         host = %config.host,
-        strategy = ?effective,
         force,
-        "Updating agent on remote host"
+        "Updating agent on remote host (immediate)"
     );
     let aid = agent_id.clone();
     let list_manager = manager.clone();
@@ -711,4 +749,254 @@ async fn run_update_agent(
     })
     .await
     .unwrap_or_else(|e| Err(e.to_string()))
+}
+
+/// The coordinated desktop-push update (#1616): stage the binary, then hand it
+/// to `agent.request_update` so the agent broadcasts `agent.update_pending` to
+/// every *other* connected host, gives them a clean disconnect window, and
+/// self-applies (swap + re-exec) — never hard-cutting sessions.
+///
+/// The connected-host guard is intentionally skipped: the notice *is* the
+/// courtesy. On a **Windows** host the agent cannot self-swap a running binary
+/// (`agent/src/update/apply.rs` is Unix-only), so this falls back to the
+/// immediate deploy path — exactly today's behaviour, with the guard intact.
+async fn run_coordinated_update(
+    force: bool,
+    agent_id: String,
+    config: RemoteAgentConfig,
+    deploy_config: AgentDeployConfig,
+    app_handle: tauri::AppHandle,
+    manager: Arc<dyn AgentRpcClient>,
+    cancellation: State<'_, AgentDeployCancellation>,
+) -> Result<AgentDeployResult, String> {
+    info!(
+        agent_id,
+        host = %config.host,
+        force,
+        "Updating agent on remote host (coordinated)"
+    );
+
+    // 1. Stage the binary (connect, detect OS, upload to temp on Unix).
+    let token = cancellation.register(&agent_id);
+    let registry = cancellation.inner().clone();
+    let stage_id = agent_id.clone();
+    let stage_config = config.clone();
+    let stage_deploy = deploy_config.clone();
+    let stage_app = app_handle.clone();
+    let stage_token = token.clone();
+    let complete_id = agent_id.clone();
+    let complete_token = token.clone();
+    let staged = tauri::async_runtime::spawn_blocking(move || {
+        let result = crate::terminal::agent_deploy::stage_agent_binary(
+            &stage_id,
+            &stage_config,
+            &stage_deploy,
+            &stage_app,
+            Some(&stage_token),
+        )
+        .map_err(|e| e.to_string());
+        registry.complete(&complete_id, &complete_token);
+        result
+    })
+    .await
+    .unwrap_or_else(|e| Err(e.to_string()))?;
+
+    // 2. Windows: the agent cannot self-swap — fall back to the immediate deploy
+    //    (shutdown + redeploy), which keeps the connected-host guard intact.
+    let Some(binary_path) = staged.upload_path else {
+        warn!(
+            agent_id,
+            remote_os = %staged.remote_os,
+            "Coordinated update on a Windows host; falling back to immediate deploy (agent self-swap is Unix-only)"
+        );
+        return run_immediate_update(
+            force,
+            agent_id,
+            config,
+            deploy_config,
+            app_handle,
+            manager,
+            cancellation,
+        )
+        .await;
+    };
+
+    // 3. Unix: dispatch the coordinated RPC. The agent notifies other hosts,
+    //    waits out the window, then self-applies from the staged path.
+    let rpc_agent = agent_id.clone();
+    let rpc_manager = manager.clone();
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    let rpc_result = tauri::async_runtime::spawn_blocking(move || {
+        let mut params = serde_json::Map::new();
+        params.insert("binaryPath".to_string(), Value::String(binary_path));
+        params.insert("version".to_string(), Value::String(version));
+        rpc_manager.send_request(&rpc_agent, "agent.request_update", Value::Object(params))
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    match rpc_result {
+        Ok(value) => Ok(coordinated_deploy_result(&value)),
+        Err(e) => {
+            let msg = e.to_string();
+            // A dropped connection right after dispatch is the agent applying an
+            // idle update — swap + re-exec tears down the transport. That is
+            // expected success, not a failure (mirrors the self-update path).
+            if is_expected_apply_disconnect(&msg) {
+                info!(
+                    agent_id,
+                    "Coordinated update dispatched; connection dropped as the agent swaps + re-execs (expected)"
+                );
+                Ok(AgentDeployResult::Coordinated {
+                    applied: true,
+                    active_sessions: 0,
+                    notified_clients: 0,
+                    all_acked: true,
+                    remaining_clients: Vec::new(),
+                })
+            } else {
+                Err(msg)
+            }
+        }
+    }
+}
+
+/// Build an [`AgentDeployResult::Coordinated`] from the `agent.request_update`
+/// JSON-RPC result (#1616). Mirrors the field extraction in
+/// [`request_agent_update`]'s [`CoordinatedUpdateResponse`].
+fn coordinated_deploy_result(value: &Value) -> AgentDeployResult {
+    AgentDeployResult::Coordinated {
+        applied: value
+            .get("applied")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        active_sessions: value
+            .get("activeSessions")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32,
+        notified_clients: value
+            .get("notifiedClients")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32,
+        all_acked: value
+            .get("allAcked")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        remaining_clients: value
+            .get("remainingClients")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
+}
+
+/// Whether an error from `agent.request_update` is the expected transport drop
+/// caused by the agent swapping its binary and re-execing on an idle apply,
+/// rather than a genuine failure. Mirrors the frontend `AgentUpdateBanner`
+/// classifier so the happy path (idle agent updates) reports success (#1616).
+fn is_expected_apply_disconnect(message: &str) -> bool {
+    let raw = message.to_ascii_lowercase();
+    [
+        "disconnect",
+        "connection",
+        "closed",
+        "timeout",
+        "reset",
+        "eof",
+        "not connected",
+        "broken pipe",
+    ]
+    .iter()
+    .any(|needle| raw.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The coordinated deploy result carries the RPC's coordination outcome so
+    /// the desktop can report "N hosts notified, M still attached" (#1616).
+    #[test]
+    fn coordinated_deploy_result_maps_rpc_fields() {
+        let value = json!({
+            "applied": false,
+            "activeSessions": 2,
+            "notifiedClients": 3,
+            "allAcked": false,
+            "remainingClients": ["id-7", "id-8"],
+        });
+        let result = coordinated_deploy_result(&value);
+        match result {
+            AgentDeployResult::Coordinated {
+                applied,
+                active_sessions,
+                notified_clients,
+                all_acked,
+                remaining_clients,
+            } => {
+                assert!(!applied);
+                assert_eq!(active_sessions, 2);
+                assert_eq!(notified_clients, 3);
+                assert!(!all_acked);
+                assert_eq!(remaining_clients, vec!["id-7", "id-8"]);
+            }
+            other => panic!("expected Coordinated, got {other:?}"),
+        }
+    }
+
+    /// Missing/garbage fields degrade to safe defaults rather than panicking.
+    #[test]
+    fn coordinated_deploy_result_defaults_on_missing_fields() {
+        let result = coordinated_deploy_result(&json!({}));
+        assert_eq!(
+            result,
+            AgentDeployResult::Coordinated {
+                applied: false,
+                active_sessions: 0,
+                notified_clients: 0,
+                all_acked: false,
+                remaining_clients: vec![],
+            }
+        );
+    }
+
+    /// A transport drop right after dispatch is the agent swapping + re-execing,
+    /// not a failure — the coordinated deploy reports it as applied success.
+    #[test]
+    fn expected_apply_disconnect_recognizes_transport_drops() {
+        for msg in [
+            "Connection reset by peer",
+            "agent disconnected",
+            "channel closed",
+            "request timeout",
+            "unexpected EOF",
+            "not connected",
+            "broken pipe",
+        ] {
+            assert!(
+                is_expected_apply_disconnect(msg),
+                "{msg:?} should be an expected apply disconnect"
+            );
+        }
+    }
+
+    /// A genuine RPC/application error must NOT be masked as success.
+    #[test]
+    fn expected_apply_disconnect_rejects_real_errors() {
+        for msg in [
+            "binary not found: /tmp/termihub-agent-upload",
+            "invalid params",
+            "permission denied",
+        ] {
+            assert!(
+                !is_expected_apply_disconnect(msg),
+                "{msg:?} is a real error and must surface"
+            );
+        }
+    }
 }

--- a/src-tauri/src/terminal/agent_deploy.rs
+++ b/src-tauri/src/terminal/agent_deploy.rs
@@ -169,6 +169,57 @@ pub enum AgentDeployResult {
     /// connected to the agent and would be hard-cut by the update.
     #[serde(rename_all = "camelCase")]
     OtherHostsConnected { hosts: Vec<ConnectedHost> },
+    /// A coordinated desktop-push update was dispatched to the agent (Unix
+    /// hosts, #1616). The binary was staged and handed to `agent.request_update`,
+    /// which broadcast `agent.update_pending` to every other connected host,
+    /// gave them a window to disconnect, then applied the staged binary through
+    /// the deferred-apply path (swap + re-exec). Because the agent re-execs, the
+    /// desktop cannot verify the installed version here — it reconnects to
+    /// observe the new version, exactly like the coordinated self-update path.
+    #[serde(rename_all = "camelCase")]
+    Coordinated {
+        /// `true` when the agent was idle and applied immediately (the
+        /// connection is expected to drop as the binary swaps); `false` when the
+        /// update was deferred until the last of `active_sessions` disconnects.
+        applied: bool,
+        /// Sessions still active on the agent (0 when applied immediately).
+        active_sessions: u32,
+        /// How many *other* hosts were sent the `agent.update_pending` notice.
+        notified_clients: u32,
+        /// `true` when every notified host disconnected inside the window (or
+        /// there was nobody to notify); `false` when the window closed with
+        /// hosts still attached.
+        all_acked: bool,
+        /// `client_id`s still attached when the window closed. Empty on success.
+        remaining_clients: Vec<String>,
+    },
+}
+
+/// A binary staged for a coordinated update (#1616) — uploaded to the remote
+/// temp path but not installed. Handed to `agent.request_update{binaryPath}`,
+/// which the agent applies via its Unix-only self-swap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagedBinary {
+    /// Detected remote OS string (e.g. `"Linux"`, `"Darwin"`, `"Windows_NT"`).
+    pub remote_os: String,
+    /// `true` when the remote host is Windows. The agent cannot self-swap a
+    /// running binary there (`agent/src/update/apply.rs` is Unix-only), so no
+    /// binary is uploaded and the caller must fall back to an immediate deploy.
+    pub is_windows: bool,
+    /// Remote temp path where the new binary was uploaded. `Some` on Unix (the
+    /// value to pass as `binaryPath`); `None` on Windows.
+    pub upload_path: Option<String>,
+}
+
+/// Whether a coordinated desktop-push update can use the agent's self-swap path
+/// on a host reporting `remote_os`.
+///
+/// Only Unix hosts qualify: the agent applies a staged `binaryPath` by replacing
+/// its own running executable and re-execing, which `agent/src/update/apply.rs`
+/// implements for Unix only. A Windows host must fall back to an immediate
+/// deploy (shutdown + redeploy) instead (#1616).
+pub fn coordinated_self_swap_supported(remote_os: &str) -> bool {
+    !agent_binary::is_windows_os(remote_os)
 }
 
 /// Decide whether an update may proceed given the hosts (other than the
@@ -462,6 +513,164 @@ where
     deploy_agent(agent_id, config, deploy_config, app_handle, cancel)
 }
 
+// ── Coordinated staging (#1616) ──────────────────────────────────────────
+
+/// Stage the agent binary for a coordinated desktop-push update (#1616).
+///
+/// Connects and detects the remote OS. On **Windows** the agent cannot self-swap
+/// a running binary, so this returns early ([`StagedBinary::is_windows`] = true,
+/// no upload) and the caller falls back to an immediate deploy. On **Unix** it
+/// resolves and validates the new binary and uploads it to the temp path
+/// *without* installing it, returning that path so the caller can hand it to
+/// `agent.request_update{binaryPath}` — the agent then broadcasts the notice,
+/// waits, and self-applies (swap + re-exec).
+///
+/// Unlike [`update_agent`], this never shuts the agent down or runs the
+/// connected-host guard: the `agent.update_pending` notice *is* the courtesy to
+/// other hosts, and the swap is the agent's job, not the desktop's.
+pub fn stage_agent_binary(
+    agent_id: &str,
+    config: &RemoteAgentConfig,
+    deploy_config: &AgentDeployConfig,
+    app_handle: &AppHandle,
+    cancel: Option<&CancellationToken>,
+) -> Result<StagedBinary, TerminalError> {
+    let remote_path = deploy_config
+        .remote_path
+        .as_deref()
+        .unwrap_or(DEFAULT_REMOTE_PATH);
+
+    // 1. SSH connect
+    bail_if_cancelled(cancel)?;
+    emit_progress(
+        app_handle,
+        agent_id,
+        "connecting",
+        "Connecting to host…",
+        -1.0,
+    );
+    let ssh_config = config.to_ssh_config();
+    let session = connect_and_authenticate(&ssh_config)?;
+
+    // 2. Detect remote OS/arch
+    bail_if_cancelled(cancel)?;
+    emit_progress(
+        app_handle,
+        agent_id,
+        "detecting",
+        "Detecting remote system…",
+        -1.0,
+    );
+    let (remote_os, remote_arch) = detect_remote_info(&session)?;
+
+    // Windows agents cannot self-swap a running binary (apply.rs is Unix-only):
+    // stop here so the caller falls back to an immediate deploy (#1616).
+    if !coordinated_self_swap_supported(&remote_os) {
+        info!(
+            agent_id,
+            %remote_os, "Coordinated update: Windows host cannot self-swap; caller falls back to immediate deploy"
+        );
+        return Ok(StagedBinary {
+            remote_os,
+            is_windows: true,
+            upload_path: None,
+        });
+    }
+
+    let arch_suffix = agent_binary::artifact_name_for_os_arch(&remote_os, &remote_arch)
+        .ok_or_else(|| {
+            TerminalError::RemoteError(format!(
+                "Unsupported remote platform: {remote_os} {remote_arch}"
+            ))
+        })?;
+
+    // 3. Resolve binary locally
+    bail_if_cancelled(cancel)?;
+    emit_progress(
+        app_handle,
+        agent_id,
+        "resolving",
+        "Resolving agent binary…",
+        0.1,
+    );
+    let version = env!("CARGO_PKG_VERSION");
+    let agent_id_owned = agent_id.to_string();
+    let app_clone = app_handle.clone();
+    let binary_path =
+        agent_binary::resolve_agent_binary(app_handle, version, arch_suffix, move |dl, total| {
+            let pct = if total > 0 {
+                dl as f64 / total as f64
+            } else {
+                -1.0
+            };
+            emit_progress(
+                &app_clone,
+                &agent_id_owned,
+                "downloading",
+                &format!("Downloading agent binary ({dl} bytes)…"),
+                pct,
+            );
+        })
+        .map_err(|e| TerminalError::RemoteError(format!("Failed to resolve binary: {e}")))?;
+
+    // 4. Validate ELF architecture (POSIX hosts only reach here)
+    emit_progress(
+        app_handle,
+        agent_id,
+        "validating",
+        "Validating binary architecture…",
+        0.3,
+    );
+    let binary_path_str = binary_path.to_string_lossy();
+    if let Ok(elf_arch) = detect_binary_arch(&binary_path_str) {
+        if let Some(expected_arch) = expected_arch_for_uname(&remote_arch) {
+            if elf_arch != expected_arch {
+                return Err(TerminalError::RemoteError(format!(
+                    "Architecture mismatch: binary is {elf_arch:?}, remote expects {expected_arch:?}"
+                )));
+            }
+        }
+    }
+
+    // 5. Upload to the temp path WITHOUT installing — the agent's self-apply
+    //    swaps the running binary from this path (never run the install command
+    //    or shut the agent down; that is the agent's job for coordinated).
+    let plan = posix_install_plan(remote_path);
+    bail_if_cancelled(cancel)?;
+    emit_progress(
+        app_handle,
+        agent_id,
+        "staging",
+        "Staging agent binary…",
+        0.4,
+    );
+    let binary_bytes = std::fs::read(&binary_path)
+        .map_err(|e| TerminalError::RemoteError(format!("Failed to read binary: {e}")))?;
+    upload_bytes_via_sftp(&session, &binary_bytes, &plan.upload_path)?;
+    if let Err(e) = bail_if_cancelled(cancel) {
+        rollback_partial_upload(&session, &plan.upload_path);
+        return Err(e);
+    }
+    info!(
+        "Staged {} bytes to {} for coordinated update",
+        binary_bytes.len(),
+        plan.upload_path
+    );
+    emit_progress(
+        app_handle,
+        agent_id,
+        "staged",
+        "Binary staged; coordinating with connected hosts…",
+        0.7,
+    );
+
+    Ok(StagedBinary {
+        remote_os,
+        is_windows: false,
+        upload_path: Some(plan.upload_path),
+    })
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────
 
 /// Best-effort removal of a partially uploaded binary after a cancel (G10, #1242).
@@ -572,6 +781,46 @@ mod tests {
         assert!(!json.contains("installedPath"));
         let parsed: AgentDeployResult = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, result);
+    }
+
+    #[test]
+    fn coordinated_result_serializes_for_the_dialog() {
+        // The desktop-push coordinated deploy (#1616) surfaces the same
+        // coordination outcome as the self-update path: notified hosts, ack
+        // state, and any hosts still attached when the window closed.
+        let result = AgentDeployResult::Coordinated {
+            applied: false,
+            active_sessions: 2,
+            notified_clients: 3,
+            all_acked: false,
+            remaining_clients: vec!["id-9".to_string()],
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"kind\":\"coordinated\""));
+        assert!(json.contains("notifiedClients"));
+        assert!(json.contains("activeSessions"));
+        assert!(json.contains("remainingClients"));
+        let parsed: AgentDeployResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, result);
+    }
+
+    /// The Unix-only self-swap gate (#1616): only Unix hosts may take the
+    /// coordinated `agent.request_update` path; Windows must fall back to an
+    /// immediate deploy because `agent/src/update/apply.rs` is Unix-only.
+    #[test]
+    fn coordinated_self_swap_supported_only_on_unix() {
+        for unix in ["Linux", "Darwin", "FreeBSD", "linux"] {
+            assert!(
+                coordinated_self_swap_supported(unix),
+                "{unix} is Unix and must support the coordinated self-swap"
+            );
+        }
+        for win in ["Windows_NT", "MINGW64_NT-10.0", "MSYS_NT-10.0", "CYGWIN_NT"] {
+            assert!(
+                !coordinated_self_swap_supported(win),
+                "{win} is Windows and must fall back to immediate"
+            );
+        }
     }
 
     fn sample_host(id: &str) -> ConnectedHost {

--- a/src-tauri/src/terminal/backend.rs
+++ b/src-tauri/src/terminal/backend.rs
@@ -31,11 +31,11 @@ pub struct ExternalAgentFile {
 
 /// Strategy governing how a shared remote agent binary is updated.
 ///
-/// Only [`UpdateStrategy::Immediate`] has an implemented dispatch path today
-/// (hard shutdown + redeploy). `Coordinated` (SI-5) and `Deferred` (SI-6) are
-/// configuration-only until those subsystems land; selecting them currently
-/// resolves back to `Immediate` at update time (see
-/// [`RemoteAgentConfig::effective_update_strategy`]).
+/// `Immediate` (hard shutdown + redeploy) and `Coordinated` (stage the binary,
+/// then broadcast a notice and let other hosts disconnect cleanly before the
+/// agent self-applies, #1616) both have dispatch paths. `Deferred` (SI-6) is
+/// still configuration-only and resolves back to `Immediate` at update time
+/// (see [`RemoteAgentConfig::effective_update_strategy`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum UpdateStrategy {
@@ -44,7 +44,8 @@ pub enum UpdateStrategy {
     #[default]
     Immediate,
     /// Broadcast an update notice to connected hosts and wait for a clean
-    /// disconnect before applying. Not yet implemented (SI-5).
+    /// disconnect before applying. Dispatched via a staged `agent.request_update`
+    /// on Unix hosts; Windows falls back to `Immediate` (#1616).
     Coordinated,
     /// Defer the update until the last session disconnects. Not yet
     /// implemented (SI-6).
@@ -213,16 +214,26 @@ impl RemoteAgentConfig {
 
     /// The update strategy that can actually be honored at update time today.
     ///
-    /// Only [`UpdateStrategy::Immediate`] has an implemented dispatch path
-    /// (hard shutdown + redeploy). `Coordinated` (SI-5) and `Deferred` (SI-6)
-    /// have no dispatch path yet, so they fall back to `Immediate` — the
-    /// configured preference is still persisted so it takes effect once those
-    /// subsystems land. See #1354.
+    /// `Immediate` (hard shutdown + redeploy) and `Coordinated` (staged
+    /// `agent.request_update` on Unix; the desktop-push deploy trigger, #1616)
+    /// both have a dispatch path. `Deferred` (SI-6) has none yet, so it falls
+    /// back to `Immediate` — the configured preference is still persisted so it
+    /// takes effect once that subsystem lands. See #1354.
+    ///
+    /// Note the platform split for `Coordinated` is decided at deploy time, not
+    /// here: the agent's apply-from-path self-swap is Unix-only
+    /// (`agent/src/update/apply.rs`), so a `Coordinated` update targeting a
+    /// Windows host falls back to an immediate deploy in
+    /// [`crate::commands::agent`]. This method reports the *configured* dispatch
+    /// intent, which the command layer then resolves per remote OS.
     pub fn effective_update_strategy(&self) -> UpdateStrategy {
         match self.update_strategy {
             UpdateStrategy::Immediate => UpdateStrategy::Immediate,
-            // No coordinated/deferred dispatch path exists yet — fall back.
-            UpdateStrategy::Coordinated | UpdateStrategy::Deferred => UpdateStrategy::Immediate,
+            // Coordinated now has a dispatch path (#1616): stage the binary, then
+            // hand it to `agent.request_update` on Unix hosts.
+            UpdateStrategy::Coordinated => UpdateStrategy::Coordinated,
+            // No deferred desktop-push dispatch path exists yet — fall back.
+            UpdateStrategy::Deferred => UpdateStrategy::Immediate,
         }
     }
 
@@ -910,23 +921,27 @@ mod tests {
         assert!(!config.allow_self_update);
     }
 
-    /// Only the immediate dispatch path exists today; coordinated/deferred fall
-    /// back to it until SI-5/SI-6 land.
+    /// Immediate and Coordinated both have a dispatch path (#1616); Deferred
+    /// still falls back to Immediate until SI-6 lands. Coordinated resolving to
+    /// itself is what lets `run_update_agent` route the desktop-push deploy
+    /// through the staged `agent.request_update` path (the per-OS Windows
+    /// fallback is applied later, at deploy time).
     #[test]
-    fn effective_update_strategy_falls_back_to_immediate() {
-        for requested in [
-            UpdateStrategy::Immediate,
-            UpdateStrategy::Coordinated,
-            UpdateStrategy::Deferred,
-        ] {
+    fn effective_update_strategy_resolves_per_dispatch_availability() {
+        let cases = [
+            (UpdateStrategy::Immediate, UpdateStrategy::Immediate),
+            (UpdateStrategy::Coordinated, UpdateStrategy::Coordinated),
+            (UpdateStrategy::Deferred, UpdateStrategy::Immediate),
+        ];
+        for (requested, expected) in cases {
             let config = RemoteAgentConfig {
                 update_strategy: requested,
                 ..RemoteAgentConfig::default()
             };
             assert_eq!(
                 config.effective_update_strategy(),
-                UpdateStrategy::Immediate,
-                "requested {requested:?} should currently resolve to Immediate"
+                expected,
+                "requested {requested:?} should resolve to {expected:?}"
             );
         }
     }

--- a/src/components/DynamicForm/agentSchema.ts
+++ b/src/components/DynamicForm/agentSchema.ts
@@ -103,8 +103,9 @@ export const AGENT_SCHEMA: SettingsSchema = {
           default: "immediate",
           description:
             "How this agent's binary is updated when a newer desktop version deploys. " +
-            "Only Immediate is active today; Coordinated and Deferred are saved and take " +
-            "effect once those subsystems land.",
+            "Immediate and Coordinated are active; Coordinated notifies other connected " +
+            "hosts and lets them reconnect cleanly before applying (Unix agents — Windows " +
+            "falls back to Immediate). Deferred is saved and takes effect once it lands.",
         },
         {
           key: "allowSelfUpdate",

--- a/src/components/Sidebar/UpdateAgentDialog.test.tsx
+++ b/src/components/Sidebar/UpdateAgentDialog.test.tsx
@@ -143,4 +143,50 @@ describe("UpdateAgentDialog", () => {
     expect(props.onOpenChange).toHaveBeenCalledWith(false);
     expect(mockedUpdateAgent).not.toHaveBeenCalled();
   });
+
+  it("closes and reports a coordinated (Unix) update result (#1616)", async () => {
+    // A coordinated-strategy agent returns `kind: "coordinated"` rather than
+    // `deployed`; the dialog must treat it as success and close.
+    mockedUpdateAgent.mockResolvedValue({
+      kind: "coordinated",
+      applied: true,
+      activeSessions: 0,
+      notifiedClients: 2,
+      allAcked: true,
+      remainingClients: [],
+    });
+    const props = baseProps();
+    const onUpdated = vi.fn();
+    render(<UpdateAgentDialog {...props} otherHosts={[]} onUpdated={onUpdated} />);
+    await act(async () => {
+      (document.querySelector('[data-testid="update-agent-confirm"]') as HTMLElement).click();
+    });
+    expect(mockedUpdateAgent).toHaveBeenCalledTimes(1);
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "coordinated", notifiedClients: 2 })
+    );
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the dialog open when a deferred coordinated update reports active sessions", async () => {
+    mockedUpdateAgent.mockResolvedValue({
+      kind: "coordinated",
+      applied: false,
+      activeSessions: 3,
+      notifiedClients: 1,
+      allAcked: false,
+      remainingClients: ["id-2"],
+    });
+    const props = baseProps();
+    const onUpdated = vi.fn();
+    render(<UpdateAgentDialog {...props} otherHosts={[]} onUpdated={onUpdated} />);
+    await act(async () => {
+      (document.querySelector('[data-testid="update-agent-confirm"]') as HTMLElement).click();
+    });
+    // Deferred is still a successful dispatch — the dialog closes and reports it.
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "coordinated", applied: false, activeSessions: 3 })
+    );
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
 });

--- a/src/components/Sidebar/UpdateAgentDialog.tsx
+++ b/src/components/Sidebar/UpdateAgentDialog.tsx
@@ -82,6 +82,29 @@ export function UpdateAgentDialog({
       );
     }
 
+    // A coordinated-strategy update (#1616) was staged and dispatched: the agent
+    // notified the other hosts and either applied now (idle) or deferred until
+    // its last session disconnects.
+    if (result.kind === "coordinated") {
+      const n = result.notifiedClients;
+      if (result.applied) {
+        toast.success(
+          n > 0
+            ? `Updating agent on ${agentName} — ${n} other host${n === 1 ? "" : "s"} notified. Reconnecting…`
+            : `Updating agent on ${agentName} — reconnecting…`
+        );
+      } else {
+        const s = result.activeSessions;
+        toast.info(
+          `Update deferred on ${agentName} — it will apply automatically when the last of ` +
+            `${s} active session${s === 1 ? "" : "s"} disconnects.`
+        );
+      }
+      onUpdated?.(result);
+      onOpenChange(false);
+      return;
+    }
+
     toast.success(`Updating agent on ${agentName}…`);
     onUpdated?.(result);
     onOpenChange(false);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1539,10 +1539,15 @@ export interface ConnectedHost {
 /**
  * Result of deploying or updating the agent on a remote host.
  *
- * Discriminated on `kind`: `deployed` is the normal outcome; the update path
- * returns `otherHostsConnected` when the connected-host guard blocks an
- * unforced update because other hosts are attached — the desktop then shows the
- * warning and may retry via {@link updateAgentForce}.
+ * Discriminated on `kind`:
+ * - `deployed` — the normal outcome of a deploy or immediate update.
+ * - `otherHostsConnected` — the connected-host guard blocked an unforced
+ *   immediate update because other hosts are attached; the desktop shows the
+ *   warning and may retry via {@link updateAgentForce}.
+ * - `coordinated` — a coordinated-strategy update (#1616) was dispatched on a
+ *   Unix host: the binary was staged and handed to `agent.request_update`, which
+ *   notified every other connected host and let the agent self-apply. Windows
+ *   coordinated updates fall back to the immediate path and return `deployed`.
  */
 export type AgentDeployResult =
   | {
@@ -1559,6 +1564,23 @@ export type AgentDeployResult =
   | {
       kind: "otherHostsConnected";
       hosts: ConnectedHost[];
+    }
+  | {
+      kind: "coordinated";
+      /**
+       * `true` when the agent was idle and applied immediately (the connection
+       * is expected to drop as the binary swaps); `false` when deferred until the
+       * last of `activeSessions` disconnects.
+       */
+      applied: boolean;
+      /** Sessions the update will wait on when `applied` is false. */
+      activeSessions: number;
+      /** How many *other* connected hosts were sent the `update_pending` notice. */
+      notifiedClients: number;
+      /** `true` when every notified host disconnected inside the window. */
+      allAcked: boolean;
+      /** Hosts still attached when the coordination window closed. */
+      remainingClients: string[];
     };
 
 /** Probe a remote host for an existing agent binary. */


### PR DESCRIPTION
Follow-up to #1602 (PR #1617) and #1351 (PR #1603). #1602 delivered the coordinated-update *notice* (receiver side) and routed the agent self-update banner's "Apply Now" through `agent.request_update`. It deliberately left the other consumer of the strategy — the **desktop-push deploy** (`update_agent` / `run_update_agent`) — resolving `Coordinated` back to `Immediate`. This PR wires that deploy trigger through the coordinated RPC.

## What changed

**Strategy resolution** — `RemoteAgentConfig::effective_update_strategy` now resolves `Coordinated → Coordinated` (was `→ Immediate`); `Deferred` still falls back to `Immediate` (no desktop-push dispatch path yet, #1352). The per-OS split for `Coordinated` is decided at deploy time, not here.

**`run_update_agent` routing** — split into `run_immediate_update` (the existing hard shutdown + redeploy) and a new `run_coordinated_update`:

- **Unix coordinated** → `stage_agent_binary` connects, detects the remote OS, resolves/validates the new binary and uploads it to the temp path **without installing**. The staged path is handed to `agent.request_update{binaryPath}`, which broadcasts `agent.update_pending` to every *other* connected host, gives them a clean disconnect + auto-reconnect window (via #1602's receiver), then self-applies (swap + re-exec). The connected-host guard is **skipped** — the notice is the courtesy — and the desktop runs **no** install/shutdown of its own (the swap is the agent's job).
- **Windows coordinated** → the agent cannot self-swap a running binary (`agent/src/update/apply.rs` is Unix-only), so `stage_agent_binary` stops after OS detection and `run_coordinated_update` **falls back to `run_immediate_update`** — exactly today's shutdown + redeploy behaviour, connected-host guard intact. No regression to the Windows update path.
- **Non-coordinated (Immediate / Deferred)** → unchanged.

A post-dispatch transport drop is the agent applying an idle update (re-exec tears down the connection); it is reported as coordinated success, mirroring the existing `AgentUpdateBanner` disconnect classifier.

**UI** — new `coordinated` variant on `AgentDeployResult`; the Update dialog reports how many hosts were notified and whether the apply was immediate or deferred. Strategy help text updated now that Coordinated is active.

## Platform matrix after this change

| Agent host | Strategy | Behaviour |
| --- | --- | --- |
| Unix | Coordinated | stage → `agent.request_update` → notice + clean reconnect → agent self-applies |
| Windows | Coordinated | falls back to immediate deploy (shutdown + redeploy, guard intact) |
| any | Immediate / Deferred | unchanged (immediate deploy) |

## Tests

Verified red under mutation (`Coordinated → Immediate`; self-swap gate forced true):

- `effective_update_strategy_resolves_per_dispatch_availability` — the new per-strategy mapping.
- `coordinated_self_swap_supported_only_on_unix` — the Unix/Windows gate over `uname`/`%OS%` strings.
- `coordinated_deploy_result_maps_rpc_fields` / `_defaults_on_missing_fields` — RPC value → result mapping.
- `expected_apply_disconnect_recognizes_transport_drops` / `_rejects_real_errors` — the re-exec disconnect classifier.
- `coordinated_result_serializes_for_the_dialog` — `kind: "coordinated"` serde round-trip.
- Vitest: the Update dialog closes and reports both the applied and deferred coordinated results.

`cargo fmt`, `cargo clippy -p termihub --all-targets`, `npx tsc --noEmit`, `pnpm lint`, and `pnpm format:check` all clean. Full Vitest suite (356 files) green.

## What I could and couldn't drive live

The routing/platform decision and the RPC-result mapping are exercised by unit tests. I did **not** drive a live 3-desktop coordinated deploy: the Unix self-swap re-execs the agent, which is hard to observe in an automated harness (same limitation #1534/#1550 documented). The manual 3-desktop test is documented below and should be run before relying on it in production.

## Manual test (3 desktops, Unix agent)

1. Connect desktops A, B, C to the same Unix agent (strategy = Coordinated). Open a persistent session on B.
2. From A, trigger **Update** on the agent.
3. Expect: B and C show the "being updated by another host" notice, suspend, and auto-reconnect; B's session survives (detached daemon). The agent applies after both leave or the 10s window closes. A's dialog reports the notified-host count.
4. Repeat with a Windows agent: the Update falls back to the immediate deploy (other hosts hard-cut with the guard warning), confirming no regression.

Closes #1616