### PR TITLE
feat(vnc): VNC/RFB backend adapter for the shared remote-desktop layer (Closes #1681)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "rustc_version",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7534,6 +7544,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "vnc-rs",
  "vte",
  "webpki-roots",
  "which",
@@ -8237,6 +8248,23 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vnc-rs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5607299ce93dc285571540ee93de681a1be7a5765c35dfb2e1f049b493652145"
+dependencies = [
+ "async_io_stream",
+ "flate2",
+ "futures",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "wasm-bindgen-futures",
+]
 
 [[package]]
 name = "vswhom"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,6 +52,11 @@ suppaftp = { version = "6", default-features = false, features = [
 futures-rustls = { version = "0.26", optional = true }
 # Mozilla root CA bundle for the FTPS (rustls) client-config trust store.
 webpki-roots = { version = "1", optional = true }
+# VNC / RFB client: async, tokio-based framebuffer decode (Raw / Zrle / CopyRect)
+# plus cursor + clipboard, decoding on the wire into the shared, protocol-agnostic
+# graphical frame stream (#1681). Library-first per the repo rules — the RFB
+# state machine is not hand-rolled.
+vnc-rs = { version = "0.5", optional = true }
 ringbuf = "0.5.0"
 shellexpand = "3.1"
 vte = "0.13"
@@ -125,3 +130,9 @@ ftp = [
 # the shared remote-desktop layer (#1680) merges and is E2E-testable with no
 # real VNC/RDP server. Pulls no extra deps (tokio + tokio-util are core deps).
 mock-remote-desktop = []
+# VNC (RFB) graphical remote-desktop backend (#1681). Decodes framebuffer
+# updates in Rust into the shared frame stream and translates the shared input /
+# clipboard events to RFB. Depends on `ssh` because the connection editor's
+# optional SSH-tunnel group reaches the VNC server through the existing SSH
+# tunnel infrastructure (as the VNC concept specifies).
+vnc = ["dep:vnc-rs", "dep:tracing", "ssh"]

--- a/core/src/backends/mod.rs
+++ b/core/src/backends/mod.rs
@@ -27,3 +27,6 @@ pub mod ftp;
 
 #[cfg(feature = "mock-remote-desktop")]
 pub mod mock_remote_desktop;
+
+#[cfg(feature = "vnc")]
+pub mod vnc;

--- a/core/src/backends/vnc/config.rs
+++ b/core/src/backends/vnc/config.rs
@@ -1,0 +1,319 @@
+//! VNC connection settings: the deserialized config plus the schema the shared
+//! connection editor renders.
+//!
+//! The schema is the **shared field base** (#1680) plus VNC-specific groups,
+//! layered through the existing schema system — the user sees the same editor as
+//! every other graphical type, only the protocol-specific rows differ. This is
+//! the additive seam: the VNC backend never edits a hand-written editor switch.
+
+use serde::Deserialize;
+
+use crate::connection::schema::{Condition, FieldType, SelectOption, SettingsField, SettingsGroup};
+use crate::connection::{shared_field_base, SettingsSchema};
+
+/// Default RFB display 0 → port 5900.
+pub const VNC_BASE_PORT: u16 = 5900;
+
+/// Deserialized VNC connection settings.
+///
+/// A superset of the shared field base plus the VNC-specific rows. Unknown keys
+/// (e.g. frontend-only `scaleMode`, `autoReconnect`) are ignored.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct VncConfig {
+    /// Target host.
+    pub host: String,
+    /// Explicit TCP port. Overridden by [`display`](Self::display) when that is set.
+    pub port: u16,
+    /// Optional VNC display number; when set, the port is `5900 + display`.
+    pub display: Option<u16>,
+    /// VNC password (classic RFB auth). Empty means "no auth" is attempted.
+    pub password: String,
+    /// Suppress all keyboard/mouse input when `true`.
+    pub view_only: bool,
+    /// Render server-pushed cursor shapes when `true`.
+    pub show_remote_cursor: bool,
+    /// Preferred framebuffer encoding: `"zrle"` (compressed) or `"raw"`.
+    pub preferred_encoding: String,
+    /// Connect through an SSH tunnel when `true` (reuses the SSH backend).
+    pub use_ssh_tunnel: bool,
+    /// SSH gateway host for the tunnel.
+    pub ssh_host: String,
+    /// SSH gateway port.
+    pub ssh_port: u16,
+    /// SSH gateway username.
+    pub ssh_username: String,
+    /// SSH gateway password.
+    pub ssh_password: String,
+}
+
+impl Default for VncConfig {
+    fn default() -> Self {
+        Self {
+            host: String::new(),
+            port: VNC_BASE_PORT,
+            display: None,
+            password: String::new(),
+            view_only: false,
+            show_remote_cursor: true,
+            preferred_encoding: "zrle".to_string(),
+            use_ssh_tunnel: false,
+            ssh_host: String::new(),
+            ssh_port: 22,
+            ssh_username: String::new(),
+            ssh_password: String::new(),
+        }
+    }
+}
+
+impl VncConfig {
+    /// The effective TCP port to reach the VNC server on.
+    ///
+    /// The display number wins when present (`5900 + display`), realizing the
+    /// concept's display↔port interplay on the connect side; otherwise the
+    /// explicit port is used.
+    pub fn effective_port(&self) -> u16 {
+        match self.display {
+            Some(d) => VNC_BASE_PORT.saturating_add(d),
+            None => self.port,
+        }
+    }
+
+    /// Whether the raw (uncompressed) encoding was requested in preference to ZRLE.
+    pub fn prefers_raw(&self) -> bool {
+        self.preferred_encoding.eq_ignore_ascii_case("raw")
+    }
+}
+
+fn field(key: &str, label: &str, field_type: FieldType) -> SettingsField {
+    SettingsField {
+        key: key.to_string(),
+        label: label.to_string(),
+        description: None,
+        help_text: None,
+        field_type,
+        required: false,
+        default: None,
+        placeholder: None,
+        supports_env_expansion: false,
+        supports_tilde_expansion: false,
+        visible_when: None,
+    }
+}
+
+/// Only shown when `useSshTunnel` is enabled.
+fn when_tunnel_enabled() -> Option<Condition> {
+    Some(Condition {
+        field: "useSshTunnel".to_string(),
+        equals: serde_json::json!(true),
+    })
+}
+
+/// The VNC connection editor schema: the shared field base plus the VNC-specific
+/// **VNC Options** and **SSH Tunnel** groups.
+pub fn vnc_settings_schema() -> SettingsSchema {
+    let mut groups = shared_field_base(VNC_BASE_PORT);
+
+    groups.push(SettingsGroup {
+        key: "vnc".to_string(),
+        label: "VNC Options".to_string(),
+        fields: vec![
+            SettingsField {
+                description: Some(
+                    "VNC display number. When set, the port becomes 5900 + display.".to_string(),
+                ),
+                field_type: FieldType::Number {
+                    min: Some(0.0),
+                    max: Some(255.0),
+                },
+                placeholder: Some("0".to_string()),
+                ..field("display", "Display Number", FieldType::Text)
+            },
+            SettingsField {
+                default: Some(serde_json::json!("zrle")),
+                description: Some(
+                    "Framebuffer encoding preference. ZRLE is compressed; Raw is uncompressed."
+                        .to_string(),
+                ),
+                ..field(
+                    "preferredEncoding",
+                    "Encoding",
+                    FieldType::Select {
+                        options: vec![
+                            SelectOption {
+                                value: "zrle".to_string(),
+                                label: "ZRLE (compressed)".to_string(),
+                            },
+                            SelectOption {
+                                value: "raw".to_string(),
+                                label: "Raw (uncompressed)".to_string(),
+                            },
+                        ],
+                    },
+                )
+            },
+            SettingsField {
+                default: Some(serde_json::json!(true)),
+                description: Some(
+                    "Render the remote cursor shape pushed by the server.".to_string(),
+                ),
+                ..field("showRemoteCursor", "Show Remote Cursor", FieldType::Boolean)
+            },
+        ],
+    });
+
+    groups.push(SettingsGroup {
+        key: "sshTunnel".to_string(),
+        label: "SSH Tunnel".to_string(),
+        fields: vec![
+            SettingsField {
+                default: Some(serde_json::json!(false)),
+                description: Some(
+                    "Reach the VNC server through an SSH tunnel (SSH local forward).".to_string(),
+                ),
+                ..field("useSshTunnel", "Use SSH Tunnel", FieldType::Boolean)
+            },
+            SettingsField {
+                required: true,
+                supports_env_expansion: true,
+                placeholder: Some("bastion.example.com".to_string()),
+                visible_when: when_tunnel_enabled(),
+                ..field("sshHost", "SSH Host", FieldType::Text)
+            },
+            SettingsField {
+                default: Some(serde_json::json!(22)),
+                visible_when: when_tunnel_enabled(),
+                ..field("sshPort", "SSH Port", FieldType::Port)
+            },
+            SettingsField {
+                supports_env_expansion: true,
+                visible_when: when_tunnel_enabled(),
+                ..field("sshUsername", "SSH Username", FieldType::Text)
+            },
+            SettingsField {
+                visible_when: when_tunnel_enabled(),
+                ..field("sshPassword", "SSH Password", FieldType::Password)
+            },
+        ],
+    });
+
+    SettingsSchema { groups }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_target_display_zero() {
+        let cfg = VncConfig::default();
+        assert_eq!(cfg.port, 5900);
+        assert_eq!(cfg.effective_port(), 5900);
+        assert!(cfg.show_remote_cursor);
+        assert!(!cfg.prefers_raw());
+    }
+
+    #[test]
+    fn display_overrides_port() {
+        let cfg: VncConfig = serde_json::from_value(serde_json::json!({
+            "host": "h", "port": 5999, "display": 3
+        }))
+        .unwrap();
+        assert_eq!(cfg.effective_port(), 5903);
+    }
+
+    #[test]
+    fn explicit_port_used_without_display() {
+        let cfg: VncConfig = serde_json::from_value(serde_json::json!({
+            "host": "h", "port": 5905
+        }))
+        .unwrap();
+        assert_eq!(cfg.effective_port(), 5905);
+    }
+
+    #[test]
+    fn effective_port_saturates() {
+        let cfg = VncConfig {
+            display: Some(u16::MAX),
+            ..Default::default()
+        };
+        assert_eq!(cfg.effective_port(), u16::MAX);
+    }
+
+    #[test]
+    fn unknown_frontend_only_keys_are_ignored() {
+        let cfg: VncConfig = serde_json::from_value(serde_json::json!({
+            "host": "h", "scaleMode": "fit", "autoReconnect": true, "colorDepth": "16"
+        }))
+        .unwrap();
+        assert_eq!(cfg.host, "h");
+    }
+
+    #[test]
+    fn raw_encoding_preference_detected() {
+        let cfg: VncConfig = serde_json::from_value(serde_json::json!({
+            "host": "h", "preferredEncoding": "raw"
+        }))
+        .unwrap();
+        assert!(cfg.prefers_raw());
+    }
+
+    #[test]
+    fn schema_extends_shared_base_with_vnc_groups() {
+        let schema = vnc_settings_schema();
+        let keys: Vec<&str> = schema.groups.iter().map(|g| g.key.as_str()).collect();
+        // Shared base first, then the protocol-specific groups appended.
+        assert_eq!(
+            keys,
+            vec!["connection", "display", "features", "vnc", "sshTunnel"]
+        );
+    }
+
+    #[test]
+    fn schema_has_no_domain_field() {
+        let schema = vnc_settings_schema();
+        let has_domain = schema
+            .groups
+            .iter()
+            .flat_map(|g| &g.fields)
+            .any(|f| f.key == "domain");
+        assert!(!has_domain, "VNC must not expose a domain field");
+    }
+
+    #[test]
+    fn schema_port_defaults_to_5900() {
+        let schema = vnc_settings_schema();
+        let port = schema.groups[0]
+            .fields
+            .iter()
+            .find(|f| f.key == "port")
+            .unwrap();
+        assert_eq!(port.default, Some(serde_json::json!(5900)));
+    }
+
+    #[test]
+    fn ssh_tunnel_fields_are_conditionally_visible() {
+        let schema = vnc_settings_schema();
+        let group = schema.groups.iter().find(|g| g.key == "sshTunnel").unwrap();
+        let host = group.fields.iter().find(|f| f.key == "sshHost").unwrap();
+        let cond = host.visible_when.as_ref().unwrap();
+        assert_eq!(cond.field, "useSshTunnel");
+        assert_eq!(cond.equals, serde_json::json!(true));
+        // The toggle itself is always visible.
+        let toggle = group
+            .fields
+            .iter()
+            .find(|f| f.key == "useSshTunnel")
+            .unwrap();
+        assert!(toggle.visible_when.is_none());
+    }
+
+    #[test]
+    fn schema_serializes() {
+        // The whole schema must round-trip through serde for the IPC boundary.
+        let schema = vnc_settings_schema();
+        let json = serde_json::to_string(&schema).unwrap();
+        let back: SettingsSchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.groups.len(), 5);
+    }
+}

--- a/core/src/backends/vnc/frame.rs
+++ b/core/src/backends/vnc/frame.rs
@@ -1,0 +1,211 @@
+//! Server-side shadow framebuffer for the VNC backend.
+//!
+//! RFB delivers a framebuffer as a stream of dirty rectangles, some of which are
+//! **CopyRect** operations — "copy this on-screen region to there" — which carry
+//! no pixel data of their own. The shared frame contract ([`FrameUpdate`] /
+//! [`DirtyRect`](crate::connection::DirtyRect)) can only *blit* pixels, so a
+//! CopyRect must be resolved against a local copy of the framebuffer before it
+//! is emitted. This shadow holds that copy.
+//!
+//! Pixels are RGBA (`width * height * 4`, row-major), matching what
+//! [`vnc::PixelFormat::rgba`] decodes into and what the shared canvas blits
+//! directly — no channel swap needed.
+
+/// A local RGBA copy of the remote framebuffer, kept in lockstep with what the
+/// frontend canvas shows so CopyRect regions can be resolved to real pixels.
+#[derive(Debug, Default)]
+pub struct FrameShadow {
+    width: u32,
+    height: u32,
+    /// RGBA, `width * height * 4` bytes, row-major.
+    data: Vec<u8>,
+}
+
+impl FrameShadow {
+    /// A zero-sized shadow (before the first resolution is known).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Current framebuffer width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Current framebuffer height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Resize the shadow to `width × height`, clearing it to transparent black.
+    ///
+    /// A resolution change repaints the whole surface on the wire, so discarding
+    /// the old contents is correct and avoids stale pixels bleeding through.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        self.width = width;
+        self.height = height;
+        self.data = vec![0u8; (width as usize) * (height as usize) * 4];
+    }
+
+    /// Whether a rectangle lies fully within the current framebuffer.
+    fn contains(&self, x: u32, y: u32, w: u32, h: u32) -> bool {
+        x.checked_add(w)
+            .zip(y.checked_add(h))
+            .is_some_and(|(right, bottom)| right <= self.width && bottom <= self.height)
+    }
+
+    /// Write `rgba` (tightly packed, `w * h * 4` bytes) into the shadow at
+    /// `(x, y)`.
+    ///
+    /// Returns `false` (writing nothing) if the rect is out of bounds or `rgba`
+    /// is the wrong length — a malformed update must never corrupt the shadow.
+    pub fn blit(&mut self, x: u32, y: u32, w: u32, h: u32, rgba: &[u8]) -> bool {
+        if w == 0 || h == 0 {
+            return rgba.is_empty();
+        }
+        if !self.contains(x, y, w, h) || rgba.len() != (w as usize) * (h as usize) * 4 {
+            return false;
+        }
+        let stride = self.width as usize * 4;
+        let row_bytes = w as usize * 4;
+        for row in 0..h as usize {
+            let dst_start = (y as usize + row) * stride + x as usize * 4;
+            let src_start = row * row_bytes;
+            self.data[dst_start..dst_start + row_bytes]
+                .copy_from_slice(&rgba[src_start..src_start + row_bytes]);
+        }
+        true
+    }
+
+    /// Resolve a CopyRect: copy the `w × h` region at `(src_x, src_y)` to
+    /// `(dst_x, dst_y)` within the shadow.
+    ///
+    /// Reads the source into a temporary first, so overlapping source and
+    /// destination regions copy correctly. Returns `false` if either rect is out
+    /// of bounds.
+    pub fn copy_rect(
+        &mut self,
+        dst_x: u32,
+        dst_y: u32,
+        src_x: u32,
+        src_y: u32,
+        w: u32,
+        h: u32,
+    ) -> bool {
+        if w == 0 || h == 0 {
+            return true;
+        }
+        if !self.contains(src_x, src_y, w, h) || !self.contains(dst_x, dst_y, w, h) {
+            return false;
+        }
+        let Some(region) = self.extract(src_x, src_y, w, h) else {
+            return false;
+        };
+        self.blit(dst_x, dst_y, w, h, &region)
+    }
+
+    /// Copy out the RGBA pixels of the `w × h` rect at `(x, y)`.
+    ///
+    /// Returns `None` if the rect is out of bounds.
+    pub fn extract(&self, x: u32, y: u32, w: u32, h: u32) -> Option<Vec<u8>> {
+        if !self.contains(x, y, w, h) {
+            return None;
+        }
+        let stride = self.width as usize * 4;
+        let row_bytes = w as usize * 4;
+        let mut out = vec![0u8; (w as usize) * (h as usize) * 4];
+        for row in 0..h as usize {
+            let src_start = (y as usize + row) * stride + x as usize * 4;
+            let dst_start = row * row_bytes;
+            out[dst_start..dst_start + row_bytes]
+                .copy_from_slice(&self.data[src_start..src_start + row_bytes]);
+        }
+        Some(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a 2×2 RGBA block filled with a single color for readable asserts.
+    fn solid(w: u32, h: u32, rgba: [u8; 4]) -> Vec<u8> {
+        rgba.iter()
+            .copied()
+            .cycle()
+            .take((w * h * 4) as usize)
+            .collect()
+    }
+
+    #[test]
+    fn resize_allocates_cleared_buffer() {
+        let mut s = FrameShadow::new();
+        s.resize(4, 3);
+        assert_eq!(s.width(), 4);
+        assert_eq!(s.height(), 3);
+        assert_eq!(s.extract(0, 0, 4, 3).unwrap(), vec![0u8; 4 * 3 * 4]);
+    }
+
+    #[test]
+    fn blit_writes_into_position_and_round_trips() {
+        let mut s = FrameShadow::new();
+        s.resize(4, 4);
+        let red = solid(2, 2, [255, 0, 0, 255]);
+        assert!(s.blit(1, 1, 2, 2, &red));
+        assert_eq!(s.extract(1, 1, 2, 2).unwrap(), red);
+        // Neighboring pixel untouched.
+        assert_eq!(s.extract(0, 0, 1, 1).unwrap(), vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn blit_rejects_out_of_bounds_and_wrong_length() {
+        let mut s = FrameShadow::new();
+        s.resize(4, 4);
+        assert!(!s.blit(3, 3, 2, 2, &solid(2, 2, [1, 2, 3, 4]))); // exceeds edge
+        assert!(!s.blit(0, 0, 2, 2, &[0, 0, 0])); // wrong length
+    }
+
+    #[test]
+    fn copy_rect_duplicates_region() {
+        let mut s = FrameShadow::new();
+        s.resize(4, 2);
+        let green = solid(2, 2, [0, 255, 0, 255]);
+        s.blit(0, 0, 2, 2, &green);
+        assert!(s.copy_rect(2, 0, 0, 0, 2, 2));
+        assert_eq!(s.extract(2, 0, 2, 2).unwrap(), green);
+    }
+
+    #[test]
+    fn copy_rect_handles_overlap() {
+        let mut s = FrameShadow::new();
+        s.resize(4, 1);
+        // Row: [A][A][.][.]
+        let a = solid(2, 1, [10, 20, 30, 255]);
+        s.blit(0, 0, 2, 1, &a);
+        // Copy [0,0]..2 → [1,0]..2 (overlapping by one column).
+        assert!(s.copy_rect(1, 0, 0, 0, 2, 1));
+        assert_eq!(s.extract(1, 0, 2, 1).unwrap(), a);
+    }
+
+    #[test]
+    fn copy_rect_rejects_out_of_bounds() {
+        let mut s = FrameShadow::new();
+        s.resize(4, 4);
+        assert!(!s.copy_rect(3, 3, 0, 0, 2, 2));
+        assert!(!s.copy_rect(0, 0, 3, 3, 2, 2));
+    }
+
+    #[test]
+    fn extract_out_of_bounds_is_none() {
+        let mut s = FrameShadow::new();
+        s.resize(2, 2);
+        assert!(s.extract(0, 0, 3, 3).is_none());
+    }
+
+    #[test]
+    fn zero_area_blit_is_a_noop_success() {
+        let mut s = FrameShadow::new();
+        s.resize(2, 2);
+        assert!(s.blit(0, 0, 0, 0, &[]));
+    }
+}

--- a/core/src/backends/vnc/keymap.rs
+++ b/core/src/backends/vnc/keymap.rs
@@ -1,0 +1,199 @@
+//! Browser `KeyboardEvent.code` → X11 keysym mapping for RFB `KeyEvent`.
+//!
+//! The shared input pipeline (#1680) delivers keyboard input as protocol-agnostic
+//! [`InputEvent::Key`](crate::connection::InputEvent::Key) events keyed by the
+//! physical `KeyboardEvent.code` (`"KeyA"`, `"Enter"`, `"ControlLeft"`, …). The
+//! RFB wire protocol ([RFC 6143 §7.5.4](https://www.rfc-editor.org/rfc/rfc6143.html#section-7.5.4))
+//! instead carries an **X11 keysym** (`u32`).
+//!
+//! This module maps the *physical* key to its *base* (unshifted) keysym. Shift,
+//! Ctrl, Alt and Meta are themselves ordinary keys that travel as their own
+//! `KeyEvent`s, so the server reconstructs shifted characters from the base key
+//! plus a held modifier — exactly how a real VNC viewer behaves. Layout-aware
+//! mapping (producing the shifted glyph directly) is intentionally out of scope;
+//! see the follow-up noted on the PR.
+
+/// Map a browser `KeyboardEvent.code` to its base X11 keysym.
+///
+/// Returns `None` for codes with no RFB-meaningful keysym; the caller drops
+/// those rather than sending a bogus key.
+pub fn code_to_keysym(code: &str) -> Option<u32> {
+    // Letters — base (lowercase) keysym; Shift is sent as its own key.
+    if let Some(rest) = code.strip_prefix("Key") {
+        if rest.len() == 1 {
+            let c = rest.as_bytes()[0];
+            if c.is_ascii_uppercase() {
+                // XK_a … XK_z == ASCII lowercase.
+                return Some((c.to_ascii_lowercase()) as u32);
+            }
+        }
+    }
+
+    // Top-row digits — Digit0 … Digit9.
+    if let Some(rest) = code.strip_prefix("Digit") {
+        if rest.len() == 1 {
+            let c = rest.as_bytes()[0];
+            if c.is_ascii_digit() {
+                return Some(c as u32); // XK_0 … XK_9 == ASCII digits.
+            }
+        }
+    }
+
+    // Numpad digits map to the same base digit keysyms (KP_0 exists but the
+    // plain digit is universally accepted and simpler for typing).
+    if let Some(rest) = code.strip_prefix("Numpad") {
+        match rest {
+            "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
+                return Some(rest.as_bytes()[0] as u32);
+            }
+            "Decimal" => return Some(0xFFAE),  // XK_KP_Decimal
+            "Add" => return Some(0xFFAB),      // XK_KP_Add
+            "Subtract" => return Some(0xFFAD), // XK_KP_Subtract
+            "Multiply" => return Some(0xFFAA), // XK_KP_Multiply
+            "Divide" => return Some(0xFFAF),   // XK_KP_Divide
+            "Enter" => return Some(0xFF8D),    // XK_KP_Enter
+            _ => {}
+        }
+    }
+
+    // Function keys F1 … F12 → XK_F1 (0xFFBE) … XK_F12 (0xFFC9).
+    if let Some(rest) = code.strip_prefix('F') {
+        if let Ok(n) = rest.parse::<u32>() {
+            if (1..=12).contains(&n) {
+                return Some(0xFFBE + (n - 1));
+            }
+        }
+    }
+
+    let keysym = match code {
+        // Whitespace / editing.
+        "Space" => 0x20,       // XK_space
+        "Enter" => 0xFF0D,     // XK_Return
+        "Tab" => 0xFF09,       // XK_Tab
+        "Backspace" => 0xFF08, // XK_BackSpace
+        "Escape" => 0xFF1B,    // XK_Escape
+        "Delete" => 0xFFFF,    // XK_Delete
+        "Insert" => 0xFF63,    // XK_Insert
+
+        // Navigation.
+        "Home" => 0xFF50,       // XK_Home
+        "End" => 0xFF57,        // XK_End
+        "PageUp" => 0xFF55,     // XK_Prior
+        "PageDown" => 0xFF56,   // XK_Next
+        "ArrowLeft" => 0xFF51,  // XK_Left
+        "ArrowUp" => 0xFF52,    // XK_Up
+        "ArrowRight" => 0xFF53, // XK_Right
+        "ArrowDown" => 0xFF54,  // XK_Down
+
+        // Modifiers.
+        "ShiftLeft" => 0xFFE1,             // XK_Shift_L
+        "ShiftRight" => 0xFFE2,            // XK_Shift_R
+        "ControlLeft" => 0xFFE3,           // XK_Control_L
+        "ControlRight" => 0xFFE4,          // XK_Control_R
+        "CapsLock" => 0xFFE5,              // XK_Caps_Lock
+        "AltLeft" => 0xFFE9,               // XK_Alt_L
+        "AltRight" => 0xFFEA,              // XK_Alt_R (AltGr)
+        "MetaLeft" | "OSLeft" => 0xFFEB,   // XK_Super_L
+        "MetaRight" | "OSRight" => 0xFFEC, // XK_Super_R
+        "ContextMenu" => 0xFF67,           // XK_Menu
+
+        // Punctuation — base (unshifted) glyph.
+        "Minus" => 0x2D,        // -
+        "Equal" => 0x3D,        // =
+        "BracketLeft" => 0x5B,  // [
+        "BracketRight" => 0x5D, // ]
+        "Backslash" => 0x5C,    // \
+        "Semicolon" => 0x3B,    // ;
+        "Quote" => 0x27,        // '
+        "Backquote" => 0x60,    // `
+        "Comma" => 0x2C,        // ,
+        "Period" => 0x2E,       // .
+        "Slash" => 0x2F,        // /
+
+        _ => return None,
+    };
+    Some(keysym)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn letters_map_to_lowercase_ascii() {
+        assert_eq!(code_to_keysym("KeyA"), Some(0x61));
+        assert_eq!(code_to_keysym("KeyZ"), Some(0x7A));
+        assert_eq!(code_to_keysym("KeyM"), Some('m' as u32));
+    }
+
+    #[test]
+    fn digits_map_to_ascii() {
+        assert_eq!(code_to_keysym("Digit0"), Some(0x30));
+        assert_eq!(code_to_keysym("Digit9"), Some(0x39));
+    }
+
+    #[test]
+    fn function_keys_span_f1_to_f12() {
+        assert_eq!(code_to_keysym("F1"), Some(0xFFBE));
+        assert_eq!(code_to_keysym("F12"), Some(0xFFC9));
+        // F13 is not a standard function-key keysym in this table.
+        assert_eq!(code_to_keysym("F13"), None);
+    }
+
+    #[test]
+    fn control_keys_map() {
+        assert_eq!(code_to_keysym("Enter"), Some(0xFF0D));
+        assert_eq!(code_to_keysym("Escape"), Some(0xFF1B));
+        assert_eq!(code_to_keysym("Backspace"), Some(0xFF08));
+        assert_eq!(code_to_keysym("Tab"), Some(0xFF09));
+        assert_eq!(code_to_keysym("Space"), Some(0x20));
+        assert_eq!(code_to_keysym("Delete"), Some(0xFFFF));
+    }
+
+    #[test]
+    fn ctrl_alt_del_components_all_map() {
+        // The toolbar's Ctrl+Alt+Del sends three physical keys; every one must
+        // resolve to a keysym or the sequence silently drops a key.
+        assert!(code_to_keysym("ControlLeft").is_some());
+        assert!(code_to_keysym("AltLeft").is_some());
+        assert!(code_to_keysym("Delete").is_some());
+    }
+
+    #[test]
+    fn modifiers_map() {
+        assert_eq!(code_to_keysym("ShiftLeft"), Some(0xFFE1));
+        assert_eq!(code_to_keysym("ControlRight"), Some(0xFFE4));
+        assert_eq!(code_to_keysym("AltRight"), Some(0xFFEA));
+        assert_eq!(code_to_keysym("MetaLeft"), Some(0xFFEB));
+    }
+
+    #[test]
+    fn arrows_map() {
+        assert_eq!(code_to_keysym("ArrowLeft"), Some(0xFF51));
+        assert_eq!(code_to_keysym("ArrowUp"), Some(0xFF52));
+        assert_eq!(code_to_keysym("ArrowRight"), Some(0xFF53));
+        assert_eq!(code_to_keysym("ArrowDown"), Some(0xFF54));
+    }
+
+    #[test]
+    fn numpad_maps() {
+        assert_eq!(code_to_keysym("Numpad5"), Some(0x35));
+        assert_eq!(code_to_keysym("NumpadEnter"), Some(0xFF8D));
+        assert_eq!(code_to_keysym("NumpadAdd"), Some(0xFFAB));
+    }
+
+    #[test]
+    fn punctuation_maps_to_base_glyph() {
+        assert_eq!(code_to_keysym("Minus"), Some('-' as u32));
+        assert_eq!(code_to_keysym("Slash"), Some('/' as u32));
+        assert_eq!(code_to_keysym("Backquote"), Some('`' as u32));
+    }
+
+    #[test]
+    fn unknown_codes_return_none() {
+        assert_eq!(code_to_keysym(""), None);
+        assert_eq!(code_to_keysym("Unidentified"), None);
+        assert_eq!(code_to_keysym("KeyAB"), None);
+        assert_eq!(code_to_keysym("Digit"), None);
+    }
+}

--- a/core/src/backends/vnc/mod.rs
+++ b/core/src/backends/vnc/mod.rs
@@ -1,0 +1,720 @@
+//! VNC (RFB) graphical remote-desktop backend.
+//!
+//! Implements the protocol-agnostic [`GraphicalBackend`] trait (#1680) over the
+//! RFB wire protocol using the `vnc-rs` client. Decode happens here, in Rust:
+//! the backend negotiates the connection, decodes framebuffer updates into the
+//! shared [`FrameUpdate`] / [`CursorUpdate`] stream, translates the shared
+//! [`InputEvent`]s into RFB `KeyEvent` / `PointerEvent`, and bridges the
+//! clipboard via RFB `ServerCutText` / `ClientCutText`. Everything the user
+//! touches — canvas, toolbar, overlays, input, clipboard, scaling — belongs to
+//! the shared layer and is untouched here; this module is the wire adapter only.
+//!
+//! It drops in beside the mock (#1680) and the coming RDP backend (#1682) under
+//! the same trait: a new `backends/vnc/` module, a schema, and one additive
+//! registry `register(...)` call — no shared match arm, no editor switch.
+
+mod config;
+mod frame;
+mod keymap;
+mod tunnel;
+
+pub use config::vnc_settings_schema;
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+use vnc::{
+    ClientKeyEvent, ClientMouseEvent, PixelFormat, VncConnector, VncEncoding, VncError, VncEvent,
+    VncVersion, X11Event,
+};
+
+use crate::connection::{
+    AuthKind, Capabilities, ConnectionType, CursorReceiver, CursorShape, CursorUpdate, DirtyRect,
+    FrameReceiver, FrameUpdate, GraphicalBackend, GraphicalCapabilities, InputEvent,
+    OutputReceiver, SettingsSchema,
+};
+use crate::errors::SessionError;
+use crate::files::FileBrowser;
+use crate::monitoring::MonitoringProvider;
+
+use config::VncConfig;
+use frame::FrameShadow;
+
+/// Bounded channel depth for frames / cursor updates (backpressure).
+const CHANNEL_DEPTH: usize = 16;
+
+/// How often the driver polls decoded events and drives incremental refreshes.
+const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(30);
+
+/// Shared, interior-mutable state touched by both the driver task and the
+/// `GraphicalBackend` command methods.
+struct VncShared {
+    /// Latest remote clipboard text (RFB `ServerCutText`), surfaced via `get_clipboard`.
+    clipboard: Mutex<String>,
+    /// Last pointer X/Y (framebuffer pixels), so a server cursor-shape update can
+    /// be positioned even though RFB carries no server cursor *position*.
+    ptr_x: AtomicU32,
+    ptr_y: AtomicU32,
+    /// Suppress input when the session is view-only.
+    view_only: bool,
+    /// Whether server cursor shapes are rendered.
+    show_remote_cursor: bool,
+}
+
+/// Live runtime of a connected VNC session.
+struct VncRuntime {
+    /// A clone of the RFB client for sending input / clipboard (methods take `&self`).
+    client: vnc::VncClient,
+    shared: Arc<VncShared>,
+    cancel: CancellationToken,
+    /// SSH tunnel kept alive for the session lifetime, if the transport uses one.
+    _tunnel: Option<tunnel::SshTunnel>,
+}
+
+/// VNC/RFB graphical remote-desktop connection.
+pub struct Vnc {
+    runtime: Option<Arc<VncRuntime>>,
+    frame_rx: StdMutex<Option<FrameReceiver>>,
+    cursor_rx: StdMutex<Option<CursorReceiver>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl Vnc {
+    /// Create a new, disconnected VNC backend.
+    pub fn new() -> Self {
+        Self {
+            runtime: None,
+            frame_rx: StdMutex::new(None),
+            cursor_rx: StdMutex::new(None),
+            task: None,
+        }
+    }
+}
+
+impl Default for Vnc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for Vnc {
+    fn drop(&mut self) {
+        if let Some(rt) = &self.runtime {
+            rt.cancel.cancel();
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+/// Translate a DOM `MouseEvent.buttons` bitmask (bit0 left, bit1 right, bit2
+/// middle) into an RFB pointer button mask (RFC 6143 §7.5.5: bit0 button1/left,
+/// bit1 button2/middle, bit2 button3/right).
+fn dom_buttons_to_rfb(buttons: u8) -> u8 {
+    let mut rfb = 0u8;
+    if buttons & 0b001 != 0 {
+        rfb |= 1 << 0; // left → button 1
+    }
+    if buttons & 0b010 != 0 {
+        rfb |= 1 << 2; // DOM right → button 3
+    }
+    if buttons & 0b100 != 0 {
+        rfb |= 1 << 1; // DOM middle → button 2
+    }
+    rfb
+}
+
+/// Encode the chosen client encodings for `cfg`, honoring the raw/ZRLE
+/// preference and whether the remote cursor is wanted. `Raw` is always included
+/// (RFC requirement); `DesktopSizePseudo` lets the server announce resolution
+/// changes.
+fn encodings_for(cfg: &VncConfig) -> Vec<VncEncoding> {
+    let mut encs = Vec::new();
+    if !cfg.prefers_raw() {
+        encs.push(VncEncoding::Zrle);
+    }
+    encs.push(VncEncoding::CopyRect);
+    encs.push(VncEncoding::Raw);
+    if cfg.show_remote_cursor {
+        encs.push(VncEncoding::CursorPseudo);
+    }
+    encs.push(VncEncoding::DesktopSizePseudo);
+    encs
+}
+
+impl Vnc {
+    /// Send a protocol-agnostic input event to the remote, translated to RFB.
+    async fn forward_input(rt: &VncRuntime, event: InputEvent) -> Result<(), SessionError> {
+        if rt.shared.view_only {
+            return Ok(());
+        }
+        match event {
+            InputEvent::Key { code, pressed } => {
+                if let Some(keysym) = keymap::code_to_keysym(&code) {
+                    rt.client
+                        .input(X11Event::KeyEvent(ClientKeyEvent {
+                            keycode: keysym,
+                            down: pressed,
+                        }))
+                        .await
+                        .map_err(map_vnc_err)?;
+                }
+            }
+            InputEvent::Pointer { x, y, buttons } => {
+                rt.shared.ptr_x.store(x, Ordering::Relaxed);
+                rt.shared.ptr_y.store(y, Ordering::Relaxed);
+                rt.client
+                    .input(X11Event::PointerEvent(ClientMouseEvent {
+                        position_x: x as u16,
+                        position_y: y as u16,
+                        bottons: dom_buttons_to_rfb(buttons),
+                    }))
+                    .await
+                    .map_err(map_vnc_err)?;
+            }
+            InputEvent::Wheel {
+                x,
+                y,
+                delta_x: _,
+                delta_y,
+            } => {
+                rt.shared.ptr_x.store(x, Ordering::Relaxed);
+                rt.shared.ptr_y.store(y, Ordering::Relaxed);
+                // RFB models the wheel as button 4 (up) / button 5 (down):
+                // a press followed immediately by a release.
+                if delta_y != 0.0 {
+                    let bit = if delta_y < 0.0 { 1 << 3 } else { 1 << 4 };
+                    let (px, py) = (x as u16, y as u16);
+                    rt.client
+                        .input(X11Event::PointerEvent(ClientMouseEvent {
+                            position_x: px,
+                            position_y: py,
+                            bottons: bit,
+                        }))
+                        .await
+                        .map_err(map_vnc_err)?;
+                    rt.client
+                        .input(X11Event::PointerEvent(ClientMouseEvent {
+                            position_x: px,
+                            position_y: py,
+                            bottons: 0,
+                        }))
+                        .await
+                        .map_err(map_vnc_err)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Map a `vnc-rs` error to a [`SessionError`], distinguishing auth rejection so
+/// the message is actionable.
+fn map_vnc_err(e: VncError) -> SessionError {
+    match e {
+        VncError::WrongPassword => {
+            SessionError::SpawnFailed("VNC authentication failed: wrong password".to_string())
+        }
+        VncError::NoPassword => SessionError::InvalidConfig(
+            "VNC server requires a password but none was provided".to_string(),
+        ),
+        other => SessionError::SpawnFailed(format!("VNC error: {other}")),
+    }
+}
+
+/// The driver task: polls decoded RFB events, maintains the shadow framebuffer,
+/// emits shared frame/cursor updates, mirrors the clipboard, and drives
+/// incremental framebuffer-update requests. Ends when cancelled or on RFB error.
+async fn drive(
+    client: vnc::VncClient,
+    shared: Arc<VncShared>,
+    cancel: CancellationToken,
+    frame_tx: mpsc::Sender<FrameUpdate>,
+    cursor_tx: mpsc::Sender<CursorUpdate>,
+) {
+    let mut shadow = FrameShadow::new();
+    // Prime the first full frame.
+    if client.input(X11Event::FullRefresh).await.is_err() {
+        return;
+    }
+    let mut request_outstanding = true;
+
+    let mut ticker = tokio::time::interval(POLL_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = ticker.tick() => {
+                let mut got_event = false;
+                loop {
+                    match client.poll_event().await {
+                        Ok(Some(event)) => {
+                            got_event = true;
+                            if !handle_event(event, &mut shadow, &shared, &frame_tx, &cursor_tx).await {
+                                return; // channel closed downstream — session gone
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            debug!(error = %e, "vnc session ended");
+                            return;
+                        }
+                    }
+                }
+                // Keep exactly one incremental request outstanding: refill it
+                // once the previous one has been answered, so an idle desktop
+                // doesn't pile up requests and input stays responsive.
+                if got_event {
+                    request_outstanding = false;
+                }
+                if !request_outstanding {
+                    if client.input(X11Event::Refresh).await.is_err() {
+                        return;
+                    }
+                    request_outstanding = true;
+                }
+            }
+        }
+    }
+}
+
+/// Handle one decoded RFB event. Returns `false` if a downstream channel closed
+/// (the session should end).
+async fn handle_event(
+    event: VncEvent,
+    shadow: &mut FrameShadow,
+    shared: &VncShared,
+    frame_tx: &mpsc::Sender<FrameUpdate>,
+    cursor_tx: &mpsc::Sender<CursorUpdate>,
+) -> bool {
+    match event {
+        VncEvent::SetResolution(screen) => {
+            shadow.resize(screen.width as u32, screen.height as u32);
+            // Resize the canvas; the server repaints on the next request.
+            frame_tx
+                .send(FrameUpdate {
+                    width: shadow.width(),
+                    height: shadow.height(),
+                    rects: Vec::new(),
+                })
+                .await
+                .is_ok()
+        }
+        VncEvent::RawImage(rect, data) => {
+            let (x, y, w, h) = (
+                rect.x as u32,
+                rect.y as u32,
+                rect.width as u32,
+                rect.height as u32,
+            );
+            // Cope with a full frame arriving before any resolution event.
+            if shadow.width() == 0 || shadow.height() == 0 {
+                shadow.resize(x + w, y + h);
+            }
+            if data.len() != (w as usize) * (h as usize) * 4 {
+                warn!(
+                    w,
+                    h,
+                    len = data.len(),
+                    "vnc raw image size mismatch — dropped"
+                );
+                return true;
+            }
+            shadow.blit(x, y, w, h, &data);
+            frame_tx
+                .send(FrameUpdate {
+                    width: shadow.width(),
+                    height: shadow.height(),
+                    rects: vec![DirtyRect {
+                        x,
+                        y,
+                        width: w,
+                        height: h,
+                        data,
+                    }],
+                })
+                .await
+                .is_ok()
+        }
+        VncEvent::Copy(dst, src) => {
+            let (w, h) = (dst.width as u32, dst.height as u32);
+            if !shadow.copy_rect(dst.x as u32, dst.y as u32, src.x as u32, src.y as u32, w, h) {
+                return true;
+            }
+            let Some(data) = shadow.extract(dst.x as u32, dst.y as u32, w, h) else {
+                return true;
+            };
+            frame_tx
+                .send(FrameUpdate {
+                    width: shadow.width(),
+                    height: shadow.height(),
+                    rects: vec![DirtyRect {
+                        x: dst.x as u32,
+                        y: dst.y as u32,
+                        width: w,
+                        height: h,
+                        data,
+                    }],
+                })
+                .await
+                .is_ok()
+        }
+        VncEvent::SetCursor(rect, data) => {
+            if !shared.show_remote_cursor {
+                return true;
+            }
+            let (w, h) = (rect.width as u32, rect.height as u32);
+            let shape = if w == 0 || h == 0 || data.len() != (w as usize) * (h as usize) * 4 {
+                None // empty / malformed cursor → hide
+            } else {
+                Some(CursorShape {
+                    width: w,
+                    height: h,
+                    hotspot_x: rect.x as u32,
+                    hotspot_y: rect.y as u32,
+                    data,
+                })
+            };
+            cursor_tx
+                .send(CursorUpdate {
+                    x: shared.ptr_x.load(Ordering::Relaxed),
+                    y: shared.ptr_y.load(Ordering::Relaxed),
+                    visible: shape.is_some(),
+                    shape,
+                })
+                .await
+                .is_ok()
+        }
+        VncEvent::Text(text) => {
+            *shared.clipboard.lock().await = text;
+            true
+        }
+        VncEvent::Error(msg) => {
+            warn!(%msg, "vnc protocol error");
+            false
+        }
+        // JpegImage (Tight, not negotiated), Bell, SetPixelFormat — no shared
+        // surface to route to; safely ignored.
+        _ => true,
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectionType for Vnc {
+    fn type_id(&self) -> &str {
+        "vnc"
+    }
+
+    fn display_name(&self) -> &str {
+        "VNC"
+    }
+
+    fn settings_schema(&self) -> SettingsSchema {
+        vnc_settings_schema()
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            monitoring: false,
+            file_browser: false,
+            // Graphical + terminal-less: routed through the GraphicalSessionManager
+            // into a remote-desktop canvas tab. `graphical: true` also gates it as
+            // experimental (#1705) with no per-protocol wiring.
+            graphical: true,
+            resize: false,
+            persistent: false,
+            terminal: false,
+        }
+    }
+
+    async fn connect(&mut self, settings: serde_json::Value) -> Result<(), SessionError> {
+        if self.runtime.is_some() {
+            return Err(SessionError::AlreadyExists("Already connected".to_string()));
+        }
+        let cfg: VncConfig = serde_json::from_value(settings)
+            .map_err(|e| SessionError::InvalidConfig(format!("Invalid VNC settings: {e}")))?;
+        if cfg.host.is_empty() {
+            return Err(SessionError::InvalidConfig(
+                "VNC host is required".to_string(),
+            ));
+        }
+
+        // Establish transport (direct TCP or SSH tunnel).
+        let (stream, tunnel) = tunnel::connect_transport(&cfg).await?;
+
+        // Negotiate RFB, decoding into RGBA so the shared canvas blits directly.
+        let password = cfg.password.clone();
+        let client = VncConnector::new(stream)
+            .set_version(VncVersion::RFB38)
+            .set_auth_method(async move { Ok::<_, VncError>(password) })
+            .set_pixel_format(PixelFormat::rgba())
+            .allow_shared(true);
+        let client = encodings_for(&cfg)
+            .into_iter()
+            .fold(client, |c, enc| c.add_encoding(enc));
+        let client = client
+            .build()
+            .map_err(map_vnc_err)?
+            .try_start()
+            .await
+            .map_err(map_vnc_err)?
+            .finish()
+            .map_err(map_vnc_err)?;
+
+        let shared = Arc::new(VncShared {
+            clipboard: Mutex::new(String::new()),
+            ptr_x: AtomicU32::new(0),
+            ptr_y: AtomicU32::new(0),
+            view_only: cfg.view_only,
+            show_remote_cursor: cfg.show_remote_cursor,
+        });
+        let cancel = CancellationToken::new();
+        let (frame_tx, frame_rx) = mpsc::channel(CHANNEL_DEPTH);
+        let (cursor_tx, cursor_rx) = mpsc::channel(CHANNEL_DEPTH);
+
+        let task = tokio::spawn(drive(
+            client.clone(),
+            shared.clone(),
+            cancel.clone(),
+            frame_tx,
+            cursor_tx,
+        ));
+
+        self.frame_rx = StdMutex::new(Some(frame_rx));
+        self.cursor_rx = StdMutex::new(Some(cursor_rx));
+        self.runtime = Some(Arc::new(VncRuntime {
+            client,
+            shared,
+            cancel,
+            _tunnel: tunnel,
+        }));
+        self.task = Some(task);
+        Ok(())
+    }
+
+    async fn disconnect(&mut self) -> Result<(), SessionError> {
+        if let Some(rt) = self.runtime.take() {
+            rt.cancel.cancel();
+            let _ = rt.client.close().await;
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+        self.frame_rx = StdMutex::new(None);
+        self.cursor_rx = StdMutex::new(None);
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.runtime.is_some()
+    }
+
+    fn write(&self, _data: &[u8]) -> Result<(), SessionError> {
+        // Graphical session: no terminal byte stream.
+        Ok(())
+    }
+
+    fn resize(&self, _cols: u16, _rows: u16) -> Result<(), SessionError> {
+        // Terminal (cols/rows) resize is meaningless; pixel resize is on the
+        // GraphicalBackend trait.
+        Ok(())
+    }
+
+    fn subscribe_output(&self) -> OutputReceiver {
+        let (_tx, rx) = mpsc::channel(1);
+        rx
+    }
+
+    fn monitoring(&self) -> Option<&dyn MonitoringProvider> {
+        None
+    }
+
+    fn file_browser(&self) -> Option<&dyn FileBrowser> {
+        None
+    }
+
+    fn graphical(&self) -> Option<&dyn GraphicalBackend> {
+        if self.runtime.is_some() {
+            Some(self as &dyn GraphicalBackend)
+        } else {
+            None
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl GraphicalBackend for Vnc {
+    fn graphical_capabilities(&self) -> GraphicalCapabilities {
+        GraphicalCapabilities {
+            auth_kinds: vec![AuthKind::None, AuthKind::Password],
+            // vnc-rs offers no client-initiated SetDesktopSize; the frontend
+            // scales the canvas instead.
+            supports_dynamic_resize: false,
+            supports_clipboard: true,
+            view_only_capable: true,
+        }
+    }
+
+    fn subscribe_frames(&self) -> FrameReceiver {
+        if let Ok(mut guard) = self.frame_rx.lock() {
+            if let Some(rx) = guard.take() {
+                return rx;
+            }
+        }
+        let (_tx, rx) = mpsc::channel(1);
+        rx
+    }
+
+    fn subscribe_cursor(&self) -> CursorReceiver {
+        if let Ok(mut guard) = self.cursor_rx.lock() {
+            if let Some(rx) = guard.take() {
+                return rx;
+            }
+        }
+        let (_tx, rx) = mpsc::channel(1);
+        rx
+    }
+
+    async fn send_input(&self, event: InputEvent) -> Result<(), SessionError> {
+        let Some(rt) = &self.runtime else {
+            return Err(SessionError::NotRunning("vnc not connected".to_string()));
+        };
+        Self::forward_input(rt, event).await
+    }
+
+    async fn resize(&self, _width_px: u16, _height_px: u16) -> Result<(), SessionError> {
+        // No client-initiated remote resize; the shared frontend scales.
+        if self.runtime.is_none() {
+            return Err(SessionError::NotRunning("vnc not connected".to_string()));
+        }
+        Ok(())
+    }
+
+    async fn get_clipboard(&self) -> Option<String> {
+        let rt = self.runtime.as_ref()?;
+        let text = rt.shared.clipboard.lock().await.clone();
+        if text.is_empty() {
+            None
+        } else {
+            Some(text)
+        }
+    }
+
+    async fn set_clipboard(&self, text: String) -> Result<(), SessionError> {
+        let Some(rt) = &self.runtime else {
+            return Err(SessionError::NotRunning("vnc not connected".to_string()));
+        };
+        if rt.shared.view_only {
+            return Ok(());
+        }
+        rt.client
+            .input(X11Event::CopyText(text))
+            .await
+            .map_err(map_vnc_err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_and_capabilities() {
+        let v = Vnc::new();
+        assert_eq!(v.type_id(), "vnc");
+        assert_eq!(v.display_name(), "VNC");
+        let caps = v.capabilities();
+        assert!(caps.graphical);
+        assert!(!caps.terminal);
+        assert!(!caps.file_browser);
+    }
+
+    #[test]
+    fn graphical_none_until_connected() {
+        assert!(Vnc::new().graphical().is_none());
+    }
+
+    #[test]
+    fn schema_is_vnc_schema() {
+        let schema = Vnc::new().settings_schema();
+        let keys: Vec<&str> = schema.groups.iter().map(|g| g.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec!["connection", "display", "features", "vnc", "sshTunnel"]
+        );
+    }
+
+    #[test]
+    fn button_mask_remaps_dom_to_rfb() {
+        assert_eq!(dom_buttons_to_rfb(0b001), 0b001); // left → button 1
+        assert_eq!(dom_buttons_to_rfb(0b010), 0b100); // DOM right → button 3
+        assert_eq!(dom_buttons_to_rfb(0b100), 0b010); // DOM middle → button 2
+        assert_eq!(dom_buttons_to_rfb(0b111), 0b111); // all three
+        assert_eq!(dom_buttons_to_rfb(0), 0);
+    }
+
+    #[test]
+    fn encodings_include_raw_always() {
+        let raw_cfg = VncConfig {
+            preferred_encoding: "raw".to_string(),
+            ..Default::default()
+        };
+        let encs = encodings_for(&raw_cfg);
+        assert!(encs.contains(&VncEncoding::Raw));
+        // Raw preference omits ZRLE.
+        assert!(!encs.contains(&VncEncoding::Zrle));
+
+        let zrle_cfg = VncConfig::default();
+        let encs = encodings_for(&zrle_cfg);
+        assert!(encs.contains(&VncEncoding::Zrle));
+        assert!(encs.contains(&VncEncoding::Raw));
+        assert!(encs.contains(&VncEncoding::CursorPseudo));
+    }
+
+    #[test]
+    fn no_cursor_encoding_when_disabled() {
+        let cfg = VncConfig {
+            show_remote_cursor: false,
+            ..Default::default()
+        };
+        assert!(!encodings_for(&cfg).contains(&VncEncoding::CursorPseudo));
+    }
+
+    #[tokio::test]
+    async fn connect_requires_host() {
+        let mut v = Vnc::new();
+        let err = v.connect(serde_json::json!({})).await.unwrap_err();
+        assert!(matches!(err, SessionError::InvalidConfig(_)));
+    }
+
+    #[tokio::test]
+    async fn graphical_methods_error_when_disconnected() {
+        let v = Vnc::new();
+        assert!(v
+            .send_input(InputEvent::Key {
+                code: "KeyA".to_string(),
+                pressed: true
+            })
+            .await
+            .is_err());
+        assert!(v.get_clipboard().await.is_none());
+        assert!(v.set_clipboard("x".to_string()).await.is_err());
+    }
+
+    #[test]
+    fn graphical_capabilities_advertise_password_and_clipboard() {
+        let caps = Vnc::new().graphical_capabilities();
+        assert!(caps.auth_kinds.contains(&AuthKind::Password));
+        assert!(caps.auth_kinds.contains(&AuthKind::None));
+        assert!(caps.supports_clipboard);
+        assert!(caps.view_only_capable);
+        assert!(!caps.supports_dynamic_resize);
+    }
+}

--- a/core/src/backends/vnc/tunnel.rs
+++ b/core/src/backends/vnc/tunnel.rs
@@ -1,0 +1,206 @@
+//! Optional SSH-tunnel transport for the VNC backend.
+//!
+//! When the connection editor's **SSH Tunnel** group is enabled, the VNC server
+//! is reached through an SSH local forward rather than a direct TCP connection —
+//! the same thing `ssh -L` does. Rather than hand-roll forwarding, this reuses
+//! the existing SSH backend ([`connect_and_authenticate`]) to establish an
+//! authenticated session, then opens a `direct-tcpip` channel to the VNC target
+//! and pumps bytes between that channel and a loopback [`TcpListener`].
+//!
+//! Why a loopback listener instead of handing the channel stream straight to the
+//! RFB client: `vnc::VncConnector` requires its transport to be
+//! `AsyncRead + AsyncWrite + Send + Sync`, and a russh channel stream is not
+//! `Sync`. Bridging through a real `TcpStream` (which is `Sync`) keeps the RFB
+//! client's bound satisfied and mirrors how a native SSH local forward presents
+//! the tunnel as a local port.
+
+use std::sync::Arc;
+
+use tokio::io::copy_bidirectional;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::backends::ssh::auth::connect_and_authenticate;
+use crate::config::SshConfig;
+use crate::errors::SessionError;
+
+use super::config::VncConfig;
+
+/// A live SSH tunnel to a VNC server.
+///
+/// Holds the loopback address the RFB client should connect to, and keeps the
+/// forwarder task alive. Dropping it cancels the token and tears the tunnel down.
+#[derive(Debug)]
+pub struct SshTunnel {
+    /// Loopback `127.0.0.1:<port>` the RFB client connects to.
+    pub local_port: u16,
+    cancel: CancellationToken,
+}
+
+impl SshTunnel {
+    /// Establish an SSH tunnel to `<vnc_host>:<vnc_port>` using the SSH settings
+    /// in `cfg`, returning the loopback endpoint to connect the RFB client to.
+    ///
+    /// The SSH session and a single-connection forwarder run on a background task
+    /// bounded by the returned tunnel's cancellation token.
+    pub async fn establish(
+        cfg: &VncConfig,
+        vnc_host: String,
+        vnc_port: u16,
+    ) -> Result<Self, SessionError> {
+        let ssh_config = SshConfig {
+            host: cfg.ssh_host.clone(),
+            port: cfg.ssh_port,
+            username: cfg.ssh_username.clone(),
+            // The editor's SSH-tunnel group only exposes password auth; richer
+            // auth (keys/agent) is a follow-up.
+            auth_method: "password".to_string(),
+            password: Some(cfg.ssh_password.clone()),
+            ..SshConfig::default()
+        };
+
+        if ssh_config.host.is_empty() {
+            return Err(SessionError::InvalidConfig(
+                "SSH tunnel enabled but no SSH host configured".to_string(),
+            ));
+        }
+
+        // Authenticate the SSH gateway first, so an SSH failure surfaces before
+        // we bind anything locally.
+        let (session, _registry) = connect_and_authenticate(&ssh_config)
+            .await
+            .map_err(|e| SessionError::SpawnFailed(format!("SSH tunnel connect failed: {e}")))?;
+        let session = Arc::new(session);
+
+        // Bind an ephemeral loopback port for the RFB client to dial.
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(|e| SessionError::SpawnFailed(format!("tunnel listener bind failed: {e}")))?;
+        let local_addr = listener
+            .local_addr()
+            .map_err(|e| SessionError::SpawnFailed(format!("tunnel listener addr failed: {e}")))?;
+        let local_port = local_addr.port();
+
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        tokio::spawn(async move {
+            run_forwarder(
+                listener,
+                session,
+                vnc_host,
+                vnc_port,
+                local_port,
+                task_cancel,
+            )
+            .await;
+        });
+
+        Ok(Self { local_port, cancel })
+    }
+}
+
+impl Drop for SshTunnel {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+/// Accept the single loopback connection from the RFB client and pump it over a
+/// `direct-tcpip` channel to the VNC target until either side closes or the
+/// tunnel is cancelled.
+async fn run_forwarder(
+    listener: TcpListener,
+    session: Arc<crate::backends::ssh::handler::SshSession>,
+    vnc_host: String,
+    vnc_port: u16,
+    local_port: u16,
+    cancel: CancellationToken,
+) {
+    let mut local = tokio::select! {
+        _ = cancel.cancelled() => return,
+        accepted = listener.accept() => match accepted {
+            Ok((sock, _)) => sock,
+            Err(e) => {
+                warn!(error = %e, "vnc ssh-tunnel accept failed");
+                return;
+            }
+        },
+    };
+
+    let channel = match session
+        .channel_open_direct_tcpip(&vnc_host, vnc_port as u32, "127.0.0.1", local_port as u32)
+        .await
+    {
+        Ok(ch) => ch,
+        Err(e) => {
+            warn!(error = %e, host = %vnc_host, port = vnc_port, "vnc ssh-tunnel direct-tcpip open failed");
+            return;
+        }
+    };
+    let mut remote = channel.into_stream();
+
+    tokio::select! {
+        _ = cancel.cancelled() => {}
+        result = copy_bidirectional(&mut local, &mut remote) => {
+            if let Err(e) = result {
+                debug!(error = %e, "vnc ssh-tunnel forward ended");
+            }
+        }
+    }
+}
+
+/// Connect the RFB transport for `cfg`, either directly or through an SSH tunnel.
+///
+/// Returns the connected [`TcpStream`] plus an optional [`SshTunnel`] guard that
+/// must be kept alive for the lifetime of the session (dropping it closes the
+/// tunnel).
+pub async fn connect_transport(
+    cfg: &VncConfig,
+) -> Result<(TcpStream, Option<SshTunnel>), SessionError> {
+    let host = cfg.host.clone();
+    let port = cfg.effective_port();
+
+    if cfg.use_ssh_tunnel {
+        let tunnel = SshTunnel::establish(cfg, host, port).await?;
+        let stream = TcpStream::connect(("127.0.0.1", tunnel.local_port))
+            .await
+            .map_err(|e| SessionError::SpawnFailed(format!("tunnel local connect failed: {e}")))?;
+        Ok((stream, Some(tunnel)))
+    } else {
+        let stream = TcpStream::connect((host.as_str(), port))
+            .await
+            .map_err(|e| SessionError::SpawnFailed(format!("VNC connect failed: {e}")))?;
+        Ok((stream, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn tunnel_requires_ssh_host() {
+        let cfg = VncConfig {
+            use_ssh_tunnel: true,
+            ..VncConfig::default()
+        };
+        let err = SshTunnel::establish(&cfg, "vnc".to_string(), 5900)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SessionError::InvalidConfig(_)));
+    }
+
+    #[tokio::test]
+    async fn direct_transport_connect_error_is_surfaced() {
+        // Port 0 with no tunnel resolves to an OS-refused connect, exercising the
+        // direct (non-tunnel) error path deterministically.
+        let cfg = VncConfig {
+            host: "127.0.0.1".to_string(),
+            port: 1, // privileged/closed on the test host → connect fails fast
+            ..VncConfig::default()
+        };
+        let result = connect_transport(&cfg).await;
+        assert!(result.is_err());
+    }
+}

--- a/docs/changes/dev0/feature/1681-vnc-backend.md
+++ b/docs/changes/dev0/feature/1681-vnc-backend.md
@@ -1,0 +1,12 @@
+### Added
+
+- VNC (RFB) remote-desktop connections. A new **VNC** connection type plugs into
+  the shared graphical remote-desktop layer (#1680): it decodes the RFB
+  framebuffer in Rust (Raw / ZRLE / CopyRect, plus server cursor shapes) into the
+  shared canvas, translates keyboard/mouse/scroll input to RFB, and syncs the
+  text clipboard both ways. The connection editor exposes VNC-specific options on
+  top of the shared fields — a display number (the port becomes `5900 + display`),
+  an encoding preference, show-remote-cursor, and an optional **SSH Tunnel** group
+  that reaches the server through an SSH local forward — with no domain field.
+  Classic VNC-password and no-auth servers are supported. Ships **experimental**:
+  hidden unless experimental features are enabled (#1705). (#1681, epic #1678)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,12 +11,16 @@ edition = "2021"
 # FTP / FTPS connection type. Enabled by default so the desktop ships it, but
 # kept as a toggle so the registry registration is gated (`#[cfg(feature = "ftp")]`)
 # and a build without it still compiles.
-default = ["ftp", "mock-remote-desktop"]
+default = ["ftp", "mock-remote-desktop", "vnc"]
 ftp = ["termihub-core/ftp"]
 # Mock graphical remote-desktop backend so the shared remote-desktop layer
 # (#1680) ships and is E2E-testable with no real VNC/RDP server. Gated so the
 # registration is `#[cfg(feature = "mock-remote-desktop")]`.
 mock-remote-desktop = ["termihub-core/mock-remote-desktop"]
+# VNC (RFB) graphical remote-desktop backend (#1681). Gated so the registration
+# is `#[cfg(feature = "vnc")]`. Ships experimental — hidden unless the user
+# enables experimental features (#1705).
+vnc = ["termihub-core/vnc"]
 
 [lib]
 # The `_lib` suffix may seem redundant but it is necessary

--- a/src-tauri/src/session/registry.rs
+++ b/src-tauri/src/session/registry.rs
@@ -88,6 +88,19 @@ pub fn build_desktop_registry() -> ConnectionTypeRegistry {
         }),
     );
 
+    // VNC (RFB) graphical remote-desktop backend (gated behind the `vnc`
+    // feature; enabled by default). Reports `graphical: true`, so it routes
+    // through the GraphicalSessionManager into a remote-desktop canvas tab and
+    // is experimental-gated (#1705) with no per-protocol wiring. Additive, like
+    // every other backend — this is the whole desktop-side registration.
+    #[cfg(feature = "vnc")]
+    registry.register(
+        "vnc",
+        "VNC",
+        "monitor",
+        Box::new(|| Box::new(termihub_core::backends::vnc::Vnc::new())),
+    );
+
     registry
 }
 
@@ -119,13 +132,18 @@ mod tests {
         #[cfg(feature = "mock-remote-desktop")]
         assert!(registry.has_type("mock-remote-desktop"));
 
+        #[cfg(feature = "vnc")]
+        assert!(registry.has_type("vnc"));
+
         // 5 always-on backends (local/serial/ssh/telnet/docker), plus WSL on
-        // Windows, FTP when the `ftp` feature is enabled, and the mock
-        // remote-desktop backend when `mock-remote-desktop` is enabled.
+        // Windows, FTP when the `ftp` feature is enabled, the mock
+        // remote-desktop backend when `mock-remote-desktop` is enabled, and the
+        // VNC backend when `vnc` is enabled.
         let expected = 5
             + cfg!(windows) as usize
             + cfg!(feature = "ftp") as usize
-            + cfg!(feature = "mock-remote-desktop") as usize;
+            + cfg!(feature = "mock-remote-desktop") as usize
+            + cfg!(feature = "vnc") as usize;
         assert_eq!(types.len(), expected);
     }
 


### PR DESCRIPTION
## Summary

Adds the **VNC (RFB) backend** for the shared graphical remote-desktop layer (#1680), realizing concept #514 under the unified concept #1679. This is purely a protocol backend: all UI, session lifecycle, toolbar, overlays, input, clipboard, scaling, sidebar and IPC already exist from #1680 and are untouched here.

Registration is **additive**, exactly as #1680 designed it — a new `core/src/backends/vnc/` module, a schema, and one `registry.register("vnc", …)` call. There is **no shared match arm and no editor switch** to touch. Because the type reports `capabilities.graphical = true`, it is **experimental-gated automatically** by #1705 (hidden unless experimental features are enabled) with no per-protocol wiring.

## RFB crate

Library-first, per the repo rules — the RFB state machine is not hand-rolled. Uses **[`vnc-rs`](https://crates.io/crates/vnc-rs) 0.5.3** (crate `vnc-rs`, imported as `vnc`): an async, tokio-based RFB client that decodes framebuffer updates (Raw / ZRLE / CopyRect) and cursor/clipboard messages. Decode happens **in Rust** into the shared, protocol-agnostic frame stream — no noVNC, no WebSocket proxy — which is the unified rendering decision from #1678/#1679.

## What it does

- **Frames:** decodes into `PixelFormat::rgba()` (no channel swap) and emits shared `FrameUpdate` dirty-rects. A small server-side **shadow framebuffer** resolves `CopyRect` (which carries no pixels) into real dirty-rect data; `DesktopSizePseudo` drives resolution changes.
- **Input:** translates shared `InputEvent`s to RFB `KeyEvent`/`PointerEvent`, with a browser-`code` → X11-keysym keymap (letters, digits, F-keys, modifiers, arrows, numpad, punctuation — Ctrl+Alt+Del included) and a DOM → RFB button-mask remap. Scroll maps to RFB button 4/5.
- **Clipboard:** bidirectional (`ServerCutText` → `get_clipboard`; local text → `ClientCutText`).
- **Cursor:** renders server cursor shapes (`CursorPseudo`) when enabled.
- **Auth:** classic VNC password / none.
- **Schema:** shared field base + VNC rows — display number (port = `5900 + display`, resolved on connect), encoding preference, show-remote-cursor, and an **SSH Tunnel** group (SSH local-forward, reusing the existing SSH connect path). **No domain field.**
- **View-only** suppresses all input.

## Tests

- 40 Rust unit tests: keymap, shadow-framebuffer blit/copy/extract, config + schema (display↔port, no-domain, conditional SSH-tunnel visibility), button remap, encoding selection, capabilities, connect/disconnect guards, tunnel config.
- The live decode/auth path against a real VNC server is **integration** (needs a server) and is **not** exercised by per-PR CI (`-m "not integration"`), per the repo gotcha — see the follow-up for a reusable Docker VNC fixture.

## Deferred (follow-ups filed, see below)

- Reusable VNC Docker test fixture + local integration test.
- VeNCrypt / key-and-agent SSH-tunnel auth (tunnel currently uses password auth).
- Tight/JPEG encoding, layout-aware keymap, and live editor auto-fill/clear of the display↔port fields (the connect-side resolution is implemented; the interactive editor nicety needs editor-component work, out of scope here).

Closes #1681


## Follow-up issues

- #1713 — reusable VNC Docker fixture + local integration test
- #1714 — VeNCrypt auth and key/agent SSH-tunnel auth
- #1715 — Tight/JPEG encoding support
- #1716 — live display↔port auto-fill in the connection editor
