### PR TITLE
feat(rdp): bind remote-clipboard files to the host OS clipboard + paste UI (Closes #1804)

### DIFF
--- a/core/src/backends/rdp_sidecar/config.rs
+++ b/core/src/backends/rdp_sidecar/config.rs
@@ -156,6 +156,22 @@ impl Default for RdpConfig {
     }
 }
 
+/// Whether this host build can bind remote-copied clipboard files onto the OS
+/// clipboard for a delayed-render local paste (#1804).
+///
+/// Only **macOS** currently has the native `NSPasteboard` promised-data binding
+/// (`src-tauri/src/macos_clipboard.rs`), so it is the only platform where the
+/// sidecar should surface the file list for delayed rendering; every other
+/// platform keeps the eager shared-folder download (#1765) as the fallback. The
+/// host process stamps [`RdpConfig::clipboard_delayed_render`] from this at
+/// connect time — it reflects a platform capability, not a user preference, so
+/// it is deliberately absent from [`rdp_settings_schema`]. Windows
+/// (`CF_HDROP`/`WM_RENDERFORMAT`) and Linux (X11/Wayland `text/uri-list`)
+/// bindings are tracked as follow-ups; wiring one here is a single-line change.
+pub const fn host_supports_clipboard_delayed_render() -> bool {
+    cfg!(target_os = "macos")
+}
+
 impl RdpConfig {
     /// The effective TCP port to reach the RDP server on.
     pub fn effective_port(&self) -> u16 {
@@ -651,6 +667,16 @@ mod tests {
         assert!(!no_transfer.clipboard_delayed_render_enabled());
         // Default is off.
         assert!(!RdpConfig::default().clipboard_delayed_render_enabled());
+    }
+
+    #[test]
+    fn host_capability_flag_matches_the_build_platform() {
+        // Delayed rendering is bound to the OS clipboard only on macOS today
+        // (#1804); every other platform keeps the eager shared-folder download.
+        assert_eq!(
+            host_supports_clipboard_delayed_render(),
+            cfg!(target_os = "macos")
+        );
     }
 
     #[test]

--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -44,7 +44,7 @@ pub mod config;
 pub mod integrity;
 pub mod protocol;
 
-pub use config::rdp_settings_schema;
+pub use config::{host_supports_clipboard_delayed_render, rdp_settings_schema};
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/core/src/backends/rdp_sidecar/mod.rs
+++ b/core/src/backends/rdp_sidecar/mod.rs
@@ -417,13 +417,20 @@ async fn supervise(mut child: tokio::process::Child, cancel: CancellationToken) 
 impl SidecarRdp {
     /// Map a settings JSON value to a validated [`RdpConfig`].
     fn parse_config(settings: serde_json::Value) -> Result<RdpConfig, SessionError> {
-        let cfg: RdpConfig = serde_json::from_value(settings)
+        let mut cfg: RdpConfig = serde_json::from_value(settings)
             .map_err(|e| SessionError::InvalidConfig(format!("Invalid RDP settings: {e}")))?;
         if cfg.host.is_empty() {
             return Err(SessionError::InvalidConfig(
                 "RDP host is required".to_string(),
             ));
         }
+        // `clipboard_delayed_render` is host-controlled, not a connection-editor
+        // field: stamp it from the host OS capability (#1804) so the sidecar only
+        // surfaces the delayed remote-clipboard file list where this build can bind
+        // it to the OS clipboard. Everywhere else it stays off and the eager
+        // shared-folder download (#1765) remains the behaviour, so nothing
+        // regresses on a platform without the binding.
+        cfg.clipboard_delayed_render = config::host_supports_clipboard_delayed_render();
         Ok(cfg)
     }
 }
@@ -842,6 +849,30 @@ mod tests {
         assert!(caps.view_only_capable);
         assert!(caps.supports_dynamic_resize);
         assert!(caps.supports_clipboard);
+    }
+
+    #[test]
+    fn parse_config_stamps_delayed_render_from_host_capability() {
+        // The flag is never taken from the settings JSON — it is host-controlled.
+        // Whatever the JSON says, parse_config overwrites it with the build's OS
+        // capability (#1804), so a platform without the binding never surfaces the
+        // delayed list.
+        let cfg = SidecarRdp::parse_config(serde_json::json!({
+            "host": "example.com",
+            "clipboardDelayedRender": true,
+        }))
+        .unwrap();
+        assert_eq!(
+            cfg.clipboard_delayed_render,
+            config::host_supports_clipboard_delayed_render()
+        );
+
+        // Absent from the JSON, it is still stamped from the host capability.
+        let cfg = SidecarRdp::parse_config(serde_json::json!({ "host": "example.com" })).unwrap();
+        assert_eq!(
+            cfg.clipboard_delayed_render,
+            config::host_supports_clipboard_delayed_render()
+        );
     }
 
     #[tokio::test]

--- a/docs/changes/dev0/feature/1804-host-clipboard-bind-paste.md
+++ b/docs/changes/dev0/feature/1804-host-clipboard-bind-paste.md
@@ -1,0 +1,15 @@
+### Added
+
+- RDP: files copied inside a remote RDP session can now be pasted into local
+  apps via the host OS clipboard, with the bytes fetched from the remote only on
+  the actual paste gesture (**delayed rendering**, not an eager download). The
+  RemoteDesktop clipboard panel lists the files the remote copied and a **Copy to
+  clipboard** button binds them onto the host OS clipboard; pasting into any app
+  (e.g. Finder) then streams each file's bytes on demand into a sanitized,
+  bounded staging file. **macOS** ships the native `NSPasteboard` binding; on
+  every other platform the feature stays off and the existing eager shared-folder
+  download (#1765) remains the behaviour, so nothing changes there. The
+  `clipboard_delayed_render` gate is stamped from a host OS-capability check, not
+  a connection setting, so it can only turn on where a real binding exists.
+  Windows (`CF_HDROP` / `WM_RENDERFORMAT`) and Linux (X11/Wayland `text/uri-list`)
+  bindings are tracked as follow-ups (#1804).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1055,6 +1055,35 @@ module, but the live PDU exchange needs a real server:
 6. Leave **Receive Clipboard Files** off and reconnect. **Expected:** no file
    formats are advertised in either direction; text clipboard still works.
 
+#### Delayed-render paste to the host OS clipboard (macOS, #1804)
+
+On macOS the remote-copied files are surfaced to the **host OS clipboard** with
+delayed rendering instead of eagerly downloaded into the shared folder: the bytes
+are streamed from the remote only when the user actually pastes into a local app.
+The selection/index logic and manager plumbing are unit-tested (`macos_clipboard`,
+`graphical_manager`), but the live `NSPasteboard` promise + real paste need a
+manual run (per-PR CI does not run the CLIPRDR wire lane, #1569):
+
+1. On **macOS**, build the sidecar and point `TERMIHUB_RDP_HELPER` at it (as
+   above); in the RDP connection editor enable **Redirect a Local Drive** (with a
+   **Shared Folder**) and **Receive Clipboard Files**, then connect to a Windows
+   RDP host.
+2. Copy one or more files in the remote session (Explorer → Ctrl+C). **Expected:**
+   the files do **not** appear in the shared folder (delayed rendering replaces the
+   eager download on macOS).
+3. Open the RemoteDesktop hover toolbar's **Clipboard** panel. **Expected:** a
+   **Remote files** section lists the copied files, with a **Copy to clipboard**
+   button.
+4. Click **Copy to clipboard**. **Expected:** a toast confirms `N file(s) ready`.
+   No bytes have been fetched yet.
+5. Paste into a local app — Finder (Cmd+V into a folder), a mail draft, etc.
+   **Expected:** the real files appear, their contents intact; the fetch happens
+   at this moment (delayed), streamed into a bounded staging file.
+6. **Non-macOS regression check:** on Windows/Linux, repeat step 2 with the same
+   options. **Expected:** unchanged #1765 behaviour — files download into the
+   shared folder, and the **Remote files** section does not appear (no host
+   binding, so nothing is surfaced).
+
 ### Deferred agent update (apply on last disconnect) (#1352)
 
 Verifies that a deferred agent update never interrupts active sessions and

--- a/src-tauri/src/commands/remote_desktop.rs
+++ b/src-tauri/src/commands/remote_desktop.rs
@@ -9,7 +9,7 @@
 use serde_json::Value;
 use tauri::State;
 
-use termihub_core::connection::InputEvent;
+use termihub_core::connection::{InputEvent, RemoteClipboardFile};
 
 use crate::session::graphical_manager::GraphicalSessionManager;
 use crate::utils::errors::TerminalError;
@@ -65,6 +65,75 @@ pub async fn remote_desktop_get_clipboard(
     manager: State<'_, GraphicalSessionManager>,
 ) -> Result<Option<String>, TerminalError> {
     manager.get_clipboard(&session_id).await
+}
+
+/// List the files the remote most recently copied to its clipboard, surfaced for
+/// a local paste with delayed rendering (#1804).
+///
+/// Empty on any platform without an OS-clipboard delayed-render binding (the
+/// sidecar keeps eagerly downloading into the shared folder there), or when the
+/// remote copied text/an image/nothing. The bytes are fetched later, only when
+/// the user actually pastes — see [`remote_desktop_bind_clipboard_files`].
+#[tauri::command]
+pub async fn remote_desktop_remote_clipboard_files(
+    session_id: String,
+    manager: State<'_, GraphicalSessionManager>,
+) -> Result<Vec<RemoteClipboardFile>, TerminalError> {
+    manager.remote_clipboard_files(&session_id).await
+}
+
+/// Bind the remote-copied clipboard files onto the host OS clipboard so they can
+/// be pasted into any local app (#1804). Returns the number of files bound.
+///
+/// The bytes are **not** fetched here: this installs a delayed-render promise on
+/// the OS clipboard, and each file's bytes are streamed from the remote via
+/// [`GraphicalSessionManager::fetch_remote_clipboard_file`] only when the user
+/// actually pastes (on macOS, the `NSPasteboard` `provideDataForType:` callback).
+/// Returns `0` when the remote copied no pasteable files, and errors on a
+/// platform without a native binding.
+#[tauri::command]
+pub async fn remote_desktop_bind_clipboard_files(
+    session_id: String,
+    app_handle: tauri::AppHandle,
+    manager: State<'_, GraphicalSessionManager>,
+) -> Result<usize, TerminalError> {
+    // Only regular files carry bytes to fetch; directories are surfaced only so a
+    // copied tree can be rebuilt and are not offered to the OS clipboard here.
+    let files: Vec<RemoteClipboardFile> = manager
+        .remote_clipboard_files(&session_id)
+        .await?
+        .into_iter()
+        .filter(|f| !f.is_dir)
+        .collect();
+    if files.is_empty() {
+        return Ok(0);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let count = files.len();
+        crate::macos_clipboard::bind_remote_clipboard_files(
+            &app_handle,
+            (*manager).clone(),
+            session_id,
+            files,
+        )
+        .map_err(|e| TerminalError::InternalError(e.to_string()))?;
+        Ok(count)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // No native OS-clipboard binding on this platform: with delayed rendering
+        // off, `remote_clipboard_files` is already empty and we returned above, so
+        // reaching here means a caller invoked the command anyway. Report rather
+        // than silently succeed. (`app_handle`/`session_id` are macOS-only inputs.)
+        let _ = (&app_handle, &session_id);
+        Err(TerminalError::InternalError(
+            "pasting remote clipboard files to the host OS clipboard is not supported on this \
+             platform yet"
+                .to_string(),
+        ))
+    }
 }
 
 /// Deliver the user's verdict for an interactive certificate-trust prompt

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,10 @@ pub mod files;
 /// Services-menu entry (#1409). macOS-only.
 #[cfg(target_os = "macos")]
 mod macos_services;
+/// Native macOS `NSPasteboard` binding for pasting remote-copied RDP clipboard
+/// files into local apps with delayed rendering (#1804). macOS-only.
+#[cfg(target_os = "macos")]
+mod macos_clipboard;
 mod macros;
 mod network;
 mod session;
@@ -668,6 +672,8 @@ pub fn run() {
             commands::remote_desktop::remote_desktop_send_input,
             commands::remote_desktop::remote_desktop_send_clipboard,
             commands::remote_desktop::remote_desktop_get_clipboard,
+            commands::remote_desktop::remote_desktop_remote_clipboard_files,
+            commands::remote_desktop::remote_desktop_bind_clipboard_files,
             commands::remote_desktop::remote_desktop_cert_decision,
             commands::remote_desktop::remote_desktop_disconnect,
             commands::remote_desktop::rdp_trust_list,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,14 +6,14 @@ mod embedded_servers;
 /// subsystem (public so integration tests can drive `SftpSession` /
 /// `TransferRegistry` directly — issue #1245).
 pub mod files;
-/// Native macOS Services provider wiring the app-level "Open in termiHub"
-/// Services-menu entry (#1409). macOS-only.
-#[cfg(target_os = "macos")]
-mod macos_services;
 /// Native macOS `NSPasteboard` binding for pasting remote-copied RDP clipboard
 /// files into local apps with delayed rendering (#1804). macOS-only.
 #[cfg(target_os = "macos")]
 mod macos_clipboard;
+/// Native macOS Services provider wiring the app-level "Open in termiHub"
+/// Services-menu entry (#1409). macOS-only.
+#[cfg(target_os = "macos")]
+mod macos_services;
 mod macros;
 mod network;
 mod session;

--- a/src-tauri/src/macos_clipboard.rs
+++ b/src-tauri/src/macos_clipboard.rs
@@ -130,9 +130,7 @@ impl RemoteClipboardProvider {
             ) {
                 Ok(path) => staged.push(NSString::from_str(&path.to_string_lossy())),
                 Err(e) => {
-                    tracing::warn!(
-                        "failed to fetch remote clipboard file {index} for paste: {e}"
-                    );
+                    tracing::warn!("failed to fetch remote clipboard file {index} for paste: {e}");
                 }
             }
         }

--- a/src-tauri/src/macos_clipboard.rs
+++ b/src-tauri/src/macos_clipboard.rs
@@ -1,0 +1,232 @@
+//! Native macOS `NSPasteboard` binding for pasting remote-copied RDP clipboard
+//! files into local apps with **delayed rendering** (#1804).
+//!
+//! Follow-up to #1793: the RDP sidecar surfaces the list of files the remote
+//! copied to its clipboard (via `GraphicalBackend::remote_clipboard_files`) and
+//! streams a file's bytes on demand (`fetch_remote_clipboard_file`) — but nothing
+//! binds that transport to the host OS clipboard. This module does, on macOS.
+//!
+//! ## Delayed rendering, the AppKit way
+//!
+//! When the user chooses "make the remote files pasteable" in the RemoteDesktop
+//! UI, [`bind_remote_clipboard_files`] declares the deprecated-but-still-honoured
+//! `NSFilenamesPboardType` on the general pasteboard with an **owner** object but
+//! writes no data. This is AppKit's *promised data* pattern: the owner's
+//! `pasteboard:provideDataForType:` is invoked only when another app actually
+//! reads that type — i.e. on the real paste gesture. Only then do we fetch each
+//! file's bytes from the remote (streamed into a sanitized, bounded temp file by
+//! the sidecar) and hand the receiver the staged paths. No bytes move on copy;
+//! memory stays bounded to whatever a single fetch stages.
+//!
+//! The provider object is kept alive as the current pasteboard owner in a
+//! main-thread [`thread_local`]; each new bind replaces (and drops) the previous
+//! one, so at most one owner is ever retained. AppKit stores the owner
+//! **unretained**, exactly like the Services provider in
+//! [`crate::macos_services`], which this module mirrors.
+//!
+//! Everything here is `#[cfg(target_os = "macos")]`-gated at the module
+//! declaration in `lib.rs`. Windows (`CF_HDROP` / `WM_RENDERFORMAT`) and Linux
+//! (X11/Wayland `text/uri-list` data source) bindings are tracked as follow-ups;
+//! on those platforms `clipboard_delayed_render` stays off and the eager
+//! shared-folder download (#1765) remains the behaviour.
+
+use std::cell::RefCell;
+
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, NSObject};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_app_kit::NSPasteboard;
+// `NSFilenamesPboardType` is deprecated in favour of per-item file URLs, but it
+// is the type the general pasteboard's promised-data (owner) mechanism serves for
+// a multi-file selection, and the type Finder and most apps accept on paste.
+#[allow(deprecated)]
+use objc2_app_kit::NSFilenamesPboardType;
+use objc2_foundation::{NSArray, NSString};
+use tauri::AppHandle;
+
+use crate::session::graphical_manager::GraphicalSessionManager;
+use termihub_core::connection::RemoteClipboardFile;
+
+/// The advertised indices of the files worth offering to the OS clipboard — the
+/// regular files, in order. Directories carry no bytes to fetch (they are
+/// surfaced only so a copied tree can be recreated), so they are dropped.
+///
+/// Pure and Objective-C-free so the selection logic is unit-testable without a
+/// pasteboard.
+fn pasteable_indices(files: &[RemoteClipboardFile]) -> Vec<u32> {
+    files
+        .iter()
+        .filter(|f| !f.is_dir)
+        .map(|f| f.index)
+        .collect()
+}
+
+/// Instance state for the pasteboard owner: how to fetch each promised file when
+/// the receiver pastes.
+struct Ivars {
+    /// Clone of the graphical manager (Arc-backed) used to reach the session's
+    /// backend for on-demand byte fetches.
+    manager: GraphicalSessionManager,
+    /// The session whose remote clipboard these files belong to.
+    session_id: String,
+    /// Advertised indices to fetch, in paste order.
+    indices: Vec<u32>,
+}
+
+define_class!(
+    /// Objective-C object installed as the general pasteboard's owner for the
+    /// promised `NSFilenamesPboardType`. Its single method fetches the remote
+    /// bytes lazily when a paste reads the type (#1804).
+    #[unsafe(super(NSObject))]
+    #[name = "TermiHubRemoteClipboardProvider"]
+    #[ivars = Ivars]
+    struct RemoteClipboardProvider;
+
+    impl RemoteClipboardProvider {
+        /// AppKit promised-data callback: the receiver is pasting and wants the
+        /// data for `_type`. We only ever declared `NSFilenamesPboardType`, so we
+        /// fetch every promised file's bytes now (delayed rendering) and set the
+        /// staged paths as the property list.
+        #[unsafe(method(pasteboard:provideDataForType:))]
+        fn provide_data(&self, pboard: &NSPasteboard, _ptype: &NSString) {
+            self.provide(pboard);
+        }
+    }
+);
+
+impl RemoteClipboardProvider {
+    /// Allocate a provider bound to a session and its promised file indices.
+    fn new(
+        manager: GraphicalSessionManager,
+        session_id: String,
+        indices: Vec<u32>,
+    ) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(Ivars {
+            manager,
+            session_id,
+            indices,
+        });
+        // SAFETY: standard NSObject designated-initializer chain for a class
+        // defined via `define_class!`.
+        unsafe { msg_send![super(this), init] }
+    }
+
+    /// Fetch each promised file's bytes on demand and hand the receiver the
+    /// staged paths as an `NSArray<NSString>` under `NSFilenamesPboardType`.
+    ///
+    /// Runs on the main thread (the pasteboard invokes the owner there). The
+    /// per-file fetch is a bounded, sanitized temp-file stage in the sidecar, so
+    /// blocking here for the duration of a paste keeps memory bounded and cannot
+    /// deadlock: the fetch drives the tokio runtime's worker threads, never the
+    /// main thread.
+    fn provide(&self, pboard: &NSPasteboard) {
+        let ivars = self.ivars();
+        let mut staged: Vec<Retained<NSString>> = Vec::new();
+        for &index in &ivars.indices {
+            match tauri::async_runtime::block_on(
+                ivars
+                    .manager
+                    .fetch_remote_clipboard_file(&ivars.session_id, index),
+            ) {
+                Ok(path) => staged.push(NSString::from_str(&path.to_string_lossy())),
+                Err(e) => {
+                    tracing::warn!(
+                        "failed to fetch remote clipboard file {index} for paste: {e}"
+                    );
+                }
+            }
+        }
+        if staged.is_empty() {
+            return;
+        }
+        let array = NSArray::from_retained_slice(&staged);
+        let plist: &AnyObject = &array;
+        // SAFETY: `NSFilenamesPboardType` is an AppKit static; the property list is
+        // an `NSArray<NSString>` of paths, the shape that type requires.
+        #[allow(deprecated)]
+        let file_type = unsafe { NSFilenamesPboardType };
+        unsafe {
+            pboard.setPropertyList_forType(plist, file_type);
+        }
+    }
+}
+
+thread_local! {
+    /// The pasteboard owner for the most recent bind. AppKit keeps the owner
+    /// unretained, so we must hold it ourselves; a new bind replaces (drops) the
+    /// previous one, since it is no longer the pasteboard's owner. Main-thread
+    /// only — `Retained` is neither `Send` nor `Sync`, and every access runs on
+    /// the main thread.
+    static CURRENT_OWNER: RefCell<Option<Retained<RemoteClipboardProvider>>> =
+        const { RefCell::new(None) };
+}
+
+/// Bind the remote-copied clipboard `files` onto the general OS pasteboard with
+/// delayed rendering (#1804), so they can be pasted into any local app. The bytes
+/// are fetched only on the actual paste, via `manager` and `session_id`.
+///
+/// Dispatches the pasteboard mutation to the main thread (AppKit requires it) and
+/// keeps the owner alive for as long as it is the current pasteboard owner.
+pub fn bind_remote_clipboard_files(
+    app_handle: &AppHandle,
+    manager: GraphicalSessionManager,
+    session_id: String,
+    files: Vec<RemoteClipboardFile>,
+) -> anyhow::Result<()> {
+    let indices = pasteable_indices(&files);
+    if indices.is_empty() {
+        return Ok(());
+    }
+
+    app_handle
+        .run_on_main_thread(move || {
+            let provider = RemoteClipboardProvider::new(manager, session_id, indices);
+            let pboard = NSPasteboard::generalPasteboard();
+            #[allow(deprecated)]
+            let file_type = unsafe { NSFilenamesPboardType };
+            let types = NSArray::from_slice(&[file_type]);
+            let owner: &AnyObject = &provider;
+            // SAFETY: declaring a promised type with `self` as the (unretained)
+            // owner. `clearContents` first drops any prior contents so a stale
+            // promise can never be served.
+            unsafe {
+                pboard.clearContents();
+                pboard.declareTypes_owner(&types, Some(owner));
+            }
+            // Retain the owner (unretained by AppKit) until the next bind replaces
+            // it; the replaced one is no longer the pasteboard owner, so dropping
+            // it here is safe.
+            CURRENT_OWNER.with(|slot| {
+                *slot.borrow_mut() = Some(provider);
+            });
+        })
+        .map_err(|e| anyhow::anyhow!("failed to bind clipboard on the main thread: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(index: u32, is_dir: bool) -> RemoteClipboardFile {
+        RemoteClipboardFile {
+            name: format!("f{index}"),
+            relative_path: None,
+            size: Some(1),
+            is_dir,
+            index,
+        }
+    }
+
+    #[test]
+    fn pasteable_indices_keep_files_in_order_and_drop_dirs() {
+        let files = vec![file(0, false), file(1, true), file(2, false)];
+        assert_eq!(pasteable_indices(&files), vec![0, 2]);
+    }
+
+    #[test]
+    fn pasteable_indices_empty_when_only_dirs_or_none() {
+        assert!(pasteable_indices(&[]).is_empty());
+        assert!(pasteable_indices(&[file(0, true), file(1, true)]).is_empty());
+    }
+}

--- a/src-tauri/src/session/graphical_manager.rs
+++ b/src-tauri/src/session/graphical_manager.rs
@@ -473,6 +473,13 @@ impl GraphicalSessionManager {
     /// rendering, #1793/#1804), staging them into a sanitized, bounded temp file
     /// and returning its path. `index` must be one a prior
     /// [`Self::remote_clipboard_files`] surfaced.
+    ///
+    /// Only the platform-native OS-clipboard binding calls this (on the real paste
+    /// gesture); macOS is wired today (`macos_clipboard`), Windows/Linux are
+    /// follow-ups (#1814/#1815). Off those platforms it has no in-crate caller
+    /// yet, so the dead-code lint is suppressed there rather than deleting a method
+    /// the pending bindings need.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub async fn fetch_remote_clipboard_file(
         &self,
         session_id: &str,

--- a/src-tauri/src/session/graphical_manager.rs
+++ b/src-tauri/src/session/graphical_manager.rs
@@ -23,7 +23,7 @@ use tracing::{debug, info, warn};
 
 use termihub_core::connection::{
     CertPrompt, CertPromptReceiver, ConnectionType, ConnectionTypeRegistry, CursorUpdate,
-    FrameUpdate, GraphicalState, InputEvent, SessionStateMachine,
+    FrameUpdate, GraphicalState, InputEvent, RemoteClipboardFile, SessionStateMachine,
 };
 
 use crate::session::rdp_trust_store::{RdpTrustStore, TrustLookup};
@@ -448,6 +448,47 @@ impl GraphicalSessionManager {
         Ok(backend.get_clipboard().await)
     }
 
+    /// The files the remote most recently copied to its clipboard, surfaced for a
+    /// local paste with delayed rendering (#1793/#1804).
+    ///
+    /// Empty unless the backend supports remote→host file transfer, the host
+    /// advertised delayed rendering (a platform capability, see
+    /// [`host_supports_clipboard_delayed_render`](termihub_core::backends::rdp_sidecar::host_supports_clipboard_delayed_render)),
+    /// and the remote actually copied files. The bytes are **not** fetched here —
+    /// that is deferred to [`Self::fetch_remote_clipboard_file`], invoked on the
+    /// real paste gesture.
+    pub async fn remote_clipboard_files(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<RemoteClipboardFile>, TerminalError> {
+        let conn = self.connection_of(session_id).await?;
+        let guard = conn.lock().await;
+        let backend = guard
+            .graphical()
+            .ok_or_else(|| TerminalError::SessionNotFound(session_id.to_string()))?;
+        Ok(backend.remote_clipboard_files().await)
+    }
+
+    /// Fetch one surfaced remote-clipboard file's bytes on demand (delayed
+    /// rendering, #1793/#1804), staging them into a sanitized, bounded temp file
+    /// and returning its path. `index` must be one a prior
+    /// [`Self::remote_clipboard_files`] surfaced.
+    pub async fn fetch_remote_clipboard_file(
+        &self,
+        session_id: &str,
+        index: u32,
+    ) -> Result<std::path::PathBuf, TerminalError> {
+        let conn = self.connection_of(session_id).await?;
+        let guard = conn.lock().await;
+        let backend = guard
+            .graphical()
+            .ok_or_else(|| TerminalError::SessionNotFound(session_id.to_string()))?;
+        backend
+            .fetch_remote_clipboard_file(index)
+            .await
+            .map_err(|e| TerminalError::InternalError(e.to_string()))
+    }
+
     /// Disconnect and clean up a graphical session.
     pub async fn disconnect(
         &self,
@@ -737,6 +778,38 @@ mod tests {
             mgr.get_clipboard(&sid).await.expect("get"),
             Some("hello".to_string())
         );
+
+        mgr.disconnect(&sid, sink).await.expect("disconnect");
+    }
+
+    #[tokio::test]
+    async fn remote_clipboard_files_default_empty_and_fetch_errors() {
+        // The mock backend keeps the seam's default impls: no remote clipboard
+        // files, and a fetch is unsupported. This exercises the manager
+        // pass-throughs (#1804) end to end without a real RDP sidecar.
+        let mgr = manager();
+        let sink = RecordingSink::default();
+        let sid = mgr
+            .connect("mock-remote-desktop", serde_json::json!({}), sink.clone())
+            .await
+            .expect("connect");
+
+        assert!(mgr
+            .remote_clipboard_files(&sid)
+            .await
+            .expect("list")
+            .is_empty());
+        let err = mgr
+            .fetch_remote_clipboard_file(&sid, 0)
+            .await
+            .expect_err("fetch unsupported on the mock backend");
+        assert!(matches!(err, TerminalError::InternalError(_)));
+
+        // Unknown sessions are reported, not silently empty.
+        assert!(matches!(
+            mgr.remote_clipboard_files("nope").await,
+            Err(TerminalError::SessionNotFound(_))
+        ));
 
         mgr.disconnect(&sid, sink).await.expect("disconnect");
     }

--- a/src/components/RemoteDesktop/RemoteDesktopTab.css
+++ b/src/components/RemoteDesktop/RemoteDesktopTab.css
@@ -201,3 +201,36 @@
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
 }
+
+.rd-clipboard__files {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-primary);
+}
+
+.rd-clipboard__files-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rd-clipboard__files-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 96px;
+  overflow-y: auto;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.rd-clipboard__file {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/src/components/RemoteDesktop/RemoteDesktopTab.tsx
+++ b/src/components/RemoteDesktop/RemoteDesktopTab.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { X } from "lucide-react";
+import { FileDown, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
 import { useRemoteDesktopSession } from "@/hooks/useRemoteDesktopSession";
 import { remoteDesktopGetClipboard } from "@/services/api";
-import type { ScaleMode } from "@/types/remoteDesktop";
+import type { RemoteClipboardFile, ScaleMode } from "@/types/remoteDesktop";
 import { SCALE_MODE_LABELS } from "@/types/remoteDesktop";
 import { RemoteDesktopCanvas } from "./RemoteDesktopCanvas";
 import { RemoteDesktopToolbar } from "./RemoteDesktopToolbar";
@@ -34,6 +34,9 @@ export function RemoteDesktopTab({ tabId, isVisible }: RemoteDesktopTabProps) {
   const [resolution, setResolution] = useState<{ width: number; height: number } | null>(null);
   const [clipboardOpen, setClipboardOpen] = useState(false);
   const [clipboardDraft, setClipboardDraft] = useState("");
+  // Files the remote copied to its clipboard, surfaced for a local paste (#1804).
+  // Empty where the host has no delayed-render binding (non-macOS today).
+  const [clipboardFiles, setClipboardFiles] = useState<RemoteClipboardFile[]>([]);
   // The scale mode can be changed at runtime via the toolbar, overriding the
   // configured default.
   const [scaleModeOverride, setScaleModeOverride] = useState<ScaleMode | null>(null);
@@ -97,17 +100,27 @@ export function RemoteDesktopTab({ tabId, isVisible }: RemoteDesktopTabProps) {
   const handleToggleClipboard = useCallback(() => {
     setClipboardOpen((open) => {
       const next = !open;
-      // Pull the current remote clipboard when opening the panel.
+      // Pull the current remote clipboard text + surfaced files when opening.
       if (next && session.sessionId) {
         void remoteDesktopGetClipboard(session.sessionId)
           .then((text) => {
             if (text) setClipboardDraft(text);
           })
           .catch(() => {});
+        void session.remoteClipboardFiles().then(setClipboardFiles);
       }
       return next;
     });
-  }, [session.sessionId]);
+  }, [session]);
+
+  const handleCopyFilesToHost = useCallback(async () => {
+    const count = await session.bindClipboardFiles();
+    if (count > 0) {
+      toast.success(`${count} file${count === 1 ? "" : "s"} ready — paste into any app`);
+    } else {
+      toast.info("No remote files to paste");
+    }
+  }, [session]);
 
   // Reflect an incoming remote clipboard into the draft while the panel is open.
   useEffect(() => {
@@ -190,6 +203,29 @@ export function RemoteDesktopTab({ tabId, isVisible }: RemoteDesktopTabProps) {
           <Button variant="secondary" size="sm" onClick={handleSendClipboard}>
             Send to remote
           </Button>
+          {clipboardFiles.length > 0 && (
+            <div className="rd-clipboard__files" data-testid="remote-desktop-clipboard-files">
+              <span className="rd-clipboard__files-label">Remote files</span>
+              <div className="rd-clipboard__files-list">
+                {clipboardFiles.map((f) => (
+                  <span key={f.index} className="rd-clipboard__file" title={f.name}>
+                    {f.name}
+                    {f.isDir ? "/" : ""}
+                  </span>
+                ))}
+              </div>
+              <Button
+                variant="secondary"
+                size="sm"
+                icon={<FileDown size={14} />}
+                onClick={handleCopyFilesToHost}
+                pendingLabel="Preparing…"
+                data-testid="remote-desktop-clipboard-copy-files"
+              >
+                Copy to clipboard
+              </Button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/hooks/useRemoteDesktopSession.test.tsx
+++ b/src/hooks/useRemoteDesktopSession.test.tsx
@@ -16,9 +16,12 @@ import {
   remoteDesktopResize,
   remoteDesktopSendInput,
   remoteDesktopSendClipboard,
+  remoteDesktopRemoteClipboardFiles,
+  remoteDesktopBindClipboardFiles,
   remoteDesktopCertDecision,
 } from "@/services/api";
 import type {
+  RemoteClipboardFile,
   RemoteDesktopStatePayload,
   RemoteDesktopCertPromptPayload,
 } from "@/types/remoteDesktop";
@@ -36,6 +39,8 @@ vi.mock("@/services/api", () => ({
   remoteDesktopSendInput: vi.fn(() => Promise.resolve()),
   remoteDesktopSendClipboard: vi.fn(() => Promise.resolve()),
   remoteDesktopGetClipboard: vi.fn(() => Promise.resolve(null)),
+  remoteDesktopRemoteClipboardFiles: vi.fn(() => Promise.resolve([])),
+  remoteDesktopBindClipboardFiles: vi.fn(() => Promise.resolve(0)),
   remoteDesktopCertDecision: vi.fn(() => Promise.resolve()),
 }));
 
@@ -61,6 +66,8 @@ const mockedDisconnect = vi.mocked(remoteDesktopDisconnect);
 const mockedResize = vi.mocked(remoteDesktopResize);
 const mockedSendInput = vi.mocked(remoteDesktopSendInput);
 const mockedSendClipboard = vi.mocked(remoteDesktopSendClipboard);
+const mockedRemoteClipboardFiles = vi.mocked(remoteDesktopRemoteClipboardFiles);
+const mockedBindClipboardFiles = vi.mocked(remoteDesktopBindClipboardFiles);
 const mockedCertDecision = vi.mocked(remoteDesktopCertDecision);
 
 let container: HTMLDivElement;
@@ -201,6 +208,40 @@ describe("useRemoteDesktopSession", () => {
 
     act(() => hoisted.clipCbs.forEach((cb) => cb({ session_id: "rd-1", text: "from-remote" })));
     expect(h.get().remoteClipboard).toBe("from-remote");
+  });
+
+  it("lists surfaced remote clipboard files and binds them to the host on paste (#1804)", async () => {
+    const files: RemoteClipboardFile[] = [
+      { name: "a.txt", relativePath: null, size: 3, isDir: false, index: 0 },
+      { name: "docs", relativePath: null, size: null, isDir: true, index: 1 },
+    ];
+    mockedRemoteClipboardFiles.mockResolvedValue(files);
+    mockedBindClipboardFiles.mockResolvedValue(1);
+
+    const tabId = addTab();
+    const h = renderSession(tabId);
+    await flush();
+
+    await act(async () => {
+      expect(await h.get().remoteClipboardFiles()).toEqual(files);
+    });
+    expect(mockedRemoteClipboardFiles).toHaveBeenCalledWith("rd-1");
+
+    await act(async () => {
+      expect(await h.get().bindClipboardFiles()).toBe(1);
+    });
+    expect(mockedBindClipboardFiles).toHaveBeenCalledWith("rd-1");
+  });
+
+  it("swallows a remote-clipboard-file listing error and returns none (#1804)", async () => {
+    mockedRemoteClipboardFiles.mockRejectedValue(new Error("not connected"));
+    const tabId = addTab();
+    const h = renderSession(tabId);
+    await flush();
+
+    await act(async () => {
+      expect(await h.get().remoteClipboardFiles()).toEqual([]);
+    });
   });
 
   it("surfaces a cert prompt and routes the accept-for-host verdict (#1767)", async () => {

--- a/src/hooks/useRemoteDesktopSession.ts
+++ b/src/hooks/useRemoteDesktopSession.ts
@@ -7,6 +7,8 @@ import {
   remoteDesktopResize,
   remoteDesktopSendInput,
   remoteDesktopSendClipboard,
+  remoteDesktopRemoteClipboardFiles,
+  remoteDesktopBindClipboardFiles,
   remoteDesktopCertDecision,
 } from "@/services/api";
 import {
@@ -16,6 +18,7 @@ import {
 } from "@/services/events";
 import type {
   GraphicalSessionState,
+  RemoteClipboardFile,
   RemoteDesktopInput,
   RemoteDesktopCertPromptPayload,
   ScaleMode,
@@ -48,6 +51,17 @@ export interface RemoteDesktopSession {
   resize: (width: number, height: number) => void;
   /** Push local clipboard text to the remote. */
   sendClipboard: (text: string) => void;
+  /**
+   * List the files the remote copied to its clipboard, surfaced for a local
+   * paste (#1804). Empty where the host has no delayed-render binding.
+   */
+  remoteClipboardFiles: () => Promise<RemoteClipboardFile[]>;
+  /**
+   * Bind the remote-copied clipboard files onto the host OS clipboard so they
+   * can be pasted into any local app (#1804). Resolves to the number bound; the
+   * bytes are fetched only on the real paste gesture.
+   */
+  bindClipboardFiles: () => Promise<number>;
   /** Manually reconnect after a failure or the auto-retry cap. */
   reconnect: () => void;
 }
@@ -210,6 +224,23 @@ export function useRemoteDesktopSession(tabId: string): RemoteDesktopSession {
     );
   }, []);
 
+  const remoteClipboardFiles = useCallback(async (): Promise<RemoteClipboardFile[]> => {
+    const id = sessionIdRef.current;
+    if (!id) return [];
+    try {
+      return await remoteDesktopRemoteClipboardFiles(id);
+    } catch (err) {
+      frontendLog("remote_desktop", `remote_clipboard_files failed: ${err}`);
+      return [];
+    }
+  }, []);
+
+  const bindClipboardFiles = useCallback(async (): Promise<number> => {
+    const id = sessionIdRef.current;
+    if (!id) return 0;
+    return await remoteDesktopBindClipboardFiles(id);
+  }, []);
+
   const reconnect = useCallback(() => {
     // Tear down any existing session, then re-run the connect effect.
     const id = sessionIdRef.current;
@@ -234,6 +265,8 @@ export function useRemoteDesktopSession(tabId: string): RemoteDesktopSession {
     sendInput,
     resize,
     sendClipboard,
+    remoteClipboardFiles,
+    bindClipboardFiles,
     reconnect,
   };
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -12,7 +12,7 @@ import {
   LineEnding,
 } from "@/types/terminal";
 import { XServerConsentDecision, XServerStatusReport } from "@/types/xserver";
-import type { RemoteDesktopInput } from "@/types/remoteDesktop";
+import type { RemoteClipboardFile, RemoteDesktopInput } from "@/types/remoteDesktop";
 import { CredentialStoreStatusInfo, SwitchCredentialStoreResult } from "@/types/credential";
 import type { SpawnRequestPayload } from "@/services/events";
 import type { ContainerRuntime, SpawnTarget } from "@/types/spawn";
@@ -379,6 +379,36 @@ export async function remoteDesktopSendClipboard(
 /** Read the remote clipboard text, if any. */
 export async function remoteDesktopGetClipboard(sessionId: SessionId): Promise<string | null> {
   return await invoke<string | null>("remote_desktop_get_clipboard", { sessionId });
+}
+
+/**
+ * List the files the remote most recently copied to its clipboard, surfaced for a
+ * local paste with delayed rendering (#1804).
+ *
+ * Empty on any platform without an OS-clipboard delayed-render binding (the
+ * sidecar keeps eagerly downloading files into the shared folder there), or when
+ * the remote copied text / an image / nothing. The bytes are fetched only on the
+ * actual paste — see {@link remoteDesktopBindClipboardFiles}.
+ */
+export async function remoteDesktopRemoteClipboardFiles(
+  sessionId: SessionId
+): Promise<RemoteClipboardFile[]> {
+  return await invoke<RemoteClipboardFile[]>("remote_desktop_remote_clipboard_files", {
+    sessionId,
+  });
+}
+
+/**
+ * Bind the remote-copied clipboard files onto the host OS clipboard so they can be
+ * pasted into any local app (#1804). Returns the number of files bound.
+ *
+ * Installs a delayed-render promise: no bytes are fetched here — each file is
+ * streamed from the remote only when the user actually pastes. Returns `0` when
+ * the remote copied no pasteable files; rejects on a platform without a native
+ * binding.
+ */
+export async function remoteDesktopBindClipboardFiles(sessionId: SessionId): Promise<number> {
+  return await invoke<number>("remote_desktop_bind_clipboard_files", { sessionId });
 }
 
 /**

--- a/src/types/remoteDesktop.ts
+++ b/src/types/remoteDesktop.ts
@@ -90,6 +90,25 @@ export interface RemoteDesktopClipboardPayload {
   text: string;
 }
 
+/**
+ * One file the remote copied to its clipboard, surfaced to the host for a local
+ * paste with delayed rendering (#1793/#1804). Mirrors the Rust
+ * `RemoteClipboardFile` (camelCase). The bytes are not present — they are fetched
+ * from the remote only on the actual paste gesture, keyed by {@link index}.
+ */
+export interface RemoteClipboardFile {
+  /** Sanitized basename (no path separators). */
+  name: string;
+  /** Sanitized `/`-separated directory portion within the copied collection, or null for a top-level entry. */
+  relativePath: string | null;
+  /** File size when the remote advertised it; null means "resolve on fetch". */
+  size: number | null;
+  /** Whether this entry is a directory (no bytes to fetch). */
+  isDir: boolean;
+  /** Position in the remote's advertised file list — the opaque fetch token. */
+  index: number;
+}
+
 /** `remote-desktop-state` event payload. */
 export interface RemoteDesktopStatePayload {
   session_id: string;


### PR DESCRIPTION
Follow-up to #1793 (PR #1803). #1793 landed the sidecar + core **transport** for
remote→host clipboard files (delayed rendering): the `GraphicalBackend` seam
exposes `remote_clipboard_files()` and `fetch_remote_clipboard_file(index)`
(staging bytes into a sanitized, bounded temp file), gated behind
`RdpConfig::clipboard_delayed_render` (off by default). Nothing bound it to the
host OS clipboard yet. This PR wires the transport through to a real local paste,
and ships the **macOS** binding end to end.

## What landed

**Full host plumbing (all platforms benefit)**
- `GraphicalSessionManager::remote_clipboard_files` / `fetch_remote_clipboard_file`
  pass-throughs (mirror `get_clipboard`).
- Two `remote_desktop` Tauri commands: `remote_desktop_remote_clipboard_files`
  (list) and `remote_desktop_bind_clipboard_files` (install the delayed-render
  promise; returns the count), registered in the invoke handler.
- `src/services/api.ts` + `RemoteClipboardFile` TS type + session-hook accessors.
- RemoteDesktop clipboard panel gains a **Remote files** section listing the
  copied files and a **Copy to clipboard** button (toast feedback, async pending
  state). It is capability-driven: hidden wherever no files are surfaced.

**Capability gate (keeps behaviour from regressing)**
- `RdpConfig::clipboard_delayed_render` is stamped in `parse_config` from a
  target-gated `host_supports_clipboard_delayed_render()` (macOS today), never
  from the connection editor. Where no host binding exists the flag stays off and
  the eager shared-folder download (#1765) remains the behaviour, so no platform
  regresses.

**macOS delayed-render binding (`src-tauri/src/macos_clipboard.rs`)**
- Declares `NSFilenamesPboardType` on the general `NSPasteboard` with an **owner**
  object (AppKit's promised-data pattern, mirroring `macos_services.rs`). Bytes
  are fetched only in `pasteboard:provideDataForType:` — i.e. on the real paste
  gesture — via `fetch_remote_clipboard_file`, so no bytes move on copy and memory
  stays bounded to a single sidecar temp-file stage. The owner is kept alive as the
  current pasteboard owner in a main-thread `thread_local` (at most one retained).

## Deferred (per-platform follow-ups)

Windows (`CF_HDROP` / `WM_RENDERFORMAT`) and Linux (X11/Wayland `text/uri-list`)
delayed-render bindings need a box to verify on and are filed as:
- #1814 — Windows binding
- #1815 — Linux binding

On those platforms `clipboard_delayed_render` stays off and the eager download is
unchanged.

## Tests / verification

- Rust unit tests: capability gate (`config`), `parse_config` stamping, manager
  pass-throughs against the mock backend, and the macOS `pasteable_indices`
  selection helper. `./scripts/check.sh` green; no `Cargo.lock` churn.
- Frontend: `useRemoteDesktopSession` tests cover the two new accessors (list +
  bind, and the swallowed-error path). Full `pnpm test` + `pnpm build` green.
- The live `NSPasteboard` promise + real paste are covered by a **documented
  manual test** in `docs/testing.md` (the CLIPRDR wire lane is release-cadence, so
  per-PR CI proves nothing there; a real RDP-with-file-copy + paste was not run in
  the authoring environment). Includes a non-macOS regression check that the eager
  shared-folder download is unchanged.

Closes #1804