### PR TITLE
feat(rdp): linux audio output for the rdp sidecar (rdpsnd)

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -126,6 +126,7 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
+            libasound2-dev \
             patchelf
 
       - name: Install frontend dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
+            libasound2-dev \
             patchelf
 
       - name: Install frontend dependencies

--- a/docs/changes/dev0/feature/1772-rdp-linux-audio.md
+++ b/docs/changes/dev0/feature/1772-rdp-linux-audio.md
@@ -1,0 +1,9 @@
+### Added
+
+- RDP audio output redirection (`rdpsnd`) now works on **Linux**, so enabling
+  "Redirect Audio Output" plays the remote session's sound locally on Linux as
+  it already did on macOS and Windows. The sidecar's `rodio`/`cpal` audio
+  backend, previously compiled only for macOS and Windows, now also builds for
+  Linux against ALSA (`libasound.so.2`, present on every desktop Linux). On a
+  host with no usable output device playback degrades to a silent no-op rather
+  than failing the session (#1772).

--- a/rdp-sidecar/Cargo.toml
+++ b/rdp-sidecar/Cargo.toml
@@ -78,13 +78,15 @@ hex = "0.4"
 # through its `Sink`. `default-features = false` drops the file-format decoders
 # (symphonia/flac/vorbis/…) we do not use, keeping only the playback core.
 #
-# Target-gated to macOS/Windows: `cpal`'s Linux backend links ALSA
-# (`libasound2-dev`), which the bundle CI does not install when it cross-builds
-# the sidecar, and which is out of this change's lane to add. Gating the crate
-# off for Linux keeps the Linux sidecar build unaffected; Linux audio is a
-# tracked follow-up. This lives in the workspace-EXCLUDED sidecar graph, so it
-# adds zero dependency-conflict risk to the main app (#1747).
-[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
+# Target-gated to macOS/Windows/Linux — the three platforms the bundle CI builds
+# the sidecar for. `cpal`'s Linux backend links ALSA (`libasound2-dev`), which
+# the bundle CI installs on its native `ubuntu` / `ubuntu-24.04-arm` sidecar
+# legs (#1772); at runtime it dynamically loads `libasound.so.2`, which every
+# desktop Linux ships. The gate stays explicit (rather than unconditional) so an
+# exotic target `cpal` cannot build for degrades to the no-op sink in audio.rs
+# instead of failing to compile. This lives in the workspace-EXCLUDED sidecar
+# graph, so it adds zero dependency-conflict risk to the main app (#1747).
+[target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 rodio = { version = "0.20", default-features = false }
 
 [dev-dependencies]

--- a/rdp-sidecar/src/audio.rs
+++ b/rdp-sidecar/src/audio.rs
@@ -32,12 +32,13 @@
 //!
 //! ## Platforms
 //!
-//! Audible playback is compiled for **macOS and Windows** only. The Linux audio
-//! backends ([`cpal`]/ALSA, which [`rodio`] links) need `libasound2-dev` present
-//! when the sidecar is built, which the bundle CI does not yet install; until
-//! that lands, the Linux build omits the audio crate entirely (advertising no
-//! formats, so the server streams nothing) rather than fail to compile. Tracked
-//! as the #1764 Linux follow-up.
+//! Audible playback is compiled for **macOS, Windows and Linux** — the three
+//! platforms the bundle CI builds the sidecar for. On Linux [`rodio`] uses
+//! [`cpal`]'s ALSA backend, which links `libasound2-dev` at build time (the
+//! bundle CI installs it on its native `ubuntu` sidecar legs, #1772) and loads
+//! `libasound.so.2` at runtime — present on every desktop Linux. Any other
+//! target `cpal` cannot build for degrades to the no-op sink below (advertising
+//! no formats, so the server streams nothing) rather than failing to compile.
 
 use std::borrow::Cow;
 
@@ -91,7 +92,7 @@ fn pcm_bytes_to_i16(bytes: &[u8]) -> Vec<i16> {
 /// Map an [`RDPSND` volume PDU](VolumePdu) (per-channel `0..=0xFFFF`) to a
 /// linear [`rodio`] gain where `1.0` is unity. Averages the two channels since
 /// the sink applies a single scalar gain.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn volume_to_gain(volume: &VolumePdu) -> f32 {
     let avg = (u32::from(volume.volume_left) + u32::from(volume.volume_right)) as f32 / 2.0;
     avg / f32::from(u16::MAX)
@@ -151,7 +152,7 @@ impl RdpsndClientHandler for RdpAudioBackend {
 // --- Host playback sink: real on macOS/Windows, a no-op elsewhere. ---
 
 /// A command sent to the playback thread.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 enum AudioCommand {
     /// Queue decoded samples for playback at the advertised channel/rate.
     Play(Vec<i16>),
@@ -164,14 +165,14 @@ enum AudioCommand {
 /// The thread owns the `!Send` output stream and sink; this handle keeps only the
 /// `Send` command sender, so the RDP session future stays `Send`-agnostic and no
 /// audio object migrates across worker threads.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 #[derive(Debug)]
 struct AudioSink {
     tx: Option<std::sync::mpsc::Sender<AudioCommand>>,
     thread: Option<std::thread::JoinHandle<()>>,
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 impl AudioSink {
     const SUPPORTED: bool = true;
 
@@ -211,7 +212,7 @@ impl AudioSink {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 impl Drop for AudioSink {
     fn drop(&mut self) {
         self.close();
@@ -222,7 +223,7 @@ impl Drop for AudioSink {
 /// PCM buffer through a [`rodio`] sink until the sender is dropped. Opening the
 /// device can fail (headless host, no audio hardware); on failure the loop simply
 /// drains and discards commands so the session keeps running without sound.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn playback_loop(rx: &std::sync::mpsc::Receiver<AudioCommand>) {
     let (_stream, handle) = match rodio::OutputStream::try_default() {
         Ok(pair) => pair,
@@ -257,13 +258,14 @@ fn playback_loop(rx: &std::sync::mpsc::Receiver<AudioCommand>) {
     tracing::debug!("rdpsnd: audio playback thread stopped");
 }
 
-/// No-op sink for platforms without a compiled audio backend (currently Linux —
-/// see the module docs). Advertises no formats, so the server never streams.
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+/// No-op sink for platforms without a compiled audio backend (any target other
+/// than macOS/Windows/Linux — see the module docs). Advertises no formats, so
+/// the server never streams.
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 #[derive(Debug)]
 struct AudioSink;
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 impl AudioSink {
     const SUPPORTED: bool = false;
 
@@ -322,7 +324,7 @@ mod tests {
         assert!(f.data.is_none());
     }
 
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
     #[test]
     fn volume_pdu_maps_to_unity_gain_at_max() {
         let full = VolumePdu {


### PR DESCRIPTION
Closes #1772. Follow-up to #1764, which landed rdpsnd audio playback in the RDP sidecar but target-gated the `rodio`/`cpal` audio backend to macOS and Windows: on Linux the sidecar omitted the audio crate entirely and advertised no formats, so the server streamed no sound.

## What changed

- **CI system dep**: added `libasound2-dev` to the Ubuntu `apt-get install` step in both workflows that build the sidecar — `.github/workflows/dev-build.yml` and `.github/workflows/release.yml`. Their Linux legs build the sidecar **natively** on `ubuntu` / `ubuntu-24.04-arm` runners (`x86_64`/`aarch64-unknown-linux-gnu`), so ALSA links directly — no musl cross-build is involved for the sidecar (the musl legs in those workflows build the separate `termihub-agent`, not this crate).
- **Enable the backend on Linux**: extended the `cfg` on the `rodio` dependency (`rdp-sidecar/Cargo.toml`) and on the audio backend (`rdp-sidecar/src/audio.rs`) from `any(macos, windows)` to `any(macos, windows, linux)`, so Linux compiles the real `AudioSink`. The gate stays explicit rather than unconditional so a target `cpal` cannot build for still degrades to the existing no-op sink instead of failing to compile.
- **No `Cargo.lock` change**: `alsa`/`alsa-sys`/`cpal`/`rodio` were already in the committed lock (the lock records all-platform deps regardless of target `cfg`), so enabling Linux needs no re-resolution.

## Backend chosen

**ALSA** (`libasound2-dev` at build, `libasound.so.2` at runtime) — `cpal`'s default Linux backend, which `rodio` links. `libasound.so.2` ships on effectively every desktop Linux, and PulseAudio/PipeWire both expose an ALSA-compatibility device, so ALSA is the portable choice. Device selection is left to `cpal`'s default-output-device pick (which resolves to the Pulse/PipeWire ALSA plugin on a typical desktop); explicit device enumeration/selection is out of scope. On a host with no usable output device, `OutputStream::try_default()` fails and playback degrades to a silent drain rather than failing the session — unchanged from macOS/Windows.

## Verification

- **Linux ALSA build (the risk area):** built the sidecar in an `ubuntu:24.04` **aarch64** container (matching the `ubuntu-24.04-arm` CI leg) with `libasound2-dev` installed, `cargo build --locked`. It compiles `alsa-sys`/`cpal`/`rodio` and links the final `termihub-rdp-helper` binary against `libasound.so.2`, with **zero** lock churn under `--locked`.
- **Existing platforms:** `cargo test` for the sidecar on macOS — 81 tests pass, including the audio unit tests (`pcm_bytes_to_i16`, `pcm_format`, `advertised_formats`, `volume_to_gain`), which now compile under the Linux-inclusive `cfg`.
- **Real-host playback** (audible sound from a live RDP server) is not headless-testable and is verified the same way #1764 verified macOS/Windows — by reasoning through the decode→sink path (unchanged; only the platform gate moved) plus manual check against a real host. Note: per-PR CI does **not** build the sidecar (the sidecar-building legs live in dev-build/release, which run on push to `develop`), so the Linux sidecar leg is exercised once this merges.

## Runtime-dependency note (follow-up candidate)

The Linux sidecar now dynamically links `libasound.so.2`. It is universally present on desktop Linux, but the `.deb`/`.rpm` bundles do not currently declare it as a package dependency. If we want a hard guarantee on minimal installs, a `libasound2` runtime `depends` could be added to the Tauri Linux bundle config — deliberately left out of this PR's lane; happy to file as `Ready2Implement` if wanted.