### PR TITLE
feat(config): guide git bash setup from the connection editor shell picker

### DIFF
--- a/docs/changes/dev2/feature/1692-gitbash-editor-picker.md
+++ b/docs/changes/dev2/feature/1692-gitbash-editor-picker.md
@@ -1,0 +1,9 @@
+### Added
+
+- Guided Git for Windows install in the Connection Editor: when you configure a
+  **local** connection on Windows and no Unix shell is detected (no Git Bash, no
+  WSL bash), the shell picker now shows a **"Git Bash — set up…"** entry point
+  that opens the same consent-gated dialog as the _Settings → General → Default
+  Shell_ picker (#1672). Install Git for Windows in a pre-loaded terminal tab or
+  open git-scm.com; once it finishes, Git Bash is re-detected and becomes
+  selectable in the picker without reopening the editor.

--- a/src/components/ConnectionEditor/ConnectionEditor.gitbash-setup.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.gitbash-setup.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Tests for the guided Git-for-Windows setup affordance in the ConnectionEditor
+ * local-shell picker (#1692), mirroring the Settings → Default Shell gate/dialog
+ * tests from #1672.
+ *
+ * The gate reuses `shouldOfferGitBashSetup`: on Windows, when the local schema's
+ * `shell` select lists no Unix shell (bash / Git Bash / WSL), a "Git Bash — set
+ * up…" entry point appears beside the picker and opens the shared
+ * `GitBashSetupDialog`. Closing the dialog re-fetches the connection-type
+ * registry so a just-installed Git Bash becomes selectable without reopening the
+ * editor. The affordance is hidden when a Unix shell is present and off Windows.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import { useAppStore } from "@/store/appStore";
+import { resetRuntimeCache } from "@/hooks/useAvailableRuntimes";
+import { isWindows } from "@/utils/platform";
+import type { ConnectionTypeInfo, SavedConnection } from "@/types/connection";
+import { ConnectionEditor } from "./ConnectionEditor";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/utils/platform", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/platform")>()),
+  isWindows: vi.fn(),
+}));
+
+// ResizeObserver is not available in jsdom
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+const mockedInvoke = vi.mocked(invoke);
+const mockedIsWindows = vi.mocked(isWindows);
+
+/** Local schema whose `shell` select offers no Unix shell (Windows-only host). */
+const LOCAL_NO_UNIX: ConnectionTypeInfo = {
+  typeId: "local",
+  displayName: "Local Shell",
+  icon: "local",
+  schema: {
+    groups: [
+      {
+        key: "general",
+        label: "General",
+        fields: [
+          {
+            key: "shell",
+            label: "Shell",
+            fieldType: {
+              type: "select",
+              options: [
+                { value: "powershell", label: "PowerShell" },
+                { value: "cmd", label: "Command Prompt" },
+                { value: "custom", label: "Custom" },
+              ],
+            },
+            required: false,
+            default: "powershell",
+          },
+        ],
+      },
+    ],
+  },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+/** Same schema but with Git Bash detected — the offer must not appear. */
+const LOCAL_WITH_GITBASH: ConnectionTypeInfo = {
+  ...LOCAL_NO_UNIX,
+  schema: {
+    groups: [
+      {
+        key: "general",
+        label: "General",
+        fields: [
+          {
+            key: "shell",
+            label: "Shell",
+            fieldType: {
+              type: "select",
+              options: [
+                { value: "powershell", label: "PowerShell" },
+                { value: "cmd", label: "Command Prompt" },
+                { value: "gitbash", label: "Git Bash" },
+                { value: "custom", label: "Custom" },
+              ],
+            },
+            required: false,
+            default: "gitbash",
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const SSH_TYPE: ConnectionTypeInfo = {
+  typeId: "ssh",
+  displayName: "SSH",
+  icon: "ssh",
+  schema: {
+    groups: [
+      {
+        key: "connection",
+        label: "Connection",
+        fields: [{ key: "host", label: "Host", fieldType: { type: "text" }, required: true }],
+      },
+    ],
+  },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderNewLocal(types: ConnectionTypeInfo[]) {
+  useAppStore.setState({
+    ...useAppStore.getInitialState(),
+    connectionTypes: types,
+  });
+  act(() => {
+    root.render(
+      <ConnectionEditor tabId="tab-gitbash-1" meta={{ connectionId: "new" }} isVisible={true} />
+    );
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function query(testId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+}
+
+function click(testId: string) {
+  const el = query(testId);
+  if (!el) throw new Error(`missing element ${testId}`);
+  act(() => (el as HTMLButtonElement).click());
+}
+
+describe("ConnectionEditor — guided Git Bash setup (#1692)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetRuntimeCache();
+    mockedIsWindows.mockReturnValue(true);
+    mockedInvoke.mockImplementation((cmd) => {
+      if (cmd === "check_docker_available") return Promise.resolve(false);
+      if (cmd === "check_podman_available") return Promise.resolve(false);
+      if (cmd === "get_connection_types") return Promise.resolve([LOCAL_WITH_GITBASH]);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("offers the setup affordance on Windows when no Unix shell is detected", async () => {
+    renderNewLocal([LOCAL_NO_UNIX]);
+    await flush();
+
+    expect(query("connection-editor-git-bash-setup")).not.toBeNull();
+  });
+
+  it("hides the affordance once a Unix shell (Git Bash) is present", async () => {
+    renderNewLocal([LOCAL_WITH_GITBASH]);
+    await flush();
+
+    expect(query("connection-editor-git-bash-setup")).toBeNull();
+  });
+
+  it("hides the affordance off Windows", async () => {
+    mockedIsWindows.mockReturnValue(false);
+    renderNewLocal([LOCAL_NO_UNIX]);
+    await flush();
+
+    expect(query("connection-editor-git-bash-setup")).toBeNull();
+  });
+
+  it("does not offer the affordance for a non-local connection type", async () => {
+    // An existing SSH connection edits as type "ssh": no local-shell picker, so
+    // the Git Bash guidance never applies even on a Unix-shell-less Windows host.
+    const sshConn: SavedConnection = {
+      id: "conn-ssh-gitbash",
+      name: "Box",
+      config: { type: "ssh", config: { host: "10.0.0.1" } },
+      folderId: null,
+    };
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      connections: [sshConn],
+      connectionTypes: [SSH_TYPE, LOCAL_NO_UNIX],
+    });
+    act(() => {
+      root.render(
+        <ConnectionEditor
+          tabId="tab-gitbash-2"
+          meta={{ connectionId: sshConn.id, folderId: null }}
+          isVisible={true}
+        />
+      );
+    });
+    await flush();
+
+    expect(query("connection-editor-git-bash-setup")).toBeNull();
+  });
+
+  it("opens the shared setup dialog when the affordance is clicked", async () => {
+    renderNewLocal([LOCAL_NO_UNIX]);
+    await flush();
+
+    click("connection-editor-git-bash-setup");
+    await flush();
+
+    expect(query("git-bash-setup")).not.toBeNull();
+  });
+
+  it("re-detects shells (re-fetches the type registry) when the dialog is dismissed", async () => {
+    const fetchedRegistry = () =>
+      mockedInvoke.mock.calls.some((c) => c[0] === "get_connection_types");
+
+    renderNewLocal([LOCAL_NO_UNIX]);
+    await flush();
+    // The editor never fetches the registry itself, so it is untouched until the
+    // dialog closes and the re-detect fires.
+    expect(fetchedRegistry()).toBe(false);
+
+    click("connection-editor-git-bash-setup");
+    await flush();
+    click("git-bash-setup-not-now");
+    await flush();
+
+    expect(fetchedRegistry()).toBe(true);
+  });
+});

--- a/src/components/ConnectionEditor/ConnectionEditor.gitbash-setup.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.gitbash-setup.test.tsx
@@ -128,7 +128,11 @@ function renderNewLocal(types: ConnectionTypeInfo[]) {
   });
   act(() => {
     root.render(
-      <ConnectionEditor tabId="tab-gitbash-1" meta={{ connectionId: "new" }} isVisible={true} />
+      <ConnectionEditor
+        tabId="tab-gitbash-1"
+        meta={{ connectionId: "new", folderId: null }}
+        isVisible={true}
+      />
     );
   });
 }

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -1243,8 +1243,8 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
             Git Bash — set up…
           </Button>
           <p className="settings-form__hint">
-            No Unix shell detected. Install Git for Windows to run bash, grep, curl and ssh from this
-            local connection.
+            No Unix shell detected. Install Git for Windows to run bash, grep, curl and ssh from
+            this local connection.
           </p>
         </div>
       )}

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -40,6 +40,8 @@ import {
   filterCredentialFields,
 } from "@/utils/schemaDefaults";
 import { useAvailableRuntimes } from "@/hooks/useAvailableRuntimes";
+import { shouldOfferGitBashSetup } from "@/utils/gitBashSetup";
+import { GitBashSetupDialog } from "@/components/OpenConnections/GitBashSetupDialog";
 import { ConnectionTerminalSettings } from "./ConnectionTerminalSettings";
 import { ConnectionAppearanceSettings } from "./ConnectionAppearanceSettings";
 import { AgentExternalFilesSettings } from "./AgentExternalFilesSettings";
@@ -183,6 +185,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   const connections = useAppStore((s) => s.connections);
   const folders = useAppStore((s) => s.folders);
   const connectionTypes = useAppStore((s) => s.connectionTypes);
+  const refreshConnectionTypes = useAppStore((s) => s.refreshConnectionTypes);
   const addConnection = useAppStore((s) => s.addConnection);
   const updateConnection = useAppStore((s) => s.updateConnection);
   const moveConnectionToFile = useAppStore((s) => s.moveConnectionToFile);
@@ -1089,6 +1092,32 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
     credentialStoreStatus?.mode,
   ]);
 
+  // Guided Git-for-Windows setup for the local-shell picker (#1692), mirroring
+  // the Settings → Default Shell affordance (#1672). The local schema's `shell`
+  // select lists the backend-detected shells, so we read the offer directly off
+  // those options: on Windows with no Unix shell (bash/Git Bash/WSL) detected we
+  // surface a "Git Bash — set up…" entry point beside the picker. Skipped in
+  // agent-definition mode, where the schema reflects a remote machine's shells
+  // rather than this Windows host's.
+  const [gitBashSetupOpen, setGitBashSetupOpen] = useState(false);
+
+  const localShellOptions = useMemo<ShellType[]>(() => {
+    if (selectedType !== "local" || !currentSchema) return [];
+    for (const group of currentSchema.groups) {
+      for (const field of group.fields) {
+        if (field.key === "shell" && field.fieldType.type === "select") {
+          return field.fieldType.options.map((o) => o.value as ShellType);
+        }
+      }
+    }
+    return [];
+  }, [selectedType, currentSchema]);
+
+  const offerGitBashSetup =
+    selectedType === "local" &&
+    !isAgentDefinitionMode &&
+    shouldOfferGitBashSetup(isWindows(), localShellOptions);
+
   // Auto-set the runtime value when only one option remains
   useEffect(() => {
     if (selectedType !== "docker" || runtimesLoading || !currentSchema) return;
@@ -1200,6 +1229,24 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
               : undefined
           }
         />
+      )}
+
+      {offerGitBashSetup && (
+        <div className="settings-panel__category" data-testid="git-bash-setup-section">
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<TerminalSquare size={13} aria-hidden />}
+            onClick={() => setGitBashSetupOpen(true)}
+            data-testid="connection-editor-git-bash-setup"
+          >
+            Git Bash — set up…
+          </Button>
+          <p className="settings-form__hint">
+            No Unix shell detected. Install Git for Windows to run bash, grep, curl and ssh from this
+            local connection.
+          </p>
+        </div>
       )}
 
       {showJumpHostSection && (
@@ -1378,6 +1425,17 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
         onCancel={handleDialogCancel}
         onJustClose={handleDialogJustClose}
         onSaveAndClose={handleDialogSaveAndClose}
+      />
+
+      <GitBashSetupDialog
+        open={gitBashSetupOpen}
+        onOpenChange={(open) => {
+          setGitBashSetupOpen(open);
+          // Re-detect on close so a just-installed Git Bash appears in the
+          // shell picker without reopening the editor (#1692).
+          if (!open) void refreshConnectionTypes();
+        }}
+        onInstallGuided={() => void refreshConnectionTypes()}
       />
     </div>
   );

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -681,6 +681,14 @@ interface AppState {
   setRecoveryDialogOpen: (open: boolean) => void;
 
   loadFromBackend: () => Promise<void>;
+  /**
+   * Re-fetch the connection-type registry from the backend and replace
+   * {@link connectionTypes}. The registry embeds backend-detected data such as
+   * the local shell field's option list, so refreshing it lets a just-installed
+   * shell (e.g. guided Git Bash, #1692) become selectable without an app
+   * restart. A backend failure leaves the current registry untouched.
+   */
+  refreshConnectionTypes: () => Promise<void>;
   updateSettings: (settings: AppSettings) => Promise<void>;
   /**
    * Persist edited shell-integration settings through the dedicated
@@ -5289,6 +5297,15 @@ export const useAppStore = create<AppState>((set, get) => {
     // SSH Tunnels
     tunnels: [],
     tunnelStates: {},
+
+    refreshConnectionTypes: async () => {
+      try {
+        const connectionTypes = await getConnectionTypes();
+        set({ connectionTypes });
+      } catch (err) {
+        console.error("Failed to refresh connection types:", err);
+      }
+    },
 
     loadTunnels: async () => {
       try {


### PR DESCRIPTION
Extends the guided Git-for-Windows install (#1672) to the per-connection local-shell picker in the ConnectionEditor, so a user configuring a **local** connection on Windows gets the same "Git Bash — set up…" guidance when no Unix shell is detected.

## What changed
- **ConnectionEditor** — when editing a local connection on Windows and the schema's `shell` select lists no Unix shell (bash / Git Bash / WSL), a "Git Bash — set up…" entry point renders beside the picker and opens the shared `GitBashSetupDialog`. Reuses `shouldOfferGitBashSetup` and `GitBashSetupDialog` as-is; no bespoke select CSS. Skipped in agent-definition mode (that schema reflects a remote host).
- **Re-detection** — closing the dialog (or completing the guided install) re-fetches the connection-type registry via a new `refreshConnectionTypes` store action, so a just-installed Git Bash becomes selectable in the picker without reopening the editor.
- **Tests** — mirror the #1672 gate/dialog tests for the new surface: gate on/off (Windows + no Unix shell vs. Git Bash present vs. off-Windows vs. non-local type), dialog opens on click, registry re-fetch on dismiss.

## Design note
The `shell` field is rendered by the schema-driven `DynamicForm`, whose generic Controller owns its own value. Threading a synthetic non-value "action" option through that generic path would fight the form's one-way state, so per the issue's stated alternative the affordance is rendered **beside** the field instead — keeping `DynamicForm` conventions intact.

## Test plan
- Frontend unit tests (`ConnectionEditor.gitbash-setup.test.tsx`) — pass locally.
- `pnpm run lint`, `pnpm run build`, `pnpm run format:check`, `pnpm markdownlint` — all clean.
- Manual (Windows, no Unix shell): open the ConnectionEditor for a local connection, confirm the "Git Bash — set up…" entry appears beside the shell picker, opens the consent dialog, and that after install Git Bash appears in the picker without reopening the editor.

Closes #1692