### PR TITLE
fix(ui): de-duplicate remediation in connection-failed dialog (Closes #1830)

### DIFF
--- a/docs/changes/dev5/fix/1830-connfail-dialog-dup-text.md
+++ b/docs/changes/dev5/fix/1830-connfail-dialog-dup-text.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Connection-failed dialog no longer shows the remediation guidance and fix
+  command twice. Serial errors whose backend message embeds a remediation hint
+  (e.g. the `sudo usermod -aG dialout $USER` advice for a permission-denied
+  serial port) previously rendered that text both in the raw error box and in
+  the formatted hint panel below it. The raw error box now shows only the
+  concise failure reason, leaving the hint panel — with its copyable command
+  (#1829) — as the single source of the remediation (#1830).

--- a/src/components/Terminal/TerminalConnectionOverlay.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.test.tsx
@@ -486,6 +486,39 @@ describe("TerminalConnectionOverlay — failed state", () => {
     expect(container.textContent).toContain("dialout");
   });
 
+  // Regression for #1830: the raw backend error embeds the same remediation
+  // (including the fix command) that the hint panel renders, so both the plain
+  // error text and the copyable CommandBlock showed the command — twice. The
+  // raw error box must drop the embedded remediation clause so the command and
+  // its guidance appear exactly once, in the hint panel.
+  it("does not duplicate the serial permission remediation command", () => {
+    const command = "sudo usermod -aG dialout $USER";
+    useAppStore.setState({
+      terminalSpawnErrors: {
+        [TAB_ID]: `Permission denied on 'COM7' — on Linux, add your user to the dialout group: ${command}`,
+      },
+    });
+    act(() => {
+      root.render(
+        <TerminalConnectionOverlay
+          tabId={TAB_ID}
+          panelId={PANEL_ID}
+          tabTitle="serial"
+          isVisible={true}
+          sessionType="serial"
+        />
+      );
+    });
+    const text = container.textContent ?? "";
+    const commandOccurrences = text.split(command).length - 1;
+    expect(commandOccurrences).toBe(1);
+    // The raw failure reason is still shown once (with the port name).
+    expect(text).toContain("Permission denied on 'COM7'");
+    // The dialout guidance appears once, in the hint panel — not echoed by the
+    // raw error box.
+    expect(text.split("dialout group").length - 1).toBe(1);
+  });
+
   it("shows serial busy hint for serial sessionType", () => {
     useAppStore.setState({
       terminalSpawnErrors: { [TAB_ID]: "Serial port '/dev/ttyUSB0' is already in use" },

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -175,6 +175,17 @@ export function TerminalConnectionOverlay({
   const isSerialBusy =
     isSerial && !isSerialPermission && SERIAL_BUSY_PATTERNS.some((p) => error.includes(p));
 
+  // When a curated hint panel is shown it fully explains the failure and, since
+  // #1829, offers the fix command with a copy affordance. Backend errors append
+  // that same remediation to the raw message after an em-dash separator (see
+  // core/src/session/serial.rs), so rendering the raw error verbatim repeated
+  // the guidance and command — once as plain text, once in the hint (#1830).
+  // Drop the trailing remediation clause from the raw error box so the hint
+  // panel is the single source of the remediation.
+  const hasHint =
+    isAgentAuth || isTimeout || isSerialNotFound || isSerialPermission || isSerialBusy;
+  const displayError = hasHint ? error.split(" — ")[0].trim() : error;
+
   const cls = `terminal-connection-overlay${isVisible ? "" : " terminal-connection-overlay--hidden"}`;
 
   if (isReattaching) {
@@ -355,7 +366,7 @@ export function TerminalConnectionOverlay({
         <p className="terminal-connection-overlay__subheading">{tabTitle}</p>
 
         <div className="terminal-connection-overlay__error-box">
-          <span className="terminal-connection-overlay__error-text">{error}</span>
+          <span className="terminal-connection-overlay__error-text">{displayError}</span>
         </div>
 
         {isAgentAuth && (


### PR DESCRIPTION
## Summary

The "Connection failed" dialog for a serial permission-denied error showed the
remediation guidance and the fix command **twice**: once as plain text inside
the raw error box, and again in the formatted hint panel below it.

Root cause: the backend serial error message embeds the remediation after an
em-dash separator (e.g. `Permission denied on 'COM7' — on Linux, add your user
to the dialout group: sudo usermod -aG dialout $USER`, from
`core/src/session/serial.rs`). The dialog rendered that raw message verbatim in
the error box **and** rendered the same guidance/command in its curated hint
panel — which, since #1829, also carries a copyable command block. The command
therefore appeared twice.

## Fix

When a curated hint panel is shown, the raw error box now displays only the
concise failure reason (the text before the em-dash separator). The hint panel
becomes the single source of the remediation and its copyable command.

This resolves #1830.

## Scope

- Untouched: the hint panel's copy button (#1829, already merged).
- Untouched: the hint panel's platform-specific advice logic — the "Linux
  dialout advice shown on Windows" problem is tracked separately in #1831 and is
  intentionally out of scope here.

## Testing

- Added a regression test asserting the fix command and its guidance render
  exactly once for a serial permission-denied error (fails without the fix).
- `pnpm test` (full suite) and `./scripts/check.sh` pass locally.