### PR TITLE
feat(rdp): receive cliprdr clipboard files into the shared folder (Part of #1765)

### DIFF
--- a/core/src/backends/rdp_sidecar/config.rs
+++ b/core/src/backends/rdp_sidecar/config.rs
@@ -103,6 +103,13 @@ pub struct RdpConfig {
     /// (#1764). Audible playback is currently macOS/Windows only — the Linux
     /// build omits the audio backend (see the #1764 Linux follow-up).
     pub audio_redirection: bool,
+    /// Opt in to CLIPRDR file transfer (#1765): when the remote copies files to
+    /// its clipboard, download them into the shared folder ([`Self::shared_folder_path`]).
+    /// Requires [`Self::drive_redirection`] and a valid shared folder — that
+    /// folder is already remote-writable via drive redirection, so receiving
+    /// clipboard files into it grants the remote no new local access. Off by
+    /// default.
+    pub clipboard_file_transfer: bool,
 }
 
 impl Default for RdpConfig {
@@ -123,6 +130,7 @@ impl Default for RdpConfig {
             shared_folder_path: String::new(),
             drive_name: String::new(),
             audio_redirection: false,
+            clipboard_file_transfer: false,
         }
     }
 }
@@ -185,6 +193,22 @@ impl RdpConfig {
     /// Whether audio output redirection (rdpsnd playback) is opted in (#1764).
     pub fn audio_enabled(&self) -> bool {
         self.audio_redirection
+    }
+
+    /// The canonicalised destination folder for files received over CLIPRDR file
+    /// transfer, or `None` when the feature is off or the shared folder is not a
+    /// valid directory (#1765).
+    ///
+    /// File transfer reuses the drive-redirection share root: that folder is
+    /// already exposed read-write to the remote via #1757, so receiving
+    /// clipboard files into it exposes nothing further. Gating on
+    /// [`Self::shared_drive_root`] keeps the "only this one opted-in folder"
+    /// guarantee in a single place.
+    pub fn clipboard_download_dir(&self) -> Option<std::path::PathBuf> {
+        if !self.clipboard_file_transfer {
+            return None;
+        }
+        self.shared_drive_root()
     }
 
     /// The user-visible label for the redirected drive, defaulting to `termiHub`
@@ -347,6 +371,20 @@ pub fn rdp_settings_schema() -> SettingsSchema {
                     FieldType::Boolean,
                 )
             },
+            SettingsField {
+                default: Some(serde_json::json!(false)),
+                visible_when: when_field_is_true("driveRedirection"),
+                description: Some(
+                    "Save files copied to the clipboard on the remote into the shared folder. \
+                     Requires drive redirection; files land only in that already-shared folder."
+                        .to_string(),
+                ),
+                ..field(
+                    "clipboardFileTransfer",
+                    "Receive Clipboard Files",
+                    FieldType::Boolean,
+                )
+            },
         ],
     });
 
@@ -461,6 +499,7 @@ mod tests {
             shared_folder_path: "/tmp/share".to_string(),
             drive_name: "Docs".to_string(),
             audio_redirection: true,
+            clipboard_file_transfer: true,
         };
         let json = serde_json::to_value(&cfg).unwrap();
         let back: RdpConfig = serde_json::from_value(json).unwrap();
@@ -477,6 +516,57 @@ mod tests {
         assert_eq!(back.shared_folder_path, "/tmp/share");
         assert_eq!(back.drive_label(), "Docs");
         assert!(back.audio_enabled());
+        assert!(back.clipboard_file_transfer);
+    }
+
+    #[test]
+    fn clipboard_download_dir_requires_opt_in_and_shared_folder() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().into_owned();
+        // Feature off → no destination even with a valid shared folder.
+        let off = RdpConfig {
+            drive_redirection: true,
+            shared_folder_path: path.clone(),
+            clipboard_file_transfer: false,
+            ..Default::default()
+        };
+        assert!(off.clipboard_download_dir().is_none());
+        // Feature on but drive redirection off → no destination (folder not shared).
+        let no_share = RdpConfig {
+            drive_redirection: false,
+            shared_folder_path: path.clone(),
+            clipboard_file_transfer: true,
+            ..Default::default()
+        };
+        assert!(no_share.clipboard_download_dir().is_none());
+        // Fully opted in with a valid folder → resolves to the canonical folder.
+        let on = RdpConfig {
+            drive_redirection: true,
+            shared_folder_path: path,
+            clipboard_file_transfer: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            on.clipboard_download_dir(),
+            Some(std::fs::canonicalize(dir.path()).unwrap())
+        );
+    }
+
+    #[test]
+    fn schema_exposes_clipboard_file_transfer_toggle() {
+        let schema = rdp_settings_schema();
+        let group = schema.groups.iter().find(|g| g.key == "rdp").unwrap();
+        let field = group
+            .fields
+            .iter()
+            .find(|f| f.key == "clipboardFileTransfer")
+            .expect("RDP schema must expose clipboardFileTransfer");
+        assert_eq!(field.default, Some(serde_json::json!(false)));
+        // Hidden until drive redirection is enabled.
+        assert_eq!(
+            field.visible_when.as_ref().map(|c| c.field.as_str()),
+            Some("driveRedirection")
+        );
     }
 
     #[test]

--- a/docs/changes/dev1/feature/1765-rdp-clipboard-file.md
+++ b/docs/changes/dev1/feature/1765-rdp-clipboard-file.md
@@ -1,0 +1,15 @@
+### Added
+
+- RDP: clipboard file receiving. When files are copied to the clipboard on an
+  RDP desktop, they can now be downloaded to the local machine over the
+  clipboard file-transfer PDUs (CLIPRDR / MS-RDPECLIP `FileGroupDescriptorW` +
+  File Contents Request/Response) in the IronRDP sidecar. It is **off by
+  default** and opt-in per connection via the new "Receive Clipboard Files"
+  option, which requires drive redirection (#1757): received files land only in
+  that already-shared folder, so the remote gains no new local access. Every
+  destination is sandboxed against `..` traversal, drive letters, and symlink
+  escapes; Windows reserved device names are rejected; colliding names are
+  deduplicated; and oversized files are skipped. The bridge only receives files,
+  so view-only sessions are unaffected. Serving local files to the remote and
+  bridging the host OS clipboard's native file list are tracked as follow-ups
+  (part of #1765).

--- a/rdp-sidecar/src/clipboard.rs
+++ b/rdp-sidecar/src/clipboard.rs
@@ -11,23 +11,54 @@
 //! `process` returns, when it again owns `&mut ActiveStage`, and performs the
 //! matching [`Cliprdr`] call (see `rdp.rs`).
 //!
-//! Scope is **text, both ways** (the issue's "text both ways"): CF_UNICODETEXT
-//! preferred, CF_TEXT as a fallback. File-transfer and locking callbacks are
-//! implemented as no-ops — we never advertise file formats or negotiate the
-//! locking capability, so the server never exercises them.
+//! Text bridging is **both ways** (#1756): CF_UNICODETEXT preferred, CF_TEXT as
+//! a fallback.
+//!
+//! ## File transfer (#1765) — receiving, sandboxed
+//!
+//! When the user opts into clipboard file transfer, the backend advertises the
+//! stream-file-clip capability and long format names so the server offers the
+//! `FileGroupDescriptorW` format when the remote copies files. On a remote file
+//! copy the backend fetches the file list and downloads each file's bytes into
+//! the **one opted-in shared folder** ([`RdpConfig::clipboard_download_dir`]) —
+//! the same folder drive redirection (#1757) already exposes read-write, so this
+//! grants the remote no new local access. Every destination path is validated
+//! through the shared [`crate::sandbox`] choke point; Windows device names are
+//! rejected; oversized files are skipped.
+//!
+//! Because IronRDP's `CliprdrBackend` methods run while the [`Cliprdr`] channel
+//! is borrowed, downloads are driven the same way as text: the backend records
+//! the next channel action as a [`ClipboardEvent`], and the driver performs it
+//! (`initiate_paste` / `request_file_contents`) once it owns the active stage.
+//!
+//! **Serving local files to the remote** (local→remote paste) and bridging the
+//! host OS clipboard's native file list are deferred follow-ups; this bridge
+//! only ever *receives* files, so a view-only session — which must never push
+//! local data to the remote — is unaffected.
 //!
 //! [`Cliprdr`]: ironrdp::cliprdr::Cliprdr
 //! [`CliprdrBackend`]: ironrdp::cliprdr::backend::CliprdrBackend
+//! [`RdpConfig::clipboard_download_dir`]: termihub_core::backends::rdp_sidecar::config::RdpConfig::clipboard_download_dir
 
+use std::collections::{HashSet, VecDeque};
+use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 
 use ironrdp::cliprdr::backend::CliprdrBackend;
+use ironrdp::cliprdr::is_windows_device_name;
 use ironrdp::cliprdr::pdu::{
-    ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest,
-    FileContentsResponse, FormatDataRequest, FormatDataResponse, LockDataId,
+    ClipboardFileAttributes, ClipboardFormat, ClipboardFormatId, ClipboardFormatName,
+    ClipboardGeneralCapabilityFlags, FileContentsFlags, FileContentsRequest, FileContentsResponse,
+    FileDescriptor, FormatDataRequest, FormatDataResponse, LockDataId,
 };
 use ironrdp::core::AsAny;
 use tracing::{debug, trace, warn};
+
+/// Cap on a single clipboard-received file. A whole file is requested in one
+/// range (position 0, size N), so this bounds the sidecar's memory for one
+/// transfer; larger files are skipped (chunked streaming is a follow-up). 32 MiB
+/// covers ordinary documents while refusing a hostile multi-gigabyte advertise.
+const MAX_CLIPBOARD_FILE_BYTES: u64 = 32 * 1024 * 1024;
 
 /// An action the CLIPRDR backend needs the driver loop to perform on the
 /// [`Cliprdr`](ironrdp::cliprdr::Cliprdr) channel once it owns `&mut ActiveStage`
@@ -46,6 +77,10 @@ pub enum ClipboardEvent {
     /// The remote wants our local clipboard data in this format; respond with a
     /// `FormatDataResponse` built from the host-provided text.
     ProvideData(ClipboardFormatId),
+    /// Ask the server for a chunk (size or byte range) of a file the remote
+    /// copied, as part of downloading it into the shared folder (#1765). The
+    /// driver calls [`Cliprdr::request_file_contents`](ironrdp::cliprdr::Cliprdr::request_file_contents).
+    RequestFileContents(FileContentsRequest),
 }
 
 /// Pick the best text format the remote advertised: prefer Unicode, fall back to
@@ -62,6 +97,20 @@ pub fn preferred_text_format(formats: &[ClipboardFormat]) -> Option<ClipboardFor
     } else {
         None
     }
+}
+
+/// Find the remote's `FileGroupDescriptorW` format (the file-list format) by its
+/// long name, returning its (remote-assigned) format id. `None` when the remote
+/// offered no file list — e.g. a text or image copy.
+pub fn file_list_format(formats: &[ClipboardFormat]) -> Option<ClipboardFormatId> {
+    formats
+        .iter()
+        .find(|f| {
+            f.name()
+                .map(|n| n.value() == ClipboardFormatName::FILE_LIST.value())
+                .unwrap_or(false)
+        })
+        .map(|f| f.id())
 }
 
 /// The text formats we advertise for a non-empty local clipboard. An empty local
@@ -110,26 +159,71 @@ pub fn decode_clipboard_text(
     }
 }
 
+/// A file from the remote's copied file list still to be downloaded into the
+/// shared folder, resolved to its sandboxed destination (#1765).
+#[derive(Debug, Clone)]
+struct PlannedDownload {
+    /// Index of this file in the remote file list (what a `FileContentsRequest`
+    /// references).
+    index: i32,
+    /// Sandboxed, deduplicated destination path inside the download folder.
+    dest: PathBuf,
+    /// File size from the descriptor, when the remote advertised it.
+    size: Option<u64>,
+}
+
+/// Which chunk of a file the in-flight [`FileContentsRequest`] is fetching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DownloadPhase {
+    /// A `SIZE` request (the descriptor omitted the size); the response carries
+    /// the file's length so we can then request its bytes.
+    Size,
+    /// A `RANGE` request for the file's bytes; the response is written to disk.
+    Range,
+}
+
+/// The single in-flight file download, keyed by the stream id we assigned.
+#[derive(Debug, Clone)]
+struct ActiveDownload {
+    stream_id: u32,
+    index: i32,
+    dest: PathBuf,
+    phase: DownloadPhase,
+}
+
 /// The sidecar's [`CliprdrBackend`]: it owns no OS clipboard (there is none in a
-/// headless sidecar); it just translates CLIPRDR callbacks into
-/// [`ClipboardEvent`]s the driver forwards over IPC to the host's real clipboard.
+/// headless sidecar); it translates CLIPRDR callbacks into [`ClipboardEvent`]s
+/// the driver forwards over IPC (text) or acts on (file downloads).
 #[derive(Debug)]
 pub struct SidecarClipboardBackend {
     /// Events flow to the driver loop over this channel.
     tx: Sender<ClipboardEvent>,
     /// A temporary directory path advertised to the server (required by the
-    /// protocol even though this text-only bridge never transfers files).
+    /// protocol).
     temp_dir: String,
-    /// The format of the most recent paste we initiated, so the eventual
+    /// The format of the most recent *text* paste we initiated, so the eventual
     /// `on_format_data_response` knows how to decode the bytes.
     pending_paste_format: Option<ClipboardFormatId>,
+    /// Destination folder for files received over CLIPRDR file transfer, or
+    /// `None` when the feature is disabled. Enabling it flips the advertised
+    /// capabilities to include stream-file-clip + long format names (#1765).
+    download_dir: Option<PathBuf>,
+    /// Files from the current remote copy still awaiting download.
+    download_queue: VecDeque<PlannedDownload>,
+    /// The single download currently in flight (one at a time keeps the memory
+    /// bound and the stream-id bookkeeping trivial).
+    active_download: Option<ActiveDownload>,
+    /// Monotonic stream-id allocator for file-contents requests.
+    next_stream_id: u32,
 }
 
 impl SidecarClipboardBackend {
-    /// Create the backend and the receiver the driver drains. The backend is
-    /// handed to [`Cliprdr::new`](ironrdp::cliprdr::Cliprdr::new); the receiver
-    /// stays with the driver loop.
-    pub fn new() -> (Self, std::sync::mpsc::Receiver<ClipboardEvent>) {
+    /// Create the backend and the receiver the driver drains. `download_dir` is
+    /// the (already sandboxed, canonical) folder received files land in, or
+    /// `None` to keep the bridge text-only. The backend is handed to
+    /// [`Cliprdr::new`](ironrdp::cliprdr::Cliprdr::new); the receiver stays with
+    /// the driver loop.
+    pub fn new(download_dir: Option<PathBuf>) -> (Self, std::sync::mpsc::Receiver<ClipboardEvent>) {
         let (tx, rx) = std::sync::mpsc::channel();
         let temp_dir = std::env::temp_dir().to_string_lossy().into_owned();
         (
@@ -137,6 +231,10 @@ impl SidecarClipboardBackend {
                 tx,
                 temp_dir,
                 pending_paste_format: None,
+                download_dir,
+                download_queue: VecDeque::new(),
+                active_download: None,
+                next_stream_id: 0,
             },
             rx,
         )
@@ -146,6 +244,170 @@ impl SidecarClipboardBackend {
         if self.tx.send(event).is_err() {
             debug!("clipboard event receiver dropped; sidecar shutting down");
         }
+    }
+
+    /// Allocate the next non-zero stream id for a file-contents request.
+    fn allocate_stream_id(&mut self) -> u32 {
+        self.next_stream_id = self.next_stream_id.wrapping_add(1);
+        if self.next_stream_id == 0 {
+            self.next_stream_id = 1;
+        }
+        self.next_stream_id
+    }
+
+    /// Plan the download of a remote file list into the download folder: skip
+    /// directories, empty/rejected names and Windows device names; flatten to
+    /// basenames within the one folder, deduplicating collisions. Returns the
+    /// queue of files to fetch.
+    fn plan_downloads(&self, files: &[FileDescriptor]) -> VecDeque<PlannedDownload> {
+        let Some(dir) = self.download_dir.as_ref() else {
+            return VecDeque::new();
+        };
+        let mut used: HashSet<String> = HashSet::new();
+        let mut queue = VecDeque::new();
+        for (index, file) in files.iter().enumerate() {
+            if file
+                .attributes
+                .map(|a| a.contains(ClipboardFileAttributes::DIRECTORY))
+                .unwrap_or(false)
+            {
+                // Directories carry no bytes to request; flattening drops the
+                // tree structure (a follow-up preserves it).
+                continue;
+            }
+            // IronRDP already sanitised the name to a basename, but re-derive it
+            // defensively and reject anything unsafe to write.
+            let base = file.name.rsplit(['\\', '/']).next().unwrap_or(&file.name);
+            if base.is_empty() || base == "." || base == ".." {
+                warn!(name = %file.name, "skipping clipboard file with unusable name");
+                continue;
+            }
+            if is_windows_device_name(base) {
+                warn!(name = %base, "skipping clipboard file with a reserved device name");
+                continue;
+            }
+            let unique = unique_name(&mut used, base);
+            let Some(dest) = crate::sandbox::resolve_in_root(dir, &unique) else {
+                warn!(name = %unique, "clipboard file rejected by sandbox");
+                continue;
+            };
+            queue.push_back(PlannedDownload {
+                index: index as i32,
+                dest,
+                size: file.file_size,
+            });
+        }
+        queue
+    }
+
+    /// Pop the next planned file and either fetch it (emitting a
+    /// [`ClipboardEvent::RequestFileContents`]) or, for a known-empty file,
+    /// create it immediately and move on. Files larger than
+    /// [`MAX_CLIPBOARD_FILE_BYTES`] are skipped.
+    fn start_next_download(&mut self) {
+        self.active_download = None;
+        while let Some(planned) = self.download_queue.pop_front() {
+            match planned.size {
+                Some(0) => {
+                    // Empty file: no range to request (a zero-length RANGE is
+                    // rejected by the protocol), so just create it.
+                    if let Err(e) = std::fs::write(&planned.dest, []) {
+                        warn!(error = %e, path = %planned.dest.display(), "failed to create empty clipboard file");
+                    } else {
+                        debug!(path = %planned.dest.display(), "received empty clipboard file");
+                    }
+                    continue;
+                }
+                Some(size) if size > MAX_CLIPBOARD_FILE_BYTES => {
+                    warn!(
+                        size,
+                        max = MAX_CLIPBOARD_FILE_BYTES,
+                        name = %planned.dest.display(),
+                        "skipping oversized clipboard file"
+                    );
+                    continue;
+                }
+                Some(size) => {
+                    // Size known: fetch the whole file in one range.
+                    let stream_id = self.allocate_stream_id();
+                    self.active_download = Some(ActiveDownload {
+                        stream_id,
+                        index: planned.index,
+                        dest: planned.dest,
+                        phase: DownloadPhase::Range,
+                    });
+                    self.emit(ClipboardEvent::RequestFileContents(range_request(
+                        stream_id,
+                        planned.index,
+                        size,
+                    )));
+                    return;
+                }
+                None => {
+                    // Size unknown: ask for it first, then the bytes.
+                    let stream_id = self.allocate_stream_id();
+                    self.active_download = Some(ActiveDownload {
+                        stream_id,
+                        index: planned.index,
+                        dest: planned.dest,
+                        phase: DownloadPhase::Size,
+                    });
+                    self.emit(ClipboardEvent::RequestFileContents(size_request(
+                        stream_id,
+                        planned.index,
+                    )));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Build a deduplicated basename: `file.txt`, then `file (1).txt`, … keeping the
+/// extension. Records the chosen name in `used`.
+fn unique_name(used: &mut HashSet<String>, base: &str) -> String {
+    if used.insert(base.to_string()) {
+        return base.to_string();
+    }
+    let (stem, ext) = match base.rsplit_once('.') {
+        Some((stem, ext)) if !stem.is_empty() => (stem, Some(ext)),
+        _ => (base, None),
+    };
+    for n in 1.. {
+        let candidate = match ext {
+            Some(ext) => format!("{stem} ({n}).{ext}"),
+            None => format!("{stem} ({n})"),
+        };
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+    unreachable!("the counter is unbounded")
+}
+
+/// A `SIZE` file-contents request (per MS-RDPECLIP 2.2.5.3: position 0,
+/// requested_size 8).
+fn size_request(stream_id: u32, index: i32) -> FileContentsRequest {
+    FileContentsRequest {
+        stream_id,
+        index,
+        flags: FileContentsFlags::SIZE,
+        position: 0,
+        requested_size: 8,
+        data_id: None,
+    }
+}
+
+/// A `RANGE` request for the whole file `[0, size)` (size is `<= MAX_CLIPBOARD_FILE_BYTES`,
+/// so it fits in the `u32` `requested_size`).
+fn range_request(stream_id: u32, index: i32, size: u64) -> FileContentsRequest {
+    FileContentsRequest {
+        stream_id,
+        index,
+        flags: FileContentsFlags::RANGE,
+        position: 0,
+        requested_size: size as u32,
+        data_id: None,
     }
 }
 
@@ -165,10 +427,18 @@ impl CliprdrBackend for SidecarClipboardBackend {
     }
 
     fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
-        // Text-only: we use the standard short format IDs (CF_UNICODETEXT /
-        // CF_TEXT) and negotiate neither long format names nor file/lock
-        // capabilities, so no flags are required.
-        ClipboardGeneralCapabilityFlags::empty()
+        if self.download_dir.is_some() {
+            // File receiving is on: negotiate stream-file-clip so the server
+            // offers file formats and services our file-contents requests, and
+            // long format names so the `FileGroupDescriptorW` format's name is
+            // exchanged (it is a named format, not a standard short id).
+            ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED
+                | ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES
+        } else {
+            // Text-only: standard short ids (CF_UNICODETEXT / CF_TEXT) need no
+            // capability flags.
+            ClipboardGeneralCapabilityFlags::empty()
+        }
     }
 
     fn on_ready(&mut self) {
@@ -189,6 +459,18 @@ impl CliprdrBackend for SidecarClipboardBackend {
     }
 
     fn on_remote_copy(&mut self, available_formats: &[ClipboardFormat]) {
+        // A remote file copy takes precedence over text when file receiving is
+        // enabled: initiate a paste for the file list, which the channel routes
+        // to `on_remote_file_list` (not `on_format_data_response`).
+        if self.download_dir.is_some() {
+            if let Some(format) = file_list_format(available_formats) {
+                // Reset any leftover download state from a previous copy.
+                self.download_queue.clear();
+                self.active_download = None;
+                self.emit(ClipboardEvent::InitiatePaste(format));
+                return;
+            }
+        }
         match preferred_text_format(available_formats) {
             Some(format) => {
                 self.pending_paste_format = Some(format);
@@ -213,16 +495,100 @@ impl CliprdrBackend for SidecarClipboardBackend {
         }
     }
 
-    // --- File transfer / locking: unused by this text-only bridge. ---
-    // We advertise no file formats and negotiate no locking capability, so a
-    // conforming server never drives these; keep them as safe no-ops.
-
-    fn on_file_contents_request(&mut self, _request: FileContentsRequest) {
-        warn!("cliprdr file contents request ignored (text-only bridge)");
+    fn on_remote_file_list(&mut self, files: &[FileDescriptor], _clip_data_id: Option<u32>) {
+        if self.download_dir.is_none() {
+            return;
+        }
+        self.download_queue = self.plan_downloads(files);
+        debug!(
+            count = self.download_queue.len(),
+            "planned clipboard file download(s) into the shared folder"
+        );
+        self.start_next_download();
     }
 
-    fn on_file_contents_response(&mut self, _response: FileContentsResponse<'_>) {
-        warn!("cliprdr file contents response ignored (text-only bridge)");
+    fn on_file_contents_request(&mut self, request: FileContentsRequest) {
+        // Serving local files to the remote is a deferred follow-up: we never
+        // advertise a local file list, so a conforming server never asks. If one
+        // does, the channel already sent an error for an unknown list; nothing to
+        // do here.
+        trace!(
+            stream_id = request.stream_id,
+            "ignoring file-contents request (receive-only bridge)"
+        );
+    }
+
+    fn on_file_contents_response(&mut self, response: FileContentsResponse<'_>) {
+        let Some(active) = self.active_download.as_ref() else {
+            trace!("file-contents response with no active download; ignoring");
+            return;
+        };
+        if active.stream_id != response.stream_id() {
+            warn!(
+                expected = active.stream_id,
+                got = response.stream_id(),
+                "file-contents response stream id mismatch; ignoring"
+            );
+            return;
+        }
+        let active = active.clone();
+
+        if response.is_error() {
+            warn!(path = %active.dest.display(), "remote returned an error for a clipboard file; skipping");
+            self.start_next_download();
+            return;
+        }
+
+        match active.phase {
+            DownloadPhase::Size => match response.data_as_size() {
+                Ok(0) => {
+                    if let Err(e) = std::fs::write(&active.dest, []) {
+                        warn!(error = %e, path = %active.dest.display(), "failed to create empty clipboard file");
+                    }
+                    self.start_next_download();
+                }
+                Ok(size) if size > MAX_CLIPBOARD_FILE_BYTES => {
+                    warn!(
+                        size,
+                        max = MAX_CLIPBOARD_FILE_BYTES,
+                        "skipping oversized clipboard file"
+                    );
+                    self.start_next_download();
+                }
+                Ok(size) => {
+                    // Size resolved: request the bytes on the same file.
+                    let stream_id = self.allocate_stream_id();
+                    self.active_download = Some(ActiveDownload {
+                        stream_id,
+                        index: active.index,
+                        dest: active.dest,
+                        phase: DownloadPhase::Range,
+                    });
+                    self.emit(ClipboardEvent::RequestFileContents(range_request(
+                        stream_id,
+                        active.index,
+                        size,
+                    )));
+                }
+                Err(e) => {
+                    warn!(error = %e, "malformed file size response; skipping file");
+                    self.start_next_download();
+                }
+            },
+            DownloadPhase::Range => {
+                match std::fs::write(&active.dest, response.data()) {
+                    Ok(()) => debug!(
+                        path = %active.dest.display(),
+                        bytes = response.data().len(),
+                        "saved clipboard file into the shared folder"
+                    ),
+                    Err(e) => {
+                        warn!(error = %e, path = %active.dest.display(), "failed to write clipboard file")
+                    }
+                }
+                self.start_next_download();
+            }
+        }
     }
 
     fn on_lock(&mut self, _data_id: LockDataId) {}
@@ -326,7 +692,7 @@ mod tests {
 
     #[test]
     fn backend_emits_paste_on_remote_text_copy() {
-        let (mut backend, rx) = SidecarClipboardBackend::new();
+        let (mut backend, rx) = SidecarClipboardBackend::new(None);
         backend.on_remote_copy(&[text(ClipboardFormatId::CF_UNICODETEXT)]);
         assert_eq!(
             rx.try_recv(),
@@ -338,7 +704,7 @@ mod tests {
 
     #[test]
     fn backend_decodes_response_using_pending_format() {
-        let (mut backend, rx) = SidecarClipboardBackend::new();
+        let (mut backend, rx) = SidecarClipboardBackend::new(None);
         // Simulate the full remote→local sequence: remote copy → paste → data.
         backend.on_remote_copy(&[text(ClipboardFormatId::CF_UNICODETEXT)]);
         let _ = rx.try_recv(); // consume the InitiatePaste
@@ -353,14 +719,14 @@ mod tests {
 
     #[test]
     fn backend_requests_advertise_on_format_list_request() {
-        let (mut backend, rx) = SidecarClipboardBackend::new();
+        let (mut backend, rx) = SidecarClipboardBackend::new(None);
         backend.on_request_format_list();
         assert_eq!(rx.try_recv(), Ok(ClipboardEvent::AdvertiseLocal));
     }
 
     #[test]
     fn backend_forwards_server_data_request() {
-        let (mut backend, rx) = SidecarClipboardBackend::new();
+        let (mut backend, rx) = SidecarClipboardBackend::new(None);
         backend.on_format_data_request(FormatDataRequest {
             format: ClipboardFormatId::CF_UNICODETEXT,
         });
@@ -370,5 +736,232 @@ mod tests {
                 ClipboardFormatId::CF_UNICODETEXT
             ))
         );
+    }
+
+    // --- File transfer (#1765) ---
+
+    use std::sync::mpsc::Receiver;
+
+    /// A file-list clipboard format (`FileGroupDescriptorW`) with the given id.
+    fn file_format(id: u32) -> ClipboardFormat {
+        ClipboardFormat::new(ClipboardFormatId::new(id)).with_name(ClipboardFormatName::FILE_LIST)
+    }
+
+    /// A backend whose received files land in a fresh temp dir.
+    fn backend_with_download() -> (
+        SidecarClipboardBackend,
+        Receiver<ClipboardEvent>,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        let (backend, rx) = SidecarClipboardBackend::new(Some(root));
+        (backend, rx, dir)
+    }
+
+    /// Drain the next queued `RequestFileContents` event, failing otherwise.
+    fn next_request(rx: &Receiver<ClipboardEvent>) -> FileContentsRequest {
+        match rx.try_recv() {
+            Ok(ClipboardEvent::RequestFileContents(req)) => req,
+            other => panic!("expected RequestFileContents, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_file_list_format_by_name() {
+        assert_eq!(
+            file_list_format(&[text(ClipboardFormatId::CF_UNICODETEXT), file_format(0xC0FE)]),
+            Some(ClipboardFormatId::new(0xC0FE))
+        );
+        assert_eq!(file_list_format(&[text(ClipboardFormatId::CF_TEXT)]), None);
+    }
+
+    #[test]
+    fn capabilities_gate_on_download_enabled() {
+        let (text_only, _rx) = SidecarClipboardBackend::new(None);
+        assert!(text_only.client_capabilities().is_empty());
+
+        let (files, _rx, _dir) = backend_with_download();
+        let caps = files.client_capabilities();
+        assert!(caps.contains(ClipboardGeneralCapabilityFlags::STREAM_FILECLIP_ENABLED));
+        assert!(caps.contains(ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES));
+    }
+
+    #[test]
+    fn remote_file_copy_initiates_a_file_paste_when_enabled() {
+        let (mut backend, rx, _dir) = backend_with_download();
+        backend.on_remote_copy(&[file_format(0xC0FE)]);
+        assert_eq!(
+            rx.try_recv(),
+            Ok(ClipboardEvent::InitiatePaste(ClipboardFormatId::new(
+                0xC0FE
+            )))
+        );
+        // A file copy must not be mistaken for a text paste.
+        assert!(backend.pending_paste_format.is_none());
+    }
+
+    #[test]
+    fn remote_file_copy_ignored_when_download_disabled() {
+        let (mut backend, rx) = SidecarClipboardBackend::new(None);
+        // Only a file format offered; text-only bridge has nothing to fetch.
+        backend.on_remote_copy(&[file_format(0xC0FE)]);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn downloads_a_known_size_file_into_the_shared_folder() {
+        let (mut backend, rx, dir) = backend_with_download();
+        backend.on_remote_file_list(&[FileDescriptor::new("hello.txt").with_file_size(5)], None);
+
+        // Size is known, so a single RANGE request for the whole file is emitted.
+        let req = next_request(&rx);
+        assert_eq!(req.index, 0);
+        assert!(req.flags.contains(FileContentsFlags::RANGE));
+        assert_eq!(req.requested_size, 5);
+
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            req.stream_id,
+            b"hello".to_vec(),
+        ));
+        assert_eq!(
+            std::fs::read(dir.path().join("hello.txt")).unwrap(),
+            b"hello"
+        );
+        // Only one file → no further request.
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn unknown_size_file_asks_for_size_then_bytes() {
+        let (mut backend, rx, dir) = backend_with_download();
+        backend.on_remote_file_list(&[FileDescriptor::new("data.bin")], None);
+
+        // No size in the descriptor → a SIZE request first.
+        let size_req = next_request(&rx);
+        assert!(size_req.flags.contains(FileContentsFlags::SIZE));
+        assert_eq!(size_req.requested_size, 8);
+
+        backend.on_file_contents_response(FileContentsResponse::new_size_response(
+            size_req.stream_id,
+            3,
+        ));
+        // Now a RANGE request for the resolved size.
+        let range_req = next_request(&rx);
+        assert!(range_req.flags.contains(FileContentsFlags::RANGE));
+        assert_eq!(range_req.requested_size, 3);
+
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            range_req.stream_id,
+            b"abc".to_vec(),
+        ));
+        assert_eq!(std::fs::read(dir.path().join("data.bin")).unwrap(), b"abc");
+    }
+
+    #[test]
+    fn empty_file_is_created_without_a_request() {
+        let (mut backend, rx, dir) = backend_with_download();
+        backend.on_remote_file_list(&[FileDescriptor::new("empty.txt").with_file_size(0)], None);
+        // No request for a zero-length file; it is created directly.
+        assert!(rx.try_recv().is_err());
+        assert!(dir.path().join("empty.txt").exists());
+        assert_eq!(std::fs::read(dir.path().join("empty.txt")).unwrap(), b"");
+    }
+
+    #[test]
+    fn oversized_file_is_skipped() {
+        let (mut backend, rx, _dir) = backend_with_download();
+        backend.on_remote_file_list(
+            &[FileDescriptor::new("huge.iso").with_file_size(MAX_CLIPBOARD_FILE_BYTES + 1)],
+            None,
+        );
+        // Too big → no request emitted, file skipped.
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn directories_are_skipped() {
+        let (mut backend, rx, _dir) = backend_with_download();
+        backend.on_remote_file_list(
+            &[FileDescriptor::new("folder").with_attributes(ClipboardFileAttributes::DIRECTORY)],
+            None,
+        );
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn reserved_device_names_are_rejected() {
+        let (mut backend, rx, _dir) = backend_with_download();
+        backend.on_remote_file_list(&[FileDescriptor::new("CON").with_file_size(4)], None);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn colliding_names_are_deduplicated() {
+        let (mut backend, rx, dir) = backend_with_download();
+        backend.on_remote_file_list(
+            &[
+                FileDescriptor::new("dup.txt").with_file_size(1),
+                FileDescriptor::new("dup.txt").with_file_size(1),
+            ],
+            None,
+        );
+        // First file.
+        let r1 = next_request(&rx);
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            r1.stream_id,
+            vec![b'a'],
+        ));
+        // Second file's request now follows.
+        let r2 = next_request(&rx);
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            r2.stream_id,
+            vec![b'b'],
+        ));
+
+        assert_eq!(std::fs::read(dir.path().join("dup.txt")).unwrap(), b"a");
+        assert_eq!(std::fs::read(dir.path().join("dup (1).txt")).unwrap(), b"b");
+    }
+
+    #[test]
+    fn error_response_skips_to_the_next_file() {
+        let (mut backend, rx, dir) = backend_with_download();
+        backend.on_remote_file_list(
+            &[
+                FileDescriptor::new("bad.txt").with_file_size(2),
+                FileDescriptor::new("good.txt").with_file_size(2),
+            ],
+            None,
+        );
+        let r1 = next_request(&rx);
+        // Remote fails the first file.
+        backend.on_file_contents_response(FileContentsResponse::new_error(r1.stream_id));
+        // Download proceeds to the second file.
+        let r2 = next_request(&rx);
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            r2.stream_id,
+            b"ok".to_vec(),
+        ));
+        assert!(!dir.path().join("bad.txt").exists());
+        assert_eq!(std::fs::read(dir.path().join("good.txt")).unwrap(), b"ok");
+    }
+
+    #[test]
+    fn response_with_wrong_stream_id_is_ignored() {
+        let (mut backend, rx, dir) = backend_with_download();
+        backend.on_remote_file_list(&[FileDescriptor::new("f.txt").with_file_size(2)], None);
+        let req = next_request(&rx);
+        // A stray response for a different stream id must not write anything.
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            req.stream_id.wrapping_add(99),
+            b"xx".to_vec(),
+        ));
+        assert!(!dir.path().join("f.txt").exists());
+        // The real response still completes the download.
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            req.stream_id,
+            b"xx".to_vec(),
+        ));
+        assert_eq!(std::fs::read(dir.path().join("f.txt")).unwrap(), b"xx");
     }
 }

--- a/rdp-sidecar/src/drive.rs
+++ b/rdp-sidecar/src/drive.rs
@@ -138,42 +138,12 @@ impl DriveRedirectBackend {
     }
 
     /// Resolve an RDP path (`\`-separated, relative to the share root) to a local
-    /// path, or `None` if it escapes the sandbox. Rejects `..` traversal, drive
-    /// letters / colons, and NUL bytes; for paths that already exist, the result
-    /// is canonicalised and re-checked against the root to defeat symlink
-    /// escapes.
+    /// path, or `None` if it escapes the sandbox. Delegates to the shared
+    /// [`crate::sandbox::resolve_in_root`] choke point (rejects `..` traversal,
+    /// drive letters / colons, and NUL bytes; canonicalises existing paths and
+    /// re-checks them against the root to defeat symlink escapes).
     fn resolve(&self, rdp_path: &str) -> Option<PathBuf> {
-        let mut out = self.root.clone();
-        for component in rdp_path.split(['\\', '/']) {
-            match component {
-                "" | "." => continue,
-                ".." => return None,
-                other => {
-                    if other.contains('\0') || other.contains(':') {
-                        return None;
-                    }
-                    out.push(other);
-                }
-            }
-        }
-        // A path that already exists must canonicalise back inside the root; this
-        // is what stops a symlink inside the share from pointing outward.
-        if let Ok(canon) = fs::canonicalize(&out) {
-            if !canon.starts_with(&self.root) {
-                return None;
-            }
-            return Some(canon);
-        }
-        // Not-yet-existing path (e.g. a create): its parent must be inside the
-        // root. `..` was already rejected lexically, so the join cannot escape.
-        if let Some(parent) = out.parent() {
-            if let Ok(parent_canon) = fs::canonicalize(parent) {
-                if !parent_canon.starts_with(&self.root) {
-                    return None;
-                }
-            }
-        }
-        Some(out)
+        crate::sandbox::resolve_in_root(&self.root, rdp_path)
     }
 
     /// Allocate the next non-zero `file_id`.

--- a/rdp-sidecar/src/main.rs
+++ b/rdp-sidecar/src/main.rs
@@ -20,6 +20,7 @@ mod drive;
 mod input;
 mod keymap;
 mod rdp;
+mod sandbox;
 
 use anyhow::{bail, Context, Result};
 use termihub_core::backends::rdp_sidecar::protocol::SidecarMessage;

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -171,10 +171,12 @@ async fn connect_session(
 
     let connector_config = build_connector_config(cfg)?;
     // Register the CLIPRDR static channel (MS-RDPECLIP) so the session can bridge
-    // text clipboard both ways (#1756). The backend translates server callbacks
-    // into `ClipboardEvent`s the driver drains once it owns the active stage
-    // again; the receiver rides back out with the connection result.
-    let (clipboard_backend, clipboard_rx) = SidecarClipboardBackend::new();
+    // text clipboard both ways (#1756) and, when opted in, download files the
+    // remote copies into the shared folder (#1765). The backend translates server
+    // callbacks into `ClipboardEvent`s the driver drains once it owns the active
+    // stage again; the receiver rides back out with the connection result.
+    let (clipboard_backend, clipboard_rx) =
+        SidecarClipboardBackend::new(cfg.clipboard_download_dir());
     // Register the Display Control Virtual Channel (MS-RDPEDISP) so the session
     // can request dynamic resolution changes (#1755). It rides the drdynvc
     // static channel; the capabilities callback needs to send nothing, the
@@ -871,6 +873,21 @@ where
                 write_message(ipc_out, &SidecarMessage::Clipboard(text))
                     .await
                     .context("failed to forward remote clipboard to host")?;
+            }
+            ClipboardEvent::RequestFileContents(request) => {
+                // Ask the server for a size or byte range of a file the remote
+                // copied; the backend writes the bytes into the shared folder
+                // when the matching response arrives (#1765).
+                let messages = match stage.get_svc_processor_mut::<CliprdrClient>() {
+                    Some(cliprdr) => cliprdr
+                        .request_file_contents(request)
+                        .context("cliprdr request_file_contents failed")?,
+                    None => {
+                        warn!("cliprdr channel unavailable; cannot request file contents");
+                        continue;
+                    }
+                };
+                write_cliprdr_messages(stage, transport, messages).await?;
             }
         }
     }

--- a/rdp-sidecar/src/sandbox.rs
+++ b/rdp-sidecar/src/sandbox.rs
@@ -1,0 +1,98 @@
+//! Shared path-sandboxing helper for the features that expose a single local
+//! folder to the (possibly untrusted) remote session — RDPDR drive redirection
+//! (#1757) and CLIPRDR file transfer (#1765).
+//!
+//! Both features must confine every remote-controlled path to exactly the one
+//! folder the user opted into, never the whole filesystem. [`resolve_in_root`]
+//! is the single choke point: it rejects `..` traversal, drive letters and NUL
+//! bytes, and — for paths that already exist — canonicalises the result and
+//! re-checks it against the root, defeating symlink escapes.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve an RDP-style path (`\`- or `/`-separated, relative to `root`) to a
+/// local path inside `root`, or `None` if it escapes the sandbox.
+///
+/// Rejects `..` traversal, drive letters / colons, and NUL bytes. For a path
+/// that already exists, the result is canonicalised and re-checked against
+/// `root` (which must itself be canonical) to defeat symlink escapes. For a
+/// not-yet-existing path (e.g. a file about to be created), the parent — if it
+/// exists — must canonicalise back inside `root`; `..` having already been
+/// rejected lexically, the join cannot escape.
+pub fn resolve_in_root(root: &Path, rdp_path: &str) -> Option<PathBuf> {
+    let mut out = root.to_path_buf();
+    for component in rdp_path.split(['\\', '/']) {
+        match component {
+            "" | "." => continue,
+            ".." => return None,
+            other => {
+                if other.contains('\0') || other.contains(':') {
+                    return None;
+                }
+                out.push(other);
+            }
+        }
+    }
+    // A path that already exists must canonicalise back inside the root; this is
+    // what stops a symlink inside the share from pointing outward.
+    if let Ok(canon) = std::fs::canonicalize(&out) {
+        if !canon.starts_with(root) {
+            return None;
+        }
+        return Some(canon);
+    }
+    // Not-yet-existing path (e.g. a create): its parent must be inside the root.
+    // `..` was already rejected lexically, so the join cannot escape.
+    if let Some(parent) = out.parent() {
+        if let Ok(parent_canon) = std::fs::canonicalize(parent) {
+            if !parent_canon.starts_with(root) {
+                return None;
+            }
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        (dir, root)
+    }
+
+    #[test]
+    fn rejects_parent_traversal() {
+        let (_d, root) = root();
+        assert!(resolve_in_root(&root, "..\\etc\\passwd").is_none());
+        assert!(resolve_in_root(&root, "sub\\..\\..\\secret").is_none());
+        assert!(resolve_in_root(&root, "a\\b\\..").is_none());
+    }
+
+    #[test]
+    fn rejects_drive_letters_and_nul() {
+        let (_d, root) = root();
+        assert!(resolve_in_root(&root, "C:\\Windows").is_none());
+        assert!(resolve_in_root(&root, "weird\0name").is_none());
+    }
+
+    #[test]
+    fn allows_nested_paths_within_root() {
+        let (dir, root) = root();
+        std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
+        let resolved = resolve_in_root(&root, "a\\b").unwrap();
+        assert!(resolved.starts_with(&root));
+        assert!(resolved.ends_with("b"));
+        // Root itself resolves back to the root.
+        assert_eq!(resolve_in_root(&root, "\\").unwrap(), root);
+    }
+
+    #[test]
+    fn allows_not_yet_existing_file_in_root() {
+        let (_d, root) = root();
+        let resolved = resolve_in_root(&root, "new-file.txt").unwrap();
+        assert_eq!(resolved, root.join("new-file.txt"));
+    }
+}


### PR DESCRIPTION
## Summary

Extends the RDP sidecar's CLIPRDR bridge (#1756 landed text) to **receive files** the remote copies to its clipboard, downloading them into the sandboxed shared folder from #1757. Opt-in, off by default.

This is **`Part of #1765`** — it delivers the receiving direction; serving local files to the remote and bridging the host OS clipboard's native file list are deferred to follow-ups (see below). The issue stays open.

## What it does

- Advertises the CLIPRDR file-transfer capability (`CB_STREAM_FILECLIP_ENABLED`) + long format names so the server offers `FileGroupDescriptorW` when the remote copies files.
- On a remote file copy: detects the file-list format, fetches the list, and downloads each file's bytes (size → range, whole-file) via the same deferred-`ClipboardEvent` pattern text uses (the backend can't re-enter the borrowed `Cliprdr` channel, so the driver performs `initiate_paste` / `request_file_contents`).
- Writes received files into the **one opted-in shared folder** — the same folder drive redirection (#1757) already exposes read-write, so this grants the remote no new local access.

## Security / sandboxing

- Off by default; opt-in via the new **"Receive Clipboard Files"** setting, which requires drive redirection (reuses its share root as the destination).
- Every destination path goes through the shared sandbox choke point (extracted from #1757's drive resolver): rejects `..` traversal, drive letters/colons, NUL, and symlink escapes.
- Windows reserved device names (`CON`, `NUL`, …) are rejected; colliding basenames are deduplicated (`file (1).txt`); files over 32 MiB are skipped (bounds sidecar memory — whole-file range).
- The bridge only ever **receives**, so a view-only session (which must never push local data to the remote) is unaffected.

## Verification

- New unit tests cover: file-list format detection, capability gating, remote-copy → paste initiation, size-known and size-unknown download sequences, empty/oversized/directory/device-name handling, dedup, error-skips-to-next, and stream-id mismatch. Sandbox + config accessor/schema tests added.
- `rdp-sidecar` (excluded crate): `cargo test` 78 passing, `cargo clippy` + `cargo fmt` clean.
- Workspace `./scripts/check.sh` green; `pnpm markdownlint` clean.
- **Live end-to-end** (real RDP host) is not exercised by per-PR CI and needs manual verification: enable drive redirection + "Receive Clipboard Files", copy a file on the remote desktop, confirm it appears in the shared folder.

## Deferred (follow-ups, Part of #1765)

- Serving local files to the remote (local→remote paste).
- Host OS-clipboard-native file integration (CF_HDROP / NSFilenames / text/uri-list) + IPC, so arbitrary host-clipboard files transfer both ways and download is tied to a real local paste gesture.
- Preserve copied directory structure (currently flattened) + chunked streaming for files over the size cap.
