### PR TITLE
feat(macro): play a macro into the active terminal (timing modes + cancel + triggers)

### DIFF
--- a/docs/changes/dev1/feature/1675-macro-playback.md
+++ b/docs/changes/dev1/feature/1675-macro-playback.md
@@ -1,0 +1,9 @@
+### Added
+
+- Play a saved macro back into the active terminal: a "Play Macro" button in the
+  terminal toolbar opens a picker to choose a macro and a timing mode — real-time
+  (honor the recorded delays), fixed (a constant delay per step), or instant (no
+  delay). Each stored macro also appears in the command palette as a `Run Macro: <name>`
+  entry that replays it with real-time timing. Playback shows live progress, can be
+  cancelled mid-run (the toolbar button turns into a stop control), and fails with a
+  recoverable notification when the target terminal is not connected (#1675).

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { matchSorter } from "match-sorter";
-import { TerminalSquare } from "lucide-react";
+import { TerminalSquare, Play } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { buildCommands } from "@/services/commands";
 import { useConnectSavedConnection } from "@/hooks/useConnectSavedConnection";
@@ -35,6 +35,13 @@ type PaletteEntry =
       /** Host used as a secondary match key, if any. */
       host: string;
       connection: SavedConnection;
+    }
+  | {
+      kind: "macro";
+      key: string;
+      label: string;
+      /** The macro to replay into the active terminal. */
+      macroId: string;
     };
 
 /**
@@ -51,6 +58,8 @@ export function CommandPalette(): React.ReactElement {
   const open = useAppStore((s) => s.commandPaletteOpen);
   const setOpen = useAppStore((s) => s.setCommandPaletteOpen);
   const connections = useAppStore((s) => s.connections);
+  const macros = useAppStore((s) => s.macros);
+  const playMacro = useAppStore((s) => s.playMacro);
   // Context-bound command availability depends on live panel/terminal state;
   // subscribe so the entry list (and its disabled affordances) recompute when
   // the focused panel, its tabs, or the active panel change.
@@ -80,13 +89,19 @@ export function CommandPalette(): React.ReactElement {
       host: String((conn.config.config as Record<string, unknown>).host ?? ""),
       connection: conn,
     }));
-    return [...commandEntries, ...connectionEntries];
+    const macroEntries: PaletteEntry[] = macros.map((m) => ({
+      kind: "macro",
+      key: `macro:${m.id}`,
+      label: `Run Macro: ${m.name}`,
+      macroId: m.id,
+    }));
+    return [...commandEntries, ...macroEntries, ...connectionEntries];
     // buildCommands() reads live panel/terminal state via the store to compute
     // each context command's availability; rootPanel and activePanelId are listed
     // so the entries (and their disabled affordances) recompute when focus moves,
     // even though they are not referenced directly in this closure.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connections, rootPanel, activePanelId]);
+  }, [connections, macros, rootPanel, activePanelId]);
 
   // Ranked results. An empty query returns every entry in declaration order.
   const results = useMemo<PaletteEntry[]>(() => {
@@ -129,11 +144,13 @@ export function CommandPalette(): React.ReactElement {
       setOpen(false);
       if (entry.kind === "command") {
         entry.run();
+      } else if (entry.kind === "macro") {
+        void playMacro(entry.macroId, { timingMode: "real-time" });
       } else {
         void connect(entry.connection);
       }
     },
-    [connect, setOpen]
+    [connect, playMacro, setOpen]
   );
 
   const handleKeyDown = useCallback(
@@ -215,6 +232,8 @@ export function CommandPalette(): React.ReactElement {
                   <span className="command-palette__icon" aria-hidden="true">
                     {entry.kind === "command" ? (
                       <TerminalSquare size={16} />
+                    ) : entry.kind === "macro" ? (
+                      <Play size={16} />
                     ) : (
                       <ConnectionIcon
                         config={entry.connection.config}
@@ -228,6 +247,8 @@ export function CommandPalette(): React.ReactElement {
                     entry.accelerator ? (
                       <span className="command-palette__accelerator">{entry.accelerator}</span>
                     ) : null
+                  ) : entry.kind === "macro" ? (
+                    <span className="command-palette__type">macro</span>
                   ) : (
                     <span className="command-palette__type">{entry.connection.config.type}</span>
                   )}

--- a/src/components/Terminal/MacroPlaybackDialog.css
+++ b/src/components/Terminal/MacroPlaybackDialog.css
@@ -1,0 +1,10 @@
+.macro-playback-dialog__empty,
+.macro-playback-dialog__hint {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.macro-playback-dialog__hint {
+  margin-top: var(--spacing-sm);
+}

--- a/src/components/Terminal/MacroPlaybackDialog.test.tsx
+++ b/src/components/Terminal/MacroPlaybackDialog.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { MacroPlaybackDialog } from "./MacroPlaybackDialog";
+import type { Macro } from "@/types/macro";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+const macro = (id: string, name: string, stepCount: number): Macro => ({
+  id,
+  name,
+  description: "",
+  tags: [],
+  steps: Array.from({ length: stepCount }, (_, i) => ({ data: `s${i}`, delayMs: 0 })),
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+});
+
+const baseProps = {
+  open: true,
+  macros: [macro("m1", "Deploy", 3), macro("m2", "Login", 2)],
+  onOpenChange: () => {},
+  onPlay: () => {},
+};
+
+describe("MacroPlaybackDialog", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<MacroPlaybackDialog {...baseProps} open={false} />);
+    expect(document.querySelector('[data-testid="macro-playback-select"]')).toBeNull();
+  });
+
+  it("renders the macro and timing pickers when open with macros", () => {
+    render(<MacroPlaybackDialog {...baseProps} />);
+    expect(document.querySelector(".ui-modal")).toBeTruthy();
+    expect(document.querySelector('[data-testid="macro-playback-select"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="macro-playback-timing"]')).toBeTruthy();
+  });
+
+  it("explains how to record when there are no macros, and disables Play", () => {
+    render(<MacroPlaybackDialog {...baseProps} macros={[]} />);
+    expect(document.querySelector('[data-testid="macro-playback-select"]')).toBeNull();
+    expect(document.body.textContent).toContain("No macros saved yet");
+    const play = document.querySelector(
+      '[data-testid="macro-playback-confirm"]'
+    ) as HTMLButtonElement;
+    expect(play.disabled).toBe(true);
+  });
+
+  it("Play fires onPlay with the default (first) macro and real-time timing", () => {
+    const onPlay = vi.fn();
+    render(<MacroPlaybackDialog {...baseProps} onPlay={onPlay} />);
+
+    act(() => {
+      (document.querySelector('[data-testid="macro-playback-confirm"]') as HTMLElement).click();
+    });
+
+    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onPlay).toHaveBeenCalledWith("m1", "real-time");
+  });
+
+  it("disables Play for a macro with no steps", () => {
+    const onPlay = vi.fn();
+    render(<MacroPlaybackDialog {...baseProps} macros={[macro("empty", "Empty", 0)]} onPlay={onPlay} />);
+
+    const play = document.querySelector(
+      '[data-testid="macro-playback-confirm"]'
+    ) as HTMLButtonElement;
+    expect(play.disabled).toBe(true);
+
+    act(() => play.click());
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+
+  it("Cancel closes the dialog without playing", () => {
+    const onPlay = vi.fn();
+    const onOpenChange = vi.fn();
+    render(<MacroPlaybackDialog {...baseProps} onPlay={onPlay} onOpenChange={onOpenChange} />);
+
+    act(() => {
+      (document.querySelector('[data-testid="macro-playback-cancel"]') as HTMLElement).click();
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onPlay).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Terminal/MacroPlaybackDialog.test.tsx
+++ b/src/components/Terminal/MacroPlaybackDialog.test.tsx
@@ -79,7 +79,9 @@ describe("MacroPlaybackDialog", () => {
 
   it("disables Play for a macro with no steps", () => {
     const onPlay = vi.fn();
-    render(<MacroPlaybackDialog {...baseProps} macros={[macro("empty", "Empty", 0)]} onPlay={onPlay} />);
+    render(
+      <MacroPlaybackDialog {...baseProps} macros={[macro("empty", "Empty", 0)]} onPlay={onPlay} />
+    );
 
     const play = document.querySelector(
       '[data-testid="macro-playback-confirm"]'

--- a/src/components/Terminal/MacroPlaybackDialog.tsx
+++ b/src/components/Terminal/MacroPlaybackDialog.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react";
+import { Modal, Button, Field, Select } from "@/components/ui";
+import type { Macro } from "@/types/macro";
+import type { MacroTimingMode } from "@/services/macroPlayback";
+import "./MacroPlaybackDialog.css";
+
+export interface MacroPlaybackDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** The stored macros available to play. */
+  macros: Macro[];
+  /** Called when the dialog should open/close. */
+  onOpenChange: (open: boolean) => void;
+  /** Called with the chosen macro id and timing mode when the user hits Play. */
+  onPlay: (macroId: string, timingMode: MacroTimingMode) => void;
+}
+
+/** Human-readable labels for each timing mode, shown in the mode picker. */
+const TIMING_MODE_OPTIONS: { value: MacroTimingMode; label: string }[] = [
+  { value: "real-time", label: "Real-time (recorded delays)" },
+  { value: "fixed", label: "Fixed delay per step" },
+  { value: "instant", label: "Instant (no delay)" },
+];
+
+/**
+ * Picker shown from the terminal toolbar's "Play Macro" action: choose a stored
+ * macro and a timing mode, then replay it into the active terminal. Composed
+ * from the shared UI primitives. When no macros exist the dialog explains how to
+ * record one rather than presenting an empty, un-actionable list.
+ */
+export function MacroPlaybackDialog({
+  open,
+  macros,
+  onOpenChange,
+  onPlay,
+}: MacroPlaybackDialogProps) {
+  const [macroId, setMacroId] = useState<string | undefined>(undefined);
+  const [timingMode, setTimingMode] = useState<MacroTimingMode>("real-time");
+
+  // Default the selection to the first macro each time the dialog opens so Play
+  // is immediately actionable; reset the mode to the sensible default.
+  useEffect(() => {
+    if (open) {
+      setMacroId(macros[0]?.id);
+      setTimingMode("real-time");
+    }
+  }, [open, macros]);
+
+  const macroOptions = useMemo(
+    () => macros.map((m) => ({ value: m.id, label: m.name })),
+    [macros]
+  );
+
+  const selected = macros.find((m) => m.id === macroId) ?? null;
+  const canPlay = selected !== null && selected.steps.length > 0;
+
+  const handlePlay = () => {
+    if (!macroId || !canPlay) return;
+    onPlay(macroId, timingMode);
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Play Macro"
+      description="Replay a stored macro's input into the active terminal"
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && canPlay) handlePlay();
+      }}
+      data-testid="macro-playback-dialog"
+      footer={
+        <>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            data-testid="macro-playback-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handlePlay}
+            disabled={!canPlay}
+            data-testid="macro-playback-confirm"
+          >
+            Play
+          </Button>
+        </>
+      }
+    >
+      {macros.length === 0 ? (
+        <p className="macro-playback-dialog__empty" role="status">
+          No macros saved yet. Record one with the terminal toolbar's record button first.
+        </p>
+      ) : (
+        <>
+          <Field label="Macro" htmlFor="macro-playback-select">
+            <Select
+              value={macroId}
+              onChange={setMacroId}
+              options={macroOptions}
+              placeholder="Select a macro"
+              aria-label="Macro to play"
+              data-testid="macro-playback-select"
+            />
+          </Field>
+          <Field label="Timing" htmlFor="macro-playback-timing">
+            <Select
+              value={timingMode}
+              onChange={(v) => setTimingMode(v as MacroTimingMode)}
+              options={TIMING_MODE_OPTIONS}
+              aria-label="Playback timing mode"
+              data-testid="macro-playback-timing"
+            />
+          </Field>
+          {selected && selected.steps.length === 0 && (
+            <p className="macro-playback-dialog__hint" role="status">
+              This macro has no recorded steps.
+            </p>
+          )}
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/Terminal/MacroPlaybackDialog.tsx
+++ b/src/components/Terminal/MacroPlaybackDialog.tsx
@@ -46,10 +46,7 @@ export function MacroPlaybackDialog({
     }
   }, [open, macros]);
 
-  const macroOptions = useMemo(
-    () => macros.map((m) => ({ value: m.id, label: m.name })),
-    [macros]
-  );
+  const macroOptions = useMemo(() => macros.map((m) => ({ value: m.id, label: m.name })), [macros]);
 
   const selected = macros.find((m) => m.id === macroId) ?? null;
   const canPlay = selected !== null && selected.steps.length > 0;

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useRef, useCallback, useMemo, ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useRef,
+  useCallback,
+  useMemo,
+  useEffect,
+  ReactNode,
+} from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon, type ISearchOptions } from "@xterm/addon-search";
@@ -9,6 +17,7 @@ import {
   writeText as writeClipboard,
 } from "@tauri-apps/plugin-clipboard-manager";
 import { sendInput } from "@/services/api";
+import { registerTerminalInputInjector } from "@/services/macroPlayback";
 import { SessionId } from "@/types/terminal";
 import { useAppStore } from "@/store/appStore";
 import { frontendLog } from "@/utils/frontendLog";
@@ -329,6 +338,14 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
     await sendInput(sessionId, data);
     return true;
   }, []);
+
+  // Expose the terminal-input seam to the macro playback service (#1675) so the
+  // store's `playMacro` can inject through the same `send_input` choke point as
+  // interactive typing, without holding a React ref. Cleared on unmount.
+  useEffect(() => {
+    registerTerminalInputInjector(sendInputToTerminal);
+    return () => registerTerminalInputInjector(null);
+  }, [sendInputToTerminal]);
 
   const registerSearchAddon = useCallback((tabId: string, addon: SearchAddon) => {
     searchAddonRegistryRef.current.set(tabId, addon);

--- a/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
+++ b/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
@@ -44,6 +44,7 @@ vi.mock("@/components/ui", () => ({
 }));
 vi.mock("./TabGroupChips", () => ({ TabGroupChips: () => null }));
 vi.mock("./MacroRecordSaveDialog", () => ({ MacroRecordSaveDialog: () => null }));
+vi.mock("./MacroPlaybackDialog", () => ({ MacroPlaybackDialog: () => null }));
 vi.mock("@/components/SplitView", () => ({ SplitView: () => null }));
 vi.mock("@/services/events", () => ({ terminalDispatcher: { init: vi.fn() } }));
 vi.mock("@/services/api", () => ({

--- a/src/components/Terminal/TerminalView.record-button.test.tsx
+++ b/src/components/Terminal/TerminalView.record-button.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@/components/ui", () => ({
 }));
 vi.mock("./TabGroupChips", () => ({ TabGroupChips: () => null }));
 vi.mock("./MacroRecordSaveDialog", () => ({ MacroRecordSaveDialog: () => null }));
+vi.mock("./MacroPlaybackDialog", () => ({ MacroPlaybackDialog: () => null }));
 vi.mock("@/components/SplitView", () => ({ SplitView: () => null }));
 vi.mock("@/services/events", () => ({ terminalDispatcher: { init: vi.fn() } }));
 vi.mock("@/services/api", () => ({

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo } from "react";
-import { Plus, Columns2, Rows2, X, PanelLeft, Circle, Square } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Columns2, Rows2, X, PanelLeft, Circle, Square, Play } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
@@ -13,6 +13,7 @@ import { Terminal } from "./Terminal";
 import { applyAgentReconnecting } from "./agentStateHandlers";
 import { TabGroupChips } from "./TabGroupChips";
 import { MacroRecordSaveDialog } from "./MacroRecordSaveDialog";
+import { MacroPlaybackDialog } from "./MacroPlaybackDialog";
 import { SplitView } from "@/components/SplitView";
 import { terminalDispatcher } from "@/services/events";
 import { listAgentSessions } from "@/services/api";
@@ -252,6 +253,11 @@ export function TerminalView() {
   const macroRecordingStepCount = useAppStore((s) => s.macroRecordingSteps.length);
   const saveRecordedMacro = useAppStore((s) => s.saveRecordedMacro);
   const discardRecordedMacro = useAppStore((s) => s.discardRecordedMacro);
+  const macros = useAppStore((s) => s.macros);
+  const macroPlayback = useAppStore((s) => s.macroPlayback);
+  const playMacro = useAppStore((s) => s.playMacro);
+  const cancelMacroPlayback = useAppStore((s) => s.cancelMacroPlayback);
+  const [macroPlaybackDialogOpen, setMacroPlaybackDialogOpen] = useState(false);
   const isMac = navigator.platform.toUpperCase().includes("MAC");
   const sidebarToggleTitle = `Toggle Sidebar (${isMac ? "Cmd" : "Ctrl"}+B)`;
 
@@ -343,6 +349,26 @@ export function TerminalView() {
                 {macroRecording ? <Square size={14} fill="currentColor" /> : <Circle size={16} />}
               </button>
             </Tooltip>
+            <Tooltip
+              content={
+                macroPlayback
+                  ? `Stop Playback (${macroPlayback.played}/${macroPlayback.total})`
+                  : "Play Macro"
+              }
+              side="bottom"
+            >
+              <button
+                className={`terminal-view__toolbar-btn${macroPlayback ? " terminal-view__toolbar-btn--recording" : ""}`}
+                onClick={() =>
+                  macroPlayback ? cancelMacroPlayback() : setMacroPlaybackDialogOpen(true)
+                }
+                aria-label={macroPlayback ? "Stop Macro Playback" : "Play Macro"}
+                aria-pressed={macroPlayback !== null}
+                data-testid="terminal-view-play-macro"
+              >
+                {macroPlayback ? <Square size={14} fill="currentColor" /> : <Play size={15} />}
+              </button>
+            </Tooltip>
             {allLeaves.length > 1 && (
               <Tooltip content="Close Panel" side="bottom">
                 <button
@@ -377,6 +403,12 @@ export function TerminalView() {
         stepCount={macroRecordingStepCount}
         onSave={(meta) => void saveRecordedMacro(meta)}
         onCancel={discardRecordedMacro}
+      />
+      <MacroPlaybackDialog
+        open={macroPlaybackDialogOpen}
+        macros={macros}
+        onOpenChange={setMacroPlaybackDialogOpen}
+        onPlay={(macroId, timingMode) => void playMacro(macroId, { timingMode })}
       />
     </TerminalPortalProvider>
   );

--- a/src/services/macroPlayback.test.ts
+++ b/src/services/macroPlayback.test.ts
@@ -36,9 +36,9 @@ describe("computeStepDelay", () => {
 
   it("real-time clamps oversized recorded delays to maxDelayMs", () => {
     expect(computeStepDelay(step(600_000), 1, { timingMode: "real-time" })).toBe(MAX_STEP_DELAY_MS);
-    expect(
-      computeStepDelay(step(600_000), 1, { timingMode: "real-time", maxDelayMs: 100 })
-    ).toBe(100);
+    expect(computeStepDelay(step(600_000), 1, { timingMode: "real-time", maxDelayMs: 100 })).toBe(
+      100
+    );
   });
 
   it("real-time floors negative delays at zero", () => {
@@ -64,7 +64,7 @@ describe("runMacroPlayback", () => {
   });
 
   it("injects every step in order for instant mode", async () => {
-    const inject = vi.fn(async () => true);
+    const inject = vi.fn(async (_data: string) => true);
     const handle = runMacroPlayback(steps([0, 100, 200]), inject, { timingMode: "instant" });
     const result = await handle.done;
 
@@ -93,9 +93,14 @@ describe("runMacroPlayback", () => {
   it("reports progress after each injected step", async () => {
     const inject = vi.fn(async () => true);
     const onProgress = vi.fn();
-    const handle = runMacroPlayback(steps([0, 0, 0]), inject, { timingMode: "instant" }, {
-      onProgress,
-    });
+    const handle = runMacroPlayback(
+      steps([0, 0, 0]),
+      inject,
+      { timingMode: "instant" },
+      {
+        onProgress,
+      }
+    );
     await handle.done;
 
     expect(onProgress.mock.calls).toEqual([

--- a/src/services/macroPlayback.test.ts
+++ b/src/services/macroPlayback.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the macro playback scheduler (#1675).
+ *
+ * Pins the timing-mode math ({@link computeStepDelay}) and the async scheduler
+ * ({@link runMacroPlayback}): step ordering, per-mode delays, delay clamping,
+ * cancellation (before and mid-delay), and the error path when injection fails.
+ * The injector is mocked so no terminal or session is required.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  computeStepDelay,
+  runMacroPlayback,
+  DEFAULT_FIXED_DELAY_MS,
+  MAX_STEP_DELAY_MS,
+  registerTerminalInputInjector,
+  getTerminalInputInjector,
+  type MacroPlaybackOptions,
+} from "./macroPlayback";
+import type { MacroStep } from "@/types/macro";
+
+const steps = (delays: number[]): MacroStep[] =>
+  delays.map((delayMs, i) => ({ data: `s${i}`, delayMs }));
+
+describe("computeStepDelay", () => {
+  const step = (delayMs: number): MacroStep => ({ data: "x", delayMs });
+
+  it("plays the first step immediately in every mode", () => {
+    for (const timingMode of ["real-time", "fixed", "instant"] as const) {
+      expect(computeStepDelay(step(999), 0, { timingMode })).toBe(0);
+    }
+  });
+
+  it("real-time honours the recorded delay", () => {
+    expect(computeStepDelay(step(250), 3, { timingMode: "real-time" })).toBe(250);
+  });
+
+  it("real-time clamps oversized recorded delays to maxDelayMs", () => {
+    expect(computeStepDelay(step(600_000), 1, { timingMode: "real-time" })).toBe(MAX_STEP_DELAY_MS);
+    expect(
+      computeStepDelay(step(600_000), 1, { timingMode: "real-time", maxDelayMs: 100 })
+    ).toBe(100);
+  });
+
+  it("real-time floors negative delays at zero", () => {
+    expect(computeStepDelay(step(-50), 2, { timingMode: "real-time" })).toBe(0);
+  });
+
+  it("fixed uses a constant per-step delay regardless of recorded timing", () => {
+    expect(computeStepDelay(step(9999), 2, { timingMode: "fixed" })).toBe(DEFAULT_FIXED_DELAY_MS);
+    expect(computeStepDelay(step(9999), 2, { timingMode: "fixed", fixedDelayMs: 100 })).toBe(100);
+  });
+
+  it("instant never delays", () => {
+    expect(computeStepDelay(step(9999), 5, { timingMode: "instant" })).toBe(0);
+  });
+});
+
+describe("runMacroPlayback", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("injects every step in order for instant mode", async () => {
+    const inject = vi.fn(async () => true);
+    const handle = runMacroPlayback(steps([0, 100, 200]), inject, { timingMode: "instant" });
+    const result = await handle.done;
+
+    expect(result).toEqual({ status: "completed", stepsPlayed: 3 });
+    expect(inject.mock.calls.map((c) => c[0])).toEqual(["s0", "s1", "s2"]);
+  });
+
+  it("waits the recorded delay between steps in real-time mode", async () => {
+    const inject = vi.fn(async () => true);
+    const opts: MacroPlaybackOptions = { timingMode: "real-time" };
+    const handle = runMacroPlayback(steps([0, 500]), inject, opts);
+
+    // First step fires immediately (delay 0).
+    await vi.advanceTimersByTimeAsync(0);
+    expect(inject).toHaveBeenCalledTimes(1);
+
+    // Second step waits 500ms.
+    await vi.advanceTimersByTimeAsync(499);
+    expect(inject).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(inject).toHaveBeenCalledTimes(2);
+
+    expect(await handle.done).toEqual({ status: "completed", stepsPlayed: 2 });
+  });
+
+  it("reports progress after each injected step", async () => {
+    const inject = vi.fn(async () => true);
+    const onProgress = vi.fn();
+    const handle = runMacroPlayback(steps([0, 0, 0]), inject, { timingMode: "instant" }, {
+      onProgress,
+    });
+    await handle.done;
+
+    expect(onProgress.mock.calls).toEqual([
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ]);
+  });
+
+  it("stops promptly when cancelled during a delay", async () => {
+    const inject = vi.fn(async () => true);
+    const handle = runMacroPlayback(steps([0, 10_000]), inject, { timingMode: "real-time" });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(inject).toHaveBeenCalledTimes(1);
+
+    handle.cancel();
+    const result = await handle.done;
+
+    expect(result).toEqual({ status: "cancelled", stepsPlayed: 1 });
+    // No further injection despite the 10s delay never elapsing.
+    expect(inject).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not inject anything when cancelled before it starts", async () => {
+    const inject = vi.fn(async () => true);
+    const handle = runMacroPlayback(steps([0, 0]), inject, { timingMode: "instant" });
+    handle.cancel();
+    const result = await handle.done;
+
+    expect(result.status).toBe("cancelled");
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it("aborts with an error when injection reports failure", async () => {
+    const inject = vi
+      .fn<(data: string) => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const handle = runMacroPlayback(steps([0, 0, 0]), inject, { timingMode: "instant" });
+    const result = await handle.done;
+
+    expect(result).toEqual({ status: "error", stepsPlayed: 1 });
+    // The third step is never attempted after the second fails.
+    expect(inject).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("terminal input injector registry", () => {
+  afterEach(() => {
+    registerTerminalInputInjector(null);
+  });
+
+  it("stores and clears the registered injector", async () => {
+    expect(getTerminalInputInjector()).toBeNull();
+
+    const fn = vi.fn(async () => true);
+    registerTerminalInputInjector(fn);
+    expect(getTerminalInputInjector()).toBe(fn);
+
+    registerTerminalInputInjector(null);
+    expect(getTerminalInputInjector()).toBeNull();
+  });
+});

--- a/src/services/macroPlayback.ts
+++ b/src/services/macroPlayback.ts
@@ -1,0 +1,181 @@
+/**
+ * Macro playback scheduler (#1675).
+ *
+ * Drives a stored macro's recorded {@link MacroStep}s back into a terminal by
+ * calling an injector callback for each step, honouring a timing mode and a
+ * cancel affordance. The scheduler is intentionally decoupled from the store and
+ * from the terminal registry: it takes a plain `inject(data) => Promise<boolean>`
+ * callback, so it can be unit-tested with a mock and reused wherever an injector
+ * is available.
+ *
+ * The single injection seam is {@link TerminalRegistry.sendInputToTerminal},
+ * which routes through the existing `send_input` choke point (line-ending
+ * normalization included). The terminal registry registers that method here via
+ * {@link registerTerminalInputInjector} so the store's `playMacro` action can
+ * reach it without holding a React ref.
+ */
+import type { MacroStep } from "@/types/macro";
+
+/** How inter-step delays are derived during playback. */
+export type MacroTimingMode = "real-time" | "fixed" | "instant";
+
+/** Default per-step delay (ms) used by the `fixed` timing mode. */
+export const DEFAULT_FIXED_DELAY_MS = 40;
+
+/**
+ * Upper bound (ms) applied to any single computed delay. Recorded `real-time`
+ * delays can be arbitrarily large (the user paused mid-recording); clamp them so
+ * playback never appears to hang for minutes on a single step.
+ */
+export const MAX_STEP_DELAY_MS = 5000;
+
+/** Injects one chunk of input into a terminal; resolves `true` when delivered. */
+export type MacroInjector = (data: string) => Promise<boolean> | boolean;
+
+/** Options controlling how a macro's steps are scheduled. */
+export interface MacroPlaybackOptions {
+  /** Timing mode governing the delay before each step. */
+  timingMode: MacroTimingMode;
+  /** Per-step delay (ms) for the `fixed` mode. Defaults to {@link DEFAULT_FIXED_DELAY_MS}. */
+  fixedDelayMs?: number;
+  /** Clamp for any single computed delay. Defaults to {@link MAX_STEP_DELAY_MS}. */
+  maxDelayMs?: number;
+}
+
+/** Terminal outcome of a playback run. */
+export type MacroPlaybackStatus = "completed" | "cancelled" | "error";
+
+/** Result of a finished playback run. */
+export interface MacroPlaybackResult {
+  status: MacroPlaybackStatus;
+  /** Number of steps successfully injected before the run ended. */
+  stepsPlayed: number;
+}
+
+/** Optional lifecycle hooks fired as playback advances. */
+export interface MacroPlaybackHooks {
+  /** Fired after each step is injected, with the 1-based count and total. */
+  onProgress?: (played: number, total: number) => void;
+}
+
+/** A running playback that can be awaited or cancelled. */
+export interface MacroPlaybackHandle {
+  /** Resolves when playback finishes (completed, cancelled, or errored). */
+  done: Promise<MacroPlaybackResult>;
+  /** Request cancellation; the run stops before the next step is injected. */
+  cancel: () => void;
+}
+
+/**
+ * Compute the delay (ms) to wait before playing `step` at position `index`.
+ *
+ * The very first step always plays immediately so playback starts promptly
+ * regardless of mode. Thereafter:
+ * - `instant` — no delay.
+ * - `fixed` — a constant `fixedDelayMs` per step, ignoring recorded timing.
+ * - `real-time` — the step's recorded `delayMs`, clamped to `[0, maxDelayMs]`.
+ */
+export function computeStepDelay(
+  step: MacroStep,
+  index: number,
+  options: MacroPlaybackOptions
+): number {
+  if (index <= 0) return 0;
+  const {
+    timingMode,
+    fixedDelayMs = DEFAULT_FIXED_DELAY_MS,
+    maxDelayMs = MAX_STEP_DELAY_MS,
+  } = options;
+  switch (timingMode) {
+    case "instant":
+      return 0;
+    case "fixed":
+      return Math.max(0, Math.min(fixedDelayMs, maxDelayMs));
+    case "real-time":
+    default:
+      return Math.max(0, Math.min(step.delayMs, maxDelayMs));
+  }
+}
+
+/**
+ * Schedule and run a macro's steps through `inject`, honouring `options` and
+ * supporting cancellation. Returns a {@link MacroPlaybackHandle} whose `done`
+ * promise resolves once the run finishes.
+ *
+ * If `inject` resolves `false` for any step (e.g. the target session vanished),
+ * the run stops with status `error`. Cancellation is checked both before each
+ * delay and after it, so a cancel during a long real-time wait stops promptly.
+ */
+export function runMacroPlayback(
+  steps: MacroStep[],
+  inject: MacroInjector,
+  options: MacroPlaybackOptions,
+  hooks?: MacroPlaybackHooks
+): MacroPlaybackHandle {
+  let cancelled = false;
+  let activeTimer: ReturnType<typeof setTimeout> | null = null;
+  let wake: (() => void) | null = null;
+
+  const cancel = (): void => {
+    cancelled = true;
+    if (activeTimer !== null) {
+      clearTimeout(activeTimer);
+      activeTimer = null;
+    }
+    if (wake) {
+      const resolve = wake;
+      wake = null;
+      resolve();
+    }
+  };
+
+  const sleep = (ms: number): Promise<void> =>
+    new Promise<void>((resolve) => {
+      if (ms <= 0 || cancelled) {
+        resolve();
+        return;
+      }
+      wake = resolve;
+      activeTimer = setTimeout(() => {
+        activeTimer = null;
+        wake = null;
+        resolve();
+      }, ms);
+    });
+
+  const done = (async (): Promise<MacroPlaybackResult> => {
+    for (let i = 0; i < steps.length; i++) {
+      if (cancelled) return { status: "cancelled", stepsPlayed: i };
+      await sleep(computeStepDelay(steps[i], i, options));
+      if (cancelled) return { status: "cancelled", stepsPlayed: i };
+      const delivered = await inject(steps[i].data);
+      if (!delivered) return { status: "error", stepsPlayed: i };
+      hooks?.onProgress?.(i + 1, steps.length);
+    }
+    return { status: "completed", stepsPlayed: steps.length };
+  })();
+
+  return { done, cancel };
+}
+
+/**
+ * Injects input into a specific terminal tab; resolves `true` when a session was
+ * found and the input sent. Mirrors {@link TerminalRegistry.sendInputToTerminal}.
+ */
+export type TerminalInputInjector = (tabId: string, data: string) => Promise<boolean>;
+
+let terminalInputInjector: TerminalInputInjector | null = null;
+
+/**
+ * Register (or clear, with `null`) the terminal-input injector used by macro
+ * playback. The terminal registry provider calls this on mount so the store can
+ * inject through the single `send_input` seam without a React ref.
+ */
+export function registerTerminalInputInjector(fn: TerminalInputInjector | null): void {
+  terminalInputInjector = fn;
+}
+
+/** The currently-registered terminal-input injector, or `null` when none. */
+export function getTerminalInputInjector(): TerminalInputInjector | null {
+  return terminalInputInjector;
+}

--- a/src/store/appStore.macroPlayback.test.ts
+++ b/src/store/appStore.macroPlayback.test.ts
@@ -99,7 +99,15 @@ describe("appStore — macro playback slice (#1675)", () => {
 
   it("injects every step in order into the active terminal (instant)", async () => {
     seedConnectedTerminal();
-    useAppStore.setState({ macros: [macro("m1", [{ data: "l", delayMs: 0 }, { data: "s", delayMs: 300 }, { data: "\r", delayMs: 50 }])] });
+    useAppStore.setState({
+      macros: [
+        macro("m1", [
+          { data: "l", delayMs: 0 },
+          { data: "s", delayMs: 300 },
+          { data: "\r", delayMs: 50 },
+        ]),
+      ],
+    });
 
     await useAppStore.getState().playMacro("m1", { timingMode: "instant" });
 
@@ -127,7 +135,14 @@ describe("appStore — macro playback slice (#1675)", () => {
   it("honours real-time delays between steps", async () => {
     vi.useFakeTimers();
     seedConnectedTerminal();
-    useAppStore.setState({ macros: [macro("m1", [{ data: "a", delayMs: 0 }, { data: "b", delayMs: 500 }])] });
+    useAppStore.setState({
+      macros: [
+        macro("m1", [
+          { data: "a", delayMs: 0 },
+          { data: "b", delayMs: 500 },
+        ]),
+      ],
+    });
 
     const done = useAppStore.getState().playMacro("m1", { timingMode: "real-time" });
 
@@ -146,7 +161,14 @@ describe("appStore — macro playback slice (#1675)", () => {
   it("can be cancelled mid-run and stops promptly", async () => {
     vi.useFakeTimers();
     seedConnectedTerminal();
-    useAppStore.setState({ macros: [macro("m1", [{ data: "a", delayMs: 0 }, { data: "b", delayMs: 10_000 }])] });
+    useAppStore.setState({
+      macros: [
+        macro("m1", [
+          { data: "a", delayMs: 0 },
+          { data: "b", delayMs: 10_000 },
+        ]),
+      ],
+    });
 
     const done = useAppStore.getState().playMacro("m1", { timingMode: "real-time" });
     await vi.advanceTimersByTimeAsync(0);

--- a/src/store/appStore.macroPlayback.test.ts
+++ b/src/store/appStore.macroPlayback.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for the macro *playback* Zustand slice (#1675).
+ *
+ * Pins `playMacro` / `cancelMacroPlayback`: steps are injected in order through
+ * the registered terminal-input injector, timing modes change observable
+ * behaviour, playback can be cancelled mid-run, and the guards (missing macro,
+ * empty macro, no connected terminal) surface a recoverable toast instead of
+ * injecting. The injector and terminal are mocked so no real session is needed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
+import type { Macro } from "@/types/macro";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/macroApi", () => ({
+  listMacros: vi.fn(() => Promise.resolve([])),
+  getMacro: vi.fn(),
+  saveMacro: vi.fn((m) => Promise.resolve(m)),
+  deleteMacro: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import { registerTerminalInputInjector } from "@/services/macroPlayback";
+import { toast } from "@/components/ui";
+
+const macro = (id: string, steps: Macro["steps"]): Macro => ({
+  id,
+  name: `Macro ${id}`,
+  description: "",
+  tags: [],
+  steps,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+});
+
+/** Seed an active, connected terminal tab so playback has a valid target. */
+function seedConnectedTerminal(tabId = "tab-active", sessionId: string | null = "sess-1") {
+  const tab: TerminalTab = {
+    id: tabId,
+    sessionId,
+    title: "term",
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: {} },
+    panelId: "leaf-1",
+    isActive: true,
+  };
+  const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs: [tab], activeTabId: tabId };
+  useAppStore.setState({ rootPanel: leaf, activePanelId: "leaf-1", terminalExitedTabs: {} });
+}
+
+describe("appStore — macro playback slice (#1675)", () => {
+  let injected: string[];
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    injected = [];
+    registerTerminalInputInjector(async (_tabId, data) => {
+      injected.push(data);
+      return true;
+    });
+    vi.spyOn(toast, "error");
+    vi.spyOn(toast, "info");
+    vi.spyOn(toast, "success");
+    vi.spyOn(toast, "loading");
+  });
+
+  afterEach(() => {
+    registerTerminalInputInjector(null);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("injects every step in order into the active terminal (instant)", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({ macros: [macro("m1", [{ data: "l", delayMs: 0 }, { data: "s", delayMs: 300 }, { data: "\r", delayMs: 50 }])] });
+
+    await useAppStore.getState().playMacro("m1", { timingMode: "instant" });
+
+    expect(injected).toEqual(["l", "s", "\r"]);
+    // Playback state is cleared once the run finishes.
+    expect(useAppStore.getState().macroPlayback).toBeNull();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("defaults the target to the active terminal tab", async () => {
+    const tabIds: string[] = [];
+    registerTerminalInputInjector(async (tabId, data) => {
+      tabIds.push(tabId);
+      injected.push(data);
+      return true;
+    });
+    seedConnectedTerminal("tab-xyz", "sess-xyz");
+    useAppStore.setState({ macros: [macro("m1", [{ data: "hi", delayMs: 0 }])] });
+
+    await useAppStore.getState().playMacro("m1", { timingMode: "instant" });
+
+    expect(tabIds).toEqual(["tab-xyz"]);
+  });
+
+  it("honours real-time delays between steps", async () => {
+    vi.useFakeTimers();
+    seedConnectedTerminal();
+    useAppStore.setState({ macros: [macro("m1", [{ data: "a", delayMs: 0 }, { data: "b", delayMs: 500 }])] });
+
+    const done = useAppStore.getState().playMacro("m1", { timingMode: "real-time" });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(injected).toEqual(["a"]);
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(injected).toEqual(["a"]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(injected).toEqual(["a", "b"]);
+
+    await done;
+    expect(useAppStore.getState().macroPlayback).toBeNull();
+  });
+
+  it("can be cancelled mid-run and stops promptly", async () => {
+    vi.useFakeTimers();
+    seedConnectedTerminal();
+    useAppStore.setState({ macros: [macro("m1", [{ data: "a", delayMs: 0 }, { data: "b", delayMs: 10_000 }])] });
+
+    const done = useAppStore.getState().playMacro("m1", { timingMode: "real-time" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(injected).toEqual(["a"]);
+    expect(useAppStore.getState().macroPlayback).not.toBeNull();
+
+    useAppStore.getState().cancelMacroPlayback();
+    await done;
+
+    expect(injected).toEqual(["a"]);
+    expect(useAppStore.getState().macroPlayback).toBeNull();
+    expect(toast.info).toHaveBeenCalled();
+  });
+
+  it("errors when the macro does not exist", async () => {
+    seedConnectedTerminal();
+    await useAppStore.getState().playMacro("missing");
+
+    expect(injected).toEqual([]);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("errors when there is no connected terminal", async () => {
+    seedConnectedTerminal("tab-active", null); // no session → not connected
+    useAppStore.setState({ macros: [macro("m1", [{ data: "x", delayMs: 0 }])] });
+
+    await useAppStore.getState().playMacro("m1");
+
+    expect(injected).toEqual([]);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("errors when the target terminal has exited", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({
+      macros: [macro("m1", [{ data: "x", delayMs: 0 }])],
+      terminalExitedTabs: { "tab-active": true },
+    });
+
+    await useAppStore.getState().playMacro("m1");
+
+    expect(injected).toEqual([]);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("does nothing but inform the user for an empty macro", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({ macros: [macro("m1", [])] });
+
+    await useAppStore.getState().playMacro("m1");
+
+    expect(injected).toEqual([]);
+    expect(toast.info).toHaveBeenCalled();
+    expect(useAppStore.getState().macroPlayback).toBeNull();
+  });
+
+  it("cancelMacroPlayback is a no-op when nothing is playing", () => {
+    expect(() => useAppStore.getState().cancelMacroPlayback()).not.toThrow();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -161,6 +161,13 @@ import {
   deleteMacro as apiDeleteMacro,
 } from "@/services/macroApi";
 import {
+  runMacroPlayback,
+  getTerminalInputInjector,
+  type MacroTimingMode,
+  type MacroInjector,
+  type MacroPlaybackHandle,
+} from "@/services/macroPlayback";
+import {
   saveLastSession as apiSaveLastSession,
   loadLastSession as apiLoadLastSession,
   clearLastSession as apiClearLastSession,
@@ -1169,6 +1176,22 @@ interface AppState {
   /** Close the save dialog and drop the captured buffer without persisting. */
   discardRecordedMacro: () => void;
 
+  // Macro playback (#1675)
+  /** Metadata for the in-flight playback, or `null` when nothing is playing. */
+  macroPlayback: MacroPlaybackState | null;
+  /**
+   * Play a stored macro's recorded input into a target terminal, injecting each
+   * step through the existing `send_input` seam and honouring the timing mode.
+   * Defaults the target to the active terminal tab. Resolves when playback
+   * finishes (completed, cancelled, or errored). Only one playback runs at a
+   * time — a fresh call cancels any in-flight playback first. Surfaces a
+   * recoverable toast when the macro is missing/empty or the target terminal is
+   * not connected.
+   */
+  playMacro: (macroId: string, opts?: PlayMacroOptions) => Promise<void>;
+  /** Cancel the in-flight macro playback, if any. Idempotent. */
+  cancelMacroPlayback: () => void;
+
   // Workspaces
   workspaces: WorkspaceSummary[];
   activeWorkspaceName: string | null;
@@ -1247,6 +1270,39 @@ interface AppState {
 }
 
 let tabCounter = 0;
+
+/** UI-facing metadata describing an in-flight macro playback (#1675). */
+export interface MacroPlaybackState {
+  /** The macro being played. */
+  macroId: string;
+  /** The macro's name, for the progress indicator. */
+  macroName: string;
+  /** The terminal tab receiving the injected input. */
+  tabId: string;
+  /** The timing mode this run is using. */
+  timingMode: MacroTimingMode;
+  /** Total number of steps in the macro. */
+  total: number;
+  /** Steps injected so far. */
+  played: number;
+}
+
+/** Options for {@link AppState.playMacro}. */
+export interface PlayMacroOptions {
+  /** Tab to inject into; defaults to the active terminal tab. */
+  targetTabId?: string;
+  /** Timing mode; defaults to `"real-time"`. */
+  timingMode?: MacroTimingMode;
+  /** Per-step delay (ms) for the `"fixed"` timing mode. */
+  fixedDelayMs?: number;
+}
+
+/**
+ * Handle for the currently-running macro playback, held at module scope so
+ * {@link AppState.cancelMacroPlayback} can stop it without threading the handle
+ * through store state (it is not serializable). `null` when nothing is playing.
+ */
+let activeMacroPlayback: MacroPlaybackHandle | null = null;
 
 /** Generate a unique macro id, falling back when `crypto.randomUUID` is absent. */
 function generateMacroId(): string {
@@ -5551,6 +5607,112 @@ export const useAppStore = create<AppState>((set, get) => {
         macroRecordingLastTime: null,
         macroSaveDialogOpen: false,
       });
+    },
+
+    // Macro playback (#1675)
+    macroPlayback: null,
+
+    playMacro: async (macroId, opts) => {
+      const state = get();
+      const macro = state.macros.find((m) => m.id === macroId);
+      if (!macro) {
+        toast.error("Macro not found");
+        return;
+      }
+
+      const targetTabId = opts?.targetTabId ?? getActiveTab(state)?.id ?? null;
+      if (!targetTabId) {
+        toast.error("No active terminal to play the macro into");
+        return;
+      }
+
+      // Guard: only inject into a connected, non-exited terminal session.
+      const tab = collectLiveTabs(state).find((t) => t.id === targetTabId);
+      if (
+        !tab ||
+        tab.contentType !== "terminal" ||
+        !tab.sessionId ||
+        state.terminalExitedTabs[targetTabId]
+      ) {
+        toast.error("The target terminal is not connected");
+        return;
+      }
+
+      if (macro.steps.length === 0) {
+        toast.info(`Macro "${macro.name}" has no steps to play`);
+        return;
+      }
+
+      // Only one playback at a time — cancel any in-flight run first.
+      if (activeMacroPlayback) {
+        activeMacroPlayback.cancel();
+        activeMacroPlayback = null;
+      }
+
+      const timingMode = opts?.timingMode ?? "real-time";
+      const injector = getTerminalInputInjector();
+      const inject: MacroInjector = (data) => {
+        if (!injector) return false;
+        return injector(targetTabId, data);
+      };
+
+      const toastId = `macro-playback-${macroId}-${targetTabId}`;
+      const total = macro.steps.length;
+      toast.loading(`Playing macro "${macro.name}"…`, {
+        id: toastId,
+        description: `0 / ${total} steps`,
+      });
+      set({
+        macroPlayback: { macroId, macroName: macro.name, tabId: targetTabId, timingMode, total, played: 0 },
+      });
+
+      const handle = runMacroPlayback(
+        macro.steps,
+        inject,
+        { timingMode, fixedDelayMs: opts?.fixedDelayMs },
+        {
+          onProgress: (played, stepTotal) => {
+            set((s) =>
+              s.macroPlayback && s.macroPlayback.macroId === macroId && s.macroPlayback.tabId === targetTabId
+                ? { macroPlayback: { ...s.macroPlayback, played } }
+                : {}
+            );
+            toast.loading(`Playing macro "${macro.name}"…`, {
+              id: toastId,
+              description: `${played} / ${stepTotal} steps`,
+            });
+          },
+        }
+      );
+      activeMacroPlayback = handle;
+
+      const result = await handle.done;
+
+      // Only clear shared state when this run is still the current one — a newer
+      // playMacro may have replaced it while this one was cancelled.
+      if (activeMacroPlayback === handle) {
+        activeMacroPlayback = null;
+        set({ macroPlayback: null });
+      }
+
+      if (result.status === "completed") {
+        toast.success(`Played macro "${macro.name}"`, { id: toastId });
+      } else if (result.status === "cancelled") {
+        toast.info(`Playback of "${macro.name}" cancelled`, {
+          id: toastId,
+          description: `Stopped after ${result.stepsPlayed} of ${total} steps`,
+        });
+      } else {
+        toast.error(`Could not play "${macro.name}" — the terminal is no longer connected`, {
+          id: toastId,
+        });
+      }
+    },
+
+    cancelMacroPlayback: () => {
+      if (activeMacroPlayback) {
+        activeMacroPlayback.cancel();
+      }
     },
 
     // Workspaces

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -5663,7 +5663,14 @@ export const useAppStore = create<AppState>((set, get) => {
         description: `0 / ${total} steps`,
       });
       set({
-        macroPlayback: { macroId, macroName: macro.name, tabId: targetTabId, timingMode, total, played: 0 },
+        macroPlayback: {
+          macroId,
+          macroName: macro.name,
+          tabId: targetTabId,
+          timingMode,
+          total,
+          played: 0,
+        },
       });
 
       const handle = runMacroPlayback(
@@ -5673,7 +5680,9 @@ export const useAppStore = create<AppState>((set, get) => {
         {
           onProgress: (played, stepTotal) => {
             set((s) =>
-              s.macroPlayback && s.macroPlayback.macroId === macroId && s.macroPlayback.tabId === targetTabId
+              s.macroPlayback &&
+              s.macroPlayback.macroId === macroId &&
+              s.macroPlayback.tabId === targetTabId
                 ? { macroPlayback: { ...s.macroPlayback, played } }
                 : {}
             );


### PR DESCRIPTION
Part of the macro recording/playback epic #1670 — implements the **playback + trigger** half of concept #517. Builds on #1673 (storage model + commands + `macroApi.ts` + appStore slice) and #1674 (recording).

## What this adds

Play a stored macro's recorded input into the active terminal by injecting each `MacroStep.data` through the existing `sendInput` / `send_input` choke point — no new backend injection path.

### Playback scheduler (`src/services/macroPlayback.ts`)
- Pure, store-independent scheduler `runMacroPlayback(steps, inject, options, hooks)` returning a `{ done, cancel }` handle.
- Timing modes: `real-time` (honor each step's recorded `delayMs`, clamped to 5s), `fixed` (constant per-step delay), `instant` (no delay). First step always plays immediately.
- Cancellation is checked before and during each delay, so a cancel during a long real-time wait stops promptly.
- Reuses `TerminalRegistry.sendInputToTerminal` as the single injection seam via a small injector registration (`registerTerminalInputInjector`), so the store never holds a React ref.

### Store (`src/store/appStore.ts`)
- `playMacro(macroId, { targetTabId?, timingMode?, fixedDelayMs? })` — defaults the target to the active terminal tab; guards on a connected, non-exited session; surfaces a recoverable toast when the macro is missing/empty or the terminal is disconnected. Live progress via `macroPlayback` state + a loading toast.
- `cancelMacroPlayback()` — stops the in-flight run. Only one playback at a time.

### Triggers
- **Command palette**: each stored macro appears as a `Run Macro: <name>` entry (real-time timing).
- **Terminal toolbar**: a Play button opens a picker (`MacroPlaybackDialog`) to choose a macro + timing mode; while playing, the button becomes a Stop control showing progress.
- **Manager launch (#1676)**: exposed via the `playMacro` store action (no UI built here).

## Acceptance criteria
- [x] Selecting a stored macro replays its bytes into the active terminal; timing mode changes observable behavior (instant vs delayed).
- [x] Playback can be canceled mid-run and stops promptly.
- [x] Playing into a disconnected/missing session fails gracefully with a toast, not a silent no-op or crash.
- [x] Unit tests for the scheduler (ordering, timing-mode math, cancellation) with injection mocked; TDD ordering.

## Tests
- `src/services/macroPlayback.test.ts` — scheduler + timing math + cancellation + injector registry.
- `src/store/appStore.macroPlayback.test.ts` — store slice: ordering, timing, cancel, guards.
- `src/components/Terminal/MacroPlaybackDialog.test.tsx` — picker component.
- Full frontend suite: 3593 passing.

Out of scope (per epic): the manager panel (#1676), import/export (#1677), and broadcast playback to multiple terminals (blocked on #516).

Closes #1675