### PR TITLE
feat(ssh): import ProxyJump chain from ~/.ssh/config into the jump-host editor (Closes #1702)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,6 +2544,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3729,6 +3744,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.5+1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3741,6 +3770,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3776,6 +3819,18 @@ dependencies = [
  "tracing-attributes",
  "uuid",
  "x509-parser",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4562,6 +4617,24 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -6804,6 +6877,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssh2-config"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e5a3352c5c624ed815d37c1c4c760aeaa119352091ca93ca5566f4ad48562c"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "dirs",
+ "git2",
+ "glob",
+ "log",
+ "thiserror 2.0.18",
+ "wildmatch",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7444,6 +7533,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "shlex",
+ "ssh2-config",
  "tauri",
  "tauri-build",
  "tauri-plugin-cli",
@@ -8238,6 +8328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8666,6 +8762,12 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "wildmatch"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
 
 [[package]]
 name = "winapi"

--- a/docs/changes/dev2/feature/1702-proxyjump-import.md
+++ b/docs/changes/dev2/feature/1702-proxyjump-import.md
@@ -1,0 +1,11 @@
+### Added
+
+- SSH connection editor: the **Jump Host** section now has an **Import from
+  ~/.ssh/config** action. It reads the user's OpenSSH client config (plus any
+  `Include`d files), lists the hosts that declare a `ProxyJump`, and — on
+  selection — populates the first-class jump-host chain (each hop resolved to
+  its own `Host` stanza's `Hostname`/`User`/`Port`/`IdentityFile`, ordered
+  outermost → innermost). Import only pre-fills the editor fields for review;
+  nothing is saved until the user saves the connection. A missing / empty /
+  unparseable config shows a friendly empty state rather than an error. Parsing
+  is handled by the maintained `ssh2-config` crate (#1702).

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,11 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 semver = "1"
 dirs = "6"
 which = "7"
+# OpenSSH client-config (`~/.ssh/config`) parser for importing a host's
+# ProxyJump chain into the jump-host editor (#1702). Library-first per the repo
+# rules — handles the tokenizer, `Include`, and `Match`/pattern semantics rather
+# than hand-rolling them.
+ssh2-config = "0.7"
 # Streaming XML reader/writer used to append/remove termiHub's Thunar custom
 # action inside a shared ~/.config/Thunar/uca.xml without disturbing foreign
 # actions (Linux file-manager registration, #1370).

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod remote_desktop;
 pub mod session;
 pub mod shell_integration;
 pub mod spawn;
+pub mod ssh_config_import;
 pub mod transfer;
 pub mod tunnel;
 pub mod update;

--- a/src-tauri/src/commands/ssh_config_import.rs
+++ b/src-tauri/src/commands/ssh_config_import.rs
@@ -307,6 +307,18 @@ Host bastion
         );
     }
 
+    // Unix-only: this fixture points `Include` at an absolute temp-dir path.
+    // ssh2-config's `resolve_include_path` treats a path as absolute only when it
+    // starts with the platform separator (`\` on Windows), so a Windows temp path
+    // (`C:\...` or `C:/...`) is misclassified as *relative* and resolved against
+    // the real `$HOME\.ssh`, never finding the fixture. There is no portable way
+    // to express an absolute temp Include path the crate accepts on Windows, and
+    // `dirs::home_dir()` on Windows ignores env vars (Known Folder API), so the
+    // real home can't be redirected under test either. Include *resolution* is the
+    // crate's own (Windows-tested) code; here we only verify termiHub consumes the
+    // included hosts, which the Unix run covers. Windows include-path behaviour is
+    // tracked as a follow-up.
+    #[cfg(unix)]
     #[test]
     fn include_pulls_hosts_from_referenced_file() {
         let dir = TempDir::new().unwrap();
@@ -322,12 +334,9 @@ Host bastion
     User b
 ",
         );
-        // ssh_config uses forward slashes on every platform, and the parser's
-        // glob-based Include resolver mangles Windows backslashes — so normalise
-        // the absolute fixture path to forward slashes (a bare backslash path
-        // fails only on Windows, which is exactly what this once regressed).
-        let include_line = included.to_string_lossy().replace('\\', "/");
-        let path = write_file(&dir, "config", &format!("Include {include_line}\n"));
+        // On Unix the absolute temp path starts with `/`, so ssh2-config opens it
+        // directly (see the module-level note above for the Windows limitation).
+        let path = write_file(&dir, "config", &format!("Include {}\n", included.display()));
 
         let hosts = parse_ssh_config_hosts(&path).unwrap();
         let target = hosts.iter().find(|h| h.name == "target");

--- a/src-tauri/src/commands/ssh_config_import.rs
+++ b/src-tauri/src/commands/ssh_config_import.rs
@@ -19,6 +19,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
+use ssh2_config::{ParseRule, SshConfig};
 
 use termihub_core::config::JumpHostConfig;
 
@@ -30,7 +31,7 @@ use crate::utils::errors::TerminalError;
 /// `name` is the `Host` alias (what the user typed as the SSH connection name);
 /// `proxy_jump` is the ordered, resolved hop chain (outermost → innermost,
 /// matching the shipped chain order).
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImportableHost {
     pub name: String,
@@ -49,9 +50,103 @@ fn default_ssh_config_path() -> Option<PathBuf> {
 /// A missing file is not an error — it yields an empty list (the friendly empty
 /// state). A genuine parse failure returns `Err`; the command layer degrades
 /// that to an empty list as well so the UI never shows an error toast.
-pub fn parse_ssh_config_hosts(_path: &Path) -> Result<Vec<ImportableHost>, String> {
-    // Implemented in the follow-up feat commit.
-    Ok(Vec::new())
+pub fn parse_ssh_config_hosts(path: &Path) -> Result<Vec<ImportableHost>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    // Permissive parsing: a real `~/.ssh/config` routinely carries directives
+    // ssh2-config doesn't model. STRICT would reject the whole file, so allow
+    // unknown/unsupported fields and simply ignore them.
+    let config = SshConfig::default()
+        .parse(
+            &mut reader,
+            ParseRule::ALLOW_UNKNOWN_FIELDS | ParseRule::ALLOW_UNSUPPORTED_FIELDS,
+        )
+        .map_err(|e| format!("parse {}: {e}", path.display()))?;
+    Ok(extract_importable_hosts(&config))
+}
+
+/// A host pattern is a concrete, importable alias only when it is neither a
+/// wildcard (`*`/`?`) nor a `Match`-style token — i.e. a literal host name the
+/// user could type as a connection.
+fn is_concrete_alias(pattern: &str) -> bool {
+    !pattern.is_empty() && !pattern.contains('*') && !pattern.contains('?')
+}
+
+/// Walk the parsed config's `Host` stanzas and turn each one that declares a
+/// usable `ProxyJump` into an [`ImportableHost`] (one per concrete alias in the
+/// stanza). Wildcard/negated patterns and `ProxyJump none` are skipped.
+fn extract_importable_hosts(config: &SshConfig) -> Vec<ImportableHost> {
+    let mut out = Vec::new();
+    for host in config.get_hosts() {
+        let proxy = match host.params.proxy_jump.as_ref() {
+            Some(p) if !p.is_empty() => p,
+            _ => continue,
+        };
+        // `ProxyJump none` explicitly disables jumping — nothing to import.
+        if proxy.len() == 1 && proxy[0].eq_ignore_ascii_case("none") {
+            continue;
+        }
+        let hops: Vec<JumpHostConfig> =
+            proxy.iter().map(|spec| resolve_hop(config, spec)).collect();
+        for clause in &host.pattern {
+            if clause.negated || !is_concrete_alias(&clause.pattern) {
+                continue;
+            }
+            out.push(ImportableHost {
+                name: clause.pattern.clone(),
+                proxy_jump: hops.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// Resolve a single `ProxyJump` spec (`[user@]host[:port]`) into a
+/// [`JumpHostConfig`], dereferencing the hop's own `Host` stanza for the real
+/// `Hostname`/`User`/`Port`/`IdentityFile`. Inline `user@`/`:port` in the spec
+/// take precedence over the stanza, matching OpenSSH.
+fn resolve_hop(config: &SshConfig, spec: &str) -> JumpHostConfig {
+    let (inline_user, host_port) = match spec.split_once('@') {
+        Some((user, rest)) => (Some(user.to_string()), rest),
+        None => (None, spec),
+    };
+    // Split a trailing `:port` only when it parses as a port — leaves bare hosts
+    // and (best-effort) bracketed IPv6 literals intact.
+    let (alias, inline_port) = match host_port.rsplit_once(':') {
+        Some((h, p)) => match p.parse::<u16>() {
+            Ok(port) => (h, Some(port)),
+            Err(_) => (host_port, None),
+        },
+        None => (host_port, None),
+    };
+
+    let params = config.query(alias);
+    let host = params
+        .host_name
+        .clone()
+        .unwrap_or_else(|| alias.to_string());
+    let port = inline_port.or(params.port).unwrap_or(22);
+    let username = inline_user.or(params.user).unwrap_or_default();
+    let (auth_method, key_path) = match params.identity_file.as_ref().and_then(|f| f.first()) {
+        Some(path) => ("key".to_string(), Some(path.to_string_lossy().into_owned())),
+        // No identity file in the config: default to agent auth, the usual
+        // bastion setup. The user can change it after import.
+        None => ("agent".to_string(), None),
+    };
+
+    JumpHostConfig {
+        connection_id: None,
+        host,
+        port,
+        username,
+        auth_method,
+        password: None,
+        key_path,
+        connect_timeout_secs: None,
+    }
 }
 
 /// Read the default `~/.ssh/config` and return its importable jump-host chains.
@@ -83,7 +178,7 @@ mod tests {
     #[test]
     fn missing_file_yields_empty_list() {
         let missing = Path::new("/nonexistent/does/not/exist/ssh_config");
-        assert_eq!(parse_ssh_config_hosts(missing).unwrap(), Vec::new());
+        assert!(parse_ssh_config_hosts(missing).unwrap().is_empty());
     }
 
     #[test]
@@ -181,7 +276,11 @@ Host bastion
         );
 
         let hosts = parse_ssh_config_hosts(&path).unwrap();
-        let hop = &hosts.iter().find(|h| h.name == "target").unwrap().proxy_jump[0];
+        let hop = &hosts
+            .iter()
+            .find(|h| h.name == "target")
+            .unwrap()
+            .proxy_jump[0];
         assert_eq!(hop.auth_method, "key");
         assert_eq!(hop.key_path.as_deref(), Some("/home/me/.ssh/id_bastion"));
     }
@@ -245,7 +344,11 @@ Host target
         );
 
         let hosts = parse_ssh_config_hosts(&path).unwrap();
-        let hop = &hosts.iter().find(|h| h.name == "target").unwrap().proxy_jump[0];
+        let hop = &hosts
+            .iter()
+            .find(|h| h.name == "target")
+            .unwrap()
+            .proxy_jump[0];
         assert_eq!(hop.host, "lonelybastion");
         assert_eq!(hop.port, 22);
     }
@@ -268,7 +371,11 @@ Host bastion
         );
 
         let hosts = parse_ssh_config_hosts(&path).unwrap();
-        let hop = &hosts.iter().find(|h| h.name == "target").unwrap().proxy_jump[0];
+        let hop = &hosts
+            .iter()
+            .find(|h| h.name == "target")
+            .unwrap()
+            .proxy_jump[0];
         assert_eq!(hop.host, "bastion.example.com");
         assert_eq!(hop.username, "carol");
         assert_eq!(hop.port, 2201);

--- a/src-tauri/src/commands/ssh_config_import.rs
+++ b/src-tauri/src/commands/ssh_config_import.rs
@@ -322,8 +322,12 @@ Host bastion
     User b
 ",
         );
-        // An absolute Include path is opened as-is by the parser.
-        let path = write_file(&dir, "config", &format!("Include {}\n", included.display()));
+        // ssh_config uses forward slashes on every platform, and the parser's
+        // glob-based Include resolver mangles Windows backslashes — so normalise
+        // the absolute fixture path to forward slashes (a bare backslash path
+        // fails only on Windows, which is exactly what this once regressed).
+        let include_line = included.to_string_lossy().replace('\\', "/");
+        let path = write_file(&dir, "config", &format!("Include {include_line}\n"));
 
         let hosts = parse_ssh_config_hosts(&path).unwrap();
         let target = hosts.iter().find(|h| h.name == "target");

--- a/src-tauri/src/commands/ssh_config_import.rs
+++ b/src-tauri/src/commands/ssh_config_import.rs
@@ -1,0 +1,276 @@
+//! Tauri command for importing a `ProxyJump` chain from the user's OpenSSH
+//! client config (`~/.ssh/config`, plus any `Include`d files) into the
+//! first-class jump-host editor (#1702).
+//!
+//! This reads the OpenSSH *client* config — distinct from termiHub's own
+//! `config`/`ssh_config` modules — enumerates the `Host` stanzas that declare a
+//! `ProxyJump`, resolves each hop against its own `Host` stanza
+//! (`Hostname`/`User`/`Port`/`IdentityFile`), and returns the chain as
+//! [`JumpHostConfig`]-shaped data the editor can drop straight into a
+//! connection's `proxyJump` array. It never creates connections: the frontend
+//! only pre-populates the editor fields, which the user reviews before saving.
+//!
+//! Parsing is delegated to the maintained [`ssh2_config`] crate (library-first
+//! per the repo rules) rather than hand-rolling the tokenizer / `Include` /
+//! `Match` semantics.
+
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use termihub_core::config::JumpHostConfig;
+
+use crate::utils::errors::TerminalError;
+
+/// A host stanza from `~/.ssh/config` that declares a `ProxyJump`, offered to
+/// the editor as an importable jump-host chain.
+///
+/// `name` is the `Host` alias (what the user typed as the SSH connection name);
+/// `proxy_jump` is the ordered, resolved hop chain (outermost → innermost,
+/// matching the shipped chain order).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportableHost {
+    pub name: String,
+    pub proxy_jump: Vec<JumpHostConfig>,
+}
+
+/// Default OpenSSH client-config path: `~/.ssh/config`
+/// (`%USERPROFILE%\.ssh\config` on Windows). `None` when no home dir resolves.
+fn default_ssh_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".ssh").join("config"))
+}
+
+/// Parse the OpenSSH client config at `path` and return the host stanzas that
+/// declare an importable `ProxyJump` chain.
+///
+/// A missing file is not an error — it yields an empty list (the friendly empty
+/// state). A genuine parse failure returns `Err`; the command layer degrades
+/// that to an empty list as well so the UI never shows an error toast.
+pub fn parse_ssh_config_hosts(_path: &Path) -> Result<Vec<ImportableHost>, String> {
+    // Implemented in the follow-up feat commit.
+    Ok(Vec::new())
+}
+
+/// Read the default `~/.ssh/config` and return its importable jump-host chains.
+///
+/// Missing / empty / unparseable config all degrade to an empty list — the
+/// picker shows a friendly empty state and never crashes or toasts.
+#[tauri::command]
+pub fn import_ssh_config_hosts() -> Result<Vec<ImportableHost>, TerminalError> {
+    let Some(path) = default_ssh_config_path() else {
+        return Ok(Vec::new());
+    };
+    Ok(parse_ssh_config_hosts(&path).unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    /// Write `contents` to `<dir>/<name>` and return the full path.
+    fn write_file(dir: &TempDir, name: &str, contents: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        let mut f = File::create(&path).expect("create fixture");
+        f.write_all(contents.as_bytes()).expect("write fixture");
+        path
+    }
+
+    #[test]
+    fn missing_file_yields_empty_list() {
+        let missing = Path::new("/nonexistent/does/not/exist/ssh_config");
+        assert_eq!(parse_ssh_config_hosts(missing).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn single_hop_resolves_hostname_user_and_port() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "config",
+            "\
+Host target
+    HostName target.internal
+    User alice
+    ProxyJump bastion
+
+Host bastion
+    HostName bastion.example.com
+    User bob
+    Port 2222
+",
+        );
+
+        let hosts = parse_ssh_config_hosts(&path).unwrap();
+        let target = hosts
+            .iter()
+            .find(|h| h.name == "target")
+            .expect("target host present");
+        assert_eq!(target.proxy_jump.len(), 1);
+        let hop = &target.proxy_jump[0];
+        assert_eq!(hop.host, "bastion.example.com");
+        assert_eq!(hop.username, "bob");
+        assert_eq!(hop.port, 2222);
+    }
+
+    #[test]
+    fn multi_hop_preserves_outer_to_inner_order() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "config",
+            "\
+Host target
+    ProxyJump edge,bastion
+
+Host edge
+    HostName edge.example.com
+    User e
+
+Host bastion
+    HostName bastion.example.com
+    User b
+",
+        );
+
+        let hosts = parse_ssh_config_hosts(&path).unwrap();
+        let target = hosts.iter().find(|h| h.name == "target").unwrap();
+        assert_eq!(target.proxy_jump.len(), 2);
+        assert_eq!(target.proxy_jump[0].host, "edge.example.com");
+        assert_eq!(target.proxy_jump[1].host, "bastion.example.com");
+    }
+
+    #[test]
+    fn proxy_jump_none_is_excluded() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "config",
+            "\
+Host direct
+    HostName direct.example.com
+    ProxyJump none
+",
+        );
+
+        let hosts = parse_ssh_config_hosts(&path).unwrap();
+        assert!(
+            !hosts.iter().any(|h| h.name == "direct"),
+            "a `ProxyJump none` host must not be importable"
+        );
+    }
+
+    #[test]
+    fn identity_file_maps_to_key_auth() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "config",
+            "\
+Host target
+    ProxyJump bastion
+
+Host bastion
+    HostName bastion.example.com
+    IdentityFile /home/me/.ssh/id_bastion
+",
+        );
+
+        let hosts = parse_ssh_config_hosts(&path).unwrap();
+        let hop = &hosts.iter().find(|h| h.name == "target").unwrap().proxy_jump[0];
+        assert_eq!(hop.auth_method, "key");
+        assert_eq!(hop.key_path.as_deref(), Some("/home/me/.ssh/id_bastion"));
+    }
+
+    #[test]
+    fn wildcard_and_negated_host_patterns_are_skipped() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "config",
+            "\
+Host *.example.com !secret.example.com
+    ProxyJump bastion
+
+Host bastion
+    HostName bastion.example.com
+",
+        );
+
+        let hosts = parse_ssh_config_hosts(&path).unwrap();
+        assert!(
+            hosts.is_empty(),
+            "wildcard/negated patterns are not concrete importable hosts"
+        );
+    }
+
+    #[test]
+    fn include_pulls_hosts_from_referenced_file() {
+        let dir = TempDir::new().unwrap();
+        let included = write_file(
+            &dir,
+            "included.conf",
+            "\
+Host target
+    ProxyJump bastion
+
+Host bastion
+    HostName bastion.example.com
+    User b
+",
+        );
+        // An absolute Include path is opened as-is by the parser.
+        let path = write_file(&dir, "config", &format!("Include {}\n", included.display()));
+
+        let hosts = parse_ssh_config_hosts(&path).unwrap();
+        let target = hosts.iter().find(|h| h.name == "target");
+        assert!(target.is_some(), "host from Included file must appear");
+        assert_eq!(target.unwrap().proxy_jump[0].host, "bastion.example.com");
+    }
+
+    #[test]
+    fn hop_without_own_stanza_falls_back_to_alias() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "config",
+            "\
+Host target
+    ProxyJump lonelybastion
+",
+        );
+
+        let hosts = parse_ssh_config_hosts(&path).unwrap();
+        let hop = &hosts.iter().find(|h| h.name == "target").unwrap().proxy_jump[0];
+        assert_eq!(hop.host, "lonelybastion");
+        assert_eq!(hop.port, 22);
+    }
+
+    #[test]
+    fn inline_user_and_port_in_proxyjump_spec_win() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "config",
+            "\
+Host target
+    ProxyJump carol@bastion:2201
+
+Host bastion
+    HostName bastion.example.com
+    User ignored
+    Port 22
+",
+        );
+
+        let hosts = parse_ssh_config_hosts(&path).unwrap();
+        let hop = &hosts.iter().find(|h| h.name == "target").unwrap().proxy_jump[0];
+        assert_eq!(hop.host, "bastion.example.com");
+        assert_eq!(hop.username, "carol");
+        assert_eq!(hop.port, 2201);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -662,6 +662,7 @@ pub fn run() {
             commands::session::cancel_connecting,
             commands::connection_path::probe_connection_path_cmd,
             commands::connection_path::cancel_connection_path_probe,
+            commands::ssh_config_import::import_ssh_config_hosts,
             commands::session::get_connection_types,
             commands::session::send_input,
             commands::session::set_session_line_ending,

--- a/src/components/ConnectionEditor/ConnectionEditor.css
+++ b/src/components/ConnectionEditor/ConnectionEditor.css
@@ -371,6 +371,23 @@
   text-decoration: underline;
 }
 
+.jump-host__import {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  color: var(--text-accent, var(--focus-border));
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  padding: var(--spacing-xs) 0;
+}
+
+.jump-host__import:hover {
+  text-decoration: underline;
+}
+
 .jump-host__errors {
   display: flex;
   align-items: flex-start;

--- a/src/components/ConnectionEditor/JumpHostSection.import.test.tsx
+++ b/src/components/ConnectionEditor/JumpHostSection.import.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { JumpHostConfig, SshConfigImportHost } from "@/types/connection";
+import { JumpHostSection } from "./JumpHostSection";
+import { importSshConfigHosts } from "@/services/api";
+
+// The section only pulls `importSshConfigHosts` from the api layer; a disabled
+// section (no hops) renders no JumpHostEntry, so nothing else touches api here.
+vi.mock("@/services/api", () => ({
+  importSshConfigHosts: vi.fn(),
+}));
+
+const mockedImport = vi.mocked(importSshConfigHosts);
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const IMPORTABLE: SshConfigImportHost[] = [
+  {
+    name: "prod-target",
+    proxyJump: [
+      { host: "edge.example.com", port: 22, username: "e", authMethod: "agent" },
+      { host: "bastion.example.com", port: 2222, username: "b", authMethod: "key" },
+    ],
+  },
+];
+
+describe("JumpHostSection — import from ~/.ssh/config", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockedImport.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("exposes an import action even when jump hosts are disabled", () => {
+    act(() => {
+      root.render(
+        <JumpHostSection value={undefined} targetHost="target" onChange={vi.fn()} />
+      );
+    });
+    expect(query("jump-host-import-open")).toBeTruthy();
+  });
+
+  it("selecting an imported host calls onChange with the resolved hop chain", async () => {
+    mockedImport.mockResolvedValue(IMPORTABLE);
+    const onChange = vi.fn<(hops: JumpHostConfig[] | undefined) => void>();
+    act(() => {
+      root.render(
+        <JumpHostSection value={undefined} targetHost="target" onChange={onChange} />
+      );
+    });
+
+    act(() => {
+      query("jump-host-import-open")!.click();
+    });
+    await flush();
+
+    act(() => {
+      (
+        document.querySelector(
+          '[data-testid="ssh-config-import-host-prod-target"]'
+        ) as HTMLElement
+      ).click();
+    });
+
+    expect(onChange).toHaveBeenCalledWith(IMPORTABLE[0].proxyJump);
+  });
+});

--- a/src/components/ConnectionEditor/JumpHostSection.import.test.tsx
+++ b/src/components/ConnectionEditor/JumpHostSection.import.test.tsx
@@ -53,9 +53,7 @@ describe("JumpHostSection — import from ~/.ssh/config", () => {
 
   it("exposes an import action even when jump hosts are disabled", () => {
     act(() => {
-      root.render(
-        <JumpHostSection value={undefined} targetHost="target" onChange={vi.fn()} />
-      );
+      root.render(<JumpHostSection value={undefined} targetHost="target" onChange={vi.fn()} />);
     });
     expect(query("jump-host-import-open")).toBeTruthy();
   });
@@ -64,9 +62,7 @@ describe("JumpHostSection — import from ~/.ssh/config", () => {
     mockedImport.mockResolvedValue(IMPORTABLE);
     const onChange = vi.fn<(hops: JumpHostConfig[] | undefined) => void>();
     act(() => {
-      root.render(
-        <JumpHostSection value={undefined} targetHost="target" onChange={onChange} />
-      );
+      root.render(<JumpHostSection value={undefined} targetHost="target" onChange={onChange} />);
     });
 
     act(() => {
@@ -76,9 +72,7 @@ describe("JumpHostSection — import from ~/.ssh/config", () => {
 
     act(() => {
       (
-        document.querySelector(
-          '[data-testid="ssh-config-import-host-prod-target"]'
-        ) as HTMLElement
+        document.querySelector('[data-testid="ssh-config-import-host-prod-target"]') as HTMLElement
       ).click();
     });
 

--- a/src/components/ConnectionEditor/JumpHostSection.tsx
+++ b/src/components/ConnectionEditor/JumpHostSection.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo } from "react";
-import { ArrowLeftRight, Plus, Trash2, AlertTriangle } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { ArrowLeftRight, Plus, Trash2, AlertTriangle, FileDown } from "lucide-react";
 import type { JumpHostConfig } from "@/types/connection";
 import type { SavedConnectionOption } from "@/utils/jumpHost";
 import { JumpHostEntry } from "./JumpHostEntry";
 import { JumpHostPathDisplay } from "./JumpHostPathDisplay";
+import { SshConfigImportDialog } from "./SshConfigImportDialog";
 
 interface JumpHostSectionProps {
   /** Current `proxyJump` chain from the SSH connection settings. */
@@ -50,6 +51,15 @@ export function JumpHostSection({
 }: JumpHostSectionProps) {
   const hops = useMemo(() => value ?? [], [value]);
   const enabled = hops.length > 0;
+  const [importOpen, setImportOpen] = useState(false);
+
+  /** Replace the chain with an imported one (enables the section if it was off). */
+  const importChain = useCallback(
+    (imported: JumpHostConfig[]) => {
+      onChange(imported.length > 0 ? imported : undefined);
+    },
+    [onChange]
+  );
 
   /** Display host for the connection-path summary: a referenced hop shows its
    * connection's label rather than its (editor-empty) inline host. */
@@ -106,6 +116,22 @@ export function JumpHostSection({
           Connect through a jump host
         </span>
       </label>
+
+      <button
+        type="button"
+        className="jump-host__import"
+        onClick={() => setImportOpen(true)}
+        data-testid="jump-host-import-open"
+      >
+        <FileDown size={13} aria-hidden />
+        Import from ~/.ssh/config
+      </button>
+
+      <SshConfigImportDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        onImport={importChain}
+      />
 
       {enabled && (
         <>

--- a/src/components/ConnectionEditor/SshConfigImportDialog.css
+++ b/src/components/ConnectionEditor/SshConfigImportDialog.css
@@ -1,0 +1,78 @@
+.ssh-config-import__status {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 0;
+  padding: 8px 0;
+}
+
+.ssh-config-import__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px 8px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.ssh-config-import__empty p {
+  margin: 0;
+  font-size: 13px;
+}
+
+.ssh-config-import__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.ssh-config-import__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.ssh-config-import__row:hover,
+.ssh-config-import__row:focus-visible {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+  border-color: var(--border-color, rgba(127, 127, 127, 0.25));
+}
+
+.ssh-config-import__row-icon {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+}
+
+.ssh-config-import__row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ssh-config-import__row-name {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.ssh-config-import__row-chain {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/ConnectionEditor/SshConfigImportDialog.test.tsx
+++ b/src/components/ConnectionEditor/SshConfigImportDialog.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { SshConfigImportHost } from "@/types/connection";
+import { SshConfigImportDialog } from "./SshConfigImportDialog";
+import { importSshConfigHosts } from "@/services/api";
+
+vi.mock("@/services/api", () => ({
+  importSshConfigHosts: vi.fn(),
+}));
+
+const mockedImport = vi.mocked(importSshConfigHosts);
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+/** Let the mocked promise resolve and effects flush. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const HOSTS: SshConfigImportHost[] = [
+  {
+    name: "target",
+    proxyJump: [{ host: "bastion.example.com", port: 2222, username: "bob", authMethod: "key" }],
+  },
+  {
+    name: "deep",
+    proxyJump: [
+      { host: "edge.example.com", port: 22, username: "e", authMethod: "agent" },
+      { host: "bastion.example.com", port: 22, username: "b", authMethod: "agent" },
+    ],
+  },
+];
+
+describe("SshConfigImportDialog", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockedImport.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when closed and does not query the config", () => {
+    mockedImport.mockResolvedValue([]);
+    render(
+      <SshConfigImportDialog open={false} onOpenChange={() => {}} onImport={() => {}} />
+    );
+    expect(document.querySelector('[data-testid="ssh-config-import-dialog"]')).toBeNull();
+    expect(mockedImport).not.toHaveBeenCalled();
+  });
+
+  it("lists hosts with a ProxyJump chain when opened", async () => {
+    mockedImport.mockResolvedValue(HOSTS);
+    render(<SshConfigImportDialog open onOpenChange={() => {}} onImport={() => {}} />);
+    await flush();
+
+    expect(document.querySelector('[data-testid="ssh-config-import-list"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="ssh-config-import-host-target"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="ssh-config-import-host-deep"]')).toBeTruthy();
+  });
+
+  it("selecting a host calls onImport with its hop chain and closes", async () => {
+    mockedImport.mockResolvedValue(HOSTS);
+    const onImport = vi.fn();
+    const onOpenChange = vi.fn();
+    render(<SshConfigImportDialog open onOpenChange={onOpenChange} onImport={onImport} />);
+    await flush();
+
+    act(() => {
+      (
+        document.querySelector('[data-testid="ssh-config-import-host-target"]') as HTMLElement
+      ).click();
+    });
+
+    expect(onImport).toHaveBeenCalledWith(HOSTS[0].proxyJump);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows a friendly empty state when no ProxyJump hosts exist", async () => {
+    mockedImport.mockResolvedValue([]);
+    render(<SshConfigImportDialog open onOpenChange={() => {}} onImport={() => {}} />);
+    await flush();
+
+    expect(document.querySelector('[data-testid="ssh-config-import-empty"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="ssh-config-import-list"]')).toBeNull();
+  });
+
+  it("shows an error state (no crash) when the query rejects", async () => {
+    mockedImport.mockRejectedValue(new Error("boom"));
+    render(<SshConfigImportDialog open onOpenChange={() => {}} onImport={() => {}} />);
+    await flush();
+
+    expect(document.querySelector('[data-testid="ssh-config-import-error"]')).toBeTruthy();
+  });
+});

--- a/src/components/ConnectionEditor/SshConfigImportDialog.test.tsx
+++ b/src/components/ConnectionEditor/SshConfigImportDialog.test.tsx
@@ -58,9 +58,7 @@ describe("SshConfigImportDialog", () => {
 
   it("renders nothing when closed and does not query the config", () => {
     mockedImport.mockResolvedValue([]);
-    render(
-      <SshConfigImportDialog open={false} onOpenChange={() => {}} onImport={() => {}} />
-    );
+    render(<SshConfigImportDialog open={false} onOpenChange={() => {}} onImport={() => {}} />);
     expect(document.querySelector('[data-testid="ssh-config-import-dialog"]')).toBeNull();
     expect(mockedImport).not.toHaveBeenCalled();
   });

--- a/src/components/ConnectionEditor/SshConfigImportDialog.tsx
+++ b/src/components/ConnectionEditor/SshConfigImportDialog.tsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from "react";
+import { FileDown, Server, AlertTriangle } from "lucide-react";
 import { Modal } from "@/components/ui";
-import type { JumpHostConfig } from "@/types/connection";
+import type { JumpHostConfig, SshConfigImportHost } from "@/types/connection";
+import { importSshConfigHosts } from "@/services/api";
 import "./SshConfigImportDialog.css";
 
 interface SshConfigImportDialogProps {
@@ -9,22 +12,108 @@ interface SshConfigImportDialogProps {
   onImport: (hops: JumpHostConfig[]) => void;
 }
 
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready"; hosts: SshConfigImportHost[] }
+  | { status: "error" };
+
+/** One-line summary of a hop chain, e.g. `bob@bastion.example.com → carol@edge`. */
+function chainSummary(hops: JumpHostConfig[]): string {
+  return hops
+    .map((h) => {
+      const port = h.port && h.port !== 22 ? `:${h.port}` : "";
+      return h.username ? `${h.username}@${h.host}${port}` : `${h.host}${port}`;
+    })
+    .join(" → ");
+}
+
 /**
  * Picker for importing a `ProxyJump` chain from the user's `~/.ssh/config`
- * (#1702). Implemented in the follow-up feat commit; this stub only renders the
- * dialog shell so the tests have a mount point.
+ * (#1702). Lists the config hosts that declare a `ProxyJump`; selecting one
+ * hands its resolved hop chain to {@link SshConfigImportDialogProps.onImport}
+ * (which populates the editor's jump-host fields for review) and closes.
+ *
+ * A missing / empty / unparseable config yields a friendly empty state, never
+ * an error toast — the backend already degrades those cases to an empty list.
  */
-export function SshConfigImportDialog({ open, onOpenChange }: SshConfigImportDialogProps) {
+export function SshConfigImportDialog({
+  open,
+  onOpenChange,
+  onImport,
+}: SshConfigImportDialogProps) {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setState({ status: "loading" });
+    importSshConfigHosts()
+      .then((hosts) => {
+        if (!cancelled) setState({ status: "ready", hosts: hosts ?? [] });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const handleSelect = (host: SshConfigImportHost) => {
+    onImport(host.proxyJump);
+    onOpenChange(false);
+  };
+
   return (
     <Modal
       open={open}
       onOpenChange={onOpenChange}
       title="Import from ~/.ssh/config"
+      description="Pick a host from your OpenSSH client config to populate the jump-host chain."
       data-testid="ssh-config-import-dialog"
     >
-      <p className="ssh-config-import__status" data-testid="ssh-config-import-loading">
-        Reading ~/.ssh/config…
-      </p>
+      {state.status === "loading" && (
+        <p className="ssh-config-import__status" data-testid="ssh-config-import-loading">
+          Reading ~/.ssh/config…
+        </p>
+      )}
+
+      {state.status === "error" && (
+        <div className="ssh-config-import__empty" data-testid="ssh-config-import-error">
+          <AlertTriangle size={20} aria-hidden />
+          <p>Could not read ~/.ssh/config.</p>
+        </div>
+      )}
+
+      {state.status === "ready" && state.hosts.length === 0 && (
+        <div className="ssh-config-import__empty" data-testid="ssh-config-import-empty">
+          <Server size={20} aria-hidden />
+          <p>No hosts with a ProxyJump were found in ~/.ssh/config.</p>
+        </div>
+      )}
+
+      {state.status === "ready" && state.hosts.length > 0 && (
+        <ul className="ssh-config-import__list" data-testid="ssh-config-import-list">
+          {state.hosts.map((host) => (
+            <li key={host.name}>
+              <button
+                type="button"
+                className="ssh-config-import__row"
+                onClick={() => handleSelect(host)}
+                data-testid={`ssh-config-import-host-${host.name}`}
+              >
+                <FileDown size={14} aria-hidden className="ssh-config-import__row-icon" />
+                <span className="ssh-config-import__row-text">
+                  <span className="ssh-config-import__row-name">{host.name}</span>
+                  <span className="ssh-config-import__row-chain">
+                    {chainSummary(host.proxyJump)}
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </Modal>
   );
 }

--- a/src/components/ConnectionEditor/SshConfigImportDialog.tsx
+++ b/src/components/ConnectionEditor/SshConfigImportDialog.tsx
@@ -1,0 +1,30 @@
+import { Modal } from "@/components/ui";
+import type { JumpHostConfig } from "@/types/connection";
+import "./SshConfigImportDialog.css";
+
+interface SshConfigImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the selected host's resolved hop chain. */
+  onImport: (hops: JumpHostConfig[]) => void;
+}
+
+/**
+ * Picker for importing a `ProxyJump` chain from the user's `~/.ssh/config`
+ * (#1702). Implemented in the follow-up feat commit; this stub only renders the
+ * dialog shell so the tests have a mount point.
+ */
+export function SshConfigImportDialog({ open, onOpenChange }: SshConfigImportDialogProps) {
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Import from ~/.ssh/config"
+      data-testid="ssh-config-import-dialog"
+    >
+      <p className="ssh-config-import__status" data-testid="ssh-config-import-loading">
+        Reading ~/.ssh/config…
+      </p>
+    </Modal>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,6 +20,7 @@ import {
   SavedConnection,
   ConnectionFolder,
   ConnectionTypeInfo,
+  SshConfigImportHost,
   FileEntry,
   Writability,
   ExternalFileError,
@@ -102,6 +103,16 @@ export async function probeConnectionPath(
  */
 export async function cancelConnectionPathProbe(probeId: string): Promise<boolean> {
   return await invoke<boolean>("cancel_connection_path_probe", { probeId });
+}
+
+/**
+ * Read the user's `~/.ssh/config` (plus any `Include`d files) and return the
+ * hosts that declare a `ProxyJump`, with each hop resolved to editor-shaped
+ * {@link SshConfigImportHost}s (#1702). Missing / empty / unparseable config
+ * degrades to an empty list on the backend — never an error.
+ */
+export async function importSshConfigHosts(): Promise<SshConfigImportHost[]> {
+  return await invoke<SshConfigImportHost[]>("import_ssh_config_hosts");
 }
 
 /**

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -129,6 +129,19 @@ export interface SshEditorSettings {
   proxyJump?: JumpHostConfig[];
 }
 
+/**
+ * A host from the user's `~/.ssh/config` that declares a `ProxyJump`, offered
+ * for one-shot import into the first-class jump-host editor (#1702).
+ *
+ * `name` is the OpenSSH `Host` alias; `proxyJump` is the resolved hop chain
+ * (outermost → innermost), reusing the same {@link JumpHostConfig} shape the
+ * editor stores so it drops straight into a connection's `proxyJump` array.
+ */
+export interface SshConfigImportHost {
+  name: string;
+  proxyJump: JumpHostConfig[];
+}
+
 export type ConnectionTreeItem =
   | { type: "folder"; folder: ConnectionFolder }
   | { type: "connection"; connection: SavedConnection };


### PR DESCRIPTION
## What & why

Users with an existing OpenSSH setup had to retype their bastion chain into termiHub's first-class jump-host editor. This adds a one-shot **import from `~/.ssh/config`** so a host's `ProxyJump` chain pre-populates the editor fields.

Builds on the delivered jump-host stack (#520, #872). Populates the **jump-host chain only** — importing whole connections is out of scope (follow-up filed).

## Changes

- **Backend** — new `import_ssh_config_hosts` Tauri command (`src-tauri/src/commands/ssh_config_import.rs`, registered in `lib.rs`). Parses the OpenSSH client config (plus `Include`d files) with the **`ssh2-config`** crate, enumerates `Host` stanzas that declare a `ProxyJump`, and resolves each hop against its own stanza (`Hostname`/`User`/`Port`/`IdentityFile`) into `JumpHostConfig`-shaped data. Skips wildcard/negated patterns and `ProxyJump none`; inline `user@host:port` in a spec wins over the stanza. Missing/empty/unparseable config → empty list (never an error).
- **Frontend** — `SshConfigImportDialog` picker composed from the shared `Modal` primitive, an **Import from ~/.ssh/config** action in `JumpHostSection`, and an `api.ts` wrapper. Selecting a host routes its resolved chain through the section's existing `onChange` (`handleJumpHostChange`), enabling + populating the fields for review. Import fills fields only — nothing persists until the user saves. Friendly empty/error states.
- Reuses `JumpHostConfig` via a new `SshConfigImportHost` type in `connection.ts`.

## Library note

Per the repo's library-first rule, parsing is delegated to `ssh2-config` (0.7) rather than hand-rolled. Heads-up for review: `ssh2-config` ≥0.5 carries a **`git2` build-dependency** (its build script regenerates default SSH algorithms only when `RELOAD_SSH_ALGO` is set, but the build-dep still compiles), which pulls `libgit2-sys`/`libssh2-sys`/`openssl-sys` into a previously all-rustls tree. `proxy_jump` support requires ≥0.5, so an earlier git2-free version (0.4.0) is not an option. The extra native compile is build-time only; no openssl on the runtime/link path for the app itself.

## Tests

- Rust unit tests (9): single/multi-hop ordering, `ProxyJump none`, `Include`, wildcard/negated skip, inline `user@host:port`, identity-file → key auth, hop without its own stanza, missing file.
- Component tests: dialog lists hosts / empty state / error state / selection fires `onImport`; and a `JumpHostSection` test proving selection calls the section's `onChange` with the resolved chain.

## Follow-ups

- Import whole connections (target host/user/port/identity) from `~/.ssh/config` — filed as a separate `Ready2Implement` issue.

Closes #1702