### PR TITLE
fix(sftp): reconcile transfer queue backstop for a dropped terminal event (Closes #1645)

### DIFF
--- a/docs/changes/dev5/fix/1645-transfer-terminal-reconcile.md
+++ b/docs/changes/dev5/fix/1645-transfer-terminal-reconcile.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Transfer Queue: a transfer now settles to its correct final state even when
+  its terminal `transfer-progress` event is dropped (e.g. under memory
+  pressure). Previously a row seeded at registration (#1632) could stay stuck at
+  `queued`/`active` forever if the `done`/`error`/`cancelled` event never
+  arrived. The backend now retains recently-terminal transfers briefly and
+  includes legacy SFTP transfers in the `transfer_list` snapshot, and the
+  frontend reconciles the queue against that snapshot while any transfer is
+  in-flight (and on window focus), settling stuck rows without ever regressing a
+  live one (#1645).

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -162,12 +162,20 @@ pub async fn sftp_download(
     let (dedicated, total) = open_transfer_channel(session, Some(remote_path.clone())).await?;
 
     let transfer_id = uuid::Uuid::new_v4().to_string();
-    let token = registry.register(&transfer_id);
+    let file_name = file_name_of(&remote_path);
+    let token = registry.register(
+        &transfer_id,
+        &session_id,
+        TransferDirection::Download,
+        &file_name,
+        &remote_path,
+        total,
+    );
     let ctx = TransferContext {
         transfer_id: transfer_id.clone(),
         session_id,
         direction: TransferDirection::Download,
-        file_name: file_name_of(&remote_path),
+        file_name,
         path: remote_path.clone(),
         total,
     };
@@ -211,7 +219,15 @@ pub async fn sftp_upload(
         .unwrap_or(0);
 
     let transfer_id = uuid::Uuid::new_v4().to_string();
-    let token = registry.register(&transfer_id);
+    let file_name = file_name_of(&remote_path);
+    let token = registry.register(
+        &transfer_id,
+        &session_id,
+        TransferDirection::Upload,
+        &file_name,
+        &remote_path,
+        total,
+    );
     let ctx = TransferContext {
         transfer_id: transfer_id.clone(),
         session_id,
@@ -222,7 +238,7 @@ pub async fn sftp_upload(
         // so this is unchanged for them — but an SFTP→SFTP paste uploads from
         // a local temp copy (`/tmp/termihub-paste-<ts>-<name>`), and the
         // destination name is the one the user actually knows the file by.
-        file_name: file_name_of(&remote_path),
+        file_name,
         path: remote_path.clone(),
         total,
     };

--- a/src-tauri/src/files/transfer/mod.rs
+++ b/src-tauri/src/files/transfer/mod.rs
@@ -373,8 +373,13 @@ async fn upload_inner(
     copy_chunked(&mut local, &mut remote, ctx, token, sink).await
 }
 
-/// Emit the terminal event, run cleanup on cancel/error, and drop the registry
-/// entry. Shared by download and upload.
+/// Emit the terminal event, run cleanup on cancel/error, and record the
+/// transfer's terminal state in the registry. Shared by download and upload.
+///
+/// The terminal state is *retained* in the registry for a bounded window
+/// (`finish_legacy`, #1645) rather than immediately dropped, so a reconcile can
+/// still settle a stuck Transfer Queue row if this terminal `transfer-progress`
+/// event was dropped (e.g. under memory pressure).
 fn finish_transfer<F: FnOnce()>(
     outcome: Result<CopyOutcome, TerminalError>,
     ctx: &TransferContext,
@@ -382,21 +387,24 @@ fn finish_transfer<F: FnOnce()>(
     sink: &ProgressSink,
     cleanup: F,
 ) {
-    match outcome {
+    let (phase, transferred) = match outcome {
         Ok(CopyOutcome::Completed { transferred }) => {
             info!(transfer_id = %ctx.transfer_id, transferred, "transfer complete");
             sink(&ctx.progress(transferred, TransferPhase::Done, None));
+            (TransferPhase::Done, transferred)
         }
         Ok(CopyOutcome::Cancelled { transferred }) => {
             info!(transfer_id = %ctx.transfer_id, transferred, "transfer cancelled");
             cleanup();
             sink(&ctx.progress(transferred, TransferPhase::Cancelled, None));
+            (TransferPhase::Cancelled, transferred)
         }
         Err(e) => {
             warn!(transfer_id = %ctx.transfer_id, error = %e, "transfer failed");
             cleanup();
             sink(&ctx.progress(0, TransferPhase::Error, Some(e.to_string())));
+            (TransferPhase::Error, 0)
         }
-    }
-    registry.drop_entry(&ctx.transfer_id);
+    };
+    registry.finish_legacy(&ctx.transfer_id, phase.state_tag(), transferred);
 }

--- a/src-tauri/src/files/transfer/registry.rs
+++ b/src-tauri/src/files/transfer/registry.rs
@@ -13,16 +13,33 @@
 //! Cross-cutting operations (`cancel`, `cancel_all`) act on both stores so a
 //! caller (or app-quit teardown) need not know which kind a transfer is.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 use super::scheduler::{Admission, SessionScheduler, DEFAULT_MAX_CONCURRENT};
-use super::state::{TransferEvent, TransferState, TransferStateTag};
+use super::state::{TransferEvent, TransferState, TransferStateTag, MAX_RETRIES};
 use super::TransferDirection;
+
+/// How long a recently-terminal transfer is retained in the registry so a
+/// frontend reconcile can still observe its final state after its live entry is
+/// gone (#1645).
+///
+/// The frontend polls `transfer_list` on a few-second tick while it holds any
+/// non-terminal row, so a window an order of magnitude larger than that tick
+/// comfortably catches a transfer whose terminal `transfer-progress` event was
+/// dropped, without holding completed transfers indefinitely.
+const TERMINAL_RETENTION: Duration = Duration::from_secs(60);
+
+/// Hard cap on the number of retained terminal transfers, so a burst of
+/// completions cannot grow the history without bound between TTL sweeps. Each
+/// retained entry is a small [`TransferSnapshot`]; 64 bounds the memory while
+/// still covering a realistic backlog.
+const TERMINAL_RETENTION_MAX: usize = 64;
 
 /// A point-in-time, serialisable view of one rich transfer, returned by
 /// `transfer_list`.
@@ -169,15 +186,68 @@ impl TransferHandle {
     }
 }
 
+/// A live legacy (SFTP) transfer: its cancellation token plus the minimal
+/// identity needed to surface it in `transfer_list` (#1645).
+///
+/// The legacy SFTP copy path reports live progress only via best-effort
+/// `transfer-progress` events (it does not update the registry mid-flight), so
+/// the registry holds just the transfer's identity and total. That is enough
+/// for a reconcile: a listed legacy transfer shows as `active` while live, and
+/// [`TransferRegistry::finish_legacy`] records its true terminal state when the
+/// copy loop ends.
+#[derive(Debug)]
+struct LegacyEntry {
+    token: CancellationToken,
+    session_id: String,
+    direction: TransferDirection,
+    file_name: String,
+    path: String,
+    total: u64,
+}
+
+impl LegacyEntry {
+    /// A live (`active`) snapshot of this legacy transfer. `transferred` is not
+    /// tracked in the registry for the legacy path, so it reports `0`; the
+    /// reconcile only ever *settles* a stuck row to a terminal state and never
+    /// moves a live row backward, so this cannot regress an event-advanced row.
+    fn snapshot(&self, transfer_id: &str) -> TransferSnapshot {
+        TransferSnapshot {
+            transfer_id: transfer_id.to_string(),
+            session_id: self.session_id.clone(),
+            direction: self.direction,
+            file_name: self.file_name.clone(),
+            path: self.path.clone(),
+            state: TransferStateTag::Active,
+            transferred: 0,
+            total: self.total,
+            speed: 0,
+            attempt: 0,
+            max_attempts: MAX_RETRIES,
+        }
+    }
+}
+
+/// A recently-terminal transfer retained for a bounded window so a reconcile
+/// can still observe its final state after its live entry is dropped (#1645).
+#[derive(Debug)]
+struct RetainedTerminal {
+    snapshot: TransferSnapshot,
+    at: Instant,
+}
+
 /// Inner, lock-guarded registry state.
 #[derive(Default)]
 struct RegistryState {
-    /// Legacy SFTP transfers (#1245): id → cancellation token.
-    legacy: HashMap<String, CancellationToken>,
+    /// Legacy SFTP transfers (#1245): id → live entry (token + identity, #1645).
+    legacy: HashMap<String, LegacyEntry>,
     /// Rich queued transfers (#1336): id → handle.
     rich: HashMap<String, Arc<TransferHandle>>,
     /// Per-session slot accounting for the rich model.
     schedulers: HashMap<String, SessionScheduler>,
+    /// Recently-terminal transfers, retained briefly so a reconcile can settle a
+    /// stuck row whose terminal event was dropped (#1645). Ordered oldest-first
+    /// (push_back), bounded by [`TERMINAL_RETENTION`] and [`TERMINAL_RETENTION_MAX`].
+    terminal: VecDeque<RetainedTerminal>,
 }
 
 /// Tracks in-flight transfers by `transfer_id`.
@@ -223,15 +293,34 @@ impl TransferRegistry {
 
     // --- Legacy SFTP API (#1245), unchanged semantics ---
 
-    /// Register a fresh legacy transfer, returning its cancellation token.
+    /// Register a fresh legacy (SFTP) transfer, returning its cancellation
+    /// token.
     ///
     /// The returned token is checked by the SFTP copy loop at each chunk
-    /// boundary.
-    pub fn register(&self, transfer_id: &str) -> CancellationToken {
+    /// boundary. The identity (`session_id`, `direction`, `file_name`, `path`,
+    /// `total`) is retained so the transfer appears in `transfer_list` and can
+    /// be settled to its terminal state by a reconcile (#1645).
+    pub fn register(
+        &self,
+        transfer_id: &str,
+        session_id: &str,
+        direction: TransferDirection,
+        file_name: &str,
+        path: &str,
+        total: u64,
+    ) -> CancellationToken {
         let token = CancellationToken::new();
-        self.lock()
-            .legacy
-            .insert(transfer_id.to_string(), token.clone());
+        self.lock().legacy.insert(
+            transfer_id.to_string(),
+            LegacyEntry {
+                token: token.clone(),
+                session_id: session_id.to_string(),
+                direction,
+                file_name: file_name.to_string(),
+                path: path.to_string(),
+                total,
+            },
+        );
         token
     }
 
@@ -241,8 +330,8 @@ impl TransferRegistry {
     pub fn cancel(&self, transfer_id: &str) -> bool {
         let handle = {
             let state = self.lock();
-            if let Some(token) = state.legacy.get(transfer_id) {
-                token.cancel();
+            if let Some(entry) = state.legacy.get(transfer_id) {
+                entry.token.cancel();
                 return true;
             }
             state.rich.get(transfer_id).cloned()
@@ -262,8 +351,8 @@ impl TransferRegistry {
     /// open during teardown. Returns the number of transfers signalled.
     pub fn cancel_all(&self) -> usize {
         let state = self.lock();
-        for token in state.legacy.values() {
-            token.cancel();
+        for entry in state.legacy.values() {
+            entry.token.cancel();
         }
         for handle in state.rich.values() {
             handle.token.cancel();
@@ -274,12 +363,65 @@ impl TransferRegistry {
 
     /// Drop a transfer's registry entry once its copy loop has finished
     /// (legacy or rich). For a rich transfer this also releases any slot it
-    /// still holds so a queued peer can be promoted.
+    /// still holds so a queued peer can be promoted, and — when the transfer
+    /// reached a terminal state — retains a snapshot briefly so a reconcile can
+    /// still settle a stuck row whose terminal event was dropped (#1645).
+    ///
+    /// The legacy SFTP path records its terminal state via [`Self::finish_legacy`]
+    /// instead (it knows the final phase and byte count); a bare `drop_entry`
+    /// for a legacy id therefore just removes the live entry.
     pub fn drop_entry(&self, transfer_id: &str) {
         let mut state = self.lock();
         state.legacy.remove(transfer_id);
         if let Some(handle) = state.rich.remove(transfer_id) {
+            let snapshot = handle.snapshot();
             Self::release_slot_locked(&mut state, &handle);
+            if snapshot.state.is_terminal() {
+                Self::record_terminal_locked(&mut state, snapshot);
+            }
+        }
+    }
+
+    /// Record a legacy (SFTP) transfer's terminal outcome and remove its live
+    /// entry (#1645). Called by the SFTP copy path when the transfer settles, so
+    /// the transfer stays snapshot-able for the retention window even if its
+    /// terminal `transfer-progress` event was dropped. A no-op for an id with no
+    /// live legacy entry (e.g. already dropped).
+    pub fn finish_legacy(&self, transfer_id: &str, state_tag: TransferStateTag, transferred: u64) {
+        let mut state = self.lock();
+        if let Some(entry) = state.legacy.remove(transfer_id) {
+            let mut snapshot = entry.snapshot(transfer_id);
+            snapshot.state = state_tag;
+            snapshot.transferred = transferred;
+            if state_tag.is_terminal() {
+                Self::record_terminal_locked(&mut state, snapshot);
+            }
+        }
+    }
+
+    /// Push a terminal snapshot into the retention history, then evict anything
+    /// past the capacity or TTL bound. Callers hold the state lock.
+    fn record_terminal_locked(state: &mut RegistryState, snapshot: TransferSnapshot) {
+        let now = Instant::now();
+        state
+            .terminal
+            .push_back(RetainedTerminal { snapshot, at: now });
+        Self::evict_terminal_locked(state, now);
+    }
+
+    /// Drop retained terminal entries beyond the capacity cap (oldest first) or
+    /// older than the TTL. The deque is oldest-first, so both bounds evict from
+    /// the front.
+    fn evict_terminal_locked(state: &mut RegistryState, now: Instant) {
+        while state.terminal.len() > TERMINAL_RETENTION_MAX {
+            state.terminal.pop_front();
+        }
+        while let Some(front) = state.terminal.front() {
+            if now.duration_since(front.at) > TERMINAL_RETENTION {
+                state.terminal.pop_front();
+            } else {
+                break;
+            }
         }
     }
 
@@ -423,15 +565,42 @@ impl TransferRegistry {
         self.lock().rich.get(transfer_id).cloned()
     }
 
-    /// Snapshot every rich transfer for `transfer_list` (optionally filtered by
-    /// session).
+    /// Snapshot every transfer for `transfer_list` (optionally filtered by
+    /// session): live rich transfers, live legacy SFTP transfers (#1645), and
+    /// recently-terminal transfers retained for the reconcile window (#1645).
+    ///
+    /// A live entry always shadows a retained snapshot for the same id, so an id
+    /// that (impossibly, given UUIDs) reappeared live would never be reported as
+    /// both live and terminal.
     pub fn list(&self, session_id: Option<&str>) -> Vec<TransferSnapshot> {
-        self.lock()
-            .rich
-            .values()
-            .filter(|h| session_id.is_none_or(|s| h.session_id == s))
-            .map(|h| h.snapshot())
-            .collect()
+        let mut state = self.lock();
+        Self::evict_terminal_locked(&mut state, Instant::now());
+
+        let matches = |s: &str| session_id.is_none_or(|f| s == f);
+        let mut live_ids: HashSet<String> = HashSet::new();
+        let mut out = Vec::new();
+
+        for handle in state.rich.values() {
+            if matches(&handle.session_id) {
+                let snap = handle.snapshot();
+                live_ids.insert(snap.transfer_id.clone());
+                out.push(snap);
+            }
+        }
+        for (id, entry) in &state.legacy {
+            if matches(&entry.session_id) {
+                live_ids.insert(id.clone());
+                out.push(entry.snapshot(id));
+            }
+        }
+        for retained in &state.terminal {
+            if matches(&retained.snapshot.session_id)
+                && !live_ids.contains(&retained.snapshot.transfer_id)
+            {
+                out.push(retained.snapshot.clone());
+            }
+        }
+        out
     }
 
     /// Whether the given session currently has any active or queued rich
@@ -461,6 +630,21 @@ impl TransferRegistry {
     pub fn contains(&self, transfer_id: &str) -> bool {
         self.lock().legacy.contains_key(transfer_id)
     }
+
+    /// Number of retained terminal snapshots (#1645 tests).
+    #[cfg(test)]
+    fn retained_len(&self) -> usize {
+        self.lock().terminal.len()
+    }
+
+    /// Force a TTL eviction pass as if the clock were `now` (#1645 tests). Using
+    /// a future `now` avoids backdating an `Instant` into the past (which can
+    /// underflow on a freshly-booted monotonic clock).
+    #[cfg(test)]
+    fn evict_at(&self, now: Instant) {
+        let mut state = self.lock();
+        Self::evict_terminal_locked(&mut state, now);
+    }
 }
 
 #[cfg(test)]
@@ -469,10 +653,23 @@ mod tests {
 
     // --- Legacy API (unchanged #1245 behaviour) ---
 
+    /// Register a legacy transfer with placeholder identity, for tests that only
+    /// exercise the token/cancel/drop semantics.
+    fn reg_legacy(reg: &TransferRegistry, id: &str) -> CancellationToken {
+        reg.register(
+            id,
+            "sess",
+            TransferDirection::Download,
+            id,
+            &format!("/remote/{id}"),
+            100,
+        )
+    }
+
     #[test]
     fn register_adds_a_live_token() {
         let reg = TransferRegistry::new();
-        let token = reg.register("t1");
+        let token = reg_legacy(&reg, "t1");
         assert!(reg.contains("t1"));
         assert_eq!(reg.len(), 1);
         assert!(!token.is_cancelled());
@@ -481,7 +678,7 @@ mod tests {
     #[test]
     fn cancel_trips_the_token_and_reports_true() {
         let reg = TransferRegistry::new();
-        let token = reg.register("t1");
+        let token = reg_legacy(&reg, "t1");
         assert!(reg.cancel("t1"), "cancelling a live transfer returns true");
         assert!(
             token.is_cancelled(),
@@ -501,9 +698,9 @@ mod tests {
     #[test]
     fn cancel_all_trips_every_token() {
         let reg = TransferRegistry::new();
-        let a = reg.register("a");
-        let b = reg.register("b");
-        let c = reg.register("c");
+        let a = reg_legacy(&reg, "a");
+        let b = reg_legacy(&reg, "b");
+        let c = reg_legacy(&reg, "c");
         assert_eq!(
             reg.cancel_all(),
             3,
@@ -523,7 +720,7 @@ mod tests {
     #[test]
     fn drop_entry_removes_the_transfer() {
         let reg = TransferRegistry::new();
-        reg.register("t1");
+        reg_legacy(&reg, "t1");
         reg.drop_entry("t1");
         assert!(!reg.contains("t1"));
         assert_eq!(reg.len(), 0);
@@ -532,7 +729,7 @@ mod tests {
     #[test]
     fn drop_entry_for_unknown_id_is_a_noop() {
         let reg = TransferRegistry::new();
-        reg.register("t1");
+        reg_legacy(&reg, "t1");
         reg.drop_entry("other");
         assert!(reg.contains("t1"), "unrelated entry must survive");
         assert_eq!(reg.len(), 1);
@@ -541,7 +738,7 @@ mod tests {
     #[test]
     fn cancel_after_drop_is_a_noop() {
         let reg = TransferRegistry::new();
-        reg.register("t1");
+        reg_legacy(&reg, "t1");
         reg.drop_entry("t1");
         assert!(!reg.cancel("t1"));
     }
@@ -666,5 +863,159 @@ mod tests {
         assert!(!reg.pause("nope"));
         assert!(!reg.resume("nope"));
         assert!(!reg.retry("nope"));
+    }
+
+    // --- Legacy SFTP in transfer_list + terminal retention (#1645) ---
+
+    #[test]
+    fn legacy_transfer_is_listed_as_active_while_live() {
+        // Before #1645 an SFTP transfer registered only in the legacy token map
+        // and never appeared in `transfer_list`. It must now show up as active,
+        // carrying its identity, so a reconcile has a snapshot to match.
+        let reg = TransferRegistry::new();
+        reg.register(
+            "s1",
+            "sess-a",
+            TransferDirection::Upload,
+            "file.txt",
+            "/remote/file.txt",
+            2048,
+        );
+
+        let list = reg.list(None);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].transfer_id, "s1");
+        assert_eq!(list[0].session_id, "sess-a");
+        assert_eq!(list[0].direction, TransferDirection::Upload);
+        assert_eq!(list[0].file_name, "file.txt");
+        assert_eq!(list[0].path, "/remote/file.txt");
+        assert_eq!(list[0].state, TransferStateTag::Active);
+        assert_eq!(list[0].total, 2048);
+    }
+
+    #[test]
+    fn finish_legacy_retains_a_terminal_snapshot_after_the_live_entry_is_gone() {
+        // The crux of #1645: an SFTP transfer whose terminal event was dropped
+        // is still observable as *completed* for the retention window, so the
+        // reconcile can settle the stuck row.
+        let reg = TransferRegistry::new();
+        reg.register(
+            "s1",
+            "sess-a",
+            TransferDirection::Download,
+            "file.txt",
+            "/remote/file.txt",
+            100,
+        );
+        reg.finish_legacy("s1", TransferStateTag::Completed, 100);
+
+        assert!(!reg.contains("s1"), "the live legacy entry is removed");
+        let list = reg.list(None);
+        assert_eq!(list.len(), 1, "the terminal snapshot is retained");
+        assert_eq!(list[0].transfer_id, "s1");
+        assert_eq!(list[0].state, TransferStateTag::Completed);
+        assert_eq!(list[0].transferred, 100);
+        assert_eq!(list[0].file_name, "file.txt");
+    }
+
+    #[test]
+    fn finish_legacy_records_a_cancelled_terminal_state() {
+        let reg = TransferRegistry::new();
+        reg.register(
+            "s1",
+            "sess-a",
+            TransferDirection::Download,
+            "f",
+            "/remote/f",
+            100,
+        );
+        reg.finish_legacy("s1", TransferStateTag::Cancelled, 42);
+        let list = reg.list(None);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].state, TransferStateTag::Cancelled);
+        assert_eq!(list[0].transferred, 42);
+    }
+
+    #[test]
+    fn finish_legacy_for_an_unknown_id_is_a_noop() {
+        let reg = TransferRegistry::new();
+        reg.finish_legacy("nope", TransferStateTag::Completed, 0);
+        assert_eq!(reg.list(None).len(), 0);
+        assert_eq!(reg.retained_len(), 0);
+    }
+
+    #[test]
+    fn dropping_a_completed_rich_transfer_retains_its_terminal_snapshot() {
+        let reg = TransferRegistry::new();
+        let h = enq(&reg, "r1", "sess-a");
+        reg.request_slot(&h); // Active
+        h.transition(TransferEvent::Complete); // Active → Completed
+        reg.drop_entry("r1");
+
+        assert!(reg.get("r1").is_none(), "the live rich entry is dropped");
+        let list = reg.list(None);
+        assert_eq!(list.len(), 1, "the completed transfer is retained");
+        assert_eq!(list[0].transfer_id, "r1");
+        assert_eq!(list[0].state, TransferStateTag::Completed);
+    }
+
+    #[test]
+    fn a_live_entry_shadows_a_retained_snapshot_for_the_same_id() {
+        // Retain a terminal snapshot, then register a *live* transfer reusing the
+        // id: the live entry must win (no duplicate, no stale terminal row).
+        let reg = TransferRegistry::new();
+        reg.register("s1", "sess-a", TransferDirection::Download, "f", "/f", 100);
+        reg.finish_legacy("s1", TransferStateTag::Completed, 100);
+        assert_eq!(reg.retained_len(), 1);
+
+        reg.register("s1", "sess-a", TransferDirection::Download, "f", "/f", 100);
+        let list = reg.list(None);
+        assert_eq!(list.len(), 1, "no duplicate for the reused id");
+        assert_eq!(
+            list[0].state,
+            TransferStateTag::Active,
+            "the live entry shadows the retained terminal snapshot"
+        );
+    }
+
+    #[test]
+    fn retained_terminals_are_evicted_past_the_capacity_cap() {
+        let reg = TransferRegistry::new();
+        for i in 0..(TERMINAL_RETENTION_MAX + 10) {
+            let id = format!("s{i}");
+            reg.register(&id, "sess-a", TransferDirection::Download, "f", "/f", 1);
+            reg.finish_legacy(&id, TransferStateTag::Completed, 1);
+        }
+        assert_eq!(
+            reg.retained_len(),
+            TERMINAL_RETENTION_MAX,
+            "history is bounded by the capacity cap"
+        );
+    }
+
+    #[test]
+    fn retained_terminals_are_evicted_after_the_ttl() {
+        let reg = TransferRegistry::new();
+        reg.register("s1", "sess-a", TransferDirection::Download, "f", "/f", 1);
+        reg.finish_legacy("s1", TransferStateTag::Completed, 1);
+        assert_eq!(reg.retained_len(), 1);
+
+        // As if the clock advanced well past the retention window.
+        reg.evict_at(Instant::now() + TERMINAL_RETENTION + Duration::from_secs(5));
+        assert_eq!(reg.retained_len(), 0, "expired terminals are dropped");
+        assert_eq!(reg.list(None).len(), 0);
+    }
+
+    #[test]
+    fn retained_terminals_respect_the_session_filter() {
+        let reg = TransferRegistry::new();
+        reg.register("s1", "sess-a", TransferDirection::Download, "f", "/f", 1);
+        reg.finish_legacy("s1", TransferStateTag::Completed, 1);
+        reg.register("s2", "sess-b", TransferDirection::Download, "f", "/f", 1);
+        reg.finish_legacy("s2", TransferStateTag::Completed, 1);
+
+        assert_eq!(reg.list(Some("sess-a")).len(), 1);
+        assert_eq!(reg.list(Some("sess-b")).len(), 1);
+        assert_eq!(reg.list(None).len(), 2);
     }
 }

--- a/src-tauri/src/files/transfer/state.rs
+++ b/src-tauri/src/files/transfer/state.rs
@@ -67,6 +67,20 @@ pub enum TransferStateTag {
     Cancelled,
 }
 
+impl TransferStateTag {
+    /// Whether this tag is a settled outcome the reconcile treats as final
+    /// (`completed`/`failed`/`cancelled`). Unlike [`TransferState::is_terminal`]
+    /// — which is about the state machine's own no-further-transitions states —
+    /// this mirrors the frontend's `TERMINAL_TRANSFER_STATES`, where a
+    /// permanently `failed` transfer is also a settled row (#1645).
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TransferStateTag::Completed | TransferStateTag::Failed | TransferStateTag::Cancelled
+        )
+    }
+}
+
 /// An event that may drive a [`TransferState`] transition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransferEvent {

--- a/src-tauri/tests/sftp_transfer.rs
+++ b/src-tauri/tests/sftp_transfer.rs
@@ -146,7 +146,14 @@ async fn cancel_mid_transfer_cleans_up_partial_file() {
 
     let registry = TransferRegistry::new();
     let transfer_id = "cancel-test".to_string();
-    let token = registry.register(&transfer_id);
+    let token = registry.register(
+        &transfer_id,
+        "s",
+        TransferDirection::Download,
+        "100mb.bin",
+        "/home/testuser/sftp-test/large-files/100mb.bin",
+        100 * 1024 * 1024,
+    );
     let sink = RecordingSink::default();
     let ctx = TransferContext {
         transfer_id: transfer_id.clone(),
@@ -269,7 +276,14 @@ async fn browsing_stays_live_during_transfer() {
     let dest_str = dest.to_string_lossy().to_string();
 
     let registry = TransferRegistry::new();
-    let token = registry.register("live-test");
+    let token = registry.register(
+        "live-test",
+        "s",
+        TransferDirection::Download,
+        "100mb.bin",
+        "/home/testuser/sftp-test/large-files/100mb.bin",
+        100 * 1024 * 1024,
+    );
     let sink = RecordingSink::default();
     let ctx = TransferContext {
         transfer_id: "live-test".to_string(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { ToastProvider, TooltipProvider } from "@/components/ui";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useTunnelEvents } from "@/hooks/useTunnelEvents";
 import { useTransferEvents } from "@/hooks/useTransferEvents";
+import { useTransferReconcile } from "@/hooks/useTransferReconcile";
 import { useEmbeddedServerEvents } from "@/hooks/useEmbeddedServerEvents";
 import { useCredentialStoreEvents } from "@/hooks/useCredentialStoreEvents";
 import { useAgentUpdateEvents } from "@/hooks/useAgentUpdateEvents";
@@ -108,6 +109,7 @@ function App() {
   useKeyboardShortcuts();
   useTunnelEvents();
   useTransferEvents();
+  useTransferReconcile();
   useEmbeddedServerEvents();
   useCredentialStoreEvents();
   useAgentUpdateEvents();

--- a/src/hooks/useTransferReconcile.test.ts
+++ b/src/hooks/useTransferReconcile.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock only `transferList`, keeping the rest of the API surface real so the
+// store (which imports many api symbols) still resolves.
+vi.mock("@/services/api", async () => {
+  const actual = await vi.importActual<typeof import("@/services/api")>("@/services/api");
+  return { ...actual, transferList: vi.fn() };
+});
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { useTransferReconcile } from "./useTransferReconcile";
+import { useAppStore } from "@/store/appStore";
+import { transferList } from "@/services/api";
+import type { TransferSnapshot } from "@/services/api";
+
+const mockTransferList = vi.mocked(transferList);
+
+function snapshot(overrides: Partial<TransferSnapshot> = {}): TransferSnapshot {
+  return {
+    transferId: "t1",
+    sessionId: "sess-a",
+    direction: "download",
+    fileName: "file.txt",
+    path: "/remote/file.txt",
+    state: "completed",
+    transferred: 100,
+    total: 100,
+    speed: 0,
+    attempt: 0,
+    maxAttempts: 3,
+    ...overrides,
+  };
+}
+
+describe("useTransferReconcile (#1645)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+    mockTransferList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function mountHook(): Promise<void> {
+    function Harness() {
+      useTransferReconcile();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    // Let the effect's async `reconcile()` resolve.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("settles a stuck row from the backend snapshot when the terminal event was dropped", async () => {
+    // A transfer was seeded (#1632) but every progress event — including the
+    // terminal one — was dropped, so the row is stuck at `queued`.
+    useAppStore.getState().seedTransferQueue({
+      id: "t1",
+      sessionId: "sess-a",
+      direction: "download",
+      name: "file.txt",
+      path: "/remote/file.txt",
+    });
+    expect(useAppStore.getState().transferQueue["t1"].state).toBe("queued");
+
+    // The backend still reports it (retained terminal snapshot, #1645).
+    mockTransferList.mockResolvedValue([snapshot({ state: "completed", transferred: 100 })]);
+
+    await mountHook();
+
+    expect(mockTransferList).toHaveBeenCalled();
+    expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({
+      state: "completed",
+      transferred: 100,
+      percent: 100,
+    });
+  });
+
+  it("makes no backend call while the queue has no pending rows", async () => {
+    // Only a terminal row present → nothing to reconcile → no polling.
+    useAppStore.getState().addTransfer({
+      id: "done",
+      sessionId: "sess-a",
+      direction: "download",
+      name: "file.txt",
+      state: "completed",
+      transferred: 100,
+      totalBytes: 100,
+      percent: 100,
+      speedBytesPerSec: null,
+      updatedAt: 0,
+    });
+
+    await mountHook();
+
+    expect(mockTransferList).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useTransferReconcile.ts
+++ b/src/hooks/useTransferReconcile.ts
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import { useAppStore } from "@/store/appStore";
+import { transferList } from "@/services/api";
+import { frontendLog } from "@/utils/frontendLog";
+import { isTerminalTransferState } from "@/types/transfer";
+
+/**
+ * How often to poll `transfer_list` while the queue holds a non-terminal row.
+ * An order of magnitude below the backend's terminal-retention window (#1645),
+ * so a transfer whose terminal event was dropped is caught well within the
+ * window the backend keeps its snapshot around.
+ */
+const RECONCILE_INTERVAL_MS = 4000;
+
+/**
+ * Backstop for a dropped *terminal* `transfer-progress` event (#1645).
+ *
+ * `useTransferEvents` folds best-effort progress events into the queue; under
+ * memory pressure the webview can miss the terminal event, leaving a seeded row
+ * (#1632) stuck at `queued`/`active` forever. This hook polls the reliable
+ * request/response `transfer_list` snapshot **while any row is non-terminal**
+ * and settles a stuck row to its true terminal state (the backend now retains
+ * recently-terminal transfers and includes legacy SFTP, #1645).
+ *
+ * Polling is gated on there being a pending row, so an idle app makes no calls.
+ * It also reconciles on window focus (a returning user's transfers settle at
+ * once) and stops as soon as every row is terminal.
+ */
+export function useTransferReconcile(): void {
+  const reconcileTransferQueue = useAppStore((s) => s.reconcileTransferQueue);
+  // Re-runs the effect only when this boolean flips (Object.is equality), so the
+  // poll starts when a transfer begins and stops when the last row settles.
+  const hasPending = useAppStore((s) =>
+    Object.values(s.transferQueue).some((e) => !isTerminalTransferState(e.state))
+  );
+
+  useEffect(() => {
+    if (!hasPending) return;
+
+    let cancelled = false;
+    const reconcile = async () => {
+      try {
+        const snapshots = await transferList();
+        if (!cancelled) reconcileTransferQueue(snapshots);
+      } catch (err) {
+        frontendLog("transfer_reconcile", `transfer_list reconcile failed: ${String(err)}`);
+      }
+    };
+
+    // Reconcile promptly, then on a tick and whenever the window regains focus.
+    void reconcile();
+    const interval = window.setInterval(() => void reconcile(), RECONCILE_INTERVAL_MS);
+    const onFocus = () => void reconcile();
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [hasPending, reconcileTransferQueue]);
+}

--- a/src/store/appStore.transferQueue.test.ts
+++ b/src/store/appStore.transferQueue.test.ts
@@ -33,7 +33,7 @@ vi.mock("@/services/api", () => ({
 }));
 
 import { useAppStore } from "./appStore";
-import type { TransferProgress } from "@/services/api";
+import type { TransferProgress, TransferSnapshot } from "@/services/api";
 import type { TransferEntry } from "@/types/transfer";
 
 function entry(overrides: Partial<TransferEntry> = {}): TransferEntry {
@@ -61,6 +61,23 @@ function progress(overrides: Partial<TransferProgress> = {}): TransferProgress {
     transferred: 0,
     total: 100,
     phase: "transferring",
+    ...overrides,
+  };
+}
+
+function snapshot(overrides: Partial<TransferSnapshot> = {}): TransferSnapshot {
+  return {
+    transferId: "t1",
+    sessionId: "sess-a",
+    direction: "download",
+    fileName: "file.txt",
+    path: "/remote/file.txt",
+    state: "completed",
+    transferred: 100,
+    total: 100,
+    speed: 0,
+    attempt: 0,
+    maxAttempts: 3,
     ...overrides,
   };
 }
@@ -231,6 +248,82 @@ describe("appStore — transfer queue slice (#1337)", () => {
         totalBytes: 2048,
         state: "queued",
       });
+    });
+  });
+
+  describe("reconcileTransferQueue (#1645)", () => {
+    it("settles a stuck seeded row when its terminal event was never delivered", () => {
+      // The exact #1645 scenario: a transfer is seeded (#1632), completes on the
+      // backend, but *every* transfer-progress event — including the terminal
+      // one — is dropped. The row is stuck at `queued`; a backend snapshot must
+      // settle it to `completed`.
+      const store = useAppStore.getState();
+      store.seedTransferQueue({
+        id: "t1",
+        sessionId: "sess-a",
+        direction: "download",
+        name: "file.txt",
+        path: "/remote/file.txt",
+      });
+      expect(useAppStore.getState().transferQueue["t1"].state).toBe("queued");
+
+      store.reconcileTransferQueue([snapshot({ state: "completed", transferred: 100 })]);
+
+      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({
+        state: "completed",
+        transferred: 100,
+        percent: 100,
+      });
+    });
+
+    it("settles a stuck active row to failed/cancelled from a terminal snapshot", () => {
+      const store = useAppStore.getState();
+      store.addTransfer(entry({ id: "t1", state: "active", transferred: 40 }));
+      store.reconcileTransferQueue([snapshot({ state: "failed", transferred: 40 })]);
+      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({ state: "failed" });
+    });
+
+    it("is idempotent — never clobbers a row an event already settled", () => {
+      const store = useAppStore.getState();
+      // An event already settled the row to cancelled…
+      store.applyTransferProgressToQueue(progress({ phase: "cancelled", transferred: 20 }));
+      expect(useAppStore.getState().transferQueue["t1"].state).toBe("cancelled");
+      // …a later snapshot reporting a different terminal state must not override.
+      store.reconcileTransferQueue([snapshot({ state: "completed", transferred: 100 })]);
+      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({
+        state: "cancelled",
+        transferred: 20,
+      });
+    });
+
+    it("does not move a live (active) row — a non-terminal snapshot is ignored", () => {
+      const store = useAppStore.getState();
+      store.addTransfer(entry({ id: "t1", state: "active", transferred: 60, percent: 60 }));
+      // A lagging snapshot that still reads active/0 must not regress the row.
+      store.reconcileTransferQueue([snapshot({ state: "active", transferred: 0 })]);
+      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({
+        state: "active",
+        transferred: 60,
+      });
+    });
+
+    it("does not resurrect a row that is not (or no longer) in the queue", () => {
+      const store = useAppStore.getState();
+      store.reconcileTransferQueue([snapshot({ transferId: "ghost", state: "completed" })]);
+      expect(useAppStore.getState().transferQueue["ghost"]).toBeUndefined();
+    });
+
+    it("settles only the stuck rows, leaving others untouched", () => {
+      const store = useAppStore.getState();
+      store.seedTransferQueue({ id: "stuck", sessionId: "s", direction: "download", name: "a" });
+      store.addTransfer(entry({ id: "done", state: "completed" }));
+      store.reconcileTransferQueue([
+        snapshot({ transferId: "stuck", state: "completed" }),
+        snapshot({ transferId: "done", state: "cancelled" }), // must be ignored (already terminal)
+      ]);
+      const q = useAppStore.getState().transferQueue;
+      expect(q["stuck"].state).toBe("completed");
+      expect(q["done"].state).toBe("completed");
     });
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -109,11 +109,14 @@ import type {
   ContainerSpawn,
   ShellSpawn,
   TransferProgress,
+  TransferSnapshot,
 } from "@/services/api";
 import type { SpawnRequestPayload } from "@/services/events";
 import {
+  isTerminalTransferState,
   transferEntryFromProgress,
   transferEntryFromSeed,
+  transferEntryFromSnapshot,
   type TransferEntry,
   type TransferSeed,
 } from "@/types/transfer";
@@ -774,6 +777,15 @@ interface AppState {
    * the id already exists, so it never clobbers a further-along event-fed row.
    */
   seedTransferQueue: (seed: TransferSeed) => void;
+  /**
+   * Reconcile the queue against a backend `transfer_list` snapshot (#1645), the
+   * backstop for a dropped *terminal* `transfer-progress` event. Settles any
+   * still-open row whose backend snapshot reports a terminal state to that
+   * state. Idempotent and conservative: it never resurrects a removed row,
+   * never clobbers an already-terminal row, and never moves a live (active)
+   * row — event delivery owns live progress; this only settles stuck rows.
+   */
+  reconcileTransferQueue: (snapshots: TransferSnapshot[]) => void;
 
   // Per-tab CWD tracking
   tabCwds: Record<string, string>;
@@ -3781,6 +3793,25 @@ export const useAppStore = create<AppState>((set, get) => {
         if (seed.id in state.transferQueue) return {};
         const entry = transferEntryFromSeed(seed, Date.now());
         return { transferQueue: { ...state.transferQueue, [entry.id]: entry } };
+      }),
+
+    reconcileTransferQueue: (snapshots: TransferSnapshot[]) =>
+      set((state) => {
+        const now = Date.now();
+        let next: Record<string, TransferEntry> | null = null;
+        for (const snap of snapshots) {
+          // Only a terminal snapshot settles a row — events own live progress,
+          // so a snapshot must never move an active row (it may lag / read 0).
+          if (!isTerminalTransferState(snap.state)) continue;
+          const prev = state.transferQueue[snap.transferId];
+          // Seed owns row creation; do not resurrect a row the user removed.
+          if (!prev) continue;
+          // Already settled (an event beat us here): idempotent no-op.
+          if (isTerminalTransferState(prev.state)) continue;
+          next ??= { ...state.transferQueue };
+          next[snap.transferId] = transferEntryFromSnapshot(snap, prev, now);
+        }
+        return next ? { transferQueue: next } : {};
       }),
 
     retrySftp: async () => {

--- a/src/types/transfer.test.ts
+++ b/src/types/transfer.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
   transferEntryFromProgress,
+  transferEntryFromSnapshot,
   stateFromPhase,
   isTerminalTransferState,
   formatThroughput,
   type TransferEntry,
 } from "./transfer";
-import type { TransferProgress } from "@/services/api";
+import type { TransferProgress, TransferSnapshot } from "@/services/api";
 
 function progress(overrides: Partial<TransferProgress> = {}): TransferProgress {
   return {
@@ -17,6 +18,23 @@ function progress(overrides: Partial<TransferProgress> = {}): TransferProgress {
     transferred: 0,
     total: 100,
     phase: "transferring",
+    ...overrides,
+  };
+}
+
+function snapshot(overrides: Partial<TransferSnapshot> = {}): TransferSnapshot {
+  return {
+    transferId: "t1",
+    sessionId: "sess-a",
+    direction: "download",
+    fileName: "file.txt",
+    path: "/remote/file.txt",
+    state: "completed",
+    transferred: 100,
+    total: 100,
+    speed: 0,
+    attempt: 0,
+    maxAttempts: 3,
     ...overrides,
   };
 }
@@ -148,6 +166,69 @@ describe("transferEntryFromProgress", () => {
       0
     );
     expect(entry.path).toBe("/new/path.txt");
+  });
+});
+
+describe("transferEntryFromSnapshot (#1645)", () => {
+  it("settles a completed snapshot to a full, 100% row", () => {
+    const entry = transferEntryFromSnapshot(snapshot({ state: "completed" }), undefined, 1000);
+    expect(entry).toMatchObject({
+      id: "t1",
+      sessionId: "sess-a",
+      direction: "download",
+      name: "file.txt",
+      path: "/remote/file.txt",
+      state: "completed",
+      transferred: 100,
+      totalBytes: 100,
+      percent: 100,
+      updatedAt: 1000,
+    });
+  });
+
+  it("maps a failed snapshot to a failed row with a fallback error", () => {
+    const entry = transferEntryFromSnapshot(
+      snapshot({ state: "failed", transferred: 30 }),
+      undefined,
+      0
+    );
+    expect(entry.state).toBe("failed");
+    expect(entry.error).toBe("Transfer failed");
+  });
+
+  it("preserves the prior row's path and error where the snapshot lacks them", () => {
+    const prev: TransferEntry = {
+      id: "t1",
+      sessionId: "sess-a",
+      direction: "download",
+      name: "file.txt",
+      path: "/prev/path.txt",
+      state: "active",
+      transferred: 50,
+      totalBytes: 100,
+      percent: 50,
+      speedBytesPerSec: 1000,
+      error: "earlier error",
+      updatedAt: 0,
+    };
+    const entry = transferEntryFromSnapshot(
+      snapshot({ path: undefined, state: "failed" }),
+      prev,
+      2000
+    );
+    expect(entry.path).toBe("/prev/path.txt");
+    expect(entry.error).toBe("earlier error");
+  });
+
+  it("reports an indeterminate percent when the total is unknown", () => {
+    const entry = transferEntryFromSnapshot(
+      snapshot({ state: "cancelled", total: 0, transferred: 10 }),
+      undefined,
+      0
+    );
+    expect(entry.state).toBe("cancelled");
+    expect(entry.percent).toBeNull();
+    expect(entry.totalBytes).toBeNull();
   });
 });
 

--- a/src/types/transfer.ts
+++ b/src/types/transfer.ts
@@ -1,4 +1,4 @@
-import type { TransferProgress, TransferQueueState } from "@/services/api";
+import type { TransferProgress, TransferQueueState, TransferSnapshot } from "@/services/api";
 
 /**
  * The connection-type-agnostic state space of a queued file transfer, as shown
@@ -193,6 +193,53 @@ export function transferEntryFromProgress(
     error: state === "failed" ? (progress.message ?? "Transfer failed") : undefined,
     attempt: progress.attempt ?? prev?.attempt,
     maxAttempts: progress.maxAttempts ?? prev?.maxAttempts,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Fold a backend {@link TransferSnapshot} (from `transfer_list`) into a
+ * {@link TransferEntry}, for the reconcile backstop (#1645).
+ *
+ * Unlike a `transfer-progress` event, a snapshot carries the rich `state`
+ * directly. This is used only to **settle a stuck non-terminal row** to its true
+ * terminal state when the terminal event was dropped — it is never used to move
+ * a live row's progress (events own that), so it cannot regress an
+ * event-advanced row. `prev` is the existing row being settled; its `path` /
+ * retry counters / error are preserved where the snapshot does not supply them.
+ */
+export function transferEntryFromSnapshot(
+  snapshot: TransferSnapshot,
+  prev: TransferEntry | undefined,
+  now: number
+): TransferEntry {
+  const totalRaw = snapshot.total;
+  const totalBytes = totalRaw && totalRaw > 0 ? totalRaw : (prev?.totalBytes ?? null);
+  const state = snapshot.state;
+
+  let percent: number | null;
+  if (state === "completed") {
+    percent = 100;
+  } else if (totalBytes && totalBytes > 0) {
+    percent = Math.min(100, Math.max(0, Math.round((snapshot.transferred / totalBytes) * 100)));
+  } else {
+    percent = null;
+  }
+
+  return {
+    id: snapshot.transferId,
+    sessionId: snapshot.sessionId,
+    direction: snapshot.direction,
+    name: snapshot.fileName,
+    path: snapshot.path ?? prev?.path,
+    state,
+    transferred: snapshot.transferred,
+    totalBytes,
+    percent,
+    speedBytesPerSec: snapshot.speed > 0 ? snapshot.speed : null,
+    error: state === "failed" ? (prev?.error ?? "Transfer failed") : undefined,
+    attempt: snapshot.attempt || prev?.attempt,
+    maxAttempts: snapshot.maxAttempts || prev?.maxAttempts,
     updatedAt: now,
   };
 }


### PR DESCRIPTION
## What & why

Follow-up to #1632 (PR #1644). #1644 makes the Transfer Queue **panel open**
independent of `transfer-progress` delivery by seeding a `queued` row from the
transfer's registration id. It does **not** self-heal a row whose *terminal*
event (`done`/`error`/`cancelled`) is also dropped under memory pressure: such a
row stays visually stuck at `queued`/`active` forever.

This adds the reconcile backstop #1645 asks for. A naive "reconcile from
`transfer_list`" could not work before, for two reasons #1632 documented:

- SFTP transfers register in the registry's **legacy token map**, not the
  **rich** map that `transfer_list` snapshots — so they never appeared at all.
- Rich transfers are `drop_entry`'d on completion — so a *completed* rich
  transfer was gone from the snapshot too.

Both are fixed here, then the frontend reconciles against the snapshot.

## Backend — make the terminal state observable

- **Legacy SFTP now appears in `transfer_list`.** `register` carries the
  transfer identity (session, direction, file name, path, total); a live legacy
  transfer lists as `active`.
- **Recently-terminal transfers are retained** in a bounded, TTL'd history
  (**60 s / 64 entries**) instead of vanishing on completion. `finish_legacy`
  records the SFTP terminal state (`completed`/`cancelled`/`failed` + final byte
  count); `drop_entry` records a completed/cancelled **rich** transfer's
  snapshot before removing it. `transfer_list` returns live rich + live legacy +
  retained-terminal, with live entries shadowing retained ones by id.

### Retention policy & why

The frontend polls on a few-second tick while any row is in-flight, so a **60 s
TTL** is an order of magnitude larger than the catch window — ample to settle a
transfer whose terminal event was dropped, without holding completed transfers
around. The **64-entry cap** bounds memory against a completion burst between
TTL sweeps (each retained entry is a small `TransferSnapshot`). Both bounds
evict oldest-first, so memory cannot leak. Transfer ids are UUIDv4, so id reuse
is a non-issue; `list()` guards it anyway by letting a live entry shadow a
retained snapshot of the same id.

## Frontend — the reconcile

`useTransferReconcile` polls the reliable request/response `transfer_list`
snapshot **while any row is non-terminal** (and on window focus) and settles a
stuck row to its true terminal state via a new `reconcileTransferQueue` store
action. It is conservative and idempotent:

- Only settles a still-open row to a **terminal** snapshot state — events own
  live progress, so a lagging/zero snapshot can never regress a live row.
- Never resurrects a removed row; never clobbers an already-terminal row.
- Polling is gated on a pending row, so an idle app makes **no** backend calls.

## Reproduction / verification

Real jetsam can't be manufactured on a shared multi-slot machine (and must not
be driven to OOM), so the fix is proven by **simulating a fully-dropped event
stream** — including the terminal event — and asserting the reconcile settles
the row from the backend snapshot alone:

- `useTransferReconcile.test.ts` — a seeded row whose every `transfer-progress`
  event was dropped settles to `completed` from the `transfer_list` snapshot;
  no backend call is made when nothing is pending.
- `appStore.transferQueue.test.ts` — `reconcileTransferQueue` settles a stuck
  seeded/active row; is idempotent; never clobbers a settled row; never moves a
  live row; never resurrects a removed row.
- `transfer.test.ts` — `transferEntryFromSnapshot` mapping.
- `registry.rs` — legacy transfer lists as active; `finish_legacy` / rich
  `drop_entry` retain terminal snapshots after the live entry is gone; capacity
  and TTL eviction; live shadows retained; session filtering.

`tsc --noEmit`, `pnpm build`, eslint, `cargo fmt`/`clippy -D warnings`, the full
frontend suite (3390) and the transfer backend tests are green.

## Follow-up

Two low-severity notes from self-review (not blocking, both self-correcting):
a rich FTP transfer transiently `failed` mid-retry could be settled to `failed`
by a reconcile; and the pending-row selector re-scans on every store mutation.
Will file a `Ready2Implement` follow-up referencing #1645 if worth hardening.

Closes #1645