### PR TITLE
docs: fix stale/dangling references to converted concept docs (Closes #1748)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -49,7 +49,7 @@ self-contained HTML file** — `docs/concepts/<status>/<name>.html` — instead 
 file holds everything: prose (the standard concept sections), Mermaid diagrams, the mockups, and
 the sync ledger. This is a **design-first loop**: the file is both the human discussion medium
 (opened in a browser) and Claude Code's implementation target. Full design:
-[`docs/concepts/ai-driven-concept-workflow.md`](../docs/concepts/implemented/ai-driven-concept-workflow.md).
+[`docs/concepts/implemented/ai-driven-concept-workflow.html`](../docs/concepts/implemented/ai-driven-concept-workflow.html).
 (Concepts with **no** visual surface stay a single `.md` — see the Concept Issues section above.)
 
 **Three fixed rules:**

--- a/.claude/skills/sync-concept/SKILL.md
+++ b/.claude/skills/sync-concept/SKILL.md
@@ -6,7 +6,7 @@ description: Reconcile a single-file HTML concept (docs/concepts/<status>/<name>
 # Sync Concept
 
 This skill is the **human-triggered sync step** of termiHub's AI-driven concept workflow
-(see `docs/concepts/implemented/ai-driven-concept-workflow.md`). It compares a concept's design
+(see `docs/concepts/implemented/ai-driven-concept-workflow.html`). It compares a concept's design
 artifacts against the actual implementation and reconciles them.
 
 **Source-of-truth rule (non-negotiable): the concept is authoritative.** When the artifacts and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -462,7 +462,7 @@ graph LR
 | **State**      | `agent/src/state/`      | Session state persistence (`~/.config/termihub-agent/state.json`) for daemon recovery after agent restart                                                                                                                             |
 | **IO**         | `agent/src/io/`         | Transport layer — stdio (production SSH mode) and TCP (development/test mode)                                                                                                                                                         |
 
-The agent was recently refactored into a **thin proxy** over the core `ConnectionType` registry. All session lifecycle methods now use the `connection.*` JSON-RPC namespace (`connection.create`, `connection.attach`, `connection.detach`, `connection.input`, `connection.resize`, `connection.close`, `connection.list`). The agent's dispatcher routes these generically through the registry — no connection-type-specific dispatch code. See [Remote Protocol](remote-protocol.md) for the full specification and [Agent Concept](concepts/handled/agent.md) for the design vision.
+The agent was recently refactored into a **thin proxy** over the core `ConnectionType` registry. All session lifecycle methods now use the `connection.*` JSON-RPC namespace (`connection.create`, `connection.attach`, `connection.detach`, `connection.input`, `connection.resize`, `connection.close`, `connection.list`). The agent's dispatcher routes these generically through the registry — no connection-type-specific dispatch code. See [Remote Protocol](remote-protocol.md) for the full specification and [Agent Concept](concepts/implemented/agent.html) for the design vision.
 
 ### Level 3: ConnectionType Architecture
 
@@ -904,7 +904,7 @@ Linux targets are cross-compiled to static musl binaries via `cross-rs` from any
 
 **Cross-platform daemon:** The session daemon is cross-platform end-to-end. Its frame protocol and IPC transport run over a Unix domain socket on unix and a Windows named pipe (per-user DACL) on windows (`agent/src/daemon/transport.rs`); shell spawning uses `portable-pty` (ConPTY on Windows); and the `SystemDaemonLauncher` spawns a detached daemon process on both platforms (orphaned child on unix, `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW` on windows). Persistent (reconnectable) agent sessions therefore work on Windows as well as unix; no `nix` fork/setsid/signal is used on the daemon path.
 
-See [Remote Protocol](remote-protocol.md) for the full protocol specification and [Agent Concept](concepts/agent.md) for the complete design vision.
+See [Remote Protocol](remote-protocol.md) for the full protocol specification and [Agent Concept](concepts/implemented/agent.html) for the complete design vision.
 
 ---
 
@@ -1325,7 +1325,7 @@ features it must not be confused with: the **SFTP file browser** (an SSH subsyst
 
 ### ADR-7: ConnectionType Trait and Registry
 
-**Context:** The original `TerminalBackend` trait (ADR-3) lived in the desktop crate, and each connection type was implemented independently in both the desktop and agent, leading to deep duplication. The [Shared Rust Core concept](concepts/shared-rust-core.md) identified that both crates implement the same session lifecycle with the only difference being the transport layer. Additionally, adding a new connection type required frontend changes — adding a variant to the `ConnectionConfig` enum, writing a type-specific settings component, and updating connection type checks throughout the UI.
+**Context:** The original `TerminalBackend` trait (ADR-3) lived in the desktop crate, and each connection type was implemented independently in both the desktop and agent, leading to deep duplication. The [Shared Rust Core concept](concepts/implemented/shared-rust-core.html) identified that both crates implement the same session lifecycle with the only difference being the transport layer. Additionally, adding a new connection type required frontend changes — adding a variant to the `ConnectionConfig` enum, writing a type-specific settings component, and updating connection type checks throughout the UI.
 
 **Decision:** Define a `ConnectionType` async trait in `termihub-core` that all backends implement, paired with a `ConnectionTypeRegistry` for runtime discovery and a `SettingsSchema` system for dynamic UI form generation. Connection types declare their settings, capabilities, and lifecycle in core; both the desktop and agent register the same implementations from core at startup.
 

--- a/docs/concepts/future/package-manager.html
+++ b/docs/concepts/future/package-manager.html
@@ -564,7 +564,7 @@
       <section>
         <h2 id="overview">Overview <a class="anchor" href="#overview">#</a></h2>
         <p>
-          The <a href="../plugin-system/concept.md">Plugin System concept</a> defines how termiHub
+          The <a href="plugin-system.html">Plugin System concept</a> defines how termiHub
           loads and runs extensions at runtime — but it only supports local, manual installation
           from <code>.termihub-plugin</code> files. There is no way to discover, browse, or
           automatically update plugins, and no mechanism to manage tool packages for an embedded
@@ -601,7 +601,7 @@
             </thead>
             <tbody>
               <tr>
-                <td><a href="../plugin-system/concept.md">Plugin System</a></td>
+                <td><a href="plugin-system.html">Plugin System</a></td>
                 <td>Runtime loading, extension points, sandboxing, permissions</td>
               </tr>
               <tr>
@@ -610,7 +610,7 @@
               </tr>
               <tr>
                 <td>
-                  <a href="../../backlog/embedded-unix-windows/concept.md"
+                  <a href="../future/embedded-unix-windows.html"
                     >Embedded Unix Environment</a
                   >
                 </td>

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -485,7 +485,7 @@ it("should have no accessibility violations", async () => {
 
 ## Comprehensive System Tests
 
-termiHub includes a comprehensive test infrastructure with 13 Docker containers (SSH variants, telnet, serial, SFTP stress, network fault injection) and Rust integration tests that exercise the app's backends directly. See the [concept document](concepts/comprehensive-test-infrastructure.md) for the full design.
+termiHub includes a comprehensive test infrastructure with 13 Docker containers (SSH variants, telnet, serial, SFTP stress, network fault injection) and Rust integration tests that exercise the app's backends directly. See the [concept document](concepts/partial/comprehensive-test-infrastructure.html) for the full design.
 
 ### Quick Start
 

--- a/src/services/syntaxHighlighting.ts
+++ b/src/services/syntaxHighlighting.ts
@@ -15,7 +15,7 @@
  * The matching logic (`compileRules`, `findMatches`) is exported as pure
  * functions so it can be tested without a terminal instance.
  *
- * See `docs/concepts/partial/terminal-syntax-highlighting.md`.
+ * See `docs/concepts/partial/terminal-syntax-highlighting.html`.
  */
 
 import type { IBufferCell, IBufferLine, IDisposable, Terminal } from "@xterm/xterm";

--- a/src/types/syntaxHighlighting.ts
+++ b/src/types/syntaxHighlighting.ts
@@ -2,7 +2,7 @@
  * Type definitions for terminal output syntax highlighting.
  *
  * These describe the rule/config data model for the client-side highlighting
- * feature (see `docs/concepts/partial/terminal-syntax-highlighting.md`). The
+ * feature (see `docs/concepts/partial/terminal-syntax-highlighting.html`). The
  * engine (`src/services/syntaxHighlighting.ts`) consumes {@link HighlightRule}s
  * and produces xterm.js decorations; the built-in rule set lives in
  * `src/services/syntaxHighlightingRules.ts`.


### PR DESCRIPTION
Follow-up to #1742 (PR #1745), which converted all concept docs from Markdown to single-file HTML. A handful of references **outside** `docs/concepts/` still pointed at the now-removed `.md` paths (some newly dangling from the rename, some already stale beforehand). This cleans them up.

## Changes

Newly dangling (file renamed to `.html` by #1745):
- `.claude/CLAUDE.md` — `ai-driven-concept-workflow.md` → `.html` (link text + URL)
- `.claude/skills/sync-concept/SKILL.md` — `ai-driven-concept-workflow.md` → `.html`
- `src/types/syntaxHighlighting.ts` (comment) — `terminal-syntax-highlighting.md` → `.html`
- `src/services/syntaxHighlighting.ts` (comment) — `terminal-syntax-highlighting.md` → `.html`

Already stale before #1745 (fixed to the correct current path):
- `docs/architecture.md` — `concepts/handled/agent.md` and `concepts/agent.md` → `concepts/implemented/agent.html`; `concepts/shared-rust-core.md` → `concepts/implemented/shared-rust-core.html`
- `docs/testing.md` — `concepts/comprehensive-test-infrastructure.md` → `concepts/partial/comprehensive-test-infrastructure.html`
- `docs/concepts/future/package-manager.html` — two legacy folder-form links (`../plugin-system/concept.md` → `plugin-system.html`; `../../backlog/embedded-unix-windows/concept.md` → `../future/embedded-unix-windows.html`)

`CHANGELOG.md` left untouched (historical record).

## Verification

Every corrected path was confirmed to point at a real file under `docs/concepts/`. A repo-wide `grep` for `concepts/*.md` (excluding `CHANGELOG.md`) now returns only intentional links to the real `docs/concepts/README.md` and generic `<name>.md` placeholders describing the still-valid plain-Markdown concept form — no dangling references to non-existent concept docs remain.

Closes #1748