### PR TITLE
fix(config): treat new or empty external file as empty on save (Closes #1821)

### DIFF
--- a/docs/changes/dev1/fix/1821-save-new-external-file.md
+++ b/docs/changes/dev1/fix/1821-save-new-external-file.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Saving a connection to a **new or empty** external / shared-connection file no
+  longer fails with "Failed to parse external file: …". The save path parsed the
+  destination file before writing, so a not-yet-existing or empty target errored
+  out before anything could be written. A missing or empty file is now treated as
+  a fresh, empty store and written cleanly; a file that genuinely exists with
+  malformed content still reports a clear parse error so it is never silently
+  overwritten (#1821).

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -1035,13 +1035,43 @@ pub(crate) fn try_load_external_file(
     })
 }
 
+/// Read and parse an external connection store from disk.
+///
+/// A **missing** file or an **empty / whitespace-only** file is treated as a fresh,
+/// empty store, so writing to a brand-new external file works (see #1821). A file
+/// that genuinely exists with malformed, non-empty content still returns a clear
+/// "Failed to parse external file" error so a corrupt file is never silently
+/// overwritten.
+fn read_external_store(file_path: &str) -> Result<ExternalConnectionStore> {
+    let data = match std::fs::read_to_string(file_path) {
+        Ok(data) => data,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(empty_external_store()),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("Failed to read external file: {}", file_path));
+        }
+    };
+
+    if data.trim().is_empty() {
+        return Ok(empty_external_store());
+    }
+
+    serde_json::from_str(&data)
+        .with_context(|| format!("Failed to parse external file: {}", file_path))
+}
+
+/// A fresh, empty external connection store using the current on-disk format.
+fn empty_external_store() -> ExternalConnectionStore {
+    ExternalConnectionStore {
+        name: None,
+        version: "2".to_string(),
+        children: Vec::new(),
+    }
+}
+
 /// Save or update a single connection in an external file (by name+folder path).
 fn save_or_update_in_external_file(file_path: &str, connection: SavedConnection) -> Result<()> {
-    let data = std::fs::read_to_string(file_path)
-        .with_context(|| format!("Failed to read external file: {}", file_path))?;
-
-    let mut ext_store: ExternalConnectionStore = serde_json::from_str(&data)
-        .with_context(|| format!("Failed to parse external file: {}", file_path))?;
+    let mut ext_store = read_external_store(file_path)?;
 
     // Flatten, update, rebuild
     let (mut conns, folders) = flatten_tree(&ext_store.children, None);

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -1435,6 +1435,63 @@ mod tests {
     }
 
     #[test]
+    fn save_to_nonexistent_external_file_creates_valid_file() {
+        // Regression for #1821: saving a connection to a brand-new (not-yet-existing)
+        // external file must succeed rather than failing with a parse error.
+        let store = crate::credential::NullStore;
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("brand_new.json");
+        let path_str = file_path.to_str().unwrap();
+        assert!(!file_path.exists());
+
+        let conn = make_local_conn("Local");
+        save_or_update_in_external_file(path_str, conn).unwrap();
+
+        // The file was created and parses back into one connection.
+        assert!(file_path.exists());
+        let main_folders: HashSet<&str> = HashSet::new();
+        let source = try_load_external_file(path_str, &main_folders, &store).unwrap();
+        assert!(source.error.is_none());
+        assert_eq!(source.connections.len(), 1);
+    }
+
+    #[test]
+    fn save_to_empty_external_file_creates_valid_file() {
+        // Regression for #1821: an existing but empty (or whitespace-only) external
+        // file must be treated as a fresh store, not a parse error.
+        let store = crate::credential::NullStore;
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("empty.json");
+        let path_str = file_path.to_str().unwrap();
+        std::fs::write(path_str, "   \n").unwrap();
+
+        let conn = make_local_conn("Local");
+        save_or_update_in_external_file(path_str, conn).unwrap();
+
+        let main_folders: HashSet<&str> = HashSet::new();
+        let source = try_load_external_file(path_str, &main_folders, &store).unwrap();
+        assert!(source.error.is_none());
+        assert_eq!(source.connections.len(), 1);
+    }
+
+    #[test]
+    fn save_to_malformed_external_file_still_errors() {
+        // A file that genuinely exists with malformed, non-empty content must still
+        // surface a clear parse error rather than being silently overwritten.
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("corrupt.json");
+        let path_str = file_path.to_str().unwrap();
+        std::fs::write(path_str, "{ this is not valid json ").unwrap();
+
+        let conn = make_local_conn("Local");
+        let err = save_or_update_in_external_file(path_str, conn).unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to parse external file"),
+            "expected parse error, got: {err}"
+        );
+    }
+
+    #[test]
     fn external_file_folder_id_falls_to_root_when_not_in_main() {
         let store = crate::credential::NullStore;
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Closes #1821

## Problem

Saving a connection to a **new or empty** external / shared-connection file failed with:

> Failed to save …: Failed to parse external file: …

The user reported this as "this looks unstable if I want to write something to a new file. it was a connection file for shared connections."

## Root cause

`save_or_update_in_external_file` (the save path reached via `save_connection_routed`) read **and parsed** the destination file before writing, so it could merge the new connection into the existing set. A brand-new (not-yet-existing) or empty target has nothing valid to parse, so `serde_json::from_str` failed and the whole save aborted before writing anything.

## Fix

A new `read_external_store` helper:

- treats a **missing** file (`NotFound`) or an **empty / whitespace-only** file as a fresh, empty store, so the save proceeds and writes valid content;
- still returns the clear "Failed to parse external file" error for a file that genuinely exists with **malformed, non-empty** content — a corrupt file the user pointed at is never silently overwritten.

The save is now robust and idempotent for new files.

## Tests

Added regression tests (committed test-first):

- `save_to_nonexistent_external_file_creates_valid_file` — save to a path that does not exist succeeds and produces a parseable file.
- `save_to_empty_external_file_creates_valid_file` — save to an existing but empty file succeeds.
- `save_to_malformed_external_file_still_errors` — a genuinely malformed existing file still reports a clear parse error.

## Notes

- No frontend changes; Rust-only.
- Change fragment added under `docs/changes/dev1/fix/1821-save-new-external-file.md`.