### PR TITLE
feat(terminal): per-connection additional highlight rules editor

### DIFF
--- a/docs/changes/dev1/feature/1744-per-connection-rules-editor.md
+++ b/docs/changes/dev1/feature/1744-per-connection-rules-editor.md
@@ -1,0 +1,10 @@
+### Added
+
+- Per-connection terminal settings now have an **"Additional rules for this
+  connection"** section under the Syntax Highlighting override. A connection can
+  define its own extra highlight rules (add / edit / delete / reorder) using the
+  same regex-safety-validated rule editor as the global custom rules. These
+  rules are appended after the global rules — they add patterns for that
+  connection only and never remove global rules — and persist across restart.
+  Clearing the last additional rule while the override is "Use global default"
+  removes the per-connection override entirely (#1744, epic #1696).

--- a/src/components/ConnectionEditor/ConnectionAdditionalRules.css
+++ b/src/components/ConnectionEditor/ConnectionAdditionalRules.css
@@ -1,0 +1,58 @@
+/* === Per-connection additional highlight rules (#1744) === */
+.connection-additional-rules__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.connection-additional-rules__empty {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+.connection-additional-rule {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+}
+
+.connection-additional-rule:hover {
+  background-color: var(--bg-tertiary);
+}
+
+.connection-additional-rule__swatch {
+  flex-shrink: 0;
+  width: var(--spacing-md);
+  height: var(--spacing-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-secondary);
+}
+
+.connection-additional-rule__name {
+  flex-shrink: 0;
+  min-width: 8rem;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+}
+
+.connection-additional-rule__pattern {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.connection-additional-rule__actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--spacing-xs);
+}

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
@@ -5,7 +5,9 @@ import { useAppStore } from "@/store/appStore";
 import {
   ConnectionTerminalSettings,
   applyHighlightingOverride,
+  applyAdditionalRules,
 } from "./ConnectionTerminalSettings";
+import { resolveHighlightingConfig } from "@/services/syntaxHighlightingConfig";
 import type { TerminalOptions } from "@/types/terminal";
 import type { HighlightRule } from "@/types/syntaxHighlighting";
 
@@ -39,10 +41,14 @@ vi.mock("@/services/api", () => ({
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
 }));
 
-vi.mock("@/themes", () => ({
-  applyTheme: vi.fn(),
-  onThemeChange: vi.fn(() => vi.fn()),
-}));
+vi.mock("@/themes", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/themes")>();
+  return {
+    ...actual,
+    applyTheme: vi.fn(),
+    onThemeChange: vi.fn(() => vi.fn()),
+  };
+});
 
 const emptyOptions: TerminalOptions = {};
 
@@ -309,5 +315,141 @@ describe("applyHighlightingOverride", () => {
       "global"
     );
     expect(next.syntaxHighlighting).toEqual({ override: "global", additionalRules: [rule] });
+  });
+});
+
+describe("applyAdditionalRules", () => {
+  const rule: HighlightRule = {
+    id: "custom-1",
+    name: "custom",
+    pattern: "foo",
+    style: { color: "#ff0000" },
+    enabled: true,
+    priority: 5,
+    builtin: false,
+  };
+
+  it("stores the rules under the current (default global) override", () => {
+    const next = applyAdditionalRules({ fontSize: 14 }, [rule]);
+    expect(next.syntaxHighlighting).toEqual({ override: "global", additionalRules: [rule] });
+    expect(next.fontSize).toBe(14);
+  });
+
+  it("preserves a non-global override when the rules change", () => {
+    const next = applyAdditionalRules(
+      { syntaxHighlighting: { override: "always-on", additionalRules: [] } },
+      [rule]
+    );
+    expect(next.syntaxHighlighting).toEqual({ override: "always-on", additionalRules: [rule] });
+  });
+
+  it("clears the whole override object when the last rule is removed under 'global'", () => {
+    const next = applyAdditionalRules(
+      { syntaxHighlighting: { override: "global", additionalRules: [rule] } },
+      []
+    );
+    expect(next.syntaxHighlighting).toBeUndefined();
+  });
+
+  it("keeps a non-global override even with no additional rules", () => {
+    const next = applyAdditionalRules(
+      { syntaxHighlighting: { override: "always-off", additionalRules: [rule] } },
+      []
+    );
+    expect(next.syntaxHighlighting).toEqual({ override: "always-off", additionalRules: [] });
+  });
+
+  it("produces a structure that resolves appended after the global rules", () => {
+    const globalRule: HighlightRule = {
+      id: "g-1",
+      name: "global",
+      pattern: "bar",
+      style: { color: "#00ff00" },
+      enabled: true,
+      priority: 1,
+      builtin: false,
+    };
+    const options = applyAdditionalRules({}, [rule]);
+    const resolved = resolveHighlightingConfig(
+      { enabled: true, builtinRules: {}, customRules: [globalRule] },
+      options.syntaxHighlighting
+    );
+    expect(resolved.customRules.map((r) => r.id)).toEqual(["g-1", "custom-1"]);
+  });
+});
+
+describe("ConnectionTerminalSettings — additional rules editor", () => {
+  const rule: HighlightRule = {
+    id: "custom-99",
+    name: "todos",
+    pattern: "TODO",
+    style: { color: "#ffaa00" },
+    enabled: true,
+    priority: 1,
+    builtin: false,
+  };
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const byTestId = (id: string) =>
+    container.querySelector(`[data-testid="${id}"]`) as HTMLElement | null;
+
+  const click = (el: Element | null) => act(() => (el as HTMLElement).click());
+
+  it("renders the additional-rules section with an add button and empty state", () => {
+    renderWith(emptyOptions);
+    expect(byTestId("connection-additional-rule-add")).not.toBeNull();
+    expect(byTestId("connection-additional-rules-empty")).not.toBeNull();
+  });
+
+  it("lists an existing connection rule", () => {
+    renderWith({
+      ...emptyOptions,
+      syntaxHighlighting: { override: "global", additionalRules: [rule] },
+    });
+    expect(byTestId(`connection-additional-rule-${rule.id}`)).not.toBeNull();
+    expect(byTestId("connection-additional-rules-empty")).toBeNull();
+  });
+
+  it("adds a connection rule through the reused CustomRuleEditor", () => {
+    const onChange = renderWith(emptyOptions);
+    click(byTestId("connection-additional-rule-add"));
+
+    setValue(byTestId("custom-rule-name") as HTMLInputElement, "My Rule");
+    setValue(byTestId("custom-rule-pattern") as HTMLInputElement, "WARN");
+    click(byTestId("custom-rule-save"));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        syntaxHighlighting: expect.objectContaining({
+          override: "global",
+          additionalRules: expect.arrayContaining([
+            expect.objectContaining({ name: "My Rule", pattern: "WARN" }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it("removes a connection rule, clearing the override object when it was the last one", () => {
+    const onChange = renderWith({
+      ...emptyOptions,
+      syntaxHighlighting: { override: "global", additionalRules: [rule] },
+    });
+    click(byTestId(`connection-additional-rule-delete-${rule.id}`));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ syntaxHighlighting: undefined })
+    );
   });
 });

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
@@ -1,8 +1,19 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Pencil, Plus, Trash2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { TerminalOptions, LineEnding } from "@/types/terminal";
-import type { ConnectionHighlightingOverride } from "@/types/syntaxHighlighting";
+import type { ConnectionHighlightingOverride, HighlightRule } from "@/types/syntaxHighlighting";
 import { DEFAULT_LINE_ENDING, LINE_ENDING_OPTIONS, lineEndingLabel } from "@/utils/lineEndings";
-import { Input, NumberInput, Select, Toggle } from "@/components/ui";
+import { Button, Checkbox, Input, NumberInput, Select, Toggle } from "@/components/ui";
+import { CustomRuleEditor } from "@/components/Settings/CustomRuleEditor";
+import {
+  addCustomRule,
+  moveCustomRule,
+  removeCustomRule,
+  updateCustomRule,
+} from "@/services/customHighlightRules";
+import { defaultHighlightingConfig } from "@/services/syntaxHighlightingConfig";
+import "./ConnectionAdditionalRules.css";
 
 interface ConnectionTerminalSettingsProps {
   options: TerminalOptions;
@@ -35,6 +46,169 @@ export function applyHighlightingOverride(
     return { ...options, syntaxHighlighting: undefined };
   }
   return { ...options, syntaxHighlighting: { override, additionalRules } };
+}
+
+/**
+ * Compute the next {@link TerminalOptions} when the connection's list of
+ * additional highlight rules changes (epic #1696, child #1744).
+ *
+ * The override is preserved; only the rules change. Clearing the last rule
+ * while the override is still "global" collapses the whole `syntaxHighlighting`
+ * object back to `undefined` (mirroring {@link applyHighlightingOverride}) so a
+ * connection with no override and no extra rules does not persist an empty
+ * terminal override.
+ */
+export function applyAdditionalRules(
+  options: TerminalOptions,
+  additionalRules: HighlightRule[]
+): TerminalOptions {
+  const override = options.syntaxHighlighting?.override ?? "global";
+  if (override === "global" && additionalRules.length === 0) {
+    return { ...options, syntaxHighlighting: undefined };
+  }
+  return { ...options, syntaxHighlighting: { override, additionalRules } };
+}
+
+/** Which per-connection additional rule the inline editor is open for, if any. */
+type AdditionalRuleEditorState = { mode: "new" } | { mode: "edit"; id: string } | null;
+
+/**
+ * Per-connection "additional highlight rules" editor (#1744).
+ *
+ * Reuses the global {@link CustomRuleEditor} (regex-safety validated) and the
+ * pure custom-rule helpers to add / edit / delete / reorder rules stored in
+ * `TerminalOptions.syntaxHighlighting.additionalRules`. These rules are
+ * appended after the global rules by `resolveHighlightingConfig` — they can add
+ * patterns for this connection but never remove global rules.
+ */
+function ConnectionAdditionalRules({ options, onChange }: ConnectionTerminalSettingsProps) {
+  const globalSettings = useAppStore((s) => s.settings);
+  const [editor, setEditor] = useState<AdditionalRuleEditorState>(null);
+
+  const rules = options.syntaxHighlighting?.additionalRules ?? [];
+  const globalConfig = globalSettings.syntaxHighlighting ?? defaultHighlightingConfig();
+
+  const setRules = (next: HighlightRule[]) => onChange(applyAdditionalRules(options, next));
+
+  const handleSave = (rule: HighlightRule) => {
+    const exists = rules.some((r) => r.id === rule.id);
+    setRules(exists ? updateCustomRule(rules, rule) : addCustomRule(rules, rule));
+    setEditor(null);
+  };
+
+  const editingRule =
+    editor?.mode === "edit" ? rules.find((r) => r.id === editor.id) : undefined;
+
+  return (
+    <div className="settings-form__field">
+      <div className="connection-additional-rules__header">
+        <span className="settings-form__label">Additional rules for this connection</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={<Plus size={14} />}
+          onClick={() => setEditor({ mode: "new" })}
+          disabled={editor !== null}
+          data-testid="connection-additional-rule-add"
+        >
+          Add Rule
+        </Button>
+      </div>
+      <span className="settings-form__hint">
+        Extra highlight rules applied only to this connection, after the global rules. They can add
+        patterns but never remove global rules.
+      </span>
+
+      {rules.length === 0 && editor?.mode !== "new" ? (
+        <span
+          className="connection-additional-rules__empty"
+          data-testid="connection-additional-rules-empty"
+        >
+          No connection-specific rules yet. Add one to highlight patterns for this connection only.
+        </span>
+      ) : null}
+
+      {rules.map((rule, index) => {
+        const isEditing = editor?.mode === "edit" && editor.id === rule.id;
+        if (isEditing) return null;
+        return (
+          <div
+            className="connection-additional-rule"
+            key={rule.id}
+            data-testid={`connection-additional-rule-${rule.id}`}
+          >
+            <Checkbox
+              checked={rule.enabled}
+              onCheckedChange={(checked) =>
+                setRules(updateCustomRule(rules, { ...rule, enabled: checked }))
+              }
+              disabled={editor !== null}
+              aria-label={`Enable ${rule.name}`}
+              data-testid={`connection-additional-rule-enabled-${rule.id}`}
+            />
+            <span
+              className="connection-additional-rule__swatch"
+              style={{ backgroundColor: rule.style.color }}
+              aria-hidden="true"
+            />
+            <span className="connection-additional-rule__name">{rule.name}</span>
+            <code className="connection-additional-rule__pattern">{rule.pattern}</code>
+            <div className="connection-additional-rule__actions">
+              <Button
+                variant="ghost"
+                size="sm"
+                iconOnly
+                icon={<ChevronUp size={14} />}
+                aria-label={`Move ${rule.name} up`}
+                disabled={editor !== null || index === 0}
+                onClick={() => setRules(moveCustomRule(rules, index, index - 1))}
+                data-testid={`connection-additional-rule-up-${rule.id}`}
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                iconOnly
+                icon={<ChevronDown size={14} />}
+                aria-label={`Move ${rule.name} down`}
+                disabled={editor !== null || index === rules.length - 1}
+                onClick={() => setRules(moveCustomRule(rules, index, index + 1))}
+                data-testid={`connection-additional-rule-down-${rule.id}`}
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                iconOnly
+                icon={<Pencil size={14} />}
+                aria-label={`Edit ${rule.name}`}
+                disabled={editor !== null}
+                onClick={() => setEditor({ mode: "edit", id: rule.id })}
+                data-testid={`connection-additional-rule-edit-${rule.id}`}
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                iconOnly
+                icon={<Trash2 size={14} />}
+                aria-label={`Delete ${rule.name}`}
+                disabled={editor !== null}
+                onClick={() => setRules(removeCustomRule(rules, rule.id))}
+                data-testid={`connection-additional-rule-delete-${rule.id}`}
+              />
+            </div>
+          </div>
+        );
+      })}
+
+      {editor !== null ? (
+        <CustomRuleEditor
+          rule={editingRule}
+          config={globalConfig}
+          onSave={handleSave}
+          onCancel={() => setEditor(null)}
+        />
+      ) : null}
+    </div>
+  );
 }
 
 export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerminalSettingsProps) {
@@ -205,6 +379,8 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
           connection regardless of the global switch.
         </span>
       </label>
+
+      <ConnectionAdditionalRules options={options} onChange={onChange} />
     </div>
   );
 }

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
@@ -96,8 +96,7 @@ function ConnectionAdditionalRules({ options, onChange }: ConnectionTerminalSett
     setEditor(null);
   };
 
-  const editingRule =
-    editor?.mode === "edit" ? rules.find((r) => r.id === editor.id) : undefined;
+  const editingRule = editor?.mode === "edit" ? rules.find((r) => r.id === editor.id) : undefined;
 
   return (
     <div className="settings-form__field">


### PR DESCRIPTION
## Summary

Adds the deferred editing UI from #1704: an **"Additional rules for this connection"** section in the per-connection terminal settings (`ConnectionTerminalSettings.tsx`), under the Syntax Highlighting override.

The data model and resolution already existed (#1698 `additionalRules`, #1704 `applyHighlightingOverride` preservation, `resolveHighlightingConfig` append-after-global). This wires the **editing UI** by **reusing the `CustomRuleEditor` component from #1703** (with its ReDoS/regex-safety validation) plus the pure custom-rule helpers — no second rule editor was built.

## Behavior

- Add / edit / delete / reorder connection-specific highlight rules, written to `TerminalOptions.syntaxHighlighting.additionalRules`.
- Rules are **appended after** the global rules — they can add patterns but never remove global rules (contract honored by `resolveHighlightingConfig`).
- A new `applyAdditionalRules` helper mirrors `applyHighlightingOverride`: clearing the last rule while the override is `global` collapses the whole `syntaxHighlighting` object back to `undefined`, so a connection with no override and no extra rules does not persist an empty terminal override.
- Regex safety is inherited from the reused editor — a catastrophic-backtracking pattern can never be saved.

## Tests

- `applyAdditionalRules` unit tests (store-under-override, preserve non-global override, clear-when-empty-and-global, append-after-global resolution via `resolveHighlightingConfig`).
- Component tests: renders section + empty state, lists an existing rule, adds a rule through the reused `CustomRuleEditor`, removes a rule (clearing the override object). `./scripts/check.sh` green; no `any`.

Closes #1744

Refs #522, #1696, #1698, #1703, #1704