### PR TITLE
feat: open terminal-less connections into a browser-only tab via a terminal capability flag (Closes #1335)

### DIFF
--- a/agent/src/protocol/methods.rs
+++ b/agent/src/protocol/methods.rs
@@ -843,6 +843,7 @@ mod tests {
                         file_browser: false,
                         resize: true,
                         persistent: false,
+                        terminal: true,
                     },
                 }],
                 max_sessions: 20,

--- a/core/src/backends/docker/mod.rs
+++ b/core/src/backends/docker/mod.rs
@@ -609,6 +609,7 @@ impl ConnectionType for Docker {
             file_browser: true,
             resize: true,
             persistent: true,
+            terminal: true,
         }
     }
 

--- a/core/src/backends/ftp/mod.rs
+++ b/core/src/backends/ftp/mod.rs
@@ -476,6 +476,9 @@ impl ConnectionType for Ftp {
             file_browser: true,
             resize: false,
             persistent: false,
+            // FTP has no interactive shell: the desktop opens it straight into a
+            // browser-only tab with no terminal session (#1335).
+            terminal: false,
         }
     }
 
@@ -597,6 +600,9 @@ mod tests {
         assert!(!caps.monitoring);
         assert!(!caps.resize);
         assert!(!caps.persistent);
+        // FTP has no interactive shell: it must report terminal-less so the
+        // desktop opens it into a browser-only tab with no terminal session (#1335).
+        assert!(!caps.terminal);
     }
 
     #[test]

--- a/core/src/backends/local_shell.rs
+++ b/core/src/backends/local_shell.rs
@@ -340,6 +340,7 @@ impl<S: LocalShellSpawner> ConnectionType for LocalShell<S> {
             // every platform (Unix domain socket on unix, named pipe on
             // windows — see `agent::daemon::transport`).
             persistent: true,
+            terminal: true,
         }
     }
 

--- a/core/src/backends/serial.rs
+++ b/core/src/backends/serial.rs
@@ -256,6 +256,7 @@ impl ConnectionType for Serial {
             file_browser: false,
             resize: false,
             persistent: true,
+            terminal: true,
         }
     }
 

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -445,6 +445,7 @@ impl ConnectionType for Ssh {
             file_browser: true,
             resize: true,
             persistent: true,
+            terminal: true,
         }
     }
 

--- a/core/src/backends/telnet.rs
+++ b/core/src/backends/telnet.rs
@@ -179,6 +179,7 @@ impl ConnectionType for Telnet {
             file_browser: false,
             resize: false,
             persistent: false,
+            terminal: true,
         }
     }
 

--- a/core/src/backends/wsl.rs
+++ b/core/src/backends/wsl.rs
@@ -640,6 +640,7 @@ impl ConnectionType for Wsl {
             file_browser: true,
             resize: true,
             persistent: true,
+            terminal: true,
         }
     }
 

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -40,6 +40,15 @@ pub type OutputSender = tokio::sync::mpsc::Sender<Vec<u8>>;
 ///
 /// The UI uses these flags to show or hide optional features
 /// (monitoring panels, file browser tabs, resize handles).
+/// Serde default for [`Capabilities::terminal`]: terminal-capable.
+///
+/// Ensures capabilities serialized before the `terminal` field existed
+/// (older agents/configs) deserialize as `terminal: true`, preserving the
+/// pre-existing behaviour where every connection type opened a terminal tab.
+fn default_terminal() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Capabilities {
@@ -51,6 +60,17 @@ pub struct Capabilities {
     pub resize: bool,
     /// Whether sessions of this type can persist across agent reconnections.
     pub persistent: bool,
+    /// Whether this connection type has an interactive terminal.
+    ///
+    /// Defaults to `true` for backward compatibility: capabilities serialized
+    /// before this field existed (older agents/configs) deserialize as
+    /// terminal-capable, and every pre-existing connection type is. Terminal-less
+    /// types — FTP, which browses files with no shell — set this to `false`, and
+    /// the desktop opens them straight into a browser-only tab with no terminal
+    /// session (no `create_connection`). Any future terminal-less type inherits
+    /// this without per-type special-casing.
+    #[serde(default = "default_terminal")]
+    pub terminal: bool,
 }
 
 /// Unified trait for all connection backends.
@@ -174,18 +194,57 @@ mod tests {
             file_browser: true,
             resize: true,
             persistent: false,
+            terminal: true,
         };
         let json = serde_json::to_value(&caps).unwrap();
         assert_eq!(json["monitoring"], true);
         assert_eq!(json["fileBrowser"], true);
         assert_eq!(json["resize"], true);
         assert_eq!(json["persistent"], false);
+        assert_eq!(json["terminal"], true);
 
         let deserialized: Capabilities = serde_json::from_value(json).unwrap();
         assert!(deserialized.monitoring);
         assert!(deserialized.file_browser);
         assert!(deserialized.resize);
         assert!(!deserialized.persistent);
+        assert!(deserialized.terminal);
+    }
+
+    #[test]
+    fn capabilities_terminal_defaults_true_when_absent() {
+        // Backward compatibility: capabilities serialized by an older agent or
+        // config predate the `terminal` field, so the wire form omits it. Such
+        // payloads must deserialize as terminal-capable, preserving the prior
+        // behaviour where every connection type opened a terminal tab.
+        let legacy = serde_json::json!({
+            "monitoring": false,
+            "fileBrowser": true,
+            "resize": false,
+            "persistent": false,
+        });
+        let deserialized: Capabilities = serde_json::from_value(legacy).unwrap();
+        assert!(
+            deserialized.terminal,
+            "missing `terminal` must default to true (terminal-capable)"
+        );
+    }
+
+    #[test]
+    fn capabilities_terminal_false_round_trips() {
+        // A terminal-less type (e.g. FTP) reports terminal: false, and that
+        // must survive a serialize → deserialize round trip unchanged.
+        let caps = Capabilities {
+            monitoring: false,
+            file_browser: true,
+            resize: false,
+            persistent: false,
+            terminal: false,
+        };
+        let json = serde_json::to_value(&caps).unwrap();
+        assert_eq!(json["terminal"], false);
+        let deserialized: Capabilities = serde_json::from_value(json).unwrap();
+        assert!(!deserialized.terminal);
     }
 
     #[test]
@@ -195,6 +254,7 @@ mod tests {
             file_browser: false,
             resize: false,
             persistent: false,
+            terminal: true,
         };
         let json = serde_json::to_value(&caps).unwrap();
         let obj = json.as_object().unwrap();
@@ -202,6 +262,7 @@ mod tests {
         assert!(obj.contains_key("fileBrowser"));
         assert!(obj.contains_key("resize"));
         assert!(obj.contains_key("persistent"));
+        assert!(obj.contains_key("terminal"));
         // Ensure snake_case keys are NOT present.
         assert!(!obj.contains_key("file_browser"));
     }

--- a/core/src/connection/registry.rs
+++ b/core/src/connection/registry.rs
@@ -188,6 +188,7 @@ mod tests {
                 file_browser: false,
                 resize: true,
                 persistent: false,
+                terminal: true,
             }
         }
         async fn connect(&mut self, _settings: serde_json::Value) -> Result<(), SessionError> {
@@ -320,6 +321,7 @@ mod tests {
                 file_browser: true,
                 resize: true,
                 persistent: false,
+                terminal: true,
             },
         };
         let json = serde_json::to_string(&info).unwrap();

--- a/docs/changes/dev0/feature/1335-terminal-capability-flag.md
+++ b/docs/changes/dev0/feature/1335-terminal-capability-flag.md
@@ -1,0 +1,8 @@
+### Added
+
+- Terminal-less connection types now open straight into a browser-only tab
+  instead of a dead terminal. Connection backends declare a new `terminal`
+  capability flag (defaulting to terminal-capable for backward compatibility);
+  FTP reports `terminal: false` and its tab renders a file-browser placeholder
+  while the sidebar file browser handles navigation and transfers. Every
+  existing terminal connection type is unaffected (#1335).

--- a/docs/concepts/partial/ftp-client.html
+++ b/docs/concepts/partial/ftp-client.html
@@ -1876,16 +1876,16 @@ registry.register(Box::new(FtpBackend::new()));
           </p>
         </blockquote>
         <p>
-          <strong>Last synced:</strong> 2026-07-16 at commit <code>dba98550</code> ·
-          <strong>Status:</strong> diverged (partially implemented — one open functional gap, #1335)
+          <strong>Last synced:</strong> 2026-07-18 (divergence #1 resolved) · previously 2026-07-16
+          at commit <code>dba98550</code> · <strong>Status:</strong> converged (no open functional
+          gaps)
         </p>
         <p>
-          Synced as part of #1340 (SI-9, docs / changelog / concept wrap-up). Because #1340 is a
-          docs-only issue (feature logic SI-1..SI-8 is out of scope), code was <em>not</em> changed
-          here; the one functional divergence (#1) is tracked by open sub-issue #1335, and the
-          skeleton/illustrative divergences (#2–#5) are reconciled by documenting the as-built code
-          in this ledger. Divergence #6 (TLS backend) is a design-reality concept edit, applied
-          above.
+          Originally synced as part of #1340 (SI-9, docs / changelog / concept wrap-up); the
+          skeleton/illustrative divergences (#2–#5) were reconciled by documenting the as-built code
+          in this ledger, and divergence #6 (TLS backend) is a design-reality concept edit applied
+          above. The final functional divergence (#1, the terminal-less tab) was resolved on
+          2026-07-18 by #1335 via the <code>terminal</code> capability flag — see Resolved below.
         </p>
 
         <h3>Open divergences</h3>
@@ -1902,28 +1902,9 @@ registry.register(Box::new(FtpBackend::new()));
             </thead>
             <tbody>
               <tr>
-                <td>1</td>
-                <td>
-                  FTP sessions open <em>directly into the file browser view — no terminal tab is
-                  created</em>; the tab body shows a non-terminal placeholder ("FTP sessions open
-                  into the file browser; there is no terminal output").
-                </td>
-                <td>
-                  Browsing itself is now wired (#1335): an FTP tab dispatches through the session
-                  layer, so <code>session_*</code> commands route file operations via the connection
-                  type's <code>file_browser()</code>. But an FTP connection still opens a
-                  <em>terminal</em> tab whose body is a dead terminal: the tab is what mints the
-                  session (<code>Terminal.tsx</code> → <code>create_connection</code>), and
-                  <code>Capabilities</code> has no flag saying a type lacks a terminal, so the UI
-                  cannot tell which types should skip the terminal body.
-                </td>
-                <td>Missing</td>
-                <td>
-                  Needs a decision before implementing: either add a <code>terminal</code> flag to
-                  <code>Capabilities</code> (a core change that also crosses the agent protocol) and
-                  render a non-terminal tab body from it, or special-case the <code>ftp</code> type
-                  in the frontend (cheaper, but not protocol-agnostic). Tracked by
-                  <a href="https://github.com/armaxri/termiHub/issues/1335">#1335</a> (SI-4).
+                <td colspan="5" style="text-align: center; color: var(--text-secondary)">
+                  None open. The last functional divergence (#1, the terminal-less tab) was
+                  resolved on 2026-07-18 — see Resolved below.
                 </td>
               </tr>
             </tbody>
@@ -1941,6 +1922,25 @@ registry.register(Box::new(FtpBackend::new()));
               </tr>
             </thead>
             <tbody>
+              <tr>
+                <td>2026-07-18</td>
+                <td>1</td>
+                <td>
+                  <strong>Terminal-less tab, via a <code>terminal</code> capability flag.</strong>
+                  Resolved by the protocol-agnostic route (#1335), not an <code>ftp</code>
+                  hardcode. A <code>terminal: bool</code> field was added to the connection-level
+                  <code>Capabilities</code> (core), defaulting to <code>true</code> via
+                  <code>#[serde(default)]</code> so agents/configs predating the field still
+                  deserialize as terminal-capable; every existing type reports <code>true</code> and
+                  FTP reports <code>false</code>. On the desktop, a connection whose type reports
+                  <code>terminal: false</code> opens into a new <code>file-browser</code> tab content
+                  type: <code>FileBrowserTab</code> mints and owns the session through its own path
+                  (not <code>Terminal.tsx</code>/no PTY) so the sidebar file browser routes to
+                  <code>tab.sessionId</code>, and renders the non-terminal placeholder body. Any
+                  future terminal-less type inherits this with no per-type special-casing. Concept
+                  matches as-built; no code change.
+                </td>
+              </tr>
               <tr>
                 <td>2026-07-16</td>
                 <td>2</td>

--- a/docs/concepts/partial/ftp-client.html
+++ b/docs/concepts/partial/ftp-client.html
@@ -1903,8 +1903,8 @@ registry.register(Box::new(FtpBackend::new()));
             <tbody>
               <tr>
                 <td colspan="5" style="text-align: center; color: var(--text-secondary)">
-                  None open. The last functional divergence (#1, the terminal-less tab) was
-                  resolved on 2026-07-18 — see Resolved below.
+                  None open. The last functional divergence (#1, the terminal-less tab) was resolved
+                  on 2026-07-18 — see Resolved below.
                 </td>
               </tr>
             </tbody>
@@ -1927,16 +1927,16 @@ registry.register(Box::new(FtpBackend::new()));
                 <td>1</td>
                 <td>
                   <strong>Terminal-less tab, via a <code>terminal</code> capability flag.</strong>
-                  Resolved by the protocol-agnostic route (#1335), not an <code>ftp</code>
-                  hardcode. A <code>terminal: bool</code> field was added to the connection-level
+                  Resolved by the protocol-agnostic route (#1335), not an <code>ftp</code> hardcode.
+                  A <code>terminal: bool</code> field was added to the connection-level
                   <code>Capabilities</code> (core), defaulting to <code>true</code> via
                   <code>#[serde(default)]</code> so agents/configs predating the field still
                   deserialize as terminal-capable; every existing type reports <code>true</code> and
                   FTP reports <code>false</code>. On the desktop, a connection whose type reports
-                  <code>terminal: false</code> opens into a new <code>file-browser</code> tab content
-                  type: <code>FileBrowserTab</code> mints and owns the session through its own path
-                  (not <code>Terminal.tsx</code>/no PTY) so the sidebar file browser routes to
-                  <code>tab.sessionId</code>, and renders the non-terminal placeholder body. Any
+                  <code>terminal: false</code> opens into a new <code>file-browser</code> tab
+                  content type: <code>FileBrowserTab</code> mints and owns the session through its
+                  own path (not <code>Terminal.tsx</code>/no PTY) so the sidebar file browser routes
+                  to <code>tab.sessionId</code>, and renders the non-terminal placeholder body. Any
                   future terminal-less type inherits this with no per-type special-casing. Concept
                   matches as-built; no code change.
                 </td>

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1493,6 +1493,7 @@ mod tests {
                 file_browser: false,
                 resize: true,
                 persistent: false,
+                terminal: true,
             }
         }
         async fn connect(&mut self, _settings: serde_json::Value) -> Result<(), SessionError> {
@@ -1907,6 +1908,7 @@ mod tests {
                 file_browser: false,
                 resize: false,
                 persistent: false,
+                terminal: true,
             }
         }
         async fn connect(&mut self, _: serde_json::Value) -> Result<(), SessionError> {
@@ -2171,6 +2173,7 @@ mod tests {
                 file_browser: false,
                 resize: true,
                 persistent: false,
+                terminal: true,
             }
         }
         async fn connect(&mut self, _settings: serde_json::Value) -> Result<(), SessionError> {

--- a/src-tauri/src/session/remote_proxy.rs
+++ b/src-tauri/src/session/remote_proxy.rs
@@ -71,6 +71,7 @@ impl RemoteProxy {
                 file_browser: false,
                 resize: true,
                 persistent: false,
+                terminal: true,
             }),
             std_output_rx: Mutex::new(None),
             connected: AtomicBool::new(false),
@@ -124,6 +125,7 @@ impl RemoteProxy {
                 file_browser: false,
                 resize: true,
                 persistent: true,
+                terminal: true,
             }),
             std_output_rx: Mutex::new(Some(std_rx)),
             connected: AtomicBool::new(true),
@@ -159,6 +161,7 @@ impl ConnectionType for RemoteProxy {
                 file_browser: false,
                 resize: true,
                 persistent: false,
+                terminal: true,
             })
     }
 

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -51,6 +51,7 @@ import { WorkspaceEditor } from "@/components/WorkspaceEditor";
 import { NetworkDiagnosticPanel } from "@/components/NetworkTools/NetworkDiagnosticPanel";
 import { TerminalSearchBar } from "@/components/Terminal/TerminalSearchBar";
 import { AgentErrorTab } from "@/components/Terminal/AgentErrorTab";
+import { FileBrowserTab } from "@/components/Terminal/FileBrowserTab";
 import { TerminalConnectionOverlay } from "@/components/Terminal/TerminalConnectionOverlay";
 import { TerminalDisconnectOverlay } from "@/components/Terminal/TerminalDisconnectOverlay";
 import { TerminalViewModeBanner } from "@/components/Terminal/TerminalViewModeBanner";
@@ -440,6 +441,12 @@ export function SplitView() {
                   meta={zoomedTab.agentErrorMeta}
                   isVisible={true}
                 />
+              ) : zoomedTab.contentType === "file-browser" ? (
+                <FileBrowserTab
+                  key={`zoom-${zoomedTabId}`}
+                  tabId={zoomedTabId}
+                  isVisible={true}
+                />
               ) : null}
             </div>
           </div>
@@ -665,6 +672,12 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
               key={tab.id}
               tabId={tab.id}
               meta={tab.agentErrorMeta}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
+            />
+          ) : tab.contentType === "file-browser" ? (
+            <FileBrowserTab
+              key={tab.id}
+              tabId={tab.id}
               isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : tab.contentType === "terminal" &&

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -442,11 +442,7 @@ export function SplitView() {
                   isVisible={true}
                 />
               ) : zoomedTab.contentType === "file-browser" ? (
-                <FileBrowserTab
-                  key={`zoom-${zoomedTabId}`}
-                  tabId={zoomedTabId}
-                  isVisible={true}
-                />
+                <FileBrowserTab key={`zoom-${zoomedTabId}`} tabId={zoomedTabId} isVisible={true} />
               ) : null}
             </div>
           </div>

--- a/src/components/Terminal/FileBrowserTab.css
+++ b/src/components/Terminal/FileBrowserTab.css
@@ -1,0 +1,93 @@
+.file-browser-tab {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--terminal-bg);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+}
+
+.file-browser-tab--hidden {
+  display: none;
+}
+
+.file-browser-tab__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xl);
+  text-align: center;
+}
+
+.file-browser-tab__icon {
+  color: var(--text-secondary);
+  opacity: 0.85;
+}
+
+.file-browser-tab__icon--error {
+  color: var(--color-error, #e05252);
+}
+
+.file-browser-tab__heading {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.file-browser-tab__hint {
+  color: var(--text-secondary);
+  max-width: 480px;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.file-browser-tab__error {
+  color: var(--color-error, #e05252);
+  max-width: 480px;
+  margin: 0;
+  word-break: break-word;
+}
+
+.file-browser-tab__retry-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background-color: var(--accent-color);
+  color: var(--text-on-accent);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.file-browser-tab__retry-btn:hover {
+  background-color: var(--accent-hover);
+}
+
+@keyframes file-browser-tab-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.file-browser-tab__spin {
+  animation: file-browser-tab-spin 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .file-browser-tab__spin {
+    animation: none;
+  }
+}

--- a/src/components/Terminal/FileBrowserTab.test.tsx
+++ b/src/components/Terminal/FileBrowserTab.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tests for {@link FileBrowserTab} — the terminal-less (browser-only) tab body
+ * used by connections whose `Capabilities.terminal === false` (FTP), added for
+ * #1335. It verifies the tab mints and owns its own session (its own
+ * session-creation entry, not via `<Terminal>`), adopts a pre-existing session,
+ * renders the placeholder, and closes the session on unmount.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { FileBrowserTab } from "./FileBrowserTab";
+import { createTerminal, closeTerminal } from "@/services/api";
+import { getAllLeaves } from "@/utils/panelTree";
+
+vi.mock("@/services/api", () => ({
+  createTerminal: vi.fn(() => Promise.resolve("ftp-session-1")),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn() } }));
+
+const mockedCreateTerminal = vi.mocked(createTerminal);
+const mockedCloseTerminal = vi.mocked(closeTerminal);
+
+function tabSessionId(tabId: string): string | null {
+  return (
+    getAllLeaves(useAppStore.getState().rootPanel)
+      .flatMap((l) => l.tabs)
+      .find((t) => t.id === tabId)?.sessionId ?? null
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+  mockedCreateTerminal.mockResolvedValue("ftp-session-1");
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  container.remove();
+});
+
+/** Create a file-browser tab in the store and return its id. */
+function addFileBrowserTab(): string {
+  return useAppStore
+    .getState()
+    .addTab(
+      "My FTP Server",
+      "ftp",
+      { type: "ftp", config: { host: "ftp.example.com" } },
+      { contentType: "file-browser" }
+    );
+}
+
+describe("FileBrowserTab", () => {
+  it("mints a session on mount and attaches it to the tab", async () => {
+    const tabId = addFileBrowserTab();
+    expect(tabSessionId(tabId)).toBeNull();
+
+    await act(async () => {
+      root.render(React.createElement(FileBrowserTab, { tabId, isVisible: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockedCreateTerminal).toHaveBeenCalledOnce();
+    expect(mockedCreateTerminal).toHaveBeenCalledWith({
+      type: "ftp",
+      config: { host: "ftp.example.com" },
+    });
+    expect(tabSessionId(tabId)).toBe("ftp-session-1");
+    expect(container.querySelector('[data-testid="file-browser-tab"]')).not.toBeNull();
+    expect(container.textContent).toContain("No terminal for this connection");
+  });
+
+  it("adopts an existing tab session instead of minting a new one", async () => {
+    const tabId = addFileBrowserTab();
+    act(() => {
+      useAppStore.getState().setTabSessionId(tabId, "pre-minted");
+    });
+
+    await act(async () => {
+      root.render(React.createElement(FileBrowserTab, { tabId, isVisible: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockedCreateTerminal).not.toHaveBeenCalled();
+    expect(tabSessionId(tabId)).toBe("pre-minted");
+  });
+
+  it("closes the owned session when the tab is closed", async () => {
+    const tabId = addFileBrowserTab();
+    await act(async () => {
+      root.render(React.createElement(FileBrowserTab, { tabId, isVisible: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(tabSessionId(tabId)).toBe("ftp-session-1");
+
+    await act(async () => {
+      root.unmount();
+    });
+    // The close is deferred (50 ms) so a StrictMode remount can cancel it.
+    expect(mockedCloseTerminal).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+    expect(mockedCloseTerminal).toHaveBeenCalledWith("ftp-session-1");
+  });
+});

--- a/src/components/Terminal/FileBrowserTab.tsx
+++ b/src/components/Terminal/FileBrowserTab.tsx
@@ -141,7 +141,10 @@ export function FileBrowserTab({ tabId, isVisible }: FileBrowserTabProps) {
 
         {phase === "error" && (
           <>
-            <AlertCircle size={32} className="file-browser-tab__icon file-browser-tab__icon--error" />
+            <AlertCircle
+              size={32}
+              className="file-browser-tab__icon file-browser-tab__icon--error"
+            />
             <p className="file-browser-tab__heading">Could not open connection</p>
             {error && <p className="file-browser-tab__error">{error}</p>}
             <button

--- a/src/components/Terminal/FileBrowserTab.tsx
+++ b/src/components/Terminal/FileBrowserTab.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FolderOpen, Loader2, AlertCircle, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { useAppStore } from "@/store/appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+import { createTerminal, closeTerminal } from "@/services/api";
+import { frontendLog } from "@/utils/frontendLog";
+import "./FileBrowserTab.css";
+
+interface FileBrowserTabProps {
+  tabId: string;
+  isVisible: boolean;
+}
+
+type Phase = "connecting" | "connected" | "error";
+
+/**
+ * Tab body for a terminal-less connection (`Capabilities.terminal === false`,
+ * e.g. FTP). Instead of mounting an xterm terminal, it mints and owns the
+ * connection's session directly — its own session-creation entry that does not
+ * go through the `<Terminal>` component — so the sidebar file browser can route
+ * to `tab.sessionId`. The body shows an informational placeholder; the actual
+ * browsing happens in the sidebar file browser (#1335).
+ *
+ * Session lifecycle mirrors `Terminal.tsx`: a session already present on the tab
+ * (e.g. pre-minted during credential validation) is adopted rather than
+ * re-created, and the owned session is closed on unmount with a short deferral
+ * so React StrictMode's mount→unmount→mount does not tear down a live session.
+ */
+export function FileBrowserTab({ tabId, isVisible }: FileBrowserTabProps) {
+  const [phase, setPhase] = useState<Phase>("connecting");
+  const [error, setError] = useState<string | null>(null);
+  // Bumped by the retry button to re-run the connect effect.
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const sessionIdRef = useRef<string | null>(null);
+  const pendingCloseRef = useRef<number | null>(null);
+
+  const setTabSessionId = useAppStore((s) => s.setTabSessionId);
+  // Title is reactive so a rename shows through; the config is read once in the
+  // effect since it is stable for the tab's lifetime.
+  const title = useAppStore(
+    (s) =>
+      getAllLeaves(s.rootPanel)
+        .flatMap((l) => l.tabs)
+        .find((t) => t.id === tabId)?.title ?? ""
+  );
+
+  useEffect(() => {
+    let canceled = false;
+
+    // A pending close from a StrictMode unmount would destroy the session we are
+    // about to reuse — cancel it so the remount adopts the same session.
+    if (pendingCloseRef.current !== null) {
+      clearTimeout(pendingCloseRef.current);
+      pendingCloseRef.current = null;
+    }
+
+    const connect = async () => {
+      const tab = getAllLeaves(useAppStore.getState().rootPanel)
+        .flatMap((l) => l.tabs)
+        .find((t) => t.id === tabId);
+      if (!tab) return;
+
+      // Adopt a session already attached to the tab (e.g. pre-minted while
+      // validating a stored credential in useConnectSavedConnection).
+      if (tab.sessionId) {
+        sessionIdRef.current = tab.sessionId;
+        setPhase("connected");
+        return;
+      }
+
+      setPhase("connecting");
+      setError(null);
+      try {
+        const sessionId = await createTerminal(tab.config);
+        if (canceled) {
+          // Superseded by a StrictMode remount — tear down the orphan session.
+          closeTerminal(sessionId).catch(() => {});
+          return;
+        }
+        sessionIdRef.current = sessionId;
+        setTabSessionId(tabId, sessionId);
+        setPhase("connected");
+        frontendLog("file_browser_tab", `session ${sessionId} opened for tab ${tabId}`);
+        toast.success("Connected", { description: tab.title });
+      } catch (err) {
+        if (canceled) return;
+        setError(String(err));
+        setPhase("error");
+      }
+    };
+
+    void connect();
+
+    return () => {
+      canceled = true;
+      const sid = sessionIdRef.current;
+      if (sid) {
+        // Defer the close so a StrictMode remount can cancel it (above) before
+        // the backend session is destroyed. On a real tab close the timer fires.
+        sessionIdRef.current = null;
+        pendingCloseRef.current = window.setTimeout(() => {
+          pendingCloseRef.current = null;
+          closeTerminal(sid).catch(() => {});
+          setTabSessionId(tabId, null);
+        }, 50);
+      }
+    };
+  }, [tabId, setTabSessionId, retryNonce]);
+
+  const handleRetry = useCallback(() => {
+    setRetryNonce((n) => n + 1);
+  }, []);
+
+  return (
+    <div
+      className={`file-browser-tab${isVisible ? "" : " file-browser-tab--hidden"}`}
+      data-testid="file-browser-tab"
+    >
+      <div className="file-browser-tab__body">
+        {phase === "connecting" && (
+          <>
+            <Loader2 size={32} className="file-browser-tab__icon file-browser-tab__spin" />
+            <p className="file-browser-tab__heading">Connecting…</p>
+            <p className="file-browser-tab__hint">Opening {title || "the connection"}.</p>
+          </>
+        )}
+
+        {phase === "connected" && (
+          <>
+            <FolderOpen size={32} className="file-browser-tab__icon" />
+            <p className="file-browser-tab__heading">No terminal for this connection</p>
+            <p className="file-browser-tab__hint">
+              {title ? `${title} browses files instead of running a shell. ` : ""}
+              This connection has no terminal output. Use the file browser in the sidebar to
+              navigate, open, and transfer files.
+            </p>
+          </>
+        )}
+
+        {phase === "error" && (
+          <>
+            <AlertCircle size={32} className="file-browser-tab__icon file-browser-tab__icon--error" />
+            <p className="file-browser-tab__heading">Could not open connection</p>
+            {error && <p className="file-browser-tab__error">{error}</p>}
+            <button
+              className="file-browser-tab__retry-btn"
+              onClick={handleRetry}
+              data-testid="file-browser-tab-retry"
+            >
+              <RefreshCw size={14} />
+              Retry
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useConnectSavedConnection.test.tsx
+++ b/src/hooks/useConnectSavedConnection.test.tsx
@@ -12,7 +12,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { useConnectSavedConnection } from "./useConnectSavedConnection";
-import type { SavedConnection } from "@/types/connection";
+import type { SavedConnection, ConnectionTypeInfo } from "@/types/connection";
 import {
   resolveCredential,
   createTerminal,
@@ -54,6 +54,33 @@ function makeSshConn(id: string, authMethod: string, savePassword?: boolean): Sa
         ...(savePassword !== undefined ? { savePassword } : {}),
       },
     },
+  };
+}
+
+/** A minimal registry entry; `terminal` omitted means terminal-capable. */
+function connType(typeId: string, terminal?: boolean): ConnectionTypeInfo {
+  return {
+    typeId,
+    displayName: typeId.toUpperCase(),
+    icon: "",
+    schema: { groups: [] },
+    capabilities: {
+      monitoring: false,
+      fileBrowser: true,
+      resize: false,
+      persistent: false,
+      ...(terminal !== undefined ? { terminal } : {}),
+    },
+  };
+}
+
+/** An FTP saved connection with a host but no credential-triggering authMethod. */
+function makeFtpConn(id: string): SavedConnection {
+  return {
+    id,
+    name: `FTP ${id}`,
+    folderId: null,
+    config: { type: "ftp", config: { host: "ftp.example.com", port: 21 } },
   };
 }
 
@@ -202,6 +229,37 @@ describe("useConnectSavedConnection", () => {
     });
     expect(mockedRemoveCredential).toHaveBeenCalledWith("pw-stale", "password");
     expect(useAppStore.getState().passwordPromptOpen).toBe(true);
+  });
+
+  it("opens a terminal-less type (FTP) into a browser-only file-browser tab (#1335)", async () => {
+    useAppStore.setState({ connectionTypes: [connType("ftp", false), connType("ssh")] });
+    const { connect } = await renderHook();
+    await act(async () => {
+      await connect(makeFtpConn("browse"));
+    });
+    expect(addTabSpy).toHaveBeenCalledWith(
+      "FTP browse",
+      "ftp",
+      expect.anything(),
+      expect.objectContaining({ contentType: "file-browser" })
+    );
+    // A terminal-less connection must not mint a session up front here; the
+    // file-browser tab creates it via its own path once mounted.
+    expect(mockedCreateTerminal).not.toHaveBeenCalled();
+  });
+
+  it("opens a terminal-capable type into a normal terminal tab (no file-browser content type)", async () => {
+    useAppStore.setState({ connectionTypes: [connType("ftp", false), connType("ssh")] });
+    const { connect } = await renderHook();
+    await act(async () => {
+      await connect(makeSshConn("agent-auth", "agent"));
+    });
+    expect(addTabSpy).toHaveBeenCalledWith(
+      "SSH agent-auth",
+      "ssh",
+      expect.anything(),
+      expect.objectContaining({ contentType: undefined })
+    );
   });
 
   it("stores the passphrase as key_passphrase when the user opts in for key auth", async () => {

--- a/src/hooks/useConnectSavedConnection.ts
+++ b/src/hooks/useConnectSavedConnection.ts
@@ -49,6 +49,22 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
       let config = connection.config;
       const cfg = config.config as unknown as Record<string, unknown>;
 
+      // A terminal-less connection type (Capabilities.terminal === false, e.g.
+      // FTP) opens into a browser-only tab instead of a terminal tab — no xterm,
+      // no PTY. The tab still owns a session so the sidebar file browser can route
+      // to it. Resolved from the registry capabilities (protocol-agnostic, never a
+      // per-type hardcode); an unknown type or absent flag stays terminal (#1335).
+      const effectiveTypeId =
+        config.type === "remote-session"
+          ? ((cfg.sessionType as string | undefined) ?? config.type)
+          : config.type;
+      const isTerminalLess =
+        useAppStore
+          .getState()
+          .connectionTypes.find((ct) => ct.typeId === effectiveTypeId)?.capabilities.terminal ===
+        false;
+      const contentType = isTerminalLess ? ("file-browser" as const) : undefined;
+
       // Connections with authMethod and password support credential store resolution
       if (cfg.authMethod && cfg.host) {
         const authMethod = cfg.authMethod as string;
@@ -68,6 +84,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
         if (!needsCredential) {
           addTab(connection.name, connection.config.type, config, {
             terminalOptions: connection.terminalOptions,
+            contentType,
           });
           return;
         }
@@ -81,6 +98,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
         if (typeof cfg.password === "string" && cfg.password.length > 0) {
           addTab(connection.name, connection.config.type, config, {
             terminalOptions: connection.terminalOptions,
+            contentType,
           });
           return;
         }
@@ -111,6 +129,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
             addTab(connection.name, connection.config.type, preConfig, {
               terminalOptions: connection.terminalOptions,
               sessionId,
+              contentType,
             });
             return;
           } catch (err) {
@@ -125,6 +144,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
               // Non-auth failure — let the Terminal component handle the error
               addTab(connection.name, connection.config.type, config, {
                 terminalOptions: connection.terminalOptions,
+                contentType,
               });
               return;
             }
@@ -164,6 +184,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
 
       addTab(connection.name, connection.config.type, config, {
         terminalOptions: connection.terminalOptions,
+        contentType,
       });
     },
     [addTab, requestPassword]

--- a/src/hooks/useConnectSavedConnection.ts
+++ b/src/hooks/useConnectSavedConnection.ts
@@ -59,10 +59,8 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
           ? ((cfg.sessionType as string | undefined) ?? config.type)
           : config.type;
       const isTerminalLess =
-        useAppStore
-          .getState()
-          .connectionTypes.find((ct) => ct.typeId === effectiveTypeId)?.capabilities.terminal ===
-        false;
+        useAppStore.getState().connectionTypes.find((ct) => ct.typeId === effectiveTypeId)
+          ?.capabilities.terminal === false;
       const contentType = isTerminalLess ? ("file-browser" as const) : undefined;
 
       // Connections with authMethod and password support credential store resolution

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -75,4 +75,16 @@ export interface Capabilities {
   fileBrowser: boolean;
   resize: boolean;
   persistent: boolean;
+  /**
+   * Whether this connection type has an interactive terminal.
+   *
+   * Optional to match the wire reality: an agent or config predating this field
+   * omits it, and an absent value means terminal-capable (the Rust
+   * `#[serde(default = "true")]`). Only an explicit `false` marks a terminal-less
+   * type (FTP), which opens directly into a browser-only tab (`"file-browser"`
+   * content type) with no terminal session — the file browser lives in the
+   * sidebar, driven by the tab's session id. Decide with `terminal === false`,
+   * never `!terminal` (#1335).
+   */
+  terminal?: boolean;
 }

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -30,7 +30,14 @@ export type TabContentType =
   | "log-viewer"
   | "tunnel-editor"
   | "workspace-editor"
-  | "network-diagnostic";
+  | "network-diagnostic"
+  /**
+   * A terminal-less connection (e.g. FTP, `Capabilities.terminal === false`).
+   * The tab owns a live session so the sidebar file browser can route to it,
+   * but renders a non-terminal placeholder body instead of an xterm terminal
+   * (#1335).
+   */
+  | "file-browser";
 
 /**
  * Reference to a session-layer file browser backing a remote editor tab (#1557).

--- a/src/utils/activeContext.ts
+++ b/src/utils/activeContext.ts
@@ -23,6 +23,7 @@ const CONTEXT_BY_CONTENT_TYPE: Record<TabContentType, ActiveContext> = {
   "network-diagnostic": "form",
   "log-viewer": "other",
   "agent-error": "other",
+  "file-browser": "other",
 };
 
 /**


### PR DESCRIPTION
Resolves the last deferred item of #1335: FTP (and any future terminal-less connection type) now opens **straight into a browser-only tab with no terminal**, via the owner-decided **`terminal` capability flag** — the protocol-agnostic route, not an `ftp` hardcode.

## What changed

**Backend (core)**
- Added a `terminal: bool` field to the connection-level `Capabilities` struct.
- Backward-compatible: `#[serde(default = "…")]` defaulting to **true**, so agents/configs serialized before the field existed still deserialize as terminal-capable.
- Every existing connection type reports `terminal: true`; **FTP reports `terminal: false`**.

**Frontend**
- New `file-browser` tab content type. A saved connection whose registry capabilities report `terminal === false` is routed to it in `useConnectSavedConnection` (protocol-agnostic; an unknown type or absent flag stays terminal).
- New `FileBrowserTab` component: it **mints and owns the connection's session through its own path** (not `Terminal.tsx`/no PTY), so the sidebar file browser routes to `tab.sessionId`, and renders a non-terminal placeholder body. It adopts a pre-minted session (credential-validation path) and closes its session on tab close.
- The TS `terminal` capability is optional (`terminal?: boolean`) to match the wire reality that an older agent omits it; the decision is `terminal === false`, never `!terminal`.

**Terminal types are unaffected** — the flag only flips behaviour on an explicit `false`, which only FTP sets.

## Concept
`docs/concepts/partial/ftp-client.html`: moved the terminal-less-tab divergence (#1) from open to resolved, documenting the as-built `terminal` flag and browser-only tab. The concept now reports **converged (no open functional gaps)**.

## Tests
- Rust: `Capabilities` round-trips with and without the new field (absent → `terminal: true`); FTP reports `terminal: false`.
- Frontend: `useConnectSavedConnection` routes a terminal-less type to a `file-browser` tab and a terminal type to a normal terminal tab (fails without the change); `FileBrowserTab` mints/adopts/closes its session and renders the placeholder.
- Full suites green: `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo fmt --check`, `pnpm build`, 3367 frontend tests, `tsc --noEmit`.

Closes #1335
