### PR TITLE
feat(terminal): add custom highlight rules editor with regex safety (Closes #1703)

### DIFF
--- a/docs/changes/dev2/feature/1703-custom-highlight-rules.md
+++ b/docs/changes/dev2/feature/1703-custom-highlight-rules.md
@@ -1,0 +1,17 @@
+### Added
+
+- The **Syntax Highlighting** settings section now supports **custom highlight
+  rules**: add, edit, delete, and reorder your own pattern → style rules
+  alongside the built-ins. An inline editor takes a name, a regex pattern,
+  case-sensitive / whole-word toggles, and a style (color plus bold / italic /
+  underline), with a live preview box that shows sample terminal output
+  highlighted by the rule together with the other active rules. Custom rules are
+  stored in the global `syntaxHighlighting` config and apply to open terminals
+  immediately (#1703, epic #1696).
+- **Regex safety for custom rules:** every custom pattern is validated before it
+  can be saved — patterns that are empty, over-length (>500 chars), syntactically
+  invalid, or prone to catastrophic backtracking (ReDoS) are rejected with an
+  inline error and cannot be persisted. As a runtime backstop, the highlighting
+  engine now scans each line under a per-line time budget and self-disables any
+  rule that overruns it (logging a recoverable error), so a slow pattern can
+  never freeze the terminal render loop.

--- a/src/components/Settings/CustomRuleEditor.css
+++ b/src/components/Settings/CustomRuleEditor.css
@@ -1,0 +1,91 @@
+/* === Custom highlight rule editor === */
+.custom-rule-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  margin-top: var(--spacing-sm);
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-secondary);
+}
+
+.custom-rule-editor__title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.custom-rule-editor__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.custom-rule-editor__check {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.custom-rule-editor__style {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.custom-rule-editor__style-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-secondary);
+}
+
+.custom-rule-editor__color {
+  width: var(--spacing-xl);
+  height: var(--spacing-xl);
+  padding: 0;
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-sm);
+  background: none;
+  cursor: pointer;
+}
+
+.custom-rule-editor__color-hex {
+  width: 9rem;
+  font-family: var(--font-mono);
+}
+
+.custom-rule-editor__preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.custom-rule-editor__preview-box {
+  margin: 0;
+  padding: var(--spacing-sm);
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-sm);
+  background-color: var(--terminal-bg, var(--bg-primary));
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.custom-rule-editor__preview-line {
+  min-height: 1.5em;
+}
+
+.custom-rule-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+}

--- a/src/components/Settings/CustomRuleEditor.test.tsx
+++ b/src/components/Settings/CustomRuleEditor.test.tsx
@@ -3,15 +3,15 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { defaultHighlightingConfig } from "@/services/syntaxHighlightingConfig";
 import { createCustomRule } from "@/services/customHighlightRules";
-import type { HighlightRule } from "@/types/syntaxHighlighting";
+import type { HighlightRule, SyntaxHighlightingConfig } from "@/types/syntaxHighlighting";
 import { CustomRuleEditor } from "./CustomRuleEditor";
 
 let container: HTMLDivElement;
 let root: Root;
 
-function render(props: Partial<React.ComponentProps<typeof CustomRuleEditor>> = {}) {
-  const onSave = props.onSave ?? vi.fn();
-  const onCancel = props.onCancel ?? vi.fn();
+function render(props: { rule?: HighlightRule; config?: SyntaxHighlightingConfig } = {}) {
+  const onSave = vi.fn();
+  const onCancel = vi.fn();
   act(() => {
     root.render(
       <CustomRuleEditor

--- a/src/components/Settings/CustomRuleEditor.test.tsx
+++ b/src/components/Settings/CustomRuleEditor.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { defaultHighlightingConfig } from "@/services/syntaxHighlightingConfig";
+import { createCustomRule } from "@/services/customHighlightRules";
+import type { HighlightRule } from "@/types/syntaxHighlighting";
+import { CustomRuleEditor } from "./CustomRuleEditor";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(props: Partial<React.ComponentProps<typeof CustomRuleEditor>> = {}) {
+  const onSave = props.onSave ?? vi.fn();
+  const onCancel = props.onCancel ?? vi.fn();
+  act(() => {
+    root.render(
+      <CustomRuleEditor
+        config={props.config ?? defaultHighlightingConfig()}
+        rule={props.rule}
+        onSave={onSave}
+        onCancel={onCancel}
+      />
+    );
+  });
+  return { onSave, onCancel };
+}
+
+function byTestId(id: string): HTMLElement {
+  return container.querySelector(`[data-testid="${id}"]`) as HTMLElement;
+}
+
+function setInput(el: HTMLElement, value: string) {
+  const input = el as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  act(() => {
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("CustomRuleEditor", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders name, pattern and preview for a new rule", () => {
+    render();
+    expect(byTestId("custom-rule-name")).not.toBeNull();
+    expect(byTestId("custom-rule-pattern")).not.toBeNull();
+    expect(byTestId("custom-rule-preview")).not.toBeNull();
+    // The sample preview text is present.
+    expect(byTestId("custom-rule-preview").textContent).toContain("cat server.log");
+  });
+
+  it("disables Save until a name and valid pattern are entered", () => {
+    render();
+    const save = byTestId("custom-rule-save") as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+
+    setInput(byTestId("custom-rule-name"), "TODO markers");
+    setInput(byTestId("custom-rule-pattern"), "TODO");
+    expect((byTestId("custom-rule-save") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("shows an error and blocks Save for an invalid regex", () => {
+    render();
+    setInput(byTestId("custom-rule-name"), "bad");
+    setInput(byTestId("custom-rule-pattern"), "(unclosed");
+    expect(container.textContent).toMatch(/invalid regular expression/i);
+    expect((byTestId("custom-rule-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("blocks Save for a catastrophic-backtracking pattern", () => {
+    render();
+    setInput(byTestId("custom-rule-name"), "danger");
+    setInput(byTestId("custom-rule-pattern"), "(a+)+$");
+    expect(container.textContent).toMatch(/backtracking|redos|slow/i);
+    expect((byTestId("custom-rule-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("calls onSave with a trimmed, normalized rule", () => {
+    const { onSave } = render();
+    setInput(byTestId("custom-rule-name"), "  TODO  ");
+    setInput(byTestId("custom-rule-pattern"), "TODO");
+    act(() => byTestId("custom-rule-save").click());
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0] as HighlightRule;
+    expect(saved.name).toBe("TODO");
+    expect(saved.pattern).toBe("TODO");
+    expect(saved.builtin).toBe(false);
+    expect(saved.enabled).toBe(true);
+    expect(saved.style.color).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it("calls onCancel without saving", () => {
+    const { onCancel, onSave } = render();
+    act(() => byTestId("custom-rule-cancel").click());
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("pre-fills fields when editing an existing rule", () => {
+    const rule = createCustomRule({
+      name: "Existing",
+      pattern: "foo",
+      style: { color: "#ff0000" },
+    });
+    render({ rule });
+    expect((byTestId("custom-rule-name") as HTMLInputElement).value).toBe("Existing");
+    expect((byTestId("custom-rule-pattern") as HTMLInputElement).value).toBe("foo");
+  });
+
+  it("highlights matching text in the preview", () => {
+    render();
+    // A pattern that matches the sample's "ERROR" keyword.
+    setInput(byTestId("custom-rule-name"), "errors");
+    setInput(byTestId("custom-rule-pattern"), "ERROR");
+    const preview = byTestId("custom-rule-preview");
+    const colored = Array.from(preview.querySelectorAll("span")).find(
+      (s) => s.textContent === "ERROR" && s.style.color !== ""
+    );
+    expect(colored).toBeDefined();
+  });
+});

--- a/src/components/Settings/CustomRuleEditor.tsx
+++ b/src/components/Settings/CustomRuleEditor.tsx
@@ -1,0 +1,258 @@
+import { useMemo, useState } from "react";
+import { Button, Checkbox, Field, Input } from "@/components/ui";
+import { compileRules, findMatches, normalizeHexColor } from "@/services/syntaxHighlighting";
+import { resolveActiveRules } from "@/services/syntaxHighlightingConfig";
+import { getThemedRuleColor } from "@/services/syntaxHighlightingRules";
+import { createCustomRule } from "@/services/customHighlightRules";
+import { validateHighlightPattern } from "@/services/regexSafety";
+import type { HighlightRule, SyntaxHighlightingConfig } from "@/types/syntaxHighlighting";
+import "./CustomRuleEditor.css";
+
+/** Sample terminal output shown in the live preview box. */
+const PREVIEW_SAMPLE = [
+  "$ cat server.log",
+  "[INFO] Server started on port 8080",
+  "[ERROR] Connection refused to 10.0.0.1",
+  "Processing file /tmp/data.csv ...",
+  "Result: 42 items found",
+];
+
+interface CustomRuleEditorProps {
+  /** The rule being edited, or `undefined` to create a new rule. */
+  rule?: HighlightRule;
+  /**
+   * Current global highlighting config. Its active rules are layered under the
+   * draft in the preview so the user sees how the new rule interacts with the
+   * ones already on.
+   */
+  config: SyntaxHighlightingConfig;
+  /** Called with the finished rule when the user saves a valid rule. */
+  onSave: (rule: HighlightRule) => void;
+  /** Called when the user cancels without saving. */
+  onCancel: () => void;
+}
+
+/** A single rendered segment of a preview line. */
+interface Segment {
+  text: string;
+  style?: React.CSSProperties;
+}
+
+/** Builds the rule list used for the preview: the draft on top of active rules. */
+function buildPreviewRules(
+  draft: HighlightRule,
+  config: SyntaxHighlightingConfig
+): HighlightRule[] {
+  const others = resolveActiveRules({
+    builtinRules: config.builtinRules,
+    customRules: config.customRules,
+  })
+    .filter((r) => r.id !== draft.id)
+    .map((r) => (r.builtin ? { ...r, style: { ...r.style, color: getThemedRuleColor(r.id) } } : r));
+  // The draft is placed first and given the lowest priority number so it wins
+  // ties, letting the user see its effect clearly.
+  return [{ ...draft, enabled: true, priority: -1 }, ...others];
+}
+
+/** Splits a line into styled/unstyled segments from its non-overlapping matches. */
+function segmentLine(line: string, matches: ReturnType<typeof findMatches>): Segment[] {
+  const segments: Segment[] = [];
+  let cursor = 0;
+  for (const match of matches) {
+    if (match.start > cursor) segments.push({ text: line.slice(cursor, match.start) });
+    const style = match.rule.style;
+    segments.push({
+      text: line.slice(match.start, match.end),
+      style: {
+        color: match.color,
+        fontWeight: style.bold ? "bold" : undefined,
+        fontStyle: style.italic ? "italic" : undefined,
+        textDecoration: style.underline ? "underline" : undefined,
+      },
+    });
+    cursor = match.end;
+  }
+  if (cursor < line.length) segments.push({ text: line.slice(cursor) });
+  return segments;
+}
+
+/**
+ * Inline editor for a single custom highlight rule: name, regex pattern,
+ * case-sensitive / whole-word toggles, color + bold/italic/underline, and a
+ * live static preview of sample terminal text with the rule (plus the other
+ * active rules) applied.
+ *
+ * The pattern is validated for regex safety on every edit via
+ * {@link validateHighlightPattern}; an invalid or catastrophic-backtracking
+ * (ReDoS) pattern surfaces an inline error and blocks Save, so a dangerous
+ * pattern can never be persisted or reach the terminal render loop.
+ */
+export function CustomRuleEditor({ rule, config, onSave, onCancel }: CustomRuleEditorProps) {
+  const [draft, setDraft] = useState<HighlightRule>(() => rule ?? createCustomRule());
+  const isNew = rule === undefined;
+
+  const patternValidation = useMemo(
+    () =>
+      validateHighlightPattern(draft.pattern, {
+        wholeWord: draft.wholeWord,
+        caseSensitive: draft.caseSensitive,
+      }),
+    [draft.pattern, draft.wholeWord, draft.caseSensitive]
+  );
+
+  const nameError = draft.name.trim() === "" ? "Name is required." : undefined;
+  const colorValid = normalizeHexColor(draft.style.color) !== null;
+  const colorError = colorValid ? undefined : "Use a #RRGGBB color.";
+  const patternError = patternValidation.valid ? undefined : patternValidation.reason;
+  const canSave = !nameError && !colorError && patternValidation.valid;
+
+  const previewLines = useMemo(() => {
+    const compiled = compileRules(buildPreviewRules(draft, config));
+    return PREVIEW_SAMPLE.map((line) => segmentLine(line, findMatches(line, compiled)));
+  }, [draft, config]);
+
+  const setStyle = (patch: Partial<HighlightRule["style"]>) =>
+    setDraft((d) => ({ ...d, style: { ...d.style, ...patch } }));
+
+  const handleSave = () => {
+    if (!canSave) return;
+    onSave({
+      ...draft,
+      name: draft.name.trim(),
+      style: { ...draft.style, color: normalizeHexColor(draft.style.color) ?? draft.style.color },
+    });
+  };
+
+  const colorSwatch = normalizeHexColor(draft.style.color) ?? "#000000";
+
+  return (
+    <div className="custom-rule-editor" data-testid="custom-rule-editor">
+      <div className="custom-rule-editor__title">{isNew ? "New Custom Rule" : "Edit Rule"}</div>
+
+      <Field label="Name" htmlFor="custom-rule-name" error={nameError}>
+        <Input
+          id="custom-rule-name"
+          value={draft.name}
+          placeholder="e.g. TODO markers"
+          error={!!nameError}
+          onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+          data-testid="custom-rule-name"
+        />
+      </Field>
+
+      <Field label="Pattern (regex)" htmlFor="custom-rule-pattern" error={patternError}>
+        <Input
+          id="custom-rule-pattern"
+          value={draft.pattern}
+          placeholder="e.g. \\b(TODO|FIXME)\\b"
+          error={!!patternError}
+          spellCheck={false}
+          autoComplete="off"
+          autoCapitalize="off"
+          onChange={(e) => setDraft((d) => ({ ...d, pattern: e.target.value }))}
+          data-testid="custom-rule-pattern"
+        />
+      </Field>
+
+      <div className="custom-rule-editor__row">
+        <label className="custom-rule-editor__check">
+          <Checkbox
+            checked={draft.caseSensitive ?? true}
+            onCheckedChange={(checked) => setDraft((d) => ({ ...d, caseSensitive: checked }))}
+            data-testid="custom-rule-case-sensitive"
+          />
+          Case sensitive
+        </label>
+        <label className="custom-rule-editor__check">
+          <Checkbox
+            checked={draft.wholeWord ?? false}
+            onCheckedChange={(checked) => setDraft((d) => ({ ...d, wholeWord: checked }))}
+            data-testid="custom-rule-whole-word"
+          />
+          Whole word
+        </label>
+      </div>
+
+      <div className="custom-rule-editor__style">
+        <span className="custom-rule-editor__style-label">Style</span>
+        <div className="custom-rule-editor__row">
+          <input
+            type="color"
+            className="custom-rule-editor__color"
+            value={colorSwatch}
+            onChange={(e) => setStyle({ color: e.target.value })}
+            aria-label="Highlight color"
+            data-testid="custom-rule-color"
+          />
+          <Input
+            value={draft.style.color}
+            error={!!colorError}
+            spellCheck={false}
+            autoComplete="off"
+            size="sm"
+            className="custom-rule-editor__color-hex"
+            onChange={(e) => setStyle({ color: e.target.value })}
+            data-testid="custom-rule-color-hex"
+            aria-label="Highlight color hex"
+          />
+        </div>
+        <div className="custom-rule-editor__row">
+          <label className="custom-rule-editor__check">
+            <Checkbox
+              checked={draft.style.bold ?? false}
+              onCheckedChange={(checked) => setStyle({ bold: checked })}
+              data-testid="custom-rule-bold"
+            />
+            Bold
+          </label>
+          <label className="custom-rule-editor__check">
+            <Checkbox
+              checked={draft.style.italic ?? false}
+              onCheckedChange={(checked) => setStyle({ italic: checked })}
+              data-testid="custom-rule-italic"
+            />
+            Italic
+          </label>
+          <label className="custom-rule-editor__check">
+            <Checkbox
+              checked={draft.style.underline ?? false}
+              onCheckedChange={(checked) => setStyle({ underline: checked })}
+              data-testid="custom-rule-underline"
+            />
+            Underline
+          </label>
+        </div>
+      </div>
+
+      <div className="custom-rule-editor__preview">
+        <span className="custom-rule-editor__style-label">Preview</span>
+        <pre className="custom-rule-editor__preview-box" data-testid="custom-rule-preview">
+          {previewLines.map((segments, i) => (
+            <div key={i} className="custom-rule-editor__preview-line">
+              {segments.map((seg, j) => (
+                <span key={j} style={seg.style}>
+                  {seg.text}
+                </span>
+              ))}
+              {"\n"}
+            </div>
+          ))}
+        </pre>
+      </div>
+
+      <div className="custom-rule-editor__actions">
+        <Button variant="ghost" onClick={onCancel} data-testid="custom-rule-cancel">
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          disabled={!canSave}
+          data-testid="custom-rule-save"
+        >
+          {isNew ? "Save Rule" : "Save Changes"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/SyntaxHighlightingSettings.css
+++ b/src/components/Settings/SyntaxHighlightingSettings.css
@@ -62,3 +62,48 @@
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
 }
+
+/* === Custom rules === */
+.syntax-rules__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-xs);
+}
+
+.syntax-custom-rule__empty {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+.syntax-custom-rule {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+}
+
+.syntax-custom-rule:hover {
+  background-color: var(--bg-tertiary);
+}
+
+.syntax-custom-rule__pattern {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.syntax-custom-rule__actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--spacing-2xs, var(--spacing-xs));
+}

--- a/src/components/Settings/SyntaxHighlightingSettings.test.tsx
+++ b/src/components/Settings/SyntaxHighlightingSettings.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, Root } from "react-dom/client";
 import { AppSettings } from "@/types/connection";
 import { BUILTIN_RULES } from "@/services/syntaxHighlightingRules";
 import { defaultHighlightingConfig } from "@/services/syntaxHighlightingConfig";
+import { createCustomRule } from "@/services/customHighlightRules";
 import { SyntaxHighlightingSettings } from "./SyntaxHighlightingSettings";
 
 let container: HTMLDivElement;
@@ -175,5 +176,113 @@ describe("SyntaxHighlightingSettings", () => {
       );
     });
     expect(masterToggle()).not.toBeNull();
+  });
+});
+
+function byTestId(id: string): HTMLElement {
+  return container.querySelector(`[data-testid="${id}"]`) as HTMLElement;
+}
+
+function setInput(el: HTMLElement, value: string) {
+  const input = el as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  act(() => input.dispatchEvent(new Event("input", { bubbles: true })));
+}
+
+function withCustomRules(...rules: ReturnType<typeof createCustomRule>[]): AppSettings {
+  return {
+    ...defaultSettings,
+    syntaxHighlighting: { ...defaultHighlightingConfig(), enabled: true, customRules: rules },
+  };
+}
+
+describe("SyntaxHighlightingSettings custom rules", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderWith(settings: AppSettings, onChange = vi.fn()) {
+    act(() => {
+      root.render(<SyntaxHighlightingSettings settings={settings} onChange={onChange} />);
+    });
+    return onChange;
+  }
+
+  it("shows the empty state when there are no custom rules", () => {
+    renderWith(defaultSettings);
+    expect(byTestId("syntax-custom-rules-empty")).not.toBeNull();
+  });
+
+  it("opens the inline editor when Add Rule is clicked", () => {
+    renderWith(defaultSettings);
+    expect(byTestId("custom-rule-editor")).toBeNull();
+    act(() => byTestId("syntax-custom-rule-add").click());
+    expect(byTestId("custom-rule-editor")).not.toBeNull();
+  });
+
+  it("persists a new custom rule to customRules on save", () => {
+    const onChange = renderWith(defaultSettings);
+    act(() => byTestId("syntax-custom-rule-add").click());
+    setInput(byTestId("custom-rule-name"), "TODO");
+    setInput(byTestId("custom-rule-pattern"), "TODO");
+    act(() => byTestId("custom-rule-save").click());
+
+    const call = onChange.mock.calls[0][0] as AppSettings;
+    expect(call.syntaxHighlighting?.customRules).toHaveLength(1);
+    expect(call.syntaxHighlighting?.customRules[0].name).toBe("TODO");
+    expect(call.syntaxHighlighting?.customRules[0].builtin).toBe(false);
+  });
+
+  it("renders existing custom rules with their pattern", () => {
+    const rule = createCustomRule({ name: "Ports", pattern: ":\\d+" });
+    renderWith(withCustomRules(rule));
+    expect(byTestId(`syntax-custom-rule-${rule.id}`)).not.toBeNull();
+    expect(container.textContent).toContain("Ports");
+    expect(container.textContent).toContain(":\\d+");
+  });
+
+  it("toggling a custom rule's enabled flag writes the update", () => {
+    const rule = createCustomRule({ name: "Ports", pattern: ":\\d+" });
+    const onChange = renderWith(withCustomRules(rule));
+    act(() => byTestId(`syntax-custom-rule-enabled-${rule.id}`).click());
+    const call = onChange.mock.calls[0][0] as AppSettings;
+    expect(call.syntaxHighlighting?.customRules[0].enabled).toBe(false);
+  });
+
+  it("deletes a custom rule", () => {
+    const rule = createCustomRule({ name: "Ports", pattern: ":\\d+" });
+    const onChange = renderWith(withCustomRules(rule));
+    act(() => byTestId(`syntax-custom-rule-delete-${rule.id}`).click());
+    const call = onChange.mock.calls[0][0] as AppSettings;
+    expect(call.syntaxHighlighting?.customRules).toHaveLength(0);
+  });
+
+  it("reorders a custom rule down", () => {
+    const a = createCustomRule({ name: "A", pattern: "a" });
+    const b = createCustomRule({ name: "B", pattern: "b" });
+    const onChange = renderWith(withCustomRules(a, b));
+    act(() => byTestId(`syntax-custom-rule-down-${a.id}`).click());
+    const call = onChange.mock.calls[0][0] as AppSettings;
+    expect(call.syntaxHighlighting?.customRules.map((r) => r.id)).toEqual([b.id, a.id]);
+  });
+
+  it("edits an existing rule through the inline editor", () => {
+    const rule = createCustomRule({ name: "Ports", pattern: ":\\d+" });
+    const onChange = renderWith(withCustomRules(rule));
+    act(() => byTestId(`syntax-custom-rule-edit-${rule.id}`).click());
+    setInput(byTestId("custom-rule-name"), "Renamed");
+    act(() => byTestId("custom-rule-save").click());
+    const call = onChange.mock.calls[0][0] as AppSettings;
+    expect(call.syntaxHighlighting?.customRules).toHaveLength(1);
+    expect(call.syntaxHighlighting?.customRules[0].name).toBe("Renamed");
+    expect(call.syntaxHighlighting?.customRules[0].id).toBe(rule.id);
   });
 });

--- a/src/components/Settings/SyntaxHighlightingSettings.tsx
+++ b/src/components/Settings/SyntaxHighlightingSettings.tsx
@@ -1,7 +1,18 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Pencil, Plus, Trash2 } from "lucide-react";
 import { AppSettings } from "@/types/connection";
-import { Checkbox, Toggle } from "@/components/ui";
+import type { HighlightRule } from "@/types/syntaxHighlighting";
+import { Button, Checkbox, Toggle } from "@/components/ui";
 import { BUILTIN_RULES, getThemedRuleColor } from "@/services/syntaxHighlightingRules";
 import { defaultHighlightingConfig } from "@/services/syntaxHighlightingConfig";
+import { normalizeHexColor } from "@/services/syntaxHighlighting";
+import {
+  addCustomRule,
+  moveCustomRule,
+  removeCustomRule,
+  updateCustomRule,
+} from "@/services/customHighlightRules";
+import { CustomRuleEditor } from "./CustomRuleEditor";
 import { SettingsField } from "./SettingsField";
 import "./SyntaxHighlightingSettings.css";
 
@@ -26,6 +37,9 @@ const RULE_EXAMPLES: Record<string, string> = {
   "hex-values": "0xdeadbeef",
 };
 
+/** Which custom rule the inline editor is open for, if any. */
+type EditorState = { mode: "new" } | { mode: "edit"; id: string } | null;
+
 interface SyntaxHighlightingSettingsProps {
   settings: AppSettings;
   onChange: (settings: AppSettings) => void;
@@ -35,25 +49,31 @@ interface SyntaxHighlightingSettingsProps {
 /**
  * Global settings section for terminal output syntax highlighting.
  *
- * Exposes the master on/off switch plus per-rule enable/disable of the shipped
- * built-in rules (see `services/syntaxHighlightingRules.ts`). Reads and writes
- * the global {@link AppSettings.syntaxHighlighting} config through the same
- * `onChange` the rest of the Settings panel uses, so edits flow through the
- * store's debounced auto-save and live terminals pick them up.
+ * Exposes the master on/off switch, per-rule enable/disable of the shipped
+ * built-in rules (see `services/syntaxHighlightingRules.ts`), and full
+ * management (add / edit / delete / reorder) of user-defined custom rules via
+ * the inline {@link CustomRuleEditor}. Reads and writes the global
+ * {@link AppSettings.syntaxHighlighting} config through the same `onChange` the
+ * rest of the Settings panel uses, so edits flow through the store's debounced
+ * auto-save and live terminals pick them up.
  *
- * The custom-rules editor (#1703) and per-connection override (#1704) are
- * intentionally out of scope here.
+ * Custom patterns are validated for regex safety in the editor before they can
+ * be saved, so a catastrophic-backtracking (ReDoS) pattern never reaches the
+ * persisted config or the terminal render loop.
  */
 export function SyntaxHighlightingSettings({
   settings,
   onChange,
   visibleFields,
 }: SyntaxHighlightingSettingsProps) {
+  const [editor, setEditor] = useState<EditorState>(null);
+
   const show = (field: string) => !visibleFields || visibleFields.has(field);
   if (!show("syntaxHighlighting")) return null;
 
   const config = settings.syntaxHighlighting ?? defaultHighlightingConfig();
   const { enabled } = config;
+  const customRules = config.customRules;
 
   const setMaster = (checked: boolean) =>
     onChange({ ...settings, syntaxHighlighting: { ...config, enabled: checked } });
@@ -66,6 +86,18 @@ export function SyntaxHighlightingSettings({
         builtinRules: { ...config.builtinRules, [ruleId]: checked },
       },
     });
+
+  const setCustomRules = (rules: HighlightRule[]) =>
+    onChange({ ...settings, syntaxHighlighting: { ...config, customRules: rules } });
+
+  const handleSave = (rule: HighlightRule) => {
+    const exists = customRules.some((r) => r.id === rule.id);
+    setCustomRules(exists ? updateCustomRule(customRules, rule) : addCustomRule(customRules, rule));
+    setEditor(null);
+  };
+
+  const editingRule =
+    editor?.mode === "edit" ? customRules.find((r) => r.id === editor.id) : undefined;
 
   return (
     <div className="settings-panel__category">
@@ -107,6 +139,109 @@ export function SyntaxHighlightingSettings({
             </div>
           );
         })}
+      </div>
+
+      <div className={`syntax-rules${enabled ? "" : " syntax-rules--dimmed"}`}>
+        <div className="syntax-rules__header">
+          <span className="syntax-rules__heading">Custom rules</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<Plus size={14} />}
+            onClick={() => setEditor({ mode: "new" })}
+            disabled={editor !== null}
+            data-testid="syntax-custom-rule-add"
+          >
+            Add Rule
+          </Button>
+        </div>
+
+        {customRules.length === 0 && editor?.mode !== "new" ? (
+          <span className="syntax-custom-rule__empty" data-testid="syntax-custom-rules-empty">
+            No custom rules yet. Add one to highlight your own patterns.
+          </span>
+        ) : null}
+
+        {customRules.map((rule, index) => {
+          const color = normalizeHexColor(rule.style.color) ?? rule.style.color;
+          const isEditing = editor?.mode === "edit" && editor.id === rule.id;
+          if (isEditing) return null;
+          return (
+            <div
+              className="syntax-custom-rule"
+              key={rule.id}
+              data-testid={`syntax-custom-rule-${rule.id}`}
+            >
+              <Checkbox
+                checked={rule.enabled}
+                onCheckedChange={(checked) =>
+                  setCustomRules(updateCustomRule(customRules, { ...rule, enabled: checked }))
+                }
+                disabled={editor !== null}
+                aria-label={`Enable ${rule.name}`}
+                data-testid={`syntax-custom-rule-enabled-${rule.id}`}
+              />
+              <span
+                className="syntax-rule__swatch"
+                style={{ backgroundColor: color }}
+                aria-hidden="true"
+              />
+              <span className="syntax-rule__name">{rule.name}</span>
+              <code className="syntax-custom-rule__pattern">{rule.pattern}</code>
+              <div className="syntax-custom-rule__actions">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  iconOnly
+                  icon={<ChevronUp size={14} />}
+                  aria-label={`Move ${rule.name} up`}
+                  disabled={editor !== null || index === 0}
+                  onClick={() => setCustomRules(moveCustomRule(customRules, index, index - 1))}
+                  data-testid={`syntax-custom-rule-up-${rule.id}`}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  iconOnly
+                  icon={<ChevronDown size={14} />}
+                  aria-label={`Move ${rule.name} down`}
+                  disabled={editor !== null || index === customRules.length - 1}
+                  onClick={() => setCustomRules(moveCustomRule(customRules, index, index + 1))}
+                  data-testid={`syntax-custom-rule-down-${rule.id}`}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  iconOnly
+                  icon={<Pencil size={14} />}
+                  aria-label={`Edit ${rule.name}`}
+                  disabled={editor !== null}
+                  onClick={() => setEditor({ mode: "edit", id: rule.id })}
+                  data-testid={`syntax-custom-rule-edit-${rule.id}`}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  iconOnly
+                  icon={<Trash2 size={14} />}
+                  aria-label={`Delete ${rule.name}`}
+                  disabled={editor !== null}
+                  onClick={() => setCustomRules(removeCustomRule(customRules, rule.id))}
+                  data-testid={`syntax-custom-rule-delete-${rule.id}`}
+                />
+              </div>
+            </div>
+          );
+        })}
+
+        {editor !== null ? (
+          <CustomRuleEditor
+            rule={editingRule}
+            config={config}
+            onSave={handleSave}
+            onCancel={() => setEditor(null)}
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/src/services/customHighlightRules.test.ts
+++ b/src/services/customHighlightRules.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_CUSTOM_RULE_PRIORITY,
+  addCustomRule,
+  createCustomRule,
+  generateRuleId,
+  moveCustomRule,
+  removeCustomRule,
+  updateCustomRule,
+} from "./customHighlightRules";
+import type { HighlightRule } from "../types/syntaxHighlighting";
+
+function ruleWith(id: string, overrides: Partial<HighlightRule> = {}): HighlightRule {
+  return createCustomRule({ name: id, pattern: id, ...overrides, id } as Partial<HighlightRule>);
+}
+
+describe("generateRuleId", () => {
+  it("produces unique, custom-prefixed ids", () => {
+    const a = generateRuleId();
+    const b = generateRuleId();
+    expect(a).toMatch(/^custom-/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("createCustomRule", () => {
+  it("fills in enabled, non-builtin defaults", () => {
+    const rule = createCustomRule({ name: "TODO", pattern: "TODO" });
+    expect(rule.builtin).toBe(false);
+    expect(rule.enabled).toBe(true);
+    expect(rule.caseSensitive).toBe(true);
+    expect(rule.wholeWord).toBe(false);
+    expect(rule.priority).toBe(DEFAULT_CUSTOM_RULE_PRIORITY);
+    expect(rule.id).toMatch(/^custom-/);
+    expect(rule.style.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+  });
+
+  it("applies overrides", () => {
+    const rule = createCustomRule({
+      name: "n",
+      pattern: "p",
+      style: { color: "#ff0000", bold: true },
+      caseSensitive: false,
+    });
+    expect(rule.name).toBe("n");
+    expect(rule.style).toEqual({ color: "#ff0000", bold: true });
+    expect(rule.caseSensitive).toBe(false);
+  });
+});
+
+describe("custom-rule list mutations", () => {
+  it("adds a rule without mutating the input", () => {
+    const original: HighlightRule[] = [];
+    const next = addCustomRule(original, ruleWith("a"));
+    expect(next).toHaveLength(1);
+    expect(original).toHaveLength(0);
+  });
+
+  it("updates the matching rule by id", () => {
+    const rules = [ruleWith("a"), ruleWith("b")];
+    const edited = { ...rules[1], name: "renamed" };
+    const next = updateCustomRule(rules, edited);
+    expect(next[1].name).toBe("renamed");
+    expect(next[0]).toBe(rules[0]);
+  });
+
+  it("leaves the list unchanged when updating a missing id", () => {
+    const rules = [ruleWith("a")];
+    const next = updateCustomRule(rules, ruleWith("zzz"));
+    expect(next).toEqual(rules);
+  });
+
+  it("removes a rule by id", () => {
+    const rules = [ruleWith("a"), ruleWith("b")];
+    const next = removeCustomRule(rules, "a");
+    expect(next.map((r) => r.id)).toEqual(["b"]);
+  });
+
+  it("reorders a rule and leaves the source array intact", () => {
+    const rules = [ruleWith("a"), ruleWith("b"), ruleWith("c")];
+    const next = moveCustomRule(rules, 0, 2);
+    expect(next.map((r) => r.id)).toEqual(["b", "c", "a"]);
+    expect(rules.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("ignores out-of-range or no-op moves", () => {
+    const rules = [ruleWith("a"), ruleWith("b")];
+    expect(moveCustomRule(rules, 0, 0).map((r) => r.id)).toEqual(["a", "b"]);
+    expect(moveCustomRule(rules, -1, 1).map((r) => r.id)).toEqual(["a", "b"]);
+    expect(moveCustomRule(rules, 0, 5).map((r) => r.id)).toEqual(["a", "b"]);
+  });
+});

--- a/src/services/customHighlightRules.ts
+++ b/src/services/customHighlightRules.ts
@@ -53,7 +53,10 @@ export function createCustomRule(
 }
 
 /** Appends a rule, returning a new array. */
-export function addCustomRule(rules: readonly HighlightRule[], rule: HighlightRule): HighlightRule[] {
+export function addCustomRule(
+  rules: readonly HighlightRule[],
+  rule: HighlightRule
+): HighlightRule[] {
   return [...rules, rule];
 }
 

--- a/src/services/customHighlightRules.ts
+++ b/src/services/customHighlightRules.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure helpers for managing the user-defined ("custom") highlight rules stored
+ * in {@link SyntaxHighlightingConfig.customRules}.
+ *
+ * These keep the add / edit / delete / reorder logic out of the React editor so
+ * it can be unit-tested independently, and so every mutation returns a fresh
+ * array (never mutates the persisted config in place, which would defeat the
+ * store's change detection and auto-save).
+ */
+
+import type { HighlightRule, HighlightStyle } from "../types/syntaxHighlighting";
+
+/**
+ * Default evaluation priority for a new custom rule. Built-ins span P0–P3; a
+ * custom rule sits at P1 so it competes on equal footing for overlapping,
+ * equal-length matches without automatically overriding the P0 keyword rules.
+ */
+export const DEFAULT_CUSTOM_RULE_PRIORITY = 1;
+
+/** Default style for a freshly-created custom rule. */
+export function defaultCustomRuleStyle(): HighlightStyle {
+  return { color: "#4fc1ff" };
+}
+
+/** Generates a stable, collision-resistant id for a new custom rule. */
+export function generateRuleId(): string {
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
+    return `custom-${cryptoObj.randomUUID()}`;
+  }
+  return `custom-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Builds a new, enabled custom rule with sensible defaults. The caller supplies
+ * the fields the user edits; everything else is filled in.
+ */
+export function createCustomRule(
+  overrides: Partial<Omit<HighlightRule, "id" | "builtin">> = {}
+): HighlightRule {
+  return {
+    id: generateRuleId(),
+    name: "",
+    pattern: "",
+    style: defaultCustomRuleStyle(),
+    caseSensitive: true,
+    wholeWord: false,
+    enabled: true,
+    priority: DEFAULT_CUSTOM_RULE_PRIORITY,
+    builtin: false,
+    ...overrides,
+  };
+}
+
+/** Appends a rule, returning a new array. */
+export function addCustomRule(rules: readonly HighlightRule[], rule: HighlightRule): HighlightRule[] {
+  return [...rules, rule];
+}
+
+/**
+ * Replaces the rule whose id matches `rule.id`, returning a new array. If no
+ * rule matches (e.g. it was deleted concurrently), the list is returned
+ * unchanged.
+ */
+export function updateCustomRule(
+  rules: readonly HighlightRule[],
+  rule: HighlightRule
+): HighlightRule[] {
+  return rules.map((r) => (r.id === rule.id ? rule : r));
+}
+
+/** Removes the rule with the given id, returning a new array. */
+export function removeCustomRule(rules: readonly HighlightRule[], id: string): HighlightRule[] {
+  return rules.filter((r) => r.id !== id);
+}
+
+/**
+ * Moves the rule at `from` to `to`, returning a new array. Out-of-range indices
+ * leave the list unchanged. Order matters: it is the final tie-breaker when two
+ * equal-length, equal-priority matches overlap.
+ */
+export function moveCustomRule(
+  rules: readonly HighlightRule[],
+  from: number,
+  to: number
+): HighlightRule[] {
+  if (from < 0 || from >= rules.length || to < 0 || to >= rules.length || from === to) {
+    return [...rules];
+  }
+  const next = [...rules];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}

--- a/src/services/regexSafety.test.ts
+++ b/src/services/regexSafety.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_PATTERN_LENGTH,
+  buildRuleSource,
+  hasNestedQuantifier,
+  exceedsAdversarialBudget,
+  validateHighlightPattern,
+} from "./regexSafety";
+
+describe("buildRuleSource", () => {
+  it("passes the raw pattern through with the global flag by default", () => {
+    expect(buildRuleSource("foo")).toEqual({ source: "foo", flags: "g" });
+  });
+
+  it("wraps whole-word patterns in word boundaries", () => {
+    expect(buildRuleSource("cat", { wholeWord: true })).toEqual({
+      source: "\\b(?:cat)\\b",
+      flags: "g",
+    });
+  });
+
+  it("adds the case-insensitive flag when caseSensitive is false", () => {
+    expect(buildRuleSource("cat", { caseSensitive: false }).flags).toBe("gi");
+  });
+});
+
+describe("hasNestedQuantifier", () => {
+  it("flags the classic (a+)+ / (a*)* star-height-2 shapes", () => {
+    expect(hasNestedQuantifier("(a+)+")).toBe(true);
+    expect(hasNestedQuantifier("(a*)*")).toBe(true);
+    expect(hasNestedQuantifier("(a+)*")).toBe(true);
+    expect(hasNestedQuantifier("(\\d+)+")).toBe(true);
+    expect(hasNestedQuantifier("([a-z]+)+")).toBe(true);
+    expect(hasNestedQuantifier("((ab)+)+")).toBe(true);
+    expect(hasNestedQuantifier("(a+){2,}")).toBe(true);
+  });
+
+  it("does not flag single-level quantifiers", () => {
+    expect(hasNestedQuantifier("\\d+")).toBe(false);
+    expect(hasNestedQuantifier("a*")).toBe(false);
+    expect(hasNestedQuantifier("(abc)+")).toBe(false);
+    expect(hasNestedQuantifier("(a|b)+")).toBe(false);
+    expect(hasNestedQuantifier("\\b(?:ERROR|WARN)\\b")).toBe(false);
+    expect(hasNestedQuantifier("(?:https?)://\\S+")).toBe(false);
+  });
+
+  it("does not flag bounded quantifiers stacked on a group", () => {
+    // {n,m} is bounded — no exponential blow-up.
+    expect(hasNestedQuantifier("(a{1,3})+")).toBe(false);
+  });
+
+  it("ignores quantifier-like characters inside character classes", () => {
+    expect(hasNestedQuantifier("[a+*]+")).toBe(false);
+  });
+});
+
+describe("exceedsAdversarialBudget", () => {
+  it("returns true for a catastrophic overlapping-alternation pattern", () => {
+    // (a|a)+ is not a nested-quantifier shape but backtracks exponentially.
+    expect(exceedsAdversarialBudget("(a|a)+$", "g")).toBe(true);
+  });
+
+  it("returns false for a normal linear pattern", () => {
+    expect(exceedsAdversarialBudget("\\berror\\b", "g")).toBe(false);
+    expect(exceedsAdversarialBudget("(?:https?)://\\S+", "g")).toBe(false);
+  });
+
+  it("uses the injected clock to decide (deterministic budget check)", () => {
+    let t = 0;
+    // Clock jumps 100ms on the first read after start -> over a 30ms budget.
+    const fakeNow = (): number => {
+      const v = t;
+      t += 100;
+      return v;
+    };
+    expect(exceedsAdversarialBudget("abc", "g", 30, fakeNow)).toBe(true);
+  });
+
+  it("stays under budget when the injected clock does not advance", () => {
+    const frozenNow = (): number => 5;
+    expect(exceedsAdversarialBudget("abc", "g", 30, frozenNow)).toBe(false);
+  });
+});
+
+describe("validateHighlightPattern", () => {
+  it("accepts a normal rule pattern", () => {
+    expect(validateHighlightPattern("\\b(?:TODO|FIXME)\\b").valid).toBe(true);
+    expect(validateHighlightPattern("(?:https?|ftp)://\\S+").valid).toBe(true);
+    expect(validateHighlightPattern("cat", { wholeWord: true, caseSensitive: false }).valid).toBe(
+      true
+    );
+  });
+
+  it("rejects an empty pattern", () => {
+    const result = validateHighlightPattern("");
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toMatch(/empty/i);
+  });
+
+  it("rejects an over-long pattern", () => {
+    const result = validateHighlightPattern("a".repeat(MAX_PATTERN_LENGTH + 1));
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toMatch(/too long/i);
+  });
+
+  it("accepts a pattern exactly at the length cap", () => {
+    expect(validateHighlightPattern("a".repeat(MAX_PATTERN_LENGTH)).valid).toBe(true);
+  });
+
+  it("rejects a syntactically invalid regex", () => {
+    const result = validateHighlightPattern("(unclosed");
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toMatch(/invalid regular expression/i);
+  });
+
+  it("rejects a nested-quantifier catastrophic-backtracking pattern", () => {
+    const result = validateHighlightPattern("(a+)+$");
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toMatch(/backtracking|nested/i);
+  });
+
+  it("rejects an overlapping-alternation ReDoS pattern via the empirical backstop", () => {
+    const result = validateHighlightPattern("(a|a)+$");
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.reason).toMatch(/backtracking|redos|slow/i);
+  });
+});

--- a/src/services/regexSafety.ts
+++ b/src/services/regexSafety.ts
@@ -256,8 +256,7 @@ export function validateHighlightPattern(
   const { source, flags } = buildRuleSource(pattern, options);
 
   try {
-    // eslint-disable-next-line no-new
-    new RegExp(source, flags);
+    void new RegExp(source, flags);
   } catch (err) {
     return { valid: false, reason: `Invalid regular expression: ${describeError(err)}` };
   }

--- a/src/services/regexSafety.ts
+++ b/src/services/regexSafety.ts
@@ -1,0 +1,294 @@
+/**
+ * Regex-safety validation for user-defined highlight rules.
+ *
+ * Custom highlight patterns are compiled into live `RegExp`s and run against
+ * every plain terminal line by the highlighting engine (`syntaxHighlighting.ts`).
+ * An unbounded or catastrophically-backtracking (ReDoS) pattern would run in the
+ * render loop and can freeze the terminal, so user input is validated *before*
+ * it is ever saved or applied.
+ *
+ * The validation is layered defence:
+ *   1. **Length cap** — patterns over {@link MAX_PATTERN_LENGTH} chars are rejected
+ *      outright (long sources are both hard to reason about and a cheap DoS vector).
+ *   2. **Compile check** — the pattern (with the same wrapping the engine applies)
+ *      must compile as a `RegExp`.
+ *   3. **Structural check** — deterministic detection of nested unbounded
+ *      quantifiers (the `(a+)+` / `(a*)*` star-height-2 shapes that drive the vast
+ *      majority of ReDoS), rejected instantly without ever executing the pattern.
+ *   4. **Empirical backstop** — the compiled pattern is run against a small battery
+ *      of adversarial inputs with a wall-clock budget; anything that blows the
+ *      budget (e.g. overlapping-alternation shapes the structural check misses) is
+ *      rejected. The separation between a safe pattern (microseconds) and a
+ *      catastrophic one (many milliseconds and up) is many orders of magnitude, so
+ *      this stays deterministic in practice.
+ *
+ * The engine additionally caps per-line length and self-disables a rule that
+ * exceeds a per-line time budget at runtime (see `findMatchesGuarded`), but this
+ * save-time gate is the primary protection: a bad pattern should never reach the
+ * engine in the first place.
+ */
+
+/** Maximum accepted pattern source length, in characters. */
+export const MAX_PATTERN_LENGTH = 500;
+
+/** Wall-clock budget (ms) for the empirical adversarial run across all probes. */
+export const ADVERSARIAL_BUDGET_MS = 30;
+
+/** Options describing how the pattern will be compiled by the engine. */
+export interface PatternValidationOptions {
+  /** Matches wrapped in `\b…\b` (mirrors {@link HighlightRule.wholeWord}). */
+  wholeWord?: boolean;
+  /** Case-insensitive matching (mirrors `caseSensitive === false`). */
+  caseSensitive?: boolean;
+}
+
+/** A validation success — the pattern is safe to compile and run. */
+export interface PatternValid {
+  valid: true;
+}
+
+/** A validation failure with a human-readable, user-facing reason. */
+export interface PatternInvalid {
+  valid: false;
+  /** Short reason suitable for an inline field error. */
+  reason: string;
+}
+
+/** Result of {@link validateHighlightPattern}. */
+export type PatternValidation = PatternValid | PatternInvalid;
+
+/**
+ * Builds the exact regex source + flags the engine would compile for a pattern,
+ * so validation checks the same thing that will actually run. Mirrors the
+ * wrapping in `compileRules` (`syntaxHighlighting.ts`).
+ */
+export function buildRuleSource(
+  pattern: string,
+  options: PatternValidationOptions = {}
+): { source: string; flags: string } {
+  const source = options.wholeWord ? `\\b(?:${pattern})\\b` : pattern;
+  const flags = options.caseSensitive === false ? "gi" : "g";
+  return { source, flags };
+}
+
+/**
+ * Detects nested unbounded quantifiers — the star-height ≥ 2 shapes such as
+ * `(a+)+`, `(a*)*`, `(\d+)*`, `([a-z]+)+`, `((ab)+)+` — that are the classic
+ * source of exponential backtracking. Deterministic and executes nothing.
+ *
+ * It walks the source once, tracking a stack of group frames. A frame remembers
+ * whether the group's body contains an unbounded quantifier (`*`, `+`, `{n,}`).
+ * When an unbounded quantifier is applied to a group that already contains one,
+ * the star heights stack and the pattern is flagged.
+ *
+ * This is a heuristic: it deliberately errs toward the well-known dangerous
+ * shapes and lets the empirical backstop catch overlap-based ReDoS it cannot see
+ * structurally. It does not reject a single-level quantifier like `\d+` or `a*`.
+ */
+export function hasNestedQuantifier(source: string): boolean {
+  interface Frame {
+    /** Body of this group contains an unbounded quantifier. */
+    hasUnbounded: boolean;
+  }
+  const stack: Frame[] = [];
+  // Unbounded quantifier of the group that just closed at `)` (else null).
+  let lastClosedUnbounded: boolean | null = null;
+
+  const markEnclosingUnbounded = (): void => {
+    if (stack.length > 0) stack[stack.length - 1].hasUnbounded = true;
+  };
+
+  const isUnboundedQuantAt = (i: number): boolean => {
+    const ch = source[i];
+    if (ch === "*" || ch === "+") return true;
+    if (ch === "{") {
+      // Open-ended `{n,}` is unbounded; `{n}` / `{n,m}` are bounded.
+      const close = source.indexOf("}", i);
+      if (close === -1) return false;
+      const body = source.slice(i + 1, close);
+      return /^\d*,\s*$/.test(body) && body.includes(",");
+    }
+    return false;
+  };
+
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+
+    if (ch === "\\") {
+      // Escaped atom; the next char is literal. It resets "last closed group".
+      i++;
+      lastClosedUnbounded = null;
+      continue;
+    }
+
+    if (ch === "[") {
+      // Character class: skip to the matching `]`, honouring escapes.
+      let j = i + 1;
+      while (j < source.length && source[j] !== "]") {
+        if (source[j] === "\\") j++;
+        j++;
+      }
+      i = j;
+      lastClosedUnbounded = null;
+      continue;
+    }
+
+    if (ch === "(") {
+      stack.push({ hasUnbounded: false });
+      lastClosedUnbounded = null;
+      continue;
+    }
+
+    if (ch === ")") {
+      const frame = stack.pop();
+      lastClosedUnbounded = frame ? frame.hasUnbounded : null;
+      continue;
+    }
+
+    if (isUnboundedQuantAt(i)) {
+      // A group that already contained an unbounded quantifier is now itself
+      // unbounded-quantified -> nested / stacked star height.
+      if (lastClosedUnbounded === true) return true;
+      // This quantifier makes the enclosing group unbounded.
+      markEnclosingUnbounded();
+      // Advance past a multi-char `{n,}` quantifier so its digits/comma are not
+      // re-scanned as atoms.
+      if (ch === "{") {
+        const close = source.indexOf("}", i);
+        if (close !== -1) i = close;
+      }
+      lastClosedUnbounded = null;
+      continue;
+    }
+
+    // Any other atom (literal, `.`, etc.) resets the just-closed-group memory.
+    lastClosedUnbounded = null;
+  }
+
+  return false;
+}
+
+/**
+ * Runs a compiled pattern against a battery of adversarial inputs and reports
+ * whether the total wall-clock time exceeds `budgetMs`. Catches ReDoS shapes the
+ * structural check misses (e.g. overlapping alternation `(a|a)+`).
+ *
+ * The probes are built from characters that appear in the pattern so that the
+ * pattern actually engages with them, each a long run followed by a
+ * non-matching sentinel that forces maximal backtracking.
+ */
+export function exceedsAdversarialBudget(
+  source: string,
+  flags: string,
+  budgetMs = ADVERSARIAL_BUDGET_MS,
+  nowFn: () => number = defaultNow
+): boolean {
+  let regex: RegExp;
+  try {
+    regex = new RegExp(source, flags);
+  } catch {
+    return false; // compile errors are handled elsewhere
+  }
+
+  const probes = buildAdversarialInputs(source);
+  const start = nowFn();
+  for (const input of probes) {
+    regex.lastIndex = 0;
+    // A single exec cannot be interrupted; the input lengths are chosen so a
+    // catastrophic pattern clearly overruns the budget while a safe one stays in
+    // the microsecond range.
+    regex.test(input);
+    if (nowFn() - start > budgetMs) return true;
+  }
+  return false;
+}
+
+/** Characters worth stress-testing, seeded from the pattern's own literals. */
+function adversarialAlphabet(source: string): string[] {
+  const chars = new Set<string>();
+  for (const ch of source) {
+    if (/[a-zA-Z0-9]/.test(ch)) chars.add(ch);
+  }
+  // Always include a couple of generic characters so `.`/class-only patterns are
+  // still exercised.
+  chars.add("a");
+  chars.add("0");
+  return [...chars].slice(0, 4);
+}
+
+/** Adversarial inputs: long single-char runs plus a failing sentinel. */
+function buildAdversarialInputs(source: string): string[] {
+  const inputs: string[] = [];
+  // ~20 repeats is deliberately modest: an exponential pattern still overruns the
+  // budget by an order of magnitude (hundreds of ms) yet the worst-case single
+  // exec stays bounded (~2^20 steps), so the validator never hangs. A linear
+  // pattern stays sub-millisecond.
+  const runLength = 20;
+  for (const ch of adversarialAlphabet(source)) {
+    inputs.push(ch.repeat(runLength) + "!");
+    inputs.push(ch.repeat(runLength) + " ");
+  }
+  return inputs;
+}
+
+/**
+ * Validates a user-entered highlight pattern for safety. Returns `{ valid: true }`
+ * for a pattern that is safe to compile and run, or `{ valid: false, reason }`
+ * with a user-facing message otherwise.
+ *
+ * Checks, in order: non-empty, length cap, compiles, no nested unbounded
+ * quantifiers, and not empirically catastrophic on adversarial input.
+ */
+export function validateHighlightPattern(
+  pattern: string,
+  options: PatternValidationOptions = {}
+): PatternValidation {
+  if (pattern.length === 0) {
+    return { valid: false, reason: "Pattern must not be empty." };
+  }
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    return {
+      valid: false,
+      reason: `Pattern is too long (max ${MAX_PATTERN_LENGTH} characters).`,
+    };
+  }
+
+  const { source, flags } = buildRuleSource(pattern, options);
+
+  try {
+    // eslint-disable-next-line no-new
+    new RegExp(source, flags);
+  } catch (err) {
+    return { valid: false, reason: `Invalid regular expression: ${describeError(err)}` };
+  }
+
+  if (hasNestedQuantifier(source)) {
+    return {
+      valid: false,
+      reason: "Pattern may cause catastrophic backtracking (nested quantifiers).",
+    };
+  }
+
+  if (exceedsAdversarialBudget(source, flags)) {
+    return {
+      valid: false,
+      reason: "Pattern is too slow on adversarial input (possible ReDoS).",
+    };
+  }
+
+  return { valid: true };
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) {
+    // Strip the noisy "Invalid regular expression: /…/: " prefix engines add.
+    return err.message.replace(/^Invalid regular expression:[^:]*:\s*/, "");
+  }
+  return String(err);
+}
+
+function defaultNow(): number {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}

--- a/src/services/syntaxHighlighting.test.ts
+++ b/src/services/syntaxHighlighting.test.ts
@@ -4,10 +4,14 @@ import {
   SyntaxHighlightingEngine,
   compileRules,
   findMatches,
+  findMatchesGuarded,
   normalizeHexColor,
   styleDecorationElement,
 } from "./syntaxHighlighting";
 import type { HighlightRule } from "../types/syntaxHighlighting";
+import { frontendLog } from "../utils/frontendLog";
+
+vi.mock("../utils/frontendLog", () => ({ frontendLog: vi.fn() }));
 
 function rule(
   overrides: Partial<HighlightRule> & Pick<HighlightRule, "id" | "pattern">
@@ -109,6 +113,39 @@ describe("findMatches overlap resolution", () => {
     // Should terminate and produce only the non-empty match.
     const matches = findMatches("xaax", compiled);
     expect(matches).toEqual([expect.objectContaining({ start: 1, end: 3 })]);
+  });
+});
+
+describe("findMatchesGuarded", () => {
+  it("returns the same matches as findMatches when the budget is not exceeded", () => {
+    const compiled = compileRules([rule({ id: "n", pattern: "\\d+" })]);
+    const { matches, timedOutRuleIds } = findMatchesGuarded("1 and 22 and 333", compiled);
+    expect(matches.map((m) => m.start)).toEqual([0, 6, 13]);
+    expect(timedOutRuleIds).toEqual([]);
+  });
+
+  it("reports rules it could not start once the deadline has passed", () => {
+    const compiled = compileRules([
+      rule({ id: "a", pattern: "A" }),
+      rule({ id: "b", pattern: "B" }),
+    ]);
+    // Clock: deadline is computed from the first read; the second read (before
+    // rule "a") is already past it, so both rules time out.
+    let t = 0;
+    const fakeNow = (): number => {
+      const v = t;
+      t += 100; // each read jumps 100ms; budget is 10ms
+      return v;
+    };
+    const { timedOutRuleIds } = findMatchesGuarded("A B", compiled, 10, fakeNow);
+    expect(timedOutRuleIds).toEqual(["a", "b"]);
+  });
+
+  it("does not time out when the injected clock stays within budget", () => {
+    const compiled = compileRules([rule({ id: "a", pattern: "A" })]);
+    const { timedOutRuleIds, matches } = findMatchesGuarded("A A", compiled, 50, () => 5);
+    expect(timedOutRuleIds).toEqual([]);
+    expect(matches).toHaveLength(2);
   });
 });
 
@@ -279,6 +316,38 @@ describe("SyntaxHighlightingEngine lifecycle", () => {
     await new Promise<void>((r) => term.write(long + "\r\n", () => r()));
 
     expect(decoSpy).not.toHaveBeenCalled();
+    engine.dispose();
+  });
+
+  it("disables a rule that overruns the per-line scan budget and logs a recoverable error", async () => {
+    vi.mocked(frontendLog).mockClear();
+    term = await makeTerm("plain ERROR here\r\n");
+    const decoSpy = vi.spyOn(term, "registerDecoration");
+
+    // Injected clock advances past the 10ms budget on every read, so the very
+    // first scanned line trips the guard and the rule self-disables.
+    let t = 0;
+    const engine = new SyntaxHighlightingEngine(term, {
+      lineScanBudgetMs: 10,
+      now: () => {
+        const v = t;
+        t += 1000;
+        return v;
+      },
+    });
+    engine.enable([errorRule]);
+
+    // The slow rule produced no decoration and was dropped.
+    expect(decoSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(frontendLog)).toHaveBeenCalledWith(
+      "syntaxHighlighting",
+      expect.stringContaining("disabled slow highlight rule")
+    );
+
+    // It stays disabled: further matching output is not decorated either.
+    await new Promise<void>((r) => term.write("another ERROR\r\n", () => r()));
+    expect(decoSpy).not.toHaveBeenCalled();
+
     engine.dispose();
   });
 

--- a/src/services/syntaxHighlighting.ts
+++ b/src/services/syntaxHighlighting.ts
@@ -66,6 +66,15 @@ export interface SyntaxHighlightingEngineOptions {
   lineBudget?: number;
   /** Max logical line length before skipping (default {@link MAX_LINE_LENGTH}). */
   maxLineLength?: number;
+  /**
+   * Per-logical-line wall-clock budget in ms (default
+   * {@link DEFAULT_LINE_SCAN_BUDGET_MS}). A rule that overruns it is disabled and
+   * a recoverable error is logged, so a slow custom pattern cannot keep freezing
+   * the render loop line after line.
+   */
+  lineScanBudgetMs?: number;
+  /** Injectable clock (for tests). Defaults to the module monotonic clock. */
+  now?: () => number;
 }
 
 /** The subset of {@link HighlightStyle} the native color recolor cannot express. */
@@ -186,41 +195,26 @@ interface Candidate extends RuleMatch {
   order: number;
 }
 
-/**
- * Runs all compiled rules against `text` and resolves overlaps into a
- * non-overlapping, left-to-right ordered set of matches.
- *
- * Resolution order when two matches overlap:
- *   1. longest match wins,
- *   2. then lower priority number wins,
- *   3. then the earlier rule in the list wins,
- *   4. then the earlier start position wins.
- */
-export function findMatches(text: string, compiled: readonly CompiledRule[]): RuleMatch[] {
-  const candidates: Candidate[] = [];
+/** Default per-logical-line wall-clock budget (ms) for the guarded scan. */
+export const DEFAULT_LINE_SCAN_BUDGET_MS = 50;
 
-  for (const c of compiled) {
-    c.regex.lastIndex = 0;
-    let m: RegExpExecArray | null;
-    while ((m = c.regex.exec(text)) !== null) {
-      const start = m.index;
-      const end = start + m[0].length;
-      // Guard against zero-width matches (would loop forever / decorate nothing).
-      if (end <= start) {
-        c.regex.lastIndex = start + 1;
-        continue;
-      }
-      candidates.push({
-        start,
-        end,
-        rule: c.rule,
-        color: c.color,
-        priority: c.priority,
-        order: c.order,
-      });
-    }
-  }
+/** How often (in matches) the guarded scan re-checks the wall-clock deadline. */
+const DEADLINE_CHECK_INTERVAL = 256;
 
+/** Result of a time-guarded line scan. */
+export interface GuardedMatchResult {
+  /** Non-overlapping, left-to-right matches (same shape as {@link findMatches}). */
+  matches: RuleMatch[];
+  /**
+   * Ids of rules whose scan was aborted because the per-line time budget was
+   * exceeded. The caller should disable these rules so a slow pattern cannot
+   * keep costing time on every subsequent line.
+   */
+  timedOutRuleIds: string[];
+}
+
+/** Resolves overlapping candidates into a non-overlapping, ordered match set. */
+function resolveOverlaps(candidates: Candidate[]): RuleMatch[] {
   // Strongest candidates first: longer, then higher priority, then earlier rule,
   // then earlier position.
   candidates.sort((a, b) => {
@@ -241,6 +235,84 @@ export function findMatches(text: string, compiled: readonly CompiledRule[]): Ru
 
   accepted.sort((a, b) => a.start - b.start);
   return accepted;
+}
+
+/**
+ * Runs all compiled rules against `text` under a wall-clock budget, resolving
+ * overlaps into a non-overlapping, left-to-right ordered set of matches.
+ *
+ * This is the ReDoS-resilient scan path. A single `RegExp.exec` cannot be
+ * interrupted, so the guard cannot pre-empt one catastrophic call — the
+ * save-time validator (`regexSafety.ts`) and the engine's line-length cap are
+ * what prevent that. What this *does* bound is the realistic runtime cost of a
+ * slow rule across a line: it checks the deadline between rules and periodically
+ * inside a rule's match loop, and reports any rule it had to abort so the engine
+ * can self-disable it rather than pay the cost on every future line.
+ *
+ * Resolution order when two matches overlap:
+ *   1. longest match wins,
+ *   2. then lower priority number wins,
+ *   3. then the earlier rule in the list wins,
+ *   4. then the earlier start position wins.
+ */
+export function findMatchesGuarded(
+  text: string,
+  compiled: readonly CompiledRule[],
+  budgetMs: number = DEFAULT_LINE_SCAN_BUDGET_MS,
+  nowFn: () => number = now
+): GuardedMatchResult {
+  const candidates: Candidate[] = [];
+  const timedOutRuleIds: string[] = [];
+  const deadline = nowFn() + budgetMs;
+
+  for (const c of compiled) {
+    if (nowFn() > deadline) {
+      // No time left even to start this rule — report it (and every remaining
+      // rule) as timed out so they are all disabled.
+      timedOutRuleIds.push(c.rule.id);
+      continue;
+    }
+
+    c.regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    let sinceCheck = 0;
+    while ((m = c.regex.exec(text)) !== null) {
+      const start = m.index;
+      const end = start + m[0].length;
+      // Guard against zero-width matches (would loop forever / decorate nothing).
+      if (end <= start) {
+        c.regex.lastIndex = start + 1;
+        continue;
+      }
+      candidates.push({
+        start,
+        end,
+        rule: c.rule,
+        color: c.color,
+        priority: c.priority,
+        order: c.order,
+      });
+
+      if (++sinceCheck >= DEADLINE_CHECK_INTERVAL) {
+        sinceCheck = 0;
+        if (nowFn() > deadline) {
+          timedOutRuleIds.push(c.rule.id);
+          break;
+        }
+      }
+    }
+  }
+
+  return { matches: resolveOverlaps(candidates), timedOutRuleIds };
+}
+
+/**
+ * Runs all compiled rules against `text` and resolves overlaps into a
+ * non-overlapping, left-to-right ordered set of matches. Unbudgeted convenience
+ * wrapper over {@link findMatchesGuarded}.
+ */
+export function findMatches(text: string, compiled: readonly CompiledRule[]): RuleMatch[] {
+  return findMatchesGuarded(text, compiled, Infinity).matches;
 }
 
 /**
@@ -287,6 +359,8 @@ export class SyntaxHighlightingEngine {
   private readonly xterm: Terminal;
   private readonly lineBudget: number;
   private readonly maxLineLength: number;
+  private readonly lineScanBudgetMs: number;
+  private readonly nowFn: () => number;
 
   private compiled: CompiledRule[] = [];
   private enabled = false;
@@ -312,6 +386,8 @@ export class SyntaxHighlightingEngine {
     this.xterm = xterm;
     this.lineBudget = options.lineBudget ?? DEFAULT_LINE_BUDGET;
     this.maxLineLength = options.maxLineLength ?? MAX_LINE_LENGTH;
+    this.lineScanBudgetMs = options.lineScanBudgetMs ?? DEFAULT_LINE_SCAN_BUDGET_MS;
+    this.nowFn = options.now ?? now;
   }
 
   /** Whether highlighting is currently active. */
@@ -484,7 +560,13 @@ export class SyntaxHighlightingEngine {
     if (logical.text.length > this.maxLineLength) return;
     if (this.compiled.length === 0) return;
 
-    const matches = findMatches(logical.text, this.compiled);
+    const { matches, timedOutRuleIds } = findMatchesGuarded(
+      logical.text,
+      this.compiled,
+      this.lineScanBudgetMs,
+      this.nowFn
+    );
+    if (timedOutRuleIds.length > 0) this.disableSlowRules(timedOutRuleIds);
     if (matches.length === 0) return;
 
     const cols = this.xterm.cols;
@@ -620,6 +702,21 @@ export class SyntaxHighlightingEngine {
       el.dataset.thHighlightStyled = "1";
     });
     out.push(sub);
+  }
+
+  /**
+   * Drops rules that overran the per-line scan budget so they cannot keep
+   * costing time on every subsequent line, and surfaces a recoverable error via
+   * the LogViewer. The rest of the engine keeps running with the safe rules.
+   */
+  private disableSlowRules(ruleIds: readonly string[]): void {
+    const slow = new Set(ruleIds);
+    this.compiled = this.compiled.filter((c) => !slow.has(c.rule.id));
+    frontendLog(
+      "syntaxHighlighting",
+      `disabled slow highlight rule(s) [${[...slow].join(", ")}] that exceeded the ` +
+        `${this.lineScanBudgetMs}ms per-line budget; highlighting continues without them.`
+    );
   }
 
   /** Disposes and forgets a single logical line's decorations. */


### PR DESCRIPTION
## Summary

Final leaf of the terminal syntax-highlighting epic (#1696): a UI to create, edit, delete, and reorder **custom highlight rules**, with **regex safety** as the headline feature so a user-entered pattern can never freeze the terminal render loop.

Closes #1703.

## What's included

- **Custom rules management** in the existing **Syntax Highlighting** settings section (`SyntaxHighlightingSettings.tsx`): a "Custom rules" list with enable toggle, color swatch, name, pattern, and per-row edit / delete / move-up / move-down, plus an "Add Rule" button. Persists to the global `syntaxHighlighting.customRules` via the existing settings `onChange` auto-save path, so custom rules flow through `resolveActiveRules` exactly like built-ins.
- **Inline editor** (`CustomRuleEditor.tsx`, new): name, regex pattern, case-sensitive / whole-word toggles, color + bold/italic/underline, and a **live static preview** that renders sample terminal text highlighted by the draft rule layered over the other active rules (reuses the engine's pure `compileRules` / `findMatches`).
- **Regex-safety validator** (`regexSafety.ts`, new): rejects empty, over-length (>500 chars), syntactically invalid, and catastrophic-backtracking (ReDoS) patterns **before save**. Layered defence: a deterministic nested-quantifier / star-height check catches the `(a+)+` family instantly, and an empirical adversarial-timing backstop catches overlap-based ReDoS (e.g. `(a|a)+`) the structural check misses. Invalid patterns surface an inline error and block Save.
- **Runtime backstop** in the engine (`syntaxHighlighting.ts`): `findMatchesGuarded` scans each line under a per-line wall-clock budget; a rule that overruns it is self-disabled with a recoverable LogViewer error, so a slow pattern degrades gracefully instead of hanging the render loop. `findMatches` is now an unbudgeted wrapper over it (public behaviour unchanged).
- Pure CRUD helpers (`customHighlightRules.ts`, new) keep add/edit/delete/reorder logic testable and immutable.

## Regex-safety approach

1. Length cap (500 chars).
2. Compile check (same `\b…\b` / flag wrapping the engine applies).
3. Deterministic structural detection of nested unbounded quantifiers (star height ≥ 2).
4. Empirical adversarial backstop with a wall-clock budget (deterministic in practice — safe vs. catastrophic patterns differ by orders of magnitude).
5. Engine per-line time budget that self-disables an overrunning rule.

## Tests

New/extended unit tests (all green, 86 across the touched files; full suite 3753 pass):

- `regexSafety.test.ts` — accepts normal rules; rejects empty / over-long / invalid / nested-quantifier / overlapping-alternation patterns; injected-clock budget checks.
- `customHighlightRules.test.ts` — CRUD + reorder immutability.
- `syntaxHighlighting.test.ts` — `findMatchesGuarded` timeout logic (injected clock) and engine self-disable + recoverable log.
- `CustomRuleEditor.test.tsx` — validation gating of Save, preview highlighting, edit pre-fill.
- `SyntaxHighlightingSettings.test.tsx` — add / edit / delete / reorder / toggle persistence.

`pnpm test`, `format:check`, `lint`, `markdownlint`, and `tsc --noEmit` all pass locally.

Part of epic #1696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
