### PR TITLE
feat(ssh): SSH agent forwarding through the jump-host chain (Closes #1699)

### DIFF
--- a/core/src/backends/ssh/agent_forward.rs
+++ b/core/src/backends/ssh/agent_forward.rs
@@ -1,0 +1,130 @@
+//! SSH agent forwarding (OpenSSH `ForwardAgent`) for the russh connect path.
+//!
+//! When a connection opts in via [`SshConfig::forward_agent`](crate::config::SshConfig::forward_agent),
+//! the session channel requests `auth-agent-req@openssh.com` (see
+//! [`connector`](super::connector)). The server then opens an
+//! `auth-agent@openssh.com` channel back whenever a program on the target
+//! contacts its `$SSH_AUTH_SOCK`; russh dispatches that to
+//! [`TermiHubHandler::server_channel_open_agent_forward`](super::handler), which
+//! calls [`spawn_forwarded_agent_bridge`] here.
+//!
+//! Bridging is library-first and protocol-agnostic: rather than re-implementing
+//! the SSH agent protocol, we open a raw stream to the **local** agent and pump
+//! bytes both ways between it and the forwarded channel. The remote speaks the
+//! agent protocol; our local `ssh-agent` answers it.
+//!
+//! Absence of a local agent (`SSH_AUTH_SOCK` unset, or the Windows OpenSSH agent
+//! stopped) is a no-op with a debug log — it never fails the connection (#1699).
+
+use russh::client::Msg;
+use russh::Channel;
+use tracing::debug;
+
+/// Connect a raw byte stream to the local SSH agent (Unix `$SSH_AUTH_SOCK`).
+#[cfg(unix)]
+async fn connect_local_agent() -> std::io::Result<tokio::net::UnixStream> {
+    let sock = std::env::var_os("SSH_AUTH_SOCK")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "SSH_AUTH_SOCK is not set (no running ssh-agent)",
+            )
+        })?;
+    tokio::net::UnixStream::connect(sock).await
+}
+
+/// Connect a raw byte stream to the local SSH agent (Windows OpenSSH named pipe).
+#[cfg(windows)]
+async fn connect_local_agent() -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeClient> {
+    tokio::net::windows::named_pipe::ClientOptions::new().open(r"\\.\pipe\openssh-ssh-agent")
+}
+
+/// Neither Unix domain sockets nor the Windows agent pipe exist on other targets;
+/// agent forwarding is unavailable there.
+#[cfg(not(any(unix, windows)))]
+async fn connect_local_agent() -> std::io::Result<tokio::net::TcpStream> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "SSH agent forwarding is not supported on this platform",
+    ))
+}
+
+/// Whether a local SSH agent is reachable right now.
+///
+/// Used by the connector as a pre-check so a `forward_agent` connection with no
+/// running agent logs one clear line and skips the request, instead of asking a
+/// server to forward an agent that cannot be bridged. It actually opens (and
+/// immediately drops) a connection, so it reflects a *live* agent rather than
+/// merely a set `SSH_AUTH_SOCK`.
+pub(crate) async fn local_agent_available() -> bool {
+    match connect_local_agent().await {
+        Ok(_) => true,
+        Err(e) => {
+            debug!("no local SSH agent available for forwarding: {e}");
+            false
+        }
+    }
+}
+
+/// Bridge a server-opened agent-forwarding channel to the local SSH agent.
+///
+/// Spawns a detached task that copies bytes in both directions between the
+/// forwarded `channel` and a freshly-connected local agent stream, for the life
+/// of the channel. If no local agent is reachable the channel is dropped (closed)
+/// with a debug log — a forwarded request that arrives with no agent to answer it
+/// is ignored, never fatal.
+pub(crate) fn spawn_forwarded_agent_bridge(channel: Channel<Msg>) {
+    tokio::spawn(async move {
+        let mut agent = match connect_local_agent().await {
+            Ok(agent) => agent,
+            Err(e) => {
+                debug!("dropping forwarded agent channel; no local agent to bridge: {e}");
+                return;
+            }
+        };
+        let mut stream = channel.into_stream();
+        match tokio::io::copy_bidirectional(&mut stream, &mut agent).await {
+            Ok((to_agent, to_server)) => debug!(
+                to_agent, to_server, "forwarded SSH agent channel closed"
+            ),
+            Err(e) => debug!("forwarded SSH agent bridge ended: {e}"),
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// With `SSH_AUTH_SOCK` unset, no agent is reported available — the connector
+    /// relies on this to skip the forwarding request and log a no-op (#1699).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_agent_unavailable_when_sock_unset() {
+        // SAFETY: single-threaded test mutating a process env var it restores.
+        let orig = std::env::var_os("SSH_AUTH_SOCK");
+        unsafe { std::env::remove_var("SSH_AUTH_SOCK") };
+        let available = local_agent_available().await;
+        if let Some(val) = orig {
+            unsafe { std::env::set_var("SSH_AUTH_SOCK", val) };
+        }
+        assert!(!available, "no agent should be reachable without SSH_AUTH_SOCK");
+    }
+
+    /// A pointer to a non-existent socket path is likewise unavailable rather than
+    /// an error that could abort a connect.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_agent_unavailable_for_dangling_sock_path() {
+        // SAFETY: single-threaded test mutating a process env var it restores.
+        let orig = std::env::var_os("SSH_AUTH_SOCK");
+        unsafe { std::env::set_var("SSH_AUTH_SOCK", "/nonexistent/thub-agent-forward-test.sock") };
+        let available = local_agent_available().await;
+        match orig {
+            Some(val) => unsafe { std::env::set_var("SSH_AUTH_SOCK", val) },
+            None => unsafe { std::env::remove_var("SSH_AUTH_SOCK") },
+        }
+        assert!(!available, "a dangling SSH_AUTH_SOCK path is not a live agent");
+    }
+}

--- a/core/src/backends/ssh/agent_forward.rs
+++ b/core/src/backends/ssh/agent_forward.rs
@@ -36,7 +36,8 @@ async fn connect_local_agent() -> std::io::Result<tokio::net::UnixStream> {
 
 /// Connect a raw byte stream to the local SSH agent (Windows OpenSSH named pipe).
 #[cfg(windows)]
-async fn connect_local_agent() -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeClient> {
+async fn connect_local_agent() -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeClient>
+{
     tokio::net::windows::named_pipe::ClientOptions::new().open(r"\\.\pipe\openssh-ssh-agent")
 }
 
@@ -85,9 +86,9 @@ pub(crate) fn spawn_forwarded_agent_bridge(channel: Channel<Msg>) {
         };
         let mut stream = channel.into_stream();
         match tokio::io::copy_bidirectional(&mut stream, &mut agent).await {
-            Ok((to_agent, to_server)) => debug!(
-                to_agent, to_server, "forwarded SSH agent channel closed"
-            ),
+            Ok((to_agent, to_server)) => {
+                debug!(to_agent, to_server, "forwarded SSH agent channel closed")
+            }
             Err(e) => debug!("forwarded SSH agent bridge ended: {e}"),
         }
     });
@@ -109,7 +110,10 @@ mod tests {
         if let Some(val) = orig {
             unsafe { std::env::set_var("SSH_AUTH_SOCK", val) };
         }
-        assert!(!available, "no agent should be reachable without SSH_AUTH_SOCK");
+        assert!(
+            !available,
+            "no agent should be reachable without SSH_AUTH_SOCK"
+        );
     }
 
     /// A pointer to a non-existent socket path is likewise unavailable rather than
@@ -125,6 +129,9 @@ mod tests {
             Some(val) => unsafe { std::env::set_var("SSH_AUTH_SOCK", val) },
             None => unsafe { std::env::remove_var("SSH_AUTH_SOCK") },
         }
-        assert!(!available, "a dangling SSH_AUTH_SOCK path is not a live agent");
+        assert!(
+            !available,
+            "a dangling SSH_AUTH_SOCK path is not a live agent"
+        );
     }
 }

--- a/core/src/backends/ssh/auth.rs
+++ b/core/src/backends/ssh/auth.rs
@@ -130,8 +130,7 @@ where
     // Enable agent-channel bridging on this session only when the connection
     // opted into forwarding (#1699). Jump hops build a minimal config with the
     // default (`false`), so a hop never bridges the agent.
-    let (handler, registry, liveness) =
-        TermiHubHandler::new_with_forwarding(config.forward_agent);
+    let (handler, registry, liveness) = TermiHubHandler::new_with_forwarding(config.forward_agent);
 
     let mut session = russh::client::connect_stream(russh_config, stream, handler)
         .await

--- a/core/src/backends/ssh/auth.rs
+++ b/core/src/backends/ssh/auth.rs
@@ -127,7 +127,11 @@ where
         ..Default::default()
     });
 
-    let (handler, registry, liveness) = TermiHubHandler::new();
+    // Enable agent-channel bridging on this session only when the connection
+    // opted into forwarding (#1699). Jump hops build a minimal config with the
+    // default (`false`), so a hop never bridges the agent.
+    let (handler, registry, liveness) =
+        TermiHubHandler::new_with_forwarding(config.forward_agent);
 
     let mut session = russh::client::connect_stream(russh_config, stream, handler)
         .await

--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -234,7 +234,9 @@ impl SshConnector for RusshSshConnector {
         if config.forward_agent {
             if super::agent_forward::local_agent_available().await {
                 match channel.agent_forward(false).await {
-                    Ok(()) => tracing::debug!(host = %config.host, "requested SSH agent forwarding"),
+                    Ok(()) => {
+                        tracing::debug!(host = %config.host, "requested SSH agent forwarding")
+                    }
                     Err(e) => tracing::warn!("SSH agent forwarding request failed: {e}"),
                 }
             } else {

--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -224,6 +224,27 @@ impl SshConnector for RusshSshConnector {
             .await
             .map_err(|e| SessionError::SpawnFailed(format!("Channel open failed: {e}")))?;
 
+        // SSH agent forwarding (#1699): request it on the session channel to the
+        // final target so the local agent's keys reach the host — and, since this
+        // channel rides the jump-host tunnel, end to end through the chain. The
+        // server later opens an `auth-agent@openssh.com` channel that the handler
+        // bridges to the local agent. Skipped (with a clear log) when no agent is
+        // running, and best-effort (`want_reply=false`) so a server that does not
+        // support forwarding never fails the connection.
+        if config.forward_agent {
+            if super::agent_forward::local_agent_available().await {
+                match channel.agent_forward(false).await {
+                    Ok(()) => tracing::debug!(host = %config.host, "requested SSH agent forwarding"),
+                    Err(e) => tracing::warn!("SSH agent forwarding request failed: {e}"),
+                }
+            } else {
+                tracing::debug!(
+                    host = %config.host,
+                    "forwardAgent is set but no local SSH agent is available; skipping"
+                );
+            }
+        }
+
         // User-specified environment variables (best-effort; many servers reject setenv).
         for (key, value) in &config.env {
             let _ = channel.set_env(false, key, value).await;

--- a/core/src/backends/ssh/handler.rs
+++ b/core/src/backends/ssh/handler.rs
@@ -80,17 +80,35 @@ pub struct TermiHubHandler {
     /// background task — so `disconnected` signals explicitly, and the sender
     /// dropping with the handler (task end) closes the channel as a backstop.
     liveness_tx: watch::Sender<bool>,
+    /// Whether this connection opted into SSH agent forwarding (#1699). Only when
+    /// `true` does [`server_channel_open_agent_forward`](Self::server_channel_open_agent_forward)
+    /// bridge an incoming `auth-agent@openssh.com` channel to the local agent; a
+    /// forwarding channel that arrives without our opt-in is rejected, so a server
+    /// cannot reach the local agent unsolicited.
+    forward_agent: bool,
 }
 
 impl TermiHubHandler {
     /// Create a new handler together with the shared channel registry and the
     /// session-liveness watch (#1297) the tunnel supervisor observes.
+    ///
+    /// Agent forwarding is off; use [`new_with_forwarding`](Self::new_with_forwarding)
+    /// to enable it for a connection that opted in.
     pub fn new() -> (Self, ForwardedChannelRegistry, LivenessWatch) {
+        Self::new_with_forwarding(false)
+    }
+
+    /// Like [`new`](Self::new), but sets whether the session should bridge a
+    /// server-opened agent-forwarding channel to the local `ssh-agent` (#1699).
+    pub fn new_with_forwarding(
+        forward_agent: bool,
+    ) -> (Self, ForwardedChannelRegistry, LivenessWatch) {
         let registry: ForwardedChannelRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (liveness_tx, liveness_rx) = watch::channel(false);
         let handler = Self {
             forwarded_channel_registry: registry.clone(),
             liveness_tx,
+            forward_agent,
         };
         (handler, registry, LivenessWatch { rx: liveness_rx })
     }
@@ -165,6 +183,30 @@ impl russh::client::Handler for TermiHubHandler {
         }
         Ok(())
     }
+
+    /// Bridge a server-opened SSH agent-forwarding channel to the local agent
+    /// (#1699), but only when this connection opted into forwarding.
+    ///
+    /// The server opens an `auth-agent@openssh.com` channel when a program on the
+    /// target contacts its `$SSH_AUTH_SOCK`. We hand it to
+    /// [`spawn_forwarded_agent_bridge`](super::agent_forward::spawn_forwarded_agent_bridge),
+    /// which pumps bytes between it and the local `ssh-agent`. When forwarding was
+    /// not requested the channel is dropped (closed), so a server can never reach
+    /// the local agent unsolicited.
+    async fn server_channel_open_agent_forward(
+        &mut self,
+        channel: russh::Channel<russh::client::Msg>,
+        _session: &mut russh::client::Session,
+    ) -> Result<(), Self::Error> {
+        if self.forward_agent {
+            debug!("bridging forwarded SSH agent channel to the local agent");
+            super::agent_forward::spawn_forwarded_agent_bridge(channel);
+        } else {
+            debug!("rejecting agent-forward channel: forwarding was not requested");
+            // Dropping `channel` closes it, refusing the unsolicited forward.
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -225,6 +267,23 @@ mod tests {
         tokio::time::timeout(Duration::from_millis(50), clone.dead())
             .await
             .expect("a cloned watch must also see the session die");
+    }
+
+    /// Agent forwarding (#1699) is off by default: a handler built with `new`
+    /// must not bridge a server-opened agent channel, so a server cannot reach the
+    /// local agent unless the connection opted in.
+    #[test]
+    fn forwarding_disabled_by_default() {
+        let (handler, _registry, _watch) = TermiHubHandler::new();
+        assert!(!handler.forward_agent);
+    }
+
+    /// A connection that opted into forwarding builds a handler that will bridge
+    /// the server's agent channel to the local agent.
+    #[test]
+    fn forwarding_enabled_when_requested() {
+        let (handler, _registry, _watch) = TermiHubHandler::new_with_forwarding(true);
+        assert!(handler.forward_agent);
     }
 
     /// `disconnected` must preserve russh's default result so we don't change how

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -4,6 +4,7 @@
 //! and file browsing (SFTP). This is the canonical SSH implementation,
 //! used by both the desktop and agent crates.
 
+mod agent_forward;
 pub mod auth;
 pub mod connector;
 pub mod exec;
@@ -185,6 +186,7 @@ pub fn parse_ssh_settings(settings: &serde_json::Value) -> SshConfig {
         save_password: opt_bool("savePassword"),
         connect_timeout_secs: opt_u64("connectTimeoutSecs"),
         proxy_jump,
+        forward_agent: bool_field("forwardAgent", false),
     }
 }
 
@@ -1136,6 +1138,8 @@ mod tests {
         assert_eq!(config.username, "admin");
         assert_eq!(config.auth_method, "password");
         assert!(!config.enable_x11_forwarding);
+        // forwardAgent absent → off, so unmodified saved connections behave as before (#1699).
+        assert!(!config.forward_agent);
         assert!(config.env.is_empty());
     }
 
@@ -1149,6 +1153,7 @@ mod tests {
             "keyPath": "~/.ssh/id_ed25519",
             "shell": "/bin/zsh",
             "enableX11Forwarding": true,
+            "forwardAgent": true,
             "savePassword": true,
             "env": [
                 {"key": "LANG", "value": "en_US.UTF-8"},
@@ -1163,6 +1168,7 @@ mod tests {
         assert_eq!(config.key_path.as_deref(), Some("~/.ssh/id_ed25519"));
         assert_eq!(config.shell.as_deref(), Some("/bin/zsh"));
         assert!(config.enable_x11_forwarding);
+        assert!(config.forward_agent);
         assert_eq!(config.save_password, Some(true));
         assert_eq!(config.env.len(), 2);
         assert_eq!(config.env.get("LANG").unwrap(), "en_US.UTF-8");

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -343,6 +343,14 @@ pub struct SshConfig {
     /// connection. Accepts the legacy `jumpHosts` key for forward compatibility.
     #[serde(default, alias = "jumpHosts", skip_serializing_if = "Vec::is_empty")]
     pub proxy_jump: Vec<JumpHostConfig>,
+    /// Forward the local `ssh-agent` to the target (OpenSSH `ForwardAgent`, #1699).
+    /// When `true`, agent forwarding is requested on the session channel so the
+    /// user's local agent keys are reachable on the final host — and, because the
+    /// forwarded-agent channel rides the jump-host tunnel, end to end through the
+    /// `proxy_jump` chain. Serde-defaults to `false` and is omitted when false so
+    /// existing saved connections stay byte-stable, mirroring `proxy_jump` above.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub forward_agent: bool,
 }
 
 impl SshConfig {
@@ -374,6 +382,7 @@ impl Default for SshConfig {
             save_password: None,
             connect_timeout_secs: None,
             proxy_jump: Vec::new(),
+            forward_agent: false,
         }
     }
 }
@@ -670,6 +679,12 @@ fn default_remove_on_exit() -> bool {
 
 fn default_ssh_port() -> u16 {
     22
+}
+
+/// `skip_serializing_if` predicate for `bool` fields that default to `false`
+/// (e.g. `SshConfig::forward_agent`), so an unset flag is omitted from the JSON.
+fn is_false(v: &bool) -> bool {
+    !*v
 }
 
 fn default_telnet_port() -> u16 {
@@ -1128,6 +1143,7 @@ mod tests {
             save_password: None,
             connect_timeout_secs: Some(15),
             proxy_jump: Vec::new(),
+            forward_agent: true,
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let back: SshConfig = serde_json::from_str(&json).unwrap();
@@ -1145,6 +1161,38 @@ mod tests {
         assert_eq!(back.enable_file_browser, Some(false));
         assert!(back.save_password.is_none());
         assert_eq!(back.connect_timeout_secs, Some(15));
+        assert!(back.forward_agent);
+    }
+
+    // --- agent forwarding (ForwardAgent) tests (#1699) ---
+
+    #[test]
+    fn ssh_config_forward_agent_roundtrip() {
+        let cfg = SshConfig {
+            forward_agent: true,
+            ..SshConfig::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        // Serializes camelCase and true.
+        assert!(json.contains("\"forwardAgent\":true"), "got: {json}");
+        let back: SshConfig = serde_json::from_str(&json).unwrap();
+        assert!(back.forward_agent);
+    }
+
+    #[test]
+    fn ssh_config_forward_agent_defaults_false_and_is_omitted() {
+        // Default (false) is never written, keeping existing saved JSON byte-stable.
+        let json = serde_json::to_string(&SshConfig::default()).unwrap();
+        assert!(!json.contains("forwardAgent"), "got: {json}");
+    }
+
+    #[test]
+    fn ssh_config_forward_agent_absent_deserializes_false() {
+        // A saved connection from before this field existed must still load, and
+        // behave exactly as before (no forwarding).
+        let json = r#"{ "host": "h", "username": "u", "authMethod": "agent" }"#;
+        let cfg: SshConfig = serde_json::from_str(json).unwrap();
+        assert!(!cfg.forward_agent);
     }
 
     // --- jump host (ProxyJump) tests ---

--- a/docs/changes/dev2/feature/1699-ssh-agent-forwarding.md
+++ b/docs/changes/dev2/feature/1699-ssh-agent-forwarding.md
@@ -1,0 +1,11 @@
+### Added
+
+- SSH agent forwarding: a new **Forward SSH agent** toggle in the SSH section of
+  the connection editor (OpenSSH `ForwardAgent`). When enabled, the local
+  `ssh-agent`'s keys are made available on the target host — and, because the
+  forwarded-agent channel rides the jump-host tunnel, end to end through the
+  `ProxyJump` chain — so onward SSH and git-over-bastion work without copying
+  private keys onto intermediate hosts. Off by default; existing saved
+  connections are unchanged. When no local agent is running
+  (`SSH_AUTH_SOCK` unset, or the Windows OpenSSH agent stopped) the option is a
+  no-op and the connection still succeeds (#1699).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1933,6 +1933,43 @@ To verify SSH tunnels actually work on macOS, do this manually against the tunne
 4. Confirm the tunnel reaches a running state (sidebar shows Stop control) and `curl http://127.0.0.1:18083` returns `TUNNEL_TEST_OK`.
 5. Click **Stop** and confirm the tunnel returns to disconnected and the Start control reappears.
 
+### SSH agent forwarding (#1699)
+
+SSH **agent forwarding** (OpenSSH `ForwardAgent`) makes the operator's local
+`ssh-agent` keys reachable on the target host — and, because the forwarded-agent
+channel rides the jump-host tunnel, end to end through a `ProxyJump` chain — so
+onward SSH (or git over a bastion) works without copying private keys onto the
+hosts. The **Forward SSH agent** toggle in the connection editor's SSH section
+drives it (per-connection `forwardAgent`). The config (de)serialization, the
+settings→`SshConfig` mapping, the handler-side opt-in gate, and the
+no-agent-available no-op are covered by **Rust unit tests**
+(`core/src/config/mod.rs`, `core/src/backends/ssh/{mod,handler,agent_forward}.rs`)
+and the toggle by **Vitest/RTL** (`ConnectionEditor.test.tsx`). The forwarding
+itself needs a **live agent + real SSH server**, which per-PR CI does not run
+(integration lane only), so verify it manually:
+
+1. Ensure a local agent has a key: `ssh-add -l` lists at least one identity
+   (add one with `ssh-add` if needed).
+2. Start an SSH fixture, e.g.
+   `docker compose -f tests/docker/docker-compose.yml up -d ssh-jumphost-target ssh-jumphost-bastion`.
+3. **Direct target:** create a key-auth SSH connection to the target, enable
+   **Forward SSH agent**, and connect. On the target run `ssh-add -l` — it must
+   list your local keys, and an onward `ssh` from the target using an agent key
+   must succeed.
+4. **Through a jump chain:** add the bastion as a `ProxyJump` hop to the same
+   connection and reconnect. `ssh-add -l` on the final target must still list the
+   local keys (forwarding survives the multi-hop tunnel).
+5. **No agent:** stop the agent (unset `SSH_AUTH_SOCK` / stop the Windows OpenSSH
+   agent) and connect with the toggle still on — the connection must **succeed**
+   with forwarding silently skipped (a debug log line notes the skip); `ssh-add -l`
+   on the target reports no agent.
+
+Note: intermediate jump hosts are pure transport (termiHub opens no interactive
+shell on a bastion), so the agent is not separately exposed as `$SSH_AUTH_SOCK`
+on a hop — it is reachable on the **final target** through the chain. Genuine
+per-bastion shell agent access would require opening a session on the hop and is
+tracked separately if ever needed.
+
 ### X11 / GUI forwarding
 
 SSH **X11 forwarding** lets a remote GUI app (`xeyes`, `xclock`, a graphical IDE)

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -1277,6 +1277,64 @@ describe("ConnectionEditor — SSH Jump Host section", () => {
     ]);
   });
 
+  it("renders the SSH Agent Forwarding toggle, off by default (#1699)", () => {
+    renderFor(SSH_CONN_PASSWORD.id);
+    expect(query("ssh-agent-forwarding-section")).toBeTruthy();
+    expect(query("connection-editor-forward-agent")?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("persists forwardAgent through save, surviving a later schema-field edit (#1699)", async () => {
+    renderFor(SSH_CONN_PASSWORD.id);
+    await flush();
+
+    // Turn on agent forwarding.
+    act(() => {
+      (query("connection-editor-forward-agent") as HTMLElement).click();
+    });
+    await flush();
+
+    // Toggle a schema field afterwards — fires the schema form's onChange, which
+    // must NOT drop the sibling forwardAgent key.
+    act(() => {
+      (query("field-savePassword") as HTMLInputElement).click();
+    });
+    await flush();
+
+    act(() => {
+      (query("connection-editor-save") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const saveCall = mockedInvoke.mock.calls.find(([cmd]) => cmd === "save_connection");
+    const persisted = (saveCall?.[1] as { connection: SavedConnection }).connection;
+    const cfg = persisted.config.config as Record<string, unknown>;
+    // The schema edit landed, and the forwardAgent flag set before it survived.
+    expect(cfg.savePassword).toBe(false);
+    expect(cfg.forwardAgent).toBe(true);
+  });
+
+  it("omits forwardAgent from saved settings when left off (#1699)", async () => {
+    renderFor(SSH_CONN_PASSWORD.id);
+    await flush();
+
+    // Make a change so save is enabled, without touching agent forwarding.
+    act(() => {
+      (query("field-savePassword") as HTMLInputElement).click();
+    });
+    await flush();
+
+    act(() => {
+      (query("connection-editor-save") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const saveCall = mockedInvoke.mock.calls.find(([cmd]) => cmd === "save_connection");
+    const persisted = (saveCall?.[1] as { connection: SavedConnection }).connection;
+    const cfg = persisted.config.config as Record<string, unknown>;
+    // Off means the key is absent, keeping saved JSON stable for existing connections.
+    expect(cfg.forwardAgent).toBeUndefined();
+  });
+
   it("blocks save while a jump host is missing required fields", async () => {
     renderFor(SSH_CONN_PASSWORD.id);
     await flush();

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -26,6 +26,7 @@ import {
   AgentSettings,
   DEFAULT_AGENT_SETTINGS,
   JumpHostConfig,
+  SshEditorSettings,
 } from "@/types/connection";
 import { SettingsNav } from "@/components/Settings";
 import { Button, Input, Select, Toggle, toast } from "@/components/ui";
@@ -312,22 +313,38 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   /** Whether the SSH "Jump Host" section applies to the current edit. */
   const showJumpHostSection = selectedType === "ssh" && !isAnyAgentMode;
 
+  /** Whether the SSH "Agent Forwarding" toggle applies (same gate as jump hosts). */
+  const showAgentForwarding = selectedType === "ssh" && !isAnyAgentMode;
+
   /** Whether the SSH "Setup SSH Agent" helper applies (SSH + agent auth). */
   const showSshAgentSetup =
     selectedType === "ssh" && !isAnyAgentMode && connSettings.authMethod === "agent";
 
   // The schema-driven form only tracks its own fields, so its onChange would drop
-  // sibling keys like `proxyJump` (managed by JumpHostSection). Re-merge it.
+  // sibling keys the editor manages directly (`proxyJump` from JumpHostSection,
+  // `forwardAgent` from the agent-forwarding toggle). Re-merge them.
   const handleSchemaSettingsChange = useCallback((values: Record<string, unknown>) => {
-    setConnSettings((prev) =>
-      prev.proxyJump !== undefined ? { ...values, proxyJump: prev.proxyJump } : values
-    );
+    setConnSettings((prev) => {
+      const merged: Record<string, unknown> = { ...values };
+      if (prev.proxyJump !== undefined) merged.proxyJump = prev.proxyJump;
+      if (prev.forwardAgent !== undefined) merged.forwardAgent = prev.forwardAgent;
+      return merged;
+    });
   }, []);
 
   const handleJumpHostChange = useCallback((hops: JumpHostConfig[] | undefined) => {
     setConnSettings((prev) => {
       if (hops && hops.length > 0) return { ...prev, proxyJump: hops };
       const { proxyJump: _omit, ...rest } = prev;
+      return rest;
+    });
+  }, []);
+
+  /** Toggle SSH agent forwarding; omit the key when off so saved JSON stays stable. */
+  const handleForwardAgentChange = useCallback((checked: boolean) => {
+    setConnSettings((prev) => {
+      if (checked) return { ...prev, forwardAgent: true };
+      const { forwardAgent: _omit, ...rest } = prev;
       return rest;
     });
   }, []);
@@ -1141,6 +1158,25 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
           errors={jumpHostValidation.errors}
           warnings={jumpHostValidation.warnings}
         />
+      )}
+
+      {showAgentForwarding && (
+        <div className="settings-panel__category" data-testid="ssh-agent-forwarding-section">
+          <h3 className="settings-panel__category-title">SSH Agent Forwarding</h3>
+          <div className="settings-form__field">
+            <span className="settings-form__label">Forward SSH agent</span>
+            <Toggle
+              checked={(connSettings as SshEditorSettings).forwardAgent === true}
+              onCheckedChange={handleForwardAgentChange}
+              aria-label="Forward SSH agent"
+              data-testid="connection-editor-forward-agent"
+            />
+            <span className="settings-form__hint">
+              Make your local <code>ssh-agent</code> keys available on the target — and through the
+              jump-host chain — so onward SSH from the host works without copying private keys.
+            </span>
+          </div>
+        </div>
       )}
 
       {showSshAgentSetup && (

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -110,6 +110,25 @@ export interface JumpHostConfig {
   connectTimeoutSecs?: number;
 }
 
+/**
+ * SSH-connection settings the connection editor manages directly (as opposed to
+ * the schema-driven fields rendered by `ConnectionSettingsForm`). They live as
+ * sibling keys on the connection's unstructured `settings` record and mirror the
+ * Rust `SshConfig` (`core/src/config/mod.rs`).
+ */
+export interface SshEditorSettings {
+  /**
+   * Forward the local `ssh-agent` to the target (OpenSSH `ForwardAgent`, #1699),
+   * so the agent's keys are usable on the final host — and, because the
+   * forwarded-agent channel rides the jump-host tunnel, through the whole
+   * `proxyJump` chain. Mirrors `SshConfig.forward_agent`; omitted/`false` by
+   * default, keeping existing saved connections unchanged.
+   */
+  forwardAgent?: boolean;
+  /** Jump-host (`ProxyJump`) chain; empty/omitted means a direct connection. */
+  proxyJump?: JumpHostConfig[];
+}
+
 export type ConnectionTreeItem =
   | { type: "folder"; folder: ConnectionFolder }
   | { type: "connection"; connection: SavedConnection };


### PR DESCRIPTION
Closes #1699.

Adds per-connection **SSH agent forwarding** (OpenSSH `ForwardAgent`) on top of the shipped jump-host stack (#520/#872). When enabled, the local `ssh-agent`'s keys are reachable on the final target — and, because the forwarded-agent channel rides the jump-host tunnel, end to end through the `ProxyJump` chain — so onward SSH / git-over-bastion works without copying private keys onto intermediate hosts.

Library-first per repo CLAUDE.md: uses russh 0.61's built-in agent-forwarding support (`Channel::agent_forward` + `Handler::server_channel_open_agent_forward`), no hand-rolled `auth-agent` protocol.

## What changed
- **Config** (`core/src/config/mod.rs`): new `forward_agent: bool` on `SshConfig` — serde-defaults `false`, omitted when false so existing saved connections stay byte-stable (mirrors `proxy_jump`). Wired through the JSON settings → `SshConfig` mapping (`core/src/backends/ssh/mod.rs`, `forwardAgent` key).
- **Transport** (`core/src/backends/ssh/`): the final-target session channel requests `auth-agent-req@openssh.com` when opted in (`connector.rs`); a new `agent_forward.rs` bridges the server-opened `auth-agent@openssh.com` channel to the local agent by pumping bytes between it and the local agent socket (Unix `$SSH_AUTH_SOCK` / Windows OpenSSH named pipe); the handler (`handler.rs`) does the bridge, gated on the connection's opt-in so a server can never reach the local agent unsolicited.
- **Editor** (`ConnectionEditor.tsx` + `src/types/connection.ts`): a "Forward SSH agent" toggle in the SSH section, gated like the jump-host section (`selectedType === "ssh" && !isAnyAgentMode`); off omits the key.
- **Graceful no-op**: no local agent (`SSH_AUTH_SOCK` unset / Windows agent stopped) skips the request with a debug log and never fails the connection.

## Note on "each hop"
Intermediate jump hosts are pure transport (termiHub opens no interactive shell on a bastion), so the agent is not separately exposed as `$SSH_AUTH_SOCK` on a hop — it is reachable on the **final target through the chain**, which is the verifiable acceptance criterion. Genuine per-bastion shell agent access would require opening a session on the hop; called out in `docs/testing.md` and a candidate follow-up.

## Tests
- Rust unit: `SshConfig` (de)serialization default/round-trip + absent-field back-compat; settings→config mapping for `forwardAgent`; handler opt-in gate; `agent_forward` availability (unset / dangling `SSH_AUTH_SOCK`).
- Frontend: toggle renders + off-by-default; `forwardAgent` survives a sibling schema-field edit through save; omitted when left off.
- Manual: agent forwarding itself needs a live agent + real SSH server (integration lane, not per-PR CI) — steps documented in `docs/testing.md` (direct, jump-chain, no-agent).

Verified locally: `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo check --workspace --all-features`, full Vitest suite, `tsc`, prettier, cargo fmt, markdownlint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Follow-up filed: #1719 (agent-side SSH agent forwarding through the remote-agent SSH backend).
