### PR TITLE
fix(ui): fold remote agents group contents on collapse (Closes #1822)

### DIFF
--- a/docs/changes/dev4/fix/1822-remote-agents-collapse.md
+++ b/docs/changes/dev4/fix/1822-remote-agents-collapse.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Connections sidebar: collapsing the **Remote Agents** group now folds its
+  contents away and reclaims the sidebar space, matching the Connections group.
+  Previously the group's children were hidden on collapse but the wrapper kept
+  its flex-grow slot, so an empty gap remained "giving free view over the side
+  bar" instead of increasing visibility of the other groups. The group toggles
+  also expose `aria-expanded` now (#1822).

--- a/src/components/Sidebar/ConnectionList.remote-agents-collapse.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-collapse.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Regression tests for #1822: collapsing the "Remote Agents" group must fold
+ * away its contents AND reclaim the sidebar space it occupied.
+ *
+ * The child items were already hidden by the `!remoteAgentsCollapsed` render
+ * guards, but the outer wrapper still grew to fill the column because its flex
+ * slot was keyed on `experimentalFeaturesEnabled` instead of the collapsed
+ * state — leaving an empty gap that "gives free view over the side bar".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import { TooltipProvider } from "@/components/ui";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({
+    agent,
+    style,
+    sectionRef,
+  }: {
+    agent: RemoteAgentDefinition;
+    style?: React.CSSProperties;
+    sectionRef?: (el: HTMLDivElement | null) => void;
+  }) =>
+    React.createElement("div", {
+      ref: sectionRef,
+      "data-testid": `agent-node-${agent.id}`,
+      style,
+    }),
+}));
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: "agent-1",
+    name: "Test Agent",
+    config: {
+      host: "10.0.0.1",
+      port: 22,
+      username: "user",
+      authMethod: "password",
+    },
+    connectionState: "disconnected",
+    isExpanded: false,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    ...overrides,
+  };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: true,
+  fileBrowserEnabled: true,
+  experimentalFeaturesEnabled: true,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(
+      React.createElement(TooltipProvider, {
+        delayDuration: 0,
+        children: React.createElement(ConnectionList),
+      })
+    );
+  });
+}
+
+function clickRemoteAgentsToggle() {
+  const toggle = container.querySelector<HTMLButtonElement>(
+    '[data-testid="connection-list-remote-agents-toggle"]'
+  );
+  act(() => {
+    toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("ConnectionList – Remote Agents collapse (#1822)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+    useAppStore.setState({ remoteAgents: [makeAgent()] });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("expanded by default: children visible and toggle marked expanded", () => {
+    render();
+
+    expect(container.querySelector('[data-testid="agent-node-agent-1"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="agent-filter-input"]')).toBeTruthy();
+    const toggle = container.querySelector('[data-testid="connection-list-remote-agents-toggle"]');
+    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("collapsing hides the agent children and the agent filter", () => {
+    render();
+    clickRemoteAgentsToggle();
+
+    expect(container.querySelector('[data-testid="agent-node-agent-1"]')).toBeNull();
+    expect(container.querySelector('[data-testid="agent-filter-input"]')).toBeNull();
+    const toggle = container.querySelector('[data-testid="connection-list-remote-agents-toggle"]');
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("collapsing removes the wrapper's flex-grow so it no longer squats on the column", () => {
+    render();
+
+    // While expanded the Remote Agents wrapper participates in the flex layout.
+    const wrapper = container.querySelector<HTMLElement>(".connection-list__remote-agents");
+    expect(wrapper).toBeTruthy();
+    expect(wrapper?.style.flex).not.toBe("");
+
+    clickRemoteAgentsToggle();
+
+    // Collapsed: no inline flex value, so it shrinks to just the header and the
+    // Connections group reclaims the freed space.
+    const collapsedWrapper = container.querySelector<HTMLElement>(
+      ".connection-list__remote-agents"
+    );
+    expect(collapsedWrapper?.style.flex).toBe("");
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -992,9 +992,14 @@ export function ConnectionList() {
   const LocalChevron = localCollapsed ? ChevronRight : ChevronDown;
   const RemoteAgentsChevron = remoteAgentsCollapsed ? ChevronRight : ChevronDown;
 
+  // The Remote Agents section only occupies a flex slot when it is both
+  // rendered (experimental) and expanded. Keying it on `experimental` alone
+  // (ignoring `remoteAgentsCollapsed`) left the collapsed wrapper flex-growing
+  // to fill the column, so its contents folded away but the empty space
+  // remained (#1822).
   const outerSectionsExpanded = useMemo(
-    () => [!localCollapsed, experimental] as boolean[],
-    [localCollapsed, experimental]
+    () => [!localCollapsed, experimental && !remoteAgentsCollapsed] as boolean[],
+    [localCollapsed, experimental, remoteAgentsCollapsed]
   );
   const { map: outerExpandedIndexMap, count: outerExpandedCount } = useMemo(
     () => buildExpandedIndexMap(outerSectionsExpanded),
@@ -1062,6 +1067,7 @@ export function ConnectionList() {
             <button
               className="connection-list__group-toggle"
               onClick={() => setLocalCollapsed((v) => !v)}
+              aria-expanded={!localCollapsed}
               data-testid="connection-list-group-toggle"
             >
               <LocalChevron size={16} className="connection-tree__chevron" />
@@ -1186,6 +1192,7 @@ export function ConnectionList() {
                 <button
                   className="connection-list__group-toggle"
                   onClick={() => setRemoteAgentsCollapsed((v) => !v)}
+                  aria-expanded={!remoteAgentsCollapsed}
                   data-testid="connection-list-remote-agents-toggle"
                 >
                   <RemoteAgentsChevron size={16} className="connection-tree__chevron" />


### PR DESCRIPTION
Closes #1822

## Problem

In the Connections sidebar, collapsing the **Remote Agents** group did not
free up sidebar space. The user reported it "doesn't fold down and gives free
view over the side bar" — an empty gap where the group used to be.

## Root cause

The group already hid its children via `!remoteAgentsCollapsed` render guards,
so the contents *were* hidden. But the outer wrapper (`connection-list__remote-agents`)
is one of two flex sections in the sidebar column, and its flex slot was keyed
on `experimentalFeaturesEnabled` alone:

```
[!localCollapsed, experimental]
```

Since the section only renders when experimental is on, that second entry was
always `true` — so the collapsed wrapper kept flex-growing to fill the column,
leaving the empty gap even though its children were gone.

## Fix

Key the flex slot on the collapsed state too:

```
[!localCollapsed, experimental && !remoteAgentsCollapsed]
```

When collapsed, the section no longer claims a flex slot, shrinks to just its
header, and the Connections group reclaims the freed space — matching how the
Connections group already behaves (`localCollapsed`, also non-persisted local
state, so behaviour stays consistent). Also added `aria-expanded` to both group
toggle buttons.

Scope kept tight to the fold behaviour (no restyle/refactor) so the separately
scheduled sidebar rendering-glitch fix (#1828) can follow without collision.

## Testing

- New regression test `ConnectionList.remote-agents-collapse.test.tsx`:
  collapsing hides the agent children + filter, flips `aria-expanded`, and
  drops the wrapper's inline flex value.
- Full `pnpm test` suite green (3836 tests); `./scripts/check.sh` passes.