### PR TITLE
fix(ui): make "X server setup failed" dialog install command copyable

### DIFF
--- a/docs/changes/dev1/fix/1819-xserver-dialog-copy.md
+++ b/docs/changes/dev1/fix/1819-xserver-dialog-copy.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- The "X server setup failed" dialog's install command is now copyable: a copy
+  button next to the command writes it to the clipboard (confirmed with a
+  success toast), and the command text itself is selectable. Previously the user
+  had to retype the command by hand (#1819).

--- a/src/components/OpenConnections/XServerSetupContent.copy.test.tsx
+++ b/src/components/OpenConnections/XServerSetupContent.copy.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Clipboard-feedback test for the X server "setup failed" install command (#1819).
+ *
+ * When X-server provisioning fails with a missing dependency, the dialog shows
+ * the install command the user is expected to run. It used to be display-only;
+ * this pins that a dedicated copy button writes the command to the clipboard and
+ * confirms with a success toast, and that the command lives in a copyable
+ * (selectable) element.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+const writeText = vi.fn((_text?: string) => Promise.resolve());
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: (text: string) => writeText(text),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(() => Promise.resolve()),
+}));
+
+import { XServerSetupContent } from "./XServerSetupContent";
+import type { XServerError } from "@/types/xserver";
+
+let container: HTMLDivElement;
+let root: Root;
+
+const command = "brew install --cask xquartz";
+
+function renderError(error: XServerError) {
+  act(() => {
+    root.render(
+      React.createElement(XServerSetupContent, {
+        open: true,
+        onOpenChange: () => {},
+        testIdPrefix: "x-server-setup",
+        phase: "error",
+        progress: null,
+        error,
+        consent: React.createElement("div", null, "consent copy"),
+        onEnable: () => {},
+        onNotNow: () => {},
+        onRetry: () => {},
+        onInstallDependency: () => Promise.resolve(),
+        onGuideTerminalInstall: () => Promise.resolve(),
+        onClose: () => {},
+      })
+    );
+  });
+}
+
+function query(testId: string): Element | null {
+  return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("XServerSetupContent — copy install command (#1819)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("copies the install command and confirms with a success toast", async () => {
+    renderError({
+      kind: "dependencyMissing",
+      message: "XQuartz is not installed",
+      dependency: "XQuartz",
+      installCommand: command,
+    });
+
+    const copyButton = query("x-server-setup-copy-command") as HTMLButtonElement | null;
+    expect(copyButton).not.toBeNull();
+
+    act(() => copyButton!.click());
+    await flush();
+
+    expect(writeText).toHaveBeenCalledWith(command);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("renders the command in a selectable element and offers no copy button without a command", () => {
+    renderError({
+      kind: "dependencyMissing",
+      message: "XQuartz is not installed",
+      dependency: "XQuartz",
+      installCommand: command,
+    });
+    const commandEl = container.querySelector<HTMLElement>(".x-server-setup__command");
+    expect(commandEl).not.toBeNull();
+    expect(commandEl?.textContent).toBe(command);
+
+    // A dependency error without a command shows neither the block nor the button.
+    renderError({
+      kind: "dependencyMissing",
+      message: "Something failed",
+      dependency: "XQuartz",
+    });
+    expect(query("x-server-setup-copy-command")).toBeNull();
+  });
+});

--- a/src/components/OpenConnections/XServerSetupContent.copy.test.tsx
+++ b/src/components/OpenConnections/XServerSetupContent.copy.test.tsx
@@ -118,7 +118,7 @@ describe("XServerSetupContent — copy install command (#1819)", () => {
       dependency: "XQuartz",
       installCommand: command,
     });
-    const commandEl = container.querySelector<HTMLElement>(".x-server-setup__command");
+    const commandEl = document.querySelector<HTMLElement>(".x-server-setup__command");
     expect(commandEl).not.toBeNull();
     expect(commandEl?.textContent).toBe(command);
 

--- a/src/components/OpenConnections/XServerSetupContent.tsx
+++ b/src/components/OpenConnections/XServerSetupContent.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { Modal, Button } from "@/components/ui";
+import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manager";
+import { Copy } from "lucide-react";
+import { Modal, Button, toast } from "@/components/ui";
 import type { XServerError, XServerProgress } from "@/types/xserver";
 import "./XServerSetupDialog.css";
 
@@ -22,6 +24,16 @@ function fallbackButtonLabel(url: string): string {
 
 /** Microsoft Store page for App Installer (winget) — the Windows guided prerequisite. */
 const APP_INSTALLER_URL = "https://apps.microsoft.com/detail/9NBLGGH4NNS1";
+
+/**
+ * Copy the install command to the clipboard so the user can paste and run it
+ * instead of retyping it by hand (#1819). Returns the promise so the Button
+ * drives its success flash; a rejection surfaces via the Button's error toast.
+ */
+async function copyInstallCommand(command: string): Promise<void> {
+  await writeClipboard(command);
+  toast.success("Command copied to clipboard");
+}
 
 /**
  * Whether the recovery is a guided-terminal install (#1309): the user runs
@@ -168,6 +180,7 @@ export function XServerSetupContent({
     const message =
       error?.message ?? (rawError instanceof Error ? rawError.message : String(rawError));
     const isDependencyMissing = error?.kind === "dependencyMissing";
+    const installCommand = isDependencyMissing ? error?.installCommand : undefined;
     return (
       <div className="x-server-setup__error">
         <p className="x-server-setup__error-message" data-testid={`${testIdPrefix}-error`}>
@@ -176,10 +189,21 @@ export function XServerSetupContent({
         {isDependencyMissing && error?.installHint && (
           <p className="x-server-setup__hint">{error.installHint}</p>
         )}
-        {isDependencyMissing && error?.installCommand && (
-          <pre className="x-server-setup__command">
-            <code>{error.installCommand}</code>
-          </pre>
+        {installCommand && (
+          <div className="x-server-setup__command-row">
+            <pre className="x-server-setup__command">
+              <code>{installCommand}</code>
+            </pre>
+            <Button
+              variant="ghost"
+              iconOnly
+              icon={<Copy size={16} aria-hidden />}
+              aria-label="Copy command"
+              title="Copy command"
+              data-testid={`${testIdPrefix}-copy-command`}
+              onClick={() => copyInstallCommand(installCommand)}
+            />
+          </div>
         )}
       </div>
     );

--- a/src/components/OpenConnections/XServerSetupDialog.css
+++ b/src/components/OpenConnections/XServerSetupDialog.css
@@ -90,14 +90,24 @@
   }
 }
 
-/* Dependency install command block */
+/* Dependency install command block, with a copy affordance (#1819) */
+.x-server-setup__command-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+}
+
 .x-server-setup__command {
+  flex: 1;
+  min-width: 0;
   margin: 0;
   padding: var(--spacing-sm) var(--spacing-md);
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
   color: var(--text-primary);
+  /* Selectable so the user can also copy the command by hand (#1819). */
+  user-select: text;
   background: var(--bg-tertiary);
   border-radius: var(--radius-sm);
 }


### PR DESCRIPTION
When X-server provisioning fails with a missing dependency, the "X server setup failed" dialog shows the install command the user is expected to run — but the text was display-only, so the user had to retype it by hand.

## Changes

- Add a copy-to-clipboard button (ghost icon Button with the lucide `copy` icon) next to the install command in the shared X-server setup/error body (`XServerSetupContent`). It writes the command via the clipboard-manager plugin and confirms with `toast.success`, reusing the established copy pattern (`EmbeddedServerItem` "Copy URL", #1342). The async Button lifecycle surfaces any failure as an error toast.
- Make the command text itself selectable (`user-select: text`) so it can also be copied by hand on every platform.
- Regression test (`XServerSetupContent.copy.test.tsx`): clicking the copy button writes the command and fires a success toast; the command renders in a selectable element; no button when there is no command.

Composes only shared `src/components/ui/` primitives and design tokens; every action gives feedback, per the design system. Scoped to the X-server dialog only — the sibling "connection failed" dialog is tracked separately (#1829).

Closes #1819