### PR TITLE
feat(rdp): re-advertise the CLIPRDR local file list when the shared folder changes

### DIFF
--- a/docs/changes/dev0/feature/1788-readvertise-on-folder-change.md
+++ b/docs/changes/dev0/feature/1788-readvertise-on-folder-change.md
@@ -1,0 +1,14 @@
+### Changed
+
+- RDP clipboard file serving now **re-advertises the shared folder's file list
+  when its contents change** while a session is connected (#1788). Previously the
+  local file list was offered only once, at connect (or on a host text copy), so a
+  file added to, removed from, or renamed inside the shared folder afterwards
+  stayed invisible to the remote until you reconnected. The sidecar now watches
+  the shared folder (via the cross-platform `notify` filesystem watcher) and
+  re-sends the CLIPRDR file offer on change, re-enumerating the current contents
+  through the same sandboxed serve pipeline. Changes are debounced and
+  rate-bounded so a busy folder cannot flood the clipboard channel, and the
+  re-advertise honours the existing opt-in and view-only gates — a view-only
+  session never advertises local files. A file dropped into the shared folder
+  after connecting can now be pasted into the remote without reconnecting.

--- a/rdp-sidecar/Cargo.lock
+++ b/rdp-sidecar/Cargo.lock
@@ -1149,6 +1149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1921,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.13.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +2340,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +2522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2558,6 +2608,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4249,6 +4326,7 @@ dependencies = [
  "ironrdp",
  "ironrdp-tls",
  "ironrdp-tokio",
+ "notify",
  "percent-encoding",
  "rodio",
  "sha2 0.11.0",
@@ -5147,6 +5225,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5178,11 +5265,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5207,6 +5311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5217,6 +5327,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5231,10 +5347,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5249,6 +5377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5259,6 +5393,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5273,6 +5413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5283,6 +5429,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/rdp-sidecar/Cargo.toml
+++ b/rdp-sidecar/Cargo.toml
@@ -72,6 +72,16 @@ termihub-core = { path = "../core", default-features = false, features = [
 ] }
 
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "io-util", "net", "sync", "time"] }
+
+# Cross-platform filesystem watcher (inotify on Linux, FSEvents on macOS,
+# ReadDirectoryChangesW on Windows) so files added to / removed from / renamed in
+# the shared folder after connect are re-advertised over CLIPRDR without a
+# reconnect (#1788). `default-features = false` drops the optional
+# crossbeam-channel event bus we do not use — the watcher forwards events into a
+# tokio channel from its callback — while `macos_fsevent` keeps the native macOS
+# backend. notify already target-gates its own platform deps (inotify/fsevent-sys/
+# windows-sys), so no per-platform gating is needed here.
+notify = { version = "8", default-features = false, features = ["macos_fsevent"] }
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rdp-sidecar/src/clipboard.rs
+++ b/rdp-sidecar/src/clipboard.rs
@@ -421,6 +421,27 @@ impl SidecarClipboardBackend {
         Some(descriptors)
     }
 
+    /// Re-advertise the local file offer after the shared folder's contents
+    /// changed while the session is connected (#1788). Reuses the exact
+    /// [`Self::build_local_file_offer`] pipeline as [`Self::on_request_format_list`],
+    /// so the refreshed [`Self::offered_files`] index map stays consistent with
+    /// what a later `FileContentsRequest` serves, and the re-enumeration stays
+    /// inside the sandbox root via [`collect_offerable_files`] exactly as the
+    /// initial offer does. The same opt-in + view-only gate applies: a view-only
+    /// or text-only session never offered local files, so a folder change emits
+    /// nothing here. When the folder — and the host clipboard — went empty, a text
+    /// advertisement replaces the stale file list (a `FormatList` wholly replaces
+    /// the previous one) so the remote stops offering files that are gone.
+    pub fn readvertise_local_files(&mut self) {
+        if !self.serves_local_files() {
+            return;
+        }
+        match self.build_local_file_offer() {
+            Some(files) => self.emit(ClipboardEvent::AdvertiseFiles(files)),
+            None => self.emit(ClipboardEvent::AdvertiseLocal),
+        }
+    }
+
     fn emit(&self, event: ClipboardEvent) {
         if self.tx.send(event).is_err() {
             debug!("clipboard event receiver dropped; sidecar shutting down");
@@ -1818,6 +1839,88 @@ mod tests {
         backend.on_request_format_list();
         // View-only must never push local files; it falls back to text (empty).
         assert_eq!(next_event(&rx), ClipboardEvent::AdvertiseLocal);
+    }
+
+    // --- Re-advertise on shared-folder change (#1788) ---
+
+    #[test]
+    fn readvertise_offers_a_file_added_after_connect() {
+        let (mut backend, rx, dir) = backend_serving(false);
+        std::fs::write(dir.path().join("first.txt"), b"1").unwrap();
+        // Initial offer at connect.
+        backend.on_request_format_list();
+        match next_event(&rx) {
+            ClipboardEvent::AdvertiseFiles(files) => assert_eq!(files.len(), 1),
+            other => panic!("expected AdvertiseFiles, got {other:?}"),
+        }
+        // A file dropped in *after* connecting is picked up on the next
+        // re-advertise, so the remote sees it without reconnecting (#1788).
+        std::fs::write(dir.path().join("second.txt"), b"2").unwrap();
+        backend.readvertise_local_files();
+        match next_event(&rx) {
+            ClipboardEvent::AdvertiseFiles(files) => {
+                let names: Vec<_> = files.iter().map(|f| f.name.clone()).collect();
+                assert_eq!(
+                    names,
+                    vec!["first.txt".to_string(), "second.txt".to_string()]
+                );
+            }
+            other => panic!("expected AdvertiseFiles, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn readvertise_falls_back_to_text_when_the_share_empties() {
+        let (mut backend, rx, dir) = backend_serving(false);
+        std::fs::write(dir.path().join("gone.txt"), b"x").unwrap();
+        backend.on_request_format_list();
+        let _ = next_event(&rx); // consume the initial AdvertiseFiles
+        std::fs::remove_file(dir.path().join("gone.txt")).unwrap();
+        backend.readvertise_local_files();
+        // The stale file list is replaced by a (text) advertisement so the remote
+        // no longer offers the removed file.
+        assert_eq!(next_event(&rx), ClipboardEvent::AdvertiseLocal);
+    }
+
+    #[test]
+    fn view_only_never_readvertises_local_files() {
+        let (mut backend, rx, dir) = backend_serving(true);
+        std::fs::write(dir.path().join("secret.txt"), b"nope").unwrap();
+        backend.readvertise_local_files();
+        // View-only offered nothing to begin with, so a change emits nothing at
+        // all — not even a text advertisement.
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn text_only_bridge_never_readvertises() {
+        let (mut backend, rx) = SidecarClipboardBackend::new(None, false);
+        backend.readvertise_local_files();
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn readvertise_skips_a_symlink_escaping_the_sandbox() {
+        let (mut backend, rx, dir) = backend_serving(false);
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), b"s").unwrap();
+        // A symlink inside the share pointing outside the sandbox must never be
+        // offered on re-enumeration.
+        std::os::unix::fs::symlink(
+            outside.path().join("secret.txt"),
+            dir.path().join("link.txt"),
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("real.txt"), b"r").unwrap();
+        backend.readvertise_local_files();
+        match next_event(&rx) {
+            ClipboardEvent::AdvertiseFiles(files) => {
+                let names: Vec<_> = files.iter().map(|f| f.name.clone()).collect();
+                assert_eq!(names, vec!["real.txt".to_string()]);
+            }
+            other => panic!("expected AdvertiseFiles, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rdp-sidecar/src/folder_watch.rs
+++ b/rdp-sidecar/src/folder_watch.rs
@@ -1,0 +1,263 @@
+//! Watches the sandboxed shared folder for changes while an RDP session is
+//! connected so the CLIPRDR local file offer can be **re-advertised** without a
+//! reconnect (#1788).
+//!
+//! At connect the sidecar advertises the shared folder's file list once
+//! (`#1778`); a file dropped into, removed from, or renamed inside the folder
+//! afterwards is invisible to the remote until the offer is re-sent. This module
+//! bridges the OS filesystem watcher ([`notify`], which uses inotify on Linux,
+//! FSEvents on macOS and `ReadDirectoryChangesW` on Windows) to a single
+//! debounced, rate-bounded "re-advertise now" tick the driver loop consumes. The
+//! driver then re-enumerates the folder through the existing serve pipeline
+//! ([`crate::clipboard::SidecarClipboardBackend::readvertise_local_files`]),
+//! which keeps the re-enumeration inside the sandbox root.
+//!
+//! **Bounding.** A churning folder must not flood the CLIPRDR channel with a
+//! format-list PDU per inotify event. [`Debouncer`] enforces three limits: a
+//! trailing quiet period ([`DEBOUNCE`]) so a burst collapses into one tick, a
+//! hard cap ([`MAX_WAIT`]) so continuous activity cannot starve the trailing edge
+//! forever, and a floor ([`MIN_INTERVAL`]) between two ticks so the re-advertise
+//! rate stays bounded regardless. The tick channel itself has capacity one and
+//! drops extra ticks (a re-advertise reads the folder's current state, so a
+//! coalesced-away tick loses nothing).
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use notify::{RecursiveMode, Watcher};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+/// Trailing quiet period after the last change before a re-advertise fires, so a
+/// burst of rapid changes collapses into a single tick.
+const DEBOUNCE: Duration = Duration::from_millis(400);
+/// Hard cap: re-advertise at most this long after the *first* change of a burst,
+/// even if the folder keeps churning — otherwise continuous activity would keep
+/// pushing the trailing-edge deadline out and never fire.
+const MAX_WAIT: Duration = Duration::from_secs(2);
+/// Floor spacing between two consecutive re-advertises, so a churning folder
+/// cannot flood the CLIPRDR channel with format-list PDUs.
+const MIN_INTERVAL: Duration = Duration::from_secs(1);
+/// Depth of the tick channel. One is enough: a pending tick already tells the
+/// driver to re-enumerate the folder's current state, so extra ticks queued
+/// behind it are redundant and dropped.
+const TICK_CAPACITY: usize = 1;
+
+/// A running shared-folder watcher. Dropping it stops the OS watcher (and, once
+/// its raw-event channel closes, the debounce task). The driver selects on
+/// [`Self::ticks`] and holds the whole value for the session's lifetime so the
+/// watcher stays alive.
+pub struct FolderWatch {
+    /// Kept alive for the session: dropping the watcher unsubscribes from OS
+    /// events. Never accessed directly after construction.
+    _watcher: notify::RecommendedWatcher,
+    /// Debounced, rate-bounded "re-advertise now" ticks.
+    pub ticks: mpsc::Receiver<()>,
+}
+
+/// Start watching `root` (the already-sandboxed, canonical shared folder)
+/// recursively for changes. Returns `None` — non-fatally — if the OS watcher
+/// cannot be created or cannot watch the folder; the session then simply keeps
+/// its connect-time offer. Must be called from within a Tokio runtime (it spawns
+/// the debounce task).
+pub fn watch_shared_folder(root: PathBuf) -> Option<FolderWatch> {
+    // The notify callback runs on notify's own thread; it forwards a bare
+    // "something changed" signal into a tokio channel (an unbounded sender's
+    // `send` is non-blocking and callable from any thread). The debounce task
+    // stamps its own clock, so the event payload is irrelevant here.
+    let (raw_tx, raw_rx) = mpsc::unbounded_channel::<()>();
+    let mut watcher = match notify::recommended_watcher(
+        move |res: notify::Result<notify::Event>| match res {
+            Ok(_event) => {
+                let _ = raw_tx.send(());
+            }
+            Err(e) => warn!(error = %e, "shared-folder watcher reported an error"),
+        },
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            warn!(
+                error = %e,
+                root = %root.display(),
+                "failed to create shared-folder watcher; files changed after connect will not be re-advertised (#1788)"
+            );
+            return None;
+        }
+    };
+    if let Err(e) = watcher.watch(&root, RecursiveMode::Recursive) {
+        warn!(
+            error = %e,
+            root = %root.display(),
+            "failed to watch the shared folder; no re-advertise on change (#1788)"
+        );
+        return None;
+    }
+
+    let (tick_tx, ticks) = mpsc::channel::<()>(TICK_CAPACITY);
+    tokio::spawn(debounce_loop(raw_rx, tick_tx, Debouncer::new()));
+    debug!(root = %root.display(), "watching shared folder for CLIPRDR re-advertise (#1788)");
+    Some(FolderWatch {
+        _watcher: watcher,
+        ticks,
+    })
+}
+
+/// The debounce + rate-limit policy, kept as a pure function of instants (no
+/// clock, no async) so the coalescing/bounding behaviour is unit-testable.
+struct Debouncer {
+    debounce: Duration,
+    max_wait: Duration,
+    min_interval: Duration,
+    /// When the last tick fired, or `None` before the first one.
+    last_fire: Option<Instant>,
+}
+
+impl Debouncer {
+    fn new() -> Self {
+        Self {
+            debounce: DEBOUNCE,
+            max_wait: MAX_WAIT,
+            min_interval: MIN_INTERVAL,
+            last_fire: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn with(debounce: Duration, max_wait: Duration, min_interval: Duration) -> Self {
+        Self {
+            debounce,
+            max_wait,
+            min_interval,
+            last_fire: None,
+        }
+    }
+
+    /// The earliest instant a re-advertise may fire, given the current burst's
+    /// first change (`burst_start`) and its most recent change (`last_change`):
+    /// the trailing-edge deadline (`last_change + debounce`), clamped so it never
+    /// waits past `burst_start + max_wait`, then floored to `last_fire +
+    /// min_interval` so two ticks stay at least a rate-cap apart.
+    fn next_fire_at(&self, burst_start: Instant, last_change: Instant) -> Instant {
+        let trailing = last_change + self.debounce;
+        let capped = trailing.min(burst_start + self.max_wait);
+        match self.last_fire {
+            Some(f) => capped.max(f + self.min_interval),
+            None => capped,
+        }
+    }
+
+    fn record_fire(&mut self, at: Instant) {
+        self.last_fire = Some(at);
+    }
+}
+
+/// Drain raw filesystem-change signals into debounced, rate-bounded ticks. Ends
+/// when the raw channel closes (watcher dropped) or the tick channel closes
+/// (driver gone).
+async fn debounce_loop(
+    mut raw_rx: mpsc::UnboundedReceiver<()>,
+    tick_tx: mpsc::Sender<()>,
+    mut debouncer: Debouncer,
+) {
+    use mpsc::error::TrySendError;
+    loop {
+        // Block until the first change of a new burst.
+        if raw_rx.recv().await.is_none() {
+            return; // watcher dropped
+        }
+        let burst_start = Instant::now();
+        let mut last_change = burst_start;
+        loop {
+            let fire_at = debouncer.next_fire_at(burst_start, last_change);
+            tokio::select! {
+                biased;
+                r = raw_rx.recv() => match r {
+                    // Another change extends the burst: reset the trailing edge.
+                    Some(()) => last_change = Instant::now(),
+                    None => return, // watcher dropped
+                },
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(fire_at)) => {
+                    debouncer.record_fire(Instant::now());
+                    match tick_tx.try_send(()) {
+                        // A full channel already holds a tick the driver will act
+                        // on, so dropping this one loses nothing.
+                        Ok(()) | Err(TrySendError::Full(())) => {}
+                        Err(TrySendError::Closed(())) => return, // driver gone
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    #[test]
+    fn coalesces_a_burst_into_one_trailing_fire() {
+        // Debounce 400ms, well under the 2s cap: a change followed by another
+        // 100ms later fires 400ms after the *last* change, i.e. once.
+        let deb = Debouncer::with(ms(400), ms(2000), ms(1000));
+        let t0 = Instant::now();
+        assert_eq!(deb.next_fire_at(t0, t0 + ms(100)), t0 + ms(500));
+    }
+
+    #[test]
+    fn caps_continuous_churn_at_max_wait() {
+        // Still churning 1900ms into the burst: the trailing edge would be
+        // t0+2300ms, but the max-wait cap forces a fire at t0+2000ms so continuous
+        // activity cannot starve the debounce forever.
+        let deb = Debouncer::with(ms(400), ms(2000), ms(1000));
+        let t0 = Instant::now();
+        assert_eq!(deb.next_fire_at(t0, t0 + ms(1900)), t0 + ms(2000));
+    }
+
+    #[test]
+    fn rate_limits_after_a_recent_fire() {
+        // A change 100ms after the previous fire: the trailing edge is t0+500ms
+        // but the min-interval floor pushes the next fire to t0+1000ms.
+        let mut deb = Debouncer::with(ms(400), ms(2000), ms(1000));
+        let t0 = Instant::now();
+        deb.record_fire(t0);
+        assert_eq!(deb.next_fire_at(t0 + ms(100), t0 + ms(100)), t0 + ms(1000));
+    }
+
+    #[tokio::test]
+    async fn debounce_loop_coalesces_a_burst_into_one_tick() {
+        let (raw_tx, raw_rx) = mpsc::unbounded_channel::<()>();
+        let (tick_tx, mut ticks) = mpsc::channel::<()>(TICK_CAPACITY);
+        // Tiny real-time durations keep the test fast; the outer timeouts are
+        // generous so it is not timing-sensitive.
+        let deb = Debouncer::with(ms(30), ms(200), ms(50));
+        tokio::spawn(debounce_loop(raw_rx, tick_tx, deb));
+
+        // A rapid burst of three changes.
+        for _ in 0..3 {
+            raw_tx.send(()).unwrap();
+        }
+        // Exactly one tick arrives after the quiet period.
+        let first = tokio::time::timeout(Duration::from_secs(2), ticks.recv()).await;
+        assert_eq!(first.expect("a tick should fire on change"), Some(()));
+        // The burst coalesced: no second tick follows from the same activity.
+        let second = tokio::time::timeout(ms(150), ticks.recv()).await;
+        assert!(second.is_err(), "a burst must coalesce into a single tick");
+    }
+
+    #[tokio::test]
+    async fn debounce_loop_stops_when_the_watcher_is_dropped() {
+        let (raw_tx, raw_rx) = mpsc::unbounded_channel::<()>();
+        let (tick_tx, mut ticks) = mpsc::channel::<()>(TICK_CAPACITY);
+        let handle = tokio::spawn(debounce_loop(raw_rx, tick_tx, Debouncer::new()));
+        // Dropping the raw sender (as dropping the watcher does) ends the loop and
+        // closes the tick channel.
+        drop(raw_tx);
+        assert!(ticks.recv().await.is_none());
+        handle.await.unwrap();
+    }
+}

--- a/rdp-sidecar/src/main.rs
+++ b/rdp-sidecar/src/main.rs
@@ -17,6 +17,7 @@ mod audio;
 mod cert;
 mod clipboard;
 mod drive;
+mod folder_watch;
 mod host_clipboard;
 mod input;
 mod keymap;

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -565,12 +565,25 @@ where
         .await
         .context("failed to write state")?;
 
+    // Watch the shared folder so files added/removed/renamed after connect are
+    // re-advertised over CLIPRDR without a reconnect (#1788). Only meaningful when
+    // we actually serve local files: file transfer opted in and not view-only.
+    // Failure to start the watcher is non-fatal — the session keeps its
+    // connect-time offer.
+    let readvertise = if cfg.view_only {
+        None
+    } else {
+        cfg.clipboard_download_dir()
+            .and_then(crate::folder_watch::watch_shared_folder)
+    };
+
     drive(
         result,
         framed,
         connector_config,
         clipboard_rx,
         cfg.view_only,
+        readvertise,
         ipc_in,
         ipc_out,
     )
@@ -585,13 +598,19 @@ where
 }
 
 /// The driver loop: owns the transport, decoded image and active stage;
-/// `select!`s between decoding server PDUs and applying host input events.
+/// `select!`s between decoding server PDUs, applying host input events, and
+/// re-advertising the local file list on a shared-folder change (#1788).
+// Each argument is a distinct capability the loop owns (transport halves, config,
+// the CLIPRDR event channel, the folder-watch ticks, the IPC endpoints); bundling
+// them into a struct would only rename them without reducing coupling.
+#[allow(clippy::too_many_arguments)]
 async fn drive<R, W>(
     result: ConnectionResult,
     framed: RdpFramed,
     connector_config: ConnectorConfig,
     clipboard_rx: std::sync::mpsc::Receiver<ClipboardEvent>,
     view_only: bool,
+    mut readvertise: Option<crate::folder_watch::FolderWatch>,
     ipc_in: &mut R,
     ipc_out: &mut W,
 ) where
@@ -794,6 +813,47 @@ async fn drive<R, W>(
                             }
                         }
                     }
+                }
+            }
+            // The shared folder changed while connected: re-enumerate and
+            // re-advertise the local file list so the remote sees the current
+            // contents without reconnecting (#1788). The tick is already debounced
+            // and rate-bounded by the watcher. When no watcher is running (text- or
+            // view-only session), this arm never fires.
+            tick = async {
+                match readvertise.as_mut() {
+                    Some(w) => w.ticks.recv().await,
+                    None => std::future::pending::<Option<()>>().await,
+                }
+            } => {
+                match tick {
+                    Some(()) => {
+                        // Drive the re-advertise through the backend so its
+                        // offered-file index map is refreshed in lockstep with what
+                        // it emits (a stale map would misserve a later paste).
+                        if let Some(cliprdr) = stage.get_svc_processor_mut::<CliprdrClient>() {
+                            if let Some(backend) =
+                                cliprdr.downcast_backend_mut::<SidecarClipboardBackend>()
+                            {
+                                backend.readvertise_local_files();
+                            }
+                        }
+                        if drain_clipboard_events(
+                            &clipboard_rx,
+                            &mut stage,
+                            &mut writer,
+                            ipc_out,
+                            local_clipboard.as_deref(),
+                        )
+                        .await
+                        .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    // The watcher task ended (folder gone / watcher dropped); stop
+                    // polling it but keep the session alive.
+                    None => readvertise = None,
                 }
             }
         }


### PR DESCRIPTION
Closes #1788

## Problem

The sandboxed shared folder is advertised to the remote over CLIPRDR only once — at connect, or when the host copies text (#1778). A file added to, removed from, or renamed inside the shared folder **after** connecting stays invisible to the remote's clipboard until a reconnect, because nothing re-sends the file offer.

## Change

Watch the shared folder in the sidecar and re-advertise the local file list on change, reusing the existing sandboxed serve pipeline (`build_host_file_offer` + the recursive enumeration from #1780).

- **`SidecarClipboardBackend::readvertise_local_files`** rebuilds the offer through the same `build_local_file_offer` path as the connect-time advertisement, so the refreshed offered-file index map stays consistent with what a later `FileContentsRequest` serves, and the re-enumeration stays inside the sandbox root (via `collect_offerable_files` / `resolve_in_root`). The opt-in + view-only gate is honoured — a view-only or text-only session re-advertises nothing. When the folder (and host clipboard) went empty, a text advertisement replaces the stale file list.
- **`folder_watch`** bridges the cross-platform `notify` OS watcher to a single debounced, rate-bounded "re-advertise now" tick. A pure, unit-tested `Debouncer` coalesces bursts (trailing quiet period), caps continuous churn (max-wait, so continuous activity can't starve the trailing edge), and floors the spacing between ticks (min-interval), so a busy folder cannot flood the CLIPRDR channel. The tick channel has capacity 1 and drops extras (a re-advertise reads current state, so a coalesced-away tick loses nothing).
- **Driver loop** gains a `select!` arm on the watch ticks; it drives the re-advertise through the backend via `downcast_backend_mut`, then drains the CLIPRDR events as usual. Watcher creation failure is non-fatal (keeps the connect-time offer).

## Security / bounding

- Re-enumeration reuses the #1780 serve path unchanged: symlink escapes skipped, every entry re-validated through the sandbox resolver, confined to the one opted-in folder.
- The opt-in gate and view-only guard are preserved.
- Debounced (400 ms trailing) + rate-bounded (2 s max-wait, 1 s min-interval) so a churning folder can't DoS the channel.
- `notify` target-gates its own platform deps (inotify/fsevent-sys/windows-sys); `default-features = false` drops the unused crossbeam-channel bus.

## Testing

`cargo test`, `cargo clippy -D warnings`, `cargo fmt --check` all green in the excluded sidecar graph. New unit tests cover:

- re-advertise offers a file added after connect; falls back to text when the share empties;
- view-only and text-only sessions never re-advertise;
- re-enumeration skips a symlink escaping the sandbox (unix);
- `Debouncer` coalescing / max-wait cap / min-interval floor (pure, deterministic);
- `debounce_loop` coalesces a burst into one tick and stops when the watcher is dropped.

Integration note: CLIPRDR file transfer is exercised over the wire only in the release-cadence lane, so this was verified via the crate's unit tests plus a local sidecar build.