### PR TITLE
fix(ui): keep connections sidebar sized on first paint (Closes #1828)

### DIFF
--- a/docs/changes/dev4/fix/1828-sidebar-render-glitch.md
+++ b/docs/changes/dev4/fix/1828-sidebar-render-glitch.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- The Connections sidebar no longer renders clipped or partially laid out on
+  launch. When the Remote Agents sections mounted (after settings and agents
+  loaded asynchronously), the section flex-sizing hook briefly returned fewer
+  flex values than there were sections, so a section laid out size-to-content
+  instead of filling its slot. On WebKit that mis-sized first paint stuck until
+  a manual tab/window resize forced a reflow. The sidebar now stays correctly
+  sized on the first paint with no resize needed (#1828).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1226,6 +1226,32 @@ stays manual. See PR for #1823.
 5. Regression check: dragging the split-view splitter to resize a terminal must
    still reflow and repaint as before.
 
+### Connections sidebar renders fully on first paint (#1828)
+
+Verifies that the Connections sidebar lays out completely on launch, with no
+clipped/partial rendering that only clears after resizing the tab or window.
+The underlying flex-sizing fix has a unit test (`useSectionResize.test.tsx`),
+but the residual mis-paint was macOS-WKWebView specific, so this stays manual.
+See PR for #1828.
+
+Requires the **Remote Agents** section (enable experimental features in
+Settings) with at least one saved remote agent, since the glitch appeared as
+those sections mounted after settings/agents loaded.
+
+1. Fully quit and cold-launch the app (do not just reload) so the sidebar mounts
+   from scratch while settings and remote agents load.
+2. **Expected:** the Connections sidebar renders fully and correctly on the
+   first paint — group headers with their chevrons **and** titles, the filter
+   box, and every connection/agent row are laid out at the right width, with no
+   truncated text, stray chevrons, cut-off search box, or clipped rows.
+3. You must **not** need to resize the tab or window to make the sidebar look
+   right.
+4. Repeat a few times (the original bug was intermittent) and at different window
+   sizes, including a narrow window.
+5. Regression check: dragging the sidebar resize handle and the inner
+   section-resize handles (between Connections and Remote Agents, and between
+   expanded agents) must still resize as before.
+
 ### Agent binary SHA-256 checksums (release dry-run, #1350)
 
 Verifies that every published agent binary has a matching `*.sha256` asset and

--- a/src/hooks/useSectionResize.test.tsx
+++ b/src/hooks/useSectionResize.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Regression tests for {@link useSectionResize}.
+ *
+ * The hook feeds per-section `flex` values straight into inline styles. If the
+ * returned array is ever shorter than `expandedCount` — which happens for the
+ * render right after the number of sections grows, before the internal reset
+ * effect runs — a section reads `flexValues[i] === undefined` and renders with
+ * `flex: undefined` (i.e. `flex: 0 1 auto`, size-to-content) instead of
+ * flex-filling its slot. That produces a clipped/mis-laid-out sidebar on first
+ * paint that only corrects after a manual resize forces a reflow (#1828).
+ *
+ * These tests assert the hook never returns a short or hole-containing array on
+ * ANY render, including the transient one where `expandedCount` just grew.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useSectionResize } from "./useSectionResize";
+
+interface Capture {
+  expandedCount: number;
+  flexValues: number[];
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function Harness({ expandedCount, log }: { expandedCount: number; log: Capture[] }) {
+  const { flexValues } = useSectionResize(expandedCount);
+  // Record what this render would hand to the section inline styles.
+  log.push({ expandedCount, flexValues });
+  return null;
+}
+
+afterEach(() => {
+  if (root) act(() => root.unmount());
+  if (container) container.remove();
+});
+
+function renderHarness(expandedCount: number, log: Capture[]) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(Harness, { expandedCount, log }));
+  });
+}
+
+describe("useSectionResize", () => {
+  it("returns one flex value per expanded section on the initial render", () => {
+    const log: Capture[] = [];
+    renderHarness(3, log);
+
+    const first = log[0];
+    expect(first.flexValues).toHaveLength(3);
+    expect(first.flexValues.every((v) => typeof v === "number" && Number.isFinite(v))).toBe(true);
+  });
+
+  it("never yields a hole or short array on the render where the count grows", () => {
+    // Start collapsed/empty (as when settings + remote agents are still loading),
+    // then grow — the async path that produced the first-paint glitch.
+    const log: Capture[] = [];
+    renderHarness(0, log);
+
+    act(() => {
+      root.render(React.createElement(Harness, { expandedCount: 4, log }));
+    });
+
+    // Every captured render — including the transient one right after the count
+    // grew, before any effect runs — must expose a full, hole-free flex array.
+    for (const { expandedCount, flexValues } of log) {
+      expect(flexValues).toHaveLength(expandedCount);
+      for (let i = 0; i < expandedCount; i++) {
+        expect(flexValues[i]).toBeTypeOf("number");
+        expect(Number.isFinite(flexValues[i])).toBe(true);
+      }
+    }
+  });
+
+  it("stays hole-free when growing from a non-zero count", () => {
+    const log: Capture[] = [];
+    renderHarness(1, log);
+
+    act(() => {
+      root.render(React.createElement(Harness, { expandedCount: 3, log }));
+    });
+
+    for (const { expandedCount, flexValues } of log) {
+      expect(flexValues).toHaveLength(expandedCount);
+      expect(flexValues.slice(0, expandedCount).some((v) => v === undefined)).toBe(false);
+    }
+  });
+});

--- a/src/hooks/useSectionResize.ts
+++ b/src/hooks/useSectionResize.ts
@@ -5,7 +5,7 @@
  * mouse-event handlers for drag-to-resize handles between them.
  */
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 
 interface ResizeState {
   /** Index of the handle being dragged (between section i and i+1). */
@@ -119,5 +119,20 @@ export function useSectionResize(expandedCount: number): UseSectionResizeResult 
     [startResize]
   );
 
-  return { flexValues, handleProps, isResizing, sectionRefs };
+  // Normalise the returned array to always be exactly `expandedCount` long,
+  // defaulting any missing slot to an even `1`. `flexValues` state lags
+  // `expandedCount` for one render whenever the section count grows (the reset
+  // effect above runs only after that render): the desktop sidebar's Remote
+  // Agents sections appear after settings + agents load asynchronously, so
+  // without this guard a section reads `flexValues[i] === undefined` on that
+  // transient render and lays out as `flex: 0 1 auto` (size-to-content) instead
+  // of flex-filling its slot. On WebKit that mis-sized first paint sticks until
+  // a manual resize forces a reflow — the #1828 glitch. Deriving the value at
+  // render time keeps every paint correctly sized.
+  const normalizedFlexValues = useMemo(
+    () => Array.from({ length: expandedCount }, (_, i) => flexValues[i] ?? 1),
+    [flexValues, expandedCount]
+  );
+
+  return { flexValues: normalizedFlexValues, handleProps, isResizing, sectionRefs };
 }


### PR DESCRIPTION
## Summary

Fixes the sidebar rendering glitch where the Connections sidebar rendered clipped / partially laid out on launch (stray chevrons without labels, truncated text, cut-off search box, mis-placed rows) and only corrected after resizing the tab once.

Closes #1828.

## Root cause

The sidebar's collapsible sections are sized with `flex` values from `useSectionResize(expandedCount)`. Those values are React state whose length lags `expandedCount` by one render whenever the section count **grows** — the internal reset effect only runs after that render. In the desktop app the **Remote Agents** sections appear after settings and remote agents load asynchronously (i.e. after the first paint), so on that transient render each new section read `flexValues[i] === undefined` and rendered with `flex: undefined` (`flex: 0 1 auto`, size-to-content) instead of flex-filling its slot.

The committed DOM was correct one render later, but on WebKit the mis-sized first paint stuck until a manual tab/window resize forced a reflow — exactly the reported "resize fixes it" symptom. This is the sidebar sibling of the terminal-side #1823.

## Fix

`useSectionResize` now derives the returned flex array at render time so it is always exactly `expandedCount` long, defaulting any not-yet-initialised slot to an even `1`. No render ever emits `flex: undefined`, so every paint — including the first one before the reset effect runs — is correctly sized. Deterministic, no forced repaint / hack.

## Testing

- New regression test `src/hooks/useSectionResize.test.tsx` captures the flex array on every render (including the transient one right after the count grows) and asserts it is never short or hole-containing. Verified it fails before the fix and passes after.
- Full frontend suite green (407 files / 3841 tests); `scripts/check.sh` passes.
- Added a manual test to `docs/testing.md` (cold-launch → sidebar renders fully without a resize). The residual mis-paint was macOS-WKWebView specific and could not be reproduced in CI/Linux, so on-device visual confirmation stays manual.

## Notes

The exact macOS-WKWebView visual could not be reproduced in this environment. The fix removes the transient wrong-layout render that WebKit's lazy compositor would otherwise leave stale, which is the concrete, provable determinism defect behind the report.