### PR TITLE
feat(ui): allow users to unbind keyboard shortcuts easily

### DIFF
--- a/docs/changes/dev3/feature/1827-unbind-shortcuts.md
+++ b/docs/changes/dev3/feature/1827-unbind-shortcuts.md
@@ -1,0 +1,10 @@
+### Added
+
+- Keyboard shortcuts can now be **unbound** directly from Settings → Keyboard
+  Shortcuts: each shortcut row has a clear (×) button that removes the binding so
+  the action has no shortcut. An unbound action is shown as an italic `(unbound)`
+  (not a blank cell), stays unbound across restarts (persisted as an empty
+  override rather than reverting to its platform default), and no longer fires on
+  its former keys. The per-row reset (↺) button restores the default, and
+  Backspace while recording a shortcut also unbinds it. The shortcuts overlay and
+  the exported HTML cheat sheet now label such actions `Unbound` too (#1827).

--- a/src/components/KeyboardShortcuts/ShortcutsOverlay.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutsOverlay.tsx
@@ -1,7 +1,12 @@
 import { useState, useMemo } from "react";
 import { Modal, Input } from "@/components/ui";
 import { ShortcutCategory, ShortcutScope } from "@/types/keybindings";
-import { getDefaultBindings, getEffectiveCombo, serializeBinding } from "@/services/keybindings";
+import {
+  getDefaultBindings,
+  getEffectiveCombo,
+  serializeBinding,
+  isUnboundCombo,
+} from "@/services/keybindings";
 import { isMac } from "@/utils/platform";
 import "./ShortcutsOverlay.css";
 
@@ -98,7 +103,11 @@ export function ShortcutsOverlay({ open, onOpenChange }: ShortcutsOverlayProps) 
                   : "Unbound";
                 const mac = binding.macDefault ? serializeBinding(binding.macDefault) : "Unbound";
                 const effective = getEffectiveCombo(binding.action);
-                const effectiveStr = effective ? serializeBinding(effective) : "";
+                const effectiveStr = isUnboundCombo(effective)
+                  ? "Unbound"
+                  : effective
+                    ? serializeBinding(effective)
+                    : "";
 
                 return (
                   <tr key={binding.action} data-testid={`shortcut-row-${binding.action}`}>

--- a/src/components/Settings/KeyboardSettings.css
+++ b/src/components/Settings/KeyboardSettings.css
@@ -94,12 +94,12 @@
 }
 
 .keyboard-settings__action-cell {
-  width: 45%;
+  width: 42%;
   color: var(--text-primary);
 }
 
 .keyboard-settings__binding-cell {
-  width: 45%;
+  width: 42%;
   cursor: pointer;
   padding: 2px var(--spacing-sm);
   border-radius: var(--radius-sm);
@@ -109,6 +109,11 @@
 
 .keyboard-settings__binding-cell:hover {
   background-color: var(--bg-hover);
+}
+
+.keyboard-settings__binding-cell--unbound {
+  color: var(--text-secondary);
+  font-style: italic;
 }
 
 .keyboard-settings__binding-cell--recording {
@@ -121,9 +126,14 @@
   background-color: var(--accent-color);
 }
 
-.keyboard-settings__reset-cell {
-  width: 10%;
-  text-align: center;
+.keyboard-settings__row-actions {
+  width: 16%;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.keyboard-settings__row-actions > * + * {
+  margin-left: var(--spacing-xs);
 }
 
 .keyboard-settings__reset-btn {

--- a/src/components/Settings/KeyboardSettings.test.tsx
+++ b/src/components/Settings/KeyboardSettings.test.tsx
@@ -195,9 +195,7 @@ describe("KeyboardSettings", () => {
     expect(bindingCell.getAttribute("data-unbound")).toBe("true");
 
     // Unbind button disappears once there is nothing left to clear.
-    expect(
-      container.querySelector('[data-testid="keybinding-unbind-toggle-sidebar"]')
-    ).toBeNull();
+    expect(container.querySelector('[data-testid="keybinding-unbind-toggle-sidebar"]')).toBeNull();
 
     // The unbind is persisted to settings as an empty override.
     const overrides = useAppStore.getState().settings.keybindingOverrides ?? [];
@@ -215,11 +213,8 @@ describe("KeyboardSettings", () => {
       ).click();
     });
     expect(
-      (
-        container.querySelector(
-          '[data-testid="keybinding-binding-toggle-sidebar"]'
-        ) as HTMLElement
-      ).textContent
+      (container.querySelector('[data-testid="keybinding-binding-toggle-sidebar"]') as HTMLElement)
+        .textContent
     ).toBe("(unbound)");
 
     act(() => {

--- a/src/components/Settings/KeyboardSettings.test.tsx
+++ b/src/components/Settings/KeyboardSettings.test.tsx
@@ -173,6 +173,72 @@ describe("KeyboardSettings", () => {
     expect(container.textContent).toContain("Press a key combination...");
   });
 
+  it("shows an unbind button for a bound action and clears it on click", async () => {
+    renderComponent();
+
+    const unbindBtn = container.querySelector(
+      '[data-testid="keybinding-unbind-toggle-sidebar"]'
+    ) as HTMLElement;
+    expect(unbindBtn).not.toBeNull();
+
+    await act(async () => {
+      unbindBtn.click();
+      // updateSettings persists asynchronously; flush the microtask queue.
+      await Promise.resolve();
+    });
+
+    // Binding cell now reads "(unbound)" and is marked as such.
+    const bindingCell = container.querySelector(
+      '[data-testid="keybinding-binding-toggle-sidebar"]'
+    ) as HTMLElement;
+    expect(bindingCell.textContent).toBe("(unbound)");
+    expect(bindingCell.getAttribute("data-unbound")).toBe("true");
+
+    // Unbind button disappears once there is nothing left to clear.
+    expect(
+      container.querySelector('[data-testid="keybinding-unbind-toggle-sidebar"]')
+    ).toBeNull();
+
+    // The unbind is persisted to settings as an empty override.
+    const overrides = useAppStore.getState().settings.keybindingOverrides ?? [];
+    const entry = overrides.find((o) => o.action === "toggle-sidebar");
+    expect(entry).toBeDefined();
+    expect(entry?.key).toBe("");
+  });
+
+  it("restores an unbound action to its default via the reset button", () => {
+    renderComponent();
+
+    act(() => {
+      (
+        container.querySelector('[data-testid="keybinding-unbind-toggle-sidebar"]') as HTMLElement
+      ).click();
+    });
+    expect(
+      (
+        container.querySelector(
+          '[data-testid="keybinding-binding-toggle-sidebar"]'
+        ) as HTMLElement
+      ).textContent
+    ).toBe("(unbound)");
+
+    act(() => {
+      (
+        container.querySelector('[data-testid="keybinding-reset-toggle-sidebar"]') as HTMLElement
+      ).click();
+    });
+
+    const bindingCell = container.querySelector(
+      '[data-testid="keybinding-binding-toggle-sidebar"]'
+    ) as HTMLElement;
+    expect(bindingCell.textContent).not.toBe("(unbound)");
+    expect(bindingCell.getAttribute("data-unbound")).toBeNull();
+    // Default is restored, so the unbind button is back.
+    expect(
+      container.querySelector('[data-testid="keybinding-unbind-toggle-sidebar"]')
+    ).not.toBeNull();
+  });
+
   it("cancels recording mode on Escape", () => {
     renderComponent();
     const bindingCell = container.querySelector(

--- a/src/components/Settings/KeyboardSettings.tsx
+++ b/src/components/Settings/KeyboardSettings.tsx
@@ -292,7 +292,7 @@ function KeybindingRow({
 }: KeybindingRowProps) {
   const combo = getEffectiveCombo(binding.action);
   const isUnbound = !combo || isUnboundCombo(combo);
-  const displayStr = isUnbound ? "(unbound)" : serializeBinding(combo);
+  const displayStr = combo && !isUnboundCombo(combo) ? serializeBinding(combo) : "(unbound)";
   const cellRef = useRef<HTMLTableCellElement>(null);
 
   useEffect(() => {

--- a/src/components/Settings/KeyboardSettings.tsx
+++ b/src/components/Settings/KeyboardSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { RotateCcw, Download } from "lucide-react";
+import { RotateCcw, Download, X } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { KeyCombo, KeyBinding, ShortcutCategory } from "@/types/keybindings";
 import {
@@ -10,6 +10,8 @@ import {
   clearOverrides,
   checkConflict,
   getOverrides,
+  unbindAction,
+  isUnboundCombo,
 } from "@/services/keybindings";
 import { exportCheatSheet } from "@/utils/cheatSheetPdf";
 import { Button, Toggle, Tooltip } from "@/components/ui";
@@ -86,6 +88,14 @@ export function KeyboardSettings({ visibleFields }: KeyboardSettingsProps) {
     [persistOverrides]
   );
 
+  const handleUnbindOne = useCallback(
+    (action: string) => {
+      unbindAction(action);
+      persistOverrides();
+    },
+    [persistOverrides]
+  );
+
   const handleRecordComplete = useCallback(
     (action: string, combo: KeyCombo | null) => {
       setRecordingAction(null);
@@ -93,7 +103,7 @@ export function KeyboardSettings({ visibleFields }: KeyboardSettingsProps) {
 
       if (combo === null) {
         // Backspace pressed — unbind
-        setOverride(action, { key: "", ctrl: false });
+        unbindAction(action);
         persistOverrides();
         return;
       }
@@ -119,8 +129,13 @@ export function KeyboardSettings({ visibleFields }: KeyboardSettingsProps) {
   const filteredBindings = searchQuery.trim()
     ? bindings.filter((b) => {
         const q = searchQuery.toLowerCase();
-        const combo = getEffectiveCombo(b.action) ?? b.winLinuxDefault;
-        const comboStr = combo ? serializeBinding(combo) : "";
+        const effective = getEffectiveCombo(b.action);
+        const combo = effective ?? b.winLinuxDefault;
+        const comboStr = isUnboundCombo(effective)
+          ? "unbound"
+          : combo
+            ? serializeBinding(combo)
+            : "";
         return (
           b.label.toLowerCase().includes(q) ||
           b.action.toLowerCase().includes(q) ||
@@ -222,6 +237,7 @@ export function KeyboardSettings({ visibleFields }: KeyboardSettingsProps) {
                     setConflictWarning(null);
                   }}
                   onReset={() => handleResetOne(binding.action)}
+                  onUnbind={() => handleUnbindOne(binding.action)}
                 />
               ))}
             </tbody>
@@ -262,6 +278,7 @@ interface KeybindingRowProps {
   onRecordComplete: (combo: KeyCombo | null) => void;
   onCancel: () => void;
   onReset: () => void;
+  onUnbind: () => void;
 }
 
 function KeybindingRow({
@@ -271,9 +288,11 @@ function KeybindingRow({
   onRecordComplete,
   onCancel,
   onReset,
+  onUnbind,
 }: KeybindingRowProps) {
   const combo = getEffectiveCombo(binding.action);
-  const displayStr = combo ? serializeBinding(combo) : "(unbound)";
+  const isUnbound = !combo || isUnboundCombo(combo);
+  const displayStr = isUnbound ? "(unbound)" : serializeBinding(combo);
   const cellRef = useRef<HTMLTableCellElement>(null);
 
   useEffect(() => {
@@ -315,13 +334,33 @@ function KeybindingRow({
       <td className="keyboard-settings__action-cell">{binding.label}</td>
       <td
         ref={cellRef}
-        className={`keyboard-settings__binding-cell ${isRecording ? "keyboard-settings__binding-cell--recording" : ""}`}
+        className={[
+          "keyboard-settings__binding-cell",
+          isRecording ? "keyboard-settings__binding-cell--recording" : "",
+          !isRecording && isUnbound ? "keyboard-settings__binding-cell--unbound" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
         onClick={!isRecording ? onStartRecording : undefined}
         data-testid={`keybinding-binding-${binding.action}`}
+        data-unbound={!isRecording && isUnbound ? "true" : undefined}
       >
-        {isRecording ? "Press a key combination..." : displayStr}
+        {isRecording ? "Press a key combination... (Backspace to unbind)" : displayStr}
       </td>
-      <td className="keyboard-settings__reset-cell">
+      <td className="keyboard-settings__row-actions">
+        {!isUnbound && (
+          <Tooltip content="Unbind (clear shortcut)">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              icon={<X size={12} />}
+              onClick={onUnbind}
+              aria-label={`Unbind ${binding.label}`}
+              data-testid={`keybinding-unbind-${binding.action}`}
+            />
+          </Tooltip>
+        )}
         <Tooltip content="Reset to default">
           <Button
             variant="ghost"
@@ -329,7 +368,7 @@ function KeybindingRow({
             iconOnly
             icon={<RotateCcw size={12} />}
             onClick={onReset}
-            aria-label="Reset to default"
+            aria-label={`Reset ${binding.label} to default`}
             data-testid={`keybinding-reset-${binding.action}`}
           />
         </Tooltip>

--- a/src/services/keybindings.test.ts
+++ b/src/services/keybindings.test.ts
@@ -19,6 +19,11 @@ import {
   isShellReservedKey,
   isEventFromTerminal,
   DEFAULT_BINDINGS,
+  unbindAction,
+  isUnboundCombo,
+  isActionUnbound,
+  getOverrides,
+  UNBOUND_COMBO,
 } from "./keybindings";
 import { KeyCombo } from "@/types/keybindings";
 
@@ -268,6 +273,69 @@ describe("overrides", () => {
     expect(restored.ctrl).toBe(true);
     expect(restored.shift).toBe(true);
     expect(restored.key).toBe("B");
+  });
+});
+
+describe("unbind", () => {
+  beforeEach(() => {
+    clearOverrides();
+  });
+
+  it("isUnboundCombo recognizes empty combos and null", () => {
+    expect(isUnboundCombo(UNBOUND_COMBO)).toBe(true);
+    expect(isUnboundCombo({ key: "" })).toBe(true);
+    expect(isUnboundCombo([])).toBe(true);
+    expect(isUnboundCombo(null)).toBe(false);
+    expect(isUnboundCombo({ key: "W", ctrl: true })).toBe(false);
+  });
+
+  it("unbindAction clears the binding so the action no longer fires on its former keys", () => {
+    // close-tab defaults to Ctrl+Shift+W on Linux/Win.
+    expect(findMatchingAction(makeKeyEvent("W", { ctrl: true, shift: true }))).toBe("close-tab");
+
+    unbindAction("close-tab");
+
+    expect(isActionUnbound("close-tab")).toBe(true);
+    expect(findMatchingAction(makeKeyEvent("W", { ctrl: true, shift: true }))).toBeNull();
+    expect(processKeyEvent(makeKeyEvent("W", { ctrl: true, shift: true }))).toBeNull();
+  });
+
+  it("an unbound action does NOT fall back to its platform default", () => {
+    unbindAction("toggle-sidebar");
+    const combo = getEffectiveCombo("toggle-sidebar");
+    expect(isUnboundCombo(combo)).toBe(true);
+    // Would be Ctrl+Shift+B if it had fallen back to the default.
+    expect(findMatchingAction(makeKeyEvent("B", { ctrl: true, shift: true }))).toBeNull();
+  });
+
+  it("unbound state persists through serialization round-trip", () => {
+    unbindAction("copy");
+    const entries = getOverrides();
+    const copyEntry = entries.find((e) => e.action === "copy");
+    expect(copyEntry).toBeDefined();
+    expect(copyEntry?.key).toBe("");
+
+    // Simulate reload from persisted settings.
+    clearOverrides();
+    expect(isActionUnbound("copy")).toBe(false);
+    setOverrides(entries);
+    expect(isActionUnbound("copy")).toBe(true);
+    expect(findMatchingAction(makeKeyEvent("C", { ctrl: true, shift: true }))).toBeNull();
+  });
+
+  it("reset-to-default restores an unbound action", () => {
+    unbindAction("close-tab");
+    expect(isActionUnbound("close-tab")).toBe(true);
+
+    setOverride("close-tab", null);
+    expect(isActionUnbound("close-tab")).toBe(false);
+    expect(findMatchingAction(makeKeyEvent("W", { ctrl: true, shift: true }))).toBe("close-tab");
+  });
+
+  it("an unbound action is not reported as a conflict for a new binding", () => {
+    unbindAction("close-tab");
+    // Binding another action to close-tab's former keys must not conflict.
+    expect(checkConflict({ key: "W", ctrl: true, shift: true }, "toggle-sidebar")).toBeNull();
   });
 });
 

--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -277,6 +277,29 @@ export const DEFAULT_BINDINGS: KeyBinding[] = [
 /** Active user overrides. */
 let overrides: KeybindingOverride[] = [];
 
+/**
+ * Sentinel combo that marks an action as explicitly unbound by the user.
+ *
+ * Unbinding is stored as an override with an empty key so the action does not
+ * fall back to its platform default — that fallback is exactly what the user is
+ * opting out of. It round-trips through serialization as an empty string.
+ */
+export const UNBOUND_COMBO: KeyCombo = { key: "" };
+
+/**
+ * Whether a resolved combo represents an explicit "unbound" state — an empty
+ * key with no meaningful modifiers. An unbound override is deliberately kept
+ * (rather than removed) so the action stays cleared instead of reverting to its
+ * platform default on the next launch.
+ */
+export function isUnboundCombo(combo: KeyCombo | KeyCombo[] | null | undefined): boolean {
+  if (!combo) return false;
+  if (Array.isArray(combo)) {
+    return combo.length === 0 || combo.every((c) => c.key === "");
+  }
+  return combo.key === "";
+}
+
 /** Serialize a KeyCombo to a human-readable string like "Ctrl+Shift+C". */
 export function serializeCombo(combo: KeyCombo): string {
   const parts: string[] = [];
@@ -391,6 +414,10 @@ export function findMatchingAction(event: KeyboardEvent): string | null {
     const combo = getEffectiveCombo(binding.action);
     if (!combo) continue;
 
+    // Skip actions the user explicitly unbound: they must not fire, and must
+    // not fall back to their platform default.
+    if (isUnboundCombo(combo)) continue;
+
     // Skip chord bindings (arrays with >1 combo)
     if (Array.isArray(combo) && combo.length > 1) continue;
 
@@ -437,6 +464,20 @@ export function setOverride(action: string, combo: KeyCombo | KeyCombo[] | null)
 }
 
 /**
+ * Explicitly unbind an action so it has no shortcut. Stored as an override (not
+ * a removal) so the action stays cleared and does not revert to its platform
+ * default. Reset-to-default (via {@link setOverride} with `null`) restores it.
+ */
+export function unbindAction(action: string): void {
+  setOverride(action, { ...UNBOUND_COMBO });
+}
+
+/** Whether an action is currently unbound (either by default or by the user). */
+export function isActionUnbound(action: string): boolean {
+  return isUnboundCombo(getEffectiveCombo(action));
+}
+
+/**
  * Check for conflicts: returns the action that already uses the given combo,
  * or null if no conflict exists.
  */
@@ -446,6 +487,7 @@ export function checkConflict(combo: KeyCombo, excludeAction?: string): string |
 
     const effective = getEffectiveCombo(binding.action);
     if (!effective) continue;
+    if (isUnboundCombo(effective)) continue;
 
     const single = Array.isArray(effective) ? effective[0] : effective;
     if (!Array.isArray(effective) || effective.length === 1) {

--- a/src/utils/cheatSheetPdf.ts
+++ b/src/utils/cheatSheetPdf.ts
@@ -5,6 +5,7 @@ import {
   getEffectiveCombo,
   serializeBinding,
   getOverrides,
+  isUnboundCombo,
 } from "@/services/keybindings";
 import { ShortcutCategory } from "@/types/keybindings";
 
@@ -42,7 +43,8 @@ export function buildCheatSheetHtml(): string {
     .map((group) => {
       const rows = group.bindings
         .map((b) => {
-          const combo = getEffectiveCombo(b.action) ?? b.winLinuxDefault;
+          const effective = getEffectiveCombo(b.action);
+          const combo = isUnboundCombo(effective) ? null : (effective ?? b.winLinuxDefault);
           const keyStr = combo ? serializeBinding(combo) : "Unbound";
           const isOverride = overriddenActions.has(b.action);
           const overrideMark = isOverride


### PR DESCRIPTION
## Summary

Users can now easily **unbind** (clear) a keyboard shortcut so an action has no
shortcut at all. Previously the only way to unbind was the undiscoverable
"click the row, press Backspace" gesture, and an unbound action rendered as a
blank cell that looked identical to a default.

## What changed

- **Settings → Keyboard Shortcuts**: each shortcut row now has a clear (×) button
  that unbinds the action. The button is hidden once the action is already
  unbound (nothing left to clear).
- **Clear unbound state**: an unbound action shows an italic `(unbound)` instead
  of a blank cell. The shortcuts overlay and the exported HTML cheat sheet label
  it `Unbound` too.
- **Persistence**: unbinding is stored as an empty override (`key: ""`), so it
  survives a restart and does **not** revert to the platform default.
- **Runtime respects it**: `findMatchingAction` / `processKeyEvent` skip unbound
  actions, so a former key no longer triggers the action and does not fall back
  to the default binding.
- **Re-bind / reset**: the per-row reset (↺) button restores the default;
  Backspace while recording still unbinds.

New service helpers: `unbindAction`, `isUnboundCombo`, `isActionUnbound`,
`UNBOUND_COMBO`.

## Tests

- Service: unbind clears the binding, no fallback to default, persistence
  round-trip, reset restores, and an unbound action is not a false conflict.
- Component: the clear button unbinds + persists + shows `(unbound)`, and reset
  restores the default.

Closes #1827