### PR TITLE
feat(vnc): live display↔port auto-fill in the connection editor

### DIFF
--- a/docs/changes/dev1/feature/1716-vnc-display-port-autofill.md
+++ b/docs/changes/dev1/feature/1716-vnc-display-port-autofill.md
@@ -1,0 +1,8 @@
+### Added
+
+- VNC connection editor: the display number and TCP port now stay in sync.
+  Entering a display number auto-fills the port to `5900 + display`, and editing
+  the port directly clears the display so the explicit port wins — matching the
+  connect-side resolution. Clearing or entering an out-of-range/non-numeric
+  display leaves the port untouched, so a deliberately custom port is never
+  overwritten (#1716).

--- a/src/components/DynamicForm/ConnectionSettingsForm.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.tsx
@@ -5,6 +5,7 @@ import type { SettingsSchema } from "@/types/schema";
 import { isFieldVisible } from "@/utils/schemaDefaults";
 import { parseHostPort } from "@/utils/parseHostPort";
 import { ftpPortForTlsMode } from "@/utils/ftpSecurity";
+import { vncPortForDisplay } from "@/utils/vncDisplayPort";
 import { settingsSchemaToZod } from "./settingsSchemaToZod";
 import { DynamicField } from "./DynamicField";
 
@@ -50,7 +51,7 @@ export function ConnectionSettingsForm({
 }: ConnectionSettingsFormProps) {
   const zodSchema = useMemo(() => settingsSchemaToZod(schema), [schema]);
 
-  const { control, watch, reset, setValue } = useForm<Record<string, unknown>>({
+  const { control, watch, reset, setValue, getValues } = useForm<Record<string, unknown>>({
     defaultValues: settings,
     resolver: zodResolver(zodSchema),
     mode: "onChange",
@@ -67,6 +68,45 @@ export function ConnectionSettingsForm({
   const hasTlsAndPort = useMemo(
     () => hasPortField && schema.groups.some((g) => g.fields.some((f) => f.key === "tlsMode")),
     [schema, hasPortField]
+  );
+
+  // Whether this schema is VNC-shaped (has both a `display` field and a `port`
+  // field) — gates the live display↔port interplay special-case below.
+  const hasVncDisplay = useMemo(
+    () => hasPortField && schema.groups.some((g) => g.fields.some((f) => f.key === "display")),
+    [schema, hasPortField]
+  );
+
+  // VNC display↔port interplay (#1716): a VNC server listens on `5900 + display`,
+  // so editing the display number auto-fills the port, and editing the port
+  // directly clears the display (the concept's rule — the explicit port then
+  // wins). Wired into the field `onChange` rather than a `watch` effect so it
+  // fires only on genuine user edits: `setValue` below updates the sibling
+  // field's value without re-invoking its `onChange`, so there is no feedback
+  // loop and no spurious change on mount/reset. Auto-fill never overwrites an
+  // intentional port with an invalid/cleared display (see `vncPortForDisplay`).
+  const syncDisplayPort = useCallback(
+    (fieldKey: string, value: unknown) => {
+      if (!hasVncDisplay) return;
+      if (fieldKey === "display") {
+        const port = vncPortForDisplay(value);
+        if (port !== null && getValues("port") !== port) {
+          setValue("port", port, { shouldValidate: true, shouldDirty: true });
+        }
+      } else if (fieldKey === "port") {
+        const currentDisplay = getValues("display");
+        if (currentDisplay !== undefined && currentDisplay !== null && currentDisplay !== "") {
+          // Clear to `null` rather than `undefined`: react-hook-form's Controller
+          // does not re-render a controlled input when a value is set back to
+          // `undefined`, so the numeric widget would keep showing the stale
+          // display. `null` clears the widget (NumberField treats it as empty)
+          // and, unlike `""`, deserializes cleanly to the backend's
+          // `display: Option<u16>` as "no display" — the explicit port then wins.
+          setValue("display", null, { shouldValidate: true, shouldDirty: true });
+        }
+      }
+    },
+    [hasVncDisplay, getValues, setValue]
   );
 
   // Auto-extract `host:port` typed into the Host field on blur (PR #195 / #895).
@@ -199,7 +239,10 @@ export function ConnectionSettingsForm({
                     <DynamicField
                       field={field}
                       value={rhfField.value}
-                      onChange={rhfField.onChange}
+                      onChange={(value: unknown) => {
+                        rhfField.onChange(value);
+                        syncDisplayPort(field.key, value);
+                      }}
                       onBlur={() => handleFieldBlur(field.key, rhfField.value)}
                       error={fieldState.error?.message}
                       credentialSaved={

--- a/src/components/DynamicForm/ConnectionSettingsForm.vnc.test.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.vnc.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * VNC-specific behavior of the schema-driven connection form (#1716):
+ *
+ * A VNC server listens on `5900 + display`, so the editor keeps the two fields
+ * in sync — entering a display number auto-fills the port, and editing the port
+ * directly clears the display. This mirrors the connect-side resolution
+ * (`VncConfig::effective_port`) as an editor convenience, applied as a small
+ * frontend special-case the `equals`-only schema condition cannot express.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { SettingsSchema } from "@/types/schema";
+import { ConnectionSettingsForm } from "./ConnectionSettingsForm";
+import { dispatchCommand, type BridgeDeps } from "@/testbridge/dispatcher";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn().mockResolvedValue(null) }));
+vi.mock("@/services/api", () => ({ listSerialPorts: vi.fn().mockResolvedValue([]) }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+const VNC_SCHEMA: SettingsSchema = {
+  groups: [
+    {
+      key: "connection",
+      label: "Connection",
+      fields: [
+        { key: "host", label: "Host", fieldType: { type: "text" }, required: true },
+        { key: "port", label: "Port", fieldType: { type: "port" }, required: true, default: 5900 },
+      ],
+    },
+    {
+      key: "vnc",
+      label: "VNC Options",
+      fields: [
+        {
+          key: "display",
+          label: "Display Number",
+          fieldType: { type: "number", min: 0, max: 255 },
+          required: false,
+        },
+      ],
+    },
+  ],
+};
+
+let lastSettings: Record<string, unknown> = {};
+
+function renderForm(settings: Record<string, unknown>) {
+  lastSettings = { ...settings };
+  act(() => {
+    root.render(
+      <ConnectionSettingsForm
+        schema={VNC_SCHEMA}
+        settings={settings}
+        onChange={(s) => {
+          lastSettings = s;
+        }}
+      />
+    );
+  });
+}
+
+const bridgeDeps: BridgeDeps = {
+  root: document.body,
+  readTerminal: () => undefined,
+  scrollTerminal: () => false,
+  getTerminalViewport: () => undefined,
+  getActiveTabId: () => undefined,
+  getState: () => ({}),
+  sendTerminalInput: async () => false,
+  resizeWindow: async () => {},
+  screenshot: async () => "data:image/png;base64,AAAA",
+  emitEvent: async () => {},
+};
+
+async function typeInto(testId: string, text: string) {
+  const deps = { ...bridgeDeps, root: container };
+  await act(async () => {
+    await dispatchCommand({ action: "type", testId, text }, deps);
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("ConnectionSettingsForm — VNC display↔port interplay", () => {
+  it("auto-fills the port to 5900 + display when the display is entered", async () => {
+    renderForm({ host: "h", port: 5900 });
+    await typeInto("field-display", "5");
+    expect((query("field-port") as HTMLInputElement).value).toBe("5905");
+    expect(lastSettings.port).toBe(5905);
+  });
+
+  it("maps display 0 to the base port 5900", async () => {
+    renderForm({ host: "h", port: 5999 });
+    await typeInto("field-display", "0");
+    expect((query("field-port") as HTMLInputElement).value).toBe("5900");
+  });
+
+  it("clears the display when the port is edited directly", async () => {
+    renderForm({ host: "h", port: 5905, display: 5 });
+    await typeInto("field-port", "5910");
+    expect((query("field-display") as HTMLInputElement).value).toBe("");
+    // Cleared to a null-ish "no display" so the explicit port wins on connect.
+    expect(lastSettings.display == null).toBe(true);
+  });
+
+  it("leaves the port untouched when the display is cleared", async () => {
+    renderForm({ host: "h", port: 5905, display: 5 });
+    await typeInto("field-display", "");
+    expect((query("field-port") as HTMLInputElement).value).toBe("5905");
+  });
+
+  it("does not fill the port for an out-of-derivable-range display", async () => {
+    renderForm({ host: "h", port: 5900 });
+    // NumberInput accepts the raw digits; the derivation guards the TCP range.
+    await typeInto("field-display", "60000");
+    expect((query("field-port") as HTMLInputElement).value).toBe("5900");
+  });
+});

--- a/src/utils/vncDisplayPort.test.ts
+++ b/src/utils/vncDisplayPort.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { VNC_BASE_PORT, vncPortForDisplay } from "./vncDisplayPort";
+
+describe("vncPortForDisplay", () => {
+  it("maps display 0 to the base port 5900", () => {
+    expect(vncPortForDisplay(0)).toBe(5900);
+    expect(VNC_BASE_PORT).toBe(5900);
+  });
+
+  it("adds the display number to the base port", () => {
+    expect(vncPortForDisplay(1)).toBe(5901);
+    expect(vncPortForDisplay(5)).toBe(5905);
+    expect(vncPortForDisplay(99)).toBe(5999);
+  });
+
+  it("accepts the top of the schema's display range (255)", () => {
+    expect(vncPortForDisplay(255)).toBe(6155);
+  });
+
+  it("returns null for a cleared / empty display so the port is left untouched", () => {
+    expect(vncPortForDisplay(undefined)).toBeNull();
+    expect(vncPortForDisplay(null)).toBeNull();
+    expect(vncPortForDisplay("")).toBeNull();
+  });
+
+  it("returns null for non-numeric or invalid input rather than fighting the user", () => {
+    expect(vncPortForDisplay("abc")).toBeNull();
+    expect(vncPortForDisplay(NaN)).toBeNull();
+    expect(vncPortForDisplay(Infinity)).toBeNull();
+  });
+
+  it("returns null for negative or non-integer displays", () => {
+    expect(vncPortForDisplay(-1)).toBeNull();
+    expect(vncPortForDisplay(1.5)).toBeNull();
+  });
+
+  it("coerces a numeric string display (as widgets may emit) to its port", () => {
+    expect(vncPortForDisplay("3")).toBe(5903);
+  });
+
+  it("returns null when the derived port would exceed the valid TCP range", () => {
+    expect(vncPortForDisplay(60000)).toBeNull();
+  });
+});

--- a/src/utils/vncDisplayPort.ts
+++ b/src/utils/vncDisplayPort.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helper for the VNC connection editor's live display↔port interplay.
+ *
+ * VNC servers listen on `5900 + display`, so the connection editor keeps the
+ * two fields in sync: entering a display number auto-fills the port, and
+ * editing the port clears the display (see {@link vncPortForDisplay} and the
+ * connection form's `syncDisplayPort` handler). The connect-side resolution is
+ * done in the Rust core (`VncConfig::effective_port`); this mirrors only the
+ * *editor* convenience so the user does not have to compute the port by hand.
+ *
+ * Keeping the derivation as a side-effect-free function makes it trivially
+ * unit-testable and matches the FTP `ftpPortForTlsMode` special-case pattern.
+ */
+
+/** RFB display 0 → TCP port 5900. Mirrors `VNC_BASE_PORT` in the Rust core. */
+export const VNC_BASE_PORT = 5900;
+
+/** Highest TCP port the auto-filled value is allowed to reach. */
+const MAX_TCP_PORT = 65535;
+
+/**
+ * Derive the VNC TCP port for a display number, or `null` when the display is
+ * empty/invalid and the port should be left untouched.
+ *
+ * The display may arrive as a number (from the numeric widget) or a string,
+ * so it is accepted as `unknown` and coerced. Only a non-negative integer whose
+ * derived port (`5900 + display`) stays within the valid TCP range yields a
+ * port; anything else — a cleared field, non-numeric text, a negative, a
+ * fractional, or an out-of-range value — returns `null` so the auto-fill
+ * assists without ever fighting the user.
+ */
+export function vncPortForDisplay(display: unknown): number | null {
+  if (display === null || display === undefined || display === "") return null;
+  const n = typeof display === "number" ? display : Number(display);
+  if (!Number.isInteger(n) || n < 0) return null;
+  const port = VNC_BASE_PORT + n;
+  if (port > MAX_TCP_PORT) return null;
+  return port;
+}


### PR DESCRIPTION
Follow-up to #1681 (PR #1712). Implements the **editor UX** side of the VNC display↔port interplay; the connect-side resolution (`VncConfig::effective_port`, `5900 + display`) already landed in #1681.

## What changed
In the schema-driven connection editor (`ConnectionSettingsForm`), the VNC `display` and `port` fields now stay in sync:

- Entering a **display** number auto-fills **port** = `5900 + display`.
- Editing the **port** directly clears the **display**, so the explicit port wins on connect (matching the concept and the backend resolution).
- Auto-fill assists without fighting the user: clearing the display, non-numeric input, or a display whose derived port falls outside the valid TCP range leaves the port untouched — a deliberately custom port is never overwritten.

## How
- New pure helper `src/utils/vncDisplayPort.ts` (`vncPortForDisplay`) mirrors the FTP `ftpPortForTlsMode` special-case pattern and is fully unit-tested.
- Wired into the field `onChange` in `ConnectionSettingsForm.tsx` (gated on the VNC-shaped schema — a `display` field plus a `port` field), not a `watch` effect, so it fires only on genuine user edits and has no feedback loop / spurious change on mount or reset.
- Cleared display is set to `null` (not `undefined`, which react-hook-form's Controller won't re-render, and not `""`, which would break the backend's `display: Option<u16>` deserialization).

## Tests
- `vncDisplayPort.test.ts` — derivation, edge cases (empty, negative, fractional, non-numeric, out-of-range, numeric string).
- `ConnectionSettingsForm.vnc.test.tsx` — display→port auto-fill (incl. display 0→5900), port→clear-display, and the non-overwrite guards.
- Full frontend suite green (3736 tests), lint + typecheck + prettier + markdownlint clean.

Scope stayed in `src/components/ConnectionEditor`/`DynamicForm` + a small util; no backend changes.

Closes #1716