### PR TITLE
feat(terminal): add syntax highlighting settings model and store state

### DIFF
--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -223,6 +223,15 @@ pub struct AppSettings {
     /// `#[serde(default)]` keeps older settings files forward-compatible.
     #[serde(default)]
     pub shell_integration: ShellIntegrationSettings,
+    /// Terminal output syntax-highlighting configuration (epic #1696).
+    ///
+    /// The full config shape is owned by the frontend
+    /// (`src/types/syntaxHighlighting.ts` / `SyntaxHighlightingConfig`); the
+    /// backend only persists it verbatim, so it is stored as an opaque JSON
+    /// value here rather than mirrored as a typed struct. Absent → the frontend
+    /// resolves the built-in defaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub syntax_highlighting: Option<serde_json::Value>,
 }
 
 impl Default for AppSettings {
@@ -264,6 +273,7 @@ impl Default for AppSettings {
             updates: UpdateSettings::default(),
             serial_port_scan_prefixes: None,
             shell_integration: ShellIntegrationSettings::default(),
+            syntax_highlighting: None,
         }
     }
 }
@@ -853,6 +863,40 @@ mod tests {
         let settings = AppSettings::default();
         let json = serde_json::to_string(&settings).unwrap();
         assert!(!json.contains("experimentalFeaturesEnabled"));
+    }
+
+    #[test]
+    fn syntax_highlighting_round_trip_preserves_opaque_config() {
+        let config = serde_json::json!({
+            "enabled": true,
+            "builtinRules": { "error-keywords": true, "quoted-strings": false },
+            "customRules": [
+                {
+                    "id": "c1",
+                    "name": "Custom",
+                    "pattern": "foo",
+                    "style": { "color": "#123456" },
+                    "enabled": true,
+                    "priority": 5,
+                    "builtin": false
+                }
+            ]
+        });
+        let settings = AppSettings {
+            syntax_highlighting: Some(config.clone()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("syntaxHighlighting"));
+        let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.syntax_highlighting, Some(config));
+    }
+
+    #[test]
+    fn syntax_highlighting_none_omitted_from_json() {
+        let settings = AppSettings::default();
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(!json.contains("syntaxHighlighting"));
     }
 
     #[test]

--- a/src/services/syntaxHighlightingConfig.test.ts
+++ b/src/services/syntaxHighlightingConfig.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_HIGHLIGHTING_ENABLED,
+  defaultBuiltinRuleFlags,
+  defaultHighlightingConfig,
+  resolveActiveRules,
+  resolveHighlightingConfig,
+} from "./syntaxHighlightingConfig";
+import { BUILTIN_RULES } from "./syntaxHighlightingRules";
+import type {
+  ConnectionHighlightingConfig,
+  HighlightRule,
+  SyntaxHighlightingConfig,
+} from "../types/syntaxHighlighting";
+
+function customRule(overrides: Partial<HighlightRule> = {}): HighlightRule {
+  return {
+    id: "custom-1",
+    name: "Custom 1",
+    pattern: "foo",
+    style: { color: "#abcdef" },
+    enabled: true,
+    priority: 5,
+    builtin: false,
+    ...overrides,
+  };
+}
+
+describe("defaultBuiltinRuleFlags", () => {
+  it("seeds every built-in rule from its shipped enabled flag", () => {
+    const flags = defaultBuiltinRuleFlags();
+    expect(Object.keys(flags).length).toBe(BUILTIN_RULES.length);
+    for (const rule of BUILTIN_RULES) {
+      expect(flags[rule.id]).toBe(rule.enabled);
+    }
+  });
+
+  it("enables P0/P1 rules and disables P2/P3 rules by default", () => {
+    const flags = defaultBuiltinRuleFlags();
+    for (const rule of BUILTIN_RULES) {
+      expect(flags[rule.id]).toBe(rule.priority <= 1);
+    }
+  });
+});
+
+describe("defaultHighlightingConfig", () => {
+  it("ships the feature off, with default rule flags and no custom rules", () => {
+    const cfg = defaultHighlightingConfig();
+    expect(cfg.enabled).toBe(DEFAULT_HIGHLIGHTING_ENABLED);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.customRules).toEqual([]);
+    expect(cfg.builtinRules).toEqual(defaultBuiltinRuleFlags());
+  });
+});
+
+describe("resolveHighlightingConfig", () => {
+  const globalOn: SyntaxHighlightingConfig = {
+    enabled: true,
+    builtinRules: { "error-keywords": true },
+    customRules: [customRule({ id: "g-custom" })],
+  };
+  const globalOff: SyntaxHighlightingConfig = { ...globalOn, enabled: false };
+
+  it("falls back to the built-in defaults when the global config is absent", () => {
+    const resolved = resolveHighlightingConfig(undefined);
+    expect(resolved.enabled).toBe(false);
+    expect(resolved.builtinRules).toEqual(defaultBuiltinRuleFlags());
+    expect(resolved.customRules).toEqual([]);
+  });
+
+  it("follows the global on/off state for the 'global' override", () => {
+    expect(
+      resolveHighlightingConfig(globalOn, { override: "global", additionalRules: [] }).enabled
+    ).toBe(true);
+    expect(
+      resolveHighlightingConfig(globalOff, { override: "global", additionalRules: [] }).enabled
+    ).toBe(false);
+  });
+
+  it("defaults to the global state when no per-connection config is given", () => {
+    expect(resolveHighlightingConfig(globalOn).enabled).toBe(true);
+    expect(resolveHighlightingConfig(globalOff).enabled).toBe(false);
+  });
+
+  it("forces highlighting on for 'always-on' even when the global switch is off", () => {
+    const perConn: ConnectionHighlightingConfig = { override: "always-on", additionalRules: [] };
+    expect(resolveHighlightingConfig(globalOff, perConn).enabled).toBe(true);
+  });
+
+  it("forces highlighting off for 'always-off' even when the global switch is on", () => {
+    const perConn: ConnectionHighlightingConfig = { override: "always-off", additionalRules: [] };
+    expect(resolveHighlightingConfig(globalOn, perConn).enabled).toBe(false);
+  });
+
+  it("appends per-connection additional rules after the global custom rules", () => {
+    const extra = customRule({ id: "conn-custom" });
+    const resolved = resolveHighlightingConfig(globalOn, {
+      override: "global",
+      additionalRules: [extra],
+    });
+    expect(resolved.customRules.map((r) => r.id)).toEqual(["g-custom", "conn-custom"]);
+  });
+
+  it("carries the global built-in rule flags through unchanged", () => {
+    const resolved = resolveHighlightingConfig(globalOn, {
+      override: "always-on",
+      additionalRules: [],
+    });
+    expect(resolved.builtinRules).toEqual({ "error-keywords": true });
+  });
+});
+
+describe("resolveActiveRules", () => {
+  it("includes a built-in rule when its flag is true and omits it when false", () => {
+    const active = resolveActiveRules({
+      builtinRules: { "error-keywords": true, "warning-keywords": false },
+      customRules: [],
+    });
+    const ids = active.map((r) => r.id);
+    expect(ids).toContain("error-keywords");
+    expect(ids).not.toContain("warning-keywords");
+  });
+
+  it("falls back to the shipped default when a built-in rule has no flag", () => {
+    const active = resolveActiveRules({ builtinRules: {}, customRules: [] });
+    const ids = new Set(active.map((r) => r.id));
+    for (const rule of BUILTIN_RULES) {
+      expect(ids.has(rule.id)).toBe(rule.enabled);
+    }
+  });
+
+  it("marks every returned built-in rule as enabled", () => {
+    const active = resolveActiveRules({ builtinRules: {}, customRules: [] });
+    expect(active.every((r) => r.enabled)).toBe(true);
+  });
+
+  it("includes enabled custom rules and skips disabled ones", () => {
+    const active = resolveActiveRules({
+      builtinRules: {},
+      customRules: [
+        customRule({ id: "on", enabled: true }),
+        customRule({ id: "off", enabled: false }),
+      ],
+    });
+    const ids = active.map((r) => r.id);
+    expect(ids).toContain("on");
+    expect(ids).not.toContain("off");
+  });
+
+  it("returns copies that do not mutate the shared built-in definitions", () => {
+    const active = resolveActiveRules({
+      builtinRules: { "error-keywords": true },
+      customRules: [],
+    });
+    const copy = active.find((r) => r.id === "error-keywords");
+    const original = BUILTIN_RULES.find((r) => r.id === "error-keywords");
+    expect(copy).not.toBe(original);
+    copy!.style.color = "#000000";
+    expect(original!.style.color).not.toBe("#000000");
+  });
+});

--- a/src/services/syntaxHighlightingConfig.ts
+++ b/src/services/syntaxHighlightingConfig.ts
@@ -1,0 +1,146 @@
+/**
+ * Settings model + resolution helpers for terminal output syntax highlighting.
+ *
+ * This layer sits between the persisted configuration
+ * ({@link SyntaxHighlightingConfig} in app settings, plus an optional
+ * per-connection {@link ConnectionHighlightingConfig}) and the engine
+ * (`src/services/syntaxHighlighting.ts`), which consumes a flat list of
+ * {@link HighlightRule}s.
+ *
+ * - {@link defaultHighlightingConfig} produces the shipped defaults (P0/P1
+ *   built-in rules on, P2/P3 off, no custom rules — see the built-in rule set
+ *   in `syntaxHighlightingRules.ts`). Absent config resolves to these defaults,
+ *   which keeps older settings files forward-compatible.
+ * - {@link resolveHighlightingConfig} folds the global config and an optional
+ *   per-connection override into a single {@link ResolvedHighlightingConfig}.
+ * - {@link resolveActiveRules} turns a resolved (or global) config into the
+ *   concrete list of enabled rules the engine should compile.
+ */
+
+import { BUILTIN_RULES } from "./syntaxHighlightingRules";
+import type {
+  ConnectionHighlightingConfig,
+  HighlightRule,
+  SyntaxHighlightingConfig,
+} from "../types/syntaxHighlighting";
+
+/**
+ * Product default for the master on/off switch.
+ *
+ * Shipped **off**: the feature is opt-in until the user enables it in settings.
+ * Built-in rules still carry their shipped per-rule enabled flags so that
+ * turning the master switch on immediately activates the P0/P1 set.
+ */
+export const DEFAULT_HIGHLIGHTING_ENABLED = false;
+
+/**
+ * Built-in rule id → enabled flag, seeded from each rule's shipped default
+ * (`HighlightRule.enabled`). P0/P1 rules are on, P2/P3 rules are off.
+ */
+export function defaultBuiltinRuleFlags(): Record<string, boolean> {
+  const flags: Record<string, boolean> = {};
+  for (const rule of BUILTIN_RULES) {
+    flags[rule.id] = rule.enabled;
+  }
+  return flags;
+}
+
+/** The shipped global configuration used when no config has been persisted. */
+export function defaultHighlightingConfig(): SyntaxHighlightingConfig {
+  return {
+    enabled: DEFAULT_HIGHLIGHTING_ENABLED,
+    builtinRules: defaultBuiltinRuleFlags(),
+    customRules: [],
+  };
+}
+
+/**
+ * A global config merged with a per-connection override, ready for the engine.
+ *
+ * `enabled` reflects the effective on/off state for the connection after
+ * applying the override; the caller should skip highlighting entirely when it
+ * is `false`. `builtinRules` and `customRules` describe *which* rules apply
+ * when highlighting runs — pass this object to {@link resolveActiveRules}.
+ */
+export interface ResolvedHighlightingConfig {
+  /** Effective on/off state after the per-connection override is applied. */
+  enabled: boolean;
+  /** Built-in rule id → enabled flag (from the global config). */
+  builtinRules: Record<string, boolean>;
+  /** Global custom rules followed by per-connection additional rules. */
+  customRules: HighlightRule[];
+}
+
+/**
+ * Folds the global config and an optional per-connection config into a single
+ * {@link ResolvedHighlightingConfig}.
+ *
+ * The per-connection `override` decides the effective on/off state:
+ * - `"always-on"` forces highlighting on regardless of the global switch;
+ * - `"always-off"` forces it off;
+ * - `"global"` (the default when no per-connection config exists) follows the
+ *   global `enabled` flag.
+ *
+ * Per-connection `additionalRules` are appended after the global custom rules —
+ * they can add patterns but never remove global rules.
+ *
+ * A missing global config falls back to {@link defaultHighlightingConfig}.
+ */
+export function resolveHighlightingConfig(
+  global: SyntaxHighlightingConfig | undefined,
+  perConnection?: ConnectionHighlightingConfig,
+): ResolvedHighlightingConfig {
+  const g = global ?? defaultHighlightingConfig();
+  const override = perConnection?.override ?? "global";
+
+  let enabled: boolean;
+  switch (override) {
+    case "always-on":
+      enabled = true;
+      break;
+    case "always-off":
+      enabled = false;
+      break;
+    default:
+      enabled = g.enabled;
+      break;
+  }
+
+  return {
+    enabled,
+    builtinRules: g.builtinRules,
+    customRules: [...g.customRules, ...(perConnection?.additionalRules ?? [])],
+  };
+}
+
+/**
+ * Produces the concrete list of rules the engine should compile, independent of
+ * the master on/off state (callers gate on `enabled` themselves).
+ *
+ * A built-in rule is included when its flag in `builtinRules` is `true`, or —
+ * when the flag is absent — when the rule ships enabled by default. Custom
+ * rules are included when their own `enabled` flag is set. Every returned rule
+ * is a shallow copy with its own `style`, so callers may recolor (e.g. theme
+ * resolution) without mutating the shared built-in definitions.
+ */
+export function resolveActiveRules(config: {
+  builtinRules: Record<string, boolean>;
+  customRules: HighlightRule[];
+}): HighlightRule[] {
+  const active: HighlightRule[] = [];
+
+  for (const rule of BUILTIN_RULES) {
+    const enabled = config.builtinRules[rule.id] ?? rule.enabled;
+    if (enabled) {
+      active.push({ ...rule, enabled: true, style: { ...rule.style } });
+    }
+  }
+
+  for (const rule of config.customRules) {
+    if (rule.enabled) {
+      active.push({ ...rule, style: { ...rule.style } });
+    }
+  }
+
+  return active;
+}

--- a/src/services/syntaxHighlightingConfig.ts
+++ b/src/services/syntaxHighlightingConfig.ts
@@ -88,7 +88,7 @@ export interface ResolvedHighlightingConfig {
  */
 export function resolveHighlightingConfig(
   global: SyntaxHighlightingConfig | undefined,
-  perConnection?: ConnectionHighlightingConfig,
+  perConnection?: ConnectionHighlightingConfig
 ): ResolvedHighlightingConfig {
   const g = global ?? defaultHighlightingConfig();
   const override = perConnection?.override ?? "global";

--- a/src/store/appStore.syntaxHighlighting.test.ts
+++ b/src/store/appStore.syntaxHighlighting.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock service modules before importing the store (mirrors other store tests).
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+import { useAppStore } from "./appStore";
+import * as storage from "@/services/storage";
+import type { SyntaxHighlightingConfig } from "@/types/syntaxHighlighting";
+
+describe("appStore — sessionHighlighting (per-session toggle)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ sessionHighlighting: {} });
+  });
+
+  it("starts empty", () => {
+    expect(useAppStore.getState().sessionHighlighting).toEqual({});
+  });
+
+  it("records an explicit per-session override", () => {
+    useAppStore.getState().setSessionHighlighting("sess-1", false);
+    expect(useAppStore.getState().sessionHighlighting).toEqual({ "sess-1": false });
+
+    useAppStore.getState().setSessionHighlighting("sess-2", true);
+    expect(useAppStore.getState().sessionHighlighting).toEqual({ "sess-1": false, "sess-2": true });
+  });
+
+  it("clears an override when set to undefined", () => {
+    useAppStore.getState().setSessionHighlighting("sess-1", true);
+    expect(useAppStore.getState().sessionHighlighting).toHaveProperty("sess-1");
+
+    useAppStore.getState().setSessionHighlighting("sess-1", undefined);
+    expect(useAppStore.getState().sessionHighlighting).not.toHaveProperty("sess-1");
+  });
+
+  it("clearing a missing override is a no-op", () => {
+    useAppStore.getState().setSessionHighlighting("never-set", undefined);
+    expect(useAppStore.getState().sessionHighlighting).toEqual({});
+  });
+});
+
+describe("appStore — global syntaxHighlighting config persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("round-trips the global config through updateSettings", async () => {
+    const config: SyntaxHighlightingConfig = {
+      enabled: true,
+      builtinRules: { "error-keywords": true, "quoted-strings": true },
+      customRules: [
+        {
+          id: "c1",
+          name: "Custom",
+          pattern: "foo",
+          style: { color: "#123456" },
+          enabled: true,
+          priority: 5,
+          builtin: false,
+        },
+      ],
+    };
+
+    const base = useAppStore.getState().settings;
+    await useAppStore.getState().updateSettings({ ...base, syntaxHighlighting: config });
+
+    // Persisted to the backend and reflected in both settings and savedSettings.
+    expect(storage.saveSettings).toHaveBeenCalledTimes(1);
+    const persisted = (storage.saveSettings as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(persisted.syntaxHighlighting).toEqual(config);
+    expect(useAppStore.getState().settings.syntaxHighlighting).toEqual(config);
+    expect(useAppStore.getState().savedSettings.syntaxHighlighting).toEqual(config);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -647,6 +647,17 @@ interface AppState {
   setTerminalSearchVisible: (tabId: string, visible: boolean) => void;
   toggleTerminalSearch: (tabId: string) => void;
 
+  /**
+   * Per-session temporary syntax-highlighting toggle (runtime-only, never
+   * persisted). Keyed by session id. Set by the status-bar quick toggle
+   * (epic #1696, child #1704) to override the resolved config for a single
+   * live session without touching saved settings. A missing entry means
+   * "follow the resolved config"; `setSessionHighlighting(id, undefined)`
+   * clears the override back to that state.
+   */
+  sessionHighlighting: Record<string, boolean>;
+  setSessionHighlighting: (sessionId: string, enabled: boolean | undefined) => void;
+
   // Large paste confirmation
   largePasteDialog: { open: boolean; charCount: number; onConfirm: (() => void) | null };
   showLargePasteDialog: (charCount: number, onConfirm: () => void) => void;
@@ -3195,6 +3206,15 @@ export const useAppStore = create<AppState>((set, get) => {
           [tabId]: !s.terminalSearchVisible[tabId],
         },
       })),
+
+    // Per-session syntax-highlighting toggle (runtime-only, never persisted)
+    sessionHighlighting: {},
+    setSessionHighlighting: (sessionId, enabled) =>
+      set((s) =>
+        enabled === undefined
+          ? { sessionHighlighting: omitKey(s.sessionHighlighting, sessionId) }
+          : { sessionHighlighting: { ...s.sessionHighlighting, [sessionId]: enabled } },
+      ),
 
     // Large paste confirmation
     largePasteDialog: { open: false, charCount: 0, onConfirm: null },

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3213,7 +3213,7 @@ export const useAppStore = create<AppState>((set, get) => {
       set((s) =>
         enabled === undefined
           ? { sessionHighlighting: omitKey(s.sessionHighlighting, sessionId) }
-          : { sessionHighlighting: { ...s.sessionHighlighting, [sessionId]: enabled } },
+          : { sessionHighlighting: { ...s.sessionHighlighting, [sessionId]: enabled } }
       ),
 
     // Large paste confirmation

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -2,6 +2,7 @@ import { ConnectionConfig, RemoteAgentConfig, TerminalOptions, LineEnding } from
 import { SettingsSchema, Capabilities } from "./schema";
 import { KeybindingOverrideEntry } from "./keybindings";
 import type { SavedContainerRuntime, SpawnKind } from "./spawn";
+import type { SyntaxHighlightingConfig } from "./syntaxHighlighting";
 
 /**
  * Explicit lifecycle status of the single desktop SFTP session (audit gap A1).
@@ -548,6 +549,13 @@ export interface AppSettings {
   serialPortScanPrefixes?: SerialPortScanPrefix[];
   /** Shell context-menu / CLI-spawn integration configuration (epic #1363). */
   shellIntegration?: ShellIntegrationSettings;
+  /**
+   * Terminal output syntax-highlighting configuration (epic #1696). Absent
+   * config resolves to the built-in defaults (see
+   * `services/syntaxHighlightingConfig.ts` → `defaultHighlightingConfig`),
+   * which keeps older settings files forward-compatible.
+   */
+  syntaxHighlighting?: SyntaxHighlightingConfig;
 }
 
 /**

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -1,3 +1,5 @@
+import type { ConnectionHighlightingConfig } from "./syntaxHighlighting";
+
 export type SessionId = string;
 
 export type ShellType =
@@ -205,6 +207,12 @@ export interface TerminalOptions {
   cursorBlink?: boolean;
   /** Per-connection line-ending override. Falls back to the global default. */
   lineEnding?: LineEnding;
+  /**
+   * Per-connection syntax-highlighting override (epic #1696). Absent → the
+   * connection follows the global setting (`override: "global"`). See
+   * `services/syntaxHighlightingConfig.ts` → `resolveHighlightingConfig`.
+   */
+  syntaxHighlighting?: ConnectionHighlightingConfig;
 }
 
 /** An external connection file configured for a remote agent. */


### PR DESCRIPTION
Settings/store foundation of the terminal syntax-highlighting epic (#1696), building on the merged engine foundation (#1697). Keeps the scope tight to what the rest of the chain (#1700/#1701/#1703/#1704) depends on.

## What this adds

- **Types** — `AppSettings.syntaxHighlighting?: SyntaxHighlightingConfig` (`src/types/connection.ts`) and `TerminalOptions.syntaxHighlighting?: ConnectionHighlightingConfig` (`src/types/terminal.ts`, where `TerminalOptions` actually lives). Both optional; absent config resolves to the built-in defaults, so older settings files stay forward-compatible.
- **Resolve helpers** (`src/services/syntaxHighlightingConfig.ts`, new file — no collision surface):
  - `defaultHighlightingConfig()` / `defaultBuiltinRuleFlags()` — shipped defaults: P0/P1 built-in rules on, P2/P3 off, no custom rules.
  - `resolveHighlightingConfig(global, perConnection)` — folds the global config and an optional per-connection override (`global` / `always-on` / `always-off`) into a `ResolvedHighlightingConfig`, appending per-connection `additionalRules` after the global custom rules.
  - `resolveActiveRules(config)` — the concrete enabled-rule list the engine compiles (builtin flags with shipped-default fallback + enabled custom rules), returned as copies so callers can recolor without mutating the shared built-in definitions.
- **Store state** (`src/store/appStore.ts`) — a runtime-only `sessionHighlighting: Record<sessionId, boolean>` map + `setSessionHighlighting(id, enabled|undefined)` action for the future status-bar quick toggle (child #1704). Never persisted; passing `undefined` clears an override. The global config lives in `settings.syntaxHighlighting` and persists via the existing `updateSettings`/`save_settings` path.
- **Backend persistence** (`src-tauri/src/connection/settings.rs`) — an additive `syntax_highlighting: Option<serde_json::Value>` field on the Rust `AppSettings` struct so the global config round-trips verbatim through settings save/restore. Stored opaquely (the config shape is owned by the frontend), following the existing `grammar: serde_json::Value` passthrough pattern. Without it the strict struct would silently drop the field on the save→load round-trip.

## Product default

The master switch ships **off** (opt-in) — the built-in rules keep their shipped P0/P1-on / P2/P3-off flags so enabling the switch immediately activates the sensible set. The issue left the default-on-vs-off choice open; flagging it here in case a default-on is preferred.

## Tests

- `src/services/syntaxHighlightingConfig.test.ts` — resolve helpers: global/always-on/always-off overrides, default fallback, additional-rule ordering, builtin-flag resolution, copy isolation.
- `src/store/appStore.syntaxHighlighting.test.ts` — per-session toggle set/clear + global-config round-trip through `updateSettings`.
- Rust: `syntax_highlighting_round_trip_preserves_opaque_config` + `syntax_highlighting_none_omitted_from_json` in `settings.rs`.

All frontend store tests (477), the resolve-helper suite, `cargo test connection::settings`, `tsc`, ESLint, Prettier, and `cargo clippy` pass locally.

Closes #1698. Part of #1696.