### PR TITLE
ci: nightly integration test lane (Closes #1569)

### DIFF
--- a/.github/workflows/system-integration.yml
+++ b/.github/workflows/system-integration.yml
@@ -1,0 +1,146 @@
+name: System Integration (nightly)
+
+# Runs the Python bridge harness **integration** lane — the suites marked
+# `@pytest.mark.integration`, which launch the REAL built desktop app (and, where
+# a suite needs them, the Docker SSH/telnet fixtures). Per-PR CI only ever runs
+# `-m "not integration"` (see code-quality.yml → System-Test Harness), so every
+# one of these ~360 tests is otherwise merely *collected*, never *run*. That dark
+# lane is how stale-testid rot slipped in unnoticed (#1568): a green PR proves the
+# harness *collects*, not that it *works*.
+#
+# This job closes that gap on a nightly cadence, separate from per-PR CI (owner's
+# decision on #1569): per-PR stays fast and unchanged, and any rot in the
+# integration lane surfaces within a day instead of at the next accidental
+# discovery. It is Docker-bound and builds the app, so it is deliberately NOT a
+# per-PR check.
+#
+# Trigger by hand from the Actions tab ("Run workflow") to validate a change to
+# the harness, the fixtures, or this workflow without waiting for the nightly run.
+
+on:
+  schedule:
+    # 04:42 UTC daily — off the top of the hour to dodge scheduler congestion,
+    # and clear of the 03:17 core-fixtures nightly (integration-fixtures.yml) so
+    # the two Docker-heavy lanes do not contend for a runner at once.
+    - cron: "42 4 * * *"
+  workflow_dispatch:
+
+# A run is self-contained (its own app build + throwaway containers); cancel an
+# in-flight run when a newer one starts on the same ref.
+concurrency:
+  group: system-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  system-integration:
+    name: System-Test Harness (integration lane)
+    runs-on: ubuntu-latest
+    # The lane builds the app (debug) and launches it once per suite against live
+    # Docker fixtures; a generous ceiling keeps a slow image build or a hung app
+    # from being read as success, while still bounding a wedged run.
+    timeout-minutes: 120
+
+    env:
+      # Run webkit2gtk headless under Xvfb: disable the DMABUF and compositing
+      # paths that assume a real GPU/display, so the Tauri webview renders in
+      # software on a GitHub runner instead of failing to initialise.
+      WEBKIT_DISABLE_DMABUF_RENDERER: "1"
+      WEBKIT_DISABLE_COMPOSITING_MODE: "1"
+      # Silence the at-spi accessibility-bus warnings that otherwise flood the
+      # app log on a headless box.
+      NO_AT_BRIDGE: "1"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          # Pin uv itself (issue #1552): "latest" resolves through the GitHub
+          # Releases API, which flakes and fast-fails unrelated to the run.
+          version: '0.11.29'
+          python-version: '3.12'
+          enable-cache: true
+          cache-dependency-glob: tests/system/uv.lock
+
+      - name: Install system dependencies (Tauri + headless display)
+        # The Tauri webview build/runtime deps (mirrors dev-build.yml) plus xvfb,
+        # so the app has a virtual X display to launch into. socat backs the
+        # virtual serial-port suites; without it those integration tests skip.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            xvfb \
+            socat
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the agent (release)
+        # The agent-lifecycle integration suites (AgentInstance) resolve
+        # target/release/termihub-agent; build it so they run instead of skipping.
+        run: cargo build --release -p termihub-agent
+
+      - name: Build the desktop app (debug)
+        # The integration lane launches the real app; the harness resolves the
+        # debug bundle (target/debug/…) when no release build is present. Debug
+        # builds far faster than release, which is what we want for a nightly.
+        run: pnpm tauri build --debug
+
+      - name: Bring up the Docker fixtures
+        # Pre-build and start the profile-less SSH/telnet fixtures so image builds
+        # happen once here (visible as their own step) rather than inside a
+        # per-suite fixture under its bring-up timeout. The harness'
+        # ComposeFixture then finds them already up; profile-gated fixtures
+        # (agent/stress/fault/ftp) are brought up on demand by the suites that
+        # need them — the agent image must be staged by the harness first.
+        run: |
+          docker compose -f tests/docker/docker-compose.yml up -d --build
+
+      - name: Run the integration lane
+        # Fail loudly: a real test failure fails the job (that is the whole point
+        # — surface rot). Xvfb gives the app a display; the harness owns launching
+        # the app and driving the fixtures. Suites whose fixtures are unavailable
+        # skip cleanly rather than error.
+        run: xvfb-run -a ./tests/system/pytest.sh -m integration -v --durations=25
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f tests/docker/docker-compose.yml --profile all logs --tail=200
+
+      - name: Upload failure artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: system-integration-artifacts
+          path: tests/system/artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Tear down the fixtures
+        if: always()
+        run: docker compose -f tests/docker/docker-compose.yml --profile all down -v


### PR DESCRIPTION
## What

Adds `.github/workflows/system-integration.yml`: a **nightly** (04:42 UTC) + `workflow_dispatch` GitHub Actions job that runs the Python bridge harness **integration lane** (`pytest -m integration`, ~360 suites that launch the real desktop app and, where needed, the Docker SSH/telnet fixtures).

## Why

The integration lane runs **nowhere** today. Per-PR CI only runs `-m "not integration"` (`code-quality.yml` → System-Test Harness), so every integration test is *collected* but never *executed*. A green PR proves the harness collects, not that it works — which is exactly how stale-testid rot slipped in unnoticed (#1568).

Per the owner's decision on #1569, this runs on a **nightly cadence, separate from per-PR CI**: per-PR stays fast and unchanged; integration-lane rot now surfaces within a day.

## How the job brings the lane up

- ubuntu-latest, Tauri webview build deps (mirrors `dev-build.yml`) + `xvfb` + `socat`.
- Builds the agent (`cargo build --release -p termihub-agent`) and the app (`pnpm tauri build --debug` — the harness resolves the debug bundle; debug builds far faster).
- Pre-builds/starts the profile-less Docker fixtures (`docker compose up -d --build`); the harness' `ComposeFixture` brings profile-gated fixtures up on demand.
- Runs `xvfb-run -a ./tests/system/pytest.sh -m integration` so the app has a headless display; webkit software-rendering env vars set for a GPU-less runner.
- **Fails loudly** on real test failures, dumps container logs and uploads harness failure artifacts.

## Validation

- `actionlint` clean; YAML parses.
- Ran the lane mechanics locally against the existing debug build: `test_app_lifecycle` (2 passed, no Docker) and `test_ssh_baseline` (7 passed, Docker-backed SSH fixtures brought up by the harness). App launch + harness + compose bring-up all work.
- The full first real-runner result will be captured via `workflow_dispatch` after merge (the lane cannot run on this PR — per-PR CI is intentionally `-m "not integration"`). First-run failures, if any, will be triaged into follow-up issues rather than papered over.

Closes #1569