### PR TITLE
feat(config): per-connection environment variables for local shells

### DIFF
--- a/core/src/backends/local_shell.rs
+++ b/core/src/backends/local_shell.rs
@@ -5,6 +5,7 @@
 //! calls `portable_pty::native_pty_system()`; tests inject `MockLocalShellSpawner`
 //! which returns in-memory pipes and never forks a real process.
 
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -26,6 +27,29 @@ use crate::session::traits::{LocalShellSpawner, SpawnedShell};
 
 /// Channel capacity for output data from the PTY reader thread.
 const OUTPUT_CHANNEL_CAPACITY: usize = 64;
+
+/// Parse the `envVars` key-value list from connection settings into a map of
+/// environment variables to apply to the spawned shell.
+///
+/// Each entry is an object with `key`/`value` string fields (the shape produced
+/// by the [`FieldType::KeyValueList`](crate::connection::FieldType) form widget).
+/// Entries missing either field are skipped. On a duplicate key the last entry
+/// wins. Returns an empty map when the field is absent or not an array.
+fn parse_env_vars(settings: &serde_json::Value) -> HashMap<String, String> {
+    settings
+        .get("envVars")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    let key = item.get("key").and_then(|v| v.as_str())?;
+                    let value = item.get("value").and_then(|v| v.as_str())?;
+                    Some((key.to_string(), value.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 // ── NativeLocalShellSpawner ────────────────────────────────────────
 
@@ -323,8 +347,30 @@ impl<S: LocalShellSpawner> ConnectionType for LocalShell<S> {
                         supports_tilde_expansion: false,
                         visible_when: None,
                     },
-                ],
-            }],
+                    ],
+                },
+                SettingsGroup {
+                    key: "environment".to_string(),
+                    label: "Environment".to_string(),
+                    fields: vec![SettingsField {
+                        key: "envVars".to_string(),
+                        label: "Environment Variables".to_string(),
+                        description: Some(
+                            "Extra environment variables for the spawned shell. \
+                             These override any inherited value of the same name."
+                                .to_string(),
+                        ),
+                        help_text: None,
+                        field_type: FieldType::KeyValueList,
+                        required: false,
+                        default: None,
+                        placeholder: None,
+                        supports_env_expansion: true,
+                        supports_tilde_expansion: false,
+                        visible_when: None,
+                    }],
+                },
+            ],
         }
     }
 
@@ -382,6 +428,7 @@ impl<S: LocalShellSpawner> ConnectionType for LocalShell<S> {
             .get("shellIntegration")
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
+        let env = parse_env_vars(&settings);
 
         // Resolve effective shell name for OSC 7 injection below.
         let effective_shell = shell
@@ -393,6 +440,7 @@ impl<S: LocalShellSpawner> ConnectionType for LocalShell<S> {
             shell: Some(effective_shell.clone()),
             starting_directory,
             initial_command,
+            env,
             ..ShellConfig::default()
         }
         .expand();
@@ -627,6 +675,8 @@ mod tests {
         killed: Arc<AtomicBool>,
         /// Dropping this sender signals EOF to the `ChannelReader`.
         reader_tx: Arc<Mutex<Option<std::sync::mpsc::SyncSender<Vec<u8>>>>>,
+        /// Captures the environment of the last spawned command.
+        captured_env: Arc<Mutex<Option<HashMap<String, String>>>>,
     }
 
     impl MockLocalShellSpawner {
@@ -637,6 +687,7 @@ mod tests {
                 resize_log: Arc::new(Mutex::new(Vec::new())),
                 killed: Arc::new(AtomicBool::new(false)),
                 reader_tx: Arc::new(Mutex::new(None)),
+                captured_env: Arc::new(Mutex::new(None)),
             }
         }
 
@@ -649,10 +700,11 @@ mod tests {
     }
 
     impl LocalShellSpawner for MockLocalShellSpawner {
-        fn spawn(&self, _command: &ShellCommand) -> Result<SpawnedShell, SessionError> {
+        fn spawn(&self, command: &ShellCommand) -> Result<SpawnedShell, SessionError> {
             if self.should_fail {
                 return Err(SessionError::SpawnFailed("mock spawn failure".to_string()));
             }
+            *self.captured_env.lock().unwrap() = Some(command.env.clone());
             let write_log = self.write_log.clone();
             let resize_log = self.resize_log.clone();
             let killed = self.killed.clone();
@@ -914,6 +966,85 @@ mod tests {
             .expect("first connect");
         let result = shell.connect(valid_settings()).await;
         assert!(result.is_err(), "second connect should fail");
+
+        shell.disconnect().await.ok();
+    }
+
+    #[test]
+    fn parse_env_vars_reads_key_value_pairs() {
+        let settings = serde_json::json!({
+            "envVars": [
+                { "key": "FOO", "value": "bar" },
+                { "key": "BAZ", "value": "qux" },
+            ]
+        });
+        let env = parse_env_vars(&settings);
+        assert_eq!(env.len(), 2);
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(env.get("BAZ").map(String::as_str), Some("qux"));
+    }
+
+    #[test]
+    fn parse_env_vars_skips_incomplete_entries() {
+        let settings = serde_json::json!({
+            "envVars": [
+                { "key": "FOO", "value": "bar" },
+                { "key": "NO_VALUE" },
+                { "value": "orphan" },
+            ]
+        });
+        let env = parse_env_vars(&settings);
+        assert_eq!(env.len(), 1);
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+    }
+
+    #[test]
+    fn parse_env_vars_absent_field_is_empty() {
+        assert!(parse_env_vars(&serde_json::json!({})).is_empty());
+        assert!(parse_env_vars(&serde_json::json!({ "envVars": "nope" })).is_empty());
+    }
+
+    #[test]
+    fn schema_has_env_vars_key_value_field() {
+        let shell = LocalShell::new();
+        let schema = shell.settings_schema();
+        let field = schema
+            .groups
+            .iter()
+            .flat_map(|g| &g.fields)
+            .find(|f| f.key == "envVars")
+            .expect("envVars field present in schema");
+        assert!(matches!(field.field_type, FieldType::KeyValueList));
+    }
+
+    #[tokio::test]
+    async fn connect_applies_env_vars_to_spawned_command() {
+        let mock = MockLocalShellSpawner::new();
+        let captured_env = mock.captured_env.clone();
+
+        let mut shell = LocalShell::with_spawner(mock);
+        let shells = detect_available_shells();
+        let sh = shells.first().cloned().unwrap_or_else(|| "sh".to_string());
+        let settings = serde_json::json!({
+            "shell": sh,
+            "envVars": [
+                { "key": "TERMIHUB_CONN_VAR", "value": "connection-value" },
+            ],
+        });
+        shell.connect(settings).await.expect("connect");
+
+        let env = captured_env
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("spawn should have captured a command");
+        assert_eq!(
+            env.get("TERMIHUB_CONN_VAR").map(String::as_str),
+            Some("connection-value"),
+            "connection env var should reach the spawned process environment"
+        );
+        // Standard terminal vars remain alongside the custom one.
+        assert_eq!(env.get("TERM").map(String::as_str), Some("xterm-256color"));
 
         shell.disconnect().await.ok();
     }

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -568,10 +568,19 @@ impl FtpConfig {
 
 impl ShellConfig {
     /// Return a copy with all `${VAR}` placeholders and `~` expanded.
+    ///
+    /// Environment-variable *values* are expanded too, so a configured value of
+    /// `${HOME}/bin` resolves against the launching process's environment. Keys
+    /// (variable names) are left verbatim.
     pub fn expand(mut self) -> Self {
         self.shell = self.shell.map(|s| expand_config_value(&s));
         self.starting_directory = self.starting_directory.map(|s| expand_config_value(&s));
         self.initial_command = self.initial_command.map(|s| expand_config_value(&s));
+        self.env = self
+            .env
+            .into_iter()
+            .map(|(k, v)| (k, expand_config_value(&v)))
+            .collect();
         self
     }
 }
@@ -1038,6 +1047,22 @@ mod tests {
         assert_eq!(back.cols, 100);
         assert_eq!(back.rows, 30);
         assert_eq!(back.env.get("FOO").unwrap(), "bar");
+    }
+
+    #[test]
+    fn shell_config_expand_expands_env_values() {
+        temp_env::with_var("TERMIHUB_TEST_ENV_HOME", Some("/opt/home"), || {
+            let cfg = ShellConfig {
+                env: HashMap::from([
+                    ("PATH_LIKE".into(), "${TERMIHUB_TEST_ENV_HOME}/bin".into()),
+                    ("LITERAL".into(), "plain".into()),
+                ]),
+                ..ShellConfig::default()
+            }
+            .expand();
+            assert_eq!(cfg.env.get("PATH_LIKE").unwrap(), "/opt/home/bin");
+            assert_eq!(cfg.env.get("LITERAL").unwrap(), "plain");
+        });
     }
 
     #[test]

--- a/docs/changes/dev5/feature/1825-per-connection-env-vars.md
+++ b/docs/changes/dev5/feature/1825-per-connection-env-vars.md
@@ -1,0 +1,11 @@
+### Added
+
+- Local shell connections now support **per-connection environment variables**.
+  A new **Environment** section in the local shell connection settings lets you
+  define `NAME`/value pairs that are applied on top of the inherited environment
+  when the terminal's shell is spawned — a connection env var overrides any
+  inherited value of the same name. Values support `${VAR}` expansion against the
+  launching process's environment (e.g. `${HOME}/bin`). Docker connections already
+  had container env vars; SSH and WSL are tracked as a follow-up (their remote/
+  distribution env handling differs — SSH needs `SetEnv`/`AcceptEnv`, WSL needs
+  `WSLENV`) (#1825).


### PR DESCRIPTION
## Summary

Implements per-connection environment variables so a local shell connection spawns its terminal with user-defined env vars set. Requested in the issue: "Setting env variables for a connection would be super, so that a terminal spawns with specific env vars."

Closes #1825

## What changed

- **Schema (`core/src/backends/local_shell.rs`)** — adds an **Environment** group with an `envVars` field of type `KeyValueList`. Because connection forms are schema-driven, `DynamicForm` renders the key/value editor automatically (the same widget Docker already uses for container env vars) — no frontend changes were needed.
- **Parsing** — `connect()` parses the `envVars` list into `ShellConfig.env`.
- **Spawn threading** — `build_shell_command` already copies `config.env` into `ShellCommand.env`, and the PTY spawner applies each var on top of the inherited environment via `CommandBuilder::env`. **Precedence:** a connection env var overrides an inherited value of the same name; all other inherited vars are preserved.
- **Expansion** — `ShellConfig::expand` now expands `${VAR}` in env *values* (e.g. `${HOME}/bin`), matching how Docker expands its env vars. Keys are left verbatim.

## Connection types covered

- **Local shell** — covered (this PR). Works on the desktop and agent paths since both use the shared `core` backend.
- **Docker** — already had container env vars; unchanged.
- **SSH / WSL** — scoped out to a follow-up. Client-side env vars do not transfer to an SSH server unless it opts in via `AcceptEnv`/`SetEnv`, and WSL env crossing the Win32/WSL boundary needs `WSLENV`. Shipping the local-shell field for these without that handling would silently do nothing, so they get correct, dedicated handling in a follow-up.
- **Serial / Telnet / FTP** — not applicable (no locally-spawned shell process).

## Testing

- `cargo test -p termihub-core --all-features` — 941 pass, including new tests:
  - `parse_env_vars_*` (parsing + skipping incomplete entries)
  - `schema_has_env_vars_key_value_field`
  - `connect_applies_env_vars_to_spawned_command` — end-to-end via mock spawner, asserts the connection var reaches the spawned command's environment alongside `TERM`
  - `shell_config_expand_expands_env_values`
- `./scripts/check.sh` — pass
- `pnpm test` — 3833 pass