### PR TITLE
feat(rdp): bind remote-clipboard files to the linux clipboard (delayed X11 text/uri-list)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7541,6 +7541,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "percent-encoding",
  "portable-pty",
  "quick-xml",
  "rand 0.8.6",
@@ -7575,6 +7576,7 @@ dependencies = [
  "which",
  "windows 0.58.0",
  "winreg 0.55.0",
+ "x11rb",
  "zeroize",
  "zip",
 ]

--- a/core/src/backends/rdp_sidecar/config.rs
+++ b/core/src/backends/rdp_sidecar/config.rs
@@ -159,17 +159,20 @@ impl Default for RdpConfig {
 /// Whether this host build can bind remote-copied clipboard files onto the OS
 /// clipboard for a delayed-render local paste (#1804).
 ///
-/// Only **macOS** currently has the native `NSPasteboard` promised-data binding
-/// (`src-tauri/src/macos_clipboard.rs`), so it is the only platform where the
-/// sidecar should surface the file list for delayed rendering; every other
-/// platform keeps the eager shared-folder download (#1765) as the fallback. The
-/// host process stamps [`RdpConfig::clipboard_delayed_render`] from this at
-/// connect time — it reflects a platform capability, not a user preference, so
-/// it is deliberately absent from [`rdp_settings_schema`]. Windows
-/// (`CF_HDROP`/`WM_RENDERFORMAT`) and Linux (X11/Wayland `text/uri-list`)
-/// bindings are tracked as follow-ups; wiring one here is a single-line change.
+/// **macOS** has the native `NSPasteboard` promised-data binding
+/// (`src-tauri/src/macos_clipboard.rs`, #1804) and **Linux** has the X11
+/// `CLIPBOARD`-selection `text/uri-list` binding
+/// (`src-tauri/src/linux_clipboard.rs`, #1815), so those are the platforms where
+/// the sidecar surfaces the file list for delayed rendering; every other platform
+/// keeps the eager shared-folder download (#1765) as the fallback. The host
+/// process stamps [`RdpConfig::clipboard_delayed_render`] from this at connect
+/// time — it reflects a platform capability, not a user preference, so it is
+/// deliberately absent from [`rdp_settings_schema`]. The Windows
+/// (`CF_HDROP`/`WM_RENDERFORMAT`) binding is tracked as a follow-up (#1814); the
+/// native-Wayland delayed data source is a follow-up too (X11 covers Wayland via
+/// XWayland). Wiring one here is a single-line change.
 pub const fn host_supports_clipboard_delayed_render() -> bool {
-    cfg!(target_os = "macos")
+    cfg!(any(target_os = "macos", target_os = "linux"))
 }
 
 impl RdpConfig {
@@ -671,11 +674,12 @@ mod tests {
 
     #[test]
     fn host_capability_flag_matches_the_build_platform() {
-        // Delayed rendering is bound to the OS clipboard only on macOS today
-        // (#1804); every other platform keeps the eager shared-folder download.
+        // Delayed rendering is bound to the OS clipboard on macOS (#1804) and Linux
+        // (#1815); every other platform keeps the eager shared-folder download
+        // (#1765).
         assert_eq!(
             host_supports_clipboard_delayed_render(),
-            cfg!(target_os = "macos")
+            cfg!(any(target_os = "macos", target_os = "linux"))
         );
     }
 

--- a/docs/changes/dev1/feature/1815-linux-clipboard-bind.md
+++ b/docs/changes/dev1/feature/1815-linux-clipboard-bind.md
@@ -1,0 +1,14 @@
+### Added
+
+- RDP on **Linux**: files copied in a remote session can now be pasted into a
+  local file manager (Files/Nautilus, Nemo, Caja, Dolphin) via the host **X11
+  `CLIPBOARD` selection**, with the bytes fetched only on the paste gesture
+  (delayed rendering) — the Linux sibling of the macOS binding (#1804). The app
+  owns the selection and serves `text/uri-list` plus the
+  `x-special/gnome-copied-files` / `x-special/mate-copied-files` variants, staging
+  each file to a sanitized, bounded temp file only when a paste converts the
+  selection, so no bytes move on copy. Under Wayland this works for the many apps
+  XWayland bridges to the X11 clipboard; a native-only Wayland (`wlr-data-control`)
+  data source is a follow-up. Advertised via the host `clipboard_delayed_render`
+  capability on Linux; the eager shared-folder download (#1765) stays the fallback
+  everywhere the binding is inactive. (#1815, follow-up to #1804)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1079,10 +1079,48 @@ manual run (per-PR CI does not run the CLIPRDR wire lane, #1569):
 5. Paste into a local app — Finder (Cmd+V into a folder), a mail draft, etc.
    **Expected:** the real files appear, their contents intact; the fetch happens
    at this moment (delayed), streamed into a bounded staging file.
-6. **Non-macOS regression check:** on Windows/Linux, repeat step 2 with the same
-   options. **Expected:** unchanged #1765 behaviour — files download into the
-   shared folder, and the **Remote files** section does not appear (no host
-   binding, so nothing is surfaced).
+6. **Windows regression check:** on Windows (which has no host binding on
+   `develop` yet, #1814), repeat step 2 with the same options. **Expected:**
+   unchanged #1765 behaviour — files download into the shared folder, and the
+   **Remote files** section does not appear (no host binding, so nothing is
+   surfaced). (Linux now has its own binding — see the next section.)
+
+#### Delayed-render paste to the host OS clipboard (Linux X11, #1815)
+
+On Linux the remote-copied files are surfaced to the **host X11 `CLIPBOARD`
+selection** with delayed rendering, the sibling of the macOS binding: instead of
+eagerly downloading into the shared folder, the app owns the selection and serves
+`text/uri-list` (plus `x-special/gnome-copied-files` /
+`x-special/mate-copied-files`) only when a paste converts the selection, and the
+bytes are streamed from the remote at that moment. The pure parts (index
+selection, `file://` URI encoding, `text/uri-list` and gnome/mate formatting) are
+unit-tested (`linux_clipboard`), but the live X11 selection ownership + real paste
+need a manual run (per-PR CI does not run the CLIPRDR wire lane, #1569, and cannot
+exercise a live X server):
+
+1. On a **Linux desktop** (X11 session, or a Wayland session with XWayland — see
+   step 6), build the sidecar and point `TERMIHUB_RDP_HELPER` at it (as above); in
+   the RDP connection editor enable **Redirect a Local Drive** (with a **Shared
+   Folder**) and **Receive Clipboard Files**, then connect to a Windows RDP host.
+2. Copy one or more files in the remote session (Explorer → Ctrl+C). **Expected:**
+   the files do **not** appear in the shared folder (delayed rendering replaces the
+   eager download on Linux now).
+3. Open the RemoteDesktop hover toolbar's **Clipboard** panel. **Expected:** a
+   **Remote files** section lists the copied files, with a **Copy to clipboard**
+   button.
+4. Click **Copy to clipboard**. **Expected:** a toast confirms `N file(s) ready`.
+   No bytes have been fetched yet (the app now owns the `CLIPBOARD` selection).
+5. Paste into a local file manager — Files/Nautilus, Nemo, Caja, or Dolphin
+   (Ctrl+V into a folder). **Expected:** the real files appear, their contents
+   intact; the fetch happens at this moment (delayed), streamed into a bounded
+   staging file. Try both a single file and several at once.
+6. **Wayland coverage.** On a Wayland session, repeat via XWayland-backed apps
+   (most GTK/Qt file managers): paste should still work because XWayland bridges
+   the X11 `CLIPBOARD`. A **native-only Wayland** client that reads solely over
+   `wlr-data-control` will not see the files yet — that is the scoped follow-up.
+7. **Filename check.** Copy a file whose name has a space and a non-ASCII
+   character (e.g. `naïve report.txt`). **Expected:** it pastes with the exact
+   name (the `file://` URI is percent-encoded and decoded back correctly).
 
 ### Deferred agent update (apply on last disconnect) (#1352)
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -144,6 +144,18 @@ zip = "2"
 winreg = "0.55"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+# X11 `CLIPBOARD`-selection owner for the remote-clipboard delayed-render binding
+# (#1815): own the selection and serve `text/uri-list` (+ gnome/mate copied-files)
+# on request, fetching the remote files only when a paste converts the selection.
+# `x11rb` is the pure-Rust (`RustConnection`), libxcb-free X11 stack the sidecar's
+# `x11-clipboard` reader already builds on, so it adds **no system-library build
+# dependency**. Linux-only — the module is `#[cfg(target_os = "linux")]` and
+# `cargo tree -i` clean off Linux. `default-features = false` keeps the C-FFI
+# `XCBConnection` out; only the pure-Rust connection is needed.
+x11rb = { version = "0.13", default-features = false }
+# Percent-encode staged temp paths into `file://` URIs for the served payloads —
+# the encode side of the sidecar reader's percent-decode. Linux-only here.
+percent-encoding = "2"
 # Linux Secret Service backend. The `async-secret-service` backend talks to the
 # Secret Service over the pure-Rust `zbus` transport (no `libdbus-sys` C
 # dependency), so it compiles in CI without `libdbus-1-dev` and without a live

--- a/src-tauri/src/commands/remote_desktop.rs
+++ b/src-tauri/src/commands/remote_desktop.rs
@@ -109,10 +109,19 @@ pub async fn remote_desktop_bind_clipboard_files(
         return Ok(0);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
         let count = files.len();
+        #[cfg(target_os = "macos")]
         crate::macos_clipboard::bind_remote_clipboard_files(
+            &app_handle,
+            (*manager).clone(),
+            session_id,
+            files,
+        )
+        .map_err(|e| TerminalError::InternalError(e.to_string()))?;
+        #[cfg(target_os = "linux")]
+        crate::linux_clipboard::bind_remote_clipboard_files(
             &app_handle,
             (*manager).clone(),
             session_id,
@@ -121,12 +130,12 @@ pub async fn remote_desktop_bind_clipboard_files(
         .map_err(|e| TerminalError::InternalError(e.to_string()))?;
         Ok(count)
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         // No native OS-clipboard binding on this platform: with delayed rendering
         // off, `remote_clipboard_files` is already empty and we returned above, so
         // reaching here means a caller invoked the command anyway. Report rather
-        // than silently succeed. (`app_handle`/`session_id` are macOS-only inputs.)
+        // than silently succeed. (`app_handle`/`session_id` are binding-only inputs.)
         let _ = (&app_handle, &session_id);
         Err(TerminalError::InternalError(
             "pasting remote clipboard files to the host OS clipboard is not supported on this \

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,11 @@ mod embedded_servers;
 /// subsystem (public so integration tests can drive `SftpSession` /
 /// `TransferRegistry` directly — issue #1245).
 pub mod files;
+/// Native Linux X11 `CLIPBOARD`-selection binding for pasting remote-copied RDP
+/// clipboard files into local apps with delayed rendering (`text/uri-list`,
+/// #1815). Linux-only.
+#[cfg(target_os = "linux")]
+mod linux_clipboard;
 /// Native macOS `NSPasteboard` binding for pasting remote-copied RDP clipboard
 /// files into local apps with delayed rendering (#1804). macOS-only.
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/linux_clipboard.rs
+++ b/src-tauri/src/linux_clipboard.rs
@@ -1,0 +1,554 @@
+//! Native Linux clipboard binding for pasting remote-copied RDP clipboard files
+//! into local apps with **delayed rendering** (#1815).
+//!
+//! The Linux sibling of [`crate::macos_clipboard`] (`NSPasteboard`, #1804) and
+//! `crate::windows_clipboard` (`CF_HDROP`, #1814): the RDP sidecar surfaces the
+//! list of files the remote copied (`GraphicalBackend::remote_clipboard_files`)
+//! and streams a file's bytes on demand (`fetch_remote_clipboard_file`); this
+//! module binds that transport to the host's **X11 `CLIPBOARD` selection**,
+//! serving the file list as `text/uri-list` (plus the
+//! `x-special/gnome-copied-files` / `x-special/mate-copied-files` variants file
+//! managers expect) so the copied files can be pasted into Files/Nautilus, Nemo,
+//! Caja, Dolphin, or any local app.
+//!
+//! ## Delayed rendering, the X11 way
+//!
+//! X11 has no "put bytes on the clipboard" primitive: a client instead **owns a
+//! selection** and answers `SelectionRequest` conversion events when another
+//! client pastes. That ownership model *is* delayed rendering — we advertise the
+//! target types on the `CLIPBOARD` selection and produce the data only when a
+//! paste converts the selection. When the target requests one of our file
+//! targets, and only then, we fetch each promised file's bytes from the remote
+//! (streamed into a sanitized, bounded temp file by the sidecar) and answer with a
+//! `text/uri-list` (or gnome/mate) payload of `file://` URIs pointing at the
+//! staged paths. No bytes move on copy; RAM stays bounded to whatever a single
+//! fetch stages, since files are fetched one at a time inside the request.
+//!
+//! The reader side (`rdp-sidecar/src/host_clipboard.rs`) uses the `x11-clipboard`
+//! crate's `store`, but that stores **fixed bytes** and answers every conversion
+//! with them — it has no per-request callback, so it cannot fetch on paste. True
+//! delayed rendering therefore needs a selection owner we drive ourselves, which
+//! is why this owns the selection directly via **`x11rb`** (the same pure-Rust,
+//! libxcb-free X11 stack `x11-clipboard` is built on — `RustConnection`, no
+//! system-library build dependency).
+//!
+//! ## The owner thread
+//!
+//! A selection owner must stay alive to answer conversion requests. This module
+//! owns a dedicated **X11 connection + hidden window** on its own thread running a
+//! blocking event loop (`wait_for_event`), created lazily on the first bind and
+//! kept for the app's lifetime — the analog of the macOS pasteboard owner object
+//! and the Windows message-only owner window. A [`bind_remote_clipboard_files`]
+//! call stores the fetch context and acquires `CLIPBOARD` ownership; the owner
+//! thread then serves conversions from that context. A new bind replaces (and
+//! drops) the previous context; a `SelectionClear` (another app took the
+//! clipboard) drops it too, so a stale promise can never be served.
+//!
+//! The per-file fetch inside a conversion drives the tokio runtime's worker
+//! threads (never the owner thread), so blocking the owner thread for the duration
+//! of a paste keeps memory bounded and cannot deadlock — the same reasoning as the
+//! macOS `provideDataForType:` callback and the Windows `WM_RENDERFORMAT` render.
+//!
+//! ## Wayland
+//!
+//! Native-Wayland clients read the clipboard over `wlr-data-control`, which
+//! `wl-clipboard-rs` serves only from **fixed bytes** (no per-request callback),
+//! so a *delayed* Wayland data source is not cleanly achievable with the in-tree
+//! crate — it is scoped to a follow-up (#1815 → Wayland). In practice a Wayland
+//! session runs XWayland, which bridges this very X11 `CLIPBOARD` selection to
+//! Wayland clients, so most desktop apps under Wayland can still paste the files;
+//! the follow-up covers the native-only apps that bypass the bridge.
+//!
+//! Everything here is `#[cfg(target_os = "linux")]`-gated at the module
+//! declaration in `lib.rs`. On a platform with no binding `clipboard_delayed_render`
+//! stays off and the eager shared-folder download (#1765) remains the behaviour.
+
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+
+use percent_encoding::{percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use tauri::AppHandle;
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+    Atom, AtomEnum, ConnectionExt as _, CreateWindowAux, EventMask, PropMode, SelectionNotifyEvent,
+    SelectionRequestEvent, Window, WindowClass, SELECTION_NOTIFY_EVENT,
+};
+use x11rb::protocol::Event;
+use x11rb::rust_connection::RustConnection;
+use x11rb::wrapper::ConnectionExt as _;
+use x11rb::{CURRENT_TIME, NONE};
+
+use crate::session::graphical_manager::GraphicalSessionManager;
+use termihub_core::connection::RemoteClipboardFile;
+
+/// Percent-encoding set for a `file://` URI path: everything that is not an RFC
+/// 3986 *unreserved* character (`ALPHA` / `DIGIT` / `-` / `.` / `_` / `~`) is
+/// encoded, except `/`, which stays literal as the path separator. This matches
+/// what file managers emit and what the sidecar's `parse_uri_list` percent-decodes
+/// on the read side.
+const PATH_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'/')
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+/// The advertised indices of the files worth offering to the OS clipboard — the
+/// regular files, in order. Directories carry no bytes to fetch (they are
+/// surfaced only so a copied tree can be recreated), so they are dropped.
+///
+/// Pure and X11-free so the selection logic is unit-testable without a display.
+fn pasteable_indices(files: &[RemoteClipboardFile]) -> Vec<u32> {
+    files
+        .iter()
+        .filter(|f| !f.is_dir)
+        .map(|f| f.index)
+        .collect()
+}
+
+/// Converts an absolute local `path` to a percent-encoded `file://` URI.
+///
+/// The raw path **bytes** are encoded (via [`std::os::unix::ffi::OsStrExt`]) so a
+/// non-UTF-8 or non-ASCII filename survives losslessly as the UTF-8/byte sequence
+/// its percent-encoding represents. An absolute path begins with `/`, so the
+/// result is the empty-authority form `file:///abs/path`.
+///
+/// Pure over a path so the encoding is unit-testable without a display; the caller
+/// passes the sidecar-staged temp path.
+fn path_to_file_uri(path: &Path) -> String {
+    let encoded = percent_encode(path.as_os_str().as_bytes(), PATH_ENCODE_SET);
+    format!("file://{encoded}")
+}
+
+/// Builds a `text/uri-list` payload (RFC 2483): one `file://` URI per line,
+/// CRLF-terminated. The inverse of the sidecar's `parse_uri_list`.
+///
+/// Pure so the format is unit-testable without a display.
+fn build_uri_list(uris: &[String]) -> Vec<u8> {
+    let mut out = String::new();
+    for uri in uris {
+        out.push_str(uri);
+        out.push_str("\r\n");
+    }
+    out.into_bytes()
+}
+
+/// Builds an `x-special/gnome-copied-files` / `x-special/mate-copied-files`
+/// payload: the literal first line `copy` (a copy, never a cut), then one
+/// `file://` URI per line, `\n`-separated with **no** trailing newline — the form
+/// Nautilus, Nemo, and Caja expect.
+///
+/// Pure so the format is unit-testable without a display.
+fn build_gnome_copied_files(uris: &[String]) -> Vec<u8> {
+    let mut out = String::from("copy");
+    for uri in uris {
+        out.push('\n');
+        out.push_str(uri);
+    }
+    out.into_bytes()
+}
+
+/// How to fetch each promised file when a paste converts the selection.
+struct BindContext {
+    /// Clone of the graphical manager (Arc-backed) used to reach the session's
+    /// backend for on-demand byte fetches.
+    manager: GraphicalSessionManager,
+    /// The session whose remote clipboard these files belong to.
+    session_id: String,
+    /// Advertised indices to fetch, in paste order.
+    indices: Vec<u32>,
+}
+
+/// The interned atoms the owner needs, resolved once at init. `Copy` (every field
+/// is an `Atom`, a `u32`) so the owner thread gets its own value copy.
+#[derive(Clone, Copy)]
+struct Atoms {
+    clipboard: Atom,
+    targets: Atom,
+    uri_list: Atom,
+    gnome: Atom,
+    mate: Atom,
+}
+
+/// The long-lived X11 selection owner: connection, hidden owner window, atoms, and
+/// the current fetch context. Shared (via `Arc`) between the caller thread (which
+/// acquires ownership and swaps the context) and the owner thread (which serves
+/// conversions).
+struct Owner {
+    conn: Arc<RustConnection>,
+    window: Window,
+    atoms: Atoms,
+    /// The context for the most recent bind; `None` after a `SelectionClear` or
+    /// before the first bind. A short lock is taken to read/replace it — never held
+    /// across a fetch.
+    current: Arc<Mutex<Option<BindContext>>>,
+}
+
+/// The process-wide selection owner, created lazily on the first successful bind.
+/// Held behind a `Mutex<Option<…>>` (not a bare `OnceLock`) so a bind attempted
+/// before an X server is reachable can retry on a later bind rather than caching
+/// the failure forever.
+static OWNER: OnceLock<Mutex<Option<Owner>>> = OnceLock::new();
+
+fn owner_slot() -> &'static Mutex<Option<Owner>> {
+    OWNER.get_or_init(|| Mutex::new(None))
+}
+
+/// Bind the remote-copied clipboard `files` onto the X11 `CLIPBOARD` selection
+/// with delayed rendering (#1815), so they can be pasted into any local app. The
+/// bytes are fetched only on the actual paste, via `manager` and `session_id`.
+///
+/// Signature mirrors [`crate::macos_clipboard::bind_remote_clipboard_files`] so
+/// the `remote_desktop_bind_clipboard_files` command calls either identically; the
+/// `AppHandle` is unused here (the owner window is our own, not Tauri's).
+pub fn bind_remote_clipboard_files(
+    _app_handle: &AppHandle,
+    manager: GraphicalSessionManager,
+    session_id: String,
+    files: Vec<RemoteClipboardFile>,
+) -> anyhow::Result<()> {
+    let indices = pasteable_indices(&files);
+    if indices.is_empty() {
+        return Ok(());
+    }
+
+    let mut slot = owner_slot()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("clipboard owner lock poisoned"))?;
+    if slot.is_none() {
+        *slot = Some(Owner::start()?);
+    }
+    let owner = slot.as_ref().expect("owner just initialised");
+
+    // Publish the fetch context, then take ownership of CLIPBOARD so the server
+    // routes conversion requests to our window. The order matters: a request could
+    // arrive the instant we own the selection, and it must find the context.
+    {
+        let mut current = owner
+            .current
+            .lock()
+            .map_err(|_| anyhow::anyhow!("clipboard context lock poisoned"))?;
+        *current = Some(BindContext {
+            manager,
+            session_id,
+            indices,
+        });
+    }
+    owner
+        .conn
+        .set_selection_owner(owner.window, owner.atoms.clipboard, CURRENT_TIME)?;
+    owner.conn.flush()?;
+    Ok(())
+}
+
+impl Owner {
+    /// Connect to the X server, create the hidden owner window, intern the atoms,
+    /// and spawn the event-loop thread. Fails (rather than panicking) when no X
+    /// server is reachable, so the caller can surface it and the round degrades to
+    /// no host paste.
+    fn start() -> anyhow::Result<Self> {
+        let (conn, screen_num) = RustConnection::connect(None)
+            .map_err(|e| anyhow::anyhow!("failed to connect to the X server: {e}"))?;
+        let conn = Arc::new(conn);
+        let screen = &conn.setup().roots[screen_num];
+        let root = screen.root;
+
+        // A 1x1, never-mapped window is enough to own a selection and receive the
+        // SelectionRequest/SelectionClear events the server routes to the owner.
+        let window = conn.generate_id()?;
+        conn.create_window(
+            screen.root_depth,
+            window,
+            root,
+            0,
+            0,
+            1,
+            1,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            screen.root_visual,
+            &CreateWindowAux::new().event_mask(EventMask::PROPERTY_CHANGE),
+        )?;
+
+        let atoms = Atoms {
+            clipboard: intern(&conn, b"CLIPBOARD")?,
+            targets: intern(&conn, b"TARGETS")?,
+            uri_list: intern(&conn, b"text/uri-list")?,
+            gnome: intern(&conn, b"x-special/gnome-copied-files")?,
+            mate: intern(&conn, b"x-special/mate-copied-files")?,
+        };
+        conn.flush()?;
+
+        let current: Arc<Mutex<Option<BindContext>>> = Arc::new(Mutex::new(None));
+
+        // The owner thread outlives this function and holds its own Arc clones, so
+        // the selection keeps being served for the app's lifetime.
+        let thread_conn = Arc::clone(&conn);
+        let thread_current = Arc::clone(&current);
+        let thread_atoms = atoms;
+        thread::Builder::new()
+            .name("termihub-clipboard-owner".to_string())
+            .spawn(move || event_loop(thread_conn, window, thread_atoms, thread_current))
+            .map_err(|e| anyhow::anyhow!("failed to spawn clipboard owner thread: {e}"))?;
+
+        Ok(Self {
+            conn,
+            window,
+            atoms,
+            current,
+        })
+    }
+}
+
+/// Intern a single atom, creating it if absent.
+fn intern(conn: &RustConnection, name: &[u8]) -> anyhow::Result<Atom> {
+    Ok(conn.intern_atom(false, name)?.reply()?.atom)
+}
+
+/// The selection owner's blocking event loop: serve `SelectionRequest`
+/// conversions from the current fetch context and drop the context on
+/// `SelectionClear`. Runs for the app's lifetime; exits only if the X connection
+/// drops.
+fn event_loop(
+    conn: Arc<RustConnection>,
+    window: Window,
+    atoms: Atoms,
+    current: Arc<Mutex<Option<BindContext>>>,
+) {
+    loop {
+        let event = match conn.wait_for_event() {
+            Ok(event) => event,
+            Err(e) => {
+                tracing::warn!("clipboard owner X11 connection dropped: {e}");
+                return;
+            }
+        };
+        match event {
+            Event::SelectionRequest(req) => {
+                if let Err(e) = serve_request(&conn, window, &atoms, &current, &req) {
+                    tracing::warn!("failed to serve clipboard conversion request: {e}");
+                }
+            }
+            Event::SelectionClear(_) => {
+                // Another app took CLIPBOARD ownership: drop the staged context so a
+                // stale promise can never be served.
+                if let Ok(mut slot) = current.lock() {
+                    *slot = None;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Answer one `SelectionRequest`: fill the requestor's property with the converted
+/// data (or refuse), then notify. Fetches the remote files only when the target is
+/// one of our file targets — this is the delayed render.
+fn serve_request(
+    conn: &RustConnection,
+    window: Window,
+    atoms: &Atoms,
+    current: &Mutex<Option<BindContext>>,
+    req: &SelectionRequestEvent,
+) -> anyhow::Result<()> {
+    // Ignore requests aimed at a stale owner window (we are the current owner only
+    // for `window`).
+    if req.owner != window {
+        return refuse(conn, req);
+    }
+
+    // Per ICCCM, a `None` property means an obsolete requestor; use the target atom
+    // as the property name in that case.
+    let property = if req.property == NONE {
+        req.target
+    } else {
+        req.property
+    };
+
+    if req.target == atoms.targets {
+        // Advertise what we can convert to.
+        let targets = [atoms.targets, atoms.uri_list, atoms.gnome, atoms.mate];
+        conn.change_property32(
+            PropMode::REPLACE,
+            req.requestor,
+            property,
+            AtomEnum::ATOM,
+            &targets,
+        )?;
+        return send_notify(conn, req, property);
+    }
+
+    let is_uri_list = req.target == atoms.uri_list;
+    let is_gnome = req.target == atoms.gnome || req.target == atoms.mate;
+    if !is_uri_list && !is_gnome {
+        // A target we never advertised (e.g. a text/plain probe) — refuse cleanly.
+        return refuse(conn, req);
+    }
+
+    // Snapshot the context out of the lock, then fetch without holding it.
+    let Some((manager, session_id, indices)) = current.lock().ok().and_then(|slot| {
+        slot.as_ref().map(|ctx| {
+            (
+                ctx.manager.clone(),
+                ctx.session_id.clone(),
+                ctx.indices.clone(),
+            )
+        })
+    }) else {
+        return refuse(conn, req);
+    };
+
+    // Delayed render: fetch each promised file's bytes now, one at a time (bounded
+    // memory), staging them to sanitized temp files and collecting `file://` URIs.
+    let mut uris: Vec<String> = Vec::new();
+    for index in indices {
+        match tauri::async_runtime::block_on(
+            manager.fetch_remote_clipboard_file(&session_id, index),
+        ) {
+            Ok(path) => uris.push(path_to_file_uri(&path)),
+            Err(e) => {
+                tracing::warn!("failed to fetch remote clipboard file {index} for paste: {e}")
+            }
+        }
+    }
+    if uris.is_empty() {
+        return refuse(conn, req);
+    }
+
+    let data = if is_gnome {
+        build_gnome_copied_files(&uris)
+    } else {
+        build_uri_list(&uris)
+    };
+    conn.change_property8(
+        PropMode::REPLACE,
+        req.requestor,
+        property,
+        req.target,
+        &data,
+    )?;
+    send_notify(conn, req, property)
+}
+
+/// Send a refusing `SelectionNotify` (property = `None`), the ICCCM way to decline
+/// a conversion.
+fn refuse(conn: &RustConnection, req: &SelectionRequestEvent) -> anyhow::Result<()> {
+    send_notify(conn, req, NONE)
+}
+
+/// Send a `SelectionNotify` to the requestor: `property` names the property we
+/// filled with the converted data, or `NONE` to refuse the conversion.
+fn send_notify(
+    conn: &RustConnection,
+    req: &SelectionRequestEvent,
+    property: Atom,
+) -> anyhow::Result<()> {
+    let event = SelectionNotifyEvent {
+        response_type: SELECTION_NOTIFY_EVENT,
+        sequence: 0,
+        time: req.time,
+        requestor: req.requestor,
+        selection: req.selection,
+        target: req.target,
+        property,
+    };
+    conn.send_event(false, req.requestor, EventMask::NO_EVENT, event)?;
+    conn.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn file(index: u32, is_dir: bool) -> RemoteClipboardFile {
+        RemoteClipboardFile {
+            name: format!("f{index}"),
+            relative_path: None,
+            size: Some(1),
+            is_dir,
+            index,
+        }
+    }
+
+    #[test]
+    fn pasteable_indices_keep_files_in_order_and_drop_dirs() {
+        let files = vec![file(0, false), file(1, true), file(2, false)];
+        assert_eq!(pasteable_indices(&files), vec![0, 2]);
+    }
+
+    #[test]
+    fn pasteable_indices_empty_when_only_dirs_or_none() {
+        assert!(pasteable_indices(&[]).is_empty());
+        assert!(pasteable_indices(&[file(0, true), file(1, true)]).is_empty());
+    }
+
+    #[test]
+    fn file_uri_encodes_absolute_path_with_empty_authority() {
+        assert_eq!(
+            path_to_file_uri(&PathBuf::from("/tmp/remote/a.txt")),
+            "file:///tmp/remote/a.txt"
+        );
+    }
+
+    #[test]
+    fn file_uri_percent_encodes_space_and_reserved_chars() {
+        // Space → %20, `#` → %23, `?` → %3F; `/`, `.`, `-`, `_` stay literal.
+        assert_eq!(
+            path_to_file_uri(&PathBuf::from("/tmp/a b#c?_d-e.txt")),
+            "file:///tmp/a%20b%23c%3F_d-e.txt"
+        );
+    }
+
+    #[test]
+    fn file_uri_percent_encodes_non_ascii_as_utf8_bytes() {
+        // `ï` is U+00EF = UTF-8 C3 AF; `é` is U+00E9 = C3 A9.
+        assert_eq!(
+            path_to_file_uri(&PathBuf::from("/tmp/naïve/café.txt")),
+            "file:///tmp/na%C3%AFve/caf%C3%A9.txt"
+        );
+    }
+
+    #[test]
+    fn uri_list_is_crlf_terminated_per_rfc_2483() {
+        let uris = vec![
+            "file:///tmp/a.txt".to_string(),
+            "file:///tmp/b.png".to_string(),
+        ];
+        assert_eq!(
+            build_uri_list(&uris),
+            b"file:///tmp/a.txt\r\nfile:///tmp/b.png\r\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn uri_list_of_single_file_still_terminates() {
+        assert_eq!(
+            build_uri_list(&["file:///tmp/only.bin".to_string()]),
+            b"file:///tmp/only.bin\r\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn gnome_copied_files_starts_with_copy_and_lf_separates() {
+        let uris = vec![
+            "file:///tmp/a.txt".to_string(),
+            "file:///tmp/b.png".to_string(),
+        ];
+        assert_eq!(
+            build_gnome_copied_files(&uris),
+            b"copy\nfile:///tmp/a.txt\nfile:///tmp/b.png".to_vec()
+        );
+    }
+
+    #[test]
+    fn gnome_copied_files_of_single_file_has_no_trailing_newline() {
+        assert_eq!(
+            build_gnome_copied_files(&["file:///tmp/only.bin".to_string()]),
+            b"copy\nfile:///tmp/only.bin".to_vec()
+        );
+    }
+}

--- a/src-tauri/src/session/graphical_manager.rs
+++ b/src-tauri/src/session/graphical_manager.rs
@@ -475,11 +475,11 @@ impl GraphicalSessionManager {
     /// [`Self::remote_clipboard_files`] surfaced.
     ///
     /// Only the platform-native OS-clipboard binding calls this (on the real paste
-    /// gesture); macOS is wired today (`macos_clipboard`), Windows/Linux are
-    /// follow-ups (#1814/#1815). Off those platforms it has no in-crate caller
-    /// yet, so the dead-code lint is suppressed there rather than deleting a method
-    /// the pending bindings need.
-    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    /// gesture); macOS (`macos_clipboard`) and Linux (`linux_clipboard`) are wired,
+    /// Windows is a follow-up (#1814). Off those platforms it has no in-crate
+    /// caller yet, so the dead-code lint is suppressed there rather than deleting a
+    /// method the pending binding needs.
+    #[cfg_attr(not(any(target_os = "macos", target_os = "linux")), allow(dead_code))]
     pub async fn fetch_remote_clipboard_file(
         &self,
         session_id: &str,


### PR DESCRIPTION
Part of #1815.

> **Not ready to auto-merge — needs a manual Linux paste test on real hardware
> first.** This deliberately says *Part of* (not *Closes*) #1815 so it will not
> auto-close on merge: the core deliverable is Linux-native and cannot be
> runtime-verified on the CI/dev machine (macOS). The maintainer should run the
> manual X11 paste test below on a Linux desktop, then merge and close #1815 by
> hand.

## What this does

The **Linux** sibling of the macOS `NSPasteboard` binding (#1804) and the pending
Windows `CF_HDROP` binding (#1814): remote-copied RDP files can be pasted into a
local file manager via the host OS clipboard, with the bytes fetched **only on the
paste gesture** (delayed rendering).

X11 has no "put bytes on the clipboard" primitive — a client instead **owns a
selection** and answers `SelectionRequest` conversion events. That ownership model
*is* delayed rendering. New `src-tauri/src/linux_clipboard.rs`
(`#[cfg(target_os = "linux")]`):

- Owns the X11 `CLIPBOARD` selection via **`x11rb`** (pure-Rust `RustConnection`,
  no libxcb build dependency — the same stack the sidecar reader's `x11-clipboard`
  is built on) from a dedicated owner thread that runs the selection event loop for
  the app's lifetime.
- Advertises `text/uri-list`, `x-special/gnome-copied-files`, and
  `x-special/mate-copied-files` via `TARGETS`. When a paste converts one of them —
  **and only then** — it calls `fetch_remote_clipboard_file` for each promised
  index (one at a time, so RAM stays bounded to a single fetch), staging each file
  to the sidecar's sanitized, bounded temp file, and replies with `file://` URIs
  pointing at the staged paths. No bytes move on copy.
- `SelectionClear` (another app takes the clipboard) drops the fetch context, so a
  stale promise can never be served.
- Flips `host_supports_clipboard_delayed_render()` to include Linux, so the sidecar
  surfaces the file list on Linux; the eager shared-folder download (#1765) stays
  the fallback everywhere the binding is inactive, and macOS is unchanged.

## X11 vs Wayland

Ships **X11 delayed rendering**. Native Wayland is scoped to a **follow-up
(#1847)**: `wl-clipboard-rs` (the in-tree Wayland crate) serves a data source only
from *fixed bytes*, with no per-request callback, so it cannot fetch lazily on
paste. In practice a Wayland session runs **XWayland**, which bridges this same X11
`CLIPBOARD` to Wayland clients, so most desktop file managers under Wayland can
already paste; #1847 covers the native-only apps that bypass the bridge.

## Tests

- **Unit-tested** (`linux_clipboard` tests, run on Linux CI): pasteable-index
  selection (drops directories, keeps order), `file://` URI percent-encoding
  (spaces, reserved chars, non-ASCII → UTF-8 bytes), RFC 2483 `text/uri-list`
  formatting (CRLF-terminated), and `x-special/gnome-copied-files` formatting
  (`copy` header, LF-separated, no trailing newline). The `config` capability-gate
  test now asserts Linux is included.
- **Manual (Linux only)** — added to `docs/testing.md`; the live X11 selection
  ownership + real paste cannot run in CI. Summary:
  1. Linux desktop; sidecar built + `TERMIHUB_RDP_HELPER` set; RDP connection with
     **Redirect a Local Drive** + **Receive Clipboard Files**; connect to a Windows
     host.
  2. Copy files in the remote session → they do **not** land in the shared folder.
  3. RemoteDesktop **Clipboard** panel shows a **Remote files** section.
  4. **Copy to clipboard** → toast `N file(s) ready`; no bytes fetched yet.
  5. Paste into Files/Nautilus, Nemo, Caja, or Dolphin → real files appear,
     contents intact; the fetch happens now (delayed). Test one file and several.
  6. Wayland: paste via XWayland-backed apps works; native-only `wlr-data-control`
     is #1847.
  7. Copy a file named e.g. `naïve report.txt` → pastes with the exact name.

## Dependency / platform hygiene

- New deps are **`#[cfg(target_os = "linux")]`-gated**: `x11rb` (already resolved
  transitively via `arboard`, so the lockfile only gains the direct edges) and
  `percent-encoding`. `cargo tree -i x11rb` is empty on the macOS target and shows
  only the Linux graph — clean off Linux, zero new system-library cost.
- Compiles on macOS (Linux module gated out); `cargo fmt --all --check` clean
  including the gated file; core unit tests pass.

## Design note (no Linux box here)

The X11 selection-owner loop and its `x11rb` API usage were written against the
x11rb 0.13 docs and mirror `x11-clipboard`'s own run loop, but could not be
compiled or run on this macOS machine (the full app cross-check needs a GTK
sysroot). The **Linux CI build is the real compile-check** for the gated code, and
the manual paste test above is the runtime check the maintainer should run before
merge. One concurrency assumption worth a look on real hardware: the caller thread
calls `set_selection_owner` on the shared `RustConnection` while the owner thread
blocks in `wait_for_event` — a pattern x11rb's `Send + Sync` `RustConnection` is
built to support, but not exercised here.