### PR TITLE
docs(concept): add multi-window ux mockups (Closes #1806)

### DIFF
--- a/docs/concepts/backlog/multi-window.html
+++ b/docs/concepts/backlog/multi-window.html
@@ -1,0 +1,785 @@
+<!doctype html>
+<!--
+  Concept: Multi-window support (detachable / movable tabs across windows).
+  Tracking issue #1806. This is STEP 1 (technical concept + limitations) of a
+  two-step concept. STEP 2 (UX designer) fills in the inline mockups where the
+  MOCKUPS placeholder appears in the UI Interface section.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Multi-Window Support (concept)</title>
+    <link rel="stylesheet" href="../_assets/mockup.css" />
+    <link rel="stylesheet" href="../_assets/concept.css" />
+  </head>
+  <body class="mockup-doc">
+    <!-- Inline lucide sprite (only the symbols referenced below). -->
+    <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+      <symbol id="i-network" viewBox="0 0 24 24">
+        <rect x="16" y="16" width="6" height="6" rx="1" />
+        <rect x="2" y="16" width="6" height="6" rx="1" />
+        <rect x="9" y="2" width="6" height="6" rx="1" />
+        <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3" />
+        <path d="M12 12V8" />
+      </symbol>
+    </svg>
+
+    <div class="concept">
+      <!-- ── Header ──────────────────────────────────────────────────── -->
+      <header class="concept-header">
+        <h1>Multi-Window Support</h1>
+        <div class="concept-meta">
+          <span class="concept-status">Backlog · not implemented</span>
+          <span
+            >GitHub Issue:
+            <a href="https://github.com/armaxri/termiHub/issues/1806">#1806</a></span
+          >
+          <span><code>docs/concepts/backlog/multi-window.html</code></span>
+        </div>
+      </header>
+
+      <blockquote>
+        <p>
+          <strong>Two-step concept.</strong> This document is <strong>step 1</strong> — the
+          <em>technical</em> concept and honest limitations, authored by an engineer against the real
+          codebase. <strong>Step 2</strong> (a UX designer) adds the interaction design and inline
+          mockups where the <code>MOCKUPS</code> placeholder appears in
+          <a href="#ui">UI Interface</a>. Nothing here is an implementation commitment.
+        </p>
+      </blockquote>
+
+      <!-- ── Table of contents ──────────────────────────────────────── -->
+      <nav class="concept-toc">
+        <h2>Contents</h2>
+        <ol>
+          <li><a href="#overview">Overview &amp; Goals</a></li>
+          <li><a href="#asis">Current Architecture (as-is)</a></li>
+          <li><a href="#ui">UI Interface (mockups → step 2)</a></li>
+          <li><a href="#approach">Proposed Approach — the three capabilities</a></li>
+          <li><a href="#reparent">Session Re-parenting Mechanism</a></li>
+          <li><a href="#state">State Ownership &amp; Event Retargeting</a></li>
+          <li><a href="#matrix">Per-Session-Type Feasibility Matrix</a></li>
+          <li><a href="#platform">Per-Platform Constraints</a></li>
+          <li><a href="#behavior">States &amp; Sequences</a></li>
+          <li><a href="#limits">Limitations · Non-Goals · Open Questions</a></li>
+          <li><a href="#impl">Preliminary Implementation Details</a></li>
+          <li><a href="#sync">Sync Ledger</a></li>
+        </ol>
+      </nav>
+
+      <!-- ── Overview ───────────────────────────────────────────────── -->
+      <section>
+        <h2 id="overview">Overview &amp; Goals <a class="anchor" href="#overview">#</a></h2>
+        <p>
+          termiHub today runs as a <strong>single application window</strong> that hosts every session
+          tab, split, and tab group. Users on multi-monitor setups repeatedly ask to spread work
+          across screens — a build tailing on one monitor, an SSH session on another. This concept
+          assesses whether termiHub can host <strong>multiple native windows</strong> and move live
+          session tabs between them <strong>without tearing down the underlying backend session</strong>.
+        </p>
+        <p>
+          <strong>The verdict is: feasible, with real caveats.</strong> The architecture is unusually
+          well-suited to it in one dimension and awkward in another. Session <em>state</em> already
+          lives in the Rust backend, keyed by session id and completely independent of any window, and
+          the backend already supports the exact primitive multi-window needs — <em>detach a view and
+          re-attach it later with scrollback replay</em> (built for persistent/agent sessions and tab
+          groups). That makes re-parenting a session tab a <em>view</em> operation, not a teardown. The
+          awkward dimension is the front end: separate native windows are separate JavaScript contexts
+          with no shared memory, and the current tab drag-and-drop stack (<code>@dnd-kit</code>) cannot
+          cross a native window boundary. So the hard limits cluster on <em>gesture and coordination</em>,
+          not on session survival.
+        </p>
+        <h3>Goals</h3>
+        <ul>
+          <li>
+            <strong>Tear out</strong> a session tab into a brand-new window (drag-out or a
+            "Move to New Window" command).
+          </li>
+          <li><strong>Create</strong> additional windows (empty, or seeded from a tab group).</li>
+          <li>
+            <strong>Move tabs between</strong> existing windows without restarting the backend session
+            (its PTY / SSH channel / serial port / RDP connection keeps running).
+          </li>
+          <li>Preserve scrollback on move to the extent the backend replay buffer allows.</li>
+        </ul>
+        <h3>Non-Goals</h3>
+        <ul>
+          <li>
+            Sharing <em>one</em> live session's terminal view across two windows simultaneously
+            (mirrored view). Out of scope — a tab lives in exactly one window at a time.
+          </li>
+          <li>Multi-window support for non-session tabs (Settings, Log Viewer) — see the matrix.</li>
+          <li>Detachable <em>sidebar</em> panels (connection tree, network tools) into their own windows.</li>
+          <li>Multi-<em>process</em> windows. Windows are additional webviews in the one Tauri process.</li>
+        </ul>
+      </section>
+
+      <!-- ── Current architecture ───────────────────────────────────── -->
+      <section>
+        <h2 id="asis">Current Architecture (as-is) <a class="anchor" href="#asis">#</a></h2>
+        <p>
+          Every claim below is grounded in the current tree. The picture that matters: the backend is
+          the authoritative, window-independent owner of session state; the frontend holds only view
+          state; and events are already delivered app-wide by broadcast.
+        </p>
+
+        <h3>One window today</h3>
+        <ul>
+          <li>
+            Tauri <strong>v2</strong> (<code>src-tauri/Cargo.toml</code>:
+            <code>tauri = { version = "2", … }</code>; config schema <code>config/2</code>).
+          </li>
+          <li>
+            Exactly one window is declared — <code>tauri.conf.json</code> → <code>app.windows[]</code>
+            has a single entry titled <code>termiHub</code>. Its runtime label is <code>"main"</code>.
+          </li>
+          <li>
+            Nothing creates a second window. The only window lookups are
+            <code>app.get_webview_window("main")</code> (<code>src-tauri/src/lib.rs:262</code>,
+            <code>src-tauri/src/spawn/handler.rs:275</code>). No
+            <code>WebviewWindowBuilder</code> / <code>WindowBuilder</code> exists in production code.
+            The frontend only ever calls <code>getCurrentWindow()</code>
+            (<code>src/App.tsx:39,209</code>) — never <code>new WebviewWindow(...)</code>.
+          </li>
+        </ul>
+
+        <h3>Session state lives in the Rust backend, keyed by id</h3>
+        <ul>
+          <li>
+            <code>SessionManager</code> (<code>src-tauri/src/session/manager.rs</code>) holds a
+            <code>sessions</code> map keyed by <code>session_id</code>. A session is a backend process
+            (PTY, SSH channel, serial port, agent proxy) — it has <strong>no notion of which window,
+            tab, or even tab group is displaying it</strong>. This is the single most important fact for
+            this feature: <em>a session already survives independently of any view</em>.
+          </li>
+          <li>
+            Graphical (RDP/VNC) sessions are owned by a separate
+            <code>GraphicalSessionManager</code> (built at <code>src-tauri/src/lib.rs:429</code>), keyed
+            by connection type id, also window-independent.
+          </li>
+          <li>
+            The backend keeps a <strong>replayable scrollback buffer</strong>: a 1&nbsp;MiB
+            <code>RingBuffer</code> (<code>core/src/buffer/mod.rs</code>, doc'd for "serial 24/7 capture,
+            daemon PTY output replay, and reconnect replay"), plus persistent/agent
+            session scrollback replay and <code>RemoteProxy::reconnect_existing</code>
+            (<code>manager.rs</code> ~L920, ~L1195, ~L2854). <strong>This is the re-parenting enabler.</strong>
+          </li>
+        </ul>
+
+        <h3>Events are a global broadcast; input is an id-keyed IPC call</h3>
+        <ul>
+          <li>
+            Output is emitted with <code>AppHandle::emit("terminal-output", event)</code> — a
+            <strong>global broadcast to every webview</strong> (<code>manager.rs:114–125</code>). Same
+            for <code>terminal-exit</code>, <code>persistent-session-state-changed</code>, and every
+            graphical stream: <code>remote-desktop-frame</code> / <code>-cursor</code> /
+            <code>-clipboard</code> / <code>-state</code> / <code>-cert-prompt</code>
+            (<code>graphical_manager.rs:115–127</code>).
+          </li>
+          <li>
+            The frontend registers <strong>one</strong> global listener per stream and fans out by
+            <code>session_id</code> — <code>SessionEventDispatcher</code> in
+            <code>src/services/events.ts</code>. Consequence for multi-window: because output is
+            already broadcast to all windows, a second window that subscribes and filters by the same
+            <code>session_id</code> <em>automatically</em> receives that session's output. No
+            <code>emit_to</code> retargeting is <em>required</em> for correctness — only as an efficiency
+            improvement (see <a href="#state">State &amp; Retargeting</a>).
+          </li>
+          <li>
+            Input / control (write, resize, close) are Tauri command calls keyed by
+            <code>session_id</code>, so they work identically from whichever window currently owns the tab.
+          </li>
+        </ul>
+
+        <h3>Frontend view state — the Zustand store</h3>
+        <ul>
+          <li>
+            <code>src/store/appStore.ts</code> (~6.4k lines) holds
+            <code>tabGroups: TabGroup[]</code>, <code>activeTabGroupId</code>, and the live
+            <code>rootPanel: PanelNode</code> (a recursive split/leaf tree —
+            <code>src/types/terminal.ts</code>). A tab (<code>TerminalTab</code>) carries a
+            <code>sessionId</code>, a <code>contentType</code>, and its config — the <em>view</em> of a
+            backend session, not the session itself.
+          </li>
+          <li>
+            <strong>Tab groups are the closest existing analog to windows.</strong> Each group is an
+            "independent panel tree that stays alive when hidden" (implemented concept
+            <code>tab-groups.html</code>): the active group uses the live <code>rootPanel</code>, every
+            other group keeps its own <code>rootPanel</code> in <code>tabGroups[]</code>. Multi-window is
+            essentially "let a tab group (or a subset of tabs) live in its own OS window" — <em>except</em>
+            groups today all share one JS context and one store; windows do not.
+          </li>
+          <li>
+            Cross-panel and cross-group tab movement already exists —
+            <code>moveTab</code>, <code>moveTabToGroup</code>, <code>addTabGroupWithTab</code>,
+            <code>splitPanelWithTab</code> in the store. These are the natural seams to extend to
+            cross-<em>window</em> movement.
+          </li>
+        </ul>
+
+        <h3>Tab drag-and-drop uses @dnd-kit (single-document)</h3>
+        <ul>
+          <li>
+            Tab drag/reorder/tear-to-split is built on <strong><code>@dnd-kit</code></strong>
+            (<code>src/components/SplitView/SplitView.tsx</code>, <code>PanelDropZone.tsx</code>): pointer
+            sensors, <code>DndContext</code>, <code>DragOverlay</code>. It uses <em>no</em> native
+            HTML5 <code>dataTransfer</code>. <strong>@dnd-kit is fundamentally single-document</strong> — its
+            pointer tracking and drag overlay live entirely inside one webview's DOM and cannot follow the
+            cursor across a native window boundary. This is the crux of the drag limitation below.
+          </li>
+          <li>
+            The one place termiHub <em>does</em> use OS-level drag is Tauri's
+            <code>onDragDropEvent</code> for external <strong>file</strong> drops into the file browser —
+            a different, OS→webview channel, not webview→webview tab drag.
+          </li>
+        </ul>
+
+        <h3>Persistence &amp; lifecycle have no window dimension</h3>
+        <ul>
+          <li>
+            Workspaces (<code>src/types/workspace.ts</code>, <code>WorkspaceDefinition</code>) capture
+            <code>tabGroups[]</code> with a layout tree — but there is <strong>no window field
+            anywhere</strong>. A restored workspace has nowhere to record "this group is in window 2."
+            Same for last-session restore.
+          </li>
+          <li>
+            Lifecycle is handled in <code>src-tauri/src/lib.rs</code> via
+            <code>RunEvent::WindowEvent { CloseRequested / Destroyed }</code> and
+            <code>RunEvent::ExitRequested</code> (~L918–930). With one window, "window closed" ≈ "app
+            quit." Multi-window breaks that identity and needs an explicit policy.
+          </li>
+          <li>
+            No single-instance plugin is used. Portable mode and the CLI workspace launch
+            (<code>tauri.conf.json</code> → <code>plugins.cli</code>) are orthogonal — multi-window is
+            multi-<em>webview-in-one-process</em>, not multi-process.
+          </li>
+        </ul>
+
+        <div class="diagram">
+          <span class="diagram__caption">As-is: one window, backend owns the session</span>
+          <pre class="mermaid">
+flowchart TB
+  subgraph BE["Rust backend (one process, window-independent)"]
+    SM["SessionManager<br/>sessions keyed by session_id"]
+    GM["GraphicalSessionManager<br/>keyed by type id"]
+    RB["RingBuffer / scrollback replay"]
+  end
+  subgraph W["Window 'main' (single webview / JS context)"]
+    ST["Zustand store<br/>tabGroups[], rootPanel"]
+    XT["xterm.js instances<br/>canvas surfaces"]
+  end
+  SM -- "emit terminal-output (broadcast)" --> ST
+  GM -- "emit remote-desktop-frame (broadcast)" --> XT
+  ST -- "write/resize/close by session_id (IPC)" --> SM
+  RB -. "replay on (re)attach" .-> ST
+          </pre>
+        </div>
+      </section>
+
+      <!-- ── UI Interface (mockups deferred to step 2) ──────────────── -->
+      <section>
+        <h2 id="ui">UI Interface <a class="anchor" href="#ui">#</a></h2>
+        <p>
+          The interaction design — the drag-to-tear gesture and its command fallback, the drag-between-windows
+          affordance, the "New Window" entry points, the empty-window state, and every edge-case surface — is
+          <strong>step 2</strong>. The technical constraints those mockups must respect are: (a) native
+          drag cannot cross windows with today's stack, so a command/menu path is mandatory and a drag gesture
+          is at best an enhancement; (b) graphical tabs may need a "moving…" placeholder while the framebuffer
+          repaints; (c) an empty window is a real state (a window can exist with zero tabs). See
+          <a href="#limits">Limitations</a> for the full list the UX must design around.
+        </p>
+        <!-- MOCKUPS: to be authored by UX step (see #1806).
+             Build inline <section class="mockup-section"> blocks here using the real
+             mockup.css classes (.app, .tab, .terminal-view__toolbar, .menu, .status-bar,
+             .activity-bar__item, …) + lucide icons. Suggested screens:
+               1. Tab context menu / toolbar overflow → "Move to New Window", "Move to Window ▸ N".
+               2. Two windows side by side, a tab mid-move (source ghost + destination insertion point).
+               3. Empty-window state (no tabs) with a call to action.
+               4. Graphical (RDP/VNC) tab move: "reconnecting view…" placeholder over the canvas.
+               5. Close-window-with-live-tabs confirmation (detach vs. close). -->
+        <div class="mockup-note">
+          Placeholder — no mockups in step 1. The UX designer slots them into the block above.
+        </div>
+      </section>
+
+      <!-- ── Proposed approach ──────────────────────────────────────── -->
+      <section>
+        <h2 id="approach">Proposed Approach — the three capabilities <a class="anchor" href="#approach">#</a></h2>
+        <p>
+          All three capabilities reduce to the same core move: <strong>detach a tab's view from window A
+          and re-attach it in window B</strong>, while the backend session keeps running untouched. They
+          differ only in whether window B already exists.
+        </p>
+
+        <h3>(a) Tear a tab out into a new window</h3>
+        <ol>
+          <li>User invokes "Move to New Window" (command / tab context menu; a drag-out gesture is a
+            later enhancement — see limits).</li>
+          <li>Backend creates a new <code>WebviewWindow</code> (label e.g. <code>win-2</code>) loading the
+            same frontend bundle. It boots a fresh, empty store.</li>
+          <li>A <strong>hand-off record</strong> for the moved tab (its <code>TerminalTab</code> view-model +
+            desired placement) is passed to the new window (via an init argument or a backend-brokered
+            claim — see <a href="#state">State &amp; Retargeting</a>).</li>
+          <li>Window B builds a leaf panel, creates a fresh xterm.js instance, subscribes to the global
+            output stream filtered by <code>session_id</code>, and requests a
+            <strong>scrollback replay</strong> to repaint history.</li>
+          <li>Window A removes the tab from its store and disposes its xterm instance. The backend session
+            never restarted.</li>
+        </ol>
+
+        <h3>(b) Create additional windows</h3>
+        <p>
+          A "New Window" command opens an empty window (empty store, no tabs) — or seeds it from a chosen
+          tab group. Mechanically identical to (a) minus the hand-off; the empty-window state is a first-class
+          UI state the UX must design.
+        </p>
+
+        <h3>(c) Move a tab between two existing windows</h3>
+        <p>
+          Same hand-off as (a) but window B already exists, so the flow is just: window B claims the tab,
+          attaches + replays; window A releases it. The only genuinely new problem is the <em>gesture</em> —
+          dragging a tab from A's tab bar onto B's tab bar is not expressible with <code>@dnd-kit</code>
+          across native windows, so the shipping mechanism is a command ("Move to Window ▸ &lt;name&gt;"),
+          with drag as a research item (<a href="#limits">open question</a>).
+        </p>
+      </section>
+
+      <!-- ── Re-parenting mechanism ─────────────────────────────────── -->
+      <section>
+        <h2 id="reparent">Session Re-parenting Mechanism <a class="anchor" href="#reparent">#</a></h2>
+        <p>
+          Re-parenting a tab is <strong>a pure view operation</strong>. The backend session is keyed by
+          <code>session_id</code> and knows nothing about windows, so "moving" a tab never touches it. In
+          one paragraph: window B instantiates a new xterm.js (or canvas) surface, begins listening to the
+          already-broadcast output stream for that <code>session_id</code>, and asks the backend to replay
+          the ring-buffered scrollback so the fresh surface repaints history; window A then drops its view
+          and disposes its surface. Input keeps flowing because <code>write</code>/<code>resize</code> are
+          id-keyed IPC calls issued from whichever window holds the tab. termiHub already does exactly this
+          when a persistent/agent tab is closed and later re-attached — multi-window reuses that machinery
+          across a window boundary instead of across time.
+        </p>
+        <div class="diagram">
+          <span class="diagram__caption">Re-parenting a live terminal tab from window A to window B</span>
+          <pre class="mermaid">
+sequenceDiagram
+  participant A as Window A (store + xterm)
+  participant BE as Backend SessionManager
+  participant B as Window B (store + xterm)
+  A->>BE: request move(sessionId → win-2)
+  BE->>B: hand-off record (TerminalTab view-model)
+  B->>B: create leaf + fresh xterm instance
+  B->>BE: subscribe/replay scrollback(sessionId)
+  BE-->>B: buffered output (RingBuffer replay)
+  Note over BE: terminal-output keeps broadcasting to all windows
+  BE-->>B: live output (filtered by sessionId)
+  A->>A: remove tab, dispose xterm
+  Note over A,B: backend PTY/SSH/serial never restarts
+          </pre>
+        </div>
+      </section>
+
+      <!-- ── State ownership & event retargeting ────────────────────── -->
+      <section>
+        <h2 id="state">State Ownership &amp; Event Retargeting <a class="anchor" href="#state">#</a></h2>
+        <p>
+          <strong>This boundary is the whole feature.</strong> Separate webviews are separate JavaScript
+          contexts — no shared DOM, no shared module memory, no shared Zustand store. What is authoritative
+          in the backend moves cleanly; what is in-memory per-window must be rebuilt on the far side.
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>State</th>
+                <th>Where it lives today</th>
+                <th>On move</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Backend session (PTY/SSH/serial/RDP, process, channel)</td>
+                <td>Rust <code>SessionManager</code>/<code>GraphicalSessionManager</code>, keyed by id</td>
+                <td><strong>Authoritative — untouched.</strong> Survives the move entirely.</td>
+              </tr>
+              <tr>
+                <td>Scrollback (replayable)</td>
+                <td>Backend <code>RingBuffer</code> (1 MiB) + agent/persistent replay</td>
+                <td>Replayed into window B's fresh xterm — <strong>bounded by buffer size</strong>.</td>
+              </tr>
+              <tr>
+                <td>xterm.js instance, rendered scrollback, viewport, selection</td>
+                <td>In window A's JS memory / DOM</td>
+                <td><strong>Discarded.</strong> Rebuilt in B from replay; anything beyond the buffer is lost.</td>
+              </tr>
+              <tr>
+                <td>Tab view-model (<code>TerminalTab</code>: title, config, badges, placement)</td>
+                <td>Window A's Zustand store</td>
+                <td>Serialized into the hand-off record; re-hydrated in B; removed from A.</td>
+              </tr>
+              <tr>
+                <td>Graphical framebuffer (RDP/VNC canvas pixels)</td>
+                <td>Window A's <code>&lt;canvas&gt;</code> memory</td>
+                <td><strong>Discarded; repaint on next full frame.</strong> Possible blank flash — see matrix.</td>
+              </tr>
+              <tr>
+                <td>Tab ↔ window ownership (who shows which session)</td>
+                <td>Implicit — one window, so unambiguous today</td>
+                <td><strong>New:</strong> needs an explicit coordinator so a tab is shown in exactly one window.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Event retargeting — needed for hygiene, not correctness</h3>
+        <p>
+          Because output is a <strong>global broadcast</strong> (<code>AppHandle::emit</code>), the moment
+          window B subscribes to <code>terminal-output</code> and filters for the session's id, output
+          "follows" the tab with zero backend change — this is a genuine gift of the current design. Two
+          non-blocking concerns remain:
+        </p>
+        <ul>
+          <li>
+            <strong>Efficiency.</strong> Every window deserializes every session's bytes even for tabs it
+            does not own. At a handful of windows this is fine; at scale it argues for switching hot streams
+            to <code>emit_to(window_label, …)</code> and having the backend track a
+            <code>session_id → owning_window</code> map, updated on each move. That map is also the natural
+            <strong>ownership coordinator</strong> above.
+          </li>
+          <li>
+            <strong>Ownership coordination.</strong> Two windows must never simultaneously render the same
+            live tab (double input, fighting resizes). The cleanest home for the authoritative
+            <code>session → window</code> assignment is the backend (it already holds the session); windows
+            claim/release through it. A pure-frontend broadcast-channel scheme is possible but more fragile
+            across crashes.
+          </li>
+        </ul>
+        <p>
+          <strong>Resize is a real subtlety:</strong> a PTY has one size. When a tab moves to a differently
+          sized window, exactly one window must own the <code>resize</code> for that session — the one
+          currently displaying it — and the backend must apply the new dimensions once, not race two windows.
+        </p>
+      </section>
+
+      <!-- ── Feasibility matrix ─────────────────────────────────────── -->
+      <section>
+        <h2 id="matrix">Per-Session-Type Feasibility Matrix <a class="anchor" href="#matrix">#</a></h2>
+        <p>
+          "Moves cleanly" = backend session survives and only the view re-attaches. The
+          <code>contentType</code> values are from <code>src/types/terminal.ts</code>.
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Session / tab type</th>
+                <th>Move difficulty</th>
+                <th>Why</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Local shell / PTY (+ xterm.js)</td>
+                <td><strong>Easy</strong></td>
+                <td>Backend PTY survives; fresh xterm + RingBuffer replay. Scrollback beyond 1 MiB is lost.</td>
+              </tr>
+              <tr>
+                <td>SSH (local or agent-mediated)</td>
+                <td><strong>Easy</strong></td>
+                <td>Same stream model. Agent/persistent sessions already support detach + re-attach with replay — the exact primitive.</td>
+              </tr>
+              <tr>
+                <td>Serial</td>
+                <td><strong>Easy</strong></td>
+                <td>24/7 RingBuffer capture already exists; re-attach replays. Port stays open in backend.</td>
+              </tr>
+              <tr>
+                <td>Telnet / Docker / WSL</td>
+                <td><strong>Easy</strong></td>
+                <td>Identical PTY/stream + id-keyed IPC model.</td>
+              </tr>
+              <tr>
+                <td>Agent sessions (remote daemon)</td>
+                <td><strong>Easy</strong></td>
+                <td>Detach/adopt/attach is already built (<code>adopt_persistent_session</code>, scrollback fetch). Best-supported case.</td>
+              </tr>
+              <tr>
+                <td>File browser / SFTP / FTP (<code>file-browser</code>, terminal-less)</td>
+                <td><strong>Medium</strong></td>
+                <td>Backend SFTP session (keyed in <code>SftpManager</code>) survives, but current dir / selection are frontend-only and must serialize. In-flight transfers use a <strong>shared Transfer Queue</strong> (<code>src/components/TransferQueue</code>) — a move must not abort them; the queue is app-scoped, so its ownership across windows is an open question.</td>
+              </tr>
+              <tr>
+                <td>RDP / VNC graphical (<code>remote-desktop</code>, <code>&lt;canvas&gt;</code>)</td>
+                <td><strong>Hard (command-only)</strong></td>
+                <td>Backend graphical session survives (frames broadcast on <code>remote-desktop-frame</code>), but the framebuffer is canvas memory in window A. Window B repaints only on the next <em>full</em> frame — there is no on-demand keyframe today — so expect a blank/stale flash. Cursor/clipboard/cert-prompt state is per-webview. <strong>Recommend command-based move with a "reconnecting view…" placeholder; a backend "request full frame on attach" hook would materially improve this.</strong></td>
+              </tr>
+              <tr>
+                <td>Editor (<code>editor</code>, Monaco)</td>
+                <td><strong>Medium</strong></td>
+                <td>Unsaved buffer + cursor live in window A's Monaco. Moving means re-opening the file in B and transferring dirty state — non-trivial; may restrict to saved files in v1.</td>
+              </tr>
+              <tr>
+                <td>Non-session tabs: Settings, Log Viewer, Connection/Tunnel/Workspace editors, Network Diagnostic</td>
+                <td><strong>N/A / restrict</strong></td>
+                <td>No backend session; some are effectively singletons (Settings, Log Viewer). Moving is pure view transfer but often meaningless. Likely non-goal — restrict to session-bearing tabs, or allow but forbid duplicates.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ── Platform constraints ───────────────────────────────────── -->
+      <section>
+        <h2 id="platform">Per-Platform Constraints <a class="anchor" href="#platform">#</a></h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>Platform</th><th>Constraint</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>macOS (WKWebView)</td>
+                <td>Closing the <em>last</em> window conventionally does <strong>not</strong> quit the app (stays in Dock) — needs an explicit policy vs. Windows/Linux. Also: <code>tauri-driver</code> has no macOS WKWebView driver (ADR-5), so multi-window <strong>E2E cannot be automated on macOS</strong> — verification is manual there.</td>
+              </tr>
+              <tr>
+                <td>Windows (WebView2) / Linux (WebKitGTK)</td>
+                <td>Last-window-close typically quits. Each new window is a full webview → real RAM cost (another React app + xterm instances). No cross-window native tab drag on any platform with the current stack.</td>
+              </tr>
+              <tr>
+                <td>All platforms</td>
+                <td>Cross-window webview→webview drag is not provided by Tauri; <code>@dnd-kit</code> is single-document. Tab-tear/inter-window drag must fall back to commands. Each window re-runs the full frontend bundle (memory + startup cost per window).</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ── States & Sequences ─────────────────────────────────────── -->
+      <section>
+        <h2 id="behavior">States &amp; Sequences <a class="anchor" href="#behavior">#</a></h2>
+        <div class="diagram">
+          <span class="diagram__caption">Window lifecycle with owned tabs</span>
+          <pre class="mermaid">
+stateDiagram-v2
+    [*] --> MainWindow
+    MainWindow --> MultiWindow: New Window / Move to New Window
+    MultiWindow --> MultiWindow: move tab A↔B (session survives)
+    MultiWindow --> CloseWithTabs: close a window holding live tabs
+    CloseWithTabs --> Detach: persistent/agent → detach (process lives)
+    CloseWithTabs --> Prompt: non-persistent live → confirm close/close-sessions
+    Detach --> MultiWindow
+    Prompt --> MultiWindow
+    MultiWindow --> MainWindow: down to one window
+    MainWindow --> [*]: last window closed → quit policy (per-OS)
+          </pre>
+        </div>
+        <div class="diagram">
+          <span class="diagram__caption">Ownership handshake (prevents a tab living in two windows)</span>
+          <pre class="mermaid">
+sequenceDiagram
+  participant A as Window A
+  participant C as Backend coordinator (session→window map)
+  participant B as Window B
+  A->>C: release(sessionId)
+  C->>B: grant(sessionId)
+  B->>C: attach + replay
+  Note over C: map now says sessionId → win-B; only B renders it
+          </pre>
+        </div>
+      </section>
+
+      <!-- ── Limitations / Non-goals / Open questions ───────────────── -->
+      <section>
+        <h2 id="limits">Limitations · Non-Goals · Open Questions <a class="anchor" href="#limits">#</a></h2>
+
+        <h3>Hard limitations (these shape the UX)</h3>
+        <ol>
+          <li>
+            <strong>No cross-window native drag.</strong> The tab DnD stack (<code>@dnd-kit</code>,
+            <code>SplitView.tsx</code>) is single-document and cannot follow the cursor across a native
+            window boundary; Tauri exposes no webview→webview drag. <strong>Tear-out and drag-between-windows
+            must ship as commands / context-menu items</strong> ("Move to New Window", "Move to Window ▸ N");
+            a drag gesture is at best a future enhancement, not the v1 mechanism.
+          </li>
+          <li>
+            <strong>Graphical (RDP/VNC) tabs move via command only, with a repaint flash.</strong> The
+            framebuffer is canvas memory in the source window; the destination repaints only on the next
+            full frame (no on-demand keyframe today), so the canvas may be blank/stale briefly. Live drag is
+            especially unsuitable here.
+          </li>
+          <li>
+            <strong>Scrollback fidelity is bounded by the backend replay buffer (1 MiB RingBuffer).</strong>
+            The source window's fully-rendered xterm scrollback is discarded (separate JS context — DOM/memory
+            cannot transfer); the destination shows only what the backend can replay. Very long histories are
+            truncated on move.
+          </li>
+          <li>
+            <strong>Separate JS contexts — no shared store.</strong> Each window is its own React/Zustand
+            instance. Cross-window features (tab counts, "move to" menus listing other windows, ownership)
+            require a coordination channel (backend-brokered is recommended over a frontend broadcast channel).
+          </li>
+          <li>
+            <strong>No window dimension in persistence.</strong> <code>WorkspaceDefinition</code> and
+            last-session restore have no field for window assignment. Saving/restoring a multi-window layout
+            needs a schema addition (a window id per tab group / per tab) and new multi-window restore
+            lifecycle.
+          </li>
+          <li>
+            <strong>Window-close policy is new.</strong> Closing a window with live tabs must choose
+            detach-vs-terminate (persistent/agent sessions should detach, not die); "last window closed →
+            quit" differs by OS (macOS keeps the app alive).
+          </li>
+          <li>
+            <strong>Resize ownership.</strong> A PTY has one size; exactly one window may own a session's
+            <code>resize</code> at a time, and the backend must apply it without racing two windows.
+          </li>
+          <li>
+            <strong>Per-window memory cost.</strong> Each window re-runs the full frontend bundle and its own
+            xterm/canvas instances — a real RAM multiplier, relevant to the app's resource footprint.
+          </li>
+          <li>
+            <strong>Automated-test gap on macOS.</strong> <code>tauri-driver</code> has no macOS driver
+            (ADR-5), and the Python bridge harness would need multi-window awareness. Multi-window behavior on
+            macOS is manual-test-only.
+          </li>
+        </ol>
+
+        <h3>Non-goals</h3>
+        <ul>
+          <li>Mirroring one live session into two windows at once.</li>
+          <li>Detaching sidebar panels (connection tree, network tools) into windows.</li>
+          <li>Moving non-session/singleton tabs (Settings, Log Viewer) — likely restricted.</li>
+          <li>Multi-process windows — these are additional webviews in one Tauri process.</li>
+        </ul>
+
+        <h3>Open questions (need the human or the UX step)</h3>
+        <ul>
+          <li>
+            <strong>Do windows map onto tab groups?</strong> Tab groups are already independent panel trees.
+            The cleanest model may be "a window owns one or more tab groups," reusing that substrate — but
+            that couples the two features. Product decision.
+          </li>
+          <li>
+            <strong>Is a drag-out gesture worth prototyping</strong> given @dnd-kit can't cross windows? (An
+            OS-drag-image + drop-detection hack is conceivable but unproven in Tauri — research item.)
+          </li>
+          <li><strong>Detach-vs-terminate default</strong> when closing a window with non-persistent live tabs.</li>
+          <li><strong>Are graphical tabs allowed to move at all in v1</strong>, or deferred until a "request full frame on attach" backend hook exists?</li>
+          <li><strong>Transfer-queue ownership</strong> when an SFTP/FTP tab with in-flight transfers moves windows.</li>
+          <li><strong>Should the Open Connections panel and workspace save/restore become window-aware</strong>, or stay window-agnostic in v1?</li>
+        </ul>
+      </section>
+
+      <!-- ── Preliminary Implementation Details ─────────────────────── -->
+      <section>
+        <h2 id="impl">Preliminary Implementation Details <a class="anchor" href="#impl">#</a></h2>
+        <p>Based on the architecture at concept-creation time. Directional, not a build plan.</p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>Area</th><th>Change</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>src-tauri/src/lib.rs</code> / new <code>window</code> module</td>
+                <td><strong>New</strong> — <code>WebviewWindowBuilder</code> to create labelled windows (<code>win-N</code>); a backend <em>session→window ownership map</em> + claim/release commands; window-aware close/quit policy in the <code>RunEvent</code> handler.</td>
+              </tr>
+              <tr>
+                <td><code>src-tauri/src/session/manager.rs</code></td>
+                <td>Add an on-demand <em>scrollback replay for a specific window</em> path (reuse the existing persistent/agent replay) and, later, optional <code>emit_to(window_label, …)</code> targeting instead of global broadcast for hot streams.</td>
+              </tr>
+              <tr>
+                <td><code>src-tauri/src/session/graphical_manager.rs</code></td>
+                <td>Add a "request full frame on (re)attach" hook so a moved RDP/VNC tab repaints immediately rather than waiting for the next full frame.</td>
+              </tr>
+              <tr>
+                <td><code>src/store/appStore.ts</code></td>
+                <td>Extend the existing <code>moveTab</code>/<code>moveTabToGroup</code> seam with <code>moveTabToWindow</code>; serialize a <code>TerminalTab</code> hand-off record; hydrate a tab into a fresh store on window boot; dispose on release.</td>
+              </tr>
+              <tr>
+                <td><code>src/services/events.ts</code></td>
+                <td><code>SessionEventDispatcher</code> already filters by <code>session_id</code> — extend so a window only subscribes for sessions it owns (feeds the efficiency/<code>emit_to</code> path).</td>
+              </tr>
+              <tr>
+                <td><code>src/types/workspace.ts</code>, workspace + last-session backend</td>
+                <td><strong>New</strong> — an optional window-assignment dimension so multi-window layouts save/restore.</td>
+              </tr>
+              <tr>
+                <td>Tab context menu / command palette (<code>SplitView</code>, <code>TabBar</code>)</td>
+                <td><strong>New</strong> — "Move to New Window" / "Move to Window ▸ N" commands (the primary mechanism; drag is a later enhancement).</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ── Sync ledger ────────────────────────────────────────────── -->
+      <section>
+        <h2 id="sync">Sync Ledger <a class="anchor" href="#sync">#</a></h2>
+        <blockquote>
+          <p>
+            Maintained by <code>/sync-concept &lt;name&gt;</code>. Records the last commit at which the
+            concept and code were reconciled, plus open divergences. The concept is the source of truth.
+          </p>
+        </blockquote>
+        <p>
+          <strong>Last synced:</strong> never (not implemented) · <strong>Status:</strong> diverged (by design — concept only)
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Artifact claim</th>
+                <th>Code reality</th>
+                <th>Type</th>
+                <th>Recommendation</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>1</td>
+                <td>Multiple application windows</td>
+                <td>Single <code>"main"</code> window; no <code>WebviewWindowBuilder</code> in production</td>
+                <td>Missing</td>
+                <td>Implement per this concept, then re-sync</td>
+              </tr>
+              <tr>
+                <td>2</td>
+                <td>Cross-window tab move (session survives)</td>
+                <td>Backend session survival + detach/re-attach replay already exist; no cross-window plumbing</td>
+                <td>Partial substrate</td>
+                <td>Reuse existing replay/adopt path; add window ownership + hand-off</td>
+              </tr>
+              <tr>
+                <td>3</td>
+                <td>Drag a tab between windows</td>
+                <td><code>@dnd-kit</code> single-document; no cross-window drag</td>
+                <td>Constraint</td>
+                <td>Ship as command; drag gesture is an open research item</td>
+              </tr>
+              <tr>
+                <td>4</td>
+                <td>Window layout persists across restart</td>
+                <td>No window field in <code>WorkspaceDefinition</code> / last-session</td>
+                <td>Missing</td>
+                <td>Add window-assignment dimension to persistence schema</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+
+    <!-- Mermaid: vendored, offline, renders <pre class="mermaid"> as text → SVG. -->
+    <script src="../_assets/mermaid.min.js"></script>
+    <script>
+      mermaid.initialize({
+        startOnLoad: true,
+        theme: "dark",
+        securityLevel: "loose",
+        fontFamily: "Geist, sans-serif",
+      });
+    </script>
+  </body>
+</html>

--- a/docs/concepts/backlog/multi-window.html
+++ b/docs/concepts/backlog/multi-window.html
@@ -12,9 +12,310 @@
     <title>Multi-Window Support (concept)</title>
     <link rel="stylesheet" href="../_assets/mockup.css" />
     <link rel="stylesheet" href="../_assets/concept.css" />
+    <!-- Mockup-scoped helpers (structure only; real chrome comes from mockup.css). -->
+    <style>
+      /* Two application windows side by side. */
+      .window-row {
+        display: flex;
+        align-items: stretch;
+        gap: 0;
+      }
+      .window-row .app {
+        flex: 1 1 0;
+        min-width: 0;
+      }
+      .window-row__arrow {
+        flex: 0 0 56px;
+        display: grid;
+        place-items: center;
+        color: var(--broadcast-accent);
+      }
+      .window-row__arrow .li {
+        width: 28px;
+        height: 28px;
+      }
+      .window-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        color: var(--text-secondary);
+        margin: 0 0 6px;
+      }
+      .window-label .li {
+        width: 13px;
+        height: 13px;
+      }
+      /* Right-clicked tab + ghost (being moved out) states. */
+      .tab--context {
+        background: var(--bg-active);
+        color: var(--text-primary);
+        border-top-color: var(--broadcast-accent);
+      }
+      .tab--ghost {
+        opacity: 0.4;
+      }
+      .tab--incoming {
+        background: var(--tab-active-bg);
+        color: var(--text-primary);
+        border-top-color: var(--broadcast-accent);
+        box-shadow: inset 0 2px 0 0 var(--broadcast-accent);
+      }
+      /* Tab-bar insertion caret for an incoming tab. */
+      .tab-insert {
+        width: 2px;
+        align-self: stretch;
+        background: var(--broadcast-accent);
+      }
+      /* Context-menu submenu arrow / anchoring. */
+      .menu.context-menu {
+        width: 260px;
+      }
+      .menu__row .menu__arrow {
+        margin-left: auto;
+        width: 14px;
+        height: 14px;
+        color: var(--text-secondary);
+      }
+      .menu__row .li {
+        width: 15px;
+        height: 15px;
+        color: var(--text-secondary);
+        flex: 0 0 auto;
+      }
+      .menu__row--new {
+        color: var(--text-primary);
+      }
+      .menu__row--new .li {
+        color: var(--text-accent);
+      }
+      .menu__row--disabled {
+        color: var(--text-disabled);
+      }
+      .menu__row--disabled .li {
+        color: var(--text-disabled);
+      }
+      .menu__sep {
+        height: 1px;
+        background: var(--border-secondary);
+        margin: 4px 0;
+      }
+      .menu__sub-label {
+        margin-left: auto;
+        color: var(--text-secondary);
+        font-size: 11px;
+      }
+      /* Empty-window call to action. */
+      .empty-state {
+        margin: auto;
+        max-width: 380px;
+        padding: 24px;
+        text-align: center;
+      }
+      .empty-state__icon {
+        width: 56px;
+        height: 56px;
+        margin: 0 auto 14px;
+        border-radius: var(--radius-lg);
+        display: grid;
+        place-items: center;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+      }
+      .empty-state__icon .li {
+        width: 28px;
+        height: 28px;
+        stroke-width: 1.5;
+      }
+      .empty-state__title {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin: 0 0 4px;
+      }
+      .empty-state__sub {
+        color: var(--text-secondary);
+        margin: 0 0 18px;
+        font-size: 12px;
+      }
+      .empty-state__actions {
+        display: flex;
+        gap: 8px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      .empty-state__actions .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .empty-state__actions .li {
+        width: 14px;
+        height: 14px;
+      }
+      /* Graphical-tab move: canvas placeholder + reconnecting overlay. */
+      .canvas-surface {
+        flex: 1 1 auto;
+        position: relative;
+        display: grid;
+        place-items: center;
+        background:
+          repeating-linear-gradient(
+            45deg,
+            #0b0d12,
+            #0b0d12 12px,
+            #0e1017 12px,
+            #0e1017 24px
+          );
+        overflow: hidden;
+      }
+      .reconnect-overlay {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        background: rgba(6, 7, 10, 0.72);
+        backdrop-filter: blur(1px);
+      }
+      .reconnect-card {
+        text-align: center;
+        color: var(--text-secondary);
+      }
+      .reconnect-card .li {
+        width: 26px;
+        height: 26px;
+        color: var(--text-accent);
+      }
+      .reconnect-card__title {
+        margin: 10px 0 2px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-primary);
+      }
+      .reconnect-card__sub {
+        font-size: 12px;
+        max-width: 280px;
+      }
+      .spin {
+        animation: spin 1.1s linear infinite;
+        transform-origin: center;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      /* Close-window decision dialog. */
+      .dialog {
+        width: 460px;
+        max-width: 100%;
+      }
+      .dialog__body {
+        padding: 14px;
+      }
+      .dialog__lead {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        margin: 0 0 12px;
+      }
+      .dialog__lead .li {
+        width: 22px;
+        height: 22px;
+        color: var(--color-warning);
+        flex: 0 0 auto;
+      }
+      .dialog__lead p {
+        margin: 0;
+        color: var(--text-secondary);
+      }
+      .session-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 10px;
+        border: 1px solid var(--border-secondary);
+        border-radius: var(--radius-md);
+        margin-bottom: 6px;
+        background: var(--bg-tertiary);
+        font-size: 12px;
+      }
+      .session-row .li {
+        width: 15px;
+        height: 15px;
+        color: var(--text-secondary);
+        flex: 0 0 auto;
+      }
+      .session-row__name {
+        color: var(--text-primary);
+      }
+      .pill {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-size: 11px;
+        font-weight: 600;
+        white-space: nowrap;
+      }
+      .pill .li {
+        width: 12px;
+        height: 12px;
+      }
+      .pill--detach {
+        color: var(--state-connected);
+        background: color-mix(in srgb, var(--state-connected) 16%, transparent);
+      }
+      .pill--detach .li {
+        color: var(--state-connected);
+      }
+      .pill--terminate {
+        color: var(--color-error);
+        background: color-mix(in srgb, var(--color-error) 16%, transparent);
+      }
+      .pill--terminate .li {
+        color: var(--color-error);
+      }
+      .btn--danger {
+        background: var(--state-disconnected);
+        border-color: var(--state-disconnected);
+        color: #fff;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .btn .li {
+        width: 14px;
+        height: 14px;
+      }
+      /* Future-enhancement drag affordance illustration. */
+      .drag-ghost {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        height: var(--tab-height);
+        padding: 0 12px;
+        border-radius: var(--radius-md);
+        background: var(--bg-active);
+        border: 1px dashed var(--broadcast-accent);
+        color: var(--text-primary);
+        font-size: 12px;
+        box-shadow: var(--shadow-overlay);
+      }
+      .drag-ghost .li {
+        width: 14px;
+        height: 14px;
+      }
+    </style>
   </head>
   <body class="mockup-doc">
-    <!-- Inline lucide sprite (only the symbols referenced below). -->
+    <!-- Inline lucide sprite (real lucide geometry) — union of all mockup symbols. -->
     <svg width="0" height="0" style="position: absolute" aria-hidden="true">
       <symbol id="i-network" viewBox="0 0 24 24">
         <rect x="16" y="16" width="6" height="6" rx="1" />
@@ -22,6 +323,152 @@
         <rect x="9" y="2" width="6" height="6" rx="1" />
         <path d="M5 16v-3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v3" />
         <path d="M12 12V8" />
+      </symbol>
+      <symbol id="i-folder-open" viewBox="0 0 24 24">
+        <path
+          d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"
+        />
+      </symbol>
+      <symbol id="i-layout-grid" viewBox="0 0 24 24">
+        <rect width="7" height="7" x="3" y="3" rx="1" />
+        <rect width="7" height="7" x="14" y="3" rx="1" />
+        <rect width="7" height="7" x="14" y="14" rx="1" />
+        <rect width="7" height="7" x="3" y="14" rx="1" />
+      </symbol>
+      <symbol id="i-scroll-text" viewBox="0 0 24 24">
+        <path d="M15 12h-5" />
+        <path d="M15 8h-5" />
+        <path d="M19 17V5a2 2 0 0 0-2-2H4" />
+        <path
+          d="M8 21h12a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1H11a1 1 0 0 0-1 1v1a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v2a1 1 0 0 0 1 1h3"
+        />
+      </symbol>
+      <symbol id="i-settings" viewBox="0 0 24 24">
+        <path
+          d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"
+        />
+        <circle cx="12" cy="12" r="3" />
+      </symbol>
+      <symbol id="i-plus" viewBox="0 0 24 24">
+        <path d="M5 12h14" />
+        <path d="M12 5v14" />
+      </symbol>
+      <symbol id="i-columns-2" viewBox="0 0 24 24">
+        <rect width="18" height="18" x="3" y="3" rx="2" />
+        <path d="M12 3v18" />
+      </symbol>
+      <symbol id="i-rows-2" viewBox="0 0 24 24">
+        <rect width="18" height="18" x="3" y="3" rx="2" />
+        <path d="M3 12h18" />
+      </symbol>
+      <symbol id="i-panel-left" viewBox="0 0 24 24">
+        <rect width="18" height="18" x="3" y="3" rx="2" />
+        <path d="M9 3v18" />
+      </symbol>
+      <symbol id="i-x" viewBox="0 0 24 24">
+        <path d="M18 6 6 18" />
+        <path d="m6 6 12 12" />
+      </symbol>
+      <symbol id="i-terminal" viewBox="0 0 24 24">
+        <path d="m4 17 6-6-6-6" />
+        <path d="M12 19h8" />
+      </symbol>
+      <symbol id="i-monitor" viewBox="0 0 24 24">
+        <rect width="20" height="14" x="2" y="3" rx="2" />
+        <line x1="8" x2="16" y1="21" y2="21" />
+        <line x1="12" x2="12" y1="17" y2="21" />
+      </symbol>
+      <symbol id="i-app-window" viewBox="0 0 24 24">
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="M10 4v4" />
+        <path d="M2 8h20" />
+        <path d="M6 4v4" />
+      </symbol>
+      <symbol id="i-external-link" viewBox="0 0 24 24">
+        <path d="M15 3h6v6" />
+        <path d="M10 14 21 3" />
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      </symbol>
+      <symbol id="i-chevron-right" viewBox="0 0 24 24">
+        <path d="m9 18 6-6-6-6" />
+      </symbol>
+      <symbol id="i-arrow-right" viewBox="0 0 24 24">
+        <path d="M5 12h14" />
+        <path d="m12 5 7 7-7 7" />
+      </symbol>
+      <symbol id="i-arrow-left-right" viewBox="0 0 24 24">
+        <path d="M8 3 4 7l4 4" />
+        <path d="M4 7h16" />
+        <path d="m16 21 4-4-4-4" />
+        <path d="M20 17H4" />
+      </symbol>
+      <symbol id="i-loader" viewBox="0 0 24 24">
+        <path d="M12 2v4" />
+        <path d="m16.2 7.8 2.9-2.9" />
+        <path d="M18 12h4" />
+        <path d="m16.2 16.2 2.9 2.9" />
+        <path d="M12 18v4" />
+        <path d="m4.9 19.1 2.9-2.9" />
+        <path d="M2 12h4" />
+        <path d="m4.9 4.9 2.9 2.9" />
+      </symbol>
+      <symbol id="i-refresh-cw" viewBox="0 0 24 24">
+        <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+        <path d="M21 3v5h-5" />
+        <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+        <path d="M8 16H3v5" />
+      </symbol>
+      <symbol id="i-triangle-alert" viewBox="0 0 24 24">
+        <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+        <path d="M12 9v4" />
+        <path d="M12 17h.01" />
+      </symbol>
+      <symbol id="i-power" viewBox="0 0 24 24">
+        <path d="M12 2v10" />
+        <path d="M18.4 6.6a9 9 0 1 1-12.77.04" />
+      </symbol>
+      <symbol id="i-plug" viewBox="0 0 24 24">
+        <path d="M12 22v-5" />
+        <path d="M9 8V2" />
+        <path d="M15 8V2" />
+        <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
+      </symbol>
+      <symbol id="i-pencil" viewBox="0 0 24 24">
+        <path
+          d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"
+        />
+      </symbol>
+      <symbol id="i-file-up" viewBox="0 0 24 24">
+        <path
+          d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"
+        />
+        <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+        <path d="M12 12v6" />
+        <path d="m15 15-3-3-3 3" />
+      </symbol>
+      <symbol id="i-clipboard" viewBox="0 0 24 24">
+        <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
+        <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+      </symbol>
+      <symbol id="i-palette" viewBox="0 0 24 24">
+        <path
+          d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z"
+        />
+        <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+        <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+        <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+        <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+      </symbol>
+      <symbol id="i-check" viewBox="0 0 24 24">
+        <path d="M20 6 9 17l-5-5" />
+      </symbol>
+      <symbol id="i-grip-vertical" viewBox="0 0 24 24">
+        <circle cx="9" cy="12" r="1" />
+        <circle cx="9" cy="5" r="1" />
+        <circle cx="9" cy="19" r="1" />
+        <circle cx="15" cy="12" r="1" />
+        <circle cx="15" cy="5" r="1" />
+        <circle cx="15" cy="19" r="1" />
       </symbol>
     </svg>
 
@@ -281,25 +728,614 @@ flowchart TB
       <section>
         <h2 id="ui">UI Interface <a class="anchor" href="#ui">#</a></h2>
         <p>
-          The interaction design — the drag-to-tear gesture and its command fallback, the drag-between-windows
-          affordance, the "New Window" entry points, the empty-window state, and every edge-case surface — is
-          <strong>step 2</strong>. The technical constraints those mockups must respect are: (a) native
-          drag cannot cross windows with today's stack, so a command/menu path is mandatory and a drag gesture
-          is at best an enhancement; (b) graphical tabs may need a "moving…" placeholder while the framebuffer
-          repaints; (c) an empty window is a real state (a window can exist with zero tabs). See
-          <a href="#limits">Limitations</a> for the full list the UX must design around.
+          This is <strong>step 2</strong> — the interaction design, authored against the engineer's
+          constraints above. The whole design turns on one fact from
+          <a href="#limits">Limitations</a>: <strong>a tab cannot be dragged across a native window
+          boundary</strong> with today's stack (<code>@dnd-kit</code> is single-document). So the v1
+          mechanism for tearing out and moving tabs is <strong>commands and context-menu items</strong>,
+          not a live drag gesture. Everything below follows from that: the tab context menu grows a
+          <em>Move to Window</em> group, an <em>empty window</em> is a first-class state with its own
+          call-to-action, graphical (RDP/VNC) tabs move with a <em>reconnecting-view</em> placeholder,
+          and closing a window that still owns live tabs raises a <em>detach-vs-terminate</em> decision.
+          A drag-to-tear gesture appears once, at the end, clearly labelled a
+          <strong>future enhancement</strong>.
         </p>
-        <!-- MOCKUPS: to be authored by UX step (see #1806).
-             Build inline <section class="mockup-section"> blocks here using the real
-             mockup.css classes (.app, .tab, .terminal-view__toolbar, .menu, .status-bar,
-             .activity-bar__item, …) + lucide icons. Suggested screens:
-               1. Tab context menu / toolbar overflow → "Move to New Window", "Move to Window ▸ N".
-               2. Two windows side by side, a tab mid-move (source ghost + destination insertion point).
-               3. Empty-window state (no tabs) with a call to action.
-               4. Graphical (RDP/VNC) tab move: "reconnecting view…" placeholder over the canvas.
-               5. Close-window-with-live-tabs confirmation (detach vs. close). -->
-        <div class="mockup-note">
-          Placeholder — no mockups in step 1. The UX designer slots them into the block above.
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Mockup</th>
+                <th>Shows</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>move-menu</code></td>
+                <td>Tab context menu with the new <em>Move to New Window</em> / <em>Move to Window ▸</em> group, and the window-picker submenu</td>
+              </tr>
+              <tr>
+                <td><code>mid-move</code></td>
+                <td>Two windows side by side: source ghost tab leaving, destination insertion point + scrollback replay</td>
+              </tr>
+              <tr>
+                <td><code>empty-window</code></td>
+                <td>A window with zero tabs and its call-to-action</td>
+              </tr>
+              <tr>
+                <td><code>graphical-move</code></td>
+                <td>An RDP/VNC tab arriving in a new window with the "reconnecting view…" placeholder over the canvas</td>
+              </tr>
+              <tr>
+                <td><code>close-decision</code></td>
+                <td>Closing a window with live tabs: the detach-vs-terminate decision surface</td>
+              </tr>
+              <tr>
+                <td><code>drag-future</code></td>
+                <td>The optional drag-to-tear affordance — a labelled future enhancement, not v1</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Core interaction model — commands, not cross-window drag</h3>
+        <p>
+          Moving a tab is a <strong>menu/command action with an explicit destination</strong>, never a
+          drag onto another window's tab bar. Every session tab exposes a <strong>Move to Window</strong>
+          group in its right-click context menu (the same Radix <code>ContextMenu</code> that today holds
+          Rename / Save to File / … — see <code>src/components/Terminal/Tab.tsx</code>):
+        </p>
+        <ul>
+          <li>
+            <strong>Move to New Window</strong> — tears the tab out into a brand-new window seeded with
+            just that tab. This is the one-click "give this its own screen" path.
+          </li>
+          <li>
+            <strong>Move to Window ▸</strong> — a submenu listing every <em>other</em> open window by
+            name and tab count, plus a <strong>New Window</strong> entry at the top (so the submenu is a
+            superset of the direct command). Picking one hands the tab to that window. The current window
+            is shown disabled ("current") so the list is unambiguous.
+          </li>
+        </ul>
+        <p>
+          Because a tab renders in <strong>exactly one window at a time</strong>, the destination is
+          brokered by the backend ownership map (<a href="#state">State &amp; Retargeting</a>): the pick
+          triggers a release-in-A → grant-to-B handshake, so there is never a window where the tab is
+          shown twice or nowhere.
+        </p>
+
+        <h3>Entry points</h3>
+        <ul>
+          <li><strong>Tab context menu</strong> — the primary surface (mockup <code>move-menu</code>).</li>
+          <li>
+            <strong>New Window</strong> — a top-level command (application menu / command palette,
+            keyboard shortcut <code>Ctrl/Cmd+Shift+N</code>) opens an empty window (mockup
+            <code>empty-window</code>). It is also the first row of the <em>Move to Window ▸</em> submenu.
+          </li>
+          <li>
+            <strong>Status-bar window affordance</strong> — when more than one window is open, the status
+            bar shows the window's name, so users can tell windows apart at a glance.
+          </li>
+        </ul>
+
+        <!-- Mockup 1: Move-to-Window context menu + submenu -->
+        <div class="mockup-section">
+          <h3>Mockup — <code>move-menu</code>: the Move-to-Window command surface</h3>
+          <div class="mockup-note">
+            Right-clicking a session tab <span class="callout">A</span> opens its context menu. The new
+            <strong>Move to Window</strong> group <span class="callout">B</span> sits just below Rename;
+            <em>Move to Window ▸</em> opens the window picker <span class="callout">C</span>. This is the
+            v1 tear-out / move mechanism — no drag required.
+          </div>
+          <div class="app" style="height: 300px">
+            <div class="app__body">
+              <nav class="activity-bar">
+                <div class="activity-bar__top">
+                  <button class="activity-bar__item activity-bar__item--active" title="Connections">
+                    <svg class="li"><use href="#i-network" /></svg>
+                    <span class="activity-bar__indicator"></span>
+                  </button>
+                  <button class="activity-bar__item" title="File Browser">
+                    <svg class="li"><use href="#i-folder-open" /></svg>
+                  </button>
+                  <button class="activity-bar__item" title="Workspaces">
+                    <svg class="li"><use href="#i-layout-grid" /></svg>
+                  </button>
+                </div>
+                <div class="activity-bar__bottom">
+                  <button class="activity-bar__item" title="Log Viewer">
+                    <svg class="li"><use href="#i-scroll-text" /></svg>
+                  </button>
+                  <button class="activity-bar__item" title="Settings">
+                    <svg class="li"><use href="#i-settings" /></svg>
+                  </button>
+                </div>
+              </nav>
+              <aside class="sidebar">
+                <div class="sidebar__header"><span class="sidebar__title">Connections</span></div>
+                <div class="sidebar__content">
+                  <div class="connection-tree__item connection-tree__item--selected">
+                    <span class="state-dot state-dot--connected"></span> server-1
+                  </div>
+                  <div class="connection-tree__item">
+                    <span class="state-dot state-dot--connected"></span> server-2
+                  </div>
+                  <div class="connection-tree__item">
+                    <span class="state-dot state-dot--connected"></span> build
+                  </div>
+                </div>
+              </aside>
+              <div class="terminal-view">
+                <div class="terminal-view__content">
+                  <div class="panel">
+                    <div class="tab-bar">
+                      <div class="tab tab--active">
+                        <svg class="li"><use href="#i-network" /></svg>
+                        <span class="tab__title">server-1</span>
+                        <button class="tab__close"><svg class="li"><use href="#i-x" /></svg></button>
+                      </div>
+                      <div class="tab tab--context" title="Right-clicked">
+                        <svg class="li"><use href="#i-network" /></svg>
+                        <span class="tab__title">server-2</span>
+                        <button class="tab__close"><svg class="li"><use href="#i-x" /></svg></button>
+                      </div>
+                      <div class="tab">
+                        <svg class="li"><use href="#i-terminal" /></svg>
+                        <span class="tab__title">build</span>
+                      </div>
+                    </div>
+                    <div class="terminal">
+                      <span class="prompt">server-1 $</span> <span class="cursor"></span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="status-bar">
+              <div class="status-bar__section status-bar__section--left">
+                <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 1</span>
+              </div>
+              <div class="status-bar__section status-bar__section--right">
+                <span class="status-bar__item">UTF-8</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="states">
+            <div>
+              <p class="state-label">Tab context menu (Move group added)</p>
+              <div class="menu context-menu">
+                <div class="menu__row"><svg class="li"><use href="#i-pencil" /></svg> Rename</div>
+                <div class="menu__sep"></div>
+                <div class="menu__row menu__row--new">
+                  <svg class="li"><use href="#i-external-link" /></svg> Move to New Window
+                </div>
+                <div class="menu__row menu__row--new menu__row--selected">
+                  <svg class="li"><use href="#i-app-window" /></svg> Move to Window
+                  <svg class="li menu__arrow"><use href="#i-chevron-right" /></svg>
+                </div>
+                <div class="menu__sep"></div>
+                <div class="menu__row"><svg class="li"><use href="#i-file-up" /></svg> Save to File</div>
+                <div class="menu__row"><svg class="li"><use href="#i-clipboard" /></svg> Copy to Clipboard</div>
+                <div class="menu__sep"></div>
+                <div class="menu__row"><svg class="li"><use href="#i-palette" /></svg> Set Color…</div>
+              </div>
+            </div>
+            <div>
+              <p class="state-label">Move to Window ▸ submenu (window picker)</p>
+              <div class="menu context-menu">
+                <div class="menu__row menu__row--new">
+                  <svg class="li"><use href="#i-plus" /></svg> New Window
+                </div>
+                <div class="menu__sep"></div>
+                <div class="menu__row menu__row--disabled">
+                  <svg class="li"><use href="#i-app-window" /></svg> Window 1
+                  <span class="menu__sub-label">current</span>
+                </div>
+                <div class="menu__row">
+                  <svg class="li"><use href="#i-app-window" /></svg> Window 2
+                  <span class="menu__sub-label">2 tabs</span>
+                </div>
+                <div class="menu__row">
+                  <svg class="li"><use href="#i-app-window" /></svg> Window 3
+                  <span class="menu__sub-label">empty</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li><span class="callout">A</span> Right-clicked tab — highlighted (<code>tab--context</code>).</li>
+              <li><span class="callout">B</span> New <strong>Move to Window</strong> group; <em>Move to New Window</em> is the one-click tear-out.</li>
+              <li><span class="callout">C</span> Window picker — lists other windows by name + tab count; <strong>New Window</strong> on top; current window disabled.</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3>User journey — moving a live tab</h3>
+        <p>
+          The move is a pure <em>view</em> operation (the backend session never restarts —
+          <a href="#reparent">Session Re-parenting</a>). What the user sees: the tab vanishes from the
+          source window and reappears in the destination, its scrollback repainted from the backend
+          replay buffer. For an ordinary terminal (local / SSH / serial / Docker) this is near-instant;
+          the only visible loss is scrollback beyond the 1&nbsp;MiB backend buffer.
+        </p>
+
+        <!-- Mockup 2: two windows mid-move -->
+        <div class="mockup-section">
+          <h3>Mockup — <code>mid-move</code>: two windows during a move</h3>
+          <div class="mockup-note">
+            <strong>server-2</strong> is moving from Window 1 to Window 2. In the source it dims to a
+            ghost <span class="callout">D</span> while its view is torn down; in the destination it lands
+            at an insertion caret <span class="callout">E</span> and repaints from replayed scrollback
+            <span class="callout">F</span>. The backend PTY/SSH session never restarts.
+          </div>
+          <div class="window-row">
+            <div style="flex: 1 1 0; min-width: 0; display: flex; flex-direction: column">
+              <div class="window-label"><svg class="li"><use href="#i-app-window" /></svg> Window 1 — source</div>
+              <div class="app" style="height: 300px">
+                <div class="app__body">
+                  <nav class="activity-bar">
+                    <div class="activity-bar__top">
+                      <button class="activity-bar__item activity-bar__item--active" title="Connections">
+                        <svg class="li"><use href="#i-network" /></svg>
+                        <span class="activity-bar__indicator"></span>
+                      </button>
+                    </div>
+                    <div class="activity-bar__bottom">
+                      <button class="activity-bar__item" title="Settings">
+                        <svg class="li"><use href="#i-settings" /></svg>
+                      </button>
+                    </div>
+                  </nav>
+                  <div class="terminal-view">
+                    <div class="terminal-view__content">
+                      <div class="panel">
+                        <div class="tab-bar">
+                          <div class="tab tab--active">
+                            <svg class="li"><use href="#i-network" /></svg>
+                            <span class="tab__title">server-1</span>
+                          </div>
+                          <div class="tab tab--ghost" title="Leaving this window">
+                            <svg class="li spin"><use href="#i-loader" /></svg>
+                            <span class="tab__title">server-2</span>
+                          </div>
+                          <div class="tab">
+                            <svg class="li"><use href="#i-terminal" /></svg>
+                            <span class="tab__title">build</span>
+                          </div>
+                        </div>
+                        <div class="terminal">
+                          <span class="prompt">server-1 $</span> uptime<span class="cursor"></span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="status-bar">
+                  <div class="status-bar__section status-bar__section--left">
+                    <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 1</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="window-row__arrow"><svg class="li"><use href="#i-arrow-right" /></svg></div>
+
+            <div style="flex: 1 1 0; min-width: 0; display: flex; flex-direction: column">
+              <div class="window-label"><svg class="li"><use href="#i-app-window" /></svg> Window 2 — destination</div>
+              <div class="app" style="height: 300px">
+                <div class="app__body">
+                  <nav class="activity-bar">
+                    <div class="activity-bar__top">
+                      <button class="activity-bar__item activity-bar__item--active" title="Connections">
+                        <svg class="li"><use href="#i-network" /></svg>
+                        <span class="activity-bar__indicator"></span>
+                      </button>
+                    </div>
+                    <div class="activity-bar__bottom">
+                      <button class="activity-bar__item" title="Settings">
+                        <svg class="li"><use href="#i-settings" /></svg>
+                      </button>
+                    </div>
+                  </nav>
+                  <div class="terminal-view">
+                    <div class="terminal-view__content">
+                      <div class="panel">
+                        <div class="tab-bar">
+                          <div class="tab">
+                            <svg class="li"><use href="#i-scroll-text" /></svg>
+                            <span class="tab__title">logs</span>
+                          </div>
+                          <div class="tab-insert" title="Insertion point"></div>
+                          <div class="tab tab--incoming">
+                            <svg class="li"><use href="#i-network" /></svg>
+                            <span class="tab__title">server-2</span>
+                            <button class="tab__close"><svg class="li"><use href="#i-x" /></svg></button>
+                          </div>
+                        </div>
+                        <div class="terminal">
+                          <span style="color: var(--text-secondary)">⟲ restored 1 MiB scrollback</span><br />
+                          <span class="prompt">server-2 $</span> uptime<span class="cursor"></span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="status-bar">
+                  <div class="status-bar__section status-bar__section--left">
+                    <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 2</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li><span class="callout">D</span> Source ghost — the tab dims and shows a spinner while its xterm view is disposed.</li>
+              <li><span class="callout">E</span> Destination insertion caret — where the incoming tab lands (<code>tab--incoming</code>).</li>
+              <li><span class="callout">F</span> Scrollback replayed from the backend <code>RingBuffer</code>; history beyond 1&nbsp;MiB is truncated.</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3>Empty window — a first-class state</h3>
+        <p>
+          A window can exist with <strong>zero tabs</strong> — right after <em>New Window</em>, or after
+          its last tab is moved or closed. Rather than an accidental blank pane, the content area shows a
+          deliberate call-to-action so the window is immediately useful.
+        </p>
+
+        <!-- Mockup 3: empty window -->
+        <div class="mockup-section">
+          <h3>Mockup — <code>empty-window</code>: the empty-window call-to-action</h3>
+          <div class="mockup-note">
+            No tab bar, no terminal — the content area holds a centred call-to-action
+            <span class="callout">G</span>. The sidebar and activity bar are still present, so a
+            connection can be launched straight into this window.
+          </div>
+          <div class="app" style="height: 320px">
+            <div class="app__body">
+              <nav class="activity-bar">
+                <div class="activity-bar__top">
+                  <button class="activity-bar__item activity-bar__item--active" title="Connections">
+                    <svg class="li"><use href="#i-network" /></svg>
+                    <span class="activity-bar__indicator"></span>
+                  </button>
+                  <button class="activity-bar__item" title="File Browser">
+                    <svg class="li"><use href="#i-folder-open" /></svg>
+                  </button>
+                </div>
+                <div class="activity-bar__bottom">
+                  <button class="activity-bar__item" title="Settings">
+                    <svg class="li"><use href="#i-settings" /></svg>
+                  </button>
+                </div>
+              </nav>
+              <aside class="sidebar">
+                <div class="sidebar__header"><span class="sidebar__title">Connections</span></div>
+                <div class="sidebar__content">
+                  <div class="connection-tree__item">
+                    <span class="state-dot state-dot--connected"></span> server-1
+                  </div>
+                  <div class="connection-tree__item">
+                    <span class="state-dot state-dot--disconnected"></span> server-2
+                  </div>
+                </div>
+              </aside>
+              <div class="terminal-view">
+                <div class="terminal-view__content">
+                  <div class="panel">
+                    <div class="empty-state">
+                      <div class="empty-state__icon"><svg class="li"><use href="#i-app-window" /></svg></div>
+                      <p class="empty-state__title">This window is empty</p>
+                      <p class="empty-state__sub">
+                        Start a session here, or move a tab in from another window with
+                        <strong>Tab ▸ Move to Window ▸ Window 3</strong>.
+                      </p>
+                      <div class="empty-state__actions">
+                        <button class="btn btn--primary"><svg class="li"><use href="#i-plus" /></svg> New Terminal</button>
+                        <button class="btn"><svg class="li"><use href="#i-network" /></svg> Open Connection…</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="status-bar">
+              <div class="status-bar__section status-bar__section--left">
+                <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 3</span>
+              </div>
+              <div class="status-bar__section status-bar__section--right">
+                <span class="status-bar__item">no session</span>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li><span class="callout">G</span> Empty-window CTA — launch a session, or accept a moved-in tab. Closing this window while empty just closes it (no decision surface — nothing is live).</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3>Graphical (RDP/VNC) tabs — move with a reconnecting placeholder</h3>
+        <p>
+          A graphical session's framebuffer is <code>&lt;canvas&gt;</code> pixels in the source window's
+          memory — it cannot transfer to another JS context. The backend session survives (frames keep
+          broadcasting), but the destination canvas is blank until the next <em>full</em> frame arrives.
+          To keep this honest, the destination shows a <strong>"reconnecting view…"</strong> overlay
+          until the first frame repaints — the session is never actually disconnected, only the pixels
+          are being re-fetched. Graphical tabs therefore move <strong>command-only</strong> (never drag).
+        </p>
+
+        <!-- Mockup 4: graphical move with reconnecting placeholder -->
+        <div class="mockup-section">
+          <h3>Mockup — <code>graphical-move</code>: RDP/VNC tab arriving in a window</h3>
+          <div class="mockup-note">
+            An <strong>RDP</strong> tab <span class="callout">H</span> has just been moved here. Its
+            canvas <span class="callout">I</span> is briefly blank, so a <strong>reconnecting view…</strong>
+            overlay <span class="callout">J</span> covers it until the first full frame repaints.
+          </div>
+          <div class="app" style="height: 320px">
+            <div class="app__body">
+              <nav class="activity-bar">
+                <div class="activity-bar__top">
+                  <button class="activity-bar__item activity-bar__item--active" title="Connections">
+                    <svg class="li"><use href="#i-network" /></svg>
+                    <span class="activity-bar__indicator"></span>
+                  </button>
+                </div>
+                <div class="activity-bar__bottom">
+                  <button class="activity-bar__item" title="Settings">
+                    <svg class="li"><use href="#i-settings" /></svg>
+                  </button>
+                </div>
+              </nav>
+              <div class="terminal-view">
+                <div class="terminal-view__content">
+                  <div class="panel">
+                    <div class="tab-bar">
+                      <div class="tab tab--active tab--incoming">
+                        <svg class="li"><use href="#i-monitor" /></svg>
+                        <span class="tab__title">win-server (RDP)</span>
+                        <button class="tab__close"><svg class="li"><use href="#i-x" /></svg></button>
+                      </div>
+                    </div>
+                    <div class="canvas-surface">
+                      <div class="reconnect-overlay">
+                        <div class="reconnect-card">
+                          <svg class="li spin"><use href="#i-loader" /></svg>
+                          <p class="reconnect-card__title">Reconnecting view…</p>
+                          <p class="reconnect-card__sub">
+                            The remote desktop is still connected — repainting the framebuffer in this window.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="status-bar">
+              <div class="status-bar__section status-bar__section--left">
+                <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 2</span>
+              </div>
+              <div class="status-bar__section status-bar__section--right">
+                <span class="status-bar__item"><svg class="li"><use href="#i-monitor" /></svg> RDP · 1920×1080</span>
+              </div>
+            </div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li><span class="callout">H</span> Moved graphical tab (lucide <code>Monitor</code>).</li>
+              <li><span class="callout">I</span> Canvas — blank/stale until the next full frame.</li>
+              <li><span class="callout">J</span> "Reconnecting view…" overlay — the session is live; only the pixels are re-fetching. A backend "request full frame on attach" hook (see <a href="#impl">Impl</a>) would shorten this to a flash.</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3>Closing a window that owns live tabs — detach vs terminate</h3>
+        <p>
+          With one window, "close window" ≈ "quit". With several, closing a window that still owns live
+          sessions needs an explicit decision, and the rule depends on the session:
+        </p>
+        <ul>
+          <li>
+            <strong>Persistent / agent sessions detach</strong> — the backend process keeps running and
+            can be re-attached later. No data is lost; these need no confirmation on their own.
+          </li>
+          <li>
+            <strong>Non-persistent sessions (local shell, serial, one-shot SSH) would be terminated</strong>
+            — so closing must confirm, and offer to <strong>move the tabs to another window</strong>
+            instead. Moving is the safe (primary) action; terminating is destructive.
+          </li>
+          <li>
+            <strong>All-persistent → no dialog.</strong> If every owned tab detaches cleanly, the window
+            closes with just a toast ("3 sessions detached — still running"); the decision surface only
+            appears when something would actually be lost.
+          </li>
+        </ul>
+
+        <!-- Mockup 5: close-with-live-tabs decision dialog -->
+        <div class="mockup-section">
+          <h3>Mockup — <code>close-decision</code>: detach-vs-terminate on window close</h3>
+          <div class="mockup-note">
+            Closing <strong>Window 2</strong> with three live sessions. Each row shows what would happen:
+            persistent detaches <span class="callout">K</span>, non-persistent would terminate
+            <span class="callout">L</span>. The safe primary action moves the tabs elsewhere
+            <span class="callout">M</span>; terminating is the red, non-default action.
+          </div>
+          <div class="menu dialog">
+            <div class="menu__title">Close this window?</div>
+            <div class="dialog__body">
+              <div class="dialog__lead">
+                <svg class="li"><use href="#i-triangle-alert" /></svg>
+                <p>Window 2 owns 3 open sessions. Choose what happens to them before it closes.</p>
+              </div>
+              <div class="session-row">
+                <svg class="li"><use href="#i-network" /></svg>
+                <span class="session-row__name">server-1</span>
+                <span style="color: var(--text-secondary)">SSH · persistent</span>
+                <span class="pill pill--detach"><svg class="li"><use href="#i-plug" /></svg> Detaches — keeps running</span>
+              </div>
+              <div class="session-row">
+                <svg class="li"><use href="#i-terminal" /></svg>
+                <span class="session-row__name">build</span>
+                <span style="color: var(--text-secondary)">local shell</span>
+                <span class="pill pill--terminate"><svg class="li"><use href="#i-power" /></svg> Would be terminated</span>
+              </div>
+              <div class="session-row">
+                <svg class="li"><use href="#i-terminal" /></svg>
+                <span class="session-row__name">/dev/ttyUSB0</span>
+                <span style="color: var(--text-secondary)">serial</span>
+                <span class="pill pill--terminate"><svg class="li"><use href="#i-power" /></svg> Would be terminated</span>
+              </div>
+            </div>
+            <div class="menu__footer" style="justify-content: flex-end">
+              <button class="btn">Cancel</button>
+              <button class="btn btn--danger"><svg class="li"><use href="#i-power" /></svg> Close &amp; end sessions</button>
+              <button class="btn btn--primary"><svg class="li"><use href="#i-arrow-right" /></svg> Move tabs to Window 1</button>
+            </div>
+          </div>
+          <div class="legend">
+            <ul>
+              <li><span class="callout">K</span> Persistent/agent session — detaches automatically, keeps running.</li>
+              <li><span class="callout">L</span> Non-persistent session — would be terminated; that is what makes the dialog appear.</li>
+              <li><span class="callout">M</span> Primary action moves the live tabs to another window (safe). "Close &amp; end sessions" is destructive (red). If every session were persistent, no dialog shows at all.</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3>Future enhancement — drag-to-tear (not v1)</h3>
+        <p>
+          A live drag gesture is the familiar way to tear out a tab, but
+          <a href="#limits">Limitation&nbsp;1</a> rules it out for v1: <code>@dnd-kit</code> cannot follow
+          the cursor across a native window boundary, and Tauri exposes no webview→webview drag. If a
+          future OS-drag-image + drop-detection approach proves viable (open research item), the gesture
+          would <em>supplement</em> — never replace — the commands above, so keyboard and menu users keep
+          a first-class path. The affordance would look like this, dropping onto an OS-level target:
+        </p>
+        <div class="mockup-section">
+          <h3>Mockup — <code>drag-future</code>: optional drag-to-tear affordance</h3>
+          <div class="mockup-note">
+            Future only. A dragged tab detaches into a floating ghost <span class="callout">N</span> that
+            can be dropped on empty desktop (→ new window) or another window's tab bar (→ move). v1 ships
+            the commands; this is a later, additive gesture.
+          </div>
+          <div style="display: flex; align-items: center; gap: 16px; padding: 12px 0">
+            <div class="drag-ghost">
+              <svg class="li"><use href="#i-grip-vertical" /></svg>
+              <svg class="li"><use href="#i-network" /></svg>
+              server-2
+            </div>
+            <svg class="li" style="width: 22px; height: 22px; color: var(--text-secondary)"><use href="#i-arrow-right" /></svg>
+            <span style="color: var(--text-secondary)">drop on desktop → new window · drop on a tab bar → move</span>
+          </div>
+          <div class="legend">
+            <ul>
+              <li><span class="callout">N</span> Floating drag ghost (<code>drag-ghost</code>) — dashed accent border marks it as detached and in-flight. <strong>Deferred; the menu commands are the shipping mechanism.</strong></li>
+            </ul>
+          </div>
         </div>
       </section>
 

--- a/docs/concepts/backlog/multi-window.html
+++ b/docs/concepts/backlog/multi-window.html
@@ -20,9 +20,11 @@
         align-items: stretch;
         gap: 0;
       }
-      .window-row .app {
+      .window-row__col {
         flex: 1 1 0;
         min-width: 0;
+        display: flex;
+        flex-direction: column;
       }
       .window-row__arrow {
         flex: 0 0 56px;
@@ -971,7 +973,7 @@ flowchart TB
             <span class="callout">F</span>. The backend PTY/SSH session never restarts.
           </div>
           <div class="window-row">
-            <div style="flex: 1 1 0; min-width: 0; display: flex; flex-direction: column">
+            <div class="window-row__col">
               <div class="window-label"><svg class="li"><use href="#i-app-window" /></svg> Window 1 — source</div>
               <div class="app" style="height: 300px">
                 <div class="app__body">
@@ -1022,7 +1024,7 @@ flowchart TB
 
             <div class="window-row__arrow"><svg class="li"><use href="#i-arrow-right" /></svg></div>
 
-            <div style="flex: 1 1 0; min-width: 0; display: flex; flex-direction: column">
+            <div class="window-row__col">
               <div class="window-label"><svg class="li"><use href="#i-app-window" /></svg> Window 2 — destination</div>
               <div class="app" style="height: 300px">
                 <div class="app__body">

--- a/docs/concepts/backlog/multi-window.html
+++ b/docs/concepts/backlog/multi-window.html
@@ -163,14 +163,13 @@
         position: relative;
         display: grid;
         place-items: center;
-        background:
-          repeating-linear-gradient(
-            45deg,
-            #0b0d12,
-            #0b0d12 12px,
-            #0e1017 12px,
-            #0e1017 24px
-          );
+        background: repeating-linear-gradient(
+          45deg,
+          #0b0d12,
+          #0b0d12 12px,
+          #0e1017 12px,
+          #0e1017 24px
+        );
         overflow: hidden;
       }
       .reconnect-overlay {
@@ -481,8 +480,7 @@
         <div class="concept-meta">
           <span class="concept-status">Backlog · not implemented</span>
           <span
-            >GitHub Issue:
-            <a href="https://github.com/armaxri/termiHub/issues/1806">#1806</a></span
+            >GitHub Issue: <a href="https://github.com/armaxri/termiHub/issues/1806">#1806</a></span
           >
           <span><code>docs/concepts/backlog/multi-window.html</code></span>
         </div>
@@ -491,9 +489,9 @@
       <blockquote>
         <p>
           <strong>Two-step concept.</strong> This document is <strong>step 1</strong> — the
-          <em>technical</em> concept and honest limitations, authored by an engineer against the real
-          codebase. <strong>Step 2</strong> (a UX designer) adds the interaction design and inline
-          mockups where the <code>MOCKUPS</code> placeholder appears in
+          <em>technical</em> concept and honest limitations, authored by an engineer against the
+          real codebase. <strong>Step 2</strong> (a UX designer) adds the interaction design and
+          inline mockups where the <code>MOCKUPS</code> placeholder appears in
           <a href="#ui">UI Interface</a>. Nothing here is an implementation commitment.
         </p>
       </blockquote>
@@ -521,34 +519,36 @@
       <section>
         <h2 id="overview">Overview &amp; Goals <a class="anchor" href="#overview">#</a></h2>
         <p>
-          termiHub today runs as a <strong>single application window</strong> that hosts every session
-          tab, split, and tab group. Users on multi-monitor setups repeatedly ask to spread work
-          across screens — a build tailing on one monitor, an SSH session on another. This concept
-          assesses whether termiHub can host <strong>multiple native windows</strong> and move live
-          session tabs between them <strong>without tearing down the underlying backend session</strong>.
+          termiHub today runs as a <strong>single application window</strong> that hosts every
+          session tab, split, and tab group. Users on multi-monitor setups repeatedly ask to spread
+          work across screens — a build tailing on one monitor, an SSH session on another. This
+          concept assesses whether termiHub can host <strong>multiple native windows</strong> and
+          move live session tabs between them
+          <strong>without tearing down the underlying backend session</strong>.
         </p>
         <p>
-          <strong>The verdict is: feasible, with real caveats.</strong> The architecture is unusually
-          well-suited to it in one dimension and awkward in another. Session <em>state</em> already
-          lives in the Rust backend, keyed by session id and completely independent of any window, and
-          the backend already supports the exact primitive multi-window needs — <em>detach a view and
-          re-attach it later with scrollback replay</em> (built for persistent/agent sessions and tab
-          groups). That makes re-parenting a session tab a <em>view</em> operation, not a teardown. The
-          awkward dimension is the front end: separate native windows are separate JavaScript contexts
-          with no shared memory, and the current tab drag-and-drop stack (<code>@dnd-kit</code>) cannot
-          cross a native window boundary. So the hard limits cluster on <em>gesture and coordination</em>,
-          not on session survival.
+          <strong>The verdict is: feasible, with real caveats.</strong> The architecture is
+          unusually well-suited to it in one dimension and awkward in another. Session
+          <em>state</em> already lives in the Rust backend, keyed by session id and completely
+          independent of any window, and the backend already supports the exact primitive
+          multi-window needs —
+          <em>detach a view and re-attach it later with scrollback replay</em> (built for
+          persistent/agent sessions and tab groups). That makes re-parenting a session tab a
+          <em>view</em> operation, not a teardown. The awkward dimension is the front end: separate
+          native windows are separate JavaScript contexts with no shared memory, and the current tab
+          drag-and-drop stack (<code>@dnd-kit</code>) cannot cross a native window boundary. So the
+          hard limits cluster on <em>gesture and coordination</em>, not on session survival.
         </p>
         <h3>Goals</h3>
         <ul>
           <li>
-            <strong>Tear out</strong> a session tab into a brand-new window (drag-out or a
-            "Move to New Window" command).
+            <strong>Tear out</strong> a session tab into a brand-new window (drag-out or a "Move to
+            New Window" command).
           </li>
           <li><strong>Create</strong> additional windows (empty, or seeded from a tab group).</li>
           <li>
-            <strong>Move tabs between</strong> existing windows without restarting the backend session
-            (its PTY / SSH channel / serial port / RDP connection keeps running).
+            <strong>Move tabs between</strong> existing windows without restarting the backend
+            session (its PTY / SSH channel / serial port / RDP connection keeps running).
           </li>
           <li>Preserve scrollback on move to the extent the backend replay buffer allows.</li>
         </ul>
@@ -558,9 +558,17 @@
             Sharing <em>one</em> live session's terminal view across two windows simultaneously
             (mirrored view). Out of scope — a tab lives in exactly one window at a time.
           </li>
-          <li>Multi-window support for non-session tabs (Settings, Log Viewer) — see the matrix.</li>
-          <li>Detachable <em>sidebar</em> panels (connection tree, network tools) into their own windows.</li>
-          <li>Multi-<em>process</em> windows. Windows are additional webviews in the one Tauri process.</li>
+          <li>
+            Multi-window support for non-session tabs (Settings, Log Viewer) — see the matrix.
+          </li>
+          <li>
+            Detachable <em>sidebar</em> panels (connection tree, network tools) into their own
+            windows.
+          </li>
+          <li>
+            Multi-<em>process</em> windows. Windows are additional webviews in the one Tauri
+            process.
+          </li>
         </ul>
       </section>
 
@@ -568,9 +576,9 @@
       <section>
         <h2 id="asis">Current Architecture (as-is) <a class="anchor" href="#asis">#</a></h2>
         <p>
-          Every claim below is grounded in the current tree. The picture that matters: the backend is
-          the authoritative, window-independent owner of session state; the frontend holds only view
-          state; and events are already delivered app-wide by broadcast.
+          Every claim below is grounded in the current tree. The picture that matters: the backend
+          is the authoritative, window-independent owner of session state; the frontend holds only
+          view state; and events are already delivered app-wide by broadcast.
         </p>
 
         <h3>One window today</h3>
@@ -580,16 +588,17 @@
             <code>tauri = { version = "2", … }</code>; config schema <code>config/2</code>).
           </li>
           <li>
-            Exactly one window is declared — <code>tauri.conf.json</code> → <code>app.windows[]</code>
-            has a single entry titled <code>termiHub</code>. Its runtime label is <code>"main"</code>.
+            Exactly one window is declared — <code>tauri.conf.json</code> →
+            <code>app.windows[]</code> has a single entry titled <code>termiHub</code>. Its runtime
+            label is <code>"main"</code>.
           </li>
           <li>
             Nothing creates a second window. The only window lookups are
             <code>app.get_webview_window("main")</code> (<code>src-tauri/src/lib.rs:262</code>,
-            <code>src-tauri/src/spawn/handler.rs:275</code>). No
-            <code>WebviewWindowBuilder</code> / <code>WindowBuilder</code> exists in production code.
-            The frontend only ever calls <code>getCurrentWindow()</code>
-            (<code>src/App.tsx:39,209</code>) — never <code>new WebviewWindow(...)</code>.
+            <code>src-tauri/src/spawn/handler.rs:275</code>). No <code>WebviewWindowBuilder</code> /
+            <code>WindowBuilder</code> exists in production code. The frontend only ever calls
+            <code>getCurrentWindow()</code> (<code>src/App.tsx:39,209</code>) — never
+            <code>new WebviewWindow(...)</code>.
           </li>
         </ul>
 
@@ -597,22 +606,25 @@
         <ul>
           <li>
             <code>SessionManager</code> (<code>src-tauri/src/session/manager.rs</code>) holds a
-            <code>sessions</code> map keyed by <code>session_id</code>. A session is a backend process
-            (PTY, SSH channel, serial port, agent proxy) — it has <strong>no notion of which window,
-            tab, or even tab group is displaying it</strong>. This is the single most important fact for
-            this feature: <em>a session already survives independently of any view</em>.
+            <code>sessions</code> map keyed by <code>session_id</code>. A session is a backend
+            process (PTY, SSH channel, serial port, agent proxy) — it has
+            <strong>no notion of which window, tab, or even tab group is displaying it</strong>.
+            This is the single most important fact for this feature:
+            <em>a session already survives independently of any view</em>.
           </li>
           <li>
             Graphical (RDP/VNC) sessions are owned by a separate
-            <code>GraphicalSessionManager</code> (built at <code>src-tauri/src/lib.rs:429</code>), keyed
-            by connection type id, also window-independent.
+            <code>GraphicalSessionManager</code> (built at <code>src-tauri/src/lib.rs:429</code>),
+            keyed by connection type id, also window-independent.
           </li>
           <li>
             The backend keeps a <strong>replayable scrollback buffer</strong>: a 1&nbsp;MiB
-            <code>RingBuffer</code> (<code>core/src/buffer/mod.rs</code>, doc'd for "serial 24/7 capture,
-            daemon PTY output replay, and reconnect replay"), plus persistent/agent
-            session scrollback replay and <code>RemoteProxy::reconnect_existing</code>
-            (<code>manager.rs</code> ~L920, ~L1195, ~L2854). <strong>This is the re-parenting enabler.</strong>
+            <code>RingBuffer</code> (<code>core/src/buffer/mod.rs</code>, doc'd for "serial 24/7
+            capture, daemon PTY output replay, and reconnect replay"), plus persistent/agent session
+            scrollback replay and <code>RemoteProxy::reconnect_existing</code> (<code
+              >manager.rs</code
+            >
+            ~L920, ~L1195, ~L2854). <strong>This is the re-parenting enabler.</strong>
           </li>
         </ul>
 
@@ -620,9 +632,9 @@
         <ul>
           <li>
             Output is emitted with <code>AppHandle::emit("terminal-output", event)</code> — a
-            <strong>global broadcast to every webview</strong> (<code>manager.rs:114–125</code>). Same
-            for <code>terminal-exit</code>, <code>persistent-session-state-changed</code>, and every
-            graphical stream: <code>remote-desktop-frame</code> / <code>-cursor</code> /
+            <strong>global broadcast to every webview</strong> (<code>manager.rs:114–125</code>).
+            Same for <code>terminal-exit</code>, <code>persistent-session-state-changed</code>, and
+            every graphical stream: <code>remote-desktop-frame</code> / <code>-cursor</code> /
             <code>-clipboard</code> / <code>-state</code> / <code>-cert-prompt</code>
             (<code>graphical_manager.rs:115–127</code>).
           </li>
@@ -630,14 +642,15 @@
             The frontend registers <strong>one</strong> global listener per stream and fans out by
             <code>session_id</code> — <code>SessionEventDispatcher</code> in
             <code>src/services/events.ts</code>. Consequence for multi-window: because output is
-            already broadcast to all windows, a second window that subscribes and filters by the same
-            <code>session_id</code> <em>automatically</em> receives that session's output. No
-            <code>emit_to</code> retargeting is <em>required</em> for correctness — only as an efficiency
-            improvement (see <a href="#state">State &amp; Retargeting</a>).
+            already broadcast to all windows, a second window that subscribes and filters by the
+            same <code>session_id</code> <em>automatically</em> receives that session's output. No
+            <code>emit_to</code> retargeting is <em>required</em> for correctness — only as an
+            efficiency improvement (see <a href="#state">State &amp; Retargeting</a>).
           </li>
           <li>
             Input / control (write, resize, close) are Tauri command calls keyed by
-            <code>session_id</code>, so they work identically from whichever window currently owns the tab.
+            <code>session_id</code>, so they work identically from whichever window currently owns
+            the tab.
           </li>
         </ul>
 
@@ -648,15 +661,16 @@
             <code>tabGroups: TabGroup[]</code>, <code>activeTabGroupId</code>, and the live
             <code>rootPanel: PanelNode</code> (a recursive split/leaf tree —
             <code>src/types/terminal.ts</code>). A tab (<code>TerminalTab</code>) carries a
-            <code>sessionId</code>, a <code>contentType</code>, and its config — the <em>view</em> of a
-            backend session, not the session itself.
+            <code>sessionId</code>, a <code>contentType</code>, and its config — the
+            <em>view</em> of a backend session, not the session itself.
           </li>
           <li>
             <strong>Tab groups are the closest existing analog to windows.</strong> Each group is an
             "independent panel tree that stays alive when hidden" (implemented concept
-            <code>tab-groups.html</code>): the active group uses the live <code>rootPanel</code>, every
-            other group keeps its own <code>rootPanel</code> in <code>tabGroups[]</code>. Multi-window is
-            essentially "let a tab group (or a subset of tabs) live in its own OS window" — <em>except</em>
+            <code>tab-groups.html</code>): the active group uses the live <code>rootPanel</code>,
+            every other group keeps its own <code>rootPanel</code> in <code>tabGroups[]</code>.
+            Multi-window is essentially "let a tab group (or a subset of tabs) live in its own OS
+            window" — <em>except</em>
             groups today all share one JS context and one store; windows do not.
           </li>
           <li>
@@ -670,37 +684,41 @@
         <h3>Tab drag-and-drop uses @dnd-kit (single-document)</h3>
         <ul>
           <li>
-            Tab drag/reorder/tear-to-split is built on <strong><code>@dnd-kit</code></strong>
-            (<code>src/components/SplitView/SplitView.tsx</code>, <code>PanelDropZone.tsx</code>): pointer
-            sensors, <code>DndContext</code>, <code>DragOverlay</code>. It uses <em>no</em> native
-            HTML5 <code>dataTransfer</code>. <strong>@dnd-kit is fundamentally single-document</strong> — its
-            pointer tracking and drag overlay live entirely inside one webview's DOM and cannot follow the
-            cursor across a native window boundary. This is the crux of the drag limitation below.
+            Tab drag/reorder/tear-to-split is built on
+            <strong><code>@dnd-kit</code></strong>
+            (<code>src/components/SplitView/SplitView.tsx</code>, <code>PanelDropZone.tsx</code>):
+            pointer sensors, <code>DndContext</code>, <code>DragOverlay</code>. It uses
+            <em>no</em> native HTML5 <code>dataTransfer</code>.
+            <strong>@dnd-kit is fundamentally single-document</strong> — its pointer tracking and
+            drag overlay live entirely inside one webview's DOM and cannot follow the cursor across
+            a native window boundary. This is the crux of the drag limitation below.
           </li>
           <li>
             The one place termiHub <em>does</em> use OS-level drag is Tauri's
-            <code>onDragDropEvent</code> for external <strong>file</strong> drops into the file browser —
-            a different, OS→webview channel, not webview→webview tab drag.
+            <code>onDragDropEvent</code> for external <strong>file</strong> drops into the file
+            browser — a different, OS→webview channel, not webview→webview tab drag.
           </li>
         </ul>
 
         <h3>Persistence &amp; lifecycle have no window dimension</h3>
         <ul>
           <li>
-            Workspaces (<code>src/types/workspace.ts</code>, <code>WorkspaceDefinition</code>) capture
-            <code>tabGroups[]</code> with a layout tree — but there is <strong>no window field
-            anywhere</strong>. A restored workspace has nowhere to record "this group is in window 2."
-            Same for last-session restore.
+            Workspaces (<code>src/types/workspace.ts</code>, <code>WorkspaceDefinition</code>)
+            capture <code>tabGroups[]</code> with a layout tree — but there is
+            <strong>no window field anywhere</strong>. A restored workspace has nowhere to record
+            "this group is in window 2." Same for last-session restore.
           </li>
           <li>
             Lifecycle is handled in <code>src-tauri/src/lib.rs</code> via
             <code>RunEvent::WindowEvent { CloseRequested / Destroyed }</code> and
-            <code>RunEvent::ExitRequested</code> (~L918–930). With one window, "window closed" ≈ "app
-            quit." Multi-window breaks that identity and needs an explicit policy.
+            <code>RunEvent::ExitRequested</code> (~L918–930). With one window, "window closed" ≈
+            "app quit." Multi-window breaks that identity and needs an explicit policy.
           </li>
           <li>
-            No single-instance plugin is used. Portable mode and the CLI workspace launch
-            (<code>tauri.conf.json</code> → <code>plugins.cli</code>) are orthogonal — multi-window is
+            No single-instance plugin is used. Portable mode and the CLI workspace launch (<code
+              >tauri.conf.json</code
+            >
+            → <code>plugins.cli</code>) are orthogonal — multi-window is
             multi-<em>webview-in-one-process</em>, not multi-process.
           </li>
         </ul>
@@ -732,15 +750,16 @@ flowchart TB
         <p>
           This is <strong>step 2</strong> — the interaction design, authored against the engineer's
           constraints above. The whole design turns on one fact from
-          <a href="#limits">Limitations</a>: <strong>a tab cannot be dragged across a native window
-          boundary</strong> with today's stack (<code>@dnd-kit</code> is single-document). So the v1
-          mechanism for tearing out and moving tabs is <strong>commands and context-menu items</strong>,
-          not a live drag gesture. Everything below follows from that: the tab context menu grows a
-          <em>Move to Window</em> group, an <em>empty window</em> is a first-class state with its own
-          call-to-action, graphical (RDP/VNC) tabs move with a <em>reconnecting-view</em> placeholder,
-          and closing a window that still owns live tabs raises a <em>detach-vs-terminate</em> decision.
-          A drag-to-tear gesture appears once, at the end, clearly labelled a
-          <strong>future enhancement</strong>.
+          <a href="#limits">Limitations</a>:
+          <strong>a tab cannot be dragged across a native window boundary</strong> with today's
+          stack (<code>@dnd-kit</code> is single-document). So the v1 mechanism for tearing out and
+          moving tabs is <strong>commands and context-menu items</strong>, not a live drag gesture.
+          Everything below follows from that: the tab context menu grows a
+          <em>Move to Window</em> group, an <em>empty window</em> is a first-class state with its
+          own call-to-action, graphical (RDP/VNC) tabs move with a
+          <em>reconnecting-view</em> placeholder, and closing a window that still owns live tabs
+          raises a <em>detach-vs-terminate</em> decision. A drag-to-tear gesture appears once, at
+          the end, clearly labelled a <strong>future enhancement</strong>.
         </p>
 
         <div class="table-wrap">
@@ -754,11 +773,17 @@ flowchart TB
             <tbody>
               <tr>
                 <td><code>move-menu</code></td>
-                <td>Tab context menu with the new <em>Move to New Window</em> / <em>Move to Window ▸</em> group, and the window-picker submenu</td>
+                <td>
+                  Tab context menu with the new <em>Move to New Window</em> /
+                  <em>Move to Window ▸</em> group, and the window-picker submenu
+                </td>
               </tr>
               <tr>
                 <td><code>mid-move</code></td>
-                <td>Two windows side by side: source ghost tab leaving, destination insertion point + scrollback replay</td>
+                <td>
+                  Two windows side by side: source ghost tab leaving, destination insertion point +
+                  scrollback replay
+                </td>
               </tr>
               <tr>
                 <td><code>empty-window</code></td>
@@ -766,7 +791,10 @@ flowchart TB
               </tr>
               <tr>
                 <td><code>graphical-move</code></td>
-                <td>An RDP/VNC tab arriving in a new window with the "reconnecting view…" placeholder over the canvas</td>
+                <td>
+                  An RDP/VNC tab arriving in a new window with the "reconnecting view…" placeholder
+                  over the canvas
+                </td>
               </tr>
               <tr>
                 <td><code>close-decision</code></td>
@@ -774,7 +802,9 @@ flowchart TB
               </tr>
               <tr>
                 <td><code>drag-future</code></td>
-                <td>The optional drag-to-tear affordance — a labelled future enhancement, not v1</td>
+                <td>
+                  The optional drag-to-tear affordance — a labelled future enhancement, not v1
+                </td>
               </tr>
             </tbody>
           </table>
@@ -782,41 +812,45 @@ flowchart TB
 
         <h3>Core interaction model — commands, not cross-window drag</h3>
         <p>
-          Moving a tab is a <strong>menu/command action with an explicit destination</strong>, never a
-          drag onto another window's tab bar. Every session tab exposes a <strong>Move to Window</strong>
-          group in its right-click context menu (the same Radix <code>ContextMenu</code> that today holds
-          Rename / Save to File / … — see <code>src/components/Terminal/Tab.tsx</code>):
+          Moving a tab is a <strong>menu/command action with an explicit destination</strong>, never
+          a drag onto another window's tab bar. Every session tab exposes a
+          <strong>Move to Window</strong> group in its right-click context menu (the same Radix
+          <code>ContextMenu</code> that today holds Rename / Save to File / … — see
+          <code>src/components/Terminal/Tab.tsx</code>):
         </p>
         <ul>
           <li>
-            <strong>Move to New Window</strong> — tears the tab out into a brand-new window seeded with
-            just that tab. This is the one-click "give this its own screen" path.
+            <strong>Move to New Window</strong> — tears the tab out into a brand-new window seeded
+            with just that tab. This is the one-click "give this its own screen" path.
           </li>
           <li>
-            <strong>Move to Window ▸</strong> — a submenu listing every <em>other</em> open window by
-            name and tab count, plus a <strong>New Window</strong> entry at the top (so the submenu is a
-            superset of the direct command). Picking one hands the tab to that window. The current window
-            is shown disabled ("current") so the list is unambiguous.
+            <strong>Move to Window ▸</strong> — a submenu listing every <em>other</em> open window
+            by name and tab count, plus a <strong>New Window</strong> entry at the top (so the
+            submenu is a superset of the direct command). Picking one hands the tab to that window.
+            The current window is shown disabled ("current") so the list is unambiguous.
           </li>
         </ul>
         <p>
           Because a tab renders in <strong>exactly one window at a time</strong>, the destination is
-          brokered by the backend ownership map (<a href="#state">State &amp; Retargeting</a>): the pick
-          triggers a release-in-A → grant-to-B handshake, so there is never a window where the tab is
-          shown twice or nowhere.
+          brokered by the backend ownership map (<a href="#state">State &amp; Retargeting</a>): the
+          pick triggers a release-in-A → grant-to-B handshake, so there is never a window where the
+          tab is shown twice or nowhere.
         </p>
 
         <h3>Entry points</h3>
         <ul>
-          <li><strong>Tab context menu</strong> — the primary surface (mockup <code>move-menu</code>).</li>
+          <li>
+            <strong>Tab context menu</strong> — the primary surface (mockup <code>move-menu</code>).
+          </li>
           <li>
             <strong>New Window</strong> — a top-level command (application menu / command palette,
             keyboard shortcut <code>Ctrl/Cmd+Shift+N</code>) opens an empty window (mockup
-            <code>empty-window</code>). It is also the first row of the <em>Move to Window ▸</em> submenu.
+            <code>empty-window</code>). It is also the first row of the
+            <em>Move to Window ▸</em> submenu.
           </li>
           <li>
-            <strong>Status-bar window affordance</strong> — when more than one window is open, the status
-            bar shows the window's name, so users can tell windows apart at a glance.
+            <strong>Status-bar window affordance</strong> — when more than one window is open, the
+            status bar shows the window's name, so users can tell windows apart at a glance.
           </li>
         </ul>
 
@@ -824,10 +858,11 @@ flowchart TB
         <div class="mockup-section">
           <h3>Mockup — <code>move-menu</code>: the Move-to-Window command surface</h3>
           <div class="mockup-note">
-            Right-clicking a session tab <span class="callout">A</span> opens its context menu. The new
-            <strong>Move to Window</strong> group <span class="callout">B</span> sits just below Rename;
-            <em>Move to Window ▸</em> opens the window picker <span class="callout">C</span>. This is the
-            v1 tear-out / move mechanism — no drag required.
+            Right-clicking a session tab <span class="callout">A</span> opens its context menu. The
+            new <strong>Move to Window</strong> group <span class="callout">B</span> sits just below
+            Rename; <em>Move to Window ▸</em> opens the window picker
+            <span class="callout">C</span>. This is the v1 tear-out / move mechanism — no drag
+            required.
           </div>
           <div class="app" style="height: 300px">
             <div class="app__body">
@@ -874,12 +909,16 @@ flowchart TB
                       <div class="tab tab--active">
                         <svg class="li"><use href="#i-network" /></svg>
                         <span class="tab__title">server-1</span>
-                        <button class="tab__close"><svg class="li"><use href="#i-x" /></svg></button>
+                        <button class="tab__close">
+                          <svg class="li"><use href="#i-x" /></svg>
+                        </button>
                       </div>
                       <div class="tab tab--context" title="Right-clicked">
                         <svg class="li"><use href="#i-network" /></svg>
                         <span class="tab__title">server-2</span>
-                        <button class="tab__close"><svg class="li"><use href="#i-x" /></svg></button>
+                        <button class="tab__close">
+                          <svg class="li"><use href="#i-x" /></svg>
+                        </button>
                       </div>
                       <div class="tab">
                         <svg class="li"><use href="#i-terminal" /></svg>
@@ -895,7 +934,9 @@ flowchart TB
             </div>
             <div class="status-bar">
               <div class="status-bar__section status-bar__section--left">
-                <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 1</span>
+                <span class="status-bar__item"
+                  ><svg class="li"><use href="#i-app-window" /></svg> Window 1</span
+                >
               </div>
               <div class="status-bar__section status-bar__section--right">
                 <span class="status-bar__item">UTF-8</span>
@@ -907,7 +948,9 @@ flowchart TB
             <div>
               <p class="state-label">Tab context menu (Move group added)</p>
               <div class="menu context-menu">
-                <div class="menu__row"><svg class="li"><use href="#i-pencil" /></svg> Rename</div>
+                <div class="menu__row">
+                  <svg class="li"><use href="#i-pencil" /></svg> Rename
+                </div>
                 <div class="menu__sep"></div>
                 <div class="menu__row menu__row--new">
                   <svg class="li"><use href="#i-external-link" /></svg> Move to New Window
@@ -917,10 +960,16 @@ flowchart TB
                   <svg class="li menu__arrow"><use href="#i-chevron-right" /></svg>
                 </div>
                 <div class="menu__sep"></div>
-                <div class="menu__row"><svg class="li"><use href="#i-file-up" /></svg> Save to File</div>
-                <div class="menu__row"><svg class="li"><use href="#i-clipboard" /></svg> Copy to Clipboard</div>
+                <div class="menu__row">
+                  <svg class="li"><use href="#i-file-up" /></svg> Save to File
+                </div>
+                <div class="menu__row">
+                  <svg class="li"><use href="#i-clipboard" /></svg> Copy to Clipboard
+                </div>
                 <div class="menu__sep"></div>
-                <div class="menu__row"><svg class="li"><use href="#i-palette" /></svg> Set Color…</div>
+                <div class="menu__row">
+                  <svg class="li"><use href="#i-palette" /></svg> Set Color…
+                </div>
               </div>
             </div>
             <div>
@@ -947,9 +996,18 @@ flowchart TB
           </div>
           <div class="legend">
             <ul>
-              <li><span class="callout">A</span> Right-clicked tab — highlighted (<code>tab--context</code>).</li>
-              <li><span class="callout">B</span> New <strong>Move to Window</strong> group; <em>Move to New Window</em> is the one-click tear-out.</li>
-              <li><span class="callout">C</span> Window picker — lists other windows by name + tab count; <strong>New Window</strong> on top; current window disabled.</li>
+              <li>
+                <span class="callout">A</span> Right-clicked tab — highlighted
+                (<code>tab--context</code>).
+              </li>
+              <li>
+                <span class="callout">B</span> New <strong>Move to Window</strong> group;
+                <em>Move to New Window</em> is the one-click tear-out.
+              </li>
+              <li>
+                <span class="callout">C</span> Window picker — lists other windows by name + tab
+                count; <strong>New Window</strong> on top; current window disabled.
+              </li>
             </ul>
           </div>
         </div>
@@ -957,29 +1015,34 @@ flowchart TB
         <h3>User journey — moving a live tab</h3>
         <p>
           The move is a pure <em>view</em> operation (the backend session never restarts —
-          <a href="#reparent">Session Re-parenting</a>). What the user sees: the tab vanishes from the
-          source window and reappears in the destination, its scrollback repainted from the backend
-          replay buffer. For an ordinary terminal (local / SSH / serial / Docker) this is near-instant;
-          the only visible loss is scrollback beyond the 1&nbsp;MiB backend buffer.
+          <a href="#reparent">Session Re-parenting</a>). What the user sees: the tab vanishes from
+          the source window and reappears in the destination, its scrollback repainted from the
+          backend replay buffer. For an ordinary terminal (local / SSH / serial / Docker) this is
+          near-instant; the only visible loss is scrollback beyond the 1&nbsp;MiB backend buffer.
         </p>
 
         <!-- Mockup 2: two windows mid-move -->
         <div class="mockup-section">
           <h3>Mockup — <code>mid-move</code>: two windows during a move</h3>
           <div class="mockup-note">
-            <strong>server-2</strong> is moving from Window 1 to Window 2. In the source it dims to a
-            ghost <span class="callout">D</span> while its view is torn down; in the destination it lands
-            at an insertion caret <span class="callout">E</span> and repaints from replayed scrollback
-            <span class="callout">F</span>. The backend PTY/SSH session never restarts.
+            <strong>server-2</strong> is moving from Window 1 to Window 2. In the source it dims to
+            a ghost <span class="callout">D</span> while its view is torn down; in the destination
+            it lands at an insertion caret <span class="callout">E</span> and repaints from replayed
+            scrollback <span class="callout">F</span>. The backend PTY/SSH session never restarts.
           </div>
           <div class="window-row">
             <div class="window-row__col">
-              <div class="window-label"><svg class="li"><use href="#i-app-window" /></svg> Window 1 — source</div>
+              <div class="window-label">
+                <svg class="li"><use href="#i-app-window" /></svg> Window 1 — source
+              </div>
               <div class="app" style="height: 300px">
                 <div class="app__body">
                   <nav class="activity-bar">
                     <div class="activity-bar__top">
-                      <button class="activity-bar__item activity-bar__item--active" title="Connections">
+                      <button
+                        class="activity-bar__item activity-bar__item--active"
+                        title="Connections"
+                      >
                         <svg class="li"><use href="#i-network" /></svg>
                         <span class="activity-bar__indicator"></span>
                       </button>
@@ -1016,21 +1079,30 @@ flowchart TB
                 </div>
                 <div class="status-bar">
                   <div class="status-bar__section status-bar__section--left">
-                    <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 1</span>
+                    <span class="status-bar__item"
+                      ><svg class="li"><use href="#i-app-window" /></svg> Window 1</span
+                    >
                   </div>
                 </div>
               </div>
             </div>
 
-            <div class="window-row__arrow"><svg class="li"><use href="#i-arrow-right" /></svg></div>
+            <div class="window-row__arrow">
+              <svg class="li"><use href="#i-arrow-right" /></svg>
+            </div>
 
             <div class="window-row__col">
-              <div class="window-label"><svg class="li"><use href="#i-app-window" /></svg> Window 2 — destination</div>
+              <div class="window-label">
+                <svg class="li"><use href="#i-app-window" /></svg> Window 2 — destination
+              </div>
               <div class="app" style="height: 300px">
                 <div class="app__body">
                   <nav class="activity-bar">
                     <div class="activity-bar__top">
-                      <button class="activity-bar__item activity-bar__item--active" title="Connections">
+                      <button
+                        class="activity-bar__item activity-bar__item--active"
+                        title="Connections"
+                      >
                         <svg class="li"><use href="#i-network" /></svg>
                         <span class="activity-bar__indicator"></span>
                       </button>
@@ -1053,11 +1125,15 @@ flowchart TB
                           <div class="tab tab--incoming">
                             <svg class="li"><use href="#i-network" /></svg>
                             <span class="tab__title">server-2</span>
-                            <button class="tab__close"><svg class="li"><use href="#i-x" /></svg></button>
+                            <button class="tab__close">
+                              <svg class="li"><use href="#i-x" /></svg>
+                            </button>
                           </div>
                         </div>
                         <div class="terminal">
-                          <span style="color: var(--text-secondary)">⟲ restored 1 MiB scrollback</span><br />
+                          <span style="color: var(--text-secondary)"
+                            >⟲ restored 1 MiB scrollback</span
+                          ><br />
                           <span class="prompt">server-2 $</span> uptime<span class="cursor"></span>
                         </div>
                       </div>
@@ -1066,7 +1142,9 @@ flowchart TB
                 </div>
                 <div class="status-bar">
                   <div class="status-bar__section status-bar__section--left">
-                    <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 2</span>
+                    <span class="status-bar__item"
+                      ><svg class="li"><use href="#i-app-window" /></svg> Window 2</span
+                    >
                   </div>
                 </div>
               </div>
@@ -1074,18 +1152,27 @@ flowchart TB
           </div>
           <div class="legend">
             <ul>
-              <li><span class="callout">D</span> Source ghost — the tab dims and shows a spinner while its xterm view is disposed.</li>
-              <li><span class="callout">E</span> Destination insertion caret — where the incoming tab lands (<code>tab--incoming</code>).</li>
-              <li><span class="callout">F</span> Scrollback replayed from the backend <code>RingBuffer</code>; history beyond 1&nbsp;MiB is truncated.</li>
+              <li>
+                <span class="callout">D</span> Source ghost — the tab dims and shows a spinner while
+                its xterm view is disposed.
+              </li>
+              <li>
+                <span class="callout">E</span> Destination insertion caret — where the incoming tab
+                lands (<code>tab--incoming</code>).
+              </li>
+              <li>
+                <span class="callout">F</span> Scrollback replayed from the backend
+                <code>RingBuffer</code>; history beyond 1&nbsp;MiB is truncated.
+              </li>
             </ul>
           </div>
         </div>
 
         <h3>Empty window — a first-class state</h3>
         <p>
-          A window can exist with <strong>zero tabs</strong> — right after <em>New Window</em>, or after
-          its last tab is moved or closed. Rather than an accidental blank pane, the content area shows a
-          deliberate call-to-action so the window is immediately useful.
+          A window can exist with <strong>zero tabs</strong> — right after <em>New Window</em>, or
+          after its last tab is moved or closed. Rather than an accidental blank pane, the content
+          area shows a deliberate call-to-action so the window is immediately useful.
         </p>
 
         <!-- Mockup 3: empty window -->
@@ -1129,15 +1216,21 @@ flowchart TB
                 <div class="terminal-view__content">
                   <div class="panel">
                     <div class="empty-state">
-                      <div class="empty-state__icon"><svg class="li"><use href="#i-app-window" /></svg></div>
+                      <div class="empty-state__icon">
+                        <svg class="li"><use href="#i-app-window" /></svg>
+                      </div>
                       <p class="empty-state__title">This window is empty</p>
                       <p class="empty-state__sub">
                         Start a session here, or move a tab in from another window with
                         <strong>Tab ▸ Move to Window ▸ Window 3</strong>.
                       </p>
                       <div class="empty-state__actions">
-                        <button class="btn btn--primary"><svg class="li"><use href="#i-plus" /></svg> New Terminal</button>
-                        <button class="btn"><svg class="li"><use href="#i-network" /></svg> Open Connection…</button>
+                        <button class="btn btn--primary">
+                          <svg class="li"><use href="#i-plus" /></svg> New Terminal
+                        </button>
+                        <button class="btn">
+                          <svg class="li"><use href="#i-network" /></svg> Open Connection…
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -1146,7 +1239,9 @@ flowchart TB
             </div>
             <div class="status-bar">
               <div class="status-bar__section status-bar__section--left">
-                <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 3</span>
+                <span class="status-bar__item"
+                  ><svg class="li"><use href="#i-app-window" /></svg> Window 3</span
+                >
               </div>
               <div class="status-bar__section status-bar__section--right">
                 <span class="status-bar__item">no session</span>
@@ -1155,19 +1250,24 @@ flowchart TB
           </div>
           <div class="legend">
             <ul>
-              <li><span class="callout">G</span> Empty-window CTA — launch a session, or accept a moved-in tab. Closing this window while empty just closes it (no decision surface — nothing is live).</li>
+              <li>
+                <span class="callout">G</span> Empty-window CTA — launch a session, or accept a
+                moved-in tab. Closing this window while empty just closes it (no decision surface —
+                nothing is live).
+              </li>
             </ul>
           </div>
         </div>
 
         <h3>Graphical (RDP/VNC) tabs — move with a reconnecting placeholder</h3>
         <p>
-          A graphical session's framebuffer is <code>&lt;canvas&gt;</code> pixels in the source window's
-          memory — it cannot transfer to another JS context. The backend session survives (frames keep
-          broadcasting), but the destination canvas is blank until the next <em>full</em> frame arrives.
-          To keep this honest, the destination shows a <strong>"reconnecting view…"</strong> overlay
-          until the first frame repaints — the session is never actually disconnected, only the pixels
-          are being re-fetched. Graphical tabs therefore move <strong>command-only</strong> (never drag).
+          A graphical session's framebuffer is <code>&lt;canvas&gt;</code> pixels in the source
+          window's memory — it cannot transfer to another JS context. The backend session survives
+          (frames keep broadcasting), but the destination canvas is blank until the next
+          <em>full</em> frame arrives. To keep this honest, the destination shows a
+          <strong>"reconnecting view…"</strong> overlay until the first frame repaints — the session
+          is never actually disconnected, only the pixels are being re-fetched. Graphical tabs
+          therefore move <strong>command-only</strong> (never drag).
         </p>
 
         <!-- Mockup 4: graphical move with reconnecting placeholder -->
@@ -1175,8 +1275,9 @@ flowchart TB
           <h3>Mockup — <code>graphical-move</code>: RDP/VNC tab arriving in a window</h3>
           <div class="mockup-note">
             An <strong>RDP</strong> tab <span class="callout">H</span> has just been moved here. Its
-            canvas <span class="callout">I</span> is briefly blank, so a <strong>reconnecting view…</strong>
-            overlay <span class="callout">J</span> covers it until the first full frame repaints.
+            canvas <span class="callout">I</span> is briefly blank, so a
+            <strong>reconnecting view…</strong> overlay <span class="callout">J</span> covers it
+            until the first full frame repaints.
           </div>
           <div class="app" style="height: 320px">
             <div class="app__body">
@@ -1200,7 +1301,9 @@ flowchart TB
                       <div class="tab tab--active tab--incoming">
                         <svg class="li"><use href="#i-monitor" /></svg>
                         <span class="tab__title">win-server (RDP)</span>
-                        <button class="tab__close"><svg class="li"><use href="#i-x" /></svg></button>
+                        <button class="tab__close">
+                          <svg class="li"><use href="#i-x" /></svg>
+                        </button>
                       </div>
                     </div>
                     <div class="canvas-surface">
@@ -1209,7 +1312,8 @@ flowchart TB
                           <svg class="li spin"><use href="#i-loader" /></svg>
                           <p class="reconnect-card__title">Reconnecting view…</p>
                           <p class="reconnect-card__sub">
-                            The remote desktop is still connected — repainting the framebuffer in this window.
+                            The remote desktop is still connected — repainting the framebuffer in
+                            this window.
                           </p>
                         </div>
                       </div>
@@ -1220,41 +1324,56 @@ flowchart TB
             </div>
             <div class="status-bar">
               <div class="status-bar__section status-bar__section--left">
-                <span class="status-bar__item"><svg class="li"><use href="#i-app-window" /></svg> Window 2</span>
+                <span class="status-bar__item"
+                  ><svg class="li"><use href="#i-app-window" /></svg> Window 2</span
+                >
               </div>
               <div class="status-bar__section status-bar__section--right">
-                <span class="status-bar__item"><svg class="li"><use href="#i-monitor" /></svg> RDP · 1920×1080</span>
+                <span class="status-bar__item"
+                  ><svg class="li"><use href="#i-monitor" /></svg> RDP · 1920×1080</span
+                >
               </div>
             </div>
           </div>
           <div class="legend">
             <ul>
-              <li><span class="callout">H</span> Moved graphical tab (lucide <code>Monitor</code>).</li>
-              <li><span class="callout">I</span> Canvas — blank/stale until the next full frame.</li>
-              <li><span class="callout">J</span> "Reconnecting view…" overlay — the session is live; only the pixels are re-fetching. A backend "request full frame on attach" hook (see <a href="#impl">Impl</a>) would shorten this to a flash.</li>
+              <li>
+                <span class="callout">H</span> Moved graphical tab (lucide <code>Monitor</code>).
+              </li>
+              <li>
+                <span class="callout">I</span> Canvas — blank/stale until the next full frame.
+              </li>
+              <li>
+                <span class="callout">J</span> "Reconnecting view…" overlay — the session is live;
+                only the pixels are re-fetching. A backend "request full frame on attach" hook (see
+                <a href="#impl">Impl</a>) would shorten this to a flash.
+              </li>
             </ul>
           </div>
         </div>
 
         <h3>Closing a window that owns live tabs — detach vs terminate</h3>
         <p>
-          With one window, "close window" ≈ "quit". With several, closing a window that still owns live
-          sessions needs an explicit decision, and the rule depends on the session:
+          With one window, "close window" ≈ "quit". With several, closing a window that still owns
+          live sessions needs an explicit decision, and the rule depends on the session:
         </p>
         <ul>
           <li>
-            <strong>Persistent / agent sessions detach</strong> — the backend process keeps running and
-            can be re-attached later. No data is lost; these need no confirmation on their own.
+            <strong>Persistent / agent sessions detach</strong> — the backend process keeps running
+            and can be re-attached later. No data is lost; these need no confirmation on their own.
           </li>
           <li>
-            <strong>Non-persistent sessions (local shell, serial, one-shot SSH) would be terminated</strong>
+            <strong
+              >Non-persistent sessions (local shell, serial, one-shot SSH) would be
+              terminated</strong
+            >
             — so closing must confirm, and offer to <strong>move the tabs to another window</strong>
             instead. Moving is the safe (primary) action; terminating is destructive.
           </li>
           <li>
-            <strong>All-persistent → no dialog.</strong> If every owned tab detaches cleanly, the window
-            closes with just a toast ("3 sessions detached — still running"); the decision surface only
-            appears when something would actually be lost.
+            <strong>All-persistent → no dialog.</strong> If every owned tab detaches cleanly, the
+            window closes with just a toast ("3 sessions detached — still running"); the decision
+            surface only appears when something would actually be lost.
           </li>
         </ul>
 
@@ -1262,10 +1381,10 @@ flowchart TB
         <div class="mockup-section">
           <h3>Mockup — <code>close-decision</code>: detach-vs-terminate on window close</h3>
           <div class="mockup-note">
-            Closing <strong>Window 2</strong> with three live sessions. Each row shows what would happen:
-            persistent detaches <span class="callout">K</span>, non-persistent would terminate
-            <span class="callout">L</span>. The safe primary action moves the tabs elsewhere
-            <span class="callout">M</span>; terminating is the red, non-default action.
+            Closing <strong>Window 2</strong> with three live sessions. Each row shows what would
+            happen: persistent detaches <span class="callout">K</span>, non-persistent would
+            terminate <span class="callout">L</span>. The safe primary action moves the tabs
+            elsewhere <span class="callout">M</span>; terminating is the red, non-default action.
           </div>
           <div class="menu dialog">
             <div class="menu__title">Close this window?</div>
@@ -1278,32 +1397,52 @@ flowchart TB
                 <svg class="li"><use href="#i-network" /></svg>
                 <span class="session-row__name">server-1</span>
                 <span style="color: var(--text-secondary)">SSH · persistent</span>
-                <span class="pill pill--detach"><svg class="li"><use href="#i-plug" /></svg> Detaches — keeps running</span>
+                <span class="pill pill--detach"
+                  ><svg class="li"><use href="#i-plug" /></svg> Detaches — keeps running</span
+                >
               </div>
               <div class="session-row">
                 <svg class="li"><use href="#i-terminal" /></svg>
                 <span class="session-row__name">build</span>
                 <span style="color: var(--text-secondary)">local shell</span>
-                <span class="pill pill--terminate"><svg class="li"><use href="#i-power" /></svg> Would be terminated</span>
+                <span class="pill pill--terminate"
+                  ><svg class="li"><use href="#i-power" /></svg> Would be terminated</span
+                >
               </div>
               <div class="session-row">
                 <svg class="li"><use href="#i-terminal" /></svg>
                 <span class="session-row__name">/dev/ttyUSB0</span>
                 <span style="color: var(--text-secondary)">serial</span>
-                <span class="pill pill--terminate"><svg class="li"><use href="#i-power" /></svg> Would be terminated</span>
+                <span class="pill pill--terminate"
+                  ><svg class="li"><use href="#i-power" /></svg> Would be terminated</span
+                >
               </div>
             </div>
             <div class="menu__footer" style="justify-content: flex-end">
               <button class="btn">Cancel</button>
-              <button class="btn btn--danger"><svg class="li"><use href="#i-power" /></svg> Close &amp; end sessions</button>
-              <button class="btn btn--primary"><svg class="li"><use href="#i-arrow-right" /></svg> Move tabs to Window 1</button>
+              <button class="btn btn--danger">
+                <svg class="li"><use href="#i-power" /></svg> Close &amp; end sessions
+              </button>
+              <button class="btn btn--primary">
+                <svg class="li"><use href="#i-arrow-right" /></svg> Move tabs to Window 1
+              </button>
             </div>
           </div>
           <div class="legend">
             <ul>
-              <li><span class="callout">K</span> Persistent/agent session — detaches automatically, keeps running.</li>
-              <li><span class="callout">L</span> Non-persistent session — would be terminated; that is what makes the dialog appear.</li>
-              <li><span class="callout">M</span> Primary action moves the live tabs to another window (safe). "Close &amp; end sessions" is destructive (red). If every session were persistent, no dialog shows at all.</li>
+              <li>
+                <span class="callout">K</span> Persistent/agent session — detaches automatically,
+                keeps running.
+              </li>
+              <li>
+                <span class="callout">L</span> Non-persistent session — would be terminated; that is
+                what makes the dialog appear.
+              </li>
+              <li>
+                <span class="callout">M</span> Primary action moves the live tabs to another window
+                (safe). "Close &amp; end sessions" is destructive (red). If every session were
+                persistent, no dialog shows at all.
+              </li>
             </ul>
           </div>
         </div>
@@ -1311,18 +1450,20 @@ flowchart TB
         <h3>Future enhancement — drag-to-tear (not v1)</h3>
         <p>
           A live drag gesture is the familiar way to tear out a tab, but
-          <a href="#limits">Limitation&nbsp;1</a> rules it out for v1: <code>@dnd-kit</code> cannot follow
-          the cursor across a native window boundary, and Tauri exposes no webview→webview drag. If a
-          future OS-drag-image + drop-detection approach proves viable (open research item), the gesture
-          would <em>supplement</em> — never replace — the commands above, so keyboard and menu users keep
-          a first-class path. The affordance would look like this, dropping onto an OS-level target:
+          <a href="#limits">Limitation&nbsp;1</a> rules it out for v1: <code>@dnd-kit</code> cannot
+          follow the cursor across a native window boundary, and Tauri exposes no webview→webview
+          drag. If a future OS-drag-image + drop-detection approach proves viable (open research
+          item), the gesture would <em>supplement</em> — never replace — the commands above, so
+          keyboard and menu users keep a first-class path. The affordance would look like this,
+          dropping onto an OS-level target:
         </p>
         <div class="mockup-section">
           <h3>Mockup — <code>drag-future</code>: optional drag-to-tear affordance</h3>
           <div class="mockup-note">
-            Future only. A dragged tab detaches into a floating ghost <span class="callout">N</span> that
-            can be dropped on empty desktop (→ new window) or another window's tab bar (→ move). v1 ships
-            the commands; this is a later, additive gesture.
+            Future only. A dragged tab detaches into a floating ghost
+            <span class="callout">N</span> that can be dropped on empty desktop (→ new window) or
+            another window's tab bar (→ move). v1 ships the commands; this is a later, additive
+            gesture.
           </div>
           <div style="display: flex; align-items: center; gap: 16px; padding: 12px 0">
             <div class="drag-ghost">
@@ -1330,12 +1471,20 @@ flowchart TB
               <svg class="li"><use href="#i-network" /></svg>
               server-2
             </div>
-            <svg class="li" style="width: 22px; height: 22px; color: var(--text-secondary)"><use href="#i-arrow-right" /></svg>
-            <span style="color: var(--text-secondary)">drop on desktop → new window · drop on a tab bar → move</span>
+            <svg class="li" style="width: 22px; height: 22px; color: var(--text-secondary)">
+              <use href="#i-arrow-right" />
+            </svg>
+            <span style="color: var(--text-secondary)"
+              >drop on desktop → new window · drop on a tab bar → move</span
+            >
           </div>
           <div class="legend">
             <ul>
-              <li><span class="callout">N</span> Floating drag ghost (<code>drag-ghost</code>) — dashed accent border marks it as detached and in-flight. <strong>Deferred; the menu commands are the shipping mechanism.</strong></li>
+              <li>
+                <span class="callout">N</span> Floating drag ghost (<code>drag-ghost</code>) —
+                dashed accent border marks it as detached and in-flight.
+                <strong>Deferred; the menu commands are the shipping mechanism.</strong>
+              </li>
             </ul>
           </div>
         </div>
@@ -1343,62 +1492,83 @@ flowchart TB
 
       <!-- ── Proposed approach ──────────────────────────────────────── -->
       <section>
-        <h2 id="approach">Proposed Approach — the three capabilities <a class="anchor" href="#approach">#</a></h2>
+        <h2 id="approach">
+          Proposed Approach — the three capabilities <a class="anchor" href="#approach">#</a>
+        </h2>
         <p>
-          All three capabilities reduce to the same core move: <strong>detach a tab's view from window A
-          and re-attach it in window B</strong>, while the backend session keeps running untouched. They
-          differ only in whether window B already exists.
+          All three capabilities reduce to the same core move:
+          <strong>detach a tab's view from window A and re-attach it in window B</strong>, while the
+          backend session keeps running untouched. They differ only in whether window B already
+          exists.
         </p>
 
         <h3>(a) Tear a tab out into a new window</h3>
         <ol>
-          <li>User invokes "Move to New Window" (command / tab context menu; a drag-out gesture is a
-            later enhancement — see limits).</li>
-          <li>Backend creates a new <code>WebviewWindow</code> (label e.g. <code>win-2</code>) loading the
-            same frontend bundle. It boots a fresh, empty store.</li>
-          <li>A <strong>hand-off record</strong> for the moved tab (its <code>TerminalTab</code> view-model +
-            desired placement) is passed to the new window (via an init argument or a backend-brokered
-            claim — see <a href="#state">State &amp; Retargeting</a>).</li>
-          <li>Window B builds a leaf panel, creates a fresh xterm.js instance, subscribes to the global
-            output stream filtered by <code>session_id</code>, and requests a
-            <strong>scrollback replay</strong> to repaint history.</li>
-          <li>Window A removes the tab from its store and disposes its xterm instance. The backend session
-            never restarted.</li>
+          <li>
+            User invokes "Move to New Window" (command / tab context menu; a drag-out gesture is a
+            later enhancement — see limits).
+          </li>
+          <li>
+            Backend creates a new <code>WebviewWindow</code> (label e.g. <code>win-2</code>) loading
+            the same frontend bundle. It boots a fresh, empty store.
+          </li>
+          <li>
+            A <strong>hand-off record</strong> for the moved tab (its
+            <code>TerminalTab</code> view-model + desired placement) is passed to the new window
+            (via an init argument or a backend-brokered claim — see
+            <a href="#state">State &amp; Retargeting</a>).
+          </li>
+          <li>
+            Window B builds a leaf panel, creates a fresh xterm.js instance, subscribes to the
+            global output stream filtered by <code>session_id</code>, and requests a
+            <strong>scrollback replay</strong> to repaint history.
+          </li>
+          <li>
+            Window A removes the tab from its store and disposes its xterm instance. The backend
+            session never restarted.
+          </li>
         </ol>
 
         <h3>(b) Create additional windows</h3>
         <p>
-          A "New Window" command opens an empty window (empty store, no tabs) — or seeds it from a chosen
-          tab group. Mechanically identical to (a) minus the hand-off; the empty-window state is a first-class
-          UI state the UX must design.
+          A "New Window" command opens an empty window (empty store, no tabs) — or seeds it from a
+          chosen tab group. Mechanically identical to (a) minus the hand-off; the empty-window state
+          is a first-class UI state the UX must design.
         </p>
 
         <h3>(c) Move a tab between two existing windows</h3>
         <p>
-          Same hand-off as (a) but window B already exists, so the flow is just: window B claims the tab,
-          attaches + replays; window A releases it. The only genuinely new problem is the <em>gesture</em> —
-          dragging a tab from A's tab bar onto B's tab bar is not expressible with <code>@dnd-kit</code>
-          across native windows, so the shipping mechanism is a command ("Move to Window ▸ &lt;name&gt;"),
-          with drag as a research item (<a href="#limits">open question</a>).
+          Same hand-off as (a) but window B already exists, so the flow is just: window B claims the
+          tab, attaches + replays; window A releases it. The only genuinely new problem is the
+          <em>gesture</em> — dragging a tab from A's tab bar onto B's tab bar is not expressible
+          with <code>@dnd-kit</code> across native windows, so the shipping mechanism is a command
+          ("Move to Window ▸ &lt;name&gt;"), with drag as a research item (<a href="#limits"
+            >open question</a
+          >).
         </p>
       </section>
 
       <!-- ── Re-parenting mechanism ─────────────────────────────────── -->
       <section>
-        <h2 id="reparent">Session Re-parenting Mechanism <a class="anchor" href="#reparent">#</a></h2>
+        <h2 id="reparent">
+          Session Re-parenting Mechanism <a class="anchor" href="#reparent">#</a>
+        </h2>
         <p>
-          Re-parenting a tab is <strong>a pure view operation</strong>. The backend session is keyed by
-          <code>session_id</code> and knows nothing about windows, so "moving" a tab never touches it. In
-          one paragraph: window B instantiates a new xterm.js (or canvas) surface, begins listening to the
-          already-broadcast output stream for that <code>session_id</code>, and asks the backend to replay
-          the ring-buffered scrollback so the fresh surface repaints history; window A then drops its view
-          and disposes its surface. Input keeps flowing because <code>write</code>/<code>resize</code> are
-          id-keyed IPC calls issued from whichever window holds the tab. termiHub already does exactly this
-          when a persistent/agent tab is closed and later re-attached — multi-window reuses that machinery
-          across a window boundary instead of across time.
+          Re-parenting a tab is <strong>a pure view operation</strong>. The backend session is keyed
+          by <code>session_id</code> and knows nothing about windows, so "moving" a tab never
+          touches it. In one paragraph: window B instantiates a new xterm.js (or canvas) surface,
+          begins listening to the already-broadcast output stream for that <code>session_id</code>,
+          and asks the backend to replay the ring-buffered scrollback so the fresh surface repaints
+          history; window A then drops its view and disposes its surface. Input keeps flowing
+          because <code>write</code>/<code>resize</code> are id-keyed IPC calls issued from
+          whichever window holds the tab. termiHub already does exactly this when a persistent/agent
+          tab is closed and later re-attached — multi-window reuses that machinery across a window
+          boundary instead of across time.
         </p>
         <div class="diagram">
-          <span class="diagram__caption">Re-parenting a live terminal tab from window A to window B</span>
+          <span class="diagram__caption"
+            >Re-parenting a live terminal tab from window A to window B</span
+          >
           <pre class="mermaid">
 sequenceDiagram
   participant A as Window A (store + xterm)
@@ -1419,11 +1589,14 @@ sequenceDiagram
 
       <!-- ── State ownership & event retargeting ────────────────────── -->
       <section>
-        <h2 id="state">State Ownership &amp; Event Retargeting <a class="anchor" href="#state">#</a></h2>
+        <h2 id="state">
+          State Ownership &amp; Event Retargeting <a class="anchor" href="#state">#</a>
+        </h2>
         <p>
-          <strong>This boundary is the whole feature.</strong> Separate webviews are separate JavaScript
-          contexts — no shared DOM, no shared module memory, no shared Zustand store. What is authoritative
-          in the backend moves cleanly; what is in-memory per-window must be rebuilt on the far side.
+          <strong>This boundary is the whole feature.</strong> Separate webviews are separate
+          JavaScript contexts — no shared DOM, no shared module memory, no shared Zustand store.
+          What is authoritative in the backend moves cleanly; what is in-memory per-window must be
+          rebuilt on the far side.
         </p>
         <div class="table-wrap">
           <table>
@@ -1437,18 +1610,25 @@ sequenceDiagram
             <tbody>
               <tr>
                 <td>Backend session (PTY/SSH/serial/RDP, process, channel)</td>
-                <td>Rust <code>SessionManager</code>/<code>GraphicalSessionManager</code>, keyed by id</td>
+                <td>
+                  Rust <code>SessionManager</code>/<code>GraphicalSessionManager</code>, keyed by id
+                </td>
                 <td><strong>Authoritative — untouched.</strong> Survives the move entirely.</td>
               </tr>
               <tr>
                 <td>Scrollback (replayable)</td>
                 <td>Backend <code>RingBuffer</code> (1 MiB) + agent/persistent replay</td>
-                <td>Replayed into window B's fresh xterm — <strong>bounded by buffer size</strong>.</td>
+                <td>
+                  Replayed into window B's fresh xterm — <strong>bounded by buffer size</strong>.
+                </td>
               </tr>
               <tr>
                 <td>xterm.js instance, rendered scrollback, viewport, selection</td>
                 <td>In window A's JS memory / DOM</td>
-                <td><strong>Discarded.</strong> Rebuilt in B from replay; anything beyond the buffer is lost.</td>
+                <td>
+                  <strong>Discarded.</strong> Rebuilt in B from replay; anything beyond the buffer
+                  is lost.
+                </td>
               </tr>
               <tr>
                 <td>Tab view-model (<code>TerminalTab</code>: title, config, badges, placement)</td>
@@ -1458,12 +1638,18 @@ sequenceDiagram
               <tr>
                 <td>Graphical framebuffer (RDP/VNC canvas pixels)</td>
                 <td>Window A's <code>&lt;canvas&gt;</code> memory</td>
-                <td><strong>Discarded; repaint on next full frame.</strong> Possible blank flash — see matrix.</td>
+                <td>
+                  <strong>Discarded; repaint on next full frame.</strong> Possible blank flash — see
+                  matrix.
+                </td>
               </tr>
               <tr>
                 <td>Tab ↔ window ownership (who shows which session)</td>
                 <td>Implicit — one window, so unambiguous today</td>
-                <td><strong>New:</strong> needs an explicit coordinator so a tab is shown in exactly one window.</td>
+                <td>
+                  <strong>New:</strong> needs an explicit coordinator so a tab is shown in exactly
+                  one window.
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1471,37 +1657,40 @@ sequenceDiagram
 
         <h3>Event retargeting — needed for hygiene, not correctness</h3>
         <p>
-          Because output is a <strong>global broadcast</strong> (<code>AppHandle::emit</code>), the moment
-          window B subscribes to <code>terminal-output</code> and filters for the session's id, output
-          "follows" the tab with zero backend change — this is a genuine gift of the current design. Two
-          non-blocking concerns remain:
+          Because output is a <strong>global broadcast</strong> (<code>AppHandle::emit</code>), the
+          moment window B subscribes to <code>terminal-output</code> and filters for the session's
+          id, output "follows" the tab with zero backend change — this is a genuine gift of the
+          current design. Two non-blocking concerns remain:
         </p>
         <ul>
           <li>
-            <strong>Efficiency.</strong> Every window deserializes every session's bytes even for tabs it
-            does not own. At a handful of windows this is fine; at scale it argues for switching hot streams
-            to <code>emit_to(window_label, …)</code> and having the backend track a
-            <code>session_id → owning_window</code> map, updated on each move. That map is also the natural
-            <strong>ownership coordinator</strong> above.
+            <strong>Efficiency.</strong> Every window deserializes every session's bytes even for
+            tabs it does not own. At a handful of windows this is fine; at scale it argues for
+            switching hot streams to <code>emit_to(window_label, …)</code> and having the backend
+            track a <code>session_id → owning_window</code> map, updated on each move. That map is
+            also the natural <strong>ownership coordinator</strong> above.
           </li>
           <li>
-            <strong>Ownership coordination.</strong> Two windows must never simultaneously render the same
-            live tab (double input, fighting resizes). The cleanest home for the authoritative
-            <code>session → window</code> assignment is the backend (it already holds the session); windows
-            claim/release through it. A pure-frontend broadcast-channel scheme is possible but more fragile
-            across crashes.
+            <strong>Ownership coordination.</strong> Two windows must never simultaneously render
+            the same live tab (double input, fighting resizes). The cleanest home for the
+            authoritative <code>session → window</code> assignment is the backend (it already holds
+            the session); windows claim/release through it. A pure-frontend broadcast-channel scheme
+            is possible but more fragile across crashes.
           </li>
         </ul>
         <p>
-          <strong>Resize is a real subtlety:</strong> a PTY has one size. When a tab moves to a differently
-          sized window, exactly one window must own the <code>resize</code> for that session — the one
-          currently displaying it — and the backend must apply the new dimensions once, not race two windows.
+          <strong>Resize is a real subtlety:</strong> a PTY has one size. When a tab moves to a
+          differently sized window, exactly one window must own the <code>resize</code> for that
+          session — the one currently displaying it — and the backend must apply the new dimensions
+          once, not race two windows.
         </p>
       </section>
 
       <!-- ── Feasibility matrix ─────────────────────────────────────── -->
       <section>
-        <h2 id="matrix">Per-Session-Type Feasibility Matrix <a class="anchor" href="#matrix">#</a></h2>
+        <h2 id="matrix">
+          Per-Session-Type Feasibility Matrix <a class="anchor" href="#matrix">#</a>
+        </h2>
         <p>
           "Moves cleanly" = backend session survives and only the view re-attaches. The
           <code>contentType</code> values are from <code>src/types/terminal.ts</code>.
@@ -1519,17 +1708,26 @@ sequenceDiagram
               <tr>
                 <td>Local shell / PTY (+ xterm.js)</td>
                 <td><strong>Easy</strong></td>
-                <td>Backend PTY survives; fresh xterm + RingBuffer replay. Scrollback beyond 1 MiB is lost.</td>
+                <td>
+                  Backend PTY survives; fresh xterm + RingBuffer replay. Scrollback beyond 1 MiB is
+                  lost.
+                </td>
               </tr>
               <tr>
                 <td>SSH (local or agent-mediated)</td>
                 <td><strong>Easy</strong></td>
-                <td>Same stream model. Agent/persistent sessions already support detach + re-attach with replay — the exact primitive.</td>
+                <td>
+                  Same stream model. Agent/persistent sessions already support detach + re-attach
+                  with replay — the exact primitive.
+                </td>
               </tr>
               <tr>
                 <td>Serial</td>
                 <td><strong>Easy</strong></td>
-                <td>24/7 RingBuffer capture already exists; re-attach replays. Port stays open in backend.</td>
+                <td>
+                  24/7 RingBuffer capture already exists; re-attach replays. Port stays open in
+                  backend.
+                </td>
               </tr>
               <tr>
                 <td>Telnet / Docker / WSL</td>
@@ -1539,27 +1737,59 @@ sequenceDiagram
               <tr>
                 <td>Agent sessions (remote daemon)</td>
                 <td><strong>Easy</strong></td>
-                <td>Detach/adopt/attach is already built (<code>adopt_persistent_session</code>, scrollback fetch). Best-supported case.</td>
+                <td>
+                  Detach/adopt/attach is already built (<code>adopt_persistent_session</code>,
+                  scrollback fetch). Best-supported case.
+                </td>
               </tr>
               <tr>
                 <td>File browser / SFTP / FTP (<code>file-browser</code>, terminal-less)</td>
                 <td><strong>Medium</strong></td>
-                <td>Backend SFTP session (keyed in <code>SftpManager</code>) survives, but current dir / selection are frontend-only and must serialize. In-flight transfers use a <strong>shared Transfer Queue</strong> (<code>src/components/TransferQueue</code>) — a move must not abort them; the queue is app-scoped, so its ownership across windows is an open question.</td>
+                <td>
+                  Backend SFTP session (keyed in <code>SftpManager</code>) survives, but current dir
+                  / selection are frontend-only and must serialize. In-flight transfers use a
+                  <strong>shared Transfer Queue</strong> (<code>src/components/TransferQueue</code>)
+                  — a move must not abort them; the queue is app-scoped, so its ownership across
+                  windows is an open question.
+                </td>
               </tr>
               <tr>
-                <td>RDP / VNC graphical (<code>remote-desktop</code>, <code>&lt;canvas&gt;</code>)</td>
+                <td>
+                  RDP / VNC graphical (<code>remote-desktop</code>, <code>&lt;canvas&gt;</code>)
+                </td>
                 <td><strong>Hard (command-only)</strong></td>
-                <td>Backend graphical session survives (frames broadcast on <code>remote-desktop-frame</code>), but the framebuffer is canvas memory in window A. Window B repaints only on the next <em>full</em> frame — there is no on-demand keyframe today — so expect a blank/stale flash. Cursor/clipboard/cert-prompt state is per-webview. <strong>Recommend command-based move with a "reconnecting view…" placeholder; a backend "request full frame on attach" hook would materially improve this.</strong></td>
+                <td>
+                  Backend graphical session survives (frames broadcast on
+                  <code>remote-desktop-frame</code>), but the framebuffer is canvas memory in window
+                  A. Window B repaints only on the next <em>full</em> frame — there is no on-demand
+                  keyframe today — so expect a blank/stale flash. Cursor/clipboard/cert-prompt state
+                  is per-webview.
+                  <strong
+                    >Recommend command-based move with a "reconnecting view…" placeholder; a backend
+                    "request full frame on attach" hook would materially improve this.</strong
+                  >
+                </td>
               </tr>
               <tr>
                 <td>Editor (<code>editor</code>, Monaco)</td>
                 <td><strong>Medium</strong></td>
-                <td>Unsaved buffer + cursor live in window A's Monaco. Moving means re-opening the file in B and transferring dirty state — non-trivial; may restrict to saved files in v1.</td>
+                <td>
+                  Unsaved buffer + cursor live in window A's Monaco. Moving means re-opening the
+                  file in B and transferring dirty state — non-trivial; may restrict to saved files
+                  in v1.
+                </td>
               </tr>
               <tr>
-                <td>Non-session tabs: Settings, Log Viewer, Connection/Tunnel/Workspace editors, Network Diagnostic</td>
+                <td>
+                  Non-session tabs: Settings, Log Viewer, Connection/Tunnel/Workspace editors,
+                  Network Diagnostic
+                </td>
                 <td><strong>N/A / restrict</strong></td>
-                <td>No backend session; some are effectively singletons (Settings, Log Viewer). Moving is pure view transfer but often meaningless. Likely non-goal — restrict to session-bearing tabs, or allow but forbid duplicates.</td>
+                <td>
+                  No backend session; some are effectively singletons (Settings, Log Viewer). Moving
+                  is pure view transfer but often meaningless. Likely non-goal — restrict to
+                  session-bearing tabs, or allow but forbid duplicates.
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1572,20 +1802,37 @@ sequenceDiagram
         <div class="table-wrap">
           <table>
             <thead>
-              <tr><th>Platform</th><th>Constraint</th></tr>
+              <tr>
+                <th>Platform</th>
+                <th>Constraint</th>
+              </tr>
             </thead>
             <tbody>
               <tr>
                 <td>macOS (WKWebView)</td>
-                <td>Closing the <em>last</em> window conventionally does <strong>not</strong> quit the app (stays in Dock) — needs an explicit policy vs. Windows/Linux. Also: <code>tauri-driver</code> has no macOS WKWebView driver (ADR-5), so multi-window <strong>E2E cannot be automated on macOS</strong> — verification is manual there.</td>
+                <td>
+                  Closing the <em>last</em> window conventionally does <strong>not</strong> quit the
+                  app (stays in Dock) — needs an explicit policy vs. Windows/Linux. Also:
+                  <code>tauri-driver</code> has no macOS WKWebView driver (ADR-5), so multi-window
+                  <strong>E2E cannot be automated on macOS</strong> — verification is manual there.
+                </td>
               </tr>
               <tr>
                 <td>Windows (WebView2) / Linux (WebKitGTK)</td>
-                <td>Last-window-close typically quits. Each new window is a full webview → real RAM cost (another React app + xterm instances). No cross-window native tab drag on any platform with the current stack.</td>
+                <td>
+                  Last-window-close typically quits. Each new window is a full webview → real RAM
+                  cost (another React app + xterm instances). No cross-window native tab drag on any
+                  platform with the current stack.
+                </td>
               </tr>
               <tr>
                 <td>All platforms</td>
-                <td>Cross-window webview→webview drag is not provided by Tauri; <code>@dnd-kit</code> is single-document. Tab-tear/inter-window drag must fall back to commands. Each window re-runs the full frontend bundle (memory + startup cost per window).</td>
+                <td>
+                  Cross-window webview→webview drag is not provided by Tauri;
+                  <code>@dnd-kit</code> is single-document. Tab-tear/inter-window drag must fall
+                  back to commands. Each window re-runs the full frontend bundle (memory + startup
+                  cost per window).
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1612,7 +1859,9 @@ stateDiagram-v2
           </pre>
         </div>
         <div class="diagram">
-          <span class="diagram__caption">Ownership handshake (prevents a tab living in two windows)</span>
+          <span class="diagram__caption"
+            >Ownership handshake (prevents a tab living in two windows)</span
+          >
           <pre class="mermaid">
 sequenceDiagram
   participant A as Window A
@@ -1628,57 +1877,68 @@ sequenceDiagram
 
       <!-- ── Limitations / Non-goals / Open questions ───────────────── -->
       <section>
-        <h2 id="limits">Limitations · Non-Goals · Open Questions <a class="anchor" href="#limits">#</a></h2>
+        <h2 id="limits">
+          Limitations · Non-Goals · Open Questions <a class="anchor" href="#limits">#</a>
+        </h2>
 
         <h3>Hard limitations (these shape the UX)</h3>
         <ol>
           <li>
             <strong>No cross-window native drag.</strong> The tab DnD stack (<code>@dnd-kit</code>,
-            <code>SplitView.tsx</code>) is single-document and cannot follow the cursor across a native
-            window boundary; Tauri exposes no webview→webview drag. <strong>Tear-out and drag-between-windows
-            must ship as commands / context-menu items</strong> ("Move to New Window", "Move to Window ▸ N");
-            a drag gesture is at best a future enhancement, not the v1 mechanism.
+            <code>SplitView.tsx</code>) is single-document and cannot follow the cursor across a
+            native window boundary; Tauri exposes no webview→webview drag.
+            <strong
+              >Tear-out and drag-between-windows must ship as commands / context-menu items</strong
+            >
+            ("Move to New Window", "Move to Window ▸ N"); a drag gesture is at best a future
+            enhancement, not the v1 mechanism.
           </li>
           <li>
-            <strong>Graphical (RDP/VNC) tabs move via command only, with a repaint flash.</strong> The
-            framebuffer is canvas memory in the source window; the destination repaints only on the next
-            full frame (no on-demand keyframe today), so the canvas may be blank/stale briefly. Live drag is
-            especially unsuitable here.
+            <strong>Graphical (RDP/VNC) tabs move via command only, with a repaint flash.</strong>
+            The framebuffer is canvas memory in the source window; the destination repaints only on
+            the next full frame (no on-demand keyframe today), so the canvas may be blank/stale
+            briefly. Live drag is especially unsuitable here.
           </li>
           <li>
-            <strong>Scrollback fidelity is bounded by the backend replay buffer (1 MiB RingBuffer).</strong>
-            The source window's fully-rendered xterm scrollback is discarded (separate JS context — DOM/memory
-            cannot transfer); the destination shows only what the backend can replay. Very long histories are
-            truncated on move.
+            <strong
+              >Scrollback fidelity is bounded by the backend replay buffer (1 MiB
+              RingBuffer).</strong
+            >
+            The source window's fully-rendered xterm scrollback is discarded (separate JS context —
+            DOM/memory cannot transfer); the destination shows only what the backend can replay.
+            Very long histories are truncated on move.
           </li>
           <li>
-            <strong>Separate JS contexts — no shared store.</strong> Each window is its own React/Zustand
-            instance. Cross-window features (tab counts, "move to" menus listing other windows, ownership)
-            require a coordination channel (backend-brokered is recommended over a frontend broadcast channel).
+            <strong>Separate JS contexts — no shared store.</strong> Each window is its own
+            React/Zustand instance. Cross-window features (tab counts, "move to" menus listing other
+            windows, ownership) require a coordination channel (backend-brokered is recommended over
+            a frontend broadcast channel).
           </li>
           <li>
-            <strong>No window dimension in persistence.</strong> <code>WorkspaceDefinition</code> and
-            last-session restore have no field for window assignment. Saving/restoring a multi-window layout
-            needs a schema addition (a window id per tab group / per tab) and new multi-window restore
-            lifecycle.
+            <strong>No window dimension in persistence.</strong>
+            <code>WorkspaceDefinition</code> and last-session restore have no field for window
+            assignment. Saving/restoring a multi-window layout needs a schema addition (a window id
+            per tab group / per tab) and new multi-window restore lifecycle.
           </li>
           <li>
             <strong>Window-close policy is new.</strong> Closing a window with live tabs must choose
-            detach-vs-terminate (persistent/agent sessions should detach, not die); "last window closed →
-            quit" differs by OS (macOS keeps the app alive).
+            detach-vs-terminate (persistent/agent sessions should detach, not die); "last window
+            closed → quit" differs by OS (macOS keeps the app alive).
           </li>
           <li>
-            <strong>Resize ownership.</strong> A PTY has one size; exactly one window may own a session's
-            <code>resize</code> at a time, and the backend must apply it without racing two windows.
+            <strong>Resize ownership.</strong> A PTY has one size; exactly one window may own a
+            session's <code>resize</code> at a time, and the backend must apply it without racing
+            two windows.
           </li>
           <li>
-            <strong>Per-window memory cost.</strong> Each window re-runs the full frontend bundle and its own
-            xterm/canvas instances — a real RAM multiplier, relevant to the app's resource footprint.
+            <strong>Per-window memory cost.</strong> Each window re-runs the full frontend bundle
+            and its own xterm/canvas instances — a real RAM multiplier, relevant to the app's
+            resource footprint.
           </li>
           <li>
-            <strong>Automated-test gap on macOS.</strong> <code>tauri-driver</code> has no macOS driver
-            (ADR-5), and the Python bridge harness would need multi-window awareness. Multi-window behavior on
-            macOS is manual-test-only.
+            <strong>Automated-test gap on macOS.</strong> <code>tauri-driver</code> has no macOS
+            driver (ADR-5), and the Python bridge harness would need multi-window awareness.
+            Multi-window behavior on macOS is manual-test-only.
           </li>
         </ol>
 
@@ -1693,18 +1953,33 @@ sequenceDiagram
         <h3>Open questions (need the human or the UX step)</h3>
         <ul>
           <li>
-            <strong>Do windows map onto tab groups?</strong> Tab groups are already independent panel trees.
-            The cleanest model may be "a window owns one or more tab groups," reusing that substrate — but
-            that couples the two features. Product decision.
+            <strong>Do windows map onto tab groups?</strong> Tab groups are already independent
+            panel trees. The cleanest model may be "a window owns one or more tab groups," reusing
+            that substrate — but that couples the two features. Product decision.
           </li>
           <li>
-            <strong>Is a drag-out gesture worth prototyping</strong> given @dnd-kit can't cross windows? (An
-            OS-drag-image + drop-detection hack is conceivable but unproven in Tauri — research item.)
+            <strong>Is a drag-out gesture worth prototyping</strong> given @dnd-kit can't cross
+            windows? (An OS-drag-image + drop-detection hack is conceivable but unproven in Tauri —
+            research item.)
           </li>
-          <li><strong>Detach-vs-terminate default</strong> when closing a window with non-persistent live tabs.</li>
-          <li><strong>Are graphical tabs allowed to move at all in v1</strong>, or deferred until a "request full frame on attach" backend hook exists?</li>
-          <li><strong>Transfer-queue ownership</strong> when an SFTP/FTP tab with in-flight transfers moves windows.</li>
-          <li><strong>Should the Open Connections panel and workspace save/restore become window-aware</strong>, or stay window-agnostic in v1?</li>
+          <li>
+            <strong>Detach-vs-terminate default</strong> when closing a window with non-persistent
+            live tabs.
+          </li>
+          <li>
+            <strong>Are graphical tabs allowed to move at all in v1</strong>, or deferred until a
+            "request full frame on attach" backend hook exists?
+          </li>
+          <li>
+            <strong>Transfer-queue ownership</strong> when an SFTP/FTP tab with in-flight transfers
+            moves windows.
+          </li>
+          <li>
+            <strong
+              >Should the Open Connections panel and workspace save/restore become
+              window-aware</strong
+            >, or stay window-agnostic in v1?
+          </li>
         </ul>
       </section>
 
@@ -1715,36 +1990,68 @@ sequenceDiagram
         <div class="table-wrap">
           <table>
             <thead>
-              <tr><th>Area</th><th>Change</th></tr>
+              <tr>
+                <th>Area</th>
+                <th>Change</th>
+              </tr>
             </thead>
             <tbody>
               <tr>
                 <td><code>src-tauri/src/lib.rs</code> / new <code>window</code> module</td>
-                <td><strong>New</strong> — <code>WebviewWindowBuilder</code> to create labelled windows (<code>win-N</code>); a backend <em>session→window ownership map</em> + claim/release commands; window-aware close/quit policy in the <code>RunEvent</code> handler.</td>
+                <td>
+                  <strong>New</strong> — <code>WebviewWindowBuilder</code> to create labelled
+                  windows (<code>win-N</code>); a backend <em>session→window ownership map</em> +
+                  claim/release commands; window-aware close/quit policy in the
+                  <code>RunEvent</code> handler.
+                </td>
               </tr>
               <tr>
                 <td><code>src-tauri/src/session/manager.rs</code></td>
-                <td>Add an on-demand <em>scrollback replay for a specific window</em> path (reuse the existing persistent/agent replay) and, later, optional <code>emit_to(window_label, …)</code> targeting instead of global broadcast for hot streams.</td>
+                <td>
+                  Add an on-demand <em>scrollback replay for a specific window</em> path (reuse the
+                  existing persistent/agent replay) and, later, optional
+                  <code>emit_to(window_label, …)</code> targeting instead of global broadcast for
+                  hot streams.
+                </td>
               </tr>
               <tr>
                 <td><code>src-tauri/src/session/graphical_manager.rs</code></td>
-                <td>Add a "request full frame on (re)attach" hook so a moved RDP/VNC tab repaints immediately rather than waiting for the next full frame.</td>
+                <td>
+                  Add a "request full frame on (re)attach" hook so a moved RDP/VNC tab repaints
+                  immediately rather than waiting for the next full frame.
+                </td>
               </tr>
               <tr>
                 <td><code>src/store/appStore.ts</code></td>
-                <td>Extend the existing <code>moveTab</code>/<code>moveTabToGroup</code> seam with <code>moveTabToWindow</code>; serialize a <code>TerminalTab</code> hand-off record; hydrate a tab into a fresh store on window boot; dispose on release.</td>
+                <td>
+                  Extend the existing <code>moveTab</code>/<code>moveTabToGroup</code> seam with
+                  <code>moveTabToWindow</code>; serialize a <code>TerminalTab</code> hand-off
+                  record; hydrate a tab into a fresh store on window boot; dispose on release.
+                </td>
               </tr>
               <tr>
                 <td><code>src/services/events.ts</code></td>
-                <td><code>SessionEventDispatcher</code> already filters by <code>session_id</code> — extend so a window only subscribes for sessions it owns (feeds the efficiency/<code>emit_to</code> path).</td>
+                <td>
+                  <code>SessionEventDispatcher</code> already filters by <code>session_id</code> —
+                  extend so a window only subscribes for sessions it owns (feeds the
+                  efficiency/<code>emit_to</code> path).
+                </td>
               </tr>
               <tr>
                 <td><code>src/types/workspace.ts</code>, workspace + last-session backend</td>
-                <td><strong>New</strong> — an optional window-assignment dimension so multi-window layouts save/restore.</td>
+                <td>
+                  <strong>New</strong> — an optional window-assignment dimension so multi-window
+                  layouts save/restore.
+                </td>
               </tr>
               <tr>
-                <td>Tab context menu / command palette (<code>SplitView</code>, <code>TabBar</code>)</td>
-                <td><strong>New</strong> — "Move to New Window" / "Move to Window ▸ N" commands (the primary mechanism; drag is a later enhancement).</td>
+                <td>
+                  Tab context menu / command palette (<code>SplitView</code>, <code>TabBar</code>)
+                </td>
+                <td>
+                  <strong>New</strong> — "Move to New Window" / "Move to Window ▸ N" commands (the
+                  primary mechanism; drag is a later enhancement).
+                </td>
               </tr>
             </tbody>
           </table>
@@ -1756,12 +2063,14 @@ sequenceDiagram
         <h2 id="sync">Sync Ledger <a class="anchor" href="#sync">#</a></h2>
         <blockquote>
           <p>
-            Maintained by <code>/sync-concept &lt;name&gt;</code>. Records the last commit at which the
-            concept and code were reconciled, plus open divergences. The concept is the source of truth.
+            Maintained by <code>/sync-concept &lt;name&gt;</code>. Records the last commit at which
+            the concept and code were reconciled, plus open divergences. The concept is the source
+            of truth.
           </p>
         </blockquote>
         <p>
-          <strong>Last synced:</strong> never (not implemented) · <strong>Status:</strong> diverged (by design — concept only)
+          <strong>Last synced:</strong> never (not implemented) · <strong>Status:</strong> diverged
+          (by design — concept only)
         </p>
         <div class="table-wrap">
           <table>
@@ -1778,14 +2087,20 @@ sequenceDiagram
               <tr>
                 <td>1</td>
                 <td>Multiple application windows</td>
-                <td>Single <code>"main"</code> window; no <code>WebviewWindowBuilder</code> in production</td>
+                <td>
+                  Single <code>"main"</code> window; no <code>WebviewWindowBuilder</code> in
+                  production
+                </td>
                 <td>Missing</td>
                 <td>Implement per this concept, then re-sync</td>
               </tr>
               <tr>
                 <td>2</td>
                 <td>Cross-window tab move (session survives)</td>
-                <td>Backend session survival + detach/re-attach replay already exist; no cross-window plumbing</td>
+                <td>
+                  Backend session survival + detach/re-attach replay already exist; no cross-window
+                  plumbing
+                </td>
                 <td>Partial substrate</td>
                 <td>Reuse existing replay/adopt path; add window ownership + hand-off</td>
               </tr>

--- a/docs/concepts/mockups-index.html
+++ b/docs/concepts/mockups-index.html
@@ -31,6 +31,7 @@
         <li><a href="backlog/git-bash-provisioning.html">git-bash-provisioning.html</a></li>
         <li><a href="backlog/macos-code-signing-notarization.html">macos-code-signing-notarization.html</a></li>
         <li><a href="backlog/macro-recording.html">macro-recording.html</a></li>
+        <li><a href="backlog/multi-window.html">multi-window.html</a></li>
         <li><a href="backlog/release-planning-and-dependency-management.html">release-planning-and-dependency-management.html</a></li>
         <li><a href="backlog/remote-desktop-sessions.html">remote-desktop-sessions.html</a></li>
       </ul></div>


### PR DESCRIPTION
## Summary

Step 2 of the two-step multi-window concept (#1806): the **UX / interaction design and
inline mockups**. Builds directly on the engineer's technical concept + limitations already
on this branch — architecture and limitations sections are left intact.

The whole design follows from one hard constraint in the technical concept: **a tab cannot be
dragged across a native window boundary** (`@dnd-kit` is single-document). So the v1 mechanism
for tearing out and moving tabs is **commands / context-menu items**, not a live drag gesture.

## Mockups authored (inline, real `mockup.css` classes + lucide icons)

- `move-menu` — tab context menu with the new **Move to New Window** / **Move to Window ▸**
  group (inserted into the real `Tab.tsx` Radix context menu), plus the window-picker submenu.
- `mid-move` — two windows side by side: the source ghost tab leaving, the destination
  insertion caret + replayed scrollback.
- `empty-window` — a zero-tab window with its call-to-action (a first-class state).
- `graphical-move` — an RDP/VNC tab arriving with the **"reconnecting view…"** overlay over the
  canvas (the framebuffer can't cross a JS context; the session stays connected).
- `close-decision` — closing a window with live tabs: the **detach-vs-terminate** decision
  surface (persistent/agent detach; non-persistent confirm or move; all-persistent → no dialog).
- `drag-future` — the optional drag-to-tear affordance, clearly labelled a future enhancement.

Prose (core interaction model, entry points, per-case user journeys) fills the `#ui` section
around the mockups. Screenshot-verified with `screenshot-mockup.sh` — reads as termiHub and
Mermaid renders. Gallery regenerated (`mockups-index.html`).

## Verification

- `screenshot-mockup.sh docs/concepts/backlog/multi-window.html` — all six mockups render as
  real termiHub chrome; engineer's Mermaid diagrams render.
- `pnpm markdownlint` — 0 errors.
- `prettier --check` — clean.

Closes #1806
