### PR TITLE
feat(shell): guide git for windows install when no unix shell present (Closes #1672)

### DIFF
--- a/docs/changes/dev1/feature/1672-guide-git-bash-install.md
+++ b/docs/changes/dev1/feature/1672-guide-git-bash-install.md
@@ -1,0 +1,11 @@
+### Added
+
+- Guided Git for Windows install: on Windows, when no Unix shell is detected
+  (no Git Bash, no WSL bash), the _Settings → General → Default Shell_ picker now
+  shows a **"Git Bash — set up…"** entry that opens a consent-gated dialog. From
+  there you can install Git for Windows in a pre-loaded terminal tab
+  (`winget install --id Git.Git -e`) or open the official git-scm.com download
+  page for machines without winget. Once the install finishes, Git Bash is
+  re-detected and offered automatically — no app restart. Builds on the hardened
+  Git Bash detection (#1671) and reuses the existing guided-install primitive
+  (#1672).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1537,6 +1537,32 @@ desktops (or two app instances) both connected to that same agent.
    plain **Update**; clicking it updates without any extra confirmation (same as
    before this change).
 
+### Guided Git for Windows install (#1672)
+
+Verifies the detect-and-guide flow that offers to install Git for Windows when no
+Unix shell is present. **Windows only** — the gate and helpers are unit-tested on
+every CI platform, but the guided install (winget terminal tab, git-scm.com deep
+link, and post-install re-detection) cannot be exercised by per-PR CI. Tracked in
+issue 1672 and its PR.
+
+Prerequisites: a Windows machine with **Git for Windows not installed** (no Git
+Bash, no WSL bash detected).
+
+1. Launch termiHub and open **Settings → General → Default Shell**.
+2. Confirm the picker shows a **"Git Bash — set up…"** entry (it must not appear
+   once Git Bash or a WSL distro is detected).
+3. Select it → a **"Set up Git Bash"** dialog opens. Nothing is installed yet.
+4. Click **Open git-scm.com** → the official download page opens in the browser.
+   Close the browser; the dialog remains.
+5. Click **Install in terminal** → a local terminal tab titled **"Install Git for
+   Windows"** opens, pre-loaded with `winget install --id Git.Git -e`, and the
+   dialog closes with a success toast.
+6. Complete the winget install in that tab (drive any UAC prompt).
+7. Re-open **Settings → General → Default Shell** (no app restart) → **Git Bash**
+   now appears as a normal selectable row and the "set up…" entry is gone.
+8. On a machine that already has Git Bash or WSL bash, confirm the "set up…" entry
+   never appears.
+
 ### Windows Explorer context-menu registration (#1368)
 
 Verifies that shell-integration registration writes/removes the Windows Explorer

--- a/src/components/OpenConnections/GitBashSetupDialog.test.tsx
+++ b/src/components/OpenConnections/GitBashSetupDialog.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for the guided Git-for-Windows setup dialog (#1672): "Install in
+ * terminal" opens a local tab pre-loaded with the winget command and closes;
+ * "Open git-scm.com" deep-links the official installer; "Not now" dismisses.
+ * Nothing installs until the user acts. Composed from shared ui primitives.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useAppStore } from "@/store/appStore";
+import { listAvailableShells } from "@/services/api";
+import { GIT_FOR_WINDOWS_DOWNLOAD_URL, GIT_FOR_WINDOWS_WINGET_COMMAND } from "@/utils/gitBashSetup";
+import { GitBashSetupDialog } from "./GitBashSetupDialog";
+
+vi.mock("@/services/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/api")>()),
+  listAvailableShells: vi.fn(),
+}));
+
+const mockedListShells = vi.mocked(listAvailableShells);
+const mockedOpenUrl = vi.mocked(openUrl);
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function click(testId: string) {
+  const el = document.querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`);
+  if (!el) throw new Error(`missing button ${testId}`);
+  act(() => el.click());
+}
+
+describe("GitBashSetupDialog", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("opens a winget install terminal, notifies the caller, and closes", async () => {
+    mockedListShells.mockResolvedValue(["powershell", "cmd"]);
+    const addTab = vi.spyOn(useAppStore.getState(), "addTab").mockReturnValue("tab-1");
+    const onOpenChange = vi.fn();
+    const onInstallGuided = vi.fn();
+
+    act(() => {
+      root.render(
+        <GitBashSetupDialog open onOpenChange={onOpenChange} onInstallGuided={onInstallGuided} />
+      );
+    });
+
+    click("git-bash-setup-install");
+    await flush();
+
+    expect(addTab).toHaveBeenCalledTimes(1);
+    const [, , config] = addTab.mock.calls[0];
+    expect(config).toMatchObject({
+      config: { initialCommand: GIT_FOR_WINDOWS_WINGET_COMMAND },
+    });
+    expect(onInstallGuided).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    addTab.mockRestore();
+  });
+
+  it("deep-links the official installer on 'Open git-scm.com'", async () => {
+    const onOpenChange = vi.fn();
+    act(() => {
+      root.render(<GitBashSetupDialog open onOpenChange={onOpenChange} />);
+    });
+
+    click("git-bash-setup-download");
+    await flush();
+
+    expect(mockedOpenUrl).toHaveBeenCalledWith(GIT_FOR_WINDOWS_DOWNLOAD_URL);
+  });
+
+  it("dismisses without installing anything on 'Not now'", async () => {
+    const addTab = vi.spyOn(useAppStore.getState(), "addTab");
+    const onOpenChange = vi.fn();
+    act(() => {
+      root.render(<GitBashSetupDialog open onOpenChange={onOpenChange} />);
+    });
+
+    click("git-bash-setup-not-now");
+    await flush();
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(addTab).not.toHaveBeenCalled();
+    expect(mockedOpenUrl).not.toHaveBeenCalled();
+    addTab.mockRestore();
+  });
+});

--- a/src/components/OpenConnections/GitBashSetupDialog.tsx
+++ b/src/components/OpenConnections/GitBashSetupDialog.tsx
@@ -1,0 +1,97 @@
+import { Download, Terminal } from "lucide-react";
+import { Button, Modal, toast } from "@/components/ui";
+import { frontendLog } from "@/utils/frontendLog";
+import { GIT_FOR_WINDOWS_WINGET_COMMAND } from "@/utils/gitBashSetup";
+import { guideGitForWindowsInstall, openGitForWindowsDownload } from "./guideGitBashInstall";
+
+interface GitBashSetupDialogProps {
+  /** Whether the dialog is open (controlled). */
+  open: boolean;
+  /** Called with the next open state (Modal fires `false` on ESC / close / cancel). */
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Invoked once the guided-install terminal tab has been opened, so the caller
+   * can re-detect the now-installing Git Bash (e.g. re-query available shells).
+   */
+  onInstallGuided?: () => void;
+}
+
+/**
+ * Consent-gated guided install for Git for Windows (#1672), shown when a Windows
+ * user asks for a Unix shell but none is detected. Nothing is installed until
+ * the user acts: "Install in terminal" opens a local tab pre-loaded with the
+ * winget command (reusing the shared `guideTerminalInstall` primitive), and
+ * "Open git-scm.com" deep-links the official installer for machines without
+ * winget. Composed from the shared `src/components/ui/` primitives — no bespoke
+ * dialog CSS. Mirrors the X-server VcXsrv consent prompt.
+ */
+export function GitBashSetupDialog({
+  open,
+  onOpenChange,
+  onInstallGuided,
+}: GitBashSetupDialogProps) {
+  const handleInstall = async () => {
+    try {
+      await guideGitForWindowsInstall();
+      frontendLog("git_bash_setup", "opened guided Git for Windows install terminal");
+      toast.success("Opened a terminal to install Git for Windows");
+      onInstallGuided?.();
+      onOpenChange(false);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      frontendLog("git_bash_setup", `guided install failed to start: ${msg}`);
+      throw e; // return the Button to idle and surface its error toast
+    }
+  };
+
+  const handleDownload = async () => {
+    await openGitForWindowsDownload();
+    frontendLog("git_bash_setup", "opened git-scm.com download page");
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Set up Git Bash"
+      description="Install Git for Windows to get a Unix shell (bash, grep, curl, ssh) on Windows."
+      data-testid="git-bash-setup"
+      footer={
+        <>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            data-testid="git-bash-setup-not-now"
+          >
+            Not now
+          </Button>
+          <Button
+            variant="ghost"
+            icon={<Download size={16} aria-hidden />}
+            onClick={handleDownload}
+            data-testid="git-bash-setup-download"
+          >
+            Open git-scm.com
+          </Button>
+          <Button
+            icon={<Terminal size={16} aria-hidden />}
+            onClick={handleInstall}
+            data-testid="git-bash-setup-install"
+          >
+            Install in terminal
+          </Button>
+        </>
+      }
+    >
+      <p>
+        A Unix shell needs <strong>Git for Windows</strong>, which isn&rsquo;t installed. It
+        provides <strong>bash, grep, sed, curl, ssh</strong> and 20+ more tools.
+      </p>
+      <p>
+        termiHub can open a terminal to run <code>{GIT_FOR_WINDOWS_WINGET_COMMAND}</code> (needs
+        winget / App&nbsp;Installer), or you can download the official installer from git-scm.com.
+        Once it finishes, Git Bash is detected and offered automatically &mdash; no app restart.
+      </p>
+    </Modal>
+  );
+}

--- a/src/components/OpenConnections/guideGitBashInstall.test.ts
+++ b/src/components/OpenConnections/guideGitBashInstall.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the guided Git-for-Windows install helpers (#1672). These reuse the
+ * existing guided-terminal-install primitive rather than building new infra:
+ * `guideGitForWindowsInstall` opens a local tab pre-loaded with the winget
+ * command, and `openGitForWindowsDownload` deep-links the official installer.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useAppStore } from "@/store/appStore";
+import { listAvailableShells } from "@/services/api";
+import { GIT_FOR_WINDOWS_DOWNLOAD_URL, GIT_FOR_WINDOWS_WINGET_COMMAND } from "@/utils/gitBashSetup";
+import {
+  GIT_FOR_WINDOWS_TAB_TITLE,
+  guideGitForWindowsInstall,
+  openGitForWindowsDownload,
+} from "./guideGitBashInstall";
+
+vi.mock("@/services/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/api")>()),
+  listAvailableShells: vi.fn(),
+}));
+
+const mockedListShells = vi.mocked(listAvailableShells);
+const mockedOpenUrl = vi.mocked(openUrl);
+
+describe("guideGitForWindowsInstall", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("opens a local terminal tab pre-loaded with the winget install command", async () => {
+    mockedListShells.mockResolvedValue(["powershell", "cmd"]);
+    const addTab = vi.spyOn(useAppStore.getState(), "addTab").mockReturnValue("tab-1");
+
+    await guideGitForWindowsInstall();
+
+    expect(addTab).toHaveBeenCalledTimes(1);
+    const [title, connectionType, config] = addTab.mock.calls[0];
+    expect(title).toBe(GIT_FOR_WINDOWS_TAB_TITLE);
+    expect(connectionType).toBe("local");
+    expect(config).toMatchObject({
+      type: "local",
+      config: { shell: "powershell", initialCommand: GIT_FOR_WINDOWS_WINGET_COMMAND },
+    });
+    addTab.mockRestore();
+  });
+
+  it("throws without opening a tab when no local shell is available", async () => {
+    mockedListShells.mockResolvedValue([]);
+    const addTab = vi.spyOn(useAppStore.getState(), "addTab");
+
+    await expect(guideGitForWindowsInstall()).rejects.toThrow();
+    expect(addTab).not.toHaveBeenCalled();
+    addTab.mockRestore();
+  });
+});
+
+describe("openGitForWindowsDownload", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("opens the official git-scm download page", async () => {
+    await openGitForWindowsDownload();
+    expect(mockedOpenUrl).toHaveBeenCalledWith(GIT_FOR_WINDOWS_DOWNLOAD_URL);
+  });
+});

--- a/src/components/OpenConnections/guideGitBashInstall.ts
+++ b/src/components/OpenConnections/guideGitBashInstall.ts
@@ -1,0 +1,29 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { GIT_FOR_WINDOWS_DOWNLOAD_URL, GIT_FOR_WINDOWS_WINGET_COMMAND } from "@/utils/gitBashSetup";
+import { guideTerminalInstall } from "./guideTerminalInstall";
+
+/** Title of the local terminal tab that hosts the guided Git-for-Windows install. */
+export const GIT_FOR_WINDOWS_TAB_TITLE = "Install Git for Windows";
+
+/**
+ * Open a local terminal tab pre-loaded with the winget install command for Git
+ * for Windows, reusing the shared guided-terminal-install helper built for the
+ * macOS Homebrew flow (#1309/#1312). The user drives any UAC / winget prompts in
+ * the tab; once the install finishes, re-detection surfaces Git Bash without an
+ * app restart. Throws when no local shell is available to host the installer
+ * (the winget-absent machine still has PowerShell, so this is rare on Windows).
+ *
+ * @throws if no local shell is available to run the installer.
+ */
+export async function guideGitForWindowsInstall(): Promise<void> {
+  await guideTerminalInstall(GIT_FOR_WINDOWS_WINGET_COMMAND, GIT_FOR_WINDOWS_TAB_TITLE);
+}
+
+/**
+ * Open the official Git for Windows download page — the manual / portable-Git
+ * fallback for machines without winget. termiHub never hosts the installer, so
+ * the help ends at this deep link.
+ */
+export async function openGitForWindowsDownload(): Promise<void> {
+  await openUrl(GIT_FOR_WINDOWS_DOWNLOAD_URL);
+}

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -1,16 +1,21 @@
-import { useState, useEffect } from "react";
+import { useCallback, useState, useEffect } from "react";
 import { AppSettings } from "@/types/connection";
 import { ShellType } from "@/types/terminal";
 import { detectAvailableShells } from "@/utils/shell-detection";
 import { getWslDistroName } from "@/utils/shell-detection";
 import { useAppStore } from "@/store/appStore";
 import { isWindows } from "@/utils/platform";
+import { shouldOfferGitBashSetup } from "@/utils/gitBashSetup";
 import { Select, SelectItem, Toggle } from "@/components/ui";
+import { GitBashSetupDialog } from "@/components/OpenConnections/GitBashSetupDialog";
 import { KeyPathInput } from "./KeyPathInput";
 import { SettingsField } from "./SettingsField";
 
 /** Sentinel value for the "platform default" shell option (Radix Select forbids empty-string item values). */
 const PLATFORM_DEFAULT_SHELL = "__platform_default__";
+
+/** Sentinel value for the "Git Bash — set up…" row that launches the guided install (#1672). */
+const GIT_BASH_SETUP = "__git_bash_setup__";
 
 const SHELL_LABELS: Record<string, string> = {
   bash: "Bash",
@@ -42,13 +47,22 @@ interface GeneralSettingsProps {
 
 export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSettingsProps) {
   const [availableShells, setAvailableShells] = useState<ShellType[]>([]);
+  const [gitBashSetupOpen, setGitBashSetupOpen] = useState(false);
   const platformDefaultShell = useAppStore((s) => s.defaultShell);
 
-  useEffect(() => {
+  const refreshShells = useCallback(() => {
     detectAvailableShells().then(setAvailableShells);
   }, []);
 
+  useEffect(() => {
+    refreshShells();
+  }, [refreshShells]);
+
   const show = (field: string) => !visibleFields || visibleFields.has(field);
+
+  // Windows-only: when no Unix shell is detected, offer a guided Git-for-Windows
+  // install instead of silently leaving bash unavailable (#1672).
+  const offerGitBashSetup = shouldOfferGitBashSetup(isWindows(), availableShells);
 
   return (
     <>
@@ -92,12 +106,18 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
             <Select
               data-testid="settings-default-shell"
               value={settings.defaultShell ?? PLATFORM_DEFAULT_SHELL}
-              onChange={(value) =>
+              onChange={(value) => {
+                // The "set up…" row launches the guided install rather than
+                // selecting a shell — leave the current default untouched.
+                if (value === GIT_BASH_SETUP) {
+                  setGitBashSetupOpen(true);
+                  return;
+                }
                 onChange({
                   ...settings,
                   defaultShell: value === PLATFORM_DEFAULT_SHELL ? undefined : value,
-                })
-              }
+                });
+              }}
             >
               <SelectItem value={PLATFORM_DEFAULT_SHELL}>
                 Platform default (
@@ -112,6 +132,9 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
                   {getShellLabel(shell, platformDefaultShell)}
                 </SelectItem>
               ))}
+              {offerGitBashSetup && (
+                <SelectItem value={GIT_BASH_SETUP}>Git Bash — set up…</SelectItem>
+              )}
             </Select>
           </SettingsField>
         )}
@@ -249,6 +272,17 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
           )}
         </div>
       )}
+
+      <GitBashSetupDialog
+        open={gitBashSetupOpen}
+        onOpenChange={(open) => {
+          setGitBashSetupOpen(open);
+          // Re-detect on close so a just-installed Git Bash appears without an
+          // app restart (#1672).
+          if (!open) refreshShells();
+        }}
+        onInstallGuided={refreshShells}
+      />
     </>
   );
 }

--- a/src/utils/gitBashSetup.test.ts
+++ b/src/utils/gitBashSetup.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the guided Git-for-Windows install gate (#1672). The gate decides
+ * when termiHub offers to install Git for Windows: only on Windows, and only
+ * when no Unix shell (Git Bash or a WSL distro) was detected. It is a pure
+ * function so it is exercised on every CI platform, not just Windows.
+ */
+import { describe, it, expect } from "vitest";
+import type { ShellType } from "@/types/terminal";
+import {
+  GIT_FOR_WINDOWS_DOWNLOAD_URL,
+  GIT_FOR_WINDOWS_WINGET_COMMAND,
+  hasUnixShell,
+  shouldOfferGitBashSetup,
+} from "./gitBashSetup";
+
+describe("gitBashSetup constants", () => {
+  it("uses the documented winget id and an -e exact match", () => {
+    expect(GIT_FOR_WINDOWS_WINGET_COMMAND).toContain("winget install");
+    expect(GIT_FOR_WINDOWS_WINGET_COMMAND).toContain("Git.Git");
+    expect(GIT_FOR_WINDOWS_WINGET_COMMAND).toContain("-e");
+  });
+
+  it("points the manual fallback at the official git-scm download page", () => {
+    expect(GIT_FOR_WINDOWS_DOWNLOAD_URL).toBe("https://git-scm.com/download/win");
+  });
+});
+
+describe("hasUnixShell", () => {
+  it("is true when Git Bash is present", () => {
+    expect(hasUnixShell(["powershell", "cmd", "gitbash"] as ShellType[])).toBe(true);
+  });
+
+  it("is true for a WSL distro", () => {
+    expect(hasUnixShell(["powershell", "cmd", "wsl:Ubuntu"] as ShellType[])).toBe(true);
+  });
+
+  it("is true for plain bash / zsh / sh", () => {
+    expect(hasUnixShell(["bash"] as ShellType[])).toBe(true);
+    expect(hasUnixShell(["zsh"] as ShellType[])).toBe(true);
+    expect(hasUnixShell(["sh"] as unknown as ShellType[])).toBe(true);
+  });
+
+  it("is false for a Windows box with only native shells", () => {
+    expect(hasUnixShell(["powershell", "cmd"] as ShellType[])).toBe(false);
+  });
+
+  it("is false for an empty list", () => {
+    expect(hasUnixShell([])).toBe(false);
+  });
+});
+
+describe("shouldOfferGitBashSetup", () => {
+  it("offers setup on Windows with no Unix shell", () => {
+    expect(shouldOfferGitBashSetup(true, ["powershell", "cmd"] as ShellType[])).toBe(true);
+  });
+
+  it("does not offer setup on Windows when Git Bash is already detected", () => {
+    expect(shouldOfferGitBashSetup(true, ["powershell", "cmd", "gitbash"] as ShellType[])).toBe(
+      false
+    );
+  });
+
+  it("does not offer setup on Windows when a WSL distro is present", () => {
+    expect(shouldOfferGitBashSetup(true, ["powershell", "wsl:Debian"] as ShellType[])).toBe(false);
+  });
+
+  it("never offers setup off Windows, even with no Unix shell", () => {
+    expect(shouldOfferGitBashSetup(false, ["cmd"] as ShellType[])).toBe(false);
+    expect(shouldOfferGitBashSetup(false, [] as ShellType[])).toBe(false);
+  });
+});

--- a/src/utils/gitBashSetup.ts
+++ b/src/utils/gitBashSetup.ts
@@ -1,0 +1,52 @@
+import type { ShellType } from "@/types/terminal";
+
+/**
+ * winget one-liner that installs Git for Windows — the MSYS2-based bundle that
+ * provides Git Bash plus coreutils, curl, OpenSSH, tar/gzip/xz, git, vim and
+ * less. termiHub does not host or redistribute it; winget (or the user) fetches
+ * it and termiHub only launches the resulting `bash.exe`.
+ */
+export const GIT_FOR_WINDOWS_WINGET_COMMAND = "winget install --id Git.Git -e";
+
+/**
+ * Official Git for Windows download page. The manual / portable-Git fallback for
+ * machines without winget (App Installer). Help ends here — termiHub never hosts
+ * the installer.
+ */
+export const GIT_FOR_WINDOWS_DOWNLOAD_URL = "https://git-scm.com/download/win";
+
+/**
+ * Shell names that provide a POSIX / Unix environment (bash + coreutils). Git
+ * Bash (`gitbash`) counts: it is the Unix-tools provider this feature guides the
+ * user to install.
+ */
+const UNIX_SHELL_NAMES: ReadonlySet<string> = new Set([
+  "bash",
+  "zsh",
+  "sh",
+  "fish",
+  "nushell",
+  "gitbash",
+]);
+
+/**
+ * True when the detected-shell list already contains a usable Unix shell — a
+ * known POSIX shell (incl. Git Bash) or a WSL distribution (`wsl:<distro>`),
+ * which brings its own bash. When this holds, no guided install is needed.
+ */
+export function hasUnixShell(shells: readonly ShellType[]): boolean {
+  return shells.some((shell) => shell.startsWith("wsl:") || UNIX_SHELL_NAMES.has(shell));
+}
+
+/**
+ * Whether to offer the guided Git-for-Windows install for the given platform and
+ * detected shells. The guidance is Windows-only (macOS/Linux ship native Unix
+ * shells) and only surfaces when no Unix shell — Git Bash or WSL bash — was
+ * detected. Pure so the gate is unit-testable on any CI platform.
+ */
+export function shouldOfferGitBashSetup(
+  isWindowsPlatform: boolean,
+  shells: readonly ShellType[]
+): boolean {
+  return isWindowsPlatform && !hasUnixShell(shells);
+}


### PR DESCRIPTION
## Summary

On Windows, when no Unix shell is detected — no Git Bash (via the hardened detection from #1671) and no WSL bash — **Settings → General → Default Shell** now shows a **"Git Bash — set up…"** entry. Selecting it opens a consent-gated **"Set up Git Bash"** dialog offering two paths:

- **Install in terminal** → opens a local terminal tab pre-loaded with `winget install --id Git.Git -e` (drives any UAC / winget prompts in the tab).
- **Open git-scm.com** → deep-links the official installer for machines without winget (also the portable-Git route).

Nothing is installed until the user acts. On dialog close the picker re-detects available shells, so a just-installed Git Bash appears as a normal selectable row **without an app restart**.

This is the detect-and-guide half of the git-bash-provisioning concept (`docs/concepts/backlog/git-bash-provisioning.html`), building on the detection hardening in #1671 and mirroring the shipped X-server VcXsrv guided-install UX.

## Approach

- **Reuses existing infra, no new backend.** The guided install goes through the existing `guideTerminalInstall` / `openLocalCommandTab` primitives (built for the macOS Homebrew→XQuartz flow, #1309/#1312); the dialog is composed from the shared `src/components/ui/` primitives (Modal/Button) — no bespoke dialog CSS.
- **Windows-only, testable everywhere.** The gate (`shouldOfferGitBashSetup` / `hasUnixShell`) is a pure function, so the offer/suppress logic is unit-tested on every CI platform even though the flow itself only surfaces on Windows.

## Files

- `src/utils/gitBashSetup.ts` — pure gate + winget command / download URL constants.
- `src/components/OpenConnections/guideGitBashInstall.ts` — winget-terminal + git-scm.com helpers.
- `src/components/OpenConnections/GitBashSetupDialog.tsx` — consent/guided-install dialog.
- `src/components/Settings/GeneralSettings.tsx` — "Git Bash — set up…" picker entry + re-detect on close.

## Tests

- Unit tests for the gate, the winget/download helpers (reuse of `guideTerminalInstall`, `openUrl` to git-scm.com), and the dialog's install / download / dismiss actions. Full frontend suite green locally (`pnpm test`, `pnpm build`, lint, prettier, markdownlint).
- The Windows guided install (winget tab, download link, post-install re-detection) is not exercised by per-PR CI — manual steps added to `docs/testing.md`.

Closes #1672