### PR TITLE
fix(ui): make connection-failed dialog fix commands copyable

### DIFF
--- a/docs/changes/dev1/fix/1829-connfail-dialog-copy.md
+++ b/docs/changes/dev1/fix/1829-connfail-dialog-copy.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- The "Connection failed" dialog's suggested fix commands are now copyable: a
+  copy button next to each command writes it to the clipboard (confirmed with a
+  success toast), and the command text itself is selectable. Previously the user
+  had to retype the command by hand (#1829).

--- a/src/components/Terminal/TerminalConnectionOverlay.copy.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.copy.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Clipboard-feedback test for the "Connection failed" dialog's suggested fix
+ * commands (#1829).
+ *
+ * When a connection fails with a recoverable error (e.g. a serial permission
+ * error), the dialog shows a shell command the user is meant to run. It used to
+ * be display-only; this pins that a dedicated copy button writes the command to
+ * the clipboard and confirms with a success toast, and that the command lives in
+ * a copyable (selectable) element.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: (...args: unknown[]) => toastSuccess(...args),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+const writeText = vi.fn((_text?: string) => Promise.resolve());
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: (text: string) => writeText(text),
+}));
+
+import { TerminalConnectionOverlay } from "./TerminalConnectionOverlay";
+import { useAppStore } from "@/store/appStore";
+
+const TAB_ID = "tab-copy";
+const PANEL_ID = "panel-copy";
+const SERIAL_COMMAND = "sudo usermod -aG dialout $USER";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function resetStore() {
+  useAppStore.setState({
+    terminalConnecting: {},
+    terminalSpawnErrors: {},
+    terminalAutoRetryCount: {},
+    terminalWaitingForAgent: {},
+    terminalRetryCounters: {},
+    terminalReattaching: {},
+  });
+}
+
+function renderSerialPermissionFailure() {
+  useAppStore.setState({
+    terminalSpawnErrors: { [TAB_ID]: "Permission denied on '/dev/ttyUSB0'" },
+  });
+  act(() => {
+    root.render(
+      <TerminalConnectionOverlay
+        tabId={TAB_ID}
+        panelId={PANEL_ID}
+        tabTitle="Poseidon uP1 Serial"
+        isVisible={true}
+        sessionType="serial"
+      />
+    );
+  });
+}
+
+function query(testId: string): Element | null {
+  return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("TerminalConnectionOverlay — copy fix command (#1829)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    resetStore();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("copies the serial fix command and confirms with a success toast", async () => {
+    renderSerialPermissionFailure();
+
+    const copyButton = query("terminal-connection-serial-copy-btn") as HTMLButtonElement | null;
+    expect(copyButton).not.toBeNull();
+
+    act(() => copyButton!.click());
+    await flush();
+
+    expect(writeText).toHaveBeenCalledWith(SERIAL_COMMAND);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("renders the fix command in a selectable element", () => {
+    renderSerialPermissionFailure();
+
+    const commandEl = document.querySelector<HTMLElement>(
+      ".terminal-connection-overlay__command-row .terminal-connection-overlay__hint-code"
+    );
+    expect(commandEl).not.toBeNull();
+    expect(commandEl?.textContent).toBe(SERIAL_COMMAND);
+  });
+});

--- a/src/components/Terminal/TerminalConnectionOverlay.css
+++ b/src/components/Terminal/TerminalConnectionOverlay.css
@@ -123,6 +123,20 @@
   white-space: pre-wrap;
 }
 
+/* Suggested fix command with a copy affordance (#1829) */
+.terminal-connection-overlay__command-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+}
+
+.terminal-connection-overlay__command-row .terminal-connection-overlay__hint-code {
+  flex: 1;
+  min-width: 0;
+  /* Selectable so the user can also copy the command by hand (#1829). */
+  user-select: text;
+}
+
 .terminal-connection-overlay__hint-text {
   max-width: 520px;
   color: var(--text-secondary);

--- a/src/components/Terminal/TerminalConnectionOverlay.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.test.tsx
@@ -10,6 +10,7 @@ vi.mock("lucide-react", () => ({
   Loader2: () => null,
   Zap: () => null,
   Ban: () => null,
+  Copy: () => null,
 }));
 
 const TAB_ID = "tab-test";

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect } from "react";
-import { ServerCrash, RefreshCw, Loader2, Zap, Ban } from "lucide-react";
+import { ServerCrash, RefreshCw, Loader2, Zap, Ban, Copy } from "lucide-react";
+import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manager";
 import { Button } from "@/components/ui/Button";
+import { toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { useElapsed } from "@/hooks/useElapsed";
 import "./TerminalConnectionOverlay.css";
@@ -34,6 +36,40 @@ function formatElapsed(seconds: number): string {
   const mins = Math.floor(seconds / 60);
   const secs = seconds % 60;
   return `${mins}m ${String(secs).padStart(2, "0")}s`;
+}
+
+/**
+ * Copy a suggested fix command to the clipboard so the user can paste and run it
+ * instead of retyping it by hand (#1829). Returns the promise so the Button drives
+ * its success flash; a rejection surfaces via the Button's error toast.
+ */
+async function copyCommand(command: string): Promise<void> {
+  await writeClipboard(command);
+  toast.success("Command copied to clipboard");
+}
+
+/**
+ * A suggested shell command shown on the failure screen, with a copy affordance
+ * (#1829): the command text is selectable, and a ghost icon button copies it to
+ * the clipboard with a success toast. Reuses the pattern established for the
+ * X-server setup dialog (#1819).
+ */
+function CommandBlock({ command, testId }: { command: string; testId?: string }) {
+  return (
+    <div className="terminal-connection-overlay__command-row">
+      <code className="terminal-connection-overlay__hint-code">{command}</code>
+      <Button
+        variant="ghost"
+        iconOnly
+        size="sm"
+        icon={<Copy size={14} aria-hidden />}
+        aria-label="Copy command"
+        title="Copy command"
+        data-testid={testId}
+        onClick={() => copyCommand(command)}
+      />
+    </div>
+  );
 }
 
 /**
@@ -329,10 +365,10 @@ export function TerminalConnectionOverlay({
               Open the connection editor and use the <strong>Setup SSH Agent</strong> button, or
               run:
             </p>
-            <code className="terminal-connection-overlay__hint-code">
-              Start-Process powershell -Verb RunAs -ArgumentList &apos;Set-Service ssh-agent
-              -StartupType Manual; Start-Service ssh-agent&apos;
-            </code>
+            <CommandBlock
+              command="Start-Process powershell -Verb RunAs -ArgumentList 'Set-Service ssh-agent -StartupType Manual; Start-Service ssh-agent'"
+              testId="terminal-connection-agent-copy-btn"
+            />
           </div>
         )}
 
@@ -353,9 +389,10 @@ export function TerminalConnectionOverlay({
           <div className="terminal-connection-overlay__hint">
             <p className="terminal-connection-overlay__hint-title">Permission denied</p>
             <p>On Linux, add your user to the dialout group and re-login:</p>
-            <code className="terminal-connection-overlay__hint-code">
-              sudo usermod -aG dialout $USER
-            </code>
+            <CommandBlock
+              command="sudo usermod -aG dialout $USER"
+              testId="terminal-connection-serial-copy-btn"
+            />
           </div>
         )}
 


### PR DESCRIPTION
When a connection fails with a recoverable error, the "Connection failed" overlay shows a shell command the user is meant to run — but the command was display-only, so the user had to retype it by hand (image002.png, serial permission case: `sudo usermod -aG dialout $USER`).

## Changes

- Add a copy-to-clipboard button (ghost icon Button with the lucide `copy` icon) next to each suggested fix command in the connection-failed overlay (`TerminalConnectionOverlay`) — both the serial dialout command and the SSH-agent command. It writes the command via the clipboard-manager plugin and confirms with `toast.success`, reusing the pattern established for the X-server dialog (#1819, PR #1833). The async Button lifecycle surfaces any failure as an error toast.
- Make the command text itself selectable (`user-select: text`) so it can also be copied by hand on every platform.
- Regression test (`TerminalConnectionOverlay.copy.test.tsx`): clicking the copy button writes the command and fires a success toast; the command renders in a selectable element.

Composes only shared `src/components/ui/` primitives and design tokens; every action gives feedback, per the design system.

## Out of scope (same dialog, separate issues)

This dialog is also the subject of #1830 (duplicated permission-error text) and #1831 (Linux `dialout` advice shown on Windows). Those are intentionally left untouched here — this PR only adds the copy affordance, keeping the diff minimal to avoid conflicting with those changes.

Closes #1829
