### PR TITLE
feat(macro): import/export macros as files

### DIFF
--- a/docs/changes/dev1/feature/1677-macro-import-export.md
+++ b/docs/changes/dev1/feature/1677-macro-import-export.md
@@ -1,0 +1,12 @@
+### Added
+
+- Import and export macros as portable JSON files, so macros can be shared
+  between machines and users. The Macro Manager panel gains an **Export All**
+  and an **Import** toolbar button, and each macro row gains an **Export**
+  action for exporting a single macro. Exports use a small, explicit, versioned
+  envelope (`{ version, macros: [...] }`) rather than the raw internal store, so
+  the format is stable. On import, files are validated (a malformed or
+  incompatible file fails with a clear, recoverable toast and never touches the
+  existing library), imported macros are assigned fresh ids, and any name that
+  collides with an existing macro is de-duplicated with an "(imported)" suffix.
+  (#1677, epic #1670)

--- a/src/components/MacroSidebar/MacroListItem.tsx
+++ b/src/components/MacroSidebar/MacroListItem.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { Play, Pencil, Copy, Trash2 } from "lucide-react";
+import { Play, Pencil, Copy, Download, Trash2 } from "lucide-react";
 import { Button, Tooltip } from "@/components/ui";
 import { SidebarListItem } from "@/components/SidebarListItem";
 import type { Macro } from "@/types/macro";
@@ -10,6 +10,7 @@ interface MacroListItemProps {
   onPlay: (macroId: string) => void;
   onEdit: (macroId: string) => void;
   onDuplicate: (macroId: string) => void;
+  onExport: (macroId: string) => void;
   onDelete: (macroId: string) => void;
   /** Roving-tabindex ref wiring the row into the sidebar's keyboard navigation. */
   rowRef?: (el: HTMLDivElement | null) => void;
@@ -28,6 +29,7 @@ export function MacroListItem({
   onPlay,
   onEdit,
   onDuplicate,
+  onExport,
   onDelete,
   rowRef,
   rowProps,
@@ -86,6 +88,20 @@ export function MacroListItem({
               onClick={(e) => {
                 e.stopPropagation();
                 onDuplicate(macro.id);
+              }}
+            />
+          </Tooltip>
+          <Tooltip content="Export" side="top">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label="Export"
+              data-testid={`macro-export-${macro.id}`}
+              icon={<Download size={12} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                onExport(macro.id);
               }}
             />
           </Tooltip>

--- a/src/components/MacroSidebar/MacroSidebar.test.tsx
+++ b/src/components/MacroSidebar/MacroSidebar.test.tsx
@@ -13,6 +13,20 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockResolvedValue(vi.fn()),
 }));
 
+const dialogSave = vi.fn();
+const dialogOpen = vi.fn();
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  save: (...args: unknown[]) => dialogSave(...args),
+  open: (...args: unknown[]) => dialogOpen(...args),
+}));
+
+const fsWriteTextFile = vi.fn();
+const fsReadTextFile = vi.fn();
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  writeTextFile: (...args: unknown[]) => fsWriteTextFile(...args),
+  readTextFile: (...args: unknown[]) => fsReadTextFile(...args),
+}));
+
 vi.mock("@/themes", () => ({
   applyTheme: vi.fn(),
   onThemeChange: vi.fn(),
@@ -92,6 +106,7 @@ describe("MacroSidebar", () => {
       playMacro: vi.fn().mockResolvedValue(undefined),
       saveMacroToBackend: vi.fn().mockResolvedValue(undefined),
       deleteMacroFromBackend: vi.fn().mockResolvedValue(undefined),
+      importMacros: vi.fn().mockResolvedValue(0),
     });
   });
 
@@ -207,5 +222,98 @@ describe("MacroSidebar", () => {
     act(() => (query("macro-edit-macro-1") as HTMLButtonElement).click());
     expect(query("macro-editor-dialog")).not.toBeNull();
     expect((query("macro-editor-name") as HTMLInputElement).value).toBe("Deploy sequence");
+  });
+
+  it("disables Export All when there are no macros", () => {
+    render();
+    expect((query("macro-export-all-btn") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("exports the whole library to a chosen file", async () => {
+    useAppStore.setState({ macros: sampleMacros });
+    dialogSave.mockResolvedValue("/tmp/macros.json");
+    fsWriteTextFile.mockResolvedValue(undefined);
+    render();
+
+    act(() => (query("macro-export-all-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(fsWriteTextFile).toHaveBeenCalledTimes(1);
+    const [, written] = fsWriteTextFile.mock.calls[0];
+    const envelope = JSON.parse(written as string);
+    expect(envelope.macros).toHaveLength(2);
+    expect(toastSuccess).toHaveBeenCalledWith("Exported 2 macros");
+  });
+
+  it("exports a single macro from its row action", async () => {
+    useAppStore.setState({ macros: sampleMacros });
+    dialogSave.mockResolvedValue("/tmp/macro.json");
+    fsWriteTextFile.mockResolvedValue(undefined);
+    render();
+
+    act(() => (query("macro-export-macro-1") as HTMLButtonElement).click());
+    await flush();
+
+    const [, written] = fsWriteTextFile.mock.calls[0];
+    const envelope = JSON.parse(written as string);
+    expect(envelope.macros).toHaveLength(1);
+    expect(envelope.macros[0].name).toBe("Deploy sequence");
+    expect(toastSuccess).toHaveBeenCalledWith('Exported "Deploy sequence"');
+  });
+
+  it("shows no toast when the export dialog is cancelled", async () => {
+    useAppStore.setState({ macros: sampleMacros });
+    dialogSave.mockResolvedValue(null);
+    render();
+
+    act(() => (query("macro-export-all-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(fsWriteTextFile).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("imports macros from a chosen file", async () => {
+    const importMacros = vi.fn().mockResolvedValue(3);
+    useAppStore.setState({ macros: [], importMacros });
+    dialogOpen.mockResolvedValue("/tmp/macros.json");
+    fsReadTextFile.mockResolvedValue('{"version":1,"macros":[]}');
+    render();
+
+    act(() => (query("macro-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(importMacros).toHaveBeenCalledWith('{"version":1,"macros":[]}');
+    expect(toastSuccess).toHaveBeenCalledWith("Imported 3 macros");
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast when the import file is malformed", async () => {
+    const importMacros = vi.fn().mockRejectedValue(new Error("Invalid macro file"));
+    useAppStore.setState({ macros: [], importMacros });
+    dialogOpen.mockResolvedValue("/tmp/bad.json");
+    fsReadTextFile.mockResolvedValue("{not json");
+    render();
+
+    act(() => (query("macro-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("shows no toast when the import dialog is cancelled", async () => {
+    const importMacros = vi.fn().mockResolvedValue(0);
+    useAppStore.setState({ macros: [], importMacros });
+    dialogOpen.mockResolvedValue(null);
+    render();
+
+    act(() => (query("macro-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(importMacros).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
   });
 });

--- a/src/components/MacroSidebar/MacroSidebar.tsx
+++ b/src/components/MacroSidebar/MacroSidebar.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useMemo, useState } from "react";
-import { Circle, Search } from "lucide-react";
+import { Circle, Download, Search, Upload } from "lucide-react";
+import { save, open } from "@tauri-apps/plugin-dialog";
+import { writeTextFile, readTextFile } from "@tauri-apps/plugin-fs";
 import { useAppStore } from "@/store/appStore";
 import { Button, Input, toast, Tooltip } from "@/components/ui";
 import { ConfirmDeleteDialog } from "@/components/Sidebar/ConfirmDeleteDialog";
 import { useFlatRovingNav } from "@/hooks/useFlatRovingNav";
+import { serializeMacros } from "@/services/macroIo";
 import type { Macro } from "@/types/macro";
 import { MacroListItem } from "./MacroListItem";
 import { MacroEditorDialog, type MacroEditorResult } from "./MacroEditorDialog";
@@ -16,6 +19,15 @@ function generateMacroId(): string {
     return `macro-${c.randomUUID()}`;
   }
   return `macro-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Turn a macro name into a filesystem-friendly slug for the default filename. */
+function slugifyMacroName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "macro";
 }
 
 /** True when the macro matches the (already lower-cased) query across name/description/tags. */
@@ -31,12 +43,14 @@ function macroMatches(macro: Macro, query: string): boolean {
  * macros. Macros are recorded from the terminal toolbar and played back into the
  * active terminal; this panel is their home for organisation. Composed from the
  * shared UI primitives and the sidebar list-item shell, mirroring the workspace
- * and tunnel managers. Import/export is intentionally out of scope here (#1677).
+ * and tunnel managers. Macros can also be exported to / imported from portable
+ * JSON files, so they can be shared between machines (#1677).
  */
 export function MacroSidebar() {
   const macros = useAppStore((s) => s.macros);
   const saveMacroToBackend = useAppStore((s) => s.saveMacroToBackend);
   const deleteMacroFromBackend = useAppStore((s) => s.deleteMacroFromBackend);
+  const importMacros = useAppStore((s) => s.importMacros);
   const playMacro = useAppStore((s) => s.playMacro);
   const startMacroRecording = useAppStore((s) => s.startMacroRecording);
 
@@ -90,6 +104,67 @@ export function MacroSidebar() {
     },
     [macros, saveMacroToBackend]
   );
+
+  // Write a serialized macro payload to a user-chosen file. A cancelled save
+  // dialog returns null before any write, so it is a silent no-op; only a real
+  // write failure surfaces an error toast.
+  const writeMacrosToFile = useCallback(
+    async (payload: Macro[], defaultPath: string, successMessage: string) => {
+      try {
+        const filePath = await save({
+          defaultPath,
+          filters: [{ name: "JSON", extensions: ["json"] }],
+        });
+        if (!filePath) return;
+        await writeTextFile(filePath, serializeMacros(payload));
+        toast.success(successMessage);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(`Failed to export macros: ${message}`);
+      }
+    },
+    []
+  );
+
+  const handleExportAll = useCallback(() => {
+    void writeMacrosToFile(
+      macros,
+      "termihub-macros.json",
+      `Exported ${macros.length} macro${macros.length === 1 ? "" : "s"}`
+    );
+  }, [macros, writeMacrosToFile]);
+
+  const handleExportOne = useCallback(
+    (macroId: string) => {
+      const macro = macros.find((m) => m.id === macroId);
+      if (!macro) return;
+      void writeMacrosToFile(
+        [macro],
+        `termihub-macro-${slugifyMacroName(macro.name)}.json`,
+        `Exported "${macro.name}"`
+      );
+    },
+    [macros, writeMacrosToFile]
+  );
+
+  const handleImport = useCallback(async () => {
+    // A cancelled open dialog is a silent no-op. A parse/validation failure is
+    // reported so the user knows nothing was imported (and the library is left
+    // untouched — importMacros validates before any backend write).
+    const filePath = await open({
+      multiple: false,
+      filters: [{ name: "JSON", extensions: ["json"] }],
+    });
+    if (!filePath || Array.isArray(filePath)) return;
+    try {
+      const json = await readTextFile(filePath);
+      const count = await importMacros(json);
+      toast.success(`Imported ${count} macro${count === 1 ? "" : "s"}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to import macros: ${message}`);
+    }
+  }, [importMacros]);
 
   const handleDelete = useCallback(
     (macroId: string) => {
@@ -161,6 +236,29 @@ export function MacroSidebar() {
             Record New
           </Button>
         </Tooltip>
+        <Tooltip content="Export All Macros" side="top">
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            icon={<Download size={14} />}
+            onClick={handleExportAll}
+            disabled={macros.length === 0}
+            aria-label="Export All Macros"
+            data-testid="macro-export-all-btn"
+          />
+        </Tooltip>
+        <Tooltip content="Import Macros" side="top">
+          <Button
+            variant="ghost"
+            size="sm"
+            iconOnly
+            icon={<Upload size={14} />}
+            onClick={handleImport}
+            aria-label="Import Macros"
+            data-testid="macro-import-btn"
+          />
+        </Tooltip>
       </div>
       <div className="macro-sidebar__search">
         <Search size={14} className="macro-sidebar__search-icon" aria-hidden="true" />
@@ -204,6 +302,7 @@ export function MacroSidebar() {
                 onPlay={handlePlay}
                 onEdit={handleEdit}
                 onDuplicate={handleDuplicate}
+                onExport={handleExportOne}
                 onDelete={handleDelete}
                 rowRef={ref}
                 rowProps={itemProps}

--- a/src/services/macroIo.test.ts
+++ b/src/services/macroIo.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the macro import/export helpers (#1677).
+ *
+ * Covers the versioned envelope serialise/deserialise round-trip, rejection of
+ * malformed/incompatible files with clear errors, and deterministic id/name
+ * collision handling when merging imported macros into an existing library.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  MACRO_EXPORT_VERSION,
+  serializeMacros,
+  parseMacroEnvelope,
+  resolveImportCollisions,
+} from "./macroIo";
+import type { Macro } from "@/types/macro";
+
+function makeMacro(overrides: Partial<Macro> = {}): Macro {
+  return {
+    id: "macro-1",
+    name: "Deploy",
+    description: "Runs deploy",
+    tags: ["ops"],
+    steps: [{ data: "deploy\r", delayMs: 0 }],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("macroIo — serialize/parse envelope", () => {
+  it("wraps macros in a versioned envelope", () => {
+    const json = serializeMacros([makeMacro()]);
+    const parsed = JSON.parse(json);
+    expect(parsed.version).toBe(MACRO_EXPORT_VERSION);
+    expect(parsed.macros).toHaveLength(1);
+    expect(parsed.macros[0].name).toBe("Deploy");
+  });
+
+  it("round-trips a macro to an equivalent, runnable macro", () => {
+    const original = makeMacro({
+      steps: [
+        { data: "cd /srv\r", delayMs: 0 },
+        { data: "ls -la\r", delayMs: 250 },
+      ],
+    });
+    const macros = parseMacroEnvelope(serializeMacros([original]));
+    expect(macros).toHaveLength(1);
+    expect(macros[0].name).toBe(original.name);
+    expect(macros[0].description).toBe(original.description);
+    expect(macros[0].tags).toEqual(original.tags);
+    expect(macros[0].steps).toEqual(original.steps);
+  });
+
+  it("round-trips the whole library", () => {
+    const lib = [makeMacro({ id: "a", name: "A" }), makeMacro({ id: "b", name: "B" })];
+    const macros = parseMacroEnvelope(serializeMacros(lib));
+    expect(macros.map((m) => m.name)).toEqual(["A", "B"]);
+  });
+
+  it("tolerates a macro with no description or tags", () => {
+    const macros = parseMacroEnvelope(
+      JSON.stringify({
+        version: MACRO_EXPORT_VERSION,
+        macros: [{ name: "Bare", steps: [{ data: "x", delayMs: 0 }] }],
+      })
+    );
+    expect(macros[0].name).toBe("Bare");
+    expect(macros[0].tags).toEqual([]);
+    expect(macros[0].description).toBeUndefined();
+  });
+});
+
+describe("macroIo — malformed/incompatible rejection", () => {
+  it("rejects invalid JSON", () => {
+    expect(() => parseMacroEnvelope("{not json")).toThrow(/not valid JSON/);
+  });
+
+  it("rejects a non-object payload", () => {
+    expect(() => parseMacroEnvelope("[]")).toThrow(/macro export object/);
+  });
+
+  it("rejects an unsupported version", () => {
+    const json = JSON.stringify({ version: 999, macros: [] });
+    expect(() => parseMacroEnvelope(json)).toThrow(/Unsupported macro file version/);
+  });
+
+  it("rejects a missing macros array", () => {
+    const json = JSON.stringify({ version: MACRO_EXPORT_VERSION });
+    expect(() => parseMacroEnvelope(json)).toThrow(/missing "macros" array/);
+  });
+
+  it("rejects a macro with no name", () => {
+    const json = JSON.stringify({
+      version: MACRO_EXPORT_VERSION,
+      macros: [{ steps: [] }],
+    });
+    expect(() => parseMacroEnvelope(json)).toThrow(/missing a name/);
+  });
+
+  it("rejects a macro whose steps are not an array", () => {
+    const json = JSON.stringify({
+      version: MACRO_EXPORT_VERSION,
+      macros: [{ name: "X", steps: "nope" }],
+    });
+    expect(() => parseMacroEnvelope(json)).toThrow(/missing its steps/);
+  });
+
+  it("rejects a malformed step", () => {
+    const json = JSON.stringify({
+      version: MACRO_EXPORT_VERSION,
+      macros: [{ name: "X", steps: [{ delayMs: 0 }] }],
+    });
+    expect(() => parseMacroEnvelope(json)).toThrow(/step 0 .* is malformed/);
+  });
+
+  it("rejects a step with a negative delay", () => {
+    const json = JSON.stringify({
+      version: MACRO_EXPORT_VERSION,
+      macros: [{ name: "X", steps: [{ data: "x", delayMs: -5 }] }],
+    });
+    expect(() => parseMacroEnvelope(json)).toThrow(/invalid delay/);
+  });
+});
+
+describe("macroIo — collision handling", () => {
+  const counter = () => {
+    let n = 0;
+    return () => `macro-new-${++n}`;
+  };
+
+  it("assigns fresh ids so imports never overwrite existing macros", () => {
+    const imported = [makeMacro({ id: "macro-1", name: "One" })];
+    const existing = [makeMacro({ id: "macro-1", name: "Existing" })];
+    const resolved = resolveImportCollisions(imported, existing, counter());
+    expect(resolved[0].id).toBe("macro-new-1");
+    expect(resolved[0].id).not.toBe("macro-1");
+  });
+
+  it("clears timestamps so the backend re-stamps them", () => {
+    const resolved = resolveImportCollisions([makeMacro()], [], counter());
+    expect(resolved[0].createdAt).toBe("");
+    expect(resolved[0].updatedAt).toBe("");
+  });
+
+  it("suffixes a name that collides with an existing macro", () => {
+    const imported = [makeMacro({ name: "Deploy" })];
+    const existing = [makeMacro({ name: "Deploy" })];
+    const resolved = resolveImportCollisions(imported, existing, counter());
+    expect(resolved[0].name).toBe("Deploy (imported)");
+  });
+
+  it("keeps a non-colliding name untouched", () => {
+    const resolved = resolveImportCollisions([makeMacro({ name: "Fresh" })], [], counter());
+    expect(resolved[0].name).toBe("Fresh");
+  });
+
+  it("de-duplicates names that collide within the same import batch", () => {
+    const imported = [
+      makeMacro({ name: "Deploy" }),
+      makeMacro({ name: "Deploy" }),
+      makeMacro({ name: "Deploy" }),
+    ];
+    const existing = [makeMacro({ name: "Deploy" })];
+    const resolved = resolveImportCollisions(imported, existing, counter());
+    expect(resolved.map((m) => m.name)).toEqual([
+      "Deploy (imported)",
+      "Deploy (imported 2)",
+      "Deploy (imported 3)",
+    ]);
+  });
+});

--- a/src/services/macroIo.ts
+++ b/src/services/macroIo.ts
@@ -1,0 +1,189 @@
+/**
+ * Import/export of macros as portable JSON files (#1677).
+ *
+ * These are pure, dependency-free helpers: serialising a set of macros into a
+ * small versioned envelope, validating/parsing an envelope back into macros, and
+ * resolving id/name collisions when merging imported macros into an existing
+ * library. File IO (the save/open dialogs) lives in the UI layer; keeping the
+ * serialise/validate/collision logic here makes it unit-testable in isolation.
+ */
+
+import type { Macro, MacroStep } from "@/types/macro";
+
+/**
+ * Current version of the macro export envelope. Bump only on an incompatible
+ * change to the on-disk shape; the parser rejects any other version so a newer
+ * file fails loudly rather than importing as a corrupt macro.
+ */
+export const MACRO_EXPORT_VERSION = 1;
+
+/**
+ * The stable, explicit on-disk shape for exported macros. A versioned wrapper
+ * around the macro list — deliberately NOT the raw internal store — so the file
+ * format can evolve independently of the runtime {@link Macro} type.
+ */
+export interface MacroExportEnvelope {
+  /** Envelope schema version; see {@link MACRO_EXPORT_VERSION}. */
+  version: number;
+  /** The exported macros. */
+  macros: Macro[];
+}
+
+/** Suffix appended to imported macro names that collide with an existing one. */
+const COLLISION_SUFFIX = "imported";
+
+/**
+ * Serialise macros into a pretty-printed export envelope string ready to write
+ * to a `.json` file. Works for a single macro (`[macro]`) or the whole library.
+ */
+export function serializeMacros(macros: Macro[]): string {
+  const envelope: MacroExportEnvelope = {
+    version: MACRO_EXPORT_VERSION,
+    macros,
+  };
+  return `${JSON.stringify(envelope, null, 2)}\n`;
+}
+
+/** Type guard: a JSON value is a non-null, non-array object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate one raw macro entry from an imported file, throwing a clear error
+ * that names the offending macro (by index) when a field is missing or the
+ * wrong type. Returns a normalised {@link Macro} — tolerant of a missing
+ * `description`/`tags`/`id`/timestamps since the importer re-stamps those, but
+ * strict about the load-bearing `name` and `steps`.
+ */
+function validateMacro(raw: unknown, index: number): Macro {
+  const where = `macro at index ${index}`;
+  if (!isRecord(raw)) {
+    throw new Error(`Invalid macro file: ${where} is not an object.`);
+  }
+  if (typeof raw.name !== "string" || raw.name.trim() === "") {
+    throw new Error(`Invalid macro file: ${where} is missing a name.`);
+  }
+  if (!Array.isArray(raw.steps)) {
+    throw new Error(`Invalid macro file: ${where} ("${raw.name}") is missing its steps.`);
+  }
+
+  const steps: MacroStep[] = raw.steps.map((step, stepIndex) => {
+    if (!isRecord(step) || typeof step.data !== "string") {
+      throw new Error(
+        `Invalid macro file: step ${stepIndex} of ${where} ("${raw.name}") is malformed.`
+      );
+    }
+    const delayMs = step.delayMs;
+    if (typeof delayMs !== "number" || !Number.isFinite(delayMs) || delayMs < 0) {
+      throw new Error(
+        `Invalid macro file: step ${stepIndex} of ${where} ("${raw.name}") has an invalid delay.`
+      );
+    }
+    return { data: step.data, delayMs };
+  });
+
+  let tags: string[] = [];
+  if (raw.tags !== undefined) {
+    if (!Array.isArray(raw.tags) || raw.tags.some((tag) => typeof tag !== "string")) {
+      throw new Error(`Invalid macro file: ${where} ("${raw.name}") has malformed tags.`);
+    }
+    tags = raw.tags as string[];
+  }
+
+  return {
+    id: typeof raw.id === "string" ? raw.id : "",
+    name: raw.name,
+    description: typeof raw.description === "string" ? raw.description : undefined,
+    tags,
+    steps,
+    createdAt: typeof raw.createdAt === "string" ? raw.createdAt : "",
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : "",
+  };
+}
+
+/**
+ * Parse and validate an exported-macro file, returning the macros it contains.
+ * Throws an `Error` with a human-readable, recoverable message for malformed
+ * JSON, a missing/unsupported envelope version, or any malformed macro — so a
+ * bad file never corrupts the library, it just surfaces a toast.
+ */
+export function parseMacroEnvelope(json: string): Macro[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("Invalid macro file: the file is not valid JSON.");
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("Invalid macro file: expected a macro export object.");
+  }
+  if (parsed.version !== MACRO_EXPORT_VERSION) {
+    throw new Error(
+      `Unsupported macro file version: ${String(parsed.version)} (expected ${MACRO_EXPORT_VERSION}).`
+    );
+  }
+  if (!Array.isArray(parsed.macros)) {
+    throw new Error('Invalid macro file: missing "macros" array.');
+  }
+
+  return parsed.macros.map((macro, index) => validateMacro(macro, index));
+}
+
+/** Default fresh-id generator; mirrors the store's `generateMacroId`. */
+function defaultGenerateId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") {
+    return `macro-${c.randomUUID()}`;
+  }
+  return `macro-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Given a desired name and the set of names already in use, return a unique name
+ * by appending "(imported)", then "(imported 2)", "(imported 3)", … until it no
+ * longer collides. Leaves the name untouched when there is no collision.
+ */
+function uniqueName(name: string, used: Set<string>): string {
+  if (!used.has(name)) return name;
+  let candidate = `${name} (${COLLISION_SUFFIX})`;
+  let n = 2;
+  while (used.has(candidate)) {
+    candidate = `${name} (${COLLISION_SUFFIX} ${n})`;
+    n += 1;
+  }
+  return candidate;
+}
+
+/**
+ * Prepare imported macros for merging into an existing library. Every imported
+ * macro is given a **fresh id** (so it never overwrites an existing macro, even
+ * when the file was exported from this same instance), has its create/update
+ * timestamps cleared (the backend re-stamps them on save), and gets a
+ * **deterministically de-duplicated name** — a name that already exists (in the
+ * library or earlier in this same batch) is suffixed with "(imported)".
+ *
+ * @param imported Macros parsed from a file (see {@link parseMacroEnvelope}).
+ * @param existing The current library, used for name-collision detection.
+ * @param generateId Injectable id generator (defaults to a crypto-based uuid).
+ */
+export function resolveImportCollisions(
+  imported: Macro[],
+  existing: Macro[],
+  generateId: () => string = defaultGenerateId
+): Macro[] {
+  const usedNames = new Set(existing.map((m) => m.name));
+  return imported.map((macro) => {
+    const name = uniqueName(macro.name, usedNames);
+    usedNames.add(name);
+    return {
+      ...macro,
+      id: generateId(),
+      name,
+      // Cleared so the backend stamps authoritative timestamps on save.
+      createdAt: "",
+      updatedAt: "",
+    };
+  });
+}

--- a/src/store/appStore.macroImport.test.ts
+++ b/src/store/appStore.macroImport.test.ts
@@ -43,10 +43,7 @@ vi.mock("@/services/macroApi", () => ({
 }));
 
 import { useAppStore } from "./appStore";
-import {
-  listMacros as apiListMacros,
-  saveMacro as apiSaveMacro,
-} from "@/services/macroApi";
+import { listMacros as apiListMacros, saveMacro as apiSaveMacro } from "@/services/macroApi";
 import type { Macro } from "@/types/macro";
 import { MACRO_EXPORT_VERSION } from "@/services/macroIo";
 

--- a/src/store/appStore.macroImport.test.ts
+++ b/src/store/appStore.macroImport.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for the macro import store action (#1677).
+ *
+ * Pins that importMacros parses+validates the file before touching the backend
+ * (a malformed file rejects and never calls saveMacro), assigns fresh ids and
+ * de-duplicated names on collision, saves each imported macro, and refreshes the
+ * list exactly once.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/macroApi", () => ({
+  listMacros: vi.fn(() => Promise.resolve([])),
+  getMacro: vi.fn(),
+  saveMacro: vi.fn((macro) => Promise.resolve(macro)),
+  deleteMacro: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import {
+  listMacros as apiListMacros,
+  saveMacro as apiSaveMacro,
+} from "@/services/macroApi";
+import type { Macro } from "@/types/macro";
+import { MACRO_EXPORT_VERSION } from "@/services/macroIo";
+
+function makeMacro(id: string, name: string): Macro {
+  return {
+    id,
+    name,
+    description: undefined,
+    tags: [],
+    steps: [{ data: "echo hi\r", delayMs: 0 }],
+    createdAt: "2026-07-19T00:00:00Z",
+    updatedAt: "2026-07-19T00:00:00Z",
+  };
+}
+
+function envelope(macros: Partial<Macro>[]): string {
+  return JSON.stringify({ version: MACRO_EXPORT_VERSION, macros });
+}
+
+describe("appStore — importMacros (#1677)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("imports macros with fresh ids and returns the count", async () => {
+    vi.mocked(apiListMacros).mockResolvedValueOnce([]);
+
+    const count = await useAppStore
+      .getState()
+      .importMacros(envelope([makeMacro("macro-1", "One"), makeMacro("macro-2", "Two")]));
+
+    expect(count).toBe(2);
+    expect(apiSaveMacro).toHaveBeenCalledTimes(2);
+    // Fresh ids: the saved macros must not reuse the file's ids.
+    const savedIds = vi.mocked(apiSaveMacro).mock.calls.map((c) => (c[0] as Macro).id);
+    expect(savedIds).not.toContain("macro-1");
+    expect(savedIds).not.toContain("macro-2");
+    // Refreshed once after all saves.
+    expect(apiListMacros).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates a name that collides with an existing macro", async () => {
+    useAppStore.setState({ macros: [makeMacro("existing", "Deploy")] });
+    vi.mocked(apiListMacros).mockResolvedValueOnce([]);
+
+    await useAppStore.getState().importMacros(envelope([makeMacro("macro-1", "Deploy")]));
+
+    const saved = vi.mocked(apiSaveMacro).mock.calls[0][0] as Macro;
+    expect(saved.name).toBe("Deploy (imported)");
+  });
+
+  it("rejects a malformed file without touching the backend", async () => {
+    useAppStore.setState({ macros: [makeMacro("existing", "Keep")] });
+
+    await expect(useAppStore.getState().importMacros("{not json")).rejects.toThrow(
+      /not valid JSON/
+    );
+
+    expect(apiSaveMacro).not.toHaveBeenCalled();
+    // Library untouched.
+    expect(useAppStore.getState().macros).toHaveLength(1);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -160,6 +160,7 @@ import {
   saveMacro as apiSaveMacro,
   deleteMacro as apiDeleteMacro,
 } from "@/services/macroApi";
+import { parseMacroEnvelope, resolveImportCollisions } from "@/services/macroIo";
 import {
   runMacroPlayback,
   getTerminalInputInjector,
@@ -1138,6 +1139,13 @@ interface AppState {
   saveMacroToBackend: (macro: Macro) => Promise<Macro>;
   /** Delete a macro by ID; only mutates local state after the backend delete resolves. */
   deleteMacroFromBackend: (macroId: string) => Promise<void>;
+  /**
+   * Import macros from an exported-macro file's JSON, merging them into the
+   * library. Malformed/incompatible files reject with a clear error and leave
+   * the library untouched; imported macros get fresh ids and de-duplicated
+   * names (see {@link resolveImportCollisions}). Returns the number imported.
+   */
+  importMacros: (json: string) => Promise<number>;
 
   // Macro recording (#1674)
   /** Whether terminal input is currently being captured into a macro. */
@@ -5507,6 +5515,19 @@ export const useAppStore = create<AppState>((set, get) => {
       set((state) => ({
         macros: state.macros.filter((m) => m.id !== macroId),
       }));
+    },
+
+    importMacros: async (json) => {
+      // Parse+validate first: a malformed file throws here, before any backend
+      // write, so a bad import can never corrupt the existing library (#1677).
+      const parsed = parseMacroEnvelope(json);
+      const prepared = resolveImportCollisions(parsed, get().macros, generateMacroId);
+      for (const macro of prepared) {
+        await apiSaveMacro(macro);
+      }
+      // Refresh once, after all saves, rather than per-macro.
+      await get().loadMacros();
+      return prepared.length;
     },
 
     // Macro recording (#1674)


### PR DESCRIPTION
Implements import/export of macros as portable JSON files — the final child of the macro epic (#1670), covering the "share macros as files" item from concept #517.

## What changed

- **Export**: the Macro Manager panel gains an **Export All** toolbar button and each macro row gains a single-macro **Export** action. Exports write a small, explicit, versioned envelope (`{ version, macros: [...] }`) — not the raw internal store — via the existing Tauri save dialog + `writeTextFile`, mirroring the workspace export flow.
- **Import**: an **Import** toolbar button opens a file, validates/parses it, and merges the macros into the library. Imported macros are assigned **fresh ids** (so an import never overwrites an existing macro, even from the same instance) and name collisions are de-duplicated deterministically with an "(imported)" suffix.
- **Validation**: malformed / incompatible files (bad JSON, wrong envelope version, missing/invalid fields, bad steps) reject with a clear, recoverable error toast and **never touch the existing library** — parse/validate happens before any backend write.

## Where

- `src/services/macroIo.ts` — pure, dependency-free envelope serialise/parse + collision helpers (unit-testable in isolation).
- `src/store/appStore.ts` — `importMacros` action (validate → resolve collisions → save → refresh once).
- `src/components/MacroSidebar/**` — export/import toolbar buttons and per-row export action.

## Tests (TDD ordering)

- `macroIo.test.ts` — envelope round-trip, malformed/incompatible rejection, collision handling.
- `appStore.macroImport.test.ts` — import action: fresh ids, name de-dup, malformed file leaves library untouched.
- `MacroSidebar.test.tsx` — export all / export one / import success + malformed + cancelled-dialog paths.

## Acceptance criteria

- [x] An exported macro re-imports to an equivalent, runnable macro.
- [x] A malformed/incompatible file fails with a clear toast and does not corrupt the library.
- [x] Name/id collisions are handled deterministically (fresh ids; documented "(imported)" suffix rule).
- [x] Unit tests for envelope serialize/deserialize + collision handling; TDD ordering.

This closes out the macro epic #1670 — all five children (#1673–#1677) are now landed.

Closes #1677