### PR TITLE
feat(rdp): interactive certificate-trust prompt + persisted trust store (Closes #1767)

### DIFF
--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -57,8 +57,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
 use crate::connection::{
-    AuthKind, Capabilities, ConnectionType, CursorReceiver, FrameReceiver, GraphicalBackend,
-    GraphicalCapabilities, InputEvent, OutputReceiver, SettingsSchema,
+    AuthKind, Capabilities, CertPrompt, CertPromptReceiver, ConnectionType, CursorReceiver,
+    FrameReceiver, GraphicalBackend, GraphicalCapabilities, InputEvent, OutputReceiver,
+    SettingsSchema,
 };
 use crate::errors::SessionError;
 use crate::files::FileBrowser;
@@ -141,6 +142,7 @@ pub struct SidecarRdp {
     runtime: Option<Arc<SidecarRuntime>>,
     frame_rx: StdMutex<Option<FrameReceiver>>,
     cursor_rx: StdMutex<Option<CursorReceiver>>,
+    cert_prompt_rx: StdMutex<Option<CertPromptReceiver>>,
     tasks: Vec<JoinHandle<()>>,
 }
 
@@ -151,6 +153,7 @@ impl SidecarRdp {
             runtime: None,
             frame_rx: StdMutex::new(None),
             cursor_rx: StdMutex::new(None),
+            cert_prompt_rx: StdMutex::new(None),
             tasks: Vec::new(),
         }
     }
@@ -164,6 +167,7 @@ impl SidecarRdp {
         }
         self.frame_rx = StdMutex::new(None);
         self.cursor_rx = StdMutex::new(None);
+        self.cert_prompt_rx = StdMutex::new(None);
     }
 }
 
@@ -190,6 +194,7 @@ async fn run_reader<R>(
     mut reader: R,
     frame_tx: mpsc::Sender<crate::connection::FrameUpdate>,
     cursor_tx: mpsc::Sender<crate::connection::CursorUpdate>,
+    cert_prompt_tx: mpsc::Sender<CertPrompt>,
     shared: Arc<SidecarShared>,
     cancel: CancellationToken,
 ) where
@@ -212,6 +217,26 @@ async fn run_reader<R>(
                     }
                     Ok(SidecarMessage::Clipboard(text)) => {
                         *shared.clipboard.lock().await = text;
+                    }
+                    Ok(SidecarMessage::CertPrompt {
+                        fingerprint,
+                        subject,
+                        issuer,
+                    }) => {
+                        // Forward the untrusted-cert prompt up to the manager,
+                        // which owns the trust store + user dialog (#1767). If the
+                        // receiver is gone the session is tearing down anyway.
+                        if cert_prompt_tx
+                            .send(CertPrompt {
+                                fingerprint,
+                                subject,
+                                issuer,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
                     }
                     Ok(SidecarMessage::State(state)) => {
                         debug!(?state, "rdp sidecar state");
@@ -378,12 +403,14 @@ impl ConnectionType for SidecarRdp {
         let cancel = CancellationToken::new();
         let (frame_tx, frame_rx) = mpsc::channel(CHANNEL_DEPTH);
         let (cursor_tx, cursor_rx) = mpsc::channel(CHANNEL_DEPTH);
+        let (cert_prompt_tx, cert_prompt_rx) = mpsc::channel(CHANNEL_DEPTH);
         let (to_sidecar, sidecar_rx) = mpsc::channel(CHANNEL_DEPTH);
 
         let reader_task = tokio::spawn(run_reader(
             stdout,
             frame_tx,
             cursor_tx,
+            cert_prompt_tx,
             shared.clone(),
             cancel.clone(),
         ));
@@ -392,6 +419,7 @@ impl ConnectionType for SidecarRdp {
 
         self.frame_rx = StdMutex::new(Some(frame_rx));
         self.cursor_rx = StdMutex::new(Some(cursor_rx));
+        self.cert_prompt_rx = StdMutex::new(Some(cert_prompt_rx));
         self.tasks = vec![reader_task, writer_task, supervisor_task];
         self.runtime = Some(Arc::new(SidecarRuntime {
             to_sidecar,
@@ -535,6 +563,23 @@ impl GraphicalBackend for SidecarRdp {
         let _ = rt.to_sidecar.send(HostMessage::SetClipboard(text)).await;
         Ok(())
     }
+
+    fn subscribe_cert_prompts(&self) -> Option<CertPromptReceiver> {
+        self.cert_prompt_rx.lock().ok().and_then(|mut g| g.take())
+    }
+
+    async fn send_cert_decision(&self, accept: bool, remember: bool) -> Result<(), SessionError> {
+        let Some(rt) = &self.runtime else {
+            return Err(SessionError::NotRunning("rdp not connected".to_string()));
+        };
+        // Route the verdict down to the sidecar, which is blocking its connect on
+        // it (#1767). `remember` is informational here — the host already
+        // persisted (or not) before calling.
+        rt.to_sidecar
+            .send(HostMessage::CertDecision { accept, remember })
+            .await
+            .map_err(|_| SessionError::NotRunning("rdp session ended".to_string()))
+    }
 }
 
 #[cfg(test)]
@@ -641,11 +686,13 @@ mod tests {
         let (mut sidecar_stdout, host_read) = tokio::io::duplex(1024 * 1024);
         let (frame_tx, mut frame_rx) = mpsc::channel(CHANNEL_DEPTH);
         let (cursor_tx, _cursor_rx) = mpsc::channel(CHANNEL_DEPTH);
+        let (cert_tx, _cert_rx) = mpsc::channel(CHANNEL_DEPTH);
         let cancel = CancellationToken::new();
         let reader = tokio::spawn(run_reader(
             host_read,
             frame_tx,
             cursor_tx,
+            cert_tx,
             test_shared(),
             cancel.clone(),
         ));
@@ -680,12 +727,14 @@ mod tests {
         let (mut sidecar_stdout, host_read) = tokio::io::duplex(1024 * 1024);
         let (frame_tx, _frame_rx) = mpsc::channel(CHANNEL_DEPTH);
         let (cursor_tx, mut cursor_rx) = mpsc::channel(CHANNEL_DEPTH);
+        let (cert_tx, _cert_rx) = mpsc::channel(CHANNEL_DEPTH);
         let shared = test_shared();
         let cancel = CancellationToken::new();
         let reader = tokio::spawn(run_reader(
             host_read,
             frame_tx,
             cursor_tx,
+            cert_tx,
             shared.clone(),
             cancel.clone(),
         ));
@@ -775,16 +824,57 @@ mod tests {
         let _ = writer.await;
     }
 
+    /// An untrusted-cert prompt written by the sidecar must surface on the
+    /// cert-prompt receiver the manager subscribes to (#1767) — the loopback
+    /// that proves the prompt reaches the trust-decision layer without a live RDP
+    /// server or an untrusted certificate.
     #[tokio::test]
-    async fn reader_stops_on_fatal_error_message() {
+    async fn reader_forwards_cert_prompt() {
         let (mut sidecar_stdout, host_read) = tokio::io::duplex(1024 * 1024);
         let (frame_tx, _frame_rx) = mpsc::channel(CHANNEL_DEPTH);
         let (cursor_tx, _cursor_rx) = mpsc::channel(CHANNEL_DEPTH);
+        let (cert_tx, mut cert_rx) = mpsc::channel(CHANNEL_DEPTH);
         let cancel = CancellationToken::new();
         let reader = tokio::spawn(run_reader(
             host_read,
             frame_tx,
             cursor_tx,
+            cert_tx,
+            test_shared(),
+            cancel.clone(),
+        ));
+
+        write_message(
+            &mut sidecar_stdout,
+            &SidecarMessage::CertPrompt {
+                fingerprint: "sha256:AB:CD".to_string(),
+                subject: Some("CN=host".to_string()),
+                issuer: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let prompt = cert_rx.recv().await.expect("cert prompt must reach the manager");
+        assert_eq!(prompt.fingerprint, "sha256:AB:CD");
+        assert_eq!(prompt.subject.as_deref(), Some("CN=host"));
+
+        cancel.cancel();
+        let _ = reader.await;
+    }
+
+    #[tokio::test]
+    async fn reader_stops_on_fatal_error_message() {
+        let (mut sidecar_stdout, host_read) = tokio::io::duplex(1024 * 1024);
+        let (frame_tx, _frame_rx) = mpsc::channel(CHANNEL_DEPTH);
+        let (cursor_tx, _cursor_rx) = mpsc::channel(CHANNEL_DEPTH);
+        let (cert_tx, _cert_rx) = mpsc::channel(CHANNEL_DEPTH);
+        let cancel = CancellationToken::new();
+        let reader = tokio::spawn(run_reader(
+            host_read,
+            frame_tx,
+            cursor_tx,
+            cert_tx,
             test_shared(),
             cancel.clone(),
         ));

--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -855,7 +855,10 @@ mod tests {
         .await
         .unwrap();
 
-        let prompt = cert_rx.recv().await.expect("cert prompt must reach the manager");
+        let prompt = cert_rx
+            .recv()
+            .await
+            .expect("cert prompt must reach the manager");
         assert_eq!(prompt.fingerprint, "sha256:AB:CD");
         assert_eq!(prompt.subject.as_deref(), Some("CN=host"));
 

--- a/core/src/backends/rdp_sidecar/protocol.rs
+++ b/core/src/backends/rdp_sidecar/protocol.rs
@@ -71,6 +71,17 @@ pub enum HostMessage {
     /// Push local clipboard text to the remote over the sidecar's CLIPRDR
     /// channel (#1756).
     SetClipboard(String),
+    /// The host's verdict on a [`SidecarMessage::CertPrompt`] (#1767): whether to
+    /// proceed with the untrusted server certificate. `remember` is consumed on
+    /// the host side (it owns the persisted trust store); the sidecar only acts
+    /// on `accept` — proceeding with the connection or aborting it.
+    CertDecision {
+        /// Proceed with the connection when `true`; abort it when `false`.
+        accept: bool,
+        /// Whether the host persisted the fingerprint for this host. Informational
+        /// to the sidecar, which does not persist anything itself.
+        remember: bool,
+    },
     /// Ask the sidecar to tear the session down and exit.
     Disconnect,
 }
@@ -87,6 +98,20 @@ pub enum SidecarMessage {
     Cursor(CursorUpdate),
     /// Remote clipboard text, decoded from the sidecar's CLIPRDR channel (#1756).
     Clipboard(String),
+    /// The server presented an untrusted certificate and the sidecar needs an
+    /// interactive trust decision (#1767). The sidecar blocks the connect until
+    /// the host replies with [`HostMessage::CertDecision`] (or a timeout aborts
+    /// it). `subject`/`issuer` are best-effort context for the prompt; the
+    /// `fingerprint` (SHA-256 of the server public key) is the identity the host
+    /// keys its trust store on.
+    CertPrompt {
+        /// SHA-256 fingerprint of the server public key (`sha256:AB:CD:…`).
+        fingerprint: String,
+        /// Certificate subject, when available.
+        subject: Option<String>,
+        /// Certificate issuer, when available.
+        issuer: Option<String>,
+    },
     /// A fatal error; the sidecar exits after sending it.
     Error(String),
 }
@@ -279,6 +304,31 @@ mod tests {
         // Pipe drained → EOF.
         let eof = read_message::<_, SidecarMessage>(&mut r).await;
         assert_eq!(eof.unwrap_err().kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn cert_prompt_and_decision_round_trip() {
+        // The interactive cert-trust handshake (#1767) must survive the framed
+        // codec in both directions.
+        let prompt = SidecarMessage::CertPrompt {
+            fingerprint: "sha256:AB:CD:EF".to_string(),
+            subject: Some("CN=host.example".to_string()),
+            issuer: None,
+        };
+        assert_eq!(round_trip_sidecar(prompt.clone()).await, prompt);
+
+        for decision in [
+            HostMessage::CertDecision {
+                accept: true,
+                remember: true,
+            },
+            HostMessage::CertDecision {
+                accept: false,
+                remember: false,
+            },
+        ] {
+            assert_eq!(round_trip_host(decision.clone()).await, decision);
+        }
     }
 
     #[tokio::test]

--- a/core/src/connection/graphical.rs
+++ b/core/src/connection/graphical.rs
@@ -168,6 +168,25 @@ pub type FrameReceiver = tokio::sync::mpsc::Receiver<FrameUpdate>;
 /// Async receiver for cursor-shape / position updates from a graphical backend.
 pub type CursorReceiver = tokio::sync::mpsc::Receiver<CursorUpdate>;
 
+/// Async receiver for interactive server-certificate trust prompts (#1767).
+pub type CertPromptReceiver = tokio::sync::mpsc::Receiver<CertPrompt>;
+
+/// A server-certificate trust prompt raised by a graphical backend that reached
+/// an untrusted certificate and needs an interactive accept/reject decision
+/// (RDP, #1767). The `fingerprint` (SHA-256 of the server public key) is the
+/// identity the host keys its persisted trust store on; `subject`/`issuer` are
+/// best-effort human context for the dialog.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CertPrompt {
+    /// SHA-256 fingerprint of the server public key (`sha256:AB:CD:…`).
+    pub fingerprint: String,
+    /// Certificate subject, when the backend could extract it.
+    pub subject: Option<String>,
+    /// Certificate issuer, when the backend could extract it.
+    pub issuer: Option<String>,
+}
+
 /// A single decoded, dirty rectangle of the remote framebuffer.
 ///
 /// `data` is tightly-packed RGBA (`width * height * 4` bytes), row-major, in the
@@ -559,6 +578,27 @@ pub trait GraphicalBackend: Send + Sync {
 
     /// Push local clipboard text to the remote.
     async fn set_clipboard(&self, text: String) -> Result<(), SessionError>;
+
+    /// Subscribe to interactive server-certificate trust prompts (#1767).
+    ///
+    /// Backends that never need a trust decision (VNC, the mock) return `None`
+    /// (the default); the RDP sidecar returns a receiver that yields a
+    /// [`CertPrompt`] whenever the server presents an untrusted certificate. The
+    /// [`GraphicalSessionManager`](../../../termihub/session) consults its trust
+    /// store and either auto-accepts or surfaces the prompt to the user.
+    fn subscribe_cert_prompts(&self) -> Option<CertPromptReceiver> {
+        None
+    }
+
+    /// Deliver the user's (or trust store's) verdict for a pending
+    /// [`CertPrompt`] (#1767): `accept` proceeds with the connection, and
+    /// `remember` reports whether the host persisted the fingerprint (the
+    /// backend does not persist anything itself). No-op for backends that never
+    /// prompt.
+    async fn send_cert_decision(&self, accept: bool, remember: bool) -> Result<(), SessionError> {
+        let _ = (accept, remember);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -19,9 +19,9 @@ pub mod schema;
 pub mod validation;
 
 pub use graphical::{
-    shared_field_base, AuthKind, CursorReceiver, CursorShape, CursorUpdate, DirtyRect,
-    FrameReceiver, FrameUpdate, GraphicalBackend, GraphicalCapabilities, GraphicalState,
-    InputEvent, SessionStateMachine, MAX_RECONNECT_ATTEMPTS,
+    shared_field_base, AuthKind, CertPrompt, CertPromptReceiver, CursorReceiver, CursorShape,
+    CursorUpdate, DirtyRect, FrameReceiver, FrameUpdate, GraphicalBackend, GraphicalCapabilities,
+    GraphicalState, InputEvent, SessionStateMachine, MAX_RECONNECT_ATTEMPTS,
 };
 pub use registry::{ConnectionFactory, ConnectionTypeInfo, ConnectionTypeRegistry};
 pub use schema::*;

--- a/docs/changes/dev0/feature/1767-rdp-cert-prompt.md
+++ b/docs/changes/dev0/feature/1767-rdp-cert-prompt.md
@@ -1,0 +1,11 @@
+### Added
+
+- RDP now shows an interactive server-certificate trust prompt instead of hard
+  failing on an untrusted certificate. When an RDP host presents a certificate
+  that is not yet trusted, a dialog surfaces the host and the SHA-256 public-key
+  fingerprint with three choices: accept once (session only), accept for host
+  (remembered), or reject. Accepted-for-host fingerprints persist in a per-host
+  trust store (`rdp_known_hosts.json`, an SSH `known_hosts` analogue) so the
+  host is not prompted again, and a changed fingerprint for a previously-trusted
+  host raises a prominent possible-man-in-the-middle warning before offering to
+  proceed. `ignoreCertErrors` still accepts unconditionally (#1767).

--- a/rdp-sidecar/src/cert.rs
+++ b/rdp-sidecar/src/cert.rs
@@ -11,11 +11,13 @@
 //! The trust model is deliberately SSH-host-key-shaped: we fingerprint the
 //! server's public key (not a CA chain — real RDP hosts are overwhelmingly
 //! self-signed, so chain validation would reject nearly every legitimate host)
-//! and decide whether to proceed. Today the decision is binary —
-//! `ignoreCertErrors` accepts, otherwise the connection is refused and the
-//! fingerprint is surfaced. An interactive accept-once / accept-for-host prompt
-//! plus a persisted per-host trust store is the sequenced follow-up;
-//! [`CertVerdict`] is the seam it slots into.
+//! and decide whether to proceed. `ignoreCertErrors` accepts unconditionally;
+//! otherwise the sidecar asks the **host** for an interactive trust decision
+//! (#1767) via [`SidecarMessage::CertPrompt`](termihub_core::backends::rdp_sidecar::protocol::SidecarMessage::CertPrompt)
+//! and blocks on the reply. The persisted per-host trust store, the
+//! auto-accept-known and changed-fingerprint (MITM) detection all live on the
+//! host, which owns the config directory; the sidecar just relays the
+//! fingerprint and applies the verdict. [`CertVerdict`] is that seam.
 
 use sha2::{Digest, Sha256};
 
@@ -41,28 +43,24 @@ pub fn public_key_fingerprint(public_key: &[u8]) -> String {
 /// The outcome of the server-certificate trust gate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CertVerdict {
-    /// Proceed with the connection.
+    /// Proceed with the connection without asking (the user set `ignoreCertErrors`).
     Accept,
-    /// Refuse the connection; the string is a user-facing explanation.
-    Reject(String),
+    /// The certificate is untrusted: ask the host for an interactive decision
+    /// before proceeding (#1767).
+    Prompt,
 }
 
-/// Decide whether to trust the server certificate identified by `fingerprint`.
+/// Decide how to handle the server certificate identified by `fingerprint`.
 ///
-/// `ignore_cert_errors` mirrors the connection's `ignoreCertErrors` setting.
-/// Until a persisted trust store / interactive prompt exists (the #1758
-/// follow-up), an unset flag means the certificate is untrusted and the
-/// connection is refused with an actionable message — never silently accepted.
-pub fn evaluate(ignore_cert_errors: bool, fingerprint: &str) -> CertVerdict {
+/// `ignore_cert_errors` mirrors the connection's `ignoreCertErrors` setting: set,
+/// it accepts unconditionally; unset, the sidecar surfaces the fingerprint to the
+/// host and waits for an interactive accept/reject decision (#1767) rather than
+/// silently accepting or hard-failing.
+pub fn evaluate(ignore_cert_errors: bool) -> CertVerdict {
     if ignore_cert_errors {
         CertVerdict::Accept
     } else {
-        CertVerdict::Reject(format!(
-            "the RDP server presented an untrusted certificate (server key {fingerprint}). \
-             termiHub does not connect to an unverified host automatically. If you trust this \
-             server, enable \"Ignore Certificate Errors\" in the connection's RDP options and \
-             reconnect."
-        ))
+        CertVerdict::Prompt
     }
 }
 
@@ -99,23 +97,13 @@ mod tests {
 
     #[test]
     fn ignore_cert_errors_accepts() {
-        assert_eq!(evaluate(true, "sha256:AA"), CertVerdict::Accept);
+        assert_eq!(evaluate(true), CertVerdict::Accept);
     }
 
     #[test]
-    fn default_rejects_with_fingerprint_and_guidance() {
-        let verdict = evaluate(false, "sha256:AB:CD");
-        match verdict {
-            CertVerdict::Reject(msg) => {
-                // The message must name the fingerprint and point at the toggle,
-                // so the failure is actionable rather than a bare error.
-                assert!(msg.contains("sha256:AB:CD"), "fingerprint surfaced: {msg}");
-                assert!(
-                    msg.contains("Ignore Certificate Errors"),
-                    "guidance surfaced: {msg}"
-                );
-            }
-            CertVerdict::Accept => panic!("default (ignoreCertErrors=false) must not accept"),
-        }
+    fn default_prompts_for_an_interactive_decision() {
+        // With ignoreCertErrors unset the sidecar must neither silently accept
+        // nor hard-fail: it asks the host (#1767).
+        assert_eq!(evaluate(false), CertVerdict::Prompt);
     }
 }

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -153,14 +153,20 @@ pub fn is_auth_error(msg: &str) -> bool {
 /// verbatim to drive the Deactivation-Reactivation Sequence on dynamic resize,
 /// #1755), and the receiver on which the registered CLIPRDR backend surfaces
 /// clipboard events for the driver (#1756).
-async fn connect_session(
+async fn connect_session<R, W>(
     cfg: &RdpConfig,
+    ipc_in: &mut R,
+    ipc_out: &mut W,
 ) -> Result<(
     ConnectionResult,
     RdpFramed,
     ConnectorConfig,
     std::sync::mpsc::Receiver<ClipboardEvent>,
-)> {
+)>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
     let host = cfg.host.clone();
     let port = cfg.effective_port();
 
@@ -233,22 +239,23 @@ async fn connect_session(
         .ok_or_else(|| anyhow!("could not extract RDP server public key"))?
         .to_vec();
 
-    // Trust gate (#1758): fingerprint the server public key and either accept
-    // (only when the user set `ignoreCertErrors`) or refuse with an actionable
-    // message naming the fingerprint — never a silent blind accept. An
-    // interactive accept-once / accept-for-host prompt + persisted trust store
-    // is the sequenced follow-up.
+    // Trust gate (#1758/#1767): fingerprint the server public key and either
+    // accept (only when the user set `ignoreCertErrors`) or ask the host for an
+    // interactive accept/reject decision — never a silent blind accept and never
+    // a bare hard-fail. The host owns the persisted per-host trust store, so it
+    // auto-answers a known-good fingerprint and only bothers the user for an
+    // unknown or changed (possible-MITM) one.
     let fingerprint = crate::cert::public_key_fingerprint(&server_public_key);
-    match crate::cert::evaluate(cfg.ignore_cert_errors, &fingerprint) {
+    match crate::cert::evaluate(cfg.ignore_cert_errors) {
         crate::cert::CertVerdict::Accept => {
-            if cfg.ignore_cert_errors {
-                warn!(
-                    %fingerprint,
-                    "accepting RDP server certificate without verification (ignoreCertErrors is enabled)"
-                );
-            }
+            warn!(
+                %fingerprint,
+                "accepting RDP server certificate without verification (ignoreCertErrors is enabled)"
+            );
         }
-        crate::cert::CertVerdict::Reject(message) => anyhow::bail!(message),
+        crate::cert::CertVerdict::Prompt => {
+            prompt_cert_decision(ipc_in, ipc_out, &fingerprint).await?;
+        }
     }
 
     let upgraded = ironrdp_tokio::mark_as_upgraded(should_upgrade, &mut connector);
@@ -269,6 +276,74 @@ async fn connect_session(
     .context("RDP CredSSP / capability exchange failed")?;
 
     Ok((result, framed, connector_config, clipboard_rx))
+}
+
+/// How long the sidecar blocks the connect waiting for the host's interactive
+/// certificate decision (#1767) before giving up. Generous: a human may be
+/// eyeballing the fingerprint. If the host never answers (e.g. a peer that does
+/// not speak the cert-prompt protocol), the connection aborts rather than hangs.
+const CERT_DECISION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+
+/// Surface an untrusted server certificate to the host and block on its verdict
+/// (#1767). Sends [`SidecarMessage::CertPrompt`] and waits for a
+/// [`HostMessage::CertDecision`]; `Ok(())` means proceed, `Err` aborts the
+/// connect (user rejected, timed out, or the peer closed the pipe).
+async fn prompt_cert_decision<R, W>(
+    ipc_in: &mut R,
+    ipc_out: &mut W,
+    fingerprint: &str,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    warn!(%fingerprint, "RDP server certificate is untrusted; asking the host for a decision");
+    write_message(
+        ipc_out,
+        &SidecarMessage::CertPrompt {
+            fingerprint: fingerprint.to_string(),
+            // Best-effort subject/issuer extraction is a sequenced follow-up; the
+            // public-key fingerprint is the identity the trust decision keys on.
+            subject: None,
+            issuer: None,
+        },
+    )
+    .await
+    .context("failed to send certificate prompt to host")?;
+
+    // Wait for the decision, tolerating input/resize/clipboard messages that the
+    // host may have already queued (its canvas is live): they are meaningless
+    // before the session establishes, so drop them and keep waiting. Only a
+    // decision, a disconnect, or the timeout ends the wait.
+    let deadline = tokio::time::Instant::now() + CERT_DECISION_TIMEOUT;
+    loop {
+        let msg = tokio::time::timeout_at(deadline, read_message::<_, HostMessage>(ipc_in))
+            .await
+            .map_err(|_| anyhow!("timed out waiting for the certificate trust decision"))?
+            .context("failed to read the certificate trust decision")?;
+        match msg {
+            HostMessage::CertDecision { accept: true, .. } => {
+                warn!(%fingerprint, "host accepted the untrusted RDP server certificate");
+                return Ok(());
+            }
+            HostMessage::CertDecision { accept: false, .. } => {
+                anyhow::bail!(
+                    "connection rejected: the RDP server certificate (server key {fingerprint}) \
+                     was not trusted"
+                )
+            }
+            HostMessage::Disconnect => {
+                anyhow::bail!("disconnected before the certificate trust decision")
+            }
+            // Pre-session input/resize/clipboard: no session yet, so discard.
+            HostMessage::Connect(_)
+            | HostMessage::Input(_)
+            | HostMessage::Resize { .. }
+            | HostMessage::SetClipboard(_) => {
+                debug!("ignoring a host message received while awaiting the cert decision");
+            }
+        }
+    }
 }
 
 /// Crop the tightly-packed RGBA pixels of an inclusive rectangle out of the
@@ -467,7 +542,8 @@ where
     .await
     .context("failed to write state")?;
 
-    let (result, framed, connector_config, clipboard_rx) = match connect_session(&cfg).await {
+    let (result, framed, connector_config, clipboard_rx) =
+        match connect_session(&cfg, ipc_in, ipc_out).await {
         Ok(v) => v,
         Err(e) => {
             let state = if is_auth_error(&format!("{e:#}")) {
@@ -986,5 +1062,96 @@ mod tests {
         let rect = crop_rect(&image, 2, 2, 100, 100).unwrap();
         assert_eq!((rect.x, rect.y, rect.width, rect.height), (2, 2, 2, 2));
         assert!(rect.is_well_formed());
+    }
+
+    /// The cert prompt must reach the host and an `accept` decision must let the
+    /// connect proceed — proven over an in-memory loopback standing in for stdio.
+    #[tokio::test]
+    async fn cert_prompt_accept_proceeds() {
+        let (mut host_out, mut sidecar_in) = tokio::io::duplex(64 * 1024);
+        let (mut sidecar_out, mut host_in) = tokio::io::duplex(64 * 1024);
+
+        let sidecar = tokio::spawn(async move {
+            prompt_cert_decision(&mut sidecar_in, &mut sidecar_out, "sha256:AA:BB").await
+        });
+
+        // Host reads the prompt, then replies "accept".
+        let prompt = read_message::<_, SidecarMessage>(&mut host_in).await.unwrap();
+        assert!(matches!(prompt, SidecarMessage::CertPrompt { fingerprint, .. } if fingerprint == "sha256:AA:BB"));
+        write_message(
+            &mut host_out,
+            &HostMessage::CertDecision {
+                accept: true,
+                remember: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        sidecar.await.unwrap().expect("accept must let the connect proceed");
+    }
+
+    /// A `reject` decision must abort the connect.
+    #[tokio::test]
+    async fn cert_prompt_reject_aborts() {
+        let (mut host_out, mut sidecar_in) = tokio::io::duplex(64 * 1024);
+        let (mut sidecar_out, mut host_in) = tokio::io::duplex(64 * 1024);
+
+        let sidecar = tokio::spawn(async move {
+            prompt_cert_decision(&mut sidecar_in, &mut sidecar_out, "sha256:CC").await
+        });
+
+        let _ = read_message::<_, SidecarMessage>(&mut host_in).await.unwrap();
+        write_message(
+            &mut host_out,
+            &HostMessage::CertDecision {
+                accept: false,
+                remember: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let err = sidecar.await.unwrap().expect_err("reject must abort");
+        assert!(err.to_string().contains("rejected"), "err: {err}");
+    }
+
+    /// Input/resize messages the host queued before deciding are discarded; the
+    /// wait continues until the real decision arrives.
+    #[tokio::test]
+    async fn cert_prompt_ignores_premature_input_then_accepts() {
+        let (mut host_out, mut sidecar_in) = tokio::io::duplex(64 * 1024);
+        let (mut sidecar_out, mut host_in) = tokio::io::duplex(64 * 1024);
+
+        let sidecar = tokio::spawn(async move {
+            prompt_cert_decision(&mut sidecar_in, &mut sidecar_out, "sha256:DD").await
+        });
+
+        let _ = read_message::<_, SidecarMessage>(&mut host_in).await.unwrap();
+        // A stray pointer event from the live canvas, then the decision.
+        write_message(
+            &mut host_out,
+            &HostMessage::Input(InputEvent::Pointer {
+                x: 1,
+                y: 2,
+                buttons: 0,
+            }),
+        )
+        .await
+        .unwrap();
+        write_message(
+            &mut host_out,
+            &HostMessage::CertDecision {
+                accept: true,
+                remember: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        sidecar
+            .await
+            .unwrap()
+            .expect("stray input must be skipped, then accept proceeds");
     }
 }

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -544,17 +544,17 @@ where
 
     let (result, framed, connector_config, clipboard_rx) =
         match connect_session(&cfg, ipc_in, ipc_out).await {
-        Ok(v) => v,
-        Err(e) => {
-            let state = if is_auth_error(&format!("{e:#}")) {
-                GraphicalState::AuthFailed
-            } else {
-                GraphicalState::ConnectFailed
-            };
-            let _ = write_message(ipc_out, &SidecarMessage::State(state)).await;
-            return Err(e);
-        }
-    };
+            Ok(v) => v,
+            Err(e) => {
+                let state = if is_auth_error(&format!("{e:#}")) {
+                    GraphicalState::AuthFailed
+                } else {
+                    GraphicalState::ConnectFailed
+                };
+                let _ = write_message(ipc_out, &SidecarMessage::State(state)).await;
+                return Err(e);
+            }
+        };
 
     write_message(ipc_out, &SidecarMessage::State(GraphicalState::Active))
         .await
@@ -1076,8 +1076,12 @@ mod tests {
         });
 
         // Host reads the prompt, then replies "accept".
-        let prompt = read_message::<_, SidecarMessage>(&mut host_in).await.unwrap();
-        assert!(matches!(prompt, SidecarMessage::CertPrompt { fingerprint, .. } if fingerprint == "sha256:AA:BB"));
+        let prompt = read_message::<_, SidecarMessage>(&mut host_in)
+            .await
+            .unwrap();
+        assert!(
+            matches!(prompt, SidecarMessage::CertPrompt { fingerprint, .. } if fingerprint == "sha256:AA:BB")
+        );
         write_message(
             &mut host_out,
             &HostMessage::CertDecision {
@@ -1088,7 +1092,10 @@ mod tests {
         .await
         .unwrap();
 
-        sidecar.await.unwrap().expect("accept must let the connect proceed");
+        sidecar
+            .await
+            .unwrap()
+            .expect("accept must let the connect proceed");
     }
 
     /// A `reject` decision must abort the connect.
@@ -1101,7 +1108,9 @@ mod tests {
             prompt_cert_decision(&mut sidecar_in, &mut sidecar_out, "sha256:CC").await
         });
 
-        let _ = read_message::<_, SidecarMessage>(&mut host_in).await.unwrap();
+        let _ = read_message::<_, SidecarMessage>(&mut host_in)
+            .await
+            .unwrap();
         write_message(
             &mut host_out,
             &HostMessage::CertDecision {
@@ -1127,7 +1136,9 @@ mod tests {
             prompt_cert_decision(&mut sidecar_in, &mut sidecar_out, "sha256:DD").await
         });
 
-        let _ = read_message::<_, SidecarMessage>(&mut host_in).await.unwrap();
+        let _ = read_message::<_, SidecarMessage>(&mut host_in)
+            .await
+            .unwrap();
         // A stray pointer event from the live canvas, then the decision.
         write_message(
             &mut host_out,

--- a/src-tauri/src/commands/remote_desktop.rs
+++ b/src-tauri/src/commands/remote_desktop.rs
@@ -67,6 +67,19 @@ pub async fn remote_desktop_get_clipboard(
     manager.get_clipboard(&session_id).await
 }
 
+/// Deliver the user's verdict for an interactive certificate-trust prompt
+/// (#1767): `accept` proceeds with the untrusted server certificate, `remember`
+/// persists its fingerprint so the host is trusted on future connects.
+#[tauri::command]
+pub async fn remote_desktop_cert_decision(
+    session_id: String,
+    accept: bool,
+    remember: bool,
+    manager: State<'_, GraphicalSessionManager>,
+) -> Result<(), TerminalError> {
+    manager.cert_decision(&session_id, accept, remember).await
+}
+
 /// Disconnect a graphical session and release its resources.
 #[tauri::command]
 pub async fn remote_desktop_disconnect(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -414,9 +414,21 @@ pub fn run() {
 
             // Graphical (remote-desktop) session manager. Uses its own copy of
             // the same registry so it can create graphical connections by
-            // type_id, independently of the terminal SessionManager.
+            // type_id, independently of the terminal SessionManager. Its RDP
+            // certificate trust store (#1767) is persisted in the config dir
+            // (portable-aware); a failure to resolve it degrades to in-memory.
+            let rdp_trust_store = std::sync::Arc::new(
+                match crate::utils::config_paths::resolve_config_dir(Some(app.handle())) {
+                    Ok(dir) => crate::session::rdp_trust_store::RdpTrustStore::open(dir),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "could not resolve config dir for RDP trust store; using in-memory");
+                        crate::session::rdp_trust_store::RdpTrustStore::in_memory()
+                    }
+                },
+            );
             let graphical_manager = crate::session::graphical_manager::GraphicalSessionManager::new(
                 std::sync::Arc::new(build_desktop_registry()),
+                rdp_trust_store,
             );
             app.manage(graphical_manager);
 
@@ -656,6 +668,7 @@ pub fn run() {
             commands::remote_desktop::remote_desktop_send_input,
             commands::remote_desktop::remote_desktop_send_clipboard,
             commands::remote_desktop::remote_desktop_get_clipboard,
+            commands::remote_desktop::remote_desktop_cert_decision,
             commands::remote_desktop::remote_desktop_disconnect,
             // Session commands (replaces old terminal commands)
             commands::session::create_connection,

--- a/src-tauri/src/session/graphical_manager.rs
+++ b/src-tauri/src/session/graphical_manager.rs
@@ -22,10 +22,11 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 use termihub_core::connection::{
-    ConnectionType, ConnectionTypeRegistry, CursorUpdate, FrameUpdate, GraphicalState, InputEvent,
-    SessionStateMachine,
+    CertPrompt, CertPromptReceiver, ConnectionType, ConnectionTypeRegistry, CursorUpdate,
+    FrameUpdate, GraphicalState, InputEvent, SessionStateMachine,
 };
 
+use crate::session::rdp_trust_store::{RdpTrustStore, TrustLookup};
 use crate::utils::errors::TerminalError;
 
 /// Maximum concurrent graphical sessions.
@@ -73,6 +74,25 @@ pub struct RemoteDesktopStateEvent {
     pub message: Option<String>,
 }
 
+/// `remote-desktop-cert-prompt` payload: an untrusted server certificate needs
+/// an interactive trust decision (#1767). The frontend renders an accept-once /
+/// accept-for-host / reject dialog and replies via `remote_desktop_cert_decision`.
+///
+/// `changed` distinguishes first contact (`false`) from a *changed* fingerprint
+/// for a previously-trusted host (`true`) — the possible-MITM case the dialog
+/// warns about prominently.
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteDesktopCertPromptEvent {
+    pub session_id: String,
+    pub host: String,
+    pub fingerprint: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+    pub changed: bool,
+}
+
 // ── Event sink abstraction (for test injection) ────────────────────
 
 /// Abstracts frontend event delivery so the manager is unit-testable without a
@@ -86,6 +106,8 @@ pub trait GraphicalEventSink: Clone + Send + Sync + 'static {
     fn emit_clipboard(&self, event: &RemoteDesktopClipboardEvent);
     /// Emit a lifecycle state change.
     fn emit_state(&self, event: &RemoteDesktopStateEvent);
+    /// Emit an interactive server-certificate trust prompt (#1767).
+    fn emit_cert_prompt(&self, event: &RemoteDesktopCertPromptEvent);
 }
 
 impl<R: tauri::Runtime> GraphicalEventSink for tauri::AppHandle<R> {
@@ -101,9 +123,17 @@ impl<R: tauri::Runtime> GraphicalEventSink for tauri::AppHandle<R> {
     fn emit_state(&self, event: &RemoteDesktopStateEvent) {
         let _ = self.emit("remote-desktop-state", event);
     }
+    fn emit_cert_prompt(&self, event: &RemoteDesktopCertPromptEvent) {
+        let _ = self.emit("remote-desktop-cert-prompt", event);
+    }
 }
 
 // ── Session record ─────────────────────────────────────────────────
+
+/// The host + fingerprint of a cert prompt awaiting the user's verdict, held so
+/// [`cert_decision`](GraphicalSessionManager::cert_decision) can persist the
+/// fingerprint on "Accept for host" (#1767).
+type PendingCert = Arc<Mutex<Option<(String, String)>>>;
 
 /// A live graphical session.
 struct GraphicalSession {
@@ -112,10 +142,12 @@ struct GraphicalSession {
     connection: Arc<Mutex<Box<dyn ConnectionType>>>,
     /// The shared lifecycle state machine.
     state: Arc<Mutex<SessionStateMachine>>,
-    /// Frame + cursor pump tasks, aborted on disconnect.
+    /// Frame + cursor (+ optional cert-prompt) pump tasks, aborted on disconnect.
     tasks: Vec<JoinHandle<()>>,
     /// Backend type id (for diagnostics).
     type_id: String,
+    /// The certificate prompt currently awaiting a user decision, if any (#1767).
+    pending_cert: PendingCert,
 }
 
 /// Manages live graphical remote-desktop sessions.
@@ -123,14 +155,18 @@ struct GraphicalSession {
 pub struct GraphicalSessionManager {
     sessions: Arc<Mutex<HashMap<String, GraphicalSession>>>,
     registry: Arc<ConnectionTypeRegistry>,
+    /// Persisted per-host RDP certificate trust store (#1767).
+    trust_store: Arc<RdpTrustStore>,
 }
 
 impl GraphicalSessionManager {
-    /// Create a new manager over the given connection-type registry.
-    pub fn new(registry: Arc<ConnectionTypeRegistry>) -> Self {
+    /// Create a new manager over the given connection-type registry, persisting
+    /// RDP certificate trust to `trust_store`.
+    pub fn new(registry: Arc<ConnectionTypeRegistry>, trust_store: Arc<RdpTrustStore>) -> Self {
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
             registry,
+            trust_store,
         }
     }
 
@@ -175,6 +211,16 @@ impl GraphicalSessionManager {
             )));
         }
 
+        // The host keys the certificate trust store (#1767). Read it before
+        // `settings` is consumed by `connect`; default to the type id so a
+        // config without a host still keys deterministically.
+        let host = settings
+            .get("host")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(type_id)
+            .to_string();
+
         // Authenticating → establish.
         emit_state(&sink, &session_id, GraphicalState::Authenticating, 0, None);
         if let Err(e) = connection.connect(settings).await {
@@ -192,14 +238,19 @@ impl GraphicalSessionManager {
             return Err(TerminalError::ConnectionFailed(msg));
         }
 
-        // Subscribe to the framebuffer surface before marking active.
-        let (frame_rx, cursor_rx) = {
+        // Subscribe to the framebuffer surface (and any cert-prompt channel)
+        // before marking active.
+        let (frame_rx, cursor_rx, cert_rx) = {
             let backend = connection.graphical().ok_or_else(|| {
                 TerminalError::ConnectionFailed(
                     "connected graphical backend did not expose a framebuffer surface".to_string(),
                 )
             })?;
-            (backend.subscribe_frames(), backend.subscribe_cursor())
+            (
+                backend.subscribe_frames(),
+                backend.subscribe_cursor(),
+                backend.subscribe_cert_prompts(),
+            )
         };
 
         {
@@ -209,6 +260,11 @@ impl GraphicalSessionManager {
         }
         emit_state(&sink, &session_id, GraphicalState::Active, 0, None);
         info!(session_id = %session_id, type_id, "graphical session active");
+
+        // The connection is shared with the cert-prompt pump (which drives
+        // `send_cert_decision` on auto-accept) and the command handlers.
+        let connection = Arc::new(Mutex::new(connection));
+        let pending_cert: PendingCert = Arc::new(Mutex::new(None));
 
         // Spawn the frame + cursor pumps.
         let mut tasks = Vec::new();
@@ -223,12 +279,28 @@ impl GraphicalSessionManager {
             let sid = session_id.clone();
             tasks.push(tokio::spawn(cursor_pump(sid, cursor_rx, sink)));
         }
+        // The cert-prompt pump only exists for backends that expose the channel
+        // (RDP); VNC/mock return `None` and never reach this branch (#1767).
+        if let Some(cert_rx) = cert_rx {
+            let sink = sink.clone();
+            let sid = session_id.clone();
+            tasks.push(tokio::spawn(cert_pump(
+                sid,
+                host,
+                cert_rx,
+                sink,
+                connection.clone(),
+                self.trust_store.clone(),
+                pending_cert.clone(),
+            )));
+        }
 
         let session = GraphicalSession {
-            connection: Arc::new(Mutex::new(connection)),
+            connection,
             state,
             tasks,
             type_id: type_id.to_string(),
+            pending_cert,
         };
         self.sessions
             .lock()
@@ -236,6 +308,45 @@ impl GraphicalSessionManager {
             .insert(session_id.clone(), session);
 
         Ok(session_id)
+    }
+
+    /// Deliver the user's verdict for a pending certificate prompt (#1767).
+    ///
+    /// On "Accept for host" (`accept && remember`) the presented fingerprint is
+    /// persisted to the trust store so the host is not prompted again; the
+    /// verdict is then routed down to the backend, which is blocking its connect
+    /// on it. Plain "Accept" is session-scoped (not remembered); "Reject" aborts.
+    pub async fn cert_decision(
+        &self,
+        session_id: &str,
+        accept: bool,
+        remember: bool,
+    ) -> Result<(), TerminalError> {
+        let (conn, pending) = {
+            let sessions = self.sessions.lock().await;
+            let s = sessions
+                .get(session_id)
+                .ok_or_else(|| TerminalError::SessionNotFound(session_id.to_string()))?;
+            (s.connection.clone(), s.pending_cert.clone())
+        };
+
+        // Persist first (so a remembered decision survives even if the backend
+        // send races a teardown), then clear the pending marker.
+        let pending_entry = pending.lock().await.take();
+        if accept && remember {
+            if let Some((host, fingerprint)) = &pending_entry {
+                self.trust_store.remember(host, fingerprint);
+            }
+        }
+
+        let guard = conn.lock().await;
+        let backend = guard
+            .graphical()
+            .ok_or_else(|| TerminalError::SessionNotFound(session_id.to_string()))?;
+        backend
+            .send_cert_decision(accept, remember)
+            .await
+            .map_err(|e| TerminalError::InternalError(e.to_string()))
     }
 
     /// Forward a protocol-agnostic input event to a session's backend.
@@ -450,6 +561,68 @@ async fn cursor_pump<S: GraphicalEventSink>(
     }
 }
 
+/// Pump interactive certificate-trust prompts from the backend (#1767).
+///
+/// For each [`CertPrompt`] the sidecar raises, consult the trust store:
+/// - **Trusted** (fingerprint already remembered for this host) → auto-accept
+///   silently, never bothering the user.
+/// - **Unknown** (first contact) → surface a `remote-desktop-cert-prompt` event
+///   for the accept/reject dialog.
+/// - **Changed** (host known, fingerprint differs) → surface the same event with
+///   `changed: true` so the dialog warns about a possible MITM.
+///
+/// For the prompted cases the verdict arrives asynchronously via
+/// [`cert_decision`](GraphicalSessionManager::cert_decision); `pending` records
+/// the host + fingerprint so that path can persist an "accept for host".
+#[allow(clippy::too_many_arguments)]
+async fn cert_pump<S: GraphicalEventSink>(
+    session_id: String,
+    host: String,
+    mut prompts: CertPromptReceiver,
+    sink: S,
+    connection: Arc<Mutex<Box<dyn ConnectionType>>>,
+    trust_store: Arc<RdpTrustStore>,
+    pending: PendingCert,
+) {
+    while let Some(prompt) = prompts.recv().await {
+        let CertPrompt {
+            fingerprint,
+            subject,
+            issuer,
+        } = prompt;
+
+        match trust_store.lookup(&host, &fingerprint) {
+            TrustLookup::Trusted => {
+                // Remembered: accept silently, no dialog.
+                debug!(session_id = %session_id, host = %host, "auto-accepting remembered RDP certificate");
+                let guard = connection.lock().await;
+                if let Some(backend) = guard.graphical() {
+                    if let Err(e) = backend.send_cert_decision(true, false).await {
+                        warn!(session_id = %session_id, error = %e, "failed to auto-accept remembered cert");
+                    }
+                }
+            }
+            lookup @ (TrustLookup::Unknown | TrustLookup::Changed) => {
+                let changed = lookup == TrustLookup::Changed;
+                *pending.lock().await = Some((host.clone(), fingerprint.clone()));
+                if changed {
+                    warn!(session_id = %session_id, host = %host, "RDP certificate fingerprint CHANGED for a trusted host (possible MITM)");
+                }
+                sink.emit_cert_prompt(&RemoteDesktopCertPromptEvent {
+                    session_id: session_id.clone(),
+                    host: host.clone(),
+                    fingerprint,
+                    subject,
+                    issuer,
+                    changed,
+                });
+                // The verdict returns via `cert_decision`; keep pumping in case
+                // the backend re-prompts (it will not for a single connect).
+            }
+        }
+    }
+}
+
 #[cfg(all(test, feature = "mock-remote-desktop"))]
 mod tests {
     use super::*;
@@ -462,6 +635,7 @@ mod tests {
         frames: Arc<StdMutex<usize>>,
         cursors: Arc<StdMutex<usize>>,
         states: Arc<StdMutex<Vec<GraphicalState>>>,
+        cert_prompts: Arc<StdMutex<Vec<RemoteDesktopCertPromptEvent>>>,
     }
 
     impl GraphicalEventSink for RecordingSink {
@@ -475,11 +649,14 @@ mod tests {
         fn emit_state(&self, event: &RemoteDesktopStateEvent) {
             self.states.lock().unwrap().push(event.state);
         }
+        fn emit_cert_prompt(&self, event: &RemoteDesktopCertPromptEvent) {
+            self.cert_prompts.lock().unwrap().push(event.clone());
+        }
     }
 
     fn manager() -> GraphicalSessionManager {
         let registry = Arc::new(crate::session::registry::build_desktop_registry());
-        GraphicalSessionManager::new(registry)
+        GraphicalSessionManager::new(registry, Arc::new(RdpTrustStore::in_memory()))
     }
 
     #[tokio::test]
@@ -583,5 +760,75 @@ mod tests {
             .await
             .expect_err("unknown session");
         assert!(matches!(err, TerminalError::SessionNotFound(_)));
+    }
+
+    /// Drive the cert pump directly with a known trust-store state and assert the
+    /// three routing outcomes (#1767): remembered → no dialog (auto-accept),
+    /// unknown → a first-contact prompt, changed → a MITM-flagged prompt.
+    async fn run_cert_pump(
+        trust_store: Arc<RdpTrustStore>,
+        host: &str,
+        fingerprint: &str,
+    ) -> RecordingSink {
+        use termihub_core::connection::ConnectionType;
+        let sink = RecordingSink::default();
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        // A disconnected mock backend: `graphical()` is None, so the auto-accept
+        // path is a no-op send — exactly what we want to observe (no dialog).
+        let registry = crate::session::registry::build_desktop_registry();
+        let conn: Box<dyn ConnectionType> = registry.create("mock-remote-desktop").unwrap();
+        let connection = Arc::new(Mutex::new(conn));
+        let pending: PendingCert = Arc::new(Mutex::new(None));
+
+        let handle = tokio::spawn(cert_pump(
+            "sid".to_string(),
+            host.to_string(),
+            rx,
+            sink.clone(),
+            connection,
+            trust_store,
+            pending,
+        ));
+
+        tx.send(CertPrompt {
+            fingerprint: fingerprint.to_string(),
+            subject: None,
+            issuer: None,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        handle.await.unwrap();
+        sink
+    }
+
+    #[tokio::test]
+    async fn cert_pump_auto_accepts_remembered_fingerprint() {
+        let store = Arc::new(RdpTrustStore::in_memory());
+        store.remember("h:3389", "sha256:AA");
+        let sink = run_cert_pump(store, "h:3389", "sha256:AA").await;
+        // Remembered → no user dialog.
+        assert!(sink.cert_prompts.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cert_pump_prompts_unknown_host() {
+        let store = Arc::new(RdpTrustStore::in_memory());
+        let sink = run_cert_pump(store, "h:3389", "sha256:AA").await;
+        let prompts = sink.cert_prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert!(!prompts[0].changed, "first contact is not a MITM warning");
+        assert_eq!(prompts[0].fingerprint, "sha256:AA");
+    }
+
+    #[tokio::test]
+    async fn cert_pump_flags_changed_fingerprint_as_mitm() {
+        let store = Arc::new(RdpTrustStore::in_memory());
+        store.remember("h:3389", "sha256:AA");
+        // A different key for a remembered host.
+        let sink = run_cert_pump(store, "h:3389", "sha256:BB").await;
+        let prompts = sink.cert_prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert!(prompts[0].changed, "changed fingerprint must warn (MITM)");
     }
 }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,5 +1,6 @@
 pub mod graphical_manager;
 pub mod line_ending;
 pub mod manager;
+pub mod rdp_trust_store;
 pub mod registry;
 pub mod remote_proxy;

--- a/src-tauri/src/session/rdp_trust_store.rs
+++ b/src-tauri/src/session/rdp_trust_store.rs
@@ -1,0 +1,204 @@
+//! Persisted per-host RDP server-certificate trust store (#1767).
+//!
+//! The SSH `known_hosts` analogue for RDP: it remembers the SHA-256 public-key
+//! fingerprints a user has chosen to trust for a given host, so a subsequent
+//! connect to a remembered host does not re-prompt, and a *changed* fingerprint
+//! for a previously-trusted host is flagged as a possible man-in-the-middle.
+//!
+//! The store lives on the **host** (not the sidecar) because only the host knows
+//! the config directory — including portable mode. The RDP sidecar merely relays
+//! the fingerprint; the [`GraphicalSessionManager`](super::graphical_manager)
+//! consults this store to decide whether to auto-accept, prompt, or warn.
+//!
+//! ## On-disk format
+//!
+//! A single JSON object mapping host → the list of accepted fingerprints:
+//!
+//! ```json
+//! { "server.example:3389": ["sha256:AB:CD:…", "sha256:12:34:…"] }
+//! ```
+//!
+//! Multiple fingerprints per host are allowed (a host may legitimately rotate
+//! its key, exactly as `known_hosts` tolerates), so "remember" appends rather
+//! than replaces. A presented fingerprint that matches *any* stored entry for
+//! the host is trusted; one that matches none while the host has entries is the
+//! changed / MITM case.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use tracing::warn;
+
+/// The trust-store file name inside the config directory.
+const FILE_NAME: &str = "rdp_known_hosts.json";
+
+/// The verdict of consulting the trust store for a presented fingerprint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustLookup {
+    /// The host+fingerprint pair is already trusted: accept without prompting.
+    Trusted,
+    /// The host has no remembered fingerprint: first contact, prompt the user.
+    Unknown,
+    /// The host is remembered but with a *different* fingerprint: possible MITM,
+    /// warn prominently before proceeding.
+    Changed,
+}
+
+/// A persisted per-host RDP certificate trust store.
+///
+/// Cheap to clone-share behind an `Arc`; all mutation goes through an internal
+/// mutex and is written through to disk immediately (the store is tiny).
+pub struct RdpTrustStore {
+    /// Backing file, or `None` for an in-memory store (tests / no config dir).
+    path: Option<PathBuf>,
+    /// host → accepted fingerprints.
+    entries: Mutex<BTreeMap<String, Vec<String>>>,
+}
+
+impl RdpTrustStore {
+    /// Open (or start) a trust store backed by `FILE_NAME` inside `config_dir`.
+    ///
+    /// A missing or unreadable file starts empty rather than failing — an absent
+    /// trust store simply means "nothing remembered yet".
+    pub fn open(config_dir: PathBuf) -> Self {
+        let path = config_dir.join(FILE_NAME);
+        let entries = load(&path);
+        Self {
+            path: Some(path),
+            entries: Mutex::new(entries),
+        }
+    }
+
+    /// An in-memory store that never touches disk. Used by tests and as a safe
+    /// fallback when no config directory could be resolved.
+    pub fn in_memory() -> Self {
+        Self {
+            path: None,
+            entries: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Classify a presented `fingerprint` for `host` against what is remembered.
+    pub fn lookup(&self, host: &str, fingerprint: &str) -> TrustLookup {
+        let entries = self.entries.lock().expect("trust store mutex poisoned");
+        match entries.get(host) {
+            Some(fps) if fps.iter().any(|f| f == fingerprint) => TrustLookup::Trusted,
+            Some(fps) if !fps.is_empty() => TrustLookup::Changed,
+            _ => TrustLookup::Unknown,
+        }
+    }
+
+    /// Remember `fingerprint` as trusted for `host` and persist immediately.
+    ///
+    /// Idempotent: remembering an already-trusted pair is a no-op. Persistence
+    /// failures are logged, not surfaced — the in-memory decision still holds for
+    /// the session.
+    pub fn remember(&self, host: &str, fingerprint: &str) {
+        {
+            let mut entries = self.entries.lock().expect("trust store mutex poisoned");
+            let fps = entries.entry(host.to_string()).or_default();
+            if fps.iter().any(|f| f == fingerprint) {
+                return;
+            }
+            fps.push(fingerprint.to_string());
+        }
+        self.persist();
+    }
+
+    /// Write the current entries to disk (no-op for an in-memory store).
+    fn persist(&self) {
+        let Some(path) = &self.path else { return };
+        let entries = self.entries.lock().expect("trust store mutex poisoned");
+        let write = || -> std::io::Result<()> {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let json = serde_json::to_string_pretty(&*entries)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            std::fs::write(path, json)
+        };
+        if let Err(e) = write() {
+            warn!(path = %path.display(), error = %e, "failed to persist RDP trust store");
+        }
+    }
+}
+
+/// Load the entries from `path`, returning an empty map on any error.
+fn load(path: &PathBuf) -> BTreeMap<String, Vec<String>> {
+    let Ok(bytes) = std::fs::read(path) else {
+        return BTreeMap::new();
+    };
+    match serde_json::from_slice(&bytes) {
+        Ok(map) => map,
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "RDP trust store is corrupt; starting empty");
+            BTreeMap::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FP_A: &str = "sha256:AA:BB:CC";
+    const FP_B: &str = "sha256:11:22:33";
+
+    #[test]
+    fn unknown_host_prompts() {
+        let store = RdpTrustStore::in_memory();
+        assert_eq!(store.lookup("host:3389", FP_A), TrustLookup::Unknown);
+    }
+
+    #[test]
+    fn remembered_fingerprint_is_trusted_silently() {
+        let store = RdpTrustStore::in_memory();
+        store.remember("host:3389", FP_A);
+        assert_eq!(store.lookup("host:3389", FP_A), TrustLookup::Trusted);
+        // A different host is still unknown.
+        assert_eq!(store.lookup("other:3389", FP_A), TrustLookup::Unknown);
+    }
+
+    #[test]
+    fn changed_fingerprint_is_flagged_as_mitm() {
+        let store = RdpTrustStore::in_memory();
+        store.remember("host:3389", FP_A);
+        // Same host, different key → the changed/MITM case, not "unknown".
+        assert_eq!(store.lookup("host:3389", FP_B), TrustLookup::Changed);
+    }
+
+    #[test]
+    fn remember_is_idempotent_and_allows_rotation() {
+        let store = RdpTrustStore::in_memory();
+        store.remember("host:3389", FP_A);
+        store.remember("host:3389", FP_A); // idempotent
+        store.remember("host:3389", FP_B); // rotation: both now trusted
+        assert_eq!(store.lookup("host:3389", FP_A), TrustLookup::Trusted);
+        assert_eq!(store.lookup("host:3389", FP_B), TrustLookup::Trusted);
+    }
+
+    #[test]
+    fn persists_and_reloads_across_instances() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        {
+            let store = RdpTrustStore::open(dir.clone());
+            store.remember("host:3389", FP_A);
+            assert_eq!(store.lookup("host:3389", FP_A), TrustLookup::Trusted);
+        }
+        // A fresh instance over the same directory sees the remembered trust.
+        let reopened = RdpTrustStore::open(dir);
+        assert_eq!(reopened.lookup("host:3389", FP_A), TrustLookup::Trusted);
+        assert_eq!(reopened.lookup("host:3389", FP_B), TrustLookup::Changed);
+    }
+
+    #[test]
+    fn corrupt_file_starts_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        std::fs::write(dir.join(FILE_NAME), b"not json").unwrap();
+        let store = RdpTrustStore::open(dir);
+        assert_eq!(store.lookup("host:3389", FP_A), TrustLookup::Unknown);
+    }
+}

--- a/src/components/RemoteDesktop/RemoteDesktopCertPrompt.css
+++ b/src/components/RemoteDesktop/RemoteDesktopCertPrompt.css
@@ -1,0 +1,85 @@
+/* Interactive RDP certificate-trust dialog (#1767). Tokens only — no magic
+   values. Composed on top of the shared Modal/Button primitives. */
+
+.rd-cert__title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.rd-cert__title-icon {
+  color: var(--color-accent, var(--text-primary));
+}
+
+.rd-cert__title-icon--warn {
+  color: var(--color-warning);
+}
+
+.rd-cert__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.rd-cert__lead {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-md);
+}
+
+.rd-cert__warning {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: flex-start;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
+.rd-cert__warning-icon {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--color-warning);
+}
+
+.rd-cert__facts {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--spacing-xs) var(--spacing-md);
+  margin: 0;
+}
+
+.rd-cert__facts dt {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.rd-cert__facts dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  word-break: break-word;
+}
+
+.rd-cert__fingerprint {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+}
+
+.rd-cert__hint {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+}
+
+.rd-cert__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: flex-end;
+}

--- a/src/components/RemoteDesktop/RemoteDesktopCertPrompt.test.tsx
+++ b/src/components/RemoteDesktop/RemoteDesktopCertPrompt.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests for {@link RemoteDesktopCertPrompt} — the interactive RDP
+ * certificate-trust dialog (#1767). Verifies the three verdicts route the right
+ * (accept, remember) pair and that a changed fingerprint shows the MITM warning.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { RemoteDesktopCertPrompt } from "./RemoteDesktopCertPrompt";
+import type { RemoteDesktopCertPromptPayload } from "@/types/remoteDesktop";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => root.render(ui));
+}
+
+function click(testid: string) {
+  act(() => {
+    (document.querySelector(`[data-testid="${testid}"]`) as HTMLElement).click();
+  });
+}
+
+const unknownPrompt: RemoteDesktopCertPromptPayload = {
+  session_id: "rd-1",
+  host: "server.example:3389",
+  fingerprint: "sha256:AB:CD:EF",
+  subject: "CN=server.example",
+  changed: false,
+};
+
+const changedPrompt: RemoteDesktopCertPromptPayload = {
+  session_id: "rd-1",
+  host: "server.example:3389",
+  fingerprint: "sha256:99:88:77",
+  changed: true,
+};
+
+describe("RemoteDesktopCertPrompt", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when there is no prompt", () => {
+    render(<RemoteDesktopCertPrompt prompt={null} onDecision={vi.fn()} />);
+    expect(document.querySelector('[data-testid="remote-desktop-cert-prompt"]')).toBeNull();
+  });
+
+  it("shows the host and fingerprint", () => {
+    render(<RemoteDesktopCertPrompt prompt={unknownPrompt} onDecision={vi.fn()} />);
+    expect(document.querySelector('[data-testid="cert-host"]')?.textContent).toBe(
+      "server.example:3389"
+    );
+    expect(document.querySelector('[data-testid="cert-fingerprint"]')?.textContent).toBe(
+      "sha256:AB:CD:EF"
+    );
+    // No MITM warning for first contact.
+    expect(document.querySelector('[data-testid="cert-mitm-warning"]')).toBeNull();
+  });
+
+  it("routes reject as (false, false)", () => {
+    const onDecision = vi.fn();
+    render(<RemoteDesktopCertPrompt prompt={unknownPrompt} onDecision={onDecision} />);
+    click("cert-reject");
+    expect(onDecision).toHaveBeenCalledWith(false, false);
+  });
+
+  it("routes accept-once as (true, false)", () => {
+    const onDecision = vi.fn();
+    render(<RemoteDesktopCertPrompt prompt={unknownPrompt} onDecision={onDecision} />);
+    click("cert-accept-once");
+    expect(onDecision).toHaveBeenCalledWith(true, false);
+  });
+
+  it("routes accept-for-host as (true, true)", () => {
+    const onDecision = vi.fn();
+    render(<RemoteDesktopCertPrompt prompt={unknownPrompt} onDecision={onDecision} />);
+    click("cert-accept-remember");
+    expect(onDecision).toHaveBeenCalledWith(true, true);
+  });
+
+  it("shows a MITM warning when the fingerprint changed", () => {
+    render(<RemoteDesktopCertPrompt prompt={changedPrompt} onDecision={vi.fn()} />);
+    const warning = document.querySelector('[data-testid="cert-mitm-warning"]');
+    expect(warning).not.toBeNull();
+    expect(warning?.textContent).toContain("changed");
+  });
+});

--- a/src/components/RemoteDesktop/RemoteDesktopCertPrompt.tsx
+++ b/src/components/RemoteDesktop/RemoteDesktopCertPrompt.tsx
@@ -107,8 +107,8 @@ export function RemoteDesktopCertPrompt({ prompt, onDecision }: RemoteDesktopCer
             </dd>
           </dl>
           <p className="rd-cert__hint">
-            Verify the fingerprint matches the one your server administrator reports.
-            &ldquo;Accept for host&rdquo; remembers it so you are not asked again.
+            Verify the fingerprint matches the one your server administrator reports. &ldquo;Accept
+            for host&rdquo; remembers it so you are not asked again.
           </p>
         </div>
       )}

--- a/src/components/RemoteDesktop/RemoteDesktopCertPrompt.tsx
+++ b/src/components/RemoteDesktop/RemoteDesktopCertPrompt.tsx
@@ -1,0 +1,117 @@
+import { ShieldCheck, ShieldAlert } from "lucide-react";
+import { Modal, Button } from "@/components/ui";
+import type { RemoteDesktopCertPromptPayload } from "@/types/remoteDesktop";
+import "./RemoteDesktopCertPrompt.css";
+
+interface RemoteDesktopCertPromptProps {
+  /** The pending prompt, or `null` when no decision is needed. */
+  prompt: RemoteDesktopCertPromptPayload | null;
+  /** Called with the user's verdict: `accept` proceeds, `remember` persists it. */
+  onDecision: (accept: boolean, remember: boolean) => void;
+}
+
+/**
+ * Interactive server-certificate trust dialog for RDP (#1767) — the SSH
+ * host-key-prompt analogue for remote desktops.
+ *
+ * The RDP host presented an untrusted certificate; the user eyeballs the
+ * SHA-256 public-key fingerprint and chooses to accept it once, accept and
+ * remember it for this host, or reject the connection. When the fingerprint
+ * *changed* for a previously-trusted host (`changed`), the dialog warns
+ * prominently about a possible man-in-the-middle before offering to proceed.
+ *
+ * Composed from the shared {@link Modal} + {@link Button} primitives; the verdict
+ * is routed back to the backend via `remoteDesktopCertDecision`.
+ */
+export function RemoteDesktopCertPrompt({ prompt, onDecision }: RemoteDesktopCertPromptProps) {
+  const open = prompt !== null;
+  const changed = prompt?.changed ?? false;
+
+  return (
+    <Modal
+      open={open}
+      // ESC / scrim / close all count as a rejection — the safe default.
+      onOpenChange={(next) => !next && onDecision(false, false)}
+      title={
+        <span className="rd-cert__title">
+          {changed ? (
+            <ShieldAlert size={16} className="rd-cert__title-icon rd-cert__title-icon--warn" />
+          ) : (
+            <ShieldCheck size={16} className="rd-cert__title-icon" />
+          )}
+          {changed ? "Certificate changed" : "Untrusted certificate"}
+        </span>
+      }
+      data-testid="remote-desktop-cert-prompt"
+      footer={
+        <div className="rd-cert__actions">
+          <Button
+            variant="ghost"
+            onClick={() => onDecision(false, false)}
+            data-testid="cert-reject"
+          >
+            Reject
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => onDecision(true, false)}
+            data-testid="cert-accept-once"
+          >
+            Accept once
+          </Button>
+          <Button
+            variant={changed ? "danger" : "primary"}
+            onClick={() => onDecision(true, true)}
+            data-testid="cert-accept-remember"
+          >
+            Accept for host
+          </Button>
+        </div>
+      }
+    >
+      {prompt && (
+        <div className="rd-cert__body">
+          {changed && (
+            <div className="rd-cert__warning" role="alert" data-testid="cert-mitm-warning">
+              <ShieldAlert size={16} className="rd-cert__warning-icon" aria-hidden="true" />
+              <span>
+                The certificate for this host <strong>changed</strong> since you last trusted it.
+                This can mean the server was reinstalled — or that someone is intercepting the
+                connection. Only continue if you expected this.
+              </span>
+            </div>
+          )}
+          <p className="rd-cert__lead">
+            {changed
+              ? "The RDP server presented a different certificate than the one you trusted for:"
+              : "The RDP server presented a certificate that is not yet trusted for:"}
+          </p>
+          <dl className="rd-cert__facts">
+            <dt>Host</dt>
+            <dd data-testid="cert-host">{prompt.host}</dd>
+            {prompt.subject && (
+              <>
+                <dt>Subject</dt>
+                <dd>{prompt.subject}</dd>
+              </>
+            )}
+            {prompt.issuer && (
+              <>
+                <dt>Issuer</dt>
+                <dd>{prompt.issuer}</dd>
+              </>
+            )}
+            <dt>Fingerprint</dt>
+            <dd className="rd-cert__fingerprint" data-testid="cert-fingerprint">
+              {prompt.fingerprint}
+            </dd>
+          </dl>
+          <p className="rd-cert__hint">
+            Verify the fingerprint matches the one your server administrator reports.
+            &ldquo;Accept for host&rdquo; remembers it so you are not asked again.
+          </p>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/RemoteDesktop/RemoteDesktopTab.tsx
+++ b/src/components/RemoteDesktop/RemoteDesktopTab.tsx
@@ -11,6 +11,7 @@ import { SCALE_MODE_LABELS } from "@/types/remoteDesktop";
 import { RemoteDesktopCanvas } from "./RemoteDesktopCanvas";
 import { RemoteDesktopToolbar } from "./RemoteDesktopToolbar";
 import { RemoteDesktopOverlay } from "./RemoteDesktopOverlay";
+import { RemoteDesktopCertPrompt } from "./RemoteDesktopCertPrompt";
 import "./RemoteDesktopTab.css";
 
 interface RemoteDesktopTabProps {
@@ -164,6 +165,8 @@ export function RemoteDesktopTab({ tabId, isVisible }: RemoteDesktopTabProps) {
         onCancel={session.reconnect}
         onReconnect={session.reconnect}
       />
+
+      <RemoteDesktopCertPrompt prompt={session.certPrompt} onDecision={session.respondCert} />
 
       {clipboardOpen && (
         <div className="rd-clipboard" data-testid="remote-desktop-clipboard-panel">

--- a/src/hooks/useRemoteDesktopSession.test.tsx
+++ b/src/hooks/useRemoteDesktopSession.test.tsx
@@ -16,12 +16,17 @@ import {
   remoteDesktopResize,
   remoteDesktopSendInput,
   remoteDesktopSendClipboard,
+  remoteDesktopCertDecision,
 } from "@/services/api";
-import type { RemoteDesktopStatePayload } from "@/types/remoteDesktop";
+import type {
+  RemoteDesktopStatePayload,
+  RemoteDesktopCertPromptPayload,
+} from "@/types/remoteDesktop";
 
 const hoisted = vi.hoisted(() => ({
   stateCbs: [] as Array<(p: unknown) => void>,
   clipCbs: [] as Array<(p: unknown) => void>,
+  certCbs: [] as Array<(p: unknown) => void>,
 }));
 
 vi.mock("@/services/api", () => ({
@@ -31,6 +36,7 @@ vi.mock("@/services/api", () => ({
   remoteDesktopSendInput: vi.fn(() => Promise.resolve()),
   remoteDesktopSendClipboard: vi.fn(() => Promise.resolve()),
   remoteDesktopGetClipboard: vi.fn(() => Promise.resolve(null)),
+  remoteDesktopCertDecision: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("@/services/events", () => ({
@@ -42,6 +48,10 @@ vi.mock("@/services/events", () => ({
     hoisted.clipCbs.push(cb);
     return Promise.resolve(() => {});
   },
+  onRemoteDesktopCertPrompt: (cb: (p: unknown) => void) => {
+    hoisted.certCbs.push(cb);
+    return Promise.resolve(() => {});
+  },
 }));
 
 vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
@@ -51,6 +61,7 @@ const mockedDisconnect = vi.mocked(remoteDesktopDisconnect);
 const mockedResize = vi.mocked(remoteDesktopResize);
 const mockedSendInput = vi.mocked(remoteDesktopSendInput);
 const mockedSendClipboard = vi.mocked(remoteDesktopSendClipboard);
+const mockedCertDecision = vi.mocked(remoteDesktopCertDecision);
 
 let container: HTMLDivElement;
 let root: Root;
@@ -63,6 +74,7 @@ beforeEach(() => {
   mockedConnect.mockResolvedValue("rd-1");
   hoisted.stateCbs.length = 0;
   hoisted.clipCbs.length = 0;
+  hoisted.certCbs.length = 0;
   useAppStore.setState(useAppStore.getInitialState());
 });
 
@@ -189,6 +201,44 @@ describe("useRemoteDesktopSession", () => {
 
     act(() => hoisted.clipCbs.forEach((cb) => cb({ session_id: "rd-1", text: "from-remote" })));
     expect(h.get().remoteClipboard).toBe("from-remote");
+  });
+
+  it("surfaces a cert prompt and routes the accept-for-host verdict (#1767)", async () => {
+    const tabId = addTab();
+    const h = renderSession(tabId);
+    await flush();
+
+    const prompt: RemoteDesktopCertPromptPayload = {
+      session_id: "rd-1",
+      host: "mock.local:3389",
+      fingerprint: "sha256:AA:BB:CC",
+      changed: false,
+    };
+    act(() => hoisted.certCbs.forEach((cb) => cb(prompt)));
+    expect(h.get().certPrompt).toEqual(prompt);
+
+    act(() => h.get().respondCert(true, true));
+    // Dialog clears optimistically and the verdict is routed to the backend.
+    expect(h.get().certPrompt).toBeNull();
+    expect(mockedCertDecision).toHaveBeenCalledWith("rd-1", true, true);
+  });
+
+  it("ignores a cert prompt for a different session", async () => {
+    const tabId = addTab();
+    const h = renderSession(tabId);
+    await flush();
+
+    act(() =>
+      hoisted.certCbs.forEach((cb) =>
+        cb({
+          session_id: "other-session",
+          host: "elsewhere",
+          fingerprint: "sha256:ZZ",
+          changed: true,
+        })
+      )
+    );
+    expect(h.get().certPrompt).toBeNull();
   });
 
   it("reconnects: tears down the old session and connects again", async () => {

--- a/src/hooks/useRemoteDesktopSession.ts
+++ b/src/hooks/useRemoteDesktopSession.ts
@@ -7,9 +7,19 @@ import {
   remoteDesktopResize,
   remoteDesktopSendInput,
   remoteDesktopSendClipboard,
+  remoteDesktopCertDecision,
 } from "@/services/api";
-import { onRemoteDesktopState, onRemoteDesktopClipboard } from "@/services/events";
-import type { GraphicalSessionState, RemoteDesktopInput, ScaleMode } from "@/types/remoteDesktop";
+import {
+  onRemoteDesktopState,
+  onRemoteDesktopClipboard,
+  onRemoteDesktopCertPrompt,
+} from "@/services/events";
+import type {
+  GraphicalSessionState,
+  RemoteDesktopInput,
+  RemoteDesktopCertPromptPayload,
+  ScaleMode,
+} from "@/types/remoteDesktop";
 import { frontendLog } from "@/utils/frontendLog";
 
 /** Everything a RemoteDesktopTab needs to drive one graphical session. */
@@ -24,6 +34,10 @@ export interface RemoteDesktopSession {
   message: string | null;
   /** Latest remote → local clipboard text (for the shared panel). */
   remoteClipboard: string | null;
+  /** Pending server-certificate trust prompt (#1767), or null when none. */
+  certPrompt: RemoteDesktopCertPromptPayload | null;
+  /** Answer the pending cert prompt: accept (once/remember) or reject. */
+  respondCert: (accept: boolean, remember: boolean) => void;
   /** Whether the session is configured view-only (input suppressed). */
   viewOnly: boolean;
   /** Configured scale mode (Fit / 1:1 / Match Window). */
@@ -56,6 +70,7 @@ export function useRemoteDesktopSession(tabId: string): RemoteDesktopSession {
   const [reconnectAttempt, setReconnectAttempt] = useState(0);
   const [message, setMessage] = useState<string | null>(null);
   const [remoteClipboard, setRemoteClipboard] = useState<string | null>(null);
+  const [certPrompt, setCertPrompt] = useState<RemoteDesktopCertPromptPayload | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
 
   const sessionIdRef = useRef<string | null>(null);
@@ -146,11 +161,30 @@ export function useRemoteDesktopSession(tabId: string): RemoteDesktopSession {
       setRemoteClipboard(payload.text);
     }).then((un) => (disposed ? un() : unlisteners.push(un)));
 
+    void onRemoteDesktopCertPrompt((payload) => {
+      if (disposed || payload.session_id !== sessionId) return;
+      setCertPrompt(payload);
+      frontendLog(
+        "remote_desktop",
+        `cert prompt for ${payload.host} (changed=${payload.changed})`
+      );
+    }).then((un) => (disposed ? un() : unlisteners.push(un)));
+
     return () => {
       disposed = true;
       unlisteners.forEach((un) => un());
     };
   }, [sessionId]);
+
+  const respondCert = useCallback((accept: boolean, remember: boolean) => {
+    const id = sessionIdRef.current;
+    // Clear the dialog optimistically; the backend applies the verdict.
+    setCertPrompt(null);
+    if (!id) return;
+    void remoteDesktopCertDecision(id, accept, remember).catch((err) =>
+      frontendLog("remote_desktop", `cert_decision failed: ${err}`)
+    );
+  }, []);
 
   const sendInput = useCallback(
     (event: RemoteDesktopInput) => {
@@ -196,6 +230,8 @@ export function useRemoteDesktopSession(tabId: string): RemoteDesktopSession {
     reconnectAttempt,
     message,
     remoteClipboard,
+    certPrompt,
+    respondCert,
     viewOnly,
     scaleMode,
     sendInput,

--- a/src/hooks/useRemoteDesktopSession.ts
+++ b/src/hooks/useRemoteDesktopSession.ts
@@ -164,10 +164,7 @@ export function useRemoteDesktopSession(tabId: string): RemoteDesktopSession {
     void onRemoteDesktopCertPrompt((payload) => {
       if (disposed || payload.session_id !== sessionId) return;
       setCertPrompt(payload);
-      frontendLog(
-        "remote_desktop",
-        `cert prompt for ${payload.host} (changed=${payload.changed})`
-      );
+      frontendLog("remote_desktop", `cert prompt for ${payload.host} (changed=${payload.changed})`);
     }).then((un) => (disposed ? un() : unlisteners.push(un)));
 
     return () => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -381,6 +381,20 @@ export async function remoteDesktopGetClipboard(sessionId: SessionId): Promise<s
   return await invoke<string | null>("remote_desktop_get_clipboard", { sessionId });
 }
 
+/**
+ * Deliver the user's verdict for an interactive certificate-trust prompt (#1767).
+ *
+ * `accept` proceeds with the untrusted server certificate; `remember` persists
+ * its fingerprint so the host is trusted (not re-prompted) on future connects.
+ */
+export async function remoteDesktopCertDecision(
+  sessionId: SessionId,
+  accept: boolean,
+  remember: boolean
+): Promise<void> {
+  await invoke("remote_desktop_cert_decision", { sessionId, accept, remember });
+}
+
 /** Disconnect a graphical remote-desktop session. */
 export async function remoteDesktopDisconnect(sessionId: SessionId): Promise<void> {
   await invoke("remote_desktop_disconnect", { sessionId });

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -14,6 +14,7 @@ import type {
   RemoteDesktopCursorPayload,
   RemoteDesktopClipboardPayload,
   RemoteDesktopStatePayload,
+  RemoteDesktopCertPromptPayload,
 } from "@/types/remoteDesktop";
 
 interface TerminalOutputPayload {
@@ -81,6 +82,19 @@ export async function onRemoteDesktopState(
   callback: (payload: RemoteDesktopStatePayload) => void
 ): Promise<UnlistenFn> {
   return await listen<RemoteDesktopStatePayload>("remote-desktop-state", (event) => {
+    callback(event.payload);
+  });
+}
+
+/**
+ * Subscribe to interactive server-certificate trust prompts (#1767). Fires when
+ * an RDP host presents an untrusted (unknown or changed) certificate; the caller
+ * filters by `payload.session_id` and shows the accept/reject dialog.
+ */
+export async function onRemoteDesktopCertPrompt(
+  callback: (payload: RemoteDesktopCertPromptPayload) => void
+): Promise<UnlistenFn> {
+  return await listen<RemoteDesktopCertPromptPayload>("remote-desktop-cert-prompt", (event) => {
     callback(event.payload);
   });
 }

--- a/src/types/remoteDesktop.ts
+++ b/src/types/remoteDesktop.ts
@@ -98,6 +98,22 @@ export interface RemoteDesktopStatePayload {
   message?: string;
 }
 
+/**
+ * `remote-desktop-cert-prompt` event payload (#1767): the server presented an
+ * untrusted certificate and needs an interactive trust decision. `changed`
+ * distinguishes first contact (`false`) from a *changed* fingerprint for a
+ * previously-trusted host (`true`) — the possible-MITM case the dialog warns
+ * about prominently.
+ */
+export interface RemoteDesktopCertPromptPayload {
+  session_id: string;
+  host: string;
+  fingerprint: string;
+  subject?: string;
+  issuer?: string;
+  changed: boolean;
+}
+
 /** Whether a state means the session is painting (or about to). */
 export function isLiveState(state: GraphicalSessionState): boolean {
   return state === "active" || state === "resizing";


### PR DESCRIPTION
## Summary

Upgrades RDP certificate handling from #1758's hard-fail-on-untrusted-cert to an
**interactive trust decision** with a **persisted per-host trust store** — the
SSH `known_hosts` analogue for remote desktops.

When an RDP host presents an untrusted certificate, a dialog surfaces the host
and the SHA-256 public-key fingerprint with three choices: **accept once**
(session-scoped), **accept for host** (remembered across restarts), or
**reject**. Remembered fingerprints skip the prompt on future connects, and a
**changed** fingerprint for a previously-trusted host raises a prominent
possible-MITM warning before offering to proceed. `ignoreCertErrors` still
accepts unconditionally.

## How the prompt round-trips

```
sidecar (untrusted cert) → SidecarMessage::CertPrompt{fingerprint,…}
  → SidecarRdp reader → CertPrompt channel → GraphicalSessionManager cert pump
    → consult RdpTrustStore:
        Trusted  → auto-accept silently (no dialog)
        Unknown  → remote-desktop-cert-prompt event  (changed:false)
        Changed  → remote-desktop-cert-prompt event  (changed:true, MITM warn)
      → React dialog → remote_desktop_cert_decision command
        → manager persists (on "accept for host") + HostMessage::CertDecision
          → SidecarRdp writer → sidecar unblocks its connect (accept) or aborts (reject)
```

The sidecar **blocks** its TLS-stage connect on the decision (180s timeout;
pre-session input/resize messages are discarded while it waits). The host owns
the trust store because only it knows the config directory (portable-aware).

## Trust store

`rdp_known_hosts.json` in the config dir: `{ host: [fingerprints…] }`. Multiple
fingerprints per host are allowed (key rotation, like `known_hosts`); a
presented fingerprint matching none while the host has entries is the
changed/MITM case. Degrades to in-memory if the config dir can't be resolved.

## Tests

- Sidecar: `evaluate` verdict; `prompt_cert_decision` loopback (accept proceeds,
  reject aborts, premature input skipped).
- Protocol: `CertPrompt` / `CertDecision` framed round-trip.
- Adapter: reader forwards `CertPrompt` to the manager channel.
- Trust store: unknown→prompt, remembered→trusted, changed→MITM, rotation,
  persistence across instances, corrupt-file tolerance.
- Manager cert pump: remembered→auto-accept (no dialog), unknown→prompt,
  changed→MITM-flagged prompt.
- Frontend: hook surfaces/routes the verdict + filters by session; dialog
  component (three verdicts + MITM warning).

Verified without a live untrusted-cert server via in-memory loopbacks over the
IPC boundary at every layer (sidecar stdio, adapter channels, manager pump) plus
the trust-store unit tests. `./scripts/check.sh`, `pnpm build`, sidecar
`cargo test`/`clippy` all green.

## Deferred (follow-ups filed)

- Populating `subject`/`issuer` in the prompt (the fields exist on the wire but
  are `None` today; the fingerprint is the security-critical identifier).
- A trust-management settings UI to review/revoke remembered fingerprints.

Closes #1767


Follow-ups: #1783 (subject/issuer), #1784 (trust-management UI).
