### PR TITLE
test(system): stabilize the macOS integration-lane split suite (Closes #1656)

### DIFF
--- a/tests/system/termihub_harness/ui/__init__.py
+++ b/tests/system/termihub_harness/ui/__init__.py
@@ -43,10 +43,12 @@ from .files import FilesUi, file_row_testid
 from .layout import LayoutUi
 from .manual import ManualUi
 from .lookups import (
+    active_leaf,
     connection_item_testid,
     connections,
     find_connection,
     find_folder,
+    find_leaf,
     folder_toggle_testid,
     folders,
     iter_tabs,
@@ -90,4 +92,6 @@ __all__ = [
     "folder_toggle_testid",
     "file_row_testid",
     "iter_tabs",
+    "find_leaf",
+    "active_leaf",
 ]

--- a/tests/system/termihub_harness/ui/lookups.py
+++ b/tests/system/termihub_harness/ui/lookups.py
@@ -71,6 +71,41 @@ def iter_tabs(root: Any) -> list[dict[str, Any]]:
     return tabs
 
 
+def find_leaf(root: Any, leaf_id: str) -> Optional[dict[str, Any]]:
+    """The ``leaf`` panel dict with ``id == leaf_id`` in a panel tree, or ``None``.
+
+    Mirrors the app's ``findLeaf`` over the ``getState("rootPanel")`` tree so the
+    harness can reason about a *specific* panel (e.g. the active one) rather than
+    the flattened tab list :func:`iter_tabs` returns.
+    """
+    if not isinstance(root, dict):
+        return None
+    if root.get("type") == "leaf":
+        return root if root.get("id") == leaf_id else None
+    for child in root.get("children") or []:
+        found = find_leaf(child, leaf_id)
+        if found is not None:
+            return found
+    return None
+
+
+def active_leaf(driver: Driver) -> Optional[dict[str, Any]]:
+    """The currently-active leaf panel (``activePanelId`` in ``rootPanel``), or ``None``.
+
+    This is the panel ``addTab`` and terminal input actually target, so it is the
+    panel a test must reason about after a split — where the freshly-created,
+    *active* panel is empty while other panels still hold terminals (#1656).
+    """
+    try:
+        active_id = driver.get_state("activePanelId")
+        root = driver.get_state("rootPanel")
+    except BridgeError:
+        return None
+    if not active_id:
+        return None
+    return find_leaf(root, active_id)
+
+
 def connection_item_testid(connection_id: str) -> str:
     """The ``data-testid`` of the sidebar item for a connection id."""
     return f"connection-item-{connection_id}"

--- a/tests/system/termihub_harness/ui/terminal.py
+++ b/tests/system/termihub_harness/ui/terminal.py
@@ -12,7 +12,7 @@ from typing import Optional
 from ..bridge import BridgeError
 from ..systemtest import DEFAULT_WAIT_TIMEOUT
 from .base import HarnessMixin
-from .lookups import iter_tabs
+from .lookups import active_leaf, iter_tabs
 
 NEW_TERMINAL = "terminal-view-new-terminal"
 
@@ -75,6 +75,35 @@ class TerminalUi(HarnessMixin):
             lambda: any(buf.strip() for buf in self._terminal_buffers()),
             what="a terminal with a shell prompt",
         )
+
+    def ensure_terminal_in_active_panel(self) -> None:
+        """Ensure the **active** panel holds a readable terminal.
+
+        Unlike :meth:`ensure_terminal`, which is satisfied by a terminal *anywhere*
+        in the tree, this targets the panel that ``addTab`` and terminal input
+        actually hit — ``activePanelId``. Right after a split the freshly-created
+        active panel is empty while the original panel still holds a readable
+        terminal, so the tree-wide check would wrongly conclude "a terminal exists"
+        and never populate the new panel — leaving input with nowhere to go ("no
+        active terminal", #1656). Synchronise on the *active panel's own* terminal
+        instead: create one there if it has none, then wait until that terminal is
+        readable (a non-empty active buffer is exactly the ``getActiveTabId`` +
+        registered-xterm signal input needs).
+        """
+        leaf = active_leaf(self.driver)
+        has_terminal = bool(leaf and any(
+            (tab.get("contentType") or "terminal") == "terminal" for tab in (leaf.get("tabs") or [])
+        ))
+        if not has_terminal:
+            self.driver.click(NEW_TERMINAL)
+        self.wait(self._active_terminal_ready, what="a readable terminal in the active panel")
+
+    def _active_terminal_ready(self) -> bool:
+        """Whether the active tab is a terminal with a shell prompt already printed."""
+        try:
+            return bool(self.driver.read_terminal().strip())
+        except BridgeError:
+            return False
 
     def open_new_terminal(self) -> None:
         """Click the toolbar "new terminal" button to open another terminal tab.

--- a/tests/system/tests/test_local_shell.py
+++ b/tests/system/tests/test_local_shell.py
@@ -144,8 +144,11 @@ class TestLocalShell(
         self.ensure_terminal()
         self.driver.click("terminal-view-split-horizontal")
         self.wait(lambda: self.leaf_count() >= 2, what="the view to split into two leaves")
-        # A terminal in the freshly-split (active) panel must accept input.
-        self.ensure_terminal()
+        # The freshly-split panel is the active one but starts empty; a plain
+        # ``ensure_terminal`` sees the *other* panel's terminal and skips it,
+        # leaving input with no active terminal (#1656). Ensure a terminal in the
+        # active panel specifically.
+        self.ensure_terminal_in_active_panel()
         marker = "SPLIT_PANEL_OK"
         self.run_command(f"echo {marker}")
         assert marker in self.wait_for_output(marker)

--- a/tests/system/tests/test_ui_helpers.py
+++ b/tests/system/tests/test_ui_helpers.py
@@ -8,7 +8,13 @@ import pytest
 
 from termihub_harness import find_connection, find_folder
 from termihub_harness.bridge import BridgeError
-from termihub_harness.ui import connection_item_testid, folder_toggle_testid, iter_tabs
+from termihub_harness.ui import (
+    active_leaf,
+    connection_item_testid,
+    find_leaf,
+    folder_toggle_testid,
+    iter_tabs,
+)
 from termihub_harness.ui.base import HarnessMixin
 from termihub_harness.ui.tabs import TabsUi
 
@@ -250,3 +256,34 @@ def test_iter_tabs_handles_a_single_leaf_and_empty_or_malformed_nodes():
     assert iter_tabs({"type": "leaf", "id": "p1", "tabs": []}) == []
     assert iter_tabs(None) == []
     assert iter_tabs({"type": "split", "children": [None, "junk"]}) == []
+
+
+_SPLIT_TREE = {
+    "type": "split",
+    "children": [
+        {"type": "leaf", "id": "p1", "tabs": [{"id": "a"}]},
+        {"type": "leaf", "id": "p2", "tabs": []},
+    ],
+}
+
+
+def test_find_leaf_locates_a_leaf_by_id_or_returns_none():
+    assert find_leaf(_SPLIT_TREE, "p1")["tabs"] == [{"id": "a"}]
+    assert find_leaf(_SPLIT_TREE, "p2")["tabs"] == []
+    assert find_leaf(_SPLIT_TREE, "missing") is None
+    # Malformed / partial nodes never raise.
+    assert find_leaf(None, "p1") is None
+    assert find_leaf({"type": "split", "children": [None, "junk"]}, "p1") is None
+
+
+def test_active_leaf_returns_the_active_panels_leaf():
+    # The freshly-split active panel (#1656) is empty while the other holds a tab.
+    driver = StubDriver({"activePanelId": "p2", "rootPanel": _SPLIT_TREE})
+    assert active_leaf(driver) == {"type": "leaf", "id": "p2", "tabs": []}
+
+
+def test_active_leaf_is_none_when_unresolved():
+    # No active panel, or a tree that hasn't loaded yet (BridgeError) → None.
+    assert active_leaf(StubDriver({"activePanelId": None, "rootPanel": _SPLIT_TREE})) is None
+    assert active_leaf(StubDriver({"rootPanel": _SPLIT_TREE})) is None
+    assert active_leaf(StubDriver({"activePanelId": "p1"})) is None


### PR DESCRIPTION
## What

Stabilizes the macOS integration-lane app-UI suites surfaced by the new
all-platform lane (#1649). Re-run on current `develop` (which already carries
#1654), the observed failure set shrank to **one consistent failure**:
`test_input_reaches_both_panels_after_a_split`. This PR fixes it at the harness
level and adds unit coverage for the new lookups.

## Root cause (harness synchronization, not a macOS app bug)

After a horizontal split, `splitPanel` creates an **empty** new leaf and makes it
the active panel (intended behavior). The test then called `ensure_terminal()` to
populate it — but `ensure_terminal` is satisfied by a readable terminal *anywhere*
in the tree, so it saw the *original* panel's terminal and never created one in
the freshly-split active panel. Terminal input then had no active terminal
(`getActiveTabId` is undefined for an empty active panel) and the send timed out
with "no active terminal to write to".

On Linux it passed only incidentally: the xterm briefly re-mounts during the
split re-layout, transiently emptying the tree-wide buffer set and tricking
`ensure_terminal` into clicking "new terminal". macOS schedules the re-layout
differently, so the buffer stayed readable and the terminal was never created.

## Fix

- Add `ensure_terminal_in_active_panel()` to `TerminalUi`, which synchronizes on
  the **active panel's own** terminal (`activePanelId` leaf) rather than the
  tree-wide buffer set — the authoritative signal for "input will land here".
- Add `find_leaf` / `active_leaf` harness lookups (mirroring the app's `findLeaf`
  over `getState("rootPanel")`).
- Use the new helper in `test_input_reaches_both_panels_after_a_split`.
- Unit-test the new lookups (StubDriver, no app).

`ensure_terminal` is left unchanged — its tree-wide check is correct for its
post-restart "any terminal exists" purpose, and other suites rely on it.

## Verification (local, Apple Silicon macOS, `--debug` build; CI-dark #1569)

- `test_input_reaches_both_panels_after_a_split`: was consistently failing on
  `develop`; **8/8** targeted stress runs green after the fix.
- All five originally-flagged tests (incl. `test_closing_a_tab_removes_it`, fixed
  by #1654) run green across **8** targeted-batch runs **+ 4** broad runs of the
  three affected files (**22/22** each) — 12 full executions, no flakes.
- Machinery suite: 218 passed. Harness unit tests: 14 passed (3 new).

The three "flaky-on-first-pass" tests from the issue did **not** reproduce as
flaky in 12 local runs on this host; they pass reliably. No blind timeout bumps
were made. If they still flake on GitHub's slower/shared macOS runners, that
should be addressed with runner evidence rather than pre-emptive sleep tuning.

Closes #1656
