### PR TITLE
feat(remote-desktop): gate the experimental remote-desktop feature behind experimentalFeaturesEnabled

### DIFF
--- a/docs/changes/dev0/feature/1705-remote-desktop-gating.md
+++ b/docs/changes/dev0/feature/1705-remote-desktop-gating.md
@@ -1,0 +1,8 @@
+### Changed
+
+- The experimental graphical remote-desktop feature (VNC/RDP session layer) is
+  now hidden behind the existing **Allow Experimental Features** setting. With
+  it off, remote-desktop connection types are absent from the New Connection
+  type picker and any saved remote-desktop connection is hidden from the
+  sidebar; with it on, the types appear labelled "— Experimental" and are fully
+  usable (#1705).

--- a/src/components/ConnectionEditor/ConnectionEditor.experimental-gating.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.experimental-gating.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Experimental gating of the connection-type picker (#1705).
+ *
+ * The New Connection type picker must not offer graphical remote-desktop types
+ * (those reporting `capabilities.graphical`) unless `experimentalFeaturesEnabled`
+ * is on. When it is on, those types appear labelled "— Experimental".
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionEditor } from "./ConnectionEditor";
+import { TooltipProvider } from "@/components/ui";
+import type { ConnectionTypeInfo } from "@/types/connection";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+const LOCAL_TYPE: ConnectionTypeInfo = {
+  typeId: "local",
+  displayName: "Local Shell",
+  icon: "terminal",
+  schema: { groups: [] },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+const MOCK_RD_TYPE: ConnectionTypeInfo = {
+  typeId: "mock-remote-desktop",
+  displayName: "Mock Remote Desktop",
+  icon: "monitor",
+  schema: { groups: [] },
+  capabilities: {
+    monitoring: false,
+    fileBrowser: false,
+    resize: true,
+    persistent: false,
+    graphical: true,
+  },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderNew(experimentalFeaturesEnabled: boolean) {
+  const initial = useAppStore.getInitialState();
+  useAppStore.setState({
+    ...initial,
+    connections: [],
+    connectionTypes: [LOCAL_TYPE, MOCK_RD_TYPE],
+    settings: { ...initial.settings, experimentalFeaturesEnabled },
+  });
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <ConnectionEditor
+          tabId="tab-1"
+          meta={{ connectionId: "new", folderId: null }}
+          isVisible={true}
+        />
+      </TooltipProvider>
+    );
+  });
+}
+
+/** Open the Radix type-select and return its rendered option elements. */
+function openTypeOptions(): HTMLElement[] {
+  const trigger = document.querySelector(
+    '[data-testid="connection-editor-type-select"]'
+  ) as HTMLElement | null;
+  if (!trigger) throw new Error("type select trigger not found");
+  for (let i = 0; i < 3 && document.querySelectorAll(".ui-select__item").length === 0; i++) {
+    act(() => {
+      trigger.focus();
+      trigger.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", code: "Enter", keyCode: 13, bubbles: true })
+      );
+    });
+  }
+  return Array.from(document.querySelectorAll<HTMLElement>(".ui-select__item"));
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("ConnectionEditor — experimental type-picker gating", () => {
+  it("omits graphical remote-desktop types when the flag is off", () => {
+    renderNew(false);
+    const options = openTypeOptions();
+    const values = options.map((o) => o.getAttribute("data-value"));
+    expect(values).toContain("local");
+    expect(values).not.toContain("mock-remote-desktop");
+  });
+
+  it("offers graphical types labelled '— Experimental' when the flag is on", () => {
+    renderNew(true);
+    const options = openTypeOptions();
+    const rd = options.find((o) => o.getAttribute("data-value") === "mock-remote-desktop");
+    expect(rd).toBeTruthy();
+    expect(rd?.textContent).toContain("Experimental");
+    const local = options.find((o) => o.getAttribute("data-value") === "local");
+    expect(local?.textContent).not.toContain("Experimental");
+  });
+});

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -49,6 +49,8 @@ import { UnsavedChangesDialog } from "./UnsavedChangesDialog";
 import { findLeafByTab } from "@/utils/panelTree";
 import { useEditorKeyboard } from "@/hooks/useEditorKeyboard";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
+import { useExperimentalFeatures } from "@/hooks/useExperimentalFeatures";
+import { buildGatedTypeOptions } from "@/utils/experimentalTypes";
 import { isWindows } from "@/utils/platform";
 import "./ConnectionEditor.css";
 
@@ -97,13 +99,6 @@ const EDITOR_ICONS: Record<EditorCategory, LucideIcon> = {
 /** Check whether any field in TerminalOptions has a non-undefined value. */
 function hasTerminalOptions(opts: TerminalOptions): boolean {
   return Object.values(opts).some((v) => v !== undefined);
-}
-
-/** Build type options from the registry. */
-function buildTypeOptions(
-  connectionTypes: ConnectionTypeInfo[]
-): { value: string; label: string }[] {
-  return connectionTypes.map((ct) => ({ value: ct.typeId, label: ct.displayName }));
 }
 
 /** Find schema for a type ID in the connection types registry. */
@@ -203,6 +198,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   const setEditorDirty = useAppStore((s) => s.setEditorDirty);
   const pendingCloseRequest = useAppStore((s) => s.pendingCloseRequest);
   const setPendingCloseRequest = useAppStore((s) => s.setPendingCloseRequest);
+  const experimental = useExperimentalFeatures();
 
   const editingConnectionId = meta.connectionId;
   const editingConnectionFolderId = meta.folderId;
@@ -491,14 +487,17 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   const [isCompact, setIsCompact] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Build type options from the effective registry
+  // Build type options from the effective registry, gating experimental
+  // (graphical remote-desktop) types behind `experimentalFeaturesEnabled`
+  // (#1705). The currently-selected type is always kept so editing an existing
+  // experimental connection never loses its selection.
   const typeOptions = useMemo(() => {
     if (isAgentDefinitionMode) {
       // Definition mode: show only agent-reported types (no "Remote Agent" entry)
-      return agentConnectionTypes.map((ct) => ({ value: ct.typeId, label: ct.displayName }));
+      return buildGatedTypeOptions(agentConnectionTypes, experimental, selectedType);
     }
-    return buildTypeOptions(connectionTypes);
-  }, [isAgentDefinitionMode, agentConnectionTypes, connectionTypes]);
+    return buildGatedTypeOptions(connectionTypes, experimental, selectedType);
+  }, [isAgentDefinitionMode, agentConnectionTypes, connectionTypes, experimental, selectedType]);
 
   // Get the current schema from the effective registry
   const currentTypeInfo = useMemo(

--- a/src/components/Sidebar/ConnectionList.experimental-gating.test.tsx
+++ b/src/components/Sidebar/ConnectionList.experimental-gating.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Experimental gating of graphical remote-desktop connections in the sidebar
+ * (#1705).
+ *
+ * A saved connection whose type reports `capabilities.graphical` (the mock
+ * backend, and the real VNC/RDP backends) must be hidden from the connection
+ * tree when `experimentalFeaturesEnabled` is off, and shown when it is on.
+ * Non-graphical connections are unaffected either way.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import { TooltipProvider } from "@/components/ui";
+import type {
+  SavedConnection,
+  RemoteAgentDefinition,
+  ConnectionTypeInfo,
+} from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+  isSshKeyEncrypted: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({ agent }: { agent: RemoteAgentDefinition }) =>
+    React.createElement("div", { "data-testid": `agent-node-${agent.id}` }),
+}));
+
+const SSH_TYPE: ConnectionTypeInfo = {
+  typeId: "ssh",
+  displayName: "SSH",
+  icon: "ssh",
+  schema: { groups: [] },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+const MOCK_RD_TYPE: ConnectionTypeInfo = {
+  typeId: "mock-remote-desktop",
+  displayName: "Mock Remote Desktop",
+  icon: "monitor",
+  schema: { groups: [] },
+  capabilities: {
+    monitoring: false,
+    fileBrowser: false,
+    resize: true,
+    persistent: false,
+    graphical: true,
+  },
+};
+
+const SSH_CONN: SavedConnection = {
+  id: "ssh-1",
+  name: "My SSH",
+  folderId: null,
+  config: { type: "ssh", config: { host: "example.com" } },
+};
+
+const RD_CONN: SavedConnection = {
+  id: "rd-1",
+  name: "My Desktop",
+  folderId: null,
+  config: { type: "mock-remote-desktop", config: { host: "example.com" } },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(experimentalFeaturesEnabled: boolean) {
+  const initial = useAppStore.getInitialState();
+  useAppStore.setState({
+    ...initial,
+    connections: [SSH_CONN, RD_CONN],
+    connectionTypes: [SSH_TYPE, MOCK_RD_TYPE],
+    settings: { ...initial.settings, experimentalFeaturesEnabled },
+  });
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <ConnectionList />
+      </TooltipProvider>
+    );
+  });
+}
+
+function row(id: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="connection-item-${id}"]`);
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("ConnectionList — experimental remote-desktop gating", () => {
+  it("hides graphical remote-desktop connections when the flag is off", () => {
+    render(false);
+    expect(row("ssh-1")).not.toBeNull();
+    expect(row("rd-1")).toBeNull();
+  });
+
+  it("shows graphical remote-desktop connections when the flag is on", () => {
+    render(true);
+    expect(row("ssh-1")).not.toBeNull();
+    expect(row("rd-1")).not.toBeNull();
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -43,6 +43,7 @@ import { useSectionResize } from "@/hooks/useSectionResize";
 import { useTreeSelection } from "@/hooks/useTreeSelection";
 import { useRovingListNav } from "@/hooks/useRovingListNav";
 import { computeVisibleTreeNodes, type VisibleTreeNode } from "@/utils/computeVisibleTreeNodes";
+import { experimentalTypeIds } from "@/utils/experimentalTypes";
 import { filterConnectionTree, type ConnectionTreeFilter } from "@/utils/connectionSearch";
 import {
   getJumpHosts,
@@ -486,9 +487,20 @@ export function ConnectionList() {
     onConfirm: () => void;
   } | null>(null);
   const folders = useAppStore((s) => s.folders);
-  const connections = useAppStore((s) => s.connections);
+  const allConnections = useAppStore((s) => s.connections);
+  const connectionTypes = useAppStore((s) => s.connectionTypes);
   const remoteAgents = useAppStore((s) => s.remoteAgents);
   const experimental = useExperimentalFeatures();
+
+  // Gate experimental (graphical remote-desktop) connections out of the sidebar
+  // when the flag is off (#1705), so an already-saved VNC/RDP/mock connection is
+  // hidden from normal navigation exactly as the type picker hides its type.
+  const connections = useMemo(() => {
+    if (experimental) return allConnections;
+    const gated = experimentalTypeIds(connectionTypes);
+    if (gated.size === 0) return allConnections;
+    return allConnections.filter((c) => !gated.has(c.config.type));
+  }, [experimental, allConnections, connectionTypes]);
   const toggleFolder = useAppStore((s) => s.toggleFolder);
   const updateConnection = useAppStore((s) => s.updateConnection);
   const openConnectionEditorTab = useAppStore((s) => s.openConnectionEditorTab);

--- a/src/utils/experimentalTypes.test.ts
+++ b/src/utils/experimentalTypes.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import type { ConnectionTypeInfo } from "@/types/connection";
+import {
+  EXPERIMENTAL_TYPE_SUFFIX,
+  isExperimentalConnectionType,
+  experimentalTypeIds,
+  buildGatedTypeOptions,
+} from "./experimentalTypes";
+
+function makeType(typeId: string, displayName: string, graphical = false): ConnectionTypeInfo {
+  return {
+    typeId,
+    displayName,
+    icon: "monitor",
+    schema: { groups: [] },
+    capabilities: {
+      monitoring: false,
+      fileBrowser: false,
+      resize: true,
+      persistent: false,
+      graphical,
+    },
+  };
+}
+
+const SSH = makeType("ssh", "SSH");
+const LOCAL = makeType("local", "Local Shell");
+const VNC = makeType("vnc", "VNC", true);
+const RDP = makeType("rdp", "RDP", true);
+const MOCK = makeType("mock-remote-desktop", "Mock Remote Desktop", true);
+
+describe("isExperimentalConnectionType", () => {
+  it("treats graphical remote-desktop types as experimental", () => {
+    expect(isExperimentalConnectionType(VNC)).toBe(true);
+    expect(isExperimentalConnectionType(RDP)).toBe(true);
+    expect(isExperimentalConnectionType(MOCK)).toBe(true);
+  });
+
+  it("treats terminal/file-browser types as non-experimental", () => {
+    expect(isExperimentalConnectionType(SSH)).toBe(false);
+    expect(isExperimentalConnectionType(LOCAL)).toBe(false);
+  });
+});
+
+describe("experimentalTypeIds", () => {
+  it("collects only the graphical type IDs", () => {
+    const ids = experimentalTypeIds([SSH, LOCAL, VNC, RDP, MOCK]);
+    expect(ids).toEqual(new Set(["vnc", "rdp", "mock-remote-desktop"]));
+  });
+});
+
+describe("buildGatedTypeOptions", () => {
+  const registry = [SSH, LOCAL, VNC, RDP, MOCK];
+
+  it("hides experimental types when the flag is off", () => {
+    const opts = buildGatedTypeOptions(registry, false);
+    const values = opts.map((o) => o.value);
+    expect(values).toEqual(["ssh", "local"]);
+    expect(values).not.toContain("vnc");
+    expect(values).not.toContain("rdp");
+    expect(values).not.toContain("mock-remote-desktop");
+  });
+
+  it("shows experimental types labelled '— Experimental' when the flag is on", () => {
+    const opts = buildGatedTypeOptions(registry, true);
+    const byValue = Object.fromEntries(opts.map((o) => [o.value, o.label]));
+    expect(byValue.ssh).toBe("SSH");
+    expect(byValue.vnc).toBe("VNC" + EXPERIMENTAL_TYPE_SUFFIX);
+    expect(byValue.rdp).toBe("RDP" + EXPERIMENTAL_TYPE_SUFFIX);
+    expect(byValue["mock-remote-desktop"]).toBe("Mock Remote Desktop" + EXPERIMENTAL_TYPE_SUFFIX);
+  });
+
+  it("does not suffix non-experimental labels when the flag is on", () => {
+    const opts = buildGatedTypeOptions(registry, true);
+    expect(opts.find((o) => o.value === "ssh")?.label).toBe("SSH");
+  });
+
+  it("retains the currently-selected experimental type even when the flag is off", () => {
+    const opts = buildGatedTypeOptions(registry, false, "vnc");
+    const values = opts.map((o) => o.value);
+    expect(values).toContain("vnc");
+    expect(values).not.toContain("rdp");
+    // Still labelled experimental so the user sees why it is unusual.
+    expect(opts.find((o) => o.value === "vnc")?.label).toBe("VNC" + EXPERIMENTAL_TYPE_SUFFIX);
+  });
+});

--- a/src/utils/experimentalTypes.ts
+++ b/src/utils/experimentalTypes.ts
@@ -1,0 +1,53 @@
+import type { ConnectionTypeInfo } from "@/types/connection";
+
+/**
+ * Experimental connection-type gating (#1705).
+ *
+ * The graphical remote-desktop feature (shared layer #1680, plus the VNC #1681
+ * and RDP #1682 backends) ships **experimental** — hidden by default and only
+ * reachable when the existing `experimentalFeaturesEnabled` setting is on. It
+ * reuses that setting rather than inventing a new toggle.
+ *
+ * A connection type is experimental when it reports `capabilities.graphical`.
+ * That is protocol-agnostic on purpose: the mock backend and both real
+ * backends all set `graphical: true`, so each is gated automatically without
+ * hard-coding `vnc` / `rdp` / `mock-remote-desktop` type IDs here.
+ */
+
+/** Label suffix marking an experimental type in a picker (mirrors `ActivityBar`). */
+export const EXPERIMENTAL_TYPE_SUFFIX = " — Experimental";
+
+/** Whether a connection type is experimental (a graphical remote-desktop type). */
+export function isExperimentalConnectionType(info: {
+  capabilities: { graphical?: boolean };
+}): boolean {
+  return info.capabilities.graphical === true;
+}
+
+/** The set of experimental type IDs present in a registry. */
+export function experimentalTypeIds(types: ConnectionTypeInfo[]): Set<string> {
+  return new Set(types.filter(isExperimentalConnectionType).map((t) => t.typeId));
+}
+
+/**
+ * Build the connection-type picker options, applying experimental gating.
+ *
+ * When `experimental` is off, experimental (graphical) types are omitted
+ * entirely. When it is on, they are kept and their label is suffixed with
+ * "— Experimental". A `keepTypeId` (the currently-selected value) is always
+ * retained so an in-progress edit never loses its selection.
+ */
+export function buildGatedTypeOptions(
+  types: ConnectionTypeInfo[],
+  experimental: boolean,
+  keepTypeId?: string
+): { value: string; label: string }[] {
+  return types
+    .filter((ct) => experimental || !isExperimentalConnectionType(ct) || ct.typeId === keepTypeId)
+    .map((ct) => ({
+      value: ct.typeId,
+      label: isExperimentalConnectionType(ct)
+        ? ct.displayName + EXPERIMENTAL_TYPE_SUFFIX
+        : ct.displayName,
+    }));
+}


### PR DESCRIPTION
## Summary

Gates the experimental graphical remote-desktop feature (shared layer from #1680, plus the VNC #1681 and RDP #1682 backends) behind the codebase's **existing** `experimentalFeaturesEnabled` setting — no new toggle, no new mechanism.

Before this change the `mock-remote-desktop` backend (registered by default via the `mock-remote-desktop` Cargo feature) surfaced as "Mock Remote Desktop" in the New Connection type picker **un-gated**. This makes the whole feature opt-in and clearly marked, so it is never broadly reachable before the real backends land.

## Approach

A connection type is treated as experimental when it reports `capabilities.graphical` (the mock backend and both real backends all set `graphical: true`). Gating on the capability rather than hard-coded `vnc`/`rdp`/`mock-remote-desktop` IDs means the VNC/RDP backends are gated automatically when they register — nothing to revisit in #1681/#1682.

New shared helper `src/utils/experimentalTypes.ts`:
- `isExperimentalConnectionType` / `experimentalTypeIds` / `buildGatedTypeOptions`.

Wired in:
- **ConnectionEditor** — the New Connection type picker omits graphical types when the flag is off, and labels them `— Experimental` when on (following the `ActivityBar` precedent). The currently-selected type is always kept so editing an existing connection never loses its selection.
- **ConnectionList** — saved graphical remote-desktop connections are hidden from the sidebar tree when the flag is off, matching the picker; with the flag on they appear as normal.

## Behaviour with the flag OFF
- No remote-desktop entry in the type picker, so no create path.
- Any already-saved remote-desktop connection is hidden from the sidebar (consistent with the picker) — turned back on, it reappears. No data is deleted.
- Backend commands/registry entries stay registered (harmless); no UI path invokes them.

## Tests
- `src/utils/experimentalTypes.test.ts` — filter + label logic (hidden when off; labelled "— Experimental" when on; selection retained).
- `ConnectionEditor.experimental-gating.test.tsx` — the type picker hides/labels graphical types by flag.
- `ConnectionList.experimental-gating.test.tsx` — the sidebar hides/shows saved graphical connections by flag.

All new tests pass; existing ConnectionEditor + ConnectionList suites (166 tests) stay green; `tsc`, ESLint and Prettier clean.

Closes #1705