### PR TITLE
test(system): dismiss confirm-session-close dialog in close_tab helper (Closes #1654)

### DIFF
--- a/tests/system/termihub_harness/ui/tabs.py
+++ b/tests/system/termihub_harness/ui/tabs.py
@@ -88,9 +88,19 @@ class TabsUi(HarnessMixin):
     def close_tab(self, tab_id: str) -> None:
         """Close the tab with the given id, confirming any close dialog.
 
-        Two dialogs can intercept a close: the keyboard-shortcut confirm
-        (``confirm-close-tab-confirm``) and the unsaved-changes dialog a dirty
-        editor/connection/settings tab raises (``unsaved-changes-just-close``).
+        Up to three dialogs can intercept a close, and they can chain:
+
+        * the keyboard-shortcut confirm (``confirm-close-tab-confirm``);
+        * the unsaved-changes dialog a dirty editor/connection/settings tab
+          raises (``unsaved-changes-just-close``);
+        * the live-session confirm a tab holding a live terminal session raises
+          (``confirm-session-close-dialog``, whose confirm button is
+          ``ConfirmDialog``'s ``confirm-dialog-confirm``). This is on by default
+          — ``settings.confirmCloseLiveSession`` defaults to ``true`` (#1654).
+
+        Dismissing the unsaved-changes dialog can in turn surface the
+        live-session dialog (``finishCloseTab`` runs only after the unsaved gate
+        clears), so the live-session dialog is checked last.
         """
         self.driver.click(f"tab-close-{tab_id}")
         time.sleep(0.3)
@@ -98,6 +108,9 @@ class TabsUi(HarnessMixin):
             self.driver.click("confirm-close-tab-confirm")
         if self.driver.exists("unsaved-changes-just-close"):
             self.driver.click("unsaved-changes-just-close")
+            time.sleep(0.3)
+        if self.driver.exists("confirm-session-close-dialog"):
+            self.driver.click("confirm-dialog-confirm")
 
     def close_all_tabs(self) -> None:
         """Close every open tab (e.g. between reconnect checks).

--- a/tests/system/tests/test_tab_management.py
+++ b/tests/system/tests/test_tab_management.py
@@ -40,6 +40,21 @@ class TestTabManagement(TerminalUi, TabsUi, SystemTest):
         self.close_tab(target)
         self.wait(lambda: target not in self.tab_ids(), what="the tab to close")
 
+    def test_closing_a_live_session_tab_dismisses_confirm_dialog(self):
+        # Regression for #1654: a tab holding a live terminal session raises
+        # ConfirmSessionCloseDialog on close (``confirmCloseLiveSession`` defaults
+        # on). ``close_tab`` must dismiss it, otherwise the tab never closes and
+        # ``close_all_tabs`` loops re-clicking the X against a stuck dialog.
+        self._reset()
+        self.driver.click(NEW)
+        self.wait(lambda: len(self.tab_ids()) >= 2, what="a second live-session tab")
+        target = self.tab_ids()[-1]
+        self.close_tab(target)
+        self.wait(lambda: target not in self.tab_ids(), what="the live-session tab to close")
+        assert not self.driver.exists(
+            "confirm-session-close-dialog"
+        ), "the live-session confirm dialog must be dismissed, not left blocking the close"
+
     def test_right_click_opens_the_tab_context_menu(self):
         self._reset()
         tab = self.tab_ids()[0]


### PR DESCRIPTION
## Summary

Fixes a test-harness gap: the `close_tab` helper (`tests/system/termihub_harness/ui/tabs.py`) could not dismiss the **confirm-session-close** dialog, so closing a tab that holds a **live terminal session** left the dialog blocking the close. `close_all_tabs` then looped re-clicking `tab-close-<id>`, re-raising the dialog each pass — the "repeated / flickering popup" the owner saw in local runs.

Root cause: `settings.confirmCloseLiveSession` defaults to `true`, so closing a live-session tab raises `ConfirmSessionCloseDialog` (`confirm-session-close-dialog`, confirmed via `ConfirmDialog`'s `confirm-dialog-confirm`). The helper only dismissed the two *other* close dialogs (`confirm-close-tab-confirm`, `unsaved-changes-just-close`) and had no handler for this one. Harness rot from the confirm-live-session feature (`ddc84679`) landing without a matching `close_tab` update; unnoticed because the integration lane is CI-dark (#1569).

## Fix — option 1 (handle it in `close_tab`)

Chose the harness handler over disabling the setting for the whole suite: it is the smallest change, mirrors how the helper already dismisses the other two dialogs, and — critically — does **not** hide the dialog from the tests that assert its behaviour (`ConfirmSessionCloseDialog.test.tsx`). A blanket `confirmCloseLiveSession: false` in the test config risked masking that behaviour.

After clicking `tab-close-<id>`, the helper now also dismisses `confirm-session-close-dialog`. It is checked **last** because dismissing the unsaved-changes dialog can itself surface the live-session dialog (`finishCloseTab` runs only after the unsaved gate clears). Because every close path (including `close_all_tabs`) funnels through `close_tab`, no other helper needed changing.

## Verification (local — integration lane is CI-dark, #1569)

- `TestTabManagement` system suite (which closes live-session terminal tabs, and whose `_reset`/`close_all_tabs` drain live terminals): **flickered/failed before, clean after.** No dialog flicker, no close loop.
- New regression `test_closing_a_live_session_tab_dismisses_confirm_dialog` asserts the tab closes and no `confirm-session-close-dialog` lingers.
- The dialog's own unit tests (`ConfirmSessionCloseDialog.test.tsx`) still pass — this change does not touch app behaviour, only the harness.

## Scope

Test-harness only. No app/product behaviour changed (the `ConfirmSessionCloseDialog` and the `confirmCloseLiveSession` default are untouched).

Closes #1654