### PR TITLE
feat(rdp): surface remote-copied files to the host with delayed rendering (Closes #1793)

### DIFF
--- a/core/src/backends/rdp_sidecar/config.rs
+++ b/core/src/backends/rdp_sidecar/config.rs
@@ -110,6 +110,17 @@ pub struct RdpConfig {
     /// clipboard files into it grants the remote no new local access. Off by
     /// default.
     pub clipboard_file_transfer: bool,
+    /// Surface remote-copied clipboard files to the host OS clipboard with
+    /// **delayed rendering** instead of eagerly downloading them into the shared
+    /// folder (#1793): the sidecar sends the host only the file *list* on a
+    /// remote copy and streams a file's bytes over CLIPRDR on demand when the
+    /// user actually pastes locally. Off by default — a host that cannot bind its
+    /// OS clipboard's delayed-render hook leaves this unset and keeps the eager
+    /// [`Self::clipboard_file_transfer`] shared-folder path as the fallback. Set
+    /// by the host process, not the connection editor: it reflects a host OS
+    /// capability, not a user preference, so it is not part of
+    /// [`rdp_settings_schema`].
+    pub clipboard_delayed_render: bool,
 }
 
 impl Default for RdpConfig {
@@ -131,6 +142,7 @@ impl Default for RdpConfig {
             drive_name: String::new(),
             audio_redirection: false,
             clipboard_file_transfer: false,
+            clipboard_delayed_render: false,
         }
     }
 }
@@ -209,6 +221,17 @@ impl RdpConfig {
             return None;
         }
         self.shared_drive_root()
+    }
+
+    /// Whether the sidecar should surface remote-copied clipboard files to the
+    /// host for delayed rendering rather than eagerly downloading them (#1793).
+    ///
+    /// Only meaningful when clipboard file transfer is opted in
+    /// ([`Self::clipboard_download_dir`] resolves): with no shared folder there is
+    /// nothing to fall back to, and the whole file path stays off. Gating both on
+    /// the same opt-in keeps the "one opted-in folder" guarantee in one place.
+    pub fn clipboard_delayed_render_enabled(&self) -> bool {
+        self.clipboard_delayed_render && self.clipboard_download_dir().is_some()
     }
 
     /// The user-visible label for the redirected drive, defaulting to `termiHub`
@@ -500,6 +523,7 @@ mod tests {
             drive_name: "Docs".to_string(),
             audio_redirection: true,
             clipboard_file_transfer: true,
+            clipboard_delayed_render: true,
         };
         let json = serde_json::to_value(&cfg).unwrap();
         let back: RdpConfig = serde_json::from_value(json).unwrap();
@@ -517,6 +541,47 @@ mod tests {
         assert_eq!(back.drive_label(), "Docs");
         assert!(back.audio_enabled());
         assert!(back.clipboard_file_transfer);
+        assert!(back.clipboard_delayed_render);
+    }
+
+    #[test]
+    fn delayed_render_requires_opt_in_and_shared_folder() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_string_lossy().into_owned();
+        // Fully opted into file transfer with a valid folder and the flag on.
+        let on = RdpConfig {
+            drive_redirection: true,
+            shared_folder_path: path.clone(),
+            clipboard_file_transfer: true,
+            clipboard_delayed_render: true,
+            ..Default::default()
+        };
+        assert!(on.clipboard_delayed_render_enabled());
+        // Flag on but file transfer off → no fallback folder, so the whole path
+        // stays off.
+        let no_transfer = RdpConfig {
+            drive_redirection: true,
+            shared_folder_path: path,
+            clipboard_file_transfer: false,
+            clipboard_delayed_render: true,
+            ..Default::default()
+        };
+        assert!(!no_transfer.clipboard_delayed_render_enabled());
+        // Default is off.
+        assert!(!RdpConfig::default().clipboard_delayed_render_enabled());
+    }
+
+    #[test]
+    fn delayed_render_is_not_a_schema_field() {
+        // It reflects a host OS capability set by the host process, not a user
+        // preference — so it must not appear in the connection editor schema.
+        let schema = rdp_settings_schema();
+        let has_field = schema
+            .groups
+            .iter()
+            .flat_map(|g| &g.fields)
+            .any(|f| f.key == "clipboardDelayedRender");
+        assert!(!has_field, "delayed-render must not be a schema field");
     }
 
     #[test]

--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -1119,4 +1119,163 @@ mod tests {
         // Consume state variant to keep the import used across cfgs.
         let _ = SidecarMessage::State(GraphicalState::AuthFailed);
     }
+
+    // --- Remote→host delayed rendering (#1793) ---
+
+    #[tokio::test]
+    async fn reader_stores_surfaced_remote_clipboard_files() {
+        let (mut sidecar_stdout, host_read) = tokio::io::duplex(1024 * 1024);
+        let (frame_tx, _f) = mpsc::channel(CHANNEL_DEPTH);
+        let (cursor_tx, _c) = mpsc::channel(CHANNEL_DEPTH);
+        let (cert_tx, _ce) = mpsc::channel(CHANNEL_DEPTH);
+        let shared = test_shared();
+        let cancel = CancellationToken::new();
+        let reader = tokio::spawn(run_reader(
+            host_read,
+            frame_tx,
+            cursor_tx,
+            cert_tx,
+            shared.clone(),
+            cancel.clone(),
+        ));
+
+        let files = vec![RemoteClipboardFile {
+            name: "report.pdf".to_string(),
+            relative_path: None,
+            size: Some(10),
+            is_dir: false,
+            index: 0,
+        }];
+        write_message(
+            &mut sidecar_stdout,
+            &SidecarMessage::RemoteClipboardFiles(files.clone()),
+        )
+        .await
+        .unwrap();
+
+        drop(sidecar_stdout);
+        let _ = reader.await;
+        assert_eq!(*shared.remote_clipboard_files.lock().await, files);
+    }
+
+    /// The full host round-trip: `fetch_remote_clipboard_file` sends a
+    /// `FetchClipboardFile`, a fake sidecar streams the bytes back, and the reader
+    /// routes them into a sanitized, bounded staging file whose contents match.
+    #[tokio::test]
+    async fn fetch_remote_clipboard_file_stages_streamed_bytes() {
+        let (host_write, mut sidecar_stdin) = tokio::io::duplex(1024 * 1024);
+        let (mut sidecar_stdout, host_read) = tokio::io::duplex(1024 * 1024);
+        let (frame_tx, _f) = mpsc::channel(CHANNEL_DEPTH);
+        let (cursor_tx, _c) = mpsc::channel(CHANNEL_DEPTH);
+        let (cert_tx, _ce) = mpsc::channel(CHANNEL_DEPTH);
+        let (to_sidecar, sidecar_rx) = mpsc::channel(CHANNEL_DEPTH);
+
+        let shared = Arc::new(SidecarShared {
+            clipboard: Mutex::new(String::new()),
+            remote_clipboard_files: Mutex::new(vec![RemoteClipboardFile {
+                name: "hello.txt".to_string(),
+                relative_path: None,
+                size: Some(5),
+                is_dir: false,
+                index: 0,
+            }]),
+            fetches: StdMutex::new(HashMap::new()),
+            view_only: false,
+        });
+        let cancel = CancellationToken::new();
+        let reader = tokio::spawn(run_reader(
+            host_read,
+            frame_tx,
+            cursor_tx,
+            cert_tx,
+            shared.clone(),
+            cancel.clone(),
+        ));
+        let writer = tokio::spawn(run_writer(host_write, sidecar_rx, cancel.clone()));
+
+        // A fake sidecar: on the fetch request, stream the file back in two chunks.
+        let fake = tokio::spawn(async move {
+            let msg = read_message::<_, HostMessage>(&mut sidecar_stdin)
+                .await
+                .expect("fetch request");
+            let HostMessage::FetchClipboardFile { request_id, index } = msg else {
+                panic!("expected FetchClipboardFile, got {msg:?}");
+            };
+            assert_eq!(index, 0);
+            for (position, data, last) in [
+                (0u64, b"hel".to_vec(), false),
+                (3u64, b"lo".to_vec(), true),
+            ] {
+                write_message(
+                    &mut sidecar_stdout,
+                    &SidecarMessage::ClipboardFileChunk {
+                        request_id,
+                        position,
+                        data,
+                        last,
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            // Keep stdout open until the test tears down.
+            sidecar_stdout
+        });
+
+        let rdp = SidecarRdp {
+            runtime: Some(Arc::new(SidecarRuntime {
+                to_sidecar,
+                shared: shared.clone(),
+                next_fetch_id: AtomicU64::new(1),
+                cancel: cancel.clone(),
+            })),
+            frame_rx: StdMutex::new(None),
+            cursor_rx: StdMutex::new(None),
+            cert_prompt_rx: StdMutex::new(None),
+            tasks: Vec::new(),
+        };
+
+        let staged = rdp
+            .fetch_remote_clipboard_file(0)
+            .await
+            .expect("fetch should stage the file");
+        assert_eq!(std::fs::read(&staged).unwrap(), b"hello");
+        // The staged file keeps the sanitized basename.
+        assert_eq!(staged.file_name().unwrap().to_str().unwrap(), "hello.txt");
+        // The fetch registration was cleaned up.
+        assert!(shared.fetches.lock().unwrap().is_empty());
+
+        // Clean up the per-fetch staging directory.
+        if let Some(parent) = staged.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+        cancel.cancel();
+        let _ = reader.await;
+        let _ = writer.await;
+        let _ = fake.await;
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_an_unknown_index_without_touching_the_sidecar() {
+        // No runtime files surfaced → an unknown index fails fast as InvalidConfig,
+        // and (with no runtime) a disconnected backend reports NotRunning.
+        let disconnected = SidecarRdp::new();
+        assert!(disconnected.remote_clipboard_files().await.is_empty());
+        assert!(matches!(
+            disconnected.fetch_remote_clipboard_file(0).await,
+            Err(SessionError::NotRunning(_))
+        ));
+    }
+
+    #[test]
+    fn sanitize_leaf_rejects_separators_and_traversal() {
+        assert_eq!(sanitize_leaf("ok.txt"), Some("ok.txt"));
+        assert!(sanitize_leaf("").is_none());
+        assert!(sanitize_leaf("..").is_none());
+        assert!(sanitize_leaf(".").is_none());
+        assert!(sanitize_leaf("a/b").is_none());
+        assert!(sanitize_leaf("a\\b").is_none());
+        assert!(sanitize_leaf("C:evil").is_none());
+        assert!(sanitize_leaf("nul\0byte").is_none());
+    }
 }

--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -1202,10 +1202,9 @@ mod tests {
                 panic!("expected FetchClipboardFile, got {msg:?}");
             };
             assert_eq!(index, 0);
-            for (position, data, last) in [
-                (0u64, b"hel".to_vec(), false),
-                (3u64, b"lo".to_vec(), true),
-            ] {
+            for (position, data, last) in
+                [(0u64, b"hel".to_vec(), false), (3u64, b"lo".to_vec(), true)]
+            {
                 write_message(
                     &mut sidecar_stdout,
                     &SidecarMessage::ClipboardFileChunk {

--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -46,8 +46,10 @@ pub mod protocol;
 
 pub use config::rdp_settings_schema;
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -59,7 +61,7 @@ use tracing::{debug, warn};
 use crate::connection::{
     AuthKind, Capabilities, CertPrompt, CertPromptReceiver, ConnectionType, CursorReceiver,
     FrameReceiver, GraphicalBackend, GraphicalCapabilities, InputEvent, OutputReceiver,
-    SettingsSchema,
+    RemoteClipboardFile, SettingsSchema,
 };
 use crate::errors::SessionError;
 use crate::files::FileBrowser;
@@ -120,11 +122,85 @@ pub fn resolve_helper_binary() -> PathBuf {
     PathBuf::from(HELPER_BIN_NAME)
 }
 
+/// Wrap a message as a [`SessionError::Io`] (its inner type is a
+/// [`std::io::Error`], so a plain string needs boxing).
+fn io_error(message: impl Into<String>) -> SessionError {
+    SessionError::Io(std::io::Error::other(message.into()))
+}
+
+/// Validate a remote-supplied basename before it becomes a host temp-file name
+/// (#1793) — defence in depth over the sidecar's own sanitisation. Rejects an
+/// empty name, `.`/`..`, and anything carrying a path separator, drive-letter
+/// colon or NUL, so a hostile name can never escape the per-fetch staging
+/// directory. Returns the name unchanged when it is safe.
+fn sanitize_leaf(name: &str) -> Option<&str> {
+    if name.is_empty() || name == "." || name == ".." {
+        return None;
+    }
+    if name.contains(['/', '\\', '\0', ':']) {
+        return None;
+    }
+    Some(name)
+}
+
+/// Build the staging path a fetched clipboard file's bytes are written to
+/// (#1793): a per-fetch subdirectory of the OS temp dir holding the sanitized
+/// basename. A fresh directory per `request_id` means two files with the same
+/// name never collide, and the sanitized leaf cannot escape it.
+fn staged_path_for(meta: &RemoteClipboardFile, request_id: u64) -> Result<PathBuf, SessionError> {
+    let name = sanitize_leaf(&meta.name)
+        .ok_or_else(|| io_error(format!("unsafe clipboard file name {:?}", meta.name)))?;
+    let dir = std::env::temp_dir().join(format!(
+        "termihub-rdp-clip-{}-{}",
+        std::process::id(),
+        request_id
+    ));
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| io_error(format!("failed to create clipboard staging dir: {e}")))?;
+    Ok(dir.join(name))
+}
+
+/// Removes an in-flight fetch's channel registration when the
+/// `fetch_remote_clipboard_file` call returns, however it returns — so a
+/// cancelled or failed fetch never leaks its slot in [`SidecarShared::fetches`].
+struct FetchGuard {
+    shared: Arc<SidecarShared>,
+    request_id: u64,
+}
+
+impl Drop for FetchGuard {
+    fn drop(&mut self) {
+        if let Ok(mut fetches) = self.shared.fetches.lock() {
+            fetches.remove(&self.request_id);
+        }
+    }
+}
+
+/// One event of an in-flight remote-clipboard file fetch (#1793), routed from the
+/// reader task to the `fetch_remote_clipboard_file` caller by `request_id`.
+#[derive(Debug)]
+enum FetchEvent {
+    /// One streamed chunk; `last` marks the final one.
+    Chunk {
+        position: u64,
+        data: Vec<u8>,
+        last: bool,
+    },
+    /// The fetch failed (unknown/withdrawn index, remote read error).
+    Error(String),
+}
+
 /// Shared, interior-mutable state touched by the reader task and the
 /// `GraphicalBackend` command methods.
 struct SidecarShared {
     /// Latest remote clipboard text, surfaced via `get_clipboard`.
     clipboard: Mutex<String>,
+    /// The files the remote most recently copied, surfaced for a local paste
+    /// (delayed rendering, #1793). Replaced wholesale on each remote copy.
+    remote_clipboard_files: Mutex<Vec<RemoteClipboardFile>>,
+    /// In-flight file fetches keyed by request id: the reader task forwards each
+    /// [`FetchEvent`] to the waiting `fetch_remote_clipboard_file` call (#1793).
+    fetches: StdMutex<HashMap<u64, mpsc::UnboundedSender<FetchEvent>>>,
     /// Suppress input when the session is view-only.
     view_only: bool,
 }
@@ -134,6 +210,9 @@ struct SidecarRuntime {
     /// Messages flow to the sidecar's stdin over this channel (via the writer task).
     to_sidecar: mpsc::Sender<HostMessage>,
     shared: Arc<SidecarShared>,
+    /// Monotonic id allocator correlating a `FetchClipboardFile` to its streamed
+    /// chunk responses (#1793).
+    next_fetch_id: AtomicU64,
     cancel: CancellationToken,
 }
 
@@ -217,6 +296,40 @@ async fn run_reader<R>(
                     }
                     Ok(SidecarMessage::Clipboard(text)) => {
                         *shared.clipboard.lock().await = text;
+                    }
+                    Ok(SidecarMessage::RemoteClipboardFiles(files)) => {
+                        // The remote copied files; surface the list for a local
+                        // paste (#1793). Bytes are fetched later, on demand.
+                        debug!(count = files.len(), "remote clipboard file list surfaced");
+                        *shared.remote_clipboard_files.lock().await = files;
+                    }
+                    Ok(SidecarMessage::ClipboardFileChunk {
+                        request_id,
+                        position,
+                        data,
+                        last,
+                    }) => {
+                        // Route the chunk to the waiting fetch; a dropped receiver
+                        // (caller gave up) just discards it.
+                        if let Ok(fetches) = shared.fetches.lock() {
+                            if let Some(tx) = fetches.get(&request_id) {
+                                let _ = tx.send(FetchEvent::Chunk {
+                                    position,
+                                    data,
+                                    last,
+                                });
+                            }
+                        }
+                    }
+                    Ok(SidecarMessage::ClipboardFileError {
+                        request_id,
+                        message,
+                    }) => {
+                        if let Ok(fetches) = shared.fetches.lock() {
+                            if let Some(tx) = fetches.get(&request_id) {
+                                let _ = tx.send(FetchEvent::Error(message));
+                            }
+                        }
                     }
                     Ok(SidecarMessage::CertPrompt {
                         fingerprint,
@@ -398,6 +511,8 @@ impl ConnectionType for SidecarRdp {
 
         let shared = Arc::new(SidecarShared {
             clipboard: Mutex::new(String::new()),
+            remote_clipboard_files: Mutex::new(Vec::new()),
+            fetches: StdMutex::new(HashMap::new()),
             view_only,
         });
         let cancel = CancellationToken::new();
@@ -424,6 +539,7 @@ impl ConnectionType for SidecarRdp {
         self.runtime = Some(Arc::new(SidecarRuntime {
             to_sidecar,
             shared,
+            next_fetch_id: AtomicU64::new(1),
             cancel,
         }));
         Ok(())
@@ -564,6 +680,114 @@ impl GraphicalBackend for SidecarRdp {
         Ok(())
     }
 
+    async fn remote_clipboard_files(&self) -> Vec<RemoteClipboardFile> {
+        let Some(rt) = &self.runtime else {
+            return Vec::new();
+        };
+        rt.shared.remote_clipboard_files.lock().await.clone()
+    }
+
+    async fn fetch_remote_clipboard_file(&self, index: u32) -> Result<PathBuf, SessionError> {
+        let rt = self
+            .runtime
+            .as_ref()
+            .ok_or_else(|| SessionError::NotRunning("rdp not connected".to_string()))?;
+
+        // The file must be one the sidecar surfaced (#1793): the remote can only
+        // ever serve an advertised index, and its name is already sanitized.
+        let meta = {
+            let files = rt.shared.remote_clipboard_files.lock().await;
+            files
+                .iter()
+                .find(|f| f.index == index)
+                .cloned()
+                .ok_or_else(|| {
+                    SessionError::InvalidConfig(format!("unknown clipboard file index {index}"))
+                })?
+        };
+        if meta.is_dir {
+            return Err(SessionError::InvalidConfig(format!(
+                "clipboard entry {index} is a directory"
+            )));
+        }
+
+        // Register a channel for this fetch before asking, so no chunk can race in
+        // ahead of us.
+        let request_id = rt.next_fetch_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, mut rx) = mpsc::unbounded_channel::<FetchEvent>();
+        rt.shared
+            .fetches
+            .lock()
+            .map_err(|_| SessionError::NotRunning("rdp session state poisoned".to_string()))?
+            .insert(request_id, tx);
+
+        // Ensure the registration is removed however we leave this function.
+        let _guard = FetchGuard {
+            shared: rt.shared.clone(),
+            request_id,
+        };
+
+        rt.to_sidecar
+            .send(HostMessage::FetchClipboardFile { request_id, index })
+            .await
+            .map_err(|_| SessionError::NotRunning("rdp session ended".to_string()))?;
+
+        // Stage the bytes into a sanitized, per-fetch temp file, writing each
+        // chunk straight to disk so memory stays bounded regardless of file size.
+        // `std::fs` (not `tokio::fs`) matches the sidecar's own file handling and
+        // avoids requiring tokio's `fs` feature, which core is built without when
+        // it is a dependency of the sidecar; each write is at most one 8 MiB chunk.
+        use std::io::Write;
+        let staged = staged_path_for(&meta, request_id)?;
+        let mut file = std::fs::File::create(&staged)
+            .map_err(|e| io_error(format!("failed to stage clipboard file: {e}")))?;
+        let cap = meta.size; // advertised size; extra bytes beyond it are refused
+        let mut written: u64 = 0;
+        loop {
+            match rx.recv().await {
+                Some(FetchEvent::Chunk {
+                    position,
+                    data,
+                    last,
+                }) => {
+                    // Chunks must arrive in order and stay within the advertised
+                    // size (a lying remote cannot make us write unboundedly).
+                    if position != written {
+                        return Err(io_error(format!(
+                            "clipboard file chunk out of order (expected {written}, got {position})"
+                        )));
+                    }
+                    if let Some(max) = cap {
+                        if written.saturating_add(data.len() as u64) > max {
+                            return Err(io_error(
+                                "clipboard file exceeded its advertised size".to_string(),
+                            ));
+                        }
+                    }
+                    file.write_all(&data)
+                        .map_err(|e| io_error(format!("failed to stage chunk: {e}")))?;
+                    written += data.len() as u64;
+                    if last {
+                        file.flush()
+                            .map_err(|e| io_error(format!("failed to flush stage: {e}")))?;
+                        return Ok(staged);
+                    }
+                }
+                Some(FetchEvent::Error(message)) => {
+                    return Err(io_error(format!(
+                        "remote clipboard file fetch failed: {message}"
+                    )));
+                }
+                // The reader task ended (session torn down) before the final chunk.
+                None => {
+                    return Err(SessionError::NotRunning(
+                        "rdp session ended during clipboard fetch".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
     fn subscribe_cert_prompts(&self) -> Option<CertPromptReceiver> {
         self.cert_prompt_rx.lock().ok().and_then(|mut g| g.take())
     }
@@ -672,6 +896,8 @@ mod tests {
     fn test_shared() -> Arc<SidecarShared> {
         Arc::new(SidecarShared {
             clipboard: Mutex::new(String::new()),
+            remote_clipboard_files: Mutex::new(Vec::new()),
+            fetches: StdMutex::new(HashMap::new()),
             view_only: false,
         })
     }

--- a/core/src/backends/rdp_sidecar/protocol.rs
+++ b/core/src/backends/rdp_sidecar/protocol.rs
@@ -42,7 +42,9 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-use crate::connection::{CursorUpdate, FrameUpdate, GraphicalState, InputEvent};
+use crate::connection::{
+    CursorUpdate, FrameUpdate, GraphicalState, InputEvent, RemoteClipboardFile,
+};
 
 use super::config::RdpConfig;
 
@@ -71,6 +73,20 @@ pub enum HostMessage {
     /// Push local clipboard text to the remote over the sidecar's CLIPRDR
     /// channel (#1756).
     SetClipboard(String),
+    /// Fetch the bytes of one remote-copied clipboard file on demand — the paste
+    /// gesture of the remote→host **delayed-rendering** path (#1793). `index` is
+    /// the [`RemoteClipboardFile::index`] the sidecar surfaced via
+    /// [`SidecarMessage::RemoteClipboardFiles`]; `request_id` correlates the
+    /// streamed [`SidecarMessage::ClipboardFileChunk`] responses (or a
+    /// [`SidecarMessage::ClipboardFileError`]) back to this request. The sidecar
+    /// re-drives a chunked CLIPRDR `FileContentsRequest`, so the bytes are never
+    /// buffered whole.
+    FetchClipboardFile {
+        /// Correlates the streamed chunk responses to this request.
+        request_id: u64,
+        /// Advertised index of the file to fetch (a surfaced `RemoteClipboardFile`).
+        index: u32,
+    },
     /// The host's verdict on a [`SidecarMessage::CertPrompt`] (#1767): whether to
     /// proceed with the untrusted server certificate. `remember` is consumed on
     /// the host side (it owns the persisted trust store); the sidecar only acts
@@ -98,6 +114,39 @@ pub enum SidecarMessage {
     Cursor(CursorUpdate),
     /// Remote clipboard text, decoded from the sidecar's CLIPRDR channel (#1756).
     Clipboard(String),
+    /// The remote copied files to its clipboard; this surfaces the sanitized file
+    /// **list** (names, sizes, indices) to the host so it can offer them for a
+    /// local paste without fetching any bytes yet — the remote→host
+    /// **delayed-rendering** path (#1793). The host pulls a file's bytes only on a
+    /// real paste via [`HostMessage::FetchClipboardFile`]. Only emitted when
+    /// clipboard file transfer is opted in and the host advertised delayed-render
+    /// support; otherwise the sidecar keeps eagerly downloading into the shared
+    /// folder (#1765).
+    RemoteClipboardFiles(Vec<RemoteClipboardFile>),
+    /// One streamed chunk of a remote-clipboard file the host requested via
+    /// [`HostMessage::FetchClipboardFile`] (#1793). Chunks arrive in order at
+    /// increasing `position`; `last` marks the final chunk (a zero-length `data`
+    /// with `last` set denotes an empty file). Each chunk is at most the CLIPRDR
+    /// streaming chunk size (8 MiB), so neither end buffers the whole file.
+    ClipboardFileChunk {
+        /// The [`HostMessage::FetchClipboardFile::request_id`] this chunk answers.
+        request_id: u64,
+        /// Byte offset of this chunk within the file.
+        position: u64,
+        /// The chunk's bytes (empty only for an empty final chunk).
+        data: Vec<u8>,
+        /// Whether this is the final chunk of the file.
+        last: bool,
+    },
+    /// A remote-clipboard file fetch failed (unknown/withdrawn index, a directory
+    /// index, or a CLIPRDR read error) — terminates the
+    /// [`HostMessage::FetchClipboardFile`] identified by `request_id` (#1793).
+    ClipboardFileError {
+        /// The [`HostMessage::FetchClipboardFile::request_id`] that failed.
+        request_id: u64,
+        /// Human-readable reason, for logs.
+        message: String,
+    },
     /// The server presented an untrusted certificate and the sidecar needs an
     /// interactive trust decision (#1767). The sidecar blocks the connect until
     /// the host replies with [`HostMessage::CertDecision`] (or a timeout aborts
@@ -329,6 +378,52 @@ mod tests {
         ] {
             assert_eq!(round_trip_host(decision.clone()).await, decision);
         }
+    }
+
+    #[tokio::test]
+    async fn remote_clipboard_files_round_trip() {
+        // The surfaced remote-copied file list (#1793) must survive the framed
+        // codec, including a nested relative path and an unknown-size entry.
+        let msg = SidecarMessage::RemoteClipboardFiles(vec![
+            RemoteClipboardFile {
+                name: "report.pdf".to_string(),
+                relative_path: None,
+                size: Some(1234),
+                is_dir: false,
+                index: 0,
+            },
+            RemoteClipboardFile {
+                name: "nested.txt".to_string(),
+                relative_path: Some("dir/sub".to_string()),
+                size: None,
+                is_dir: false,
+                index: 2,
+            },
+        ]);
+        assert_eq!(round_trip_sidecar(msg.clone()).await, msg);
+    }
+
+    #[tokio::test]
+    async fn fetch_clipboard_file_and_chunk_round_trip() {
+        let fetch = HostMessage::FetchClipboardFile {
+            request_id: 7,
+            index: 3,
+        };
+        assert_eq!(round_trip_host(fetch.clone()).await, fetch);
+
+        let chunk = SidecarMessage::ClipboardFileChunk {
+            request_id: 7,
+            position: 8,
+            data: vec![9, 8, 7, 6, 5],
+            last: true,
+        };
+        assert_eq!(round_trip_sidecar(chunk.clone()).await, chunk);
+
+        let err = SidecarMessage::ClipboardFileError {
+            request_id: 7,
+            message: "unknown index".to_string(),
+        };
+        assert_eq!(round_trip_sidecar(err.clone()).await, err);
     }
 
     #[tokio::test]

--- a/core/src/connection/graphical.rs
+++ b/core/src/connection/graphical.rs
@@ -345,6 +345,35 @@ pub struct GraphicalCapabilities {
     pub view_only_capable: bool,
 }
 
+/// Metadata for one file the remote copied to its clipboard, surfaced to the
+/// host so it can offer the file for a local paste and fetch the bytes on demand
+/// — **delayed rendering** (#1793).
+///
+/// The [`index`](Self::index) is the file's position in the remote's advertised
+/// file list; it is the opaque token the host passes back to
+/// [`GraphicalBackend::fetch_remote_clipboard_file`] to pull the bytes. The
+/// remote only ever selects an advertised index, never a path, so it can never
+/// coax the host into fetching a file it did not copy. `name`/`relative_path`
+/// are already sanitized by the backend before they are surfaced (no `..`,
+/// absolute paths, drive letters, `:`/NUL, or reserved device names), but the
+/// host re-validates them before they reach any local path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteClipboardFile {
+    /// Sanitized basename (no path separators).
+    pub name: String,
+    /// Sanitized `/`-separated directory portion within the copied collection, or
+    /// `None` for a top-level entry — lets the host rebuild a copied tree.
+    pub relative_path: Option<String>,
+    /// File size when the remote advertised it; `None` means "resolve on fetch".
+    pub size: Option<u64>,
+    /// Whether this entry is a directory (no bytes to fetch, offered only so the
+    /// host can recreate the folder).
+    pub is_dir: bool,
+    /// Position in the remote's advertised file list — the fetch token.
+    pub index: u32,
+}
+
 /// The shared graphical-session lifecycle state.
 ///
 /// Identical for every protocol: the frontend renders overlays and the tab
@@ -578,6 +607,33 @@ pub trait GraphicalBackend: Send + Sync {
 
     /// Push local clipboard text to the remote.
     async fn set_clipboard(&self, text: String) -> Result<(), SessionError>;
+
+    /// The files the remote most recently copied to its clipboard, surfaced for a
+    /// local paste (#1793). Empty when the backend does not support remote→host
+    /// file transfer, the feature is not opted in, or the remote copied no files
+    /// (it copied text, an image, or nothing). The bytes are **not** fetched here
+    /// — that is deferred to [`Self::fetch_remote_clipboard_file`], which pulls
+    /// them on the paste gesture (delayed rendering). Defaults to empty.
+    async fn remote_clipboard_files(&self) -> Vec<RemoteClipboardFile> {
+        Vec::new()
+    }
+
+    /// Fetch the bytes of one surfaced remote-clipboard file on demand (delayed
+    /// rendering, #1793), streaming them into a sanitized, bounded local staging
+    /// file and returning its path. `index` is the
+    /// [`RemoteClipboardFile::index`] of an entry a prior
+    /// [`Self::remote_clipboard_files`] surfaced — the only files a fetch can
+    /// name. Backends without remote→host file transfer return
+    /// [`SessionError::NotRunning`]. Defaults to unsupported.
+    async fn fetch_remote_clipboard_file(
+        &self,
+        index: u32,
+    ) -> Result<std::path::PathBuf, SessionError> {
+        let _ = index;
+        Err(SessionError::NotRunning(
+            "remote clipboard file transfer is not supported by this backend".to_string(),
+        ))
+    }
 
     /// Subscribe to interactive server-certificate trust prompts (#1767).
     ///

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -21,7 +21,7 @@ pub mod validation;
 pub use graphical::{
     shared_field_base, AuthKind, CertPrompt, CertPromptReceiver, CursorReceiver, CursorShape,
     CursorUpdate, DirtyRect, FrameReceiver, FrameUpdate, GraphicalBackend, GraphicalCapabilities,
-    GraphicalState, InputEvent, SessionStateMachine, MAX_RECONNECT_ATTEMPTS,
+    GraphicalState, InputEvent, RemoteClipboardFile, SessionStateMachine, MAX_RECONNECT_ATTEMPTS,
 };
 pub use registry::{ConnectionFactory, ConnectionTypeInfo, ConnectionTypeRegistry};
 pub use schema::*;

--- a/rdp-sidecar/src/clipboard.rs
+++ b/rdp-sidecar/src/clipboard.rs
@@ -2483,4 +2483,304 @@ mod tests {
             other => panic!("expected the shared-folder offer, got {other:?}"),
         }
     }
+
+    // --- Remote→host delayed rendering (#1793) ---
+
+    /// A file-transfer backend with delayed rendering enabled.
+    fn backend_delayed() -> (
+        SidecarClipboardBackend,
+        Receiver<ClipboardEvent>,
+        tempfile::TempDir,
+    ) {
+        let (mut backend, rx, dir) = backend_with_download();
+        backend.set_delayed_render(true);
+        (backend, rx, dir)
+    }
+
+    #[test]
+    fn sanitize_descriptor_keeps_safe_paths_and_rejects_escapes() {
+        // A plain file keeps its name/size and top-level (no relative path).
+        let m = sanitize_descriptor(&FileDescriptor::new("a.txt").with_file_size(3), 0).unwrap();
+        assert_eq!(m.name, "a.txt");
+        assert_eq!(m.relative_path, None);
+        assert_eq!(m.size, Some(3));
+        assert!(!m.is_dir);
+        assert_eq!(m.index, 0);
+
+        // A nested file's `\`-relative path becomes a `/`-separated one; the
+        // descriptor index is preserved as the fetch token.
+        let nested = FileDescriptor::new("leaf.bin")
+            .with_relative_path("dir\\sub")
+            .with_file_size(1);
+        let m = sanitize_descriptor(&nested, 5).unwrap();
+        assert_eq!(m.name, "leaf.bin");
+        assert_eq!(m.relative_path.as_deref(), Some("dir/sub"));
+        assert_eq!(m.index, 5);
+
+        // A directory descriptor is surfaced as a directory (no bytes).
+        let d =
+            FileDescriptor::new("folder").with_attributes(ClipboardFileAttributes::DIRECTORY);
+        assert!(sanitize_descriptor(&d, 0).unwrap().is_dir);
+
+        // Hostile paths are dropped: `..`, traversal in the relative path, a drive
+        // letter / colon, and a reserved device name on any component.
+        assert!(sanitize_descriptor(&FileDescriptor::new("..").with_file_size(1), 0).is_none());
+        assert!(sanitize_descriptor(
+            &FileDescriptor::new("evil").with_relative_path("..\\..\\etc"),
+            0
+        )
+        .is_none());
+        assert!(sanitize_descriptor(&FileDescriptor::new("C:").with_file_size(1), 0).is_none());
+        assert!(sanitize_descriptor(
+            &FileDescriptor::new("x").with_relative_path("C:\\Windows"),
+            0
+        )
+        .is_none());
+        assert!(sanitize_descriptor(&FileDescriptor::new("CON").with_file_size(1), 0).is_none());
+    }
+
+    #[test]
+    fn delayed_render_surfaces_a_sanitized_list_without_downloading() {
+        let (mut backend, rx, _dir) = backend_delayed();
+        backend.on_remote_file_list(
+            &[
+                FileDescriptor::new("doc.txt").with_file_size(5),
+                // Hostile entry — dropped from the surfaced list.
+                FileDescriptor::new("..").with_file_size(9),
+                FileDescriptor::new("nested.bin")
+                    .with_relative_path("d")
+                    .with_file_size(2),
+            ],
+            None,
+        );
+        match next_event(&rx) {
+            ClipboardEvent::SurfaceRemoteFiles(files) => {
+                assert_eq!(files.len(), 2);
+                assert_eq!(files[0].name, "doc.txt");
+                assert_eq!(files[0].index, 0);
+                assert_eq!(files[1].name, "nested.bin");
+                assert_eq!(files[1].relative_path.as_deref(), Some("d"));
+                // The original descriptor index (2) survives the dropped entry, so
+                // it still keys the right file for a fetch.
+                assert_eq!(files[1].index, 2);
+            }
+            other => panic!("expected SurfaceRemoteFiles, got {other:?}"),
+        }
+        // Delayed rendering never eagerly downloads: no file-contents request.
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn eager_download_stays_the_default_without_delayed_render() {
+        let (mut backend, rx, _dir) = backend_with_download();
+        backend.on_remote_file_list(&[FileDescriptor::new("f.txt").with_file_size(3)], None);
+        // The eager path issues a file-contents request, not a surface event.
+        let req = next_request(&rx);
+        assert!(req.flags.contains(FileContentsFlags::RANGE));
+    }
+
+    #[test]
+    fn delayed_render_without_opt_in_surfaces_nothing() {
+        // Delayed rendering is meaningless without the file-transfer opt-in (no
+        // shared folder), so a remote copy surfaces nothing.
+        let (mut backend, rx) = SidecarClipboardBackend::new(None, false);
+        backend.set_delayed_render(true);
+        backend.on_remote_file_list(&[FileDescriptor::new("a.txt").with_file_size(1)], None);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn fetch_streams_a_file_to_the_host_in_bounded_chunks() {
+        let (mut backend, rx, _dir) = backend_delayed();
+        backend.set_chunk_bytes(4);
+        backend.on_remote_file_list(&[FileDescriptor::new("big.bin").with_file_size(10)], None);
+        let _ = next_event(&rx); // SurfaceRemoteFiles
+
+        backend.fetch_remote_file(42, 0);
+
+        // Chunk 1: a RANGE request bounded to the chunk size, streamed to the host.
+        let r1 = next_request(&rx);
+        assert_eq!(r1.position, 0);
+        assert_eq!(r1.requested_size, 4);
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            r1.stream_id,
+            b"aaaa".to_vec(),
+        ));
+        match next_event(&rx) {
+            ClipboardEvent::ProvideRemoteFileChunk {
+                request_id,
+                position,
+                data,
+                last,
+            } => {
+                assert_eq!(request_id, 42);
+                assert_eq!(position, 0);
+                assert_eq!(data, b"aaaa");
+                // Never more than one chunk in memory.
+                assert!(data.len() as u64 <= 4);
+                assert!(!last);
+            }
+            other => panic!("expected a streamed chunk, got {other:?}"),
+        }
+
+        // Chunk 2: [4, 8).
+        let r2 = next_request(&rx);
+        assert_eq!(r2.position, 4);
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            r2.stream_id,
+            b"bbbb".to_vec(),
+        ));
+        let _ = next_event(&rx);
+
+        // Chunk 3: [8, 10) — only the remaining 2 bytes, marked last.
+        let r3 = next_request(&rx);
+        assert_eq!(r3.position, 8);
+        assert_eq!(r3.requested_size, 2);
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            r3.stream_id,
+            b"cc".to_vec(),
+        ));
+        match next_event(&rx) {
+            ClipboardEvent::ProvideRemoteFileChunk {
+                position, data, last, ..
+            } => {
+                assert_eq!(position, 8);
+                assert_eq!(data, b"cc");
+                assert!(last);
+            }
+            other => panic!("expected the final chunk, got {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn fetch_resolves_an_unknown_size_then_streams() {
+        let (mut backend, rx, _dir) = backend_delayed();
+        backend.on_remote_file_list(&[FileDescriptor::new("data.bin")], None);
+        let _ = next_event(&rx); // surface (no advertised size)
+
+        backend.fetch_remote_file(7, 0);
+        let size_req = next_request(&rx);
+        assert!(size_req.flags.contains(FileContentsFlags::SIZE));
+        backend.on_file_contents_response(FileContentsResponse::new_size_response(
+            size_req.stream_id,
+            3,
+        ));
+        let range_req = next_request(&rx);
+        assert!(range_req.flags.contains(FileContentsFlags::RANGE));
+        assert_eq!(range_req.requested_size, 3);
+        backend.on_file_contents_response(FileContentsResponse::new_data_response(
+            range_req.stream_id,
+            b"abc".to_vec(),
+        ));
+        match next_event(&rx) {
+            ClipboardEvent::ProvideRemoteFileChunk {
+                request_id,
+                data,
+                last,
+                ..
+            } => {
+                assert_eq!(request_id, 7);
+                assert_eq!(data, b"abc");
+                assert!(last);
+            }
+            other => panic!("expected the streamed chunk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fetch_of_an_empty_file_yields_an_empty_final_chunk() {
+        let (mut backend, rx, _dir) = backend_delayed();
+        backend.on_remote_file_list(&[FileDescriptor::new("empty.txt").with_file_size(0)], None);
+        let _ = next_event(&rx); // surface
+
+        backend.fetch_remote_file(1, 0);
+        match next_event(&rx) {
+            ClipboardEvent::ProvideRemoteFileChunk {
+                position,
+                data,
+                last,
+                ..
+            } => {
+                assert_eq!(position, 0);
+                assert!(data.is_empty());
+                assert!(last);
+            }
+            other => panic!("expected an empty final chunk, got {other:?}"),
+        }
+        // An empty file needs no byte-range request.
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn fetch_rejects_unknown_directory_and_not_enabled() {
+        // An index the remote never advertised is refused.
+        let (mut backend, rx, _dir) = backend_delayed();
+        backend.on_remote_file_list(&[FileDescriptor::new("a.txt").with_file_size(1)], None);
+        let _ = next_event(&rx);
+        backend.fetch_remote_file(1, 99);
+        assert!(matches!(
+            next_event(&rx),
+            ClipboardEvent::RemoteFileError { request_id: 1, .. }
+        ));
+
+        // A directory index carries no bytes.
+        let (mut backend, rx, _dir) = backend_delayed();
+        backend.on_remote_file_list(
+            &[FileDescriptor::new("dir").with_attributes(ClipboardFileAttributes::DIRECTORY)],
+            None,
+        );
+        let _ = next_event(&rx);
+        backend.fetch_remote_file(2, 0);
+        assert!(matches!(
+            next_event(&rx),
+            ClipboardEvent::RemoteFileError { request_id: 2, .. }
+        ));
+
+        // A backend that is not in delayed-render mode has surfaced nothing.
+        let (mut backend, rx, _dir) = backend_with_download();
+        backend.fetch_remote_file(3, 0);
+        assert!(matches!(
+            next_event(&rx),
+            ClipboardEvent::RemoteFileError { request_id: 3, .. }
+        ));
+    }
+
+    #[test]
+    fn a_second_fetch_while_one_is_in_flight_is_rejected() {
+        let (mut backend, rx, _dir) = backend_delayed();
+        backend.on_remote_file_list(
+            &[
+                FileDescriptor::new("a.bin").with_file_size(4),
+                FileDescriptor::new("b.bin").with_file_size(4),
+            ],
+            None,
+        );
+        let _ = next_event(&rx);
+        backend.fetch_remote_file(1, 0);
+        let _ = next_request(&rx); // first fetch now in flight
+        backend.fetch_remote_file(2, 1);
+        assert!(matches!(
+            next_event(&rx),
+            ClipboardEvent::RemoteFileError { request_id: 2, .. }
+        ));
+    }
+
+    #[test]
+    fn a_remote_error_mid_fetch_terminates_and_frees_the_slot() {
+        let (mut backend, rx, _dir) = backend_delayed();
+        backend.on_remote_file_list(&[FileDescriptor::new("a.bin").with_file_size(4)], None);
+        let _ = next_event(&rx);
+        backend.fetch_remote_file(5, 0);
+        let req = next_request(&rx);
+        backend.on_file_contents_response(FileContentsResponse::new_error(req.stream_id));
+        assert!(matches!(
+            next_event(&rx),
+            ClipboardEvent::RemoteFileError { request_id: 5, .. }
+        ));
+        // The in-flight slot was freed, so a fresh fetch can proceed.
+        backend.fetch_remote_file(6, 0);
+        let req2 = next_request(&rx);
+        assert!(req2.flags.contains(FileContentsFlags::RANGE));
+    }
 }

--- a/rdp-sidecar/src/clipboard.rs
+++ b/rdp-sidecar/src/clipboard.rs
@@ -1345,7 +1345,10 @@ impl CliprdrBackend for SidecarClipboardBackend {
                     self.start_next_download();
                 }
                 TransferDest::Host { request_id } => {
-                    warn!(request_id, "remote returned an error for a fetched clipboard file");
+                    warn!(
+                        request_id,
+                        "remote returned an error for a fetched clipboard file"
+                    );
                     self.finish_host_fetch(*request_id, Err("remote refused the file".to_string()));
                 }
             }
@@ -1430,7 +1433,11 @@ impl CliprdrBackend for SidecarClipboardBackend {
                             self.start_next_download();
                         }
                         TransferDest::Host { request_id } => {
-                            debug!(request_id, bytes = written, "streamed fetched clipboard file to host");
+                            debug!(
+                                request_id,
+                                bytes = written,
+                                "streamed fetched clipboard file to host"
+                            );
                             self.active_download = None;
                         }
                     }
@@ -2518,8 +2525,7 @@ mod tests {
         assert_eq!(m.index, 5);
 
         // A directory descriptor is surfaced as a directory (no bytes).
-        let d =
-            FileDescriptor::new("folder").with_attributes(ClipboardFileAttributes::DIRECTORY);
+        let d = FileDescriptor::new("folder").with_attributes(ClipboardFileAttributes::DIRECTORY);
         assert!(sanitize_descriptor(&d, 0).unwrap().is_dir);
 
         // Hostile paths are dropped: `..`, traversal in the relative path, a drive
@@ -2642,7 +2648,10 @@ mod tests {
         ));
         match next_event(&rx) {
             ClipboardEvent::ProvideRemoteFileChunk {
-                position, data, last, ..
+                position,
+                data,
+                last,
+                ..
             } => {
                 assert_eq!(position, 8);
                 assert_eq!(data, b"cc");

--- a/rdp-sidecar/src/clipboard.rs
+++ b/rdp-sidecar/src/clipboard.rs
@@ -88,6 +88,7 @@ use ironrdp::cliprdr::pdu::{
     FileDescriptor, FormatDataRequest, FormatDataResponse, LockDataId,
 };
 use ironrdp::core::AsAny;
+use termihub_core::connection::RemoteClipboardFile;
 use tracing::{debug, trace, warn};
 
 use crate::host_clipboard::read_host_clipboard_files;
@@ -129,6 +130,32 @@ pub enum ClipboardEvent {
     /// while pasting (#1778). The driver calls
     /// [`Cliprdr::submit_file_contents`](ironrdp::cliprdr::Cliprdr::submit_file_contents).
     ProvideFileContents(FileContentsResponse<'static>),
+    /// The remote copied files and delayed rendering is on: surface the sanitized
+    /// file **list** to the host (over IPC) so it can offer them for a local paste
+    /// without fetching any bytes yet (#1793). The driver forwards it as
+    /// [`SidecarMessage::RemoteClipboardFiles`](termihub_core::backends::rdp_sidecar::protocol::SidecarMessage::RemoteClipboardFiles).
+    SurfaceRemoteFiles(Vec<RemoteClipboardFile>),
+    /// One streamed chunk of a remote-clipboard file the host asked for by index
+    /// (#1793): the driver forwards it as
+    /// [`SidecarMessage::ClipboardFileChunk`](termihub_core::backends::rdp_sidecar::protocol::SidecarMessage::ClipboardFileChunk).
+    ProvideRemoteFileChunk {
+        /// Correlates to the host's `FetchClipboardFile` request.
+        request_id: u64,
+        /// Byte offset of this chunk within the file.
+        position: u64,
+        /// The chunk's bytes (empty only for an empty final chunk).
+        data: Vec<u8>,
+        /// Whether this is the final chunk.
+        last: bool,
+    },
+    /// A host file-fetch failed; the driver forwards it as
+    /// [`SidecarMessage::ClipboardFileError`](termihub_core::backends::rdp_sidecar::protocol::SidecarMessage::ClipboardFileError) (#1793).
+    RemoteFileError {
+        /// Correlates to the host's `FetchClipboardFile` request.
+        request_id: u64,
+        /// Human-readable reason.
+        message: String,
+    },
 }
 
 /// Pick the best text format the remote advertised: prefer Unicode, fall back to
@@ -230,15 +257,29 @@ enum DownloadPhase {
     Range,
 }
 
-/// The single in-flight file download, keyed by the stream id we assigned. A
+/// Where an in-flight file transfer's bytes go: eagerly onto disk in the shared
+/// folder (#1765), or streamed back to the host for a delayed-render paste
+/// (#1793). The two never interleave — an eager download runs only when delayed
+/// rendering is off, and a host fetch only when it is on — so a single in-flight
+/// slot serves both.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TransferDest {
+    /// Eager download: write each chunk into this sandboxed shared-folder path.
+    Disk(PathBuf),
+    /// Delayed render: forward each chunk to the host for this fetch request.
+    Host { request_id: u64 },
+}
+
+/// The single in-flight file transfer, keyed by the stream id we assigned. A
 /// large file is fetched over several `RANGE` requests; `position`/`total` track
-/// how far the streaming write has progressed so each chunk lands at the right
-/// offset and the transfer stops at EOF (#1780).
+/// how far the streaming transfer has progressed so each chunk lands at the right
+/// offset and it stops at EOF (#1780). `dest` decides whether a chunk is written
+/// to disk or streamed to the host (#1793).
 #[derive(Debug, Clone)]
 struct ActiveDownload {
     stream_id: u32,
     index: i32,
-    dest: PathBuf,
+    dest: TransferDest,
     phase: DownloadPhase,
     /// Byte offset the next `RANGE` chunk is written at (0 during a `SIZE` phase).
     position: u64,
@@ -286,6 +327,16 @@ pub struct SidecarClipboardBackend {
     /// [`CLIPBOARD_CHUNK_BYTES`]; a field so tests can shrink it to exercise the
     /// multi-chunk path without multi-megabyte fixtures.
     chunk_bytes: u64,
+    /// When `true`, a remote file copy is **surfaced** to the host as a file list
+    /// (delayed rendering, #1793) instead of eagerly downloaded into the shared
+    /// folder (#1765). Set from [`RdpConfig::clipboard_delayed_render_enabled`].
+    delayed_render: bool,
+    /// The sanitized file list last surfaced to the host in delayed-render mode
+    /// (#1793). A [`Self::fetch_remote_file`] may only name an `index` present
+    /// here, so the remote can never coax a fetch of a file it did not advertise.
+    /// Empty until a remote copy is surfaced; carries each entry's advertised size
+    /// and directory flag.
+    remote_offer: Vec<RemoteClipboardFile>,
 }
 
 impl std::fmt::Debug for SidecarClipboardBackend {
@@ -301,6 +352,8 @@ impl std::fmt::Debug for SidecarClipboardBackend {
             .field("view_only", &self.view_only)
             .field("offered_files", &self.offered_files)
             .field("chunk_bytes", &self.chunk_bytes)
+            .field("delayed_render", &self.delayed_render)
+            .field("remote_offer", &self.remote_offer)
             .finish_non_exhaustive()
     }
 }
@@ -369,9 +422,20 @@ impl SidecarClipboardBackend {
                 offered_files: Vec::new(),
                 host_clip_reader: Box::new(host_clip_reader),
                 chunk_bytes: CLIPBOARD_CHUNK_BYTES,
+                delayed_render: false,
+                remote_offer: Vec::new(),
             },
             rx,
         )
+    }
+
+    /// Enable (or disable) remote→host delayed rendering (#1793). When on, a
+    /// remote file copy surfaces its file list to the host rather than eagerly
+    /// downloading it into the shared folder; the host then fetches a file's
+    /// bytes on demand via [`Self::fetch_remote_file`]. Set from
+    /// [`RdpConfig::clipboard_delayed_render_enabled`] at connect time.
+    pub fn set_delayed_render(&mut self, enabled: bool) {
+        self.delayed_render = enabled;
     }
 
     /// Shrink the streaming chunk size (tests only) so the multi-chunk download
@@ -445,6 +509,19 @@ impl SidecarClipboardBackend {
     fn emit(&self, event: ClipboardEvent) {
         if self.tx.send(event).is_err() {
             debug!("clipboard event receiver dropped; sidecar shutting down");
+        }
+    }
+
+    /// Terminate an in-flight host fetch (#1793): clear the in-flight slot and
+    /// tell the host the fetch failed, so its paste never hangs on a request the
+    /// remote refused or could not answer.
+    fn finish_host_fetch(&mut self, request_id: u64, result: Result<(), String>) {
+        self.active_download = None;
+        if let Err(message) = result {
+            self.emit(ClipboardEvent::RemoteFileError {
+                request_id,
+                message,
+            });
         }
     }
 
@@ -542,7 +619,11 @@ impl SidecarClipboardBackend {
                 }
                 Some(size) => {
                     // Size known: stream it, starting with the first chunk.
-                    self.begin_range_download(planned.index, planned.dest, size);
+                    self.begin_range_download(
+                        planned.index,
+                        TransferDest::Disk(planned.dest),
+                        size,
+                    );
                     return;
                 }
                 None => {
@@ -551,7 +632,7 @@ impl SidecarClipboardBackend {
                     self.active_download = Some(ActiveDownload {
                         stream_id,
                         index: planned.index,
-                        dest: planned.dest,
+                        dest: TransferDest::Disk(planned.dest),
                         phase: DownloadPhase::Size,
                         position: 0,
                         total: 0,
@@ -567,10 +648,11 @@ impl SidecarClipboardBackend {
     }
 
     /// Begin (or, from [`Self::start_next_download`], restart) a chunked byte
-    /// download of a known-size file: request the first [`Self::chunk_bytes`]
+    /// transfer of a known-size file: request the first [`Self::chunk_bytes`]
     /// range and record the transfer so [`Self::on_file_contents_response`]
-    /// continues it chunk by chunk until EOF (#1780).
-    fn begin_range_download(&mut self, index: i32, dest: PathBuf, total: u64) {
+    /// continues it chunk by chunk until EOF (#1780). `dest` routes each chunk to
+    /// disk (eager download) or the host (delayed render, #1793).
+    fn begin_range_download(&mut self, index: i32, dest: TransferDest, total: u64) {
         let stream_id = self.allocate_stream_id();
         let want = total.min(self.chunk_bytes);
         self.active_download = Some(ActiveDownload {
@@ -585,6 +667,124 @@ impl SidecarClipboardBackend {
             stream_id, index, 0, want,
         )));
     }
+
+    /// Fetch one remote-clipboard file's bytes on demand — the paste gesture of
+    /// the delayed-render path (#1793). Validates `index` against the sanitized
+    /// [`Self::remote_offer`] the host was shown (so the remote can only ever
+    /// serve a file it advertised), then drives the same chunked CLIPRDR
+    /// `FileContentsRequest` machinery as an eager download, but streams each
+    /// chunk back to the host instead of writing it to disk. Any failure emits a
+    /// [`ClipboardEvent::RemoteFileError`] so the host's fetch always terminates.
+    ///
+    /// Serves one fetch at a time: a request arriving while another is in flight
+    /// is rejected (the host paces its fetches), which keeps the single-in-flight
+    /// memory bound and stream-id bookkeeping trivial.
+    pub fn fetch_remote_file(&mut self, request_id: u64, index: u32) {
+        if !self.delayed_render || self.download_dir.is_none() {
+            self.emit(ClipboardEvent::RemoteFileError {
+                request_id,
+                message: "remote clipboard file transfer is not enabled".to_string(),
+            });
+            return;
+        }
+        let Some(meta) = self.remote_offer.iter().find(|f| f.index == index) else {
+            self.emit(ClipboardEvent::RemoteFileError {
+                request_id,
+                message: format!("unknown clipboard file index {index}"),
+            });
+            return;
+        };
+        if meta.is_dir {
+            self.emit(ClipboardEvent::RemoteFileError {
+                request_id,
+                message: format!("clipboard entry {index} is a directory"),
+            });
+            return;
+        }
+        if self.active_download.is_some() {
+            self.emit(ClipboardEvent::RemoteFileError {
+                request_id,
+                message: "another clipboard fetch is already in progress".to_string(),
+            });
+            return;
+        }
+        let size = meta.size;
+        // The advertised list index is the CLIPRDR file-list index the server
+        // keys a `FileContentsRequest` on.
+        let Ok(idx) = i32::try_from(index) else {
+            self.emit(ClipboardEvent::RemoteFileError {
+                request_id,
+                message: format!("clipboard file index {index} out of range"),
+            });
+            return;
+        };
+        let dest = TransferDest::Host { request_id };
+        match size {
+            Some(0) => {
+                // Known-empty file: no range to request; hand the host an empty
+                // final chunk so its fetch completes.
+                self.emit(ClipboardEvent::ProvideRemoteFileChunk {
+                    request_id,
+                    position: 0,
+                    data: Vec::new(),
+                    last: true,
+                });
+            }
+            Some(total) => self.begin_range_download(idx, dest, total),
+            None => {
+                // Size unknown: ask for it first, then the bytes.
+                let stream_id = self.allocate_stream_id();
+                self.active_download = Some(ActiveDownload {
+                    stream_id,
+                    index: idx,
+                    dest,
+                    phase: DownloadPhase::Size,
+                    position: 0,
+                    total: 0,
+                });
+                self.emit(ClipboardEvent::RequestFileContents(size_request(
+                    stream_id, idx,
+                )));
+            }
+        }
+    }
+}
+
+/// Sanitize one remote file descriptor into the metadata surfaced to the host
+/// (#1793), or `None` when its path is unusable/hostile. The descriptor's
+/// `relative_path\name` is split into components, each of which must be a plain
+/// name — no `.`/`..`, no drive letter or `:`/NUL, no reserved Windows device
+/// name — so nothing that reaches the host clipboard or a host temp path can
+/// escape a directory or name a device. The returned `index` is the descriptor's
+/// position in the remote file list, which a later `FileContentsRequest` keys on.
+fn sanitize_descriptor(file: &FileDescriptor, index: usize) -> Option<RemoteClipboardFile> {
+    let rel = descriptor_rel_path(file)?;
+    let mut parts: Vec<String> = Vec::new();
+    for component in rel.split(['\\', '/']) {
+        if component.is_empty() {
+            continue;
+        }
+        if component == "." || component == ".." {
+            return None;
+        }
+        if component.contains('\0') || component.contains(':') {
+            return None;
+        }
+        if is_windows_device_name(component) {
+            return None;
+        }
+        parts.push(component.to_string());
+    }
+    let name = parts.pop()?;
+    let relative_path = (!parts.is_empty()).then(|| parts.join("/"));
+    let index = u32::try_from(index).ok()?;
+    Some(RemoteClipboardFile {
+        name,
+        relative_path,
+        size: file.file_size,
+        is_dir: descriptor_is_dir(file),
+        index,
+    })
 }
 
 /// Build a deduplicated basename: `file.txt`, then `file (1).txt`, … keeping the
@@ -1081,6 +1281,24 @@ impl CliprdrBackend for SidecarClipboardBackend {
         if self.download_dir.is_none() {
             return;
         }
+        if self.delayed_render {
+            // Delayed rendering: surface the sanitized list to the host and fetch
+            // bytes only when it later pastes (#1793) — do not download eagerly.
+            self.download_queue.clear();
+            self.active_download = None;
+            let offer: Vec<RemoteClipboardFile> = files
+                .iter()
+                .enumerate()
+                .filter_map(|(i, f)| sanitize_descriptor(f, i))
+                .collect();
+            debug!(
+                count = offer.len(),
+                "surfacing remote clipboard file list to host (delayed render)"
+            );
+            self.remote_offer = offer.clone();
+            self.emit(ClipboardEvent::SurfaceRemoteFiles(offer));
+            return;
+        }
         self.download_queue = self.plan_downloads(files);
         debug!(
             count = self.download_queue.len(),
@@ -1121,54 +1339,101 @@ impl CliprdrBackend for SidecarClipboardBackend {
         let active = active.clone();
 
         if response.is_error() {
-            warn!(path = %active.dest.display(), "remote returned an error for a clipboard file; skipping");
-            self.start_next_download();
+            match &active.dest {
+                TransferDest::Disk(dest) => {
+                    warn!(path = %dest.display(), "remote returned an error for a clipboard file; skipping");
+                    self.start_next_download();
+                }
+                TransferDest::Host { request_id } => {
+                    warn!(request_id, "remote returned an error for a fetched clipboard file");
+                    self.finish_host_fetch(*request_id, Err("remote refused the file".to_string()));
+                }
+            }
             return;
         }
 
         match active.phase {
             DownloadPhase::Size => match response.data_as_size() {
-                Ok(0) => {
-                    if let Err(e) = std::fs::write(&active.dest, []) {
-                        warn!(error = %e, path = %active.dest.display(), "failed to create empty clipboard file");
+                Ok(0) => match &active.dest {
+                    TransferDest::Disk(dest) => {
+                        if let Err(e) = std::fs::write(dest, []) {
+                            warn!(error = %e, path = %dest.display(), "failed to create empty clipboard file");
+                        }
+                        self.start_next_download();
                     }
-                    self.start_next_download();
-                }
+                    TransferDest::Host { request_id } => {
+                        let request_id = *request_id;
+                        self.active_download = None;
+                        self.emit(ClipboardEvent::ProvideRemoteFileChunk {
+                            request_id,
+                            position: 0,
+                            data: Vec::new(),
+                            last: true,
+                        });
+                    }
+                },
                 Ok(size) => {
-                    // Size resolved: stream the bytes, chunked, on the same file.
+                    // Size resolved: stream the bytes, chunked, to the same dest.
                     self.begin_range_download(active.index, active.dest, size);
                 }
-                Err(e) => {
-                    warn!(error = %e, "malformed file size response; skipping file");
-                    self.start_next_download();
-                }
+                Err(e) => match &active.dest {
+                    TransferDest::Disk(_) => {
+                        warn!(error = %e, "malformed file size response; skipping file");
+                        self.start_next_download();
+                    }
+                    TransferDest::Host { request_id } => {
+                        warn!(error = %e, "malformed file size response for a host fetch");
+                        self.finish_host_fetch(
+                            *request_id,
+                            Err("malformed file size response".to_string()),
+                        );
+                    }
+                },
             },
             DownloadPhase::Range => {
                 let chunk = response.data();
-                if let Err(e) = write_chunk(&active.dest, active.position, chunk) {
-                    warn!(error = %e, path = %active.dest.display(), "failed to write clipboard file chunk; skipping file");
-                    self.start_next_download();
-                    return;
-                }
                 let written = active.position + chunk.len() as u64;
                 // Stop at EOF: either we reached the advertised total, or the
                 // remote returned a short/empty chunk (all it had left).
-                if chunk.is_empty() || written >= active.total {
-                    if written < active.total {
-                        warn!(
-                            got = written,
-                            expected = active.total,
-                            path = %active.dest.display(),
-                            "clipboard file ended before its advertised size; wrote a partial file"
-                        );
-                    } else {
-                        debug!(
-                            path = %active.dest.display(),
-                            bytes = written,
-                            "saved clipboard file into the shared folder"
-                        );
+                let last = chunk.is_empty() || written >= active.total;
+                match &active.dest {
+                    TransferDest::Disk(dest) => {
+                        if let Err(e) = write_chunk(dest, active.position, chunk) {
+                            warn!(error = %e, path = %dest.display(), "failed to write clipboard file chunk; skipping file");
+                            self.start_next_download();
+                            return;
+                        }
                     }
-                    self.start_next_download();
+                    TransferDest::Host { request_id } => {
+                        // Stream the chunk to the host; it never buffers whole.
+                        self.emit(ClipboardEvent::ProvideRemoteFileChunk {
+                            request_id: *request_id,
+                            position: active.position,
+                            data: chunk.to_vec(),
+                            last,
+                        });
+                    }
+                }
+                if last {
+                    match &active.dest {
+                        TransferDest::Disk(dest) => {
+                            if written < active.total {
+                                warn!(
+                                    got = written,
+                                    expected = active.total,
+                                    path = %dest.display(),
+                                    "clipboard file ended before its advertised size; wrote a partial file"
+                                );
+                            } else {
+                                debug!(path = %dest.display(), bytes = written, "saved clipboard file into the shared folder");
+                            }
+                            self.start_next_download();
+                        }
+                        TransferDest::Host { request_id } => {
+                            debug!(request_id, bytes = written, "streamed fetched clipboard file to host");
+                            self.active_download = None;
+                        }
+                    }
                 } else {
                     // More to fetch: request the next chunk from where we stopped.
                     let stream_id = self.allocate_stream_id();

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -181,8 +181,12 @@ where
     // remote copies into the shared folder (#1765). The backend translates server
     // callbacks into `ClipboardEvent`s the driver drains once it owns the active
     // stage again; the receiver rides back out with the connection result.
-    let (clipboard_backend, clipboard_rx) =
+    let (mut clipboard_backend, clipboard_rx) =
         SidecarClipboardBackend::new(cfg.clipboard_download_dir(), cfg.view_only);
+    // When the host advertised delayed-render support (#1793), surface a remote
+    // file copy to the host OS clipboard and fetch bytes on demand instead of
+    // eagerly downloading into the shared folder.
+    clipboard_backend.set_delayed_render(cfg.clipboard_delayed_render_enabled());
     // Register the Display Control Virtual Channel (MS-RDPEDISP) so the session
     // can request dynamic resolution changes (#1755). It rides the drdynvc
     // static channel; the capabilities callback needs to send nothing, the
@@ -344,7 +348,8 @@ where
             HostMessage::Connect(_)
             | HostMessage::Input(_)
             | HostMessage::Resize { .. }
-            | HostMessage::SetClipboard(_) => {
+            | HostMessage::SetClipboard(_)
+            | HostMessage::FetchClipboardFile { .. } => {
                 debug!("ignoring a host message received while awaiting the cert decision");
             }
         }
@@ -734,6 +739,31 @@ async fn drive<R, W>(
                             break;
                         }
                     }
+                    HostMessage::FetchClipboardFile { request_id, index } => {
+                        // The host is pasting a remote-copied file locally: drive
+                        // the on-demand, chunked CLIPRDR fetch through the backend
+                        // (#1793). The backend queues the channel actions as
+                        // ClipboardEvents, drained just below.
+                        if let Some(cliprdr) = stage.get_svc_processor_mut::<CliprdrClient>() {
+                            if let Some(backend) =
+                                cliprdr.downcast_backend_mut::<SidecarClipboardBackend>()
+                            {
+                                backend.fetch_remote_file(request_id, index);
+                            }
+                        }
+                        if drain_clipboard_events(
+                            &clipboard_rx,
+                            &mut stage,
+                            &mut writer,
+                            ipc_out,
+                            local_clipboard.as_deref(),
+                        )
+                        .await
+                        .is_err()
+                        {
+                            break;
+                        }
+                    }
                     HostMessage::Disconnect => break,
                     // A duplicate Connect is ignored.
                     other => debug!(?other, "rdp sidecar ignored host message"),
@@ -1058,6 +1088,48 @@ where
                     }
                 };
                 write_cliprdr_messages(stage, transport, messages).await?;
+            }
+            ClipboardEvent::SurfaceRemoteFiles(files) => {
+                // Delayed rendering (#1793): hand the host the sanitized file
+                // list so it can offer them for a local paste; no bytes yet.
+                debug!(count = files.len(), "surfacing remote clipboard files to host");
+                write_message(ipc_out, &SidecarMessage::RemoteClipboardFiles(files))
+                    .await
+                    .context("failed to surface remote clipboard files to host")?;
+            }
+            ClipboardEvent::ProvideRemoteFileChunk {
+                request_id,
+                position,
+                data,
+                last,
+            } => {
+                // Stream one chunk of a fetched remote file back to the host
+                // (#1793); the host writes it out incrementally.
+                write_message(
+                    ipc_out,
+                    &SidecarMessage::ClipboardFileChunk {
+                        request_id,
+                        position,
+                        data,
+                        last,
+                    },
+                )
+                .await
+                .context("failed to forward remote clipboard file chunk to host")?;
+            }
+            ClipboardEvent::RemoteFileError {
+                request_id,
+                message,
+            } => {
+                write_message(
+                    ipc_out,
+                    &SidecarMessage::ClipboardFileError {
+                        request_id,
+                        message,
+                    },
+                )
+                .await
+                .context("failed to forward remote clipboard file error to host")?;
             }
         }
     }

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -1092,7 +1092,10 @@ where
             ClipboardEvent::SurfaceRemoteFiles(files) => {
                 // Delayed rendering (#1793): hand the host the sanitized file
                 // list so it can offer them for a local paste; no bytes yet.
-                debug!(count = files.len(), "surfacing remote clipboard files to host");
+                debug!(
+                    count = files.len(),
+                    "surfacing remote clipboard files to host"
+                );
                 write_message(ipc_out, &SidecarMessage::RemoteClipboardFiles(files))
                     .await
                     .context("failed to surface remote clipboard files to host")?;


### PR DESCRIPTION
## What

Implements the **remote→host** direction of RDP clipboard file transfer with
**delayed rendering** (#1793): when the remote copies files, the sidecar surfaces
the sanitized file *list* to the host, and a file's bytes are fetched over CLIPRDR
**on demand** (on the paste gesture) rather than eagerly downloaded into the
shared folder. The eager shared-folder download (#1765) stays the default and the
fallback.

`Closes #1793`

## How

- **Protocol** (`core/.../rdp_sidecar/protocol.rs`): `SidecarMessage::RemoteClipboardFiles`
  surfaces the list; `HostMessage::FetchClipboardFile` + `SidecarMessage::ClipboardFileChunk`
  / `ClipboardFileError` carry the on-demand, chunked fetch. A protocol-blind
  `RemoteClipboardFile` DTO lives on the shared `GraphicalBackend` seam.
- **Sidecar backend** (`rdp-sidecar/src/clipboard.rs`): in delayed-render mode
  `on_remote_file_list` surfaces a **sanitized** list instead of downloading; a
  `TransferDest` on the single in-flight transfer routes chunks to disk (eager) or
  the host (fetch), reusing the existing SIZE/RANGE streaming so no file is ever
  buffered whole (8 MiB chunk cap). A fetch may only name an **advertised index**.
- **Sidecar driver** (`rdp-sidecar/src/rdp.rs`): forwards the surface/chunk/error
  events and drives `fetch_remote_file` on a `FetchClipboardFile`.
- **Host adapter** (`core/.../rdp_sidecar/mod.rs`): stores the surfaced list
  (`GraphicalBackend::remote_clipboard_files`) and streams a fetched file into a
  **sanitized, per-fetch, bounded** staging temp file
  (`fetch_remote_clipboard_file`) — in-order, size-capped, slot freed on any exit.
- **Config**: `RdpConfig::clipboard_delayed_render` (host-set, **not** a schema
  field), gated on the existing clipboard-file-transfer opt-in. Default **off**, so
  production behaviour is unchanged until a host binds its OS-clipboard hook.

## Security

- Remote-supplied names are sanitized before they reach the host clipboard or any
  temp path: `..`, absolute paths, drive letters, `:`/NUL and reserved Windows
  device names are rejected — in the sidecar (`sanitize_descriptor`) **and again**
  on the host (`sanitize_leaf`).
- Bytes stream in the existing 8 MiB chunks; the host writes each chunk straight to
  disk (never buffering a whole file), enforces in-order offsets, and refuses bytes
  beyond the advertised size.
- The whole path stays behind the existing opt-in (`clipboardFileTransfer` +
  shared folder); a fetch can only reference an index the sidecar advertised.

## Scope / follow-up

Per the issue's second checkbox ("place that file list on the host OS clipboard
using delayed rendering … crosses into the app/OS-clipboard surface + frontend"),
the actual **per-OS clipboard promise binding** (NSPasteboard promises / CF_HDROP
delayed render / Wayland data source) and the **paste UI** are genuinely
cross-lane, per-platform, and not exercisable in per-PR CI. They are left to a
scoped follow-up; this PR delivers the fully unit-tested transport + host seam they
build on, with the eager download preserved as the fallback until they land.

## Tests

- Sidecar: descriptor sanitization (rejects escapes / device names, keeps nested
  paths + fetch index), delayed surfacing without download, eager-default
  preserved, opt-in required, bounded chunked fetch, unknown-size resolve, empty
  file, unknown/dir/disabled index, concurrent-fetch rejection, mid-fetch error +
  slot recovery.
- Host: reader stores the surfaced list; full fetch round-trip stages streamed
  bytes into the sanitized temp file over an in-memory pipe; `sanitize_leaf` unit
  tests; disconnected-backend behaviour.
- `cargo test` / `clippy` / `fmt` green on `termihub-core` (with `rdp-sidecar`) and
  the `rdp-sidecar` crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
