### PR TITLE
feat(rdp): rdpsnd compressed audio formats — ms-adpcm / ima-dvi adpcm (Closes #1812)

### DIFF
--- a/docs/changes/dev0/feature/1812-rdpsnd-compressed-audio.md
+++ b/docs/changes/dev0/feature/1812-rdpsnd-compressed-audio.md
@@ -1,0 +1,11 @@
+### Added
+
+- RDP audio redirection now plays **compressed** `rdpsnd` streams in addition to
+  PCM: an RDP server that offers **MS-ADPCM** (`WAVE_FORMAT_ADPCM`) or **IMA/DVI
+  ADPCM** (`WAVE_FORMAT_DVI_ADPCM`) has that format negotiated and decoded to
+  16-bit PCM before playback, at the format's own sample rate and channel count
+  (so the multi-rate "chipmunk audio" guard from #1773 still holds). Decoding uses
+  the pure-Rust Symphonia ADPCM codec, target-gated to macOS/Windows/Linux like
+  the rest of the sidecar audio path and adding no native build dependency. Opus
+  (`WAVE_FORMAT_OPUS`) remains unsupported for now — its decoders link the native
+  `libopus` C library — and is tracked as a follow-up (#1812).

--- a/rdp-sidecar/Cargo.lock
+++ b/rdp-sidecar/Cargo.lock
@@ -4168,6 +4168,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4328,6 +4351,8 @@ dependencies = [
  "percent-encoding",
  "rodio",
  "sha2 0.11.0",
+ "symphonia-codec-adpcm",
+ "symphonia-core",
  "tempfile",
  "termihub-core",
  "tokio",

--- a/rdp-sidecar/Cargo.toml
+++ b/rdp-sidecar/Cargo.toml
@@ -117,6 +117,24 @@ percent-encoding = "2"
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 rodio = { version = "0.20", default-features = false }
 
+# Compressed rdpsnd audio decoding (#1812): MS-ADPCM (`WAVE_FORMAT_ADPCM`, 0x0002)
+# and IMA/DVI ADPCM (0x0011) `wave` payloads are decoded to 16-bit PCM before the
+# existing jitter buffer + rodio sink. Symphonia is a mature, widely-used, pure-Rust
+# multimedia library; its `adpcm` codec decodes both formats a Windows `rdpsnd`
+# server offers besides PCM. `default-features = false` keeps only the codec + core
+# (no format demuxers we do not use), and both crates are pure Rust with no system
+# libraries, so they add no C build dependency and are cleanly cross-platform.
+#
+# Target-gated to the same macOS/Windows/Linux set as `rodio`: ADPCM is only ever
+# decoded where the audio sink is compiled and formats are advertised, so gating it
+# alongside `rodio` keeps the decoder out of the no-op-sink builds. This lives in the
+# workspace-EXCLUDED sidecar graph, so it adds zero dependency-conflict risk to the
+# main app (#1747). Opus (`WAVE_FORMAT_OPUS`, 0x704F) is deferred — its maintained
+# bindings link the native `libopus` C library, a cross-platform CI cost tracked as a
+# follow-up.
+symphonia-core = { version = "0.5", default-features = false }
+symphonia-codec-adpcm = { version = "0.5", default-features = false }
+
 # Read the host OS clipboard's native file list to bridge it to CLIPRDR (#1779):
 # the sidecar runs on the host, so it can read what the user copied in their file
 # manager and serve those real files to the remote (`host_clipboard.rs`).

--- a/rdp-sidecar/src/adpcm.rs
+++ b/rdp-sidecar/src/adpcm.rs
@@ -1,0 +1,347 @@
+//! Compressed `rdpsnd` audio decoding: **MS-ADPCM** (`WAVE_FORMAT_ADPCM`, 0x0002)
+//! and **IMA/DVI ADPCM** (`WAVE_FORMAT_DVI_ADPCM`, 0x0011) → 16-bit PCM (#1812,
+//! follow-up to #1773).
+//!
+//! A Windows `rdpsnd` server can offer these block-compressed formats besides
+//! plain PCM. Unlike PCM they cannot be advertised by structural equality — the
+//! server picks the block layout (`n_block_align`, `wSamplesPerBlock`, and, for
+//! MS-ADPCM, the coefficient table in the format's extra `data`) and the client
+//! cannot predict it. The vendored `ironrdp-rdpsnd` fork therefore lets the
+//! handler *accept a server format by codec* ([`can_decode`]) and echoes that
+//! exact [`AudioFormat`] back, so [`decode`] here receives the server's concrete
+//! block parameters.
+//!
+//! ## Decoder
+//!
+//! Decoding is delegated to [`symphonia_codec_adpcm`] — the pure-Rust ADPCM codec
+//! from the widely-used Symphonia project — rather than hand-rolled (repo policy:
+//! prefer maintained libraries). Symphonia decodes both MS-ADPCM and IMA-ADPCM to
+//! signed samples; we drive it one `wave` payload at a time and convert its output
+//! to the same interleaved 16-bit [`super::audio::PcmBuffer`] the PCM path
+//! produces, at the format's own sample rate — so the #1773 "chipmunk audio"
+//! invariant (play at the negotiated rate, never a fixed assumption) holds for
+//! compressed formats too.
+//!
+//! Opus (`WAVE_FORMAT_OPUS`, 0x704F) is intentionally **not** handled here — its
+//! maintained decoders link the native `libopus` C library, a cross-platform CI
+//! cost deferred to a follow-up.
+
+use ironrdp::rdpsnd::pdu::{AudioFormat, WaveFormat};
+use symphonia_codec_adpcm::AdpcmDecoder;
+use symphonia_core::audio::{Channels, SampleBuffer};
+use symphonia_core::codecs::{
+    CodecParameters, CodecType, Decoder, DecoderOptions, CODEC_TYPE_ADPCM_IMA_WAV,
+    CODEC_TYPE_ADPCM_MS,
+};
+use symphonia_core::formats::Packet;
+
+use crate::audio::PcmBuffer;
+
+/// Bytes of block preamble per channel for MS-ADPCM (`bPredictor` + `iDelta` +
+/// `iSamp1` + `iSamp2` = 1 + 2 + 2 + 2), which also carries the first two output
+/// samples of the block. Used by the [`frames_per_block`] fallback formula.
+const MS_PREAMBLE_BYTES_PER_CHANNEL: usize = 7;
+
+/// Bytes of block preamble per channel for IMA/DVI ADPCM (`predictor` +
+/// `step_index` + reserved = 2 + 1 + 1), which carries the first output sample of
+/// the block. Used by the [`frames_per_block`] fallback formula.
+const IMA_PREAMBLE_BYTES_PER_CHANNEL: usize = 4;
+
+/// Map a supported ADPCM [`WaveFormat`] tag to its Symphonia [`CodecType`].
+/// Returns `None` for any tag this module does not decode, so callers reject
+/// unsupported formats rather than mis-decoding them.
+fn codec_type(format: WaveFormat) -> Option<CodecType> {
+    match format {
+        WaveFormat::ADPCM => Some(CODEC_TYPE_ADPCM_MS),
+        WaveFormat::DVI_ADPCM => Some(CODEC_TYPE_ADPCM_IMA_WAV),
+        _ => None,
+    }
+}
+
+/// Map an advertised channel count to a Symphonia channel mask. Only mono and
+/// stereo are meaningful for `rdpsnd`; anything else is unsupported.
+fn channel_mask(n_channels: u16) -> Option<Channels> {
+    match n_channels {
+        1 => Some(Channels::FRONT_LEFT),
+        2 => Some(Channels::FRONT_LEFT | Channels::FRONT_RIGHT),
+        _ => None,
+    }
+}
+
+/// Frames (samples per channel) in one compressed block.
+///
+/// Prefers `wSamplesPerBlock` from the format's extra `data` — present in both
+/// `ADPCMWAVEFORMAT` and `IMAADPCMWAVEFORMAT` as the first two little-endian
+/// bytes — which is authoritative. Falls back to the standard formula derived
+/// from `n_block_align` when the server sends no (or truncated) extra data.
+///
+/// The value is critical: Symphonia frames blocks by `frames_per_block`, so a
+/// wrong value would desync every block, not just clip one.
+fn frames_per_block(format: &AudioFormat) -> Option<usize> {
+    if let Some(data) = &format.data {
+        if data.len() >= 2 {
+            let samples_per_block = u16::from_le_bytes([data[0], data[1]]) as usize;
+            if samples_per_block >= 2 {
+                return Some(samples_per_block);
+            }
+        }
+    }
+
+    let channels = usize::from(format.n_channels);
+    let block_align = usize::from(format.n_block_align);
+    if channels == 0 {
+        return None;
+    }
+    let bytes_per_channel = block_align / channels;
+    match format.format {
+        // MS-ADPCM: 2 preamble samples, then each post-preamble byte is 2 samples.
+        WaveFormat::ADPCM => {
+            let data_bytes = bytes_per_channel.checked_sub(MS_PREAMBLE_BYTES_PER_CHANNEL)?;
+            Some(data_bytes * 2 + 2)
+        }
+        // IMA/DVI ADPCM: 1 preamble sample, then each post-preamble byte is 2 samples.
+        WaveFormat::DVI_ADPCM => {
+            let data_bytes = bytes_per_channel.checked_sub(IMA_PREAMBLE_BYTES_PER_CHANNEL)?;
+            Some(data_bytes * 2 + 1)
+        }
+        _ => None,
+    }
+}
+
+/// Whether [`decode`] can turn this server-advertised compressed format into PCM.
+///
+/// The vendored `ironrdp-rdpsnd` fork calls this (via
+/// `RdpsndClientHandler::accepts_format`) to decide whether to advertise the
+/// server's ADPCM format back to it. Advertising is therefore gated on real
+/// decodability: a supported codec tag, mono/stereo, a non-zero sample rate, and a
+/// resolvable, sane block size — so we never advertise a format we would then drop.
+pub fn can_decode(format: &AudioFormat) -> bool {
+    codec_type(format.format).is_some()
+        && channel_mask(format.n_channels).is_some()
+        && format.n_samples_per_sec > 0
+        && format.n_block_align > 0
+        && frames_per_block(format).is_some_and(|frames| frames >= 2)
+}
+
+/// Decode a compressed `wave` payload into an interleaved 16-bit [`PcmBuffer`] at
+/// the format's own channel count and sample rate.
+///
+/// Returns `None` (drop the buffer, never mis-play it) when the format is not a
+/// supported ADPCM codec, the parameters are unusable, the payload holds no whole
+/// block, or the underlying decode fails.
+pub fn decode(format: &AudioFormat, data: &[u8]) -> Option<PcmBuffer> {
+    let codec = codec_type(format.format)?;
+    let channels = channel_mask(format.n_channels)?;
+    let sample_rate = format.n_samples_per_sec;
+    if sample_rate == 0 {
+        return None;
+    }
+    let block_align = usize::from(format.n_block_align);
+    if block_align == 0 {
+        return None;
+    }
+    let frames_per_block = frames_per_block(format)?;
+    if frames_per_block < 2 {
+        return None;
+    }
+
+    // Only decode whole blocks: a trailing partial block (a misbehaving server, or
+    // a truncated PDU) is discarded rather than decoded past its end.
+    let block_count = data.len() / block_align;
+    if block_count == 0 {
+        return None;
+    }
+    let total_frames = block_count.checked_mul(frames_per_block)?;
+    let usable = &data[..block_count * block_align];
+
+    let mut params = CodecParameters::new();
+    params
+        .for_codec(codec)
+        .with_sample_rate(sample_rate)
+        .with_channels(channels)
+        .with_frames_per_block(frames_per_block as u64)
+        .with_max_frames_per_packet(total_frames as u64);
+
+    let mut decoder = AdpcmDecoder::try_new(&params, &DecoderOptions::default()).ok()?;
+    // Symphonia frames the packet's blocks from `block_dur() / frames_per_block`,
+    // so the packet duration must be the whole-block frame count.
+    let packet = Packet::new_from_slice(0, 0, total_frames as u64, usable);
+    let decoded = decoder.decode(&packet).ok()?;
+
+    // Convert Symphonia's (signed 32-bit, planar) output to the interleaved 16-bit
+    // samples the sink consumes. The ADPCM codec stores each sample as `(i16) <<
+    // 16`, so the S32→S16 conversion (`>> 16`) recovers the exact 16-bit value.
+    let spec = *decoded.spec();
+    let mut sample_buf = SampleBuffer::<i16>::new(total_frames as u64, spec);
+    sample_buf.copy_interleaved_ref(decoded);
+    let samples = sample_buf.samples().to_vec();
+    if samples.is_empty() {
+        return None;
+    }
+
+    Some(PcmBuffer::new(samples, format.n_channels, sample_rate))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// MS-ADPCM mono block whose data nibbles are all zero. With block predictor
+    /// index 0 (`coeff1 = 256`, `coeff2 = 0`) a zero nibble reproduces the previous
+    /// sample exactly, so the decoded output is the two verbatim preamble samples
+    /// (`iSamp2`, then `iSamp1`) followed by `iSamp1` repeated — a closed-form
+    /// vector independent of the adaptation math.
+    fn ms_mono_block(delta: i16, sample1: i16, sample2: i16, data_bytes: usize) -> Vec<u8> {
+        let mut block = vec![0x00u8]; // bPredictor = 0
+        block.extend_from_slice(&delta.to_le_bytes());
+        block.extend_from_slice(&sample1.to_le_bytes());
+        block.extend_from_slice(&sample2.to_le_bytes());
+        block.extend(std::iter::repeat_n(0x00u8, data_bytes));
+        block
+    }
+
+    fn ms_mono_format(n_block_align: u16, data: Option<Vec<u8>>) -> AudioFormat {
+        AudioFormat {
+            format: WaveFormat::ADPCM,
+            n_channels: 1,
+            n_samples_per_sec: 22_050,
+            n_avg_bytes_per_sec: 11_155,
+            n_block_align,
+            bits_per_sample: 4,
+            data,
+        }
+    }
+
+    fn ima_mono_format(n_block_align: u16, data: Option<Vec<u8>>) -> AudioFormat {
+        AudioFormat {
+            format: WaveFormat::DVI_ADPCM,
+            n_channels: 1,
+            n_samples_per_sec: 11_025,
+            n_avg_bytes_per_sec: 5_610,
+            n_block_align,
+            bits_per_sample: 4,
+            data,
+        }
+    }
+
+    #[test]
+    fn ms_adpcm_mono_decodes_to_pcm_at_the_negotiated_rate() {
+        // 10-byte block = 7 preamble + 3 data bytes -> 8 samples per block.
+        let block = ms_mono_block(16, 100, 200, 3);
+        assert_eq!(block.len(), 10);
+        let format = ms_mono_format(10, None); // fall back to the block-align formula
+
+        let pcm = decode(&format, &block).expect("MS-ADPCM mono decodes");
+
+        // Rate/channels come from the format, never a fixed assumption (#1773 guard).
+        assert_eq!(pcm.sample_rate(), 22_050);
+        assert_eq!(pcm.channels(), 1);
+        // iSamp2, iSamp1, then iSamp1 held by the zero nibbles.
+        assert_eq!(pcm.samples(), &[200, 100, 100, 100, 100, 100, 100, 100]);
+    }
+
+    #[test]
+    fn ms_adpcm_reads_frames_per_block_from_extra_data() {
+        // Same block, but drive frames-per-block from wSamplesPerBlock in the extra
+        // data (authoritative) rather than the block-align fallback.
+        let block = ms_mono_block(16, 7, 9, 3);
+        let extra = 8u16.to_le_bytes().to_vec(); // wSamplesPerBlock = 8
+        let format = ms_mono_format(10, Some(extra));
+
+        let pcm = decode(&format, &block).expect("MS-ADPCM mono decodes via extra data");
+        assert_eq!(pcm.samples(), &[9, 7, 7, 7, 7, 7, 7, 7]);
+    }
+
+    #[test]
+    fn ms_adpcm_decodes_multiple_blocks() {
+        // Two concatenated blocks -> 16 samples, proving the block loop advances.
+        let mut data = ms_mono_block(16, 100, 200, 3);
+        data.extend(ms_mono_block(16, 5, 6, 3));
+        let format = ms_mono_format(10, None);
+
+        let pcm = decode(&format, &data).expect("two MS-ADPCM blocks decode");
+        assert_eq!(pcm.samples().len(), 16);
+        assert_eq!(
+            &pcm.samples()[..8],
+            &[200, 100, 100, 100, 100, 100, 100, 100]
+        );
+        assert_eq!(&pcm.samples()[8..], &[6, 5, 5, 5, 5, 5, 5, 5]);
+    }
+
+    #[test]
+    fn ima_adpcm_mono_decodes_to_pcm_at_the_negotiated_rate() {
+        // 8-byte block = 4 preamble + 4 data bytes -> 9 samples per block. IMA step
+        // index 0 has step 7, so a zero nibble adds `(1*7)>>3 == 0`: the predictor
+        // is held, giving the verbatim preamble sample repeated.
+        let mut block = 500i16.to_le_bytes().to_vec(); // predictor = 500
+        block.push(0x00); // step_index = 0
+        block.push(0x00); // reserved
+        block.extend(std::iter::repeat_n(0x00u8, 4));
+        assert_eq!(block.len(), 8);
+        let format = ima_mono_format(8, None);
+
+        let pcm = decode(&format, &block).expect("IMA/DVI-ADPCM mono decodes");
+        assert_eq!(pcm.sample_rate(), 11_025);
+        assert_eq!(pcm.channels(), 1);
+        assert_eq!(pcm.samples(), &[500; 9]);
+    }
+
+    #[test]
+    fn frames_per_block_matches_the_standard_formulas() {
+        // MS mono: (block_align - 7) * 2 + 2.
+        assert_eq!(frames_per_block(&ms_mono_format(10, None)), Some(8));
+        // MS stereo: (block_align/2 - 7) * 2 + 2.
+        let mut ms_stereo = ms_mono_format(24, None);
+        ms_stereo.n_channels = 2;
+        assert_eq!(frames_per_block(&ms_stereo), Some(12));
+        // IMA mono: (block_align - 4) * 2 + 1.
+        assert_eq!(frames_per_block(&ima_mono_format(8, None)), Some(9));
+        // IMA stereo: (block_align/2 - 4) * 2 + 1.
+        let mut ima_stereo = ima_mono_format(20, None);
+        ima_stereo.n_channels = 2;
+        assert_eq!(frames_per_block(&ima_stereo), Some(13));
+        // Extra data wins over the formula when present and sane.
+        assert_eq!(
+            frames_per_block(&ms_mono_format(10, Some(505u16.to_le_bytes().to_vec()))),
+            Some(505)
+        );
+    }
+
+    #[test]
+    fn can_decode_accepts_supported_adpcm_and_rejects_the_rest() {
+        assert!(can_decode(&ms_mono_format(10, None)));
+        assert!(can_decode(&ima_mono_format(8, None)));
+
+        // Unsupported codec tag.
+        let mut opus = ms_mono_format(10, None);
+        opus.format = WaveFormat::OPUS;
+        assert!(!can_decode(&opus));
+        // PCM is handled by the PCM path, not here.
+        let mut pcm = ms_mono_format(10, None);
+        pcm.format = WaveFormat::PCM;
+        assert!(!can_decode(&pcm));
+        // Unsupported channel count.
+        let mut three = ms_mono_format(10, None);
+        three.n_channels = 3;
+        assert!(!can_decode(&three));
+        // Zero sample rate / zero block align.
+        let mut no_rate = ms_mono_format(10, None);
+        no_rate.n_samples_per_sec = 0;
+        assert!(!can_decode(&no_rate));
+        let mut no_align = ms_mono_format(0, None);
+        no_align.n_block_align = 0;
+        assert!(!can_decode(&no_align));
+    }
+
+    #[test]
+    fn decode_rejects_unusable_input() {
+        // Unsupported tag -> None (dropped, not mis-decoded).
+        let mut opus = ms_mono_format(10, None);
+        opus.format = WaveFormat::OPUS;
+        assert!(decode(&opus, &[0u8; 10]).is_none());
+        // Fewer bytes than one whole block -> None.
+        assert!(decode(&ms_mono_format(10, None), &[0u8; 9]).is_none());
+        // Empty payload -> None.
+        assert!(decode(&ms_mono_format(10, None), &[]).is_none());
+    }
+}

--- a/rdp-sidecar/src/audio.rs
+++ b/rdp-sidecar/src/audio.rs
@@ -30,8 +30,19 @@
 //! (risking "chipmunk" audio — e.g. playing 22.05 kHz data at 44.1 kHz). The fork
 //! passes the concrete [`AudioFormat`] to [`wave`](RdpsndClientHandler::wave), so
 //! each buffer is decoded and played at its **own** channel count and sample rate;
-//! [`rodio`] resamples to the device rate. Compressed formats (ADPCM/Opus) remain
-//! a follow-up — see #1773.
+//! [`rodio`] resamples to the device rate.
+//!
+//! ## Scope: compressed formats (#1812)
+//!
+//! Besides the advertised PCM table the handler also accepts a server's
+//! **MS-ADPCM** (`WAVE_FORMAT_ADPCM`) and **IMA/DVI ADPCM** (`WAVE_FORMAT_DVI_ADPCM`)
+//! formats and decodes them to PCM (via [`crate::adpcm`]) before the jitter buffer
+//! and sink. Because a server chooses a compressed format's block layout, these
+//! cannot be advertised by structural equality like PCM; the vendored fork's
+//! [`accepts_format`](RdpsndClientHandler::accepts_format) hook lets the handler
+//! accept them by codec and echoes the server's exact format back, so `wave` still
+//! receives concrete, decodable parameters. Opus (`WAVE_FORMAT_OPUS`) remains a
+//! follow-up — its decoders link the native `libopus` C library.
 //!
 //! ## Platforms
 //!
@@ -85,10 +96,42 @@ const MAX_LATENCY: Duration = Duration::from_millis(250);
 /// negotiation sound: the value the server negotiated travels with the samples,
 /// so nothing downstream can guess (and mis-guess) the rate.
 #[derive(Debug, Clone, PartialEq)]
-struct PcmBuffer {
+pub(crate) struct PcmBuffer {
     samples: Vec<i16>,
     channels: u16,
     sample_rate: u32,
+}
+
+impl PcmBuffer {
+    /// Build a decoded buffer from interleaved 16-bit samples and the playback
+    /// parameters they must be played at. Used by the compressed-format decoders
+    /// in [`crate::adpcm`], which produce PCM from a different module.
+    #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+    pub(crate) fn new(samples: Vec<i16>, channels: u16, sample_rate: u32) -> Self {
+        Self {
+            samples,
+            channels,
+            sample_rate,
+        }
+    }
+
+    /// The interleaved 16-bit samples. Used by the compressed-format decode tests.
+    #[cfg(test)]
+    pub(crate) fn samples(&self) -> &[i16] {
+        &self.samples
+    }
+
+    /// The channel count the samples must be played at.
+    #[cfg(test)]
+    pub(crate) fn channels(&self) -> u16 {
+        self.channels
+    }
+
+    /// The sample rate (Hz) the samples must be played at.
+    #[cfg(test)]
+    pub(crate) fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
 }
 
 /// Build one PCM [`AudioFormat`]. Every field must match a format the server
@@ -125,19 +168,40 @@ fn advertised_formats() -> Vec<AudioFormat> {
 }
 
 /// Decode a `wave` payload into a [`PcmBuffer`] using the **negotiated**
-/// [`AudioFormat`] the server selected. Only 16-bit LE PCM is supported (every
-/// advertised format is such); any other format is rejected with `None` so an
-/// unexpected buffer is dropped rather than played at the wrong rate or width.
+/// [`AudioFormat`] the server selected, dispatching on the format tag: 16-bit LE
+/// PCM here, and the compressed codecs (MS-ADPCM / IMA-DVI ADPCM) via
+/// [`crate::adpcm`]. Any other format is rejected with `None` so an unexpected
+/// buffer is dropped rather than played at the wrong rate or width.
 ///
-/// The channel count and sample rate come straight from `format`, so the buffer
-/// is always played at exactly the rate it was negotiated at — this is the guard
-/// against "chipmunk" audio.
+/// Whatever the codec, the channel count and sample rate come straight from
+/// `format`, so the buffer is always played at exactly the rate it was negotiated
+/// at — this is the guard against "chipmunk" audio.
 fn decode_wave(format: &AudioFormat, data: &[u8]) -> Option<PcmBuffer> {
-    if format.format != WaveFormat::PCM || format.bits_per_sample != AUDIO_BITS_PER_SAMPLE {
+    match format.format {
+        WaveFormat::PCM => decode_pcm(format, data),
+        // Compressed formats are only advertised — and so only ever received —
+        // where the decoder (and audio sink) are compiled; on other targets they
+        // fall through to the rejection below.
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+        WaveFormat::ADPCM | WaveFormat::DVI_ADPCM => crate::adpcm::decode(format, data),
+        _ => {
+            tracing::warn!(
+                ?format.format,
+                bits = format.bits_per_sample,
+                "rdpsnd: unsupported wave format, dropping buffer"
+            );
+            None
+        }
+    }
+}
+
+/// Decode a 16-bit LE PCM `wave` payload. Every advertised PCM format is 16-bit;
+/// a non-16-bit or zero-parameter format is rejected with `None`.
+fn decode_pcm(format: &AudioFormat, data: &[u8]) -> Option<PcmBuffer> {
+    if format.bits_per_sample != AUDIO_BITS_PER_SAMPLE {
         tracing::warn!(
-            ?format.format,
             bits = format.bits_per_sample,
-            "rdpsnd: unsupported wave format, dropping buffer"
+            "rdpsnd: unsupported PCM bit depth, dropping buffer"
         );
         return None;
     }
@@ -335,6 +399,25 @@ impl Default for RdpAudioBackend {
 impl RdpsndClientHandler for RdpAudioBackend {
     fn get_formats(&self) -> &[AudioFormat] {
         &self.formats
+    }
+
+    /// Accept a server-advertised format we can play: the exact PCM table entries
+    /// (matched by the vendored fork's default `contains` check) plus any
+    /// compressed format whose codec [`crate::adpcm`] can decode, at whatever block
+    /// layout the server chose. The fork echoes accepted formats back verbatim, so
+    /// [`wave`](Self::wave) always receives concrete, decodable parameters — we
+    /// never advertise a compressed format we would then have to drop.
+    fn accepts_format(&self, format: &AudioFormat) -> bool {
+        if self.formats.contains(format) {
+            return true;
+        }
+        // A compressed format is accepted only where the decoder is compiled; on
+        // other targets no formats are advertised at all, so this is unreachable.
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+        let compressed = crate::adpcm::can_decode(format);
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+        let compressed = false;
+        compressed
     }
 
     fn wave(&mut self, format: &AudioFormat, _ts: u32, data: Cow<'_, [u8]>) {
@@ -591,10 +674,11 @@ mod tests {
     #[test]
     fn decode_wave_rejects_unsupported_formats() {
         let bytes = [0x00, 0x01, 0x00, 0x02];
-        // Non-PCM (e.g. ADPCM tag) is dropped, not misplayed.
-        let mut adpcm = pcm_format(2, 44_100);
-        adpcm.format = WaveFormat::ADPCM;
-        assert!(decode_wave(&adpcm, &bytes).is_none());
+        // A codec we do not decode (e.g. µ-law) is dropped, not misplayed. (PCM and
+        // ADPCM are handled; the ADPCM decode path has its own tests in `adpcm`.)
+        let mut mulaw = pcm_format(2, 44_100);
+        mulaw.format = WaveFormat::MULAW;
+        assert!(decode_wave(&mulaw, &bytes).is_none());
         // 8-bit PCM is not advertised, so it is rejected rather than mis-decoded.
         let mut eight_bit = pcm_format(2, 44_100);
         eight_bit.bits_per_sample = 8;

--- a/rdp-sidecar/src/main.rs
+++ b/rdp-sidecar/src/main.rs
@@ -13,6 +13,10 @@
 //! out on stdout while applying host input read from stdin. All logging goes to
 //! stderr so it never corrupts the binary IPC stream on stdout.
 
+// Compressed rdpsnd audio decoding (#1812): gated to the same platforms as the
+// audio sink and its `symphonia` decoder dependency (macOS/Windows/Linux).
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+mod adpcm;
 mod audio;
 mod cert;
 mod clipboard;

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/README.md
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/README.md
@@ -11,9 +11,9 @@ This is a vendored fork of `ironrdp-rdpsnd` **0.9.0** for termiHub's RDP sidecar
 patched into the workspace-excluded `rdp-sidecar` crate via `[patch.crates-io]`,
 mirroring how `vendor/vnc-rs` is patched into the main app.
 
-**The only functional change** (in `src/client.rs`) makes the client `wave`
-callback receive the concrete negotiated `AudioFormat` instead of a bare
-`format_no` index:
+There are **two functional changes**, both in `src/client.rs`.
+
+### 1. `wave` receives the concrete `AudioFormat` ([#1773])
 
 - Upstream `Rdpsnd::client_formats()` built the Client Audio Formats list from a
   `HashSet` intersection — non-deterministically ordered — and then discarded it,
@@ -26,9 +26,31 @@ callback receive the concrete negotiated `AudioFormat` instead of a bare
   remembers the exact list sent, and changes the trait method to
   `RdpsndClientHandler::wave(&mut self, format: &AudioFormat, ts, data)`.
 
+### 2. `accepts_format` for server-chosen compressed formats ([#1812])
+
+Multi-rate PCM negotiates fine by structural equality because PCM formats are
+canonical (the client can reproduce the server's exact `AudioFormat`). Compressed
+formats cannot: the server picks the block layout (`n_block_align`,
+`wSamplesPerBlock`, and — for MS-ADPCM — the coefficient `data`), which the client
+cannot predict, so the exact-equality intersection can *never* select an ADPCM
+format however many the handler advertises.
+
+- This fork adds `RdpsndClientHandler::accepts_format(&self, &AudioFormat) -> bool`
+  (default: `get_formats().contains(format)`, i.e. the prior exact-match behaviour)
+  and rewrites `client_formats()` to iterate the **server's** advertised formats in
+  order and keep the ones the handler accepts, echoing each accepted server format
+  back **verbatim**. A handler that decodes a codec regardless of block layout
+  overrides `accepts_format` to accept it; because the echoed format is the
+  server's own, `wave` then receives concrete, decodable block parameters. The
+  returned list is also now deterministic (server order) where the `HashSet`
+  intersection was not.
+
 `pdu.rs`, `server.rs` and `lib.rs` are byte-for-byte upstream 0.9.0. The intended
-upstream contribution is exactly this signature change. Sibling `ironrdp-*` deps
+upstream contribution is exactly these two changes. Sibling `ironrdp-*` deps
 remain registry versions so nothing else forks.
+
+[#1773]: https://github.com/armaxri/termiHub/issues/1773
+[#1812]: https://github.com/armaxri/termiHub/issues/1812
 
 [IronRDP]: https://github.com/Devolutions/IronRDP
 [MS-RDPEA]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpea/bea2d5cf-e3b9-4419-92e5-0e074ff9bc5b

--- a/rdp-sidecar/vendor/ironrdp-rdpsnd/src/client.rs
+++ b/rdp-sidecar/vendor/ironrdp-rdpsnd/src/client.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::HashSet;
 
 use ironrdp_core::{Decode as _, EncodeResult, ReadCursor, cast_length, impl_as_any};
 use ironrdp_pdu::gcc::ChannelName;
@@ -16,6 +15,20 @@ pub trait RdpsndClientHandler: Send + core::fmt::Debug {
     }
 
     fn get_formats(&self) -> &[AudioFormat];
+
+    // termiHub vendored-fork change (#1812): whether the handler can play a
+    // server-advertised `format`. Compressed formats (ADPCM/Opus) are advertised
+    // by the server with a server-chosen block layout (`n_block_align`,
+    // `wSamplesPerBlock`, coefficient `data`) the client cannot predict, so the
+    // exact-equality intersection used for PCM in `client_formats()` can never
+    // select one. Overriding this lets a handler accept a server format by codec
+    // regardless of its block layout; `client_formats()` then echoes that exact
+    // `AudioFormat` back, so `wave` still receives concrete, decodable parameters.
+    // The default preserves the pre-#1812 exact-match behaviour (accept only what
+    // `get_formats()` advertises verbatim).
+    fn accepts_format(&self, format: &AudioFormat) -> bool {
+        self.get_formats().contains(format)
+    }
 
     // termiHub vendored-fork change (#1773): the handler receives the concrete
     // negotiated `AudioFormat` instead of a bare `format_no` index. See the note
@@ -108,15 +121,27 @@ impl Rdpsnd {
     pub fn client_formats(&mut self) -> PduResult<RdpsndSvcMessages> {
         // Windows seems to be confused if the client replies with more formats, or unknown formats (e.g.: opus).
         // We ensure to only send supported formats in common with the server.
-        let server_format: HashSet<_> = self
+        //
+        // termiHub vendored-fork change (#1773, extended #1812): iterate the
+        // server's advertised formats in order and keep the ones the handler
+        // accepts. PCM formats match by structural equality (the handler
+        // advertises a fixed table, so `accepts_format` defaults to a `contains`
+        // check); compressed formats (ADPCM) cannot be predicted — the server
+        // chooses the block layout — so a handler overriding `accepts_format`
+        // accepts them by codec and we echo the server's exact `AudioFormat` back,
+        // which is what gives `wave` concrete, decodable block parameters. This
+        // also makes the sent list deterministic (server order) where upstream's
+        // `HashSet` intersection was not.
+        let server_formats = self
             .server_format
             .as_ref()
             .ok_or_else(|| pdu_other_err!("invalid state - no server format"))?
             .formats
-            .iter()
+            .clone();
+        let formats: Vec<AudioFormat> = server_formats
+            .into_iter()
+            .filter(|format| self.handler.accepts_format(format))
             .collect();
-        let formats: HashSet<_> = self.handler.get_formats().iter().collect();
-        let formats: Vec<AudioFormat> = formats.intersection(&server_format).map(|&x| x.clone()).collect();
 
         // termiHub vendored-fork change (#1773): remember the exact list we send,
         // in the exact order it is encoded, so a later `Wave2 { format_no }` can be


### PR DESCRIPTION
Follow-up to #1773 (PR #1811). Adds **compressed** `rdpsnd` audio playback on top of the multi-rate PCM path.

Closes #1812.

## What ships

- **MS-ADPCM** (`WAVE_FORMAT_ADPCM`, 0x0002) and **IMA/DVI ADPCM** (`WAVE_FORMAT_DVI_ADPCM`, 0x0011) are now advertised, negotiated, and decoded to 16-bit PCM before the existing jitter buffer + rodio sink.
- Each `wave` payload is decoded at the format's **own** sample rate and channel count, so the #1773 "chipmunk audio" guard (play at the negotiated rate, never a fixed assumption) holds for compressed formats too.

**Opus is deferred**, not shipped — its maintained decoders link the native `libopus` C library, a cross-platform CI cost. Filed as a dedicated follow-up (linked below). Opus was optional in the issue ("and/or"), and the "Done when" criterion (a server offering ADPCM has it negotiated and played correctly, verified by a test) is met by this PR.

## Decoder choice

Decoding is delegated to **Symphonia** (`symphonia-codec-adpcm` + `symphonia-core`) rather than hand-rolled, per the repo's "prefer maintained libraries" policy. Symphonia is the pure-Rust, widely-used multimedia library; its ADPCM codec covers both formats the issue names.

- Added only to the **workspace-excluded** sidecar graph (its own `Cargo.lock`), target-gated to macOS/Windows/Linux alongside `rodio`, `default-features = false`.
- **No native/C build dependency** and `cargo tree` clean: the two crates pull only pure-Rust deps already present in the graph; the lock gains exactly `symphonia-core` and `symphonia-codec-adpcm`. Zero impact on the desktop app's dependency graph.

## Why the vendored `ironrdp-rdpsnd` fork needed a change

The issue anticipated no further fork change, but the negotiation is an exact-equality `HashSet` intersection over the whole `AudioFormat`. A compressed format's block layout (`nBlockAlign`, `wSamplesPerBlock`, and MS-ADPCM coefficient `data`) is **server-chosen and unpredictable**, so a fixed client advertisement can never match it. The minimal fix:

- Adds `RdpsndClientHandler::accepts_format` (default = the prior exact-match behaviour).
- Rewrites `client_formats()` to iterate the **server's** formats in order and echo back the accepted ones **verbatim** — so `wave` still receives concrete, decodable parameters. Also makes the sent list deterministic where the `HashSet` was not.

`RdpAudioBackend::accepts_format` only accepts an ADPCM format the decoder can actually handle (supported codec, mono/stereo, non-zero rate, resolvable block size), so we never advertise a format we would then drop.

## Correctness guard (per format)

Decode-correctness tests assert exact PCM output against closed-form ADPCM vectors — blocks whose zero-value nibbles hold the verbatim preamble sample(s), independent of the adaptation math — at the negotiated rate, for both codecs. Plus multi-block decode, the frames-per-block formulas (mono + stereo, both codecs), and rejection of unsupported/unusable formats (dropped, never mis-decoded).

## Verification

The sidecar is workspace-excluded, so per-PR CI (`cargo clippy --workspace`) does not cover it. Validated **locally in `rdp-sidecar/`**:

- `cargo test` — 169 pass (7 new ADPCM tests)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Test plan

- [x] Unit: MS-ADPCM mono decodes to expected PCM at 22.05 kHz / 1 ch
- [x] Unit: IMA/DVI ADPCM mono decodes to expected PCM at 11.025 kHz / 1 ch
- [x] Unit: multi-block decode; frames-per-block formulas; extra-data `wSamplesPerBlock` path
- [x] Unit: unsupported/unusable formats rejected, not mis-decoded
- [ ] Manual: connect to a Windows RDP server offering ADPCM and confirm audible, correctly-pitched playback (requires a live server; no ADPCM-offering server available in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)