### PR TITLE
test(vnc): assert server→client clipboard echo in the VNC integration test (Closes #1737)

### DIFF
--- a/core/tests/vnc.rs
+++ b/core/tests/vnc.rs
@@ -27,6 +27,10 @@ const VNC_PASSWORD: &str = "testpass";
 /// The fixture's framebuffer geometry.
 const FB_WIDTH: u32 = 1024;
 const FB_HEIGHT: u32 = 768;
+/// The known X selection the fixture owns, which x11vnc forwards to the client
+/// as an RFB `ServerCutText`. MUST match `CLIPBOARD_TEXT` in
+/// `tests/docker/vnc-server/entrypoint.sh`.
+const VNC_SERVER_CLIPBOARD: &str = "termiHub vnc server clipboard 4711";
 
 /// Settings JSON for the fixture with the correct password.
 fn vnc_settings(port: u16) -> serde_json::Value {
@@ -260,12 +264,46 @@ async fn vnc_03_input_and_clipboard() {
         .await
         .expect("VNC-03: set_clipboard should reach the server");
 
-    // get_clipboard reads the last server-pushed cut text; the fixture pushes
-    // none, so this must not error and simply reports no remote clipboard.
-    let remote = graphical.get_clipboard().await;
-    assert!(
-        remote.is_none(),
-        "VNC-03: fixture pushes no clipboard, expected None, got {remote:?}"
+    // get_clipboard reads the last server-pushed cut text. It must never error;
+    // its value is timing-dependent (the fixture pushes asynchronously), so the
+    // deterministic server->client assertion lives in VNC-05, not here.
+    let _ = graphical.get_clipboard().await;
+
+    vnc.disconnect().await.expect("disconnect should succeed");
+}
+
+// ── VNC-05: Server->client clipboard echo (ServerCutText) ───────────
+
+#[tokio::test]
+async fn vnc_05_server_clipboard_echo() {
+    require_docker!(port_vnc());
+
+    let mut vnc = Vnc::new();
+    vnc.connect(vnc_settings(port_vnc()))
+        .await
+        .expect("VNC-05: connect should succeed");
+
+    let graphical = vnc.graphical().expect("VNC-05: graphical backend present");
+
+    // The fixture owns a known X selection that x11vnc forwards as an RFB
+    // ServerCutText; the backend routes it (VncEvent::Text) into get_clipboard.
+    // Delivery is asynchronous — the fixture re-asserts the selection on a loop,
+    // so poll until the known value arrives rather than reading once.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let mut received = None;
+    while tokio::time::Instant::now() < deadline {
+        if let Some(text) = graphical.get_clipboard().await {
+            received = Some(text);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    assert_eq!(
+        received.as_deref(),
+        Some(VNC_SERVER_CLIPBOARD),
+        "VNC-05: expected the server->client clipboard echo to surface the \
+         fixture's known selection, got {received:?}"
     );
 
     vnc.disconnect().await.expect("disconnect should succeed");

--- a/core/tests/vnc.rs
+++ b/core/tests/vnc.rs
@@ -287,13 +287,16 @@ async fn vnc_05_server_clipboard_echo() {
 
     // The fixture owns a known X selection that x11vnc forwards as an RFB
     // ServerCutText; the backend routes it (VncEvent::Text) into get_clipboard.
-    // Delivery is asynchronous — the fixture re-asserts the selection on a loop,
-    // so poll until the known value arrives rather than reading once.
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    // Delivery is asynchronous and the fixture alternates the selection with a
+    // priming value to force genuine changes, so get_clipboard may transiently
+    // report the priming value — poll until the known value surfaces. The
+    // timeout is generous because x11vnc's selection forwarding takes a little
+    // while to warm up after the fixture starts (see tests/docker/vnc-server).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(45);
     let mut received = None;
     while tokio::time::Instant::now() < deadline {
-        if let Some(text) = graphical.get_clipboard().await {
-            received = Some(text);
+        received = graphical.get_clipboard().await;
+        if received.as_deref() == Some(VNC_SERVER_CLIPBOARD) {
             break;
         }
         tokio::time::sleep(Duration::from_millis(250)).await;

--- a/tests/docker/vnc-server/Dockerfile
+++ b/tests/docker/vnc-server/Dockerfile
@@ -14,6 +14,9 @@
 #           BLUE, bottom-right WHITE. Solid regions decode to exact RGBA under
 #           every encoding, so the integration test can assert the decoded
 #           framebuffer pixel-for-pixel without tolerance games.
+# Clipboard: the entrypoint owns a known X selection (via xclip) so x11vnc
+#           forwards it to the client as an RFB ServerCutText — the server->client
+#           clipboard path (#1737) that the integration test asserts end to end.
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -22,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     feh \
     imagemagick \
     x11-utils \
+    xclip \
     && rm -rf /var/lib/apt/lists/*
 
 # Bake the deterministic test pattern (four primary-colour quadrants of a

--- a/tests/docker/vnc-server/Dockerfile
+++ b/tests/docker/vnc-server/Dockerfile
@@ -17,6 +17,9 @@
 # Clipboard: the entrypoint owns a known X selection (via xclip) so x11vnc
 #           forwards it to the client as an RFB ServerCutText — the server->client
 #           clipboard path (#1737) that the integration test asserts end to end.
+#           A persistent internal xtightvncviewer (rendered to a throwaway Xvfb
+#           :1) keeps x11vnc's selection machinery warm, since a fresh x11vnc
+#           does not reliably forward the selection to its very first client.
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -26,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     imagemagick \
     x11-utils \
     xclip \
+    xtightvncviewer \
     && rm -rf /var/lib/apt/lists/*
 
 # Bake the deterministic test pattern (four primary-colour quadrants of a

--- a/tests/docker/vnc-server/entrypoint.sh
+++ b/tests/docker/vnc-server/entrypoint.sh
@@ -49,4 +49,31 @@ for _ in 1 2 3; do
     sleep 0.5
 done
 
+# Own a known X selection so x11vnc forwards it to the client as an RFB
+# ServerCutText — the server->client clipboard path asserted by the VNC
+# integration test (#1737). This string MUST match VNC_SERVER_CLIPBOARD in
+# core/tests/vnc.rs. Kept pure ASCII so it survives the RFB latin-1 cut-text
+# encoding unchanged.
+CLIPBOARD_TEXT="termiHub vnc server clipboard 4711"
+
+# x11vnc only emits a ServerCutText on a genuine selection *change*, and it
+# de-duplicates identical text, so a one-shot set that predates the client
+# connection may never reach it. Re-assert the selection in a loop: `xclip
+# -loops 1` holds ownership until the selection is read exactly once (x11vnc's
+# read counts), then exits, leaving the selection empty; the next iteration
+# re-owns it, which x11vnc sees as an empty->known change and pushes. This keeps
+# the known value flowing to whichever client is connected, so a client that
+# attaches at any time receives it within one iteration. PRIMARY and CLIPBOARD
+# are both covered because x11vnc may forward either.
+own_selection() {
+    sel="$1"
+    while true; do
+        printf '%s' "$CLIPBOARD_TEXT" \
+            | xclip -display :0 -selection "$sel" -loops 1 -quiet >/dev/null 2>&1 || true
+        sleep 1
+    done
+}
+own_selection primary &
+own_selection clipboard &
+
 wait "$x11vnc_pid"

--- a/tests/docker/vnc-server/entrypoint.sh
+++ b/tests/docker/vnc-server/entrypoint.sh
@@ -49,31 +49,56 @@ for _ in 1 2 3; do
     sleep 0.5
 done
 
+# Keep x11vnc's selection machinery warm. A freshly started x11vnc does not
+# reliably forward the X selection as a ServerCutText to its *first* connecting
+# client — the selection watching only settles a little while after a client has
+# been attached. So hold a persistent internal VNC viewer connected: it renders
+# to a throwaway headless Xvfb :1 (never the served :0 framebuffer, so the test
+# pattern is untouched) and simply keeps a client attached, so the real test
+# client always connects to an already-warm server and receives the echo
+# promptly. The loop reconnects if the viewer ever drops.
+Xvfb :1 -screen 0 320x240x16 -nolisten tcp &
+for _ in $(seq 1 50); do
+    if xdpyinfo -display :1 >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.2
+done
+while true; do
+    DISPLAY=:1 xtightvncviewer -passwd /root/.vnc/passwd -viewonly \
+        127.0.0.1:5900 >/dev/null 2>&1 || true
+    sleep 1
+done &
+
 # Own a known X selection so x11vnc forwards it to the client as an RFB
 # ServerCutText — the server->client clipboard path asserted by the VNC
 # integration test (#1737). This string MUST match VNC_SERVER_CLIPBOARD in
 # core/tests/vnc.rs. Kept pure ASCII so it survives the RFB latin-1 cut-text
 # encoding unchanged.
 CLIPBOARD_TEXT="termiHub vnc server clipboard 4711"
+# A distinct priming value the loop alternates with. x11vnc only emits a
+# ServerCutText on a *genuine* selection change and de-duplicates identical
+# text, and it does not replay its cached selection to a client that connects
+# later. Re-asserting the same value would therefore reach only whoever was
+# already attached for the very first change. Alternating between two different
+# values guarantees a real change every cycle, so a client attaching at any time
+# receives CLIPBOARD_TEXT on the next cycle.
+PRIMING_TEXT="termiHub vnc priming selection"
 
-# x11vnc only emits a ServerCutText on a genuine selection *change*, and it
-# de-duplicates identical text, so a one-shot set that predates the client
-# connection may never reach it. Re-assert the selection in a loop: `xclip
-# -loops 1` holds ownership until the selection is read exactly once (x11vnc's
-# read counts), then exits, leaving the selection empty; the next iteration
-# re-owns it, which x11vnc sees as an empty->known change and pushes. This keeps
-# the known value flowing to whichever client is connected, so a client that
-# attaches at any time receives it within one iteration. PRIMARY and CLIPBOARD
-# are both covered because x11vnc may forward either.
-own_selection() {
-    sel="$1"
-    while true; do
-        printf '%s' "$CLIPBOARD_TEXT" \
-            | xclip -display :0 -selection "$sel" -loops 1 -quiet >/dev/null 2>&1 || true
-        sleep 1
-    done
+# Each `xclip` invocation (no -loops) forks into the background and holds the
+# selection until a newer owner replaces it, so re-running it flips the value
+# and produces the change x11vnc forwards. Set both PRIMARY and CLIPBOARD every
+# phase because x11vnc may forward either.
+set_selection() {
+    text="$1"
+    printf '%s' "$text" | xclip -display :0 -selection primary >/dev/null 2>&1 || true
+    printf '%s' "$text" | xclip -display :0 -selection clipboard >/dev/null 2>&1 || true
 }
-own_selection primary &
-own_selection clipboard &
+while true; do
+    set_selection "$PRIMING_TEXT"
+    sleep 2
+    set_selection "$CLIPBOARD_TEXT"
+    sleep 2
+done &
 
 wait "$x11vnc_pid"


### PR DESCRIPTION
Follow-up to #1713 (PR #1736). Completes the bidirectional VNC clipboard round-trip: #1713 covered client→server (`ClientCutText`); this adds the server→client path (`ServerCutText` → `VncEvent::Text` → `get_clipboard`).

## What changed
- **`tests/docker/vnc-server` fixture** now owns a known X selection so x11vnc forwards it to the client as an RFB `ServerCutText`:
  - `xclip` sets a known CLIPBOARD/PRIMARY value, **alternated with a priming value** every ~2s. x11vnc de-duplicates identical cut-text and does not replay its cached selection to a late-connecting client, so genuine alternating changes are required to guarantee the known value reaches whichever client is attached.
  - A **persistent internal `xtightvncviewer`** (rendered to a throwaway headless `Xvfb :1`, never the served `:0` framebuffer) keeps x11vnc's selection machinery warm. A freshly-started x11vnc does not reliably forward the selection to its *first* client until the watching has settled (~15s); the internal viewer makes the server already-warm for the real test client.
- **`core/tests/vnc.rs`**:
  - New **VNC-05** polls `get_clipboard()` until it returns the fixture's known selection, asserting the server→client echo end to end.
  - VNC-03's stale `get_clipboard().is_none()` assertion is dropped (the fixture now pushes clipboard); the deterministic assertion lives in the polling VNC-05.

## Local verification
Integration tests do **not** run in per-PR CI (excluded from the `not integration` lane), so this was verified **locally against the live fixture** (Docker daemon down → built and ran via podman, as #1713's agent did):

- Built the fixture image and ran the full `vnc` suite (`cargo test -p termihub-core --features vnc --test vnc`) against a **cold** container.
- Result: **5 passed; 0 failed** (VNC-01…05), repeatedly. VNC-05 confirmed `get_clipboard()` returns the exact fixture selection `"termiHub vnc server clipboard 4711"`.
- Independently confirmed via the raw `vnc-rs` client and the `Vnc` backend that the `ServerCutText` surfaces through `VncEvent::Text` into `get_clipboard`.

No VNC backend source (`core/src/backends/vnc/**`) was changed — this is test-coverage only.

Closes #1737