### PR TITLE
feat(workflow): workflow data model, storage, engine, and minimal end-to-end run (Closes #1852)

### DIFF
--- a/docs/changes/dev0/feature/1852-workflow-foundation.md
+++ b/docs/changes/dev0/feature/1852-workflow-foundation.md
@@ -1,0 +1,11 @@
+### Added
+
+- Groundwork for **Workflow Automation** (authored multi-step workflows, epic
+  #1851): a new versioned `workflows.json` store and its CRUD command surface,
+  the complete workflow data model (typed `send-command`, `run-script`,
+  `run-macro`, `wait`, and guarded `run-local-process` steps; `manual`,
+  `on-connect`, and `hotkey` triggers), and a run engine that streams a
+  workflow's steps into the active terminal through the same `send_input` seam
+  macros use, with live progress and cancel. Only the `send-command` step
+  executes so far; the sidebar/editor UI, the remaining step types, and trigger
+  dispatch land in later updates. No user-facing UI yet.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -16,5 +16,6 @@ pub mod ssh_config_import;
 pub mod transfer;
 pub mod tunnel;
 pub mod update;
+pub mod workflows;
 pub mod workspace;
 pub mod xserver;

--- a/src-tauri/src/commands/workflows.rs
+++ b/src-tauri/src/commands/workflows.rs
@@ -1,0 +1,41 @@
+use tauri::State;
+
+use crate::utils::errors::TerminalError;
+use crate::workflows::config::Workflow;
+use crate::workflows::manager::WorkflowManager;
+
+/// List all stored workflows.
+#[tauri::command]
+pub fn list_workflows(
+    manager: State<'_, WorkflowManager>,
+) -> Result<Vec<Workflow>, TerminalError> {
+    manager.list_workflows()
+}
+
+/// Get a single workflow by ID.
+#[tauri::command]
+pub fn get_workflow(
+    workflow_id: String,
+    manager: State<'_, WorkflowManager>,
+) -> Result<Workflow, TerminalError> {
+    manager.get_workflow(&workflow_id)
+}
+
+/// Save (add or update) a workflow. Returns the stored workflow with
+/// authoritative timestamps.
+#[tauri::command]
+pub fn save_workflow(
+    workflow_def: Workflow,
+    manager: State<'_, WorkflowManager>,
+) -> Result<Workflow, TerminalError> {
+    manager.save_workflow(workflow_def)
+}
+
+/// Delete a workflow by ID.
+#[tauri::command]
+pub fn delete_workflow(
+    workflow_id: String,
+    manager: State<'_, WorkflowManager>,
+) -> Result<(), TerminalError> {
+    manager.delete_workflow(&workflow_id)
+}

--- a/src-tauri/src/commands/workflows.rs
+++ b/src-tauri/src/commands/workflows.rs
@@ -6,9 +6,7 @@ use crate::workflows::manager::WorkflowManager;
 
 /// List all stored workflows.
 #[tauri::command]
-pub fn list_workflows(
-    manager: State<'_, WorkflowManager>,
-) -> Result<Vec<Workflow>, TerminalError> {
+pub fn list_workflows(manager: State<'_, WorkflowManager>) -> Result<Vec<Workflow>, TerminalError> {
     manager.list_workflows()
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,7 +18,6 @@ mod macros;
 mod network;
 mod session;
 mod spawn;
-mod workflows;
 mod terminal;
 mod tunnel;
 mod utils;
@@ -26,6 +25,7 @@ mod utils;
 /// into local apps with delayed rendering (`CF_HDROP`, #1814). Windows-only.
 #[cfg(windows)]
 mod windows_clipboard;
+mod workflows;
 mod workspace;
 
 use std::sync::{Arc, Mutex};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod macros;
 mod network;
 mod session;
 mod spawn;
+mod workflows;
 mod terminal;
 mod tunnel;
 mod utils;
@@ -515,6 +516,23 @@ pub fn run() {
                 }
             }
 
+            // Initialize workflow manager with recovery loading.
+            // On failure, the app still starts but workflows are unavailable.
+            match workflows::manager::WorkflowManager::new(app.handle()) {
+                Ok(manager) => {
+                    recovery_warnings.extend(manager.take_recovery_warnings());
+                    app.manage(manager);
+                }
+                Err(e) => {
+                    tracing::error!("Failed to initialize workflow manager: {e}");
+                    recovery_warnings.push(RecoveryWarning {
+                        file_name: "workflows.json".to_string(),
+                        message: "Could not initialize workflow storage. Workflows are unavailable until the app is restarted.".to_string(),
+                        details: Some(e.to_string()),
+                    });
+                }
+            }
+
             // Initialize the last-session manager. On failure the app still starts;
             // session restore is simply unavailable until the next launch.
             match workspace::last_session::LastSessionManager::new(app.handle()) {
@@ -854,6 +872,11 @@ pub fn run() {
             commands::macros::get_macro,
             commands::macros::save_macro,
             commands::macros::delete_macro,
+            // Workflows
+            commands::workflows::list_workflows,
+            commands::workflows::get_workflow,
+            commands::workflows::save_workflow,
+            commands::workflows::delete_workflow,
             // Network diagnostics
             commands::network::network_port_scan,
             commands::network::network_port_scan_cancel,

--- a/src-tauri/src/utils/errors.rs
+++ b/src-tauri/src/utils/errors.rs
@@ -55,6 +55,9 @@ pub enum TerminalError {
     #[error("Macro error: {0}")]
     MacroError(String),
 
+    #[error("Workflow error: {0}")]
+    WorkflowError(String),
+
     #[error("Network error: {0}")]
     NetworkError(String),
 

--- a/src-tauri/src/workflows/config.rs
+++ b/src-tauri/src/workflows/config.rs
@@ -1,0 +1,280 @@
+use serde::{Deserialize, Serialize};
+
+/// A single, typed step of a workflow.
+///
+/// Unlike a [`crate::macros::config::MacroStep`] (an opaque recorded input
+/// chunk), a workflow step is *authored* and *discriminated*: the `kind` tag
+/// selects one of a fixed set of actions. The complete v1 union is defined here
+/// up front — only `send-command` is executed by the runner in the foundation
+/// (#1852); the remaining variants are typed placeholders that later children of
+/// the Workflow Automation epic (#1851) wire up (#1853 run-script/run-macro/wait,
+/// #1857 run-local-process) without having to edit this model.
+///
+/// The tag is `kind` (matching the TS discriminated union) and variant names are
+/// kebab-case (`send-command`, `run-script`, …); struct-variant fields are
+/// camelCase so the JSON shape matches the TypeScript `Workflow` type exactly.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum WorkflowStep {
+    /// Send a single authored command line into the active session (with a
+    /// trailing newline). The everyday building block — "run `git status`".
+    #[serde(rename_all = "camelCase")]
+    SendCommand {
+        /// The command line to send (a trailing newline is added on execution).
+        command: String,
+    },
+
+    /// Stream a saved multi-line script's *text* into the session, line by line,
+    /// with an optional per-line delay. Executed by #1853.
+    #[serde(rename_all = "camelCase")]
+    RunScript {
+        /// The script body (one command per line).
+        script: String,
+        /// Optional delay (ms) inserted between each streamed line.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        per_line_delay_ms: Option<u64>,
+        /// Optional on-disk path the script body was loaded from.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_path: Option<String>,
+    },
+
+    /// Replay an existing stored macro by id, reusing the macro's own timing
+    /// mode. Executed by #1853 (dispatches back into macro playback).
+    #[serde(rename_all = "camelCase")]
+    RunMacro {
+        /// The id of the stored macro to replay.
+        macro_id: String,
+    },
+
+    /// Pause for a fixed number of milliseconds before the next step. Executed
+    /// by #1853.
+    #[serde(rename_all = "camelCase")]
+    Wait {
+        /// How long to pause, in milliseconds.
+        delay_ms: u64,
+    },
+
+    /// Spawn a **local** helper process (not on the remote host). Security-
+    /// sensitive; gated behind an explicit opt-in and confirm-on-first-run.
+    /// Executed by #1857 — kept in the model now so no later child edits it.
+    #[serde(rename_all = "camelCase")]
+    RunLocalProcess {
+        /// The local program to spawn.
+        program: String,
+        /// Arguments passed to the program.
+        #[serde(default)]
+        args: Vec<String>,
+    },
+}
+
+/// A trigger that launches a workflow. The complete v1 union is defined here up
+/// front; dispatch is wired by #1855 (manual palette/hotkey + on-connect).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum WorkflowTrigger {
+    /// The user runs it from the palette, the Workflow sidebar, or a button.
+    Manual,
+
+    /// Fires when a session opens for one of the named connections.
+    #[serde(rename_all = "camelCase")]
+    OnConnect {
+        /// Connection ids this trigger is bound to.
+        #[serde(default)]
+        connection_ids: Vec<String>,
+    },
+
+    /// Fires when a user-assigned keybinding is pressed while a session is
+    /// focused.
+    #[serde(rename_all = "camelCase")]
+    Hotkey {
+        /// The keybinding string (e.g. `Ctrl+Alt+H`).
+        binding: String,
+    },
+}
+
+/// An authored, ordered list of typed steps launched by zero or more triggers.
+///
+/// Mirrors the shipped [`crate::macros::config::Macro`] shape (id, name,
+/// description, tags, timestamps) but replaces the homogeneous `MacroStep[]`
+/// with a discriminated [`WorkflowStep`] list and adds a [`WorkflowTrigger`]
+/// list.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Workflow {
+    /// Unique workflow identifier.
+    pub id: String,
+    /// User-friendly name for this workflow.
+    pub name: String,
+    /// Optional free-text description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional tags for grouping/filtering in the manager UI.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// The ordered steps that make up this workflow.
+    #[serde(default)]
+    pub steps: Vec<WorkflowStep>,
+    /// The triggers that can launch this workflow.
+    #[serde(default)]
+    pub triggers: Vec<WorkflowTrigger>,
+    /// RFC 3339 timestamp of when the workflow was first created.
+    #[serde(default)]
+    pub created_at: String,
+    /// RFC 3339 timestamp of the workflow's last update.
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+/// Top-level schema for the workflows JSON file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowStore {
+    /// Schema version, for forward-compatible migrations.
+    pub version: String,
+    /// All stored workflows.
+    pub workflows: Vec<Workflow>,
+}
+
+impl Default for WorkflowStore {
+    fn default() -> Self {
+        Self {
+            version: "1".to_string(),
+            workflows: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_store_default_is_empty() {
+        let store = WorkflowStore::default();
+        assert_eq!(store.version, "1");
+        assert!(store.workflows.is_empty());
+    }
+
+    #[test]
+    fn send_command_step_serializes_with_kind_tag() {
+        let step = WorkflowStep::SendCommand {
+            command: "git status".to_string(),
+        };
+        let json = serde_json::to_string(&step).unwrap();
+        assert!(json.contains("\"kind\":\"send-command\""));
+        assert!(json.contains("\"command\":\"git status\""));
+        let parsed: WorkflowStep = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, step);
+    }
+
+    #[test]
+    fn run_script_step_uses_camel_case_optional_fields() {
+        let step = WorkflowStep::RunScript {
+            script: "echo one\necho two".to_string(),
+            per_line_delay_ms: Some(50),
+            source_path: Some("/tmp/health.sh".to_string()),
+        };
+        let json = serde_json::to_string(&step).unwrap();
+        assert!(json.contains("\"kind\":\"run-script\""));
+        assert!(json.contains("\"perLineDelayMs\":50"));
+        assert!(json.contains("\"sourcePath\":\"/tmp/health.sh\""));
+        let parsed: WorkflowStep = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, step);
+    }
+
+    #[test]
+    fn run_script_step_omits_absent_optional_fields() {
+        let step = WorkflowStep::RunScript {
+            script: "echo hi".to_string(),
+            per_line_delay_ms: None,
+            source_path: None,
+        };
+        let json = serde_json::to_string(&step).unwrap();
+        assert!(!json.contains("perLineDelayMs"));
+        assert!(!json.contains("sourcePath"));
+        // A file that never wrote the optional fields still parses.
+        let parsed: WorkflowStep =
+            serde_json::from_str(r#"{"kind":"run-script","script":"echo hi"}"#).unwrap();
+        assert_eq!(parsed, step);
+    }
+
+    #[test]
+    fn all_step_kinds_round_trip() {
+        let steps = vec![
+            WorkflowStep::SendCommand {
+                command: "sudo -v".to_string(),
+            },
+            WorkflowStep::RunScript {
+                script: "a\nb".to_string(),
+                per_line_delay_ms: Some(10),
+                source_path: None,
+            },
+            WorkflowStep::RunMacro {
+                macro_id: "macro-1".to_string(),
+            },
+            WorkflowStep::Wait { delay_ms: 500 },
+            WorkflowStep::RunLocalProcess {
+                program: "notify-send".to_string(),
+                args: vec!["done".to_string()],
+            },
+        ];
+        let json = serde_json::to_string(&steps).unwrap();
+        assert!(json.contains("\"kind\":\"run-macro\""));
+        assert!(json.contains("\"macroId\":\"macro-1\""));
+        assert!(json.contains("\"kind\":\"wait\""));
+        assert!(json.contains("\"delayMs\":500"));
+        assert!(json.contains("\"kind\":\"run-local-process\""));
+        let parsed: Vec<WorkflowStep> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, steps);
+    }
+
+    #[test]
+    fn all_trigger_kinds_round_trip() {
+        let triggers = vec![
+            WorkflowTrigger::Manual,
+            WorkflowTrigger::OnConnect {
+                connection_ids: vec!["prod-web-1".to_string(), "prod-web-2".to_string()],
+            },
+            WorkflowTrigger::Hotkey {
+                binding: "Ctrl+Alt+H".to_string(),
+            },
+        ];
+        let json = serde_json::to_string(&triggers).unwrap();
+        assert!(json.contains("\"kind\":\"manual\""));
+        assert!(json.contains("\"kind\":\"on-connect\""));
+        assert!(json.contains("\"connectionIds\""));
+        assert!(json.contains("\"kind\":\"hotkey\""));
+        let parsed: Vec<WorkflowTrigger> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, triggers);
+    }
+
+    #[test]
+    fn workflow_serializes_with_camel_case_keys() {
+        let wf = Workflow {
+            id: "wf-1".to_string(),
+            name: "Prod login".to_string(),
+            description: Some("Login and health check".to_string()),
+            tags: vec!["ops".to_string()],
+            steps: vec![WorkflowStep::SendCommand {
+                command: "sudo -v".to_string(),
+            }],
+            triggers: vec![WorkflowTrigger::Manual],
+            created_at: "2026-07-24T00:00:00Z".to_string(),
+            updated_at: "2026-07-24T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&wf).unwrap();
+        assert!(json.contains("\"createdAt\""));
+        assert!(json.contains("\"updatedAt\""));
+        let parsed: Workflow = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, wf);
+    }
+
+    #[test]
+    fn workflow_defaults_absent_collections() {
+        // A minimal workflow (only id + name) parses with empty collections.
+        let wf: Workflow = serde_json::from_str(r#"{"id":"wf-1","name":"Bare"}"#).unwrap();
+        assert!(wf.steps.is_empty());
+        assert!(wf.triggers.is_empty());
+        assert!(wf.tags.is_empty());
+        assert_eq!(wf.description, None);
+    }
+}

--- a/src-tauri/src/workflows/manager.rs
+++ b/src-tauri/src/workflows/manager.rs
@@ -1,0 +1,266 @@
+use std::sync::Mutex;
+
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+
+use super::config::{Workflow, WorkflowStore};
+use super::storage::WorkflowStorage;
+use crate::connection::recovery::RecoveryWarning;
+use crate::utils::errors::TerminalError;
+
+/// Central workflow manager: CRUD for stored workflows, persisting through
+/// storage. Mirrors [`crate::macros::manager::MacroManager`].
+pub struct WorkflowManager {
+    store: Mutex<WorkflowStore>,
+    storage: WorkflowStorage,
+    recovery_warnings: Mutex<Vec<RecoveryWarning>>,
+}
+
+impl WorkflowManager {
+    /// Initialize from disk, with recovery on corruption.
+    pub fn new(app_handle: &AppHandle) -> Result<Self> {
+        let storage =
+            WorkflowStorage::new(app_handle).context("Failed to initialize workflow storage")?;
+        let result = storage
+            .load_with_recovery()
+            .context("Failed to load workflows")?;
+
+        Ok(Self {
+            store: Mutex::new(result.data),
+            storage,
+            recovery_warnings: Mutex::new(result.warnings),
+        })
+    }
+
+    /// Take ownership of any recovery warnings (only the first call returns them).
+    pub fn take_recovery_warnings(&self) -> Vec<RecoveryWarning> {
+        self.recovery_warnings
+            .lock()
+            .map(|mut w| std::mem::take(&mut *w))
+            .unwrap_or_default()
+    }
+
+    /// List all stored workflows.
+    pub fn list_workflows(&self) -> Result<Vec<Workflow>, TerminalError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|e| TerminalError::WorkflowError(e.to_string()))?;
+        Ok(store.workflows.clone())
+    }
+
+    /// Get a single workflow by ID.
+    pub fn get_workflow(&self, id: &str) -> Result<Workflow, TerminalError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|e| TerminalError::WorkflowError(e.to_string()))?;
+        store
+            .workflows
+            .iter()
+            .find(|w| w.id == id)
+            .cloned()
+            .ok_or_else(|| TerminalError::WorkflowError(format!("Workflow not found: {id}")))
+    }
+
+    /// Save (add or update) a workflow, stamping timestamps.
+    ///
+    /// On update the original `created_at` is preserved; `updated_at` is always
+    /// set to now. The stored workflow (with authoritative timestamps) is returned.
+    pub fn save_workflow(&self, mut workflow: Workflow) -> Result<Workflow, TerminalError> {
+        let now = now_rfc3339();
+
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|e| TerminalError::WorkflowError(e.to_string()))?;
+
+        workflow.updated_at = now.clone();
+
+        if let Some(existing) = store.workflows.iter_mut().find(|w| w.id == workflow.id) {
+            // Preserve the original creation timestamp on update.
+            workflow.created_at = existing.created_at.clone();
+            *existing = workflow.clone();
+        } else {
+            if workflow.created_at.is_empty() {
+                workflow.created_at = now;
+            }
+            store.workflows.push(workflow.clone());
+        }
+
+        self.storage
+            .save(&store)
+            .map_err(|e| TerminalError::WorkflowError(e.to_string()))?;
+
+        Ok(workflow)
+    }
+
+    /// Delete a workflow by ID.
+    pub fn delete_workflow(&self, id: &str) -> Result<(), TerminalError> {
+        let mut store = self
+            .store
+            .lock()
+            .map_err(|e| TerminalError::WorkflowError(e.to_string()))?;
+
+        let len_before = store.workflows.len();
+        store.workflows.retain(|w| w.id != id);
+
+        if store.workflows.len() == len_before {
+            return Err(TerminalError::WorkflowError(format!(
+                "Workflow not found: {id}"
+            )));
+        }
+
+        self.storage
+            .save(&store)
+            .map_err(|e| TerminalError::WorkflowError(e.to_string()))
+    }
+}
+
+/// Current time as an RFC 3339 string.
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflows::config::{WorkflowStep, WorkflowTrigger};
+    use tempfile::TempDir;
+
+    fn create_test_manager(dir: &TempDir) -> WorkflowManager {
+        WorkflowManager {
+            store: Mutex::new(WorkflowStore::default()),
+            storage: WorkflowStorage::new_test(dir.path()),
+            recovery_warnings: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn sample_workflow(id: &str, name: &str) -> Workflow {
+        Workflow {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: None,
+            tags: vec![],
+            steps: vec![WorkflowStep::SendCommand {
+                command: "echo hi".to_string(),
+            }],
+            triggers: vec![WorkflowTrigger::Manual],
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn list_workflows_empty() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+        assert!(mgr.list_workflows().unwrap().is_empty());
+    }
+
+    #[test]
+    fn save_and_list_workflows() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        mgr.save_workflow(sample_workflow("wf-1", "First")).unwrap();
+        mgr.save_workflow(sample_workflow("wf-2", "Second"))
+            .unwrap();
+
+        let workflows = mgr.list_workflows().unwrap();
+        assert_eq!(workflows.len(), 2);
+        assert_eq!(workflows[0].name, "First");
+        assert_eq!(workflows[1].name, "Second");
+    }
+
+    #[test]
+    fn save_stamps_created_and_updated() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        let saved = mgr.save_workflow(sample_workflow("wf-1", "First")).unwrap();
+        assert!(!saved.created_at.is_empty());
+        assert!(!saved.updated_at.is_empty());
+    }
+
+    #[test]
+    fn save_update_preserves_created_at() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        let first = mgr
+            .save_workflow(sample_workflow("wf-1", "Original"))
+            .unwrap();
+
+        let mut updated = sample_workflow("wf-1", "Renamed");
+        // A client may send a bogus created_at on update; the manager must ignore it.
+        updated.created_at = "1999-01-01T00:00:00Z".to_string();
+        let second = mgr.save_workflow(updated).unwrap();
+
+        assert_eq!(second.created_at, first.created_at);
+
+        let workflows = mgr.list_workflows().unwrap();
+        assert_eq!(workflows.len(), 1);
+        assert_eq!(workflows[0].name, "Renamed");
+    }
+
+    #[test]
+    fn get_workflow_found_and_not_found() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        mgr.save_workflow(sample_workflow("wf-1", "First")).unwrap();
+
+        let got = mgr.get_workflow("wf-1").unwrap();
+        assert_eq!(got.name, "First");
+        assert_eq!(
+            got.steps[0],
+            WorkflowStep::SendCommand {
+                command: "echo hi".to_string()
+            }
+        );
+
+        assert!(mgr.get_workflow("nope").is_err());
+    }
+
+    #[test]
+    fn delete_workflow_removes_it() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        mgr.save_workflow(sample_workflow("wf-1", "First")).unwrap();
+        mgr.delete_workflow("wf-1").unwrap();
+
+        assert!(mgr.list_workflows().unwrap().is_empty());
+    }
+
+    #[test]
+    fn delete_workflow_not_found() {
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+        assert!(mgr.delete_workflow("nope").is_err());
+    }
+
+    #[test]
+    fn workflows_persist_across_manager_reload() {
+        let dir = TempDir::new().unwrap();
+        {
+            let mgr = create_test_manager(&dir);
+            mgr.save_workflow(sample_workflow("wf-1", "Persisted"))
+                .unwrap();
+        }
+
+        // A fresh manager reading the same file sees the saved workflow.
+        let storage = WorkflowStorage::new_test(dir.path());
+        let loaded = storage.load_with_recovery().unwrap();
+        let mgr = WorkflowManager {
+            store: Mutex::new(loaded.data),
+            storage,
+            recovery_warnings: Mutex::new(Vec::new()),
+        };
+
+        let workflows = mgr.list_workflows().unwrap();
+        assert_eq!(workflows.len(), 1);
+        assert_eq!(workflows[0].name, "Persisted");
+    }
+}

--- a/src-tauri/src/workflows/mod.rs
+++ b/src-tauri/src/workflows/mod.rs
@@ -1,0 +1,3 @@
+pub mod config;
+pub mod manager;
+pub mod storage;

--- a/src-tauri/src/workflows/storage.rs
+++ b/src-tauri/src/workflows/storage.rs
@@ -1,0 +1,181 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+
+use super::config::WorkflowStore;
+use crate::connection::recovery::{RecoveryResult, RecoveryWarning};
+use crate::utils::config_paths::resolve_config_dir;
+
+const FILE_NAME: &str = "workflows.json";
+
+/// Handles reading/writing the workflows JSON file. Mirrors
+/// [`crate::macros::storage::MacroStorage`].
+pub struct WorkflowStorage {
+    file_path: PathBuf,
+}
+
+impl WorkflowStorage {
+    /// Create a new storage instance, resolving the config directory.
+    ///
+    /// If `TERMIHUB_CONFIG_DIR` is set, it overrides the default Tauri config directory.
+    pub fn new(app_handle: &AppHandle) -> Result<Self> {
+        let config_dir = resolve_config_dir(Some(app_handle))?;
+
+        fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
+
+        Ok(Self {
+            file_path: config_dir.join(FILE_NAME),
+        })
+    }
+
+    /// Load with recovery: on parse failure, backs up the corrupt file and resets to defaults.
+    pub fn load_with_recovery(&self) -> Result<RecoveryResult<WorkflowStore>> {
+        if !self.file_path.exists() {
+            return Ok(RecoveryResult {
+                data: WorkflowStore::default(),
+                warnings: Vec::new(),
+            });
+        }
+
+        let data = fs::read_to_string(&self.file_path).context("Failed to read workflows file")?;
+
+        // Fast path: normal parse succeeds
+        if let Ok(store) = serde_json::from_str::<WorkflowStore>(&data) {
+            return Ok(RecoveryResult {
+                data: store,
+                warnings: Vec::new(),
+            });
+        }
+
+        // Parse failed — back up and reset to defaults
+        let backup_path = self.file_path.with_extension("json.bak");
+        let _ = fs::copy(&self.file_path, &backup_path);
+        tracing::warn!(
+            "Workflows file is corrupt, backed up to {}",
+            backup_path.display()
+        );
+
+        let parse_error = serde_json::from_str::<WorkflowStore>(&data)
+            .err()
+            .map(|e| e.to_string());
+
+        let warning = RecoveryWarning {
+            file_name: FILE_NAME.to_string(),
+            message: "Workflows file was corrupt and has been reset.".to_string(),
+            details: parse_error,
+        };
+        tracing::error!("Workflows file corrupt, resetting to defaults");
+
+        let defaults = WorkflowStore::default();
+        self.save(&defaults)
+            .context("Failed to save default workflows after recovery")?;
+
+        Ok(RecoveryResult {
+            data: defaults,
+            warnings: vec![warning],
+        })
+    }
+
+    /// Save the workflow store to disk (pretty-printed JSON).
+    pub fn save(&self, store: &WorkflowStore) -> Result<()> {
+        let data = serde_json::to_string_pretty(store).context("Failed to serialize workflows")?;
+
+        fs::write(&self.file_path, data).context("Failed to write workflows file")?;
+
+        Ok(())
+    }
+
+    /// Create a storage instance for testing (bypasses Tauri AppHandle).
+    #[cfg(test)]
+    pub fn new_test(dir: &std::path::Path) -> Self {
+        Self {
+            file_path: dir.join(FILE_NAME),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflows::config::{Workflow, WorkflowStep, WorkflowTrigger};
+    use tempfile::TempDir;
+
+    fn create_test_storage(dir: &TempDir) -> WorkflowStorage {
+        WorkflowStorage {
+            file_path: dir.path().join(FILE_NAME),
+        }
+    }
+
+    fn sample_store() -> WorkflowStore {
+        WorkflowStore {
+            version: "1".to_string(),
+            workflows: vec![Workflow {
+                id: "wf-1".to_string(),
+                name: "Login".to_string(),
+                description: Some("Login sequence".to_string()),
+                tags: vec!["ops".to_string()],
+                steps: vec![
+                    WorkflowStep::SendCommand {
+                        command: "sudo -v".to_string(),
+                    },
+                    WorkflowStep::Wait { delay_ms: 500 },
+                ],
+                triggers: vec![WorkflowTrigger::OnConnect {
+                    connection_ids: vec!["prod-web-1".to_string()],
+                }],
+                created_at: "2026-07-24T00:00:00Z".to_string(),
+                updated_at: "2026-07-24T00:00:00Z".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn load_with_recovery_missing_file_returns_defaults() {
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+
+        let result = storage.load_with_recovery().unwrap();
+        assert!(result.warnings.is_empty());
+        assert!(result.data.workflows.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+
+        let store = sample_store();
+        storage.save(&store).unwrap();
+
+        let result = storage.load_with_recovery().unwrap();
+        assert!(result.warnings.is_empty());
+        assert_eq!(result.data.workflows.len(), 1);
+        assert_eq!(result.data.workflows[0].name, "Login");
+        assert_eq!(result.data.workflows[0].steps.len(), 2);
+        assert_eq!(
+            result.data.workflows[0].steps[0],
+            WorkflowStep::SendCommand {
+                command: "sudo -v".to_string()
+            }
+        );
+        assert_eq!(result.data.workflows[0].triggers.len(), 1);
+    }
+
+    #[test]
+    fn load_with_recovery_corrupt_json() {
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+        fs::write(&storage.file_path, "corrupt workflow data!!!").unwrap();
+
+        let result = storage.load_with_recovery().unwrap();
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].message.contains("corrupt"));
+        assert!(result.data.workflows.is_empty());
+
+        // Backup should exist
+        let backup = storage.file_path.with_extension("json.bak");
+        assert!(backup.exists());
+    }
+}

--- a/src/services/workflowApi.test.ts
+++ b/src/services/workflowApi.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import { listWorkflows, getWorkflow, saveWorkflow, deleteWorkflow } from "./workflowApi";
+import type { Workflow } from "@/types/workflow";
+
+const mockedInvoke = vi.mocked(invoke);
+
+function sampleWorkflow(): Workflow {
+  return {
+    id: "wf-1",
+    name: "Login",
+    description: "Login sequence",
+    tags: ["ops"],
+    steps: [{ kind: "send-command", command: "sudo -v" }],
+    triggers: [{ kind: "manual" }],
+    createdAt: "2026-07-24T00:00:00Z",
+    updatedAt: "2026-07-24T00:00:00Z",
+  };
+}
+
+describe("workflowApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("listWorkflows invokes correct command", async () => {
+    mockedInvoke.mockResolvedValue([]);
+    const result = await listWorkflows();
+    expect(mockedInvoke).toHaveBeenCalledWith("list_workflows");
+    expect(result).toEqual([]);
+  });
+
+  it("getWorkflow invokes correct command with id", async () => {
+    const workflow = sampleWorkflow();
+    mockedInvoke.mockResolvedValue(workflow);
+    const result = await getWorkflow("wf-1");
+    expect(mockedInvoke).toHaveBeenCalledWith("get_workflow", { workflowId: "wf-1" });
+    expect(result).toEqual(workflow);
+  });
+
+  it("saveWorkflow invokes correct command with workflowDef arg", async () => {
+    const workflow = sampleWorkflow();
+    mockedInvoke.mockResolvedValue(workflow);
+    const result = await saveWorkflow(workflow);
+    expect(mockedInvoke).toHaveBeenCalledWith("save_workflow", { workflowDef: workflow });
+    expect(result).toEqual(workflow);
+  });
+
+  it("deleteWorkflow invokes correct command with id", async () => {
+    mockedInvoke.mockResolvedValue(undefined);
+    await deleteWorkflow("wf-1");
+    expect(mockedInvoke).toHaveBeenCalledWith("delete_workflow", { workflowId: "wf-1" });
+  });
+});

--- a/src/services/workflowApi.ts
+++ b/src/services/workflowApi.ts
@@ -1,0 +1,29 @@
+/**
+ * Tauri command wrappers for workflow operations (#1852).
+ *
+ * A thin layer over the `list/get/save/delete_workflow` Tauri commands, mirroring
+ * {@link "@/services/macroApi"}.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { Workflow } from "@/types/workflow";
+
+/** List all stored workflows. */
+export async function listWorkflows(): Promise<Workflow[]> {
+  return await invoke<Workflow[]>("list_workflows");
+}
+
+/** Get a single workflow by ID. */
+export async function getWorkflow(workflowId: string): Promise<Workflow> {
+  return await invoke<Workflow>("get_workflow", { workflowId });
+}
+
+/** Save (add or update) a workflow. Returns the stored workflow with authoritative timestamps. */
+export async function saveWorkflow(workflow: Workflow): Promise<Workflow> {
+  return await invoke<Workflow>("save_workflow", { workflowDef: workflow });
+}
+
+/** Delete a workflow by ID. */
+export async function deleteWorkflow(workflowId: string): Promise<void> {
+  await invoke("delete_workflow", { workflowId });
+}

--- a/src/services/workflowIo.test.ts
+++ b/src/services/workflowIo.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for workflow import/export serialisation (#1852).
+ *
+ * Covers the round-trip (serialise → parse), strict validation of the
+ * discriminated step/trigger unions and the envelope version, and the
+ * fresh-id + name-dedupe collision resolution used when merging an imported
+ * file into an existing library.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  serializeWorkflows,
+  parseWorkflowEnvelope,
+  resolveImportCollisions,
+  WORKFLOW_EXPORT_VERSION,
+} from "./workflowIo";
+import type { Workflow } from "@/types/workflow";
+
+function sampleWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: "wf-1",
+    name: "Login",
+    description: "Login sequence",
+    tags: ["ops"],
+    steps: [
+      { kind: "send-command", command: "sudo -v" },
+      { kind: "run-script", script: "a\nb", perLineDelayMs: 50 },
+      { kind: "run-macro", macroId: "m-1" },
+      { kind: "wait", delayMs: 500 },
+      { kind: "run-local-process", program: "echo", args: ["done"] },
+    ],
+    triggers: [
+      { kind: "manual" },
+      { kind: "on-connect", connectionIds: ["prod-web-1"] },
+      { kind: "hotkey", binding: "Ctrl+Alt+H" },
+    ],
+    createdAt: "2026-07-24T00:00:00Z",
+    updatedAt: "2026-07-24T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("serializeWorkflows / parseWorkflowEnvelope", () => {
+  it("round-trips a workflow with every step and trigger kind", () => {
+    const wf = sampleWorkflow();
+    const json = serializeWorkflows([wf]);
+    expect(json.endsWith("\n")).toBe(true);
+
+    const parsed = parseWorkflowEnvelope(json);
+    expect(parsed).toEqual([wf]);
+  });
+
+  it("writes the current envelope version", () => {
+    const json = serializeWorkflows([sampleWorkflow()]);
+    expect(JSON.parse(json).version).toBe(WORKFLOW_EXPORT_VERSION);
+  });
+
+  it("rejects non-JSON input", () => {
+    expect(() => parseWorkflowEnvelope("not json {")).toThrow(/not valid JSON/);
+  });
+
+  it("rejects an unsupported version", () => {
+    const json = JSON.stringify({ version: 999, workflows: [] });
+    expect(() => parseWorkflowEnvelope(json)).toThrow(/Unsupported workflow file version/);
+  });
+
+  it("rejects a missing workflows array", () => {
+    const json = JSON.stringify({ version: WORKFLOW_EXPORT_VERSION });
+    expect(() => parseWorkflowEnvelope(json)).toThrow(/missing "workflows" array/);
+  });
+
+  it("rejects a workflow with no name", () => {
+    const json = JSON.stringify({
+      version: WORKFLOW_EXPORT_VERSION,
+      workflows: [{ steps: [] }],
+    });
+    expect(() => parseWorkflowEnvelope(json)).toThrow(/missing a name/);
+  });
+
+  it("rejects a step with an unknown kind", () => {
+    const json = JSON.stringify({
+      version: WORKFLOW_EXPORT_VERSION,
+      workflows: [{ name: "X", steps: [{ kind: "teleport" }] }],
+    });
+    expect(() => parseWorkflowEnvelope(json)).toThrow(/unknown kind "teleport"/);
+  });
+
+  it("rejects a send-command missing its command", () => {
+    const json = JSON.stringify({
+      version: WORKFLOW_EXPORT_VERSION,
+      workflows: [{ name: "X", steps: [{ kind: "send-command" }] }],
+    });
+    expect(() => parseWorkflowEnvelope(json)).toThrow(/missing "command"/);
+  });
+
+  it("rejects a wait with a negative delay", () => {
+    const json = JSON.stringify({
+      version: WORKFLOW_EXPORT_VERSION,
+      workflows: [{ name: "X", steps: [{ kind: "wait", delayMs: -5 }] }],
+    });
+    expect(() => parseWorkflowEnvelope(json)).toThrow(/invalid "delayMs"/);
+  });
+
+  it("rejects an on-connect trigger with malformed connectionIds", () => {
+    const json = JSON.stringify({
+      version: WORKFLOW_EXPORT_VERSION,
+      workflows: [
+        { name: "X", steps: [], triggers: [{ kind: "on-connect", connectionIds: [42] }] },
+      ],
+    });
+    expect(() => parseWorkflowEnvelope(json)).toThrow(/invalid "connectionIds"/);
+  });
+
+  it("tolerates absent optional collections (triggers/tags/timestamps)", () => {
+    const json = JSON.stringify({
+      version: WORKFLOW_EXPORT_VERSION,
+      workflows: [{ name: "Bare", steps: [{ kind: "send-command", command: "ls" }] }],
+    });
+    const parsed = parseWorkflowEnvelope(json);
+    expect(parsed[0]).toMatchObject({
+      name: "Bare",
+      id: "",
+      tags: [],
+      triggers: [],
+      createdAt: "",
+      updatedAt: "",
+    });
+  });
+});
+
+describe("resolveImportCollisions", () => {
+  let counter = 0;
+  const genId = (): string => `gen-${(counter += 1)}`;
+
+  it("gives each imported workflow a fresh id and clears timestamps", () => {
+    counter = 0;
+    const imported = [sampleWorkflow({ id: "old", createdAt: "x", updatedAt: "y" })];
+    const [result] = resolveImportCollisions(imported, [], genId);
+
+    expect(result.id).toBe("gen-1");
+    expect(result.createdAt).toBe("");
+    expect(result.updatedAt).toBe("");
+  });
+
+  it("de-duplicates a name that collides with the existing library", () => {
+    counter = 0;
+    const existing = [sampleWorkflow({ name: "Login" })];
+    const imported = [sampleWorkflow({ name: "Login" })];
+    const [result] = resolveImportCollisions(imported, existing, genId);
+
+    expect(result.name).toBe("Login (imported)");
+  });
+
+  it("de-duplicates names that collide within the same batch", () => {
+    counter = 0;
+    const imported = [sampleWorkflow({ name: "Deploy" }), sampleWorkflow({ name: "Deploy" })];
+    const results = resolveImportCollisions(imported, [], genId);
+
+    expect(results.map((w) => w.name)).toEqual(["Deploy", "Deploy (imported)"]);
+  });
+
+  it("leaves a non-colliding name untouched", () => {
+    counter = 0;
+    const [result] = resolveImportCollisions([sampleWorkflow({ name: "Unique" })], [], genId);
+    expect(result.name).toBe("Unique");
+  });
+});

--- a/src/services/workflowIo.ts
+++ b/src/services/workflowIo.ts
@@ -147,7 +147,10 @@ function validateTrigger(raw: unknown, where: string, triggerIndex: number): Wor
     case "manual":
       return { kind };
     case "on-connect":
-      if (!Array.isArray(raw.connectionIds) || raw.connectionIds.some((c) => typeof c !== "string")) {
+      if (
+        !Array.isArray(raw.connectionIds) ||
+        raw.connectionIds.some((c) => typeof c !== "string")
+      ) {
         throw new Error(`Invalid workflow file: ${at} (on-connect) has invalid "connectionIds".`);
       }
       return { kind, connectionIds: raw.connectionIds as string[] };

--- a/src/services/workflowIo.ts
+++ b/src/services/workflowIo.ts
@@ -1,0 +1,300 @@
+/**
+ * Import/export of workflows as portable JSON files (#1852 foundation; the
+ * file-dialog UI that drives these is #1856).
+ *
+ * Pure, dependency-free helpers: serialising workflows into a small versioned
+ * envelope, validating/parsing an envelope back into workflows (including the
+ * discriminated {@link WorkflowStep} / {@link WorkflowTrigger} unions), and
+ * resolving id/name collisions when merging imported workflows into an existing
+ * library. Mirrors {@link "@/services/macroIo"}; keeping the
+ * serialise/validate/collision logic here makes it unit-testable in isolation.
+ */
+
+import type {
+  Workflow,
+  WorkflowStep,
+  WorkflowStepKind,
+  WorkflowTrigger,
+  WorkflowTriggerKind,
+} from "@/types/workflow";
+
+/**
+ * Current version of the workflow export envelope. Bump only on an incompatible
+ * change to the on-disk shape; the parser rejects any other version so a newer
+ * file fails loudly rather than importing as a corrupt workflow.
+ */
+export const WORKFLOW_EXPORT_VERSION = 1;
+
+/**
+ * The stable, explicit on-disk shape for exported workflows. A versioned wrapper
+ * around the workflow list — deliberately NOT the raw internal store — so the
+ * file format can evolve independently of the runtime {@link Workflow} type.
+ */
+export interface WorkflowExportEnvelope {
+  /** Envelope schema version; see {@link WORKFLOW_EXPORT_VERSION}. */
+  version: number;
+  /** The exported workflows. */
+  workflows: Workflow[];
+}
+
+/** Suffix appended to imported workflow names that collide with an existing one. */
+const COLLISION_SUFFIX = "imported";
+
+/** All valid step-kind discriminants. */
+const STEP_KINDS: readonly WorkflowStepKind[] = [
+  "send-command",
+  "run-script",
+  "run-macro",
+  "wait",
+  "run-local-process",
+];
+
+/** All valid trigger-kind discriminants. */
+const TRIGGER_KINDS: readonly WorkflowTriggerKind[] = ["manual", "on-connect", "hotkey"];
+
+/**
+ * Serialise workflows into a pretty-printed export envelope string ready to
+ * write to a `.json` file. Works for a single workflow (`[workflow]`) or the
+ * whole library.
+ */
+export function serializeWorkflows(workflows: Workflow[]): string {
+  const envelope: WorkflowExportEnvelope = {
+    version: WORKFLOW_EXPORT_VERSION,
+    workflows,
+  };
+  return `${JSON.stringify(envelope, null, 2)}\n`;
+}
+
+/** Type guard: a JSON value is a non-null, non-array object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Validate one raw step, throwing a clear error that names the offending step. */
+function validateStep(raw: unknown, where: string, stepIndex: number): WorkflowStep {
+  const at = `step ${stepIndex} of ${where}`;
+  if (!isRecord(raw) || typeof raw.kind !== "string") {
+    throw new Error(`Invalid workflow file: ${at} is malformed.`);
+  }
+  const kind = raw.kind as WorkflowStepKind;
+  if (!STEP_KINDS.includes(kind)) {
+    throw new Error(`Invalid workflow file: ${at} has unknown kind "${raw.kind}".`);
+  }
+
+  switch (kind) {
+    case "send-command":
+      if (typeof raw.command !== "string") {
+        throw new Error(`Invalid workflow file: ${at} (send-command) is missing "command".`);
+      }
+      return { kind, command: raw.command };
+    case "run-script": {
+      if (typeof raw.script !== "string") {
+        throw new Error(`Invalid workflow file: ${at} (run-script) is missing "script".`);
+      }
+      const step: WorkflowStep = { kind, script: raw.script };
+      if (raw.perLineDelayMs !== undefined) {
+        if (typeof raw.perLineDelayMs !== "number" || raw.perLineDelayMs < 0) {
+          throw new Error(`Invalid workflow file: ${at} (run-script) has an invalid delay.`);
+        }
+        step.perLineDelayMs = raw.perLineDelayMs;
+      }
+      if (raw.sourcePath !== undefined) {
+        if (typeof raw.sourcePath !== "string") {
+          throw new Error(`Invalid workflow file: ${at} (run-script) has an invalid sourcePath.`);
+        }
+        step.sourcePath = raw.sourcePath;
+      }
+      return step;
+    }
+    case "run-macro":
+      if (typeof raw.macroId !== "string") {
+        throw new Error(`Invalid workflow file: ${at} (run-macro) is missing "macroId".`);
+      }
+      return { kind, macroId: raw.macroId };
+    case "wait":
+      if (typeof raw.delayMs !== "number" || !Number.isFinite(raw.delayMs) || raw.delayMs < 0) {
+        throw new Error(`Invalid workflow file: ${at} (wait) has an invalid "delayMs".`);
+      }
+      return { kind, delayMs: raw.delayMs };
+    case "run-local-process": {
+      if (typeof raw.program !== "string") {
+        throw new Error(`Invalid workflow file: ${at} (run-local-process) is missing "program".`);
+      }
+      if (!Array.isArray(raw.args) || raw.args.some((a) => typeof a !== "string")) {
+        throw new Error(`Invalid workflow file: ${at} (run-local-process) has invalid "args".`);
+      }
+      return { kind, program: raw.program, args: raw.args as string[] };
+    }
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`Invalid workflow file: ${at} has unknown kind ${String(_exhaustive)}.`);
+    }
+  }
+}
+
+/** Validate one raw trigger, throwing a clear error when a field is malformed. */
+function validateTrigger(raw: unknown, where: string, triggerIndex: number): WorkflowTrigger {
+  const at = `trigger ${triggerIndex} of ${where}`;
+  if (!isRecord(raw) || typeof raw.kind !== "string") {
+    throw new Error(`Invalid workflow file: ${at} is malformed.`);
+  }
+  const kind = raw.kind as WorkflowTriggerKind;
+  if (!TRIGGER_KINDS.includes(kind)) {
+    throw new Error(`Invalid workflow file: ${at} has unknown kind "${raw.kind}".`);
+  }
+
+  switch (kind) {
+    case "manual":
+      return { kind };
+    case "on-connect":
+      if (!Array.isArray(raw.connectionIds) || raw.connectionIds.some((c) => typeof c !== "string")) {
+        throw new Error(`Invalid workflow file: ${at} (on-connect) has invalid "connectionIds".`);
+      }
+      return { kind, connectionIds: raw.connectionIds as string[] };
+    case "hotkey":
+      if (typeof raw.binding !== "string") {
+        throw new Error(`Invalid workflow file: ${at} (hotkey) is missing "binding".`);
+      }
+      return { kind, binding: raw.binding };
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`Invalid workflow file: ${at} has unknown kind ${String(_exhaustive)}.`);
+    }
+  }
+}
+
+/**
+ * Validate one raw workflow entry from an imported file, throwing a clear error
+ * that names the offending workflow (by index). Returns a normalised
+ * {@link Workflow} — tolerant of a missing `description`/`tags`/`id`/timestamps
+ * since the importer re-stamps those, but strict about the load-bearing `name`,
+ * `steps`, and `triggers`.
+ */
+function validateWorkflow(raw: unknown, index: number): Workflow {
+  const where = `workflow at index ${index}`;
+  if (!isRecord(raw)) {
+    throw new Error(`Invalid workflow file: ${where} is not an object.`);
+  }
+  if (typeof raw.name !== "string" || raw.name.trim() === "") {
+    throw new Error(`Invalid workflow file: ${where} is missing a name.`);
+  }
+  if (!Array.isArray(raw.steps)) {
+    throw new Error(`Invalid workflow file: ${where} ("${raw.name}") is missing its steps.`);
+  }
+
+  const label = `${where} ("${raw.name}")`;
+  const steps = raw.steps.map((step, i) => validateStep(step, label, i));
+
+  let triggers: WorkflowTrigger[] = [];
+  if (raw.triggers !== undefined) {
+    if (!Array.isArray(raw.triggers)) {
+      throw new Error(`Invalid workflow file: ${label} has malformed triggers.`);
+    }
+    triggers = raw.triggers.map((trigger, i) => validateTrigger(trigger, label, i));
+  }
+
+  let tags: string[] = [];
+  if (raw.tags !== undefined) {
+    if (!Array.isArray(raw.tags) || raw.tags.some((tag) => typeof tag !== "string")) {
+      throw new Error(`Invalid workflow file: ${label} has malformed tags.`);
+    }
+    tags = raw.tags as string[];
+  }
+
+  return {
+    id: typeof raw.id === "string" ? raw.id : "",
+    name: raw.name,
+    description: typeof raw.description === "string" ? raw.description : undefined,
+    tags,
+    steps,
+    triggers,
+    createdAt: typeof raw.createdAt === "string" ? raw.createdAt : "",
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : "",
+  };
+}
+
+/**
+ * Parse and validate an exported-workflow file, returning the workflows it
+ * contains. Throws an `Error` with a human-readable, recoverable message for
+ * malformed JSON, a missing/unsupported envelope version, or any malformed
+ * workflow — so a bad file never corrupts the library, it just surfaces a toast.
+ */
+export function parseWorkflowEnvelope(json: string): Workflow[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("Invalid workflow file: the file is not valid JSON.");
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("Invalid workflow file: expected a workflow export object.");
+  }
+  if (parsed.version !== WORKFLOW_EXPORT_VERSION) {
+    throw new Error(
+      `Unsupported workflow file version: ${String(parsed.version)} (expected ${WORKFLOW_EXPORT_VERSION}).`
+    );
+  }
+  if (!Array.isArray(parsed.workflows)) {
+    throw new Error('Invalid workflow file: missing "workflows" array.');
+  }
+
+  return parsed.workflows.map((workflow, index) => validateWorkflow(workflow, index));
+}
+
+/** Default fresh-id generator; mirrors the store's `generateWorkflowId`. */
+function defaultGenerateId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") {
+    return `workflow-${c.randomUUID()}`;
+  }
+  return `workflow-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Given a desired name and the set of names already in use, return a unique name
+ * by appending "(imported)", then "(imported 2)", … until it no longer collides.
+ * Leaves the name untouched when there is no collision.
+ */
+function uniqueName(name: string, used: Set<string>): string {
+  if (!used.has(name)) return name;
+  let candidate = `${name} (${COLLISION_SUFFIX})`;
+  let n = 2;
+  while (used.has(candidate)) {
+    candidate = `${name} (${COLLISION_SUFFIX} ${n})`;
+    n += 1;
+  }
+  return candidate;
+}
+
+/**
+ * Prepare imported workflows for merging into an existing library. Every imported
+ * workflow is given a **fresh id** (so it never overwrites an existing one, even
+ * when the file was exported from this same instance), has its create/update
+ * timestamps cleared (the backend re-stamps them on save), and gets a
+ * **deterministically de-duplicated name** — a name that already exists (in the
+ * library or earlier in this same batch) is suffixed with "(imported)".
+ *
+ * @param imported Workflows parsed from a file (see {@link parseWorkflowEnvelope}).
+ * @param existing The current library, used for name-collision detection.
+ * @param generateId Injectable id generator (defaults to a crypto-based uuid).
+ */
+export function resolveImportCollisions(
+  imported: Workflow[],
+  existing: Workflow[],
+  generateId: () => string = defaultGenerateId
+): Workflow[] {
+  const usedNames = new Set(existing.map((w) => w.name));
+  return imported.map((workflow) => {
+    const name = uniqueName(workflow.name, usedNames);
+    usedNames.add(name);
+    return {
+      ...workflow,
+      id: generateId(),
+      name,
+      // Cleared so the backend stamps authoritative timestamps on save.
+      createdAt: "",
+      updatedAt: "",
+    };
+  });
+}

--- a/src/services/workflowRunner.test.ts
+++ b/src/services/workflowRunner.test.ts
@@ -57,11 +57,8 @@ describe("executeStep", () => {
 
 describe("runWorkflow", () => {
   it("executes every send-command step in order", async () => {
-    const send = vi.fn(async () => true);
-    const handle = runWorkflow(
-      [sendCommand("a"), sendCommand("b"), sendCommand("c")],
-      deps(send)
-    );
+    const send = vi.fn(async (_data: string) => true);
+    const handle = runWorkflow([sendCommand("a"), sendCommand("b"), sendCommand("c")], deps(send));
     const result = await handle.done;
 
     expect(result).toEqual({ status: "completed", stepsCompleted: 3 });
@@ -139,10 +136,7 @@ describe("runWorkflow", () => {
       .fn<(data: string) => Promise<boolean>>()
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false);
-    const handle = runWorkflow(
-      [sendCommand("a"), sendCommand("b"), sendCommand("c")],
-      deps(send)
-    );
+    const handle = runWorkflow([sendCommand("a"), sendCommand("b"), sendCommand("c")], deps(send));
     const result = await handle.done;
 
     expect(result.status).toBe("failed");
@@ -154,10 +148,7 @@ describe("runWorkflow", () => {
 
   it("fails at a not-yet-implemented step kind", async () => {
     const send = vi.fn(async () => true);
-    const handle = runWorkflow(
-      [sendCommand("a"), { kind: "wait", delayMs: 10 }],
-      deps(send)
-    );
+    const handle = runWorkflow([sendCommand("a"), { kind: "wait", delayMs: 10 }], deps(send));
     const result = await handle.done;
 
     expect(result.status).toBe("failed");

--- a/src/services/workflowRunner.test.ts
+++ b/src/services/workflowRunner.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the workflow run engine (#1852).
+ *
+ * Pins the dispatch/execution contract the whole Workflow Automation epic
+ * (#1851) builds on: `send-command` steps reach the send seam in order, progress
+ * is reported per step, cancellation stops the run between steps (a step already
+ * in flight finishes but the next never starts), a failing seam fails the run at
+ * the offending step, and the not-yet-implemented placeholder kinds fail loudly.
+ * The send seam is mocked so no terminal or session is required.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  runWorkflow,
+  executeStep,
+  type WorkflowRunnerDeps,
+  type WorkflowSendSeam,
+} from "./workflowRunner";
+import type { WorkflowStep } from "@/types/workflow";
+
+const sendCommand = (command: string): WorkflowStep => ({ kind: "send-command", command });
+
+const deps = (send: WorkflowSendSeam): WorkflowRunnerDeps => ({ send });
+
+describe("executeStep", () => {
+  it("sends a send-command with a trailing newline through the seam", async () => {
+    const send = vi.fn(async () => true);
+    const outcome = await executeStep(sendCommand("git status"), deps(send));
+
+    expect(outcome).toEqual({ ok: true });
+    expect(send).toHaveBeenCalledWith("git status\n");
+  });
+
+  it("fails a send-command when the seam reports the session vanished", async () => {
+    const send = vi.fn(async () => false);
+    const outcome = await executeStep(sendCommand("ls"), deps(send));
+
+    expect(outcome.ok).toBe(false);
+  });
+
+  it.each(["run-script", "run-macro", "wait", "run-local-process"] as const)(
+    "fails loudly for the not-yet-implemented %s step",
+    async (kind) => {
+      // Build a minimal step of the given placeholder kind.
+      const byKind: Record<string, WorkflowStep> = {
+        "run-script": { kind: "run-script", script: "echo hi" },
+        "run-macro": { kind: "run-macro", macroId: "m-1" },
+        wait: { kind: "wait", delayMs: 100 },
+        "run-local-process": { kind: "run-local-process", program: "echo", args: [] },
+      };
+      const outcome = await executeStep(byKind[kind], deps(vi.fn(async () => true)));
+
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.error).toContain(kind);
+    }
+  );
+});
+
+describe("runWorkflow", () => {
+  it("executes every send-command step in order", async () => {
+    const send = vi.fn(async () => true);
+    const handle = runWorkflow(
+      [sendCommand("a"), sendCommand("b"), sendCommand("c")],
+      deps(send)
+    );
+    const result = await handle.done;
+
+    expect(result).toEqual({ status: "completed", stepsCompleted: 3 });
+    expect(send.mock.calls.map((c) => c[0])).toEqual(["a\n", "b\n", "c\n"]);
+  });
+
+  it("reports progress after each completed step", async () => {
+    const send = vi.fn(async () => true);
+    const onProgress = vi.fn();
+    const steps = [sendCommand("a"), sendCommand("b")];
+    const handle = runWorkflow(steps, deps(send), { onProgress });
+    await handle.done;
+
+    expect(onProgress.mock.calls).toEqual([
+      [1, 2, steps[0]],
+      [2, 2, steps[1]],
+    ]);
+  });
+
+  it("completes vacuously for an empty workflow", async () => {
+    const send = vi.fn(async () => true);
+    const result = await runWorkflow([], deps(send)).done;
+
+    expect(result).toEqual({ status: "completed", stepsCompleted: 0 });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("stops between steps when cancelled — the in-flight step finishes, the next never starts", async () => {
+    // Signals when the first send has genuinely started, and gates its return so
+    // we can cancel while it is truly in flight.
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    const send = vi.fn(async (_data: string) => {
+      call += 1;
+      if (call === 1) {
+        markFirstStarted();
+        await firstGate;
+      }
+      return true;
+    });
+
+    const handle = runWorkflow([sendCommand("a"), sendCommand("b")], deps(send));
+
+    // Wait until the first step is genuinely in flight, then cancel and let it finish.
+    await firstStarted;
+    handle.cancel();
+    releaseFirst();
+    const result = await handle.done;
+
+    // The in-flight first step completed; the second was never attempted.
+    expect(result).toEqual({ status: "cancelled", stepsCompleted: 1 });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("a\n");
+  });
+
+  it("does not run anything when cancelled before it starts", async () => {
+    const send = vi.fn(async () => true);
+    const handle = runWorkflow([sendCommand("a")], deps(send));
+    handle.cancel();
+    const result = await handle.done;
+
+    expect(result).toEqual({ status: "cancelled", stepsCompleted: 0 });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("fails at the offending step when the seam reports failure", async () => {
+    const send = vi
+      .fn<(data: string) => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const handle = runWorkflow(
+      [sendCommand("a"), sendCommand("b"), sendCommand("c")],
+      deps(send)
+    );
+    const result = await handle.done;
+
+    expect(result.status).toBe("failed");
+    expect(result.stepsCompleted).toBe(1);
+    expect(result.failedStepIndex).toBe(1);
+    // The third step is never attempted after the second fails.
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails at a not-yet-implemented step kind", async () => {
+    const send = vi.fn(async () => true);
+    const handle = runWorkflow(
+      [sendCommand("a"), { kind: "wait", delayMs: 10 }],
+      deps(send)
+    );
+    const result = await handle.done;
+
+    expect(result.status).toBe("failed");
+    expect(result.failedStepIndex).toBe(1);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/workflowRunner.ts
+++ b/src/services/workflowRunner.ts
@@ -1,0 +1,172 @@
+/**
+ * Workflow run engine (#1852) — the foundation of the Workflow Automation epic
+ * (#1851).
+ *
+ * Generalises the macro playback scheduler ({@link "@/services/macroPlayback"})
+ * from a homogeneous list of recorded input chunks to an ordered list of *typed*
+ * {@link WorkflowStep}s. The runner walks the steps in order, dispatching each by
+ * `kind` through an **injectable send seam** so it is fully unit-testable with a
+ * mock and no live terminal — exactly the `inject` seam macro playback uses.
+ *
+ * Run lifecycle (per the concept's state machine): a run is created in an
+ * implicit *pending* state, transitions to *running* as it walks the steps, and
+ * ends in exactly one terminal state — **completed** (last step done),
+ * **cancelled** (the caller cancelled between steps), or **failed** (a step's
+ * seam reported failure, or the step kind is not yet executable). Cancellation is
+ * honoured between steps: a step already in flight finishes, then the run stops
+ * before the next step begins.
+ *
+ * Only the `send-command` step executes in this foundation PR. The remaining v1
+ * step kinds (`run-script`, `run-macro`, `wait`, `run-local-process`) are
+ * clearly-marked dispatch placeholders that fail loudly until their owning child
+ * issues wire them up:
+ *  - #1853 — `run-script`, `run-macro`, `wait` (the latter reuses
+ *    `macroPlayback.MAX_STEP_DELAY_MS` to clamp its delay).
+ *  - #1857 — `run-local-process` (guarded, security-critical).
+ * Later children extend the runner by adding their seam to
+ * {@link WorkflowRunnerDeps} and replacing the placeholder in {@link executeStep}.
+ */
+
+import type { WorkflowStep } from "@/types/workflow";
+
+/** Terminal outcome of a workflow run (the state machine's end states). */
+export type WorkflowRunStatus = "completed" | "cancelled" | "failed";
+
+/** Result of a finished workflow run. */
+export interface WorkflowRunResult {
+  /** Which terminal state the run ended in. */
+  status: WorkflowRunStatus;
+  /** Number of steps that completed successfully before the run ended. */
+  stepsCompleted: number;
+  /** For `failed`: the 0-based index of the step that failed. */
+  failedStepIndex?: number;
+  /** For `failed`: a human-readable reason. */
+  error?: string;
+}
+
+/**
+ * The single send seam every send-based step routes through — the same
+ * `send_input` choke point macro playback uses. Resolves `true` when the input
+ * was delivered, `false` when the target session has vanished.
+ */
+export type WorkflowSendSeam = (data: string) => Promise<boolean> | boolean;
+
+/**
+ * Injectable dependencies the runner dispatches steps through. `send` is the only
+ * seam the foundation requires; later children add optional seams here (e.g. a
+ * macro-playback runner for `run-macro`, a guarded local-process spawner for
+ * `run-local-process`) alongside their dispatch handler in {@link executeStep}.
+ */
+export interface WorkflowRunnerDeps {
+  /** Injects text into the target session (the `send_input` seam). */
+  send: WorkflowSendSeam;
+}
+
+/** Optional lifecycle hooks fired as a run advances. */
+export interface WorkflowRunHooks {
+  /** Fired after each step completes, with the 1-based count, total, and step. */
+  onProgress?: (completed: number, total: number, step: WorkflowStep) => void;
+}
+
+/** A running workflow that can be awaited or cancelled. */
+export interface WorkflowRunHandle {
+  /** Resolves when the run finishes (completed, cancelled, or failed). */
+  done: Promise<WorkflowRunResult>;
+  /** Request cancellation; the run stops before the next step begins. */
+  cancel: () => void;
+}
+
+/** Outcome of executing a single step. */
+type StepOutcome = { ok: true } | { ok: false; error: string };
+
+/** Line terminator appended to an authored `send-command`; the `send_input` seam
+ * normalises it to the session's configured line ending. */
+const COMMAND_TERMINATOR = "\n";
+
+/**
+ * Error message for a step kind that is defined in the model but not yet
+ * executable in the foundation. Surfacing it as a step failure (rather than a
+ * silent skip) means a workflow authored with a not-yet-wired step fails loudly
+ * at that step until the owning child issue implements it.
+ */
+function notYetImplemented(kind: WorkflowStep["kind"]): StepOutcome {
+  return { ok: false, error: `workflow step kind "${kind}" is not yet implemented` };
+}
+
+/**
+ * Execute a single workflow step by dispatching on its `kind`. The `switch` is
+ * exhaustive over the {@link WorkflowStep} union (the `never` default is a
+ * compile-time guard), so adding a step kind to the model forces a matching
+ * dispatch entry here.
+ */
+export async function executeStep(
+  step: WorkflowStep,
+  deps: WorkflowRunnerDeps
+): Promise<StepOutcome> {
+  switch (step.kind) {
+    case "send-command": {
+      const delivered = await deps.send(step.command + COMMAND_TERMINATOR);
+      return delivered
+        ? { ok: true }
+        : { ok: false, error: "the target terminal is no longer connected" };
+    }
+    // --- Placeholders wired by later epic children (see module docs). ---
+    case "run-script": // #1853
+    case "run-macro": // #1853
+    case "wait": // #1853
+    case "run-local-process": // #1857
+      return notYetImplemented(step.kind);
+    default: {
+      // Exhaustiveness guard: a new step kind must add a case above.
+      const _exhaustive: never = step;
+      return { ok: false, error: `unknown workflow step kind: ${JSON.stringify(_exhaustive)}` };
+    }
+  }
+}
+
+/**
+ * Run a workflow's steps in order through `deps`, honouring cancellation and
+ * reporting progress. Returns a {@link WorkflowRunHandle} whose `done` promise
+ * resolves once the run reaches a terminal state.
+ *
+ * Cancellation is checked before each step: a step already in flight finishes,
+ * then the run stops before the next step begins (status `cancelled`). If a
+ * step's seam reports failure — or the step kind is not yet executable — the run
+ * stops immediately with status `failed` and records the offending step.
+ */
+export function runWorkflow(
+  steps: WorkflowStep[],
+  deps: WorkflowRunnerDeps,
+  hooks?: WorkflowRunHooks
+): WorkflowRunHandle {
+  let cancelled = false;
+
+  const cancel = (): void => {
+    cancelled = true;
+  };
+
+  const done = (async (): Promise<WorkflowRunResult> => {
+    // Yield once before the first step so a cancel() issued synchronously right
+    // after this handle is returned lands before any step runs — a run cancelled
+    // before it starts does nothing.
+    await Promise.resolve();
+    for (let i = 0; i < steps.length; i++) {
+      if (cancelled) return { status: "cancelled", stepsCompleted: i };
+
+      const outcome = await executeStep(steps[i], deps);
+      if (!outcome.ok) {
+        return {
+          status: "failed",
+          stepsCompleted: i,
+          failedStepIndex: i,
+          error: outcome.error,
+        };
+      }
+
+      hooks?.onProgress?.(i + 1, steps.length, steps[i]);
+    }
+    return { status: "completed", stepsCompleted: steps.length };
+  })();
+
+  return { done, cancel };
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -168,6 +168,21 @@ import {
   type MacroInjector,
   type MacroPlaybackHandle,
 } from "@/services/macroPlayback";
+import { Workflow } from "@/types/workflow";
+import {
+  listWorkflows as apiListWorkflows,
+  saveWorkflow as apiSaveWorkflow,
+  deleteWorkflow as apiDeleteWorkflow,
+} from "@/services/workflowApi";
+import {
+  parseWorkflowEnvelope,
+  resolveImportCollisions as resolveWorkflowImportCollisions,
+} from "@/services/workflowIo";
+import {
+  runWorkflow as runWorkflowSteps,
+  type WorkflowSendSeam,
+  type WorkflowRunHandle,
+} from "@/services/workflowRunner";
 import {
   saveLastSession as apiSaveLastSession,
   loadLastSession as apiLoadLastSession,
@@ -1231,6 +1246,36 @@ interface AppState {
   /** Cancel the in-flight macro playback, if any. Idempotent. */
   cancelMacroPlayback: () => void;
 
+  // Workflows (#1852) — the foundation of the Workflow Automation epic (#1851).
+  /** All stored workflows. */
+  workflows: Workflow[];
+  /** Load the workflow library from the backend into the store. */
+  loadWorkflows: () => Promise<void>;
+  /** Save (add or update) a workflow, then refresh the list. Returns the stored workflow. */
+  saveWorkflowToBackend: (workflow: Workflow) => Promise<Workflow>;
+  /** Delete a workflow by ID; only mutates local state after the backend delete resolves. */
+  deleteWorkflowFromBackend: (workflowId: string) => Promise<void>;
+  /**
+   * Import workflows from an exported-workflow file's JSON, merging them into the
+   * library. Malformed/incompatible files reject with a clear error and leave
+   * the library untouched; imported workflows get fresh ids and de-duplicated
+   * names. Returns the number imported.
+   */
+  importWorkflows: (json: string) => Promise<number>;
+  /** Metadata for the in-flight workflow run, or `null` when nothing is running. */
+  workflowRun: WorkflowRunState | null;
+  /**
+   * Run a stored workflow's steps against a target terminal, dispatching each
+   * step through the shared `send_input` seam and surfacing live progress.
+   * Defaults the target to the active terminal tab. Only one run happens at a
+   * time — a fresh call cancels any in-flight run first. Surfaces a recoverable
+   * toast when the workflow is missing/empty, the target terminal is not
+   * connected, or a step fails.
+   */
+  runWorkflow: (workflowId: string, opts?: RunWorkflowOptions) => Promise<void>;
+  /** Cancel the in-flight workflow run, if any. Idempotent. */
+  cancelWorkflowRun: () => void;
+
   // Workspaces
   workspaces: WorkspaceSummary[];
   activeWorkspaceName: string | null;
@@ -1350,6 +1395,42 @@ function generateMacroId(): string {
     return `macro-${c.randomUUID()}`;
   }
   return `macro-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** UI-facing metadata describing an in-flight workflow run (#1852). */
+export interface WorkflowRunState {
+  /** The workflow being run. */
+  workflowId: string;
+  /** The workflow's name, for the progress indicator. */
+  workflowName: string;
+  /** The terminal tab the workflow is running against. */
+  tabId: string;
+  /** Total number of steps in the workflow. */
+  total: number;
+  /** Steps completed so far. */
+  completed: number;
+}
+
+/** Options for {@link AppState.runWorkflow}. */
+export interface RunWorkflowOptions {
+  /** Tab to run against; defaults to the active terminal tab. */
+  targetTabId?: string;
+}
+
+/**
+ * Handle for the currently-running workflow, held at module scope so
+ * {@link AppState.cancelWorkflowRun} can stop it without threading the handle
+ * through store state (it is not serializable). `null` when nothing is running.
+ */
+let activeWorkflowRun: WorkflowRunHandle | null = null;
+
+/** Generate a unique workflow id, falling back when `crypto.randomUUID` is absent. */
+function generateWorkflowId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") {
+    return `workflow-${c.randomUUID()}`;
+  }
+  return `workflow-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 let layoutPersistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -3375,6 +3456,8 @@ export const useAppStore = create<AppState>((set, get) => {
       get().loadWorkspaces();
       // Load macros
       get().loadMacros();
+      // Load workflows
+      get().loadWorkflows();
       // Load app mode (portable vs. installed) for status bar and settings display
       await get().loadAppMode();
       // Load credential store status (dialog opens on-demand when credentials are needed)
@@ -5840,6 +5923,159 @@ export const useAppStore = create<AppState>((set, get) => {
     cancelMacroPlayback: () => {
       if (activeMacroPlayback) {
         activeMacroPlayback.cancel();
+      }
+    },
+
+    // Workflows (#1852)
+    workflows: [],
+
+    loadWorkflows: async () => {
+      try {
+        const workflows = await apiListWorkflows();
+        set({ workflows });
+      } catch (err) {
+        console.error("Failed to load workflows:", err);
+      }
+    },
+
+    saveWorkflowToBackend: async (workflow) => {
+      const saved = await apiSaveWorkflow(workflow);
+      await get().loadWorkflows();
+      return saved;
+    },
+
+    deleteWorkflowFromBackend: async (workflowId) => {
+      await apiDeleteWorkflow(workflowId);
+      set((state) => ({
+        workflows: state.workflows.filter((w) => w.id !== workflowId),
+      }));
+    },
+
+    importWorkflows: async (json) => {
+      // parseWorkflowEnvelope throws on a malformed/incompatible file; let the
+      // error propagate so the caller can surface a recoverable toast.
+      const parsed = parseWorkflowEnvelope(json);
+      const prepared = resolveWorkflowImportCollisions(parsed, get().workflows, generateWorkflowId);
+      for (const workflow of prepared) {
+        await apiSaveWorkflow(workflow);
+      }
+      // Refresh once, after all saves, rather than per-workflow.
+      await get().loadWorkflows();
+      return prepared.length;
+    },
+
+    workflowRun: null,
+
+    runWorkflow: async (workflowId, opts) => {
+      const state = get();
+      const workflow = state.workflows.find((w) => w.id === workflowId);
+      if (!workflow) {
+        toast.error("Workflow not found");
+        return;
+      }
+
+      const targetTabId = opts?.targetTabId ?? getActiveTab(state)?.id ?? null;
+      if (!targetTabId) {
+        toast.error("No active terminal to run the workflow against");
+        return;
+      }
+
+      // Guard: only run against a connected, non-exited terminal session.
+      const tab = collectLiveTabs(state).find((t) => t.id === targetTabId);
+      if (
+        !tab ||
+        tab.contentType !== "terminal" ||
+        !tab.sessionId ||
+        state.terminalExitedTabs[targetTabId]
+      ) {
+        toast.error("The target terminal is not connected");
+        return;
+      }
+
+      if (workflow.steps.length === 0) {
+        toast.info(`Workflow "${workflow.name}" has no steps to run`);
+        return;
+      }
+
+      // Only one run at a time — cancel any in-flight run first.
+      if (activeWorkflowRun) {
+        activeWorkflowRun.cancel();
+        activeWorkflowRun = null;
+      }
+
+      // The workflow runner reuses the macro `send_input` injector seam, bound to
+      // the target tab, so send-based steps route through the single choke point.
+      const injector = getTerminalInputInjector();
+      const send: WorkflowSendSeam = (data) => {
+        if (!injector) return false;
+        return injector(targetTabId, data);
+      };
+
+      const toastId = `workflow-run-${workflowId}-${targetTabId}`;
+      const total = workflow.steps.length;
+      toast.loading(`Running workflow "${workflow.name}"…`, {
+        id: toastId,
+        description: `0 / ${total} steps`,
+      });
+      set({
+        workflowRun: {
+          workflowId,
+          workflowName: workflow.name,
+          tabId: targetTabId,
+          total,
+          completed: 0,
+        },
+      });
+
+      const handle = runWorkflowSteps(
+        workflow.steps,
+        { send },
+        {
+          onProgress: (completed, stepTotal) => {
+            set((s) =>
+              s.workflowRun &&
+              s.workflowRun.workflowId === workflowId &&
+              s.workflowRun.tabId === targetTabId
+                ? { workflowRun: { ...s.workflowRun, completed } }
+                : {}
+            );
+            toast.loading(`Running workflow "${workflow.name}"…`, {
+              id: toastId,
+              description: `${completed} / ${stepTotal} steps`,
+            });
+          },
+        }
+      );
+      activeWorkflowRun = handle;
+
+      const result = await handle.done;
+
+      // Only clear shared state when this run is still the current one — a newer
+      // runWorkflow may have replaced it while this one was cancelled.
+      if (activeWorkflowRun === handle) {
+        activeWorkflowRun = null;
+        set({ workflowRun: null });
+      }
+
+      if (result.status === "completed") {
+        toast.success(`Ran workflow "${workflow.name}"`, { id: toastId });
+      } else if (result.status === "cancelled") {
+        toast.info(`Workflow "${workflow.name}" cancelled`, {
+          id: toastId,
+          description: `Stopped after ${result.stepsCompleted} of ${total} steps`,
+        });
+      } else {
+        const stepNumber = (result.failedStepIndex ?? result.stepsCompleted) + 1;
+        toast.error(`Workflow "${workflow.name}" failed at step ${stepNumber}`, {
+          id: toastId,
+          description: result.error,
+        });
+      }
+    },
+
+    cancelWorkflowRun: () => {
+      if (activeWorkflowRun) {
+        activeWorkflowRun.cancel();
       }
     },
 

--- a/src/store/appStore.workflowRun.test.ts
+++ b/src/store/appStore.workflowRun.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the workflow *run* Zustand slice (#1852) — the epic foundation's
+ * end-to-end path.
+ *
+ * Pins `runWorkflow` / `cancelWorkflowRun`: an authored `send-command` workflow
+ * run against a connected terminal streams each command (with a trailing
+ * newline) through the registered `send_input` injector in order, live progress
+ * is tracked and cleared, a run can be cancelled, and the guards (missing
+ * workflow, empty workflow, no connected terminal, exited terminal) surface a
+ * recoverable toast instead of injecting. Also covers the CRUD + import actions.
+ * The injector, terminal, and backend are mocked so no real session is needed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
+import type { Workflow, WorkflowStep } from "@/types/workflow";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+const savedWorkflows: Workflow[] = [];
+vi.mock("@/services/workflowApi", () => ({
+  listWorkflows: vi.fn(() => Promise.resolve([...savedWorkflows])),
+  getWorkflow: vi.fn(),
+  saveWorkflow: vi.fn((w: Workflow) => {
+    savedWorkflows.push(w);
+    return Promise.resolve(w);
+  }),
+  deleteWorkflow: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import { registerTerminalInputInjector } from "@/services/macroPlayback";
+import { serializeWorkflows } from "@/services/workflowIo";
+import { toast } from "@/components/ui";
+
+const workflow = (id: string, steps: WorkflowStep[]): Workflow => ({
+  id,
+  name: `Workflow ${id}`,
+  description: "",
+  tags: [],
+  steps,
+  triggers: [{ kind: "manual" }],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+});
+
+const cmd = (command: string): WorkflowStep => ({ kind: "send-command", command });
+
+/** Seed an active, connected terminal tab so a run has a valid target. */
+function seedConnectedTerminal(tabId = "tab-active", sessionId: string | null = "sess-1") {
+  const tab: TerminalTab = {
+    id: tabId,
+    sessionId,
+    title: "term",
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: {} },
+    panelId: "leaf-1",
+    isActive: true,
+  };
+  const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs: [tab], activeTabId: tabId };
+  useAppStore.setState({ rootPanel: leaf, activePanelId: "leaf-1", terminalExitedTabs: {} });
+}
+
+describe("appStore — workflow run slice (#1852)", () => {
+  let injected: string[];
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    savedWorkflows.length = 0;
+    injected = [];
+    registerTerminalInputInjector(async (_tabId, data) => {
+      injected.push(data);
+      return true;
+    });
+    vi.spyOn(toast, "error");
+    vi.spyOn(toast, "info");
+    vi.spyOn(toast, "success");
+    vi.spyOn(toast, "loading");
+  });
+
+  afterEach(() => {
+    registerTerminalInputInjector(null);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("runs every send-command step in order (with trailing newlines) into the active terminal", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({
+      workflows: [workflow("w1", [cmd("sudo -v"), cmd("git status"), cmd("exit")])],
+    });
+
+    await useAppStore.getState().runWorkflow("w1");
+
+    expect(injected).toEqual(["sudo -v\n", "git status\n", "exit\n"]);
+    // Run state is cleared once the run finishes.
+    expect(useAppStore.getState().workflowRun).toBeNull();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("defaults the target to the active terminal tab", async () => {
+    const tabIds: string[] = [];
+    registerTerminalInputInjector(async (tabId, data) => {
+      tabIds.push(tabId);
+      injected.push(data);
+      return true;
+    });
+    seedConnectedTerminal("tab-xyz", "sess-xyz");
+    useAppStore.setState({ workflows: [workflow("w1", [cmd("hi")])] });
+
+    await useAppStore.getState().runWorkflow("w1");
+
+    expect(tabIds).toEqual(["tab-xyz"]);
+  });
+
+  it("can be cancelled mid-run — the in-flight step finishes, the rest do not run", async () => {
+    // Gate the first injection so the run is genuinely in flight when we cancel.
+    let markStarted!: () => void;
+    const started = new Promise<void>((r) => (markStarted = r));
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let call = 0;
+    registerTerminalInputInjector(async (_tabId, data) => {
+      call += 1;
+      injected.push(data);
+      if (call === 1) {
+        markStarted();
+        await gate;
+      }
+      return true;
+    });
+    seedConnectedTerminal();
+    useAppStore.setState({ workflows: [workflow("w1", [cmd("a"), cmd("b")])] });
+
+    const done = useAppStore.getState().runWorkflow("w1");
+    await started;
+    expect(useAppStore.getState().workflowRun).not.toBeNull();
+
+    useAppStore.getState().cancelWorkflowRun();
+    release();
+    await done;
+
+    expect(injected).toEqual(["a\n"]);
+    expect(useAppStore.getState().workflowRun).toBeNull();
+    expect(toast.info).toHaveBeenCalled();
+  });
+
+  it("fails with a toast when a step kind is not yet implemented", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({
+      workflows: [workflow("w1", [cmd("a"), { kind: "wait", delayMs: 10 }])],
+    });
+
+    await useAppStore.getState().runWorkflow("w1");
+
+    expect(injected).toEqual(["a\n"]);
+    expect(useAppStore.getState().workflowRun).toBeNull();
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("errors when the workflow does not exist", async () => {
+    seedConnectedTerminal();
+    await useAppStore.getState().runWorkflow("missing");
+
+    expect(injected).toEqual([]);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("errors when there is no connected terminal", async () => {
+    seedConnectedTerminal("tab-active", null); // no session → not connected
+    useAppStore.setState({ workflows: [workflow("w1", [cmd("x")])] });
+
+    await useAppStore.getState().runWorkflow("w1");
+
+    expect(injected).toEqual([]);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("errors when the target terminal has exited", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({
+      workflows: [workflow("w1", [cmd("x")])],
+      terminalExitedTabs: { "tab-active": true },
+    });
+
+    await useAppStore.getState().runWorkflow("w1");
+
+    expect(injected).toEqual([]);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("does nothing but inform the user for an empty workflow", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({ workflows: [workflow("w1", [])] });
+
+    await useAppStore.getState().runWorkflow("w1");
+
+    expect(injected).toEqual([]);
+    expect(toast.info).toHaveBeenCalled();
+    expect(useAppStore.getState().workflowRun).toBeNull();
+  });
+
+  it("cancelWorkflowRun is a no-op when nothing is running", () => {
+    expect(() => useAppStore.getState().cancelWorkflowRun()).not.toThrow();
+  });
+
+  it("saves a workflow to the backend and refreshes the library", async () => {
+    await useAppStore.getState().saveWorkflowToBackend(workflow("w1", [cmd("ls")]));
+    expect(useAppStore.getState().workflows.map((w) => w.id)).toEqual(["w1"]);
+  });
+
+  it("imports workflows from an exported file, giving them fresh ids", async () => {
+    useAppStore.setState({ workflows: [] });
+    const json = serializeWorkflows([workflow("original", [cmd("ls")])]);
+
+    const count = await useAppStore.getState().importWorkflows(json);
+
+    expect(count).toBe(1);
+    const imported = useAppStore.getState().workflows;
+    expect(imported).toHaveLength(1);
+    // A fresh id is assigned on import (never the file's original id).
+    expect(imported[0].id).not.toBe("original");
+    expect(imported[0].steps).toEqual([cmd("ls")]);
+  });
+});

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -1,0 +1,105 @@
+/**
+ * Workflow data model (#1852) — the foundation of the Workflow Automation epic
+ * (#1851).
+ *
+ * A workflow is an *authored* (not recorded) ordered list of typed steps that
+ * can be launched by one or more triggers. This mirrors the Rust model in
+ * `src-tauri/src/workflows/config.rs` byte-for-byte over the wire (the Rust enums
+ * are `#[serde(tag = "kind")]` with kebab-case variant names and camelCase
+ * fields), so these types are the single source of truth the store, runner, and
+ * later epic children build on.
+ *
+ * The **complete** v1 step and trigger unions are defined here up front. Only
+ * `send-command` is executed by {@link "@/services/workflowRunner"} in the
+ * foundation PR; the remaining kinds are typed placeholders that later children
+ * fill in (#1853 run-script/run-macro/wait, #1857 run-local-process, #1855
+ * trigger dispatch).
+ */
+
+/** A single, typed step of a workflow. Discriminated by {@link WorkflowStep.kind}. */
+export type WorkflowStep =
+  | {
+      /** Send a single authored command line into the active session. */
+      kind: "send-command";
+      /** The command line to send (a trailing newline is added on execution). */
+      command: string;
+    }
+  | {
+      /** Stream a saved multi-line script's text into the session, line by line. */
+      kind: "run-script";
+      /** The script body (one command per line). */
+      script: string;
+      /** Optional delay (ms) inserted between each streamed line. */
+      perLineDelayMs?: number;
+      /** Optional on-disk path the script body was loaded from. */
+      sourcePath?: string;
+    }
+  | {
+      /** Replay an existing stored macro by id, reusing its own timing mode. */
+      kind: "run-macro";
+      /** The id of the stored macro to replay. */
+      macroId: string;
+    }
+  | {
+      /** Pause for a fixed number of milliseconds before the next step. */
+      kind: "wait";
+      /** How long to pause, in milliseconds. */
+      delayMs: number;
+    }
+  | {
+      /** Spawn a local helper process (guarded; not on the remote host). */
+      kind: "run-local-process";
+      /** The local program to spawn. */
+      program: string;
+      /** Arguments passed to the program. */
+      args: string[];
+    };
+
+/** The discriminant literal of a {@link WorkflowStep}. */
+export type WorkflowStepKind = WorkflowStep["kind"];
+
+/** A trigger that launches a workflow. Discriminated by {@link WorkflowTrigger.kind}. */
+export type WorkflowTrigger =
+  | {
+      /** Run from the palette, the Workflow sidebar, or a toolbar button. */
+      kind: "manual";
+    }
+  | {
+      /** Fire when a session opens for one of the named connections. */
+      kind: "on-connect";
+      /** Connection ids this trigger is bound to. */
+      connectionIds: string[];
+    }
+  | {
+      /** Fire when a user-assigned keybinding is pressed while a session is focused. */
+      kind: "hotkey";
+      /** The keybinding string (e.g. `Ctrl+Alt+H`). */
+      binding: string;
+    };
+
+/** The discriminant literal of a {@link WorkflowTrigger}. */
+export type WorkflowTriggerKind = WorkflowTrigger["kind"];
+
+/**
+ * An authored, ordered list of typed steps launched by zero or more triggers.
+ * Mirrors the shipped {@link "@/types/macro".Macro} shape but with a
+ * discriminated step list and a trigger list.
+ */
+export interface Workflow {
+  /** Unique workflow identifier. */
+  id: string;
+  /** User-friendly name for this workflow. */
+  name: string;
+  /** Optional free-text description. */
+  description?: string;
+  /** Tags for grouping/filtering in the manager UI. */
+  tags: string[];
+  /** The ordered steps that make up this workflow. */
+  steps: WorkflowStep[];
+  /** The triggers that can launch this workflow. */
+  triggers: WorkflowTrigger[];
+  /** RFC 3339 timestamp of when the workflow was first created. */
+  createdAt: string;
+  /** RFC 3339 timestamp of the workflow's last update. */
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary

Foundation of the **Workflow Automation epic (#1851)** — the single serializing
child that defines the whole contract, so every other child (#1853–#1857) plugs
into a stable, tested model. A **workflow** is an *authored* ordered list of
typed steps, launched by triggers, run against the active terminal through the
same `send_input` seam macros use. This PR ships the complete type model, the
`workflows.json` store, the CRUD/import surface, the run engine, and one step
type (`send-command`) working end-to-end — **no UI** (that is #1854).

Mirrors the shipped macro system (`src-tauri/src/macros/`, `macroApi.ts`,
`macroPlayback.ts`, the `registerTerminalInputInjector` seam) throughout.

## What landed

**Backend (`src-tauri/src/workflows/`, mirrors `macros/`)**
- `config.rs` — the **complete** discriminated model: `WorkflowStep`
  (`send-command`, `run-script`, `run-macro`, `wait`, `run-local-process`) and
  `WorkflowTrigger` (`manual`, `on-connect`, `hotkey`), tagged on `kind` with
  kebab-case variants + camelCase fields so the JSON matches the TS types
  byte-for-byte. Versioned `WorkflowStore`.
- `storage.rs` / `manager.rs` — versioned `workflows.json` with corruption
  recovery + backup, and a CRUD manager that stamps/preserves timestamps.
- `commands/workflows.rs` + `lib.rs` — `list/get/save/delete_workflow` commands,
  manager init with recovery warnings, and command registration.
- `errors.rs` — new `TerminalError::WorkflowError`.

**Frontend**
- `types/workflow.ts` — the complete `Workflow` / `WorkflowStep` /
  `WorkflowTrigger` discriminated unions (the stable contract downstream builds on).
- `services/workflowApi.ts` — thin Tauri command wrappers.
- `services/workflowRunner.ts` — the run engine: walks typed steps in order,
  dispatching by `kind` through an **injectable/mockable send seam**, with a
  `pending→running→completed|cancelled|failed` lifecycle, per-step progress, and
  cancel-between-steps. Only `send-command` executes; the other kinds are
  clearly-marked placeholders that fail loudly until their owning child wires them.
- `services/workflowIo.ts` — pure serialize/parse/collision helpers for
  import/export (validates the discriminated unions + envelope version).
- `store/appStore.ts` — a workflow slice (CRUD, import, `runWorkflow` /
  `cancelWorkflowRun`) reusing the macro `send_input` injector, with live
  progress toasts and single-run-at-a-time semantics; loads at startup.

## Tests

- Rust: model serde round-trips (all step + trigger kinds), store save/load +
  corruption recovery, manager CRUD + timestamp rules (19 tests).
- Frontend: runner step-ordering / progress / cancel-between-steps / failure
  paths / placeholder-fails-loudly; api wrappers; io round-trip + validation;
  and an **end-to-end store test** that authors a `send-command` workflow and
  runs it against a mock injector, asserting the command text (with trailing
  newline) reaches the seam, plus cancel/guard/import coverage (43 tests).
- Full suites green: 3898 frontend, 1190 app-lib + 944 core Rust. (The lone
  `core/tests/docker_spawn` failure is a Docker-daemon integration test
  unrelated to this change and outside the per-PR CI lane.)

## For the downstream children

The step + trigger unions in `types/workflow.ts` / `config.rs` are **final** —
no child needs to edit the model. `#1853` implements the `run-script` /
`run-macro` / `wait` placeholders in `executeStep` (adding seams to
`WorkflowRunnerDeps`); `#1857` implements the guarded `run-local-process`;
`#1854` builds the sidebar/editor on the store slice; `#1855` wires trigger
dispatch; `#1856` wires the file-dialog UI onto the existing `workflowIo` +
`importWorkflows`.

Closes #1852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
