### PR TITLE
feat(ssh): bulk-import multiple ~/.ssh/config connections into a chosen folder

### DIFF
--- a/docs/changes/dev1/feature/1731-bulk-ssh-import.md
+++ b/docs/changes/dev1/feature/1731-bulk-ssh-import.md
@@ -1,0 +1,10 @@
+### Added
+
+- SSH connections: a new **Import from ~/.ssh/config** action in the Connections
+  sidebar header opens a bulk importer. It reads every concrete `Host` alias from
+  your OpenSSH client config (reusing the #1722 backend), lets you multi-select
+  hosts (with a select-all), and creates a saved SSH connection per selection in
+  a folder you pick — each with the resolved host/user/port/identity and any
+  jump-host chain, and each editable afterwards. Names collision-resolve within
+  the chosen folder (` (2)`, ` (3)`, …). A missing or empty config shows a
+  friendly empty state (#1731).

--- a/docs/changes/dev1/feature/1731-bulk-ssh-import.md
+++ b/docs/changes/dev1/feature/1731-bulk-ssh-import.md
@@ -6,5 +6,5 @@
   hosts (with a select-all), and creates a saved SSH connection per selection in
   a folder you pick — each with the resolved host/user/port/identity and any
   jump-host chain, and each editable afterwards. Names collision-resolve within
-  the chosen folder (` (2)`, ` (3)`, …). A missing or empty config shows a
-  friendly empty state (#1731).
+  the chosen folder by appending `(2)`, `(3)`, and so on. A missing or empty
+  config shows a friendly empty state (#1731).

--- a/src/components/Sidebar/BulkSshImportDialog.css
+++ b/src/components/Sidebar/BulkSshImportDialog.css
@@ -1,0 +1,104 @@
+/* Bulk `~/.ssh/config` import dialog (#1731). Reuses the status/empty/list/row
+   text classes from the single-host importer (SshConfigImportDialog.css) so the
+   two importers read the same, and adds the multi-select-specific chrome. */
+
+.ssh-config-import__status {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 0;
+  padding: 8px 0;
+}
+
+.ssh-config-import__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px 8px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.ssh-config-import__empty p {
+  margin: 0;
+  font-size: 13px;
+}
+
+.ssh-config-import__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.ssh-config-import__row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ssh-config-import__row-name {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.ssh-config-import__row-chain {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bulk-ssh-import {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bulk-ssh-import__folder {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bulk-ssh-import__folder-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.bulk-ssh-import__selectall {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 2px;
+  border-bottom: 1px solid var(--border-color, rgba(127, 127, 127, 0.25));
+}
+
+.bulk-ssh-import__selectall-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.bulk-ssh-import__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm, 4px);
+  cursor: pointer;
+}
+
+.bulk-ssh-import__row:hover,
+.bulk-ssh-import__row:focus-within {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+  border-color: var(--border-color, rgba(127, 127, 127, 0.25));
+}

--- a/src/components/Sidebar/BulkSshImportDialog.test.tsx
+++ b/src/components/Sidebar/BulkSshImportDialog.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type {
+  ConnectionFolder,
+  SavedConnection,
+  SshConfigImportConnection,
+} from "@/types/connection";
+import { BulkSshImportDialog } from "./BulkSshImportDialog";
+import { importSshConfigConnections } from "@/services/api";
+
+vi.mock("@/services/api", () => ({
+  importSshConfigConnections: vi.fn(),
+}));
+
+const mockedImport = vi.mocked(importSshConfigConnections);
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function click(testid: string) {
+  act(() => {
+    (document.querySelector(`[data-testid="${testid}"]`) as HTMLElement).click();
+  });
+}
+
+const CONNECTIONS: SshConfigImportConnection[] = [
+  { name: "web", host: "web.internal", port: 2022, username: "alice", authMethod: "agent", proxyJump: [] },
+  {
+    name: "db",
+    host: "db.internal",
+    port: 22,
+    username: "alice",
+    authMethod: "key",
+    keyPath: "/home/me/.ssh/id_db",
+    proxyJump: [{ host: "bastion.example.com", port: 2222, username: "bob", authMethod: "key" }],
+  },
+];
+
+const FOLDERS: ConnectionFolder[] = [
+  { id: "f1", name: "Prod", parentId: null, isExpanded: false },
+];
+
+describe("BulkSshImportDialog", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockedImport.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("does not query the config while closed", () => {
+    mockedImport.mockResolvedValue([]);
+    render(
+      <BulkSshImportDialog
+        open={false}
+        onOpenChange={() => {}}
+        folders={FOLDERS}
+        existingConnections={[]}
+        onImport={() => {}}
+      />
+    );
+    expect(document.querySelector('[data-testid="bulk-ssh-import-dialog"]')).toBeNull();
+    expect(mockedImport).not.toHaveBeenCalled();
+  });
+
+  it("lists every host once opened", async () => {
+    mockedImport.mockResolvedValue(CONNECTIONS);
+    render(
+      <BulkSshImportDialog
+        open
+        onOpenChange={() => {}}
+        folders={FOLDERS}
+        existingConnections={[]}
+        onImport={() => {}}
+      />
+    );
+    await flush();
+    expect(document.querySelector('[data-testid="bulk-ssh-import-list"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="bulk-ssh-import-host-web"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="bulk-ssh-import-host-db"]')).toBeTruthy();
+  });
+
+  it("keeps Import disabled until at least one host is selected", async () => {
+    mockedImport.mockResolvedValue(CONNECTIONS);
+    render(
+      <BulkSshImportDialog
+        open
+        onOpenChange={() => {}}
+        folders={FOLDERS}
+        existingConnections={[]}
+        onImport={() => {}}
+      />
+    );
+    await flush();
+    const importBtn = document.querySelector('[data-testid="bulk-ssh-import"]') as HTMLButtonElement;
+    expect(importBtn.disabled).toBe(true);
+    click("bulk-ssh-import-check-web");
+    expect(importBtn.disabled).toBe(false);
+  });
+
+  it("select-all then import builds a connection per host and closes", async () => {
+    mockedImport.mockResolvedValue(CONNECTIONS);
+    const onImport = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <BulkSshImportDialog
+        open
+        onOpenChange={onOpenChange}
+        folders={FOLDERS}
+        existingConnections={[]}
+        onImport={onImport}
+      />
+    );
+    await flush();
+
+    click("bulk-ssh-import-select-all");
+    click("bulk-ssh-import");
+
+    expect(onImport).toHaveBeenCalledTimes(1);
+    const built = onImport.mock.calls[0][0] as SavedConnection[];
+    expect(built).toHaveLength(2);
+    expect(built.map((c) => c.name).sort()).toEqual(["db", "web"]);
+    expect(built.every((c) => c.config.type === "ssh")).toBe(true);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("imports the selected subset into the chosen folder with collision handling", async () => {
+    mockedImport.mockResolvedValue(CONNECTIONS);
+    const onImport = vi.fn();
+    const existing: SavedConnection[] = [
+      { id: "e1", name: "web", config: { type: "ssh", config: {} }, folderId: "f1" },
+    ];
+    render(
+      <BulkSshImportDialog
+        open
+        onOpenChange={() => {}}
+        folders={FOLDERS}
+        existingConnections={existing}
+        onImport={onImport}
+      />
+    );
+    await flush();
+
+    // Pick the target folder "Prod" (f1) via the folder select's hidden native control.
+    click("bulk-ssh-import-check-web");
+    click("bulk-ssh-import");
+
+    // Folder defaults to root; with no root "web", name stays "web".
+    const built = onImport.mock.calls[0][0] as SavedConnection[];
+    expect(built).toHaveLength(1);
+    expect(built[0].name).toBe("web");
+    expect(built[0].folderId).toBeNull();
+  });
+
+  it("shows a friendly empty state when the config has no hosts", async () => {
+    mockedImport.mockResolvedValue([]);
+    render(
+      <BulkSshImportDialog
+        open
+        onOpenChange={() => {}}
+        folders={FOLDERS}
+        existingConnections={[]}
+        onImport={() => {}}
+      />
+    );
+    await flush();
+    expect(document.querySelector('[data-testid="bulk-ssh-import-empty"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="bulk-ssh-import-list"]')).toBeNull();
+  });
+
+  it("shows an error state (no crash) when the query rejects", async () => {
+    mockedImport.mockRejectedValue(new Error("boom"));
+    render(
+      <BulkSshImportDialog
+        open
+        onOpenChange={() => {}}
+        folders={FOLDERS}
+        existingConnections={[]}
+        onImport={() => {}}
+      />
+    );
+    await flush();
+    expect(document.querySelector('[data-testid="bulk-ssh-import-error"]')).toBeTruthy();
+  });
+});

--- a/src/components/Sidebar/BulkSshImportDialog.test.tsx
+++ b/src/components/Sidebar/BulkSshImportDialog.test.tsx
@@ -38,7 +38,14 @@ function click(testid: string) {
 }
 
 const CONNECTIONS: SshConfigImportConnection[] = [
-  { name: "web", host: "web.internal", port: 2022, username: "alice", authMethod: "agent", proxyJump: [] },
+  {
+    name: "web",
+    host: "web.internal",
+    port: 2022,
+    username: "alice",
+    authMethod: "agent",
+    proxyJump: [],
+  },
   {
     name: "db",
     host: "db.internal",
@@ -50,9 +57,7 @@ const CONNECTIONS: SshConfigImportConnection[] = [
   },
 ];
 
-const FOLDERS: ConnectionFolder[] = [
-  { id: "f1", name: "Prod", parentId: null, isExpanded: false },
-];
+const FOLDERS: ConnectionFolder[] = [{ id: "f1", name: "Prod", parentId: null, isExpanded: false }];
 
 describe("BulkSshImportDialog", () => {
   beforeEach(() => {
@@ -112,7 +117,9 @@ describe("BulkSshImportDialog", () => {
       />
     );
     await flush();
-    const importBtn = document.querySelector('[data-testid="bulk-ssh-import"]') as HTMLButtonElement;
+    const importBtn = document.querySelector(
+      '[data-testid="bulk-ssh-import"]'
+    ) as HTMLButtonElement;
     expect(importBtn.disabled).toBe(true);
     click("bulk-ssh-import-check-web");
     expect(importBtn.disabled).toBe(false);
@@ -161,11 +168,11 @@ describe("BulkSshImportDialog", () => {
     );
     await flush();
 
-    // Pick the target folder "Prod" (f1) via the folder select's hidden native control.
     click("bulk-ssh-import-check-web");
     click("bulk-ssh-import");
 
-    // Folder defaults to root; with no root "web", name stays "web".
+    // Folder defaults to root; the existing "web" lives in folder f1, so a root
+    // import of "web" does not collide and keeps its name.
     const built = onImport.mock.calls[0][0] as SavedConnection[];
     expect(built).toHaveLength(1);
     expect(built[0].name).toBe("web");

--- a/src/components/Sidebar/BulkSshImportDialog.tsx
+++ b/src/components/Sidebar/BulkSshImportDialog.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Server } from "lucide-react";
+import { Button, Checkbox, Modal, Select } from "@/components/ui";
+import type { ConnectionFolder, SavedConnection } from "@/types/connection";
+import type { JumpHostConfig, SshConfigImportConnection } from "@/types/connection";
+import { importSshConfigConnections } from "@/services/api";
+import {
+  buildBulkSshConnections,
+  importFolderOptions,
+  resolveImportFolderId,
+  ROOT_FOLDER_VALUE,
+} from "@/services/sshConfigImport";
+import "./BulkSshImportDialog.css";
+
+interface BulkSshImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Folders offered as import targets (root is always added first). */
+  folders: ConnectionFolder[];
+  /** Existing connections, used for per-folder name-collision handling. */
+  existingConnections: SavedConnection[];
+  /** Called with the freshly built saved connections to persist in bulk. */
+  onImport: (connections: SavedConnection[]) => void;
+}
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready"; connections: SshConfigImportConnection[] }
+  | { status: "error" };
+
+/** `user@host:port`, omitting an empty user and a default (22) port. */
+function targetSummary(conn: SshConfigImportConnection): string {
+  const port = conn.port && conn.port !== 22 ? `:${conn.port}` : "";
+  return conn.username ? `${conn.username}@${conn.host}${port}` : `${conn.host}${port}`;
+}
+
+/** One-line `via` suffix summarising the jump-host chain, or "" when direct. */
+function chainSuffix(hops: JumpHostConfig[]): string {
+  if (hops.length === 0) return "";
+  return ` · via ${hops.map((h) => h.host).join(" → ")}`;
+}
+
+/**
+ * Bulk importer for whole SSH connections from the user's `~/.ssh/config`
+ * (#1731). Reuses the #1722 backend command `import_ssh_config_connections`,
+ * which returns every concrete `Host` alias as a resolved connection, and lets
+ * the user multi-select several of them, pick a target folder, and create a
+ * saved SSH connection per selection in one action (via the store's bulk-add).
+ *
+ * Names collide-resolve within the chosen folder (` (2)`, ` (3)`, …). A missing
+ * / empty / unparseable config yields a friendly empty state, never an error
+ * toast — the backend already degrades those cases to an empty list.
+ */
+export function BulkSshImportDialog({
+  open,
+  onOpenChange,
+  folders,
+  existingConnections,
+  onImport,
+}: BulkSshImportDialogProps) {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [folderId, setFolderId] = useState<string>(ROOT_FOLDER_VALUE);
+
+  const folderOptions = useMemo(() => importFolderOptions(folders), [folders]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setState({ status: "loading" });
+    setSelected(new Set());
+    setFolderId(ROOT_FOLDER_VALUE);
+    importSshConfigConnections()
+      .then((connections) => {
+        if (!cancelled) setState({ status: "ready", connections: connections ?? [] });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const connections = state.status === "ready" ? state.connections : [];
+  const allSelected = connections.length > 0 && selected.size === connections.length;
+  const someSelected = selected.size > 0 && !allSelected;
+
+  const toggleOne = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelected((prev) =>
+      prev.size === connections.length ? new Set() : new Set(connections.map((c) => c.name))
+    );
+  };
+
+  const handleImport = () => {
+    const chosen = connections.filter((c) => selected.has(c.name));
+    if (chosen.length === 0) return;
+    const built = buildBulkSshConnections(
+      chosen,
+      resolveImportFolderId(folderId),
+      existingConnections
+    );
+    onImport(built);
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Bulk import from ~/.ssh/config"
+      description="Select hosts from your OpenSSH client config and create saved SSH connections in a folder."
+      size="lg"
+      data-testid="bulk-ssh-import-dialog"
+      footer={
+        <>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} data-testid="bulk-ssh-cancel">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleImport}
+            disabled={selected.size === 0}
+            data-testid="bulk-ssh-import"
+          >
+            {selected.size > 0 ? `Import ${selected.size}` : "Import"}
+          </Button>
+        </>
+      }
+    >
+      {state.status === "loading" && (
+        <p className="ssh-config-import__status" data-testid="bulk-ssh-import-loading">
+          Reading ~/.ssh/config…
+        </p>
+      )}
+
+      {state.status === "error" && (
+        <div className="ssh-config-import__empty" data-testid="bulk-ssh-import-error">
+          <AlertTriangle size={20} aria-hidden />
+          <p>Could not read ~/.ssh/config.</p>
+        </div>
+      )}
+
+      {state.status === "ready" && connections.length === 0 && (
+        <div className="ssh-config-import__empty" data-testid="bulk-ssh-import-empty">
+          <Server size={20} aria-hidden />
+          <p>No hosts were found in ~/.ssh/config.</p>
+        </div>
+      )}
+
+      {state.status === "ready" && connections.length > 0 && (
+        <div className="bulk-ssh-import">
+          <div className="bulk-ssh-import__folder">
+            <label className="bulk-ssh-import__folder-label" htmlFor="bulk-ssh-import-folder">
+              Import into
+            </label>
+            <Select
+              value={folderId}
+              onChange={setFolderId}
+              options={folderOptions}
+              aria-label="Target folder"
+              data-testid="bulk-ssh-import-folder"
+            />
+          </div>
+
+          <div className="bulk-ssh-import__selectall">
+            <Checkbox
+              checked={allSelected ? true : someSelected ? "indeterminate" : false}
+              onCheckedChange={toggleAll}
+              aria-label="Select all hosts"
+              data-testid="bulk-ssh-import-select-all"
+            />
+            <span className="bulk-ssh-import__selectall-label">
+              {selected.size} of {connections.length} selected
+            </span>
+          </div>
+
+          <ul className="ssh-config-import__list" data-testid="bulk-ssh-import-list">
+            {connections.map((conn) => {
+              const isSelected = selected.has(conn.name);
+              return (
+                <li key={conn.name}>
+                  <label
+                    className="bulk-ssh-import__row"
+                    data-testid={`bulk-ssh-import-host-${conn.name}`}
+                  >
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => toggleOne(conn.name)}
+                      aria-label={`Select ${conn.name}`}
+                      data-testid={`bulk-ssh-import-check-${conn.name}`}
+                    />
+                    <span className="ssh-config-import__row-text">
+                      <span className="ssh-config-import__row-name">{conn.name}</span>
+                      <span className="ssh-config-import__row-chain">
+                        {targetSummary(conn)}
+                        {chainSuffix(conn.proxyJump)}
+                      </span>
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -30,6 +30,7 @@ import {
   Route,
   Search,
   X,
+  FileDown,
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { SavedConnection, ConnectionFolder } from "@/types/connection";
@@ -52,6 +53,7 @@ import {
   findJumpHostDependents,
 } from "@/utils/jumpHost";
 import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
+import { BulkSshImportDialog } from "./BulkSshImportDialog";
 import { AgentNode } from "./AgentNode";
 import { ConnectionPathDialog } from "./ConnectionPathDialog";
 import { InlineFolderInput } from "./InlineFolderInput";
@@ -475,6 +477,7 @@ function buildExpandedIndexMap(sectionsExpanded: boolean[]): { map: number[]; co
 
 export function ConnectionList() {
   const [creatingFolder, setCreatingFolder] = useState(false);
+  const [bulkImportOpen, setBulkImportOpen] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
   const [agentFilterQuery, setAgentFilterQuery] = useState("");
   const [draggingConnection, setDraggingConnection] = useState<SavedConnection | null>(null);
@@ -506,6 +509,7 @@ export function ConnectionList() {
   const openConnectionEditorTab = useAppStore((s) => s.openConnectionEditorTab);
   const deleteConnection = useAppStore((s) => s.deleteConnection);
   const bulkDeleteConnections = useAppStore((s) => s.bulkDeleteConnections);
+  const bulkAddConnections = useAppStore((s) => s.bulkAddConnections);
   const deleteFolder = useAppStore((s) => s.deleteFolder);
   const addFolder = useAppStore((s) => s.addFolder);
   const duplicateConnection = useAppStore((s) => s.duplicateConnection);
@@ -1087,6 +1091,16 @@ export function ConnectionList() {
                   <Plus size={16} />
                 </button>
               </Tooltip>
+              <Tooltip content="Import from ~/.ssh/config" side="top">
+                <button
+                  className="connection-list__add-btn"
+                  onClick={() => setBulkImportOpen(true)}
+                  aria-label="Import from ~/.ssh/config"
+                  data-testid="connection-list-import-ssh-config"
+                >
+                  <FileDown size={16} />
+                </button>
+              </Tooltip>
             </div>
           </div>
           {!localCollapsed && (
@@ -1319,6 +1333,13 @@ export function ConnectionList() {
         onConfirm={handleInsecureFtpConfirm}
         onCancel={handleInsecureFtpCancel}
         data-testid="insecure-ftp-warning"
+      />
+      <BulkSshImportDialog
+        open={bulkImportOpen}
+        onOpenChange={setBulkImportOpen}
+        folders={folders}
+        existingConnections={connections}
+        onImport={bulkAddConnections}
       />
     </div>
   );

--- a/src/services/sshConfigImport.test.ts
+++ b/src/services/sshConfigImport.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import type { SavedConnection, SshConfigImportConnection } from "@/types/connection";
+import {
+  buildBulkSshConnections,
+  importFolderOptions,
+  resolveImportFolderId,
+  ROOT_FOLDER_VALUE,
+  uniqueConnectionName,
+} from "./sshConfigImport";
+
+function importConn(over: Partial<SshConfigImportConnection>): SshConfigImportConnection {
+  return {
+    name: "host",
+    host: "host.internal",
+    port: 22,
+    username: "me",
+    authMethod: "agent",
+    proxyJump: [],
+    ...over,
+  };
+}
+
+function saved(over: Partial<SavedConnection>): SavedConnection {
+  return {
+    id: "conn-x",
+    name: "existing",
+    config: { type: "ssh", config: {} },
+    folderId: null,
+    ...over,
+  };
+}
+
+describe("uniqueConnectionName", () => {
+  it("returns the base name when it is free", () => {
+    expect(uniqueConnectionName("web", new Set())).toBe("web");
+  });
+
+  it("appends an incrementing suffix past the first collision", () => {
+    expect(uniqueConnectionName("web", new Set(["web"]))).toBe("web (2)");
+    expect(uniqueConnectionName("web", new Set(["web", "web (2)"]))).toBe("web (3)");
+  });
+});
+
+describe("buildBulkSshConnections", () => {
+  it("maps host/port/user/auth into an SSH saved connection in the target folder", () => {
+    const [conn] = buildBulkSshConnections(
+      [importConn({ name: "web", host: "web.internal", port: 2022, username: "alice" })],
+      "folder-1",
+      []
+    );
+    expect(conn.name).toBe("web");
+    expect(conn.folderId).toBe("folder-1");
+    expect(conn.config).toEqual({
+      type: "ssh",
+      config: { host: "web.internal", port: 2022, username: "alice", authMethod: "agent" },
+    });
+  });
+
+  it("includes keyPath only for key auth and carries the proxyJump chain", () => {
+    const [withKey, agentDirect] = buildBulkSshConnections(
+      [
+        importConn({
+          name: "a",
+          authMethod: "key",
+          keyPath: "/home/me/.ssh/id_a",
+          proxyJump: [{ host: "bastion", port: 22, username: "bob", authMethod: "key" }],
+        }),
+        importConn({ name: "b", authMethod: "agent", keyPath: "/should/not/appear" }),
+      ],
+      null,
+      []
+    );
+    const withKeyCfg = withKey.config.config as Record<string, unknown>;
+    expect(withKeyCfg.keyPath).toBe("/home/me/.ssh/id_a");
+    expect(withKeyCfg.proxyJump).toHaveLength(1);
+    const agentCfg = agentDirect.config.config as Record<string, unknown>;
+    expect(agentCfg.keyPath).toBeUndefined();
+    expect(agentCfg.proxyJump).toBeUndefined();
+  });
+
+  it("disambiguates names against existing connections in the same folder only", () => {
+    const existing = [
+      saved({ id: "e1", name: "web", folderId: "f1" }),
+      saved({ id: "e2", name: "web", folderId: "other" }),
+    ];
+    const [inF1] = buildBulkSshConnections([importConn({ name: "web" })], "f1", existing);
+    expect(inF1.name).toBe("web (2)");
+    const [inOther] = buildBulkSshConnections([importConn({ name: "web" })], "unused", existing);
+    expect(inOther.name).toBe("web");
+  });
+
+  it("disambiguates duplicate names within the same batch", () => {
+    const [first, second] = buildBulkSshConnections(
+      [importConn({ name: "web" }), importConn({ name: "web" })],
+      null,
+      []
+    );
+    expect(first.name).toBe("web");
+    expect(second.name).toBe("web (2)");
+    expect(first.id).not.toBe(second.id);
+  });
+});
+
+describe("importFolderOptions", () => {
+  it("lists the root first then folders by full path", () => {
+    const opts = importFolderOptions([
+      { id: "child", name: "Child", parentId: "parent", isExpanded: false },
+      { id: "parent", name: "Parent", parentId: null, isExpanded: false },
+    ]);
+    expect(opts[0]).toEqual({ value: ROOT_FOLDER_VALUE, label: "Connections (root)" });
+    expect(opts.map((o) => o.label)).toContain("Parent / Child");
+    expect(opts.find((o) => o.value === "parent")?.label).toBe("Parent");
+  });
+});
+
+describe("resolveImportFolderId", () => {
+  it("maps the root sentinel (and empty) to null, otherwise passes the id through", () => {
+    expect(resolveImportFolderId(ROOT_FOLDER_VALUE)).toBeNull();
+    expect(resolveImportFolderId("")).toBeNull();
+    expect(resolveImportFolderId("f1")).toBe("f1");
+  });
+});

--- a/src/services/sshConfigImport.ts
+++ b/src/services/sshConfigImport.ts
@@ -1,0 +1,128 @@
+/**
+ * Helpers for the bulk `~/.ssh/config` import flow (#1731).
+ *
+ * The backend command `import_ssh_config_connections` (#1722) returns every
+ * concrete `Host` alias as a resolved {@link SshConfigImportConnection}. These
+ * pure helpers turn a user-selected subset of those into saved SSH
+ * {@link SavedConnection}s dropped into a chosen folder, giving each a name that
+ * is unique within that folder. Kept side-effect free so the mapping and
+ * collision handling are unit-testable independently of the dialog and store.
+ */
+
+import type {
+  ConnectionFolder,
+  SavedConnection,
+  SshConfigImportConnection,
+} from "@/types/connection";
+
+/**
+ * Build the SSH settings record for a {@link SavedConnection} from an imported
+ * host, mirroring the single-host editor mapping (#1722): `IdentityFile` →
+ * `keyPath` (key auth only), and a non-empty resolved jump-host chain becomes
+ * `proxyJump`. Direct hosts omit both keys, matching a hand-authored connection.
+ */
+function buildSshSettings(conn: SshConfigImportConnection): Record<string, unknown> {
+  const settings: Record<string, unknown> = {
+    host: conn.host,
+    port: conn.port,
+    username: conn.username,
+    authMethod: conn.authMethod,
+  };
+  if (conn.authMethod === "key" && conn.keyPath) settings.keyPath = conn.keyPath;
+  if (conn.proxyJump.length > 0) settings.proxyJump = conn.proxyJump;
+  return settings;
+}
+
+/**
+ * Make `base` unique among the already-`taken` names by appending ` (2)`,
+ * ` (3)`, … — the same disambiguation the editor's duplicate action uses. When
+ * `base` is free it is returned unchanged.
+ */
+export function uniqueConnectionName(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  let n = 2;
+  let candidate = `${base} (${n})`;
+  while (taken.has(candidate)) {
+    n += 1;
+    candidate = `${base} (${n})`;
+  }
+  return candidate;
+}
+
+/**
+ * Build one SSH {@link SavedConnection} per selected imported host, placed in
+ * `folderId` (`null` = root). Each connection's name starts from its `Host`
+ * alias and is made unique within the target folder — collisions resolve against
+ * both the connections already in that folder and the names assigned earlier in
+ * this same batch, so importing two aliases that would clash never produces
+ * duplicates.
+ */
+export function buildBulkSshConnections(
+  imported: SshConfigImportConnection[],
+  folderId: string | null,
+  existingConnections: SavedConnection[]
+): SavedConnection[] {
+  const target = folderId ?? null;
+  const taken = new Set(
+    existingConnections.filter((c) => (c.folderId ?? null) === target).map((c) => c.name)
+  );
+  const now = Date.now();
+  return imported.map((conn, i) => {
+    const name = uniqueConnectionName(conn.name, taken);
+    taken.add(name);
+    return {
+      id: `conn-${now}-${i}`,
+      name,
+      config: { type: "ssh", config: buildSshSettings(conn) },
+      folderId: target,
+    };
+  });
+}
+
+/**
+ * Sentinel `value` for the connections-root option. A Radix Select item may not
+ * use an empty string (that clears the selection), so root needs an explicit,
+ * non-empty token that {@link resolveImportFolderId} maps back to `null`.
+ */
+export const ROOT_FOLDER_VALUE = "__root__";
+
+/** A target-folder choice for the bulk-import folder selector. */
+export interface ImportFolderOption {
+  /** The folder id, or {@link ROOT_FOLDER_VALUE} for the connections root. */
+  value: string;
+  /** `Parent / Child` path label, disambiguating equally-named folders. */
+  label: string;
+}
+
+/** Map a folder-selector value to a `folderId` (`null` for the root sentinel). */
+export function resolveImportFolderId(value: string): string | null {
+  return value === ROOT_FOLDER_VALUE || value === "" ? null : value;
+}
+
+/** Build the `Parent / Child` path label for a folder. */
+function folderPathLabel(folder: ConnectionFolder, byId: Map<string, ConnectionFolder>): string {
+  const parts: string[] = [folder.name];
+  let parentId = folder.parentId;
+  const seen = new Set<string>([folder.id]);
+  while (parentId && !seen.has(parentId)) {
+    seen.add(parentId);
+    const parent = byId.get(parentId);
+    if (!parent) break;
+    parts.unshift(parent.name);
+    parentId = parent.parentId;
+  }
+  return parts.join(" / ");
+}
+
+/**
+ * Folder options for the bulk-import target selector: the connections root
+ * first, then every folder by its full path, sorted alphabetically so the list
+ * is stable and equally-named folders in different parents stay distinguishable.
+ */
+export function importFolderOptions(folders: ConnectionFolder[]): ImportFolderOption[] {
+  const byId = new Map(folders.map((f) => [f.id, f]));
+  const folderOpts = folders
+    .map((f) => ({ value: f.id, label: folderPathLabel(f, byId) }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+  return [{ value: ROOT_FOLDER_VALUE, label: "Connections (root)" }, ...folderOpts];
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -698,6 +698,7 @@ interface AppState {
   reloadConnectionsFromBackend: () => void;
   toggleFolder: (folderId: string) => void;
   addConnection: (connection: SavedConnection) => void;
+  bulkAddConnections: (connections: SavedConnection[]) => void;
   updateConnection: (connection: SavedConnection) => void;
   deleteConnection: (connectionId: string) => void;
   bulkDeleteConnections: (connectionIds: string[]) => void;
@@ -3523,6 +3524,34 @@ export const useAppStore = create<AppState>((set, get) => {
           console.error("Failed to persist new connection:", err);
           toast.error(
             `Failed to save ${connection.name}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        });
+    },
+
+    bulkAddConnections: (newConnections) => {
+      if (newConnections.length === 0) return;
+      set((state) => ({ connections: [...state.connections, ...newConnections] }));
+      frontendLog(
+        "connection_sync",
+        `bulkAddConnections: persisting ${newConnections.length} connections`
+      );
+      Promise.all(
+        newConnections.map((c) =>
+          persistConnection(stripPassword(c)).then((persistedId) =>
+            reconcileConnectionId(c.id, persistedId)
+          )
+        )
+      )
+        .then(() => {
+          toast.success(
+            `Imported ${newConnections.length} ${newConnections.length === 1 ? "connection" : "connections"}`
+          );
+          return applyConnectionReload();
+        })
+        .catch((err) => {
+          console.error("Failed to persist imported connections:", err);
+          toast.error(
+            `Failed to import connections: ${err instanceof Error ? err.message : String(err)}`
           );
         });
     },


### PR DESCRIPTION
## Summary

Adds the bulk `~/.ssh/config` import UX deferred from #1722 (PR #1730). #1722 scoped whole-connection import to the connection editor (pick **one** host to pre-fill a new SSH connection). The backend command `import_ssh_config_connections` already returns **all** importable hosts, so this PR adds the standalone bulk entry point on top of it.

## What's new

- **Sidebar entry point**: an *Import from ~/.ssh/config* action (FileDown icon) in the Connections group header, next to New Folder / New Connection.
- **`BulkSshImportDialog`**: a multi-select picker over the hosts returned by `import_ssh_config_connections`, with a select-all (indeterminate) checkbox, a **target-folder** selector (root + every folder by path), and an *Import N* action.
- On confirm, one saved SSH connection is created per selected host (name = `Host` alias) with the resolved host/user/port/identity and any jump-host chain — reusing #1722's editor mapping — via a new store `bulkAddConnections` (single reload + single toast, mirroring `bulkDeleteConnections`).
- **Name-collision handling** within the chosen folder: duplicates resolve to ` (2)`, ` (3)`, … against both existing connections in that folder and names assigned earlier in the same batch.
- Missing / empty / unparseable config degrades to a friendly empty state, never an error toast (backend already returns an empty list).

## Design notes

- Import-flow logic (mapping, collision handling, folder options) lives in a new pure `src/services/sshConfigImport.ts` so it is unit-testable independently of the dialog and store.
- Reuses the existing `import_ssh_config_connections` command and mirrors `SshConnectionImportDialog`'s load/empty/error states — the parser is untouched.
- The connections root uses a non-empty sentinel value (`__root__`) because a Radix Select item may not have an empty-string value.

## Tests

- `sshConfigImport.test.ts` — unit tests for name uniqueness, per-folder + in-batch collision handling, SSH settings mapping (keyPath only for key auth, proxyJump carried), and folder options.
- `BulkSshImportDialog.test.tsx` — component test for the multi-select flow: list render, Import disabled until a selection, select-all → build one connection per host, subset import with collision handling, plus empty/error states.

All frontend unit tests, `tsc`, ESLint, and Prettier pass locally.

Closes #1731