### PR TITLE
fix(terminal): repaint zoomed tab so content shows without scrolling (Closes #1823)

### DIFF
--- a/docs/changes/dev2/fix/1823-zoom-rerender.md
+++ b/docs/changes/dev2/fix/1823-zoom-rerender.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Zooming a tab now repaints the terminal immediately at its new size. Content
+  was often invisible until you scrolled up and down to force a rerender: when
+  the terminal element is reparented into the zoom overlay, `fitAddon.fit()` is a
+  no-op if the new container yields the same number of rows/columns, so the
+  renderer kept showing stale/blank rows until a scroll marked them dirty. The
+  fit path now forces a full viewport repaint after fitting, so zoomed content
+  renders right away with no manual scroll (#1823).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1205,6 +1205,27 @@ correctly in both themes. See PR #1504.
    have no close button; confirm the toast they resolve into (success/error)
    does.
 
+### Zoomed tab repaints terminal content immediately (#1823)
+
+Verifies that zooming a terminal tab repaints its content at the new size right
+away, with no need to scroll up/down to force a rerender. The fit + refresh path
+has a unit test (`TerminalRegistry.test.tsx` → `fitTerminal`), but the actual GPU
+repaint of the reparented terminal is visual and macOS-WKWebView specific, so it
+stays manual. See PR for #1823.
+
+1. Open a terminal tab and produce a full screen of visible content
+   (e.g. run `ls -la /usr/bin` or `seq 1 200`) so the viewport is not blank.
+2. Zoom the tab into the overlay (**Cmd+Shift+Enter** on macOS,
+   **Ctrl+Shift+Enter** elsewhere, or the tab's zoom control).
+3. **Expected:** the terminal content is visible in the zoom overlay
+   **immediately**, at the new size — you do **not** have to scroll up/down to
+   make it appear.
+4. Repeat several times (the original bug was intermittent) and with both zoom
+   in and out (Esc / the close button to un-zoom). Content must always render
+   without a manual scroll.
+5. Regression check: dragging the split-view splitter to resize a terminal must
+   still reflow and repaint as before.
+
 ### Agent binary SHA-256 checksums (release dry-run, #1350)
 
 Verifies that every published agent binary has a matching `*.sha256` asset and

--- a/src/components/Terminal/TerminalRegistry.test.tsx
+++ b/src/components/Terminal/TerminalRegistry.test.tsx
@@ -33,6 +33,9 @@ function createMockXterm(selection?: string): XTerm {
     write: vi.fn((_data: unknown, cb?: () => void) => cb?.()),
     clear: vi.fn(),
     scrollToBottom: vi.fn(),
+    refresh: vi.fn(),
+    cols: 80,
+    rows: 24,
     buffer: {
       active: {
         length: 1,
@@ -370,6 +373,53 @@ describe("pasteToTerminal", () => {
 
     expect(sendInput).toHaveBeenCalledTimes(1);
     expect(sendInput).toHaveBeenCalledWith("session-dup", "hello");
+  });
+});
+
+describe("fitTerminal", () => {
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Run the queued animation-frame callback synchronously so the post-fit
+    // scroll + refresh can be asserted without waiting for a real frame.
+    rafSpy = vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+  });
+
+  it("does nothing when no terminal is registered for the tabId", () => {
+    // Should not throw
+    act(() => {
+      registryActions.fitTerminal("nonexistent");
+    });
+  });
+
+  it("fits the addon and forces a full viewport repaint so reparented content shows", () => {
+    // Regression for #1823: zooming a tab reparents the terminal element into the
+    // overlay. fitAddon.fit() is a no-op when the new container yields the same
+    // cols/rows, so without an explicit refresh the renderer keeps stale/blank
+    // rows until the user scrolls. fitTerminal must fit AND refresh every row.
+    const xterm = createMockXterm();
+    const fitAddon = createMockFitAddon();
+    const el = document.createElement("div");
+
+    act(() => {
+      registryActions.register("tab-fit", el, xterm, fitAddon);
+    });
+
+    act(() => {
+      registryActions.fitTerminal("tab-fit");
+    });
+
+    expect(fitAddon.fit).toHaveBeenCalled();
+    expect(xterm.scrollToBottom).toHaveBeenCalled();
+    // 80×24 mock → refresh the full 0..rows-1 range.
+    expect(xterm.refresh).toHaveBeenCalledWith(0, 23);
   });
 });
 

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -168,7 +168,17 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
       frontendLog("terminal_registry", `fitTerminal fit error tab=${tabId}: ${err}`);
     }
     if (xterm) {
-      requestAnimationFrame(() => xterm.scrollToBottom());
+      requestAnimationFrame(() => {
+        xterm.scrollToBottom();
+        // Force a full repaint of the viewport. fitAddon.fit() only re-renders
+        // when the computed cols/rows actually change; when a terminal is
+        // reparented into a same-size container — e.g. zooming a tab into the
+        // overlay — fit() is a no-op, so the renderer keeps showing stale/blank
+        // rows until a scroll event marks them dirty. That is why zoomed content
+        // only appeared after scrolling up/down. Refreshing every visible row
+        // makes the repaint deterministic so content shows immediately (#1823).
+        xterm.refresh(0, Math.max(0, xterm.rows - 1));
+      });
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes #1823: after zooming a tab, terminal content was frequently not repainted at the new size — the user had to scroll up and down to force a rerender before content appeared.

Closes #1823

## Root cause

Zooming a tab reparents the terminal's DOM element into the zoom overlay (`TerminalSlot` adoption in `SplitView.tsx`), which calls `fitTerminal()`. `fitTerminal` runs `fitAddon.fit()` and then `xterm.scrollToBottom()`.

`fitAddon.fit()` only calls `xterm.resize()` — and thus only triggers a re-render — when the computed cols/rows actually change. When the zoom overlay yields the same (or near-same) number of rows/columns, `fit()` is a no-op, and `scrollToBottom()` while already pinned to the bottom is a no-op too. So nothing marks the viewport rows dirty, and the DOM renderer keeps showing the stale/blank rows from before the reparent. Scrolling up/down changes `viewportY`, which marks rows dirty and forces the repaint — exactly the workaround the user found.

## Fix

After fitting, `fitTerminal` now forces a deterministic full repaint of the viewport with `xterm.refresh(0, rows - 1)` (inside the same rAF as the existing `scrollToBottom`). This makes the reparented terminal render immediately regardless of whether the dimensions changed. Normal resize already worked (it changes dimensions, so `fit()` re-renders); the added refresh is cheap and harmless there, and the fix routes through the single shared fit path so both zoom and resize behave identically.

## Testing

- Unit: added a `fitTerminal` regression test in `TerminalRegistry.test.tsx` asserting `fit()` + `scrollToBottom()` + `refresh(0, rows-1)` are called (would fail without the fix).
- Full frontend suite green (`pnpm test`), `./scripts/check.sh` passes.
- Manual: added steps to `docs/testing.md` (open a terminal with content, zoom, confirm content repaints immediately without scrolling; plus a resize regression check). The GPU repaint is macOS-WKWebView specific, so it stays a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)