### PR TITLE
feat(sftp): reflect external changes for remote editor files (Closes #1627)

### DIFF
--- a/docs/changes/dev0/feature/1627-remote-editor-external-change.md
+++ b/docs/changes/dev0/feature/1627-remote-editor-external-change.md
@@ -1,0 +1,13 @@
+### Added
+
+- The file editor now reflects external on-disk changes to open **remote**
+  (SFTP, Docker, FTP, and agent-session) files, not just local ones. Remote
+  transports cannot use OS file-watching, so the focused, visible editor tab
+  re-`stat`s its open file on a short interval (paused while the app window is
+  not focused) and, when the file's modification time or size changes
+  out-of-band, reuses the same reload/conflict handling as local files: a clean
+  buffer reloads silently, while a buffer with unsaved edits surfaces the
+  "changed on disk" banner (Reload from disk / Keep my changes) without
+  clobbering either side. Detection is a single lightweight metadata request and
+  is confined to the open file, so it does not hammer remote connections (#1627,
+  follow-up to #1620).

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -60,6 +60,25 @@ pub async fn sftp_list_dir(
         .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
 }
 
+/// Get metadata (size, mtime, permissions) for a single remote file via SFTP.
+///
+/// Backs the editor's remote external-change detection (#1627): the frontend
+/// re-stats the open file on an interval and compares `modified`/`size` to spot
+/// an out-of-band change. A stat is a single metadata round-trip — far cheaper
+/// than re-reading the file — so this is the lightweight poll primitive.
+#[tauri::command]
+pub async fn sftp_stat(
+    session_id: String,
+    path: String,
+    manager: State<'_, SftpManager>,
+) -> Result<FileEntry, TerminalError> {
+    debug!(session_id, path, "SFTP stat");
+    let session = manager.get_session(&session_id)?;
+    tokio::task::spawn_blocking(move || lock_session(&session)?.stat(&path))
+        .await
+        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+}
+
 /// Resolve a remote path to its canonical absolute form via SFTP realpath.
 ///
 /// Passing `"."` yields the session's home directory so the file browser can

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -260,6 +260,20 @@ pub async fn session_read_file(
     manager.read_file(&session_id, &path).await
 }
 
+/// Get metadata for a single file via a session's file browser capability.
+///
+/// Backs the editor's remote external-change detection (#1627): the frontend
+/// re-stats the open file on an interval and compares `modified`/`size`.
+#[tauri::command]
+pub async fn session_stat(
+    session_id: String,
+    path: String,
+    manager: State<'_, SessionManager>,
+) -> Result<FileEntry, TerminalError> {
+    debug!(session_id, path, "Session file stat");
+    manager.stat_file(&session_id, &path).await
+}
+
 /// Write a file via a session's file browser capability.
 #[tauri::command]
 pub async fn session_write_file(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -649,6 +649,7 @@ pub fn run() {
             // Session-based file browsing
             commands::session::session_list_files,
             commands::session::session_read_file,
+            commands::session::session_stat,
             commands::session::session_write_file,
             commands::session::session_delete_file,
             commands::session::session_rename_file,
@@ -701,6 +702,7 @@ pub fn run() {
             commands::files::sftp_open,
             commands::files::sftp_close,
             commands::files::sftp_list_dir,
+            commands::files::sftp_stat,
             commands::files::sftp_realpath,
             commands::files::sftp_check_writable,
             commands::files::sftp_download,

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -572,6 +572,31 @@ impl SessionManager {
             .map_err(|e| TerminalError::RemoteError(e.to_string()))
     }
 
+    /// Get metadata for a single file via a session's file browser capability.
+    ///
+    /// Backs the editor's remote external-change detection (#1627): the frontend
+    /// polls this to compare `modified`/`size` against the last-seen values. It
+    /// routes through the same `connection.files.stat` RPC the file browser
+    /// already uses — no new protocol.
+    pub async fn stat_file(
+        &self,
+        session_id: &str,
+        path: &str,
+    ) -> Result<FileEntry, TerminalError> {
+        let sessions = self.sessions.lock().await;
+        let entry = sessions
+            .get(session_id)
+            .ok_or_else(|| TerminalError::SessionNotFound(session_id.to_string()))?;
+        let browser = entry
+            .connection
+            .file_browser()
+            .ok_or_else(|| TerminalError::RemoteError("No file browser capability".to_string()))?;
+        browser
+            .stat(path)
+            .await
+            .map_err(|e| TerminalError::RemoteError(e.to_string()))
+    }
+
     /// Write a file via a session's file browser capability.
     pub async fn write_file(
         &self,

--- a/src/components/FileEditor/FileEditor.remote-external-change.test.tsx
+++ b/src/components/FileEditor/FileEditor.remote-external-change.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import React from "react";
+import { createRoot, Root } from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import { useAppStore } from "@/store/appStore";
+import { FileEditor, REMOTE_POLL_INTERVAL_MS } from "./FileEditor";
+import type { EditorTabMeta } from "@/types/terminal";
+
+// Remote tabs don't OS-watch, but FileEditor still imports onLocalFileChanged;
+// stub it so the module resolves (it is never invoked for remote tabs).
+vi.mock("@/services/events", () => ({
+  onLocalFileChanged: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+// Functional Monaco mock: renders a textarea, calls onMount with a small fake
+// editor backed by a mutable model string, and reflects model.setValue back
+// into the textarea — so the reload path (which drives the model directly) is
+// observable end to end. Mirrors the sibling local external-change suite.
+let currentModelValue = "";
+vi.mock("@monaco-editor/react", () => {
+  const MockEditor = ({
+    defaultValue,
+    onChange,
+    onMount,
+  }: {
+    defaultValue?: string;
+    onChange?: (value: string | undefined) => void;
+    onMount?: (editor: unknown) => void;
+  }) => {
+    const ref = React.useRef<HTMLTextAreaElement | null>(null);
+    React.useEffect(() => {
+      currentModelValue = defaultValue ?? "";
+      const ta = ref.current;
+      const fakeModel = {
+        getValue: () => currentModelValue,
+        setValue: (v: string) => {
+          currentModelValue = v;
+          if (ta) ta.value = v;
+          onChange?.(v);
+        },
+        getOptions: () => ({ tabSize: 4, insertSpaces: true }),
+        getLanguageId: () => "plaintext",
+        getEOL: () => "\n",
+        updateOptions: () => {},
+        setEOL: () => {},
+      };
+      const fakeEditor = {
+        getModel: () => fakeModel,
+        getPosition: () => ({ lineNumber: 1, column: 1 }),
+        getDomNode: () => document.createElement("div"),
+        addAction: () => {},
+        onDidChangeCursorPosition: () => {},
+        saveViewState: () => ({}),
+        restoreViewState: () => {},
+        setValue: (v: string) => fakeModel.setValue(v),
+      };
+      onMount?.(fakeEditor);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return React.createElement("textarea", {
+      ref,
+      "data-testid": "mock-monaco",
+      defaultValue,
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        currentModelValue = e.target.value;
+        onChange?.(e.target.value);
+      },
+    });
+  };
+  return { default: MockEditor, loader: { config: vi.fn() } };
+});
+
+vi.mock("monaco-editor", () => ({
+  KeyMod: { CtrlCmd: 2048 },
+  KeyCode: { KeyS: 49 },
+  editor: {
+    setTheme: vi.fn(),
+    setModelLanguage: vi.fn(),
+    EndOfLineSequence: { LF: 0, CRLF: 1 },
+  },
+  languages: {
+    getLanguages: vi.fn(() => [{ id: "plaintext", aliases: ["Plain Text"] }]),
+    register: vi.fn(),
+    setMonarchTokensProvider: vi.fn(),
+    setLanguageConfiguration: vi.fn(),
+  },
+}));
+
+vi.mock("@/themes", () => ({
+  getCurrentTheme: () => ({ id: "dark" }),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+const mockedInvoke = vi.mocked(invoke);
+
+const TAB_ID = "tab-fe-remote-1";
+const SFTP_META: EditorTabMeta = {
+  filePath: "/etc/app.conf",
+  isRemote: true,
+  sftpSessionId: "sftp-sess-1",
+};
+const SESSION_META: EditorTabMeta = {
+  filePath: "/etc/app.conf",
+  isRemote: true,
+  sessionBrowser: { sessionId: "sess-1", connectionType: "docker" },
+};
+
+const INITIAL = "key = 1\n";
+
+// Mutable "remote" state the invoke mock reads. Tests mutate these, then advance
+// the poll interval to make the editor observe the change.
+let diskContent = INITIAL;
+let statValue: { modified: string; size: number } = { modified: "t0", size: INITIAL.length };
+
+function statEntry() {
+  return { name: "app.conf", path: SFTP_META.filePath, isDirectory: false, ...statValue };
+}
+
+function installInvoke() {
+  mockedInvoke.mockImplementation((cmd) => {
+    switch (cmd) {
+      case "sftp_read_file_content":
+        return Promise.resolve(diskContent);
+      case "session_read_file":
+        return Promise.resolve(Array.from(new TextEncoder().encode(diskContent)));
+      case "sftp_stat":
+      case "session_stat":
+        return Promise.resolve(statEntry());
+      case "sftp_check_writable":
+        return Promise.resolve("unknown");
+      case "sftp_has_exec_capability":
+        return Promise.resolve(false);
+      case "sftp_realpath":
+        return Promise.resolve("/home/user");
+      default:
+        return Promise.resolve(undefined);
+    }
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(meta: EditorTabMeta, isVisible = true) {
+  act(() => {
+    root.render(<FileEditor tabId={TAB_ID} meta={meta} isVisible={isVisible} />);
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function query(testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+function editContent(value: string): void {
+  const ta = query("mock-monaco") as HTMLTextAreaElement;
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value"
+  )!.set!;
+  act(() => {
+    setter.call(ta, value);
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+/** Advance one poll interval and flush the async stat + reload chain. */
+async function pollOnce(): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(REMOTE_POLL_INTERVAL_MS + 1);
+  });
+  await flush();
+}
+
+/** Mutate the "remote" file: new content bumps size/mtime. */
+function setRemoteFile(content: string, modified = "t1"): void {
+  diskContent = content;
+  statValue = { modified, size: content.length };
+}
+
+function countInvokes(cmd: string): number {
+  return mockedInvoke.mock.calls.filter((c) => c[0] === cmd).length;
+}
+
+describe("FileEditor — remote external-change poll (#1627)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+    currentModelValue = "";
+    diskContent = INITIAL;
+    statValue = { modified: "t0", size: INITIAL.length };
+    // jsdom reports the window as focused so the poll is not paused.
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    installInvoke();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("re-stats an SFTP file on an interval and does not watch it via the OS", async () => {
+    render(SFTP_META);
+    await flush();
+    // No OS file watch for remote files.
+    expect(countInvokes("watch_local_file")).toBe(0);
+    // Seeds the baseline (immediate stat) on mount…
+    const seeded = countInvokes("sftp_stat");
+    expect(seeded).toBeGreaterThan(0);
+    // …and keeps polling on the interval.
+    await pollOnce();
+    expect(countInvokes("sftp_stat")).toBeGreaterThan(seeded);
+  });
+
+  it("reflects the new content on an SFTP mtime/size change with a clean buffer", async () => {
+    render(SFTP_META);
+    await flush();
+    expect(currentModelValue).toBe(INITIAL);
+
+    setRemoteFile("key = 1\nkey = 2 (external)\n");
+    await pollOnce();
+
+    expect(currentModelValue).toBe("key = 1\nkey = 2 (external)\n");
+    // Clean reload: no conflict banner, buffer stays clean.
+    expect(query("file-editor-disk-changed-banner")).toBeNull();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("does not clobber unsaved edits, surfacing the conflict banner instead", async () => {
+    render(SFTP_META);
+    await flush();
+
+    editContent("key = 1\nmy local edit\n");
+    await flush();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(false);
+
+    setRemoteFile("key = 1\nexternal edit\n");
+    await pollOnce();
+
+    // Edits preserved (not overwritten by the remote change), conflict surfaced.
+    expect(currentModelValue).toBe("key = 1\nmy local edit\n");
+    expect(query("file-editor-disk-changed-banner")).not.toBeNull();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("does not re-read the file when mtime/size is unchanged", async () => {
+    render(SFTP_META);
+    await flush();
+    const readsAfterLoad = countInvokes("sftp_read_file_content");
+
+    // Several polls with no remote change.
+    await pollOnce();
+    await pollOnce();
+
+    // Stat kept polling, but no extra content reads happened.
+    expect(countInvokes("sftp_read_file_content")).toBe(readsAfterLoad);
+    expect(query("file-editor-disk-changed-banner")).toBeNull();
+  });
+
+  it("does not poll a remote file that is not the visible tab", async () => {
+    render(SFTP_META, /* isVisible */ false);
+    await flush();
+    await pollOnce();
+    expect(countInvokes("sftp_stat")).toBe(0);
+  });
+
+  it("reflects an external change for a session-layer (Docker/FTP/agent) file", async () => {
+    render(SESSION_META);
+    await flush();
+    expect(currentModelValue).toBe(INITIAL);
+    expect(countInvokes("session_stat")).toBeGreaterThan(0);
+
+    setRemoteFile("key = 1\nsession external\n");
+    await pollOnce();
+
+    expect(currentModelValue).toBe("key = 1\nsession external\n");
+    expect(query("file-editor-disk-changed-banner")).toBeNull();
+  });
+});

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -36,7 +36,9 @@ import {
   sftpCheckWritable,
   sftpDownload,
   sftpRealpath,
+  sftpStat,
   sessionReadFile,
+  sessionStat,
   sessionWriteFile,
   storeCredential,
   resolveCredential,
@@ -53,6 +55,22 @@ import "./FileEditor.css";
 
 /** Maximum number of sudo-password attempts before falling back to the error banner. */
 const MAX_SUDO_ATTEMPTS = 3;
+
+/**
+ * Poll interval for remote (SFTP / session) editor tabs' external-change
+ * detection (#1627). Remote transports cannot use OS file-watching (which backs
+ * the local path in #1620), so the open file is re-`stat`ed on this interval and
+ * its `modified`/`size` compared to spot an out-of-band change.
+ *
+ * Chosen to stay lightweight: a stat is a single metadata round-trip, polling is
+ * confined to the *focused, visible* editor tab (paused when the window is not
+ * focused — see the poll effect), and only the currently-open file is watched.
+ * At 4s that is 0.25 req/s per open remote editor — negligible next to
+ * interactive SFTP browsing — while still reflecting a teammate's edit within a
+ * few seconds. Kept a single constant so a future setting could gate/tune it
+ * (the owner reserves whether remote polling should be opt-in — see #1627).
+ */
+export const REMOTE_POLL_INTERVAL_MS = 4000;
 
 // Use local monaco-editor package instead of CDN (important for Tauri/offline)
 loader.config({ monaco });
@@ -449,14 +467,30 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     }
   }, []);
 
-  // Reflect the current on-disk contents of a locally-watched file (#1620).
-  // Invoked (debounced) when the OS reports the open file changed underneath us.
+  // Read the current on-disk contents of the open file via whichever transport
+  // backs the tab (local / SFTP / session layer). Used by both the external-
+  // change reload paths and the "Reload from disk" button so local (#1620) and
+  // remote (#1627) files share one read path.
+  const readEffectiveContent = useCallback(async (): Promise<string> => {
+    if (meta.isRemote && meta.sftpSessionId) {
+      return await sftpReadFileContent(meta.sftpSessionId, effectivePath);
+    }
+    if (meta.isRemote && meta.sessionBrowser) {
+      return await sessionReadFileContent(meta.sessionBrowser.sessionId, effectivePath);
+    }
+    return await localReadFile(effectivePath);
+  }, [meta.isRemote, meta.sftpSessionId, meta.sessionBrowser, effectivePath]);
+
+  // Reflect the current on-disk contents when the open file changed underneath
+  // us — driven by the OS watcher for local files (#1620) and by the re-stat
+  // poll for remote files (#1627). Both feed the same clean-reload / conflict
+  // decision below.
   const reloadFromDisk = useCallback(async () => {
-    // Only local, on-disk editor buffers are watched.
-    if (meta.isRemote || isUnsavedScratch) return;
+    // A scratch buffer that was never saved has no on-disk counterpart.
+    if (isUnsavedScratch) return;
     let disk: string;
     try {
-      disk = await localReadFile(effectivePath);
+      disk = await readEffectiveContent();
     } catch (err) {
       frontendLog(
         "file_editor",
@@ -490,24 +524,24 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     applyDiskContent(disk);
     frontendLog("file_editor", `reloaded tab ${tabId} from external on-disk change`);
   }, [
-    meta.isRemote,
     isUnsavedScratch,
-    effectivePath,
+    readEffectiveContent,
     savedContent,
     content,
     tabId,
     applyDiskContent,
   ]);
 
-  // Banner action "Reload from disk" (#1620): discard the unsaved buffer edits
-  // and load the on-disk version. Reuses the clean-case reload path; the only
-  // difference is it proceeds despite a dirty buffer. Once applied, the buffer
-  // matches disk (clean), which also clears the conflict banner.
+  // Banner action "Reload from disk" (#1620, #1627): discard the unsaved buffer
+  // edits and load the on-disk version (local or remote). Reuses the clean-case
+  // read path; the only difference is it proceeds despite a dirty buffer. Once
+  // applied, the buffer matches disk (clean), which also clears the conflict
+  // banner.
   const handleReloadFromDisk = useCallback(async () => {
-    if (meta.isRemote || isUnsavedScratch) return;
+    if (isUnsavedScratch) return;
     let disk: string;
     try {
-      disk = await localReadFile(effectivePath);
+      disk = await readEffectiveContent();
     } catch (err) {
       frontendLog(
         "file_editor",
@@ -520,7 +554,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     applyDiskContent(disk);
     setDiskChangedWhileDirty(false);
     frontendLog("file_editor", `reloaded tab ${tabId} from disk, discarding unsaved edits`);
-  }, [meta.isRemote, isUnsavedScratch, effectivePath, tabId, applyDiskContent]);
+  }, [isUnsavedScratch, readEffectiveContent, tabId, applyDiskContent]);
 
   // Banner action "Keep my changes" (#1620): dismiss the conflict banner and
   // ignore the on-disk change. Clears the pending-conflict state so a later
@@ -537,6 +571,15 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // calls the latest reload logic without re-subscribing on every keystroke.
   const reloadFromDiskRef = useRef(reloadFromDisk);
   reloadFromDiskRef.current = reloadFromDisk;
+
+  // Last-seen remote stat (mtime + size) for the external-change poll (#1627),
+  // keyed to the file identity so it survives visibility toggles (returning to a
+  // tab detects a change that landed while it was hidden) but resets when the
+  // tab points at a different file.
+  const remoteBaselineRef = useRef<{
+    key: string;
+    value: { modified: string; size: number } | null;
+  }>({ key: "", value: null });
 
   // Watch the open local file for external on-disk changes and reflect them
   // (#1620). Remote (SFTP / session) files use their own transports and are not
@@ -586,6 +629,98 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       });
     };
   }, [meta.isRemote, isUnsavedScratch, effectivePath, watchId, tabId]);
+
+  // Poll a remote (SFTP / session) file for external on-disk changes (#1627).
+  // Remote transports can't OS-watch, so we re-`stat` the open file on an
+  // interval and compare mtime/size to the last-seen baseline; a change routes
+  // through the same reload/conflict path (#1620) the local watcher uses. Kept
+  // lightweight: only the focused, *visible* tab polls, it pauses while the
+  // window is not focused, and a stat is a single metadata round-trip. A
+  // detected change re-reads the full file (via `reloadFromDisk`) only then.
+  useEffect(() => {
+    if (!meta.isRemote || isUnsavedScratch || !isVisible) return;
+    const sftpSessionId = meta.sftpSessionId;
+    const sessionId = meta.sessionBrowser?.sessionId;
+    if (!sftpSessionId && !sessionId) return;
+    const filePath = effectivePath;
+
+    // Reset the baseline when the tab now points at a different remote file;
+    // preserve it across visibility toggles (same identity) so a change that
+    // landed while the tab was hidden is caught on the next visible poll.
+    const identityKey = `${sftpSessionId ?? ""}|${sessionId ?? ""}|${filePath}`;
+    if (remoteBaselineRef.current.key !== identityKey) {
+      remoteBaselineRef.current = { key: identityKey, value: null };
+    }
+
+    let disposed = false;
+
+    const statFile = async (): Promise<{ modified: string; size: number } | null> => {
+      try {
+        const entry = sftpSessionId
+          ? await sftpStat(sftpSessionId, filePath)
+          : await sessionStat(sessionId!, filePath);
+        return { modified: entry.modified, size: entry.size };
+      } catch (err) {
+        frontendLog(
+          "file_editor",
+          `remote stat poll failed for tab ${tabId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        return null;
+      }
+    };
+
+    const tick = async () => {
+      if (disposed) return;
+      // Pause while the window is not focused — no point polling a remote file
+      // the user isn't looking at. (jsdom / older envs may lack hasFocus.)
+      if (typeof document !== "undefined" && typeof document.hasFocus === "function") {
+        if (!document.hasFocus()) return;
+      }
+      const current = await statFile();
+      if (disposed || !current) return;
+      const baseline = remoteBaselineRef.current.value;
+      // Seed the baseline on the first successful stat; only later changes fire.
+      if (baseline === null) {
+        remoteBaselineRef.current = { key: identityKey, value: current };
+        return;
+      }
+      if (current.modified !== baseline.modified || current.size !== baseline.size) {
+        remoteBaselineRef.current = { key: identityKey, value: current };
+        frontendLog(
+          "file_editor",
+          `remote external change detected for tab ${tabId} (mtime/size changed)`
+        );
+        void reloadFromDiskRef.current();
+      }
+    };
+
+    // Seed immediately so the first real detection latency is one interval, then
+    // poll, and re-check the moment the window regains focus.
+    void tick();
+    const interval = setInterval(() => {
+      void tick();
+    }, REMOTE_POLL_INTERVAL_MS);
+    const onFocus = () => {
+      void tick();
+    };
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      disposed = true;
+      clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [
+    meta.isRemote,
+    meta.sftpSessionId,
+    meta.sessionBrowser,
+    isUnsavedScratch,
+    isVisible,
+    effectivePath,
+    tabId,
+  ]);
 
   // A file that failed to load (e.g. the connection dropped) shows the
   // error-only view, which doesn't render the UnsavedChangesDialog. If such a

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -523,14 +523,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     // Happy path: the buffer is clean, so reflect the new content silently.
     applyDiskContent(disk);
     frontendLog("file_editor", `reloaded tab ${tabId} from external on-disk change`);
-  }, [
-    isUnsavedScratch,
-    readEffectiveContent,
-    savedContent,
-    content,
-    tabId,
-    applyDiskContent,
-  ]);
+  }, [isUnsavedScratch, readEffectiveContent, savedContent, content, tabId, applyDiskContent]);
 
   // Banner action "Reload from disk" (#1620, #1627): discard the unsaved buffer
   // edits and load the on-disk version (local or remote). Reuses the clean-case

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -746,6 +746,17 @@ export async function sftpListDir(sessionId: string, path: string): Promise<File
 }
 
 /**
+ * Get metadata (size, mtime, permissions) for a single remote file via SFTP.
+ *
+ * Backs the editor's remote external-change detection (#1627): a stat is a
+ * single metadata round-trip, so it is the cheap poll primitive used to spot an
+ * out-of-band change before deciding to re-read the file.
+ */
+export async function sftpStat(sessionId: string, path: string): Promise<FileEntry> {
+  return await invoke<FileEntry>("sftp_stat", { sessionId, path });
+}
+
+/**
  * Resolve a remote path to its canonical absolute form via SFTP realpath.
  *
  * Pass `"."` to resolve the session's home directory instead of guessing
@@ -1177,6 +1188,16 @@ export async function sessionListFiles(sessionId: string, path: string): Promise
 /** Read a file via a session's file browser capability. Returns raw bytes. */
 export async function sessionReadFile(sessionId: string, path: string): Promise<number[]> {
   return await invoke<number[]>("session_read_file", { sessionId, path });
+}
+
+/**
+ * Get metadata for a single file via a session's file browser capability.
+ *
+ * Backs the editor's remote external-change detection (#1627): the frontend
+ * re-stats the open file on an interval and compares `modified`/`size`.
+ */
+export async function sessionStat(sessionId: string, path: string): Promise<FileEntry> {
+  return await invoke<FileEntry>("session_stat", { sessionId, path });
 }
 
 /** Write raw bytes to a file via a session's file browser capability. */


### PR DESCRIPTION
## What

Reflects external on-disk changes to open **remote** (SFTP / Docker / FTP / agent-session) files in the editor — the remote half of #1620, which handled local files only. Closes #1627.

## Detection strategy

Remote transports can't use OS file-watching (FSEvents/inotify), so this polls instead:

- The **focused, visible** editor tab re-`stat`s its open file on a **4s interval**, **paused while the app window is not focused**, and re-checks immediately on window refocus.
- It compares the file's **mtime + size** against the last-seen baseline (kept per file identity, so returning to a backgrounded tab still catches a change that landed while it was hidden).
- On a detected metadata change it re-reads the full file **only then**, and feeds it into the **same** reload/conflict logic #1620 added:
  - clean buffer → silent reload (`applyDiskContent`);
  - dirty buffer → the existing conflict banner (**Reload from disk** / **Keep my changes**), never clobbering either side.

A stat is a single metadata round-trip, and polling is confined to the one open, focused file, so it stays lightweight and does not hammer remote connections. The interval is a single constant so a future setting could gate or tune it.

### New backend commands

`sftp_stat` and `session_stat` (and `SessionManager::stat_file`) return one `FileEntry` via the **existing** `FileBackend::stat` / `connection.files.stat` path — no new protocol, no agent-side change.

## Reuse

The local read path (`localReadFile` / `sftpReadFileContent` / session read) is unified into one `readEffectiveContent` helper, so the reload and conflict banner from #1620 are reused unchanged — the poll just feeds change-detection into that same path.

## Tests

- **Frontend** (`FileEditor.remote-external-change.test.tsx`, 6 tests): SFTP + session tabs re-stat on interval and are not OS-watched; an mtime/size change with a clean buffer reloads; with a dirty buffer surfaces the conflict banner without clobbering edits; unchanged stat triggers no re-read; a non-visible tab does not poll.
- **Backend**: the `connection.files.stat` agent path already has coverage; the new commands are thin passthroughs over the already-tested `FileBackend::stat`.
- `pnpm build` (tsc), `cargo check`, and `./scripts/check.sh` (eslint / prettier / clippy / fmt / markdownlint) all pass.

## Open product question (not blocking)

I shipped this **always-on when the tab is focused** (consistent with the local watcher in #1620, which is not opt-in), wired behind a single constant so a setting could gate/tune it later. Whether remote polling should instead be **opt-in** or its interval user-configurable is a product call the owner reserves — flagging it rather than inventing a settings UI.

Follow-up to #1620.