### PR TITLE
perf(agent): cheaper startup update byte-compare (Closes #1630)

### DIFF
--- a/agent/src/update/apply.rs
+++ b/agent/src/update/apply.rs
@@ -95,9 +95,18 @@ fn pending_update_is_applied(
 
 /// Whether two paths are existing regular files with identical contents.
 ///
-/// Compares lengths first so the (rare) SHA-256 pass only runs on a real
-/// candidate. Any I/O error means "cannot prove identical" → `false`, which
-/// keeps the pending update rather than dropping it on a guess.
+/// Two cheap metadata checks settle the common cases before a single byte is
+/// read: a non-file or a **size mismatch** returns immediately, which is what a
+/// genuinely different staged update looks like (a new build differs in length).
+/// Only when the sizes match are the contents compared — byte for byte, with an
+/// early exit on the first mismatch (see [`streams_identical`]). This is cheaper
+/// than hashing both files: the identical case pays a plain memory compare
+/// instead of SHA-256 over every byte, and a same-length-but-different binary
+/// stops at the first differing byte rather than reading both to the end. It is
+/// also strictly correct — an exact byte compare has no hash-collision risk.
+///
+/// Any I/O error means "cannot prove identical" → `false`, which keeps the
+/// pending update rather than dropping it on a guess.
 fn files_identical(a: &Path, b: &Path) -> bool {
     let (Ok(meta_a), Ok(meta_b)) = (std::fs::metadata(a), std::fs::metadata(b)) else {
         return false;
@@ -105,21 +114,45 @@ fn files_identical(a: &Path, b: &Path) -> bool {
     if !meta_a.is_file() || !meta_b.is_file() || meta_a.len() != meta_b.len() {
         return false;
     }
-    match (file_digest(a), file_digest(b)) {
-        (Some(da), Some(db)) => da == db,
-        _ => false,
+    streams_identical(a, b).unwrap_or(false)
+}
+
+/// Byte-compare two files chunk by chunk, returning `false` at the first
+/// differing byte. Neither file is ever fully buffered, and a mismatch early in
+/// the file exits without reading the rest. Errors surface as `Err`, which the
+/// caller treats as "cannot prove identical".
+fn streams_identical(a: &Path, b: &Path) -> std::io::Result<bool> {
+    let mut fa = std::fs::File::open(a)?;
+    let mut fb = std::fs::File::open(b)?;
+    let mut buf_a = [0u8; 16 * 1024];
+    let mut buf_b = [0u8; 16 * 1024];
+    loop {
+        let na = fill(&mut fa, &mut buf_a)?;
+        let nb = fill(&mut fb, &mut buf_b)?;
+        if na != nb || buf_a[..na] != buf_b[..nb] {
+            return Ok(false);
+        }
+        if na == 0 {
+            return Ok(true);
+        }
     }
 }
 
-/// SHA-256 of a file's contents, streamed so a large binary is never fully
-/// buffered. `None` on any I/O error.
-fn file_digest(path: &Path) -> Option<[u8; 32]> {
-    use sha2::{Digest, Sha256};
+/// Read into `buf` until it is full or EOF, retrying short and interrupted
+/// reads; returns the number of bytes read (`0` only at EOF).
+fn fill(file: &mut std::fs::File, buf: &mut [u8]) -> std::io::Result<usize> {
+    use std::io::Read;
 
-    let mut file = std::fs::File::open(path).ok()?;
-    let mut hasher = Sha256::new();
-    std::io::copy(&mut file, &mut hasher).ok()?;
-    Some(hasher.finalize().into())
+    let mut filled = 0;
+    while filled < buf.len() {
+        match file.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(filled)
 }
 
 /// Applies a staged agent update by swapping the running binary and re-execing.
@@ -357,11 +390,19 @@ mod tests {
         std::fs::write(&differ_late, &late).unwrap();
 
         let mut state = state_with(pending("9.9.9", &identical));
-        assert!(prune_applied_pending_update(&mut state, "0.1.0", Some(&running)));
+        assert!(prune_applied_pending_update(
+            &mut state,
+            "0.1.0",
+            Some(&running)
+        ));
         assert!(state.update.pending_update.is_none());
 
         let mut state = state_with(pending("9.9.9", &differ_late));
-        assert!(!prune_applied_pending_update(&mut state, "0.1.0", Some(&running)));
+        assert!(!prune_applied_pending_update(
+            &mut state,
+            "0.1.0",
+            Some(&running)
+        ));
         assert!(state.update.pending_update.is_some());
     }
 

--- a/agent/src/update/apply.rs
+++ b/agent/src/update/apply.rs
@@ -317,6 +317,55 @@ mod tests {
     }
 
     #[test]
+    fn prune_keeps_update_when_staged_binary_differs_in_size() {
+        // Different sizes settle it via the cheap metadata check alone (no bytes
+        // are read). A genuinely newer staged build is a different length, so
+        // this is the common production shape.
+        let tmp = tempfile::tempdir().unwrap();
+        let staged = tmp.path().join("staged-agent");
+        let running = tmp.path().join("running-agent");
+        std::fs::write(&staged, b"NEW-BINARY-THAT-IS-LONGER").unwrap();
+        std::fs::write(&running, b"OLD").unwrap();
+
+        let mut state = state_with(pending("9.9.9", &staged));
+        assert!(!prune_applied_pending_update(
+            &mut state,
+            "0.1.0",
+            Some(&running)
+        ));
+        assert!(state.update.pending_update.is_some());
+    }
+
+    #[test]
+    fn prune_verdict_matches_across_multi_chunk_binaries() {
+        // Binaries larger than one read buffer exercise the streaming compare:
+        // identical multi-chunk contents clear; a single differing byte late in
+        // an otherwise-identical, same-length binary keeps.
+        let tmp = tempfile::tempdir().unwrap();
+        let running = tmp.path().join("running-agent");
+        let identical = tmp.path().join("staged-identical");
+        let differ_late = tmp.path().join("staged-differ-late");
+
+        let mut base = vec![0xABu8; 200 * 1024];
+        for (i, b) in base.iter_mut().enumerate() {
+            *b = (i % 251) as u8;
+        }
+        std::fs::write(&running, &base).unwrap();
+        std::fs::write(&identical, &base).unwrap();
+        let mut late = base.clone();
+        *late.last_mut().unwrap() ^= 0xFF; // same length, last byte differs
+        std::fs::write(&differ_late, &late).unwrap();
+
+        let mut state = state_with(pending("9.9.9", &identical));
+        assert!(prune_applied_pending_update(&mut state, "0.1.0", Some(&running)));
+        assert!(state.update.pending_update.is_none());
+
+        let mut state = state_with(pending("9.9.9", &differ_late));
+        assert!(!prune_applied_pending_update(&mut state, "0.1.0", Some(&running)));
+        assert!(state.update.pending_update.is_some());
+    }
+
+    #[test]
     fn prune_keeps_update_with_unparsable_version_and_different_binary() {
         // `agent.request_deferred_update` may stage a path with no version at
         // all. With nothing to compare and different bytes running, keep it.


### PR DESCRIPTION
## What

Follow-up to #1579 (PR #1628). #1579 moved the socket bind *after* `SessionManager::new`, but it did not make the work itself cheaper. The remaining cost is in the #1551 startup prune (`prune_applied_pending_update`): when a pending update record exists whose version cannot settle whether it was applied, the running executable is compared against the staged binary. That compare hashed **both** multi-MB files with a streamed SHA-256 and compared digests — always reading both files in full and paying crypto per byte.

This replaces the double SHA-256 with a **chunked byte comparison that early-exits on the first differing byte** (`streams_identical`). Neither file is fully buffered.

The size-first cheap reject from #1551 stays in place, so a genuinely different staged update (different length) is still settled from metadata alone with **zero bytes read** — that is the common production shape.

When the sizes match:
- **identical** binaries (the live self-update test's shape, a byte copy of the same build): read both once with a plain memory compare, no SHA-256 over every byte;
- **same length but different**: stop at the first differing chunk instead of reading both to the end.

## Correctness — the #1551 guarantee is preserved

The clear/keep verdict is **unchanged** on every case:

| Case | Verdict |
| --- | --- |
| identical binaries | clear (pruned) |
| same size, different bytes | keep |
| different size | keep (metadata reject, no read) |
| missing staged file | keep |

Proven three ways:
- a **20,000-pair differential fuzz** comparing the new byte-compare against the old digest compare (identical / single-byte-diff / size-diff / last-byte-diff / empty / missing-file) — **0 verdict mismatches**;
- the existing #1551 prune tests still pass (`applied_update_does_not_re_exec_on_the_next_idle`, `failed_apply_keeps_pending_update`, …);
- new regression tests pinning the size-mismatch reject and multi-chunk (>read-buffer) identical/differing verdicts.

An exact byte compare also removes the (astronomically small) hash-collision risk the digest compare carried.

## Perf

Micro-benchmark on an 8 MiB pair (old model uses a cheaper-than-SHA hash, so real double-SHA-256 is even slower):
- **identical 8 MiB**: ~23 ms → ~1.4 ms (same bytes read, no crypto);
- **same size, differs at byte 4096**: ~23 ms reading 16 MiB → ~25 µs reading 32 KiB (early exit).

## Testing

- `cargo test -p termihub-agent` (386 tests) green on macOS.
- Self-update integration suite **hammered 10×** in `rust:1-bookworm` under ~4-CPU concurrency, non-root (uid 501, so `failed_apply_keeps_pending_update`'s `chmod 0o500` is honored): **10/10 green**.
- `cargo fmt --check` and `cargo clippy -p termihub-agent --all-targets --all-features` clean.

Closes #1630