### PR TITLE
fix(sftp): seed transfer queue on registration so the panel survives dropped events (Closes #1632)

### DIFF
--- a/docs/changes/dev1/fix/1632-transfer-progress-reconcile.md
+++ b/docs/changes/dev1/fix/1632-transfer-progress-reconcile.md
@@ -1,0 +1,9 @@
+# Changes
+
+## Fixed
+
+- The Transfer Queue panel now opens as soon as a transfer is registered, even
+  when its `transfer-progress` events are dropped or delayed (e.g. under memory
+  pressure). Each SFTP transfer seeds a `queued` row from the id its start
+  command returns over the reliable request/response channel, so panel
+  visibility no longer depends on the best-effort progress-event stream (#1632).

--- a/src/hooks/useFileSystem.test.ts
+++ b/src/hooks/useFileSystem.test.ts
@@ -158,7 +158,9 @@ describe("useFileSystem (SFTP) — uploadFileFromPath API call", () => {
     expect(vi.mocked(sftpUpload)).toHaveBeenCalledWith(
       "sess-1",
       "/local/image.png",
-      "/uploads/image.png"
+      "/uploads/image.png",
+      // Seed callback for the Transfer Queue row (#1632).
+      expect.any(Function)
     );
   });
 
@@ -183,8 +185,47 @@ describe("useFileSystem (SFTP) — uploadFileFromPath API call", () => {
     expect(vi.mocked(sftpUpload)).toHaveBeenCalledWith(
       "sess-1",
       "/local/report.pdf",
-      "/report.pdf"
+      "/report.pdf",
+      // Seed callback for the Transfer Queue row (#1632).
+      expect.any(Function)
     );
+  });
+
+  it("seeds a Transfer Queue row from the registration callback (#1632)", async () => {
+    useAppStore.setState({ sftpSessionId: "sess-1", currentPath: "/uploads" });
+
+    // Simulate the backend returning a transferId, but emitting NO
+    // transfer-progress event (the memory-pressure drop). The row must still
+    // appear, proving panel-open no longer depends on the event stream.
+    vi.mocked(sftpUpload).mockImplementationOnce(
+      async (_sessionId, _localPath, remotePath, onRegistered) => {
+        onRegistered?.("tid-1632");
+        void remotePath;
+        return 0;
+      }
+    );
+
+    let uploadFn: ((path: string) => Promise<void>) | undefined;
+    function Harness() {
+      const { uploadFileFromPath } = useFileSystem();
+      uploadFn = uploadFileFromPath;
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    await act(async () => {
+      await uploadFn!("/local/report.pdf");
+    });
+
+    expect(useAppStore.getState().transferQueue["tid-1632"]).toMatchObject({
+      id: "tid-1632",
+      sessionId: "sess-1",
+      direction: "upload",
+      name: "report.pdf",
+      path: "/uploads/report.pdf",
+      state: "queued",
+    });
   });
 
   it("does nothing when sftpSessionId is null", async () => {

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -15,6 +15,12 @@ import { FileEntry } from "@/types/connection";
 import { toast } from "@/components/ui";
 import { frontendLog } from "@/utils/frontendLog";
 
+/** Basename of a POSIX/Windows path (the file name the queue row displays). */
+function baseName(path: string): string {
+  const parts = path.replace(/\\/g, "/").split("/");
+  return parts[parts.length - 1] || path;
+}
+
 /** Extract a human-readable message from an unknown transfer error. */
 function transferErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -79,6 +85,39 @@ export function useFileSystem() {
   const sftpError = useAppStore((s) => s.sftpError);
   const navigateSftp = useAppStore((s) => s.navigateSftp);
   const refreshSftp = useAppStore((s) => s.refreshSftp);
+  const seedTransferQueue = useAppStore((s) => s.seedTransferQueue);
+
+  // Wrap the transfer helpers so every transfer seeds a `queued` Transfer Queue
+  // row from the id the start command returns — the panel then opens without
+  // waiting for a `transfer-progress` event, which can be dropped/delayed under
+  // memory pressure (#1632). The row is keyed by the backend `transferId`, so a
+  // later event upserts (never duplicates) it.
+  const startDownload = useCallback(
+    (sessionId: string, remotePath: string, localPath: string) =>
+      sftpDownload(sessionId, remotePath, localPath, (transferId) =>
+        seedTransferQueue({
+          id: transferId,
+          sessionId,
+          direction: "download",
+          name: baseName(remotePath),
+          path: remotePath,
+        })
+      ),
+    [seedTransferQueue]
+  );
+  const startUpload = useCallback(
+    (sessionId: string, localPath: string, remotePath: string) =>
+      sftpUpload(sessionId, localPath, remotePath, (transferId) =>
+        seedTransferQueue({
+          id: transferId,
+          sessionId,
+          direction: "upload",
+          name: baseName(remotePath),
+          path: remotePath,
+        })
+      ),
+    [seedTransferQueue]
+  );
 
   const navigateTo = useCallback(
     (path: string) => {
@@ -102,11 +141,11 @@ export function useFileSystem() {
       if (!sftpSessionId) return;
       const localPath = await save({ title: "Save file as...", defaultPath: fileName });
       if (!localPath) return;
-      await runTransfer("Download", () => sftpDownload(sftpSessionId, remotePath, localPath), {
+      await runTransfer("Download", () => startDownload(sftpSessionId, remotePath, localPath), {
         loading: `Downloading ${fileName}…`,
       });
     },
-    [sftpSessionId]
+    [sftpSessionId, startDownload]
   );
 
   const uploadFile = useCallback(async () => {
@@ -115,11 +154,13 @@ export function useFileSystem() {
     if (!localPath) return;
     const fileName = localPath.split("/").pop() ?? localPath.split("\\").pop() ?? "upload";
     const remotePath = currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
-    const ok = await runTransfer("Upload", () => sftpUpload(sftpSessionId, localPath, remotePath), {
-      loading: `Uploading ${fileName}…`,
-    });
+    const ok = await runTransfer(
+      "Upload",
+      () => startUpload(sftpSessionId, localPath, remotePath),
+      { loading: `Uploading ${fileName}…` }
+    );
     if (ok) refreshSftp();
-  }, [sftpSessionId, currentPath, refreshSftp]);
+  }, [sftpSessionId, currentPath, refreshSftp, startUpload]);
 
   const uploadFileFromPath = useCallback(
     async (localPath: string) => {
@@ -129,12 +170,12 @@ export function useFileSystem() {
       const remotePath = currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
       const ok = await runTransfer(
         "Upload",
-        () => sftpUpload(sftpSessionId, localPath, remotePath),
+        () => startUpload(sftpSessionId, localPath, remotePath),
         { loading: `Uploading ${fileName}…` }
       );
       if (ok) refreshSftp();
     },
-    [sftpSessionId, currentPath, refreshSftp]
+    [sftpSessionId, currentPath, refreshSftp, startUpload]
   );
 
   const createDirectory = useCallback(
@@ -228,20 +269,20 @@ export function useFileSystem() {
           } else {
             // Different SFTP session — download to temp then upload
             const tempPath = `/tmp/termihub-paste-${Date.now()}-${clipEntry.name}`;
-            await sftpDownload(clipboard.sftpSessionId!, clipEntry.path, tempPath);
-            await sftpUpload(sftpSessionId, tempPath, destPath);
+            await startDownload(clipboard.sftpSessionId!, clipEntry.path, tempPath);
+            await startUpload(sftpSessionId, tempPath, destPath);
           }
         } else {
           // Copy within SFTP: download to temp, re-upload
           const tempPath = `/tmp/termihub-paste-${Date.now()}-${clipEntry.name}`;
           if (clipboard.sftpSessionId) {
-            await sftpDownload(clipboard.sftpSessionId, clipEntry.path, tempPath);
-            await sftpUpload(sftpSessionId, tempPath, destPath);
+            await startDownload(clipboard.sftpSessionId, clipEntry.path, tempPath);
+            await startUpload(sftpSessionId, tempPath, destPath);
           }
         }
       } else {
         // local→sftp: upload local file to remote destination
-        await sftpUpload(sftpSessionId, clipEntry.path, destPath);
+        await startUpload(sftpSessionId, clipEntry.path, destPath);
       }
     };
 
@@ -259,7 +300,7 @@ export function useFileSystem() {
     }
 
     refreshSftp();
-  }, [sftpSessionId, currentPath, refreshSftp]);
+  }, [sftpSessionId, currentPath, refreshSftp, startDownload, startUpload]);
 
   return {
     fileEntries,

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -545,17 +545,10 @@ describe("api service", () => {
       mockedInvoke.mockResolvedValue("transfer-seed-d");
       const onRegistered = vi.fn();
 
-      const pending = sftpDownload(
-        "sftp-1",
-        "/remote/file.txt",
-        "/local/file.txt",
-        onRegistered
-      );
+      const pending = sftpDownload("sftp-1", "/remote/file.txt", "/local/file.txt", onRegistered);
       // onRegistered must fire from the command's synchronous return, ahead of
       // any transfer-progress event (which may be dropped under memory pressure).
-      await vi.waitFor(() =>
-        expect(onRegistered).toHaveBeenCalledWith("transfer-seed-d")
-      );
+      await vi.waitFor(() => expect(onRegistered).toHaveBeenCalledWith("transfer-seed-d"));
 
       await fireWhenListening({ transferId: "transfer-seed-d", phase: "done", transferred: 1 });
       await pending;
@@ -566,15 +559,8 @@ describe("api service", () => {
       mockedInvoke.mockResolvedValue("transfer-seed-u");
       const onRegistered = vi.fn();
 
-      const pending = sftpUpload(
-        "sftp-1",
-        "/local/file.txt",
-        "/remote/file.txt",
-        onRegistered
-      );
-      await vi.waitFor(() =>
-        expect(onRegistered).toHaveBeenCalledWith("transfer-seed-u")
-      );
+      const pending = sftpUpload("sftp-1", "/local/file.txt", "/remote/file.txt", onRegistered);
+      await vi.waitFor(() => expect(onRegistered).toHaveBeenCalledWith("transfer-seed-u"));
 
       await fireWhenListening({ transferId: "transfer-seed-u", phase: "done", transferred: 1 });
       await pending;

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -541,6 +541,46 @@ describe("api service", () => {
       expect(result).toBe(2048);
     });
 
+    it("sftpDownload fires onRegistered with the transfer id before completion (#1632)", async () => {
+      mockedInvoke.mockResolvedValue("transfer-seed-d");
+      const onRegistered = vi.fn();
+
+      const pending = sftpDownload(
+        "sftp-1",
+        "/remote/file.txt",
+        "/local/file.txt",
+        onRegistered
+      );
+      // onRegistered must fire from the command's synchronous return, ahead of
+      // any transfer-progress event (which may be dropped under memory pressure).
+      await vi.waitFor(() =>
+        expect(onRegistered).toHaveBeenCalledWith("transfer-seed-d")
+      );
+
+      await fireWhenListening({ transferId: "transfer-seed-d", phase: "done", transferred: 1 });
+      await pending;
+      expect(onRegistered).toHaveBeenCalledTimes(1);
+    });
+
+    it("sftpUpload fires onRegistered with the transfer id before completion (#1632)", async () => {
+      mockedInvoke.mockResolvedValue("transfer-seed-u");
+      const onRegistered = vi.fn();
+
+      const pending = sftpUpload(
+        "sftp-1",
+        "/local/file.txt",
+        "/remote/file.txt",
+        onRegistered
+      );
+      await vi.waitFor(() =>
+        expect(onRegistered).toHaveBeenCalledWith("transfer-seed-u")
+      );
+
+      await fireWhenListening({ transferId: "transfer-seed-u", phase: "done", transferred: 1 });
+      await pending;
+      expect(onRegistered).toHaveBeenCalledTimes(1);
+    });
+
     it("sftpDownload rejects when the transfer is cancelled", async () => {
       mockedInvoke.mockResolvedValue("transfer-3");
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -894,17 +894,25 @@ async function awaitTransfer(transferId: string): Promise<number> {
  *
  * Registers a background transfer on a dedicated channel and resolves with the
  * bytes transferred once it completes (#1245).
+ *
+ * `onRegistered` fires once with the backend `transferId` the instant the start
+ * command returns — over the reliable request/response channel, before any
+ * best-effort `transfer-progress` event. Callers use it to seed the Transfer
+ * Queue so the panel opens even if progress events are dropped/delayed under
+ * memory pressure (#1632).
  */
 export async function sftpDownload(
   sessionId: string,
   remotePath: string,
-  localPath: string
+  localPath: string,
+  onRegistered?: (transferId: string) => void
 ): Promise<number> {
   const transferId = await invoke<string>("sftp_download", {
     sessionId,
     remotePath,
     localPath,
   });
+  onRegistered?.(transferId);
   return await awaitTransfer(transferId);
 }
 
@@ -913,17 +921,23 @@ export async function sftpDownload(
  *
  * Registers a background transfer on a dedicated channel and resolves with the
  * bytes transferred once it completes (#1245).
+ *
+ * `onRegistered` fires once with the backend `transferId` the instant the start
+ * command returns (see {@link sftpDownload}), for seeding the Transfer Queue
+ * ahead of any progress event (#1632).
  */
 export async function sftpUpload(
   sessionId: string,
   localPath: string,
-  remotePath: string
+  remotePath: string,
+  onRegistered?: (transferId: string) => void
 ): Promise<number> {
   const transferId = await invoke<string>("sftp_upload", {
     sessionId,
     localPath,
     remotePath,
   });
+  onRegistered?.(transferId);
   return await awaitTransfer(transferId);
 }
 

--- a/src/store/appStore.transferQueue.test.ts
+++ b/src/store/appStore.transferQueue.test.ts
@@ -153,4 +153,84 @@ describe("appStore — transfer queue slice (#1337)", () => {
       expect(q["t1"].transferred).toBe(60);
     });
   });
+
+  describe("seedTransferQueue (#1632)", () => {
+    it("opens the panel by adding a queued row without any transfer-progress event", () => {
+      // The reported failure: every `transfer-progress` event for a transfer is
+      // dropped/delayed under memory pressure, so the panel never opens. Seeding
+      // from the registration snapshot makes the slice non-empty on its own.
+      expect(useAppStore.getState().transferQueue).toEqual({});
+
+      useAppStore.getState().seedTransferQueue({
+        id: "seed-1",
+        sessionId: "sess-a",
+        direction: "download",
+        name: "file.txt",
+        path: "/remote/file.txt",
+      });
+
+      const row = useAppStore.getState().transferQueue["seed-1"];
+      expect(row).toMatchObject({
+        id: "seed-1",
+        sessionId: "sess-a",
+        direction: "download",
+        name: "file.txt",
+        path: "/remote/file.txt",
+        state: "queued",
+        transferred: 0,
+        totalBytes: null,
+        percent: null,
+      });
+    });
+
+    it("is idempotent — never clobbers a row an event already advanced", () => {
+      const store = useAppStore.getState();
+      // An event arrives first and advances the row well past `queued`…
+      store.applyTransferProgressToQueue(
+        progress({ transferId: "t1", phase: "done", transferred: 100 })
+      );
+      // …then a late seed for the same id must not reset it to `queued`.
+      store.seedTransferQueue({
+        id: "t1",
+        sessionId: "sess-a",
+        direction: "download",
+        name: "file.txt",
+      });
+      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({
+        state: "completed",
+        transferred: 100,
+        percent: 100,
+      });
+    });
+
+    it("a later event upserts (does not duplicate) a seeded row", () => {
+      const store = useAppStore.getState();
+      store.seedTransferQueue({
+        id: "t1",
+        sessionId: "sess-a",
+        direction: "download",
+        name: "file.txt",
+      });
+      store.applyTransferProgressToQueue(progress({ transferId: "t1", transferred: 40 }));
+
+      const q = useAppStore.getState().transferQueue;
+      expect(Object.keys(q)).toHaveLength(1);
+      expect(q["t1"]).toMatchObject({ state: "active", transferred: 40 });
+    });
+
+    it("carries a known total (upload) through to the seeded row", () => {
+      useAppStore.getState().seedTransferQueue({
+        id: "up-1",
+        sessionId: "sess-a",
+        direction: "upload",
+        name: "big.bin",
+        totalBytes: 2048,
+      });
+      expect(useAppStore.getState().transferQueue["up-1"]).toMatchObject({
+        direction: "upload",
+        totalBytes: 2048,
+        state: "queued",
+      });
+    });
+  });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -111,7 +111,12 @@ import type {
   TransferProgress,
 } from "@/services/api";
 import type { SpawnRequestPayload } from "@/services/events";
-import { transferEntryFromProgress, type TransferEntry } from "@/types/transfer";
+import {
+  transferEntryFromProgress,
+  transferEntryFromSeed,
+  type TransferEntry,
+  type TransferSeed,
+} from "@/types/transfer";
 import { RemoteAgentConfig } from "@/types/terminal";
 import { TunnelConfig, TunnelState } from "@/types/tunnel";
 import { EmbeddedServerConfig, ServerState as EmbeddedServerState } from "@/types/embeddedServer";
@@ -762,6 +767,13 @@ interface AppState {
   setTransferQueueMinimized: (minimized: boolean) => void;
   /** Fold a `transfer-progress` event into the queue (upsert, retaining terminal rows). */
   applyTransferProgressToQueue: (progress: TransferProgress) => void;
+  /**
+   * Seed a `queued` queue row from a transfer's registration snapshot (#1632),
+   * so the panel opens without waiting for a `transfer-progress` event that may
+   * be dropped/delayed under memory pressure. Idempotent: a no-op when a row for
+   * the id already exists, so it never clobbers a further-along event-fed row.
+   */
+  seedTransferQueue: (seed: TransferSeed) => void;
 
   // Per-tab CWD tracking
   tabCwds: Record<string, string>;
@@ -3760,6 +3772,14 @@ export const useAppStore = create<AppState>((set, get) => {
       set((state) => {
         const prev = state.transferQueue[progress.transferId];
         const entry = transferEntryFromProgress(progress, prev, Date.now());
+        return { transferQueue: { ...state.transferQueue, [entry.id]: entry } };
+      }),
+
+    seedTransferQueue: (seed: TransferSeed) =>
+      set((state) => {
+        // Idempotent: never overwrite a row an event already advanced (#1632).
+        if (seed.id in state.transferQueue) return {};
+        const entry = transferEntryFromSeed(seed, Date.now());
         return { transferQueue: { ...state.transferQueue, [entry.id]: entry } };
       }),
 

--- a/src/types/transfer.ts
+++ b/src/types/transfer.ts
@@ -67,6 +67,55 @@ export interface TransferEntry {
 }
 
 /**
+ * The minimal description of a transfer known at **registration time** — before
+ * any `transfer-progress` event has been delivered (#1632).
+ *
+ * A transfer command (`sftp_download` / `sftp_upload`) returns its `transferId`
+ * synchronously over the reliable request/response IPC channel, whereas live
+ * progress arrives as best-effort fan-out events that can be dropped or delayed
+ * when the webview is starved (e.g. under memory pressure / jetsam). Seeding the
+ * queue from this snapshot at registration makes the Transfer Queue panel open
+ * as soon as a transfer is known, independent of whether any progress event is
+ * ever observed — a later event simply upserts the row.
+ */
+export interface TransferSeed {
+  /** The backend `transferId` returned by the start command. */
+  id: string;
+  /** Owning SFTP/FTP session id. */
+  sessionId: string;
+  /** Upload or download. */
+  direction: TransferDirection;
+  /** Display name (file name). */
+  name: string;
+  /** Remote path, when known. */
+  path?: string;
+  /** Total bytes when already known (uploads), else `null`/omitted. */
+  totalBytes?: number | null;
+}
+
+/**
+ * Build a `queued` {@link TransferEntry} from a {@link TransferSeed}, for the
+ * pre-event registration seed (#1632). Progress/throughput are unknown until the
+ * first `transfer-progress` event folds over this row.
+ */
+export function transferEntryFromSeed(seed: TransferSeed, now: number): TransferEntry {
+  const totalBytes = seed.totalBytes && seed.totalBytes > 0 ? seed.totalBytes : null;
+  return {
+    id: seed.id,
+    sessionId: seed.sessionId,
+    direction: seed.direction,
+    name: seed.name,
+    path: seed.path,
+    state: "queued",
+    transferred: 0,
+    totalBytes,
+    percent: null,
+    speedBytesPerSec: null,
+    updatedAt: now,
+  };
+}
+
+/**
  * Map a backend {@link TransferProgress} legacy `phase` to a queue
  * {@link TransferQueueState}, for events that predate the #1336 `state` field.
  */


### PR DESCRIPTION
## What & why

Follow-up to #1619 (PR #1631). The live SFTP paste test flaked as *"timed out
waiting for the Transfer Queue panel"* under a multi-slot round's memory
pressure. #1631 hardened the **test**; this fixes the suspected **app** bug.

## Mechanism — dropped delivery, not a folding bug

The panel renders whenever the `transferQueue` store slice is non-empty. That
slice is fed **only** by `transfer-progress` Tauri events, folded in the
`useTransferEvents` `listen` callback. That fold is **synchronous and
unconditional** — if the callback fires, the slice updates (confirmed by
#1631's <30ms store→paint measurement). So the slice staying empty can only mean
the event never reached the webview `listen` subscription: a **dropped/delayed
best-effort event**, not a folding failure. The backend `emit` is explicitly
best-effort (logs on failure); under jetsam the webview event loop can miss a
burst, and a small/fast transfer may emit only that one missed burst.

Crucially, the reliable **request/response** IPC still worked in the reported
failure (`last error: None`; the transfer ran) — only the fire-and-forget event
fan-out was lossy.

### Why a `transfer_list` snapshot reconcile would **not** fix this

I evaluated the issue's suggested "reconcile from a backend snapshot" and found
it insufficient for the reported case:

- SFTP transfers (the failing test) register in the registry's **legacy token
  map**, not the **rich** map that `transfer_list` snapshots — so they never
  appear in the snapshot.
- Rich transfers are `drop_entry`'d on completion, so a *completed* transfer is
  gone from the snapshot too.

A snapshot reconcile therefore cannot recover a completed SFTP transfer whose
events were dropped. Filed as follow-up (below) since it needs backend changes.

## The fix — seed the queue at registration

Make panel-open independent of the event stream: each SFTP transfer seeds a
`queued` row from the `transferId` its start command returns over the reliable
request/response channel, **before** any progress event. `sftpDownload` /
`sftpUpload` gained an optional `onRegistered(transferId)` callback, wired
through `useFileSystem` to a new idempotent `seedTransferQueue` store action.

- **Idempotent**: a no-op if a row for that id already exists, so it never
  clobbers an event-advanced row; a later event upserts the same key (no dupes).
- **Low-risk**: in the happy path the panel opens a few ms earlier than the
  backend's start event would have; in the failure path it opens regardless.

## Reproduction

Not reproduced live — like the owner, I could not manufacture real jetsam
(and must not, on a shared multi-slot machine). The fix is argued from the code
path (synchronous fold ⇒ delivery drop) and defended above, not from an observed
drop. The regression tests simulate a fully-dropped event stream: the queue row
must still appear from the registration seed alone.

## Tests

- `appStore.transferQueue.test.ts` — `seedTransferQueue` opens the panel with no
  event; is idempotent; a later event upserts; carries a known upload total.
- `api.test.ts` — `sftpDownload`/`sftpUpload` fire `onRegistered` with the id
  ahead of completion.
- `useFileSystem.test.ts` — a transfer seeds a correctly-populated queue row
  when the backend emits **no** progress event.

Full frontend suite (3369) green; `tsc`, eslint, prettier, `pnpm build` clean.
No backend changes.

## Follow-up

Will file: make a snapshot reconcile actually able to self-heal a dropped
*terminal* event — retain recently-terminal transfers in the registry and
include legacy SFTP transfers in `transfer_list` — so a stuck seeded row (if the
terminal event is also dropped) can reconcile to its final state.

Closes #1632
