### PR TITLE
fix(sftp): include backing session identity in editor tab dedup key (Closes #1599)

### DIFF
--- a/docs/changes/dev5/fix/1599-editor-tab-session-dedup.md
+++ b/docs/changes/dev5/fix/1599-editor-tab-session-dedup.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- Editor tabs: opening the same file path from two different remote sessions no
+  longer collapses into a single tab that silently re-points at the second
+  session. Previously editing `/etc/hosts` on SSH host A and then on host B (or
+  the same path across an FTP host and a Docker container) reused one tab and
+  jumped its content and save target to the second session, risking a save to
+  the wrong host. Editor-tab deduplication now includes the backing session's
+  stable identity (SFTP `hostLabel`, or the owning terminal tab for session-layer
+  browsers), so different sessions get independent tabs while reconnecting the
+  same connection still refreshes the existing tab in place rather than
+  duplicating it (#1599).

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/services/api", () => ({
   localListDir: vi.fn(),
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
   attachPersistentTab: vi.fn(() => Promise.resolve(1)),
+  sessionGetCapabilities: vi.fn(() => Promise.resolve({ monitoring: false, fileBrowser: true })),
 }));
 
 import { useAppStore, _resetConnectionReloadSeq } from "./appStore";
@@ -439,6 +440,122 @@ describe("appStore", () => {
       const leaves = getAllLeaves(state.rootPanel);
       const tabs = leaves.flatMap((l) => l.tabs).filter((t) => t.contentType === "editor");
       expect(tabs).toHaveLength(1);
+    });
+
+    it("reuses one tab for the same path + same local file", () => {
+      useAppStore.getState().openEditorTab("/etc/hosts", false);
+      useAppStore.getState().openEditorTab("/etc/hosts", false);
+
+      const state = useAppStore.getState();
+      const tabs = getAllLeaves(state.rootPanel)
+        .flatMap((l) => l.tabs)
+        .filter((t) => t.contentType === "editor");
+      expect(tabs).toHaveLength(1);
+    });
+
+    it("opens two tabs for the same path on two different SFTP hosts (#1599)", () => {
+      // Two live SFTP sessions to different hosts.
+      useAppStore.setState({
+        sftpSessions: {
+          "sess-a": { hostLabel: "user@host-a:22", owningTabId: "" },
+          "sess-b": { hostLabel: "user@host-b:22", owningTabId: "" },
+        },
+      });
+
+      useAppStore.getState().openEditorTab("/etc/hosts", true, "sess-a");
+      useAppStore.getState().openEditorTab("/etc/hosts", true, "sess-b");
+
+      const state = useAppStore.getState();
+      const tabs = getAllLeaves(state.rootPanel)
+        .flatMap((l) => l.tabs)
+        .filter((t) => t.contentType === "editor");
+      // Different hosts => two independent tabs, each backed by its own session.
+      expect(tabs).toHaveLength(2);
+      const sessionIds = tabs.map((t) => t.editorMeta?.sftpSessionId).sort();
+      expect(sessionIds).toEqual(["sess-a", "sess-b"]);
+    });
+
+    it("refreshes one SFTP tab when the same host reconnects with a new session id (#1599)", () => {
+      // A reconnect mints a new SFTP session id but keeps the same host label.
+      useAppStore.setState({
+        sftpSessions: {
+          "sess-old": { hostLabel: "user@host-a:22", owningTabId: "" },
+          "sess-new": { hostLabel: "user@host-a:22", owningTabId: "" },
+        },
+      });
+
+      useAppStore.getState().openEditorTab("/etc/hosts", true, "sess-old");
+      useAppStore.getState().openEditorTab("/etc/hosts", true, "sess-new");
+
+      const state = useAppStore.getState();
+      const tabs = getAllLeaves(state.rootPanel)
+        .flatMap((l) => l.tabs)
+        .filter((t) => t.contentType === "editor");
+      // Same host, new session => the existing tab is refreshed, not duplicated.
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].editorMeta?.sftpSessionId).toBe("sess-new");
+    });
+
+    it("opens two tabs for the same path on two different session-layer connections (#1599)", () => {
+      // Two live session-layer terminals (e.g. an FTP host and a Docker
+      // container), each owning its own session id.
+      useAppStore
+        .getState()
+        .addTab("FTP", "remote-session", { type: "ftp", config: {} }, { sessionId: "ftp-sess" });
+      useAppStore
+        .getState()
+        .addTab(
+          "Docker",
+          "remote-session",
+          { type: "docker", config: {} },
+          { sessionId: "docker-sess" }
+        );
+
+      useAppStore.getState().openEditorTab("/app/config.yml", true, undefined, undefined, {
+        sessionId: "ftp-sess",
+        connectionType: "ftp",
+      });
+      useAppStore.getState().openEditorTab("/app/config.yml", true, undefined, undefined, {
+        sessionId: "docker-sess",
+        connectionType: "docker",
+      });
+
+      const state = useAppStore.getState();
+      const tabs = getAllLeaves(state.rootPanel)
+        .flatMap((l) => l.tabs)
+        .filter((t) => t.contentType === "editor");
+      expect(tabs).toHaveLength(2);
+    });
+
+    it("refreshes one session-layer tab when its connection reconnects with a new session id (#1599)", () => {
+      // A single session-layer terminal; capture its stable tab id.
+      useAppStore
+        .getState()
+        .addTab("FTP", "remote-session", { type: "ftp", config: {} }, { sessionId: "ftp-sess-1" });
+      const ftpTabId = getAllLeaves(useAppStore.getState().rootPanel)
+        .flatMap((l) => l.tabs)
+        .find((t) => t.sessionId === "ftp-sess-1")!.id;
+
+      useAppStore.getState().openEditorTab("/app/config.yml", true, undefined, undefined, {
+        sessionId: "ftp-sess-1",
+        connectionType: "ftp",
+      });
+
+      // Reconnect: same tab, new backing session id.
+      useAppStore.getState().setTabSessionId(ftpTabId, "ftp-sess-2");
+
+      useAppStore.getState().openEditorTab("/app/config.yml", true, undefined, undefined, {
+        sessionId: "ftp-sess-2",
+        connectionType: "ftp",
+      });
+
+      const state = useAppStore.getState();
+      const tabs = getAllLeaves(state.rootPanel)
+        .flatMap((l) => l.tabs)
+        .filter((t) => t.contentType === "editor");
+      // Same logical connection => refreshed in place, not duplicated.
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].editorMeta?.sessionBrowser?.sessionId).toBe("ftp-sess-2");
     });
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1261,6 +1261,46 @@ function collectRestoreCohort(groups: TabGroup[]): {
 }
 
 /**
+ * Resolve the stable identity of the remote session backing an editor tab, used
+ * as part of the {@link AppState.openEditorTab} dedup key (#1599).
+ *
+ * The raw session id is deliberately *not* used: it changes when a connection
+ * reconnects, which would spawn a duplicate tab instead of refreshing the
+ * existing one. Instead this returns a value that stays constant across a
+ * reconnect of the same logical connection but differs between distinct
+ * connections, so opening the same path on two different hosts yields two tabs
+ * while reconnecting one host refreshes its tab:
+ *
+ * - SFTP (`sftpSessionId`) → the session's `hostLabel` (`user@host:port`). A
+ *   reconnect mints a new session id under the same label.
+ * - Session layer (`sessionBrowser`) → the id of the terminal tab that owns the
+ *   session. A reconnect swaps the session id but keeps the same tab.
+ *
+ * Returns `undefined` for local tabs and for remote tabs whose identity cannot
+ * be resolved (unknown host, or no owning tab found); callers then fall back to
+ * path-only dedup, preserving the pre-#1599 behaviour.
+ */
+function resolveEditorSessionKey(
+  state: { rootPanel: PanelNode; sftpSessions: Record<string, SftpSessionEntry> },
+  isRemote: boolean,
+  sftpSessionId?: string,
+  sessionBrowser?: EditorSessionRef
+): string | undefined {
+  if (!isRemote) return undefined;
+  if (sftpSessionId) {
+    const hostLabel = state.sftpSessions[sftpSessionId]?.hostLabel;
+    return hostLabel ? `sftp:${hostLabel}` : undefined;
+  }
+  if (sessionBrowser) {
+    const owner = getAllLeaves(state.rootPanel)
+      .flatMap((l) => l.tabs)
+      .find((t) => t.sessionId === sessionBrowser.sessionId);
+    return owner ? `session:${owner.id}` : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Enumerate every live tab across all tab groups (the active group is
  * represented by the live `rootPanel`, the others by their stored trees). Used
  * by the bulk-reconnect control to filter captured failed ids down to tabs that
@@ -2385,13 +2425,19 @@ export const useAppStore = create<AppState>((set, get) => {
       set((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
-        // Look for an existing editor tab for this file
+        // Stable identity of the backing session, so the same path opened from
+        // two different remote sessions gets two tabs while a reconnect of the
+        // same connection refreshes one (#1599).
+        const sessionKey = resolveEditorSessionKey(state, isRemote, sftpSessionId, sessionBrowser);
+
+        // Look for an existing editor tab for this file on the same session.
         for (const leaf of allLeaves) {
           const existing = leaf.tabs.find(
             (t) =>
               t.contentType === "editor" &&
               t.editorMeta?.filePath === filePath &&
-              t.editorMeta?.isRemote === isRemote
+              t.editorMeta?.isRemote === isRemote &&
+              t.editorMeta?.sessionKey === sessionKey
           );
           if (existing) {
             const rootPanel = updateLeaf(state.rootPanel, leaf.id, (l) => ({
@@ -2406,9 +2452,19 @@ export const useAppStore = create<AppState>((set, get) => {
                 let updatedMeta = t.editorMeta;
                 if (isRemote && t.editorMeta) {
                   if (sftpSessionId) {
-                    updatedMeta = { ...t.editorMeta, sftpSessionId, sessionBrowser: undefined };
+                    updatedMeta = {
+                      ...t.editorMeta,
+                      sftpSessionId,
+                      sessionBrowser: undefined,
+                      sessionKey,
+                    };
                   } else if (sessionBrowser) {
-                    updatedMeta = { ...t.editorMeta, sessionBrowser, sftpSessionId: undefined };
+                    updatedMeta = {
+                      ...t.editorMeta,
+                      sessionBrowser,
+                      sftpSessionId: undefined,
+                      sessionKey,
+                    };
                   }
                 }
                 return { ...t, isActive: true, editorMeta: updatedMeta };
@@ -2431,6 +2487,7 @@ export const useAppStore = create<AppState>((set, get) => {
           sftpSessionId,
           permissions,
           sessionBrowser,
+          sessionKey,
         };
         const newTab = createTab(fileName, "local", dummyConfig, targetPanelId, "editor");
         newTab.editorMeta = editorMeta;

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -72,6 +72,24 @@ export interface EditorTabMeta {
    */
   sessionBrowser?: EditorSessionRef;
   /**
+   * Stable identity of the remote session backing this tab, used to deduplicate
+   * editor tabs (#1599). The raw session id is the wrong key on its own: it
+   * changes on reconnect, so keying on it would open a duplicate tab instead of
+   * refreshing the existing one. This holds a value that is *stable across a
+   * reconnect of the same logical connection* but *distinct between different
+   * connections*:
+   *
+   * - SFTP tabs → the session's `hostLabel` (`user@host:port`); a reconnect to
+   *   the same host reuses the label.
+   * - Session-layer tabs → the id of the terminal tab that owns the backing
+   *   session; a reconnect swaps the session id but keeps the tab.
+   *
+   * Undefined for local tabs (deduped on path alone) and for remote tabs whose
+   * identity could not be resolved, in which case dedup falls back to
+   * path + `isRemote` only (the pre-#1599 behaviour).
+   */
+  sessionKey?: string;
+  /**
    * Unix permission string (e.g. `-rw-r--r--`) for a remote file, captured from
    * the file-browser listing when the editor was opened. Surfaced in the
    * read-only badge tooltip; `null`/absent when unknown (local files or a


### PR DESCRIPTION
Follow-up to #1557 (PR #1598).

## Problem

`openEditorTab` in `src/store/appStore.ts` deduplicated editor tabs on `filePath` + `isRemote` only — the backing session was not part of the key. So opening the *same path* from two *different remote sessions* reused one tab and silently re-pointed it at the second session. Open `/etc/hosts` on SSH host A, then on host B, and you got one tab whose content and save target jumped to B — a user could edit-and-save over the wrong host's file. This was pre-existing for two SSH hosts; #1557 widened the blast radius by letting FTP/Docker/agent (session-layer) browsers open editor tabs too, and common paths (`/etc/hosts`, `/app/config.yml`) make it trivial to hit.

## Fix

The dedup key now also carries a **stable** identity of the backing session (`EditorTabMeta.sessionKey`, resolved by `resolveEditorSessionKey`). "Stable" is the crux: a raw session id is the wrong key because it changes on reconnect, which would break the deliberate reconnect-refresh behaviour. Instead:

- **SFTP** (`sftpSessionId`) → the session's `hostLabel` (`user@host:port`), looked up from `sftpSessions`. A reconnect mints a new session id under the **same** label.
- **Session layer** (`sessionBrowser`) → the id of the terminal tab that **owns** the backing session. A reconnect swaps the session id (`setTabSessionId`) but keeps the **same** tab.
- **Local** files → no session key; dedup on path alone, unchanged.
- Unresolved identity (unknown host / no owning tab) → falls back to path-only dedup, preserving pre-#1599 behaviour.

Result: the same path on two different hosts/containers opens two independent tabs, each saving to its own session, while reconnecting a session still refreshes the existing tab in place.

The refresh branch already cleared the unused transport (#1557); it now also stamps the fresh `sessionKey`.

## Tests

`src/store/appStore.test.ts`, in `openEditorTab`:

- **red-first** — same path on two different SFTP hosts opens two tabs (failed before the fix: got 1, expected 2).
- **red-first** — same path on two different session-layer connections opens two tabs (failed before the fix: got 1, expected 2).
- **guard** — same SFTP host reconnecting with a new session id refreshes one tab (`sftpSessionId` updated).
- **guard** — a session-layer connection reconnecting (new session id, same owning tab) refreshes one tab (`sessionBrowser.sessionId` updated).
- **guard** — a local path still reuses one tab.

`npx tsc --noEmit` passes; full frontend suite green.

## Scope / follow-up

Kept strictly to the dedup key. The issue also floats *disambiguating the tab title* when two same-basename tabs are open from different sessions — deferred as a UI follow-up (filed, referencing #1599).