### PR TITLE
feat(rdp): re-advertise host-clipboard files on a mid-session change (Closes #1794)

### DIFF
--- a/docs/changes/dev0/feature/1794-readvertise-on-clipboard-change.md
+++ b/docs/changes/dev0/feature/1794-readvertise-on-clipboard-change.md
@@ -1,0 +1,15 @@
+### Changed
+
+- RDP clipboard file serving now **re-advertises the host clipboard's file list
+  when you copy files locally mid-session** (#1794). Previously the host-clipboard
+  file list was read only at connect (or when the server re-requested it), so files
+  you copied in your file manager *after* connecting stayed invisible to the remote
+  until the server asked again. The sidecar now polls the host OS clipboard's native
+  file list while connected and, on a change, re-sends the CLIPRDR file offer through
+  the same sandboxed serve pipeline — the file sibling of the existing text push
+  seam. This is an independent trigger from the shared-folder watcher (#1788): either
+  a clipboard copy or a shared-folder change can re-advertise on its own. The poll
+  interval rate-bounds the re-advertise so rapid host copies cannot flood the
+  clipboard channel, and it honours the existing opt-in and view-only gates — a
+  view-only or text-only session never polls the clipboard. Files copied locally
+  after connecting can now be pasted into the remote without reconnecting.

--- a/docs/changes/dev0/feature/1794-readvertise-on-clipboard-change.md
+++ b/docs/changes/dev0/feature/1794-readvertise-on-clipboard-change.md
@@ -3,7 +3,7 @@
 - RDP clipboard file serving now **re-advertises the host clipboard's file list
   when you copy files locally mid-session** (#1794). Previously the host-clipboard
   file list was read only at connect (or when the server re-requested it), so files
-  you copied in your file manager *after* connecting stayed invisible to the remote
+  you copied in your file manager _after_ connecting stayed invisible to the remote
   until the server asked again. The sidecar now polls the host OS clipboard's native
   file list while connected and, on a change, re-sends the CLIPRDR file offer through
   the same sandboxed serve pipeline — the file sibling of the existing text push

--- a/rdp-sidecar/src/host_clipboard_watch.rs
+++ b/rdp-sidecar/src/host_clipboard_watch.rs
@@ -1,0 +1,283 @@
+//! Watches the **host OS clipboard's file list** for changes while an RDP session
+//! is connected so files copied locally mid-session are **re-advertised** over
+//! CLIPRDR without a reconnect (#1794).
+//!
+//! ## Why a poll, not an event
+//!
+//! The sidecar already reads the host clipboard's native file list at CLIPRDR
+//! **format-list** time ([`crate::host_clipboard::read_host_clipboard_files`], via
+//! [`crate::clipboard::SidecarClipboardBackend::build_local_file_offer`], #1779):
+//! files copied *before* connect — or when the server re-requests — are offered.
+//! Files copied *after* connect are invisible until the server asks again. Text has
+//! the same push seam today ([`crate::protocol::HostMessage::SetClipboard`]
+//! re-advertises on a local text copy); files need an equivalent trigger. This
+//! module is the file-list sibling of the shared-folder watcher (#1788): both drive
+//! the one re-advertise pipeline
+//! ([`crate::clipboard::SidecarClipboardBackend::readvertise_local_files`]).
+//!
+//! Unlike the shared folder, an OS clipboard has no cheap, cross-platform,
+//! window-less change notification the headless sidecar can subscribe to (Windows'
+//! `AddClipboardFormatListener` needs a message loop, XFixes needs an X event
+//! thread, macOS exposes only a `changeCount` to poll). So this watcher **polls**
+//! the existing platform readers on a fixed interval and diffs the returned list
+//! against the previous poll, emitting a tick only when the file list actually
+//! changed. The poll interval is itself the rate bound: a change re-advertises at
+//! most once per [`POLL_INTERVAL`], so rapid host copies cannot flood the CLIPRDR
+//! channel. Each read runs on the blocking pool ([`tokio::task::spawn_blocking`])
+//! because a platform reader can block (the Linux X11 reader waits up to 3s for the
+//! selection), so it never stalls the async driver.
+//!
+//! ## Gating
+//!
+//! The watcher is decoupled from — and independent of — the shared-folder watcher:
+//! either source can re-advertise without the other having changed. It is started
+//! only when the session actually serves local files (file transfer opted in and
+//! not view-only), the same gate the connect-time host-clipboard offer already
+//! honours (#1778/#1779), so a view-only or text-only session never polls the
+//! clipboard. A re-advertise triggered by this watcher still runs through
+//! [`readvertise_local_files`](crate::clipboard::SidecarClipboardBackend::readvertise_local_files),
+//! which re-applies the opt-in + view-only gate and keeps host-clipboard serving
+//! bounded to the paths the user actually copied.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::debug;
+
+/// Interval between two host-clipboard polls. Also the re-advertise rate bound: a
+/// mid-session file copy is re-advertised at most once per interval, so a burst of
+/// rapid copies cannot flood the CLIPRDR channel. Kept modest so a real X11/Wayland
+/// selection round-trip per poll stays cheap.
+const POLL_INTERVAL: Duration = Duration::from_millis(750);
+/// Depth of the tick channel. One is enough: a pending tick already tells the
+/// driver to re-enumerate the clipboard's current state, so extra ticks queued
+/// behind it are redundant and dropped.
+const TICK_CAPACITY: usize = 1;
+
+/// A running host-clipboard file-list watcher. Dropping it (which the driver does
+/// at session end by dropping the value that owns [`Self::ticks`]) closes the tick
+/// channel, and the poll task exits at its next wakeup. The driver selects on
+/// [`Self::ticks`] and holds the whole value for the session's lifetime so the
+/// watcher stays alive.
+pub struct HostClipboardWatch {
+    /// Debounced-by-polling "re-advertise now" ticks.
+    pub ticks: mpsc::Receiver<()>,
+}
+
+/// Start polling the host OS clipboard's file list. Must be called from within a
+/// Tokio runtime (it spawns the poll task). The connect-time offer already
+/// advertised whatever was on the clipboard, so the first poll only establishes the
+/// baseline — the watcher ticks on *subsequent* changes.
+pub fn watch_host_clipboard() -> HostClipboardWatch {
+    watch_with(
+        Arc::new(crate::host_clipboard::read_host_clipboard_files),
+        POLL_INTERVAL,
+    )
+}
+
+/// Like [`watch_host_clipboard`] but with an injected reader and interval, so tests
+/// can script a sequence of clipboard states and drive the poll loop fast without
+/// touching the real OS clipboard.
+fn watch_with(
+    read_files: Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>,
+    interval: Duration,
+) -> HostClipboardWatch {
+    let (tick_tx, ticks) = mpsc::channel::<()>(TICK_CAPACITY);
+    tokio::spawn(poll_loop(read_files, tick_tx, interval));
+    debug!("watching host clipboard for CLIPRDR re-advertise (#1794)");
+    HostClipboardWatch { ticks }
+}
+
+/// Read the host clipboard's current file list on the blocking pool so a slow
+/// platform reader never stalls the async driver.
+async fn read_current(read_files: &Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>) -> Vec<PathBuf> {
+    let reader = Arc::clone(read_files);
+    // A panic in the reader (there should be none — every reader swallows its own
+    // errors) degrades to "no files", never a torn-down session.
+    tokio::task::spawn_blocking(move || reader())
+        .await
+        .unwrap_or_default()
+}
+
+/// Poll the clipboard file list and emit a tick whenever it differs from the
+/// previous poll. Ends when the tick channel closes (driver gone). The first read
+/// seeds the baseline without ticking: the connect-time offer already covered it.
+async fn poll_loop(
+    read_files: Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync>,
+    tick_tx: mpsc::Sender<()>,
+    interval: Duration,
+) {
+    use mpsc::error::TrySendError;
+    let mut previous = read_current(&read_files).await;
+    loop {
+        // Wait out the interval, but wake immediately if the driver dropped the
+        // receiver so the poll task exits promptly at session end.
+        tokio::select! {
+            biased;
+            _ = tick_tx.closed() => return,
+            _ = tokio::time::sleep(interval) => {}
+        }
+        let current = read_current(&read_files).await;
+        if current == previous {
+            continue;
+        }
+        debug!(
+            was = previous.len(),
+            now = current.len(),
+            "host clipboard file list changed; re-advertising (#1794)"
+        );
+        previous = current;
+        match tick_tx.try_send(()) {
+            // A full channel already holds a tick the driver will act on, so
+            // dropping this one loses nothing (a re-advertise reads the clipboard's
+            // current state).
+            Ok(()) | Err(TrySendError::Full(())) => {}
+            Err(TrySendError::Closed(())) => return, // driver gone
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    /// A reader that hands out a scripted sequence of clipboard states, one per
+    /// call, repeating the final state once the script is exhausted (so the poll
+    /// loop keeps seeing "no change" and stops ticking).
+    fn scripted(states: Vec<Vec<PathBuf>>) -> Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync> {
+        let states = Arc::new(states);
+        let calls = Arc::new(AtomicUsize::new(0));
+        Arc::new(move || {
+            let i = calls.fetch_add(1, Ordering::SeqCst);
+            let idx = i.min(states.len().saturating_sub(1));
+            states.get(idx).cloned().unwrap_or_default()
+        })
+    }
+
+    async fn recv_timeout(rx: &mut mpsc::Receiver<()>, ms: u64) -> Option<()> {
+        tokio::time::timeout(Duration::from_millis(ms), rx.recv())
+            .await
+            .ok()
+            .flatten()
+    }
+
+    #[tokio::test]
+    async fn ticks_when_the_file_list_changes_after_the_baseline() {
+        // Baseline empty, then a file copied: exactly one tick fires.
+        let watch = watch_with(
+            scripted(vec![vec![], vec![p("/home/me/a.txt")]]),
+            Duration::from_millis(5),
+        );
+        let mut ticks = watch.ticks;
+        assert_eq!(
+            recv_timeout(&mut ticks, 500).await,
+            Some(()),
+            "a mid-session copy must re-advertise"
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_tick_when_the_baseline_is_unchanged() {
+        // The clipboard already holds files at connect and never changes: the
+        // connect-time offer covered it, so the watcher stays silent.
+        let watch = watch_with(
+            scripted(vec![vec![p("/home/me/a.txt")]]),
+            Duration::from_millis(5),
+        );
+        let mut ticks = watch.ticks;
+        assert!(
+            recv_timeout(&mut ticks, 120).await.is_none(),
+            "an unchanged clipboard must not re-advertise"
+        );
+    }
+
+    #[tokio::test]
+    async fn ticks_when_files_are_replaced_by_a_different_set() {
+        let watch = watch_with(
+            scripted(vec![vec![p("/a")], vec![p("/b"), p("/c")]]),
+            Duration::from_millis(5),
+        );
+        let mut ticks = watch.ticks;
+        assert_eq!(recv_timeout(&mut ticks, 500).await, Some(()));
+    }
+
+    #[tokio::test]
+    async fn ticks_when_the_file_list_is_cleared() {
+        // Copying text after files empties the file list; the watcher re-advertises
+        // so the now-stale file offer is dropped (the driver falls back to the
+        // shared folder or a text advertisement).
+        let watch = watch_with(
+            scripted(vec![vec![p("/a")], vec![]]),
+            Duration::from_millis(5),
+        );
+        let mut ticks = watch.ticks;
+        assert_eq!(recv_timeout(&mut ticks, 500).await, Some(()));
+    }
+
+    #[tokio::test]
+    async fn coalesces_repeated_reads_of_the_same_list() {
+        // After the single change, the list stays put: only one tick, never a
+        // steady stream of them.
+        let watch = watch_with(
+            scripted(vec![vec![], vec![p("/a")]]),
+            Duration::from_millis(5),
+        );
+        let mut ticks = watch.ticks;
+        assert_eq!(recv_timeout(&mut ticks, 500).await, Some(()));
+        assert!(
+            recv_timeout(&mut ticks, 100).await.is_none(),
+            "a stable clipboard must not keep re-advertising"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_task_stops_when_the_receiver_is_dropped() {
+        // Track reads so we can prove the task stopped polling after the receiver
+        // went away.
+        let count = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::clone(&count);
+        let reader: Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync> = Arc::new(move || {
+            seen.fetch_add(1, Ordering::SeqCst);
+            Vec::new()
+        });
+        let watch = watch_with(reader, Duration::from_millis(5));
+        drop(watch.ticks); // as the driver does at session end
+                           // Give the task a chance to observe the closed channel and exit.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        let after_drop = count.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            after_drop,
+            "the poll task must stop reading once the receiver is dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn survives_a_reader_that_briefly_holds_a_lock() {
+        // The real readers can block; a reader that serializes on a mutex must not
+        // deadlock the loop. This mostly guards that reads run on the blocking pool.
+        let gate = Arc::new(Mutex::new(0u32));
+        let g = Arc::clone(&gate);
+        let reader: Arc<dyn Fn() -> Vec<PathBuf> + Send + Sync> = Arc::new(move || {
+            let mut n = g.lock().expect("lock");
+            *n += 1;
+            if *n >= 2 {
+                vec![p("/late")]
+            } else {
+                Vec::new()
+            }
+        });
+        let watch = watch_with(reader, Duration::from_millis(5));
+        let mut ticks = watch.ticks;
+        assert_eq!(recv_timeout(&mut ticks, 500).await, Some(()));
+    }
+}

--- a/rdp-sidecar/src/main.rs
+++ b/rdp-sidecar/src/main.rs
@@ -19,6 +19,7 @@ mod clipboard;
 mod drive;
 mod folder_watch;
 mod host_clipboard;
+mod host_clipboard_watch;
 mod input;
 mod keymap;
 mod rdp;

--- a/rdp-sidecar/src/rdp.rs
+++ b/rdp-sidecar/src/rdp.rs
@@ -575,11 +575,22 @@ where
     // we actually serve local files: file transfer opted in and not view-only.
     // Failure to start the watcher is non-fatal — the session keeps its
     // connect-time offer.
-    let readvertise = if cfg.view_only {
-        None
+    //
+    // The host-clipboard watcher (#1794) is the sibling trigger: it re-advertises
+    // when the user copies **files onto the host OS clipboard** mid-session. It is
+    // an independent source — either watcher can re-advertise without the other
+    // having changed — but shares the same serve gate (opt-in + not view-only), so
+    // a view-only or text-only session polls neither. Both are non-fatal to start.
+    let (readvertise, host_clip_watch) = if cfg.view_only {
+        (None, None)
     } else {
-        cfg.clipboard_download_dir()
-            .and_then(crate::folder_watch::watch_shared_folder)
+        match cfg.clipboard_download_dir() {
+            Some(root) => (
+                crate::folder_watch::watch_shared_folder(root),
+                Some(crate::host_clipboard_watch::watch_host_clipboard()),
+            ),
+            None => (None, None),
+        }
     };
 
     drive(
@@ -589,6 +600,7 @@ where
         clipboard_rx,
         cfg.view_only,
         readvertise,
+        host_clip_watch,
         ipc_in,
         ipc_out,
     )
@@ -604,7 +616,8 @@ where
 
 /// The driver loop: owns the transport, decoded image and active stage;
 /// `select!`s between decoding server PDUs, applying host input events, and
-/// re-advertising the local file list on a shared-folder change (#1788).
+/// re-advertising the local file list on a shared-folder change (#1788) or a
+/// host-clipboard file-list change (#1794).
 // Each argument is a distinct capability the loop owns (transport halves, config,
 // the CLIPRDR event channel, the folder-watch ticks, the IPC endpoints); bundling
 // them into a struct would only rename them without reducing coupling.
@@ -616,6 +629,7 @@ async fn drive<R, W>(
     clipboard_rx: std::sync::mpsc::Receiver<ClipboardEvent>,
     view_only: bool,
     mut readvertise: Option<crate::folder_watch::FolderWatch>,
+    mut host_clip_watch: Option<crate::host_clipboard_watch::HostClipboardWatch>,
     ipc_in: &mut R,
     ipc_out: &mut W,
 ) where
@@ -858,19 +872,9 @@ async fn drive<R, W>(
             } => {
                 match tick {
                     Some(()) => {
-                        // Drive the re-advertise through the backend so its
-                        // offered-file index map is refreshed in lockstep with what
-                        // it emits (a stale map would misserve a later paste).
-                        if let Some(cliprdr) = stage.get_svc_processor_mut::<CliprdrClient>() {
-                            if let Some(backend) =
-                                cliprdr.downcast_backend_mut::<SidecarClipboardBackend>()
-                            {
-                                backend.readvertise_local_files();
-                            }
-                        }
-                        if drain_clipboard_events(
-                            &clipboard_rx,
+                        if readvertise_and_drain(
                             &mut stage,
+                            &clipboard_rx,
                             &mut writer,
                             ipc_out,
                             local_clipboard.as_deref(),
@@ -886,8 +890,67 @@ async fn drive<R, W>(
                     None => readvertise = None,
                 }
             }
+            // The host OS clipboard's file list changed while connected: the user
+            // copied files locally mid-session, so re-advertise them over CLIPRDR
+            // without waiting for a server-initiated format-list (#1794). This is an
+            // independent trigger from the shared-folder watcher above but shares the
+            // exact re-advertise pipeline; the tick is rate-bounded by the poll
+            // interval. When no watcher is running (text- or view-only session),
+            // this arm never fires.
+            clip_tick = async {
+                match host_clip_watch.as_mut() {
+                    Some(w) => w.ticks.recv().await,
+                    None => std::future::pending::<Option<()>>().await,
+                }
+            } => {
+                match clip_tick {
+                    Some(()) => {
+                        if readvertise_and_drain(
+                            &mut stage,
+                            &clipboard_rx,
+                            &mut writer,
+                            ipc_out,
+                            local_clipboard.as_deref(),
+                        )
+                        .await
+                        .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    // The poll task ended (receiver closed); stop polling it but keep
+                    // the session alive.
+                    None => host_clip_watch = None,
+                }
+            }
         }
     }
+}
+
+/// Re-enumerate and re-advertise the local file offer, then flush the CLIPRDR
+/// actions it queued. Shared by the shared-folder-change (#1788) and
+/// host-clipboard-change (#1794) triggers. The re-advertise is driven **through the
+/// backend** so its offered-file index map is refreshed in lockstep with what it
+/// emits — a stale map would misserve a later paste — and the backend re-applies
+/// the opt-in + view-only gate, so a session that never offered local files emits
+/// nothing here.
+async fn readvertise_and_drain<T, W>(
+    stage: &mut ActiveStage,
+    clipboard_rx: &std::sync::mpsc::Receiver<ClipboardEvent>,
+    transport: &mut T,
+    ipc_out: &mut W,
+    local_clipboard: Option<&str>,
+) -> Result<()>
+where
+    T: FramedWrite,
+    W: AsyncWrite + Unpin,
+{
+    if let Some(cliprdr) = stage.get_svc_processor_mut::<CliprdrClient>() {
+        if let Some(backend) = cliprdr.downcast_backend_mut::<SidecarClipboardBackend>() {
+            backend.readvertise_local_files();
+        }
+    }
+    drain_clipboard_events(clipboard_rx, stage, transport, ipc_out, local_clipboard).await
 }
 
 /// Run the [Deactivation-Reactivation Sequence] after a server Deactivate All


### PR DESCRIPTION
Follow-up to #1779. The sidecar read the host OS clipboard's native file list only at CLIPRDR **format-list** time — session init or a server re-request — so files copied locally *after* connecting were invisible to the remote until the server asked again. Text already had a push seam (`HostMessage::SetClipboard` re-advertises on a local text copy); files did not.

## What changed

- New sidecar module `host_clipboard_watch.rs`: a **host-clipboard poll watcher**, the file-list sibling of the shared-folder watcher (#1788). An OS clipboard has no cheap, cross-platform, window-less change notification a headless sidecar can subscribe to, so it **polls** the existing platform readers (`read_host_clipboard_files`) on a fixed interval, diffs the returned list against the previous poll, and emits a re-advertise tick only when the file list actually changed.
- The driver `select!` gains a second, **independent** re-advertise arm for clipboard-change ticks. Both the folder-change (#1788) and clipboard-change (#1794) triggers now flow through one shared `readvertise_and_drain` helper that drives the backend's existing `readvertise_local_files` pipeline — so the offered-file index map stays in lockstep and a stale map can never misserve a later paste.

## Gating / decoupling

- The host-clipboard source is **decoupled from** the shared-folder source: either trigger can re-advertise without the other having changed.
- The watcher shares the **same serve gate** as the connect-time host-clipboard offer (#1778/#1779): started only when file transfer is opted in and the session is not view-only, so a view-only or text-only session polls neither watcher. The re-advertise itself re-applies the opt-in + view-only gate inside `readvertise_local_files`.

## Security / bounds

- Reuses the existing sandboxed serve pipeline unchanged — host-clipboard files are still served only from the real paths the user copied, bounded by the existing 8 MiB chunk streaming; the remote only ever selects an advertised index.
- The poll interval rate-bounds the re-advertise, so rapid host copies cannot flood the CLIPRDR channel. Reads run on the blocking pool so a slow platform reader (e.g. the Linux X11 3s selection wait) never stalls the async driver.

## Testing

- 7 new unit tests over the poll loop: ticks on a mid-session copy, stays silent on an unchanged baseline, ticks on replacement and on clear-to-empty, coalesces a stable list, stops polling when the receiver is dropped, and survives a blocking reader.
- Full sidecar suite green (150 tests), `cargo clippy --all-targets` clean, `cargo fmt --check` clean. Note: the RDP sidecar is a workspace-excluded crate not built in per-PR CI, so these were verified locally.

## Follow-up

- The deeper "decouple the host-clipboard serving gate from drive redirection" item from #1794 (serving host-clipboard files without a configured shared folder) needs a config/opt-in change and is filed as #1808 rather than grown into this PR.

Closes #1794