### PR TITLE
feat(rdp): windows console-flash suppression and server-cert trust gate

### DIFF
--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -67,6 +67,16 @@ use protocol::{read_message, write_message, HostMessage, SidecarMessage};
 /// Bounded channel depth for frames / cursor updates / input (backpressure).
 const CHANNEL_DEPTH: usize = 32;
 
+/// Windows `CREATE_NO_WINDOW` process-creation flag (#1758).
+///
+/// The desktop is a GUI-subsystem process; spawning the console-subsystem
+/// sidecar from it makes Windows allocate a fresh console, which flashes a
+/// window on every RDP connect. This flag gives the child no console at all.
+/// stdout/stdin are piped and stderr is inherited, so those handles (and the
+/// sidecar's stderr logging) are unaffected — only the phantom console goes away.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
 /// Environment variable that overrides the sidecar binary path (dev + tests).
 pub const HELPER_PATH_ENV: &str = "TERMIHUB_RDP_HELPER";
 
@@ -313,19 +323,22 @@ impl ConnectionType for SidecarRdp {
         let view_only = cfg.view_only;
 
         let helper = resolve_helper_binary();
-        let mut child = tokio::process::Command::new(&helper)
+        let mut command = tokio::process::Command::new(&helper);
+        command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(|e| {
-                SessionError::SpawnFailed(format!(
-                    "failed to launch RDP helper '{}': {e}. Build it with \
-                     scripts/build-rdp-sidecar.sh (or set {HELPER_PATH_ENV}).",
-                    helper.display()
-                ))
-            })?;
+            .kill_on_drop(true);
+        // Suppress the console-window flash on Windows (#1758). No-op elsewhere.
+        #[cfg(windows)]
+        command.creation_flags(CREATE_NO_WINDOW);
+        let mut child = command.spawn().map_err(|e| {
+            SessionError::SpawnFailed(format!(
+                "failed to launch RDP helper '{}': {e}. Build it with \
+                 scripts/build-rdp-sidecar.sh (or set {HELPER_PATH_ENV}).",
+                helper.display()
+            ))
+        })?;
 
         let mut stdin = child
             .stdin

--- a/docs/changes/dev1/feature/1758-rdp-windows-polish.md
+++ b/docs/changes/dev1/feature/1758-rdp-windows-polish.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- RDP (experimental): on Windows the `termihub-rdp-helper` sidecar no longer
+  flashes a console window each time an RDP session is opened. It is spawned with
+  `CREATE_NO_WINDOW`; stderr logging is unaffected.
+
+### Security
+
+- RDP (experimental): the sidecar no longer silently accepts any server
+  certificate. When "Ignore Certificate Errors" is off (the default), an
+  untrusted server certificate now refuses the connection with an actionable
+  message that names the server public-key fingerprint, instead of connecting
+  unverified. Enable "Ignore Certificate Errors" in the connection's RDP options
+  to trust a specific host. An interactive accept-once / accept-for-host prompt
+  with a persisted per-host trust store is a follow-up.

--- a/rdp-sidecar/Cargo.lock
+++ b/rdp-sidecar/Cargo.lock
@@ -3383,9 +3383,11 @@ name = "termihub-rdp-sidecar"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "hex",
  "ironrdp",
  "ironrdp-tls",
  "ironrdp-tokio",
+ "sha2",
  "tempfile",
  "termihub-core",
  "tokio",

--- a/rdp-sidecar/Cargo.toml
+++ b/rdp-sidecar/Cargo.toml
@@ -65,6 +65,13 @@ anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Server-certificate trust gate (#1758): fingerprint the server's public key so
+# an untrusted certificate can be rejected with an actionable message instead of
+# being silently accepted. Both already resolve in this graph (IronRDP's CredSSP
+# crypto pulls them in), so this adds no new locked dependency.
+sha2 = "0.11"
+hex = "0.4"
+
 [dev-dependencies]
 # Temp directories back the drive-redirection filesystem tests (#1757), which
 # exercise the RDPDR backend against a real folder without a live RDP server.

--- a/rdp-sidecar/src/cert.rs
+++ b/rdp-sidecar/src/cert.rs
@@ -1,0 +1,121 @@
+//! Server-certificate trust gate for the RDP sidecar (#1758).
+//!
+//! IronRDP's TLS layer (`ironrdp_tls::upgrade`) accepts *any* server certificate
+//! so the handshake can complete and the CredSSP layer can bind trust to the
+//! server public key. On its own, though, that blind accept means an untrusted
+//! or spoofed server is taken with no signal at all — exactly the "always
+//! accept" behaviour #1758 sets out to replace. This module turns the blind
+//! accept into an explicit, auditable decision keyed off the connection's
+//! `ignoreCertErrors` setting.
+//!
+//! The trust model is deliberately SSH-host-key-shaped: we fingerprint the
+//! server's public key (not a CA chain — real RDP hosts are overwhelmingly
+//! self-signed, so chain validation would reject nearly every legitimate host)
+//! and decide whether to proceed. Today the decision is binary —
+//! `ignoreCertErrors` accepts, otherwise the connection is refused and the
+//! fingerprint is surfaced. An interactive accept-once / accept-for-host prompt
+//! plus a persisted per-host trust store is the sequenced follow-up;
+//! [`CertVerdict`] is the seam it slots into.
+
+use sha2::{Digest, Sha256};
+
+/// A SHA-256 fingerprint of the server's public key, formatted as uppercase
+/// colon-separated hex with a `sha256:` prefix (e.g. `sha256:AB:CD:…`) — the
+/// shape an operator can eyeball against the value a server administrator
+/// reports.
+pub fn public_key_fingerprint(public_key: &[u8]) -> String {
+    let digest = Sha256::digest(public_key);
+    let hex = hex::encode_upper(digest);
+    let mut out = String::with_capacity("sha256:".len() + hex.len() + hex.len() / 2);
+    out.push_str("sha256:");
+    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+        if i > 0 {
+            out.push(':');
+        }
+        // `chunk` is always valid ASCII hex from `encode_upper`.
+        out.push_str(std::str::from_utf8(chunk).expect("hex is ascii"));
+    }
+    out
+}
+
+/// The outcome of the server-certificate trust gate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CertVerdict {
+    /// Proceed with the connection.
+    Accept,
+    /// Refuse the connection; the string is a user-facing explanation.
+    Reject(String),
+}
+
+/// Decide whether to trust the server certificate identified by `fingerprint`.
+///
+/// `ignore_cert_errors` mirrors the connection's `ignoreCertErrors` setting.
+/// Until a persisted trust store / interactive prompt exists (the #1758
+/// follow-up), an unset flag means the certificate is untrusted and the
+/// connection is refused with an actionable message — never silently accepted.
+pub fn evaluate(ignore_cert_errors: bool, fingerprint: &str) -> CertVerdict {
+    if ignore_cert_errors {
+        CertVerdict::Accept
+    } else {
+        CertVerdict::Reject(format!(
+            "the RDP server presented an untrusted certificate (server key {fingerprint}). \
+             termiHub does not connect to an unverified host automatically. If you trust this \
+             server, enable \"Ignore Certificate Errors\" in the connection's RDP options and \
+             reconnect."
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_stable_and_formatted() {
+        // SHA-256 of the empty input is a known constant; formatted uppercase,
+        // colon-separated, with the algorithm prefix.
+        let fp = public_key_fingerprint(b"");
+        assert_eq!(
+            fp,
+            "sha256:E3:B0:C4:42:98:FC:1C:14:9A:FB:F4:C8:99:6F:B9:24:\
+             27:AE:41:E4:64:9B:93:4C:A4:95:99:1B:78:52:B8:55"
+        );
+        // Byte pairs → 32 hex octets → 31 separators between them.
+        assert_eq!(fp.matches(':').count(), 32); // 1 after the prefix + 31 between octets
+    }
+
+    #[test]
+    fn fingerprint_differs_per_key() {
+        assert_ne!(
+            public_key_fingerprint(b"key-a"),
+            public_key_fingerprint(b"key-b")
+        );
+        // Deterministic for the same input.
+        assert_eq!(
+            public_key_fingerprint(b"key-a"),
+            public_key_fingerprint(b"key-a")
+        );
+    }
+
+    #[test]
+    fn ignore_cert_errors_accepts() {
+        assert_eq!(evaluate(true, "sha256:AA"), CertVerdict::Accept);
+    }
+
+    #[test]
+    fn default_rejects_with_fingerprint_and_guidance() {
+        let verdict = evaluate(false, "sha256:AB:CD");
+        match verdict {
+            CertVerdict::Reject(msg) => {
+                // The message must name the fingerprint and point at the toggle,
+                // so the failure is actionable rather than a bare error.
+                assert!(msg.contains("sha256:AB:CD"), "fingerprint surfaced: {msg}");
+                assert!(
+                    msg.contains("Ignore Certificate Errors"),
+                    "guidance surfaced: {msg}"
+                );
+            }
+            CertVerdict::Accept => panic!("default (ignoreCertErrors=false) must not accept"),
+        }
+    }
+}

--- a/rdp-sidecar/src/main.rs
+++ b/rdp-sidecar/src/main.rs
@@ -13,6 +13,7 @@
 //! out on stdout while applying host input read from stdin. All logging goes to
 //! stderr so it never corrupts the binary IPC stream on stdout.
 
+mod cert;
 mod clipboard;
 mod drive;
 mod input;

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -205,9 +205,9 @@ async fn connect_session(
         .await
         .context("RDP X.224 negotiation failed")?;
 
-    // 2) TLS upgrade. IronRDP's TLS layer accepts the server certificate and
-    //    binds trust to the server public key during CredSSP; the interactive
-    //    accept-once / accept-for-host prompt is a follow-up.
+    // 2) TLS upgrade. IronRDP's TLS layer accepts the server certificate at the
+    //    handshake so CredSSP can bind trust to the server public key; we then
+    //    gate on that key ourselves (#1758) rather than accepting blindly.
     let (initial_stream, leftover) = framed.into_inner();
     let (tls_stream, server_cert) = ironrdp_tls::upgrade(initial_stream, host.as_str())
         .await
@@ -215,6 +215,24 @@ async fn connect_session(
     let server_public_key = ironrdp_tls::extract_tls_server_public_key(&server_cert)
         .ok_or_else(|| anyhow!("could not extract RDP server public key"))?
         .to_vec();
+
+    // Trust gate (#1758): fingerprint the server public key and either accept
+    // (only when the user set `ignoreCertErrors`) or refuse with an actionable
+    // message naming the fingerprint — never a silent blind accept. An
+    // interactive accept-once / accept-for-host prompt + persisted trust store
+    // is the sequenced follow-up.
+    let fingerprint = crate::cert::public_key_fingerprint(&server_public_key);
+    match crate::cert::evaluate(cfg.ignore_cert_errors, &fingerprint) {
+        crate::cert::CertVerdict::Accept => {
+            if cfg.ignore_cert_errors {
+                warn!(
+                    %fingerprint,
+                    "accepting RDP server certificate without verification (ignoreCertErrors is enabled)"
+                );
+            }
+        }
+        crate::cert::CertVerdict::Reject(message) => anyhow::bail!(message),
+    }
 
     let upgraded = ironrdp_tokio::mark_as_upgraded(should_upgrade, &mut connector);
     let mut framed = TokioFramed::new_with_leftover(tls_stream, leftover);


### PR DESCRIPTION
Part of #1758 — lands the two RDP sidecar hardening items that can be delivered entirely within the sidecar crate + `SidecarRdp` adapter, and defers the interactive prompt UI to a follow-up.

## What this does

### 1. Windows console-flash suppression (complete)
The desktop is a GUI-subsystem process; spawning the console-subsystem `termihub-rdp-helper` from it made Windows allocate a fresh console, flashing a window on every RDP connect. The sidecar is now spawned with `CREATE_NO_WINDOW`. stdin/stdout are piped and stderr is inherited, so the child's stderr logging is unaffected — only the phantom console goes away. Chose the creation flag over `#![windows_subsystem = "windows"]` on the helper so running the helper standalone (for debugging) still attaches to a console normally.

### 2. Certificate trust gate — no more blind accept (wires `ignoreCertErrors`)
`ironrdp_tls::upgrade` accepts *any* server certificate, and `ignoreCertErrors` was previously unwired — so termiHub connected to unverified RDP servers silently. The sidecar now fingerprints the server public key (SHA-256, SSH-host-key-style) and applies an explicit decision:

- `ignoreCertErrors` **on** → accept (logs the accepted fingerprint at WARN).
- `ignoreCertErrors` **off** (default) → refuse the connection with an actionable message naming the fingerprint and pointing at the toggle — surfaced as a connect failure — instead of silently connecting.

The trust model is deliberately public-key/TOFU-shaped rather than CA-chain validation, because real RDP hosts are overwhelmingly self-signed. `cert::CertVerdict` is the seam the interactive/persisted follow-up slots into.

## Deferred → #1767 (Ready2Implement)
The **interactive** accept-once / accept-for-host prompt and a persisted per-host trust store are filed as #1767. They can't live in the sidecar crate + adapter alone: the adapter has no prompt channel to the frontend, and adding one touches shared graphical-session infrastructure (also serving VNC/the mock) — its own change, not this hardening PR.

## Testing
- New unit tests in `rdp-sidecar/src/cert.rs`: fingerprint format/stability (verified against the known SHA-256 of the empty input) and the accept/reject verdict incl. the actionable message.
- Full sidecar suite green (56 tests), `cargo clippy` clean, `cargo fmt --check` clean.
- Note: the `rdp-sidecar` crate is workspace-excluded and **not** built by per-PR CI, so it was built/clipped/tested locally. Windows console behavior is not unit-testable and is reasoned through in code comments + the change fragment.
- `sha2`/`hex` were already resolved in the sidecar's lockfile (IronRDP's CredSSP crypto pulls them in), so this adds no new locked dependency — only the two direct-dep edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
