### PR TITLE
feat(remote-desktop): status-bar segment for graphical sessions (host:port, resolution, color-depth)

### DIFF
--- a/docs/changes/dev1/feature/1709-remote-desktop-statusbar.md
+++ b/docs/changes/dev1/feature/1709-remote-desktop-statusbar.md
@@ -1,0 +1,9 @@
+### Added
+
+- Status bar: while a graphical remote-desktop tab (VNC/RDP) is active, the
+  status bar now shows a live `monitor host:port · WxH · N-bit` segment — the
+  host and port and colour depth come from the connection config, and the `WxH`
+  resolution tracks the live framebuffer. The segment disappears when a
+  non-graphical tab is focused. The active session's framebuffer resolution is
+  now surfaced to the app store (keyed by session id) so shared chrome can read
+  it (#1709, follow-up to #1680).

--- a/src/components/RemoteDesktop/RemoteDesktopTab.tsx
+++ b/src/components/RemoteDesktop/RemoteDesktopTab.tsx
@@ -40,6 +40,17 @@ export function RemoteDesktopTab({ tabId, isVisible }: RemoteDesktopTabProps) {
   const session = useRemoteDesktopSession(tabId);
   const scaleMode = scaleModeOverride ?? session.scaleMode;
 
+  const setRemoteDesktopResolution = useAppStore((s) => s.setRemoteDesktopResolution);
+  const clearRemoteDesktopResolution = useAppStore((s) => s.clearRemoteDesktopResolution);
+
+  // Surface the live framebuffer resolution to the store (keyed by session id)
+  // for the shared status-bar segment (#1709); drop it when the session ends.
+  useEffect(() => {
+    const id = session.sessionId;
+    if (!id) return;
+    return () => clearRemoteDesktopResolution(id);
+  }, [session.sessionId, clearRemoteDesktopResolution]);
+
   const title = useAppStore(
     (s) =>
       getAllLeaves(s.rootPanel)
@@ -122,7 +133,12 @@ export function RemoteDesktopTab({ tabId, isVisible }: RemoteDesktopTabProps) {
           viewOnly={session.viewOnly}
           onInput={session.sendInput}
           onResize={session.resize}
-          onDimensions={(width, height) => setResolution({ width, height })}
+          onDimensions={(width, height) => {
+            setResolution({ width, height });
+            if (session.sessionId) {
+              setRemoteDesktopResolution(session.sessionId, width, height);
+            }
+          }}
         />
       )}
 

--- a/src/components/StatusBar/StatusBar.remote-desktop.test.tsx
+++ b/src/components/StatusBar/StatusBar.remote-desktop.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for the shared remote-desktop status-bar segment (#1709).
+ *
+ * While a graphical `remote-desktop` tab is active, the status bar shows a
+ * `<monitor> host:port · WxH · N-bit` segment: host:port and colour depth from
+ * the connection config, and the live resolution from the framebuffer surfaced
+ * to the store. It disappears for any other active tab.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { StatusBar } from "./StatusBar";
+import type { ConnectionConfig, TerminalTab } from "@/types/terminal";
+
+function setActiveTab(tab: Partial<TerminalTab> & { config: ConnectionConfig }) {
+  const leafId = useAppStore.getState().rootPanel.id;
+  const fullTab: TerminalTab = {
+    id: "tab-1",
+    sessionId: "s1",
+    title: "target",
+    connectionType: "remote-session",
+    contentType: "remote-desktop",
+    panelId: leafId,
+    isActive: true,
+    ...tab,
+  };
+  useAppStore.setState({
+    rootPanel: { type: "leaf", id: leafId, tabs: [fullTab], activeTabId: fullTab.id },
+    activePanelId: leafId,
+  });
+}
+
+describe("StatusBar — remote-desktop segment", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const query = () => container.querySelector('[data-testid="status-bar-remote-desktop"]');
+
+  it("shows host:port and colour depth for an active remote-desktop tab", () => {
+    setActiveTab({
+      config: { type: "vnc", config: { host: "kiosk", port: 5901, colorDepth: "32" } },
+    });
+
+    act(() => root.render(React.createElement(StatusBar)));
+
+    const item = query();
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("kiosk:5901");
+    expect(item!.textContent).toContain("32-bit");
+  });
+
+  it("includes the live framebuffer resolution once it is surfaced to the store", () => {
+    setActiveTab({
+      sessionId: "vnc-1",
+      config: { type: "vnc", config: { host: "kiosk", port: 5901, colorDepth: "16" } },
+    });
+    act(() => useAppStore.getState().setRemoteDesktopResolution("vnc-1", 1920, 1080));
+
+    act(() => root.render(React.createElement(StatusBar)));
+
+    const item = query();
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("1920×1080");
+    expect(item!.textContent).toContain("16-bit");
+  });
+
+  it("hides the resolution before the first frame arrives", () => {
+    setActiveTab({
+      sessionId: "vnc-2",
+      config: { type: "vnc", config: { host: "kiosk", port: 5901, colorDepth: "24" } },
+    });
+
+    act(() => root.render(React.createElement(StatusBar)));
+
+    const item = query();
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("kiosk:5901");
+    expect(item!.textContent).not.toContain("×");
+  });
+
+  it("renders nothing when the active tab is not a remote-desktop tab", () => {
+    setActiveTab({
+      connectionType: "ssh",
+      contentType: "terminal",
+      config: { type: "ssh", config: { host: "app-server", username: "deploy" } },
+    });
+
+    act(() => root.render(React.createElement(StatusBar)));
+
+    expect(query()).toBeNull();
+  });
+});

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -13,6 +13,7 @@ import {
   X,
   Check,
   ArrowUpCircle,
+  Monitor,
 } from "lucide-react";
 import { useAppStore, getActiveTab, monitorKeyForTab, selectMonitor } from "@/store/appStore";
 import { frontendLog } from "@/utils/frontendLog";
@@ -103,6 +104,7 @@ export function StatusBar() {
       <div className="status-bar__section status-bar__section--left">
         <PortableBadge />
         <JumpHostStatus />
+        <RemoteDesktopStatus />
         <MonitoringStatus />
         <ServicesIndicator />
         <AgentUpdatesIndicator />
@@ -212,6 +214,52 @@ function JumpHostStatus() {
     <span className="status-bar__item" data-testid="status-bar-jump-host" title={`SSH: ${label}`}>
       <Route size={13} />
       SSH: {label}
+    </span>
+  );
+}
+
+/**
+ * Shared status-bar segment for the active graphical remote-desktop tab (#1709).
+ *
+ * Shows `<monitor> host:port · WxH · N-bit` while a `remote-desktop` tab is
+ * active: `host:port` and colour depth come from the connection config, and the
+ * live `WxH` resolution comes from the framebuffer surfaced to the store
+ * (`remoteDesktopResolutions`, keyed by session id). Renders nothing for any
+ * other active tab, so it disappears the moment a non-graphical tab is focused.
+ */
+function RemoteDesktopStatus() {
+  const activeTab = useAppStore((s) => {
+    const tab = getActiveTab(s);
+    return tab?.contentType === "remote-desktop" ? tab : null;
+  });
+  const sessionId = activeTab?.sessionId ?? null;
+  const resolution = useAppStore((s) =>
+    sessionId ? s.remoteDesktopResolutions[sessionId] : undefined
+  );
+
+  if (!activeTab) return null;
+
+  const cfg = activeTab.config.config as Record<string, unknown>;
+  const host = (cfg.host as string | undefined) || activeTab.title || "remote";
+  const port = cfg.port;
+  const hostPort = port !== undefined && port !== null && port !== "" ? `${host}:${port}` : host;
+  const colorDepth = cfg.colorDepth;
+
+  const parts = [hostPort];
+  if (resolution) parts.push(`${resolution.width}×${resolution.height}`);
+  if (colorDepth !== undefined && colorDepth !== null && colorDepth !== "") {
+    parts.push(`${colorDepth}-bit`);
+  }
+  const label = parts.join(" · ");
+
+  return (
+    <span
+      className="status-bar__item"
+      data-testid="status-bar-remote-desktop"
+      title={`Remote desktop: ${label}`}
+    >
+      <Monitor size={13} />
+      {label}
     </span>
   );
 }

--- a/src/store/appStore.remoteDesktopResolution.test.ts
+++ b/src/store/appStore.remoteDesktopResolution.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+import { useAppStore } from "./appStore";
+
+/**
+ * The live framebuffer resolution surfaced to the store (#1709) — keyed by
+ * session id, fed from the remote-desktop frame path, and cleared when a
+ * session ends. This is the substrate the shared status-bar segment reads.
+ */
+describe("appStore remote-desktop resolution", () => {
+  beforeEach(() => {
+    useAppStore.setState({ remoteDesktopResolutions: {} });
+  });
+
+  it("starts empty", () => {
+    expect(useAppStore.getState().remoteDesktopResolutions).toEqual({});
+  });
+
+  it("records and overwrites a session's resolution", () => {
+    useAppStore.getState().setRemoteDesktopResolution("s1", 800, 600);
+    expect(useAppStore.getState().remoteDesktopResolutions.s1).toEqual({ width: 800, height: 600 });
+
+    useAppStore.getState().setRemoteDesktopResolution("s1", 1920, 1080);
+    expect(useAppStore.getState().remoteDesktopResolutions.s1).toEqual({
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  it("keeps sessions independent by id", () => {
+    useAppStore.getState().setRemoteDesktopResolution("s1", 800, 600);
+    useAppStore.getState().setRemoteDesktopResolution("s2", 1024, 768);
+    expect(useAppStore.getState().remoteDesktopResolutions).toEqual({
+      s1: { width: 800, height: 600 },
+      s2: { width: 1024, height: 768 },
+    });
+  });
+
+  it("does not create a new object reference for an unchanged resolution", () => {
+    useAppStore.getState().setRemoteDesktopResolution("s1", 800, 600);
+    const before = useAppStore.getState().remoteDesktopResolutions;
+    useAppStore.getState().setRemoteDesktopResolution("s1", 800, 600);
+    expect(useAppStore.getState().remoteDesktopResolutions).toBe(before);
+  });
+
+  it("clears a session's resolution without disturbing others", () => {
+    useAppStore.getState().setRemoteDesktopResolution("s1", 800, 600);
+    useAppStore.getState().setRemoteDesktopResolution("s2", 1024, 768);
+
+    useAppStore.getState().clearRemoteDesktopResolution("s1");
+
+    expect(useAppStore.getState().remoteDesktopResolutions).toEqual({
+      s2: { width: 1024, height: 768 },
+    });
+  });
+
+  it("clearing an unknown session is a no-op", () => {
+    useAppStore.getState().setRemoteDesktopResolution("s1", 800, 600);
+    const before = useAppStore.getState().remoteDesktopResolutions;
+    useAppStore.getState().clearRemoteDesktopResolution("nope");
+    expect(useAppStore.getState().remoteDesktopResolutions).toBe(before);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1106,6 +1106,16 @@ interface AppState {
     caps: { monitoring: boolean; fileBrowser: boolean }
   ) => void;
 
+  /**
+   * Live framebuffer resolution of each active graphical remote-desktop session,
+   * keyed by session id (#1709). Fed from the `remote-desktop-frame` /
+   * `onDimensions` path so the shared status-bar segment can show `WxH` for the
+   * active tab. Cleared when the session ends.
+   */
+  remoteDesktopResolutions: Record<string, { width: number; height: number }>;
+  setRemoteDesktopResolution: (sessionId: string, width: number, height: number) => void;
+  clearRemoteDesktopResolution: (sessionId: string) => void;
+
   // SSH Tunnels
   tunnels: TunnelConfig[];
   tunnelStates: Record<string, TunnelState>;
@@ -5040,6 +5050,7 @@ export const useAppStore = create<AppState>((set, get) => {
     monitors: {},
     monitoringStatsCache: {},
     sessionCapabilities: {},
+    remoteDesktopResolutions: {},
 
     clearMonitoringError: (key) =>
       set((state) => {
@@ -5052,6 +5063,26 @@ export const useAppStore = create<AppState>((set, get) => {
       set((state) => ({
         sessionCapabilities: { ...state.sessionCapabilities, [sessionId]: caps },
       })),
+
+    setRemoteDesktopResolution: (sessionId, width, height) =>
+      set((state) => {
+        const prev = state.remoteDesktopResolutions[sessionId];
+        if (prev && prev.width === width && prev.height === height) return {};
+        return {
+          remoteDesktopResolutions: {
+            ...state.remoteDesktopResolutions,
+            [sessionId]: { width, height },
+          },
+        };
+      }),
+
+    clearRemoteDesktopResolution: (sessionId) =>
+      set((state) => {
+        if (!(sessionId in state.remoteDesktopResolutions)) return {};
+        return {
+          remoteDesktopResolutions: omitKey(state.remoteDesktopResolutions, sessionId),
+        };
+      }),
 
     connectMonitoring: async (sessionId: string, host: string | null = null) => {
       const { monitoringStatsCache, monitors } = useAppStore.getState();


### PR DESCRIPTION
## Summary

Adds the shared **status-bar segment for graphical remote-desktop sessions** deferred from the remote-desktop layer (#1680). While a `remote-desktop` tab is active, the status bar now shows a live `monitor host:port · WxH · N-bit` segment, and disappears when a non-graphical tab is focused.

## Substrate assessment

The deferral note flagged that the segment needs the live framebuffer **resolution** in the frontend store. Assessed on-branch: the `remote-desktop-frame` event already carries `width`/`height` to the frontend (consumed in `RemoteDesktopCanvas` via `onDimensions`). So this was a **clean frontend-only change** — no backend / `core/src/backends/**` / event-payload edits needed.

## Changes

- **Store (`appStore.ts`)**: new `remoteDesktopResolutions` record keyed by session id, plus `setRemoteDesktopResolution` / `clearRemoteDesktopResolution`. Deduped writes (no new reference for an unchanged resolution).
- **`RemoteDesktopTab.tsx`**: pushes the live resolution to the store from the existing `onDimensions` path, and clears the entry when the session ends/unmounts.
- **`StatusBar.tsx`**: new `RemoteDesktopStatus` segment — monitor icon, `host:port` and color depth from `config.config`, `WxH` from the store. Rendered only when the active tab's `contentType === "remote-desktop"`.

## Tests

- `StatusBar.remote-desktop.test.tsx` — renders host:port + color depth for a remote-desktop active tab; includes resolution once surfaced; hides resolution before the first frame; renders nothing for a non-remote-desktop tab.
- `appStore.remoteDesktopResolution.test.ts` — set/overwrite/independent-by-id/dedup/clear/no-op-clear.

Full suite green locally (3655 tests). TDD ordering: `test(...)` commit precedes `feat(...)`.

Closes #1709