### PR TITLE
feat(backend): sha-256 integrity check for the bundled rdp sidecar (Closes #1762)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,6 +3,14 @@ name = "termihub-core"
 version = "0.1.0"
 description = "Shared core library for termiHub desktop and agent"
 edition = "2021"
+build = "build.rs"
+
+# Hashing the staged `termihub-rdp-helper` externalBin to embed its SHA-256 at
+# build time for the adapter's pre-spawn integrity check (#1762). Always compiled
+# (build-deps cannot be feature-gated), but tiny and pure-Rust.
+[build-dependencies]
+sha2 = "0.10"
+hex = "0.4"
 
 [dependencies]
 async-trait = { workspace = true }
@@ -161,4 +169,11 @@ vnc = ["dep:vnc-rs", "dep:zune-jpeg", "dep:tracing", "ssh"]
 # compiles the adapter + IPC protocol + config. `tokio/process` is needed to
 # spawn/supervise the child. The sidecar binary is built separately
 # (scripts/build-rdp-sidecar.sh) and bundled next to the app binary.
-rdp-sidecar = ["dep:rmp-serde", "dep:tracing", "tokio/process"]
+rdp-sidecar = [
+    "dep:rmp-serde",
+    "dep:tracing",
+    "tokio/process",
+    # Pre-spawn SHA-256 integrity verification of the bundled sidecar (#1762).
+    "dep:sha2",
+    "dep:hex",
+]

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,0 +1,98 @@
+//! Build script for `termihub-core`.
+//!
+//! # RDP sidecar integrity digest (#1762)
+//!
+//! A released build ships the `termihub-rdp-helper` sidecar next to the desktop
+//! binary via Tauri `externalBin` (#1754). The [`rdp_sidecar`] adapter verifies
+//! the resolved binary against a known-good SHA-256 before spawning it, so a
+//! tampered/corrupted/wrong-arch helper is rejected. This script produces that
+//! expected digest and embeds it as the `TERMIHUB_RDP_HELPER_SHA256` env var,
+//! which the adapter reads with `option_env!`.
+//!
+//! The digest is resolved from, in order:
+//!   1. `$TERMIHUB_RDP_HELPER_SHA256` — an explicit 64-hex override (CI or manual
+//!      testing may set it directly), else
+//!   2. the staged `externalBin` at
+//!      `src-tauri/binaries/termihub-rdp-helper-<target>[.exe]` — the exact bytes
+//!      Tauri bundles, produced by `scripts/build-rdp-sidecar.sh --tauri-externalbin`
+//!      before the release/dev-build Tauri step runs. Its contents are hashed here.
+//!
+//! When neither is present — per-PR compile/test jobs and plain dev builds never
+//! stage the sidecar — no digest is emitted, and the runtime check is skipped
+//! (exactly how the agent-binary path tolerates a missing checksum sidecar).
+//!
+//! This script never fails the build: an unreadable or absent staged binary just
+//! means "no embedded digest", not a compile error.
+//!
+//! [`rdp_sidecar`]: crate::backends::rdp_sidecar
+
+use std::path::{Path, PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=TERMIHUB_RDP_HELPER_SHA256");
+
+    let staged = staged_helper_path();
+    // Re-run when the staged binary appears/changes (rerun-if-changed on a
+    // not-yet-existing path fires once it is created).
+    println!("cargo:rerun-if-changed={}", staged.display());
+
+    if let Some(digest) = resolve_digest(&staged) {
+        println!("cargo:rustc-env=TERMIHUB_RDP_HELPER_SHA256={digest}");
+    }
+}
+
+/// Resolve the expected sidecar SHA-256 (lowercase hex), or `None`.
+fn resolve_digest(staged: &Path) -> Option<String> {
+    if let Ok(raw) = std::env::var("TERMIHUB_RDP_HELPER_SHA256") {
+        let v = raw.trim().to_ascii_lowercase();
+        if is_sha256_hex(&v) {
+            return Some(v);
+        }
+        if !v.is_empty() {
+            println!(
+                "cargo:warning=Ignoring TERMIHUB_RDP_HELPER_SHA256: not a 64-char hex SHA-256"
+            );
+        }
+    }
+
+    if staged.is_file() {
+        match sha256_hex_of_file(staged) {
+            Ok(digest) => return Some(digest),
+            Err(e) => println!(
+                "cargo:warning=Failed to hash staged RDP helper {}: {e}",
+                staged.display()
+            ),
+        }
+    }
+
+    None
+}
+
+/// Path to the staged `externalBin` for the target being compiled.
+fn staged_helper_path() -> PathBuf {
+    let manifest = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
+    let target = std::env::var("TARGET").unwrap_or_default();
+    let name = if target.contains("windows") {
+        format!("termihub-rdp-helper-{target}.exe")
+    } else {
+        format!("termihub-rdp-helper-{target}")
+    };
+    // core/ -> repo root -> src-tauri/binaries/<name>
+    manifest
+        .join("..")
+        .join("src-tauri")
+        .join("binaries")
+        .join(name)
+}
+
+fn is_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn sha256_hex_of_file(path: &Path) -> std::io::Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    Ok(hex::encode(hasher.finalize()))
+}

--- a/core/src/backends/rdp_sidecar/integrity.rs
+++ b/core/src/backends/rdp_sidecar/integrity.rs
@@ -1,0 +1,169 @@
+//! SHA-256 integrity verification for the bundled `termihub-rdp-helper` sidecar.
+//!
+//! A released build ships the sidecar next to the desktop binary via Tauri
+//! `externalBin` (#1754). Before spawning it (#1762) the adapter verifies the
+//! resolved binary against a **known-good SHA-256 embedded at build time**, so a
+//! tampered, corrupted, or wrong-arch helper is rejected before it ever runs —
+//! mirroring the agent-binary checksum verification in `src-tauri`.
+//!
+//! The expected digest is produced by `core/build.rs`, which hashes the staged
+//! `externalBin` (the exact bytes Tauri bundles) and emits it as the
+//! `TERMIHUB_RDP_HELPER_SHA256` compile-time env var, read here via
+//! [`option_env!`]. When no digest is embedded — per-PR compile/test jobs and
+//! plain dev builds never stage the sidecar — the check is **skipped**, exactly
+//! as the agent path tolerates a missing checksum sidecar. The
+//! `$TERMIHUB_RDP_HELPER` dev/test override also skips the check, so a
+//! locally-built helper still runs.
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+use tracing::{debug, warn};
+
+/// The known-good sidecar SHA-256 (lowercase hex), embedded at build time by
+/// `core/build.rs`. `None` when no digest was staged (dev/branch builds).
+pub const EXPECTED_HELPER_SHA256: Option<&str> = option_env!("TERMIHUB_RDP_HELPER_SHA256");
+
+/// Compute the lowercase-hex SHA-256 digest of a file's contents.
+///
+/// The file is streamed through the hasher, so an arbitrarily large binary is
+/// hashed without loading it all into memory.
+pub fn sha256_hex_of_file(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Verify the resolved sidecar binary against its build-time SHA-256 before it
+/// is spawned.
+///
+/// Returns `Ok(())` — the binary may be spawned — when:
+/// - `override_active` is set (the `$TERMIHUB_RDP_HELPER` dev/test override is in
+///   use, so the operator picked the binary deliberately), or
+/// - `expected` is `None` (no digest was embedded — an out-of-scope dev/branch
+///   build that does not stage the sidecar), in which case integrity cannot be
+///   verified and the connection proceeds with a warning.
+///
+/// Returns `Err(message)` — refuse to spawn — when a digest is embedded and the
+/// binary's actual SHA-256 does not match it, or the binary cannot be read. The
+/// message names the file and both digests so the failure is actionable.
+pub fn verify_helper_integrity(
+    path: &Path,
+    override_active: bool,
+    expected: Option<&str>,
+) -> Result<(), String> {
+    if override_active {
+        debug!(
+            path = %path.display(),
+            "TERMIHUB_RDP_HELPER override is set — skipping sidecar integrity check"
+        );
+        return Ok(());
+    }
+
+    let expected = match expected {
+        Some(e) if !e.trim().is_empty() => e.trim().to_ascii_lowercase(),
+        _ => {
+            warn!(
+                path = %path.display(),
+                "no build-time SHA-256 embedded for the RDP helper — spawning without \
+                 integrity verification (dev/branch build)"
+            );
+            return Ok(());
+        }
+    };
+
+    let actual = sha256_hex_of_file(path).map_err(|e| {
+        format!(
+            "failed to read RDP helper '{}' for integrity verification: {e}",
+            path.display()
+        )
+    })?;
+
+    if actual == expected {
+        debug!(path = %path.display(), "RDP helper SHA-256 verified");
+        Ok(())
+    } else {
+        Err(format!(
+            "RDP helper integrity check failed for '{}': expected SHA-256 {expected}, \
+             computed {actual}. Refusing to spawn a sidecar that does not match the digest \
+             embedded at build time. Rebuild it with scripts/build-rdp-sidecar.sh, or point \
+             {env} at a trusted binary.",
+            path.display(),
+            env = super::HELPER_PATH_ENV,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// The canonical SHA-256 test vector: `sha256("abc")`.
+    const SHA256_OF_ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    fn write_temp(bytes: &[u8]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("termihub-rdp-helper");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(bytes).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn sha256_hex_of_file_matches_known_vector() {
+        let (_dir, path) = write_temp(b"abc");
+        assert_eq!(sha256_hex_of_file(&path).unwrap(), SHA256_OF_ABC);
+    }
+
+    #[test]
+    fn sha256_hex_of_file_is_lowercase_64_hex() {
+        let (_dir, path) = write_temp(b"anything");
+        let digest = sha256_hex_of_file(&path).unwrap();
+        assert_eq!(digest.len(), 64);
+        assert!(digest.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn sha256_hex_of_file_missing_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(sha256_hex_of_file(&dir.path().join("nope")).is_err());
+    }
+
+    #[test]
+    fn verify_accepts_a_matching_digest() {
+        let (_dir, path) = write_temp(b"abc");
+        assert!(verify_helper_integrity(&path, false, Some(SHA256_OF_ABC)).is_ok());
+        // Case-insensitive on the expected side.
+        let upper = SHA256_OF_ABC.to_ascii_uppercase();
+        assert!(verify_helper_integrity(&path, false, Some(&upper)).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_a_mismatched_digest_with_a_clear_error() {
+        // A file whose digest is NOT SHA256_OF_ABC.
+        let (_dir, path) = write_temp(b"tampered");
+        let err = verify_helper_integrity(&path, false, Some(SHA256_OF_ABC)).unwrap_err();
+        assert!(err.contains("integrity check failed"), "got: {err}");
+        assert!(err.contains(SHA256_OF_ABC), "error should name the expected digest: {err}");
+    }
+
+    #[test]
+    fn verify_skips_when_no_digest_is_embedded() {
+        // No embedded digest (dev/branch build) → cannot verify, must not fail.
+        let (_dir, path) = write_temp(b"abc");
+        assert!(verify_helper_integrity(&path, false, None).is_ok());
+        assert!(verify_helper_integrity(&path, false, Some("   ")).is_ok());
+    }
+
+    #[test]
+    fn verify_skips_when_override_is_active() {
+        // With the $TERMIHUB_RDP_HELPER override in use the check is skipped even
+        // when the digest would otherwise mismatch — and even for a missing file.
+        let (_dir, path) = write_temp(b"tampered");
+        assert!(verify_helper_integrity(&path, true, Some(SHA256_OF_ABC)).is_ok());
+        let dir = tempfile::tempdir().unwrap();
+        assert!(verify_helper_integrity(&dir.path().join("nope"), true, Some(SHA256_OF_ABC)).is_ok());
+    }
+}

--- a/core/src/backends/rdp_sidecar/integrity.rs
+++ b/core/src/backends/rdp_sidecar/integrity.rs
@@ -122,7 +122,9 @@ mod tests {
         let (_dir, path) = write_temp(b"anything");
         let digest = sha256_hex_of_file(&path).unwrap();
         assert_eq!(digest.len(), 64);
-        assert!(digest.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert!(digest
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
     }
 
     #[test]
@@ -146,7 +148,10 @@ mod tests {
         let (_dir, path) = write_temp(b"tampered");
         let err = verify_helper_integrity(&path, false, Some(SHA256_OF_ABC)).unwrap_err();
         assert!(err.contains("integrity check failed"), "got: {err}");
-        assert!(err.contains(SHA256_OF_ABC), "error should name the expected digest: {err}");
+        assert!(
+            err.contains(SHA256_OF_ABC),
+            "error should name the expected digest: {err}"
+        );
     }
 
     #[test]
@@ -164,6 +169,8 @@ mod tests {
         let (_dir, path) = write_temp(b"tampered");
         assert!(verify_helper_integrity(&path, true, Some(SHA256_OF_ABC)).is_ok());
         let dir = tempfile::tempdir().unwrap();
-        assert!(verify_helper_integrity(&dir.path().join("nope"), true, Some(SHA256_OF_ABC)).is_ok());
+        assert!(
+            verify_helper_integrity(&dir.path().join("nope"), true, Some(SHA256_OF_ABC)).is_ok()
+        );
     }
 }

--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -41,6 +41,7 @@
 //! crossing this IPC boundary.
 
 pub mod config;
+pub mod integrity;
 pub mod protocol;
 
 pub use config::rdp_settings_schema;
@@ -325,6 +326,18 @@ impl ConnectionType for SidecarRdp {
         let view_only = cfg.view_only;
 
         let helper = resolve_helper_binary();
+        // Refuse to launch a sidecar whose bytes do not match the SHA-256
+        // embedded at build time (#1762) — a tampered/corrupted/wrong-arch
+        // helper fails the connection here, before it can run. The check is
+        // skipped when the $TERMIHUB_RDP_HELPER override is set (dev/test) or no
+        // digest was embedded (dev/branch builds); see [`integrity`].
+        let override_active = std::env::var_os(HELPER_PATH_ENV).is_some();
+        integrity::verify_helper_integrity(
+            &helper,
+            override_active,
+            integrity::EXPECTED_HELPER_SHA256,
+        )
+        .map_err(SessionError::SpawnFailed)?;
         let mut command = tokio::process::Command::new(&helper);
         command
             .stdin(Stdio::piped())

--- a/docs/changes/dev0/feature/1762-rdp-sidecar-integrity.md
+++ b/docs/changes/dev0/feature/1762-rdp-sidecar-integrity.md
@@ -1,0 +1,7 @@
+### Security
+
+- RDP now verifies the bundled `termihub-rdp-helper` sidecar against a SHA-256
+  digest embedded at build time before spawning it, so a tampered, corrupted, or
+  wrong-architecture helper fails the connection with an actionable error instead
+  of being executed. The check is skipped for the `$TERMIHUB_RDP_HELPER` dev/test
+  override and for local builds that do not bundle the sidecar (#1762).

--- a/scripts/build-rdp-sidecar.cmd
+++ b/scripts/build-rdp-sidecar.cmd
@@ -54,8 +54,22 @@ if "%EXTERNALBIN%"=="1" (
         exit /b 1
     )
     if not exist "src-tauri\binaries" mkdir "src-tauri\binaries"
-    copy /y "%BIN_PATH%" "src-tauri\binaries\termihub-rdp-helper-!TRIPLE!.exe" >nul
-    echo Staged for Tauri externalBin: src-tauri\binaries\termihub-rdp-helper-!TRIPLE!.exe
+    set "STAGE_NAME=termihub-rdp-helper-!TRIPLE!.exe"
+    copy /y "%BIN_PATH%" "src-tauri\binaries\!STAGE_NAME!" >nul
+    echo Staged for Tauri externalBin: src-tauri\binaries\!STAGE_NAME!
+
+    REM Compute the sidecar's SHA-256 (#1762). core\build.rs hashes this exact
+    REM staged binary to embed the expected digest the adapter checks before
+    REM spawn; this writes a `.sha256` sidecar and prints the digest purely for
+    REM transparency/local verification. certutil ships with Windows.
+    for /f "skip=1 tokens=* delims=" %%h in ('certutil -hashfile "src-tauri\binaries\!STAGE_NAME!" SHA256 ^| findstr /r "^[0-9a-fA-F ]*$"') do (
+        if not defined DIGEST set "DIGEST=%%h"
+    )
+    REM certutil prints the hash with spaces between byte pairs; strip them.
+    set "DIGEST=!DIGEST: =!"
+    >"src-tauri\binaries\!STAGE_NAME!.sha256" echo !DIGEST!  !STAGE_NAME!
+    echo SHA-256: !DIGEST!
+    echo Wrote checksum sidecar: src-tauri\binaries\!STAGE_NAME!.sha256
 )
 
 echo Point termiHub at it by placing it next to the desktop binary, or set:

--- a/scripts/build-rdp-sidecar.sh
+++ b/scripts/build-rdp-sidecar.sh
@@ -112,6 +112,22 @@ if [ "$EXTERNALBIN" -eq 1 ]; then
     mkdir -p "$STAGE_DIR"
     cp "$BIN_PATH" "$STAGE_DIR/$STAGE_NAME"
     echo "Staged for Tauri externalBin: $STAGE_DIR/$STAGE_NAME"
+
+    # Compute the sidecar's SHA-256 (#1762). `core/build.rs` hashes this exact
+    # staged binary to embed the expected digest the adapter checks before spawn,
+    # so this is purely for transparency/local verification: it prints the digest
+    # and writes a `.sha256` sidecar next to the staged binary. Tauri `externalBin`
+    # only picks the exact `termihub-rdp-helper-<triple>[.exe]` name, so the extra
+    # `.sha256` file is ignored by the bundler.
+    if command -v sha256sum >/dev/null 2>&1; then
+        DIGEST="$(sha256sum "$STAGE_DIR/$STAGE_NAME" | cut -d' ' -f1)"
+    else
+        # macOS has no sha256sum; `shasum -a 256` is the BSD equivalent.
+        DIGEST="$(shasum -a 256 "$STAGE_DIR/$STAGE_NAME" | cut -d' ' -f1)"
+    fi
+    printf '%s  %s\n' "$DIGEST" "$STAGE_NAME" >"$STAGE_DIR/$STAGE_NAME.sha256"
+    echo "SHA-256: $DIGEST"
+    echo "Wrote checksum sidecar: $STAGE_DIR/$STAGE_NAME.sha256"
 fi
 
 if [ -n "$OUT_DIR" ]; then


### PR DESCRIPTION
## Summary

Adds a SHA-256 integrity check for the bundled `termihub-rdp-helper` sidecar, mirroring the agent-binary checksum verification. Before `SidecarRdp` spawns the resolved helper, it verifies the binary against a known-good digest **embedded at build time**; a tampered, corrupted, or wrong-architecture helper fails the connection with an actionable error instead of being executed.

Closes #1762. Follow-up to #1754 (which bundled the sidecar via Tauri `externalBin` and deferred this optional check).

## Mechanism

- **`core/build.rs` (new)** hashes the staged `externalBin` (`src-tauri/binaries/termihub-rdp-helper-<target>[.exe]`) — the exact bytes Tauri bundles — and emits its SHA-256 as the `TERMIHUB_RDP_HELPER_SHA256` compile-time env var (also honoring an explicit `TERMIHUB_RDP_HELPER_SHA256` override). It never fails the build.
- **`core/src/backends/rdp_sidecar/integrity.rs` (new)** reads that digest via `option_env!` and verifies the resolved binary's SHA-256 before spawn.
- **`SidecarRdp::connect`** calls the verifier before launching the child; a mismatch returns `SpawnFailed` with both digests named.
- **Self-contained across platforms:** `release.yml` / `dev-build.yml` already build+stage one target per matrix leg before `tauri build`, so each platform's app embeds its own helper's digest with no workflow changes.

## Skip paths (mirroring the agent path's tolerance)

- `$TERMIHUB_RDP_HELPER` override set (dev/test) → skipped.
- No digest embedded (per-PR compile/test jobs and plain dev builds never stage the sidecar) → skipped with a warning; integrity cannot be verified but the connection proceeds.

## Tests

- 7 unit tests in `integrity.rs`: known SHA-256 vector, lowercase-hex shape, matching digest accepts (case-insensitive), mismatch rejects with a clear error, missing/empty digest skips, override skips.
- Verified locally end-to-end: staged a helper, confirmed `build.rs` embeds its digest into the compiled artifact, and that removing it re-embeds nothing. `./scripts/check.sh` green (fmt, clippy workspace-wide, eslint, markdownlint).

## Notes

- The build scripts (`build-rdp-sidecar.{sh,cmd}`) additionally write a `.sha256` sidecar next to the staged binary and print the digest, purely for transparency/local verification — the runtime check uses the embedded const, not that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)