### PR TITLE
feat(macro): macro manager panel (browse, search, edit, delete, launch)

### DIFF
--- a/docs/changes/dev1/feature/1676-macro-manager-panel.md
+++ b/docs/changes/dev1/feature/1676-macro-manager-panel.md
@@ -1,0 +1,11 @@
+### Added
+
+- Macro Manager panel: a new **Macros** entry in the Activity Bar opens a panel
+  to browse, search, edit, delete, duplicate and launch stored macros. Each row
+  shows the macro name, a step count, a one-line preview of the recorded input
+  and its tags, with Play / Edit / Duplicate / Delete actions. Search filters by
+  name, description or tag. The edit dialog lets you rename a macro, change its
+  description and tags, and review the recorded step list — adjusting a step's
+  delay, reordering steps, or deleting individual steps. A "Record New" button
+  starts a fresh recording. Every mutating action gives toast feedback and
+  deletes are confirmed. (#1676, epic #1670)

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -4,6 +4,7 @@ import {
   FolderOpen,
   ArrowLeftRight,
   LayoutGrid,
+  Clapperboard,
   Server,
   Settings,
   Download,
@@ -59,6 +60,7 @@ const REQUIRED_ITEMS: ActivityBarItemDef[] = [
 const OPTIONAL_ITEMS: ActivityBarItemDef[] = [
   { view: "files", icon: FolderOpen, label: "File Browser" },
   { view: "workspaces", icon: LayoutGrid, label: "Workspaces" },
+  { view: "macros", icon: Clapperboard, label: "Macros" },
   { view: "tunnels", icon: ArrowLeftRight, label: "SSH Tunnels", experimental: true },
   { view: "services", icon: Server, label: "Services", experimental: true },
   { view: "network-tools", icon: Stethoscope, label: "Network Tools", experimental: true },

--- a/src/components/MacroSidebar/MacroEditorDialog.css
+++ b/src/components/MacroSidebar/MacroEditorDialog.css
@@ -1,0 +1,84 @@
+.macro-editor__steps-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 8px;
+  margin-bottom: 4px;
+}
+
+.macro-editor__steps-title {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.macro-editor__steps {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 4px;
+}
+
+.macro-editor__step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.macro-editor__step:hover {
+  background: var(--bg-hover);
+}
+
+.macro-editor__step-index {
+  flex-shrink: 0;
+  width: 20px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  text-align: right;
+}
+
+.macro-editor__step-data {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.macro-editor__step-delay {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.macro-editor__step-delay .ui-input {
+  width: 72px;
+}
+
+.macro-editor__step-unit {
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.macro-editor__step-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.macro-editor__empty {
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 12px;
+  text-align: center;
+}

--- a/src/components/MacroSidebar/MacroEditorDialog.test.tsx
+++ b/src/components/MacroSidebar/MacroEditorDialog.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { MacroEditorDialog, type MacroEditorResult } from "./MacroEditorDialog";
+import { withTooltip } from "@/test/tooltip";
+import type { Macro } from "@/types/macro";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+function setInput(testId: string, value: string) {
+  const input = query(testId) as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+const macro: Macro = {
+  id: "macro-1",
+  name: "Deploy sequence",
+  description: "Runs the deploy",
+  tags: ["ops", "release"],
+  steps: [
+    { data: "step-one\r", delayMs: 0 },
+    { data: "step-two\r", delayMs: 50 },
+    { data: "step-three\r", delayMs: 100 },
+  ],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("MacroEditorDialog", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(props: Partial<Parameters<typeof MacroEditorDialog>[0]> = {}) {
+    const onSave = props.onSave ?? vi.fn();
+    const onOpenChange = props.onOpenChange ?? vi.fn();
+    act(() => {
+      root.render(
+        withTooltip(
+          <MacroEditorDialog
+            open={props.open ?? true}
+            macro={props.macro ?? macro}
+            onOpenChange={onOpenChange}
+            onSave={onSave}
+          />
+        )
+      );
+    });
+    return { onSave, onOpenChange };
+  }
+
+  it("pre-fills the fields and step list from the macro", () => {
+    render();
+    expect((query("macro-editor-name") as HTMLInputElement).value).toBe("Deploy sequence");
+    expect((query("macro-editor-description") as HTMLInputElement).value).toBe("Runs the deploy");
+    expect((query("macro-editor-tags") as HTMLInputElement).value).toBe("ops, release");
+    expect(query("macro-editor-step-0")).not.toBeNull();
+    expect(query("macro-editor-step-1")).not.toBeNull();
+    expect(query("macro-editor-step-2")).not.toBeNull();
+  });
+
+  it("saves the edited name, description and tags", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render({ onSave });
+
+    setInput("macro-editor-name", "Renamed");
+    setInput("macro-editor-description", "New desc");
+    setInput("macro-editor-tags", "a, b, a");
+
+    act(() => (query("macro-editor-save") as HTMLButtonElement).click());
+    await flush();
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const result = onSave.mock.calls[0][0] as MacroEditorResult;
+    expect(result.name).toBe("Renamed");
+    expect(result.description).toBe("New desc");
+    // De-duplicated tag list.
+    expect(result.tags).toEqual(["a", "b"]);
+    expect(result.steps).toHaveLength(3);
+  });
+
+  it("deletes an individual step before saving", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render({ onSave });
+
+    act(() => (query("macro-editor-step-delete-1") as HTMLButtonElement).click());
+    // The middle step is gone; the list re-indexes to two steps.
+    expect(query("macro-editor-step-2")).toBeNull();
+
+    act(() => (query("macro-editor-save") as HTMLButtonElement).click());
+    await flush();
+
+    const result = onSave.mock.calls[0][0] as MacroEditorResult;
+    expect(result.steps.map((s) => s.data)).toEqual(["step-one\r", "step-three\r"]);
+  });
+
+  it("reorders steps with the move-up control", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render({ onSave });
+
+    act(() => (query("macro-editor-step-up-1") as HTMLButtonElement).click());
+    act(() => (query("macro-editor-save") as HTMLButtonElement).click());
+    await flush();
+
+    const result = onSave.mock.calls[0][0] as MacroEditorResult;
+    expect(result.steps.map((s) => s.data)).toEqual(["step-two\r", "step-one\r", "step-three\r"]);
+  });
+
+  it("disables Save when the name is emptied", () => {
+    render();
+    setInput("macro-editor-name", "   ");
+    expect((query("macro-editor-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("disables Save when all steps are removed", () => {
+    render();
+    act(() => (query("macro-editor-step-delete-2") as HTMLButtonElement).click());
+    act(() => (query("macro-editor-step-delete-1") as HTMLButtonElement).click());
+    act(() => (query("macro-editor-step-delete-0") as HTMLButtonElement).click());
+    expect(query("macro-editor-no-steps")).not.toBeNull();
+    expect((query("macro-editor-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/src/components/MacroSidebar/MacroEditorDialog.tsx
+++ b/src/components/MacroSidebar/MacroEditorDialog.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useMemo, useState } from "react";
+import { ArrowDown, ArrowUp, Trash2 } from "lucide-react";
+import { Modal, Button, Input, Field, NumberInput } from "@/components/ui";
+import type { Macro, MacroStep } from "@/types/macro";
+import { formatMacroStepData } from "./macroStepFormat";
+import "./MacroEditorDialog.css";
+
+/** The editable fields the dialog collects before saving a macro. */
+export interface MacroEditorResult {
+  name: string;
+  description?: string;
+  tags: string[];
+  steps: MacroStep[];
+}
+
+export interface MacroEditorDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** The macro being edited, or `null` when the dialog is closed. */
+  macro: Macro | null;
+  /** Called when the dialog should open/close. */
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Called with the edited fields when the user saves. May be async — the Save
+   * button shows a pending state and the dialog stays open on rejection so the
+   * user can retry without losing edits.
+   */
+  onSave: (result: MacroEditorResult) => void | Promise<void>;
+}
+
+/** Split a comma-separated tag string into a trimmed, de-duplicated list. */
+function parseTags(raw: string): string[] {
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const part of raw.split(",")) {
+    const tag = part.trim();
+    if (tag && !seen.has(tag)) {
+      seen.add(tag);
+      tags.push(tag);
+    }
+  }
+  return tags;
+}
+
+/**
+ * Detail/edit view for a stored macro: edit the name, description and tags, and
+ * review the recorded step list — each step shows a readable preview of its
+ * input plus its inter-step delay, which can be adjusted. Steps can be reordered
+ * or deleted individually. Composed entirely from the shared UI primitives.
+ *
+ * Edits are held locally and only persisted when the user saves, so cancelling
+ * discards them. Removing every step is disallowed at the Save gate (a macro
+ * with no steps has nothing to play), and the name is required.
+ */
+export function MacroEditorDialog({ open, macro, onOpenChange, onSave }: MacroEditorDialogProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [tags, setTags] = useState("");
+  const [steps, setSteps] = useState<MacroStep[]>([]);
+
+  // Reload the working copy each time a macro is opened so a prior edit never
+  // leaks in and cancel truly discards.
+  useEffect(() => {
+    if (open && macro) {
+      setName(macro.name);
+      setDescription(macro.description ?? "");
+      setTags(macro.tags.join(", "));
+      setSteps(macro.steps.map((s) => ({ ...s })));
+    }
+  }, [open, macro]);
+
+  const trimmedName = name.trim();
+  const canSave = trimmedName.length > 0 && steps.length > 0;
+
+  const moveStep = (index: number, direction: -1 | 1) => {
+    setSteps((prev) => {
+      const target = index + direction;
+      if (target < 0 || target >= prev.length) return prev;
+      const next = [...prev];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const deleteStep = (index: number) => {
+    setSteps((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const setStepDelay = (index: number, delayMs: number) => {
+    setSteps((prev) =>
+      prev.map((s, i) => (i === index ? { ...s, delayMs: Math.max(0, Math.round(delayMs)) } : s))
+    );
+  };
+
+  // Returns the parent's (possibly async) save promise so the Button drives its
+  // own pending spinner. The parent closes the dialog on success and surfaces
+  // its own error toast, so `errorToast` is disabled on the Button to avoid a
+  // duplicate; a rejection just returns the button to idle with the dialog open.
+  const handleSave = () => {
+    if (!canSave) return;
+    return onSave({
+      name: trimmedName,
+      description: description.trim() || undefined,
+      tags: parseTags(tags),
+      steps,
+    });
+  };
+
+  const stepRows = useMemo(
+    () =>
+      steps.map((step, index) => (
+        <div className="macro-editor__step" key={index} data-testid={`macro-editor-step-${index}`}>
+          <span className="macro-editor__step-index">{index + 1}</span>
+          <code className="macro-editor__step-data" data-testid={`macro-editor-step-data-${index}`}>
+            {formatMacroStepData(step.data) || "(empty)"}
+          </code>
+          <div className="macro-editor__step-delay">
+            <NumberInput
+              value={step.delayMs}
+              min={0}
+              step={10}
+              onValueChange={(v) => setStepDelay(index, v === "" ? 0 : v)}
+              aria-label={`Delay before step ${index + 1} in milliseconds`}
+              data-testid={`macro-editor-step-delay-${index}`}
+            />
+            <span className="macro-editor__step-unit">ms</span>
+          </div>
+          <div className="macro-editor__step-actions">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label={`Move step ${index + 1} up`}
+              disabled={index === 0}
+              icon={<ArrowUp size={12} />}
+              onClick={() => moveStep(index, -1)}
+              data-testid={`macro-editor-step-up-${index}`}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label={`Move step ${index + 1} down`}
+              disabled={index === steps.length - 1}
+              icon={<ArrowDown size={12} />}
+              onClick={() => moveStep(index, 1)}
+              data-testid={`macro-editor-step-down-${index}`}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label={`Delete step ${index + 1}`}
+              icon={<Trash2 size={12} />}
+              onClick={() => deleteStep(index)}
+              data-testid={`macro-editor-step-delete-${index}`}
+            />
+          </div>
+        </div>
+      )),
+    [steps]
+  );
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit Macro"
+      description="Edit a stored macro's details and recorded steps"
+      size="lg"
+      data-testid="macro-editor-dialog"
+      footer={
+        <>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            data-testid="macro-editor-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            disabled={!canSave}
+            errorToast={false}
+            data-testid="macro-editor-save"
+          >
+            Save
+          </Button>
+        </>
+      }
+    >
+      <Field label="Name" htmlFor="macro-editor-name">
+        <Input
+          id="macro-editor-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Macro name"
+          data-testid="macro-editor-name"
+        />
+      </Field>
+      <Field label="Description (optional)" htmlFor="macro-editor-description">
+        <Input
+          id="macro-editor-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What this macro does"
+          data-testid="macro-editor-description"
+        />
+      </Field>
+      <Field label="Tags (optional, comma-separated)" htmlFor="macro-editor-tags">
+        <Input
+          id="macro-editor-tags"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          placeholder="ops, release"
+          data-testid="macro-editor-tags"
+        />
+      </Field>
+      <div className="macro-editor__steps-header">
+        <span className="macro-editor__steps-title">Steps ({steps.length})</span>
+      </div>
+      {steps.length === 0 ? (
+        <p className="macro-editor__empty" role="status" data-testid="macro-editor-no-steps">
+          This macro has no steps. Add one by recording, or it cannot be saved.
+        </p>
+      ) : (
+        <div className="macro-editor__steps" data-testid="macro-editor-steps">
+          {stepRows}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/MacroSidebar/MacroListItem.tsx
+++ b/src/components/MacroSidebar/MacroListItem.tsx
@@ -1,0 +1,131 @@
+import type React from "react";
+import { Play, Pencil, Copy, Trash2 } from "lucide-react";
+import { Button, Tooltip } from "@/components/ui";
+import { SidebarListItem } from "@/components/SidebarListItem";
+import type { Macro } from "@/types/macro";
+import { summariseMacroSteps } from "./macroStepFormat";
+
+interface MacroListItemProps {
+  macro: Macro;
+  onPlay: (macroId: string) => void;
+  onEdit: (macroId: string) => void;
+  onDuplicate: (macroId: string) => void;
+  onDelete: (macroId: string) => void;
+  /** Roving-tabindex ref wiring the row into the sidebar's keyboard navigation. */
+  rowRef?: (el: HTMLDivElement | null) => void;
+  /** Roving-tabindex row props (role, tabIndex, aria-level, onFocus) for keyboard nav. */
+  rowProps?: React.HTMLAttributes<HTMLDivElement>;
+}
+
+/**
+ * A single macro row in the manager sidebar: name, a step-count badge, a
+ * one-line preview of the recorded input, and the Play / Edit / Duplicate /
+ * Delete actions. Double-click plays the macro (matching the workspace row's
+ * double-click-to-launch affordance). Composed from the shared list-item shell.
+ */
+export function MacroListItem({
+  macro,
+  onPlay,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  rowRef,
+  rowProps,
+}: MacroListItemProps) {
+  const stepCount = macro.steps.length;
+  const preview = summariseMacroSteps(macro.steps);
+
+  return (
+    <SidebarListItem
+      ref={rowRef}
+      {...rowProps}
+      testId={`macro-item-${macro.id}`}
+      nameTestId={`macro-name-${macro.id}`}
+      name={macro.name}
+      badge={`${stepCount} step${stepCount === 1 ? "" : "s"}`}
+      badgeTestId={`macro-steps-${macro.id}`}
+      onDoubleClick={() => onPlay(macro.id)}
+      actions={
+        <>
+          <Tooltip content="Play" side="top">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label="Play"
+              data-testid={`macro-play-${macro.id}`}
+              icon={<Play size={12} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                onPlay(macro.id);
+              }}
+            />
+          </Tooltip>
+          <Tooltip content="Edit" side="top">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label="Edit"
+              data-testid={`macro-edit-${macro.id}`}
+              icon={<Pencil size={12} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(macro.id);
+              }}
+            />
+          </Tooltip>
+          <Tooltip content="Duplicate" side="top">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label="Duplicate"
+              data-testid={`macro-duplicate-${macro.id}`}
+              icon={<Copy size={12} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDuplicate(macro.id);
+              }}
+            />
+          </Tooltip>
+          <Tooltip content="Delete" side="top">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label="Delete"
+              data-testid={`macro-delete-${macro.id}`}
+              icon={<Trash2 size={12} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(macro.id);
+              }}
+            />
+          </Tooltip>
+        </>
+      }
+      details={
+        <>
+          {macro.description ? (
+            <span className="macro-item__description">{macro.description}</span>
+          ) : null}
+          {preview ? (
+            <code className="macro-item__preview" data-testid={`macro-preview-${macro.id}`}>
+              {preview}
+            </code>
+          ) : null}
+          {macro.tags.length > 0 ? (
+            <span className="macro-item__tags" data-testid={`macro-tags-${macro.id}`}>
+              {macro.tags.map((tag) => (
+                <span className="macro-item__tag" key={tag}>
+                  {tag}
+                </span>
+              ))}
+            </span>
+          ) : null}
+        </>
+      }
+    />
+  );
+}

--- a/src/components/MacroSidebar/MacroSidebar.css
+++ b/src/components/MacroSidebar/MacroSidebar.css
@@ -1,0 +1,99 @@
+.macro-sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.macro-sidebar__actions {
+  display: flex;
+  padding: 4px 8px;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.macro-sidebar__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.macro-sidebar__search-icon {
+  position: absolute;
+  left: 16px;
+  color: var(--text-secondary);
+  pointer-events: none;
+}
+
+.macro-sidebar__search .ui-input {
+  padding-left: 26px;
+}
+
+.macro-sidebar__list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.macro-sidebar__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 24px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-align: center;
+  gap: 8px;
+}
+
+.macro-sidebar__empty-link {
+  border: none;
+  background: none;
+  padding: 0;
+  color: var(--accent-color);
+  cursor: pointer;
+  font-size: inherit;
+  text-decoration: underline;
+}
+
+/*
+ * Macro rows compose from the shared `SidebarListItem` shell, so the row layout
+ * (container, header, badge, name, actions, details) lives in
+ * `SidebarListItem.css`. Only the macro-specific detail lines remain here.
+ */
+.macro-item__description {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.macro-item__preview {
+  display: block;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.macro-item__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding-top: 2px;
+}
+
+.macro-item__tag {
+  padding: 0 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 16px;
+}

--- a/src/components/MacroSidebar/MacroSidebar.test.tsx
+++ b/src/components/MacroSidebar/MacroSidebar.test.tsx
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { MacroSidebar } from "./MacroSidebar";
+import { withTooltip } from "@/test/tooltip";
+import type { Macro } from "@/types/macro";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+// Keep the real UI primitives so the ConfirmDeleteDialog/Modal render, but spy
+// on the toast helpers to assert action feedback.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return {
+    ...actual,
+    toast: {
+      ...actual.toast,
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+    },
+  };
+});
+
+import { useAppStore } from "@/store/appStore";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+function setSearch(value: string) {
+  const input = query("macro-search") as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+const sampleMacros: Macro[] = [
+  {
+    id: "macro-1",
+    name: "Deploy sequence",
+    description: "Runs the deploy",
+    tags: ["ops", "release"],
+    steps: [{ data: "deploy\r", delayMs: 0 }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "macro-2",
+    name: "Login banner",
+    tags: [],
+    steps: [{ data: "whoami\r", delayMs: 10 }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+];
+
+describe("MacroSidebar", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+    // Reset the store slice used by this component to known defaults.
+    useAppStore.setState({
+      macros: [],
+      startMacroRecording: vi.fn(),
+      playMacro: vi.fn().mockResolvedValue(undefined),
+      saveMacroToBackend: vi.fn().mockResolvedValue(undefined),
+      deleteMacroFromBackend: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render() {
+    act(() => {
+      root.render(withTooltip(<MacroSidebar />));
+    });
+  }
+
+  it("shows the empty message when no macros exist", () => {
+    render();
+    expect(query("macro-empty-message")).not.toBeNull();
+    expect(query("macro-list")).toBeNull();
+  });
+
+  it("renders a row for each macro", () => {
+    useAppStore.setState({ macros: sampleMacros });
+    render();
+    expect(query("macro-list")).not.toBeNull();
+    expect(query("macro-item-macro-1")).not.toBeNull();
+    expect(query("macro-item-macro-2")).not.toBeNull();
+    expect(query("macro-name-macro-1")?.textContent).toBe("Deploy sequence");
+  });
+
+  it("filters the list by the search query across name/description/tags", () => {
+    useAppStore.setState({ macros: sampleMacros });
+    render();
+
+    setSearch("login");
+    expect(query("macro-item-macro-2")).not.toBeNull();
+    expect(query("macro-item-macro-1")).toBeNull();
+
+    // Matches on a tag, too.
+    setSearch("release");
+    expect(query("macro-item-macro-1")).not.toBeNull();
+    expect(query("macro-item-macro-2")).toBeNull();
+  });
+
+  it("shows a no-results state when the query matches nothing", () => {
+    useAppStore.setState({ macros: sampleMacros });
+    render();
+    setSearch("nonexistent");
+    expect(query("macro-no-results")).not.toBeNull();
+    expect(query("macro-list")).toBeNull();
+  });
+
+  it("starts recording when the record button is clicked", () => {
+    const startMacroRecording = vi.fn();
+    useAppStore.setState({ macros: [], startMacroRecording });
+    render();
+    act(() => (query("macro-record-btn") as HTMLButtonElement).click());
+    expect(startMacroRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it("plays a macro when its Play action is clicked", () => {
+    const playMacro = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ macros: sampleMacros, playMacro });
+    render();
+    act(() => (query("macro-play-macro-1") as HTMLButtonElement).click());
+    expect(playMacro).toHaveBeenCalledWith("macro-1");
+  });
+
+  it("duplicates a macro through the backend and reports success", async () => {
+    const saveMacroToBackend = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ macros: sampleMacros, saveMacroToBackend });
+    render();
+
+    act(() => (query("macro-duplicate-macro-1") as HTMLButtonElement).click());
+    await flush();
+
+    expect(saveMacroToBackend).toHaveBeenCalledTimes(1);
+    const saved = saveMacroToBackend.mock.calls[0][0] as Macro;
+    expect(saved.name).toBe("Copy of Deploy sequence");
+    expect(saved.id).not.toBe("macro-1");
+    expect(saved.steps).toEqual(sampleMacros[0].steps);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks for confirmation before deleting and does not delete on click alone", () => {
+    const deleteMacroFromBackend = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ macros: [sampleMacros[0]], deleteMacroFromBackend });
+    render();
+
+    expect(query("confirm-delete-dialog")).toBeNull();
+    act(() => (query("macro-delete-macro-1") as HTMLButtonElement).click());
+    expect(query("confirm-delete-dialog")).not.toBeNull();
+    expect(deleteMacroFromBackend).not.toHaveBeenCalled();
+  });
+
+  it("deletes and reports success when the user confirms", async () => {
+    const deleteMacroFromBackend = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ macros: [sampleMacros[0]], deleteMacroFromBackend });
+    render();
+
+    act(() => (query("macro-delete-macro-1") as HTMLButtonElement).click());
+    act(() => (query("confirm-delete-confirm") as HTMLButtonElement).click());
+    await flush();
+
+    expect(deleteMacroFromBackend).toHaveBeenCalledWith("macro-1");
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("opens the editor dialog when a macro's Edit action is clicked", () => {
+    useAppStore.setState({ macros: sampleMacros });
+    render();
+    expect(query("macro-editor-dialog")).toBeNull();
+    act(() => (query("macro-edit-macro-1") as HTMLButtonElement).click());
+    expect(query("macro-editor-dialog")).not.toBeNull();
+    expect((query("macro-editor-name") as HTMLInputElement).value).toBe("Deploy sequence");
+  });
+});

--- a/src/components/MacroSidebar/MacroSidebar.tsx
+++ b/src/components/MacroSidebar/MacroSidebar.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useMemo, useState } from "react";
+import { Circle, Search } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { Button, Input, toast, Tooltip } from "@/components/ui";
+import { ConfirmDeleteDialog } from "@/components/Sidebar/ConfirmDeleteDialog";
+import { useFlatRovingNav } from "@/hooks/useFlatRovingNav";
+import type { Macro } from "@/types/macro";
+import { MacroListItem } from "./MacroListItem";
+import { MacroEditorDialog, type MacroEditorResult } from "./MacroEditorDialog";
+import "./MacroSidebar.css";
+
+/** Generate a unique macro id for a duplicated macro. */
+function generateMacroId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") {
+    return `macro-${c.randomUUID()}`;
+  }
+  return `macro-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** True when the macro matches the (already lower-cased) query across name/description/tags. */
+function macroMatches(macro: Macro, query: string): boolean {
+  if (!query) return true;
+  if (macro.name.toLowerCase().includes(query)) return true;
+  if (macro.description?.toLowerCase().includes(query)) return true;
+  return macro.tags.some((tag) => tag.toLowerCase().includes(query));
+}
+
+/**
+ * The Macro Manager panel: browse, search, edit, delete and launch stored
+ * macros. Macros are recorded from the terminal toolbar and played back into the
+ * active terminal; this panel is their home for organisation. Composed from the
+ * shared UI primitives and the sidebar list-item shell, mirroring the workspace
+ * and tunnel managers. Import/export is intentionally out of scope here (#1677).
+ */
+export function MacroSidebar() {
+  const macros = useAppStore((s) => s.macros);
+  const saveMacroToBackend = useAppStore((s) => s.saveMacroToBackend);
+  const deleteMacroFromBackend = useAppStore((s) => s.deleteMacroFromBackend);
+  const playMacro = useAppStore((s) => s.playMacro);
+  const startMacroRecording = useAppStore((s) => s.startMacroRecording);
+
+  const [query, setQuery] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return macros.filter((m) => macroMatches(m, q));
+  }, [macros, query]);
+
+  const editingMacro = useMemo(
+    () => macros.find((m) => m.id === editingId) ?? null,
+    [macros, editingId]
+  );
+
+  const handleRecord = useCallback(() => {
+    startMacroRecording();
+  }, [startMacroRecording]);
+
+  const handlePlay = useCallback(
+    (macroId: string) => {
+      void playMacro(macroId);
+    },
+    [playMacro]
+  );
+
+  const handleEdit = useCallback((macroId: string) => setEditingId(macroId), []);
+
+  const handleDuplicate = useCallback(
+    async (macroId: string) => {
+      const original = macros.find((m) => m.id === macroId);
+      if (!original) return;
+      const duplicate: Macro = {
+        ...original,
+        id: generateMacroId(),
+        name: `Copy of ${original.name}`,
+        steps: original.steps.map((s) => ({ ...s })),
+        // The backend stamps authoritative created/updated timestamps.
+        createdAt: "",
+        updatedAt: "",
+      };
+      try {
+        await saveMacroToBackend(duplicate);
+        toast.success(`Duplicated "${original.name}"`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(`Failed to duplicate "${original.name}"`, { description: message });
+      }
+    },
+    [macros, saveMacroToBackend]
+  );
+
+  const handleDelete = useCallback(
+    (macroId: string) => {
+      const macro = macros.find((m) => m.id === macroId);
+      if (!macro) return;
+      setPendingDelete({ id: macro.id, name: macro.name });
+    },
+    [macros]
+  );
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    const { id, name } = pendingDelete;
+    setPendingDelete(null);
+    try {
+      await deleteMacroFromBackend(id);
+      toast.success(`Deleted macro "${name}"`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to delete macro: ${message}`);
+    }
+  }, [pendingDelete, deleteMacroFromBackend]);
+
+  const handleSaveEdit = useCallback(
+    async (result: MacroEditorResult) => {
+      if (!editingMacro) return;
+      const updated: Macro = {
+        ...editingMacro,
+        name: result.name,
+        description: result.description,
+        tags: result.tags,
+        steps: result.steps,
+      };
+      try {
+        await saveMacroToBackend(updated);
+        setEditingId(null);
+        toast.success(`Saved macro "${result.name}"`);
+      } catch (err) {
+        // Keep the dialog open so the edits are not lost on a failed save.
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(`Failed to save macro: ${message}`);
+        throw err;
+      }
+    },
+    [editingMacro, saveMacroToBackend]
+  );
+
+  // Roving-tabindex keyboard navigation over the filtered list, matching the
+  // other management sidebars. Enter plays the focused macro.
+  const handleActivate = useCallback((macro: Macro) => handlePlay(macro.id), [handlePlay]);
+  const nav = useFlatRovingNav<Macro, HTMLDivElement>(
+    filtered,
+    (macro) => macro.name,
+    handleActivate
+  );
+
+  return (
+    <div className="macro-sidebar" data-testid="macro-sidebar">
+      <div className="macro-sidebar__actions">
+        <Tooltip content="Record New Macro" side="top">
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<Circle size={12} />}
+            onClick={handleRecord}
+            aria-label="Record New Macro"
+            data-testid="macro-record-btn"
+          >
+            Record New
+          </Button>
+        </Tooltip>
+      </div>
+      <div className="macro-sidebar__search">
+        <Search size={14} className="macro-sidebar__search-icon" aria-hidden="true" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search macros"
+          aria-label="Search macros"
+          data-testid="macro-search"
+        />
+      </div>
+      {macros.length === 0 ? (
+        <div className="macro-sidebar__empty" data-testid="macro-empty-message">
+          <span>No macros recorded yet.</span>
+          <span>
+            Record one with the terminal toolbar&apos;s record button, or{" "}
+            <button className="macro-sidebar__empty-link" onClick={handleRecord} type="button">
+              start recording now
+            </button>
+            .
+          </span>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="macro-sidebar__empty" data-testid="macro-no-results">
+          <span>No macros match &quot;{query}&quot;.</span>
+        </div>
+      ) : (
+        <div
+          className="macro-sidebar__list"
+          data-testid="macro-list"
+          role="tree"
+          aria-label="Macros"
+          onKeyDown={nav.onKeyDown}
+        >
+          {filtered.map((macro, index) => {
+            const { ref, ...itemProps } = nav.getItemProps(index);
+            return (
+              <MacroListItem
+                key={macro.id}
+                macro={macro}
+                onPlay={handlePlay}
+                onEdit={handleEdit}
+                onDuplicate={handleDuplicate}
+                onDelete={handleDelete}
+                rowRef={ref}
+                rowProps={itemProps}
+              />
+            );
+          })}
+        </div>
+      )}
+      <MacroEditorDialog
+        open={editingMacro !== null}
+        macro={editingMacro}
+        onOpenChange={(open) => {
+          if (!open) setEditingId(null);
+        }}
+        onSave={handleSaveEdit}
+      />
+      <ConfirmDeleteDialog
+        open={pendingDelete !== null}
+        message={
+          pendingDelete ? `Delete macro "${pendingDelete.name}"? This cannot be undone.` : ""
+        }
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </div>
+  );
+}

--- a/src/components/MacroSidebar/index.ts
+++ b/src/components/MacroSidebar/index.ts
@@ -1,0 +1,1 @@
+export { MacroSidebar } from "./MacroSidebar";

--- a/src/components/MacroSidebar/macroStepFormat.test.ts
+++ b/src/components/MacroSidebar/macroStepFormat.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { formatMacroStepData, summariseMacroSteps } from "./macroStepFormat";
+
+describe("formatMacroStepData", () => {
+  it("passes printable characters through unchanged", () => {
+    expect(formatMacroStepData("ls -la")).toBe("ls -la");
+  });
+
+  it("renders Enter, Tab and ESC as friendly glyphs", () => {
+    expect(formatMacroStepData("ls\r")).toBe("ls⏎");
+    expect(formatMacroStepData("\t")).toBe("⇥");
+    expect(formatMacroStepData("\x1b")).toBe("⎋");
+  });
+
+  it("uses caret notation for other control characters", () => {
+    // Ctrl-C is 0x03 → "^C".
+    expect(formatMacroStepData("\x03")).toBe("^C");
+    // Backspace (0x7f) → "⌫" (a named control), not caret.
+    expect(formatMacroStepData("\x7f")).toBe("⌫");
+  });
+
+  it("truncates long input with an ellipsis", () => {
+    const long = "a".repeat(200);
+    const out = formatMacroStepData(long, 10);
+    expect(out).toHaveLength(10);
+    expect(out.endsWith("…")).toBe(true);
+  });
+});
+
+describe("summariseMacroSteps", () => {
+  it("joins step data into one readable preview", () => {
+    expect(
+      summariseMacroSteps([
+        { data: "echo hi", delayMs: 0 },
+        { data: "\r", delayMs: 5 },
+      ])
+    ).toBe("echo hi⏎");
+  });
+
+  it("returns an empty string for no steps", () => {
+    expect(summariseMacroSteps([])).toBe("");
+  });
+});

--- a/src/components/MacroSidebar/macroStepFormat.ts
+++ b/src/components/MacroSidebar/macroStepFormat.ts
@@ -1,0 +1,67 @@
+/**
+ * Formatting helpers for presenting recorded macro steps in the manager UI.
+ *
+ * A {@link MacroStep} holds raw terminal input — the exact bytes a user typed,
+ * including control characters (Enter is `\r`, ESC starts escape sequences).
+ * Rendering that verbatim would be invisible or corrupt the layout, so the
+ * manager shows a human-readable, single-line preview using caret notation
+ * (`^M` for carriage return, `^[` for ESC, …) with a few friendly labels.
+ */
+import type { MacroStep } from "@/types/macro";
+
+/** Friendly labels for the most common control characters typed in a terminal. */
+const NAMED_CONTROLS: Record<string, string> = {
+  "\r": "⏎",
+  "\n": "⏎",
+  "\t": "⇥",
+  "\x1b": "⎋",
+  "\x7f": "⌫",
+};
+
+/**
+ * Render a single control/non-printable character as a readable token. Named
+ * controls (Enter, Tab, ESC, Backspace) use a glyph; every other control byte
+ * uses caret notation (`^A` … `^_`), and anything else falls back to a hex
+ * escape so the preview is always printable and unambiguous.
+ */
+function formatControlChar(ch: string): string {
+  const named = NAMED_CONTROLS[ch];
+  if (named) return named;
+  const code = ch.codePointAt(0) ?? 0;
+  if (code < 0x20) {
+    // Caret notation: control char + 0x40 (e.g. 0x03 → "^C").
+    return `^${String.fromCharCode(code + 0x40)}`;
+  }
+  if (code === 0x7f) return "^?";
+  return `\\x${code.toString(16).padStart(2, "0")}`;
+}
+
+/**
+ * Produce a readable, single-line preview of a step's recorded input. Printable
+ * characters pass through; control and non-printable characters are replaced
+ * with a caret/glyph token. The result is truncated with an ellipsis when it
+ * exceeds {@link maxLength} so long steps never blow out the row width.
+ *
+ * @param data      The step's raw recorded input.
+ * @param maxLength Maximum preview length before truncation (default 80).
+ */
+export function formatMacroStepData(data: string, maxLength = 80): string {
+  let out = "";
+  for (const ch of data) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 || code === 0x7f ? formatControlChar(ch) : ch;
+  }
+  if (out.length > maxLength) {
+    return `${out.slice(0, maxLength - 1)}…`;
+  }
+  return out;
+}
+
+/**
+ * Summarise a macro's whole step list into a compact one-line preview, joining
+ * the per-step previews. Used for the collapsed list row where only a hint of
+ * the macro's content is shown.
+ */
+export function summariseMacroSteps(steps: MacroStep[], maxLength = 80): string {
+  return formatMacroStepData(steps.map((s) => s.data).join(""), maxLength);
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import { ConnectionList } from "./ConnectionList";
 import { FileBrowser } from "./FileBrowser";
 import { TunnelSidebar } from "@/components/TunnelSidebar";
 import { WorkspaceSidebar } from "@/components/WorkspaceSidebar";
+import { MacroSidebar } from "@/components/MacroSidebar";
 import { NetworkToolsSidebar } from "@/components/NetworkTools/NetworkToolsSidebar";
 import { EmbeddedServerSidebar } from "@/components/EmbeddedServerSidebar";
 import "./Sidebar.css";
@@ -13,6 +14,7 @@ const VIEW_TITLES: Record<string, string> = {
   tunnels: "SSH Tunnels",
   services: "Services",
   workspaces: "Workspaces",
+  macros: "Macros",
   "network-tools": "Network Tools",
 };
 
@@ -37,6 +39,7 @@ export function Sidebar({ width }: SidebarProps) {
         {sidebarView === "tunnels" && <TunnelSidebar />}
         {sidebarView === "services" && <EmbeddedServerSidebar />}
         {sidebarView === "workspaces" && <WorkspaceSidebar />}
+        {sidebarView === "macros" && <MacroSidebar />}
         {sidebarView === "network-tools" && <NetworkToolsSidebar />}
       </div>
     </div>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -212,6 +212,7 @@ export type SidebarView =
   | "tunnels"
   | "services"
   | "workspaces"
+  | "macros"
   | "network-tools";
 
 /** Clipboard state for file browser copy/cut operations. */


### PR DESCRIPTION
## Summary

Implements the **Macro Manager** panel — the last UI child of the macro recording/playback epic **#1670** (concept #517). Builds on the merged foundation (#1673), recording (#1674) and playback (#1675) children.

Adds a new **Macros** entry to the Activity Bar that opens a management sidebar, modelled on the existing Workspace/Tunnel managers and composed entirely from the shared `ui/` primitives and the `SidebarListItem` shell.

### What it does
- **Browse + search/filter**: lists all stored macros; a search box filters by name, description or tag. Empty and no-results states.
- **Per-row actions**: Play (invokes `playMacro` into the active terminal), Edit, Duplicate, Delete (confirmed). Double-click / Enter plays the focused row (roving-tabindex keyboard nav).
- **Edit dialog**: rename, edit description/tags, and review the recorded step list — each step shows a readable preview of its bytes (caret/glyph notation for control chars) plus its inter-step delay, which can be adjusted; steps can be reordered (up/down) or deleted individually. Save persists via `saveMacroToBackend` (`save_macro`) and round-trips; name is required and a macro cannot be saved with zero steps.
- **Record entry point**: a "Record New" button starts a fresh recording (`startMacroRecording`).
- **Feedback**: every mutating action gives a pending → success/error toast; delete is confirmed.

Import/export is intentionally out of scope (tracked separately as #1677).

### Files
- New `src/components/MacroSidebar/` (MacroSidebar, MacroListItem, MacroEditorDialog, `macroStepFormat` util + CSS).
- Wiring: `SidebarView` union + `Sidebar.tsx` view, `ActivityBar.tsx` entry.

### Tests (TDD ordering — `test` commit precedes `feat`)
- `macroStepFormat.test.ts` — control-char formatting + truncation.
- `MacroSidebar.test.tsx` — list/search/empty/no-results, record, play, duplicate, delete-confirm, open-editor.
- `MacroEditorDialog.test.tsx` — pre-fill, save name/desc/tags, delete/reorder steps, save-gate disabling.

Full `pnpm test`, `tsc`, and `./scripts/check.sh` (eslint, prettier, clippy, markdownlint) all pass locally.

Closes #1676