### PR TITLE
build(rdp): bundle the termihub-rdp-helper sidecar and enable rdp by default (Closes #1754)

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -134,8 +134,10 @@ jobs:
       # The RDP sidecar (#1747) is a workspace-excluded crate with its own
       # Cargo.lock. It ships next to the desktop binary via Tauri `externalBin`
       # (#1754), so it must be cross-built for this matrix target and staged into
-      # src-tauri/binaries/ BEFORE tauri-action runs — the bundle step fails if
-      # the declared externalBin is missing. Run through Git Bash on all runners.
+      # src-tauri/binaries/ BEFORE tauri-action runs — tauri-build rejects a
+      # missing externalBin. `externalBin` lives in the bundle-only config
+      # fragment tauri.sidecar.conf.json (merged via --config below), so per-PR
+      # compile/test jobs stay sidecar-free. Run through Git Bash on all runners.
       - name: Build RDP sidecar for bundling
         shell: bash
         run: ./scripts/build-rdp-sidecar.sh --release --target ${{ matrix.rust_target }} --tauri-externalbin
@@ -152,7 +154,7 @@ jobs:
           releaseBody: ''
           releaseDraft: false
           prerelease: false
-          args: --target ${{ matrix.rust_target }} ${{ matrix.extra_args }}
+          args: --config src-tauri/tauri.sidecar.conf.json --target ${{ matrix.rust_target }} ${{ matrix.extra_args }}
 
       # Tauri's internal ad-hoc signing can leave the bundle in an inconsistent state
       # (inner components signed in the wrong order), which Gatekeeper classifies as

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -131,6 +131,15 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
+      # The RDP sidecar (#1747) is a workspace-excluded crate with its own
+      # Cargo.lock. It ships next to the desktop binary via Tauri `externalBin`
+      # (#1754), so it must be cross-built for this matrix target and staged into
+      # src-tauri/binaries/ BEFORE tauri-action runs — the bundle step fails if
+      # the declared externalBin is missing. Run through Git Bash on all runners.
+      - name: Build RDP sidecar for bundling
+        shell: bash
+        run: ./scripts/build-rdp-sidecar.sh --release --target ${{ matrix.rust_target }} --tauri-externalbin
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,10 @@ jobs:
       # The RDP sidecar (#1747) is a workspace-excluded crate with its own
       # Cargo.lock. It ships next to the desktop binary via Tauri `externalBin`
       # (#1754), so it must be cross-built for this matrix target and staged into
-      # src-tauri/binaries/ BEFORE tauri-action runs — the bundle step fails if
-      # the declared externalBin is missing. Run through Git Bash on all runners.
+      # src-tauri/binaries/ BEFORE tauri-action runs — tauri-build rejects a
+      # missing externalBin. `externalBin` lives in the bundle-only config
+      # fragment tauri.sidecar.conf.json (merged via --config below), so per-PR
+      # compile/test jobs stay sidecar-free. Run through Git Bash on all runners.
       - name: Build RDP sidecar for bundling
         shell: bash
         run: ./scripts/build-rdp-sidecar.sh --release --target ${{ matrix.rust_target }} --tauri-externalbin
@@ -158,7 +160,7 @@ jobs:
           releaseBody: ''
           releaseDraft: false
           prerelease: false
-          args: --target ${{ matrix.rust_target }} ${{ matrix.extra_args }}
+          args: --config src-tauri/tauri.sidecar.conf.json --target ${{ matrix.rust_target }} ${{ matrix.extra_args }}
 
       - name: Find and rename release artifact
         id: find_artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,15 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
+      # The RDP sidecar (#1747) is a workspace-excluded crate with its own
+      # Cargo.lock. It ships next to the desktop binary via Tauri `externalBin`
+      # (#1754), so it must be cross-built for this matrix target and staged into
+      # src-tauri/binaries/ BEFORE tauri-action runs — the bundle step fails if
+      # the declared externalBin is missing. Run through Git Bash on all runners.
+      - name: Build RDP sidecar for bundling
+        shell: bash
+        run: ./scripts/build-rdp-sidecar.sh --release --target ${{ matrix.rust_target }} --tauri-externalbin
+
       - name: Build Tauri app for release
         uses: tauri-apps/tauri-action@v0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ tests/system/testid-catalog.md
 
 # RDP sidecar (#1747) is an excluded crate with its own target dir
 /rdp-sidecar/target/
+
+# RDP sidecar binaries staged for Tauri `externalBin` bundling (#1754). Built by
+# scripts/build-rdp-sidecar.sh --tauri-externalbin; never checked in.
+/src-tauri/binaries/

--- a/docs/changes/dev0/feature/1754-bundle-rdp-sidecar.md
+++ b/docs/changes/dev0/feature/1754-bundle-rdp-sidecar.md
@@ -1,0 +1,10 @@
+### Added
+
+- RDP connections now ship in released desktop builds. The IronRDP sidecar
+  helper (`termihub-rdp-helper`, #1747) is built and bundled next to the app via
+  Tauri `externalBin`, so a shipped termiHub locates and spawns it with no manual
+  `TERMIHUB_RDP_HELPER` setup. The `rdp-sidecar` desktop feature is now enabled by
+  default. Like the rest of the graphical remote-desktop feature, RDP stays
+  **experimental** — hidden unless "Allow Experimental Features" is enabled
+  (#1705). Release and dev CI cross-build the sidecar for every shipping target
+  (macOS Intel/Apple Silicon, Windows, Linux x64/arm64) (#1754).

--- a/scripts/build-rdp-sidecar.cmd
+++ b/scripts/build-rdp-sidecar.cmd
@@ -1,22 +1,39 @@
 @echo off
-REM Build the RDP sidecar (termihub-rdp-helper.exe) for the host platform.
+REM Build the RDP sidecar (termihub-rdp-helper.exe) and optionally stage it for Tauri.
 REM
 REM The sidecar (#1747) is a workspace-EXCLUDED crate with its own Cargo.lock:
 REM IronRDP's CredSSP crypto and russh pin incompatible RustCrypto pre-releases,
 REM and Cargo allows one version per crate per lockfile (#1725). It builds as its
 REM own cargo unit, separate from the main workspace build. It runs on the SAME
-REM machine as termiHub, so only a native host build is needed.
+REM machine as termiHub, so a released build ships it NEXT TO the desktop binary
+REM via Tauri `externalBin` (#1754).
 REM
-REM Usage: scripts\build-rdp-sidecar.cmd [--release]
-setlocal
+REM Usage: scripts\build-rdp-sidecar.cmd [--release] [--tauri-externalbin]
+REM   --release             Build with optimizations (default: debug).
+REM   --tauri-externalbin   Stage the binary into src-tauri\binaries\ named
+REM                         termihub-rdp-helper-<host-triple>.exe, the layout
+REM                         Tauri `externalBin` expects.
+setlocal enabledelayedexpansion
 cd /d "%~dp0\.."
 
 set "CARGO_FLAGS="
 set "PROFILE=debug"
+set "EXTERNALBIN=0"
+
+:parse
+if "%~1"=="" goto after_parse
 if "%~1"=="--release" (
     set "CARGO_FLAGS=--release"
     set "PROFILE=release"
+) else if "%~1"=="--tauri-externalbin" (
+    set "EXTERNALBIN=1"
+) else (
+    echo Unknown argument: %~1 1>&2
+    exit /b 2
 )
+shift
+goto parse
+:after_parse
 
 echo === Building RDP sidecar (%PROFILE%) ===
 cargo build --manifest-path rdp-sidecar\Cargo.toml %CARGO_FLAGS%
@@ -28,6 +45,19 @@ if not exist "%BIN_PATH%" (
     exit /b 1
 )
 echo Built: %BIN_PATH%
+
+if "%EXTERNALBIN%"=="1" (
+    REM Resolve the host target triple for the externalBin filename suffix.
+    for /f "tokens=2" %%i in ('rustc -vV ^| findstr /b "host:"') do set "TRIPLE=%%i"
+    if not defined TRIPLE (
+        echo ERROR: could not determine host target triple from 'rustc -vV' 1>&2
+        exit /b 1
+    )
+    if not exist "src-tauri\binaries" mkdir "src-tauri\binaries"
+    copy /y "%BIN_PATH%" "src-tauri\binaries\termihub-rdp-helper-!TRIPLE!.exe" >nul
+    echo Staged for Tauri externalBin: src-tauri\binaries\termihub-rdp-helper-!TRIPLE!.exe
+)
+
 echo Point termiHub at it by placing it next to the desktop binary, or set:
 echo   set TERMIHUB_RDP_HELPER=%CD%\%BIN_PATH%
 endlocal

--- a/scripts/build-rdp-sidecar.sh
+++ b/scripts/build-rdp-sidecar.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
-# Build the RDP sidecar (termihub-rdp-helper) for the host platform.
+# Build the RDP sidecar (termihub-rdp-helper) and optionally stage it for Tauri.
 #
 # The sidecar (#1747) is a workspace-EXCLUDED crate with its own Cargo.lock:
 # IronRDP's CredSSP crypto and russh pin incompatible RustCrypto pre-releases,
 # and Cargo allows one version per crate per lockfile (#1725). It therefore
 # builds as its own cargo unit, separate from the main workspace build.
 #
-# Unlike the remote agent (scripts/build-agents.sh), the sidecar runs on the
-# SAME machine as termiHub, so only a native host build is needed. Cross-target
-# release bundling (Tauri externalBin + CI matrix) is a sequenced follow-up.
+# The sidecar runs on the SAME machine as termiHub, so a released build ships it
+# NEXT TO the desktop binary via Tauri `externalBin` (#1754). The app resolves
+# the helper next to its own executable, or via $TERMIHUB_RDP_HELPER.
 #
-# Usage: ./scripts/build-rdp-sidecar.sh [--release] [--out <dir>] [--help]
-#   --release     Build with optimizations (default: debug).
-#   --out <dir>   After building, copy the binary into <dir> (e.g. next to the
-#                 desktop binary, or the Tauri resources dir). The app resolves
-#                 the helper next to its own executable, or via $TERMIHUB_RDP_HELPER.
+# Usage: ./scripts/build-rdp-sidecar.sh [--release] [--target <triple>]
+#                                       [--tauri-externalbin] [--out <dir>]
+#   --release             Build with optimizations (default: debug).
+#   --target <triple>     Cross-build for a specific Rust target triple (e.g.
+#                         x86_64-apple-darwin). Default: the host triple. Output
+#                         lands under rdp-sidecar/target/<triple>/<profile>/.
+#   --tauri-externalbin   Stage the built binary into src-tauri/binaries/ named
+#                         `termihub-rdp-helper-<triple>[.exe]`, the layout Tauri
+#                         `externalBin` expects. Tauri strips the -<triple>
+#                         suffix and drops the helper next to the app binary,
+#                         where SidecarRdp's next-to-exe resolution finds it.
+#   --out <dir>           Also copy the binary into <dir> (e.g. next to a
+#                         locally-built desktop binary for manual testing).
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -22,6 +30,8 @@ cd "$(git rev-parse --show-toplevel)"
 PROFILE="debug"
 CARGO_FLAGS=()
 OUT_DIR=""
+TARGET=""
+EXTERNALBIN=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -30,12 +40,20 @@ while [ $# -gt 0 ]; do
         CARGO_FLAGS+=(--release)
         shift
         ;;
+    --target)
+        TARGET="${2:?--target requires a triple}"
+        shift 2
+        ;;
+    --tauri-externalbin)
+        EXTERNALBIN=1
+        shift
+        ;;
     --out)
         OUT_DIR="${2:?--out requires a directory}"
         shift 2
         ;;
     --help | -h)
-        sed -n '2,20p' "$0"
+        sed -n '2,25p' "$0"
         exit 0
         ;;
     *)
@@ -45,21 +63,56 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-BIN_NAME="termihub-rdp-helper"
-case "$(uname -s)" in
-MINGW* | MSYS* | CYGWIN* | Windows_NT) BIN_NAME="termihub-rdp-helper.exe" ;;
-esac
+# `externalBin` staging needs a concrete triple for the filename suffix, so
+# resolve the host triple when none was given. Without either flag we keep the
+# historical host-native layout (rdp-sidecar/target/<profile>/) untouched.
+if [ "$EXTERNALBIN" -eq 1 ] && [ -z "$TARGET" ]; then
+    TARGET="$(rustc -vV | sed -n 's/^host: //p')"
+    if [ -z "$TARGET" ]; then
+        echo "ERROR: could not determine host target triple from 'rustc -vV'" >&2
+        exit 1
+    fi
+fi
 
-echo "=== Building RDP sidecar (${PROFILE}) ==="
+# The `.exe` suffix and cargo output dir depend on the *target*, not the host,
+# so a cross-build (e.g. a Windows target) names the file correctly.
+if [ -n "$TARGET" ]; then
+    case "$TARGET" in
+    *windows*) BIN_NAME="termihub-rdp-helper.exe" ;;
+    *) BIN_NAME="termihub-rdp-helper" ;;
+    esac
+    CARGO_FLAGS+=(--target "$TARGET")
+    BIN_PATH="rdp-sidecar/target/${TARGET}/${PROFILE}/${BIN_NAME}"
+else
+    BIN_NAME="termihub-rdp-helper"
+    case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN* | Windows_NT) BIN_NAME="termihub-rdp-helper.exe" ;;
+    esac
+    BIN_PATH="rdp-sidecar/target/${PROFILE}/${BIN_NAME}"
+fi
+
+echo "=== Building RDP sidecar (${PROFILE}${TARGET:+, ${TARGET}}) ==="
 # The excluded crate is built by pointing cargo at its own manifest.
 cargo build --manifest-path rdp-sidecar/Cargo.toml "${CARGO_FLAGS[@]}"
 
-BIN_PATH="rdp-sidecar/target/${PROFILE}/${BIN_NAME}"
 if [ ! -f "$BIN_PATH" ]; then
     echo "ERROR: expected binary not found at $BIN_PATH" >&2
     exit 1
 fi
 echo "Built: $BIN_PATH"
+
+if [ "$EXTERNALBIN" -eq 1 ]; then
+    STAGE_DIR="src-tauri/binaries"
+    # Tauri appends -<triple> and (on Windows) .exe; it strips the triple at
+    # bundle time, leaving `termihub-rdp-helper[.exe]` next to the app binary.
+    case "$TARGET" in
+    *windows*) STAGE_NAME="termihub-rdp-helper-${TARGET}.exe" ;;
+    *) STAGE_NAME="termihub-rdp-helper-${TARGET}" ;;
+    esac
+    mkdir -p "$STAGE_DIR"
+    cp "$BIN_PATH" "$STAGE_DIR/$STAGE_NAME"
+    echo "Staged for Tauri externalBin: $STAGE_DIR/$STAGE_NAME"
+fi
 
 if [ -n "$OUT_DIR" ]; then
     mkdir -p "$OUT_DIR"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,14 +13,16 @@ if [ ! -d node_modules ]; then
 fi
 
 # The RDP sidecar (#1747) ships next to the desktop binary via Tauri
-# `externalBin` (#1754), so it must be built and staged BEFORE `tauri build` —
-# the bundle step fails if the declared externalBin is missing. Host-native
-# build; release cross-targets are staged per-target in CI (release.yml).
+# `externalBin` (#1754). `externalBin` is declared in a bundle-only config
+# fragment (tauri.sidecar.conf.json) rather than the base config, so per-PR
+# compile/test/clippy jobs — which never bundle — don't need the helper built.
+# Here we do bundle, so build+stage the host sidecar first (tauri-build rejects
+# a missing externalBin), then merge the fragment via `--config`.
 echo "=== Building RDP sidecar for bundling ==="
 "$(dirname "$0")/build-rdp-sidecar.sh" --release --tauri-externalbin
 
 echo "Building termiHub for production..."
-pnpm tauri build
+pnpm tauri build --config src-tauri/tauri.sidecar.conf.json
 
 # --- Cross-compile agent binaries for Linux (macOS only) ---
 #

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,13 @@ if [ ! -d node_modules ]; then
     echo ""
 fi
 
+# The RDP sidecar (#1747) ships next to the desktop binary via Tauri
+# `externalBin` (#1754), so it must be built and staged BEFORE `tauri build` —
+# the bundle step fails if the declared externalBin is missing. Host-native
+# build; release cross-targets are staged per-target in CI (release.yml).
+echo "=== Building RDP sidecar for bundling ==="
+"$(dirname "$0")/build-rdp-sidecar.sh" --release --tauri-externalbin
+
 echo "Building termiHub for production..."
 pnpm tauri build
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 # FTP / FTPS connection type. Enabled by default so the desktop ships it, but
 # kept as a toggle so the registry registration is gated (`#[cfg(feature = "ftp")]`)
 # and a build without it still compiles.
-default = ["ftp", "mock-remote-desktop", "vnc"]
+default = ["ftp", "mock-remote-desktop", "vnc", "rdp-sidecar"]
 ftp = ["termihub-core/ftp"]
 # Mock graphical remote-desktop backend so the shared remote-desktop layer
 # (#1680) ships and is E2E-testable with no real VNC/RDP server. Gated so the
@@ -22,12 +22,11 @@ mock-remote-desktop = ["termihub-core/mock-remote-desktop"]
 # enables experimental features (#1705).
 vnc = ["termihub-core/vnc"]
 # RDP graphical remote-desktop backend via the IronRDP sidecar (#1747). Gated so
-# the registration is `#[cfg(feature = "rdp-sidecar")]`. NOT in `default` yet:
-# the `termihub-rdp-helper` binary must be built and bundled next to the app
-# (scripts/build-rdp-sidecar.sh) for a connect to succeed, and the Tauri
-# externalBin / release-CI cross-build wiring is a sequenced follow-up. CI still
-# exercises this path via `--all-features`. Ships experimental — hidden unless
-# the user enables experimental features (#1705).
+# the registration is `#[cfg(feature = "rdp-sidecar")]`. In `default` since #1754:
+# the `termihub-rdp-helper` binary is built by scripts/build-rdp-sidecar.sh and
+# bundled next to the app via Tauri `externalBin` (see tauri.conf.json), so
+# SidecarRdp's next-to-exe resolution finds it in a shipped build. Ships
+# experimental — hidden unless the user enables experimental features (#1705).
 rdp-sidecar = ["termihub-core/rdp-sidecar"]
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "externalBin": ["binaries/termihub-rdp-helper"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,6 +51,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": ["binaries/termihub-rdp-helper"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.sidecar.conf.json
+++ b/src-tauri/tauri.sidecar.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "externalBin": ["binaries/termihub-rdp-helper"]
+  }
+}


### PR DESCRIPTION
## Summary

Wires the IronRDP sidecar (`termihub-rdp-helper`, #1747) into the build/bundle/release pipeline so a **shipped** termiHub locates and spawns it with no manual `TERMIHUB_RDP_HELPER`, and enables RDP by default. This is the sequencing gate that lets the RDP graphical remote-desktop feature actually ship.

RDP stays **experimental** — the `rdp-sidecar` feature only gates registration; the type remains hidden unless "Allow Experimental Features" is on (#1705), same as `vnc`.

## What changed

- **Tauri `externalBin`, bundle-only** (`src-tauri/tauri.sidecar.conf.json`): declares `binaries/termihub-rdp-helper`. It lives in a **separate config fragment merged via `--config`** — not the base `tauri.conf.json` — because `tauri-build` validates `externalBin` existence at **compile time**, which would otherwise force every per-PR cargo job (compile/clippy/test) to build the sidecar. Only the actual bundling paths merge the fragment. Tauri bundles the helper next to the app binary (stripping the target-triple suffix), where `SidecarRdp`'s next-to-exe resolution finds it. macOS: the existing inside-out ad-hoc re-sign loop signs it automatically.
- **Default feature** (`src-tauri/Cargo.toml`): adds `rdp-sidecar` to `default`. The core `rdp-sidecar` feature only pulls the IPC/protocol types (`rmp-serde`, `tokio/process`) — **not** IronRDP — so the main workspace build is unchanged in weight; IronRDP stays in the excluded sidecar crate.
- **Build scripts** (`scripts/build-rdp-sidecar.{sh,cmd}`): new `--target <triple>` (cross-build) and `--tauri-externalbin` (stage into `src-tauri/binaries/termihub-rdp-helper-<triple>[.exe]`). Old `--out`/host-native behaviour preserved when neither flag is passed.
- **Local build** (`scripts/build.sh`): builds + stages the host sidecar, then `pnpm tauri build --config src-tauri/tauri.sidecar.conf.json`.
- **Release + dev CI** (`release.yml`, `dev-build.yml`): a "Build RDP sidecar for bundling" step cross-builds the sidecar for each matrix target (macOS Intel/Apple Silicon, Windows MSVC, Linux x64/arm64) before `tauri-action`, which now passes `--config`.
- `.gitignore`: staged `src-tauri/binaries/` never checked in.

## Verification

- **Local `.app` bundle** (`pnpm tauri build --config src-tauri/tauri.sidecar.conf.json --bundles app`) confirms `termihub-rdp-helper` lands in `Contents/MacOS/` next to `termihub`, i.e. exactly where `resolve_helper_binary()`'s `current_exe()` sibling lookup finds it — no `TERMIHUB_RDP_HELPER` needed.
- Running the bundled helper directly emits its MessagePack `connecting` IPC frame and then blocks on stdin, confirming it spawns and runs.
- `./scripts/check.sh` green with `rdp-sidecar` now in `default` (clippy compiles the path).
- **Note:** full release cross-build is release-cadence, not per-PR CI. In particular the **macOS Intel** leg cross-compiles the sidecar (`x86_64-apple-darwin` on an arm64 runner) — the target toolchain is installed by the matrix, but this specific cross-build is only exercised at release/dev-build time, not in this PR's CI.

Closes #1754