### PR TITLE
feat(agent): SSH agent forwarding through the remote-agent SSH backend

### DIFF
--- a/agent/src/daemon/process.rs
+++ b/agent/src/daemon/process.rs
@@ -436,6 +436,82 @@ mod tests {
         std::env::remove_var("TERMIHUB_TYPE_ID");
     }
 
+    // ── SSH agent forwarding through the remote-agent backend (#1719) ─────
+    //
+    // The remote-agent SSH backend is the reused `termihub_core` SSH
+    // `ConnectionType` (see `crate::registry`), so `forwardAgent` is honored on
+    // the agent's SSH leg by the same connector/handler that #1699 added: the
+    // session channel requests `auth-agent-req@openssh.com` and the forwarded
+    // agent channel is bridged to the ssh-agent local to the **agent host**
+    // (`$SSH_AUTH_SOCK` / the Windows OpenSSH pipe). The daemon inherits the
+    // agent's environment (`SystemDaemonLauncher` never clears it), so when the
+    // desktop→agent SSH leg itself forwards the agent, that host-local socket
+    // transparently chains back to the operator's own agent — end to end,
+    // without a bespoke JSON-RPC relay. The chosen model is documented in
+    // `docs/testing.md` → "SSH agent forwarding through the remote agent".
+    //
+    // These tests pin the agent-side seam: the `forwardAgent` flag survives the
+    // `TERMIHUB_SETTINGS` transport untouched and, fed to the core parser
+    // exactly as the daemon feeds it at connect time, yields an SshConfig with
+    // forwarding enabled. The connector request, the handler bridge, and the
+    // no-agent-available no-op themselves are covered by core unit tests.
+
+    /// `forwardAgent: true` in the connection settings survives the env-var
+    /// transport into the daemon and maps to `SshConfig.forward_agent`, so the
+    /// reused core SSH backend requests forwarding on the agent's SSH leg.
+    #[test]
+    fn daemon_ssh_settings_carry_forward_agent() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        std::env::set_var("TERMIHUB_TYPE_ID", "ssh");
+        std::env::set_var(
+            "TERMIHUB_SETTINGS",
+            r#"{"host":"target.example","username":"me","authMethod":"agent","forwardAgent":true}"#,
+        );
+        std::env::remove_var("TERMIHUB_SOCKET_PATH");
+        std::env::remove_var("TERMIHUB_BUFFER_SIZE");
+
+        let config = DaemonConfig::from_env("fwd-agent-1").unwrap();
+        // The flag reaches the daemon verbatim …
+        assert_eq!(config.settings["forwardAgent"], serde_json::json!(true));
+        // … and the daemon feeds exactly these settings to the core SSH backend,
+        // whose parser turns it into an enabled `forward_agent`.
+        let ssh = termihub_core::backends::ssh::parse_ssh_settings(&config.settings);
+        assert!(
+            ssh.forward_agent,
+            "forwardAgent must reach the core SSH backend through the agent"
+        );
+
+        std::env::remove_var("TERMIHUB_TYPE_ID");
+        std::env::remove_var("TERMIHUB_SETTINGS");
+    }
+
+    /// With `forwardAgent` absent (every pre-#1699 saved connection), the
+    /// agent's SSH leg leaves forwarding off — a graceful default, so those
+    /// connections behave exactly as before.
+    #[test]
+    fn daemon_ssh_settings_default_forward_agent_off() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        std::env::set_var("TERMIHUB_TYPE_ID", "ssh");
+        std::env::set_var(
+            "TERMIHUB_SETTINGS",
+            r#"{"host":"target.example","username":"me"}"#,
+        );
+        std::env::remove_var("TERMIHUB_SOCKET_PATH");
+        std::env::remove_var("TERMIHUB_BUFFER_SIZE");
+
+        let config = DaemonConfig::from_env("fwd-agent-2").unwrap();
+        let ssh = termihub_core::backends::ssh::parse_ssh_settings(&config.settings);
+        assert!(
+            !ssh.forward_agent,
+            "an absent forwardAgent must leave the agent's SSH leg unforwarded"
+        );
+
+        std::env::remove_var("TERMIHUB_TYPE_ID");
+        std::env::remove_var("TERMIHUB_SETTINGS");
+    }
+
     // ── Generation-counter regression tests ──────────────────────────────
     //
     // These tests verify that a stale Disconnected from an old connection

--- a/agent/src/registry.rs
+++ b/agent/src/registry.rs
@@ -30,7 +30,18 @@ pub fn build_registry() -> ConnectionTypeRegistry {
         Box::new(|| Box::new(termihub_core::backends::serial::Serial::new())),
     );
 
-    // SSH
+    // SSH.
+    //
+    // The agent reuses the core SSH backend verbatim, so SSH **agent
+    // forwarding** (`forwardAgent`, #1699) is honored on the agent's SSH leg by
+    // the same connector/handler as the desktop path (#1719). The forwarded
+    // agent channel is bridged to the ssh-agent **local to the agent host**
+    // (`$SSH_AUTH_SOCK` / the Windows OpenSSH pipe); the session daemon inherits
+    // the agent's environment, so when the desktop→agent SSH leg itself forwards
+    // the agent, that host-local socket transparently chains back to the
+    // operator's own agent end to end — no bespoke JSON-RPC relay. Absence of a
+    // host-local agent is a graceful no-op. See `docs/testing.md` → "SSH agent
+    // forwarding through the remote agent".
     registry.register(
         "ssh",
         "SSH",

--- a/docs/changes/dev1/feature/1719-agent-ssh-agent-forwarding.md
+++ b/docs/changes/dev1/feature/1719-agent-ssh-agent-forwarding.md
@@ -1,0 +1,9 @@
+### Added
+
+- SSH agent forwarding (`forwardAgent`) now also applies when an SSH session is
+  routed through a **deployed termiHub agent**, not just the desktop path
+  (#1699). The agent reuses the core SSH backend, so the forwarded-agent channel
+  is bridged to the ssh-agent local to the **agent host**; when the desktop
+  reaches that host over SSH with agent forwarding enabled, the operator's keys
+  chain through to the final target end to end. No local agent on the host is a
+  graceful no-op and the connection still succeeds (#1719).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1970,6 +1970,52 @@ on a hop — it is reachable on the **final target** through the chain. Genuine
 per-bastion shell agent access would require opening a session on the hop and is
 tracked separately if ever needed.
 
+### SSH agent forwarding through the remote agent (#1719)
+
+Issue #1699 delivered `forwardAgent` for the desktop russh path. When an SSH session is
+routed through a **deployed termiHub agent** instead, the agent reuses the same
+core SSH backend (`agent/src/registry.rs` registers
+`termihub_core::backends::ssh::Ssh`) and runs it in the per-session daemon
+(`agent/src/daemon/process.rs`), so `forwardAgent` is honored on the agent→target
+leg by the very same connector request and handler bridge — no separate agent-side
+implementation.
+
+**Chosen model — agent-host-local agent.** The forwarded-agent channel is bridged
+to the ssh-agent **local to the agent host** (`$SSH_AUTH_SOCK` on Unix, the
+`\\.\pipe\openssh-ssh-agent` OpenSSH pipe on Windows). The session daemon inherits
+the agent's environment (`SystemDaemonLauncher` never clears it), so no bespoke
+transport is added. The important consequence: when the **desktop→agent leg is
+itself SSH with agent forwarding enabled**, the agent host's `$SSH_AUTH_SOCK`
+already points at a socket that forwards to the operator's own agent, so the
+operator's keys reach the final target **end to end** transparently — this is
+standard OpenSSH agent chaining, not a termiHub relay. The no-agent-available case
+(agent host has no live ssh-agent) is the same graceful no-op as the desktop path.
+
+The agent-side seam (the `forwardAgent` flag surviving the `TERMIHUB_SETTINGS`
+daemon transport and mapping to `SshConfig.forward_agent`) is covered by **Rust
+unit tests** (`agent/src/daemon/process.rs`); the connector request, handler
+bridge and no-op are covered by the core tests from #1699. End-to-end forwarding
+needs a live agent + real SSH server (integration lane only, not per-PR CI), so
+verify manually:
+
+1. Reach a target through a deployed agent (deploy the agent to an intermediate
+   host and add an agent-routed SSH connection to the final target).
+2. Ensure an ssh-agent with a key is reachable on the agent host — either run
+   `ssh-add` there, or reach the agent host over SSH **with agent forwarding on**
+   so its `$SSH_AUTH_SOCK` chains to your local agent.
+3. Enable **Forward SSH agent** on the target connection and connect. On the
+   target run `ssh-add -l` — it must list the forwarded identities, and an onward
+   `ssh` from the target using an agent key must succeed.
+4. **No agent:** with no ssh-agent reachable on the agent host, connect with the
+   toggle still on — the connection must **succeed** with forwarding silently
+   skipped (a debug log notes it).
+
+Limitation / future work: when the desktop reaches the agent over the **TCP
+transport** (`--listen`) rather than SSH, there is no SSH leg to piggyback, so the
+operator's agent is only reachable if the agent host runs its own agent. Relaying
+the desktop's agent to the agent host over the desktop↔agent JSON-RPC transport
+would close that gap and is tracked as a follow-up.
+
 ### X11 / GUI forwarding
 
 SSH **X11 forwarding** lets a remote GUI app (`xeyes`, `xclock`, a graphical IDE)


### PR DESCRIPTION
Follow-up to #1699 (PR #1718), which delivered SSH agent forwarding (`forwardAgent`) for the desktop russh path only. This brings the same capability to SSH sessions routed through a **deployed termiHub agent**.

## Model decision — agent-host-local agent

The agent already reuses the core SSH backend verbatim (`agent/src/registry.rs` registers `termihub_core::backends::ssh::Ssh`) and runs it in the per-session daemon (`agent/src/daemon/process.rs`). So `forwardAgent` is honored on the agent→target leg by the very same connector request (`auth-agent-req@openssh.com`) and handler bridge that #1699 added — no separate agent-side transport implementation.

Of the two models the issue floated, this PR adopts the **agent-host-local agent** model (and documents it, per the issue's scope): the forwarded-agent channel is bridged to the ssh-agent local to the **agent host** (`$SSH_AUTH_SOCK` / the Windows OpenSSH pipe). The session daemon inherits the agent's environment (`SystemDaemonLauncher` never clears it), so when the **desktop→agent leg is itself SSH with agent forwarding enabled**, the agent host's `$SSH_AUTH_SOCK` already chains to the operator's own agent — the operator's keys reach the final target end to end, transparently, via standard OpenSSH agent chaining rather than a bespoke JSON-RPC relay. No host-local agent is a graceful no-op (reused from #1699).

The heavier JSON-RPC-relay alternative (needed only when the desktop reaches the agent over the TCP `--listen` transport, which has no SSH leg to piggyback) is documented as a limitation and filed as a follow-up.

## Changes

- `agent/src/registry.rs` — doc the chosen forwarding model on the SSH registration (production statement of the model).
- `agent/src/daemon/process.rs` — Rust unit tests pinning the agent-side seam: `forwardAgent` survives the `TERMIHUB_SETTINGS` daemon transport and maps to `SshConfig.forward_agent`; absent → off (graceful default).
- `docs/testing.md` — new section documenting the model + manual verification steps (integration lane only; not per-PR CI).
- Change fragment.

## Test plan

- `cargo test -p termihub-agent daemon_ssh_settings` — new tests pass.
- Connector request, handler bridge and no-agent no-op remain covered by the core tests from #1699.
- Manual end-to-end steps documented in `docs/testing.md` → "SSH agent forwarding through the remote agent".

Closes #1719