### PR TITLE
feat(rdp): multi-format rdpsnd negotiation via vendored ironrdp-rdpsnd (Closes #1773)

### DIFF
--- a/docs/changes/dev0/feature/1773-multiformat-rdpsnd.md
+++ b/docs/changes/dev0/feature/1773-multiformat-rdpsnd.md
@@ -1,0 +1,8 @@
+### Added
+
+- RDP audio (`rdpsnd`) now negotiates **multiple PCM formats** instead of a
+  single fixed one. The sidecar advertises a table of common sample rates
+  (48/44.1/22.05/11.025 kHz) in both mono and stereo (16-bit PCM) and plays each
+  audio buffer at exactly the rate and channel count the server selected, so
+  audio from servers that stream at a non-CD rate is no longer forced through a
+  single 44.1 kHz stereo assumption (#1773).

--- a/rdp-sidecar/Cargo.lock
+++ b/rdp-sidecar/Cargo.lock
@@ -2139,8 +2139,6 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdpsnd"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1a4f7092ae8fdc0a2f61be8e100277dc6f4ad51b85455dc9e8157979993ea2"
 dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core",

--- a/rdp-sidecar/Cargo.toml
+++ b/rdp-sidecar/Cargo.toml
@@ -171,3 +171,18 @@ wl-clipboard-rs = { version = "0.8", default-features = false, features = [
 # Temp directories back the drive-redirection filesystem tests (#1757), which
 # exercise the RDPDR backend against a real folder without a live RDP server.
 tempfile = "3"
+
+# Vendored fork of ironrdp-rdpsnd 0.9.0 (#1773), patched in the same way as
+# `vendor/vnc-rs` is patched into the main app (#1714). Upstream 0.9.0 hands the
+# `wave` callback only a `format_no` index into a non-deterministically-ordered,
+# then-discarded client-format list, so a handler advertising more than one audio
+# format cannot map a played buffer back to its negotiated rate (risking
+# "chipmunk" audio). The fork remembers the exact list it sent and passes the
+# concrete `AudioFormat` to `wave`, which is what makes multi-format rdpsnd
+# negotiation sound. `ironrdp` (the meta crate) depends on `ironrdp-rdpsnd = "0.9"`
+# and re-exports it as `ironrdp::rdpsnd`, so patching crates-io redirects that
+# re-export to the fork. This lives in the workspace-EXCLUDED sidecar graph with
+# its own Cargo.lock, so it never touches the desktop app's dependency graph.
+# See `vendor/ironrdp-rdpsnd/README.md` for exactly what changed vs upstream.
+[patch.crates-io]
+ironrdp-rdpsnd = { path = "vendor/ironrdp-rdpsnd" }

--- a/rdp-sidecar/src/audio.rs
+++ b/rdp-sidecar/src/audio.rs
@@ -1,14 +1,15 @@
 //! Audio output redirection (MS-RDPEAUDIO / `rdpsnd`) for the RDP sidecar
-//! (#1764).
+//! (#1764, multi-format negotiation #1773).
 //!
 //! IronRDP's [`Rdpsnd`](ironrdp::rdpsnd::client::Rdpsnd) static virtual channel
 //! decodes the server's audio stream and drives an
 //! [`RdpsndClientHandler`](ironrdp::rdpsnd::client::RdpsndClientHandler): the
 //! handler advertises the [`AudioFormat`]s it can play via
 //! [`get_formats`](RdpsndClientHandler::get_formats), and the channel calls
-//! [`wave`](RdpsndClientHandler::wave) with each decoded audio buffer in one of
-//! those formats. [`RdpAudioBackend`] plays those buffers on a **host audio
-//! output device**, so the remote session's sound is heard locally.
+//! [`wave`](RdpsndClientHandler::wave) with each decoded audio buffer, handing us
+//! the **concrete negotiated [`AudioFormat`]** the buffer is in. [`RdpAudioBackend`]
+//! plays those buffers on a **host audio output device**, so the remote session's
+//! sound is heard locally.
 //!
 //! ## Where playback happens
 //!
@@ -18,17 +19,19 @@
 //! decoded samples over a channel; the handler only holds the `Send` sender, so
 //! nothing audio-related touches the async session future.
 //!
-//! ## Scope (v1, PCM only)
+//! ## Scope: multi-rate PCM negotiation (#1773)
 //!
-//! The handler advertises a **single** PCM format — 44.1 kHz, 16-bit, stereo —
-//! and plays `wave` PDUs in it. One format is deliberate: IronRDP 0.9's
-//! `wave(format_no, …)` reports an index into the *intersection* of the client
-//! and server format lists, which IronRDP builds from a `HashSet` (non-deterministic
-//! order) and does not expose to the handler — so with more than one advertised
-//! format the handler cannot reliably map `format_no` back to a concrete format.
-//! Advertising exactly one keeps that mapping unambiguous (`format_no` is always
-//! `0`). Multi-format negotiation, ADPCM/Opus decode, and jitter/latency tuning
-//! are follow-ups (see #1764).
+//! The handler advertises a **table** of common PCM formats (48/44.1/22.05/11.025
+//! kHz, 16-bit, mono and stereo) and plays each `wave` PDU in whichever format the
+//! server selected. This is only sound because termiHub vendors a patched
+//! `ironrdp-rdpsnd` (see `vendor/ironrdp-rdpsnd/`): upstream 0.9.0 reported only a
+//! `format_no` index into a non-deterministically-ordered, then-discarded list, so
+//! more than one advertised format could not be mapped back to a concrete rate
+//! (risking "chipmunk" audio — e.g. playing 22.05 kHz data at 44.1 kHz). The fork
+//! passes the concrete [`AudioFormat`] to [`wave`](RdpsndClientHandler::wave), so
+//! each buffer is decoded and played at its **own** channel count and sample rate;
+//! [`rodio`] resamples to the device rate. Compressed formats (ADPCM/Opus) remain
+//! a follow-up — see #1773.
 //!
 //! ## Platforms
 //!
@@ -49,12 +52,18 @@ use std::time::{Duration, Instant};
 use ironrdp::rdpsnd::client::RdpsndClientHandler;
 use ironrdp::rdpsnd::pdu::{AudioFormat, PitchPdu, VolumePdu, WaveFormat};
 
-/// Channels in the advertised PCM format (stereo).
-const AUDIO_CHANNELS: u16 = 2;
-/// Sample rate of the advertised PCM format, in Hz (CD quality).
-const AUDIO_SAMPLE_RATE: u32 = 44_100;
-/// Bit depth of the advertised PCM format (16-bit signed little-endian).
+/// Bit depth of the PCM formats the handler advertises (16-bit signed LE). Every
+/// advertised format is 16-bit; [`decode_wave`] rejects anything else, so a
+/// mismatched buffer is dropped rather than played at the wrong width.
 const AUDIO_BITS_PER_SAMPLE: u16 = 16;
+
+/// Sample rates advertised, in Hz. A broad-but-standard set so the intersection
+/// with a typical Windows `rdpsnd` server's table is non-empty across servers;
+/// [`rodio`] resamples whichever the server picks to the device rate.
+const ADVERTISED_SAMPLE_RATES: [u32; 4] = [48_000, 44_100, 22_050, 11_025];
+
+/// Channel counts advertised (mono and stereo).
+const ADVERTISED_CHANNELS: [u16; 2] = [2, 1];
 
 /// Target amount of audio to buffer ahead of the play head before playback
 /// starts, and to rebuild after every underrun. This small cushion is what late
@@ -71,32 +80,79 @@ const TARGET_LATENCY: Duration = Duration::from_millis(80);
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 const MAX_LATENCY: Duration = Duration::from_millis(250);
 
-/// Build the single PCM [`AudioFormat`] the handler advertises. Every field must
-/// match a format the server offers verbatim (IronRDP intersects the two lists
-/// by structural equality), so the derived `nBlockAlign` / `nAvgBytesPerSec`
-/// follow the standard PCM formulas a Windows `rdpsnd` server uses.
-fn pcm_format() -> AudioFormat {
-    let block_align = AUDIO_CHANNELS * (AUDIO_BITS_PER_SAMPLE / 8);
+/// A decoded PCM buffer together with the playback parameters it must be played
+/// at. Carrying `channels`/`sample_rate` per buffer is what makes multi-format
+/// negotiation sound: the value the server negotiated travels with the samples,
+/// so nothing downstream can guess (and mis-guess) the rate.
+#[derive(Debug, Clone, PartialEq)]
+struct PcmBuffer {
+    samples: Vec<i16>,
+    channels: u16,
+    sample_rate: u32,
+}
+
+/// Build one PCM [`AudioFormat`]. Every field must match a format the server
+/// offers verbatim (IronRDP intersects the two lists by structural equality), so
+/// the derived `nBlockAlign` / `nAvgBytesPerSec` follow the standard PCM formulas
+/// a Windows `rdpsnd` server uses.
+fn pcm_format(channels: u16, sample_rate: u32) -> AudioFormat {
+    let block_align = channels * (AUDIO_BITS_PER_SAMPLE / 8);
     AudioFormat {
         format: WaveFormat::PCM,
-        n_channels: AUDIO_CHANNELS,
-        n_samples_per_sec: AUDIO_SAMPLE_RATE,
-        n_avg_bytes_per_sec: AUDIO_SAMPLE_RATE * u32::from(block_align),
+        n_channels: channels,
+        n_samples_per_sec: sample_rate,
+        n_avg_bytes_per_sec: sample_rate * u32::from(block_align),
         n_block_align: block_align,
         bits_per_sample: AUDIO_BITS_PER_SAMPLE,
         data: None,
     }
 }
 
-/// The formats the handler advertises to the server: one PCM format on platforms
-/// with a compiled audio backend, empty elsewhere (so the server streams no
-/// audio, matching the no-op behaviour).
+/// The formats the handler advertises to the server: the full PCM table on
+/// platforms with a compiled audio backend, empty elsewhere (so the server
+/// streams no audio, matching the no-op behaviour).
 fn advertised_formats() -> Vec<AudioFormat> {
-    if AudioSink::SUPPORTED {
-        vec![pcm_format()]
-    } else {
-        Vec::new()
+    if !AudioSink::SUPPORTED {
+        return Vec::new();
     }
+    let mut formats = Vec::with_capacity(ADVERTISED_SAMPLE_RATES.len() * ADVERTISED_CHANNELS.len());
+    for &rate in &ADVERTISED_SAMPLE_RATES {
+        for &channels in &ADVERTISED_CHANNELS {
+            formats.push(pcm_format(channels, rate));
+        }
+    }
+    formats
+}
+
+/// Decode a `wave` payload into a [`PcmBuffer`] using the **negotiated**
+/// [`AudioFormat`] the server selected. Only 16-bit LE PCM is supported (every
+/// advertised format is such); any other format is rejected with `None` so an
+/// unexpected buffer is dropped rather than played at the wrong rate or width.
+///
+/// The channel count and sample rate come straight from `format`, so the buffer
+/// is always played at exactly the rate it was negotiated at — this is the guard
+/// against "chipmunk" audio.
+fn decode_wave(format: &AudioFormat, data: &[u8]) -> Option<PcmBuffer> {
+    if format.format != WaveFormat::PCM || format.bits_per_sample != AUDIO_BITS_PER_SAMPLE {
+        tracing::warn!(
+            ?format.format,
+            bits = format.bits_per_sample,
+            "rdpsnd: unsupported wave format, dropping buffer"
+        );
+        return None;
+    }
+    if format.n_channels == 0 || format.n_samples_per_sec == 0 {
+        return None;
+    }
+    let samples = pcm_bytes_to_i16(data);
+    if samples.is_empty() {
+        return None;
+    }
+    Some(PcmBuffer {
+        samples,
+        channels: format.n_channels,
+        sample_rate: format.n_samples_per_sec,
+    })
 }
 
 /// Decode a little-endian 16-bit PCM byte buffer into signed samples. A trailing
@@ -117,13 +173,16 @@ fn volume_to_gain(volume: &VolumePdu) -> f32 {
     avg / f32::from(u16::MAX)
 }
 
-/// Wall-clock duration of a decoded PCM buffer at the advertised channel count
-/// and sample rate. Playback consumes exactly one frame per sample period, so
-/// this is the time the buffer will occupy on the output device.
+/// Wall-clock duration of a decoded PCM buffer at the given channel count and
+/// sample rate. Playback consumes exactly one frame per sample period, so this is
+/// the time the buffer will occupy on the output device.
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
-fn samples_duration(sample_count: usize) -> Duration {
-    let frames = sample_count / AUDIO_CHANNELS as usize;
-    Duration::from_nanos((frames as u64 * 1_000_000_000) / u64::from(AUDIO_SAMPLE_RATE))
+fn samples_duration(sample_count: usize, channels: u16, sample_rate: u32) -> Duration {
+    if channels == 0 || sample_rate == 0 {
+        return Duration::ZERO;
+    }
+    let frames = sample_count / channels as usize;
+    Duration::from_nanos((frames as u64 * 1_000_000_000) / u64::from(sample_rate))
 }
 
 /// A bounded jitter / latency buffer sitting in front of the [`rodio`] sink.
@@ -152,9 +211,10 @@ fn samples_duration(sample_count: usize) -> Duration {
 ///   than ~`MAX_LATENCY` of audio, and this struct itself holds at most
 ///   ~`TARGET_LATENCY`.
 ///
-/// The buffer never resamples or reshapes sample data — buffers pass through
-/// byte-for-byte in the single negotiated PCM format — so it cannot introduce
-/// pitch or rate errors.
+/// The buffer never resamples or reshapes sample data — each [`PcmBuffer`] passes
+/// through byte-for-byte in its own negotiated format, and its duration is
+/// computed from that format — so it cannot introduce pitch or rate errors even
+/// when the negotiated format changes mid-session.
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 #[derive(Debug)]
 struct JitterBuffer {
@@ -163,7 +223,7 @@ struct JitterBuffer {
     /// the backlog and underrun model.
     playing_until: Option<Instant>,
     /// Buffers held while (re)building the [`TARGET_LATENCY`] cushion.
-    pending: VecDeque<Vec<i16>>,
+    pending: VecDeque<PcmBuffer>,
     /// Total duration currently held in `pending`.
     pending_duration: Duration,
     /// Whether we are accumulating the initial / post-underrun cushion.
@@ -187,10 +247,15 @@ impl JitterBuffer {
         }
     }
 
+    /// Wall-clock duration one [`PcmBuffer`] will occupy on the device.
+    fn buffer_duration(buf: &PcmBuffer) -> Duration {
+        samples_duration(buf.samples.len(), buf.channels, buf.sample_rate)
+    }
+
     /// Admit one decoded buffer, returning the buffers (if any) to hand to the
     /// sink now, in order. `now` is the current wall clock, injected so the
     /// timeline model can be unit-tested without real time.
-    fn push(&mut self, samples: Vec<i16>, now: Instant) -> Vec<Vec<i16>> {
+    fn push(&mut self, buf: PcmBuffer, now: Instant) -> Vec<PcmBuffer> {
         // Has the modelled play head reached the end of the queued audio? If we
         // were streaming, that is an underrun: drop back to prebuffering so the
         // cushion is rebuilt before playback resumes.
@@ -209,13 +274,13 @@ impl JitterBuffer {
         }
 
         if self.filling {
-            self.pending_duration += samples_duration(samples.len());
-            self.pending.push_back(samples);
+            self.pending_duration += Self::buffer_duration(&buf);
+            self.pending.push_back(buf);
             if self.pending_duration < TARGET_LATENCY {
                 return Vec::new();
             }
             // Cushion is full: release it as a batch and start the timeline now.
-            let released: Vec<Vec<i16>> = self.pending.drain(..).collect();
+            let released: Vec<PcmBuffer> = self.pending.drain(..).collect();
             self.playing_until = Some(now + self.pending_duration);
             self.pending_duration = Duration::ZERO;
             self.filling = false;
@@ -227,7 +292,7 @@ impl JitterBuffer {
             .playing_until
             .map(|until| until.saturating_duration_since(now))
             .unwrap_or(Duration::ZERO);
-        let dur = samples_duration(samples.len());
+        let dur = Self::buffer_duration(&buf);
         if backlog + dur > MAX_LATENCY {
             // Overrun: tail-drop this buffer to cap latency and queued memory.
             self.dropped += 1;
@@ -239,12 +304,12 @@ impl JitterBuffer {
         }
         let base = self.playing_until.unwrap_or(now).max(now);
         self.playing_until = Some(base + dur);
-        vec![samples]
+        vec![buf]
     }
 }
 
-/// The RDPSND client handler: advertises PCM and plays received `wave` buffers on
-/// a host output device.
+/// The RDPSND client handler: advertises a PCM format table and plays received
+/// `wave` buffers, each in its negotiated format, on a host output device.
 #[derive(Debug)]
 pub struct RdpAudioBackend {
     formats: Vec<AudioFormat>,
@@ -272,12 +337,12 @@ impl RdpsndClientHandler for RdpAudioBackend {
         &self.formats
     }
 
-    fn wave(&mut self, _format_no: usize, _ts: u32, data: Cow<'_, [u8]>) {
-        // Only one PCM format is advertised, so `format_no` is always 0 and the
-        // buffer is 16-bit LE PCM at the advertised channel/rate.
-        let samples = pcm_bytes_to_i16(&data);
-        if !samples.is_empty() {
-            self.sink.play(samples);
+    fn wave(&mut self, format: &AudioFormat, _ts: u32, data: Cow<'_, [u8]>) {
+        // `format` is the concrete format the server negotiated (thanks to the
+        // vendored ironrdp-rdpsnd fork), so the buffer is decoded and played at
+        // exactly its own channel count and sample rate — never guessed.
+        if let Some(buffer) = decode_wave(format, &data) {
+            self.sink.play(buffer);
         }
     }
 
@@ -294,13 +359,13 @@ impl RdpsndClientHandler for RdpAudioBackend {
     }
 }
 
-// --- Host playback sink: real on macOS/Windows, a no-op elsewhere. ---
+// --- Host playback sink: real on macOS/Windows/Linux, a no-op elsewhere. ---
 
 /// A command sent to the playback thread.
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 enum AudioCommand {
-    /// Queue decoded samples for playback at the advertised channel/rate.
-    Play(Vec<i16>),
+    /// Queue a decoded buffer for playback at its own channel count / sample rate.
+    Play(PcmBuffer),
     /// Set the output gain (`1.0` = unity).
     Volume(f32),
 }
@@ -333,11 +398,11 @@ impl AudioSink {
         }
     }
 
-    fn play(&self, samples: Vec<i16>) {
+    fn play(&self, buffer: PcmBuffer) {
         if let Some(tx) = &self.tx {
             // A send error means the playback thread has exited (no device); drop
             // the buffer silently rather than crashing the session.
-            let _ = tx.send(AudioCommand::Play(samples));
+            let _ = tx.send(AudioCommand::Play(buffer));
         }
     }
 
@@ -390,15 +455,17 @@ fn playback_loop(rx: &std::sync::mpsc::Receiver<AudioCommand>) {
     let mut jitter = JitterBuffer::new();
     for cmd in rx.iter() {
         match cmd {
-            AudioCommand::Play(samples) => {
+            AudioCommand::Play(buffer) => {
                 // Admit through the jitter buffer, which prebuffers a cushion,
                 // caps latency/memory (tail-drop) and rides out underruns before
-                // handing buffers to the sink.
-                for buf in jitter.push(samples, Instant::now()) {
+                // handing buffers to the sink. Each buffer plays at its own
+                // negotiated channel count / sample rate; rodio resamples to the
+                // device rate.
+                for buf in jitter.push(buffer, Instant::now()) {
                     sink.append(rodio::buffer::SamplesBuffer::new(
-                        AUDIO_CHANNELS,
-                        AUDIO_SAMPLE_RATE,
-                        buf,
+                        buf.channels,
+                        buf.sample_rate,
+                        buf.samples,
                     ));
                 }
             }
@@ -424,7 +491,7 @@ impl AudioSink {
         AudioSink
     }
 
-    fn play(&self, _samples: Vec<i16>) {}
+    fn play(&self, _buffer: PcmBuffer) {}
 
     fn set_volume(&self, _volume: &VolumePdu) {}
 
@@ -451,21 +518,38 @@ mod tests {
     }
 
     #[test]
-    fn advertised_formats_are_empty_without_a_backend() {
+    fn advertised_formats_cover_the_pcm_table() {
         // On platforms without a compiled audio backend the handler advertises
-        // nothing (so the server streams no audio); with one it advertises PCM.
-        if AudioSink::SUPPORTED {
-            assert_eq!(advertised_formats().len(), 1);
-        } else {
-            assert!(advertised_formats().is_empty());
+        // nothing (so the server streams no audio); with one it advertises the
+        // full rate x channel PCM table, all 16-bit PCM with correct derivations.
+        let formats = advertised_formats();
+        if !AudioSink::SUPPORTED {
+            assert!(formats.is_empty());
+            return;
         }
+        assert_eq!(
+            formats.len(),
+            ADVERTISED_SAMPLE_RATES.len() * ADVERTISED_CHANNELS.len()
+        );
+        for f in &formats {
+            assert_eq!(f.format, WaveFormat::PCM);
+            assert_eq!(f.bits_per_sample, 16);
+            assert!(ADVERTISED_SAMPLE_RATES.contains(&f.n_samples_per_sec));
+            assert!(ADVERTISED_CHANNELS.contains(&f.n_channels));
+            // Standard PCM derivations must match what a Windows server offers.
+            let block_align = f.n_channels * 2;
+            assert_eq!(f.n_block_align, block_align);
+            assert_eq!(f.n_avg_bytes_per_sec, f.n_samples_per_sec * u32::from(block_align));
+            assert!(f.data.is_none());
+        }
+        // The classic CD-quality stereo format is present.
+        assert!(formats.contains(&pcm_format(2, 44_100)));
     }
 
     #[test]
     fn pcm_format_matches_standard_cd_quality_stereo() {
-        // These exact field values must match a format the server offers, so pin
-        // the standard PCM derivations (block align 4, avg 176 400 B/s).
-        let f = pcm_format();
+        // Pin the standard PCM derivations (block align 4, avg 176 400 B/s).
+        let f = pcm_format(2, 44_100);
         assert_eq!(f.format, WaveFormat::PCM);
         assert_eq!(f.n_channels, 2);
         assert_eq!(f.n_samples_per_sec, 44_100);
@@ -473,6 +557,47 @@ mod tests {
         assert_eq!(f.n_block_align, 4);
         assert_eq!(f.n_avg_bytes_per_sec, 176_400);
         assert!(f.data.is_none());
+    }
+
+    /// The load-bearing format-correctness guard (#1773): a `wave` buffer must be
+    /// decoded at *exactly* the negotiated format's channel count and sample
+    /// rate, never a fixed assumption — otherwise a 22.05 kHz stream would play at
+    /// 44.1 kHz ("chipmunk" audio). This is the regression test for that class of
+    /// bug that multi-format negotiation introduces.
+    #[test]
+    fn decode_wave_uses_the_negotiated_rate_not_a_fixed_one() {
+        // 0x0100 = 256, 0x0200 = 512.
+        let bytes = [0x00, 0x01, 0x00, 0x02];
+
+        // A 22.05 kHz mono buffer must report 22 050 Hz / 1 channel.
+        let mono = pcm_format(1, 22_050);
+        let decoded = decode_wave(&mono, &bytes).expect("mono PCM decodes");
+        assert_eq!(decoded.sample_rate, 22_050);
+        assert_eq!(decoded.channels, 1);
+        assert_eq!(decoded.samples, vec![256, 512]);
+
+        // The same bytes under a 48 kHz stereo format report 48 000 Hz / 2 —
+        // proving the rate/channels come from the format, not the payload.
+        let stereo = pcm_format(2, 48_000);
+        let decoded = decode_wave(&stereo, &bytes).expect("stereo PCM decodes");
+        assert_eq!(decoded.sample_rate, 48_000);
+        assert_eq!(decoded.channels, 2);
+        assert_eq!(decoded.samples, vec![256, 512]);
+    }
+
+    #[test]
+    fn decode_wave_rejects_unsupported_formats() {
+        let bytes = [0x00, 0x01, 0x00, 0x02];
+        // Non-PCM (e.g. ADPCM tag) is dropped, not misplayed.
+        let mut adpcm = pcm_format(2, 44_100);
+        adpcm.format = WaveFormat::ADPCM;
+        assert!(decode_wave(&adpcm, &bytes).is_none());
+        // 8-bit PCM is not advertised, so it is rejected rather than mis-decoded.
+        let mut eight_bit = pcm_format(2, 44_100);
+        eight_bit.bits_per_sample = 8;
+        assert!(decode_wave(&eight_bit, &bytes).is_none());
+        // Empty payload yields nothing.
+        assert!(decode_wave(&pcm_format(2, 44_100), &[]).is_none());
     }
 
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
@@ -497,19 +622,28 @@ mod jitter_tests {
     use super::*;
     use std::time::{Duration, Instant};
 
-    /// A silent PCM buffer occupying exactly `ms` milliseconds at the advertised
-    /// stereo 44.1 kHz format.
-    fn buf_of(ms: u64) -> Vec<i16> {
-        let frames = (u64::from(AUDIO_SAMPLE_RATE) * ms / 1000) as usize;
-        vec![0i16; frames * AUDIO_CHANNELS as usize]
+    /// A silent stereo 44.1 kHz PCM buffer occupying exactly `ms` milliseconds.
+    fn buf_of(ms: u64) -> PcmBuffer {
+        let channels = 2u16;
+        let sample_rate = 44_100u32;
+        let frames = (u64::from(sample_rate) * ms / 1000) as usize;
+        PcmBuffer {
+            samples: vec![0i16; frames * channels as usize],
+            channels,
+            sample_rate,
+        }
     }
 
     #[test]
     fn samples_duration_matches_frame_count() {
         // One second of stereo audio = sample_rate frames = 2*sample_rate samples.
-        let one_sec = AUDIO_SAMPLE_RATE as usize * AUDIO_CHANNELS as usize;
-        assert_eq!(samples_duration(one_sec), Duration::from_secs(1));
-        assert_eq!(samples_duration(0), Duration::ZERO);
+        let one_sec = 44_100 * 2;
+        assert_eq!(samples_duration(one_sec, 2, 44_100), Duration::from_secs(1));
+        // A lower rate stretches the same sample count over more time — the whole
+        // point of per-buffer rate: 22 050 Hz mono => 2x the wall-clock duration.
+        assert_eq!(samples_duration(22_050, 1, 22_050), Duration::from_secs(1));
+        assert_eq!(samples_duration(0, 2, 44_100), Duration::ZERO);
+        assert_eq!(samples_duration(100, 2, 0), Duration::ZERO);
     }
 
     #[test]
@@ -534,7 +668,8 @@ mod jitter_tests {
         // no channel/rate mangling (guards the chipmunk-audio class of bug).
         let t = Instant::now();
         let mut jb = JitterBuffer::new();
-        let payload: Vec<i16> = (0..(buf_of(100).len() as i32)).map(|i| i as i16).collect();
+        let mut payload = buf_of(100);
+        payload.samples = (0..(payload.samples.len() as i32)).map(|i| i as i16).collect();
         let released = jb.push(payload.clone(), t);
         assert_eq!(released.len(), 1);
         assert_eq!(released[0], payload);

--- a/rdp-sidecar/src/audio.rs
+++ b/rdp-sidecar/src/audio.rs
@@ -539,7 +539,10 @@ mod tests {
             // Standard PCM derivations must match what a Windows server offers.
             let block_align = f.n_channels * 2;
             assert_eq!(f.n_block_align, block_align);
-            assert_eq!(f.n_avg_bytes_per_sec, f.n_samples_per_sec * u32::from(block_align));
+            assert_eq!(
+                f.n_avg_bytes_per_sec,
+                f.n_samples_per_sec * u32::from(block_align)
+            );
             assert!(f.data.is_none());
         }
         // The classic CD-quality stereo format is present.
@@ -669,7 +672,9 @@ mod jitter_tests {
         let t = Instant::now();
         let mut jb = JitterBuffer::new();
         let mut payload = buf_of(100);
-        payload.samples = (0..(payload.samples.len() as i32)).map(|i| i as i16).collect();
+        payload.samples = (0..(payload.samples.len() as i32))
+            .map(|i| i as i16)
+            .collect();
         let released = jb.push(payload.clone(), t);
         assert_eq!(released.len(), 1);
         assert_eq!(released[0], payload);

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/CHANGELOG.md
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [[0.9.0](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.8.1...ironrdp-rdpsnd-v0.9.0)] - 2026-07-10
+
+### <!-- 1 -->Features
+
+- [**breaking**] Misuse-resistant format negotiation for RdpsndServerHandler ([#1359](https://github.com/Devolutions/IronRDP/issues/1359)) ([2d3bdef1a7](https://github.com/Devolutions/IronRDP/commit/2d3bdef1a7167d2acdc478a92917cbb2f018960b)) 
+
+  Move the negotiation into the crate and split selection from lifecycle:
+  
+  ```rust
+  fn choose_format<'a>(&mut self, common: &'a [NegotiatedFormat]) -> Option<&'a NegotiatedFormat>;
+  fn start(&mut self, format: &NegotiatedFormat);
+  ```
+
+
+
+## [[0.8.1](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.8.0...ironrdp-rdpsnd-v0.8.1)] - 2026-06-05
+
+### <!-- 6 -->Documentation
+
+- Document RdpsndServerHandler::start wFormatNo contract ([#1343](https://github.com/Devolutions/IronRDP/issues/1343)) ([7894d9f093](https://github.com/Devolutions/IronRDP/commit/7894d9f093db3c80f7358af8e0d8beb18964ce45)) 
+
+  Adds Rustdoc documentation to `RdpsndServerHandler`, focusing on the contract for `start()`’s `Option<u16>` return value so implementers correctly compute `wFormatNo` for Wave/Wave2 PDUs.
+
+
+
+## [[0.8.0](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.7.0...ironrdp-rdpsnd-v0.8.0)] - 2026-05-27
+
+### <!-- 4 -->Bug Fixes
+
+- Replace all from_bits_truncate with from_bits_retain ([#1144](https://github.com/Devolutions/IronRDP/issues/1144)) ([353e30ddfd](https://github.com/Devolutions/IronRDP/commit/353e30ddfdaafc897db10b8663e364ef7775a7fd)) 
+
+  from_bits_truncate silently discards unknown bits, which breaks the
+  encode/decode round-trip property. This matters for fuzzing because a
+  PDU that decodes and re-encodes should produce identical bytes.
+  from_bits_retain preserves all bits, including those not yet defined in
+  our bitflags types, so the round-trip property holds.
+
+- Handle AudioFormat renegotiation in Ready state ([#1164](https://github.com/Devolutions/IronRDP/issues/1164)) ([2fe6fd0424](https://github.com/Devolutions/IronRDP/commit/2fe6fd04244a7031a19af5a321bdf44308f6df2d)) 
+
+  Sometimes Windows Server re-sends `SNDC_FORMATS` during Ready state
+  (e.g., after mute/unmute in remote browser). Previously this hit the
+  wildcard branch, entering Stop and permanently killing audio.
+    
+  Add an `AudioFormat` arm in Ready state to close the current stream and
+  restart negotiation.
+
+### <!-- 7 -->Build
+
+- Bump the patch group across 1 directory with 2 updates ([#1222](https://github.com/Devolutions/IronRDP/issues/1222)) ([3fe6d157e0](https://github.com/Devolutions/IronRDP/commit/3fe6d157e0b55bddfdac20af290a6cfa6e550576)) 
+
+
+## [[0.5.0](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.4.0...ironrdp-rdpsnd-v0.5.0)] - 2025-05-27
+
+### <!-- 1 -->Features
+
+- Add support for client custom flags ([7bd92c0ce5](https://github.com/Devolutions/IronRDP/commit/7bd92c0ce5c686fe18c062b7edfeed46a709fc23)) 
+
+  Client can support various flags, but always set ALIVE.
+
+### <!-- 4 -->Bug Fixes
+
+- Correct TrainingPdu wPackSize field ([abcc42e01f](https://github.com/Devolutions/IronRDP/commit/abcc42e01fda3ce9c8e1739524e0fc73b8778d83)) 
+
+- Reply to TrainingPdu ([5dcc526f51](https://github.com/Devolutions/IronRDP/commit/5dcc526f513e8083ff335cad3cc80d2effeb7265)) 
+
+- Lookup the associated format from the client list ([3d7bc28b97](https://github.com/Devolutions/IronRDP/commit/3d7bc28b9764b1f37b038bb2fbb676ec464ee5ee)) 
+
+- Send client formats that match server (#742) ([a8b9614323](https://github.com/Devolutions/IronRDP/commit/a8b96143236ad457b5241f6a2f8acfaf969472b6)) 
+
+  Windows seems to be confused if the client replies with more formats, or unknown formats (opus).
+
+### Refactor
+
+- [**breaking**] Pass format_no instead of AudioFormat ([4172571e8e](https://github.com/Devolutions/IronRDP/commit/4172571e8e061a6a120643393881b5e37f1e61ab)) 
+
+## [[0.4.0](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.3.1...ironrdp-rdpsnd-v0.4.0)] - 2025-03-12
+
+### <!-- 7 -->Build
+
+- Bump ironrdp-pdu
+
+## [[0.3.1](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.3.0...ironrdp-rdpsnd-v0.3.1)] - 2025-03-12
+
+### <!-- 7 -->Build
+
+- Update dependencies (#695) ([c21fa44fd6](https://github.com/Devolutions/IronRDP/commit/c21fa44fd6f3c6a6b74788ff68e83133c1314caa)) 
+
+
+## [[0.3.0](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.2.0...ironrdp-rdpsnd-v0.3.0)] - 2025-02-05
+
+### <!-- 1 -->Features
+
+- New required method `get_formats` for the `RdpsndClientHandler` trait (#661) ([ccf6348270](https://github.com/Devolutions/IronRDP/commit/ccf63482706ecfbbdc6038028ea2ee086d0e3640)) 
+
+
+## [[0.2.0](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.1.1...ironrdp-rdpsnd-v0.2.0)] - 2025-01-28
+
+### <!-- 1 -->Features
+
+- Support for volume setting (#641) ([a6c36511f6](https://github.com/Devolutions/IronRDP/commit/a6c36511f6584f67b8c6e795c34d5007ec2b24a4)) 
+
+  Add server messages and API to support setting client volume.
+
+### <!-- 6 -->Documentation
+
+- Use CDN URLs instead of the blob storage URLs for Devolutions logo (#631) ([dd249909a8](https://github.com/Devolutions/IronRDP/commit/dd249909a894004d4f728d30b3a4aa77a0f8193b)) 
+
+
+## [[0.1.1](https://github.com/Devolutions/IronRDP/compare/ironrdp-rdpsnd-v0.1.0...ironrdp-rdpsnd-v0.1.1)] - 2024-12-14
+
+### Other
+
+- Symlinks to license files in packages ([#604](https://github.com/Devolutions/IronRDP/pull/604)) ([6c2de344c2](https://github.com/Devolutions/IronRDP/commit/6c2de344c2dd93ce9621834e0497ed7c3bfaf91a)) 

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/Cargo.toml
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/Cargo.toml
@@ -1,0 +1,67 @@
+# termiHub vendored fork of ironrdp-rdpsnd 0.9.0.
+#
+# WHAT WAS CHANGED vs upstream (the only functional edit — see `src/client.rs`):
+# the client `wave` callback now receives the *concrete negotiated* `AudioFormat`
+# instead of a bare `format_no` index. Upstream 0.9.0 built the Client Audio
+# Formats list in `Rdpsnd::client_formats()` from a `HashSet` intersection (so its
+# order is a non-deterministic per-process `RandomState`) and then discarded it,
+# handing the client handler only `wave(format_no, ..)` — an index into a list the
+# handler can neither see nor order. With more than one advertised format that
+# index is therefore unresolvable, so a client that advertised several PCM rates
+# could not tell which rate a given `wave` buffer was in and risked playing e.g.
+# 22.05 kHz data at 44.1 kHz ("chipmunk" audio). The fork makes `Rdpsnd` remember
+# the exact `Vec<AudioFormat>` it sent (`negotiated_formats`) and changes the
+# `RdpsndClientHandler::wave` signature to `wave(&mut self, format: &AudioFormat,
+# ts, data)`, so the handler always maps a buffer to its true format. This
+# unblocks multi-format `rdpsnd` negotiation in the sidecar (#1773) without
+# waiting on an upstream release.
+#
+# UPSTREAM CHANGE THIS REPRESENTS: pass the selected `AudioFormat` to
+# `RdpsndClientHandler::wave` instead of an index into the discarded, non-
+# deterministically-ordered client-format list. Filed to be offered back to
+# Devolutions/IronRDP. Everything else (pdu.rs, server.rs, lib.rs) is byte-for-byte
+# upstream 0.9.0. The sibling `ironrdp-*` deps stay registry versions so nothing
+# else in the graph forks.
+#
+# Wired into the workspace-EXCLUDED sidecar graph via `[patch.crates-io]` in
+# `rdp-sidecar/Cargo.toml`, exactly as `vendor/vnc-rs` is patched into the main
+# app (#1714). The sidecar has its own Cargo.lock, so this fork never touches the
+# desktop app's dependency graph.
+
+[package]
+name = "ironrdp-rdpsnd"
+version = "0.9.0"
+edition = "2024"
+rust-version = "1.89"
+authors = [
+    "Devolutions Inc. <infos@devolutions.net>",
+    "Teleport <goteleport.com>",
+]
+description = "RDPSND static channel for audio output implemented as described in MS-RDPEA (termiHub vendored fork exposing the negotiated AudioFormat to wave callbacks)"
+homepage = "https://github.com/Devolutions/IronRDP"
+repository = "https://github.com/Devolutions/IronRDP"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+keywords = ["rdp", "remote-desktop", "network", "client", "protocol"]
+categories = ["network-programming"]
+
+[lib]
+name = "ironrdp_rdpsnd"
+path = "src/lib.rs"
+doctest = false
+test = false
+
+[features]
+default = []
+std = []
+# Internal (PRIVATE!) upstream feature used only by IronRDP's own integration
+# testsuite. Kept for byte-for-byte fidelity with server.rs; never enabled here.
+__test = ["dep:visibility"]
+
+[dependencies]
+bitflags = "2.11"
+tracing = { version = "0.1", features = ["log"] }
+ironrdp-svc = { version = "0.8" }
+ironrdp-core = { version = "0.2", features = ["alloc"] }
+ironrdp-pdu = { version = "0.9", features = ["alloc"] }
+visibility = { version = "0.1", optional = true }

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/LICENSE-APACHE
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/LICENSE-MIT
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/README.md
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/README.md
@@ -1,0 +1,34 @@
+# IronRDP RDPSND (termiHub vendored fork)
+
+RDPSND static channel for audio output implemented as described in [MS-RDPEA].
+
+This crate is part of the [IronRDP] project.
+
+## termiHub vendored fork
+
+This is a vendored fork of `ironrdp-rdpsnd` **0.9.0** for termiHub's RDP sidecar
+(see [`termiHub#1773`](https://github.com/armaxri/termiHub/issues/1773)). It is
+patched into the workspace-excluded `rdp-sidecar` crate via `[patch.crates-io]`,
+mirroring how `vendor/vnc-rs` is patched into the main app.
+
+**The only functional change** (in `src/client.rs`) makes the client `wave`
+callback receive the concrete negotiated `AudioFormat` instead of a bare
+`format_no` index:
+
+- Upstream `Rdpsnd::client_formats()` built the Client Audio Formats list from a
+  `HashSet` intersection — non-deterministically ordered — and then discarded it,
+  handing the handler only `wave(format_no, ..)`, an index into a list the handler
+  can neither see nor order. With more than one advertised format that index is
+  unresolvable, so a client advertising several PCM rates could not tell which
+  rate a `wave` buffer was in (risking "chipmunk" audio from playing e.g. 22.05
+  kHz data at 44.1 kHz).
+- This fork adds a `negotiated_formats: Vec<AudioFormat>` field to `Rdpsnd` that
+  remembers the exact list sent, and changes the trait method to
+  `RdpsndClientHandler::wave(&mut self, format: &AudioFormat, ts, data)`.
+
+`pdu.rs`, `server.rs` and `lib.rs` are byte-for-byte upstream 0.9.0. The intended
+upstream contribution is exactly this signature change. Sibling `ironrdp-*` deps
+remain registry versions so nothing else forks.
+
+[IronRDP]: https://github.com/Devolutions/IronRDP
+[MS-RDPEA]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpea/bea2d5cf-e3b9-4419-92e5-0e074ff9bc5b

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/src/client.rs
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/src/client.rs
@@ -1,0 +1,270 @@
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+use ironrdp_core::{Decode as _, EncodeResult, ReadCursor, cast_length, impl_as_any};
+use ironrdp_pdu::gcc::ChannelName;
+use ironrdp_pdu::{PduResult, decode_err, encode_err, pdu_other_err};
+use ironrdp_svc::{CompressionCondition, SvcClientProcessor, SvcMessage, SvcProcessor};
+use tracing::{debug, error};
+
+use crate::pdu::{self, AudioFormat, PitchPdu, ServerAudioFormatPdu, TrainingPdu, VolumePdu};
+use crate::server::RdpsndSvcMessages;
+
+pub trait RdpsndClientHandler: Send + core::fmt::Debug {
+    fn get_flags(&self) -> pdu::AudioFormatFlags {
+        pdu::AudioFormatFlags::empty()
+    }
+
+    fn get_formats(&self) -> &[AudioFormat];
+
+    // termiHub vendored-fork change (#1773): the handler receives the concrete
+    // negotiated `AudioFormat` instead of a bare `format_no` index. See the note
+    // in this crate's Cargo.toml — upstream passed only the index into the
+    // non-deterministically-ordered, then-discarded client-format list, so a
+    // multi-format handler could not map a `wave` buffer back to its rate.
+    fn wave(&mut self, format: &AudioFormat, ts: u32, data: Cow<'_, [u8]>);
+
+    fn set_volume(&mut self, volume: VolumePdu);
+
+    fn set_pitch(&mut self, pitch: PitchPdu);
+
+    fn close(&mut self);
+}
+
+#[derive(Debug)]
+pub struct NoopRdpsndBackend;
+
+impl RdpsndClientHandler for NoopRdpsndBackend {
+    fn get_formats(&self) -> &[AudioFormat] {
+        &[]
+    }
+
+    fn wave(&mut self, _format: &AudioFormat, _ts: u32, _data: Cow<'_, [u8]>) {}
+
+    fn set_volume(&mut self, _volume: VolumePdu) {}
+
+    fn set_pitch(&mut self, _pitch: PitchPdu) {}
+
+    fn close(&mut self) {}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum RdpsndState {
+    Start,
+    WaitingForTraining,
+    Ready,
+    Stop,
+}
+
+/// Required for rdpdr to work: [\[MS-RDPEFS\] Appendix A<1>]
+///
+/// [\[MS-RDPEFS\] Appendix A<1>]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/fd28bfd9-dae2-4a78-abe1-b4efa208b7aa#Appendix_A_1
+#[derive(Debug)]
+pub struct Rdpsnd {
+    handler: Box<dyn RdpsndClientHandler>,
+    state: RdpsndState,
+    server_format: Option<ServerAudioFormatPdu>,
+    /// termiHub vendored-fork field (#1773): the exact, order-preserving list of
+    /// formats sent to the server in `client_formats()`. The server's `Wave2`
+    /// `format_no` indexes this list (the client-format list per MS-RDPEA), so
+    /// remembering it is what lets `wave` recover the concrete `AudioFormat`
+    /// rather than a bare index into a list the handler never sees.
+    negotiated_formats: Vec<AudioFormat>,
+}
+
+impl Rdpsnd {
+    pub const NAME: ChannelName = ChannelName::from_static(b"rdpsnd\0\0");
+
+    pub fn new(handler: Box<dyn RdpsndClientHandler>) -> Self {
+        Self {
+            handler,
+            state: RdpsndState::Start,
+            server_format: None,
+            negotiated_formats: Vec::new(),
+        }
+    }
+
+    pub fn get_format(&self, format_no: u16) -> PduResult<&AudioFormat> {
+        let server_format = self
+            .server_format
+            .as_ref()
+            .ok_or_else(|| pdu_other_err!("invalid state - no format"))?;
+
+        server_format
+            .formats
+            .get(usize::from(format_no))
+            .ok_or_else(|| pdu_other_err!("invalid format"))
+    }
+
+    pub fn version(&self) -> PduResult<pdu::Version> {
+        let server_format = self
+            .server_format
+            .as_ref()
+            .ok_or_else(|| pdu_other_err!("invalid state - no version"))?;
+
+        Ok(server_format.version)
+    }
+
+    pub fn client_formats(&mut self) -> PduResult<RdpsndSvcMessages> {
+        // Windows seems to be confused if the client replies with more formats, or unknown formats (e.g.: opus).
+        // We ensure to only send supported formats in common with the server.
+        let server_format: HashSet<_> = self
+            .server_format
+            .as_ref()
+            .ok_or_else(|| pdu_other_err!("invalid state - no server format"))?
+            .formats
+            .iter()
+            .collect();
+        let formats: HashSet<_> = self.handler.get_formats().iter().collect();
+        let formats: Vec<AudioFormat> = formats.intersection(&server_format).map(|&x| x.clone()).collect();
+
+        // termiHub vendored-fork change (#1773): remember the exact list we send,
+        // in the exact order it is encoded, so a later `Wave2 { format_no }` can be
+        // resolved to the concrete `AudioFormat` in `process()` below.
+        self.negotiated_formats = formats.clone();
+
+        let pdu = pdu::ClientAudioFormatPdu {
+            version: self.version()?,
+            flags: self.handler.get_flags() | pdu::AudioFormatFlags::ALIVE,
+            formats,
+            volume_left: 0xFFFF,
+            volume_right: 0xFFFF,
+            pitch: 0x00010000,
+            dgram_port: 0,
+        };
+        Ok(RdpsndSvcMessages::new(vec![
+            pdu::ClientAudioOutputPdu::AudioFormat(pdu).into(),
+        ]))
+    }
+
+    pub fn quality_mode(&mut self) -> PduResult<RdpsndSvcMessages> {
+        let pdu = pdu::QualityModePdu {
+            quality_mode: pdu::QualityMode::High,
+        };
+        Ok(RdpsndSvcMessages::new(vec![
+            pdu::ClientAudioOutputPdu::QualityMode(pdu).into(),
+        ]))
+    }
+
+    pub fn training_confirm(&mut self, pdu: &TrainingPdu) -> PduResult<RdpsndSvcMessages> {
+        let pack_size: EncodeResult<_> = cast_length!("wPackSize", pdu.data.len());
+        let pack_size = pack_size.map_err(|e| encode_err!(e))?;
+        let pdu = pdu::TrainingConfirmPdu {
+            timestamp: pdu.timestamp,
+            pack_size,
+        };
+        Ok(RdpsndSvcMessages::new(vec![
+            pdu::ClientAudioOutputPdu::TrainingConfirm(pdu).into(),
+        ]))
+    }
+
+    pub fn wave_confirm(&mut self, timestamp: u16, block_no: u8) -> PduResult<RdpsndSvcMessages> {
+        let pdu = pdu::WaveConfirmPdu { timestamp, block_no };
+        Ok(RdpsndSvcMessages::new(vec![
+            pdu::ClientAudioOutputPdu::WaveConfirm(pdu).into(),
+        ]))
+    }
+}
+
+impl_as_any!(Rdpsnd);
+
+impl SvcProcessor for Rdpsnd {
+    fn channel_name(&self) -> ChannelName {
+        Self::NAME
+    }
+
+    fn compression_condition(&self) -> CompressionCondition {
+        CompressionCondition::Never
+    }
+
+    fn process(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+        let pdu = pdu::ServerAudioOutputPdu::decode(&mut ReadCursor::new(payload)).map_err(|e| decode_err!(e))?;
+
+        debug!(?pdu, ?self.state);
+        let msg = match self.state {
+            RdpsndState::Start => {
+                let pdu::ServerAudioOutputPdu::AudioFormat(af) = pdu else {
+                    error!("Invalid pdu");
+                    self.state = RdpsndState::Stop;
+                    return Ok(vec![]);
+                };
+                self.server_format = Some(af);
+                self.state = RdpsndState::WaitingForTraining;
+                let mut msgs: Vec<SvcMessage> = self.client_formats()?.into();
+                if self.version()? >= pdu::Version::V6 {
+                    let mut m = self.quality_mode()?.into();
+                    msgs.append(&mut m);
+                }
+                msgs
+            }
+            RdpsndState::WaitingForTraining => {
+                let pdu::ServerAudioOutputPdu::Training(pdu) = pdu else {
+                    error!("Invalid PDU");
+                    self.state = RdpsndState::Stop;
+                    return Ok(vec![]);
+                };
+                self.state = RdpsndState::Ready;
+                self.training_confirm(&pdu)?.into()
+            }
+            RdpsndState::Ready => {
+                match pdu {
+                    // TODO: handle WaveInfo for < v8
+                    pdu::ServerAudioOutputPdu::Wave2(pdu) => {
+                        let format_no = usize::from(pdu.format_no);
+                        let ts = pdu.audio_timestamp;
+                        // termiHub vendored-fork change (#1773): resolve the index
+                        // against the exact list we advertised and hand the handler
+                        // the concrete `AudioFormat`. An out-of-range `format_no`
+                        // (a misbehaving server) is dropped rather than guessed.
+                        match self.negotiated_formats.get(format_no) {
+                            Some(format) => self.handler.wave(format, ts, pdu.data),
+                            None => error!(format_no, "Wave2 format_no out of range"),
+                        }
+                        return Ok(self.wave_confirm(pdu.timestamp, pdu.block_no)?.into());
+                    }
+                    pdu::ServerAudioOutputPdu::Volume(pdu) => {
+                        self.handler.set_volume(pdu);
+                    }
+                    pdu::ServerAudioOutputPdu::Pitch(pdu) => {
+                        self.handler.set_pitch(pdu);
+                    }
+                    pdu::ServerAudioOutputPdu::Close => {
+                        self.handler.close();
+                    }
+                    pdu::ServerAudioOutputPdu::Training(pdu) => return Ok(self.training_confirm(&pdu)?.into()),
+                    pdu::ServerAudioOutputPdu::AudioFormat(af) => {
+                        self.handler.close();
+                        self.server_format = Some(af);
+                        self.state = RdpsndState::WaitingForTraining;
+                        let mut msgs: Vec<SvcMessage> = self.client_formats()?.into();
+                        if self.version()? >= pdu::Version::V6 {
+                            let mut m = self.quality_mode()?.into();
+                            msgs.append(&mut m);
+                        }
+                        return Ok(msgs);
+                    }
+                    _ => {
+                        error!("Invalid PDU");
+                        self.state = RdpsndState::Stop;
+                        return Ok(vec![]);
+                    }
+                }
+                vec![]
+            }
+            state => {
+                error!(?state, "Invalid state");
+                vec![]
+            }
+        };
+
+        Ok(msg)
+    }
+}
+
+impl Drop for Rdpsnd {
+    fn drop(&mut self) {
+        self.handler.close();
+    }
+}
+
+impl SvcClientProcessor for Rdpsnd {}

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/src/lib.rs
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/src/lib.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+
+pub mod client;
+pub mod pdu;
+pub mod server;

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/src/pdu/mod.rs
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/src/pdu/mod.rs
@@ -1,0 +1,1366 @@
+//! Audio Output Virtual Channel Extension PDUs  [MS-RDPEA][1] implementation.
+//!
+//! [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpea/bea2d5cf-e3b9-4419-92e5-0e074ff9bc5b
+
+use std::borrow::Cow;
+use std::fmt;
+
+use bitflags::bitflags;
+use ironrdp_core::{
+    Decode, DecodeError, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length,
+    ensure_fixed_part_size, ensure_size, invalid_field_err, other_err,
+};
+use ironrdp_pdu::{read_padding, write_padding};
+use ironrdp_svc::SvcEncode;
+
+const SNDC_FORMATS: u8 = 0x07;
+const SNDC_QUALITYMODE: u8 = 0x0C;
+const SNDC_CRYPTKEY: u8 = 0x08;
+const SNDC_TRAINING: u8 = 0x06;
+const SNDC_WAVE: u8 = 0x02;
+const SNDC_WAVECONFIRM: u8 = 0x05;
+const SNDC_WAVEENCRYPT: u8 = 0x09;
+const SNDC_CLOSE: u8 = 0x01;
+const SNDC_WAVE2: u8 = 0x0D;
+const SNDC_VOLUME: u8 = 0x03;
+const SNDC_PITCH: u8 = 0x04;
+
+// TODO: UDP PDUs
+
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq)]
+pub enum Version {
+    V2 = 0x02,
+    V5 = 0x05,
+    V6 = 0x06,
+    V8 = 0x08,
+}
+
+impl TryFrom<u16> for Version {
+    type Error = DecodeError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0x02 => Ok(Self::V2),
+            0x05 => Ok(Self::V5),
+            0x06 => Ok(Self::V6),
+            0x08 => Ok(Self::V8),
+            _ => Err(invalid_field_err!("Version", "unknown audio output version")),
+        }
+    }
+}
+
+impl From<Version> for u16 {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn from(version: Version) -> Self {
+        version as u16
+    }
+}
+
+// format tag:
+// http://tools.ietf.org/html/rfc2361
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WaveFormat(u16);
+
+macro_rules! wave_formats {
+    (
+        $(
+            ($konst:ident, $num:expr);
+        )+
+    ) => {
+        impl WaveFormat {
+        $(
+            pub const $konst: WaveFormat = WaveFormat($num);
+        )+
+
+            fn as_str(&self) -> Option<&'static str> {
+                match self.0 {
+                    $(
+                        $num => Some(stringify!($konst)),
+                    )+
+                        _ => None
+                }
+            }
+        }
+    }
+}
+
+wave_formats! {
+    (UNKNOWN, 0x0000);
+    (PCM, 0x0001);
+    (ADPCM, 0x0002);
+    (IEEE_FLOAT, 0x0003);
+    (VSELP, 0x0004);
+    (IBM_CVSD, 0x0005);
+    (ALAW, 0x0006);
+    (MULAW, 0x0007);
+    (OKI_ADPCM, 0x0010);
+    (DVI_ADPCM, 0x0011);
+    (MEDIASPACE_ADPCM, 0x0012);
+    (SIERRA_ADPCM, 0x0013);
+    (G723_ADPCM, 0x0014);
+    (DIGISTD, 0x0015);
+    (DIGIFIX, 0x0016);
+    (DIALOGIC_OKI_ADPCM, 0x0017);
+    (MEDIAVISION_ADPCM, 0x0018);
+    (CU_CODEC, 0x0019);
+    (YAMAHA_ADPCM, 0x0020);
+    (SONARC, 0x0021);
+    (DSPGROUP_TRUESPEECH, 0x0022);
+    (ECHOSC1, 0x0023);
+    (AUDIOFILE_AF36, 0x0024);
+    (APTX, 0x0025);
+    (AUDIOFILE_AF10, 0x0026);
+    (PROSODY_1612, 0x0027);
+    (LRC, 0x0028);
+    (DOLBY_AC2, 0x0030);
+    (GSM610, 0x0031);
+    (MSNAUDIO, 0x0032);
+    (ANTEX_ADPCME, 0x0033);
+    (CONTROL_RES_VQLPC, 0x0034);
+    (DIGIREAL, 0x0035);
+    (DIGIADPCM, 0x0036);
+    (CONTROL_RES_CR10, 0x0037);
+    (NMS_VBXADPCM, 0x0038);
+    (ROLAND_RDAC, 0x0039);
+    (ECHOSC3, 0x003A);
+    (ROCKWELL_ADPCM, 0x003B);
+    (ROCKWELL_DIGITALK, 0x003C);
+    (XEBEC, 0x003D);
+    (G721_ADPCM, 0x0040);
+    (G728_CELP, 0x0041);
+    (MSG723, 0x0042);
+    (MPEG, 0x0050);
+    (RT24, 0x0052);
+    (PAC, 0x0053);
+    (MPEGLAYER3, 0x0055);
+    (LUCENT_G723, 0x0059);
+    (CIRRUS, 0x0060);
+    (ESPCM, 0x0061);
+    (VOXWARE, 0x0062);
+    (CANOPUS_ATRAC, 0x0063);
+    (G726_ADPCM, 0x0064);
+    (G722_ADPCM, 0x0065);
+    (DSAT, 0x0066);
+    (DSAT_DISPLAY, 0x0067);
+    (VOXWARE_BYTE_ALIGNED, 0x0069);
+    (VOXWARE_AC8, 0x0070);
+    (VOXWARE_AC10, 0x0071);
+    (VOXWARE_AC16, 0x0072);
+    (VOXWARE_AC20, 0x0073);
+    (VOXWARE_RT24, 0x0074);
+    (VOXWARE_RT29, 0x0075);
+    (VOXWARE_RT29HW, 0x0076);
+    (VOXWARE_VR12, 0x0077);
+    (VOXWARE_VR18, 0x0078);
+    (VOXWARE_TQ40, 0x0079);
+    (SOFTSOUND, 0x0080);
+    (VOXWARE_TQ60, 0x0081);
+    (MSRT24, 0x0082);
+    (G729A, 0x0083);
+    (MVI_MV12, 0x0084);
+    (DF_G726, 0x0085);
+    (DF_GSM610, 0x0086);
+    (ISIAUDIO, 0x0088);
+    (ONLIVE, 0x0089);
+    (SBC24, 0x0091);
+    (DOLBY_AC3_SPDIF, 0x0092);
+    (ZYXEL_ADPCM, 0x0097);
+    (PHILIPS_LPCBB, 0x0098);
+    (PACKED, 0x0099);
+    (RHETOREX_ADPCM, 0x0100);
+    (IRAT, 0x0101);
+    (VIVO_G723, 0x0111);
+    (VIVO_SIREN, 0x0112);
+    (DIGITAL_G723, 0x0123);
+    (WMAUDIO2, 0x0161);
+    (WMAUDIO3, 0x0162);
+    (WMAUDIO_LOSSLESS, 0x0163);
+    (CREATIVE_ADPCM, 0x0200);
+    (CREATIVE_FASTSPEECH8, 0x0202);
+    (CREATIVE_FASTSPEECH10, 0x0203);
+    (QUARTERDECK, 0x0220);
+    (FM_TOWNS_SND, 0x0300);
+    (BTV_DIGITAL, 0x0400);
+    (VME_VMPCM, 0x0680);
+    (OLIGSM, 0x1000);
+    (OLIADPCM, 0x1001);
+    (OLICELP, 0x1002);
+    (OLISBC, 0x1003);
+    (OLIOPR, 0x1004);
+    (LH_CODEC, 0x1100);
+    (NORRIS, 0x1400);
+    (SOUNDSPACE_MUSICOMPRESS, 0x1500);
+    (DVM, 0x2000);
+    (OPUS, 0x704F);
+    (AAC_MS, 0xA106);
+    (EXTENSIBLE, 0xFFFE);
+}
+
+impl fmt::Debug for WaveFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for WaveFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {}", self.0, self.as_str().unwrap_or("<unknown wave format>"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AudioFormat {
+    pub format: WaveFormat,
+    pub n_channels: u16,
+    pub n_samples_per_sec: u32,
+    pub n_avg_bytes_per_sec: u32,
+    pub n_block_align: u16,
+    pub bits_per_sample: u16,
+    pub data: Option<Vec<u8>>,
+}
+
+impl AudioFormat {
+    const NAME: &'static str = "SERVER_AUDIO_VERSION_AND_FORMATS";
+
+    const FIXED_PART_SIZE: usize =
+        2 /* wFormatTag */
+        + 2 /* nChannels */
+        + 4 /* nSamplesPerSec */
+        + 4 /* nAvgBytesPerSec */
+        + 2 /* nBlockAlign */
+        + 2 /* wBitsPerSample */
+        + 2 /* cbSize */;
+}
+
+impl Encode for AudioFormat {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.format.0);
+        dst.write_u16(self.n_channels);
+        dst.write_u32(self.n_samples_per_sec);
+        dst.write_u32(self.n_avg_bytes_per_sec);
+        dst.write_u16(self.n_block_align);
+        dst.write_u16(self.bits_per_sample);
+        let len = self.data.as_ref().map_or(0, |d| d.len());
+        dst.write_u16(cast_length!("AudioFormat::cbSize", len)?);
+        if let Some(data) = &self.data {
+            dst.write_slice(data);
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(self.data.as_ref().map_or(0, |d| d.len()))
+            .expect("never overflow")
+    }
+}
+
+impl<'de> Decode<'de> for AudioFormat {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let format = WaveFormat(src.read_u16());
+        let n_channels = src.read_u16();
+        let n_samples_per_sec = src.read_u32();
+        let n_avg_bytes_per_sec = src.read_u32();
+        let n_block_align = src.read_u16();
+        let bits_per_sample = src.read_u16();
+        let cb_size = cast_length!("cbSize", src.read_u16())?;
+
+        ensure_size!(in: src, size: cb_size);
+        let data = if cb_size > 0 {
+            Some(src.read_slice(cb_size).into())
+        } else {
+            None
+        };
+
+        Ok(Self {
+            format,
+            n_channels,
+            n_samples_per_sec,
+            n_avg_bytes_per_sec,
+            n_block_align,
+            bits_per_sample,
+            data,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerAudioFormatPdu {
+    pub version: Version,
+    pub formats: Vec<AudioFormat>,
+}
+
+impl ServerAudioFormatPdu {
+    const NAME: &'static str = "SERVER_AUDIO_VERSION_AND_FORMATS";
+
+    const FIXED_PART_SIZE: usize =
+        4 /* dwFlags */
+        + 4 /* dwVolume */
+        + 4 /* dwPitch */
+        + 2 /* wDGramPort */
+        + 2 /* wNumberOfFormats */
+        + 1 /* cLastBlockConfirmed */
+        + 2 /* wVersion */
+        + 1 /* bPad */;
+}
+
+impl Encode for ServerAudioFormatPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        write_padding!(dst, 4); /* flags */
+        write_padding!(dst, 4); /* volume */
+        write_padding!(dst, 4); /* pitch */
+        write_padding!(dst, 2); /* DGramPort */
+        dst.write_u16(cast_length!("AudioFormatPdu::n_formats", self.formats.len())?);
+        write_padding!(dst, 1); /* blockNo */
+        dst.write_u16(self.version.into());
+        write_padding!(dst, 1);
+        for fmt in self.formats.iter() {
+            fmt.encode(dst)?;
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(self.formats.iter().map(|fmt| fmt.size()).sum::<usize>())
+            .expect("never overflow")
+    }
+}
+
+impl<'de> Decode<'de> for ServerAudioFormatPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        read_padding!(src, 4); /* flags */
+        read_padding!(src, 4); /* volume */
+        read_padding!(src, 4); /* pitch */
+        read_padding!(src, 2); /* DGramPort */
+        let n_formats = usize::from(src.read_u16());
+        read_padding!(src, 1); /* blockNo */
+        let version = Version::try_from(src.read_u16())?;
+        read_padding!(src, 1);
+        let formats = core::iter::repeat_with(|| AudioFormat::decode(src))
+            .take(n_formats)
+            .collect::<DecodeResult<_>>()?;
+
+        Ok(Self { version, formats })
+    }
+}
+
+bitflags! {
+    /// Represents `dwFlags` field of `CLIENT_AUDIO_VERSION_AND_FORMATS` structure.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct AudioFormatFlags: u32 {
+        /// The client is capable of consuming audio data. This flag MUST be set
+        /// for audio data to be transferred.
+        const ALIVE = 0x0000_0001;
+        /// The client is capable of applying a volume change to all the audio
+        /// data that is received.
+        const VOLUME = 0x0000_0002;
+        /// The client is capable of applying a pitch change to all the audio
+        /// data that is received.
+        const PITCH = 0x0000_00004;
+        // The source may set any bits
+        const _ = !0;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientAudioFormatPdu {
+    pub version: Version,
+    pub flags: AudioFormatFlags,
+    pub formats: Vec<AudioFormat>,
+    pub volume_left: u16,
+    pub volume_right: u16,
+    pub pitch: u32,
+    pub dgram_port: u16,
+}
+
+impl ClientAudioFormatPdu {
+    const NAME: &'static str = "CLIENT_AUDIO_VERSION_AND_FORMATS";
+
+    const FIXED_PART_SIZE: usize =
+        4 /* dwFlags */
+        + 4 /* dwVolume */
+        + 4 /* dwPitch */
+        + 2 /* wDGramPort */
+        + 2 /* wNumberOfFormats */
+        + 1 /* cLastBlockConfirmed */
+        + 2 /* wVersion */
+        + 1 /* bPad */;
+}
+
+impl Encode for ClientAudioFormatPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u32(self.flags.bits());
+        let volume = (u32::from(self.volume_right) << 16) | u32::from(self.volume_left);
+        dst.write_u32(volume);
+        dst.write_u32(self.pitch);
+        dst.write_u16_be(self.dgram_port);
+        dst.write_u16(cast_length!("AudioFormatPdu::n_formats", self.formats.len())?);
+        dst.write_u8(0); /* blockNo */
+        dst.write_u16(self.version.into());
+        write_padding!(dst, 1);
+        for fmt in self.formats.iter() {
+            fmt.encode(dst)?;
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(self.formats.iter().map(|fmt| fmt.size()).sum::<usize>())
+            .expect("never overflow")
+    }
+}
+
+impl<'de> Decode<'de> for ClientAudioFormatPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let flags = AudioFormatFlags::from_bits_retain(src.read_u32());
+        let volume_left = src.read_u16();
+        let volume_right = src.read_u16();
+        let pitch = src.read_u32();
+        let dgram_port = src.read_u16_be();
+        let n_formats = usize::from(src.read_u16());
+        let _block_no = src.read_u8();
+        let version = Version::try_from(src.read_u16())?;
+        read_padding!(src, 1);
+        let formats = core::iter::repeat_with(|| AudioFormat::decode(src))
+            .take(n_formats)
+            .collect::<DecodeResult<_>>()?;
+
+        Ok(Self {
+            version,
+            flags,
+            formats,
+            volume_left,
+            volume_right,
+            pitch,
+            dgram_port,
+        })
+    }
+}
+
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum QualityMode {
+    Dynamic = 0x00,
+    Medium = 0x01,
+    High = 0x02,
+}
+
+impl TryFrom<u16> for QualityMode {
+    type Error = DecodeError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(Self::Dynamic),
+            0x01 => Ok(Self::Medium),
+            0x02 => Ok(Self::High),
+            _ => Err(invalid_field_err!("QualityMode", "unknown audio quality mode")),
+        }
+    }
+}
+
+impl From<QualityMode> for u16 {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn from(mode: QualityMode) -> Self {
+        mode as u16
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QualityModePdu {
+    pub quality_mode: QualityMode,
+}
+
+impl QualityModePdu {
+    const NAME: &'static str = "AUDIO_QUALITY_MODE";
+
+    const FIXED_PART_SIZE: usize =
+        2 /* wQualityMode */
+        + 2 /* reserved */;
+}
+
+impl Encode for QualityModePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.quality_mode.into());
+        write_padding!(dst, 2); /* reserved */
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for QualityModePdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let quality_mode = QualityMode::try_from(src.read_u16())?;
+        read_padding!(src, 2); /* reserved */
+
+        Ok(Self { quality_mode })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CryptKeyPdu {
+    pub seed: [u8; 32],
+}
+
+impl CryptKeyPdu {
+    const NAME: &'static str = "SNDCRYPT";
+
+    const FIXED_PART_SIZE: usize =
+        4 /* reserved */
+        + 32 /* seed */;
+}
+
+impl Encode for CryptKeyPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        write_padding!(dst, 4); /* reserved */
+        dst.write_array(self.seed);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for CryptKeyPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        read_padding!(src, 4); /* reserved */
+        let seed = src.read_array();
+
+        Ok(Self { seed })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrainingPdu {
+    pub timestamp: u16,
+    pub data: Vec<u8>,
+}
+
+impl TrainingPdu {
+    const NAME: &'static str = "SNDTRAINING";
+
+    const FIXED_PART_SIZE: usize =
+        2 /* wTimeStamp */
+        + 2 /* wPackSize */;
+}
+
+impl Encode for TrainingPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.timestamp);
+        let len = if self.data.is_empty() {
+            0
+        } else {
+            self.size() + ServerAudioOutputPdu::FIXED_PART_SIZE
+        };
+        dst.write_u16(cast_length!("TrainingPdu::wPackSize", len)?);
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(self.data.len())
+            .expect("never overflow")
+    }
+}
+
+impl<'de> Decode<'de> for TrainingPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let timestamp = src.read_u16();
+        let len = usize::from(src.read_u16());
+        let data = if len != 0 {
+            if len < Self::FIXED_PART_SIZE + ServerAudioOutputPdu::FIXED_PART_SIZE {
+                return Err(invalid_field_err!("TrainingPdu::wPackSize", "too small"));
+            }
+            let len = len - Self::FIXED_PART_SIZE - ServerAudioOutputPdu::FIXED_PART_SIZE;
+            ensure_size!(in: src, size: len);
+            src.read_slice(len).into()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self { timestamp, data })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrainingConfirmPdu {
+    pub timestamp: u16,
+    pub pack_size: u16,
+}
+
+impl TrainingConfirmPdu {
+    const NAME: &'static str = "SNDTRAININGCONFIRM";
+
+    const FIXED_PART_SIZE: usize =
+        2 /* wTimeStamp */
+        + 2 /* wPackSize */;
+}
+
+impl Encode for TrainingConfirmPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.timestamp);
+        dst.write_u16(self.pack_size);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for TrainingConfirmPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let timestamp = src.read_u16();
+        let pack_size = src.read_u16();
+
+        Ok(Self { timestamp, pack_size })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WaveInfoPdu {
+    pub timestamp: u16,
+    pub format_no: u16,
+    pub block_no: u8,
+    pub data: [u8; 4],
+}
+
+impl WaveInfoPdu {
+    const NAME: &'static str = "SNDWAVEINFO";
+
+    const FIXED_PART_SIZE: usize =
+        2 /* wTimeStamp */
+        + 2 /* wFormatNo */
+        + 1 /* cBlockNo */
+        + 3 /* bPad */
+        + 4 /* data */;
+}
+
+impl Encode for WaveInfoPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.timestamp);
+        dst.write_u16(self.format_no);
+        dst.write_u8(self.block_no);
+        write_padding!(dst, 3);
+        dst.write_array(self.data);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for WaveInfoPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let timestamp = src.read_u16();
+        let format_no = src.read_u16();
+        let block_no = src.read_u8();
+        read_padding!(src, 3);
+        let data = src.read_array();
+
+        Ok(Self {
+            timestamp,
+            format_no,
+            block_no,
+            data,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SndWavePdu {
+    pub data: Vec<u8>,
+}
+
+impl SndWavePdu {
+    const NAME: &'static str = "SNDWAVE";
+
+    const FIXED_PART_SIZE: usize = 4 /* bPad */;
+
+    fn decode(src: &mut ReadCursor<'_>, data_len: usize) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        read_padding!(src, 4);
+        ensure_size!(in: src, size: data_len);
+        let data = src.read_slice(data_len).into();
+
+        Ok(Self { data })
+    }
+}
+
+impl Encode for SndWavePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        write_padding!(dst, 4);
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(self.data.len())
+            .expect("never overflow")
+    }
+}
+
+// combines WaveInfoPdu + WavePdu
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WavePdu<'a> {
+    pub timestamp: u16,
+    pub format_no: u16,
+    pub block_no: u8,
+    pub data: Cow<'a, [u8]>,
+}
+
+impl WavePdu<'_> {
+    const NAME: &'static str = "WavePdu";
+
+    fn body_size(&self) -> usize {
+        (WaveInfoPdu::FIXED_PART_SIZE - 4)
+            .checked_add(self.data.len())
+            .expect("never overflow")
+    }
+}
+
+impl Encode for WavePdu<'_> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let info = WaveInfoPdu {
+            timestamp: self.timestamp,
+            format_no: self.format_no,
+            block_no: self.block_no,
+            data: self.data[0..4]
+                .try_into()
+                .map_err(|e| other_err!("invalid data", source: e))?,
+        };
+        let wave = SndWavePdu {
+            data: self.data[4..].into(),
+        };
+        info.encode(dst)?;
+        wave.encode(dst)?;
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        (WaveInfoPdu::FIXED_PART_SIZE + SndWavePdu::FIXED_PART_SIZE - 4)
+            .checked_add(self.data.len())
+            .expect("never overflow")
+    }
+}
+
+impl WavePdu<'_> {
+    fn decode(src: &mut ReadCursor<'_>, body_size: u16) -> DecodeResult<Self> {
+        let info = WaveInfoPdu::decode(src)?;
+        let body_size = usize::from(body_size);
+        let data_len = body_size
+            .checked_sub(info.size())
+            .ok_or_else(|| invalid_field_err!("Length", "WaveInfo body_size is too small"))?;
+        let wave = SndWavePdu::decode(src, data_len)?;
+
+        let mut data = Vec::with_capacity(wave.size());
+        data.extend_from_slice(&info.data);
+        data.extend_from_slice(&wave.data);
+
+        Ok(Self {
+            timestamp: info.timestamp,
+            format_no: info.format_no,
+            block_no: info.block_no,
+            data: data.into(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WaveConfirmPdu {
+    pub timestamp: u16,
+    pub block_no: u8,
+}
+
+impl WaveConfirmPdu {
+    const NAME: &'static str = "SNDWAV_CONFIRM";
+
+    const FIXED_PART_SIZE: usize =
+        2 /* wTimeStamp */
+        + 1 /* cConfirmBlockNo */
+        + 1 /* pad */;
+}
+
+impl Encode for WaveConfirmPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.timestamp);
+        dst.write_u8(self.block_no);
+        write_padding!(dst, 1);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for WaveConfirmPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let timestamp = src.read_u16();
+        let block_no = src.read_u8();
+        read_padding!(src, 1);
+
+        Ok(Self { timestamp, block_no })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WaveEncryptPdu {
+    pub timestamp: u16,
+    pub format_no: u16,
+    pub block_no: u8,
+    pub signature: Option<[u8; 8]>,
+    // TODO: use Cow?
+    pub data: Vec<u8>,
+}
+
+impl WaveEncryptPdu {
+    const NAME: &'static str = "SNDWAVECRYPT";
+
+    const FIXED_PART_SIZE: usize =
+        2 /* wTimeStamp */
+        + 2 /* wFormatNo */
+        + 1 /* cBlockNo */
+        + 3 /* bPad */;
+
+    fn decode(src: &mut ReadCursor<'_>, version: Version) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let timestamp = src.read_u16();
+        let format_no = src.read_u16();
+        let block_no = src.read_u8();
+        read_padding!(src, 3);
+        let signature = if version >= Version::V5 {
+            ensure_size!(in: src, size: 8);
+            Some(src.read_array())
+        } else {
+            None
+        };
+        let data = src.read_remaining().into();
+
+        Ok(Self {
+            timestamp,
+            format_no,
+            block_no,
+            signature,
+            data,
+        })
+    }
+}
+
+impl Encode for WaveEncryptPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.timestamp);
+        dst.write_u16(self.format_no);
+        dst.write_u8(self.block_no);
+        write_padding!(dst, 3);
+        if let Some(sig) = self.signature.as_ref() {
+            dst.write_slice(sig);
+        }
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(self.signature.map_or(0, |_| 8))
+            .expect("never overflow")
+            .checked_add(self.data.len())
+            .expect("never overflow")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct Wave2Pdu<'a> {
+    pub timestamp: u16,
+    pub format_no: u16,
+    pub block_no: u8,
+    pub audio_timestamp: u32,
+    pub data: Cow<'a, [u8]>,
+}
+
+impl fmt::Debug for Wave2Pdu<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Wave2Pdu")
+            .field("timestamp", &self.timestamp)
+            .field("format_no", &self.format_no)
+            .field("block_no", &self.block_no)
+            .field("audio_timestamp", &self.audio_timestamp)
+            .finish()
+    }
+}
+
+impl Wave2Pdu<'_> {
+    const NAME: &'static str = "SNDWAVE2";
+
+    const FIXED_PART_SIZE: usize =
+        2 /* wTimeStamp */
+        + 2 /* wFormatNo */
+        + 1 /* cBlockNo */
+        + 3 /* bPad */
+        + 4 /* dwAudioTimestamp */;
+}
+
+impl Encode for Wave2Pdu<'_> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.timestamp);
+        dst.write_u16(self.format_no);
+        dst.write_u8(self.block_no);
+        write_padding!(dst, 3);
+        dst.write_u32(self.audio_timestamp);
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(self.data.len())
+            .expect("never overflow")
+    }
+}
+
+impl<'de> Decode<'de> for Wave2Pdu<'_> {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let timestamp = src.read_u16();
+        let format_no = src.read_u16();
+        let block_no = src.read_u8();
+        read_padding!(src, 3);
+        let audio_timestamp = src.read_u32();
+        let data = src.read_remaining().to_vec().into();
+
+        Ok(Self {
+            timestamp,
+            format_no,
+            block_no,
+            audio_timestamp,
+            data,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VolumePdu {
+    pub volume_left: u16,
+    pub volume_right: u16,
+}
+
+impl VolumePdu {
+    const NAME: &'static str = "SNDVOL";
+
+    const FIXED_PART_SIZE: usize = 4;
+}
+
+impl Encode for VolumePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let volume = (u32::from(self.volume_right) << 16) | u32::from(self.volume_left);
+        dst.write_u32(volume);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for VolumePdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let volume_left = src.read_u16();
+        let volume_right = src.read_u16();
+
+        Ok(Self {
+            volume_left,
+            volume_right,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PitchPdu {
+    pub pitch: u32,
+}
+
+impl PitchPdu {
+    const NAME: &'static str = "SNDPITCH";
+
+    const FIXED_PART_SIZE: usize = 4;
+}
+
+impl Encode for PitchPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u32(self.pitch);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for PitchPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let pitch = src.read_u32();
+
+        Ok(Self { pitch })
+    }
+}
+
+/// Server Audio Output Channel message (PDU prefixed with `SNDPROLOG`)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerAudioOutputPdu<'a> {
+    AudioFormat(ServerAudioFormatPdu),
+    CryptKey(CryptKeyPdu),
+    Training(TrainingPdu),
+    Wave(WavePdu<'a>),
+    WaveEncrypt(WaveEncryptPdu),
+    Close,
+    Wave2(Wave2Pdu<'a>),
+    Volume(VolumePdu),
+    Pitch(PitchPdu),
+}
+
+impl ServerAudioOutputPdu<'_> {
+    const NAME: &'static str = "ServerAudioOutputPdu";
+
+    const FIXED_PART_SIZE: usize = 1 /* msgType */ + 1 /* padding*/ + 2 /* bodySize */;
+}
+
+impl Encode for ServerAudioOutputPdu<'_> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+
+        let (msg_type, pdu_size) = match self {
+            Self::AudioFormat(pdu) => (SNDC_FORMATS, pdu.size()),
+            Self::CryptKey(pdu) => (SNDC_CRYPTKEY, pdu.size()),
+            Self::Training(pdu) => (SNDC_TRAINING, pdu.size()),
+            Self::Wave(pdu) => (SNDC_WAVE, pdu.body_size()),
+            Self::WaveEncrypt(pdu) => (SNDC_WAVEENCRYPT, pdu.size()),
+            Self::Close => (SNDC_CLOSE, 0),
+            Self::Wave2(pdu) => (SNDC_WAVE2, pdu.size()),
+            Self::Volume(pdu) => (SNDC_VOLUME, pdu.size()),
+            Self::Pitch(pdu) => (SNDC_PITCH, pdu.size()),
+        };
+
+        dst.write_u8(msg_type);
+        write_padding!(dst, 1);
+        dst.write_u16(cast_length!("ServerAudioOutputPdu::bodySize", pdu_size)?);
+
+        match self {
+            Self::AudioFormat(pdu) => pdu.encode(dst),
+            Self::CryptKey(pdu) => pdu.encode(dst),
+            Self::Training(pdu) => pdu.encode(dst),
+            Self::Wave(pdu) => pdu.encode(dst),
+            Self::WaveEncrypt(pdu) => pdu.encode(dst),
+            Self::Close => Ok(()),
+            Self::Wave2(pdu) => pdu.encode(dst),
+            Self::Volume(pdu) => pdu.encode(dst),
+            Self::Pitch(pdu) => pdu.encode(dst),
+        }?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(match self {
+                Self::AudioFormat(pdu) => pdu.size(),
+                Self::CryptKey(pdu) => pdu.size(),
+                Self::Training(pdu) => pdu.size(),
+                Self::Wave(pdu) => pdu.size(),
+                Self::WaveEncrypt(pdu) => pdu.size(),
+                Self::Close => 0,
+                Self::Wave2(pdu) => pdu.size(),
+                Self::Volume(pdu) => pdu.size(),
+                Self::Pitch(pdu) => pdu.size(),
+            })
+            .expect("never overflow")
+    }
+}
+
+impl<'de> Decode<'de> for ServerAudioOutputPdu<'_> {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let msg_type = src.read_u8();
+        read_padding!(src, 1);
+        let body_size = src.read_u16();
+
+        match msg_type {
+            SNDC_FORMATS => {
+                let pdu = ServerAudioFormatPdu::decode(src)?;
+                Ok(Self::AudioFormat(pdu))
+            }
+            SNDC_CRYPTKEY => {
+                let pdu = CryptKeyPdu::decode(src)?;
+                Ok(Self::CryptKey(pdu))
+            }
+            SNDC_TRAINING => {
+                let pdu = TrainingPdu::decode(src)?;
+                Ok(Self::Training(pdu))
+            }
+            SNDC_WAVE => {
+                let pdu = WavePdu::decode(src, body_size)?;
+                Ok(Self::Wave(pdu))
+            }
+            SNDC_WAVEENCRYPT => {
+                let pdu = WaveEncryptPdu::decode(src, Version::V5)?;
+                Ok(Self::WaveEncrypt(pdu))
+            }
+            SNDC_CLOSE => Ok(Self::Close),
+            SNDC_WAVE2 => {
+                let pdu = Wave2Pdu::decode(src)?;
+                Ok(Self::Wave2(pdu))
+            }
+            SNDC_VOLUME => {
+                let pdu = VolumePdu::decode(src)?;
+                Ok(Self::Volume(pdu))
+            }
+            SNDC_PITCH => {
+                let pdu = PitchPdu::decode(src)?;
+                Ok(Self::Pitch(pdu))
+            }
+            _ => Err(invalid_field_err!(
+                "ServerAudioOutputPdu::msgType",
+                "Unknown audio output PDU type"
+            )),
+        }
+    }
+}
+
+impl SvcEncode for ServerAudioOutputPdu<'_> {}
+
+/// Client Audio Output Channel message (PDU prefixed with `SNDPROLOG`)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClientAudioOutputPdu {
+    AudioFormat(ClientAudioFormatPdu),
+    QualityMode(QualityModePdu),
+    TrainingConfirm(TrainingConfirmPdu),
+    WaveConfirm(WaveConfirmPdu),
+}
+
+impl ClientAudioOutputPdu {
+    const NAME: &'static str = "ClientAudioOutputPdu";
+
+    const FIXED_PART_SIZE: usize = 1 /* msgType */ + 1 /* padding*/ + 2 /* bodySize */;
+}
+
+impl Encode for ClientAudioOutputPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+
+        let (msg_type, body_size) = match self {
+            Self::AudioFormat(pdu) => (SNDC_FORMATS, pdu.size()),
+            Self::QualityMode(pdu) => (SNDC_QUALITYMODE, pdu.size()),
+            Self::TrainingConfirm(pdu) => (SNDC_TRAINING, pdu.size()),
+            Self::WaveConfirm(pdu) => (SNDC_WAVECONFIRM, pdu.size()),
+        };
+
+        dst.write_u8(msg_type);
+        write_padding!(dst, 1);
+        dst.write_u16(cast_length!("ClientAudioOutputPdu::bodySize", body_size)?);
+
+        match self {
+            Self::AudioFormat(pdu) => pdu.encode(dst),
+            Self::QualityMode(pdu) => pdu.encode(dst),
+            Self::TrainingConfirm(pdu) => pdu.encode(dst),
+            Self::WaveConfirm(pdu) => pdu.encode(dst),
+        }?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+            .checked_add(match self {
+                Self::AudioFormat(pdu) => pdu.size(),
+                Self::QualityMode(pdu) => pdu.size(),
+                Self::TrainingConfirm(pdu) => pdu.size(),
+                Self::WaveConfirm(pdu) => pdu.size(),
+            })
+            .expect("never overflow")
+    }
+}
+
+impl<'de> Decode<'de> for ClientAudioOutputPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let msg_type = src.read_u8();
+        read_padding!(src, 1);
+        let _body_size = src.read_u16();
+
+        match msg_type {
+            SNDC_FORMATS => {
+                let pdu = ClientAudioFormatPdu::decode(src)?;
+                Ok(Self::AudioFormat(pdu))
+            }
+            SNDC_QUALITYMODE => {
+                let pdu = QualityModePdu::decode(src)?;
+                Ok(Self::QualityMode(pdu))
+            }
+            SNDC_TRAINING => {
+                let pdu = TrainingConfirmPdu::decode(src)?;
+                Ok(Self::TrainingConfirm(pdu))
+            }
+            SNDC_WAVECONFIRM => {
+                let pdu = WaveConfirmPdu::decode(src)?;
+                Ok(Self::WaveConfirm(pdu))
+            }
+            _ => Err(invalid_field_err!(
+                "ClientAudioOutputPdu::msgType",
+                "Unknown audio output PDU type"
+            )),
+        }
+    }
+}
+
+impl SvcEncode for ClientAudioOutputPdu {}

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/src/server.rs
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/src/server.rs
@@ -1,0 +1,392 @@
+use ironrdp_core::{Decode as _, ReadCursor, impl_as_any};
+use ironrdp_pdu::gcc::ChannelName;
+use ironrdp_pdu::{PduResult, decode_err, pdu_other_err};
+use ironrdp_svc::{CompressionCondition, SvcMessage, SvcProcessor, SvcProcessorMessages, SvcServerProcessor};
+use tracing::{debug, error};
+
+use crate::pdu::{self, ClientAudioFormatPdu, QualityMode};
+
+pub type RdpsndSvcMessages = SvcProcessorMessages<RdpsndServer>;
+
+pub trait RdpsndError: core::error::Error + Send + Sync + 'static {}
+
+impl<T> RdpsndError for T where T: core::error::Error + Send + Sync + 'static {}
+
+/// Message sent by the event loop.
+#[derive(Debug)]
+pub enum RdpsndServerMessage {
+    /// Wave data, with timestamp
+    Wave(Vec<u8>, u32),
+    SetVolume {
+        left: u16,
+        right: u16,
+    },
+    Close,
+    /// Failure received from the OS event loop.
+    ///
+    /// Implementation should log/display this error.
+    Error(Box<dyn RdpsndError>),
+}
+
+/// A server-offered audio format that the client also advertised support for,
+/// paired with the `wFormatNo` the client expects for it on the wire.
+///
+/// The crate computes the set of these — the intersection of the server's
+/// [`get_formats`] and the client's accepted formats — and hands it to
+/// [`RdpsndServerHandler::choose_format`], which returns the one to stream.
+///
+/// `wformat_no` is intentionally private and there is no public constructor:
+/// a handler can neither build nor mutate a `NegotiatedFormat`, so the index
+/// stamped onto every Wave/Wave2 PDU is always a valid position in the
+/// client's own format list. This makes it impossible to emit an out-of-range
+/// `wFormatNo` (which a compliant client rejects, silently dropping all audio
+/// — the classic footgun of the old index-returning API).
+///
+/// [`get_formats`]: RdpsndServerHandler::get_formats
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NegotiatedFormat {
+    /// The negotiated audio format (common to server and client).
+    format: pdu::AudioFormat,
+    /// Position of `format` in the client's Client Audio Formats list — the
+    /// `wFormatNo` the client resolves each wave against. Crate-owned.
+    wformat_no: u16,
+}
+
+impl NegotiatedFormat {
+    /// The negotiated audio format — common to both server and client, and the
+    /// one the returned wave data should match.
+    pub fn format(&self) -> &pdu::AudioFormat {
+        &self.format
+    }
+
+    /// Test-only accessor for the crate-private `wformat_no`, exposed for the
+    /// integration testsuite behind the private `__test` feature. Not a stable API.
+    #[cfg(feature = "__test")]
+    #[doc(hidden)]
+    pub fn wformat_no(&self) -> u16 {
+        self.wformat_no
+    }
+}
+
+/// Handler for the server side of the Audio Output Virtual Channel (`RDPSND`).
+///
+/// Implementations supply the list of audio formats the server offers, choose
+/// which negotiated format to use once the client replies, and produce the
+/// audio waves to stream (via [`RdpsndServer::wave`]).
+pub trait RdpsndServerHandler: Send + core::fmt::Debug {
+    /// The audio formats the server advertises in the Server Audio Formats and
+    /// Version PDU (MS-RDPEA 2.2.2.1).
+    fn get_formats(&self) -> &[pdu::AudioFormat];
+
+    /// Select which format to stream, once the client has replied with the
+    /// formats it accepts.
+    ///
+    /// `common` is the set of formats from [`get_formats`] that the client also
+    /// advertised, in the server's preference order; each carries the
+    /// `wFormatNo` the client expects, so the crate — not the handler — owns
+    /// the index arithmetic and the MS-RDPEA rule that `wFormatNo` addresses
+    /// the *client's* list. `common` is never empty: when server and client
+    /// share no format, this method is not called and no audio is streamed.
+    ///
+    /// Return the [`NegotiatedFormat`] to stream (a reference borrowed from
+    /// `common`), or [`None`] to decline. Returning a borrow from `common`
+    /// — rather than an index or a constructed value — makes it impossible to
+    /// pick a format the client did not accept or to produce an invalid
+    /// `wFormatNo`. This is a pure selection step: any encoder/producer setup
+    /// belongs in [`start`], which the crate calls next with the chosen format.
+    ///
+    /// [`get_formats`]: RdpsndServerHandler::get_formats
+    /// [`start`]: RdpsndServerHandler::start
+    fn choose_format<'a>(&mut self, common: &'a [NegotiatedFormat]) -> Option<&'a NegotiatedFormat>;
+
+    /// Begin streaming with the `format` just selected by [`choose_format`].
+    ///
+    /// Called once per session, immediately after a successful
+    /// [`choose_format`]. This is the lifecycle hook: initialize encoder state,
+    /// spawn the producer, etc. Waves are then emitted via [`RdpsndServer::wave`].
+    ///
+    /// Return `Err` if initialization fails (e.g. the encoder can't be created).
+    /// The crate then **declines the negotiated format** — exactly as if
+    /// [`choose_format`] had returned [`None`] — rather than leaving the channel
+    /// "negotiated" but silently producing no audio. The error is logged by the
+    /// crate.
+    ///
+    /// [`choose_format`]: RdpsndServerHandler::choose_format
+    fn start(&mut self, format: &NegotiatedFormat) -> Result<(), Box<dyn RdpsndError>>;
+
+    /// Called when the audio stream is torn down (e.g. the client closed the
+    /// channel or the session ended).
+    fn stop(&mut self);
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum RdpsndState {
+    Start,
+    WaitingForClientFormats,
+    WaitingForQualityMode,
+    WaitingForTrainingConfirm,
+    Ready,
+    Stop,
+}
+
+#[derive(Debug)]
+pub struct RdpsndServer {
+    handler: Box<dyn RdpsndServerHandler>,
+    state: RdpsndState,
+    client_format: Option<ClientAudioFormatPdu>,
+    quality_mode: Option<QualityMode>,
+    block_no: u8,
+    format_no: Option<u16>,
+}
+
+impl RdpsndServer {
+    pub const NAME: ChannelName = ChannelName::from_static(b"rdpsnd\0\0");
+
+    pub fn new(handler: Box<dyn RdpsndServerHandler>) -> Self {
+        Self {
+            handler,
+            state: RdpsndState::Start,
+            client_format: None,
+            quality_mode: None,
+            format_no: None,
+            block_no: 0,
+        }
+    }
+
+    pub fn version(&self) -> PduResult<pdu::Version> {
+        let client_format = self
+            .client_format
+            .as_ref()
+            .ok_or_else(|| pdu_other_err!("invalid state, client format not yet received"))?;
+
+        Ok(client_format.version)
+    }
+
+    pub fn flags(&self) -> PduResult<pdu::AudioFormatFlags> {
+        let client_format = self
+            .client_format
+            .as_ref()
+            .ok_or_else(|| pdu_other_err!("invalid state, client format not yet received"))?;
+
+        Ok(client_format.flags)
+    }
+
+    pub fn training_pdu(&mut self) -> PduResult<RdpsndSvcMessages> {
+        let pdu = pdu::TrainingPdu {
+            timestamp: 4231, // a random number
+            data: vec![],
+        };
+        Ok(RdpsndSvcMessages::new(vec![
+            pdu::ServerAudioOutputPdu::Training(pdu).into(),
+        ]))
+    }
+
+    pub fn wave(&mut self, data: Vec<u8>, ts: u32) -> PduResult<RdpsndSvcMessages> {
+        let version = self.version()?;
+        let format_no = self
+            .format_no
+            .ok_or_else(|| pdu_other_err!("invalid state - no format"))?;
+
+        // The server doesn't wait for wave confirm, apparently FreeRDP neither.
+        let msg = if version >= pdu::Version::V8 {
+            let pdu = pdu::Wave2Pdu {
+                block_no: self.block_no,
+                timestamp: 0,
+                audio_timestamp: ts,
+                format_no,
+                data: data.into(),
+            };
+            RdpsndSvcMessages::new(vec![pdu::ServerAudioOutputPdu::Wave2(pdu).into()])
+        } else {
+            let pdu = pdu::WavePdu {
+                block_no: self.block_no,
+                format_no,
+                timestamp: 0,
+                data: data.into(),
+            };
+            RdpsndSvcMessages::new(vec![pdu::ServerAudioOutputPdu::Wave(pdu).into()])
+        };
+
+        self.block_no = self.block_no.overflowing_add(1).0;
+
+        Ok(msg)
+    }
+
+    pub fn set_volume(&mut self, volume_left: u16, volume_right: u16) -> PduResult<RdpsndSvcMessages> {
+        if !self.flags()?.contains(pdu::AudioFormatFlags::VOLUME) {
+            return Err(pdu_other_err!("client doesn't support volume"));
+        }
+        let pdu = pdu::VolumePdu {
+            volume_left,
+            volume_right,
+        };
+        Ok(RdpsndSvcMessages::new(vec![
+            pdu::ServerAudioOutputPdu::Volume(pdu).into(),
+        ]))
+    }
+
+    pub fn close(&mut self) -> PduResult<RdpsndSvcMessages> {
+        Ok(RdpsndSvcMessages::new(vec![pdu::ServerAudioOutputPdu::Close.into()]))
+    }
+}
+
+/// Build the set of formats common to the server (`server_formats`, kept in the
+/// server's preference order) and the client (`client_formats`), each tagged
+/// with its `wFormatNo` — its index in the *client's* list, which is what the
+/// client resolves waves against (MS-RDPEA). The result mirrors the server's
+/// ordering so the handler can express preference simply by `get_formats`
+/// order, while the `wFormatNo` always points into the client list.
+#[cfg_attr(feature = "__test", visibility::make(pub))]
+fn negotiate_formats(
+    server_formats: &[pdu::AudioFormat],
+    client_formats: &[pdu::AudioFormat],
+) -> Vec<NegotiatedFormat> {
+    server_formats
+        .iter()
+        .filter_map(|server_format| {
+            client_formats
+                .iter()
+                .position(|client_fmt| audio_format_eq(client_fmt, server_format))
+                .and_then(|idx| u16::try_from(idx).ok())
+                .map(|wformat_no| NegotiatedFormat {
+                    format: server_format.clone(),
+                    wformat_no,
+                })
+        })
+        .collect()
+}
+
+/// Compare two audio formats for negotiation. The WAVEFORMATEX identity fields
+/// — wave format tag, channel count, sample rate, bit depth — must match, and so
+/// must the codec-specific extra-data blob (`data`).
+///
+/// The two derived fields (`n_avg_bytes_per_sec`, `n_block_align`) are
+/// deliberately ignored: they are computable from the others and a client may
+/// legitimately not echo them back byte-for-byte. The `data` blob is a different
+/// category, though — for codecs whose extra-format bytes carry real
+/// configuration (AAC's HEAACWAVEINFO extra data is the clear case, MS-RDPEA
+/// 2.2.2.1.1's `cbSize` + extra data), ignoring it could match two genuinely
+/// incompatible formats, so it IS compared.
+#[cfg_attr(feature = "__test", visibility::make(pub))]
+fn audio_format_eq(a: &pdu::AudioFormat, b: &pdu::AudioFormat) -> bool {
+    a.format == b.format
+        && a.n_channels == b.n_channels
+        && a.n_samples_per_sec == b.n_samples_per_sec
+        && a.bits_per_sample == b.bits_per_sample
+        && a.data == b.data
+}
+
+impl_as_any!(RdpsndServer);
+
+impl SvcProcessor for RdpsndServer {
+    fn channel_name(&self) -> ChannelName {
+        Self::NAME
+    }
+
+    fn compression_condition(&self) -> CompressionCondition {
+        CompressionCondition::Never
+    }
+
+    fn process(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+        let pdu = pdu::ClientAudioOutputPdu::decode(&mut ReadCursor::new(payload)).map_err(|e| decode_err!(e))?;
+        debug!(?pdu);
+        let msg = match self.state {
+            RdpsndState::WaitingForClientFormats => {
+                let pdu::ClientAudioOutputPdu::AudioFormat(af) = pdu else {
+                    error!("Invalid PDU");
+                    self.state = RdpsndState::Stop;
+                    return Ok(vec![]);
+                };
+                self.client_format = Some(af);
+                if self.version()? >= pdu::Version::V6 {
+                    self.state = RdpsndState::WaitingForQualityMode;
+                    vec![]
+                } else {
+                    self.state = RdpsndState::WaitingForTrainingConfirm;
+                    self.training_pdu()?.into()
+                }
+            }
+            RdpsndState::WaitingForQualityMode => {
+                let pdu::ClientAudioOutputPdu::QualityMode(pdu) = pdu else {
+                    error!("Invalid PDU");
+                    self.state = RdpsndState::Stop;
+                    return Ok(vec![]);
+                };
+                self.quality_mode = Some(pdu.quality_mode);
+                self.state = RdpsndState::WaitingForTrainingConfirm;
+                self.training_pdu()?.into()
+            }
+            RdpsndState::WaitingForTrainingConfirm => {
+                let pdu::ClientAudioOutputPdu::TrainingConfirm(_) = pdu else {
+                    error!("Invalid PDU");
+                    self.state = RdpsndState::Stop;
+                    return Ok(vec![]);
+                };
+                let client_format = self.client_format.as_ref().expect("available in this state");
+                // Formats common to server and client, in the server's
+                // preference order, each tagged with its wFormatNo (its
+                // position in the *client's* list). Keeping this in the crate
+                // means the handler never does index arithmetic and can't emit
+                // an out-of-range wFormatNo.
+                let common = negotiate_formats(self.handler.get_formats(), &client_format.formats);
+                self.state = RdpsndState::Ready;
+                if common.is_empty() {
+                    debug!("No audio format in common with the client; audio disabled");
+                } else if let Some(chosen) = self.handler.choose_format(&common) {
+                    // `chosen` borrows `common` (a local), not `self`, so the
+                    // handler is free to borrow `&mut self` again for `start`.
+                    let wformat_no = chosen.wformat_no;
+                    // Commit the index BEFORE the `start` lifecycle hook: if `start`
+                    // spawns a producer that emits a wave immediately, `wave()` must
+                    // already see a valid `format_no` rather than racing an unset one.
+                    self.format_no = Some(wformat_no);
+                    if let Err(e) = self.handler.start(chosen) {
+                        // Initialization failed (e.g. the encoder couldn't be
+                        // created). Roll back to a cleanly *declined* state — the
+                        // same outcome as `choose_format` returning `None` — instead
+                        // of leaving the channel "negotiated" but silently producing
+                        // no audio.
+                        error!(error = %e, "rdpsnd handler failed to start; declining the negotiated format");
+                        self.format_no = None;
+                    }
+                } else {
+                    debug!("Handler declined every common audio format; audio disabled");
+                }
+                vec![]
+            }
+            RdpsndState::Ready => {
+                if let pdu::ClientAudioOutputPdu::WaveConfirm(c) = pdu {
+                    debug!(?c);
+                }
+                vec![]
+            }
+            state => {
+                error!(?state, "Invalid state");
+                vec![]
+            }
+        };
+        Ok(msg)
+    }
+
+    fn start(&mut self) -> PduResult<Vec<SvcMessage>> {
+        if self.state != RdpsndState::Start {
+            error!("Attempted to start rdpsnd channel in invalid state");
+        }
+
+        let pdu = pdu::ServerAudioOutputPdu::AudioFormat(pdu::ServerAudioFormatPdu {
+            version: pdu::Version::V8,
+            formats: self.handler.get_formats().into(),
+        });
+
+        self.state = RdpsndState::WaitingForClientFormats;
+        Ok(vec![SvcMessage::from(pdu)])
+    }
+}
+
+impl Drop for RdpsndServer {
+    fn drop(&mut self) {
+        self.handler.stop();
+    }
+}
+
+impl SvcServerProcessor for RdpsndServer {}


### PR DESCRIPTION
Closes #1773

## Summary

Enables sound **multi-format `rdpsnd` (RDP audio) negotiation**. The sidecar now advertises a table of common PCM formats (48 / 44.1 / 22.05 / 11.025 kHz, mono and stereo, 16-bit) and plays each `wave` buffer at exactly the channel count and sample rate the server negotiated — instead of forcing everything through one fixed 44.1 kHz stereo format.

## Why this needed a vendored crate

Issue #1773 was blocked on an upstream `ironrdp-rdpsnd` API limitation (documented by a prior investigation on the issue): upstream 0.9.0 hands the client `wave` callback only a `format_no` **index** into the Client Audio Formats list, and it builds that list from a `HashSet` intersection (non-deterministic per-process order) then **discards** it. With more than one advertised format, the handler cannot map a played buffer back to its negotiated rate — so advertising multiple rates risked "chipmunk" audio (e.g. playing 22.05 kHz data at 44.1 kHz). Advertising a single format was the only sound option.

Per the maintainer's decision, this **vendors and patches `ironrdp-rdpsnd`** rather than waiting on upstream — the same pattern as the existing `vendor/vnc-rs` fork.

## What changed vs upstream (the vendored fork)

`rdp-sidecar/vendor/ironrdp-rdpsnd/` is a fork of upstream 0.9.0, patched into the workspace-excluded sidecar graph via `[patch.crates-io]` (the meta `ironrdp` crate depends on `ironrdp-rdpsnd = "0.9"` and re-exports it, so the patch redirects that re-export). The **only functional change** (in `src/client.rs`):

- `Rdpsnd` now remembers the exact, order-preserving `Vec<AudioFormat>` it sent in `client_formats()` (`negotiated_formats`).
- The trait method becomes `RdpsndClientHandler::wave(&mut self, format: &AudioFormat, ts, data)` — passing the **concrete negotiated format** instead of an unresolvable index. `Wave2 { format_no }` is resolved against the remembered list; an out-of-range index is dropped, not guessed.

`pdu/mod.rs`, `server.rs` and `lib.rs` are byte-for-byte upstream. Sibling `ironrdp-*` deps stay registry versions, so the fork adds **no new locked crate** (verified: the only `Cargo.lock` change is the patched crate losing its registry source/checksum; `visibility` stays out of the lock). This is exactly the change intended to be offered upstream to Devolutions/IronRDP. See `vendor/ironrdp-rdpsnd/README.md`.

## Sidecar side (`rdp-sidecar/src/audio.rs`)

- Advertises the PCM format table; decodes and plays each buffer at its own negotiated `(channels, sample_rate)` — rodio resamples to the device rate.
- The jitter/latency buffer is now **format-aware** (durations computed from each buffer's own rate/channels), so a mid-session format change cannot introduce a pitch/rate error.
- Non-PCM and non-16-bit buffers are rejected rather than mis-played.

## Soundness guard (no chipmunk-audio regression)

A dedicated test asserts the load-bearing property: the **same bytes** decoded under a 22.05 kHz mono format report 22 050 Hz / 1 channel, and under a 48 kHz stereo format report 48 000 Hz / 2 channels — proving the playback rate comes from the negotiated format, never a fixed assumption. Plus tests for the format table's PCM derivations, format rejection, and the existing jitter-buffer invariants (updated to be format-aware). All 12 audio tests pass.

## Cross-platform

No new dependencies; `rodio` and its target gating are unchanged. `cargo tree -i ironrdp-rdpsnd` shows only the meta crate as dependent. The vendored fork lives entirely in the workspace-excluded sidecar graph, so it cannot affect the desktop app's dependency resolution.

## Deferred

ADPCM / Opus decode is higher-scope (needs a mature, cleanly-integrable, correctness-verifiable decoder crate) and is filed as a follow-up. Multi-PCM-rate negotiation is the safe, high-value core and ships here.

## Testing

- `cargo build --manifest-path rdp-sidecar/Cargo.toml` — clean.
- `cargo test --manifest-path rdp-sidecar/Cargo.toml audio::` — 12/12 pass.
- `cargo clippy --manifest-path rdp-sidecar/Cargo.toml --all-targets` — clean.
- `cargo fmt --manifest-path rdp-sidecar/Cargo.toml --check` — clean.

Note: the sidecar is built only by the bundle/release CI, not per-PR CI, so the above were run locally.