### PR TITLE
fix(serial): surface lost COM/serial port as a disconnect (Closes #1824)

### DIFF
--- a/core/src/backends/serial.rs
+++ b/core/src/backends/serial.rs
@@ -134,6 +134,85 @@ fn flow_control_options() -> Vec<SelectOption> {
     ]
 }
 
+/// Minimal async byte-source abstraction for the serial reader loop.
+///
+/// Extracted so [`run_serial_reader`] can be unit-tested with an injected mock
+/// instead of a real serial port, which would require hardware.
+#[async_trait::async_trait]
+trait SerialByteReader: Send + Sync {
+    /// Read available bytes into `buf`, returning the number read (`0` = EOF).
+    async fn read_bytes(&self, buf: &mut [u8]) -> std::io::Result<usize>;
+}
+
+#[async_trait::async_trait]
+impl SerialByteReader for serial2_tokio::SerialPort {
+    async fn read_bytes(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.read(buf).await
+    }
+}
+
+/// Read from the serial port until EOF or a fatal error, forwarding bytes to
+/// the current output subscriber.
+///
+/// On exit — whether the port reported EOF (`Ok(0)`) or a fatal I/O error
+/// (device removed, cable unplugged, broken pipe) — the stored output sender is
+/// cleared. Dropping the sender closes the output channel, which is how the
+/// desktop session manager detects the session ended and emits `terminal-exit`,
+/// flipping the tab out of the connected (green) state and showing the
+/// disconnect overlay. Without this drop a vanished COM/serial port left the tab
+/// green forever with no notification ([#1824]).
+///
+/// This mirrors the local-shell backend, whose reader thread clears its sender
+/// on exit for exactly the same reason. Transient `TimedOut` / `WouldBlock`
+/// errors are ignored so a merely quiet port is not mistaken for a lost one.
+///
+/// [#1824]: https://github.com/armaxri/termiHub/issues/1824
+async fn run_serial_reader<R: SerialByteReader>(
+    port_reader: Arc<R>,
+    output_tx: Arc<Mutex<Option<OutputSender>>>,
+    alive: Arc<AtomicBool>,
+) {
+    let mut buf = [0u8; 1024];
+    loop {
+        match port_reader.read_bytes(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let data = buf[..n].to_vec();
+                // Clone the sender out before any await — MutexGuard is not Send.
+                let sender = {
+                    let Ok(guard) = output_tx.lock() else {
+                        break;
+                    };
+                    guard.clone()
+                };
+                match sender {
+                    Some(s) => {
+                        if s.send(data).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::TimedOut
+                    || e.kind() == std::io::ErrorKind::WouldBlock =>
+            {
+                continue
+            }
+            Err(_) => break,
+        }
+    }
+
+    // Port is gone or closed: mark it dead and drop the stored output sender so
+    // the session manager observes the channel close and surfaces the disconnect
+    // (tab dot leaves green + disconnect overlay). See the doc comment above.
+    alive.store(false, Ordering::SeqCst);
+    if let Ok(mut guard) = output_tx.lock() {
+        *guard = None;
+    }
+}
+
 #[async_trait::async_trait]
 impl ConnectionType for Serial {
     fn type_id(&self) -> &str {
@@ -325,44 +404,14 @@ impl ConnectionType for Serial {
             *guard = Some(tx);
         }
 
-        // Reader task: async reads forwarded to the output channel.
-        let port_reader = port.clone();
-        let alive_clone = alive.clone();
-        let output_tx_clone = self.output_tx.clone();
-        let reader_task = tokio::spawn(async move {
-            let mut buf = [0u8; 1024];
-            loop {
-                match port_reader.read(&mut buf).await {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        let data = buf[..n].to_vec();
-                        // Clone the sender out before any await — MutexGuard is not Send.
-                        let sender = {
-                            let Ok(guard) = output_tx_clone.lock() else {
-                                break;
-                            };
-                            guard.clone()
-                        };
-                        match sender {
-                            Some(s) => {
-                                if s.send(data).await.is_err() {
-                                    break;
-                                }
-                            }
-                            None => break,
-                        }
-                    }
-                    Err(e)
-                        if e.kind() == std::io::ErrorKind::TimedOut
-                            || e.kind() == std::io::ErrorKind::WouldBlock =>
-                    {
-                        continue
-                    }
-                    Err(_) => break,
-                }
-            }
-            alive_clone.store(false, Ordering::SeqCst);
-        });
+        // Reader task: async reads forwarded to the output channel. On exit it
+        // drops the stored output sender so a lost port surfaces as a disconnect
+        // (see `run_serial_reader`).
+        let reader_task = tokio::spawn(run_serial_reader(
+            port.clone(),
+            self.output_tx.clone(),
+            alive.clone(),
+        ));
 
         // Writer task: drains the write channel and sends to the serial port.
         let port_writer = port.clone();
@@ -660,5 +709,105 @@ mod tests {
             .disconnect()
             .await
             .expect("disconnect should not fail");
+    }
+
+    // --- run_serial_reader / lost-port disconnect (#1824) -----------------
+
+    use std::collections::VecDeque;
+    use std::io;
+    use std::time::Duration;
+
+    /// Scripted async reader returning a queue of results, then EOF.
+    struct MockSerialReader {
+        results: Mutex<VecDeque<io::Result<Vec<u8>>>>,
+    }
+
+    impl MockSerialReader {
+        fn new(results: Vec<io::Result<Vec<u8>>>) -> Self {
+            Self {
+                results: Mutex::new(results.into_iter().collect()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SerialByteReader for MockSerialReader {
+        async fn read_bytes(&self, buf: &mut [u8]) -> io::Result<usize> {
+            let next = self.results.lock().expect("mock lock").pop_front();
+            match next {
+                Some(Ok(bytes)) => {
+                    let n = bytes.len().min(buf.len());
+                    buf[..n].copy_from_slice(&bytes[..n]);
+                    Ok(n)
+                }
+                Some(Err(e)) => Err(e),
+                None => Ok(0), // exhausted → EOF
+            }
+        }
+    }
+
+    fn make_output_channel() -> (
+        Arc<Mutex<Option<OutputSender>>>,
+        tokio::sync::mpsc::Receiver<Vec<u8>>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let output_tx = Arc::new(Mutex::new(Some(tx)));
+        (output_tx, rx)
+    }
+
+    /// Regression test for #1824: when the port raises a fatal I/O error (device
+    /// removed / cable unplugged), the reader must drop the stored sender so the
+    /// output channel closes — that is what makes the desktop emit `terminal-exit`
+    /// and flip the tab out of the green "connected" state.
+    #[tokio::test]
+    async fn reader_drops_sender_and_closes_channel_on_fatal_error() {
+        let (output_tx, mut rx) = make_output_channel();
+        let alive = Arc::new(AtomicBool::new(true));
+        let reader = Arc::new(MockSerialReader::new(vec![
+            Ok(b"hello".to_vec()),
+            Err(io::Error::from(io::ErrorKind::BrokenPipe)),
+        ]));
+
+        run_serial_reader(reader, output_tx.clone(), alive.clone()).await;
+
+        assert_eq!(rx.recv().await, Some(b"hello".to_vec()));
+        // The channel must close so the session manager surfaces the disconnect.
+        // Bounded so a regression (sender not dropped) fails cleanly, not hangs.
+        let closed = tokio::time::timeout(Duration::from_secs(1), rx.recv()).await;
+        assert_eq!(
+            closed,
+            Ok(None),
+            "channel must close on port loss so terminal-exit fires (#1824)"
+        );
+        assert!(
+            !alive.load(Ordering::SeqCst),
+            "alive must be false after the port is lost"
+        );
+        assert!(
+            output_tx.lock().expect("lock").is_none(),
+            "stored output sender must be dropped so the channel closes"
+        );
+    }
+
+    /// Transient `TimedOut` / `WouldBlock` reads must not be mistaken for a lost
+    /// port; the reader keeps going and only ends on a real EOF.
+    #[tokio::test]
+    async fn reader_ignores_transient_errors_then_ends_on_eof() {
+        let (output_tx, mut rx) = make_output_channel();
+        let alive = Arc::new(AtomicBool::new(true));
+        let reader = Arc::new(MockSerialReader::new(vec![
+            Err(io::Error::from(io::ErrorKind::TimedOut)),
+            Ok(b"data".to_vec()),
+            Err(io::Error::from(io::ErrorKind::WouldBlock)),
+            Ok(Vec::new()), // Ok(0) → clean EOF
+        ]));
+
+        run_serial_reader(reader, output_tx.clone(), alive.clone()).await;
+
+        assert_eq!(rx.recv().await, Some(b"data".to_vec()));
+        let closed = tokio::time::timeout(Duration::from_secs(1), rx.recv()).await;
+        assert_eq!(closed, Ok(None), "channel must close on EOF");
+        assert!(!alive.load(Ordering::SeqCst));
+        assert!(output_tx.lock().expect("lock").is_none());
     }
 }

--- a/docs/changes/dev3/fix/1824-serial-disconnect-notification.md
+++ b/docs/changes/dev3/fix/1824-serial-disconnect-notification.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Serial: a lost COM/serial connection now surfaces as a disconnect instead of
+  silently staying "connected". When the port disappears mid-session (adapter
+  removed, cable unplugged, read/write error), the reader now closes the output
+  channel so the tab's status dot leaves green and the "connection was lost"
+  disconnect overlay appears — the same way SSH and local sessions already
+  report a dropped connection. Previously the tab stayed green with no
+  notification (#1824).

--- a/tests/manual/serial.yaml
+++ b/tests/manual/serial.yaml
@@ -155,6 +155,26 @@ tests:
     verification: manual
     tags: [serial]
 
+  # --- Lost-port disconnect notification (#1824) ---
+
+  - id: MT-SER-10
+    name: "Losing the serial/COM port flips the tab out of green and notifies"
+    issue: 1824
+    platforms: [all]
+    prerequisites:
+      - app: true
+      - hardware: "a real USB serial adapter (or a socat virtual pair whose backing process can be killed)"
+    instructions:
+      - "Create a Serial connection to a live USB serial adapter and open it"
+      - "Confirm the tab connects and its status dot is green (connected)"
+      - "Physically remove the adapter / unplug the cable (or kill the socat process backing the virtual port)"
+    expected:
+      - "Within a moment the tab's status dot leaves green (turns to the disconnected/error color)"
+      - "The disconnect overlay appears on the terminal ('Session disconnected / The connection was lost.')"
+      - "The app stays stable (no crash, no hang)"
+    verification: manual
+    tags: [serial, disconnect]
+
   # --- Configurable line endings (PR #791) ---
 
   - id: MT-SER-06


### PR DESCRIPTION
## Problem

When a serial/COM connection is lost mid-session (adapter removed, cable unplugged, port read/write error), the tab's status dot stayed green and no disconnect notification appeared — the session was silently dead. Reported user feedback: "I lost a com connection but it was still green and no notification that the com port is gone."

Closes #1824

## Root cause

The desktop session manager detects a session's end purely by the backend's **output channel closing** (`run_output_reader` loops until `output_rx.recv()` returns `None`, then emits `terminal-exit`). There is no `is_connected()` watchdog.

The serial reader task (`core/src/backends/serial.rs`) detected the failure and flipped its `alive` flag on a read error/EOF, but — unlike the local-shell backend — it never dropped the stored `OutputSender`. So the output channel stayed open forever, `terminal-exit` never fired, and the frontend never left the connected (green) state or showed the disconnect overlay.

`local_shell.rs` already does the right thing: on reader exit it sets `*output_tx = None`, which closes the channel.

## Fix

Drop the stored output sender when the serial reader loop exits, mirroring the local-shell backend. This closes the channel → the manager emits `terminal-exit` → the frontend's existing disconnect path runs: the tab's status dot leaves green (`deriveTabStatus` returns `disconnected`) and the `TerminalDisconnectOverlay` shows "The connection was lost." — identical to how SSH and local sessions already report a dropped connection. No parallel notification mechanism was introduced.

Transient `TimedOut` / `WouldBlock` reads are still ignored so a merely quiet port is not mistaken for a lost one.

The reader loop is extracted into `run_serial_reader` over a tiny `SerialByteReader` trait so it can be unit-tested with a mock instead of real hardware. Public backend API is unchanged.

Detection works for both the direct desktop serial path and the agent-relayed path, since the agent uses this same canonical core `Serial` backend.

## Testing

- **Unit (regression):** two new tests drive `run_serial_reader` with a scripted mock reader:
  - a fatal I/O error (device removed) forwards buffered data, then closes the output channel and clears the sender — verified to **fail without the fix** (channel never closes).
  - transient `TimedOut`/`WouldBlock` reads are ignored; only a real EOF ends the session.
- `cargo test -p termihub-core --features serial` — 501 pass.
- `./scripts/check.sh` — all checks pass (fmt, clippy, lint, version drift).
- **Manual:** added MT-SER-10 to `tests/manual/serial.yaml` — open a serial connection to a real USB adapter, physically remove it, confirm the dot leaves green and the disconnect overlay appears. Real-hardware unplug can't be automated.

## Test plan

1. Open a serial connection to a live USB serial adapter; confirm the tab dot is green.
2. Unplug the adapter (or kill the socat process backing a virtual port).
3. Confirm the dot leaves green and the "connection was lost" overlay appears, with no crash.