### PR TITLE
feat(rdp): audio output redirection (rdpsnd) in the sidecar (Closes #1764)

### DIFF
--- a/core/src/backends/rdp_sidecar/config.rs
+++ b/core/src/backends/rdp_sidecar/config.rs
@@ -97,6 +97,12 @@ pub struct RdpConfig {
     /// User-visible name for the redirected drive; the remote shows it as
     /// "`<drive_name>` on termiHub". Defaults to `termiHub` when empty (#1757).
     pub drive_name: String,
+    /// Opt in to audio output redirection (rdpsnd): play the remote session's
+    /// audio on the local host. Off by default; the sidecar advertises PCM
+    /// formats and plays received `wave` PDUs through a host output device
+    /// (#1764). Audible playback is currently macOS/Windows only — the Linux
+    /// build omits the audio backend (see the #1764 Linux follow-up).
+    pub audio_redirection: bool,
 }
 
 impl Default for RdpConfig {
@@ -116,6 +122,7 @@ impl Default for RdpConfig {
             drive_redirection: false,
             shared_folder_path: String::new(),
             drive_name: String::new(),
+            audio_redirection: false,
         }
     }
 }
@@ -173,6 +180,11 @@ impl RdpConfig {
         }
         let canonical = std::fs::canonicalize(path).ok()?;
         canonical.is_dir().then_some(canonical)
+    }
+
+    /// Whether audio output redirection (rdpsnd playback) is opted in (#1764).
+    pub fn audio_enabled(&self) -> bool {
+        self.audio_redirection
     }
 
     /// The user-visible label for the redirected drive, defaulting to `termiHub`
@@ -322,6 +334,19 @@ pub fn rdp_settings_schema() -> SettingsSchema {
                 placeholder: Some("termiHub".to_string()),
                 ..field("driveName", "Drive Name", FieldType::Text)
             },
+            SettingsField {
+                default: Some(serde_json::json!(false)),
+                description: Some(
+                    "Play the remote session's audio on this computer. Currently available on \
+                     macOS and Windows; Linux support is planned."
+                        .to_string(),
+                ),
+                ..field(
+                    "audioRedirection",
+                    "Redirect Audio Output",
+                    FieldType::Boolean,
+                )
+            },
         ],
     });
 
@@ -435,6 +460,7 @@ mod tests {
             drive_redirection: true,
             shared_folder_path: "/tmp/share".to_string(),
             drive_name: "Docs".to_string(),
+            audio_redirection: true,
         };
         let json = serde_json::to_value(&cfg).unwrap();
         let back: RdpConfig = serde_json::from_value(json).unwrap();
@@ -450,6 +476,29 @@ mod tests {
         assert!(back.drive_redirection);
         assert_eq!(back.shared_folder_path, "/tmp/share");
         assert_eq!(back.drive_label(), "Docs");
+        assert!(back.audio_enabled());
+    }
+
+    #[test]
+    fn audio_redirection_defaults_off() {
+        assert!(!RdpConfig::default().audio_enabled());
+        let on = RdpConfig {
+            audio_redirection: true,
+            ..Default::default()
+        };
+        assert!(on.audio_enabled());
+    }
+
+    #[test]
+    fn schema_exposes_audio_redirection_toggle() {
+        let schema = rdp_settings_schema();
+        let group = schema.groups.iter().find(|g| g.key == "rdp").unwrap();
+        let audio = group
+            .fields
+            .iter()
+            .find(|f| f.key == "audioRedirection")
+            .expect("RDP schema must expose audioRedirection");
+        assert_eq!(audio.default, Some(serde_json::json!(false)));
     }
 
     #[test]

--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -31,12 +31,14 @@
 //!
 //! Connect (TLS/NLA) → decode frames → keyboard/pointer/wheel input → server
 //! cursor → Display-Control dynamic resize (#1755) → CLIPRDR text clipboard both
-//! ways (#1756) → RDPDR drive redirection of one opted-in folder (#1757). Audio
-//! playback (rdpsnd) and CLIPRDR file transfer are sequenced follow-ups of
-//! #1757. Drive redirection is configured purely through [`config::RdpConfig`]
-//! (`driveRedirection` / `sharedFolderPath` / `driveName`), which flows to the
-//! sidecar in `HostMessage::Connect`, so this adapter needs no per-feature
-//! wiring.
+//! ways (#1756) → RDPDR drive redirection of one opted-in folder (#1757) →
+//! rdpsnd audio output played on the host (#1764, macOS/Windows). CLIPRDR file
+//! transfer remains a sequenced follow-up. Every one of these is configured
+//! purely through [`config::RdpConfig`] (`driveRedirection` / `sharedFolderPath`
+//! / `driveName` / `audioRedirection`), which flows to the sidecar in
+//! `HostMessage::Connect`, so this adapter needs no per-feature wiring — audio in
+//! particular is decoded **and played** inside the sidecar process, never
+//! crossing this IPC boundary.
 
 pub mod config;
 pub mod protocol;

--- a/docs/changes/dev1/feature/1764-rdp-audio.md
+++ b/docs/changes/dev1/feature/1764-rdp-audio.md
@@ -1,0 +1,9 @@
+### Added
+
+- RDP: audio output redirection. The remote session's audio can now be played on
+  this computer over the audio channel (rdpsnd / MS-RDPEAUDIO) in the IronRDP
+  sidecar. The sidecar advertises a PCM format, decodes the server's audio
+  stream, and plays it through a host output device — decode and playback stay
+  inside the sidecar process. Redirection is **off by default** and opt-in per
+  connection via the new "Redirect Audio Output" option. Audible playback is
+  available on macOS and Windows; Linux support is planned (#1764).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -960,8 +960,28 @@ filesystem backend is covered by unit tests against a temp directory
 5. Leave **Redirect a Local Drive** off and reconnect. **Expected:** no drive
    appears in the remote session.
 
-Audio (rdpsnd, #1764) and CLIPRDR file transfer (#1765) are follow-ups and are
-expected to be inert in this slice.
+#### Audio output redirection (rdpsnd, #1764)
+
+Audio output is off by default and opt-in per connection. The PCM decode and
+format advertisement are covered by unit tests (`rdp-sidecar` `audio` module),
+but audible playback needs a real server and a host audio device, and is
+**macOS/Windows only** in this slice (the Linux sidecar omits the audio backend
+— see PR #1764's Linux follow-up). Verify on macOS or Windows:
+
+1. Build the sidecar and point `TERMIHUB_RDP_HELPER` at it (as above).
+2. In the RDP connection editor, enable **Redirect Audio Output**.
+3. Connect to a Windows RDP host, then play sound in the remote session (e.g. a
+   YouTube clip, a system sound, or `Test-Sound`).
+   **Expected:** the audio is heard through this computer's speakers/output
+   device, reasonably in sync with the remote.
+4. Adjust the remote volume — local playback volume tracks it.
+5. Leave **Redirect Audio Output** off and reconnect. **Expected:** no remote
+   audio plays locally (the client advertises no audio formats).
+6. On a host with no audio device (or headless), confirm the session still
+   connects and runs normally, just without sound.
+
+CLIPRDR file transfer (#1765) is a follow-up and is expected to be inert in this
+slice.
 
 ### Deferred agent update (apply on last disconnect) (#1352)
 

--- a/rdp-sidecar/Cargo.lock
+++ b/rdp-sidecar/Cargo.lock
@@ -74,6 +74,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +249,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +365,22 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -354,6 +409,17 @@ dependencies = [
  "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -408,6 +474,49 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
 
 [[package]]
 name = "cpubits"
@@ -597,6 +706,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -1115,7 +1230,7 @@ dependencies = [
  "hickory-proto",
  "idna",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "rand 0.10.2",
  "thiserror 2.0.19",
  "tinyvec",
@@ -1133,7 +1248,7 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "once_cell",
  "prefix-trie",
  "rand 0.10.2",
@@ -1156,7 +1271,7 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "moka",
  "ndk-context",
  "once_cell",
@@ -1431,7 +1546,7 @@ dependencies = [
  "socket2 0.6.5",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1692,10 +1807,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "jni"
@@ -1706,7 +1846,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
  "thiserror 2.0.19",
@@ -1725,6 +1865,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -1847,6 +1996,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,10 +2093,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
 
 [[package]]
 name = "no-std-net"
@@ -2019,6 +2200,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni 0.21.1",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2473,6 +2699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rodio"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
+dependencies = [
+ "cpal",
+]
+
+[[package]]
 name = "rsa"
 version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2997,12 @@ dependencies = [
  "spki 0.8.0",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3055,6 +3305,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -3219,7 +3475,7 @@ dependencies = [
  "url",
  "uuid",
  "widestring",
- "windows",
+ "windows 0.62.2",
  "windows-registry",
  "winscard",
  "zeroize",
@@ -3387,6 +3643,7 @@ dependencies = [
  "ironrdp",
  "ironrdp-tls",
  "ironrdp-tokio",
+ "rodio",
  "sha2",
  "tempfile",
  "termihub-core",
@@ -3570,6 +3827,36 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -3938,12 +4225,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -3954,7 +4251,17 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3966,7 +4273,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -3976,7 +4283,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
 ]
@@ -4015,7 +4322,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
 ]
 
@@ -4026,8 +4333,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4050,11 +4366,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4063,7 +4388,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4077,18 +4402,33 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4102,15 +4442,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4126,9 +4484,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4138,15 +4508,36 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/rdp-sidecar/Cargo.toml
+++ b/rdp-sidecar/Cargo.toml
@@ -72,6 +72,21 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sha2 = "0.11"
 hex = "0.4"
 
+# Host audio output for rdpsnd audio redirection (#1764). `rodio` (a maintained,
+# widely-used Rust audio library on top of `cpal`) opens the default output
+# device, resamples our advertised PCM to it, and queues decoded `wave` buffers
+# through its `Sink`. `default-features = false` drops the file-format decoders
+# (symphonia/flac/vorbis/…) we do not use, keeping only the playback core.
+#
+# Target-gated to macOS/Windows: `cpal`'s Linux backend links ALSA
+# (`libasound2-dev`), which the bundle CI does not install when it cross-builds
+# the sidecar, and which is out of this change's lane to add. Gating the crate
+# off for Linux keeps the Linux sidecar build unaffected; Linux audio is a
+# tracked follow-up. This lives in the workspace-EXCLUDED sidecar graph, so it
+# adds zero dependency-conflict risk to the main app (#1747).
+[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
+rodio = { version = "0.20", default-features = false }
+
 [dev-dependencies]
 # Temp directories back the drive-redirection filesystem tests (#1757), which
 # exercise the RDPDR backend against a real folder without a live RDP server.

--- a/rdp-sidecar/src/audio.rs
+++ b/rdp-sidecar/src/audio.rs
@@ -1,0 +1,339 @@
+//! Audio output redirection (MS-RDPEAUDIO / `rdpsnd`) for the RDP sidecar
+//! (#1764).
+//!
+//! IronRDP's [`Rdpsnd`](ironrdp::rdpsnd::client::Rdpsnd) static virtual channel
+//! decodes the server's audio stream and drives an
+//! [`RdpsndClientHandler`](ironrdp::rdpsnd::client::RdpsndClientHandler): the
+//! handler advertises the [`AudioFormat`]s it can play via
+//! [`get_formats`](RdpsndClientHandler::get_formats), and the channel calls
+//! [`wave`](RdpsndClientHandler::wave) with each decoded audio buffer in one of
+//! those formats. [`RdpAudioBackend`] plays those buffers on a **host audio
+//! output device**, so the remote session's sound is heard locally.
+//!
+//! ## Where playback happens
+//!
+//! Playback stays entirely inside the sidecar process — the decoded PCM never
+//! crosses the IPC boundary to the desktop app. A dedicated OS thread owns the
+//! [`rodio`] output stream and sink (both `!Send`, and callback-driven), fed
+//! decoded samples over a channel; the handler only holds the `Send` sender, so
+//! nothing audio-related touches the async session future.
+//!
+//! ## Scope (v1, PCM only)
+//!
+//! The handler advertises a **single** PCM format — 44.1 kHz, 16-bit, stereo —
+//! and plays `wave` PDUs in it. One format is deliberate: IronRDP 0.9's
+//! `wave(format_no, …)` reports an index into the *intersection* of the client
+//! and server format lists, which IronRDP builds from a `HashSet` (non-deterministic
+//! order) and does not expose to the handler — so with more than one advertised
+//! format the handler cannot reliably map `format_no` back to a concrete format.
+//! Advertising exactly one keeps that mapping unambiguous (`format_no` is always
+//! `0`). Multi-format negotiation, ADPCM/Opus decode, and jitter/latency tuning
+//! are follow-ups (see #1764).
+//!
+//! ## Platforms
+//!
+//! Audible playback is compiled for **macOS and Windows** only. The Linux audio
+//! backends ([`cpal`]/ALSA, which [`rodio`] links) need `libasound2-dev` present
+//! when the sidecar is built, which the bundle CI does not yet install; until
+//! that lands, the Linux build omits the audio crate entirely (advertising no
+//! formats, so the server streams nothing) rather than fail to compile. Tracked
+//! as the #1764 Linux follow-up.
+
+use std::borrow::Cow;
+
+use ironrdp::rdpsnd::client::RdpsndClientHandler;
+use ironrdp::rdpsnd::pdu::{AudioFormat, PitchPdu, VolumePdu, WaveFormat};
+
+/// Channels in the advertised PCM format (stereo).
+const AUDIO_CHANNELS: u16 = 2;
+/// Sample rate of the advertised PCM format, in Hz (CD quality).
+const AUDIO_SAMPLE_RATE: u32 = 44_100;
+/// Bit depth of the advertised PCM format (16-bit signed little-endian).
+const AUDIO_BITS_PER_SAMPLE: u16 = 16;
+
+/// Build the single PCM [`AudioFormat`] the handler advertises. Every field must
+/// match a format the server offers verbatim (IronRDP intersects the two lists
+/// by structural equality), so the derived `nBlockAlign` / `nAvgBytesPerSec`
+/// follow the standard PCM formulas a Windows `rdpsnd` server uses.
+fn pcm_format() -> AudioFormat {
+    let block_align = AUDIO_CHANNELS * (AUDIO_BITS_PER_SAMPLE / 8);
+    AudioFormat {
+        format: WaveFormat::PCM,
+        n_channels: AUDIO_CHANNELS,
+        n_samples_per_sec: AUDIO_SAMPLE_RATE,
+        n_avg_bytes_per_sec: AUDIO_SAMPLE_RATE * u32::from(block_align),
+        n_block_align: block_align,
+        bits_per_sample: AUDIO_BITS_PER_SAMPLE,
+        data: None,
+    }
+}
+
+/// The formats the handler advertises to the server: one PCM format on platforms
+/// with a compiled audio backend, empty elsewhere (so the server streams no
+/// audio, matching the no-op behaviour).
+fn advertised_formats() -> Vec<AudioFormat> {
+    if AudioSink::SUPPORTED {
+        vec![pcm_format()]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Decode a little-endian 16-bit PCM byte buffer into signed samples. A trailing
+/// odd byte (a truncated sample) is dropped rather than misaligned.
+fn pcm_bytes_to_i16(bytes: &[u8]) -> Vec<i16> {
+    bytes
+        .chunks_exact(2)
+        .map(|pair| i16::from_le_bytes([pair[0], pair[1]]))
+        .collect()
+}
+
+/// Map an [`RDPSND` volume PDU](VolumePdu) (per-channel `0..=0xFFFF`) to a
+/// linear [`rodio`] gain where `1.0` is unity. Averages the two channels since
+/// the sink applies a single scalar gain.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn volume_to_gain(volume: &VolumePdu) -> f32 {
+    let avg = (u32::from(volume.volume_left) + u32::from(volume.volume_right)) as f32 / 2.0;
+    avg / f32::from(u16::MAX)
+}
+
+/// The RDPSND client handler: advertises PCM and plays received `wave` buffers on
+/// a host output device.
+#[derive(Debug)]
+pub struct RdpAudioBackend {
+    formats: Vec<AudioFormat>,
+    sink: AudioSink,
+}
+
+impl RdpAudioBackend {
+    /// Create the backend, starting the host-audio playback path.
+    pub fn new() -> Self {
+        Self {
+            formats: advertised_formats(),
+            sink: AudioSink::new(),
+        }
+    }
+}
+
+impl Default for RdpAudioBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RdpsndClientHandler for RdpAudioBackend {
+    fn get_formats(&self) -> &[AudioFormat] {
+        &self.formats
+    }
+
+    fn wave(&mut self, _format_no: usize, _ts: u32, data: Cow<'_, [u8]>) {
+        // Only one PCM format is advertised, so `format_no` is always 0 and the
+        // buffer is 16-bit LE PCM at the advertised channel/rate.
+        let samples = pcm_bytes_to_i16(&data);
+        if !samples.is_empty() {
+            self.sink.play(samples);
+        }
+    }
+
+    fn set_volume(&mut self, volume: VolumePdu) {
+        self.sink.set_volume(&volume);
+    }
+
+    fn set_pitch(&mut self, _pitch: PitchPdu) {
+        // Playback pitch shifting is not implemented; servers rarely send it.
+    }
+
+    fn close(&mut self) {
+        self.sink.close();
+    }
+}
+
+// --- Host playback sink: real on macOS/Windows, a no-op elsewhere. ---
+
+/// A command sent to the playback thread.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+enum AudioCommand {
+    /// Queue decoded samples for playback at the advertised channel/rate.
+    Play(Vec<i16>),
+    /// Set the output gain (`1.0` = unity).
+    Volume(f32),
+}
+
+/// Host audio sink backed by a dedicated [`rodio`] playback thread.
+///
+/// The thread owns the `!Send` output stream and sink; this handle keeps only the
+/// `Send` command sender, so the RDP session future stays `Send`-agnostic and no
+/// audio object migrates across worker threads.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[derive(Debug)]
+struct AudioSink {
+    tx: Option<std::sync::mpsc::Sender<AudioCommand>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+impl AudioSink {
+    const SUPPORTED: bool = true;
+
+    fn new() -> Self {
+        let (tx, rx) = std::sync::mpsc::channel::<AudioCommand>();
+        let thread = std::thread::Builder::new()
+            .name("rdp-audio".to_string())
+            .spawn(move || playback_loop(&rx))
+            .ok();
+        Self {
+            tx: Some(tx),
+            thread,
+        }
+    }
+
+    fn play(&self, samples: Vec<i16>) {
+        if let Some(tx) = &self.tx {
+            // A send error means the playback thread has exited (no device); drop
+            // the buffer silently rather than crashing the session.
+            let _ = tx.send(AudioCommand::Play(samples));
+        }
+    }
+
+    fn set_volume(&self, volume: &VolumePdu) {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(AudioCommand::Volume(volume_to_gain(volume)));
+        }
+    }
+
+    fn close(&mut self) {
+        // Dropping the sender ends the playback loop; then join so the output
+        // stream is torn down before we return.
+        self.tx = None;
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+impl Drop for AudioSink {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+/// The playback thread body: open a default output device and play every queued
+/// PCM buffer through a [`rodio`] sink until the sender is dropped. Opening the
+/// device can fail (headless host, no audio hardware); on failure the loop simply
+/// drains and discards commands so the session keeps running without sound.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn playback_loop(rx: &std::sync::mpsc::Receiver<AudioCommand>) {
+    let (_stream, handle) = match rodio::OutputStream::try_default() {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::warn!(error = %e, "rdpsnd: no audio output device; audio disabled");
+            for _ in rx.iter() {}
+            return;
+        }
+    };
+    let sink = match rodio::Sink::try_new(&handle) {
+        Ok(sink) => sink,
+        Err(e) => {
+            tracing::warn!(error = %e, "rdpsnd: failed to create audio sink; audio disabled");
+            for _ in rx.iter() {}
+            return;
+        }
+    };
+    tracing::debug!("rdpsnd: audio playback thread started");
+    for cmd in rx.iter() {
+        match cmd {
+            AudioCommand::Play(samples) => {
+                sink.append(rodio::buffer::SamplesBuffer::new(
+                    AUDIO_CHANNELS,
+                    AUDIO_SAMPLE_RATE,
+                    samples,
+                ));
+            }
+            AudioCommand::Volume(gain) => sink.set_volume(gain),
+        }
+    }
+    // `_stream` drops here, stopping the device.
+    tracing::debug!("rdpsnd: audio playback thread stopped");
+}
+
+/// No-op sink for platforms without a compiled audio backend (currently Linux —
+/// see the module docs). Advertises no formats, so the server never streams.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[derive(Debug)]
+struct AudioSink;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+impl AudioSink {
+    const SUPPORTED: bool = false;
+
+    fn new() -> Self {
+        AudioSink
+    }
+
+    fn play(&self, _samples: Vec<i16>) {}
+
+    fn set_volume(&self, _volume: &VolumePdu) {}
+
+    fn close(&mut self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pcm_bytes_to_i16_decodes_little_endian_pairs() {
+        // 0x0100 = 256, 0xFFFF = -1, 0x8000 = i16::MIN.
+        let bytes = [0x00, 0x01, 0xFF, 0xFF, 0x00, 0x80];
+        assert_eq!(pcm_bytes_to_i16(&bytes), vec![256, -1, i16::MIN]);
+    }
+
+    #[test]
+    fn pcm_bytes_to_i16_drops_trailing_odd_byte() {
+        // A truncated final sample is dropped, not misaligned.
+        assert_eq!(pcm_bytes_to_i16(&[0x00, 0x01, 0x7F]), vec![256]);
+        assert!(pcm_bytes_to_i16(&[]).is_empty());
+        assert!(pcm_bytes_to_i16(&[0x42]).is_empty());
+    }
+
+    #[test]
+    fn advertised_formats_are_empty_without_a_backend() {
+        // On platforms without a compiled audio backend the handler advertises
+        // nothing (so the server streams no audio); with one it advertises PCM.
+        if AudioSink::SUPPORTED {
+            assert_eq!(advertised_formats().len(), 1);
+        } else {
+            assert!(advertised_formats().is_empty());
+        }
+    }
+
+    #[test]
+    fn pcm_format_matches_standard_cd_quality_stereo() {
+        // These exact field values must match a format the server offers, so pin
+        // the standard PCM derivations (block align 4, avg 176 400 B/s).
+        let f = pcm_format();
+        assert_eq!(f.format, WaveFormat::PCM);
+        assert_eq!(f.n_channels, 2);
+        assert_eq!(f.n_samples_per_sec, 44_100);
+        assert_eq!(f.bits_per_sample, 16);
+        assert_eq!(f.n_block_align, 4);
+        assert_eq!(f.n_avg_bytes_per_sec, 176_400);
+        assert!(f.data.is_none());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn volume_pdu_maps_to_unity_gain_at_max() {
+        let full = VolumePdu {
+            volume_left: u16::MAX,
+            volume_right: u16::MAX,
+        };
+        assert!((volume_to_gain(&full) - 1.0).abs() < 1e-6);
+        let silent = VolumePdu {
+            volume_left: 0,
+            volume_right: 0,
+        };
+        assert_eq!(volume_to_gain(&silent), 0.0);
+    }
+}

--- a/rdp-sidecar/src/main.rs
+++ b/rdp-sidecar/src/main.rs
@@ -13,6 +13,7 @@
 //! out on stdout while applying host input read from stdin. All logging goes to
 //! stderr so it never corrupts the binary IPC stream on stdout.
 
+mod audio;
 mod cert;
 mod clipboard;
 mod drive;

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -32,7 +32,7 @@ use ironrdp::pdu::input::fast_path::FastPathInputEvent;
 use ironrdp::pdu::rdp::capability_sets::{client_codecs_capabilities, MajorPlatformType};
 use ironrdp::pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use ironrdp::rdpdr::Rdpdr;
-use ironrdp::rdpsnd::client::{NoopRdpsndBackend, Rdpsnd};
+use ironrdp::rdpsnd::client::{NoopRdpsndBackend, Rdpsnd, RdpsndClientHandler};
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput};
 use ironrdp_tokio::reqwest::ReqwestNetworkClient;
@@ -52,6 +52,7 @@ use termihub_core::connection::{
 use crate::clipboard::{
     build_format_data_response, local_text_formats, ClipboardEvent, SidecarClipboardBackend,
 };
+use crate::audio::RdpAudioBackend;
 use crate::drive::DriveRedirectBackend;
 use crate::input;
 
@@ -120,7 +121,10 @@ fn build_connector_config(cfg: &RdpConfig) -> Result<ConnectorConfig> {
         license_cache: None,
         enable_server_pointer: true,
         autologon: false,
-        enable_audio_playback: false,
+        // When off, IronRDP sets the NO_AUDIO_PLAYBACK client-info flag telling
+        // the server to suppress audio; enabling it (opt-in per connection, #1764)
+        // lets the server stream to our rdpsnd handler.
+        enable_audio_playback: cfg.audio_enabled(),
         request_data: None,
         pointer_software_rendering: false,
         multitransport_flags: None,
@@ -182,21 +186,32 @@ async fn connect_session(
                 .with_dynamic_channel(DisplayControlClient::new(|_caps| Ok(Vec::new()))),
         );
 
+    // The `rdpsnd` (MS-RDPEAUDIO) channel carries audio output (#1764) and is
+    // *also* required to be co-advertised whenever `rdpdr` drive redirection is
+    // on (MS-RDPEFS talks back to `rdpdr` over it, #1757). So register it when
+    // either feature is opted in: a real audio-playing handler when audio is on,
+    // otherwise the no-op handler that just satisfies the RDPDR requirement.
+    let drive_root = cfg.shared_drive_root();
+    if cfg.audio_enabled() || drive_root.is_some() {
+        let rdpsnd_handler: Box<dyn RdpsndClientHandler> = if cfg.audio_enabled() {
+            debug!("registering rdpsnd audio output redirection");
+            Box::new(RdpAudioBackend::new())
+        } else {
+            Box::new(NoopRdpsndBackend)
+        };
+        connector = connector.with_static_channel(Rdpsnd::new(rdpsnd_handler));
+    }
+
     // Drive redirection (MS-RDPEFS) is opt-in per connection and serves exactly
-    // the one folder the user selected (#1757). MS-RDPEFS requires the `rdpsnd`
-    // channel to be co-advertised for the server to talk back to `rdpdr`, so we
-    // register a no-op `rdpsnd` handler alongside it (audio playback itself is a
-    // sequenced follow-up). When redirection is off, neither channel is
-    // registered and nothing on the local filesystem is exposed.
-    if let Some(root) = cfg.shared_drive_root() {
+    // the one folder the user selected (#1757). When redirection is off, the
+    // channel is not registered and nothing on the local filesystem is exposed.
+    if let Some(root) = drive_root {
         debug!(root = %root.display(), "registering rdpdr drive redirection");
         let backend = DriveRedirectBackend::new(root);
-        connector = connector
-            .with_static_channel(Rdpsnd::new(Box::new(NoopRdpsndBackend)))
-            .with_static_channel(
-                Rdpdr::new(Box::new(backend), CLIENT_NAME.to_string())
-                    .with_drives(Some(vec![(DRIVE_DEVICE_ID, cfg.drive_label())])),
-            );
+        connector = connector.with_static_channel(
+            Rdpdr::new(Box::new(backend), CLIENT_NAME.to_string())
+                .with_drives(Some(vec![(DRIVE_DEVICE_ID, cfg.drive_label())])),
+        );
     }
 
     // 1) X.224 negotiation up to the security-upgrade point.

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -49,10 +49,10 @@ use termihub_core::connection::{
     CursorShape, CursorUpdate, DirtyRect, FrameUpdate, GraphicalState, InputEvent,
 };
 
+use crate::audio::RdpAudioBackend;
 use crate::clipboard::{
     build_format_data_response, local_text_formats, ClipboardEvent, SidecarClipboardBackend,
 };
-use crate::audio::RdpAudioBackend;
 use crate::drive::DriveRedirectBackend;
 use crate::input;
 


### PR DESCRIPTION
## What

Implements audio output redirection (rdpsnd / MS-RDPEAUDIO) for the RDP sidecar: the remote session's audio is decoded and **played on a host output device**, so remote sound is heard locally. Opt-in per connection, off by default.

Closes #1764

## Approach

- New `rdp-sidecar/src/audio.rs`: `RdpAudioBackend` implements IronRDP's `RdpsndClientHandler`. It advertises a single PCM format (44.1 kHz / 16-bit / stereo), decodes each `wave` PDU to `i16` samples, and plays them through a dedicated **rodio** playback thread that owns the (`!Send`, callback-driven) output stream and sink. Decode and playback stay **inside the sidecar process** — no audio crosses the IPC boundary, so the protocol, the `SidecarRdp` adapter, and the shared frontend are all untouched. (The issue offered "Web Audio in the webview *or* a Rust-side cpal/rodio sink" — this PR takes the sink-in-sidecar path.)
- `rdp.rs`: registers `rdpsnd` when audio **or** drive redirection is opted in (a real audio handler when audio is on, else the existing no-op that RDPDR requires), and sets the connector's `enable_audio_playback` so the server actually streams (otherwise IronRDP sets the `NO_AUDIO_PLAYBACK` client-info flag).
- `core` config: new `audioRedirection` boolean (default off) on `RdpConfig` + the RDP editor schema, mirroring the drive-redirection opt-in. Schema-driven, so no `ConnectionEditor` change.

## Audio crate

`rodio` 0.20 (`default-features = false`, dropping the file-format decoders) → `cpal`. It lives in the workspace-**excluded** sidecar graph, so zero dependency-conflict risk to the app (#1747). `cargo tree` confirms a clean resolve.

## Platform scope / what's deferred

`rodio`/`cpal` are **target-gated to macOS + Windows**. `cpal`'s Linux backend links ALSA (`libasound2-dev`), which the bundle CI does not install when it builds the sidecar (dev-build.yml / release.yml) — and that CI config was out of this change's lane. Gating keeps the Linux sidecar build unaffected (`cargo tree --target x86_64-unknown-linux-gnu` shows no rodio/cpal/alsa); on Linux the handler advertises no formats, so the server streams nothing. Deferred follow-ups:

- **#1772** — Linux audio (add `libasound2-dev` to the two build workflows + drop the target-gate). **This is the one gap in cross-platform coverage — flagging for a maintainer call on whether it should block closing #1764.**
- **#1773** — multi-format negotiation (single PCM format is a deliberate constraint of IronRDP 0.9's `wave(format_no, …)`, which doesn't expose the concrete format to the handler).
- **#1774** — jitter/latency buffering.

## Testing

- Unit tests (headless): PCM byte→`i16` decode (incl. odd trailing byte), the advertised format's exact fields, volume→gain mapping, config default/round-trip, schema exposes `audioRedirection`. `rdp-sidecar` `cargo test` (61 pass) + `termihub-core` config tests pass; sidecar + workspace `--all-features` clippy clean; fmt + markdownlint clean.
- Live audio + host-device playback is not headless-testable — documented a manual test in `docs/testing.md` (macOS/Windows: enable "Redirect Audio Output", play sound on a Windows host, hear it locally; volume tracks; off → silent; no-device host still connects).

Per-PR CI does not build the sidecar or exercise a live server, so audibility was verified by reasoning + the manual steps; the macOS sidecar build (with rodio/cpal/coreaudio) compiles, tests, and clippies clean locally.
