### PR TITLE
feat(ui): disambiguate editor tab titles by session (Closes #1640)

### DIFF
--- a/docs/changes/dev5/feature/1640-editor-tab-title-disambiguation.md
+++ b/docs/changes/dev5/feature/1640-editor-tab-title-disambiguation.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Editor tabs: when two or more editor tabs share the same file basename but
+  are backed by different remote sessions, the tab title now appends a session
+  qualifier so they are distinguishable — e.g. two `hosts` tabs on different
+  SSH hosts show as `hosts — user@host-a` and `hosts — user@host-b`. For
+  SFTP-backed tabs the qualifier is the host label; for session-layer tabs it is
+  the title of the owning terminal tab. A lone editor tab, a local file, and any
+  case with no basename clash keep their plain basename (#1640).

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -34,6 +34,7 @@ import {
 import { useAppStore } from "@/store/appStore";
 import { PanelNode, LeafPanel, TerminalTab, DropEdge } from "@/types/terminal";
 import { getAllLeaves, findLeafByTab } from "@/utils/panelTree";
+import { getEditorTabDisplayTitle } from "@/utils/editorTabTitle";
 import { isWindows, isMac } from "@/utils/platform";
 import { usePaneFileDrop } from "@/hooks/usePaneFileDrop";
 import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manager";
@@ -96,6 +97,13 @@ export function SplitView() {
     }
     return null;
   }, [zoomedTabId, rootPanel]);
+
+  // Disambiguated title for the zoomed editor tab (#1640), matching the tab strip.
+  const zoomedTabTitle = useMemo(() => {
+    if (!zoomedTab) return "";
+    const allTabs = getAllLeaves(rootPanel).flatMap((leaf) => leaf.tabs);
+    return getEditorTabDisplayTitle(zoomedTab, allTabs);
+  }, [zoomedTab, rootPanel]);
 
   const dismissZoom = useCallback(() => setZoomedTabId(null), [setZoomedTabId]);
 
@@ -286,7 +294,7 @@ export function SplitView() {
                       className="zoom-overlay__icon"
                     />
                   )}
-                  <span className="zoom-overlay__title">{zoomedTab.title}</span>
+                  <span className="zoom-overlay__title">{zoomedTabTitle}</span>
                   <span className="zoom-overlay__hint">
                     {isMac() ? "⌘⇧↵" : "Ctrl+Shift+Enter"} · Esc to close
                   </span>

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -46,6 +46,11 @@ interface TabProps {
   onSetColor?: () => void;
   /** Per-tab connection status; drives the status dot. `undefined` hides the dot. */
   status?: TabStatus;
+  /**
+   * Title to display, disambiguated when two editor tabs share a basename
+   * (#1640). Falls back to `tab.title` when omitted.
+   */
+  displayTitle?: string;
 }
 
 export function Tab({
@@ -63,7 +68,9 @@ export function Tab({
   onRename,
   onSetColor,
   status,
+  displayTitle,
 }: TabProps) {
+  const shownTitle = displayTitle ?? tab.title;
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: tab.id,
     data: { panelId: tab.panelId, type: "tab" },
@@ -105,7 +112,7 @@ export function Tab({
           onClose();
         }
       }}
-      title={tab.title}
+      title={shownTitle}
       data-testid={`tab-${tab.id}`}
       {...attributes}
       {...listeners}
@@ -124,7 +131,7 @@ export function Tab({
       )}
       <span className="tab__title">
         {isDirty && <span className="tab__dirty-dot" />}
-        {tab.title}
+        {shownTitle}
       </span>
       {tab.persistentConnectionId && <span className="tab__persistent-badge">∞</span>}
       {tab.spawned && (

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
 import { useAppStore } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
+import { getAllLeaves } from "@/utils/panelTree";
+import { getEditorTabDisplayTitle } from "@/utils/editorTabTitle";
 import { deriveTabStatus } from "@/utils/tabStatus";
 import { tabHasLiveSession } from "@/utils/tabLiveSession";
 import { reopenPayloadForTab, showReopenToast } from "@/utils/reopenTab";
@@ -19,6 +21,7 @@ interface TabBarProps {
 
 export function TabBar({ panelId, tabs }: TabBarProps) {
   const isFocused = useAppStore((s) => s.activePanelId === panelId);
+  const rootPanel = useAppStore((s) => s.rootPanel);
   const setActiveTab = useAppStore((s) => s.setActiveTab);
   const closeTab = useAppStore((s) => s.closeTab);
   const tabHorizontalScrolling = useAppStore((s) => s.tabHorizontalScrolling);
@@ -104,6 +107,14 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
 
   const renameTabData = renameTabId ? tabs.find((t) => t.id === renameTabId) : null;
 
+  // Editor-tab title disambiguation (#1640) is judged across the whole active
+  // tab group, so two same-basename editor tabs are distinguishable even when
+  // they live in different split panels.
+  const allTabs = useMemo(
+    () => getAllLeaves(rootPanel).flatMap((leaf) => leaf.tabs),
+    [rootPanel]
+  );
+
   return (
     <div className={`tab-bar${isFocused ? " tab-bar--focused" : ""}`}>
       <SortableContext items={tabs.map((t) => t.id)} strategy={horizontalListSortingStrategy}>
@@ -126,6 +137,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               tabColor={tabColors[tab.id]}
               onRename={() => setRenameTabId(tab.id)}
               onSetColor={() => setColorPickerTabId(tab.id)}
+              displayTitle={getEditorTabDisplayTitle(tab, allTabs)}
               status={
                 tab.contentType === "terminal"
                   ? deriveTabStatus(

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -110,10 +110,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   // Editor-tab title disambiguation (#1640) is judged across the whole active
   // tab group, so two same-basename editor tabs are distinguishable even when
   // they live in different split panels.
-  const allTabs = useMemo(
-    () => getAllLeaves(rootPanel).flatMap((leaf) => leaf.tabs),
-    [rootPanel]
-  );
+  const allTabs = useMemo(() => getAllLeaves(rootPanel).flatMap((leaf) => leaf.tabs), [rootPanel]);
 
   return (
     <div className={`tab-bar${isFocused ? " tab-bar--focused" : ""}`}>

--- a/src/utils/editorTabTitle.test.ts
+++ b/src/utils/editorTabTitle.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { EditorTabMeta, TerminalTab } from "@/types/terminal";
-import {
-  getEditorSessionQualifier,
-  getEditorTabDisplayTitle,
-} from "./editorTabTitle";
+import { getEditorSessionQualifier, getEditorTabDisplayTitle } from "./editorTabTitle";
 
 function makeTab(overrides: Partial<TerminalTab> & { id: string }): TerminalTab {
   return {

--- a/src/utils/editorTabTitle.test.ts
+++ b/src/utils/editorTabTitle.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import type { EditorTabMeta, TerminalTab } from "@/types/terminal";
+import {
+  getEditorSessionQualifier,
+  getEditorTabDisplayTitle,
+} from "./editorTabTitle";
+
+function makeTab(overrides: Partial<TerminalTab> & { id: string }): TerminalTab {
+  return {
+    sessionId: null,
+    title: "tab",
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: {} },
+    panelId: "panel-1",
+    isActive: false,
+    ...overrides,
+  };
+}
+
+function makeEditorTab(
+  id: string,
+  title: string,
+  meta: Partial<EditorTabMeta> & { filePath: string; isRemote: boolean }
+): TerminalTab {
+  return makeTab({
+    id,
+    title,
+    contentType: "editor",
+    editorMeta: meta,
+  });
+}
+
+describe("getEditorSessionQualifier", () => {
+  it("returns the host label for an SFTP-backed tab", () => {
+    const tab = makeEditorTab("a", "hosts", {
+      filePath: "/etc/hosts",
+      isRemote: true,
+      sessionKey: "sftp:user@host-a:22",
+    });
+    expect(getEditorSessionQualifier(tab, [tab])).toBe("user@host-a:22");
+  });
+
+  it("returns the owning terminal tab's title for a session-layer tab", () => {
+    const owner = makeTab({ id: "owner-1", title: "prod-box" });
+    const editor = makeEditorTab("a", "config.yml", {
+      filePath: "/app/config.yml",
+      isRemote: true,
+      sessionKey: "session:owner-1",
+    });
+    expect(getEditorSessionQualifier(editor, [owner, editor])).toBe("prod-box");
+  });
+
+  it("returns undefined for a local tab (no sessionKey)", () => {
+    const tab = makeEditorTab("a", "hosts", {
+      filePath: "/etc/hosts",
+      isRemote: false,
+    });
+    expect(getEditorSessionQualifier(tab, [tab])).toBeUndefined();
+  });
+
+  it("returns undefined when the session-layer owner is gone", () => {
+    const editor = makeEditorTab("a", "config.yml", {
+      filePath: "/app/config.yml",
+      isRemote: true,
+      sessionKey: "session:missing",
+    });
+    expect(getEditorSessionQualifier(editor, [editor])).toBeUndefined();
+  });
+});
+
+describe("getEditorTabDisplayTitle", () => {
+  it("keeps the plain basename for a lone remote editor tab", () => {
+    const tab = makeEditorTab("a", "hosts", {
+      filePath: "/etc/hosts",
+      isRemote: true,
+      sessionKey: "sftp:user@host-a:22",
+    });
+    expect(getEditorTabDisplayTitle(tab, [tab])).toBe("hosts");
+  });
+
+  it("disambiguates two same-basename tabs from different sessions", () => {
+    const a = makeEditorTab("a", "hosts", {
+      filePath: "/etc/hosts",
+      isRemote: true,
+      sessionKey: "sftp:user@host-a:22",
+    });
+    const b = makeEditorTab("b", "hosts", {
+      filePath: "/etc/hosts",
+      isRemote: true,
+      sessionKey: "sftp:user@host-b:22",
+    });
+    const all = [a, b];
+    expect(getEditorTabDisplayTitle(a, all)).toBe("hosts — user@host-a:22");
+    expect(getEditorTabDisplayTitle(b, all)).toBe("hosts — user@host-b:22");
+    // The two titles must differ.
+    expect(getEditorTabDisplayTitle(a, all)).not.toBe(getEditorTabDisplayTitle(b, all));
+  });
+
+  it("does not suffix a remote tab whose basename is unique", () => {
+    const a = makeEditorTab("a", "hosts", {
+      filePath: "/etc/hosts",
+      isRemote: true,
+      sessionKey: "sftp:user@host-a:22",
+    });
+    const b = makeEditorTab("b", "passwd", {
+      filePath: "/etc/passwd",
+      isRemote: true,
+      sessionKey: "sftp:user@host-b:22",
+    });
+    const all = [a, b];
+    expect(getEditorTabDisplayTitle(a, all)).toBe("hosts");
+    expect(getEditorTabDisplayTitle(b, all)).toBe("passwd");
+  });
+
+  it("leaves a local editor tab plain even when a remote tab shares the basename", () => {
+    const local = makeEditorTab("a", "hosts", {
+      filePath: "/etc/hosts",
+      isRemote: false,
+    });
+    const remote = makeEditorTab("b", "hosts", {
+      filePath: "/etc/hosts",
+      isRemote: true,
+      sessionKey: "sftp:user@host-b:22",
+    });
+    const all = [local, remote];
+    // Local keeps the bare basename; the remote one carries the qualifier.
+    expect(getEditorTabDisplayTitle(local, all)).toBe("hosts");
+    expect(getEditorTabDisplayTitle(remote, all)).toBe("hosts — user@host-b:22");
+  });
+
+  it("does not touch non-editor tabs", () => {
+    const term = makeTab({ id: "t", title: "bash", contentType: "terminal" });
+    expect(getEditorTabDisplayTitle(term, [term])).toBe("bash");
+  });
+});

--- a/src/utils/editorTabTitle.ts
+++ b/src/utils/editorTabTitle.ts
@@ -1,0 +1,77 @@
+import type { TerminalTab } from "@/types/terminal";
+
+/**
+ * Editor tabs disambiguated by session (#1640). An editor tab's `sessionKey`
+ * (#1599) is a machine key — `sftp:<hostLabel>` or `session:<owning-tab-id>` —
+ * not something to show a user. These helpers turn that key into a readable
+ * qualifier and decide when a tab actually needs one.
+ */
+
+const SFTP_KEY_PREFIX = "sftp:";
+const SESSION_KEY_PREFIX = "session:";
+
+/** Separator between an editor tab's basename and its session qualifier. */
+export const EDITOR_TAB_QUALIFIER_SEPARATOR = " — ";
+
+/**
+ * Human-readable label identifying the remote session backing an editor tab,
+ * derived from its `editorMeta.sessionKey` (#1599):
+ *
+ * - SFTP tabs (`sftp:user@host:port`) → the host label (`user@host:port`).
+ * - Session-layer tabs (`session:<tab-id>`) → the title of the terminal tab that
+ *   owns the backing session, resolved from `allTabs`.
+ *
+ * Returns `undefined` for local tabs (no `sessionKey`), for remote tabs whose
+ * identity could not be resolved, and when a session-layer owner is gone — in
+ * every such case there is no meaningful qualifier to surface.
+ */
+export function getEditorSessionQualifier(
+  tab: TerminalTab,
+  allTabs: readonly TerminalTab[]
+): string | undefined {
+  const sessionKey = tab.editorMeta?.sessionKey;
+  if (!sessionKey) return undefined;
+
+  if (sessionKey.startsWith(SFTP_KEY_PREFIX)) {
+    return sessionKey.slice(SFTP_KEY_PREFIX.length) || undefined;
+  }
+
+  if (sessionKey.startsWith(SESSION_KEY_PREFIX)) {
+    const ownerId = sessionKey.slice(SESSION_KEY_PREFIX.length);
+    const owner = allTabs.find((t) => t.id === ownerId);
+    return owner?.title || undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Visible title for a tab, disambiguating editor tabs only **when there is
+ * ambiguity** (#1640): if another editor tab shares this tab's basename, a
+ * session qualifier is appended so the two are distinguishable (e.g.
+ * `hosts — user@host-a`). A lone editor tab, a local editor tab (which has no
+ * `sessionKey`), and every non-editor tab keep their plain title.
+ *
+ * @param tab The tab whose display title is wanted.
+ * @param allTabs All tabs the ambiguity is judged against (the current tab group).
+ */
+export function getEditorTabDisplayTitle(
+  tab: TerminalTab,
+  allTabs: readonly TerminalTab[]
+): string {
+  if (tab.contentType !== "editor") return tab.title;
+
+  // Local tabs (no sessionKey) never carry a qualifier: two tabs on the same
+  // local path dedup to one, so a local basename is never ambiguous.
+  const qualifier = getEditorSessionQualifier(tab, allTabs);
+  if (!qualifier) return tab.title;
+
+  // Only disambiguate when a different editor tab shows the same basename.
+  const isAmbiguous = allTabs.some(
+    (other) =>
+      other.id !== tab.id && other.contentType === "editor" && other.title === tab.title
+  );
+  if (!isAmbiguous) return tab.title;
+
+  return `${tab.title}${EDITOR_TAB_QUALIFIER_SEPARATOR}${qualifier}`;
+}

--- a/src/utils/editorTabTitle.ts
+++ b/src/utils/editorTabTitle.ts
@@ -68,8 +68,7 @@ export function getEditorTabDisplayTitle(
 
   // Only disambiguate when a different editor tab shows the same basename.
   const isAmbiguous = allTabs.some(
-    (other) =>
-      other.id !== tab.id && other.contentType === "editor" && other.title === tab.title
+    (other) => other.id !== tab.id && other.contentType === "editor" && other.title === tab.title
   );
   if (!isAmbiguous) return tab.title;
 


### PR DESCRIPTION
## Summary

Completes the optional item deferred from #1599 (PR #1639): when two or more editor tabs share the same file basename but are backed by **different remote sessions**, their titles are now disambiguated so the user can tell which host/session each tab edits.

Closes #1640.

## Approach

- New pure helper `src/utils/editorTabTitle.ts`:
  - `getEditorSessionQualifier(tab, allTabs)` turns #1599's machine `sessionKey` into a human label — SFTP (`sftp:user@host:port`) → the host label; session-layer (`session:<owning-tab-id>`) → the owning terminal tab's title.
  - `getEditorTabDisplayTitle(tab, allTabs)` returns the plain basename unless **another editor tab shares that basename**, in which case it appends `` — <qualifier>`` (e.g. `hosts — user@host-a`).
- Applied at the tab strip (`Tab`/`TabBar`, judged across the whole active tab group so split panels disambiguate too) and the zoom overlay title.
- Computed dynamically at render, so closing one of the pair reverts the other to its bare basename.

## Only-when-ambiguous / local

- A lone editor tab keeps its plain basename.
- Local editor tabs have no `sessionKey` and never get a suffix — two tabs on the same local path already dedup to one, so a local basename is never ambiguous. When a local `hosts` and a remote `hosts` coexist, only the remote one carries the qualifier.
- Non-editor tabs are untouched.

## Tests

`src/utils/editorTabTitle.test.ts` covers: two same-basename remote tabs get distinct disambiguated titles; a lone tab keeps the bare basename; unique basenames stay plain; the local case stays plain while the remote sibling is qualified; session-layer qualifier resolves to the owner tab title. The two disambiguation assertions fail without the change (verified by neutralising the display logic).

`npx tsc --noEmit` and a full `pnpm build` pass; no testid catalog drift.