### PR TITLE
docs(concept): retire embedded-unix env, adopt guided git bash installation (Closes #1683)

### DIFF
--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -101,16 +101,16 @@ These features have something built, but there are meaningful gaps. See the
 
 Not started yet — realistic and planned for the near to medium term.
 
-| Document                                                                                               | Summary                                                                                      |
-| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| [app-icons.md](backlog/app-icons.md)                                                                   | Custom application icon design — placeholder Tauri icons are in place, not the designed ones |
-| [broadcast-input.html](backlog/broadcast-input.html)                                                   | Synchronised input across multiple terminals simultaneously                                  |
-| [embedded-unix-windows.html](backlog/embedded-unix-windows.html)                                       | Bundle BusyBox-w32 + Unix tools with the Windows build                                       |
-| [macos-code-signing-notarization.md](backlog/macos-code-signing-notarization.md)                       | Developer-ID signing + notarization for the macOS build (only ad-hoc signing today)          |
-| [macro-recording.html](backlog/macro-recording.html)                                                   | Record and replay terminal input sequences                                                   |
-| [rdp-sessions.html](backlog/rdp-sessions.html)                                                         | Embedded RDP (Remote Desktop Protocol) client sessions                                       |
-| [release-planning-and-dependency-management.md](backlog/release-planning-and-dependency-management.md) | Structured release cadence, Dependabot, hotfix branching                                     |
-| [vnc-sessions.html](backlog/vnc-sessions.html)                                                         | Embedded noVNC client with WebSocket-to-TCP proxy                                            |
+| Document                                                                                               | Summary                                                                                       |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| [app-icons.md](backlog/app-icons.md)                                                                   | Custom application icon design — placeholder Tauri icons are in place, not the designed ones  |
+| [broadcast-input.html](backlog/broadcast-input.html)                                                   | Synchronised input across multiple terminals simultaneously                                   |
+| [git-bash-provisioning.html](backlog/git-bash-provisioning.html)                                       | Detect Git for Windows and guide its install; use Git Bash as the Windows Unix-tools provider |
+| [macos-code-signing-notarization.md](backlog/macos-code-signing-notarization.md)                       | Developer-ID signing + notarization for the macOS build (only ad-hoc signing today)           |
+| [macro-recording.html](backlog/macro-recording.html)                                                   | Record and replay terminal input sequences                                                    |
+| [rdp-sessions.html](backlog/rdp-sessions.html)                                                         | Embedded RDP (Remote Desktop Protocol) client sessions                                        |
+| [release-planning-and-dependency-management.md](backlog/release-planning-and-dependency-management.md) | Structured release cadence, Dependabot, hotfix branching                                      |
+| [vnc-sessions.html](backlog/vnc-sessions.html)                                                         | Embedded noVNC client with WebSocket-to-TCP proxy                                             |
 
 ---
 
@@ -119,10 +119,11 @@ Not started yet — realistic and planned for the near to medium term.
 Speculative features, long-horizon research, or low-priority legacy protocols.
 These may eventually be implemented, but there is no active plan.
 
-| Document                                                  | Summary                                           | Why future                                          |
-| --------------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------- |
-| [package-manager.html](future/package-manager.html)       | Plugin/tool repository with dependency resolution | Blocked on plugin system                            |
-| [plugin-system.html](future/plugin-system.html)           | Dynamic extension API (Rust + JS)                 | Very high complexity, no active demand              |
-| [remote-client-mode.html](future/remote-client-mode.html) | termiHub as a browser/iPad app via WebSocket      | Significant architectural change                    |
-| [rlogin-rsh.md](future/rlogin-rsh.md)                     | Legacy BSD rlogin/rsh protocol support            | Superseded by SSH; rarely needed                    |
-| [xdmcp-sessions.md](future/xdmcp-sessions.md)             | XDMCP remote desktop sessions                     | Requires X11 server embedding; very high complexity |
+| Document                                                        | Summary                                                | Why future                                                                       |
+| --------------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| [embedded-unix-windows.html](future/embedded-unix-windows.html) | Bundle BusyBox-w32 + Unix tools with the Windows build | Superseded by [git-bash-provisioning](backlog/git-bash-provisioning.html) (#519) |
+| [package-manager.html](future/package-manager.html)             | Plugin/tool repository with dependency resolution      | Blocked on plugin system                                                         |
+| [plugin-system.html](future/plugin-system.html)                 | Dynamic extension API (Rust + JS)                      | Very high complexity, no active demand                                           |
+| [remote-client-mode.html](future/remote-client-mode.html)       | termiHub as a browser/iPad app via WebSocket           | Significant architectural change                                                 |
+| [rlogin-rsh.md](future/rlogin-rsh.md)                           | Legacy BSD rlogin/rsh protocol support                 | Superseded by SSH; rarely needed                                                 |
+| [xdmcp-sessions.md](future/xdmcp-sessions.md)                   | XDMCP remote desktop sessions                          | Requires X11 server embedding; very high complexity                              |

--- a/docs/concepts/backlog/git-bash-provisioning.html
+++ b/docs/concepts/backlog/git-bash-provisioning.html
@@ -1,0 +1,927 @@
+<!doctype html>
+<!--
+  Single-file concept: Guided Git Bash / Git-for-Windows installation.
+  Everything lives here — prose, Mermaid diagrams (editable text, rendered
+  client-side), the mockups (inline, real mockup.css classes + lucide icons),
+  and the sync ledger. See docs/concepts/implemented/ai-driven-concept-workflow.md.
+  Screenshot-verify: scripts/internal/screenshot-mockup.sh <this file>.
+
+  Supersedes docs/concepts/future/embedded-unix-windows.html (#519). Modeled on the
+  detect-and-guide pattern of docs/concepts/implemented/x-server-provisioning.html.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Guided Git Bash Installation on Windows (concept)</title>
+    <link rel="stylesheet" href="../_assets/mockup.css" />
+    <link rel="stylesheet" href="../_assets/concept.css" />
+  </head>
+  <body class="mockup-doc">
+    <!-- Inline lucide sprite (real lucide geometry). -->
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="i-network" viewBox="0 0 24 24">
+        <rect x="16" y="16" width="6" height="6" rx="1" />
+        <rect x="2" y="16" width="6" height="6" rx="1" />
+        <rect x="9" y="2" width="6" height="6" rx="1" />
+        <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3" />
+        <path d="M12 12V8" />
+      </symbol>
+      <symbol id="i-settings" viewBox="0 0 24 24">
+        <path
+          d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"
+        />
+        <circle cx="12" cy="12" r="3" />
+      </symbol>
+      <symbol id="i-terminal" viewBox="0 0 24 24">
+        <path d="m4 17 6-6-6-6" />
+        <path d="M12 19h8" />
+      </symbol>
+      <symbol id="i-download" viewBox="0 0 24 24">
+        <path d="M12 15V3" />
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <path d="m7 10 5 5 5-5" />
+      </symbol>
+      <symbol id="i-circle-check" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" />
+        <path d="m9 12 2 2 4-4" />
+      </symbol>
+      <symbol id="i-app-window" viewBox="0 0 24 24">
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="M10 4v4" />
+        <path d="M2 8h20" />
+        <path d="M6 4v4" />
+      </symbol>
+      <symbol id="i-search" viewBox="0 0 24 24">
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+      </symbol>
+      <symbol id="i-x" viewBox="0 0 24 24">
+        <path d="M18 6 6 18" />
+        <path d="m6 6 12 12" />
+      </symbol>
+    </svg>
+
+    <div class="concept">
+      <!-- ── Header ──────────────────────────────────────────────────── -->
+      <header class="concept-header">
+        <h1>Guided Git Bash Installation on Windows</h1>
+        <div class="concept-meta">
+          <span class="concept-status">Backlog · not implemented</span>
+          <span>detect-and-guide, no bundling</span>
+          <span
+            >GitHub Issue: <a href="https://github.com/armaxri/termiHub/issues/519">#519</a></span
+          >
+          <span
+            >Implementation: <a href="https://github.com/armaxri/termiHub/issues/1671">#1671</a>,
+            <a href="https://github.com/armaxri/termiHub/issues/1672">#1672</a></span
+          >
+          <span><code>docs/concepts/backlog/git-bash-provisioning.html</code></span>
+        </div>
+      </header>
+
+      <blockquote>
+        <p>
+          <strong>Single-file concept</strong> (AI-driven concept workflow). Prose, diagrams,
+          mockups, and the concept↔code reconciliation ledger all live in this one HTML file. The
+          concept is the source of truth; run <code>/sync-concept git-bash-provisioning</code> to
+          reconcile it with the implementation.
+        </p>
+      </blockquote>
+
+      <blockquote style="border-left-color: var(--color-success)">
+        <p>
+          <strong
+            >Supersedes
+            <a href="../future/embedded-unix-windows.html">Embedded Unix Command Environment</a>
+            (#519).</strong
+          >
+          Instead of bundling BusyBox-w32 + standalone binaries with the Windows build, termiHub
+          <strong
+            >detects Git for Windows and, when it is missing, guides the user through installing
+            it</strong
+          >
+          — then uses the installed <strong>Git Bash</strong> as the Unix-shell + coreutils
+          provider. This mirrors the already-shipped
+          <a href="../implemented/x-server-provisioning.html">X Server Provisioning</a> pattern
+          (detect-or-guide VcXsrv/XQuartz), reusing its consent/progress UX and the
+          <code>guideTerminalInstall</code> mechanism.
+        </p>
+      </blockquote>
+
+      <!-- ── Table of contents ──────────────────────────────────────── -->
+      <nav class="concept-toc">
+        <h2>Contents</h2>
+        <ol>
+          <li><a href="#overview">Overview</a></li>
+          <li><a href="#ui">UI Interface</a></li>
+          <li><a href="#handling">General Handling</a></li>
+          <li><a href="#behavior">States &amp; Sequences</a></li>
+          <li><a href="#impl">Preliminary Implementation Details</a></li>
+          <li><a href="#sync">Sync Ledger</a></li>
+        </ol>
+      </nav>
+
+      <!-- ── Overview ───────────────────────────────────────────────── -->
+      <section>
+        <h2 id="overview">Overview <a class="anchor" href="#overview">#</a></h2>
+        <p>
+          Windows users often want a <strong>Unix-style local shell</strong> —
+          <code>bash</code> with <code>grep</code>, <code>sed</code>, <code>awk</code>,
+          <code>curl</code>, <code>ssh</code>, <code>tar</code>, <code>git</code>, and the rest.
+          Today termiHub offers <strong>Git Bash</strong> as a local-shell option, but only when it
+          <em>happens to be installed</em> — and detection checks just two hardcoded paths (<code
+            >C:\Program Files\Git\bin\bash.exe</code
+          >
+          and the <code>(x86)</code> tree). A user who has never installed Git for Windows sees no
+          bash option and no guidance; a user who installed it via winget, scoop, or into a
+          user-scope directory is missed entirely.
+        </p>
+        <p>
+          This concept adds a subsystem that <strong>ensures a usable Git Bash exists</strong> when
+          the user asks for a Unix shell: it detects Git for Windows robustly, and when it is absent
+          it <strong>guides a consent-based install</strong> (winget → official installer → portable
+          fallback), then re-detects and offers Git Bash —
+          <strong>with no manual PATH surgery and no app restart</strong>. The installed Git Bash
+          <em>is</em> the Unix-tools provider.
+        </p>
+
+        <h3>Why guide an install instead of bundling one</h3>
+        <div class="diagram">
+          <span class="diagram__caption"
+            >Retired #519 bundled an env; this concept relies on Git for Windows instead</span
+          >
+          <pre class="mermaid">
+flowchart LR
+    subgraph WANT["User wants Unix tools on Windows"]
+        T["bash · coreutils · curl<br/>ssh · tar · git · vim · less"]
+    end
+    subgraph OLD["Retired #519 — embedded env"]
+        B["Bundle BusyBox-w32 +<br/>standalone binaries (~36 MB)<br/>update CDN · AV false positives ·<br/>own CVE response for curl/ssh"]
+    end
+    subgraph NEW["THIS CONCEPT — guided install"]
+        D["Detect Git for Windows"] --> G["Absent? Guide install<br/>winget / installer / portable"]
+        G --> R["Use installed Git Bash"]
+    end
+    T -.retired.-> B
+    T --> D
+    style B fill:#7a2b2b,stroke:#333,color:#fff
+    style R fill:#e87d0d,stroke:#333,color:#fff
+          </pre>
+        </div>
+        <p>
+          <strong>termiHub needs none of these binaries for its own features.</strong> SSH and SFTP
+          run on the <code>russh</code> Rust library (not an <code>ssh.exe</code>); OSC&nbsp;7 CWD
+          tracking (the file browser) is emitted by the shell prompt and already works with Git Bash
+          (<code>shell.rs</code> treats <code>gitbash</code> as an OSC&nbsp;7 shell). The embedded
+          tools were only ever a <em>user convenience</em>.
+          <strong>Git for Windows already provides the whole list</strong> — it is an MSYS2
+          environment shipping bash, coreutils, curl, OpenSSH, tar/gzip/xz, git, vim, and less from
+          one well-maintained installer — and termiHub <em>already</em> knows how to launch it
+          (<code>resolve_git_bash</code>). Bundling is a heavy, recurring liability (a hosted update
+          manifest, BusyBox-w32's well-known antivirus false positives, and owning CVE response for
+          bundled <code>curl</code>/OpenSSH). Guiding an install pushes all of that onto Git for
+          Windows. Full analysis: <a href="https://github.com/armaxri/termiHub/issues/519">#519</a>.
+        </p>
+
+        <h3>Goals</h3>
+        <ul>
+          <li>
+            Make a working Unix shell (bash + coreutils + curl/ssh/tar/git/…) available on Windows
+            with <strong>guided, consent-based setup</strong> — no manual install on the common
+            path, no bundling.
+          </li>
+          <li>
+            <strong>Harden Git Bash detection</strong> beyond the two hardcoded
+            <code>Program Files</code> paths — registry, winget/scoop, user-scope, and PATH-derived
+            locations (<a href="https://github.com/armaxri/termiHub/issues/1671">#1671</a>).
+          </li>
+          <li>
+            When Git Bash is absent, <strong>guide its install</strong> via winget (<code
+              >winget install -e --id Git.Git</code
+            >), with an official-installer link and a portable-Git fallback (<a
+              href="https://github.com/armaxri/termiHub/issues/1672"
+              >#1672</a
+            >).
+          </li>
+          <li>
+            Re-detect Git Bash after the install completes and offer it without an app restart.
+          </li>
+          <li>
+            Frame installed Git Bash as the answer to "I want
+            <code>grep</code>/<code>curl</code>/<code>ssh</code>
+            on Windows" — the Unix-tools provider — in the shell picker and Settings.
+          </li>
+          <li>
+            <strong>Reuse the X-server guided-install mechanism</strong> — the same consent/progress
+            UX and the existing <code>guideTerminalInstall</code> / <code>openLocalCommandTab</code>
+            helpers — rather than inventing a new install surface.
+          </li>
+        </ul>
+
+        <h3>Non-Goals</h3>
+        <ul>
+          <li>
+            Bundling or embedding any Unix environment (BusyBox/MSYS2/Cygwin) — that is the
+            <strong>retired</strong> <a href="../future/embedded-unix-windows.html">#519</a> concept
+            this one supersedes.
+          </li>
+          <li>
+            A package/plugin manager for installing extra Unix tools — that is
+            <a href="../future/package-manager.html">#521</a>, out of scope here.
+          </li>
+          <li>
+            macOS or Linux (native Unix tools already exist; this subsystem is
+            <strong>Windows-only</strong>).
+          </li>
+          <li>
+            Replacing WSL — the dedicated WSL connection type is unchanged and remains the answer
+            for running real Linux binaries.
+          </li>
+          <li>
+            Auto-installing MSYS2 or Cygwin — Git Bash is the single supported guided target; a user
+            who prefers another environment can still point a custom shell at it.
+          </li>
+          <li>
+            Managing Git for Windows' version or updates — Git/winget owns that (a strict win over
+            bundling, which would put the update treadmill on termiHub).
+          </li>
+        </ul>
+      </section>
+
+      <!-- ── UI Interface ───────────────────────────────────────────── -->
+      <section>
+        <h2 id="ui">UI Interface <a class="anchor" href="#ui">#</a></h2>
+        <p>
+          Git Bash already appears in the local-shell picker (connection editor and
+          <em>Settings → General → Default Shell</em>) <strong>when detected</strong>. This concept
+          adds two things: hardened detection so it shows up whenever Git for Windows is installed
+          <em>anywhere</em>, and — when it is <strong>not</strong> installed — a
+          <strong>"Git Bash (set up…)"</strong> entry that launches a guided, consent-based install.
+          Nothing is downloaded or installed without explicit consent, exactly as with the X server.
+        </p>
+
+        <!-- Mockup 1 -->
+        <div class="mockup-section">
+          <h3>Mockup — Default Shell picker, consent, installing &amp; installed</h3>
+          <div class="mockup-note">
+            <em>Settings → General → Default Shell.</em> When Git for Windows is missing, the picker
+            shows a <strong>"Git Bash — set up…"</strong> row <span class="callout">A</span> instead
+            of a disabled entry; choosing it opens the consent prompt. Detected installs appear as a
+            normal selectable <strong>Git Bash</strong> row.
+          </div>
+          <div class="menu" style="width: 340px">
+            <div class="menu__title">
+              <svg class="li"><use href="#i-settings" /></svg> Default Shell
+            </div>
+            <div class="menu__row menu__row--selected">
+              <span class="check">✓</span> PowerShell <span class="count">default</span>
+            </div>
+            <div class="menu__row"><span class="check"></span> Command Prompt (cmd)</div>
+            <div class="menu__row" style="color: var(--text-secondary)">
+              <span class="check"></span>
+              <svg class="li"><use href="#i-terminal" /></svg> Git Bash — set up…
+              <span class="count">not installed</span>
+            </div>
+            <div class="menu__row"><span class="check"></span> WSL: Ubuntu</div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li>
+                <span class="callout">A</span> When detection finds no Git for Windows, the row
+                reads <strong>"Git Bash — set up…"</strong> and launches the guided install rather
+                than silently disappearing. When Git Bash <em>is</em> detected, it is a plain
+                selectable row (no "set up…" affix).
+              </li>
+            </ul>
+          </div>
+
+          <div class="mockup-note" style="margin-top: 16px">
+            Guided-install flow (Windows), shown when the user picks <em>"Git Bash — set up…"</em>.
+            <strong>Nothing is downloaded before consent</strong> <span class="callout">B</span> —
+            identical shape to the X-server VcXsrv consent prompt.
+          </div>
+          <div class="states">
+            <div>
+              <p class="state-label">Step 1 — consent prompt</p>
+              <div class="menu">
+                <div class="menu__title">
+                  <svg class="li"><use href="#i-app-window" /></svg> Set up Git Bash
+                </div>
+                <div class="menu__row" style="display: block; color: var(--text-secondary)">
+                  A Unix shell needs <strong>Git for Windows</strong>, which isn't installed. It
+                  provides <strong>bash, grep, sed, curl, ssh</strong> and 20+ more tools. termiHub
+                  can install it via <strong>winget</strong> (one time).
+                </div>
+                <div class="menu__footer">
+                  <button class="btn btn--primary">
+                    <svg class="li"><use href="#i-download" /></svg> Install &amp; Enable
+                  </button>
+                  <button class="btn btn--link">Open git-scm.com</button>
+                  <button class="btn">Not now</button>
+                </div>
+              </div>
+            </div>
+            <div>
+              <p class="state-label">Step 2 — installing</p>
+              <div class="menu">
+                <div class="menu__title">
+                  <svg class="li"><use href="#i-download" /></svg> Setting up Git Bash
+                </div>
+                <div class="menu__row">
+                  <span class="state-dot state-dot--connecting"></span> Installing Git for Windows
+                  via winget…
+                </div>
+                <div style="padding: 0 14px 12px">
+                  <div style="height: 4px; border-radius: 2px; background: var(--bg-active)">
+                    <div
+                      style="
+                        width: 55%;
+                        height: 100%;
+                        border-radius: 2px;
+                        background: var(--accent-color);
+                      "
+                    ></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <p class="state-label">Step 3 — installed &amp; selected</p>
+              <div class="menu">
+                <div class="menu__title" style="color: var(--color-success)">
+                  <svg class="li"><use href="#i-circle-check" /></svg> Git Bash ready
+                </div>
+                <div class="menu__row">
+                  <span class="state-dot state-dot--running"></span> Git Bash
+                  <code>2.45.0</code>
+                  <span class="count">detected</span>
+                </div>
+                <div class="menu__row" style="display: block; color: var(--text-secondary)">
+                  Set as the default shell for new local connections. bash, grep, curl, ssh &amp;
+                  more now work in every local terminal.
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li>
+                <span class="callout">B</span> Nothing installs until the user picks
+                <strong>Install &amp; Enable</strong>. Progress is driven by backend events (install
+                / re-detect), reusing the X-server progress-event shape. Once installed, later runs
+                skip Steps&nbsp;1–2 — Git Bash is simply detected and offered.
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- Mockup 2 -->
+        <div class="mockup-section">
+          <h3>Mockup — winget absent: guided fallback</h3>
+          <div class="mockup-note">
+            When winget (App Installer) is missing, the automatic install can't run — so termiHub
+            guides the user instead of failing, symmetric to the X-server winget-absent path.
+            <strong>Install in terminal</strong> <span class="callout">C</span> opens a local
+            terminal tab pre-loaded with the winget/installer command (reusing
+            <code>guideTerminalInstall</code>); <strong>Open git-scm.com</strong>
+            <span class="callout">D</span> is the manual-download fallback.
+          </div>
+          <div class="menu" style="width: 380px">
+            <div class="menu__title">
+              <svg class="li"><use href="#i-app-window" /></svg> Install Git for Windows
+            </div>
+            <div class="menu__row" style="display: block; color: var(--text-secondary)">
+              The automatic install needs <strong>winget</strong> (App Installer), which isn't
+              available. Open a terminal to run the install yourself, or download the official
+              installer.
+            </div>
+            <div class="menu__footer">
+              <button class="btn btn--primary">
+                <svg class="li"><use href="#i-terminal" /></svg> Install in terminal
+              </button>
+              <button class="btn btn--link">
+                <svg class="li"><use href="#i-download" /></svg> Open git-scm.com
+              </button>
+              <button class="btn">Not now</button>
+            </div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li>
+                <span class="callout">C</span> <strong>Install in terminal</strong> — opens a local
+                shell tab pre-loaded with the installer command (<code
+                  >winget install -e --id Git.Git</code
+                >
+                when winget is present; otherwise a documented manual command), and the user drives
+                any UAC / prompts. termiHub re-detects Git Bash when the tab's command finishes.
+                Reuses the existing <code>guideTerminalInstall</code> /
+                <code>openLocalCommandTab</code> helpers.
+              </li>
+              <li>
+                <span class="callout">D</span> <strong>Open git-scm.com</strong> — deep link to the
+                official installer for a fully manual install (also the portable-Git route). Help
+                ends here; termiHub never hosts or redistributes the installer.
+              </li>
+              <li>
+                On a locked-down / corporate machine where the user cannot install anything, the
+                prompt still surfaces the manual link and a hint that <strong>WSL</strong> is an
+                alternative — never a silent dead end.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── General Handling ───────────────────────────────────────── -->
+      <section>
+        <h2 id="handling">General Handling <a class="anchor" href="#handling">#</a></h2>
+        <ul>
+          <li>
+            <strong>Detection is layered.</strong> Beyond the two hardcoded
+            <code>Program Files</code> paths, resolve Git for Windows from: the registry (<code
+              >HKLM\SOFTWARE\GitForWindows</code
+            >
+            / <code>HKCU\…</code> <code>InstallPath</code>), the user-scope install
+            (<code>%LOCALAPPDATA%\Programs\Git</code>), winget/scoop locations, and a PATH-derived
+            lookup (locate <code>git.exe</code>, derive <code>..\bin\bash.exe</code>). First hit
+            wins; the hardcoded paths remain as final fallbacks. One resolved path feeds both
+            <code>detect_available_shells()</code> and <code>resolve_git_bash()</code> (single
+            source of truth) — <a href="https://github.com/armaxri/termiHub/issues/1671">#1671</a>.
+          </li>
+          <li>
+            <strong>Guidance is lazy &amp; consent-gated.</strong> Nothing is installed until the
+            user opens/selects a Unix (bash) shell <em>and</em> confirms the prompt. A user who
+            never wants bash never installs anything — the picker just doesn't show a "set up…" row
+            unless asked.
+          </li>
+          <li>
+            <strong>Install strategy (in order):</strong> winget (<code
+              >winget install -e --id Git.Git --accept-package-agreements
+              --accept-source-agreements</code
+            >) → official installer link (<code>git-scm.com/download/win</code>) → portable Git
+            (same link; detected afterwards via PATH). winget-absent is a guided terminal install,
+            not a failure.
+          </li>
+          <li>
+            <strong>Re-detect after install, no restart.</strong> When the install completes (winget
+            command returns, or the guided terminal tab's command finishes), re-run detection and,
+            if found, select Git Bash for the pending connection.
+          </li>
+          <li>
+            <strong>Reuse, don't reinvent.</strong> The guided-terminal path reuses
+            <code>guideTerminalInstall</code> / <code>openLocalCommandTab</code> (built for the
+            macOS Homebrew→XQuartz flow, #1309/#1312); the consent/progress UX mirrors the X-server
+            prompt.
+          </li>
+          <li>
+            <strong>Failure is actionable, never silent.</strong> If winget errors, surface its
+            output verbatim with a retry and the manual link. If the user declines, the custom-shell
+            and WSL options remain — termiHub never leaves the user staring at a missing shell with
+            no path forward.
+          </li>
+          <li>
+            <strong>Windows-only.</strong> On macOS/Linux this subsystem is inert — native shells
+            are detected as today.
+          </li>
+        </ul>
+      </section>
+
+      <!-- ── States & Sequences ─────────────────────────────────────── -->
+      <section>
+        <h2 id="behavior">States &amp; Sequences <a class="anchor" href="#behavior">#</a></h2>
+
+        <div class="diagram">
+          <span class="diagram__caption"
+            >Top-level: ensure a Unix shell when the user asks for one</span
+          >
+          <pre class="mermaid">
+flowchart TD
+    A[User selects a Unix/bash<br/>local shell] --> B{Git for Windows<br/>detected? layered probe}
+    B -->|Yes| Z[Offer / select Git Bash<br/>resolve_git_bash path]
+    B -->|No| C[Show 'Set up Git Bash'<br/>consent prompt]
+    C -->|Not now| W[Keep PowerShell/cmd;<br/>WSL + custom-shell still available]
+    C -->|Install & Enable| D{winget present?}
+    D -->|Yes| E["winget install -e --id Git.Git"]
+    D -->|No| F[Guided terminal install<br/>+ git-scm.com link]
+    E --> G{Re-detect finds<br/>Git Bash?}
+    F --> G
+    G -->|Yes| Z
+    G -->|No| X[Surface installer error<br/>+ manual link + WSL hint]
+    style E fill:#e87d0d,stroke:#333,color:#fff
+    style Z fill:#e87d0d,stroke:#333,color:#fff
+          </pre>
+        </div>
+
+        <div class="diagram">
+          <span class="diagram__caption">Layered Git Bash detection (#1671)</span>
+          <pre class="mermaid">
+flowchart TD
+    A[detect_git_bash: Windows] --> R{Registry InstallPath?<br/>HKLM/HKCU GitForWindows}
+    R -->|found| OK[Resolve &lt;InstallPath&gt;\bin\bash.exe]
+    R -->|no| U{User-scope install?<br/>%LOCALAPPDATA%\Programs\Git}
+    U -->|found| OK
+    U -->|no| P{PATH-derived?<br/>where git → ..\bin\bash.exe}
+    P -->|found| OK
+    P -->|no| H{Hardcoded fallbacks?<br/>Program Files [ (x86) ]}
+    H -->|found| OK
+    H -->|no| N[Not installed → offer guided setup]
+    OK --> V{bash.exe --version ok?}
+    V -->|yes| Y["gitbash shell available<br/>(single resolved path)"]
+    V -->|no| N
+    style Y fill:#e87d0d,stroke:#333,color:#fff
+          </pre>
+        </div>
+
+        <div class="diagram">
+          <span class="diagram__caption">Guided install workflow (#1672)</span>
+          <pre class="mermaid">
+flowchart TD
+    A[User: Install & Enable] --> B{winget present?}
+    B -->|Yes| C["run: winget install -e --id Git.Git<br/>--accept-package-agreements<br/>--accept-source-agreements"]
+    B -->|No| D[guideTerminalInstall:<br/>open local tab w/ install command]
+    C --> E{exit 0?}
+    D --> F[User drives UAC / prompts;<br/>command finishes]
+    E -->|yes| G[Re-run layered detection]
+    E -->|no| H[Show winget error verbatim<br/>+ 'Open git-scm.com' + Retry]
+    F --> G
+    G -->|found| I[Select Git Bash<br/>for pending connection]
+    G -->|not found| H
+    style C fill:#e87d0d,stroke:#333,color:#fff
+    style I fill:#e87d0d,stroke:#333,color:#fff
+          </pre>
+        </div>
+
+        <div class="diagram">
+          <span class="diagram__caption">Git Bash provisioning state machine</span>
+          <pre class="mermaid">
+stateDiagram-v2
+    [*] --> Detecting
+    Detecting --> Available: layered probe finds Git for Windows
+    Detecting --> Absent: nothing found
+    Absent --> Prompting: user selects 'Git Bash — set up…'
+    Prompting --> Absent: Not now
+    Prompting --> Installing: Install & Enable (winget)
+    Prompting --> Guiding: winget absent → guided terminal
+    Installing --> Available: re-detect succeeds
+    Installing --> Failed: winget error / not found after install
+    Guiding --> Available: re-detect succeeds
+    Guiding --> Failed: still not found
+    Failed --> Prompting: Retry
+    Failed --> Absent: user gives up (WSL/custom remain)
+    Available --> Selected: chosen as shell for a connection
+    Selected --> [*]
+          </pre>
+        </div>
+
+        <div class="diagram">
+          <span class="diagram__caption">Session/select sequence (winget path)</span>
+          <pre class="mermaid">
+sequenceDiagram
+    participant User
+    participant UI as Shell picker (frontend)
+    participant Cmd as Tauri commands
+    participant Det as shell.rs detect_git_bash
+    participant WG as winget
+    User->>UI: Select 'Git Bash — set up…'
+    UI->>Cmd: git_bash_status()
+    Cmd->>Det: layered probe
+    Det-->>Cmd: NotInstalled
+    Cmd-->>UI: NotInstalled → show consent prompt
+    User->>UI: Install & Enable
+    UI->>Cmd: git_bash_install() (winget present)
+    Cmd->>WG: winget install -e --id Git.Git …
+    WG-->>Cmd: exit 0 (progress events → UI)
+    Cmd->>Det: re-probe
+    Det-->>Cmd: Some(path\bin\bash.exe)
+    Cmd-->>UI: Available(2.45.0)
+    UI->>User: Git Bash selected for the connection
+          </pre>
+        </div>
+
+        <h3>Edge cases</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Scenario</th>
+                <th>Behavior</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  Git installed via winget/scoop or user-scope (not in <code>Program Files</code>)
+                </td>
+                <td>
+                  Registry / user-scope / PATH probe finds it; appears as a normal Git Bash row
+                  (#1671)
+                </td>
+              </tr>
+              <tr>
+                <td>Git in a custom directory</td>
+                <td>Registry <code>InstallPath</code> or PATH-derived lookup resolves it</td>
+              </tr>
+              <tr>
+                <td>Multiple Git installs</td>
+                <td>
+                  Prefer the registry <code>InstallPath</code>; the one resolved path is used
+                  consistently
+                </td>
+              </tr>
+              <tr>
+                <td>winget (App Installer) absent</td>
+                <td>
+                  Guided terminal install + <code>git-scm.com</code> manual link — never silent
+                </td>
+              </tr>
+              <tr>
+                <td>winget install fails</td>
+                <td>
+                  Surface winget's error verbatim; offer Retry + manual link (never a partial state)
+                </td>
+              </tr>
+              <tr>
+                <td>Portable Git (no installer)</td>
+                <td>
+                  Detected afterwards via PATH; the git-scm.com link covers the portable download
+                </td>
+              </tr>
+              <tr>
+                <td>User declines the install</td>
+                <td>PowerShell/cmd stay default; WSL + custom-shell remain; no nagging</td>
+              </tr>
+              <tr>
+                <td>Corporate-locked machine (install blocked)</td>
+                <td>
+                  Manual link + WSL hint shown; termiHub never claims success it can't deliver
+                </td>
+              </tr>
+              <tr>
+                <td>Bare <code>bash</code> on Windows (WSL interception)</td>
+                <td>
+                  Unchanged — <code>resolve_git_bash()</code> already maps bare bash to Git Bash to
+                  dodge WSL
+                </td>
+              </tr>
+              <tr>
+                <td>macOS / Linux</td>
+                <td>Subsystem inert; native shells detected as today (Windows-only feature)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ── Preliminary Implementation Details ─────────────────────── -->
+      <section>
+        <h2 id="impl">Preliminary Implementation Details <a class="anchor" href="#impl">#</a></h2>
+        <p>
+          Based on the current architecture at concept-creation time; the codebase may evolve before
+          implementation. The work splits cleanly into two issues:
+          <strong>detection hardening</strong> (<a
+            href="https://github.com/armaxri/termiHub/issues/1671"
+            >#1671</a
+          >) and the
+          <strong>detect-and-guide install flow</strong>
+          (<a href="https://github.com/armaxri/termiHub/issues/1672">#1672</a>), the second building
+          on the first.
+        </p>
+
+        <h3>New and modified files</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Change</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>core/src/session/shell.rs</code></td>
+                <td>
+                  <strong>Modify (#1671)</strong> — replace the 2-entry
+                  <code>GIT_BASH_PATHS</code> with a layered resolver (registry
+                  <code>InstallPath</code>, user-scope, winget/scoop, PATH-derived, then the
+                  hardcoded fallbacks). Have <code>detect_available_shells()</code> and
+                  <code>resolve_git_bash()</code> share the one resolved path. Unit tests for
+                  resolution order (inject paths; gate Windows bits with
+                  <code>#[cfg(windows)]</code>).
+                </td>
+              </tr>
+              <tr>
+                <td><code>src-tauri/src/utils/shell_detect.rs</code></td>
+                <td>
+                  <strong>Reuse</strong> — thin delegator to <code>termihub_core</code>; picks up
+                  the hardened detection for free.
+                </td>
+              </tr>
+              <tr>
+                <td><code>src-tauri/src/commands/…</code> (new <code>git_bash.rs</code>)</td>
+                <td>
+                  <strong>New (#1672)</strong> — <code>git_bash_status</code> /
+                  <code>git_bash_install</code> commands + progress events, modeled on the X-server
+                  <code>x_server_status</code> / <code>_ensure</code> /
+                  <code>_install_dependency</code>
+                  commands.
+                </td>
+              </tr>
+              <tr>
+                <td><code>src/components/OpenConnections/guideTerminalInstall.ts</code></td>
+                <td>
+                  <strong>Reuse (#1672)</strong> — open a local tab pre-loaded with the install
+                  command for the winget-absent / manual path (same helper as the Homebrew flow).
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>src/components/ConnectionEditor/*</code> &amp; Settings default-shell UI
+                </td>
+                <td>
+                  <strong>Modify (#1672)</strong> — render the "Git Bash — set up…" row when absent;
+                  wire the consent/progress prompt (compose from <code>src/components/ui/</code>
+                  primitives — Modal/Button — no bespoke dialog CSS).
+                </td>
+              </tr>
+              <tr>
+                <td><code>src/utils/shell-detection.ts</code></td>
+                <td>
+                  <strong>Reuse</strong> — <code>detectAvailableShells()</code> already surfaces the
+                  backend list; re-detection after install re-queries it.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Detection (#1671)</h3>
+        <p>
+          Today <code>detect_available_shells()</code> pushes <code>gitbash</code> only if one of
+          the two <code>GIT_BASH_PATHS</code> exists, and <code>resolve_git_bash()</code> launches
+          from the same list. Replace both with a shared resolver that probes, in order: the Git for
+          Windows registry key (<code>HKLM\SOFTWARE\GitForWindows</code> /
+          <code>HKCU\Software\GitForWindows</code>, value <code>InstallPath</code> →
+          <code>\bin\bash.exe</code>); the user-scope install
+          (<code>%LOCALAPPDATA%\Programs\Git\bin\bash.exe</code>); a PATH-derived lookup (find
+          <code>git.exe</code>, derive its sibling <code>..\bin\bash.exe</code>); then the existing
+          hardcoded paths. Verify the candidate with <code>bash.exe --version</code> before offering
+          it. Keep the change Windows-gated; Unix detection is untouched.
+        </p>
+
+        <h3>Guided install (#1672)</h3>
+        <p>
+          Mirror the X-server acquisition path. When the user picks "Git Bash — set up…", check for
+          winget; if present, run
+          <code
+            >winget install -e --id Git.Git --accept-package-agreements
+            --accept-source-agreements</code
+          >
+          and stream progress via events; if absent, call
+          <code>guideTerminalInstall(command, "Install Git for Windows")</code> to open a terminal
+          tab pre-loaded with the command, plus a <code>git-scm.com/download/win</code> deep link.
+          On completion, re-run detection (#1671) and select Git Bash for the pending connection.
+          The consent/progress dialog composes from the shared
+          <code>src/components/ui/</code> primitives.
+        </p>
+
+        <h3>Licensing</h3>
+        <p>
+          termiHub does <strong>not</strong> host or redistribute Git for Windows — winget or the
+          user fetches it, and termiHub only <em>runs</em> <code>bash.exe</code> as a separate
+          process (no linking). So Git for Windows' GPL-2.0 terms impose no redistribution
+          obligation on termiHub here; the posture is the standard "we launch a
+          package-manager-installed program," identical to the VcXsrv/winget resolution reached for
+          the X server (#1076/#1056/#1318).
+        </p>
+
+        <h3>Implementation order</h3>
+        <ol>
+          <li>
+            <strong>Detection hardening</strong> (<code>shell.rs</code>, #1671) — land first;
+            independently useful and the foundation for reliable post-install re-detection.
+          </li>
+          <li>
+            <strong>Backend commands + events</strong> (new <code>git_bash.rs</code>, #1672) —
+            <code>git_bash_status</code> / <code>git_bash_install</code>, modeled on the X-server
+            commands.
+          </li>
+          <li>
+            <strong>Frontend consent/progress UI</strong> (#1672) — "set up…" row, consent prompt,
+            progress, winget-absent fallback via <code>guideTerminalInstall</code>; re-detect +
+            select.
+          </li>
+          <li>
+            Docs + manual test steps (guided install is not exercised by per-PR CI on Windows).
+          </li>
+        </ol>
+      </section>
+
+      <!-- ── Sync ledger ────────────────────────────────────────────── -->
+      <section>
+        <h2 id="sync">Sync Ledger <a class="anchor" href="#sync">#</a></h2>
+        <blockquote>
+          <p>
+            Maintained by <code>/sync-concept git-bash-provisioning</code>. Records the last commit
+            at which the concept and code were reconciled, plus open divergences. The concept is the
+            source of truth.
+          </p>
+        </blockquote>
+        <p>
+          <strong>Last synced:</strong> never (not implemented) · <strong>Status:</strong> diverged
+          — new concept; replaces the retired embedded-Unix concept (#519). Detection groundwork
+          exists (<code>GIT_BASH_PATHS</code> / <code>resolve_git_bash</code> in
+          <code>core/src/session/shell.rs</code>) but is not yet hardened; the guided-install flow
+          is unbuilt. Implementation tracked by
+          <a href="https://github.com/armaxri/termiHub/issues/1671">#1671</a> and
+          <a href="https://github.com/armaxri/termiHub/issues/1672">#1672</a>.
+        </p>
+
+        <h3>Open divergences</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Artifact claim</th>
+                <th>Code reality</th>
+                <th>Type</th>
+                <th>Recommendation</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>1</td>
+                <td>Layered Git Bash detection (registry / user-scope / winget / PATH)</td>
+                <td>
+                  Only two hardcoded <code>Program Files</code> paths in
+                  <code>GIT_BASH_PATHS</code> (<code>core/src/session/shell.rs</code>)
+                </td>
+                <td>Missing</td>
+                <td>Implement in #1671, then re-sync</td>
+              </tr>
+              <tr>
+                <td>2</td>
+                <td>Consent/progress guided-install UI + "Git Bash — set up…" picker row</td>
+                <td>
+                  No install surface; picker only lists <code>gitbash</code> when already detected
+                </td>
+                <td>Missing</td>
+                <td>Implement in #1672</td>
+              </tr>
+              <tr>
+                <td>3</td>
+                <td>
+                  Backend <code>git_bash_status</code> / <code>git_bash_install</code> commands +
+                  winget-absent guided-terminal fallback
+                </td>
+                <td>
+                  No such commands; <code>guideTerminalInstall</code> exists but is X-server-only
+                </td>
+                <td>Missing</td>
+                <td>Implement in #1672 (reuse <code>guideTerminalInstall</code>)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Resolved</h3>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>#</th>
+                <th>Resolution</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>2026-07-19</td>
+                <td>#519</td>
+                <td>
+                  Concept created, superseding the retired embedded-Unix environment
+                  (<code>docs/concepts/future/embedded-unix-windows.html</code>). Product decision
+                  on #519: detect-and-guide Git for Windows rather than bundle BusyBox-w32.
+                  Implementation split into detection hardening (#1671) and the guided-install flow
+                  (#1672).
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+
+    <!-- Mermaid: vendored, offline, renders <pre class="mermaid"> text → SVG. -->
+    <script src="../_assets/mermaid.min.js"></script>
+    <script>
+      mermaid.initialize({
+        startOnLoad: true,
+        theme: "dark",
+        securityLevel: "loose",
+        fontFamily: "Geist, sans-serif",
+      });
+    </script>
+  </body>
+</html>

--- a/docs/concepts/future/embedded-unix-windows.html
+++ b/docs/concepts/future/embedded-unix-windows.html
@@ -353,20 +353,46 @@
       <header class="concept-header">
         <h1>Embedded Unix Command Environment on Windows</h1>
         <div class="concept-meta">
-          <span class="concept-status">Backlog · not implemented</span>
+          <span class="concept-status">Superseded · will not be implemented</span>
           <span
             >GitHub Issue: <a href="https://github.com/armaxri/termiHub/issues/519">#519</a></span
           >
-          <span><code>docs/concepts/backlog/embedded-unix-windows.html</code></span>
+          <span><code>docs/concepts/future/embedded-unix-windows.html</code></span>
         </div>
       </header>
 
-      <blockquote>
+      <blockquote style="border-left-color: var(--color-warning)">
         <p>
-          <strong>Single-file concept</strong> (AI-driven concept workflow). Prose, diagrams,
-          mockups, and the concept↔code reconciliation ledger all live in this one HTML file. The
-          concept is the source of truth; run <code>/sync-concept embedded-unix-windows</code> to
-          reconcile it with the implementation.
+          <strong>⚠ Superseded — retired concept, kept for history.</strong> This concept (bundling
+          BusyBox-w32 + standalone Unix binaries with the Windows build) has been
+          <strong>replaced</strong> by
+          <a href="git-bash-provisioning.html"><strong>Guided Git Bash Installation</strong></a>
+          (<code>docs/concepts/backlog/git-bash-provisioning.html</code>). The product decision on
+          <a href="https://github.com/armaxri/termiHub/issues/519">#519</a> is to
+          <strong>detect Git for Windows and guide the user through installing it</strong> — using
+          the installed Git Bash as the Unix-shell + coreutils provider — rather than shipping an
+          embedded environment.
+        </p>
+        <p>
+          <strong>Why:</strong> termiHub needs none of these binaries for its own features (SSH/SFTP
+          run on <code>russh</code>, not <code>ssh.exe</code>; OSC&nbsp;7 CWD tracking already works
+          with Git Bash). Git for Windows already provides essentially the whole tool list (bash,
+          coreutils, curl, OpenSSH, tar/gzip/xz, git, vim, less) from one well-maintained installer,
+          and termiHub <em>already</em> detects Git Bash (<code>resolve_git_bash</code> /
+          <code>GIT_BASH_PATHS</code>). Bundling is a heavy, recurring maintenance/security
+          liability (BusyBox-w32 antivirus false positives, an update CDN, and owning CVE response
+          for bundled <code>curl</code>/OpenSSH). The full analysis lives on
+          <a href="https://github.com/armaxri/termiHub/issues/519">#519</a>; the replacement work is
+          tracked by <a href="https://github.com/armaxri/termiHub/issues/1671">#1671</a> (detection
+          hardening) and
+          <a href="https://github.com/armaxri/termiHub/issues/1672">#1672</a> (detect-and-guide
+          install).
+        </p>
+        <p>
+          Moved to <code>future/</code> and left unimplemented. It is retained only as a last-resort
+          reference for the narrow offline / corporate-locked-machine case where a user genuinely
+          cannot install Git for Windows. Everything below is the original concept, kept verbatim
+          for that history — it is <strong>not</strong> the current plan.
         </p>
       </blockquote>
 

--- a/docs/concepts/mockups-index.html
+++ b/docs/concepts/mockups-index.html
@@ -26,13 +26,14 @@
       <div class="idx-group">
         <h2><code>backlog</code></h2><ul>
         <li><a href="backlog/broadcast-input.html">broadcast-input.html</a></li>
-        <li><a href="backlog/embedded-unix-windows.html">embedded-unix-windows.html</a></li>
+        <li><a href="backlog/git-bash-provisioning.html">git-bash-provisioning.html</a></li>
         <li><a href="backlog/macro-recording.html">macro-recording.html</a></li>
         <li><a href="backlog/rdp-sessions.html">rdp-sessions.html</a></li>
         <li><a href="backlog/vnc-sessions.html">vnc-sessions.html</a></li>
       </ul></div>
       <div class="idx-group">
         <h2><code>future</code></h2><ul>
+        <li><a href="future/embedded-unix-windows.html">embedded-unix-windows.html</a></li>
         <li><a href="future/package-manager.html">package-manager.html</a></li>
         <li><a href="future/plugin-system.html">plugin-system.html</a></li>
         <li><a href="future/remote-client-mode.html">remote-client-mode.html</a></li>


### PR DESCRIPTION
## What & why

The user decided to **retire the embedded-Unix-environment concept (#519)** and replace it with a concept oriented around **guided Git Bash / Git-for-Windows installation**, modeled on the shipped X-server guided-install mechanism (`x-server-provisioning.html`, `guideTerminalInstall.ts`, #1309/#1312).

Rationale (full analysis on #519): termiHub needs none of the bundled Unix binaries for its own features — SSH/SFTP run on `russh`, and OSC-7 CWD tracking already works with Git Bash. Git for Windows already provides essentially the whole tool list (bash, coreutils, curl, OpenSSH, tar/gzip/xz, git, vim, less) from one well-maintained installer, and termiHub already detects Git Bash (`resolve_git_bash` / `GIT_BASH_PATHS`). Bundling BusyBox-w32 is a heavy, recurring maintenance/security liability.

## Changes (docs / concepts only — no application code)

- **Retire** `docs/concepts/backlog/embedded-unix-windows.html` → moved to `docs/concepts/future/embedded-unix-windows.html` with a "Superseded" banner pointing to the new concept; the original body is kept verbatim for history. (`future/` is where superseded concepts live, e.g. `rlogin-rsh.md`.)
- **New concept** `docs/concepts/backlog/git-bash-provisioning.html` — single-file HTML concept (Overview / UI Interface / General Handling / States & Sequences / Preliminary Implementation Details / Sync Ledger), with Mermaid diagrams and mockups reusing the real app class names + lucide icons. It frames installed Git Bash as the Unix-shell + coreutils provider, references #1671 (detection hardening) and #1672 (detect-and-guide install) as the implementation issues, and #519 as the retired predecessor.
- **README** status tables updated (embedded-unix → future/ with a "Superseded by…" note; new concept added to backlog/).
- **Regenerated** `docs/concepts/mockups-index.html`.

Screenshot-verified with `scripts/internal/screenshot-mockup.sh` (renders as termiHub, Mermaid + both banners display). Prettier + markdownlint pass.

## Test plan

Docs-only change — no runtime surface. Verified: `pnpm run markdownlint` (0 errors), `npx prettier --check` on the changed files (clean), and a headless-Chrome render of the new concept for visual fidelity.

Closes #1683

Refs #519, #1671, #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)
