### PR TITLE
docs(sftp): correct stale ftp-client concept path in transfer state comment

### DIFF
--- a/src-tauri/src/files/transfer/state.rs
+++ b/src-tauri/src/files/transfer/state.rs
@@ -4,7 +4,7 @@
 //! no I/O, no async, no Tauri. That keeps every transition (valid and invalid)
 //! unit-testable without a live FTP/SFTP server, which is the high-value,
 //! macOS-runnable coverage called for by the concept
-//! (`docs/concepts/partial/ftp-client.html`, "Transfer Queue State Machine").
+//! (`docs/concepts/implemented/ftp-client.html`, "Transfer Queue State Machine").
 //!
 //! ```text
 //! [*] --> Queued


### PR DESCRIPTION
Updates the doc-comment in `src-tauri/src/files/transfer/state.rs` that still pointed at the pre-reconciliation path `docs/concepts/partial/ftp-client.html`. The concept moved to `docs/concepts/implemented/ftp-client.html` in PRs #1665/#1666 (which were scoped to `docs/` only).

Verified the new path exists and that a repo-wide grep for the other listed pre-reconciliation concept paths (`concepts/partial/ftp-client`, `concepts/backlog/elevated-sftp`, `concepts/backlog/remote-agent-update`, `concepts/partial/shell-context-menu`, `concepts/backlog/confirm-dialog`) across `src-tauri core agent src` returns no other hits.

Comment-only change, no runtime or user-facing surface.

Closes #1667