### PR TITLE
feat(terminal): per-connection highlighting override and status-bar quick toggle

### DIFF
--- a/docs/changes/dev1/feature/1704-per-connection-highlighting-toggle.md
+++ b/docs/changes/dev1/feature/1704-per-connection-highlighting-toggle.md
@@ -1,0 +1,11 @@
+### Added
+
+- Terminal output syntax highlighting can now be controlled per connection and
+  per session:
+  - **Connection Editor → Terminal** gains a **Syntax Highlighting** override
+    (`Use global default` / `Always on` / `Always off`) that forces highlighting
+    on or off for that connection regardless of the global switch.
+  - The **status bar** shows a `Highlighting: ON/OFF` indicator for the active
+    terminal session (visible once the feature is enabled or effectively on).
+    Clicking it flips a temporary, non-persisted per-session toggle — reconnect
+    or reopen returns to the resolved default (#1704, epic #1696).

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
-import { ConnectionTerminalSettings, applyHighlightingOverride } from "./ConnectionTerminalSettings";
+import {
+  ConnectionTerminalSettings,
+  applyHighlightingOverride,
+} from "./ConnectionTerminalSettings";
 import type { TerminalOptions } from "@/types/terminal";
 import type { HighlightRule } from "@/types/syntaxHighlighting";
 
@@ -231,12 +234,18 @@ describe("ConnectionTerminalSettings — syntax highlighting override", () => {
   });
 
   it("reflects a stored 'always-off' override", () => {
-    renderWith({ ...emptyOptions, syntaxHighlighting: { override: "always-off", additionalRules: [] } });
+    renderWith({
+      ...emptyOptions,
+      syntaxHighlighting: { override: "always-off", additionalRules: [] },
+    });
     expect(trigger().getAttribute("data-value")).toBe("always-off");
   });
 
   it("reflects a stored 'always-on' override", () => {
-    renderWith({ ...emptyOptions, syntaxHighlighting: { override: "always-on", additionalRules: [] } });
+    renderWith({
+      ...emptyOptions,
+      syntaxHighlighting: { override: "always-on", additionalRules: [] },
+    });
     expect(trigger().getAttribute("data-value")).toBe("always-on");
   });
 

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
-import { ConnectionTerminalSettings } from "./ConnectionTerminalSettings";
+import { ConnectionTerminalSettings, applyHighlightingOverride } from "./ConnectionTerminalSettings";
 import type { TerminalOptions } from "@/types/terminal";
+import type { HighlightRule } from "@/types/syntaxHighlighting";
 
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>
@@ -199,5 +200,105 @@ describe("ConnectionTerminalSettings — font size", () => {
     const onChange = renderWith({ ...emptyOptions, fontSize: 16 });
     setValue(fieldInput("Font Size"), "");
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ fontSize: undefined }));
+  });
+});
+
+describe("ConnectionTerminalSettings — syntax highlighting override", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const trigger = () =>
+    container.querySelector('[data-testid="connection-syntax-highlighting"]') as HTMLElement;
+
+  it("renders the syntax-highlighting override select", () => {
+    renderWith(emptyOptions);
+    expect(trigger()).not.toBeNull();
+  });
+
+  it("defaults to 'global' when no per-connection override is set", () => {
+    renderWith(emptyOptions);
+    expect(trigger().getAttribute("data-value")).toBe("global");
+  });
+
+  it("reflects a stored 'always-off' override", () => {
+    renderWith({ ...emptyOptions, syntaxHighlighting: { override: "always-off", additionalRules: [] } });
+    expect(trigger().getAttribute("data-value")).toBe("always-off");
+  });
+
+  it("reflects a stored 'always-on' override", () => {
+    renderWith({ ...emptyOptions, syntaxHighlighting: { override: "always-on", additionalRules: [] } });
+    expect(trigger().getAttribute("data-value")).toBe("always-on");
+  });
+
+  it("global-default hint reflects the global on/off state", () => {
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings,
+        syntaxHighlighting: { enabled: true, builtinRules: {}, customRules: [] },
+      },
+    });
+    renderWith(emptyOptions);
+    const label = Array.from(container.querySelectorAll(".settings-form__label")).find(
+      (l) => l.textContent === "Syntax Highlighting"
+    );
+    const field = label?.closest(".settings-form__field");
+    expect(field?.textContent?.toLowerCase()).toContain("on");
+  });
+});
+
+describe("applyHighlightingOverride", () => {
+  const rule: HighlightRule = {
+    id: "custom-1",
+    name: "custom",
+    pattern: "foo",
+    style: { color: "#ff0000" },
+    enabled: true,
+    priority: 5,
+    builtin: false,
+  };
+
+  it("clears the override entirely when 'global' is chosen with no additional rules", () => {
+    const next = applyHighlightingOverride(
+      { fontSize: 14, syntaxHighlighting: { override: "always-on", additionalRules: [] } },
+      "global"
+    );
+    expect(next.syntaxHighlighting).toBeUndefined();
+    expect(next.fontSize).toBe(14);
+  });
+
+  it("stores 'always-on' with an empty additional-rules list", () => {
+    const next = applyHighlightingOverride({}, "always-on");
+    expect(next.syntaxHighlighting).toEqual({ override: "always-on", additionalRules: [] });
+  });
+
+  it("stores 'always-off'", () => {
+    const next = applyHighlightingOverride({}, "always-off");
+    expect(next.syntaxHighlighting).toEqual({ override: "always-off", additionalRules: [] });
+  });
+
+  it("preserves connection-specific additional rules when changing the override", () => {
+    const next = applyHighlightingOverride(
+      { syntaxHighlighting: { override: "global", additionalRules: [rule] } },
+      "always-on"
+    );
+    expect(next.syntaxHighlighting).toEqual({ override: "always-on", additionalRules: [rule] });
+  });
+
+  it("keeps the override object when 'global' is chosen but additional rules exist", () => {
+    const next = applyHighlightingOverride(
+      { syntaxHighlighting: { override: "always-off", additionalRules: [rule] } },
+      "global"
+    );
+    expect(next.syntaxHighlighting).toEqual({ override: "global", additionalRules: [rule] });
   });
 });

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
@@ -1,5 +1,6 @@
 import { useAppStore } from "@/store/appStore";
 import { TerminalOptions, LineEnding } from "@/types/terminal";
+import type { ConnectionHighlightingOverride } from "@/types/syntaxHighlighting";
 import { DEFAULT_LINE_ENDING, LINE_ENDING_OPTIONS, lineEndingLabel } from "@/utils/lineEndings";
 import { Input, NumberInput, Select, Toggle } from "@/components/ui";
 
@@ -15,6 +16,27 @@ interface ConnectionTerminalSettingsProps {
  */
 const GLOBAL_DEFAULT = "__global__";
 
+/**
+ * Compute the next {@link TerminalOptions} when the per-connection syntax
+ * highlighting override changes (epic #1696, child #1704).
+ *
+ * Any connection-specific additional rules are preserved across override
+ * changes — they can only be edited elsewhere (#1703). Choosing "global" with
+ * no additional rules clears the whole `syntaxHighlighting` override back to
+ * `undefined` so the connection cleanly inherits the global setting (and does
+ * not count as a persisted terminal override).
+ */
+export function applyHighlightingOverride(
+  options: TerminalOptions,
+  override: ConnectionHighlightingOverride
+): TerminalOptions {
+  const additionalRules = options.syntaxHighlighting?.additionalRules ?? [];
+  if (override === "global" && additionalRules.length === 0) {
+    return { ...options, syntaxHighlighting: undefined };
+  }
+  return { ...options, syntaxHighlighting: { override, additionalRules } };
+}
+
 export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerminalSettingsProps) {
   const globalSettings = useAppStore((s) => s.settings);
 
@@ -26,6 +48,8 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
   const globalCursorBlink = globalSettings.cursorBlink ?? true;
   const globalHorizontalScrolling = globalSettings.defaultHorizontalScrolling ?? false;
   const globalLineEnding = globalSettings.defaultLineEnding ?? DEFAULT_LINE_ENDING;
+  const globalHighlightingEnabled = globalSettings.syntaxHighlighting?.enabled ?? false;
+  const highlightingOverride = options.syntaxHighlighting?.override ?? "global";
 
   return (
     <div className="settings-panel__category">
@@ -156,6 +180,31 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
           )}
         </span>
       </div>
+
+      <label className="settings-form__field">
+        <span className="settings-form__label">Syntax Highlighting</span>
+        <Select
+          value={highlightingOverride}
+          onChange={(v) =>
+            onChange(applyHighlightingOverride(options, v as ConnectionHighlightingOverride))
+          }
+          options={[
+            {
+              value: "global",
+              label: `Use global default (${globalHighlightingEnabled ? "on" : "off"})`,
+            },
+            { value: "always-on", label: "Always on" },
+            { value: "always-off", label: "Always off" },
+          ]}
+          aria-label="Syntax Highlighting"
+          data-testid="connection-syntax-highlighting"
+        />
+        <span className="settings-form__hint">
+          Override terminal output syntax highlighting for this connection. &ldquo;Use global
+          default&rdquo; follows the global setting; &ldquo;Always on/off&rdquo; forces it for this
+          connection regardless of the global switch.
+        </span>
+      </label>
     </div>
   );
 }

--- a/src/components/StatusBar/StatusBar.highlighting.test.tsx
+++ b/src/components/StatusBar/StatusBar.highlighting.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for the terminal syntax-highlighting status-bar indicator + quick
+ * toggle (#1704).
+ *
+ * For the active terminal session the status bar shows "Highlighting: ON/OFF"
+ * reflecting the resolved state (global config folded with the per-connection
+ * override) plus the runtime per-session toggle. Clicking flips the
+ * non-persisted per-session toggle (`setSessionHighlighting`). The indicator
+ * stays hidden until the feature is globally enabled or already effectively on
+ * for the session.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import { StatusBar } from "./StatusBar";
+import type { ConnectionConfig, TerminalOptions, TerminalTab } from "@/types/terminal";
+import type { SyntaxHighlightingConfig } from "@/types/syntaxHighlighting";
+
+function setActiveTab(tab: Partial<TerminalTab> & { config: ConnectionConfig }) {
+  const leafId = useAppStore.getState().rootPanel.id;
+  const fullTab: TerminalTab = {
+    id: "tab-1",
+    sessionId: "s1",
+    title: "target",
+    connectionType: "ssh",
+    contentType: "terminal",
+    panelId: leafId,
+    isActive: true,
+    ...tab,
+  };
+  useAppStore.setState({
+    rootPanel: { type: "leaf", id: leafId, tabs: [fullTab], activeTabId: fullTab.id },
+    activePanelId: leafId,
+  });
+}
+
+function setGlobalHighlighting(config: Partial<SyntaxHighlightingConfig>) {
+  useAppStore.setState({
+    settings: {
+      ...useAppStore.getState().settings,
+      syntaxHighlighting: { enabled: false, builtinRules: {}, customRules: [], ...config },
+    },
+  });
+}
+
+function setPerConnection(tabId: string, options: TerminalOptions) {
+  useAppStore.setState({
+    tabTerminalOptions: { ...useAppStore.getState().tabTerminalOptions, [tabId]: options },
+  });
+}
+
+describe("StatusBar — syntax-highlighting indicator", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const query = () => container.querySelector('[data-testid="status-bar-highlighting"]');
+  const render = () =>
+    act(() =>
+      root.render(React.createElement(TooltipProvider, null, React.createElement(StatusBar)))
+    );
+
+  const sshConfig: ConnectionConfig = { type: "ssh", config: { host: "app", username: "deploy" } };
+
+  it("is hidden while the feature is globally disabled and no override applies", () => {
+    setActiveTab({ config: sshConfig });
+    render();
+    expect(query()).toBeNull();
+  });
+
+  it("shows 'Highlighting: ON' for an active terminal session when the feature is on", () => {
+    setActiveTab({ config: sshConfig });
+    setGlobalHighlighting({ enabled: true });
+    render();
+    const item = query();
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("Highlighting: ON");
+  });
+
+  it("shows 'Highlighting: OFF' when a per-connection override forces it off (global on)", () => {
+    setActiveTab({ config: sshConfig });
+    setGlobalHighlighting({ enabled: true });
+    setPerConnection("tab-1", { syntaxHighlighting: { override: "always-off", additionalRules: [] } });
+    render();
+    const item = query();
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("Highlighting: OFF");
+  });
+
+  it("shows the indicator when a per-connection override forces it on while global is off", () => {
+    setActiveTab({ config: sshConfig });
+    setPerConnection("tab-1", { syntaxHighlighting: { override: "always-on", additionalRules: [] } });
+    render();
+    const item = query();
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("Highlighting: ON");
+  });
+
+  it("clicking flips the per-session toggle without persisting", () => {
+    setActiveTab({ config: sshConfig });
+    setGlobalHighlighting({ enabled: true });
+    render();
+
+    act(() => {
+      (query() as HTMLButtonElement).click();
+    });
+
+    expect(useAppStore.getState().sessionHighlighting["s1"]).toBe(false);
+    expect(query()!.textContent).toContain("Highlighting: OFF");
+
+    act(() => {
+      (query() as HTMLButtonElement).click();
+    });
+    expect(useAppStore.getState().sessionHighlighting["s1"]).toBe(true);
+    expect(query()!.textContent).toContain("Highlighting: ON");
+  });
+
+  it("is hidden for a non-terminal (editor) tab", () => {
+    setActiveTab({ contentType: "editor", config: sshConfig });
+    setGlobalHighlighting({ enabled: true });
+    render();
+    expect(query()).toBeNull();
+  });
+
+  it("is hidden when the active terminal tab has no live session", () => {
+    setActiveTab({ sessionId: null, config: sshConfig });
+    setGlobalHighlighting({ enabled: true });
+    render();
+    expect(query()).toBeNull();
+  });
+});

--- a/src/components/StatusBar/StatusBar.highlighting.test.tsx
+++ b/src/components/StatusBar/StatusBar.highlighting.test.tsx
@@ -93,7 +93,9 @@ describe("StatusBar — syntax-highlighting indicator", () => {
   it("shows 'Highlighting: OFF' when a per-connection override forces it off (global on)", () => {
     setActiveTab({ config: sshConfig });
     setGlobalHighlighting({ enabled: true });
-    setPerConnection("tab-1", { syntaxHighlighting: { override: "always-off", additionalRules: [] } });
+    setPerConnection("tab-1", {
+      syntaxHighlighting: { override: "always-off", additionalRules: [] },
+    });
     render();
     const item = query();
     expect(item).not.toBeNull();
@@ -102,7 +104,9 @@ describe("StatusBar — syntax-highlighting indicator", () => {
 
   it("shows the indicator when a per-connection override forces it on while global is off", () => {
     setActiveTab({ config: sshConfig });
-    setPerConnection("tab-1", { syntaxHighlighting: { override: "always-on", additionalRules: [] } });
+    setPerConnection("tab-1", {
+      syntaxHighlighting: { override: "always-on", additionalRules: [] },
+    });
     render();
     const item = query();
     expect(item).not.toBeNull();

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -14,8 +14,10 @@ import {
   Check,
   ArrowUpCircle,
   Monitor,
+  Highlighter,
 } from "lucide-react";
 import { useAppStore, getActiveTab, monitorKeyForTab, selectMonitor } from "@/store/appStore";
+import { resolveHighlightingConfig } from "@/services/syntaxHighlightingConfig";
 import { frontendLog } from "@/utils/frontendLog";
 import { useDesktopVersion } from "@/hooks/useDesktopVersion";
 import { summarizeAgentUpdates } from "@/utils/agentVersion";
@@ -119,6 +121,7 @@ export function StatusBar() {
         )}
       </div>
       <div className="status-bar__section status-bar__section--right">
+        <HighlightingIndicator />
         <UpdateIndicator />
         {editorStatus && (
           <>
@@ -261,6 +264,67 @@ function RemoteDesktopStatus() {
       <Monitor size={13} />
       {label}
     </span>
+  );
+}
+
+/**
+ * Terminal output syntax-highlighting indicator + quick toggle (epic #1696,
+ * child #1704).
+ *
+ * For the active terminal session it shows "Highlighting: ON/OFF" reflecting
+ * the resolved state — the global config folded with the per-connection
+ * override ({@link resolveHighlightingConfig}) — plus the runtime per-session
+ * toggle. Clicking flips the non-persisted per-session toggle
+ * (`setSessionHighlighting`) that the terminal engine reacts to (#1700), so a
+ * reconnect/reopen (new session id) returns to the resolved default.
+ *
+ * Stays hidden unless the feature is globally enabled or already effectively on
+ * for this session, keeping the status bar uncluttered until highlighting is in
+ * use.
+ */
+function HighlightingIndicator() {
+  const activeTab = useAppStore((s) => {
+    const tab = getActiveTab(s);
+    return tab?.contentType === "terminal" ? tab : null;
+  });
+  const tabId = activeTab?.id ?? null;
+  const sessionId = activeTab?.sessionId ?? null;
+  const globalConfig = useAppStore((s) => s.settings.syntaxHighlighting);
+  const perConnection = useAppStore((s) =>
+    tabId ? s.tabTerminalOptions[tabId]?.syntaxHighlighting : undefined
+  );
+  const sessionOverride = useAppStore((s) =>
+    sessionId ? s.sessionHighlighting[sessionId] : undefined
+  );
+  const setSessionHighlighting = useAppStore((s) => s.setSessionHighlighting);
+
+  if (!activeTab || !sessionId) return null;
+
+  const resolved = resolveHighlightingConfig(globalConfig, perConnection);
+  const effective = sessionOverride ?? resolved.enabled;
+  const globalEnabled = globalConfig?.enabled ?? false;
+
+  // Stay hidden until the feature is in play: globally enabled, or already
+  // effectively on for this session via a per-connection/-session override.
+  if (!globalEnabled && !effective) return null;
+
+  const tooltip = effective
+    ? "Syntax highlighting is on for this session — click to turn off"
+    : "Syntax highlighting is off for this session — click to turn on";
+
+  return (
+    <Tooltip content={tooltip} side="top">
+      <button
+        className="status-bar__item status-bar__item--interactive"
+        aria-label={tooltip}
+        aria-pressed={effective}
+        data-testid="status-bar-highlighting"
+        onClick={() => setSessionHighlighting(sessionId, !effective)}
+      >
+        <Highlighter size={12} />
+        Highlighting: {effective ? "ON" : "OFF"}
+      </button>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
Exposes the two remaining user controls for terminal output syntax highlighting (epic #1696), building on the settings model (#1698) and terminal wiring (#1700) that already read global config, per-connection override, and per-session toggle.

## Changes

- **Per-connection override** — `ConnectionEditor → Terminal` gains a **Syntax Highlighting** select (`Use global default` / `Always on` / `Always off`) that writes `TerminalOptions.syntaxHighlighting.override`. `Always on/off` forces highlighting for that connection regardless of the global switch; `Use global default` follows the global setting. A new pure helper `applyHighlightingOverride` preserves any connection-specific additional rules (edited elsewhere, #1703) and clears the whole override back to `undefined` when `global` is chosen with no additional rules, so it does not count as a persisted terminal override.
- **Status-bar quick toggle** — a `Highlighting: ON/OFF` indicator for the active terminal session, folding global config + per-connection override (`resolveHighlightingConfig`) with the runtime per-session toggle. Clicking flips the non-persisted per-session override via `setSessionHighlighting`, which the engine already honors (#1700); a reconnect/reopen (new session id) returns to the resolved default. The indicator stays hidden until the feature is globally enabled or already effectively on for the session, keeping the status bar uncluttered.

## Scope notes

- No `appStore.ts` change was needed: the per-connection override flows through the existing `ConnectionTerminalSettings` `onChange`, and the session toggle uses the existing `setSessionHighlighting` action.
- Connection-specific **additional rules** (the optional part of this issue) are deferred to the custom-rules editor (#1703) — the override control preserves them but does not yet edit them.

## Tests

- `ConnectionTerminalSettings.test.tsx`: dropdown resolution (stored override reflected in the trigger) + `applyHighlightingOverride` unit tests (clear-on-global, force on/off, additional-rules preservation).
- `StatusBar.highlighting.test.tsx`: visibility gating, ON/OFF resolution across global/per-connection states, and the click-toggle flipping the per-session override without persisting.
- Full frontend suite green (3723 tests); `pnpm build`, ESLint, Prettier, and markdownlint pass.

Closes #1704