### PR TITLE
feat(macro): macro storage model, backend module + commands, frontend api/state

### DIFF
--- a/src-tauri/src/commands/macros.rs
+++ b/src-tauri/src/commands/macros.rs
@@ -1,0 +1,38 @@
+use tauri::State;
+
+use crate::macros::config::Macro;
+use crate::macros::manager::MacroManager;
+use crate::utils::errors::TerminalError;
+
+/// List all stored macros.
+#[tauri::command]
+pub fn list_macros(manager: State<'_, MacroManager>) -> Result<Vec<Macro>, TerminalError> {
+    manager.list_macros()
+}
+
+/// Get a single macro by ID.
+#[tauri::command]
+pub fn get_macro(
+    macro_id: String,
+    manager: State<'_, MacroManager>,
+) -> Result<Macro, TerminalError> {
+    manager.get_macro(&macro_id)
+}
+
+/// Save (add or update) a macro. Returns the stored macro with authoritative timestamps.
+#[tauri::command]
+pub fn save_macro(
+    macro_def: Macro,
+    manager: State<'_, MacroManager>,
+) -> Result<Macro, TerminalError> {
+    manager.save_macro(macro_def)
+}
+
+/// Delete a macro by ID.
+#[tauri::command]
+pub fn delete_macro(
+    macro_id: String,
+    manager: State<'_, MacroManager>,
+) -> Result<(), TerminalError> {
+    manager.delete_macro(&macro_id)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod credential;
 pub mod embedded_servers;
 pub mod files;
 pub mod logs;
+pub mod macros;
 pub mod network;
 pub mod portable;
 pub mod session;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod files;
 /// Services-menu entry (#1409). macOS-only.
 #[cfg(target_os = "macos")]
 mod macos_services;
+mod macros;
 mod network;
 mod session;
 mod spawn;
@@ -469,6 +470,23 @@ pub fn run() {
                 }
             }
 
+            // Initialize macro manager with recovery loading.
+            // On failure, the app still starts but macros are unavailable.
+            match macros::manager::MacroManager::new(app.handle()) {
+                Ok(manager) => {
+                    recovery_warnings.extend(manager.take_recovery_warnings());
+                    app.manage(manager);
+                }
+                Err(e) => {
+                    tracing::error!("Failed to initialize macro manager: {e}");
+                    recovery_warnings.push(RecoveryWarning {
+                        file_name: "macros.json".to_string(),
+                        message: "Could not initialize macro storage. Macros are unavailable until the app is restarted.".to_string(),
+                        details: Some(e.to_string()),
+                    });
+                }
+            }
+
             // Initialize the last-session manager. On failure the app still starts;
             // session restore is simply unavailable until the next launch.
             match workspace::last_session::LastSessionManager::new(app.handle()) {
@@ -789,6 +807,11 @@ pub fn run() {
             commands::workspace::save_last_session,
             commands::workspace::load_last_session,
             commands::workspace::clear_last_session,
+            // Macros
+            commands::macros::list_macros,
+            commands::macros::get_macro,
+            commands::macros::save_macro,
+            commands::macros::delete_macro,
             // Network diagnostics
             commands::network::network_port_scan,
             commands::network::network_port_scan_cancel,

--- a/src-tauri/src/macros/config.rs
+++ b/src-tauri/src/macros/config.rs
@@ -1,0 +1,102 @@
+use serde::{Deserialize, Serialize};
+
+/// A single recorded step of a macro.
+///
+/// A step is one chunk of terminal input plus the delay that precedes it during
+/// playback. `data` holds the raw input as either UTF-8 text or a base64-encoded
+/// byte string — recording (#1674) and playback (#1675) decide the encoding; the
+/// storage layer treats it as an opaque string.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MacroStep {
+    /// The recorded input for this step (UTF-8 text or base64-encoded bytes).
+    pub data: String,
+    /// Delay in milliseconds to wait before this step is played back.
+    #[serde(default)]
+    pub delay_ms: u64,
+}
+
+/// A named, stored sequence of recorded terminal input.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Macro {
+    /// Unique macro identifier.
+    pub id: String,
+    /// User-friendly name for this macro.
+    pub name: String,
+    /// Optional free-text description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional tags for grouping/filtering in the manager UI.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// The ordered steps that make up this macro.
+    #[serde(default)]
+    pub steps: Vec<MacroStep>,
+    /// RFC 3339 timestamp of when the macro was first created.
+    #[serde(default)]
+    pub created_at: String,
+    /// RFC 3339 timestamp of the macro's last update.
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+/// Top-level schema for the macros JSON file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MacroStore {
+    /// Schema version, for forward-compatible migrations.
+    pub version: String,
+    /// All stored macros.
+    pub macros: Vec<Macro>,
+}
+
+impl Default for MacroStore {
+    fn default() -> Self {
+        Self {
+            version: "1".to_string(),
+            macros: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macro_store_default_is_empty() {
+        let store = MacroStore::default();
+        assert_eq!(store.version, "1");
+        assert!(store.macros.is_empty());
+    }
+
+    #[test]
+    fn macro_serializes_with_camel_case_keys() {
+        let m = Macro {
+            id: "macro-1".to_string(),
+            name: "Deploy".to_string(),
+            description: Some("Deploy sequence".to_string()),
+            tags: vec!["ops".to_string()],
+            steps: vec![MacroStep {
+                data: "ls\r".to_string(),
+                delay_ms: 250,
+            }],
+            created_at: "2026-07-19T00:00:00Z".to_string(),
+            updated_at: "2026-07-19T00:00:00Z".to_string(),
+        };
+
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(json.contains("\"delayMs\":250"));
+        assert!(json.contains("\"createdAt\""));
+        assert!(json.contains("\"updatedAt\""));
+        // Round-trips back to an equal value.
+        let parsed: Macro = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn macro_step_delay_defaults_to_zero() {
+        let step: MacroStep = serde_json::from_str(r#"{ "data": "x" }"#).unwrap();
+        assert_eq!(step.delay_ms, 0);
+    }
+}

--- a/src-tauri/src/macros/manager.rs
+++ b/src-tauri/src/macros/manager.rs
@@ -1,0 +1,254 @@
+use std::sync::Mutex;
+
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+
+use super::config::{Macro, MacroStore};
+use super::storage::MacroStorage;
+use crate::connection::recovery::RecoveryWarning;
+use crate::utils::errors::TerminalError;
+
+/// Central macro manager: CRUD for stored macros, persisting through storage.
+pub struct MacroManager {
+    store: Mutex<MacroStore>,
+    storage: MacroStorage,
+    recovery_warnings: Mutex<Vec<RecoveryWarning>>,
+}
+
+impl MacroManager {
+    /// Initialize from disk, with recovery on corruption.
+    pub fn new(app_handle: &AppHandle) -> Result<Self> {
+        let storage =
+            MacroStorage::new(app_handle).context("Failed to initialize macro storage")?;
+        let result = storage
+            .load_with_recovery()
+            .context("Failed to load macros")?;
+
+        Ok(Self {
+            store: Mutex::new(result.data),
+            storage,
+            recovery_warnings: Mutex::new(result.warnings),
+        })
+    }
+
+    /// Take ownership of any recovery warnings (only the first call returns them).
+    pub fn take_recovery_warnings(&self) -> Vec<RecoveryWarning> {
+        self.recovery_warnings
+            .lock()
+            .map(|mut w| std::mem::take(&mut *w))
+            .unwrap_or_default()
+    }
+
+    /// List all stored macros.
+    pub fn list_macros(&self) -> Result<Vec<Macro>, TerminalError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|e| TerminalError::MacroError(e.to_string()))?;
+        Ok(store.macros.clone())
+    }
+
+    /// Get a single macro by ID.
+    pub fn get_macro(&self, id: &str) -> Result<Macro, TerminalError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|e| TerminalError::MacroError(e.to_string()))?;
+        store
+            .macros
+            .iter()
+            .find(|m| m.id == id)
+            .cloned()
+            .ok_or_else(|| TerminalError::MacroError(format!("Macro not found: {id}")))
+    }
+
+    /// Save (add or update) a macro, stamping timestamps.
+    ///
+    /// On update the original `created_at` is preserved; `updated_at` is always
+    /// set to now. The stored macro (with authoritative timestamps) is returned.
+    pub fn save_macro(&self, mut macro_def: Macro) -> Result<Macro, TerminalError> {
+        let now = now_rfc3339();
+
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|e| TerminalError::MacroError(e.to_string()))?;
+
+        macro_def.updated_at = now.clone();
+
+        if let Some(existing) = store.macros.iter_mut().find(|m| m.id == macro_def.id) {
+            // Preserve the original creation timestamp on update.
+            macro_def.created_at = existing.created_at.clone();
+            *existing = macro_def.clone();
+        } else {
+            if macro_def.created_at.is_empty() {
+                macro_def.created_at = now;
+            }
+            store.macros.push(macro_def.clone());
+        }
+
+        self.storage
+            .save(&store)
+            .map_err(|e| TerminalError::MacroError(e.to_string()))?;
+
+        Ok(macro_def)
+    }
+
+    /// Delete a macro by ID.
+    pub fn delete_macro(&self, id: &str) -> Result<(), TerminalError> {
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|e| TerminalError::MacroError(e.to_string()))?;
+
+        let len_before = store.macros.len();
+        store.macros.retain(|m| m.id != id);
+
+        if store.macros.len() == len_before {
+            return Err(TerminalError::MacroError(format!("Macro not found: {id}")));
+        }
+
+        self.storage
+            .save(&store)
+            .map_err(|e| TerminalError::MacroError(e.to_string()))
+    }
+}
+
+/// Current time as an RFC 3339 string.
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::macros::config::MacroStep;
+    use tempfile::TempDir;
+
+    fn create_test_manager(dir: &TempDir) -> MacroManager {
+        MacroManager {
+            store: Mutex::new(MacroStore::default()),
+            storage: MacroStorage::new_test(dir.path()),
+            recovery_warnings: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn sample_macro(id: &str, name: &str) -> Macro {
+        Macro {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: None,
+            tags: vec![],
+            steps: vec![MacroStep {
+                data: "echo hi\r".to_string(),
+                delay_ms: 50,
+            }],
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn list_macros_empty() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+        assert!(mgr.list_macros().unwrap().is_empty());
+    }
+
+    #[test]
+    fn save_and_list_macros() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        mgr.save_macro(sample_macro("m-1", "First")).unwrap();
+        mgr.save_macro(sample_macro("m-2", "Second")).unwrap();
+
+        let macros = mgr.list_macros().unwrap();
+        assert_eq!(macros.len(), 2);
+        assert_eq!(macros[0].name, "First");
+        assert_eq!(macros[1].name, "Second");
+    }
+
+    #[test]
+    fn save_stamps_created_and_updated() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        let saved = mgr.save_macro(sample_macro("m-1", "First")).unwrap();
+        assert!(!saved.created_at.is_empty());
+        assert!(!saved.updated_at.is_empty());
+    }
+
+    #[test]
+    fn save_update_preserves_created_at() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        let first = mgr.save_macro(sample_macro("m-1", "Original")).unwrap();
+
+        let mut updated = sample_macro("m-1", "Renamed");
+        // A client may send a bogus created_at on update; the manager must ignore it.
+        updated.created_at = "1999-01-01T00:00:00Z".to_string();
+        let second = mgr.save_macro(updated).unwrap();
+
+        assert_eq!(second.created_at, first.created_at);
+
+        let macros = mgr.list_macros().unwrap();
+        assert_eq!(macros.len(), 1);
+        assert_eq!(macros[0].name, "Renamed");
+    }
+
+    #[test]
+    fn get_macro_found_and_not_found() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        mgr.save_macro(sample_macro("m-1", "First")).unwrap();
+
+        let got = mgr.get_macro("m-1").unwrap();
+        assert_eq!(got.name, "First");
+        assert_eq!(got.steps[0].data, "echo hi\r");
+
+        assert!(mgr.get_macro("nope").is_err());
+    }
+
+    #[test]
+    fn delete_macro_removes_it() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        mgr.save_macro(sample_macro("m-1", "First")).unwrap();
+        mgr.delete_macro("m-1").unwrap();
+
+        assert!(mgr.list_macros().unwrap().is_empty());
+    }
+
+    #[test]
+    fn delete_macro_not_found() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+        assert!(mgr.delete_macro("nope").is_err());
+    }
+
+    #[test]
+    fn macros_persist_across_manager_reload() {
+        let dir = TempDir::new().unwrap();
+        {
+            let mgr = create_test_manager(&dir);
+            mgr.save_macro(sample_macro("m-1", "Persisted")).unwrap();
+        }
+
+        // A fresh manager reading the same file sees the saved macro.
+        let storage = MacroStorage::new_test(dir.path());
+        let loaded = storage.load_with_recovery().unwrap();
+        let mgr = MacroManager {
+            store: Mutex::new(loaded.data),
+            storage,
+            recovery_warnings: Mutex::new(Vec::new()),
+        };
+
+        let macros = mgr.list_macros().unwrap();
+        assert_eq!(macros.len(), 1);
+        assert_eq!(macros[0].name, "Persisted");
+    }
+}

--- a/src-tauri/src/macros/mod.rs
+++ b/src-tauri/src/macros/mod.rs
@@ -1,0 +1,3 @@
+pub mod config;
+pub mod manager;
+pub mod storage;

--- a/src-tauri/src/macros/storage.rs
+++ b/src-tauri/src/macros/storage.rs
@@ -1,0 +1,169 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+
+use super::config::MacroStore;
+use crate::connection::recovery::{RecoveryResult, RecoveryWarning};
+use crate::utils::config_paths::resolve_config_dir;
+
+const FILE_NAME: &str = "macros.json";
+
+/// Handles reading/writing the macros JSON file.
+pub struct MacroStorage {
+    file_path: PathBuf,
+}
+
+impl MacroStorage {
+    /// Create a new storage instance, resolving the config directory.
+    ///
+    /// If `TERMIHUB_CONFIG_DIR` is set, it overrides the default Tauri config directory.
+    pub fn new(app_handle: &AppHandle) -> Result<Self> {
+        let config_dir = resolve_config_dir(Some(app_handle))?;
+
+        fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
+
+        Ok(Self {
+            file_path: config_dir.join(FILE_NAME),
+        })
+    }
+
+    /// Load with recovery: on parse failure, backs up the corrupt file and resets to defaults.
+    pub fn load_with_recovery(&self) -> Result<RecoveryResult<MacroStore>> {
+        if !self.file_path.exists() {
+            return Ok(RecoveryResult {
+                data: MacroStore::default(),
+                warnings: Vec::new(),
+            });
+        }
+
+        let data = fs::read_to_string(&self.file_path).context("Failed to read macros file")?;
+
+        // Fast path: normal parse succeeds
+        if let Ok(store) = serde_json::from_str::<MacroStore>(&data) {
+            return Ok(RecoveryResult {
+                data: store,
+                warnings: Vec::new(),
+            });
+        }
+
+        // Parse failed — back up and reset to defaults
+        let backup_path = self.file_path.with_extension("json.bak");
+        let _ = fs::copy(&self.file_path, &backup_path);
+        tracing::warn!(
+            "Macros file is corrupt, backed up to {}",
+            backup_path.display()
+        );
+
+        let parse_error = serde_json::from_str::<MacroStore>(&data)
+            .err()
+            .map(|e| e.to_string());
+
+        let warning = RecoveryWarning {
+            file_name: FILE_NAME.to_string(),
+            message: "Macros file was corrupt and has been reset.".to_string(),
+            details: parse_error,
+        };
+        tracing::error!("Macros file corrupt, resetting to defaults");
+
+        let defaults = MacroStore::default();
+        self.save(&defaults)
+            .context("Failed to save default macros after recovery")?;
+
+        Ok(RecoveryResult {
+            data: defaults,
+            warnings: vec![warning],
+        })
+    }
+
+    /// Save the macro store to disk (pretty-printed JSON).
+    pub fn save(&self, store: &MacroStore) -> Result<()> {
+        let data = serde_json::to_string_pretty(store).context("Failed to serialize macros")?;
+
+        fs::write(&self.file_path, data).context("Failed to write macros file")?;
+
+        Ok(())
+    }
+
+    /// Create a storage instance for testing (bypasses Tauri AppHandle).
+    #[cfg(test)]
+    pub fn new_test(dir: &std::path::Path) -> Self {
+        Self {
+            file_path: dir.join(FILE_NAME),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::macros::config::{Macro, MacroStep};
+    use tempfile::TempDir;
+
+    fn create_test_storage(dir: &TempDir) -> MacroStorage {
+        MacroStorage {
+            file_path: dir.path().join(FILE_NAME),
+        }
+    }
+
+    fn sample_store() -> MacroStore {
+        MacroStore {
+            version: "1".to_string(),
+            macros: vec![Macro {
+                id: "macro-1".to_string(),
+                name: "List".to_string(),
+                description: Some("List files".to_string()),
+                tags: vec!["fs".to_string()],
+                steps: vec![MacroStep {
+                    data: "ls -la\r".to_string(),
+                    delay_ms: 100,
+                }],
+                created_at: "2026-07-19T00:00:00Z".to_string(),
+                updated_at: "2026-07-19T00:00:00Z".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn load_with_recovery_missing_file_returns_defaults() {
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+
+        let result = storage.load_with_recovery().unwrap();
+        assert!(result.warnings.is_empty());
+        assert!(result.data.macros.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+
+        let store = sample_store();
+        storage.save(&store).unwrap();
+
+        let result = storage.load_with_recovery().unwrap();
+        assert!(result.warnings.is_empty());
+        assert_eq!(result.data.macros.len(), 1);
+        assert_eq!(result.data.macros[0].name, "List");
+        assert_eq!(result.data.macros[0].steps[0].data, "ls -la\r");
+        assert_eq!(result.data.macros[0].steps[0].delay_ms, 100);
+    }
+
+    #[test]
+    fn load_with_recovery_corrupt_json() {
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+        fs::write(&storage.file_path, "corrupt macro data!!!").unwrap();
+
+        let result = storage.load_with_recovery().unwrap();
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].message.contains("corrupt"));
+        assert!(result.data.macros.is_empty());
+
+        // Backup should exist
+        let backup = storage.file_path.with_extension("json.bak");
+        assert!(backup.exists());
+    }
+}

--- a/src-tauri/src/utils/errors.rs
+++ b/src-tauri/src/utils/errors.rs
@@ -52,6 +52,9 @@ pub enum TerminalError {
     #[error("Workspace error: {0}")]
     WorkspaceError(String),
 
+    #[error("Macro error: {0}")]
+    MacroError(String),
+
     #[error("Network error: {0}")]
     NetworkError(String),
 

--- a/src/services/macroApi.test.ts
+++ b/src/services/macroApi.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import { listMacros, getMacro, saveMacro, deleteMacro } from "./macroApi";
+import type { Macro } from "@/types/macro";
+
+const mockedInvoke = vi.mocked(invoke);
+
+function sampleMacro(): Macro {
+  return {
+    id: "macro-1",
+    name: "Deploy",
+    description: "Deploy sequence",
+    tags: ["ops"],
+    steps: [{ data: "ls\r", delayMs: 250 }],
+    createdAt: "2026-07-19T00:00:00Z",
+    updatedAt: "2026-07-19T00:00:00Z",
+  };
+}
+
+describe("macroApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("listMacros invokes correct command", async () => {
+    mockedInvoke.mockResolvedValue([]);
+    const result = await listMacros();
+    expect(mockedInvoke).toHaveBeenCalledWith("list_macros");
+    expect(result).toEqual([]);
+  });
+
+  it("getMacro invokes correct command with id", async () => {
+    const macro = sampleMacro();
+    mockedInvoke.mockResolvedValue(macro);
+    const result = await getMacro("macro-1");
+    expect(mockedInvoke).toHaveBeenCalledWith("get_macro", { macroId: "macro-1" });
+    expect(result).toEqual(macro);
+  });
+
+  it("saveMacro invokes correct command with macroDef arg", async () => {
+    const macro = sampleMacro();
+    mockedInvoke.mockResolvedValue(macro);
+    const result = await saveMacro(macro);
+    expect(mockedInvoke).toHaveBeenCalledWith("save_macro", { macroDef: macro });
+    expect(result).toEqual(macro);
+  });
+
+  it("deleteMacro invokes correct command with id", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+    await deleteMacro("macro-1");
+    expect(mockedInvoke).toHaveBeenCalledWith("delete_macro", { macroId: "macro-1" });
+  });
+});

--- a/src/services/macroApi.ts
+++ b/src/services/macroApi.ts
@@ -1,0 +1,26 @@
+/**
+ * Tauri command wrappers for macro operations.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { Macro } from "@/types/macro";
+
+/** List all stored macros. */
+export async function listMacros(): Promise<Macro[]> {
+  return await invoke<Macro[]>("list_macros");
+}
+
+/** Get a single macro by ID. */
+export async function getMacro(macroId: string): Promise<Macro> {
+  return await invoke<Macro>("get_macro", { macroId });
+}
+
+/** Save (add or update) a macro. Returns the stored macro with authoritative timestamps. */
+export async function saveMacro(macro: Macro): Promise<Macro> {
+  return await invoke<Macro>("save_macro", { macroDef: macro });
+}
+
+/** Delete a macro by ID. */
+export async function deleteMacro(macroId: string): Promise<void> {
+  await invoke("delete_macro", { macroId });
+}

--- a/src/store/appStore.macro.test.ts
+++ b/src/store/appStore.macro.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the macro Zustand slice (#1673).
+ *
+ * Pins that the store's macro actions round-trip through the macroApi service:
+ * loadMacros populates state, saveMacroToBackend refreshes the list and returns
+ * the stored macro, and deleteMacroFromBackend only mutates state after the
+ * backend delete resolves (and rethrows on failure without desyncing).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock the service modules the store imports at module load. The store pulls in
+// the full graph, so stub the ones with side effects on import.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/macroApi", () => ({
+  listMacros: vi.fn(() => Promise.resolve([])),
+  getMacro: vi.fn(),
+  saveMacro: vi.fn(),
+  deleteMacro: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import {
+  listMacros as apiListMacros,
+  saveMacro as apiSaveMacro,
+  deleteMacro as apiDeleteMacro,
+} from "@/services/macroApi";
+import type { Macro } from "@/types/macro";
+
+function makeMacro(id: string, name: string): Macro {
+  return {
+    id,
+    name,
+    description: undefined,
+    tags: [],
+    steps: [{ data: "echo hi\r", delayMs: 0 }],
+    createdAt: "2026-07-19T00:00:00Z",
+    updatedAt: "2026-07-19T00:00:00Z",
+  };
+}
+
+describe("appStore — macro slice (#1673)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loadMacros populates state from the api", async () => {
+    vi.mocked(apiListMacros).mockResolvedValueOnce([makeMacro("m-1", "First")]);
+
+    await useAppStore.getState().loadMacros();
+
+    expect(apiListMacros).toHaveBeenCalled();
+    expect(useAppStore.getState().macros).toHaveLength(1);
+    expect(useAppStore.getState().macros[0].name).toBe("First");
+  });
+
+  it("saveMacroToBackend saves, refreshes the list, and returns the stored macro", async () => {
+    const stored = makeMacro("m-1", "Saved");
+    vi.mocked(apiSaveMacro).mockResolvedValueOnce(stored);
+    vi.mocked(apiListMacros).mockResolvedValueOnce([stored]);
+
+    const result = await useAppStore.getState().saveMacroToBackend(makeMacro("m-1", "Saved"));
+
+    expect(apiSaveMacro).toHaveBeenCalled();
+    expect(apiListMacros).toHaveBeenCalled();
+    expect(result).toEqual(stored);
+    expect(useAppStore.getState().macros).toHaveLength(1);
+  });
+
+  it("deleteMacroFromBackend removes the macro after the backend delete resolves", async () => {
+    useAppStore.setState({ macros: [makeMacro("m-1", "First"), makeMacro("m-2", "Second")] });
+
+    await useAppStore.getState().deleteMacroFromBackend("m-1");
+
+    expect(apiDeleteMacro).toHaveBeenCalledWith("m-1");
+    const remaining = useAppStore.getState().macros;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe("m-2");
+  });
+
+  it("deleteMacroFromBackend keeps the macro and rethrows when the backend fails", async () => {
+    useAppStore.setState({ macros: [makeMacro("m-1", "First")] });
+    vi.mocked(apiDeleteMacro).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(useAppStore.getState().deleteMacroFromBackend("m-1")).rejects.toThrow("boom");
+
+    // On failure the row must NOT be optimistically removed (no desync).
+    expect(useAppStore.getState().macros).toHaveLength(1);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -154,6 +154,12 @@ import {
   captureAllTabGroups,
   getWorkspaceLeaves,
 } from "@/utils/workspaceLayout";
+import { Macro } from "@/types/macro";
+import {
+  listMacros as apiListMacros,
+  saveMacro as apiSaveMacro,
+  deleteMacro as apiDeleteMacro,
+} from "@/services/macroApi";
 import {
   saveLastSession as apiSaveLastSession,
   loadLastSession as apiLoadLastSession,
@@ -1116,6 +1122,14 @@ interface AppState {
   stopEmbeddedServer: (serverId: string) => Promise<void>;
   updateEmbeddedServerState: (state: EmbeddedServerState) => void;
   quickShareServer: (path: string, protocol: ServerType) => Promise<string>;
+
+  // Macros
+  macros: Macro[];
+  loadMacros: () => Promise<void>;
+  /** Save (add or update) a macro, then refresh the list. Returns the stored macro. */
+  saveMacroToBackend: (macro: Macro) => Promise<Macro>;
+  /** Delete a macro by ID; only mutates local state after the backend delete resolves. */
+  deleteMacroFromBackend: (macroId: string) => Promise<void>;
 
   // Workspaces
   workspaces: WorkspaceSummary[];
@@ -3207,6 +3221,8 @@ export const useAppStore = create<AppState>((set, get) => {
       get().loadEmbeddedServers();
       // Load workspaces
       get().loadWorkspaces();
+      // Load macros
+      get().loadMacros();
       // Load app mode (portable vs. installed) for status bar and settings display
       await get().loadAppMode();
       // Load credential store status (dialog opens on-demand when credentials are needed)
@@ -5359,6 +5375,33 @@ export const useAppStore = create<AppState>((set, get) => {
       // Refresh server list so the new entry shows up in the sidebar.
       await get().loadEmbeddedServers();
       return serverId;
+    },
+
+    // Macros
+    macros: [],
+
+    loadMacros: async () => {
+      try {
+        const macros = await apiListMacros();
+        set({ macros });
+      } catch (err) {
+        console.error("Failed to load macros:", err);
+      }
+    },
+
+    saveMacroToBackend: async (macro) => {
+      const saved = await apiSaveMacro(macro);
+      await get().loadMacros();
+      return saved;
+    },
+
+    deleteMacroFromBackend: async (macroId) => {
+      // Only mutate local state after the backend delete resolves, and rethrow
+      // on failure so the caller can surface the error (mirrors workspaces).
+      await apiDeleteMacro(macroId);
+      set((state) => ({
+        macros: state.macros.filter((m) => m.id !== macroId),
+      }));
     },
 
     // Workspaces

--- a/src/types/macro.ts
+++ b/src/types/macro.ts
@@ -1,0 +1,29 @@
+/**
+ * A single recorded step of a macro: one chunk of terminal input plus the delay
+ * that precedes it during playback. `data` holds the raw input as either UTF-8
+ * text or a base64-encoded byte string.
+ */
+export interface MacroStep {
+  /** The recorded input for this step (UTF-8 text or base64-encoded bytes). */
+  data: string;
+  /** Delay in milliseconds to wait before this step is played back. */
+  delayMs: number;
+}
+
+/** A named, stored sequence of recorded terminal input. */
+export interface Macro {
+  /** Unique macro identifier. */
+  id: string;
+  /** User-friendly name for this macro. */
+  name: string;
+  /** Optional free-text description. */
+  description?: string;
+  /** Tags for grouping/filtering in the manager UI. */
+  tags: string[];
+  /** The ordered steps that make up this macro. */
+  steps: MacroStep[];
+  /** RFC 3339 timestamp of when the macro was first created. */
+  createdAt: string;
+  /** RFC 3339 timestamp of the macro's last update. */
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary

Foundation for the macro recording/playback epic (#1670, concept #517). Adds the persistence layer and data model for macros, mirroring the existing tunnel/workspace storage pattern. **No recording, playback, or UI** in this PR — just the model, backend module, Tauri commands, and frontend plumbing so the later children (#1674–#1677) have a stable base.

## Backend (`src-tauri/src/macros/`, new module)

- `config.rs` — `Macro { id, name, description, tags, steps, createdAt, updatedAt }`, `MacroStep { data, delayMs }`, `MacroStore { version, macros }`. Serde camelCase on the wire.
- `storage.rs` — reads/writes `macros.json` via `resolve_config_dir`, with the same corrupt-file backup + reset recovery path (`load_with_recovery`) used by tunnel/workspace storage.
- `manager.rs` — in-memory `MacroManager` with `list`/`get`/`save`/`delete` CRUD, persisting through storage. `save_macro` stamps `updated_at`, sets `created_at` on insert, and preserves the original `created_at` on update; it returns the stored macro with authoritative timestamps.
- Registered in `lib.rs` state (with recovery-warning propagation) and the invoke handler. New `MacroError` variant on `TerminalError`.
- `commands/macros.rs` — `list_macros`, `get_macro`, `save_macro`, `delete_macro`.

## Frontend

- `src/types/macro.ts` — `Macro` / `MacroStep` types (no `any`).
- `src/services/macroApi.ts` — thin `invoke` wrappers mirroring `tunnelApi.ts`.
- `src/store/appStore.ts` — `macros` array + `loadMacros` / `saveMacroToBackend` / `deleteMacroFromBackend`, loaded at startup alongside tunnels/workspaces.

## Acceptance criteria

- `macros.json` is created under the resolved config dir on first save and survives restart; a corrupt file is backed up (`.json.bak`) and reset — same behavior as `tunnels.json` (covered by storage tests).
- The four commands round-trip a macro (save → list → get → delete).
- Unit tests: Rust storage round-trip + corrupt-file recovery + manager CRUD (14 tests); frontend api + store-slice tests. Test commit precedes the impl commit.
- No UI surface and no terminal wiring introduced.

## Test plan

- `cargo test --lib macros` — 14 passed.
- `pnpm test` — full frontend suite green (incl. new `macroApi.test.ts`, `appStore.macro.test.ts`).
- `./scripts/check.sh` — fmt / clippy / eslint / prettier / markdownlint all pass.
- `pnpm build` — TypeScript typecheck + build pass.

Refs #1670, #517.

Closes #1673