### PR TITLE
fix(ui): clear shared-name fields when connection type changes (Closes #1820)

### DIFF
--- a/docs/changes/dev2/fix/1820-ssh-shell-field-default.md
+++ b/docs/changes/dev2/fix/1820-ssh-shell-field-default.md
@@ -1,0 +1,12 @@
+# Changes
+
+## Fixed
+
+- **SSH connection editor**: the Advanced → Shell field on a new SSH connection no
+  longer auto-fills the local host's default shell (`powershell` on Windows) and can
+  now be left empty or cleared. Switching the connection type used to leak the previous
+  type's value for any field with a shared name — the schema-driven form kept
+  react-hook-form's cached value for the `shell` field — so a new SSH connection
+  inherited the local shell and could not clear it. The form now explicitly clears
+  every field of the newly selected type, so a field the new type does not default
+  (like the SSH remote shell) starts empty and stays empty when cleared.

--- a/src/components/DynamicForm/ConnectionSettingsForm.test.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.test.tsx
@@ -127,6 +127,72 @@ describe("ConnectionSettingsForm", () => {
     expect(query("dynamic-field-password")).toBeNull();
   });
 
+  // Regression for #1820: when the connection type changes, the previous type's
+  // value for a field whose name is shared between schemas (both the local shell
+  // and SSH have a `shell` field) must not leak into the new type. Without the
+  // fix, react-hook-form's per-name value cache re-populated the SSH Advanced →
+  // Shell field with the local default shell (`powershell` on Windows), which
+  // the user could not clear.
+  it("clears a shared-name field when switching to a schema that omits its default (#1820)", () => {
+    // A local-shell-like schema whose `shell` field is pre-filled.
+    const LOCAL_SCHEMA: SettingsSchema = {
+      groups: [
+        {
+          key: "shell",
+          label: "Shell",
+          fields: [
+            {
+              key: "shell",
+              label: "Shell",
+              fieldType: {
+                type: "select",
+                options: [
+                  { value: "powershell", label: "PowerShell" },
+                  { value: "cmd", label: "cmd" },
+                ],
+              },
+              required: false,
+              default: "powershell",
+            },
+          ],
+        },
+      ],
+    };
+    // An SSH-like schema whose Advanced `shell` field is a free-text field with
+    // no default (matches the real core SSH schema).
+    const SSH_WITH_SHELL: SettingsSchema = {
+      groups: [
+        {
+          key: "connection",
+          label: "Connection",
+          fields: [{ key: "host", label: "Host", fieldType: { type: "text" }, required: true }],
+        },
+        {
+          key: "advanced",
+          label: "Advanced",
+          fields: [
+            {
+              key: "shell",
+              label: "Shell",
+              fieldType: { type: "text" },
+              required: false,
+              placeholder: "/bin/bash",
+            },
+          ],
+        },
+      ],
+    };
+
+    const onChange = vi.fn();
+    renderForm(LOCAL_SCHEMA, { shell: "powershell" }, onChange);
+    // Switch to the SSH schema with settings that carry no `shell` value.
+    renderForm(SSH_WITH_SHELL, {}, onChange);
+
+    const shellInput = query("field-shell") as HTMLInputElement | null;
+    expect(shellInput).toBeTruthy();
+    expect(shellInput!.value).toBe("");
+  });
+
   it("hides fields when visibility condition is not met", () => {
     renderForm(SSH_SCHEMA, { authMethod: "password", port: 22 }, vi.fn());
     // Password visible when authMethod = "password"

--- a/src/components/DynamicForm/ConnectionSettingsForm.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.tsx
@@ -127,6 +127,16 @@ export function ConnectionSettingsForm({
   // Reset the form when the connection type changes (schema groups differ).
   // isResetting suppresses the watch callback that reset fires synchronously,
   // preventing a spurious onChange call back to the parent on type switch.
+  //
+  // Every field key in the new schema is seeded to `undefined` before the new
+  // settings are layered on top. react-hook-form keeps a value cache keyed by
+  // field name (shouldUnregister defaults to false), so when two connection
+  // types share a field name (e.g. both local and SSH have a `shell` field) a
+  // bare `reset(settings)` that omits that key leaves the *previous* type's
+  // cached value in place — the local shell (`powershell` on Windows) then
+  // leaks into a new SSH connection's Advanced → Shell field and cannot be
+  // cleared (#1820). Explicitly clearing every current-schema key overrides the
+  // stale cache so absent keys reset to empty.
   const schemaKey = schema.groups.map((g) => g.key).join("|");
   const prevSchemaKey = useRef(schemaKey);
   const isResetting = useRef(false);
@@ -134,7 +144,18 @@ export function ConnectionSettingsForm({
     if (prevSchemaKey.current !== schemaKey) {
       prevSchemaKey.current = schemaKey;
       isResetting.current = true;
-      reset(settings);
+      const cleared: Record<string, unknown> = {};
+      for (const group of schema.groups) {
+        for (const field of group.fields) {
+          // Clear to `null`, not `undefined`: react-hook-form's `reset` ignores
+          // keys whose value is `undefined` and falls back to its per-name value
+          // cache, which is exactly what leaks the previous type's shared-name
+          // field (#1820). `null` is an explicit "empty" that overrides the cache
+          // and renders as blank in every widget (`value ?? ""`).
+          cleared[field.key] = null;
+        }
+      }
+      reset({ ...cleared, ...settings });
     }
     // Only trigger on schema change, not on every settings update.
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

Fixes #1820: when creating a **new SSH connection**, the Advanced → Shell field auto-filled the local host's default shell (`powershell` on Windows) and could not be cleared.

Closes #1820

## Confirmed root cause

The maintainer suspected a UI-default bug leaking the local shell into the SSH config, and that is exactly what it is — but the leak is **not** a hard default in either schema. The core SSH schema's `shell` field has `default: None` (placeholder `/bin/bash`, description "leave empty for default"), and the frontend does not seed a shell for SSH.

The real mechanism is in the schema-driven form (`ConnectionSettingsForm`):

- The connection editor opens a new connection as **local**, whose schema seeds `shell` with the detected default shell (`powershell` on Windows).
- Switching the type to **SSH** rebuilds the settings without a `shell` key.
- But react-hook-form keeps a **per-field-name value cache** (`shouldUnregister` defaults to `false`). Both the local-shell schema and the SSH schema have a field named `shell`, so when the form reset ran with a settings object that omitted `shell`, RHF restored the cached `powershell` for the SSH field — which the user then could not clear.

This also explains why the reported value is exactly the platform's local shell (`powershell` on Windows): it is the local default leaking through the shared field name, not clipboard/paste behaviour.

## Fix

On a schema change, explicitly reset **every field of the newly selected schema to `null`** before layering the new settings on top. `reset()` ignores keys whose value is `undefined` and falls back to its cache, so `null` is used as an explicit empty that overrides the cache and renders blank in every widget (`value ?? ""`). An empty/`null` SSH shell round-trips through the backend `opt_str("shell")` as `None` (i.e. "use the remote's login shell"), so clearing the field persists correctly.

The fix is general (any shared-name field across connection types), not a `shell`-specific special case.

## Testing

- Added a red/green regression test in `ConnectionSettingsForm.test.tsx` that switches from a local-shell-shaped schema (with `shell: "powershell"`) to an SSH-shaped schema whose settings omit `shell`, and asserts the Advanced shell field renders empty. Verified it fails on the pre-fix behaviour (`undefined`) and passes with the fix (`null`).
- `./scripts/check.sh` — all checks pass (prettier, eslint, cargo fmt, clippy).
- Full frontend suite: 3831 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)