### PR TITLE
fix(agent): buffer notifications arriving during initialize handshake (Closes #1660)

### DIFF
--- a/docs/changes/dev2/fix/1660-preinit-notification-drop.md
+++ b/docs/changes/dev2/fix/1660-preinit-notification-drop.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Agent: a notification the remote agent emits during the `initialize` handshake
+  (before it answers `initialize`) is no longer silently dropped. The desktop
+  connect path skipped every pre-initialize message while scanning for the init
+  response, so an on-attach notice such as a staged `agent.update_available`
+  never reached the frontend. Such notifications are now buffered during the
+  handshake and replayed once initialize completes, on both the initial connect
+  and the reconnect paths (#1660).

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -639,15 +639,19 @@ impl AgentConnectionManager {
                 TerminalError::RemoteError(format!("Write initialize failed: {}", e))
             })?;
 
-            // Read the initialize response from the channel, skipping any
-            // notifications the agent emits before it answers (e.g. output
-            // from a session it recovered on startup). We loop until we see
-            // the message whose id matches our initialize request; otherwise
-            // a pre-initialize notification would be misread as the response
-            // ("Unexpected response to initialize"). A generous cap guards
-            // against a runaway agent that never sends the response.
+            // Read the initialize response from the channel. The agent may emit
+            // notifications before it answers (e.g. output from a session it
+            // recovered on startup, or a staged `agent.update_available` notice
+            // sent on attach). We loop until we see the message whose id matches
+            // our initialize request; otherwise a pre-initialize notification
+            // would be misread as the response ("Unexpected response to
+            // initialize"). Those notifications are buffered here and replayed
+            // once init completes (#1660) rather than dropped, so an on-attach
+            // notification is delivered to the desktop handlers. A generous cap
+            // guards against a runaway agent that never sends the response.
             const MAX_PRE_INIT_MESSAGES: u32 = 1000;
             let mut skipped: u32 = 0;
+            let mut pending_notifications: Vec<(String, Value)> = Vec::new();
             let mut line_buf = String::new();
             let (capabilities, agent_version, protocol_version, client_id) = loop {
                 let resp_line =
@@ -709,6 +713,20 @@ impl AgentConnectionManager {
                             message
                         )));
                     }
+                    jsonrpc::HandshakeOutcome::Buffer { method, params } => {
+                        skipped += 1;
+                        if skipped > MAX_PRE_INIT_MESSAGES {
+                            emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
+                            return Err(TerminalError::RemoteError(
+                                "Agent sent too many messages before the initialize response"
+                                    .into(),
+                            ));
+                        }
+                        // Retain the notification and replay it after init so an
+                        // on-attach notice is not dropped (#1660).
+                        pending_notifications.push((method, params));
+                        continue;
+                    }
                     jsonrpc::HandshakeOutcome::Skip => {
                         skipped += 1;
                         if skipped > MAX_PRE_INIT_MESSAGES {
@@ -750,6 +768,7 @@ impl AgentConnectionManager {
                     settings_task,
                     request_id,
                     agents_weak_task,
+                    pending_notifications,
                 )
                 .await;
             });
@@ -1646,6 +1665,7 @@ async fn agent_io_task(
     agent_settings: AgentSettings,
     mut request_id: u64,
     agents: WeakAgentMap,
+    pending_notifications: Vec<(String, Value)>,
 ) {
     let b64 = base64::engine::general_purpose::STANDARD;
     let mut line_buf = String::new();
@@ -1654,6 +1674,23 @@ async fn agent_io_task(
     let mut pending_responses: HashMap<u64, oneshot::Sender<Result<Value, String>>> =
         HashMap::new();
     let mut connection_error: Option<String> = None;
+
+    // Replay notifications that arrived during the `initialize` handshake before
+    // entering the live loop (#1660). Agent-level notices (`agent.update_*`) go
+    // straight to the frontend; session/monitoring notifications route through
+    // the (as-yet-empty) sender maps and are no-ops until a session registers,
+    // matching how a post-init notification for an unknown session behaves.
+    for (method, params) in &pending_notifications {
+        dispatch_agent_notification(
+            &app_handle,
+            &agent_id,
+            method,
+            params,
+            &session_outputs,
+            &monitoring_outputs,
+            &b64,
+        );
+    }
 
     // Keep the current session handle alive. On reconnect this is replaced so
     // the old session is dropped and the new one is held for the next loop iteration.
@@ -1770,21 +1807,9 @@ async fn agent_io_task(
                                         }
                                     }
                                     Ok(jsonrpc::JsonRpcMessage::Notification { method, params }) => {
-                                        if method == "agent.update_available" {
-                                            emit_agent_update_available(
-                                                &app_handle,
-                                                &agent_id,
-                                                &params,
-                                            );
-                                        }
-                                        if method == "agent.update_pending" {
-                                            emit_remote_agent_update_pending(
-                                                &app_handle,
-                                                &agent_id,
-                                                &params,
-                                            );
-                                        }
-                                        handle_notification(
+                                        dispatch_agent_notification(
+                                            &app_handle,
+                                            &agent_id,
                                             &method,
                                             &params,
                                             &session_outputs,
@@ -1838,7 +1863,7 @@ async fn agent_io_task(
         info!("Agent {}: connection lost, attempting reconnect", agent_id);
 
         match reconnect_agent(&config, &agent_settings, &mut request_id, &alive).await {
-            Ok((new_session, new_channel)) => {
+            Ok((new_session, new_channel, reconnect_notifications)) => {
                 // Replace the current session handle with the new one.
                 // This drops the old (broken) session and keeps the new one alive
                 // for the next iteration of the outer loop.
@@ -1846,6 +1871,22 @@ async fn agent_io_task(
                 channel = new_channel;
                 line_buf.clear();
                 connection_error = None;
+
+                // Replay any notifications the agent emitted before answering
+                // `initialize` on this reconnect (#1660). Sessions are already
+                // registered here, so a buffered `connection.output` routes to
+                // its channel and an `agent.update_*` notice reaches the frontend.
+                for (method, params) in &reconnect_notifications {
+                    dispatch_agent_notification(
+                        &app_handle,
+                        &agent_id,
+                        method,
+                        params,
+                        &session_outputs,
+                        &monitoring_outputs,
+                        &b64,
+                    );
+                }
 
                 // G7 (#1239): reconcile the output/monitoring senders against the
                 // sessions the agent actually recovered. Senders keyed by ids that
@@ -1953,6 +1994,34 @@ async fn list_recovered_session_ids(
     }
 }
 
+/// Dispatch a single agent notification to every place that consumes it.
+///
+/// Surfaces the agent-level update notices (`agent.update_available`,
+/// `agent.update_pending`) to the frontend, then routes session/monitoring
+/// notifications to their registered channels via [`handle_notification`].
+///
+/// Shared by the live I/O loop and the pre-init replay path (#1660): a
+/// notification that arrived during the `initialize` handshake is buffered and
+/// replayed through this same function once init completes, so on-attach
+/// notifications are no longer silently dropped.
+fn dispatch_agent_notification(
+    app_handle: &AppHandle,
+    agent_id: &str,
+    method: &str,
+    params: &Value,
+    session_outputs: &HashMap<String, OutputSender>,
+    monitoring_outputs: &HashMap<String, MonitoringSender>,
+    b64: &base64::engine::GeneralPurpose,
+) {
+    if method == "agent.update_available" {
+        emit_agent_update_available(app_handle, agent_id, params);
+    }
+    if method == "agent.update_pending" {
+        emit_remote_agent_update_pending(app_handle, agent_id, params);
+    }
+    handle_notification(method, params, session_outputs, monitoring_outputs, b64);
+}
+
 /// Handle a notification from the agent.
 ///
 /// Routes `connection.output` to session output channels and
@@ -2004,12 +2073,20 @@ fn handle_notification(
 ///
 /// Respects the `alive` flag — if it becomes `false` during the inter-attempt
 /// delay the function returns immediately so the caller can exit cleanly.
+#[allow(clippy::type_complexity)]
 async fn reconnect_agent(
     config: &RemoteAgentConfig,
     agent_settings: &AgentSettings,
     request_id: &mut u64,
     alive: &Arc<AtomicBool>,
-) -> Result<(SshSession, russh::Channel<russh::client::Msg>), String> {
+) -> Result<
+    (
+        SshSession,
+        russh::Channel<russh::client::Msg>,
+        Vec<(String, Value)>,
+    ),
+    String,
+> {
     const MAX_RETRIES: u32 = 10;
     const MAX_BACKOFF_SECS: u64 = 30;
 
@@ -2097,6 +2174,11 @@ async fn reconnect_agent(
         let mut line_buf = String::new();
         let mut skipped: u32 = 0;
         let mut success = false;
+        // Notifications the agent emits before answering `initialize` on this
+        // reconnect — buffered for replay after the channel is handed back, so
+        // an on-attach notice is not dropped (#1660). Reset per attempt: a
+        // failed attempt's buffer belongs to a channel that is being discarded.
+        let mut buffered: Vec<(String, Value)> = Vec::new();
         loop {
             let resp_line =
                 match read_handshake_line(&mut channel, &config.host, &mut line_buf).await {
@@ -2135,6 +2217,18 @@ async fn reconnect_agent(
                     );
                     break;
                 }
+                jsonrpc::HandshakeOutcome::Buffer { method, params } => {
+                    skipped += 1;
+                    if skipped > MAX_PRE_INIT_MESSAGES {
+                        warn!(
+                            "Reconnect attempt {} failed (too many messages before init response)",
+                            attempt + 1
+                        );
+                        break;
+                    }
+                    buffered.push((method, params));
+                    continue;
+                }
                 jsonrpc::HandshakeOutcome::Skip => {
                     skipped += 1;
                     if skipped > MAX_PRE_INIT_MESSAGES {
@@ -2150,7 +2244,7 @@ async fn reconnect_agent(
         }
 
         if success {
-            return Ok((session, channel));
+            return Ok((session, channel, buffered));
         }
     }
 
@@ -2555,6 +2649,65 @@ mod tests {
         assert_eq!(stats.hostname, "myhost");
         assert!((stats.cpu_usage_percent - 50.0).abs() < f64::EPSILON);
         assert_eq!(stats.os_info, "Linux 6.1");
+    }
+
+    /// Regression test for #1660: a notification the agent emits *before* it
+    /// answers `initialize` must be buffered during the handshake and replayed
+    /// afterwards, not silently dropped. This reproduces the handshake read
+    /// loop's classification over a message stream (notification, then the init
+    /// response) and confirms the buffered notification still reaches the
+    /// desktop handlers. Before the fix, `classify_handshake_message` returned
+    /// `Skip` for the notification and the pre-init notice was discarded.
+    #[test]
+    fn preinit_notification_is_buffered_and_replayed() {
+        let request_id: u64 = 1;
+
+        // The agent emits a session output notification, then answers initialize.
+        let payload = base64::engine::general_purpose::STANDARD.encode(b"hello");
+        let lines = [
+            format!(
+                r#"{{"jsonrpc":"2.0","method":"connection.output","params":{{"session_id":"sess-1","data":"{payload}"}}}}"#
+            ),
+            r#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}"#.to_string(),
+        ];
+
+        // Drive the same classification the handshake loop uses, collecting
+        // pre-init notifications until the initialize response arrives.
+        let mut buffered: Vec<(String, Value)> = Vec::new();
+        let mut saw_response = false;
+        for line in &lines {
+            let msg = jsonrpc::parse_message(line).expect("valid message");
+            match jsonrpc::classify_handshake_message(msg, request_id) {
+                jsonrpc::HandshakeOutcome::Response(_) => {
+                    saw_response = true;
+                    break;
+                }
+                jsonrpc::HandshakeOutcome::Buffer { method, params } => {
+                    buffered.push((method, params));
+                }
+                jsonrpc::HandshakeOutcome::Rejected(m) => panic!("unexpected rejection: {m}"),
+                jsonrpc::HandshakeOutcome::Skip => panic!("notification should be buffered"),
+            }
+        }
+
+        assert!(saw_response, "should have seen the initialize response");
+        assert_eq!(buffered.len(), 1, "pre-init notification must be retained");
+        assert_eq!(buffered[0].0, "connection.output");
+
+        // Replaying the buffered notification after init reaches the registered
+        // session output channel — the same dispatch the live loop performs.
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let mut session_outputs: HashMap<String, OutputSender> = HashMap::new();
+        let monitoring_outputs: HashMap<String, MonitoringSender> = HashMap::new();
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(4);
+        session_outputs.insert("sess-1".to_string(), tx);
+
+        for (method, params) in &buffered {
+            handle_notification(method, params, &session_outputs, &monitoring_outputs, &b64);
+        }
+
+        let data = rx.try_recv().expect("buffered output should be delivered");
+        assert_eq!(data, b"hello".to_vec());
     }
 
     /// handle_notification silently ignores monitoring data for unknown hosts.

--- a/src-tauri/src/terminal/jsonrpc.rs
+++ b/src-tauri/src/terminal/jsonrpc.rs
@@ -87,17 +87,26 @@ pub enum HandshakeOutcome {
     Response(Value),
     /// An error response to our request — carries the error message.
     Rejected(String),
-    /// Some other message (a notification, or a reply for a different id) that
-    /// arrived before our response. Skip it and keep waiting.
+    /// A notification that arrived before our response. It is not the init
+    /// response, but it must not be lost: the caller buffers it and replays it
+    /// once `initialize` completes (#1660). Previously these were dropped, so an
+    /// agent notification emitted during the handshake window (e.g. a staged
+    /// `agent.update_available` sent on attach) was silently discarded.
+    Buffer { method: String, params: Value },
+    /// Some other message (a reply for a different id) that arrived before our
+    /// response. Skip it and keep waiting.
     Skip,
 }
 
 /// Decide how to handle `msg` while waiting for the response to `request_id`.
 ///
 /// The agent may emit notifications before it answers `initialize` — for
-/// example, output from a session it recovered on startup. Those must be
-/// skipped rather than mistaken for the initialize response (which previously
-/// surfaced as "Unexpected response to initialize" and failed the connection).
+/// example, output from a session it recovered on startup, or an
+/// `agent.update_available` notice for a staged update. Those must not be
+/// mistaken for the initialize response (which previously surfaced as
+/// "Unexpected response to initialize" and failed the connection), but they
+/// also must not be dropped: they are returned as [`HandshakeOutcome::Buffer`]
+/// so the caller can replay them once init completes (#1660).
 pub fn classify_handshake_message(msg: JsonRpcMessage, request_id: u64) -> HandshakeOutcome {
     match msg {
         JsonRpcMessage::Response { id, result } if id == request_id => {
@@ -105,6 +114,9 @@ pub fn classify_handshake_message(msg: JsonRpcMessage, request_id: u64) -> Hands
         }
         JsonRpcMessage::Error { id, message, .. } if id == request_id => {
             HandshakeOutcome::Rejected(message)
+        }
+        JsonRpcMessage::Notification { method, params } => {
+            HandshakeOutcome::Buffer { method, params }
         }
         _ => HandshakeOutcome::Skip,
     }
@@ -243,15 +255,23 @@ mod tests {
     }
 
     #[test]
-    fn classify_skips_notification_before_response() {
-        // A session the agent recovered on startup may emit output before the
-        // agent answers `initialize`; that notification must be skipped, not
-        // mistaken for the initialize response.
+    fn classify_buffers_notification_before_response() {
+        // Regression for #1660: a notification arriving before the agent answers
+        // `initialize` must not be mistaken for the initialize response, but it
+        // must also not be dropped — it is buffered for replay after init. This
+        // covers both a recovered-session `connection.output` and an
+        // `agent.update_available` notice staged on attach.
         let msg = JsonRpcMessage::Notification {
-            method: "connection.output".into(),
-            params: serde_json::json!({"sessionId": "abc"}),
+            method: "agent.update_available".into(),
+            params: serde_json::json!({"availableVersion": "1.2.3", "staged": true}),
         };
-        assert_eq!(classify_handshake_message(msg, 1), HandshakeOutcome::Skip);
+        assert_eq!(
+            classify_handshake_message(msg, 1),
+            HandshakeOutcome::Buffer {
+                method: "agent.update_available".into(),
+                params: serde_json::json!({"availableVersion": "1.2.3", "staged": true}),
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The desktop connect path skipped every pre-`initialize` message while scanning for the init response (`agent_manager.rs` → `HandshakeOutcome::Skip`), so any agent notification emitted *before* `initialize` completed was silently discarded. The concrete latent case: an on-attach `agent.update_available` notice for a staged update never reached the frontend.

## Fix

- Add a new `HandshakeOutcome::Buffer { method, params }` variant; `classify_handshake_message` now returns it for a notification received during the handshake instead of dropping it as `Skip`. Stray replies for other ids still `Skip`.
- Retain buffered notifications through the handshake and replay them once `initialize` completes, on **both** the initial connect path and the reconnect path.
- Extract the shared `dispatch_agent_notification` helper so the live loop and the pre-init replay dispatch identically (agent-level `agent.update_*` notices to the frontend; session/monitoring notifications to their channels).

At initial connect the session/monitoring maps are still empty, so a buffered `connection.output` is a no-op (no session to route to yet) exactly as a post-init notification for an unknown session would be — the meaningful pre-init case is the agent-level update notice, which is delivered. On reconnect the maps are already populated, so buffered session output also routes correctly.

## Tests

- `jsonrpc`: `classify_buffers_notification_before_response` — a pre-init notification classifies as `Buffer`, preserving method + params (replaces the old skip-based test).
- `agent_manager`: `preinit_notification_is_buffered_and_replayed` — drives the handshake classification over a `connection.output` notification followed by the init response, then replays the buffered notification and confirms it reaches the registered session channel. Fails without the fix (the notification would classify as `Skip` and be dropped).

`cargo test` (jsonrpc + agent_manager), `cargo fmt --check`, and `cargo clippy -D warnings` all pass locally.

Closes #1660

From #1520 / PR #1655.