### PR TITLE
feat(ui): auto-refresh sidebar file browser on external on-disk changes (Closes #1626)

### DIFF
--- a/docs/changes/dev0/feature/1626-sidebar-refresh-external-change.md
+++ b/docs/changes/dev0/feature/1626-sidebar-refresh-external-change.md
@@ -1,0 +1,10 @@
+### Added
+
+- The sidebar file browser now refreshes its listing automatically when the
+  local directory it is showing changes on disk under another process. Adding,
+  removing, renaming or modifying a file in the browsed directory updates the
+  list without a manual Refresh — detection reuses the OS directory watcher
+  (FSEvents / inotify / ReadDirectoryChangesW) with debouncing, re-targets as you
+  navigate, and is torn down when the panel closes. The Refresh button remains as
+  a manual backstop. Local browsing only; remote (SFTP / session) browsers are
+  unaffected. (#1626)

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -360,6 +360,33 @@ pub fn unwatch_local_file(
     manager.unwatch(&watch_id);
 }
 
+/// Start watching a local directory for external on-disk changes (#1626).
+///
+/// `watch_id` is an opaque per-browser-instance key the frontend also matches
+/// the resulting `local-dir-changed` events against; re-watching the same id
+/// replaces the previous watch (used to re-target when the browsed directory
+/// changes). Only the local file browser watches — remote (SFTP / session)
+/// browsers use their own transports and never call this.
+#[tauri::command]
+pub fn watch_local_dir(
+    watch_id: String,
+    path: String,
+    manager: State<'_, crate::files::watcher::FileWatchManager>,
+    app_handle: tauri::AppHandle,
+) -> Result<(), TerminalError> {
+    manager.watch_dir(app_handle, watch_id, path)
+}
+
+/// Stop watching a local directory previously registered with
+/// [`watch_local_dir`]. Unknown ids are a harmless no-op.
+#[tauri::command]
+pub fn unwatch_local_dir(
+    watch_id: String,
+    manager: State<'_, crate::files::watcher::FileWatchManager>,
+) {
+    manager.unwatch(&watch_id);
+}
+
 /// Read a remote file's contents as a UTF-8 string via SFTP.
 #[tauri::command]
 pub async fn sftp_read_file_content(

--- a/src-tauri/src/files/watcher.rs
+++ b/src-tauri/src/files/watcher.rs
@@ -18,6 +18,13 @@
 //! - **One watcher per editor instance**, keyed by an opaque `watch_id` supplied
 //!   by the frontend. Re-watching the same id replaces the previous watcher, and
 //!   dropping it stops the underlying OS watch — so a closed tab leaks nothing.
+//!
+//! The sidebar file browser (#1626) reuses this same machinery through the
+//! [`FileWatchManager::watch_dir`] variant: instead of filtering events to one
+//! target file name, it watches a **directory** (non-recursively) and fires on
+//! any add / remove / rename / modify of a direct child, so the listing can
+//! refresh itself. It shares the debounce, the per-`watch_id` keying and the
+//! leak-free teardown; only the event filter and the emitted event name differ.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -42,6 +49,17 @@ const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(300);
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct FileChangedPayload {
+    watch_id: String,
+    path: String,
+}
+
+/// Emitted to the frontend when the contents of a watched local directory
+/// change on disk (a direct child added / removed / renamed / modified). The
+/// `watch_id` routes the event back to the browser instance that registered the
+/// watch; `path` echoes the watched directory (#1626).
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DirChangedPayload {
     watch_id: String,
     path: String,
 }
@@ -138,6 +156,84 @@ impl FileWatchManager {
         Ok(())
     }
 
+    /// Start (or replace) a watch on the directory `path` for `watch_id`. On any
+    /// add / remove / rename / modify of a direct child, a `local-dir-changed`
+    /// event carrying `watch_id` and `path` is emitted to the frontend so the
+    /// file-browser listing can refresh (#1626).
+    pub fn watch_dir(
+        &self,
+        app: AppHandle,
+        watch_id: String,
+        path: String,
+    ) -> Result<(), TerminalError> {
+        self.watch_dir_with_sink(watch_id, path, move |watch_id, path| {
+            let _ = app.emit("local-dir-changed", DirChangedPayload { watch_id, path });
+        })
+    }
+
+    /// Core of [`Self::watch_dir`], parameterised by the notification `sink` so
+    /// the OS-watch pipeline can be exercised against a real directory without a
+    /// Tauri `AppHandle`. The sink is called with `(watch_id, path)` on each
+    /// debounced change to a direct child of the watched directory.
+    fn watch_dir_with_sink<F>(
+        &self,
+        watch_id: String,
+        path: String,
+        sink: F,
+    ) -> Result<(), TerminalError>
+    where
+        F: Fn(String, String) + Send + 'static,
+    {
+        // The directory itself is the watch root (non-recursive), so events for
+        // its direct children are reported; a filter keeps out deeper events that
+        // the platform's recursive backend (e.g. FSEvents) may still surface.
+        let watch_dir = PathBuf::from(&path);
+
+        // Match against the canonical form: macOS FSEvents reports canonical
+        // `/private/var/...` paths even for a `/var/...` (symlinked) watch, so a
+        // raw compare would miss every event. Fall back to the raw path when the
+        // directory cannot be resolved.
+        let dir_for_cb = canonicalize_or(&watch_dir);
+        let watch_id_cb = watch_id.clone();
+        let emit_path = path.clone();
+
+        let mut debouncer = new_debouncer(
+            DEBOUNCE_TIMEOUT,
+            None,
+            move |result: DebounceEventResult| match result {
+                Ok(events) => {
+                    let touched = events
+                        .iter()
+                        .flat_map(|ev| ev.paths.iter())
+                        .any(|p| is_dir_child_or_self(p, &dir_for_cb));
+                    if touched {
+                        sink(watch_id_cb.clone(), emit_path.clone());
+                    }
+                }
+                Err(errors) => {
+                    for e in errors {
+                        warn!("local dir watch error: {e}");
+                    }
+                }
+            },
+        )
+        .map_err(|e| TerminalError::EditorError(format!("failed to create dir watcher: {e}")))?;
+
+        debouncer
+            .watch(&watch_dir, RecursiveMode::NonRecursive)
+            .map_err(|e| {
+                TerminalError::EditorError(format!("failed to watch {}: {e}", watch_dir.display()))
+            })?;
+
+        // Inserting over an existing id drops the previous debouncer, which stops
+        // its OS watch and background thread — so re-targeting to a new directory
+        // (or the same browser re-watching) leaks nothing.
+        let mut guard = self.watchers.lock().unwrap_or_else(|e| e.into_inner());
+        guard.insert(watch_id.clone(), debouncer);
+        debug!(watch_id, "watching local directory for external changes");
+        Ok(())
+    }
+
     /// Stop watching for `watch_id`. Unknown ids are a harmless no-op.
     pub fn unwatch(&self, watch_id: &str) {
         let mut guard = self.watchers.lock().unwrap_or_else(|e| e.into_inner());
@@ -155,6 +251,33 @@ fn paths_match(event_path: &Path, target: &Path) -> bool {
     match (event_path.file_name(), target.file_name()) {
         (Some(a), Some(b)) => a == b,
         _ => event_path == target,
+    }
+}
+
+/// Canonicalize `p`, falling back to `p` unchanged when it cannot be resolved
+/// (e.g. a just-removed child, or a non-existent path in a unit test). Directory
+/// matching canonicalizes both sides so a symlinked path prefix does not defeat
+/// the compare — macOS FSEvents reports canonical `/private/var/...` paths for a
+/// `/var/...` watch.
+fn canonicalize_or(p: &Path) -> PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Whether a filesystem event path is a **direct child** of the watched
+/// directory (an entry the listing shows) or the directory itself. This scopes
+/// the browser refresh to add / remove / rename / modify of the listing's own
+/// entries and filters out deeper events a recursive OS backend may surface.
+///
+/// `canonical_dir` must already be canonicalized (see [`canonicalize_or`]); the
+/// event path (or, for a child, its still-existing parent) is canonicalized here
+/// so the two are compared in the same form.
+fn is_dir_child_or_self(event_path: &Path, canonical_dir: &Path) -> bool {
+    if canonicalize_or(event_path) == canonical_dir {
+        return true;
+    }
+    match event_path.parent() {
+        Some(parent) => canonicalize_or(parent) == canonical_dir,
+        None => false,
     }
 }
 
@@ -260,6 +383,136 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(400));
         std::fs::write(&file, "after teardown").expect("external write");
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(800)).is_err(),
+            "no event should arrive after unwatch"
+        );
+    }
+
+    #[test]
+    fn dir_matches_direct_child() {
+        assert!(is_dir_child_or_self(
+            Path::new("/home/u/new.txt"),
+            Path::new("/home/u")
+        ));
+    }
+
+    #[test]
+    fn dir_matches_itself() {
+        assert!(is_dir_child_or_self(
+            Path::new("/home/u"),
+            Path::new("/home/u")
+        ));
+    }
+
+    #[test]
+    fn dir_ignores_grandchild() {
+        // A modify deep in a subtree is not a change to this listing's entries.
+        assert!(!is_dir_child_or_self(
+            Path::new("/home/u/sub/deep.txt"),
+            Path::new("/home/u")
+        ));
+    }
+
+    #[test]
+    fn dir_ignores_sibling_entry() {
+        assert!(!is_dir_child_or_self(
+            Path::new("/home/other.txt"),
+            Path::new("/home/u")
+        ));
+    }
+
+    /// End-to-end against a real directory: creating a new file in the watched
+    /// directory must drive the sink with the directory's `watch_id`. Exercises
+    /// the actual OS watcher, not a mock.
+    #[test]
+    fn dir_sink_fires_on_child_created() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let manager = FileWatchManager::new();
+        let (tx, rx) = mpsc::channel();
+        manager
+            .watch_dir_with_sink(
+                "d1".to_string(),
+                dir.path().to_string_lossy().to_string(),
+                move |watch_id, _path| {
+                    let _ = tx.send(watch_id);
+                },
+            )
+            .expect("watch starts");
+
+        // Let the OS watch arm before writing (FSEvents in particular is lazy).
+        std::thread::sleep(Duration::from_millis(400));
+        std::fs::write(dir.path().join("added.txt"), "hello").expect("create child");
+
+        let got = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("a change event should arrive");
+        assert_eq!(got, "d1");
+
+        manager.unwatch("d1");
+    }
+
+    /// Removing an entry from the watched directory must also drive the sink —
+    /// the listing has to reflect deletions, not just additions.
+    #[test]
+    fn dir_sink_fires_on_child_removed() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let victim = dir.path().join("victim.txt");
+        std::fs::write(&victim, "bye").expect("seed child");
+
+        let manager = FileWatchManager::new();
+        let (tx, rx) = mpsc::channel();
+        manager
+            .watch_dir_with_sink(
+                "d1".to_string(),
+                dir.path().to_string_lossy().to_string(),
+                move |watch_id, _path| {
+                    let _ = tx.send(watch_id);
+                },
+            )
+            .expect("watch starts");
+
+        std::thread::sleep(Duration::from_millis(400));
+        std::fs::remove_file(&victim).expect("remove child");
+
+        let got = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("a removal event should arrive");
+        assert_eq!(got, "d1");
+
+        manager.unwatch("d1");
+    }
+
+    /// Dropping the directory watch (via `unwatch`) stops delivery: changes after
+    /// teardown must not reach the sink — the resource-cleanup guarantee.
+    #[test]
+    fn dir_sink_stops_after_unwatch() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let manager = FileWatchManager::new();
+        let (tx, rx) = mpsc::channel();
+        manager
+            .watch_dir_with_sink(
+                "d1".to_string(),
+                dir.path().to_string_lossy().to_string(),
+                move |watch_id, _path| {
+                    let _ = tx.send(watch_id);
+                },
+            )
+            .expect("watch starts");
+
+        manager.unwatch("d1");
+        // Drain any event that may have been queued before teardown.
+        while rx.try_recv().is_ok() {}
+
+        std::thread::sleep(Duration::from_millis(400));
+        std::fs::write(dir.path().join("after.txt"), "late").expect("create child");
 
         assert!(
             rx.recv_timeout(Duration::from_millis(800)).is_err(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -727,6 +727,8 @@ pub fn run() {
             commands::files::local_write_file,
             commands::files::watch_local_file,
             commands::files::unwatch_local_file,
+            commands::files::watch_local_dir,
+            commands::files::unwatch_local_dir,
             commands::files::sftp_read_file_content,
             commands::files::sftp_write_file_content,
             commands::files::sftp_write_file_content_elevated,

--- a/src/components/Sidebar/FileBrowser.actionfeedback.test.tsx
+++ b/src/components/Sidebar/FileBrowser.actionfeedback.test.tsx
@@ -58,6 +58,7 @@ vi.mock("@/themes", () => ({
 
 vi.mock("@/services/events", () => ({
   onVscodeEditComplete: vi.fn(() => Promise.resolve(vi.fn())),
+  onLocalDirChanged: vi.fn(() => Promise.resolve(vi.fn())),
 }));
 
 vi.mock("@/services/api", async (importOriginal) => {

--- a/src/components/Sidebar/FileBrowser.inline-input.test.tsx
+++ b/src/components/Sidebar/FileBrowser.inline-input.test.tsx
@@ -29,6 +29,7 @@ vi.mock("@/themes", () => ({
 
 vi.mock("@/services/events", () => ({
   onVscodeEditComplete: vi.fn(() => Promise.resolve(vi.fn())),
+  onLocalDirChanged: vi.fn(() => Promise.resolve(vi.fn())),
 }));
 
 vi.mock("@/services/api", async (importOriginal) => {

--- a/src/components/Sidebar/FileBrowser.multidelete.test.tsx
+++ b/src/components/Sidebar/FileBrowser.multidelete.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@/themes", () => ({
 
 vi.mock("@/services/events", () => ({
   onVscodeEditComplete: vi.fn(() => Promise.resolve(vi.fn())),
+  onLocalDirChanged: vi.fn(() => Promise.resolve(vi.fn())),
 }));
 
 vi.mock("@/services/api", async (importOriginal) => {

--- a/src/components/Sidebar/FileBrowser.rename.test.tsx
+++ b/src/components/Sidebar/FileBrowser.rename.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/themes", () => ({
 
 vi.mock("@/services/events", () => ({
   onVscodeEditComplete: vi.fn(() => Promise.resolve(vi.fn())),
+  onLocalDirChanged: vi.fn(() => Promise.resolve(vi.fn())),
 }));
 
 vi.mock("@/services/api", async (importOriginal) => {

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/themes", () => ({
 
 vi.mock("@/services/events", () => ({
   onVscodeEditComplete: vi.fn(() => Promise.resolve(vi.fn())),
+  onLocalDirChanged: vi.fn(() => Promise.resolve(vi.fn())),
 }));
 
 vi.mock("@/services/api", async (importOriginal) => {

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -58,6 +58,7 @@ import { baseNameSelectionEnd } from "@/utils/fileNameSelection";
 import { frontendLog } from "@/utils/frontendLog";
 import { useRovingListNav } from "@/hooks/useRovingListNav";
 import { useOsFileDrop } from "@/hooks/useOsFileDrop";
+import { useLocalDirWatch } from "@/hooks/useLocalDirWatch";
 import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
 import { FileBrowserPathBar } from "./FileBrowserPathBar";
 import "./FileBrowser.css";
@@ -894,6 +895,12 @@ export function FileBrowser() {
   );
 
   const { isDragOver } = useOsFileDrop(containerRef, handleOsDrop);
+
+  // Auto-refresh the local listing when its directory changes on disk under
+  // another process (#1626). Event-driven via the backend directory watcher;
+  // local transport only (remote external-change detection is #1627). The
+  // toolbar Refresh button stays as a manual backstop.
+  useLocalDirWatch(mode === "local", mode === "local" ? currentPath : null, refresh);
 
   const disconnectSftp = useAppStore((s) => s.disconnectSftp);
   const retrySftp = useAppStore((s) => s.retrySftp);

--- a/src/components/Sidebar/FileBrowser.virtualization.test.tsx
+++ b/src/components/Sidebar/FileBrowser.virtualization.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/themes", () => ({
 
 vi.mock("@/services/events", () => ({
   onVscodeEditComplete: vi.fn(() => Promise.resolve(vi.fn())),
+  onLocalDirChanged: vi.fn(() => Promise.resolve(vi.fn())),
 }));
 
 vi.mock("@/services/api", async (importOriginal) => {

--- a/src/components/Sidebar/FileBrowser.vscode-feedback.test.tsx
+++ b/src/components/Sidebar/FileBrowser.vscode-feedback.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@/services/events", () => ({
       return Promise.resolve(vi.fn());
     }
   ),
+  onLocalDirChanged: vi.fn(() => Promise.resolve(vi.fn())),
 }));
 
 vi.mock("@tauri-apps/api/window", () => ({

--- a/src/hooks/useLocalDirWatch.test.ts
+++ b/src/hooks/useLocalDirWatch.test.ts
@@ -13,8 +13,8 @@ vi.mock("@/services/events", () => ({
   }),
 }));
 
-const watchLocalDir = vi.fn(() => Promise.resolve());
-const unwatchLocalDir = vi.fn(() => Promise.resolve());
+const watchLocalDir = vi.fn<(id: string, path: string) => Promise<void>>(() => Promise.resolve());
+const unwatchLocalDir = vi.fn<(id: string) => Promise<void>>(() => Promise.resolve());
 vi.mock("@/services/api", () => ({
   watchLocalDir: (id: string, path: string) => watchLocalDir(id, path),
   unwatchLocalDir: (id: string) => unwatchLocalDir(id),

--- a/src/hooks/useLocalDirWatch.test.ts
+++ b/src/hooks/useLocalDirWatch.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+// Capture the event callback the hook registers so tests can fire a simulated
+// `local-dir-changed` event at it, plus the unlisten it returns.
+let dirChangeCb: ((watchId: string, path: string) => void) | null = null;
+const unlisten = vi.fn();
+vi.mock("@/services/events", () => ({
+  onLocalDirChanged: vi.fn((cb: (watchId: string, path: string) => void) => {
+    dirChangeCb = cb;
+    return Promise.resolve(unlisten);
+  }),
+}));
+
+const watchLocalDir = vi.fn(() => Promise.resolve());
+const unwatchLocalDir = vi.fn(() => Promise.resolve());
+vi.mock("@/services/api", () => ({
+  watchLocalDir: (id: string, path: string) => watchLocalDir(id, path),
+  unwatchLocalDir: (id: string) => unwatchLocalDir(id),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+import { useLocalDirWatch } from "./useLocalDirWatch";
+
+/** Minimal harness component that drives the hook with test-controlled props. */
+function Harness(props: { enabled: boolean; path: string | null; onChange: () => void }) {
+  useLocalDirWatch(props.enabled, props.path, props.onChange);
+  return null;
+}
+
+describe("useLocalDirWatch", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    dirChangeCb = null;
+    watchLocalDir.mockClear();
+    unwatchLocalDir.mockClear();
+    unlisten.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  /** Render/update the harness and flush the hook's async start(). */
+  async function renderHarness(props: {
+    enabled: boolean;
+    path: string | null;
+    onChange: () => void;
+  }) {
+    await act(async () => {
+      root.render(createElement(Harness, props));
+    });
+  }
+
+  it("registers a directory watch when enabled with a path", async () => {
+    await renderHarness({ enabled: true, path: "/home/u", onChange: vi.fn() });
+    expect(watchLocalDir).toHaveBeenCalledTimes(1);
+    expect(watchLocalDir.mock.calls[0][1]).toBe("/home/u");
+  });
+
+  it("does not watch when disabled", async () => {
+    await renderHarness({ enabled: false, path: "/home/u", onChange: vi.fn() });
+    expect(watchLocalDir).not.toHaveBeenCalled();
+  });
+
+  it("does not watch when path is null", async () => {
+    await renderHarness({ enabled: true, path: null, onChange: vi.fn() });
+    expect(watchLocalDir).not.toHaveBeenCalled();
+  });
+
+  it("refreshes (debounced) on a matching change event", async () => {
+    const onChange = vi.fn();
+    await renderHarness({ enabled: true, path: "/home/u", onChange });
+    const watchId = watchLocalDir.mock.calls[0][0];
+
+    act(() => {
+      dirChangeCb?.(watchId, "/home/u");
+    });
+    // Debounced: nothing yet.
+    expect(onChange).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces a burst of events into one refresh", async () => {
+    const onChange = vi.fn();
+    await renderHarness({ enabled: true, path: "/home/u", onChange });
+    const watchId = watchLocalDir.mock.calls[0][0];
+
+    act(() => {
+      dirChangeCb?.(watchId, "/home/u");
+      dirChangeCb?.(watchId, "/home/u");
+      dirChangeCb?.(watchId, "/home/u");
+      vi.advanceTimersByTime(200);
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores events for a different watch id", async () => {
+    const onChange = vi.fn();
+    await renderHarness({ enabled: true, path: "/home/u", onChange });
+
+    act(() => {
+      dirChangeCb?.("some-other-id", "/home/u");
+      vi.advanceTimersByTime(200);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("unwatches and unsubscribes on unmount", async () => {
+    await renderHarness({ enabled: true, path: "/home/u", onChange: vi.fn() });
+    const watchId = watchLocalDir.mock.calls[0][0];
+
+    await act(async () => {
+      root.render(createElement("div"));
+    });
+    expect(unwatchLocalDir).toHaveBeenCalledWith(watchId);
+    expect(unlisten).toHaveBeenCalled();
+  });
+
+  it("re-targets the watch when the path changes", async () => {
+    const onChange = vi.fn();
+    await renderHarness({ enabled: true, path: "/home/u", onChange });
+    expect(watchLocalDir).toHaveBeenCalledTimes(1);
+
+    await renderHarness({ enabled: true, path: "/home/u/sub", onChange });
+    // Old watch torn down, new directory watched.
+    expect(unwatchLocalDir).toHaveBeenCalled();
+    expect(watchLocalDir).toHaveBeenCalledTimes(2);
+    expect(watchLocalDir.mock.calls[1][1]).toBe("/home/u/sub");
+  });
+});

--- a/src/hooks/useLocalDirWatch.ts
+++ b/src/hooks/useLocalDirWatch.ts
@@ -1,0 +1,85 @@
+import { useEffect, useId, useRef } from "react";
+import { watchLocalDir, unwatchLocalDir } from "@/services/api";
+import { onLocalDirChanged } from "@/services/events";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * Coalesce a burst of directory events into a single refresh on the frontend
+ * too — belt-and-braces over the backend's own debounce, so a recursive copy or
+ * multi-file operation triggers one re-list, not a storm.
+ */
+const REFRESH_DEBOUNCE_MS = 150;
+
+/**
+ * Watch a **local** directory for external on-disk changes and refresh the
+ * listing when a direct child is added / removed / renamed / modified (#1626).
+ *
+ * Reuses the backend `FileWatchManager` directory-watch that #1620 introduced
+ * for editor files. One OS watch per browser instance (keyed off a stable
+ * `useId`) is torn down on unmount and re-targeted whenever `path` changes, so
+ * navigating never leaks a watch. The watcher is event-driven; the toolbar
+ * Refresh button remains as a manual backstop (there is no competing poll in the
+ * app — the directory was previously only re-read on navigation/refresh).
+ *
+ * Local only: remote (SFTP / session) browsers use their own transports and must
+ * not OS-watch a remote path (that is #1627).
+ *
+ * @param enabled Whether watching is active (false in non-local browser modes).
+ * @param path The absolute local directory to watch, or `null` to watch nothing.
+ * @param onExternalChange Called (debounced) when the directory's entries change.
+ */
+export function useLocalDirWatch(
+  enabled: boolean,
+  path: string | null,
+  onExternalChange: () => void
+): void {
+  const watchId = useId();
+
+  // Keep a stable ref so the (path-scoped) watch effect always calls the latest
+  // refresh logic without re-subscribing when the callback identity changes.
+  const onChangeRef = useRef(onExternalChange);
+  onChangeRef.current = onExternalChange;
+
+  useEffect(() => {
+    if (!enabled || !path) return;
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const start = async () => {
+      try {
+        await watchLocalDir(watchId, path);
+      } catch (err) {
+        frontendLog(
+          "file_browser",
+          `failed to start local dir watch for ${path}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+      const off = await onLocalDirChanged((changedWatchId) => {
+        if (changedWatchId !== watchId) return;
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          onChangeRef.current();
+        }, REFRESH_DEBOUNCE_MS);
+      });
+      // The effect may have been torn down while awaiting; drop the listener.
+      if (disposed) {
+        off();
+      } else {
+        unlisten = off;
+      }
+    };
+    void start();
+
+    return () => {
+      disposed = true;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      unlisten?.();
+      void unwatchLocalDir(watchId).catch(() => {
+        // best-effort teardown
+      });
+    };
+  }, [enabled, path, watchId]);
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1069,6 +1069,23 @@ export async function unwatchLocalFile(watchId: string): Promise<void> {
   await invoke("unwatch_local_file", { watchId });
 }
 
+/**
+ * Start watching a local directory for external on-disk changes (#1626).
+ *
+ * `watchId` is an opaque per-browser-instance key; the resulting
+ * `local-dir-changed` events carry it back so the right file browser refreshes.
+ * Re-watching the same id replaces the previous watch (used to re-target when
+ * the browsed directory changes).
+ */
+export async function watchLocalDir(watchId: string, path: string): Promise<void> {
+  await invoke("watch_local_dir", { watchId, path });
+}
+
+/** Stop watching a local directory previously registered with {@link watchLocalDir}. */
+export async function unwatchLocalDir(watchId: string): Promise<void> {
+  await invoke("unwatch_local_dir", { watchId });
+}
+
 /** Read a remote file's contents as a UTF-8 string via SFTP. */
 export async function sftpReadFileContent(sessionId: string, remotePath: string): Promise<string> {
   return await invoke<string>("sftp_read_file_content", { sessionId, remotePath });

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -438,6 +438,25 @@ export async function onLocalFileChanged(
   });
 }
 
+interface LocalDirChangedPayload {
+  watchId: string;
+  path: string;
+}
+
+/**
+ * Subscribe to external on-disk change events for a watched local directory
+ * (#1626) — a direct child added / removed / renamed / modified. The `watchId`
+ * identifies which file-browser instance registered the watch; callers filter
+ * to their own id and refresh the listing.
+ */
+export async function onLocalDirChanged(
+  callback: (watchId: string, path: string) => void
+): Promise<UnlistenFn> {
+  return await listen<LocalDirChangedPayload>("local-dir-changed", (event) => {
+    callback(event.payload.watchId, event.payload.path);
+  });
+}
+
 /** Subscribe to real-time log entry events from the backend. */
 export async function onLogEntry(callback: (entry: LogEntry) => void): Promise<UnlistenFn> {
   return await listen<LogEntry>("log-entry", (event) => {


### PR DESCRIPTION
## What & why

The sidebar **file browser** listing did not refresh when files/directories changed on disk under another process — the directory was only ever re-read on navigation or a manual Refresh. #1629 fixed the same class of staleness for the **editor** (open local files); this is the file-browser half.

Reported from real usage (the follow-up scope of #1620/#1629).

## Behaviour

- A **local** directory shown in the sidebar now reflects externally-made **add / remove / rename / modify** of its entries automatically — no manual Refresh.
- Re-targets as you navigate; the watch is torn down when the panel unmounts (sidebar closes / switches view).
- **Local only.** Remote (SFTP / session) browsers use their own transports and are not OS-watched — that is a separate issue (#1627).

## How it works

- **Reuses the existing `FileWatchManager`** (`src-tauri/src/files/watcher.rs`) that #1629 introduced, rather than a second mechanism. Added a sibling **directory-watch** variant (`watch_dir` / `watch_local_dir` / `unwatch_local_dir` commands) alongside the untouched file-watch path: it watches the directory non-recursively and emits a debounced `local-dir-changed` event on any change to a **direct child**. Deeper events a recursive backend (FSEvents) may surface are filtered out, and matching canonicalizes both sides so a symlinked path prefix (macOS `/private/var` vs `/var`) does not defeat the compare.
- Shares the 300 ms backend debounce, the per-`watch_id` keying (one OS watch per browser instance, keyed off a stable `useId`), and the leak-free teardown.
- Frontend `useLocalDirWatch` hook subscribes, debounces 150 ms, and calls the existing `refreshLocal` action.

### Design decisions (per the issue's judgement calls)

- **Extend, don't fork.** A directory-watch mode alongside the file-watch, sharing the debouncer/keying/teardown — additive, so it does not disturb #1629's file-watch path.
- **Replace, not augment — because there was no app-side poll to fight.** The ~2 s poll is in the *test harness* (`wait_for_file_row`); the app only re-read on navigation/refresh. So the watcher becomes the auto-refresh and the toolbar Refresh button stays as a manual backstop. No two mechanisms double-refreshing.
- **Virtualization (from #1582):** the refresh re-lists via `localListDir` and updates the store entry model (`localFileEntries`), which drives `useVirtualizer`'s count/total-size — so an externally-added file appears in the underlying model even when it sorts outside the ~33 mounted rows, not just in the visible DOM.

## Tests

- **Rust real-filesystem integration tests** (like #1629's): watch a real temp directory and assert a genuine external file create and file remove reach the sink, and that `unwatch` stops delivery — exercising the actual OS watcher, not a mock. Plus unit tests for the direct-child filter. All 13 `files::watcher` tests green.
- **Frontend**: `useLocalDirWatch` unit tests (registration, debounced refresh, burst coalescing, watch-id filtering, unmount teardown, path re-targeting). Full frontend suite green (3346 tests).

## Verification

Drove the real OS directory-watch end to end via the real-filesystem integration test (stable across runs on macOS): a genuine external create/remove in the watched directory fires the watcher. The full GUI click-through on macOS is not automatable (no WKWebView `tauri-driver`, ADR-5) and the integration UI lane is CI-dark (#1569), which is why the real-fs Rust test is the load-bearing evidence.

Closes #1626