### PR TITLE
feat(rdp): bind remote-clipboard files to the Windows clipboard (CF_HDROP delayed render)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7574,6 +7574,7 @@ dependencies = [
  "uuid",
  "which",
  "windows 0.58.0",
+ "windows-sys 0.59.0",
  "winreg 0.55.0",
  "zeroize",
  "zip",

--- a/core/src/backends/rdp_sidecar/config.rs
+++ b/core/src/backends/rdp_sidecar/config.rs
@@ -159,17 +159,18 @@ impl Default for RdpConfig {
 /// Whether this host build can bind remote-copied clipboard files onto the OS
 /// clipboard for a delayed-render local paste (#1804).
 ///
-/// Only **macOS** currently has the native `NSPasteboard` promised-data binding
-/// (`src-tauri/src/macos_clipboard.rs`), so it is the only platform where the
-/// sidecar should surface the file list for delayed rendering; every other
-/// platform keeps the eager shared-folder download (#1765) as the fallback. The
-/// host process stamps [`RdpConfig::clipboard_delayed_render`] from this at
-/// connect time — it reflects a platform capability, not a user preference, so
-/// it is deliberately absent from [`rdp_settings_schema`]. Windows
-/// (`CF_HDROP`/`WM_RENDERFORMAT`) and Linux (X11/Wayland `text/uri-list`)
-/// bindings are tracked as follow-ups; wiring one here is a single-line change.
+/// **macOS** has the native `NSPasteboard` promised-data binding
+/// (`src-tauri/src/macos_clipboard.rs`, #1804) and **Windows** has the `CF_HDROP`
+/// delayed-render binding (`src-tauri/src/windows_clipboard.rs`, #1814), so those
+/// are the platforms where the sidecar surfaces the file list for delayed
+/// rendering; every other platform keeps the eager shared-folder download (#1765)
+/// as the fallback. The host process stamps
+/// [`RdpConfig::clipboard_delayed_render`] from this at connect time — it reflects
+/// a platform capability, not a user preference, so it is deliberately absent from
+/// [`rdp_settings_schema`]. The Linux (X11/Wayland `text/uri-list`) binding is
+/// tracked as a follow-up (#1815); wiring one here is a single-line change.
 pub const fn host_supports_clipboard_delayed_render() -> bool {
-    cfg!(target_os = "macos")
+    cfg!(any(target_os = "macos", windows))
 }
 
 impl RdpConfig {
@@ -671,11 +672,12 @@ mod tests {
 
     #[test]
     fn host_capability_flag_matches_the_build_platform() {
-        // Delayed rendering is bound to the OS clipboard only on macOS today
-        // (#1804); every other platform keeps the eager shared-folder download.
+        // Delayed rendering is bound to the OS clipboard on macOS (#1804) and
+        // Windows (#1814); every other platform keeps the eager shared-folder
+        // download (#1765).
         assert_eq!(
             host_supports_clipboard_delayed_render(),
-            cfg!(target_os = "macos")
+            cfg!(any(target_os = "macos", windows))
         );
     }
 

--- a/docs/changes/dev0/feature/1814-windows-clipboard-bind.md
+++ b/docs/changes/dev0/feature/1814-windows-clipboard-bind.md
@@ -1,0 +1,10 @@
+### Added
+
+- RDP: on **Windows**, files copied in a remote RDP session can now be pasted
+  into any local app (Explorer, etc.) via the OS clipboard, with each file's
+  bytes fetched from the remote only on the actual paste gesture rather than
+  eagerly downloaded. The host advertises the delayed-render capability on
+  Windows and binds the surfaced remote files to the clipboard as a delayed-render
+  `CF_HDROP`, served on `WM_RENDERFORMAT` from a dedicated message-only owner
+  window. This mirrors the macOS binding (#1804); other platforms keep the eager
+  shared-folder download (#1765) as the fallback (#1814).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1079,10 +1079,41 @@ manual run (per-PR CI does not run the CLIPRDR wire lane, #1569):
 5. Paste into a local app — Finder (Cmd+V into a folder), a mail draft, etc.
    **Expected:** the real files appear, their contents intact; the fetch happens
    at this moment (delayed), streamed into a bounded staging file.
-6. **Non-macOS regression check:** on Windows/Linux, repeat step 2 with the same
-   options. **Expected:** unchanged #1765 behaviour — files download into the
-   shared folder, and the **Remote files** section does not appear (no host
-   binding, so nothing is surfaced).
+6. **Non-macOS regression check:** on Linux, repeat step 2 with the same options.
+   **Expected:** unchanged #1765 behaviour — files download into the shared folder,
+   and the **Remote files** section does not appear (no host binding, so nothing is
+   surfaced).
+
+#### Delayed-render paste to the host OS clipboard (Windows, #1814)
+
+The Windows sibling of the macOS binding above: remote-copied files are offered to
+the **Windows clipboard** as a delayed-render `CF_HDROP` and served on the real
+paste gesture (`WM_RENDERFORMAT`) from a dedicated message-only owner window. The
+pure parts are unit-tested (`windows_clipboard`: the `CF_HDROP` builder round-trip
+and the pasteable-index selection; `graphical_manager`), but the live
+`WM_RENDERFORMAT` render + real paste need a message loop and a live session, so
+they need a **manual run on Windows** (per-PR CI does not run the CLIPRDR wire
+lane, #1569):
+
+1. On **Windows**, build the sidecar and point `TERMIHUB_RDP_HELPER` at it (as
+   above); in the RDP connection editor enable **Redirect a Local Drive** (with a
+   **Shared Folder**) and **Receive Clipboard Files**, then connect to a Windows
+   RDP host.
+2. Copy one or more files in the remote session (Explorer → Ctrl+C). **Expected:**
+   the files do **not** appear in the shared folder (delayed rendering replaces the
+   eager download on Windows).
+3. Open the RemoteDesktop hover toolbar's **Clipboard** panel. **Expected:** a
+   **Remote files** section lists the copied files, with a **Copy to clipboard**
+   button.
+4. Click **Copy to clipboard**. **Expected:** a toast confirms `N file(s) ready`.
+   No bytes have been fetched yet (the clipboard holds only the delayed-render
+   `CF_HDROP` offer with a NULL handle).
+5. Paste into a local app — Explorer (Ctrl+V into a folder), an Outlook draft, etc.
+   **Expected:** the real files appear, their contents intact; the fetch happens at
+   this moment (delayed), streamed into a bounded staging file, and the `CF_HDROP`
+   is built from the staged local paths.
+6. **Regression check:** the eager shared-folder path (#1765) still applies when
+   **Receive Clipboard Files** is off, and Linux is unchanged (no host binding).
 
 ### Deferred agent update (apply on last disconnect) (#1352)
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -133,6 +133,19 @@ windows = { version = "0.58", features = [
     "Win32_System_Console",
     "Win32_Foundation",
 ] }
+# Low-level Win32 for the remote-clipboard delayed-render binding (#1814): a
+# message-only owner window that offers CF_HDROP with a NULL handle and renders
+# the file list on WM_RENDERFORMAT. windows-sys (already used by `termihub-core`)
+# gives the raw clipboard / window / message-loop APIs with predictable C-style
+# signatures. Windows-only — the module is `#[cfg(windows)]` and `cargo tree -i`
+# clean off Windows.
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_DataExchange",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
+    "Win32_UI_WindowsAndMessaging",
+] }
 # Windows Credential Manager backend for the `keyring` crate.
 keyring = { version = "3", default-features = false, features = ["windows-native"] }
 # VcXsrv acquisition (X server provisioning): download + extract. Windows-only —

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -141,6 +141,7 @@ windows = { version = "0.58", features = [
 # clean off Windows.
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_System_DataExchange",
     "Win32_System_LibraryLoader",
     "Win32_System_Memory",

--- a/src-tauri/src/commands/remote_desktop.rs
+++ b/src-tauri/src/commands/remote_desktop.rs
@@ -109,10 +109,19 @@ pub async fn remote_desktop_bind_clipboard_files(
         return Ok(0);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", windows))]
     {
         let count = files.len();
+        #[cfg(target_os = "macos")]
         crate::macos_clipboard::bind_remote_clipboard_files(
+            &app_handle,
+            (*manager).clone(),
+            session_id,
+            files,
+        )
+        .map_err(|e| TerminalError::InternalError(e.to_string()))?;
+        #[cfg(windows)]
+        crate::windows_clipboard::bind_remote_clipboard_files(
             &app_handle,
             (*manager).clone(),
             session_id,
@@ -121,12 +130,12 @@ pub async fn remote_desktop_bind_clipboard_files(
         .map_err(|e| TerminalError::InternalError(e.to_string()))?;
         Ok(count)
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", windows)))]
     {
         // No native OS-clipboard binding on this platform: with delayed rendering
         // off, `remote_clipboard_files` is already empty and we returned above, so
         // reaching here means a caller invoked the command anyway. Report rather
-        // than silently succeed. (`app_handle`/`session_id` are macOS-only inputs.)
+        // than silently succeed. (`app_handle`/`session_id` are binding-only inputs.)
         let _ = (&app_handle, &session_id);
         Err(TerminalError::InternalError(
             "pasting remote clipboard files to the host OS clipboard is not supported on this \

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,10 @@ mod macos_clipboard;
 mod macos_services;
 mod macros;
 mod network;
+/// Native Windows clipboard binding for pasting remote-copied RDP clipboard files
+/// into local apps with delayed rendering (`CF_HDROP`, #1814). Windows-only.
+#[cfg(windows)]
+mod windows_clipboard;
 mod session;
 mod spawn;
 mod terminal;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,15 +16,15 @@ mod macos_clipboard;
 mod macos_services;
 mod macros;
 mod network;
-/// Native Windows clipboard binding for pasting remote-copied RDP clipboard files
-/// into local apps with delayed rendering (`CF_HDROP`, #1814). Windows-only.
-#[cfg(windows)]
-mod windows_clipboard;
 mod session;
 mod spawn;
 mod terminal;
 mod tunnel;
 mod utils;
+/// Native Windows clipboard binding for pasting remote-copied RDP clipboard files
+/// into local apps with delayed rendering (`CF_HDROP`, #1814). Windows-only.
+#[cfg(windows)]
+mod windows_clipboard;
 mod workspace;
 
 use std::sync::{Arc, Mutex};

--- a/src-tauri/src/session/graphical_manager.rs
+++ b/src-tauri/src/session/graphical_manager.rs
@@ -475,11 +475,11 @@ impl GraphicalSessionManager {
     /// [`Self::remote_clipboard_files`] surfaced.
     ///
     /// Only the platform-native OS-clipboard binding calls this (on the real paste
-    /// gesture); macOS is wired today (`macos_clipboard`), Windows/Linux are
-    /// follow-ups (#1814/#1815). Off those platforms it has no in-crate caller
-    /// yet, so the dead-code lint is suppressed there rather than deleting a method
-    /// the pending bindings need.
-    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    /// gesture); macOS (`macos_clipboard`) and Windows (`windows_clipboard`) are
+    /// wired, Linux is a follow-up (#1815). Off those platforms it has no in-crate
+    /// caller yet, so the dead-code lint is suppressed there rather than deleting a
+    /// method the pending binding needs.
+    #[cfg_attr(not(any(target_os = "macos", windows)), allow(dead_code))]
     pub async fn fetch_remote_clipboard_file(
         &self,
         session_id: &str,

--- a/src-tauri/src/windows_clipboard.rs
+++ b/src-tauri/src/windows_clipboard.rs
@@ -52,7 +52,6 @@
 //! shared-folder download (#1765) remains the behaviour.
 
 use std::cell::RefCell;
-use std::ffi::c_void;
 use std::ptr;
 use std::sync::mpsc;
 use std::sync::OnceLock;
@@ -343,9 +342,13 @@ unsafe fn offer_delayed_hdrop(hwnd: HWND) {
 unsafe fn render_hdrop() {
     // Snapshot the context so we do not hold the RefCell borrow across the fetch.
     let Some((manager, session_id, indices)) = CURRENT.with(|slot| {
-        slot.borrow()
-            .as_ref()
-            .map(|ctx| (ctx.manager.clone(), ctx.session_id.clone(), ctx.indices.clone()))
+        slot.borrow().as_ref().map(|ctx| {
+            (
+                ctx.manager.clone(),
+                ctx.session_id.clone(),
+                ctx.indices.clone(),
+            )
+        })
     }) else {
         return;
     };
@@ -421,8 +424,7 @@ mod tests {
     fn parse_wide_hdrop(bytes: &[u8]) -> Vec<String> {
         const HEADER: usize = 20;
         assert!(bytes.len() >= HEADER);
-        let files_offset =
-            u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+        let files_offset = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
         let wide = u32::from_le_bytes([bytes[16], bytes[17], bytes[18], bytes[19]]) != 0;
         assert_eq!(files_offset, HEADER);
         assert!(wide, "build_cf_hdrop always emits wide paths");

--- a/src-tauri/src/windows_clipboard.rs
+++ b/src-tauri/src/windows_clipboard.rs
@@ -1,0 +1,468 @@
+//! Native Windows clipboard binding for pasting remote-copied RDP clipboard
+//! files into local apps with **delayed rendering** (#1814).
+//!
+//! The Windows sibling of [`crate::macos_clipboard`]: the RDP sidecar surfaces
+//! the list of files the remote copied (`GraphicalBackend::remote_clipboard_files`)
+//! and streams a file's bytes on demand (`fetch_remote_clipboard_file`); this
+//! module binds that transport to the host OS clipboard as a **`CF_HDROP`** file
+//! list, so the copied files can be pasted into Explorer or any local app.
+//!
+//! ## Delayed rendering, the Win32 way
+//!
+//! When the user chooses "make the remote files pasteable" in the RemoteDesktop
+//! UI, [`bind_remote_clipboard_files`] places `CF_HDROP` on the clipboard with a
+//! **NULL data handle** (`SetClipboardData(CF_HDROP, NULL)`). This is Win32's
+//! *delayed rendering* pattern: the clipboard owner window is asked to produce the
+//! data only when another app actually reads that format — Windows sends the owner
+//! `WM_RENDERFORMAT` (a single format on paste) or `WM_RENDERALLFORMATS` (all
+//! formats, before the owner goes away). Only then do we fetch each file's bytes
+//! from the remote (streamed into a sanitized, bounded temp file by the sidecar)
+//! and build the `CF_HDROP` from the staged local paths. No bytes move on copy;
+//! memory stays bounded to whatever a single fetch stages.
+//!
+//! `CF_HDROP` is a list of **file paths**, not bytes — exactly like macOS's
+//! `NSFilenamesPboardType` — so staging each remote file to a real temp file and
+//! handing Explorer that path is the correct analog; `CFSTR_FILECONTENTS` /
+//! `CFSTR_FILEDESCRIPTOR` (virtual files that hand over bytes directly) are not
+//! needed and are deliberately not implemented.
+//!
+//! ## The owner window
+//!
+//! Delayed rendering needs a window that owns the clipboard and stays alive to
+//! answer `WM_RENDERFORMAT`. Tauri owns the app's main window and its `WndProc`,
+//! which we must not subclass, so this module owns a dedicated **message-only
+//! window** (`HWND_MESSAGE`) on its own thread running a `GetMessage` pump. The
+//! window is created lazily on the first bind and lives for the app's lifetime.
+//! Because the clipboard owner is tied to that window's thread, the actual
+//! `OpenClipboard`/`SetClipboardData` offer and every render run **on the pump
+//! thread**: [`bind_remote_clipboard_files`] hands the fetch context to it with a
+//! synchronous `SendMessageW`, which Windows dispatches into the pump thread's
+//! `WndProc`. The context is stored in a pump-thread [`thread_local`]; a new bind
+//! replaces (and drops) the previous one.
+//!
+//! The per-file fetch inside a render drives the tokio runtime's worker threads
+//! (never the pump thread), so blocking the pump thread for the duration of a
+//! paste keeps memory bounded and cannot deadlock — the same reasoning as the
+//! macOS `provideDataForType:` callback.
+//!
+//! Everything here is `#[cfg(windows)]`-gated at the module declaration in
+//! `lib.rs`. macOS uses [`crate::macos_clipboard`]; Linux (X11/Wayland
+//! `text/uri-list` data source) is tracked as a follow-up (#1815). On a platform
+//! with no binding `clipboard_delayed_render` stays off and the eager
+//! shared-folder download (#1765) remains the behaviour.
+
+use std::cell::RefCell;
+use std::ffi::c_void;
+use std::ptr;
+use std::sync::mpsc;
+use std::sync::OnceLock;
+use std::thread;
+
+use tauri::AppHandle;
+use windows_sys::Win32::Foundation::{HANDLE, HGLOBAL, HWND, LPARAM, LRESULT, WPARAM};
+use windows_sys::Win32::System::DataExchange::{
+    CloseClipboard, EmptyClipboard, GetClipboardOwner, OpenClipboard, SetClipboardData,
+};
+use windows_sys::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows_sys::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, RegisterClassW, SendMessageW,
+    TranslateMessage, HWND_MESSAGE, MSG, WM_APP, WM_DESTROYCLIPBOARD, WM_RENDERALLFORMATS,
+    WM_RENDERFORMAT, WNDCLASSW,
+};
+
+use crate::session::graphical_manager::GraphicalSessionManager;
+use termihub_core::connection::RemoteClipboardFile;
+
+/// The standard `CF_HDROP` clipboard format (a `DROPFILES` header + a
+/// double-null-terminated path list). Defined locally as its numeric value so we
+/// need not pull in the `Win32_System_Ole` feature just for the constant; the
+/// sidecar's `parse_cf_hdrop` decodes the very same format.
+const CF_HDROP: u32 = 15;
+
+/// Private window message that carries a freshly-boxed [`BindContext`] pointer to
+/// the pump thread so the clipboard offer runs on the owner window's thread.
+const WM_APP_BIND: u32 = WM_APP + 1;
+
+/// The advertised indices of the files worth offering to the OS clipboard — the
+/// regular files, in order. Directories carry no bytes to fetch (they are
+/// surfaced only so a copied tree can be recreated), so they are dropped.
+///
+/// Pure and Win32-free so the selection logic is unit-testable without a
+/// clipboard.
+fn pasteable_indices(files: &[RemoteClipboardFile]) -> Vec<u32> {
+    files
+        .iter()
+        .filter(|f| !f.is_dir)
+        .map(|f| f.index)
+        .collect()
+}
+
+/// Builds the raw bytes of a `CF_HDROP` clipboard object from local file `paths`,
+/// in order — the inverse of the sidecar's `parse_cf_hdrop`.
+///
+/// The layout is a [`DROPFILES`](https://learn.microsoft.com/windows/win32/api/shlobj_core/ns-shlobj_core-dropfiles)
+/// header (20 bytes: `pFiles` offset = 20, a zero `POINT`, `fNC` = 0, `fWide` = 1)
+/// followed by a **double-null-terminated** list of UTF-16LE paths. Wide (`fWide`)
+/// is always used so non-ASCII paths survive.
+///
+/// Pure over `&str` (rather than `OsStr`) so the encoding is unit-testable on any
+/// platform; the caller passes `path.to_string_lossy()`.
+fn build_cf_hdrop(paths: &[String]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&20u32.to_le_bytes()); // pFiles: list starts right after the header
+    bytes.extend_from_slice(&[0u8; 8]); // POINT { x, y }
+    bytes.extend_from_slice(&0u32.to_le_bytes()); // fNC
+    bytes.extend_from_slice(&1u32.to_le_bytes()); // fWide = true (UTF-16LE paths)
+    for path in paths {
+        for unit in path.encode_utf16() {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // NUL after each path
+    }
+    bytes.extend_from_slice(&0u16.to_le_bytes()); // final NUL terminates the list
+    bytes
+}
+
+/// How to fetch each promised file when a paste renders the `CF_HDROP` format.
+struct BindContext {
+    /// Clone of the graphical manager (Arc-backed) used to reach the session's
+    /// backend for on-demand byte fetches.
+    manager: GraphicalSessionManager,
+    /// The session whose remote clipboard these files belong to.
+    session_id: String,
+    /// Advertised indices to fetch, in paste order.
+    indices: Vec<u32>,
+}
+
+thread_local! {
+    /// The fetch context for the most recent bind, held on the pump thread. A new
+    /// bind replaces (drops) the previous one; `WM_DESTROYCLIPBOARD` clears it when
+    /// another app takes clipboard ownership. Only ever touched on the pump thread,
+    /// so a plain `RefCell` is enough.
+    static CURRENT: RefCell<Option<BindContext>> = const { RefCell::new(None) };
+}
+
+/// Handle of the message-only owner window, as `usize` (an `HWND` is not `Send`).
+/// Initialised once on the first bind; `0` means creation failed.
+static OWNER_HWND: OnceLock<usize> = OnceLock::new();
+
+/// Bind the remote-copied clipboard `files` onto the Windows clipboard as a
+/// delayed-render `CF_HDROP` (#1814), so they can be pasted into any local app.
+/// The bytes are fetched only on the actual paste, via `manager` and `session_id`.
+///
+/// Signature mirrors [`crate::macos_clipboard::bind_remote_clipboard_files`] so
+/// the `remote_desktop_bind_clipboard_files` command calls either identically; the
+/// `AppHandle` is unused here (the owner window is our own, not Tauri's).
+pub fn bind_remote_clipboard_files(
+    _app_handle: &AppHandle,
+    manager: GraphicalSessionManager,
+    session_id: String,
+    files: Vec<RemoteClipboardFile>,
+) -> anyhow::Result<()> {
+    let indices = pasteable_indices(&files);
+    if indices.is_empty() {
+        return Ok(());
+    }
+
+    let hwnd = ensure_owner_window();
+    if hwnd == 0 {
+        anyhow::bail!("failed to create the clipboard owner window");
+    }
+
+    // Hand the fetch context to the pump thread. `SendMessageW` is synchronous —
+    // it blocks until the owner thread's `WndProc` has processed the message — so
+    // ownership of the leaked box transfers cleanly with no concurrent access.
+    let ctx = Box::new(BindContext {
+        manager,
+        session_id,
+        indices,
+    });
+    let ptr = Box::into_raw(ctx) as usize;
+    // SAFETY: `hwnd` is a live window owned by the pump thread; `WM_APP_BIND`
+    // carries the boxed `BindContext` pointer, which the `WndProc` reconstructs
+    // and takes ownership of.
+    unsafe {
+        SendMessageW(hwnd as HWND, WM_APP_BIND, ptr as WPARAM, 0);
+    }
+    Ok(())
+}
+
+/// Lazily create the message-only clipboard owner window on its own pump thread
+/// and return its `HWND` as `usize` (`0` on failure). Idempotent: subsequent calls
+/// return the same window.
+fn ensure_owner_window() -> usize {
+    *OWNER_HWND.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<usize>();
+        let spawned = thread::Builder::new()
+            .name("termihub-clipboard-owner".to_string())
+            .spawn(move || owner_thread_main(tx));
+        if let Err(e) = spawned {
+            tracing::warn!("failed to spawn clipboard owner thread: {e}");
+            return 0;
+        }
+        // Wait for the thread to report the created window handle (or 0).
+        rx.recv().unwrap_or(0)
+    })
+}
+
+/// Body of the clipboard owner thread: register the window class, create the
+/// message-only window, report its handle back, then run a classic `GetMessage`
+/// pump for the app's lifetime so `WM_RENDERFORMAT` (and our `WM_APP_BIND`) reach
+/// the `WndProc`.
+fn owner_thread_main(tx: mpsc::Sender<usize>) {
+    // SAFETY: standard Win32 window-class registration + creation. The class name
+    // buffer outlives both calls; `RegisterClassW` copies it.
+    unsafe {
+        let hinstance = GetModuleHandleW(ptr::null());
+        let class_name: Vec<u16> = "TermiHubRemoteClipboardOwner\0".encode_utf16().collect();
+
+        let wnd_class = WNDCLASSW {
+            style: 0,
+            lpfnWndProc: Some(wnd_proc),
+            cbClsExtra: 0,
+            cbWndExtra: 0,
+            hInstance: hinstance,
+            hIcon: ptr::null_mut(),
+            hCursor: ptr::null_mut(),
+            hbrBackground: ptr::null_mut(),
+            lpszMenuName: ptr::null(),
+            lpszClassName: class_name.as_ptr(),
+        };
+        // A duplicate registration is harmless; the returned atom is unused.
+        RegisterClassW(&wnd_class);
+
+        let hwnd = CreateWindowExW(
+            0,
+            class_name.as_ptr(),
+            ptr::null(),
+            0,
+            0,
+            0,
+            0,
+            0,
+            HWND_MESSAGE,
+            ptr::null_mut(),
+            hinstance,
+            ptr::null(),
+        );
+
+        let _ = tx.send(hwnd as usize);
+        if hwnd.is_null() {
+            tracing::warn!("failed to create the message-only clipboard owner window");
+            return;
+        }
+
+        let mut msg: MSG = std::mem::zeroed();
+        // `GetMessageW` returns >0 for a message, 0 for WM_QUIT, -1 on error.
+        while GetMessageW(&mut msg, ptr::null_mut(), 0, 0) > 0 {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+    }
+}
+
+/// Window procedure for the clipboard owner window. Runs on the pump thread.
+///
+/// # Safety
+/// Called by Windows with valid message parameters. `WM_APP_BIND`'s `wparam` is a
+/// `Box<BindContext>` pointer produced by [`bind_remote_clipboard_files`].
+unsafe extern "system" fn wnd_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    match msg {
+        WM_APP_BIND => {
+            // Take ownership of the boxed context and make it current (dropping any
+            // previous one), then place the delayed-render offer on the clipboard.
+            let ctx = if wparam != 0 {
+                Some(*Box::from_raw(wparam as *mut BindContext))
+            } else {
+                None
+            };
+            CURRENT.with(|slot| *slot.borrow_mut() = ctx);
+            offer_delayed_hdrop(hwnd);
+            0
+        }
+        WM_RENDERFORMAT => {
+            // A paste is reading a single format. Render only if it wants CF_HDROP;
+            // the clipboard is already open for us in this message's context, so we
+            // must not Open/Close it here.
+            if wparam as u32 == CF_HDROP {
+                render_hdrop();
+            }
+            0
+        }
+        WM_RENDERALLFORMATS => {
+            // The owner is going away (e.g. app shutdown): flush the delayed format
+            // if we are still the owner. Here we must open the clipboard ourselves
+            // and must NOT call EmptyClipboard.
+            if OpenClipboard(hwnd) != 0 {
+                if GetClipboardOwner() == hwnd {
+                    render_hdrop();
+                }
+                CloseClipboard();
+            }
+            0
+        }
+        WM_DESTROYCLIPBOARD => {
+            // Another app took clipboard ownership; drop the staged context so a
+            // stale promise can never be served.
+            CURRENT.with(|slot| *slot.borrow_mut() = None);
+            0
+        }
+        _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+    }
+}
+
+/// Place the `CF_HDROP` format on the clipboard with a NULL data handle — the
+/// delayed-render offer. Runs on the pump thread. No bytes are fetched here.
+///
+/// # Safety
+/// `hwnd` must be the live owner window on this (pump) thread.
+unsafe fn offer_delayed_hdrop(hwnd: HWND) {
+    if OpenClipboard(hwnd) == 0 {
+        tracing::warn!("failed to open clipboard to offer remote files");
+        return;
+    }
+    EmptyClipboard();
+    // NULL data handle = delayed rendering: Windows will ask us to render on paste.
+    SetClipboardData(CF_HDROP, ptr::null_mut());
+    CloseClipboard();
+}
+
+/// Fetch every promised file's bytes on demand, build a `CF_HDROP` from the staged
+/// local paths, and hand it to the clipboard via `SetClipboardData`. Runs on the
+/// pump thread during a render message.
+///
+/// # Safety
+/// Must run inside a `WM_RENDERFORMAT`/`WM_RENDERALLFORMATS` render where the
+/// clipboard is open and we are (still) the owner.
+unsafe fn render_hdrop() {
+    // Snapshot the context so we do not hold the RefCell borrow across the fetch.
+    let Some((manager, session_id, indices)) = CURRENT.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|ctx| (ctx.manager.clone(), ctx.session_id.clone(), ctx.indices.clone()))
+    }) else {
+        return;
+    };
+
+    let mut staged: Vec<String> = Vec::new();
+    for index in indices {
+        match tauri::async_runtime::block_on(
+            manager.fetch_remote_clipboard_file(&session_id, index),
+        ) {
+            Ok(path) => staged.push(path.to_string_lossy().into_owned()),
+            Err(e) => {
+                tracing::warn!("failed to fetch remote clipboard file {index} for paste: {e}");
+            }
+        }
+    }
+    if staged.is_empty() {
+        return;
+    }
+
+    let bytes = build_cf_hdrop(&staged);
+
+    // Copy the CF_HDROP into a movable global; SetClipboardData takes ownership on
+    // success, so we must not free it afterwards.
+    let hglobal: HGLOBAL = GlobalAlloc(GMEM_MOVEABLE, bytes.len());
+    if hglobal.is_null() {
+        tracing::warn!("GlobalAlloc failed for CF_HDROP render");
+        return;
+    }
+    let dst = GlobalLock(hglobal);
+    if dst.is_null() {
+        tracing::warn!("GlobalLock failed for CF_HDROP render");
+        return;
+    }
+    ptr::copy_nonoverlapping(bytes.as_ptr(), dst as *mut u8, bytes.len());
+    GlobalUnlock(hglobal);
+
+    if SetClipboardData(CF_HDROP, hglobal as HANDLE).is_null() {
+        // Ownership did not transfer; the global leaks rather than risking a
+        // double free, but a failed render is already an error path.
+        tracing::warn!("SetClipboardData(CF_HDROP) failed during render");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(index: u32, is_dir: bool) -> RemoteClipboardFile {
+        RemoteClipboardFile {
+            name: format!("f{index}"),
+            relative_path: None,
+            size: Some(1),
+            is_dir,
+            index,
+        }
+    }
+
+    #[test]
+    fn pasteable_indices_keep_files_in_order_and_drop_dirs() {
+        let files = vec![file(0, false), file(1, true), file(2, false)];
+        assert_eq!(pasteable_indices(&files), vec![0, 2]);
+    }
+
+    #[test]
+    fn pasteable_indices_empty_when_only_dirs_or_none() {
+        assert!(pasteable_indices(&[]).is_empty());
+        assert!(pasteable_indices(&[file(0, true), file(1, true)]).is_empty());
+    }
+
+    /// Decodes a `CF_HDROP` buffer back into paths — a local mirror of the
+    /// sidecar's `parse_cf_hdrop` — so a round-trip can assert `build_cf_hdrop`
+    /// produces the exact layout Explorer expects.
+    fn parse_wide_hdrop(bytes: &[u8]) -> Vec<String> {
+        const HEADER: usize = 20;
+        assert!(bytes.len() >= HEADER);
+        let files_offset =
+            u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+        let wide = u32::from_le_bytes([bytes[16], bytes[17], bytes[18], bytes[19]]) != 0;
+        assert_eq!(files_offset, HEADER);
+        assert!(wide, "build_cf_hdrop always emits wide paths");
+        let units: Vec<u16> = bytes[files_offset..]
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect();
+        let mut paths = Vec::new();
+        for segment in units.split(|&u| u == 0) {
+            if segment.is_empty() {
+                break;
+            }
+            paths.push(String::from_utf16_lossy(segment));
+        }
+        paths
+    }
+
+    #[test]
+    fn build_cf_hdrop_round_trips_multiple_paths() {
+        let paths = vec![r"C:\Users\me\a.txt".to_string(), r"D:\b.png".to_string()];
+        assert_eq!(parse_wide_hdrop(&build_cf_hdrop(&paths)), paths);
+    }
+
+    #[test]
+    fn build_cf_hdrop_round_trips_single_path() {
+        let paths = vec![r"C:\only.bin".to_string()];
+        assert_eq!(parse_wide_hdrop(&build_cf_hdrop(&paths)), paths);
+    }
+
+    #[test]
+    fn build_cf_hdrop_preserves_non_ascii_paths() {
+        let paths = vec![r"C:\Users\Zoë\naïve — file.txt".to_string()];
+        assert_eq!(parse_wide_hdrop(&build_cf_hdrop(&paths)), paths);
+    }
+
+    #[test]
+    fn build_cf_hdrop_is_double_null_terminated() {
+        // A single "A" path: 20-byte header + 'A'(2) + NUL(2) + final NUL(2).
+        let bytes = build_cf_hdrop(&["A".to_string()]);
+        assert_eq!(bytes.len(), 20 + 2 + 2 + 2);
+        assert_eq!(&bytes[bytes.len() - 4..], &[0, 0, 0, 0]);
+    }
+}


### PR DESCRIPTION
## Summary

Windows sibling of the macOS host-clipboard delayed-render binding (#1804, PR #1816). Adds the **Windows** platform hook so files copied in a remote RDP session can be pasted into any local app (Explorer, etc.) via the OS clipboard, with each file's bytes fetched from the remote **only on the paste gesture** rather than eagerly downloaded.

Part of #1814.

> **Ready for manual Windows verification — not yet merged.** This item cannot be runtime-verified by the author (macOS machine) or by per-PR CI (the CLIPRDR wire lane is release-cadence only, #1569). The Windows CI runner compile-checks the `#[cfg(windows)]` code. Please run the manual paste test below on Windows before merging. The `Part of #1814` wording is intentional so an accidental merge does not auto-close the issue.

## What changed

- **New `src-tauri/src/windows_clipboard.rs`** (`#[cfg(windows)]`), mirroring `macos_clipboard.rs`:
  - Offers `CF_HDROP` on the clipboard with a **NULL data handle** (`SetClipboardData(CF_HDROP, NULL)`) — Win32 delayed rendering. No bytes move on copy.
  - Serves the data only on **`WM_RENDERFORMAT`** (a paste reading the format) / **`WM_RENDERALLFORMATS`** (owner going away), fetching each file's bytes via `GraphicalSessionManager::fetch_remote_clipboard_file` (streamed into the sidecar's sanitized, bounded temp stage) and building the `CF_HDROP` from the staged local paths.
  - `CF_HDROP` is a list of **paths** (like macOS `NSFilenamesPboardType`), so staging each file to a temp file and handing Explorer that path is the correct analog; `CFSTR_FILECONTENTS`/`CFSTR_FILEDESCRIPTOR` are not needed.
  - **Owner window:** delayed rendering needs a window that owns the clipboard and stays alive to answer `WM_RENDERFORMAT`. Tauri owns the main window and its `WndProc` (which we must not subclass), so the module owns a dedicated **message-only window** (`HWND_MESSAGE`) on its own thread running a `GetMessage` pump, created lazily on first bind. The offer and every render run on that pump thread; `bind_remote_clipboard_files` hands the fetch context to it via a synchronous `SendMessageW`.
- **Capability gate:** `host_supports_clipboard_delayed_render()` now returns true on `windows` too, so `parse_config` stamps `clipboard_delayed_render` and the sidecar surfaces the remote file list on Windows. Other platforms keep the eager shared-folder download (#1765).
- **Command:** `remote_desktop_bind_clipboard_files` gains a `#[cfg(windows)]` branch calling the new binding (same signature as the macOS one).
- **Dependency:** `windows-sys` (already used by `termihub-core`) added **target-gated to `cfg(windows)`** for the raw clipboard/window/message-loop/memory APIs — `cargo tree -i` clean off Windows. No new native stack; no new dep off Windows.

## Library / crate choice

Built the Win32 write + delayed-render path on **`windows-sys`** (already in the workspace, predictable C-style signatures) rather than adding a native stack. `clipboard-win` (used by the sidecar to *read* `CF_HDROP`) offers no delayed-render helper, and delayed rendering needs the raw message-only window + `WndProc` regardless. All of it is `#[cfg(windows)]`-gated.

## Tests

**Unit-tested** (`windows_clipboard`, runs on Windows CI): pasteable-index selection (regular files in order, directories dropped) and the `CF_HDROP` builder (round-trips multi-path, single-path and non-ASCII paths; asserts the double-null terminator). The capability-gate stamping is covered on every platform by the existing `graphical_manager` / `rdp_sidecar::config` tests.

The live `WM_RENDERFORMAT` render + real paste need a message loop and a live RDP session, so they are a **documented manual test** (added to `docs/testing.md`):

### Manual test plan (Windows)

1. On **Windows**, build the sidecar and point `TERMIHUB_RDP_HELPER` at it; in the RDP connection editor enable **Redirect a Local Drive** (with a **Shared Folder**) and **Receive Clipboard Files**, then connect to a Windows RDP host.
2. Copy one or more files in the remote session (Explorer -> Ctrl+C). **Expected:** the files do **not** appear in the shared folder (delayed rendering replaces the eager download).
3. Open the RemoteDesktop hover toolbar's **Clipboard** panel. **Expected:** a **Remote files** section lists the copied files, with a **Copy to clipboard** button.
4. Click **Copy to clipboard**. **Expected:** a toast confirms `N file(s) ready`. No bytes fetched yet (the clipboard holds only the delayed-render `CF_HDROP` offer with a NULL handle).
5. Paste into a local app — Explorer (Ctrl+V into a folder), an Outlook draft, etc. **Expected:** the real files appear, contents intact; the fetch happens now (delayed), streamed into a bounded staging file.
6. **Regression check:** with **Receive Clipboard Files** off, the eager shared-folder path (#1765) still applies; Linux is unchanged (no host binding).

## Notes / uncertainties (no Windows box to design against)

- The **message-only owner window on a dedicated pump thread** is the standard way to own delayed-render formats without touching Tauri's `WndProc`; it is documented in the module. It compiles on the Windows CI runner but the live render path is what the manual test above exercises.
- I cross-checked the exact `windows-sys` API surface (imports, `WNDCLASSW`, `SetClipboardData`, `GlobalAlloc`/`GlobalLock`, the `WndProc` signature, `HWND_MESSAGE`) against the `x86_64-pc-windows-msvc` target in isolation, which is how the required `Win32_Graphics_Gdi` feature (gating `RegisterClassW`/`WNDCLASSW`) was found.

## Follow-up

- Linux (X11/Wayland `text/uri-list` data source) binding remains #1815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
