### PR TITLE
feat(rdp): CLIPRDR clipboard bridging over the sidecar IPC (Closes #1756)

### DIFF
--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -30,8 +30,9 @@
 //! ## v1 scope
 //!
 //! Connect (TLS/NLA) → decode frames → keyboard/pointer/wheel input → server
-//! cursor → Display-Control dynamic resize (#1755). CLIPRDR clipboard, drive
-//! redirection and audio are sequenced follow-ups (see #1747 / the PR).
+//! cursor → Display-Control dynamic resize (#1755) → CLIPRDR text clipboard both
+//! ways (#1756). Drive redirection and audio are sequenced follow-ups (see #1747
+//! / the PR).
 
 pub mod config;
 pub mod protocol;
@@ -424,8 +425,9 @@ impl GraphicalBackend for SidecarRdp {
             // Dynamic resize renegotiates the remote resolution over the Display
             // Control channel in the sidecar (#1755).
             supports_dynamic_resize: true,
-            // CLIPRDR clipboard bridging is a follow-up.
-            supports_clipboard: false,
+            // Text clipboard bridges bidirectionally over the CLIPRDR channel in
+            // the sidecar (#1756).
+            supports_clipboard: true,
             view_only_capable: true,
         }
     }
@@ -496,8 +498,8 @@ impl GraphicalBackend for SidecarRdp {
         if rt.shared.view_only {
             return Ok(());
         }
-        // CLIPRDR bridging is a follow-up; the message is plumbed so the seam is
-        // in place.
+        // Forwarded to the sidecar, which mirrors the text to the remote over the
+        // CLIPRDR channel (#1756).
         let _ = rt.to_sidecar.send(HostMessage::SetClipboard(text)).await;
         Ok(())
     }
@@ -538,7 +540,7 @@ mod tests {
         assert!(caps.auth_kinds.contains(&AuthKind::Nla));
         assert!(caps.view_only_capable);
         assert!(caps.supports_dynamic_resize);
-        assert!(!caps.supports_clipboard);
+        assert!(caps.supports_clipboard);
     }
 
     #[tokio::test]

--- a/core/src/backends/rdp_sidecar/protocol.rs
+++ b/core/src/backends/rdp_sidecar/protocol.rs
@@ -68,7 +68,8 @@ pub enum HostMessage {
         /// Requested height in pixels.
         height: u16,
     },
-    /// Push local clipboard text to the remote (CLIPRDR is a follow-up).
+    /// Push local clipboard text to the remote over the sidecar's CLIPRDR
+    /// channel (#1756).
     SetClipboard(String),
     /// Ask the sidecar to tear the session down and exit.
     Disconnect,
@@ -84,7 +85,7 @@ pub enum SidecarMessage {
     Frame(FrameUpdate),
     /// A cursor position / shape update.
     Cursor(CursorUpdate),
-    /// Remote clipboard text (CLIPRDR is a follow-up; unused for now).
+    /// Remote clipboard text, decoded from the sidecar's CLIPRDR channel (#1756).
     Clipboard(String),
     /// A fatal error; the sidecar exits after sending it.
     Error(String),

--- a/docs/changes/dev1/feature/1756-rdp-clipboard.md
+++ b/docs/changes/dev1/feature/1756-rdp-clipboard.md
@@ -1,0 +1,8 @@
+### Added
+
+- RDP: clipboard bridging. Text copied on an RDP desktop now transfers both
+  ways over the clipboard redirection channel (CLIPRDR / MS-RDPECLIP) in the
+  IronRDP sidecar. A remote copy is mirrored to the local clipboard panel, and
+  the local clipboard is offered to the remote (Unicode preferred, ANSI as a
+  fallback). View-only sessions never push the local clipboard to the remote.
+  The RDP backend now advertises `supports_clipboard` (#1756).

--- a/rdp-sidecar/Cargo.lock
+++ b/rdp-sidecar/Cargo.lock
@@ -1444,6 +1444,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f910b8dc8e7b8e001c61fd742be442e8604fb2499ded713cadf911e7645ade4"
 dependencies = [
+ "ironrdp-cliprdr",
  "ironrdp-connector",
  "ironrdp-core",
  "ironrdp-displaycontrol",
@@ -1471,6 +1472,19 @@ name = "ironrdp-bulk"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e548d9fd162558a5a8aaed72e528556ce88e77773634e3722b8d01d6f170388"
+
+[[package]]
+name = "ironrdp-cliprdr"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9050999a1e032f4313788ac5a6d06e897a4f672f1de2ed98683001fc1abf56"
+dependencies = [
+ "bitflags 2.13.1",
+ "ironrdp-core",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
 
 [[package]]
 name = "ironrdp-connector"

--- a/rdp-sidecar/Cargo.toml
+++ b/rdp-sidecar/Cargo.toml
@@ -32,6 +32,10 @@ ironrdp = { version = "0.17", default-features = false, features = [
     # `displaycontrol` the monitor-layout resize processor that rides it.
     "dvc",
     "displaycontrol",
+    # Clipboard redirection static channel (MS-RDPECLIP) for bidirectional
+    # text clipboard bridging (#1756): `cliprdr` provides the CLIPRDR SVC
+    # processor plus its `CliprdrBackend` integration seam.
+    "cliprdr",
 ] }
 ironrdp-tokio = { version = "0.10", features = ["reqwest"] }
 ironrdp-tls = { version = "0.2", default-features = false, features = [

--- a/rdp-sidecar/src/clipboard.rs
+++ b/rdp-sidecar/src/clipboard.rs
@@ -1,0 +1,361 @@
+//! CLIPRDR (MS-RDPECLIP) clipboard bridging for the RDP sidecar (#1756).
+//!
+//! IronRDP's clipboard channel ([`ironrdp::cliprdr::Cliprdr`]) is a static
+//! virtual channel driven by a [`CliprdrBackend`] the integrator supplies. The
+//! backend's methods are called **synchronously** from inside
+//! [`ActiveStage::process`](ironrdp::session::ActiveStage) while a server
+//! CLIPRDR PDU is being decoded — at which point the [`Cliprdr`] channel is
+//! mutably borrowed, so the backend cannot call back into it (initiate a paste,
+//! submit data). Instead the backend records what needs to happen as a
+//! [`ClipboardEvent`] on a channel; the driver loop drains those events *after*
+//! `process` returns, when it again owns `&mut ActiveStage`, and performs the
+//! matching [`Cliprdr`] call (see `rdp.rs`).
+//!
+//! Scope is **text, both ways** (the issue's "text both ways"): CF_UNICODETEXT
+//! preferred, CF_TEXT as a fallback. File-transfer and locking callbacks are
+//! implemented as no-ops — we never advertise file formats or negotiate the
+//! locking capability, so the server never exercises them.
+//!
+//! [`Cliprdr`]: ironrdp::cliprdr::Cliprdr
+//! [`CliprdrBackend`]: ironrdp::cliprdr::backend::CliprdrBackend
+
+use std::sync::mpsc::Sender;
+
+use ironrdp::cliprdr::backend::CliprdrBackend;
+use ironrdp::cliprdr::pdu::{
+    ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
+    FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
+};
+use tracing::{debug, trace, warn};
+
+/// An action the CLIPRDR backend needs the driver loop to perform on the
+/// [`Cliprdr`](ironrdp::cliprdr::Cliprdr) channel once it owns `&mut ActiveStage`
+/// again (the backend is called while that channel is borrowed and cannot call
+/// back into it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClipboardEvent {
+    /// The channel finished initializing (or the remote asked us to re-advertise):
+    /// send our local clipboard's format list to the server.
+    AdvertiseLocal,
+    /// The remote copied something; fetch its data in this (text) format so it can
+    /// be mirrored to the host clipboard.
+    InitiatePaste(ClipboardFormatId),
+    /// Text received from the remote clipboard, ready to hand to the host over IPC.
+    RemoteText(String),
+    /// The remote wants our local clipboard data in this format; respond with a
+    /// `FormatDataResponse` built from the host-provided text.
+    ProvideData(ClipboardFormatId),
+}
+
+/// Pick the best text format the remote advertised: prefer Unicode, fall back to
+/// ANSI. Returns `None` when the remote offered no text format (e.g. a bitmap or
+/// file copy), which this text-only bridge ignores.
+pub fn preferred_text_format(formats: &[ClipboardFormat]) -> Option<ClipboardFormatId> {
+    if formats.iter().any(|f| f.id() == ClipboardFormatId::CF_UNICODETEXT) {
+        Some(ClipboardFormatId::CF_UNICODETEXT)
+    } else if formats.iter().any(|f| f.id() == ClipboardFormatId::CF_TEXT) {
+        Some(ClipboardFormatId::CF_TEXT)
+    } else {
+        None
+    }
+}
+
+/// The text formats we advertise for a non-empty local clipboard. An empty local
+/// clipboard advertises nothing (an empty format list), which still completes the
+/// CLIPRDR initialization handshake so the remote→local direction works.
+pub fn local_text_formats(local: Option<&str>) -> Vec<ClipboardFormat> {
+    match local {
+        Some(text) if !text.is_empty() => vec![
+            ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT),
+            ClipboardFormat::new(ClipboardFormatId::CF_TEXT),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+/// Build the response to a server `FormatDataRequest` for our local clipboard.
+/// Encodes the host text as Unicode or ANSI per the requested format; a request
+/// for a non-text format, or with no local text available, yields an error
+/// response (`is_error`), which the spec allows.
+pub fn build_format_data_response(
+    format: ClipboardFormatId,
+    local: Option<&str>,
+) -> FormatDataResponse<'static> {
+    match (format, local) {
+        (ClipboardFormatId::CF_UNICODETEXT, Some(text)) => {
+            FormatDataResponse::new_unicode_string(text)
+        }
+        (ClipboardFormatId::CF_TEXT, Some(text)) => FormatDataResponse::new_string(text),
+        _ => FormatDataResponse::new_error(),
+    }
+}
+
+/// Decode remote clipboard text from a `FormatDataResponse`, given the format we
+/// requested. Returns `None` for an error response or a non-text format.
+pub fn decode_clipboard_text(
+    format: ClipboardFormatId,
+    response: &FormatDataResponse<'_>,
+) -> Option<String> {
+    if response.is_error() {
+        return None;
+    }
+    match format {
+        ClipboardFormatId::CF_UNICODETEXT => response.to_unicode_string().ok(),
+        ClipboardFormatId::CF_TEXT => response.to_string().ok(),
+        _ => None,
+    }
+}
+
+/// The sidecar's [`CliprdrBackend`]: it owns no OS clipboard (there is none in a
+/// headless sidecar); it just translates CLIPRDR callbacks into
+/// [`ClipboardEvent`]s the driver forwards over IPC to the host's real clipboard.
+#[derive(Debug)]
+pub struct SidecarClipboardBackend {
+    /// Events flow to the driver loop over this channel.
+    tx: Sender<ClipboardEvent>,
+    /// A temporary directory path advertised to the server (required by the
+    /// protocol even though this text-only bridge never transfers files).
+    temp_dir: String,
+    /// The format of the most recent paste we initiated, so the eventual
+    /// `on_format_data_response` knows how to decode the bytes.
+    pending_paste_format: Option<ClipboardFormatId>,
+}
+
+impl SidecarClipboardBackend {
+    /// Create the backend and the receiver the driver drains. The backend is
+    /// handed to [`Cliprdr::new`](ironrdp::cliprdr::Cliprdr::new); the receiver
+    /// stays with the driver loop.
+    pub fn new() -> (Self, std::sync::mpsc::Receiver<ClipboardEvent>) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let temp_dir = std::env::temp_dir().to_string_lossy().into_owned();
+        (
+            Self {
+                tx,
+                temp_dir,
+                pending_paste_format: None,
+            },
+            rx,
+        )
+    }
+
+    fn emit(&self, event: ClipboardEvent) {
+        if self.tx.send(event).is_err() {
+            debug!("clipboard event receiver dropped; sidecar shutting down");
+        }
+    }
+}
+
+impl CliprdrBackend for SidecarClipboardBackend {
+    fn temporary_directory(&self) -> &str {
+        &self.temp_dir
+    }
+
+    fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
+        // Text-only: we use the standard short format IDs (CF_UNICODETEXT /
+        // CF_TEXT) and negotiate neither long format names nor file/lock
+        // capabilities, so no flags are required.
+        ClipboardGeneralCapabilityFlags::empty()
+    }
+
+    fn on_ready(&mut self) {
+        debug!("cliprdr channel ready");
+    }
+
+    fn on_request_format_list(&mut self) {
+        // The initialization sequence needs us to send a format list; the driver
+        // advertises whatever the host clipboard currently holds (possibly empty).
+        self.emit(ClipboardEvent::AdvertiseLocal);
+    }
+
+    fn on_process_negotiated_capabilities(
+        &mut self,
+        capabilities: ClipboardGeneralCapabilityFlags,
+    ) {
+        trace!(?capabilities, "cliprdr negotiated capabilities");
+    }
+
+    fn on_remote_copy(&mut self, available_formats: &[ClipboardFormat]) {
+        match preferred_text_format(available_formats) {
+            Some(format) => {
+                self.pending_paste_format = Some(format);
+                self.emit(ClipboardEvent::InitiatePaste(format));
+            }
+            None => trace!("remote clipboard offered no text format; ignoring"),
+        }
+    }
+
+    fn on_format_data_request(&mut self, request: FormatDataRequest) {
+        self.emit(ClipboardEvent::ProvideData(request.format));
+    }
+
+    fn on_format_data_response(&mut self, response: FormatDataResponse<'_>) {
+        let Some(format) = self.pending_paste_format.take() else {
+            trace!("format data response with no pending paste; ignoring");
+            return;
+        };
+        match decode_clipboard_text(format, &response) {
+            Some(text) => self.emit(ClipboardEvent::RemoteText(text)),
+            None => debug!("remote clipboard text unavailable or undecodable"),
+        }
+    }
+
+    // --- File transfer / locking: unused by this text-only bridge. ---
+    // We advertise no file formats and negotiate no locking capability, so a
+    // conforming server never drives these; keep them as safe no-ops.
+
+    fn on_file_contents_request(&mut self, _request: FileContentsRequest) {
+        warn!("cliprdr file contents request ignored (text-only bridge)");
+    }
+
+    fn on_file_contents_response(&mut self, _response: FileContentsResponse<'_>) {
+        warn!("cliprdr file contents response ignored (text-only bridge)");
+    }
+
+    fn on_lock(&mut self, _data_id: LockDataId) {}
+
+    fn on_unlock(&mut self, _data_id: LockDataId) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(id: ClipboardFormatId) -> ClipboardFormat {
+        ClipboardFormat::new(id)
+    }
+
+    #[test]
+    fn prefers_unicode_over_ansi() {
+        let formats = [
+            text(ClipboardFormatId::CF_TEXT),
+            text(ClipboardFormatId::CF_UNICODETEXT),
+        ];
+        assert_eq!(
+            preferred_text_format(&formats),
+            Some(ClipboardFormatId::CF_UNICODETEXT)
+        );
+    }
+
+    #[test]
+    fn falls_back_to_ansi_text() {
+        let formats = [text(ClipboardFormatId::CF_TEXT)];
+        assert_eq!(
+            preferred_text_format(&formats),
+            Some(ClipboardFormatId::CF_TEXT)
+        );
+    }
+
+    #[test]
+    fn ignores_non_text_formats() {
+        // CF_BITMAP (2) and a random custom id — neither is text.
+        let formats = [text(ClipboardFormatId(2)), text(ClipboardFormatId(0xC001))];
+        assert_eq!(preferred_text_format(&formats), None);
+    }
+
+    #[test]
+    fn empty_local_clipboard_advertises_nothing() {
+        assert!(local_text_formats(None).is_empty());
+        assert!(local_text_formats(Some("")).is_empty());
+    }
+
+    #[test]
+    fn non_empty_local_clipboard_advertises_both_text_formats() {
+        let formats = local_text_formats(Some("hello"));
+        let ids: Vec<_> = formats.iter().map(|f| f.id()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                ClipboardFormatId::CF_UNICODETEXT,
+                ClipboardFormatId::CF_TEXT
+            ]
+        );
+    }
+
+    #[test]
+    fn unicode_text_round_trips_through_response() {
+        // Build the response we'd send to the server, then decode it the way the
+        // remote→local path would — the two text codecs must agree. Non-ASCII
+        // exercises the UTF-16 path.
+        let original = "héllo wörld ☺";
+        let response = build_format_data_response(
+            ClipboardFormatId::CF_UNICODETEXT,
+            Some(original),
+        );
+        let decoded =
+            decode_clipboard_text(ClipboardFormatId::CF_UNICODETEXT, &response).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn ansi_text_round_trips_through_response() {
+        let original = "plain ascii";
+        let response =
+            build_format_data_response(ClipboardFormatId::CF_TEXT, Some(original));
+        let decoded = decode_clipboard_text(ClipboardFormatId::CF_TEXT, &response).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn missing_local_text_yields_error_response() {
+        let response =
+            build_format_data_response(ClipboardFormatId::CF_UNICODETEXT, None);
+        assert!(response.is_error());
+        assert_eq!(
+            decode_clipboard_text(ClipboardFormatId::CF_UNICODETEXT, &response),
+            None
+        );
+    }
+
+    #[test]
+    fn error_response_decodes_to_none() {
+        let response = FormatDataResponse::new_error();
+        assert_eq!(
+            decode_clipboard_text(ClipboardFormatId::CF_UNICODETEXT, &response),
+            None
+        );
+    }
+
+    #[test]
+    fn backend_emits_paste_on_remote_text_copy() {
+        let (mut backend, rx) = SidecarClipboardBackend::new();
+        backend.on_remote_copy(&[text(ClipboardFormatId::CF_UNICODETEXT)]);
+        assert_eq!(
+            rx.try_recv(),
+            Ok(ClipboardEvent::InitiatePaste(ClipboardFormatId::CF_UNICODETEXT))
+        );
+    }
+
+    #[test]
+    fn backend_decodes_response_using_pending_format() {
+        let (mut backend, rx) = SidecarClipboardBackend::new();
+        // Simulate the full remote→local sequence: remote copy → paste → data.
+        backend.on_remote_copy(&[text(ClipboardFormatId::CF_UNICODETEXT)]);
+        let _ = rx.try_recv(); // consume the InitiatePaste
+        let response =
+            build_format_data_response(ClipboardFormatId::CF_UNICODETEXT, Some("copied"));
+        backend.on_format_data_response(response);
+        assert_eq!(
+            rx.try_recv(),
+            Ok(ClipboardEvent::RemoteText("copied".to_string()))
+        );
+    }
+
+    #[test]
+    fn backend_requests_advertise_on_format_list_request() {
+        let (mut backend, rx) = SidecarClipboardBackend::new();
+        backend.on_request_format_list();
+        assert_eq!(rx.try_recv(), Ok(ClipboardEvent::AdvertiseLocal));
+    }
+
+    #[test]
+    fn backend_forwards_server_data_request() {
+        let (mut backend, rx) = SidecarClipboardBackend::new();
+        backend.on_format_data_request(FormatDataRequest {
+            format: ClipboardFormatId::CF_UNICODETEXT,
+        });
+        assert_eq!(
+            rx.try_recv(),
+            Ok(ClipboardEvent::ProvideData(ClipboardFormatId::CF_UNICODETEXT))
+        );
+    }
+}

--- a/rdp-sidecar/src/clipboard.rs
+++ b/rdp-sidecar/src/clipboard.rs
@@ -26,6 +26,7 @@ use ironrdp::cliprdr::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
     FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
 };
+use ironrdp::core::AsAny;
 use tracing::{debug, trace, warn};
 
 /// An action the CLIPRDR backend needs the driver loop to perform on the
@@ -51,7 +52,10 @@ pub enum ClipboardEvent {
 /// ANSI. Returns `None` when the remote offered no text format (e.g. a bitmap or
 /// file copy), which this text-only bridge ignores.
 pub fn preferred_text_format(formats: &[ClipboardFormat]) -> Option<ClipboardFormatId> {
-    if formats.iter().any(|f| f.id() == ClipboardFormatId::CF_UNICODETEXT) {
+    if formats
+        .iter()
+        .any(|f| f.id() == ClipboardFormatId::CF_UNICODETEXT)
+    {
         Some(ClipboardFormatId::CF_UNICODETEXT)
     } else if formats.iter().any(|f| f.id() == ClipboardFormatId::CF_TEXT) {
         Some(ClipboardFormatId::CF_TEXT)
@@ -142,6 +146,16 @@ impl SidecarClipboardBackend {
         if self.tx.send(event).is_err() {
             debug!("clipboard event receiver dropped; sidecar shutting down");
         }
+    }
+}
+
+impl AsAny for SidecarClipboardBackend {
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+        self
     }
 }
 
@@ -277,28 +291,23 @@ mod tests {
         // remote→local path would — the two text codecs must agree. Non-ASCII
         // exercises the UTF-16 path.
         let original = "héllo wörld ☺";
-        let response = build_format_data_response(
-            ClipboardFormatId::CF_UNICODETEXT,
-            Some(original),
-        );
-        let decoded =
-            decode_clipboard_text(ClipboardFormatId::CF_UNICODETEXT, &response).unwrap();
+        let response =
+            build_format_data_response(ClipboardFormatId::CF_UNICODETEXT, Some(original));
+        let decoded = decode_clipboard_text(ClipboardFormatId::CF_UNICODETEXT, &response).unwrap();
         assert_eq!(decoded, original);
     }
 
     #[test]
     fn ansi_text_round_trips_through_response() {
         let original = "plain ascii";
-        let response =
-            build_format_data_response(ClipboardFormatId::CF_TEXT, Some(original));
+        let response = build_format_data_response(ClipboardFormatId::CF_TEXT, Some(original));
         let decoded = decode_clipboard_text(ClipboardFormatId::CF_TEXT, &response).unwrap();
         assert_eq!(decoded, original);
     }
 
     #[test]
     fn missing_local_text_yields_error_response() {
-        let response =
-            build_format_data_response(ClipboardFormatId::CF_UNICODETEXT, None);
+        let response = build_format_data_response(ClipboardFormatId::CF_UNICODETEXT, None);
         assert!(response.is_error());
         assert_eq!(
             decode_clipboard_text(ClipboardFormatId::CF_UNICODETEXT, &response),
@@ -321,7 +330,9 @@ mod tests {
         backend.on_remote_copy(&[text(ClipboardFormatId::CF_UNICODETEXT)]);
         assert_eq!(
             rx.try_recv(),
-            Ok(ClipboardEvent::InitiatePaste(ClipboardFormatId::CF_UNICODETEXT))
+            Ok(ClipboardEvent::InitiatePaste(
+                ClipboardFormatId::CF_UNICODETEXT
+            ))
         );
     }
 
@@ -355,7 +366,9 @@ mod tests {
         });
         assert_eq!(
             rx.try_recv(),
-            Ok(ClipboardEvent::ProvideData(ClipboardFormatId::CF_UNICODETEXT))
+            Ok(ClipboardEvent::ProvideData(
+                ClipboardFormatId::CF_UNICODETEXT
+            ))
         );
     }
 }

--- a/rdp-sidecar/src/main.rs
+++ b/rdp-sidecar/src/main.rs
@@ -13,6 +13,7 @@
 //! out on stdout while applying host input read from stdin. All logging goes to
 //! stderr so it never corrupts the binary IPC stream on stdout.
 
+mod clipboard;
 mod input;
 mod keymap;
 mod rdp;

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -14,6 +14,7 @@
 //! active stage, `select!`-ing between server PDUs and host input events.
 
 use anyhow::{anyhow, Context, Result};
+use ironrdp::cliprdr::{Client as CliprdrRole, CliprdrClient, CliprdrSvcMessages};
 use ironrdp::connector::connection_activation::{
     ConnectionActivationSequence, ConnectionActivationState,
 };
@@ -21,7 +22,6 @@ use ironrdp::connector::{
     BitmapConfig, ClientConnector, Config as ConnectorConfig, ConnectionResult, Credentials,
     DesktopSize, ServerName,
 };
-use ironrdp::cliprdr::{Client as CliprdrRole, CliprdrClient, CliprdrSvcMessages};
 use ironrdp::core::WriteBuf;
 use ironrdp::displaycontrol::client::DisplayControlClient;
 use ironrdp::displaycontrol::pdu::MonitorLayoutEntry;

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -21,6 +21,7 @@ use ironrdp::connector::{
     BitmapConfig, ClientConnector, Config as ConnectorConfig, ConnectionResult, Credentials,
     DesktopSize, ServerName,
 };
+use ironrdp::cliprdr::{Client as CliprdrRole, CliprdrClient, CliprdrSvcMessages};
 use ironrdp::core::WriteBuf;
 use ironrdp::displaycontrol::client::DisplayControlClient;
 use ironrdp::displaycontrol::pdu::MonitorLayoutEntry;
@@ -46,6 +47,9 @@ use termihub_core::connection::{
     CursorShape, CursorUpdate, DirtyRect, FrameUpdate, GraphicalState, InputEvent,
 };
 
+use crate::clipboard::{
+    build_format_data_response, local_text_formats, ClipboardEvent, SidecarClipboardBackend,
+};
 use crate::input;
 
 /// The framed RDP transport after the TLS upgrade.
@@ -133,12 +137,18 @@ pub fn is_auth_error(msg: &str) -> bool {
 
 /// Run the IronRDP connect sequence to an active session: TCP → X.224 → TLS →
 /// CredSSP/NLA → capability exchange. Returns the negotiated result, the framed
-/// transport for the driver to take over, and the connector [`Config`] (needed
+/// transport for the driver to take over, the connector [`Config`] (needed
 /// verbatim to drive the Deactivation-Reactivation Sequence on dynamic resize,
-/// #1755).
+/// #1755), and the receiver on which the registered CLIPRDR backend surfaces
+/// clipboard events for the driver (#1756).
 async fn connect_session(
     cfg: &RdpConfig,
-) -> Result<(ConnectionResult, RdpFramed, ConnectorConfig)> {
+) -> Result<(
+    ConnectionResult,
+    RdpFramed,
+    ConnectorConfig,
+    std::sync::mpsc::Receiver<ClipboardEvent>,
+)> {
     let host = cfg.host.clone();
     let port = cfg.effective_port();
 
@@ -148,11 +158,17 @@ async fn connect_session(
     let client_addr = tcp.local_addr().context("RDP local address failed")?;
 
     let connector_config = build_connector_config(cfg)?;
+    // Register the CLIPRDR static channel (MS-RDPECLIP) so the session can bridge
+    // text clipboard both ways (#1756). The backend translates server callbacks
+    // into `ClipboardEvent`s the driver drains once it owns the active stage
+    // again; the receiver rides back out with the connection result.
+    let (clipboard_backend, clipboard_rx) = SidecarClipboardBackend::new();
     // Register the Display Control Virtual Channel (MS-RDPEDISP) so the session
     // can request dynamic resolution changes (#1755). It rides the drdynvc
     // static channel; the capabilities callback needs to send nothing, the
     // channel just has to be ready before we encode a resize.
     let mut connector = ClientConnector::new(connector_config.clone(), client_addr)
+        .with_static_channel(CliprdrClient::new(Box::new(clipboard_backend)))
         .with_static_channel(
             DrdynvcClient::new()
                 .with_dynamic_channel(DisplayControlClient::new(|_caps| Ok(Vec::new()))),
@@ -192,7 +208,7 @@ async fn connect_session(
     .await
     .context("RDP CredSSP / capability exchange failed")?;
 
-    Ok((result, framed, connector_config))
+    Ok((result, framed, connector_config, clipboard_rx))
 }
 
 /// Crop the tightly-packed RGBA pixels of an inclusive rectangle out of the
@@ -391,7 +407,7 @@ where
     .await
     .context("failed to write state")?;
 
-    let (result, framed, connector_config) = match connect_session(&cfg).await {
+    let (result, framed, connector_config, clipboard_rx) = match connect_session(&cfg).await {
         Ok(v) => v,
         Err(e) => {
             let state = if is_auth_error(&format!("{e:#}")) {
@@ -412,6 +428,7 @@ where
         result,
         framed,
         connector_config,
+        clipboard_rx,
         cfg.view_only,
         ipc_in,
         ipc_out,
@@ -432,6 +449,7 @@ async fn drive<R, W>(
     result: ConnectionResult,
     framed: RdpFramed,
     connector_config: ConnectorConfig,
+    clipboard_rx: std::sync::mpsc::Receiver<ClipboardEvent>,
     view_only: bool,
     ipc_in: &mut R,
     ipc_out: &mut W,
@@ -478,6 +496,10 @@ async fn drive<R, W>(
 
     let mut prev_buttons: u8 = 0;
     let mut cursor: (u32, u32) = (0, 0);
+    // The latest host clipboard text pushed via `SetClipboard`, served back to the
+    // server when it requests our clipboard data (#1756). `None` until the host
+    // copies something.
+    let mut local_clipboard: Option<String> = None;
 
     loop {
         tokio::select! {
@@ -533,8 +555,27 @@ async fn drive<R, W>(
                             ),
                         }
                     }
+                    HostMessage::SetClipboard(text) => {
+                        // The host copied text locally; mirror it to the remote
+                        // over CLIPRDR (#1756). View-only sessions never push the
+                        // local clipboard to the server.
+                        if view_only {
+                            continue;
+                        }
+                        local_clipboard = Some(text);
+                        if advertise_local_clipboard(
+                            &mut stage,
+                            &mut writer,
+                            local_clipboard.as_deref(),
+                        )
+                        .await
+                        .is_err()
+                        {
+                            break;
+                        }
+                    }
                     HostMessage::Disconnect => break,
-                    // Clipboard is a follow-up; a duplicate Connect is ignored.
+                    // A duplicate Connect is ignored.
                     other => debug!(?other, "rdp sidecar ignored host message"),
                 }
             }
@@ -553,6 +594,21 @@ async fn drive<R, W>(
                         break;
                     }
                 };
+                // Processing the PDU may have run CLIPRDR backend callbacks, which
+                // queue clipboard actions. Now that the active stage is ours again,
+                // drain them (#1756) before handling the graphics outputs.
+                if drain_clipboard_events(
+                    &clipboard_rx,
+                    &mut stage,
+                    &mut writer,
+                    ipc_out,
+                    local_clipboard.as_deref(),
+                )
+                .await
+                .is_err()
+                {
+                    break;
+                }
                 match handle_outputs(outputs, &image, &mut writer, ipc_out, &mut cursor).await {
                     Flow::Continue => {}
                     Flow::Stop => break,
@@ -659,6 +715,108 @@ async fn reactivate(
         }
     }
     Ok(framed)
+}
+
+/// Encode a batch of CLIPRDR channel messages against the active stage and write
+/// the resulting frame on the RDP transport. Building the messages needs a `&mut`
+/// borrow of the channel; encoding only needs `&self`, so callers build first,
+/// then hand the owned messages here (#1756).
+async fn write_cliprdr_messages<T>(
+    stage: &ActiveStage,
+    transport: &mut T,
+    messages: CliprdrSvcMessages<CliprdrRole>,
+) -> Result<()>
+where
+    T: FramedWrite,
+{
+    let frame = stage
+        .process_svc_processor_messages(messages)
+        .context("failed to encode cliprdr messages")?;
+    transport
+        .write_all(&frame)
+        .await
+        .context("failed to write cliprdr frame")?;
+    Ok(())
+}
+
+/// Advertise the host's current clipboard formats to the server (an empty list
+/// when the host clipboard is empty, which still drives the CLIPRDR init
+/// handshake to completion). Called both when the channel first requests a format
+/// list and whenever the host copies new text (#1756).
+async fn advertise_local_clipboard<T>(
+    stage: &mut ActiveStage,
+    transport: &mut T,
+    local_clipboard: Option<&str>,
+) -> Result<()>
+where
+    T: FramedWrite,
+{
+    let formats = local_text_formats(local_clipboard);
+    let messages = match stage.get_svc_processor_mut::<CliprdrClient>() {
+        Some(cliprdr) => cliprdr
+            .initiate_copy(&formats)
+            .context("cliprdr initiate_copy failed")?,
+        None => {
+            warn!("cliprdr channel unavailable; cannot advertise local clipboard");
+            return Ok(());
+        }
+    };
+    write_cliprdr_messages(stage, transport, messages).await
+}
+
+/// Drain the CLIPRDR backend's queued [`ClipboardEvent`]s now that the driver
+/// owns the active stage again, performing each channel action (advertise / fetch
+/// / provide) or forwarding received remote text to the host over IPC (#1756).
+async fn drain_clipboard_events<T, W>(
+    rx: &std::sync::mpsc::Receiver<ClipboardEvent>,
+    stage: &mut ActiveStage,
+    transport: &mut T,
+    ipc_out: &mut W,
+    local_clipboard: Option<&str>,
+) -> Result<()>
+where
+    T: FramedWrite,
+    W: AsyncWrite + Unpin,
+{
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            ClipboardEvent::AdvertiseLocal => {
+                advertise_local_clipboard(stage, transport, local_clipboard).await?;
+            }
+            ClipboardEvent::InitiatePaste(format) => {
+                let messages = match stage.get_svc_processor_mut::<CliprdrClient>() {
+                    Some(cliprdr) => cliprdr
+                        .initiate_paste(format)
+                        .context("cliprdr initiate_paste failed")?,
+                    None => {
+                        warn!("cliprdr channel unavailable; cannot paste remote clipboard");
+                        continue;
+                    }
+                };
+                write_cliprdr_messages(stage, transport, messages).await?;
+            }
+            ClipboardEvent::ProvideData(format) => {
+                let response = build_format_data_response(format, local_clipboard);
+                let messages = match stage.get_svc_processor_mut::<CliprdrClient>() {
+                    Some(cliprdr) => cliprdr
+                        .submit_format_data(response)
+                        .context("cliprdr submit_format_data failed")?,
+                    None => {
+                        warn!("cliprdr channel unavailable; cannot serve clipboard data");
+                        continue;
+                    }
+                };
+                write_cliprdr_messages(stage, transport, messages).await?;
+            }
+            ClipboardEvent::RemoteText(text) => {
+                debug!(len = text.len(), "forwarding remote clipboard text to host");
+                write_message(ipc_out, &SidecarMessage::Clipboard(text))
+                    .await
+                    .context("failed to forward remote clipboard to host")?;
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Wires the IronRDP **CLIPRDR** static channel (MS-RDPECLIP) into the RDP sidecar so **text clipboard flows both ways**, bridging into the existing #1680 clipboard layer. Follow-up to #1747 (sidecar foundation) and #1755 (resize, whose channel-registration pattern this mirrors).

Closes #1756

## What changed

- **`rdp-sidecar/src/clipboard.rs`** (new): a headless `CliprdrBackend` (`SidecarClipboardBackend`). It owns no OS clipboard — it translates CLIPRDR callbacks into `ClipboardEvent`s over an mpsc channel, plus pure text-codec helpers (Unicode/ANSI encode + decode, format preference) with unit tests.
- **`rdp-sidecar/src/rdp.rs`**: registers `CliprdrClient` on connect (beside drdynvc/displaycontrol); the driver loop drains queued clipboard events after each `stage.process` — when it again owns `&mut ActiveStage` — and performs the matching `initiate_copy` / `initiate_paste` / `submit_format_data`. A new `HostMessage::SetClipboard` handler advertises the host clipboard to the server.
- **`core/src/backends/rdp_sidecar/mod.rs`**: flips `supports_clipboard` to `true` (the adapter already routed `SidecarMessage::Clipboard` → shared clipboard and `set_clipboard` → `HostMessage::SetClipboard`).
- Doc/comment refresh in `protocol.rs` / `mod.rs`; change fragment.

## Design note

CLIPRDR backend callbacks run **synchronously inside `ActiveStage::process`**, while the `Cliprdr` channel is mutably borrowed — so the backend cannot call back into it. It records the required action as an event; the driver performs it once `process` returns. Reaching the channel's `Ready` state requires the client to send a FormatList, so init advertises the (possibly empty) local clipboard.

**Direction summary**
- remote → local: server FormatList → `on_remote_copy` → `initiate_paste` → `on_format_data_response` → `SidecarMessage::Clipboard` → #1680 layer.
- local → remote: `HostMessage::SetClipboard` → `initiate_copy` → server FormatDataRequest → `on_format_data_request` → `submit_format_data`.

**View-only** sessions never push the local clipboard to the remote.

## Verification

No live RDP server is available (as with #1755, live clipboard needs a real host). Verified via:
- **Unit tests** (12 new in `clipboard.rs`): format preference (Unicode>ANSI, non-text ignored), local-format advertisement, Unicode/ANSI response round-trips, error responses, and backend callback → event emission (remote-copy → paste → decode, format-list request, server data request). All 38 sidecar tests pass.
- `cargo build` / `cargo clippy -D warnings` / `cargo test` on the excluded sidecar crate; `cargo clippy`/`test` on `termihub-core --features rdp-sidecar`; `pnpm markdownlint`.

Text-only by design; file-transfer and clipboard locking are left as no-ops (no file formats advertised, locking capability not negotiated) and can be a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)