### PR TITLE
ci: disable fail-fast on the Run Tests matrix

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -137,6 +137,12 @@ jobs:
     name: Run Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't cancel sibling legs when one platform fails: a single real
+      # failure (e.g. Windows) otherwise cancels the others, and downstream
+      # `gh pr checks` renders cancellations as `fail` — making one broken
+      # platform look like all three are red. Let every leg run to completion
+      # so each reports its own true pass/fail. (#1669)
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 


### PR DESCRIPTION
## What

Set `strategy.fail-fast: false` on the `Run Tests` matrix in `.github/workflows/code-quality.yml`.

## Why

The matrix used the default `fail-fast: true`, so when one platform leg failed, GitHub cancelled the sibling legs. Downstream, `gh pr checks` renders those cancellations as `fail` — so a single real failure on one platform presented as all three platforms red, indistinguishable from a genuine cross-platform break without querying the jobs API. This repeatedly misled reviewers/automation.

With `fail-fast: false`, every platform runs to completion and reports its own true pass/fail, so `gh pr checks` and the PR mergebox show reality. Cost is slightly more CI minutes on a doomed run — a worthwhile trade for honest per-platform signal.

## Scope

Only the `Run Tests` matrix was missing this — the Build matrix (`build.yml`), agent matrices (`agent.yml`), and system-integration matrix already set `fail-fast: false`.

Closes #1669