### PR TITLE
fix(serial): platform-aware serial permission advice (Closes #1831)

### DIFF
--- a/core/src/session/serial.rs
+++ b/core/src/session/serial.rs
@@ -77,6 +77,26 @@ pub fn parse_serial_config(config: &SerialConfig) -> Result<ParsedSerialConfig, 
     })
 }
 
+/// Platform-appropriate remediation for a serial-port permission error.
+///
+/// Only Linux gates serial ports behind the `dialout` group, so the `usermod`
+/// fix applies there alone. On Windows a denied `COM` port and on macOS a denied
+/// `/dev/tty.*`/`/dev/cu.*` port almost always mean another program holds the
+/// port or the user lacks access — there is no group to join, so we return plain
+/// guidance rather than a bogus command (#1831). This runs on the machine that
+/// owns the port (the host for local ports, the remote agent for agent-hosted
+/// ports), so the advice matches where the device physically lives.
+fn serial_permission_hint() -> &'static str {
+    #[cfg(target_os = "linux")]
+    {
+        "on Linux, add your user to the dialout group: sudo usermod -aG dialout $USER"
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        "another application may be using the port, or you may not have permission to access it"
+    }
+}
+
 /// Open a serial port using a pre-parsed configuration.
 ///
 /// Returns a [`serial2_tokio::SerialPort`] ready for async I/O.
@@ -102,8 +122,9 @@ pub fn open_serial_port(config: &ParsedSerialConfig) -> Result<SerialPort, Sessi
                 config.port
             ),
             std::io::ErrorKind::PermissionDenied => format!(
-                "Permission denied on '{}' — on Linux, add your user to the dialout group: sudo usermod -aG dialout $USER",
-                config.port
+                "Permission denied on '{}' — {}",
+                config.port,
+                serial_permission_hint()
             ),
             _ => {
                 let desc = e.to_string();
@@ -640,6 +661,36 @@ mod tests {
             matches!(err, SessionError::SpawnFailed(_)),
             "expected SpawnFailed, got: {:?}",
             err
+        );
+    }
+
+    // --- serial_permission_hint tests ------------------------------------
+    //
+    // The permission-error remediation must be host-OS specific: the Linux
+    // `dialout` advice is wrong on Windows/macOS, where there is no such group
+    // (#1831). CI runs on all three platforms, so each leg pins its own case.
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn permission_hint_mentions_dialout_on_linux() {
+        assert!(
+            serial_permission_hint().contains("dialout"),
+            "Linux hint should recommend the dialout group, got: {:?}",
+            serial_permission_hint()
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn permission_hint_omits_dialout_off_linux() {
+        let hint = serial_permission_hint();
+        assert!(
+            !hint.contains("dialout"),
+            "non-Linux hint must not mention the dialout group, got: {hint:?}"
+        );
+        assert!(
+            !hint.is_empty(),
+            "non-Linux hint should still offer generic guidance"
         );
     }
 }

--- a/docs/changes/dev5/fix/1831-serial-platform-advice.md
+++ b/docs/changes/dev5/fix/1831-serial-platform-advice.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Connection-failed dialog no longer shows Linux `dialout`-group instructions
+  for a serial permission error on Windows or macOS. The advice is now
+  host-OS aware: Linux still offers the copyable `sudo usermod -aG dialout $USER`
+  fix, while Windows and macOS show generic guidance ("another application may
+  be using the port, or you may not have permission to access it") with no bogus
+  command. The backend permission-denied message is likewise platform-gated at
+  its source (#1831).

--- a/src/components/Terminal/TerminalConnectionOverlay.platform.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.platform.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Platform-awareness test for the "Connection failed" dialog's serial permission
+ * hint (#1831).
+ *
+ * A serial permission error used to show the Linux `dialout`-group instruction on
+ * every OS — including Windows, where the port is a `COM` port and there is no
+ * such group. These tests pin that the remediation now follows the host OS:
+ * Linux shows the `usermod` fix command, while Windows and macOS show generic
+ * guidance and never the dialout advice. The OS is injected by mocking
+ * `getPlatform`, so the branching is exercised deterministically on any CI host.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+const platformMock = vi.hoisted(() => ({ value: "linux" as "windows" | "macos" | "linux" }));
+
+vi.mock("@/utils/platform", () => ({
+  getPlatform: () => platformMock.value,
+  isWindows: () => platformMock.value === "windows",
+  isMac: () => platformMock.value === "macos",
+}));
+
+vi.mock("lucide-react", () => ({
+  ServerCrash: () => null,
+  RefreshCw: () => null,
+  Loader2: () => null,
+  Zap: () => null,
+  Ban: () => null,
+  Copy: () => null,
+}));
+
+import { TerminalConnectionOverlay } from "./TerminalConnectionOverlay";
+import { useAppStore } from "@/store/appStore";
+
+const TAB_ID = "tab-platform";
+const PANEL_ID = "panel-platform";
+const DIALOUT_COMMAND = "sudo usermod -aG dialout $USER";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderSerialPermissionFailure(port: string) {
+  useAppStore.setState({
+    terminalConnecting: {},
+    terminalSpawnErrors: { [TAB_ID]: `Permission denied on '${port}'` },
+    terminalAutoRetryCount: {},
+    terminalWaitingForAgent: {},
+    terminalRetryCounters: {},
+    terminalReattaching: {},
+  });
+  act(() => {
+    root.render(
+      <TerminalConnectionOverlay
+        tabId={TAB_ID}
+        panelId={PANEL_ID}
+        tabTitle="serial"
+        isVisible={true}
+        sessionType="serial"
+      />
+    );
+  });
+}
+
+describe("TerminalConnectionOverlay — platform-aware serial permission hint (#1831)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    platformMock.value = "linux";
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows the dialout fix command on Linux", () => {
+    platformMock.value = "linux";
+    renderSerialPermissionFailure("/dev/ttyUSB0");
+    const text = container.textContent ?? "";
+    expect(text).toContain("Permission denied");
+    expect(text).toContain("dialout");
+    expect(text).toContain(DIALOUT_COMMAND);
+  });
+
+  it("does not show the Linux dialout advice on Windows", () => {
+    platformMock.value = "windows";
+    renderSerialPermissionFailure("COM7");
+    const text = container.textContent ?? "";
+    // Still surfaces the permission failure, just not the Linux remedy.
+    expect(text).toContain("Permission denied");
+    expect(text).not.toContain("dialout");
+    expect(text).not.toContain(DIALOUT_COMMAND);
+    // No copyable command block on Windows — there is no valid one to run.
+    expect(
+      container.querySelector("[data-testid='terminal-connection-serial-copy-btn']")
+    ).toBeNull();
+    // Windows-appropriate guidance instead.
+    expect(text).toContain("Another application may be using the port");
+  });
+
+  it("does not show the Linux dialout advice on macOS", () => {
+    platformMock.value = "macos";
+    renderSerialPermissionFailure("/dev/tty.usbserial");
+    const text = container.textContent ?? "";
+    expect(text).toContain("Permission denied");
+    expect(text).not.toContain("dialout");
+    expect(text).not.toContain(DIALOUT_COMMAND);
+    expect(
+      container.querySelector("[data-testid='terminal-connection-serial-copy-btn']")
+    ).toBeNull();
+  });
+});

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/Button";
 import { toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { useElapsed } from "@/hooks/useElapsed";
+import { getPlatform } from "@/utils/platform";
 import "./TerminalConnectionOverlay.css";
 
 interface TerminalConnectionOverlayProps {
@@ -26,6 +27,21 @@ const TIMEOUT_PATTERN = "timed out";
 const SERIAL_NOT_FOUND_PATTERNS = ["No such file", "cannot find", "not found"];
 const SERIAL_PERMISSION_PATTERN = "Permission denied";
 const SERIAL_BUSY_PATTERNS = ["busy", "in use", "Access is denied"];
+
+/**
+ * Platform-appropriate guidance for a serial permission error on non-Linux hosts
+ * (#1831). Only Linux gates serial ports behind the `dialout` group, so its hint
+ * offers the `usermod` fix command (rendered separately as a copyable block). On
+ * Windows a denied `COM` port and on macOS a denied `/dev/tty.*` port almost
+ * always mean another program holds the port or the user lacks access — there is
+ * no group to join, so we show plain guidance rather than a bogus command.
+ */
+const SERIAL_PERMISSION_HINT: Record<"windows" | "macos", string> = {
+  windows:
+    "Another application may be using the port, or you may not have permission to access it. Close any program using the port and try again.",
+  macos:
+    "You may not have permission to access this port, or another application may be using it. Close any program using the port and try again.",
+};
 
 /** Seconds after which a still-pending connect is flagged as unusually slow. */
 const SLOW_CONNECT_THRESHOLD_SECONDS = 20;
@@ -168,6 +184,9 @@ export function TerminalConnectionOverlay({
   }, [tabId, reconnectTerminal]);
 
   const isSerial = sessionType === "serial";
+  // The serial permission remediation is host-OS specific: only Linux has the
+  // dialout group, so the `usermod` fix must not be shown on Windows/macOS (#1831).
+  const platform = getPlatform();
   const isAgentAuth = error.includes(SSH_AGENT_PATTERN);
   const isTimeout = error.includes(TIMEOUT_PATTERN) && !isAgentAuth;
   const isSerialNotFound = isSerial && SERIAL_NOT_FOUND_PATTERNS.some((p) => error.includes(p));
@@ -399,11 +418,17 @@ export function TerminalConnectionOverlay({
         {isSerialPermission && (
           <div className="terminal-connection-overlay__hint">
             <p className="terminal-connection-overlay__hint-title">Permission denied</p>
-            <p>On Linux, add your user to the dialout group and re-login:</p>
-            <CommandBlock
-              command="sudo usermod -aG dialout $USER"
-              testId="terminal-connection-serial-copy-btn"
-            />
+            {platform === "linux" ? (
+              <>
+                <p>On Linux, add your user to the dialout group and re-login:</p>
+                <CommandBlock
+                  command="sudo usermod -aG dialout $USER"
+                  testId="terminal-connection-serial-copy-btn"
+                />
+              </>
+            ) : (
+              <p>{SERIAL_PERMISSION_HINT[platform]}</p>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

A serial connection that fails with a permission error showed the **Linux `dialout`-group** remedy on **every** OS. On Windows a denied `COM7` port displayed "on Linux, add your user to the dialout group: sudo usermod -aG dialout $USER" — advice that is meaningless there (no dialout group; the port is a COM port). Reported from image002.png.

Closes #1831.

## What changed

The permission remediation is hardcoded to Linux in the two places it is generated; both are now host-OS aware:

- **Frontend hint panel** (`TerminalConnectionOverlay.tsx`) — this is the remediation the user actually sees (since #1830 made it the single source). It now branches on `getPlatform()`:
  - **Linux** — unchanged: "add your user to the dialout group and re-login" plus the copyable `sudo usermod -aG dialout $USER` command block (#1829's copy button).
  - **Windows** — "Another application may be using the port, or you may not have permission to access it. Close any program using the port and try again." No command block.
  - **macOS** — "You may not have permission to access this port, or another application may be using it. Close any program using the port and try again." No command block.
- **Backend** (`core/src/session/serial.rs`) — the raw permission-denied message is gated with `#[cfg(target_os = ...)]` so the string reflects the machine that owns the port (host for local, agent for remote), instead of always naming Linux.

Scope kept localized: #1829's copy affordance and #1830's de-duplication are preserved untouched.

## Testing

- New deterministic OS-branching component tests (`TerminalConnectionOverlay.platform.test.tsx`) mock the platform: Linux shows the dialout command; Windows/macOS show generic guidance and no dialout advice / no copy button.
- New Rust per-platform tests: the Linux leg asserts the hint mentions `dialout`; the non-Linux legs assert it does not. CI covers all three platforms.
- Full frontend suite (3855 tests) green; `./scripts/check.sh` passes.