### PR TITLE
fix(settings): persist lineHeight and confirmCloseLiveSession fields

### DIFF
--- a/docs/changes/dev0/feature/1735-persist-dropped-settings.md
+++ b/docs/changes/dev0/feature/1735-persist-dropped-settings.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- The **Line Height** appearance setting and the **confirm-before-closing-a-live-session**
+  preference now survive a restart. Both fields existed on the frontend but were
+  missing from the backend `AppSettings` struct, so they were silently dropped on
+  the save→load round-trip. The most visible symptom: ticking "Don't ask again" in
+  the live-session close dialog persisted `confirmCloseLiveSession: false`, but the
+  backend threw it away, so the confirmation came back on the next launch. Both
+  values are now stored and restored.

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -130,6 +130,11 @@ pub struct AppSettings {
     pub font_family: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<u32>,
+    /// Terminal line-height multiplier (e.g. `1.0`–`2.0`). `None` → the
+    /// frontend default (`1.0`). Owned by the frontend `AppSettings.lineHeight`;
+    /// the backend only persists it so it survives a restart (#1735).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_height: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_horizontal_scrolling: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -146,6 +151,14 @@ pub struct AppSettings {
     /// close-tab-group keyboard shortcut. The X-button on a tab is not affected.
     #[serde(default = "default_true")]
     pub confirm_close_tab_on_shortcut: bool,
+    /// Show a confirmation dialog before closing a tab or split panel that holds
+    /// a live session (via the tab X, middle-click, or panel close button). The
+    /// dialog's "Don't ask again" opt-out flips this to `false`. `None` → the
+    /// frontend default (treated as `true`). Owned by the frontend
+    /// `AppSettings.confirmCloseLiveSession`; the backend only persists it so the
+    /// opt-out survives a restart (#1735).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirm_close_live_session: Option<bool>,
     /// When true (default), saving terminal content to a file shows a dialog
     /// offering to open the saved file in a Monaco editor tab. When false, the
     /// file is saved silently and no dialog or editor tab is opened.
@@ -245,6 +258,7 @@ impl Default for AppSettings {
             theme: None,
             font_family: None,
             font_size: None,
+            line_height: None,
             default_horizontal_scrolling: None,
             scrollback_buffer: None,
             cursor_style: None,
@@ -252,6 +266,7 @@ impl Default for AppSettings {
             power_monitoring_enabled: true,
             file_browser_enabled: true,
             confirm_close_tab_on_shortcut: true,
+            confirm_close_live_session: None,
             ask_open_saved_file_in_tab: true,
             default_shell_integration: true,
             default_x11_forwarding: true,

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -900,6 +900,52 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_without_line_height_and_confirm_close_live_session() {
+        let json = r#"{"version":"1","externalConnectionFiles":[]}"#;
+        let settings: AppSettings = serde_json::from_str(json).unwrap();
+        assert!(settings.line_height.is_none());
+        assert!(settings.confirm_close_live_session.is_none());
+    }
+
+    #[test]
+    fn deserialize_with_line_height_and_confirm_close_live_session() {
+        let json = r#"{
+            "version": "1",
+            "externalConnectionFiles": [],
+            "lineHeight": 1.2,
+            "confirmCloseLiveSession": false
+        }"#;
+        let settings: AppSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.line_height, Some(1.2));
+        assert_eq!(settings.confirm_close_live_session, Some(false));
+    }
+
+    #[test]
+    fn line_height_and_confirm_close_live_session_round_trip() {
+        // Regression for #1735: these two frontend AppSettings fields were
+        // absent from the Rust struct and silently dropped on save→load.
+        let settings = AppSettings {
+            line_height: Some(1.4),
+            confirm_close_live_session: Some(false),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("lineHeight"));
+        assert!(json.contains("confirmCloseLiveSession"));
+        let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.line_height, Some(1.4));
+        assert_eq!(deserialized.confirm_close_live_session, Some(false));
+    }
+
+    #[test]
+    fn line_height_and_confirm_close_live_session_none_omitted_from_json() {
+        let settings = AppSettings::default();
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(!json.contains("lineHeight"));
+        assert!(!json.contains("confirmCloseLiveSession"));
+    }
+
+    #[test]
     fn round_trip_serialization() {
         let settings = AppSettings {
             default_user: Some("testuser".to_string()),


### PR DESCRIPTION
## Summary

The frontend `AppSettings` fields `lineHeight` and `confirmCloseLiveSession` existed on the TS side but were absent from the Rust `AppSettings` struct in `src-tauri/src/connection/settings.rs`, so they were silently dropped on the save→load round-trip. The most visible symptom: ticking "Don't ask again" in the live-session close dialog persisted `confirmCloseLiveSession: false`, but the backend threw it away, so the confirmation reappeared after a restart.

## Changes

- Added `line_height: Option<f64>` and `confirm_close_live_session: Option<bool>` to the Rust `AppSettings` struct, mirroring the frontend's optional semantics.
- Both use `#[serde(skip_serializing_if = "Option::is_none")]` so omitted-on-default keeps existing settings files byte-stable (matching the convention of neighbouring fields like `cursor_blink`, `font_size`, and the #1698 back-compat approach).
- `line_height` is `f64` because the frontend value is a fractional multiplier (0.8–2.0, step 0.1).

## Tests

Added (TDD, test commit precedes the fix):
- legacy-JSON-without-fields → both `None`
- explicit values deserialize
- full round-trip preserves both values
- `None` values omitted from serialized JSON

## Audit

Compared the full TS `AppSettings` interface against the Rust struct: all other 39 fields are present. Only these two were dropped.

Closes #1735