### PR TITLE
chore(bundle): declare libasound2 runtime dependency for linux packages

### DIFF
--- a/docs/changes/dev1/feature/1786-libasound2-bundle-dep.md
+++ b/docs/changes/dev1/feature/1786-libasound2-bundle-dep.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Linux packages: the `.deb` and `.rpm` bundles now declare a runtime dependency
+  on ALSA (`libasound2t64 | libasound2` for deb, `alsa-lib` for rpm), so the
+  bundled RDP audio sidecar (`termihub-rdp-helper`, which dynamically links
+  `libasound.so.2`) is guaranteed its shared library on minimal installs. The
+  sidecar ships as a Tauri `externalBin`, which the deb autodetection does not
+  scan, so the dependency has to be declared explicitly (#1786).

--- a/src-tauri/tauri.sidecar.conf.json
+++ b/src-tauri/tauri.sidecar.conf.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
-    "externalBin": ["binaries/termihub-rdp-helper"]
+    "externalBin": ["binaries/termihub-rdp-helper"],
+    "linux": {
+      "deb": {
+        "depends": ["libasound2t64 | libasound2"]
+      },
+      "rpm": {
+        "depends": ["alsa-lib"]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Declares an ALSA runtime dependency in the Tauri Linux `.deb`/`.rpm` bundles so the bundled RDP audio sidecar always finds its shared library on a fresh install.

Since #1772 (PR #1785), the `termihub-rdp-helper` sidecar dynamically links `libasound.so.2` (ALSA, via `cpal`). The sidecar ships as a Tauri `externalBin`, which the deb shlib-dependency autodetection does **not** scan — so on a minimal Linux install `libasound2` could be absent and the sidecar would fail to load, breaking the whole RDP session (not just audio).

## Changes

Added to the bundle-only config fragment `src-tauri/tauri.sidecar.conf.json` (merged via `--config` at bundle time only — per-PR compile/test jobs stay sidecar-free), alongside the `externalBin` that causes the dependency:

- `bundle.linux.deb.depends`: `["libasound2t64 | libasound2"]`
- `bundle.linux.rpm.depends`: `["alsa-lib"]`

### Why the OR for deb

The `t64` (64-bit `time_t`) transition renamed the Debian/Ubuntu ALSA package. The alternative dependency resolves on both sides of the transition:

- `libasound2t64` — Ubuntu 24.04+ (both release Linux bundle jobs run Ubuntu 24.04), Debian Trixie/Sid.
- `libasound2` — Debian 12 (Bookworm), Ubuntu 22.04 and earlier.

`|` is standard Debian `Depends` alternative syntax. For rpm, `alsa-lib` is the Fedora/RHEL/CentOS package that provides `libasound.so.2`.

## Validation

- JSON validated; formatting confirmed with `prettier --check` and `pnpm markdownlint`.
- Per-PR CI does not build the `.deb`/`.rpm` (release-cadence only), so the generated packages can't be asserted here; the config change is minimal and matches the Tauri v2 schema keys (`bundle.linux.deb.depends` / `bundle.linux.rpm.depends`, both `string[]`).

Closes #1786