### PR TITLE
feat(workflow): remaining v1 step types — run-script, run-macro, wait

### DIFF
--- a/docs/changes/dev0/feature/1853-workflow-step-types.md
+++ b/docs/changes/dev0/feature/1853-workflow-step-types.md
@@ -1,0 +1,15 @@
+### Added
+
+- **Workflow Automation** (epic #1851): the remaining v1 terminal-native
+  workflow step types now execute. A workflow can **`run-script`** (stream a
+  saved multi-line script into the session line by line, with an optional
+  per-line delay and an optional on-disk `sourcePath`), **`run-macro`** (replay
+  an existing stored macro by id through the macro-playback service, reusing its
+  recorded timing), and **`wait`** (pause a fixed number of milliseconds between
+  steps). Script and inter-step delays are clamped to the same
+  `MAX_STEP_DELAY_MS` guard macro playback uses, per-step progress and
+  cancellation keep working across all kinds (a cancel aborts an in-flight
+  script's remaining lines), and a mixed workflow of `send-command`,
+  `run-script`, `wait`, and `run-macro` runs its steps in order. The guarded
+  `run-local-process` step remains deferred to #1857. No user-facing UI yet
+  (#1853).

--- a/src/services/workflowRunner.test.ts
+++ b/src/services/workflowRunner.test.ts
@@ -140,10 +140,7 @@ describe("executeStep", () => {
   describe("run-macro", () => {
     it("delegates to the run-macro seam and succeeds when it replays", async () => {
       const runMacro: WorkflowRunMacroSeam = vi.fn(async () => true);
-      const outcome = await executeStep(
-        { kind: "run-macro", macroId: "m-1" },
-        deps({ runMacro })
-      );
+      const outcome = await executeStep({ kind: "run-macro", macroId: "m-1" }, deps({ runMacro }));
 
       expect(outcome).toEqual({ ok: true });
       expect(runMacro).toHaveBeenCalledWith("m-1");
@@ -151,10 +148,7 @@ describe("executeStep", () => {
 
     it("fails when the macro cannot be replayed", async () => {
       const runMacro: WorkflowRunMacroSeam = vi.fn(async () => false);
-      const outcome = await executeStep(
-        { kind: "run-macro", macroId: "gone" },
-        deps({ runMacro })
-      );
+      const outcome = await executeStep({ kind: "run-macro", macroId: "gone" }, deps({ runMacro }));
 
       expect(outcome.ok).toBe(false);
     });

--- a/src/services/workflowRunner.test.ts
+++ b/src/services/workflowRunner.test.ts
@@ -50,7 +50,7 @@ describe("executeStep", () => {
 
   describe("run-script", () => {
     it("streams each line into the send seam with a trailing newline", async () => {
-      const send = vi.fn(async () => true);
+      const send = vi.fn(async (_data: string) => true);
       const step: WorkflowStep = { kind: "run-script", script: "echo a\necho b\necho c" };
       const outcome = await executeStep(step, deps({ send }));
 
@@ -59,7 +59,7 @@ describe("executeStep", () => {
     });
 
     it("drops a single trailing newline but keeps interior blank lines", async () => {
-      const send = vi.fn(async () => true);
+      const send = vi.fn(async (_data: string) => true);
       const step: WorkflowStep = { kind: "run-script", script: "a\n\nb\n" };
       await executeStep(step, deps({ send }));
 
@@ -93,7 +93,7 @@ describe("executeStep", () => {
     });
 
     it("reads the body from sourcePath when a read seam is provided", async () => {
-      const send = vi.fn(async () => true);
+      const send = vi.fn(async (_data: string) => true);
       const readScriptFile: WorkflowReadFileSeam = vi.fn(async () => "fromdisk1\nfromdisk2");
       const step: WorkflowStep = {
         kind: "run-script",
@@ -107,7 +107,7 @@ describe("executeStep", () => {
     });
 
     it("falls back to the embedded script when the sourcePath read fails", async () => {
-      const send = vi.fn(async () => true);
+      const send = vi.fn(async (_data: string) => true);
       const readScriptFile: WorkflowReadFileSeam = vi.fn(async () => {
         throw new Error("no such file");
       });

--- a/src/services/workflowRunner.test.ts
+++ b/src/services/workflowRunner.test.ts
@@ -1,12 +1,15 @@
 /**
- * Tests for the workflow run engine (#1852).
+ * Tests for the workflow run engine (#1852, extended by #1853).
  *
  * Pins the dispatch/execution contract the whole Workflow Automation epic
- * (#1851) builds on: `send-command` steps reach the send seam in order, progress
- * is reported per step, cancellation stops the run between steps (a step already
- * in flight finishes but the next never starts), a failing seam fails the run at
- * the offending step, and the not-yet-implemented placeholder kinds fail loudly.
- * The send seam is mocked so no terminal or session is required.
+ * (#1851) builds on: `send-command` and `run-script` steps reach the send seam
+ * in order, `run-macro` delegates to the macro-playback seam, `wait` (and
+ * per-line delays) route through the timer seam clamped to `MAX_STEP_DELAY_MS`,
+ * progress is reported per step, cancellation stops the run between steps and
+ * aborts an in-flight `run-script`'s remaining line injections, a failing seam
+ * fails the run at the offending step, and the still-unimplemented
+ * `run-local-process` kind fails loudly. All seams are mocked so no terminal or
+ * session is required.
  */
 import { describe, it, expect, vi } from "vitest";
 import {
@@ -14,17 +17,25 @@ import {
   executeStep,
   type WorkflowRunnerDeps,
   type WorkflowSendSeam,
+  type WorkflowRunMacroSeam,
+  type WorkflowWaitSeam,
+  type WorkflowReadFileSeam,
 } from "./workflowRunner";
+import { MAX_STEP_DELAY_MS } from "./macroPlayback";
 import type { WorkflowStep } from "@/types/workflow";
 
 const sendCommand = (command: string): WorkflowStep => ({ kind: "send-command", command });
 
-const deps = (send: WorkflowSendSeam): WorkflowRunnerDeps => ({ send });
+/** Build deps with a no-op send by default; override any seam per test. */
+const deps = (over: Partial<WorkflowRunnerDeps> = {}): WorkflowRunnerDeps => ({
+  send: vi.fn(async () => true),
+  ...over,
+});
 
 describe("executeStep", () => {
   it("sends a send-command with a trailing newline through the seam", async () => {
     const send = vi.fn(async () => true);
-    const outcome = await executeStep(sendCommand("git status"), deps(send));
+    const outcome = await executeStep(sendCommand("git status"), deps({ send }));
 
     expect(outcome).toEqual({ ok: true });
     expect(send).toHaveBeenCalledWith("git status\n");
@@ -32,44 +43,207 @@ describe("executeStep", () => {
 
   it("fails a send-command when the seam reports the session vanished", async () => {
     const send = vi.fn(async () => false);
-    const outcome = await executeStep(sendCommand("ls"), deps(send));
+    const outcome = await executeStep(sendCommand("ls"), deps({ send }));
 
     expect(outcome.ok).toBe(false);
   });
 
-  it.each(["run-script", "run-macro", "wait", "run-local-process"] as const)(
-    "fails loudly for the not-yet-implemented %s step",
-    async (kind) => {
-      // Build a minimal step of the given placeholder kind.
-      const byKind: Record<string, WorkflowStep> = {
-        "run-script": { kind: "run-script", script: "echo hi" },
-        "run-macro": { kind: "run-macro", macroId: "m-1" },
-        wait: { kind: "wait", delayMs: 100 },
-        "run-local-process": { kind: "run-local-process", program: "echo", args: [] },
+  describe("run-script", () => {
+    it("streams each line into the send seam with a trailing newline", async () => {
+      const send = vi.fn(async () => true);
+      const step: WorkflowStep = { kind: "run-script", script: "echo a\necho b\necho c" };
+      const outcome = await executeStep(step, deps({ send }));
+
+      expect(outcome).toEqual({ ok: true });
+      expect(send.mock.calls.map((c) => c[0])).toEqual(["echo a\n", "echo b\n", "echo c\n"]);
+    });
+
+    it("drops a single trailing newline but keeps interior blank lines", async () => {
+      const send = vi.fn(async () => true);
+      const step: WorkflowStep = { kind: "run-script", script: "a\n\nb\n" };
+      await executeStep(step, deps({ send }));
+
+      expect(send.mock.calls.map((c) => c[0])).toEqual(["a\n", "\n", "b\n"]);
+    });
+
+    it("waits the clamped per-line delay between lines (not before the first)", async () => {
+      const send = vi.fn(async () => true);
+      const wait = vi.fn(async () => {});
+      const step: WorkflowStep = {
+        kind: "run-script",
+        script: "a\nb\nc",
+        perLineDelayMs: MAX_STEP_DELAY_MS + 10_000,
       };
-      const outcome = await executeStep(byKind[kind], deps(vi.fn(async () => true)));
+      await executeStep(step, deps({ send, wait }));
+
+      // One delay between each of the three lines (two gaps), each clamped.
+      expect(wait.mock.calls).toEqual([[MAX_STEP_DELAY_MS], [MAX_STEP_DELAY_MS]]);
+    });
+
+    it("fails when the send seam reports the session vanished mid-stream", async () => {
+      const send = vi
+        .fn<(data: string) => Promise<boolean>>()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      const step: WorkflowStep = { kind: "run-script", script: "a\nb\nc" };
+      const outcome = await executeStep(step, deps({ send }));
 
       expect(outcome.ok).toBe(false);
-      if (!outcome.ok) expect(outcome.error).toContain(kind);
-    }
-  );
+      expect(send).toHaveBeenCalledTimes(2);
+    });
+
+    it("reads the body from sourcePath when a read seam is provided", async () => {
+      const send = vi.fn(async () => true);
+      const readScriptFile: WorkflowReadFileSeam = vi.fn(async () => "fromdisk1\nfromdisk2");
+      const step: WorkflowStep = {
+        kind: "run-script",
+        script: "stale",
+        sourcePath: "/tmp/s.sh",
+      };
+      await executeStep(step, deps({ send, readScriptFile }));
+
+      expect(readScriptFile).toHaveBeenCalledWith("/tmp/s.sh");
+      expect(send.mock.calls.map((c) => c[0])).toEqual(["fromdisk1\n", "fromdisk2\n"]);
+    });
+
+    it("falls back to the embedded script when the sourcePath read fails", async () => {
+      const send = vi.fn(async () => true);
+      const readScriptFile: WorkflowReadFileSeam = vi.fn(async () => {
+        throw new Error("no such file");
+      });
+      const step: WorkflowStep = {
+        kind: "run-script",
+        script: "embedded",
+        sourcePath: "/tmp/missing.sh",
+      };
+      await executeStep(step, deps({ send, readScriptFile }));
+
+      expect(send.mock.calls.map((c) => c[0])).toEqual(["embedded\n"]);
+    });
+
+    it("aborts remaining lines when the signal reports cancellation", async () => {
+      const send = vi.fn(async () => true);
+      let cancelled = false;
+      const step: WorkflowStep = { kind: "run-script", script: "a\nb\nc" };
+      // Cancel right after the first line is sent.
+      send.mockImplementation(async () => {
+        cancelled = true;
+        return true;
+      });
+      const outcome = await executeStep(step, deps({ send }), { isCancelled: () => cancelled });
+
+      expect(outcome).toEqual({ ok: true, cancelled: true });
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("run-macro", () => {
+    it("delegates to the run-macro seam and succeeds when it replays", async () => {
+      const runMacro: WorkflowRunMacroSeam = vi.fn(async () => true);
+      const outcome = await executeStep(
+        { kind: "run-macro", macroId: "m-1" },
+        deps({ runMacro })
+      );
+
+      expect(outcome).toEqual({ ok: true });
+      expect(runMacro).toHaveBeenCalledWith("m-1");
+    });
+
+    it("fails when the macro cannot be replayed", async () => {
+      const runMacro: WorkflowRunMacroSeam = vi.fn(async () => false);
+      const outcome = await executeStep(
+        { kind: "run-macro", macroId: "gone" },
+        deps({ runMacro })
+      );
+
+      expect(outcome.ok).toBe(false);
+    });
+
+    it("fails loudly when no run-macro seam is wired", async () => {
+      const outcome = await executeStep({ kind: "run-macro", macroId: "m-1" }, deps());
+
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.error).toContain("run-macro");
+    });
+  });
+
+  describe("wait", () => {
+    it("sleeps the clamped delay through the timer seam", async () => {
+      const wait: WorkflowWaitSeam = vi.fn(async () => {});
+      const outcome = await executeStep({ kind: "wait", delayMs: 250 }, deps({ wait }));
+
+      expect(outcome).toEqual({ ok: true });
+      expect(wait).toHaveBeenCalledWith(250);
+    });
+
+    it("clamps an over-long wait to MAX_STEP_DELAY_MS", async () => {
+      const wait: WorkflowWaitSeam = vi.fn(async () => {});
+      await executeStep({ kind: "wait", delayMs: MAX_STEP_DELAY_MS + 999_999 }, deps({ wait }));
+
+      expect(wait).toHaveBeenCalledWith(MAX_STEP_DELAY_MS);
+    });
+  });
+
+  it("fails loudly for the still-unimplemented run-local-process step", async () => {
+    const outcome = await executeStep(
+      { kind: "run-local-process", program: "echo", args: [] },
+      deps()
+    );
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.error).toContain("run-local-process");
+  });
 });
 
 describe("runWorkflow", () => {
   it("executes every send-command step in order", async () => {
     const send = vi.fn(async (_data: string) => true);
-    const handle = runWorkflow([sendCommand("a"), sendCommand("b"), sendCommand("c")], deps(send));
+    const handle = runWorkflow(
+      [sendCommand("a"), sendCommand("b"), sendCommand("c")],
+      deps({ send })
+    );
     const result = await handle.done;
 
     expect(result).toEqual({ status: "completed", stepsCompleted: 3 });
     expect(send.mock.calls.map((c) => c[0])).toEqual(["a\n", "b\n", "c\n"]);
   });
 
+  it("runs a mixed-kind workflow in order across all seams", async () => {
+    const order: string[] = [];
+    const send: WorkflowSendSeam = vi.fn(async (data: string) => {
+      order.push(`send:${JSON.stringify(data)}`);
+      return true;
+    });
+    const runMacro: WorkflowRunMacroSeam = vi.fn(async (id: string) => {
+      order.push(`macro:${id}`);
+      return true;
+    });
+    const wait: WorkflowWaitSeam = vi.fn(async (ms: number) => {
+      order.push(`wait:${ms}`);
+    });
+    const steps: WorkflowStep[] = [
+      sendCommand("first"),
+      { kind: "run-script", script: "s1\ns2" },
+      { kind: "wait", delayMs: 500 },
+      { kind: "run-macro", macroId: "tail-log" },
+    ];
+    const result = await runWorkflow(steps, deps({ send, runMacro, wait })).done;
+
+    expect(result).toEqual({ status: "completed", stepsCompleted: 4 });
+    expect(order).toEqual([
+      'send:"first\\n"',
+      'send:"s1\\n"',
+      'send:"s2\\n"',
+      "wait:500",
+      "macro:tail-log",
+    ]);
+  });
+
   it("reports progress after each completed step", async () => {
     const send = vi.fn(async () => true);
     const onProgress = vi.fn();
     const steps = [sendCommand("a"), sendCommand("b")];
-    const handle = runWorkflow(steps, deps(send), { onProgress });
+    const handle = runWorkflow(steps, deps({ send }), { onProgress });
     await handle.done;
 
     expect(onProgress.mock.calls).toEqual([
@@ -80,7 +254,7 @@ describe("runWorkflow", () => {
 
   it("completes vacuously for an empty workflow", async () => {
     const send = vi.fn(async () => true);
-    const result = await runWorkflow([], deps(send)).done;
+    const result = await runWorkflow([], deps({ send })).done;
 
     expect(result).toEqual({ status: "completed", stepsCompleted: 0 });
     expect(send).not.toHaveBeenCalled();
@@ -107,7 +281,7 @@ describe("runWorkflow", () => {
       return true;
     });
 
-    const handle = runWorkflow([sendCommand("a"), sendCommand("b")], deps(send));
+    const handle = runWorkflow([sendCommand("a"), sendCommand("b")], deps({ send }));
 
     // Wait until the first step is genuinely in flight, then cancel and let it finish.
     await firstStarted;
@@ -121,9 +295,42 @@ describe("runWorkflow", () => {
     expect(send).toHaveBeenCalledWith("a\n");
   });
 
+  it("aborts an in-flight run-script's remaining lines when cancelled", async () => {
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    const send = vi.fn(async (_data: string) => {
+      call += 1;
+      if (call === 1) {
+        markStarted();
+        await gate;
+      }
+      return true;
+    });
+    const steps: WorkflowStep[] = [{ kind: "run-script", script: "a\nb\nc" }, sendCommand("z")];
+    const handle = runWorkflow(steps, deps({ send }));
+
+    await started;
+    handle.cancel();
+    releaseFirst();
+    const result = await handle.done;
+
+    // The run-script aborted after its first line and is not counted completed;
+    // the following send-command never ran.
+    expect(result).toEqual({ status: "cancelled", stepsCompleted: 0 });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("a\n");
+  });
+
   it("does not run anything when cancelled before it starts", async () => {
     const send = vi.fn(async () => true);
-    const handle = runWorkflow([sendCommand("a")], deps(send));
+    const handle = runWorkflow([sendCommand("a")], deps({ send }));
     handle.cancel();
     const result = await handle.done;
 
@@ -136,7 +343,10 @@ describe("runWorkflow", () => {
       .fn<(data: string) => Promise<boolean>>()
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false);
-    const handle = runWorkflow([sendCommand("a"), sendCommand("b"), sendCommand("c")], deps(send));
+    const handle = runWorkflow(
+      [sendCommand("a"), sendCommand("b"), sendCommand("c")],
+      deps({ send })
+    );
     const result = await handle.done;
 
     expect(result.status).toBe("failed");
@@ -148,7 +358,10 @@ describe("runWorkflow", () => {
 
   it("fails at a not-yet-implemented step kind", async () => {
     const send = vi.fn(async () => true);
-    const handle = runWorkflow([sendCommand("a"), { kind: "wait", delayMs: 10 }], deps(send));
+    const handle = runWorkflow(
+      [sendCommand("a"), { kind: "run-local-process", program: "x", args: [] }],
+      deps({ send })
+    );
     const result = await handle.done;
 
     expect(result.status).toBe("failed");

--- a/src/services/workflowRunner.ts
+++ b/src/services/workflowRunner.ts
@@ -1,32 +1,37 @@
 /**
- * Workflow run engine (#1852) — the foundation of the Workflow Automation epic
- * (#1851).
+ * Workflow run engine — the foundation (#1852) of the Workflow Automation epic
+ * (#1851), extended with the remaining v1 terminal-native step types (#1853).
  *
  * Generalises the macro playback scheduler ({@link "@/services/macroPlayback"})
  * from a homogeneous list of recorded input chunks to an ordered list of *typed*
  * {@link WorkflowStep}s. The runner walks the steps in order, dispatching each by
- * `kind` through an **injectable send seam** so it is fully unit-testable with a
- * mock and no live terminal — exactly the `inject` seam macro playback uses.
+ * `kind` through **injectable seams** so it is fully unit-testable with mocks and
+ * no live terminal — exactly the `inject` seam macro playback uses.
  *
  * Run lifecycle (per the concept's state machine): a run is created in an
  * implicit *pending* state, transitions to *running* as it walks the steps, and
  * ends in exactly one terminal state — **completed** (last step done),
- * **cancelled** (the caller cancelled between steps), or **failed** (a step's
+ * **cancelled** (the caller cancelled between steps, or a multi-line step
+ * observed the cancel and aborted its remaining sends), or **failed** (a step's
  * seam reported failure, or the step kind is not yet executable). Cancellation is
- * honoured between steps: a step already in flight finishes, then the run stops
- * before the next step begins.
+ * honoured between steps; the multi-line `run-script` step additionally checks it
+ * at each line boundary, so a cancel aborts its remaining line injections.
  *
- * Only the `send-command` step executes in this foundation PR. The remaining v1
- * step kinds (`run-script`, `run-macro`, `wait`, `run-local-process`) are
- * clearly-marked dispatch placeholders that fail loudly until their owning child
- * issues wire them up:
- *  - #1853 — `run-script`, `run-macro`, `wait` (the latter reuses
- *    `macroPlayback.MAX_STEP_DELAY_MS` to clamp its delay).
- *  - #1857 — `run-local-process` (guarded, security-critical).
- * Later children extend the runner by adding their seam to
- * {@link WorkflowRunnerDeps} and replacing the placeholder in {@link executeStep}.
+ * Executable step kinds and the seam each routes through:
+ *  - `send-command` / `run-script` — the `send_input` seam ({@link WorkflowRunnerDeps.send}).
+ *  - `run-macro` — the macro-playback replay seam ({@link WorkflowRunnerDeps.runMacro}).
+ *  - `wait` / `run-script` inter-line delays — the timer seam
+ *    ({@link WorkflowRunnerDeps.wait}), with every delay clamped to
+ *    {@link "@/services/macroPlayback".MAX_STEP_DELAY_MS} exactly as macro
+ *    playback clamps its own delays.
+ *
+ * The only remaining placeholder is `run-local-process` (guarded,
+ * security-critical), wired by #1857; it fails loudly until then. Later children
+ * extend the runner by adding their seam to {@link WorkflowRunnerDeps} and
+ * replacing the placeholder in {@link executeStep}.
  */
 
+import { MAX_STEP_DELAY_MS } from "@/services/macroPlayback";
 import type { WorkflowStep } from "@/types/workflow";
 
 /** Terminal outcome of a workflow run (the state machine's end states). */
@@ -52,14 +57,47 @@ export interface WorkflowRunResult {
 export type WorkflowSendSeam = (data: string) => Promise<boolean> | boolean;
 
 /**
+ * Replays a stored macro by id via the macro-playback service, reusing the
+ * macro's own timing mode. Resolves `true` when the macro replayed to
+ * completion, `false` when it was missing, empty, or the target session vanished.
+ */
+export type WorkflowRunMacroSeam = (macroId: string) => Promise<boolean> | boolean;
+
+/**
+ * Sleeps for `ms` milliseconds before resolving — the scheduler timer both the
+ * `wait` step and the `run-script` inter-line delay route through. Injectable so
+ * tests can assert the (already clamped) delay without real time passing.
+ */
+export type WorkflowWaitSeam = (ms: number) => Promise<void> | void;
+
+/**
+ * Reads a script body from an on-disk path (the `run-script` `sourcePath`
+ * affordance). Resolves the file's UTF-8 contents; rejects when it cannot be
+ * read, in which case the runner falls back to the step's embedded `script`.
+ */
+export type WorkflowReadFileSeam = (path: string) => Promise<string>;
+
+/**
  * Injectable dependencies the runner dispatches steps through. `send` is the only
- * seam the foundation requires; later children add optional seams here (e.g. a
- * macro-playback runner for `run-macro`, a guarded local-process spawner for
- * `run-local-process`) alongside their dispatch handler in {@link executeStep}.
+ * required seam; the rest back a specific step kind and are optional so a step
+ * kind that never appears needs no seam (and isolated unit tests can inject just
+ * what they exercise). A step whose seam is absent fails loudly at that step.
  */
 export interface WorkflowRunnerDeps {
   /** Injects text into the target session (the `send_input` seam). */
   send: WorkflowSendSeam;
+  /** Replays a stored macro by id (the `run-macro` seam). */
+  runMacro?: WorkflowRunMacroSeam;
+  /** Sleeps for a (clamped) number of ms (the `wait` / inter-line-delay seam). */
+  wait?: WorkflowWaitSeam;
+  /** Reads a script body from disk (the `run-script` `sourcePath` seam). */
+  readScriptFile?: WorkflowReadFileSeam;
+}
+
+/** A poll the runner threads into a step so long/multi-part steps can abort. */
+export interface WorkflowStepSignal {
+  /** `true` once the owning run has been cancelled. */
+  isCancelled: () => boolean;
 }
 
 /** Optional lifecycle hooks fired as a run advances. */
@@ -76,21 +114,67 @@ export interface WorkflowRunHandle {
   cancel: () => void;
 }
 
-/** Outcome of executing a single step. */
-type StepOutcome = { ok: true } | { ok: false; error: string };
+/**
+ * Outcome of executing a single step. `cancelled` marks a multi-part step (i.e.
+ * `run-script`) that observed the cancel and aborted mid-flight — the run ends
+ * `cancelled` without counting that step as completed.
+ */
+type StepOutcome = { ok: true; cancelled?: boolean } | { ok: false; error: string };
 
-/** Line terminator appended to an authored `send-command`; the `send_input` seam
- * normalises it to the session's configured line ending. */
-const COMMAND_TERMINATOR = "\n";
+/** Line terminator appended to each sent line; the `send_input` seam normalises
+ * it to the session's configured line ending. */
+const LINE_TERMINATOR = "\n";
+
+/** Error surfaced when a session vanishes mid-send. */
+const SESSION_GONE = "the target terminal is no longer connected";
 
 /**
- * Error message for a step kind that is defined in the model but not yet
- * executable in the foundation. Surfacing it as a step failure (rather than a
- * silent skip) means a workflow authored with a not-yet-wired step fails loudly
- * at that step until the owning child issue implements it.
+ * Clamp a caller-authored delay to `[0, MAX_STEP_DELAY_MS]` (and treat a
+ * non-finite value as 0), matching the guard macro playback applies so a single
+ * `wait` or per-line delay can never appear to hang the run for minutes.
  */
-function notYetImplemented(kind: WorkflowStep["kind"]): StepOutcome {
-  return { ok: false, error: `workflow step kind "${kind}" is not yet implemented` };
+function clampDelay(ms: number | undefined): number {
+  if (ms === undefined || !Number.isFinite(ms)) return 0;
+  return Math.max(0, Math.min(ms, MAX_STEP_DELAY_MS));
+}
+
+/** Default timer seam: a real `setTimeout` sleep (no-op for non-positive ms). */
+function defaultWait(ms: number): Promise<void> {
+  return ms <= 0 ? Promise.resolve() : new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Sleep for `ms` through the injected timer seam, or the real timer by default. */
+async function sleepFor(ms: number, deps: WorkflowRunnerDeps): Promise<void> {
+  await (deps.wait ?? defaultWait)(ms);
+}
+
+/**
+ * Split a script body into the lines to stream. Newlines of any flavour split
+ * lines; a single trailing empty line produced by a terminating newline is
+ * dropped so `"a\nb\n"` streams two commands, not two plus a blank enter.
+ * Interior blank lines are preserved.
+ */
+function splitScriptLines(script: string): string[] {
+  const lines = script.split(/\r\n|\r|\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+/**
+ * Resolve a `run-script` step's body: read it fresh from `sourcePath` when both
+ * the path and a read seam are present, falling back to the step's embedded
+ * `script` when there is no path/seam or the read fails.
+ */
+async function resolveScriptBody(
+  step: Extract<WorkflowStep, { kind: "run-script" }>,
+  deps: WorkflowRunnerDeps
+): Promise<string> {
+  if (!step.sourcePath || !deps.readScriptFile) return step.script;
+  try {
+    return await deps.readScriptFile(step.sourcePath);
+  } catch {
+    return step.script;
+  }
 }
 
 /**
@@ -98,24 +182,53 @@ function notYetImplemented(kind: WorkflowStep["kind"]): StepOutcome {
  * exhaustive over the {@link WorkflowStep} union (the `never` default is a
  * compile-time guard), so adding a step kind to the model forces a matching
  * dispatch entry here.
+ *
+ * `signal` lets a long or multi-part step abort when the run is cancelled; it is
+ * optional so a step can be unit-tested in isolation without a run around it.
  */
 export async function executeStep(
   step: WorkflowStep,
-  deps: WorkflowRunnerDeps
+  deps: WorkflowRunnerDeps,
+  signal?: WorkflowStepSignal
 ): Promise<StepOutcome> {
+  const cancelled = (): boolean => signal?.isCancelled() ?? false;
+
   switch (step.kind) {
     case "send-command": {
-      const delivered = await deps.send(step.command + COMMAND_TERMINATOR);
-      return delivered
-        ? { ok: true }
-        : { ok: false, error: "the target terminal is no longer connected" };
+      const delivered = await deps.send(step.command + LINE_TERMINATOR);
+      return delivered ? { ok: true } : { ok: false, error: SESSION_GONE };
     }
-    // --- Placeholders wired by later epic children (see module docs). ---
-    case "run-script": // #1853
-    case "run-macro": // #1853
-    case "wait": // #1853
-    case "run-local-process": // #1857
-      return notYetImplemented(step.kind);
+    case "run-script": {
+      const lines = splitScriptLines(await resolveScriptBody(step, deps));
+      const perLineDelay = clampDelay(step.perLineDelayMs);
+      for (let i = 0; i < lines.length; i++) {
+        if (cancelled()) return { ok: true, cancelled: true };
+        if (i > 0 && perLineDelay > 0) await sleepFor(perLineDelay, deps);
+        if (cancelled()) return { ok: true, cancelled: true };
+        const delivered = await deps.send(lines[i] + LINE_TERMINATOR);
+        if (!delivered) return { ok: false, error: SESSION_GONE };
+      }
+      return { ok: true };
+    }
+    case "run-macro": {
+      if (!deps.runMacro) {
+        return { ok: false, error: 'the "run-macro" step requires a macro-playback seam' };
+      }
+      const replayed = await deps.runMacro(step.macroId);
+      return replayed
+        ? { ok: true }
+        : { ok: false, error: `macro "${step.macroId}" could not be replayed` };
+    }
+    case "wait": {
+      await sleepFor(clampDelay(step.delayMs), deps);
+      return { ok: true };
+    }
+    // --- Placeholder wired by a later epic child (see module docs). ---
+    case "run-local-process": // #1857 (guarded, security-critical)
+      return {
+        ok: false,
+        error: `workflow step kind "${step.kind}" is not yet implemented`,
+      };
     default: {
       // Exhaustiveness guard: a new step kind must add a case above.
       const _exhaustive: never = step;
@@ -129,10 +242,13 @@ export async function executeStep(
  * reporting progress. Returns a {@link WorkflowRunHandle} whose `done` promise
  * resolves once the run reaches a terminal state.
  *
- * Cancellation is checked before each step: a step already in flight finishes,
- * then the run stops before the next step begins (status `cancelled`). If a
- * step's seam reports failure — or the step kind is not yet executable — the run
- * stops immediately with status `failed` and records the offending step.
+ * Cancellation is checked before each step and again after it: a `send-command`,
+ * `run-macro`, or `wait` already in flight finishes and counts as completed,
+ * then the run stops before the next step begins (status `cancelled`). A
+ * `run-script` that observes the cancel between its lines aborts its remaining
+ * sends and is *not* counted as completed. If a step's seam reports failure — or
+ * the step kind is not yet executable — the run stops immediately with status
+ * `failed` and records the offending step.
  */
 export function runWorkflow(
   steps: WorkflowStep[],
@@ -145,6 +261,8 @@ export function runWorkflow(
     cancelled = true;
   };
 
+  const signal: WorkflowStepSignal = { isCancelled: () => cancelled };
+
   const done = (async (): Promise<WorkflowRunResult> => {
     // Yield once before the first step so a cancel() issued synchronously right
     // after this handle is returned lands before any step runs — a run cancelled
@@ -153,7 +271,7 @@ export function runWorkflow(
     for (let i = 0; i < steps.length; i++) {
       if (cancelled) return { status: "cancelled", stepsCompleted: i };
 
-      const outcome = await executeStep(steps[i], deps);
+      const outcome = await executeStep(steps[i], deps, signal);
       if (!outcome.ok) {
         return {
           status: "failed",
@@ -162,6 +280,9 @@ export function runWorkflow(
           error: outcome.error,
         };
       }
+      // A multi-part step that aborted mid-flight on cancel: end the run without
+      // counting it as completed and without firing its progress hook.
+      if (outcome.cancelled) return { status: "cancelled", stepsCompleted: i };
 
       hooks?.onProgress?.(i + 1, steps.length, steps[i]);
     }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -6020,11 +6020,9 @@ export const useAppStore = create<AppState>((set, get) => {
         if (!injector) return false;
         const macro = get().macros.find((m) => m.id === macroId);
         if (!macro || macro.steps.length === 0) return false;
-        const macroHandle = runMacroPlayback(
-          macro.steps,
-          (data) => injector(targetTabId, data),
-          { timingMode: "real-time" }
-        );
+        const macroHandle = runMacroPlayback(macro.steps, (data) => injector(targetTabId, data), {
+          timingMode: "real-time",
+        });
         const macroResult = await macroHandle.done;
         return macroResult.status === "completed";
       };

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -103,6 +103,7 @@ import {
   closeTerminal as apiCloseTerminal,
   detachPersistentTab as apiDetachPersistentTab,
   saveShellIntegrationSettings,
+  localReadFile,
 } from "@/services/api";
 import type {
   ConnectionTypeInfo,
@@ -181,6 +182,7 @@ import {
 import {
   runWorkflow as runWorkflowSteps,
   type WorkflowSendSeam,
+  type WorkflowRunMacroSeam,
   type WorkflowRunHandle,
 } from "@/services/workflowRunner";
 import {
@@ -6004,11 +6006,27 @@ export const useAppStore = create<AppState>((set, get) => {
       }
 
       // The workflow runner reuses the macro `send_input` injector seam, bound to
-      // the target tab, so send-based steps route through the single choke point.
+      // the target tab, so send-based steps (send-command, run-script) route
+      // through the single choke point.
       const injector = getTerminalInputInjector();
       const send: WorkflowSendSeam = (data) => {
         if (!injector) return false;
         return injector(targetTabId, data);
+      };
+
+      // A `run-macro` step replays a stored macro by id through the macro-playback
+      // service, into the same target tab, reusing the macro's recorded timing.
+      const runMacro: WorkflowRunMacroSeam = async (macroId) => {
+        if (!injector) return false;
+        const macro = get().macros.find((m) => m.id === macroId);
+        if (!macro || macro.steps.length === 0) return false;
+        const macroHandle = runMacroPlayback(
+          macro.steps,
+          (data) => injector(targetTabId, data),
+          { timingMode: "real-time" }
+        );
+        const macroResult = await macroHandle.done;
+        return macroResult.status === "completed";
       };
 
       const toastId = `workflow-run-${workflowId}-${targetTabId}`;
@@ -6029,7 +6047,7 @@ export const useAppStore = create<AppState>((set, get) => {
 
       const handle = runWorkflowSteps(
         workflow.steps,
-        { send },
+        { send, runMacro, readScriptFile: localReadFile },
         {
           onProgress: (completed, stepTotal) => {
             set((s) =>

--- a/src/store/appStore.workflowRun.test.ts
+++ b/src/store/appStore.workflowRun.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { LeafPanel, TerminalTab } from "@/types/terminal";
 import type { Workflow, WorkflowStep } from "@/types/workflow";
+import type { Macro } from "@/types/macro";
 
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>
@@ -170,10 +171,41 @@ describe("appStore — workflow run slice (#1852)", () => {
     expect(toast.info).toHaveBeenCalled();
   });
 
+  it("runs run-script, wait, and run-macro steps end to end (#1853)", async () => {
+    seedConnectedTerminal();
+    const macro: Macro = {
+      id: "m1",
+      name: "tail log",
+      tags: [],
+      steps: [{ data: "tail -f app.log\n", delayMs: 0 }],
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+    useAppStore.setState({
+      macros: [macro],
+      workflows: [
+        workflow("w1", [
+          { kind: "run-script", script: "line1\nline2" },
+          { kind: "wait", delayMs: 0 },
+          { kind: "run-macro", macroId: "m1" },
+        ]),
+      ],
+    });
+
+    await useAppStore.getState().runWorkflow("w1");
+
+    // run-script streams each line, then run-macro replays via the same injector.
+    expect(injected).toEqual(["line1\n", "line2\n", "tail -f app.log\n"]);
+    expect(useAppStore.getState().workflowRun).toBeNull();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
   it("fails with a toast when a step kind is not yet implemented", async () => {
     seedConnectedTerminal();
     useAppStore.setState({
-      workflows: [workflow("w1", [cmd("a"), { kind: "wait", delayMs: 10 }])],
+      workflows: [
+        workflow("w1", [cmd("a"), { kind: "run-local-process", program: "x", args: [] }]),
+      ],
     });
 
     await useAppStore.getState().runWorkflow("w1");


### PR DESCRIPTION
Implements the remaining v1 terminal-native workflow step types on top of the merged foundation (#1852, PR #1858). Builds on the shipped step model and runner without changing the type union — only the runner placeholders are filled in.

## What changed

`src/services/workflowRunner.ts` — the `run-script`, `run-macro`, and `wait` dispatch cases now execute, each routed through an injectable seam added to `WorkflowRunnerDeps` (keeps the runner unit-testable with mocks, no live terminal):

- **`wait {delayMs}`** — pauses via the timer seam, clamped to `macroPlayback.MAX_STEP_DELAY_MS`.
- **`run-script {script, perLineDelayMs?, sourcePath?}`** — streams the script's lines into the session over the `send_input` seam (each line + `\n`, line-ending normalised downstream). Honours `perLineDelayMs` (clamped) between lines; when `sourcePath` and a read seam are present, reads the body fresh from disk, falling back to the embedded `script`. A cancel aborts the remaining line injections.
- **`run-macro {macroId}`** — replays an existing stored macro by id through the macro-playback service, reusing the macro's recorded timing.

The exhaustive `switch` stays exhaustive (`run-local-process` remains the loud placeholder for #1857), and the run lifecycle (pending→running→completed|cancelled|failed), per-step progress, and cancel-between-steps are intact.

### Seams added to `WorkflowRunnerDeps` (for #1855/#1857)

- `runMacro?: (macroId: string) => Promise<boolean> | boolean`
- `wait?: (ms: number) => Promise<void> | void` (defaults to a real `setTimeout`)
- `readScriptFile?: (path: string) => Promise<string>`

Store wiring (`appStore.ts`) binds `runMacro` to `runMacroPlayback` on the target tab and `readScriptFile` to `localReadFile`.

## Verification

- New unit tests for each step type via the injected seams: run-script line streaming, trailing-newline handling, clamped per-line delay, `sourcePath` read + fallback, mid-script cancel; run-macro delegation + failure + missing-seam; wait clamp; a mixed-kind workflow running in order; plus a store-level end-to-end test.
- `pnpm test` (3912 passed), `tsc --noEmit`, and `./scripts/check.sh` all green locally.

Closes #1853