### PR TITLE
feat(macro): record terminal input into a macro (start/stop + save) (Closes #1674)

### DIFF
--- a/docs/changes/dev0/feature/1674-macro-record.md
+++ b/docs/changes/dev0/feature/1674-macro-record.md
@@ -1,0 +1,7 @@
+### Added
+
+- Record terminal input into a reusable macro: a record/stop button in the terminal
+  toolbar (with an active-recording indicator) captures what you type in the active
+  terminal, then prompts for a name, optional description, and tags to save it. A
+  `Record Macro (Start/Stop)` command is available in the command palette and as an
+  (unbound by default) configurable keyboard shortcut (#1674).

--- a/src/components/KeyboardShortcuts/ShortcutsOverlay.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutsOverlay.tsx
@@ -93,8 +93,10 @@ export function ShortcutsOverlay({ open, onOpenChange }: ShortcutsOverlayProps) 
                 </td>
               </tr>
               {group.bindings.map((binding) => {
-                const winLinux = serializeBinding(binding.winLinuxDefault);
-                const mac = serializeBinding(binding.macDefault);
+                const winLinux = binding.winLinuxDefault
+                  ? serializeBinding(binding.winLinuxDefault)
+                  : "Unbound";
+                const mac = binding.macDefault ? serializeBinding(binding.macDefault) : "Unbound";
                 const effective = getEffectiveCombo(binding.action);
                 const effectiveStr = effective ? serializeBinding(effective) : "";
 

--- a/src/components/Settings/KeyboardSettings.tsx
+++ b/src/components/Settings/KeyboardSettings.tsx
@@ -119,13 +119,13 @@ export function KeyboardSettings({ visibleFields }: KeyboardSettingsProps) {
   const filteredBindings = searchQuery.trim()
     ? bindings.filter((b) => {
         const q = searchQuery.toLowerCase();
+        const combo = getEffectiveCombo(b.action) ?? b.winLinuxDefault;
+        const comboStr = combo ? serializeBinding(combo) : "";
         return (
           b.label.toLowerCase().includes(q) ||
           b.action.toLowerCase().includes(q) ||
           b.category.toLowerCase().includes(q) ||
-          serializeBinding(getEffectiveCombo(b.action) ?? b.winLinuxDefault)
-            .toLowerCase()
-            .includes(q)
+          comboStr.toLowerCase().includes(q)
         );
       })
     : bindings;

--- a/src/components/Terminal/MacroRecordSaveDialog.css
+++ b/src/components/Terminal/MacroRecordSaveDialog.css
@@ -1,0 +1,5 @@
+.macro-save-dialog__summary {
+  margin: 0 0 var(--spacing-md);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}

--- a/src/components/Terminal/MacroRecordSaveDialog.test.tsx
+++ b/src/components/Terminal/MacroRecordSaveDialog.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { MacroRecordSaveDialog } from "./MacroRecordSaveDialog";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function setInput(testid: string, value: string) {
+  const input = document.querySelector(`[data-testid="${testid}"]`) as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+const baseProps = {
+  open: true,
+  stepCount: 3,
+  onSave: () => {},
+  onCancel: () => {},
+};
+
+describe("MacroRecordSaveDialog", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<MacroRecordSaveDialog {...baseProps} open={false} />);
+    expect(document.querySelector('[data-testid="macro-save-name"]')).toBeNull();
+  });
+
+  it("renders through the Modal primitive and shows the captured step count", () => {
+    render(<MacroRecordSaveDialog {...baseProps} stepCount={5} />);
+    expect(document.querySelector(".ui-modal")).toBeTruthy();
+    expect(document.querySelector('[data-testid="macro-save-name"]')).toBeTruthy();
+    expect(document.body.textContent).toContain("5");
+  });
+
+  it("disables Save until a name is entered", () => {
+    render(<MacroRecordSaveDialog {...baseProps} />);
+    const save = document.querySelector('[data-testid="macro-save-confirm"]') as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    setInput("macro-save-name", "Deploy");
+    expect(save.disabled).toBe(false);
+  });
+
+  it("Save fires onSave with trimmed name, description, and parsed tags", () => {
+    const onSave = vi.fn();
+    render(<MacroRecordSaveDialog {...baseProps} onSave={onSave} />);
+
+    setInput("macro-save-name", "  Deploy  ");
+    setInput("macro-save-description", "prod release");
+    setInput("macro-save-tags", "ops, release ,, prod");
+
+    act(() => {
+      (document.querySelector('[data-testid="macro-save-confirm"]') as HTMLElement).click();
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith({
+      name: "Deploy",
+      description: "prod release",
+      tags: ["ops", "release", "prod"],
+    });
+  });
+
+  it("omits an empty description", () => {
+    const onSave = vi.fn();
+    render(<MacroRecordSaveDialog {...baseProps} onSave={onSave} />);
+    setInput("macro-save-name", "Bare");
+    act(() => {
+      (document.querySelector('[data-testid="macro-save-confirm"]') as HTMLElement).click();
+    });
+    expect(onSave).toHaveBeenCalledWith({ name: "Bare", description: undefined, tags: [] });
+  });
+
+  it("Cancel fires onCancel without saving", () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    render(<MacroRecordSaveDialog {...baseProps} onSave={onSave} onCancel={onCancel} />);
+    act(() => {
+      (document.querySelector('[data-testid="macro-save-cancel"]') as HTMLElement).click();
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Terminal/MacroRecordSaveDialog.tsx
+++ b/src/components/Terminal/MacroRecordSaveDialog.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { Modal, Button, Input, Field } from "@/components/ui";
+import "./MacroRecordSaveDialog.css";
+
+/** Metadata the user supplies when saving a recorded macro. */
+export interface RecordedMacroMeta {
+  name: string;
+  description?: string;
+  tags: string[];
+}
+
+export interface MacroRecordSaveDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Number of steps captured, shown so the user knows what they are saving. */
+  stepCount: number;
+  /** Called with the entered metadata when the user confirms the save. */
+  onSave: (meta: RecordedMacroMeta) => void;
+  /** Called when the user cancels — the recording is discarded. */
+  onCancel: () => void;
+}
+
+/** Split a comma-separated tag string into a trimmed, de-duplicated list. */
+function parseTags(raw: string): string[] {
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const part of raw.split(",")) {
+    const tag = part.trim();
+    if (tag && !seen.has(tag)) {
+      seen.add(tag);
+      tags.push(tag);
+    }
+  }
+  return tags;
+}
+
+/**
+ * Prompt shown after a macro recording stops: name the macro (required) plus an
+ * optional description and tags, then persist it. Composed from the shared UI
+ * primitives. Cancelling discards the recording without saving.
+ */
+export function MacroRecordSaveDialog({
+  open,
+  stepCount,
+  onSave,
+  onCancel,
+}: MacroRecordSaveDialogProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [tags, setTags] = useState("");
+
+  // Reset the fields each time the dialog opens so a prior entry never leaks in.
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setDescription("");
+      setTags("");
+    }
+  }, [open]);
+
+  const trimmedName = name.trim();
+  const canSave = trimmedName.length > 0;
+
+  const handleSave = () => {
+    if (!canSave) return;
+    const trimmedDescription = description.trim();
+    onSave({
+      name: trimmedName,
+      description: trimmedDescription || undefined,
+      tags: parseTags(tags),
+    });
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+      title="Save Recorded Macro"
+      description={`${stepCount} step${stepCount === 1 ? "" : "s"} captured`}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && canSave) handleSave();
+      }}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onCancel} data-testid="macro-save-cancel">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            disabled={!canSave}
+            data-testid="macro-save-confirm"
+          >
+            Save Macro
+          </Button>
+        </>
+      }
+    >
+      <p className="macro-save-dialog__summary">
+        {stepCount} input step{stepCount === 1 ? "" : "s"} captured.
+      </p>
+      <Field label="Name" htmlFor="macro-save-name">
+        <Input
+          id="macro-save-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Deploy sequence"
+          autoFocus
+          data-testid="macro-save-name"
+        />
+      </Field>
+      <Field label="Description (optional)" htmlFor="macro-save-description">
+        <Input
+          id="macro-save-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What this macro does"
+          data-testid="macro-save-description"
+        />
+      </Field>
+      <Field label="Tags (optional, comma-separated)" htmlFor="macro-save-tags">
+        <Input
+          id="macro-save-tags"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          placeholder="ops, release"
+          data-testid="macro-save-tags"
+        />
+      </Field>
+    </Modal>
+  );
+}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -695,6 +695,11 @@ export function Terminal({
             // Line-ending translation (Enter / paste) happens in the backend
             // send_input choke point using the session's configured ending.
             sendInput(sessionIdRef.current, data);
+            // Tap the input stream for macro recording (#1674). This is the
+            // single point where user-typed bytes flow to the PTY, so it
+            // captures input only (never terminal output). No-op unless a
+            // recording is active — the store guards on the recording flag.
+            useAppStore.getState().recordMacroInput(data);
           }
         });
 

--- a/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
+++ b/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@/components/ui", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => children,
 }));
 vi.mock("./TabGroupChips", () => ({ TabGroupChips: () => null }));
+vi.mock("./MacroRecordSaveDialog", () => ({ MacroRecordSaveDialog: () => null }));
 vi.mock("@/components/SplitView", () => ({ SplitView: () => null }));
 vi.mock("@/services/events", () => ({ terminalDispatcher: { init: vi.fn() } }));
 vi.mock("@/services/api", () => ({

--- a/src/components/Terminal/TerminalView.css
+++ b/src/components/Terminal/TerminalView.css
@@ -47,6 +47,30 @@
   color: var(--text-primary);
 }
 
+/* Active-recording indicator: the record button turns the error/red accent and
+   gently pulses so the user always knows input is being captured (#1674). */
+.terminal-view__toolbar-btn--recording,
+.terminal-view__toolbar-btn--recording:hover {
+  color: var(--color-error);
+  animation: terminal-view-record-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes terminal-view-record-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .terminal-view__toolbar-btn--recording {
+    animation: none;
+  }
+}
+
 .terminal-view__content {
   flex: 1;
   overflow: hidden;

--- a/src/components/Terminal/TerminalView.record-button.test.tsx
+++ b/src/components/Terminal/TerminalView.record-button.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * The terminal toolbar exposes a record/stop button wired to the macro
+ * recording store slice (#1674): it toggles recording and reflects the active
+ * state so the user always sees whether input is being captured.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("./TerminalRegistry", () => ({
+  TerminalPortalProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("./TerminalCommandBridge", () => ({ TerminalCommandBridge: () => null }));
+vi.mock("@/testbridge/TestBridge", () => ({ TestBridge: () => null }));
+vi.mock("./Terminal", () => ({ Terminal: () => null }));
+vi.mock("@/components/ui", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+vi.mock("./TabGroupChips", () => ({ TabGroupChips: () => null }));
+vi.mock("./MacroRecordSaveDialog", () => ({ MacroRecordSaveDialog: () => null }));
+vi.mock("@/components/SplitView", () => ({ SplitView: () => null }));
+vi.mock("@/services/events", () => ({ terminalDispatcher: { init: vi.fn() } }));
+vi.mock("@/services/api", () => ({
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+}));
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+import { TerminalView } from "./TerminalView";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function recordButton(): HTMLButtonElement {
+  return document.querySelector('[data-testid="terminal-view-record-macro"]') as HTMLButtonElement;
+}
+
+describe("TerminalView — macro record button (#1674)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root.render(<TerminalView />));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the record button in an idle state", () => {
+    const btn = recordButton();
+    expect(btn).toBeTruthy();
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+    expect(btn.className).not.toContain("terminal-view__toolbar-btn--recording");
+  });
+
+  it("clicking starts recording and reflects the active state", () => {
+    act(() => recordButton().click());
+
+    expect(useAppStore.getState().macroRecording).toBe(true);
+    const btn = recordButton();
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+    expect(btn.className).toContain("terminal-view__toolbar-btn--recording");
+  });
+
+  it("clicking again stops recording (opening the save dialog after capture)", () => {
+    act(() => recordButton().click());
+    // Simulate captured input so stopping routes to the save dialog.
+    act(() => useAppStore.getState().recordMacroInput("ls\r"));
+    act(() => recordButton().click());
+
+    expect(useAppStore.getState().macroRecording).toBe(false);
+    expect(useAppStore.getState().macroSaveDialogOpen).toBe(true);
+  });
+});

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react";
-import { Plus, Columns2, Rows2, X, PanelLeft } from "lucide-react";
+import { Plus, Columns2, Rows2, X, PanelLeft, Circle, Square } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
@@ -12,6 +12,7 @@ import { TestBridge } from "@/testbridge/TestBridge";
 import { Terminal } from "./Terminal";
 import { applyAgentReconnecting } from "./agentStateHandlers";
 import { TabGroupChips } from "./TabGroupChips";
+import { MacroRecordSaveDialog } from "./MacroRecordSaveDialog";
 import { SplitView } from "@/components/SplitView";
 import { terminalDispatcher } from "@/services/events";
 import { listAgentSessions } from "@/services/api";
@@ -245,6 +246,12 @@ export function TerminalView() {
   const confirmCloseLiveSession = useAppStore((s) => s.settings.confirmCloseLiveSession);
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
+  const macroRecording = useAppStore((s) => s.macroRecording);
+  const toggleMacroRecording = useAppStore((s) => s.toggleMacroRecording);
+  const macroSaveDialogOpen = useAppStore((s) => s.macroSaveDialogOpen);
+  const macroRecordingStepCount = useAppStore((s) => s.macroRecordingSteps.length);
+  const saveRecordedMacro = useAppStore((s) => s.saveRecordedMacro);
+  const discardRecordedMacro = useAppStore((s) => s.discardRecordedMacro);
   const isMac = navigator.platform.toUpperCase().includes("MAC");
   const sidebarToggleTitle = `Toggle Sidebar (${isMac ? "Cmd" : "Ctrl"}+B)`;
 
@@ -322,6 +329,20 @@ export function TerminalView() {
                 <Rows2 size={16} />
               </button>
             </Tooltip>
+            <Tooltip
+              content={macroRecording ? "Stop Recording Macro" : "Record Macro"}
+              side="bottom"
+            >
+              <button
+                className={`terminal-view__toolbar-btn${macroRecording ? " terminal-view__toolbar-btn--recording" : ""}`}
+                onClick={toggleMacroRecording}
+                aria-label={macroRecording ? "Stop Recording Macro" : "Record Macro"}
+                aria-pressed={macroRecording}
+                data-testid="terminal-view-record-macro"
+              >
+                {macroRecording ? <Square size={14} fill="currentColor" /> : <Circle size={16} />}
+              </button>
+            </Tooltip>
             {allLeaves.length > 1 && (
               <Tooltip content="Close Panel" side="bottom">
                 <button
@@ -351,6 +372,12 @@ export function TerminalView() {
           <SplitView />
         </div>
       </div>
+      <MacroRecordSaveDialog
+        open={macroSaveDialogOpen}
+        stepCount={macroRecordingStepCount}
+        onSave={(meta) => void saveRecordedMacro(meta)}
+        onCancel={discardRecordedMacro}
+      />
     </TerminalPortalProvider>
   );
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -148,6 +148,11 @@ export function useKeyboardShortcuts() {
           useAppStore.getState().addTabGroup();
           break;
 
+        case "toggle-macro-recording":
+          e.preventDefault();
+          useAppStore.getState().toggleMacroRecording();
+          break;
+
         case "close-tab-group": {
           e.preventDefault();
           const { tabGroups, activeTabGroupId, settings } = useAppStore.getState();

--- a/src/services/commands.ts
+++ b/src/services/commands.ts
@@ -49,6 +49,7 @@ const STORE_RUNNERS: Record<string, () => void> = {
   "new-tab-group": () => {
     useAppStore.getState().addTabGroup();
   },
+  "toggle-macro-recording": () => useAppStore.getState().toggleMacroRecording(),
 };
 
 /**

--- a/src/services/keybindings.test.ts
+++ b/src/services/keybindings.test.ts
@@ -344,6 +344,8 @@ describe("getDefaultBindings", () => {
     // (Custom user overrides are protected separately by pass-through.)
     for (const binding of DEFAULT_BINDINGS) {
       const combo = binding.winLinuxDefault;
+      // Actions that ship unbound (null default) cannot collide with anything.
+      if (!combo) continue;
       const single = Array.isArray(combo) ? combo[0] : combo;
       // Simulate the modifier state that a key event would carry for this combo.
       const fakeEvent = {

--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -112,6 +112,17 @@ export const DEFAULT_BINDINGS: KeyBinding[] = [
     configurable: true,
     scope: "terminal",
   },
+  {
+    action: "toggle-macro-recording",
+    label: "Record Macro (Start/Stop)",
+    category: "terminal",
+    // Ships unbound to avoid colliding with shell/tmux/vim keys; the user can
+    // assign a binding in Settings. Reachable now via the toolbar button and the
+    // command palette.
+    macDefault: null,
+    winLinuxDefault: null,
+    configurable: true,
+  },
 
   // Clipboard
   {

--- a/src/store/appStore.macroRecording.test.ts
+++ b/src/store/appStore.macroRecording.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the macro *recording* Zustand slice (#1674).
+ *
+ * Pins the recorder logic: starting a recording clears prior state, each
+ * captured input chunk is appended as a `MacroStep` whose `delayMs` is the
+ * elapsed time since the previous chunk (0 for the first), stopping opens the
+ * save dialog only when something was captured, saving builds a macro payload
+ * from the recorded steps, and cancelling/discarding drops the buffer without
+ * persisting.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock the service modules the store imports at module load. The store pulls in
+// the full graph, so stub the ones with side effects on import.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/macroApi", () => ({
+  listMacros: vi.fn(() => Promise.resolve([])),
+  getMacro: vi.fn(),
+  saveMacro: vi.fn((m) => Promise.resolve(m)),
+  deleteMacro: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import { saveMacro as apiSaveMacro } from "@/services/macroApi";
+
+describe("appStore — macro recording slice (#1674)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts recording with a clean, empty buffer", () => {
+    // Seed some stale state to prove start clears it.
+    useAppStore.setState({
+      macroRecordingSteps: [{ data: "old", delayMs: 5 }],
+      macroSaveDialogOpen: true,
+    });
+
+    useAppStore.getState().startMacroRecording();
+
+    const s = useAppStore.getState();
+    expect(s.macroRecording).toBe(true);
+    expect(s.macroRecordingSteps).toEqual([]);
+    expect(s.macroSaveDialogOpen).toBe(false);
+  });
+
+  it("appends captured input as steps with per-step delays (0 for the first)", () => {
+    const now = vi.spyOn(Date, "now");
+
+    useAppStore.getState().startMacroRecording();
+
+    now.mockReturnValue(1000);
+    useAppStore.getState().recordMacroInput("l");
+    now.mockReturnValue(1200);
+    useAppStore.getState().recordMacroInput("s");
+    now.mockReturnValue(1250);
+    useAppStore.getState().recordMacroInput("\r");
+
+    expect(useAppStore.getState().macroRecordingSteps).toEqual([
+      { data: "l", delayMs: 0 },
+      { data: "s", delayMs: 200 },
+      { data: "\r", delayMs: 50 },
+    ]);
+  });
+
+  it("ignores input when not recording", () => {
+    useAppStore.getState().recordMacroInput("noise");
+    expect(useAppStore.getState().macroRecordingSteps).toEqual([]);
+  });
+
+  it("stopping after capture stops recording and opens the save dialog", () => {
+    useAppStore.getState().startMacroRecording();
+    useAppStore.getState().recordMacroInput("ls\r");
+    useAppStore.getState().stopMacroRecording();
+
+    const s = useAppStore.getState();
+    expect(s.macroRecording).toBe(false);
+    expect(s.macroSaveDialogOpen).toBe(true);
+    // Steps are retained so the dialog can build the save payload.
+    expect(s.macroRecordingSteps).toHaveLength(1);
+  });
+
+  it("stopping with no captured input does not open the save dialog", () => {
+    useAppStore.getState().startMacroRecording();
+    useAppStore.getState().stopMacroRecording();
+
+    const s = useAppStore.getState();
+    expect(s.macroRecording).toBe(false);
+    expect(s.macroSaveDialogOpen).toBe(false);
+    expect(s.macroRecordingSteps).toEqual([]);
+  });
+
+  it("toggle starts then stops recording", () => {
+    useAppStore.getState().toggleMacroRecording();
+    expect(useAppStore.getState().macroRecording).toBe(true);
+
+    useAppStore.getState().recordMacroInput("x");
+    useAppStore.getState().toggleMacroRecording();
+    expect(useAppStore.getState().macroRecording).toBe(false);
+    expect(useAppStore.getState().macroSaveDialogOpen).toBe(true);
+  });
+
+  it("cancelling discards the buffer without persisting", () => {
+    useAppStore.getState().startMacroRecording();
+    useAppStore.getState().recordMacroInput("secret");
+    useAppStore.getState().cancelMacroRecording();
+
+    const s = useAppStore.getState();
+    expect(s.macroRecording).toBe(false);
+    expect(s.macroRecordingSteps).toEqual([]);
+    expect(s.macroSaveDialogOpen).toBe(false);
+    expect(apiSaveMacro).not.toHaveBeenCalled();
+  });
+
+  it("saveRecordedMacro builds a macro payload from the recorded steps and clears state", async () => {
+    const now = vi.spyOn(Date, "now");
+
+    useAppStore.getState().startMacroRecording();
+    now.mockReturnValue(1000);
+    useAppStore.getState().recordMacroInput("echo hi");
+    now.mockReturnValue(1300);
+    useAppStore.getState().recordMacroInput("\r");
+    useAppStore.getState().stopMacroRecording();
+
+    await useAppStore.getState().saveRecordedMacro({
+      name: "Greeting",
+      description: "says hi",
+      tags: ["demo"],
+    });
+
+    expect(apiSaveMacro).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(apiSaveMacro).mock.calls[0][0];
+    expect(payload.name).toBe("Greeting");
+    expect(payload.description).toBe("says hi");
+    expect(payload.tags).toEqual(["demo"]);
+    expect(payload.id).toBeTruthy();
+    expect(payload.steps).toEqual([
+      { data: "echo hi", delayMs: 0 },
+      { data: "\r", delayMs: 300 },
+    ]);
+
+    // After a successful save the recording state is fully reset.
+    const s = useAppStore.getState();
+    expect(s.macroRecordingSteps).toEqual([]);
+    expect(s.macroSaveDialogOpen).toBe(false);
+  });
+
+  it("discardRecordedMacro closes the dialog and drops the buffer", () => {
+    useAppStore.getState().startMacroRecording();
+    useAppStore.getState().recordMacroInput("x");
+    useAppStore.getState().stopMacroRecording();
+    expect(useAppStore.getState().macroSaveDialogOpen).toBe(true);
+
+    useAppStore.getState().discardRecordedMacro();
+
+    const s = useAppStore.getState();
+    expect(s.macroSaveDialogOpen).toBe(false);
+    expect(s.macroRecordingSteps).toEqual([]);
+    expect(apiSaveMacro).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -154,7 +154,7 @@ import {
   captureAllTabGroups,
   getWorkspaceLeaves,
 } from "@/utils/workspaceLayout";
-import { Macro } from "@/types/macro";
+import { Macro, MacroStep } from "@/types/macro";
 import {
   listMacros as apiListMacros,
   saveMacro as apiSaveMacro,
@@ -1131,6 +1131,44 @@ interface AppState {
   /** Delete a macro by ID; only mutates local state after the backend delete resolves. */
   deleteMacroFromBackend: (macroId: string) => Promise<void>;
 
+  // Macro recording (#1674)
+  /** Whether terminal input is currently being captured into a macro. */
+  macroRecording: boolean;
+  /** The steps captured so far in the in-progress (or just-stopped) recording. */
+  macroRecordingSteps: MacroStep[];
+  /**
+   * Timestamp (ms) of the last captured chunk, used to derive the next step's
+   * `delayMs`. Internal to the recorder; `null` before the first chunk.
+   */
+  macroRecordingLastTime: number | null;
+  /** Whether the post-recording "name & save" dialog is open. */
+  macroSaveDialogOpen: boolean;
+  /** Begin a fresh recording, discarding any prior buffer. */
+  startMacroRecording: () => void;
+  /**
+   * Append one chunk of user input to the in-progress recording. No-op unless a
+   * recording is active. `delayMs` is the elapsed time since the previous chunk
+   * (0 for the first).
+   */
+  recordMacroInput: (data: string) => void;
+  /**
+   * Stop capturing. If anything was recorded, opens the save dialog; otherwise
+   * discards the empty recording and notifies the user.
+   */
+  stopMacroRecording: () => void;
+  /** Toggle recording: start if idle, stop (and prompt to save) if active. */
+  toggleMacroRecording: () => void;
+  /** Abort recording and discard the captured buffer without saving. */
+  cancelMacroRecording: () => void;
+  /** Persist the just-recorded steps as a named macro, then reset the recorder. */
+  saveRecordedMacro: (meta: {
+    name: string;
+    description?: string;
+    tags: string[];
+  }) => Promise<void>;
+  /** Close the save dialog and drop the captured buffer without persisting. */
+  discardRecordedMacro: () => void;
+
   // Workspaces
   workspaces: WorkspaceSummary[];
   activeWorkspaceName: string | null;
@@ -1209,6 +1247,16 @@ interface AppState {
 }
 
 let tabCounter = 0;
+
+/** Generate a unique macro id, falling back when `crypto.randomUUID` is absent. */
+function generateMacroId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") {
+    return `macro-${c.randomUUID()}`;
+  }
+  return `macro-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 let layoutPersistTimer: ReturnType<typeof setTimeout> | null = null;
 /** Debounce timer for auto-saving the last session on layout changes. */
 let lastSessionPersistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -5402,6 +5450,107 @@ export const useAppStore = create<AppState>((set, get) => {
       set((state) => ({
         macros: state.macros.filter((m) => m.id !== macroId),
       }));
+    },
+
+    // Macro recording (#1674)
+    macroRecording: false,
+    macroRecordingSteps: [],
+    macroRecordingLastTime: null,
+    macroSaveDialogOpen: false,
+
+    startMacroRecording: () => {
+      set({
+        macroRecording: true,
+        macroRecordingSteps: [],
+        macroRecordingLastTime: null,
+        macroSaveDialogOpen: false,
+      });
+      toast.info("Recording macro — type in the terminal, then stop to save");
+    },
+
+    recordMacroInput: (data) => {
+      const state = get();
+      if (!state.macroRecording) return;
+      const now = Date.now();
+      const last = state.macroRecordingLastTime;
+      const delayMs = last === null ? 0 : Math.max(0, now - last);
+      set({
+        macroRecordingSteps: [...state.macroRecordingSteps, { data, delayMs }],
+        macroRecordingLastTime: now,
+      });
+    },
+
+    stopMacroRecording: () => {
+      const state = get();
+      if (!state.macroRecording) return;
+      if (state.macroRecordingSteps.length === 0) {
+        // Nothing was typed — discard the empty recording rather than prompting.
+        set({
+          macroRecording: false,
+          macroRecordingLastTime: null,
+          macroSaveDialogOpen: false,
+        });
+        toast.info("No input was recorded");
+        return;
+      }
+      set({
+        macroRecording: false,
+        macroRecordingLastTime: null,
+        macroSaveDialogOpen: true,
+      });
+    },
+
+    toggleMacroRecording: () => {
+      if (get().macroRecording) {
+        get().stopMacroRecording();
+      } else {
+        get().startMacroRecording();
+      }
+    },
+
+    cancelMacroRecording: () => {
+      set({
+        macroRecording: false,
+        macroRecordingSteps: [],
+        macroRecordingLastTime: null,
+        macroSaveDialogOpen: false,
+      });
+      toast.info("Recording discarded");
+    },
+
+    saveRecordedMacro: async ({ name, description, tags }) => {
+      const steps = get().macroRecordingSteps;
+      const macro: Macro = {
+        id: generateMacroId(),
+        name,
+        description,
+        tags,
+        steps,
+        // The backend stamps authoritative created/updated timestamps.
+        createdAt: "",
+        updatedAt: "",
+      };
+      try {
+        await get().saveMacroToBackend(macro);
+        set({
+          macroRecordingSteps: [],
+          macroRecordingLastTime: null,
+          macroSaveDialogOpen: false,
+        });
+        toast.success(`Saved macro "${name}"`);
+      } catch (err) {
+        // Keep the dialog open so the user can retry without losing the capture.
+        toast.error(`Failed to save macro: ${err instanceof Error ? err.message : String(err)}`);
+        throw err;
+      }
+    },
+
+    discardRecordedMacro: () => {
+      set({
+        macroRecordingSteps: [],
+        macroRecordingLastTime: null,
+        macroSaveDialogOpen: false,
+      });
     },
 
     // Workspaces

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -30,10 +30,10 @@ export interface KeyBinding {
   label: string;
   /** Group for display in overlay/settings. */
   category: ShortcutCategory;
-  /** Default key combo for macOS. */
-  macDefault: KeyCombo | KeyCombo[];
-  /** Default key combo for Windows/Linux. */
-  winLinuxDefault: KeyCombo | KeyCombo[];
+  /** Default key combo for macOS. `null` means the action ships unbound. */
+  macDefault: KeyCombo | KeyCombo[] | null;
+  /** Default key combo for Windows/Linux. `null` means the action ships unbound. */
+  winLinuxDefault: KeyCombo | KeyCombo[] | null;
   /** Whether the user can rebind this shortcut. */
   configurable: boolean;
   /**

--- a/src/utils/cheatSheetPdf.ts
+++ b/src/utils/cheatSheetPdf.ts
@@ -43,7 +43,7 @@ export function buildCheatSheetHtml(): string {
       const rows = group.bindings
         .map((b) => {
           const combo = getEffectiveCombo(b.action) ?? b.winLinuxDefault;
-          const keyStr = serializeBinding(combo);
+          const keyStr = combo ? serializeBinding(combo) : "Unbound";
           const isOverride = overriddenActions.has(b.action);
           const overrideMark = isOverride
             ? '<span class="override-mark" title="Custom binding">&dagger;</span>'


### PR DESCRIPTION
## Summary

Implements the **recording** half of the macro recording/playback epic (#1670) — the "record terminal input" scope of #1674, building directly on the storage model, backend commands, `macroApi.ts`, and appStore macro slice landed in #1673.

Closes #1674.

### What it does
- **Capture** — taps the single `xterm.onData` choke point in `Terminal.tsx` (right where input is forwarded to the PTY) so recording captures **user input only, never terminal output**. When a recording is active, each input chunk is appended as a `MacroStep { data, delayMs }`, where `delayMs` is the elapsed time since the previous captured chunk (0 for the first). Recording is global/session-scoped — it records whichever terminal has focus.
- **Store slice** (`appStore.ts`) — `startMacroRecording` / `recordMacroInput` / `stopMacroRecording` / `toggleMacroRecording` / `cancelMacroRecording` / `saveRecordedMacro` / `discardRecordedMacro`, plus `macroRecording` / `macroRecordingSteps` / `macroSaveDialogOpen` state. Save builds a macro payload from the captured steps and persists via the existing `saveMacroToBackend` (`save_macro`); the backend stamps authoritative timestamps.
- **Toolbar affordance** — a record/stop button in the terminal-view toolbar with a clear active-recording indicator (error-token color + gentle pulse, disabled under reduced-motion).
- **Save dialog** — on stop, a `Modal`-based dialog (composed from `ui/` primitives) prompts for **name** (required), optional **description**, and comma-separated **tags**. Cancel discards.
- **Keybinding + command palette** — new `toggle-macro-recording` action, **unbound by default** (leaves the binding for the user to assign, avoiding shell/tmux/vim collisions) and configurable; also a command-palette entry. Adds nullable defaults to the `KeyBinding` type for ship-unbound actions and renders "Unbound"/"(unbound)" wherever defaults are displayed.

### Not in scope
Playback (#1675) and the manager panel (#1676) are separate, later links in the chain.

## Tests
- `appStore.macroRecording.test.ts` — start → append-with-timing → stop → save payload; cancel/discard; no-input stop; toggle. (TDD: test commit precedes impl.)
- `MacroRecordSaveDialog.test.tsx` — name-required gating, trimmed name, parsed/deduped tags, omitted empty description, cancel.
- `TerminalView.record-button.test.tsx` — button idle/active state and toggle wiring.
- Full frontend suite (3424 tests) green; `./scripts/check.sh` passes (ESLint, Prettier, markdownlint, cargo fmt, clippy).

## Manual test
Start a recording via the toolbar record button, type a few commands in the active terminal, click stop, name the macro, and save — confirm a stored macro whose steps reproduce the typed bytes in order with per-step delays, and that canceling discards without saving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)