### PR TITLE
fix(sftp): harden transfer-queue reconcile against transient rich-failed + selector re-scan (Closes #1657)

### DIFF
--- a/docs/changes/dev3/fix/1657-transfer-reconcile-harden.md
+++ b/docs/changes/dev3/fix/1657-transfer-reconcile-harden.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Transfer Queue: the reconcile backstop (#1645) no longer risks freezing a
+  rich (FTP) transfer at `failed` while it is actually auto-retrying. The
+  backend `transfer_list` snapshot now marks whether a transfer is *genuinely*
+  settled, so a live handle that is momentarily `failed` mid retry — or awaiting
+  a manual retry — is never folded into a terminal `failed` row; only real
+  terminals (completed/cancelled, and genuinely-final legacy SFTP failures)
+  settle a stuck row (#1657).

--- a/docs/changes/dev3/fix/1657-transfer-reconcile-harden.md
+++ b/docs/changes/dev3/fix/1657-transfer-reconcile-harden.md
@@ -2,7 +2,7 @@
 
 - Transfer Queue: the reconcile backstop (#1645) no longer risks freezing a
   rich (FTP) transfer at `failed` while it is actually auto-retrying. The
-  backend `transfer_list` snapshot now marks whether a transfer is *genuinely*
+  backend `transfer_list` snapshot now marks whether a transfer is _genuinely_
   settled, so a live handle that is momentarily `failed` mid retry — or awaiting
   a manual retry — is never folded into a terminal `failed` row; only real
   terminals (completed/cancelled, and genuinely-final legacy SFTP failures)

--- a/src-tauri/src/files/transfer/registry.rs
+++ b/src-tauri/src/files/transfer/registry.rs
@@ -54,6 +54,19 @@ pub struct TransferSnapshot {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub path: String,
     pub state: TransferStateTag,
+    /// Whether this snapshot is a *genuinely* settled outcome the frontend
+    /// reconcile may fold into a stuck row (#1657).
+    ///
+    /// This is stricter than [`TransferStateTag::is_terminal`]. A **live** rich
+    /// (FTP) handle in a `failed` state is not settled: it may still auto-retry
+    /// after backoff, or sit awaiting a manual retry — so it reports
+    /// `state: failed` with `settled: false`. Only [`TransferState::is_terminal`]
+    /// states from a live handle (`completed`/`cancelled`) and
+    /// [retained-terminal](Self) snapshots (a completed/cancelled rich transfer,
+    /// or a genuinely-final legacy SFTP transfer) are `settled`. This stops a
+    /// transient mid-retry failure from being reconciled into a terminal
+    /// `failed` row (which the reconcile guard would then never re-settle).
+    pub settled: bool,
     pub transferred: u64,
     pub total: u64,
     pub speed: u64,
@@ -177,6 +190,10 @@ impl TransferHandle {
             file_name: self.file_name.clone(),
             path: self.path.clone(),
             state: c.state.tag(),
+            // A live rich handle is settled only when genuinely terminal
+            // (completed/cancelled). A live `failed` handle may still auto-retry
+            // or await a manual retry, so it is *not* settled (#1657).
+            settled: c.state.is_terminal(),
             transferred: c.transferred,
             total: c.total,
             speed: c.speed,
@@ -218,6 +235,8 @@ impl LegacyEntry {
             file_name: self.file_name.clone(),
             path: self.path.clone(),
             state: TransferStateTag::Active,
+            // A live legacy transfer is always in-flight, never settled (#1657).
+            settled: false,
             transferred: 0,
             total: self.total,
             speed: 0,
@@ -401,7 +420,11 @@ impl TransferRegistry {
 
     /// Push a terminal snapshot into the retention history, then evict anything
     /// past the capacity or TTL bound. Callers hold the state lock.
-    fn record_terminal_locked(state: &mut RegistryState, snapshot: TransferSnapshot) {
+    fn record_terminal_locked(state: &mut RegistryState, mut snapshot: TransferSnapshot) {
+        // A retained terminal is, by definition, a genuinely-final outcome the
+        // reconcile may settle a stuck row to — including a legacy SFTP failure
+        // (which, unlike a live rich `failed` handle, never retries) (#1657).
+        snapshot.settled = true;
         let now = Instant::now();
         state
             .terminal
@@ -957,6 +980,66 @@ mod tests {
         assert_eq!(list.len(), 1, "the completed transfer is retained");
         assert_eq!(list[0].transfer_id, "r1");
         assert_eq!(list[0].state, TransferStateTag::Completed);
+        assert!(list[0].settled, "a retained completed transfer is settled");
+    }
+
+    // --- Genuinely-settled vs transient rich `failed` (#1657) ---
+
+    #[test]
+    fn a_live_rich_failed_handle_is_listed_failed_but_not_settled() {
+        // A rich (FTP) transfer that failed an attempt but may still auto-retry
+        // (retryable) — or has exhausted retries and sits awaiting a manual
+        // retry (non-retryable) — is a *live* handle. It must surface its
+        // `failed` state for display, but must NOT be `settled`, so a reconcile
+        // never folds a still-recoverable transfer into a terminal `failed` row
+        // (#1657).
+        for attempt in [1, MAX_RETRIES] {
+            let reg = TransferRegistry::new();
+            let h = enq(&reg, "r1", "sess-a");
+            reg.request_slot(&h); // Queued → Active
+            h.transition(TransferEvent::Fail { attempt }); // Active → Failed
+            assert!(
+                matches!(h.state(), TransferState::Failed { .. }),
+                "the handle is in a failed state"
+            );
+
+            let list = reg.list(None);
+            assert_eq!(list.len(), 1, "the live failed handle is still listed");
+            assert_eq!(list[0].state, TransferStateTag::Failed);
+            assert!(
+                !list[0].settled,
+                "a live rich `failed` handle (attempt {attempt}) is not settled — it may still retry"
+            );
+        }
+    }
+
+    #[test]
+    fn a_retained_legacy_failure_is_settled() {
+        // Unlike a live rich `failed` handle, a legacy SFTP transfer that failed
+        // is genuinely final (it does not retry through the registry), so its
+        // retained snapshot is settled and a reconcile may fold it in (#1657).
+        let reg = TransferRegistry::new();
+        reg.register("s1", "sess-a", TransferDirection::Download, "f", "/f", 100);
+        reg.finish_legacy("s1", TransferStateTag::Failed, 30);
+
+        let list = reg.list(None);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].state, TransferStateTag::Failed);
+        assert!(
+            list[0].settled,
+            "a retained legacy failure is genuinely settled"
+        );
+    }
+
+    #[test]
+    fn a_live_active_rich_handle_is_not_settled() {
+        let reg = TransferRegistry::new();
+        let h = enq(&reg, "r1", "sess-a");
+        reg.request_slot(&h); // Active
+        let list = reg.list(None);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].state, TransferStateTag::Active);
+        assert!(!list[0].settled, "a live active transfer is not settled");
     }
 
     #[test]

--- a/src/hooks/useTransferReconcile.test.ts
+++ b/src/hooks/useTransferReconcile.test.ts
@@ -9,14 +9,24 @@ vi.mock("@/services/api", async () => {
 
 vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
 
+// Spy on `isTerminalTransferState` (keeping its real behaviour) so a test can
+// prove the pending-row scan is memoized and does not re-run on unrelated store
+// mutations (#1657).
+vi.mock("@/types/transfer", async () => {
+  const actual = await vi.importActual<typeof import("@/types/transfer")>("@/types/transfer");
+  return { ...actual, isTerminalTransferState: vi.fn(actual.isTerminalTransferState) };
+});
+
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { useTransferReconcile } from "./useTransferReconcile";
 import { useAppStore } from "@/store/appStore";
 import { transferList } from "@/services/api";
+import { isTerminalTransferState } from "@/types/transfer";
 import type { TransferSnapshot } from "@/services/api";
 
 const mockTransferList = vi.mocked(transferList);
+const mockIsTerminal = vi.mocked(isTerminalTransferState);
 
 function snapshot(overrides: Partial<TransferSnapshot> = {}): TransferSnapshot {
   return {
@@ -26,6 +36,7 @@ function snapshot(overrides: Partial<TransferSnapshot> = {}): TransferSnapshot {
     fileName: "file.txt",
     path: "/remote/file.txt",
     state: "completed",
+    settled: true,
     transferred: 100,
     total: 100,
     speed: 0,
@@ -111,5 +122,49 @@ describe("useTransferReconcile (#1645)", () => {
     await mountHook();
 
     expect(mockTransferList).not.toHaveBeenCalled();
+  });
+
+  it("does not settle a stuck row from a transient rich `failed` snapshot (settled:false, #1657)", async () => {
+    // The row is seeded/stuck at `queued`; the backend reports the transfer as
+    // `failed` but `settled: false` — a live rich handle mid auto-retry. The
+    // reconcile must leave the row non-terminal so a later recovery can settle
+    // it, rather than freezing it at `failed`.
+    useAppStore.getState().seedTransferQueue({
+      id: "t1",
+      sessionId: "sess-a",
+      direction: "download",
+      name: "file.txt",
+      path: "/remote/file.txt",
+    });
+    mockTransferList.mockResolvedValue([snapshot({ state: "failed", settled: false })]);
+
+    await mountHook();
+
+    expect(mockTransferList).toHaveBeenCalled();
+    expect(useAppStore.getState().transferQueue["t1"].state).toBe("queued");
+  });
+
+  it("does not re-scan the queue for pending rows on an unrelated store mutation (#1657)", async () => {
+    // With a pending row present, the pending-row derivation is memoized on the
+    // `transferQueue` reference, so an unrelated `setState` (which leaves that
+    // reference untouched) must not re-run the O(rows) scan.
+    useAppStore.getState().seedTransferQueue({
+      id: "t1",
+      sessionId: "sess-a",
+      direction: "download",
+      name: "file.txt",
+      path: "/remote/file.txt",
+    });
+
+    await mountHook();
+    // The mount's initial render already ran the scan; from here it must not.
+    mockIsTerminal.mockClear();
+
+    act(() => {
+      // A mutation to an unrelated slice — the queue reference is unchanged.
+      useAppStore.setState({ tabCwds: { "tab-1": "/home/user" } });
+    });
+
+    expect(mockIsTerminal).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useTransferReconcile.ts
+++ b/src/hooks/useTransferReconcile.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useAppStore } from "@/store/appStore";
 import { transferList } from "@/services/api";
 import { frontendLog } from "@/utils/frontendLog";
@@ -28,10 +28,15 @@ const RECONCILE_INTERVAL_MS = 4000;
  */
 export function useTransferReconcile(): void {
   const reconcileTransferQueue = useAppStore((s) => s.reconcileTransferQueue);
-  // Re-runs the effect only when this boolean flips (Object.is equality), so the
-  // poll starts when a transfer begins and stops when the last row settles.
-  const hasPending = useAppStore((s) =>
-    Object.values(s.transferQueue).some((e) => !isTerminalTransferState(e.state))
+  // Select the queue slice by reference (O(1) per store mutation), then derive
+  // the pending flag with `useMemo` so the O(rows) scan runs *only* when the
+  // queue actually changes — not on every unrelated `setState` (#1657). The
+  // effect below still re-runs only when this boolean flips, so the poll starts
+  // when a transfer begins and stops when the last row settles.
+  const transferQueue = useAppStore((s) => s.transferQueue);
+  const hasPending = useMemo(
+    () => Object.values(transferQueue).some((e) => !isTerminalTransferState(e.state)),
+    [transferQueue]
   );
 
   useEffect(() => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -826,6 +826,14 @@ export interface TransferSnapshot {
   /** Remote path of the transferred file, when the backend supplies one (#1531). */
   path?: string;
   state: TransferQueueState;
+  /**
+   * Whether this snapshot is a *genuinely* settled outcome the reconcile may
+   * fold into a stuck row (#1657). Stricter than `isTerminalTransferState`: a
+   * live rich (FTP) transfer that is momentarily `failed` mid auto-retry — or
+   * awaiting a manual retry — reports `state: "failed"` with `settled: false`,
+   * so a transient failure is never reconciled into a terminal `failed` row.
+   */
+  settled: boolean;
   transferred: number;
   total: number;
   speed: number;

--- a/src/store/appStore.transferQueue.test.ts
+++ b/src/store/appStore.transferQueue.test.ts
@@ -73,6 +73,7 @@ function snapshot(overrides: Partial<TransferSnapshot> = {}): TransferSnapshot {
     fileName: "file.txt",
     path: "/remote/file.txt",
     state: "completed",
+    settled: true,
     transferred: 100,
     total: 100,
     speed: 0,
@@ -279,8 +280,24 @@ describe("appStore — transfer queue slice (#1337)", () => {
     it("settles a stuck active row to failed/cancelled from a terminal snapshot", () => {
       const store = useAppStore.getState();
       store.addTransfer(entry({ id: "t1", state: "active", transferred: 40 }));
-      store.reconcileTransferQueue([snapshot({ state: "failed", transferred: 40 })]);
+      store.reconcileTransferQueue([snapshot({ state: "failed", settled: true, transferred: 40 })]);
       expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({ state: "failed" });
+    });
+
+    it("does NOT settle a row from a transient rich `failed` snapshot (settled:false, #1657)", () => {
+      // A rich (FTP) transfer that is momentarily `failed` mid auto-retry — or
+      // awaiting a manual retry — lists as `failed` but `settled: false`. The
+      // reconcile must leave the row non-terminal, so a subsequent recovery (or
+      // its dropped terminal event) can still settle it correctly.
+      const store = useAppStore.getState();
+      store.addTransfer(entry({ id: "t1", state: "active", transferred: 40, percent: 40 }));
+      store.reconcileTransferQueue([
+        snapshot({ state: "failed", settled: false, transferred: 40 }),
+      ]);
+      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({
+        state: "active",
+        transferred: 40,
+      });
     });
 
     it("is idempotent — never clobbers a row an event already settled", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3800,9 +3800,13 @@ export const useAppStore = create<AppState>((set, get) => {
         const now = Date.now();
         let next: Record<string, TransferEntry> | null = null;
         for (const snap of snapshots) {
-          // Only a terminal snapshot settles a row — events own live progress,
-          // so a snapshot must never move an active row (it may lag / read 0).
-          if (!isTerminalTransferState(snap.state)) continue;
+          // Only a *genuinely settled* terminal snapshot settles a row. A live
+          // rich `failed` handle mid auto-retry (or awaiting a manual retry)
+          // reports `settled: false` though its state is `failed`, so a
+          // transient failure is never folded into a terminal row the reconcile
+          // guard would then never re-settle (#1657). Events own live progress,
+          // so a non-terminal snapshot must never move an active row anyway.
+          if (!snap.settled || !isTerminalTransferState(snap.state)) continue;
           const prev = state.transferQueue[snap.transferId];
           // Seed owns row creation; do not resurrect a row the user removed.
           if (!prev) continue;

--- a/src/types/transfer.test.ts
+++ b/src/types/transfer.test.ts
@@ -30,6 +30,7 @@ function snapshot(overrides: Partial<TransferSnapshot> = {}): TransferSnapshot {
     fileName: "file.txt",
     path: "/remote/file.txt",
     state: "completed",
+    settled: true,
     transferred: 100,
     total: 100,
     speed: 0,


### PR DESCRIPTION
Follow-up to #1645 (PR #1653, merge \`818082f9\`). Addresses the two low-severity self-review notes #1657 raised, without regressing the #1645 reconcile backstop.

## Item 1 — transient rich \`failed\` is no longer settled as terminal

**The bug (real, verified):** a rich (FTP) transfer that is momentarily \`Failed\` is a **live handle** — either mid auto-retry during backoff (\`Failed { retryable: true }\`, \`ftp.rs\`) or awaiting a manual retry after exhausting attempts (\`Failed { retryable: false }\`, which the executor keeps live rather than dropping). Its \`transfer_list\` snapshot reported \`state: failed\`, which \`isTerminalTransferState\` treats as terminal, so the reconcile could settle a still-open row to terminal \`failed\`. The guard \`if isTerminalTransferState(prev.state) continue\` then never re-settles it — so if the later success event was *also* dropped, the row froze at \`failed\`.

Rich transfers never *retain* a \`failed\` snapshot (only \`completed\`/\`cancelled\` via \`drop_entry\`); a retained \`failed\` only ever comes from a legacy SFTP \`finish_legacy\`, which **is** genuinely final.

**The fix:** \`TransferSnapshot\` gains a \`settled\` flag — whether the snapshot is a *genuinely* final outcome the reconcile may fold into a stuck row.
- A **live** rich handle is \`settled\` only when truly terminal (\`completed\`/\`cancelled\`, via \`TransferState::is_terminal\`); a live \`failed\` handle is **not** settled.
- A live legacy transfer is never settled (always active).
- **Retained-terminal** snapshots are always settled (a completed/cancelled rich transfer, or a genuinely-final legacy SFTP failure).

The frontend reconcile now skips \`!snap.settled\`, so a transient/awaiting-retry rich \`failed\` is never settled, while a genuinely-dropped terminal event still settles the stuck row exactly as #1645 intended.

## Item 2 — pending-row selector no longer re-scans on unrelated mutations

\`useTransferReconcile\`'s selector ran \`Object.values(transferQueue).some(...)\` on **every** \`setState\` (Zustand evaluates all selectors per mutation), not only on transferQueue changes. Now the hook selects the queue slice by reference (O(1) per mutation) and derives the pending flag with \`useMemo\`, so the O(rows) scan runs only when the queue actually changes.

## Tests

- **Backend** (\`registry.rs\`): a live rich \`failed\` handle (both retryable and exhausted) lists as \`failed\` but \`settled: false\`; a retained legacy failure is \`settled: true\`; a live active handle is not settled; the retained completed assertion now also checks \`settled\`.
- **Store** (\`appStore.transferQueue.test.ts\`): a \`settled: false\` \`failed\` snapshot does **not** settle a live row; existing settle/idempotent/no-regress/no-resurrect tests unchanged and green.
- **Hook** (\`useTransferReconcile.test.ts\`): a transient rich \`failed\` snapshot does not settle a stuck row; an unrelated store mutation does **not** re-run the pending scan (spies on \`isTerminalTransferState\`).
- **Mapping** (\`transfer.test.ts\`): unchanged, helper updated for the new field.

All #1645 regression tests still pass. \`tsc --noEmit\`, prettier, \`cargo fmt\`/\`clippy -D warnings\`, the full transfer frontend + backend suites are green.

Closes #1657