### PR TITLE
feat(terminal): render bold/italic/underline for syntax highlight rules

### DIFF
--- a/docs/changes/dev0/feature/1707-highlight-text-styles.md
+++ b/docs/changes/dev0/feature/1707-highlight-text-styles.md
@@ -1,0 +1,7 @@
+### Added
+
+- Syntax-highlighting rules now render **bold**, _italic_ and underline, not
+  just color. Built-in rules that set `underline` (URLs, email addresses) now
+  visibly underline matched text, and custom rules can combine color with any of
+  bold/italic/underline. Server-set ANSI colors are still never overridden.
+  Follow-up to the syntax-highlighting engine (#1697, #1707).

--- a/src/services/syntaxHighlighting.test.ts
+++ b/src/services/syntaxHighlighting.test.ts
@@ -5,6 +5,7 @@ import {
   compileRules,
   findMatches,
   normalizeHexColor,
+  styleDecorationElement,
 } from "./syntaxHighlighting";
 import type { HighlightRule } from "../types/syntaxHighlighting";
 
@@ -108,6 +109,47 @@ describe("findMatches overlap resolution", () => {
     // Should terminate and produce only the non-empty match.
     const matches = findMatches("xaax", compiled);
     expect(matches).toEqual([expect.objectContaining({ start: 1, end: 3 })]);
+  });
+});
+
+describe("styleDecorationElement", () => {
+  it("fills the (otherwise empty) overlay with text and applies bold/italic/underline", () => {
+    const el = document.createElement("div");
+    styleDecorationElement(
+      el,
+      "ERROR",
+      "#f44747",
+      { bold: true, italic: true, underline: true },
+      { fontFamily: "monospace", fontSize: 14, letterSpacing: 1 }
+    );
+    expect(el.textContent).toBe("ERROR");
+    expect(el.style.fontWeight).toBe("bold");
+    expect(el.style.fontStyle).toBe("italic");
+    expect(el.style.textDecoration).toBe("underline");
+    expect(el.style.fontFamily).toBe("monospace");
+    expect(el.style.fontSize).toBe("14px");
+    expect(el.style.letterSpacing).toBe("1px");
+    // Never intercept selection / clicks meant for the real text underneath.
+    expect(el.style.pointerEvents).toBe("none");
+    // The color is set so the overlay glyphs are visible on the top layer.
+    expect(el.style.color).not.toBe("");
+  });
+
+  it("applies only the styles the rule requests (underline-only)", () => {
+    const el = document.createElement("div");
+    styleDecorationElement(el, "https://x.io", "#3794ff", { underline: true });
+    expect(el.textContent).toBe("https://x.io");
+    expect(el.style.textDecoration).toBe("underline");
+    expect(el.style.fontWeight).toBe("");
+    expect(el.style.fontStyle).toBe("");
+  });
+
+  it("leaves weight/slant/decoration unset when the rule has no text style", () => {
+    const el = document.createElement("div");
+    styleDecorationElement(el, "x", "#ffffff", {});
+    expect(el.style.fontWeight).toBe("");
+    expect(el.style.fontStyle).toBe("");
+    expect(el.style.textDecoration).toBe("");
   });
 });
 
@@ -269,6 +311,60 @@ describe("SyntaxHighlightingEngine lifecycle", () => {
     await new Promise<void>((r) => term.write("now an ERROR appears\r\n", () => r()));
     expect(decoSpy).toHaveBeenCalledTimes(1);
     expect(decoSpy.mock.calls[0][0].width).toBe(5);
+    engine.dispose();
+  });
+
+  it("renders color-only rules on the bottom layer (selection stays legible)", async () => {
+    term = await makeTerm("plain ERROR here\r\n");
+    const decoSpy = vi.spyOn(term, "registerDecoration");
+
+    const engine = new SyntaxHighlightingEngine(term);
+    engine.enable([errorRule]);
+
+    expect(decoSpy).toHaveBeenCalledTimes(1);
+    expect(decoSpy.mock.calls[0][0].layer).toBe("bottom");
+    engine.dispose();
+  });
+
+  it("renders a styled (color + underline) rule on the top layer and styles the overlay", async () => {
+    term = await makeTerm("see https://x.io now\r\n");
+    const urlRule = rule({
+      id: "url",
+      pattern: "https?://\\S+",
+      style: { color: "#3794ff", underline: true },
+    });
+
+    const overlays: HTMLElement[] = [];
+    vi.spyOn(term, "registerDecoration").mockImplementation((opts) => {
+      // Styled runs must sit above the text layer to be visible.
+      expect(opts.layer).toBe("top");
+      expect(opts.foregroundColor).toBe("#3794ff");
+      const el = document.createElement("div");
+      overlays.push(el);
+      return {
+        marker: opts.marker,
+        element: el,
+        isDisposed: false,
+        onRender: (cb: (e: HTMLElement) => void) => {
+          cb(el); // simulate xterm rendering the decoration
+          return { dispose: () => {} };
+        },
+        onDispose: () => ({ dispose: () => {} }),
+        dispose: () => {},
+      } as unknown as ReturnType<typeof term.registerDecoration>;
+    });
+
+    const engine = new SyntaxHighlightingEngine(term);
+    engine.enable([urlRule]);
+
+    expect(overlays.length).toBeGreaterThan(0);
+    const joined = overlays.map((el) => el.textContent ?? "").join("");
+    expect(joined).toContain("https://x.io");
+    expect(overlays.every((el) => el.style.textDecoration === "underline")).toBe(true);
+    expect(overlays.every((el) => el.style.color !== "")).toBe(true);
+    // Underline-only: no weight/slant applied.
+    expect(overlays.every((el) => el.style.fontWeight === "")).toBe(true);
+
     engine.dispose();
   });
 });

--- a/src/services/syntaxHighlighting.ts
+++ b/src/services/syntaxHighlighting.ts
@@ -68,6 +68,59 @@ export interface SyntaxHighlightingEngineOptions {
   maxLineLength?: number;
 }
 
+/** The subset of {@link HighlightStyle} the native color recolor cannot express. */
+type TextStyle = Pick<HighlightStyle, "bold" | "italic" | "underline">;
+
+/** Font attributes copied onto a styled overlay so its glyphs line up with the cells. */
+export interface DecorationFont {
+  fontFamily?: string;
+  fontSize?: number;
+  letterSpacing?: number;
+}
+
+/** Whether a rule asks for any attribute the native `foregroundColor` recolor cannot render. */
+function hasTextStyle(style: TextStyle): boolean {
+  return !!(style.bold || style.italic || style.underline);
+}
+
+/**
+ * Fills a decoration's overlay element with the matched text and applies
+ * bold/italic/underline.
+ *
+ * xterm's native `IDecorationOptions.foregroundColor` recolors the real buffer
+ * cell, which is how the color path works — but it cannot express weight, slant
+ * or underline. The decoration's `onRender` element is a separate, empty,
+ * exactly-sized (`width` cells × cell height, correct `line-height`) overlay
+ * `div.xterm-decoration`. Styling that *empty* div (the buggy approach shown in
+ * the concept doc) has no glyph to act on, so nothing renders.
+ *
+ * Giving the overlay the matched text — in the rule color, with the terminal's
+ * own font metrics so the monospace glyphs land exactly over the recolored
+ * cells — is what makes the styles visible. Registered on the top layer, the
+ * styled copy over-paints the (identically colored) real glyph, adding the
+ * weight/slant/underline that the recolor alone cannot.
+ */
+export function styleDecorationElement(
+  el: HTMLElement,
+  text: string,
+  color: string,
+  style: TextStyle,
+  font: DecorationFont = {}
+): void {
+  el.textContent = text;
+  el.style.color = color;
+  el.style.whiteSpace = "pre";
+  el.style.overflow = "hidden";
+  // The real text underneath owns selection and clicks; never intercept them.
+  el.style.pointerEvents = "none";
+  if (font.fontFamily) el.style.fontFamily = font.fontFamily;
+  if (font.fontSize) el.style.fontSize = `${font.fontSize}px`;
+  if (font.letterSpacing) el.style.letterSpacing = `${font.letterSpacing}px`;
+  el.style.fontWeight = style.bold ? "bold" : "";
+  el.style.fontStyle = style.italic ? "italic" : "";
+  el.style.textDecoration = style.underline ? "underline" : "";
+}
+
 const HEX_FULL = /^#[0-9a-fA-F]{6}$/;
 const HEX_SHORT = /^#[0-9a-fA-F]{3}$/;
 
@@ -469,11 +522,13 @@ export class SyntaxHighlightingEngine {
     let runRow = -1;
     let runStartX = -1;
     let runWidth = 0;
+    let runText = "";
 
     const flush = (): void => {
       if (runWidth <= 0) return;
-      this.decorate(runRow, runStartX, runWidth, cursorAbs, match.color, out);
+      this.decorate(runRow, runStartX, runWidth, cursorAbs, match, runText, out);
       runWidth = 0;
+      runText = "";
     };
 
     for (let col = match.start; col < match.end; col++) {
@@ -484,43 +539,61 @@ export class SyntaxHighlightingEngine {
       const line = physRow === undefined ? undefined : getRowLine(physRow);
       const cell = line?.getCell(x, cellRef);
       const decorable = !!cell && cell.isFgDefault();
+      // One char per decorable cell keeps the styled overlay's text aligned with
+      // the cells it covers. Blank/trailing cells fall back to a space.
+      const char = decorable && cell ? cell.getChars() || " " : "";
 
       const contiguous = decorable && physRow === runRow && x === runStartX + runWidth;
       if (contiguous) {
         runWidth++;
+        runText += char;
       } else {
         flush();
         if (decorable) {
           runRow = physRow as number;
           runStartX = x;
           runWidth = 1;
+          runText = char;
         } else {
           runWidth = 0;
+          runText = "";
         }
       }
     }
     flush();
   }
 
-  /** Registers a marker + foreground-color decoration for one run of cells. */
+  /**
+   * Registers a marker + decoration for one run of cells. The native
+   * `foregroundColor` recolors the real glyph (the color path). When the rule
+   * also asks for bold/italic/underline — which the recolor cannot express —
+   * the decoration renders on the top layer and its overlay element is filled
+   * with the run's styled text on render (see {@link styleDecorationElement}).
+   */
   private decorate(
     physRow: number,
     x: number,
     width: number,
     cursorAbs: number,
-    color: string,
+    match: RuleMatch,
+    text: string,
     out: IDisposable[]
   ): void {
     const marker = this.xterm.registerMarker(physRow - cursorAbs);
     if (!marker) return;
 
+    const style = match.rule.style;
+    const styled = hasTextStyle(style);
+
     const decoration = this.xterm.registerDecoration({
       marker,
       x,
       width,
-      foregroundColor: color,
-      // Render under the selection so selected text stays legible.
-      layer: "bottom",
+      foregroundColor: match.color,
+      // Color-only runs render under the selection so selected text stays
+      // legible. Styled runs put their glyphs in the overlay, which must sit
+      // above the text layer to be seen, so they render on top.
+      layer: styled ? "top" : "bottom",
     });
 
     // If the decoration could not be created (e.g. alt buffer raced in), drop
@@ -531,6 +604,22 @@ export class SyntaxHighlightingEngine {
     }
 
     out.push(decoration, marker);
+
+    if (!styled) return;
+
+    const font: DecorationFont = {
+      fontFamily: this.xterm.options.fontFamily,
+      fontSize: this.xterm.options.fontSize,
+      letterSpacing: this.xterm.options.letterSpacing,
+    };
+    const sub = decoration.onRender((el) => {
+      // Idempotent per element: xterm fires onRender every frame, so style each
+      // (re)created overlay only once to avoid needless layout churn on scroll.
+      if (el.dataset.thHighlightStyled === "1") return;
+      styleDecorationElement(el, text, match.color, style, font);
+      el.dataset.thHighlightStyled = "1";
+    });
+    out.push(sub);
   }
 
   /** Disposes and forgets a single logical line's decorations. */


### PR DESCRIPTION
## Summary

Follow-up to the syntax-highlighting engine (#1697). Highlight rules already carry `bold`/`italic`/`underline` (several built-ins set `underline: true`), but the engine rendered **color only**.

Root cause: xterm's native `IDecorationOptions.foregroundColor` recolors the *real* buffer cell (the color path, ANSI-safe), but it cannot express weight/slant/underline. The decoration's `onRender` element is a separate, **empty**, exactly-sized (`width` cells × cell height) overlay `div.xterm-decoration` — so styling that empty div (the approach the concept doc sketches) has no glyph to act on and renders nothing. Grounded this by reading the bundled xterm v6 DOM-renderer source (`_createElement` / `forEachDecorationAtCell`).

## Mechanism

For runs whose rule requests any text style, fill the overlay with the matched run text, in the rule color, using the terminal's own font metrics (`fontFamily`/`fontSize`/`letterSpacing`), styled with the requested `font-weight` / `font-style` / `text-decoration`, registered on the **top** layer so the styled copy over-paints the (identically recolored) real glyph. `pointer-events: none` keeps selection/clicks on the real text.

- Color-only runs are unchanged: bottom layer, no overlay text, no `onRender` cost.
- The `isFgDefault()` ANSI-conflict guard, alt-screen skip, throttling and per-line disposal are all intact.
- Overlay styling is idempotent per element (guarded), so heavy scroll does not re-style every frame.

Changes are confined to `src/services/syntaxHighlighting.ts` and its test.

## Tests

TDD (test commit precedes the feat commit):
- `styleDecorationElement` unit tests — text/color/weight/slant/underline/font/pointer-events, and that only requested styles are applied.
- Engine wiring — color-only rules register on the **bottom** layer; a color+underline rule registers on the **top** layer, and the captured `onRender` fills+styles the overlay.

`pnpm run lint`, `tsc --noEmit`, `prettier --check`, and the highlighting suites (106 tests) all pass.

## Manual verification

Visual weight/slant/underline can only be confirmed against a real renderer (jsdom has no layout): enable the URLs built-in rule and confirm matched URLs on default-fg text are underlined, and a custom bold/italic rule renders accordingly, without overriding server ANSI colors.

Closes #1707