### PR TITLE
fix(terminal): repaint viewport after output so rows paint in order (Closes #1849)

### DIFF
--- a/docs/changes/dev2/fix/1849-terminal-output-order.md
+++ b/docs/changes/dev2/fix/1849-terminal-output-order.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Terminal output no longer paints out of order under rapid scrolling output. On
+  Windows local CMD (ConPTY), a `git status` with many untracked files could
+  render with later prompt lines spliced into the middle of the file list, and
+  the glitch only cleared after resizing the tab. xterm's DOM renderer repaints
+  only rows it has marked dirty, so during fast scrolling output the WebView
+  could leave rows painted at stale vertical positions. The output-flush path now
+  forces a full-viewport repaint after each write, so command output always
+  renders top-to-bottom in buffer order without a manual resize (#1849).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1226,6 +1226,35 @@ stays manual. See PR for #1823.
 5. Regression check: dragging the split-view splitter to resize a terminal must
    still reflow and repaint as before.
 
+### Terminal output stays in order under scrolling output (#1849)
+
+Verifies that command output paints top-to-bottom in buffer order, with no later
+prompt/command line spliced between an earlier command's output lines. The
+symptom (from image001.png) was a `git status` whose two trailing prompt lines
+were painted in the middle of the untracked-files list, clearing only after the
+tab was resized. The output-flush path forces a full-viewport `xterm.refresh`
+after each write (unit-tested in `Terminal.output-repaint.test.tsx`), but the
+underlying stale-row repaint is renderer/WebView specific — it was reported on
+**Windows local CMD (ConPTY)** — so this stays manual.
+
+Run on **Windows** against a **local CMD** session (the ConPTY path):
+
+1. Open a local CMD terminal tab and `cd` into a directory with **many untracked
+   files** in a fresh git repo (e.g. `git init` in a project folder), so a
+   `git status` produces a long "Untracked files:" list that scrolls the
+   viewport.
+2. Run `git status`, then immediately press Enter a couple of times to emit a
+   few bare prompt lines right after it.
+3. **Expected:** the untracked-files list renders as one contiguous block, and
+   the bare prompt lines appear **after** the whole `git status` output — never
+   spliced into the middle of the file list — **without** resizing the tab.
+4. Repeat a few times (the original glitch was intermittent) and try other
+   scrolling output (e.g. `dir /s`, `type` of a large file). Rows must always
+   stay in order.
+5. Regression check: resizing the tab/window and high-throughput output
+   (e.g. a large file dump) must still render and scroll normally with no
+   visible slowdown.
+
 ### Connections sidebar renders fully on first paint (#1828)
 
 Verifies that the Connections sidebar lays out completely on launch, with no

--- a/src/components/Terminal/Terminal.output-repaint.test.tsx
+++ b/src/components/Terminal/Terminal.output-repaint.test.tsx
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+
+// Regression test for #1849: terminal output painted out of order (a later
+// prompt line rendered between an earlier command's output lines) until the tab
+// is resized. The maintainer confirmed a resize fixes it, proving the xterm.js
+// buffer is correct but the DOM renderer paints rows at stale positions during
+// rapid scrolling output (Windows ConPTY redrawing a `git status`). The fix
+// forces a full-viewport `xterm.refresh(0, rows - 1)` after each output flush so
+// the repaint is deterministic without a manual resize. This test locks in that
+// the refresh is issued on the output path.
+
+let capturedWriteCallback: (() => void) | null = null;
+let capturedOnScrollHandler: (() => void) | null = null;
+const mockScrollToBottom = vi.fn();
+const mockRefresh = vi.fn();
+const mockBuffer = {
+  active: { viewportY: 100, baseY: 100, length: 1, getLine: vi.fn() },
+};
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onScroll = vi.fn((handler: () => void) => {
+      capturedOnScrollHandler = handler;
+      return { dispose: vi.fn() };
+    });
+    onCursorMove = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    scrollToLine = vi.fn();
+    write = vi.fn((_data: unknown, cb?: () => void) => {
+      capturedWriteCallback = cb ?? null;
+    });
+    writeln = vi.fn();
+    scrollToBottom = mockScrollToBottom;
+    refresh = mockRefresh;
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn();
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = mockBuffer;
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class MockFitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-unicode11", () => {
+  class MockUnicode11Addon {
+    dispose = vi.fn();
+  }
+  return { Unicode11Addon: MockUnicode11Addon };
+});
+
+vi.mock("@xterm/addon-search", () => {
+  class MockSearchAddon {
+    dispose = vi.fn();
+  }
+  return { SearchAddon: MockSearchAddon };
+});
+
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/api", () => ({
+  createTerminal: vi.fn().mockResolvedValue("session-1"),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: vi.fn((_id: string, cb: (data: Uint8Array) => void) => {
+      outputCallback = cb;
+      return vi.fn();
+    }),
+    subscribeExit: vi.fn(() => vi.fn()),
+  },
+}));
+
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+let outputCallback: ((data: Uint8Array) => void) | null = null;
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+let rafCallbacks: Array<() => void> = [];
+const originalRAF = globalThis.requestAnimationFrame;
+const originalCAF = globalThis.cancelAnimationFrame;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  let rafId = 0;
+  globalThis.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+    const id = ++rafId;
+    rafCallbacks.push(() => cb(0));
+    return id;
+  });
+  globalThis.cancelAnimationFrame = vi.fn();
+});
+
+function flushRaf() {
+  const cbs = [...rafCallbacks];
+  rafCallbacks = [];
+  cbs.forEach((cb) => cb());
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  capturedWriteCallback = null;
+  capturedOnScrollHandler = null;
+  mockScrollToBottom.mockClear();
+  mockRefresh.mockClear();
+  mockBuffer.active.viewportY = 100;
+  mockBuffer.active.baseY = 100;
+  outputCallback = null;
+
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  globalThis.requestAnimationFrame = originalRAF;
+  globalThis.cancelAnimationFrame = originalCAF;
+});
+
+function renderTerminal() {
+  act(() => {
+    root.render(
+      <TerminalPortalProvider>
+        <Terminal tabId="tab-1" config={{ type: "local", config: {} }} isVisible={true} />
+      </TerminalPortalProvider>
+    );
+  });
+}
+
+async function pushOutputAndFlush() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
+  if (outputCallback) {
+    act(() => {
+      outputCallback!(new Uint8Array([65, 66, 67]));
+    });
+  }
+
+  // Flush the output RAF (flushOutput → xterm.write)
+  act(() => flushRaf());
+
+  // Run the write callback (afterWrite schedules the repaint RAF)
+  if (capturedWriteCallback) {
+    act(() => capturedWriteCallback!());
+  }
+
+  // Flush the scroll/refresh RAF
+  act(() => flushRaf());
+}
+
+describe("Terminal output repaint (#1849)", () => {
+  it("forces a full-viewport refresh after appended output", async () => {
+    renderTerminal();
+    await pushOutputAndFlush();
+
+    expect(mockRefresh).toHaveBeenCalledWith(0, 23);
+  });
+
+  it("still refreshes when the user has scrolled up (stale rows stay correct)", async () => {
+    renderTerminal();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Simulate the user scrolling away from the bottom: onScroll marks the
+    // terminal as scrolled-up so auto-scroll is suppressed.
+    mockBuffer.active.viewportY = 50;
+    mockBuffer.active.baseY = 100;
+    expect(capturedOnScrollHandler).not.toBeNull();
+    act(() => capturedOnScrollHandler!());
+    mockScrollToBottom.mockClear();
+    mockRefresh.mockClear();
+
+    if (outputCallback) {
+      act(() => {
+        outputCallback!(new Uint8Array([68, 69, 70]));
+      });
+    }
+    act(() => flushRaf());
+    if (capturedWriteCallback) {
+      act(() => capturedWriteCallback!());
+    }
+    act(() => flushRaf());
+
+    // Auto-scroll is suppressed while scrolled up, but the viewport is still
+    // repainted so no stale rows are left behind.
+    expect(mockScrollToBottom).not.toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalledWith(0, 23);
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -629,14 +629,30 @@ export function Terminal({
           // the old content height.  Defer to a RAF so the render pass
           // completes first and scrollToBottom() targets the correct
           // position.
-          const scrollAfterWrite = () => {
-            if (!userScrolledUpRef.current) {
-              requestAnimationFrame(() => xterm.scrollToBottom());
-            }
+          //
+          // The same RAF also forces a full-viewport repaint. xterm's DOM
+          // renderer only repaints rows it has marked dirty; during rapid
+          // scrolling output — e.g. Windows ConPTY redrawing a `git status`
+          // with many untracked files — WebView2/WebKit can leave rows painted
+          // at stale vertical positions, so a later prompt line appears spliced
+          // into earlier output until a resize forces a full re-render (#1849).
+          // Refreshing every visible row after each flush makes the paint
+          // deterministic without a manual resize, mirroring the #1823 fit+
+          // refresh fix. The range is bounded by the viewport height (the same
+          // rows a scroll already repaints), so it stays cheap on high-
+          // throughput output. Runs regardless of scroll position so stale rows
+          // are corrected even when the user has scrolled up.
+          const afterWrite = () => {
+            requestAnimationFrame(() => {
+              if (!userScrolledUpRef.current) {
+                xterm.scrollToBottom();
+              }
+              xterm.refresh(0, Math.max(0, xterm.rows - 1));
+            });
           };
 
           if (outputBuffer.length === 1) {
-            xterm.write(outputBuffer[0], scrollAfterWrite);
+            xterm.write(outputBuffer[0], afterWrite);
           } else {
             // Concatenate all buffered chunks into one write
             let totalLen = 0;
@@ -647,7 +663,7 @@ export function Terminal({
               merged.set(chunk, offset);
               offset += chunk.length;
             }
-            xterm.write(merged, scrollAfterWrite);
+            xterm.write(merged, afterWrite);
           }
           outputBuffer.length = 0;
         };

--- a/src/components/Terminal/TerminalAutoScroll.test.tsx
+++ b/src/components/Terminal/TerminalAutoScroll.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@xterm/xterm", () => {
     });
     writeln = vi.fn();
     scrollToBottom = mockScrollToBottom;
+    refresh = vi.fn();
     scrollLines = vi.fn();
     selectAll = vi.fn();
     hasSelection = vi.fn(() => false);


### PR DESCRIPTION
## Summary

Fixes the real defect in **image001.png** (re-scoped from #1828, which fixed a separate sidebar bug): terminal output painted **out of order** — two bare `C:\develop\raspi_info_screen>` prompt lines rendered *between* the lines of an earlier `git status`'s untracked-files list, instead of after it. The maintainer confirmed **resizing the tab once clears it**.

## Render-bug, not write-bug (evidence)

- **Write side ruled out.** `core::output::OutputCoalescer` is a plain append-only byte buffer (`push` extends, `flush`/`try_coalesce` drain in order — no reordering). The frontend pushes output chunks into `outputBuffer` in arrival order and merges them in order before a single `xterm.write`. So bytes reach xterm in PTY order.
- **Buffer is correct; only the paint is wrong.** The maintainer's "a resize fixes it" is the decisive tell: a resize does not change buffer *content*, it forces a full re-render. So the xterm.js buffer already holds the rows in the right order — the **DOM renderer** left rows painted at stale vertical positions.
- Same "stale render until resize" family as #1823 (fixed with `xterm.refresh(0, rows-1)` after fit) and #1828.

## Mechanism

xterm's DOM renderer repaints only the rows it has marked dirty. During rapid scrolling output — e.g. Windows **ConPTY** redrawing a `git status` with many untracked files via cursor-positioning sequences — the WebView can leave already-scrolled rows painted at stale positions, so a later prompt line visually overlaps earlier output until a resize (fit → full re-render) corrects it.

## Fix

In the output-flush RAF path (`Terminal.tsx` `flushOutput`), after each `xterm.write` I force a full-viewport repaint — `xterm.refresh(0, Math.max(0, rows - 1))` — deferred to the same RAF as `scrollToBottom`, mirroring the #1823 fit+refresh fix. The refresh range is bounded by the viewport height (the same rows a scroll already repaints), so it stays cheap on high-throughput output, and it runs regardless of scroll position so stale rows are corrected even when the user has scrolled up.

## Tests

- **Regression test** `Terminal.output-repaint.test.tsx` (committed red first, per TDD): asserts appended output issues `xterm.refresh(0, 23)` after the write, including when the user has scrolled up.
- Added `refresh` to the `TerminalAutoScroll.test.tsx` xterm mock.
- Full suite green (3857 tests); `./scripts/check.sh` passes.
- **Documented manual test** added to `docs/testing.md` (Windows CMD `git status` with many untracked files → output stays in order without a resize).

## Reproduced vs inferred

**Inferred, not reproduced.** This is Windows-CMD/ConPTY + WebView specific; I verified on macOS and cannot reproduce the exact visual. The mechanism is strongly supported by the "resize fixes it" diagnostic (proves buffer-correct/paint-wrong) and by the identical fix that resolved the sibling #1823. The fix is behaviorally conservative — a bounded, deterministic repaint on the existing output RAF.

## What the maintainer should verify on Windows

- Local **CMD (ConPTY)**: `git status` with many untracked files followed by a couple of Enter presses → the untracked list stays one contiguous block and the trailing prompts appear **after** it, with **no manual resize**.
- No visible slowdown or flicker on high-throughput output (e.g. a large file dump) and normal scrolling.

Closes #1849
