### PR TITLE
feat(rdp): read the linux host clipboard file list (text/uri-list) for cliprdr serving

### DIFF
--- a/docs/changes/dev0/feature/1792-linux-urilist-clipboard.md
+++ b/docs/changes/dev0/feature/1792-linux-urilist-clipboard.md
@@ -1,0 +1,15 @@
+### Added
+
+- RDP: on **Linux**, paste **any local file** into the remote session, not just
+  files staged in the shared folder. The sidecar now reads the host clipboard's
+  `text/uri-list` selection on both **X11** (via `x11-clipboard`) and **Wayland**
+  (via `wl-clipboard-rs`, with an X11 fallback for compositors without
+  `wlr-data-control`), decodes the `file://` URIs to real paths, and offers those
+  files to the remote over CLIPRDR — so a file copied in a Linux file manager can
+  be pasted into the RDP session (#1792). This completes the host-clipboard file
+  bridge across all three desktop platforms (macOS #1779, Windows #1791). As on
+  the other platforms, the host clipboard takes precedence over the shared folder,
+  files are served read-only from their real paths (regular files only,
+  size-capped), the remote only ever selects an advertised index, it is gated
+  behind the same opt-in as clipboard file transfer (#1778), and **view-only
+  sessions never advertise or serve host-clipboard files.**

--- a/rdp-sidecar/Cargo.lock
+++ b/rdp-sidecar/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.19",
@@ -434,7 +434,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -452,6 +452,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chacha20"
@@ -839,7 +845,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
 ]
@@ -860,6 +866,17 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive-new"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "des"
@@ -923,6 +940,21 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -1067,6 +1099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1126,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1264,6 +1308,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -1497,6 +1551,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1845,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2461,6 +2524,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2549,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2641,6 +2725,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "p256"
 version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2847,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
 
 [[package]]
 name = "picky"
@@ -3154,6 +3259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3494,7 +3608,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -3567,6 +3681,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4129,6 +4249,7 @@ dependencies = [
  "ironrdp",
  "ironrdp-tls",
  "ironrdp-tokio",
+ "percent-encoding",
  "rodio",
  "sha2 0.11.0",
  "tempfile",
@@ -4136,6 +4257,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wl-clipboard-rs",
+ "x11-clipboard",
  "x509-cert",
 ]
 
@@ -4499,6 +4622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4706,6 +4840,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "libc",
+ "log",
+ "memoffset",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5138,6 +5348,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d28c02747d9b7d2244548438caeb176dc628f3f452831578132b6aa39ccffa"
+dependencies = [
+ "derive-new",
+ "libc",
+ "log",
+ "nix",
+ "os_pipe",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5151,6 +5381,33 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "x11-clipboard"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
+dependencies = [
+ "libc",
+ "x11rb",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "x25519-dalek"

--- a/rdp-sidecar/Cargo.toml
+++ b/rdp-sidecar/Cargo.toml
@@ -83,6 +83,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sha2 = "0.11"
 hex = "0.4"
 
+# Percent-decode the path component of `file:` URIs when parsing a Linux
+# `text/uri-list` clipboard payload (#1792). Platform-agnostic (used by the
+# unit-tested `host_clipboard::parse_uri_list`), pure Rust, no system libs; already
+# resolved transitively in this graph, so naming it directly adds no new locked
+# crate.
+percent-encoding = "2"
+
 # Host audio output for rdpsnd audio redirection (#1764). `rodio` (a maintained,
 # widely-used Rust audio library on top of `cpal`) opens the default output
 # device, resamples our advertised PCM to it, and queues decoded `wave` buffers
@@ -125,6 +132,30 @@ clipboard-files = "0.1.2"
 # sidecar graph, so it adds zero dependency-conflict risk to the main app (#1747).
 [target.'cfg(windows)'.dependencies]
 clipboard-win = "4.5"
+
+# Read the Linux clipboard's `text/uri-list` file list (#1792) — the Linux half
+# of the macOS/Windows readers above. Both crates hand `host_clipboard.rs` the raw
+# selection text, which its own [`parse_uri_list`] decodes, so the parse stays
+# unit-testable off Linux (a live X11/Wayland clipboard cannot be read in headless
+# CI).
+#
+# Chosen over the `gtk`-based `clipboard-files` Linux path deliberately: GTK
+# clipboard reads require the process main thread and a running GTK main loop,
+# which a headless sidecar called from a tokio worker cannot promise. These two
+# are window-less, thread-agnostic blocking clients and, crucially, add **no
+# system-library build dependency** — `x11-clipboard` is pure Rust over `x11rb`
+# (no `libxcb`), and `wl-clipboard-rs` with `dlopen` loads `libwayland` at runtime
+# (no link-time `libwayland-dev`), so the bundle CI's existing ubuntu packages
+# suffice.
+#
+# Gated to **Linux only**: they link nothing on other platforms and must never
+# enter the macOS/Windows sidecar graph. This lives in the workspace-EXCLUDED
+# sidecar graph, so it adds zero dependency-conflict risk to the main app (#1747).
+[target.'cfg(target_os = "linux")'.dependencies]
+x11-clipboard = "0.9"
+wl-clipboard-rs = { version = "0.8", default-features = false, features = [
+    "dlopen",
+] }
 
 [dev-dependencies]
 # Temp directories back the drive-redirection filesystem tests (#1757), which

--- a/rdp-sidecar/src/host_clipboard.rs
+++ b/rdp-sidecar/src/host_clipboard.rs
@@ -14,30 +14,53 @@
 //! ## Platform coverage
 //!
 //! This module reads the **macOS** pasteboard (via the `clipboard-files` crate,
-//! which asks `NSPasteboard` for file URLs) and the **Windows** clipboard's
-//! `CF_HDROP` file list (via `clipboard-win`, #1791). Linux (`text/uri-list`)
-//! reading is a sequenced follow-up: there the reader returns an empty list, so
+//! which asks `NSPasteboard` for file URLs), the **Windows** clipboard's
+//! `CF_HDROP` file list (via `clipboard-win`, #1791), and the **Linux**
+//! clipboard's `text/uri-list` selection on both **X11** and **Wayland** (#1792).
+//! On any platform whose reader is not wired the reader returns an empty list, so
 //! the backend simply falls back to the #1778 sandboxed-shared-folder offer — the
 //! feature degrades per platform rather than breaking. Keeping the platform reader
 //! behind this one function means adding a platform is a single-function change.
 //!
 //! Each platform crate is intentionally target-gated (see the sidecar
 //! `Cargo.toml`): `clipboard-files` is **macOS only** (its Linux path links `gtk`,
-//! its Windows path links `clipboard-win`), and `clipboard-win` is **Windows
-//! only**. Dragging either into a platform whose reader is not wired would be pure
-//! cost. Both live in the workspace-**excluded** sidecar graph, so they add zero
+//! its Windows path links `clipboard-win`), `clipboard-win` is **Windows only**,
+//! and the Linux readers (`x11-clipboard`, `wl-clipboard-rs`) are **Linux only**.
+//! Dragging any of them into a platform whose reader is not wired would be pure
+//! cost. All live in the workspace-**excluded** sidecar graph, so they add zero
 //! conflict risk to the main app (#1747).
 //!
-//! On Windows the raw `CF_HDROP` bytes (a `DROPFILES` header followed by a
-//! double-null-terminated path list) are parsed by [`parse_cf_hdrop`] rather than
-//! by `clipboard-win`'s `DragQueryFileW`-based helper: our own parser is a pure
-//! function over a byte slice, so the decode is unit-testable on non-Windows CI,
-//! where a live Win32 clipboard cannot be read.
+//! On **Windows** the raw `CF_HDROP` bytes (a `DROPFILES` header followed by a
+//! double-null-terminated path list) are parsed by [`parse_cf_hdrop`], and on
+//! **Linux** the raw `text/uri-list` selection is parsed by [`parse_uri_list`],
+//! rather than by a platform crate's own helper: both are pure functions over the
+//! clipboard bytes, so the decode is unit-testable on any CI runner, where a live
+//! OS clipboard cannot be read.
+//!
+//! The Linux reader deliberately avoids `gtk` (which `clipboard-files` would pull
+//! in): GTK clipboard reads require the process's main thread and a running GTK
+//! main loop, which a headless sidecar called from a tokio worker cannot promise.
+//! `x11-clipboard` (pure Rust over `x11rb`, no `libxcb`) and `wl-clipboard-rs`
+//! (with `dlopen`, no link-time `libwayland`) are window-less, thread-agnostic,
+//! blocking clients that fit the sidecar and add no system-library build
+//! dependency to the bundle CI. Under Wayland the reader tries the Wayland
+//! clipboard first and falls back to X11, because XWayland bridges the same
+//! selection and some compositors do not implement the `wlr-data-control`
+//! protocol `wl-clipboard-rs` needs.
 
 use std::path::PathBuf;
 
-#[cfg_attr(not(any(target_os = "macos", windows)), allow(unused_imports))]
-use tracing::{debug, warn};
+// `debug` is used by the macOS, Windows and Linux readers; on a platform with no
+// reader wired the fallback stub logs nothing, so allow it to go unused there.
+#[cfg_attr(
+    not(any(target_os = "macos", windows, target_os = "linux")),
+    allow(unused_imports)
+)]
+use tracing::debug;
+// `warn` is only emitted by the macOS and Windows readers (the Linux path treats
+// every failure as an expected "no files" case and logs at debug).
+#[cfg(any(target_os = "macos", windows))]
+use tracing::warn;
 
 /// Absolute paths of the files currently on the host OS clipboard's native file
 /// list.
@@ -106,10 +129,111 @@ pub fn read_host_clipboard_files() -> Vec<PathBuf> {
     paths
 }
 
-/// The Linux (`text/uri-list`) reader is a sequenced follow-up; until then Linux
-/// offers no host-clipboard files and the backend falls back to the sandboxed
-/// shared folder (#1778).
-#[cfg(not(any(target_os = "macos", windows)))]
+/// Reads the Linux clipboard's `text/uri-list` selection — the files the user
+/// copied in their file manager — and returns their absolute paths in clipboard
+/// order (#1792).
+///
+/// Any failure (no display, no `text/uri-list` on the clipboard, unreadable data)
+/// yields an empty list: that is the "nothing to offer" signal the backend uses
+/// to fall back to the sandboxed shared folder (#1778), so a broken read must
+/// never tear down the session. The chosen client hands us the raw selection
+/// bytes; the platform-agnostic [`parse_uri_list`] decodes them.
+///
+/// Under Wayland the Wayland clipboard is tried first with an X11 fallback (see
+/// the module docs); otherwise only X11 is consulted.
+#[cfg(target_os = "linux")]
+pub fn read_host_clipboard_files() -> Vec<PathBuf> {
+    let raw = if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+        read_wayland_uri_list().or_else(read_x11_uri_list)
+    } else {
+        read_x11_uri_list()
+    };
+
+    match raw {
+        Some(text) => {
+            let paths = parse_uri_list(&text);
+            debug!(
+                count = paths.len(),
+                "read host clipboard file list (text/uri-list)"
+            );
+            paths
+        }
+        None => Vec::new(),
+    }
+}
+
+/// Reads the `text/uri-list` target of the X11 `CLIPBOARD` selection, returning
+/// the raw selection text or `None` when there is no X server, no such target, or
+/// the read fails. Uses `x11-clipboard` (pure Rust over `x11rb`), which owns a
+/// hidden window and a background event thread, so it is safe to call from any
+/// thread without a GTK main loop.
+#[cfg(target_os = "linux")]
+fn read_x11_uri_list() -> Option<String> {
+    use std::time::Duration;
+
+    let clipboard = match x11_clipboard::Clipboard::new() {
+        Ok(clipboard) => clipboard,
+        Err(error) => {
+            // No X server reachable (`$DISPLAY` unset / headless) — expected off a
+            // desktop, not an error worth escalating.
+            debug!(%error, "no X11 clipboard available; offering no files");
+            return None;
+        }
+    };
+
+    let target = clipboard.getter.get_atom("text/uri-list").ok()?;
+    let bytes = clipboard
+        .load(
+            clipboard.getter.atoms.clipboard,
+            target,
+            clipboard.getter.atoms.property,
+            Duration::from_secs(3),
+        )
+        .ok()?;
+
+    // The clipboard holds no file list (it is text / an image / empty) — the
+    // expected common case.
+    if bytes.is_empty() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// Reads the `text/uri-list` MIME type of the regular Wayland clipboard, returning
+/// the raw selection text or `None` when there is no Wayland display, the
+/// compositor offers no such type, or the read fails. `wl-clipboard-rs` is a
+/// window-less blocking client (no GTK main loop required).
+#[cfg(target_os = "linux")]
+fn read_wayland_uri_list() -> Option<String> {
+    use std::io::Read;
+    use wl_clipboard_rs::paste::{get_contents, ClipboardType, MimeType, Seat};
+
+    match get_contents(
+        ClipboardType::Regular,
+        Seat::Unspecified,
+        MimeType::Specific("text/uri-list"),
+    ) {
+        Ok((mut pipe, _mime)) => {
+            let mut bytes = Vec::new();
+            if pipe.read_to_end(&mut bytes).is_err() || bytes.is_empty() {
+                return None;
+            }
+            Some(String::from_utf8_lossy(&bytes).into_owned())
+        }
+        // An empty clipboard, no matching MIME type, or no seat all mean "nothing
+        // to offer" — the expected common case, not an error. A missing
+        // `wlr-data-control` protocol also lands here, and the caller falls back
+        // to X11.
+        Err(error) => {
+            debug!(%error, "no text/uri-list on the Wayland clipboard; offering none");
+            None
+        }
+    }
+}
+
+/// Host-clipboard file reading is not wired for this platform, so it offers no
+/// files and the backend falls back to the sandboxed shared folder (#1778).
+#[cfg(not(any(target_os = "macos", windows, target_os = "linux")))]
 pub fn read_host_clipboard_files() -> Vec<PathBuf> {
     Vec::new()
 }
@@ -169,9 +293,70 @@ fn parse_cf_hdrop(bytes: &[u8]) -> Vec<PathBuf> {
     paths
 }
 
+/// Decodes a Linux `text/uri-list` clipboard payload into absolute paths, in
+/// clipboard order (#1792).
+///
+/// Per [RFC 2483](https://www.rfc-editor.org/rfc/rfc2483#section-5) a
+/// `text/uri-list` is CRLF-separated lines where a `#` line is a comment; file
+/// managers put one `file:` URI per line. Each URI's path component is
+/// percent-decoded. Non-`file:` schemes and `file://<remote-host>/…` URIs (a path
+/// on another machine we cannot serve locally) are skipped rather than mis-served;
+/// an empty host or `localhost` denotes this machine and is kept.
+///
+/// This is a pure function over the clipboard string on purpose: it keeps the
+/// `text/uri-list` decode unit-testable on any platform (a real X11/Wayland
+/// clipboard cannot be read in headless CI), which is why the decode is done here
+/// rather than via a platform crate's own URI helper.
+#[cfg(any(target_os = "linux", test))]
+fn parse_uri_list(data: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for line in data.lines() {
+        // `str::lines` splits on `\n` and strips a trailing `\r`, so CRLF and LF
+        // payloads both arrive CR-free here; trim any other stray whitespace.
+        let line = line.trim();
+        // Blank lines and `#` comment lines carry no URI.
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(path) = file_uri_to_path(line) {
+            paths.push(path);
+        }
+    }
+    paths
+}
+
+/// Converts a single `file:` URI to a local path, or `None` when it is not a local
+/// `file:` URI this host can serve. Handles `file://<host>/path`, `file:///path`,
+/// and the authority-less `file:/path`; percent-decodes the path component.
+#[cfg(any(target_os = "linux", test))]
+fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
+    use percent_encoding::percent_decode_str;
+
+    let rest = uri.strip_prefix("file:")?;
+    let encoded_path = if let Some(after_slashes) = rest.strip_prefix("//") {
+        // `//<host>/path`: the authority runs up to the next `/`. An empty host or
+        // `localhost` means this machine; a real remote host is not a local path.
+        let slash = after_slashes.find('/')?;
+        let host = &after_slashes[..slash];
+        if !host.is_empty() && !host.eq_ignore_ascii_case("localhost") {
+            return None;
+        }
+        &after_slashes[slash..]
+    } else {
+        // `file:/path`: no authority component, `rest` is already the path.
+        rest
+    };
+
+    let decoded = percent_decode_str(encoded_path).decode_utf8_lossy();
+    if decoded.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(decoded.into_owned()))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parse_cf_hdrop;
+    use super::{parse_cf_hdrop, parse_uri_list};
     use std::path::PathBuf;
 
     /// Builds a synthetic `CF_HDROP` byte buffer from UTF-16LE (`wide = true`)
@@ -275,5 +460,76 @@ mod tests {
         let mut bad = 999u32.to_le_bytes().to_vec();
         bad.extend_from_slice(&[0u8; 16]);
         assert!(parse_cf_hdrop(&bad).is_empty());
+    }
+
+    #[test]
+    fn parses_crlf_uri_list_in_order() {
+        let data = "file:///home/me/a.txt\r\nfile:///tmp/b.png\r\n";
+        assert_eq!(
+            parse_uri_list(data),
+            vec![PathBuf::from("/home/me/a.txt"), PathBuf::from("/tmp/b.png"),]
+        );
+    }
+
+    #[test]
+    fn accepts_lf_only_line_endings() {
+        // Some producers emit bare LF rather than the RFC 2483 CRLF.
+        let data = "file:///a\nfile:///b";
+        assert_eq!(
+            parse_uri_list(data),
+            vec![PathBuf::from("/a"), PathBuf::from("/b")]
+        );
+    }
+
+    #[test]
+    fn percent_decodes_paths() {
+        // `%20` space and a UTF-8 multi-byte sequence (`é` = %C3%A9).
+        let data = "file:///home/me/b%20c.txt\r\nfile:///home/Zo%C3%AB/na%C3%AFve.txt\r\n";
+        assert_eq!(
+            parse_uri_list(data),
+            vec![
+                PathBuf::from("/home/me/b c.txt"),
+                PathBuf::from("/home/Zoë/naïve.txt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn skips_comment_and_blank_lines() {
+        let data = "# a comment\r\n\r\nfile:///real\r\n   \r\n";
+        assert_eq!(parse_uri_list(data), vec![PathBuf::from("/real")]);
+    }
+
+    #[test]
+    fn skips_non_file_schemes() {
+        let data = "https://example.com/x\r\nfile:///keep\r\nmailto:me@x\r\n";
+        assert_eq!(parse_uri_list(data), vec![PathBuf::from("/keep")]);
+    }
+
+    #[test]
+    fn accepts_empty_and_localhost_authority_but_skips_remote_host() {
+        let data = "file:///local/a\r\nfile://localhost/local/b\r\nfile://remote.example/c\r\n";
+        assert_eq!(
+            parse_uri_list(data),
+            vec![PathBuf::from("/local/a"), PathBuf::from("/local/b")]
+        );
+    }
+
+    #[test]
+    fn accepts_authority_less_file_uri() {
+        // `file:/path` (no `//` authority) is a valid, if rarer, form.
+        assert_eq!(
+            parse_uri_list("file:/etc/hosts\r\n"),
+            vec![PathBuf::from("/etc/hosts")]
+        );
+    }
+
+    #[test]
+    fn empty_or_schemeless_input_yields_no_paths() {
+        assert!(parse_uri_list("").is_empty());
+        assert!(parse_uri_list("\r\n\r\n").is_empty());
+        assert!(parse_uri_list("/not/a/uri\r\n").is_empty());
+        // `file://host` with no path component names nothing servable.
+        assert!(parse_uri_list("file://host\r\n").is_empty());
     }
 }


### PR DESCRIPTION
Implements the **Linux** half of the host-clipboard file paste bridge, after macOS (#1779) and Windows (#1791). `read_host_clipboard_files` returned empty on Linux; it now reads the clipboard's `text/uri-list` selection, decodes `file://` URIs to absolute paths, and feeds them into the existing `build_host_file_offer` serve pipeline — so a file copied in a Linux file manager pastes into the RDP session, under the same opt-in / view-only gate as #1779.

Closes #1792

## Approach

- **X11 and Wayland both covered.** Under Wayland the Wayland clipboard is tried first (`wl-clipboard-rs`) with an **X11 fallback** (`x11-clipboard`), because XWayland bridges the same selection and some compositors (e.g. GNOME Mutter, historically) don't implement the `wlr-data-control` protocol `wl-clipboard-rs` needs. Otherwise only X11 is consulted.
- **Deliberately not `gtk`/`clipboard-files`.** The `clipboard-files` Linux path calls `gtk::init()` + `wait_for_uris()`, which require the process main thread and a running GTK main loop — a headless sidecar called from a tokio worker cannot promise either. The chosen crates are window-less, thread-agnostic blocking clients and, crucially, add **no system-library build dependency**: `x11-clipboard` is pure Rust over `x11rb` (no `libxcb`), and `wl-clipboard-rs` with `dlopen` loads `libwayland` at runtime (no link-time `libwayland-dev`). The bundle CI's existing ubuntu packages suffice — no workflow change needed.
- **Platform-agnostic parser.** The `text/uri-list` decode lives in a pure `parse_uri_list` helper (percent-decoding, CRLF/LF line splitting, `#` comments, `file://<remote-host>/…` skipped, empty/`localhost` host kept), unit-tested off Linux — mirroring #1791's `parse_cf_hdrop`, since a live X11/Wayland clipboard can't be read in headless CI.

## Dependency gating

New deps are `cfg(target_os = "linux")`-gated in the workspace-**excluded** sidecar graph (zero main-app risk). `cargo tree` verified they and all transitives (`x11rb`, `wayland-client`, …) are **absent** on `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`. `percent-encoding` was already resolved transitively, so naming it directly added no new locked crate. `Cargo.lock` diff is additions-only.

## Validation

- **Unit tests** (macOS host, run in this crate's `cargo test`): 8 new `parse_uri_list` cases — CRLF & LF, percent-decoding (space + UTF-8), comment/blank skip, non-`file:` scheme skip, empty/`localhost`/remote host handling, authority-less `file:/path`, malformed input. All pass.
- **Linux compile + clippy**: the `#[cfg(target_os = "linux")]` reader can't build on macOS normally, so it was cross-checked against `x86_64-unknown-linux-musl` (same Linux cfg) using the local musl cross-toolchain — `cargo check` and `cargo clippy -- -D warnings` both pass clean against the real crate APIs.

> **Note:** per-PR CI does not build the RDP sidecar (it's built in `dev-build.yml` on push to `develop`), so the Linux path is compiled by CI only post-merge — hence the local cross-compile verification above.

## Test plan

Manual (real desktop): with clipboard file transfer enabled and a non-view-only RDP session, copy a file in a Linux file manager (test both an X11 and a Wayland session), paste into the remote, and confirm the real file transfers. A view-only session must offer nothing.