### PR TITLE
feat(workflow): flag imported run-local-process steps (Closes #1856)

### DIFF
--- a/docs/changes/dev1/feature/1856-workflow-import-export.md
+++ b/docs/changes/dev1/feature/1856-workflow-import-export.md
@@ -1,0 +1,8 @@
+### Added
+
+- Importing a workflow now flags any `run-local-process` step it carries. Such a
+  step runs a program on your local machine, so an imported one is **preserved
+  but never auto-authorized**: a persistent toast surfaces how many local-process
+  steps were imported and that they stay disabled until you review and authorize
+  them. A clean import still reports just the count. This closes out the workflow
+  import/export UI on the sidebar's export/import affordances (epic #1851, #1856).

--- a/src/components/WorkflowSidebar/WorkflowSidebar.test.tsx
+++ b/src/components/WorkflowSidebar/WorkflowSidebar.test.tsx
@@ -106,7 +106,9 @@ describe("WorkflowSidebar", () => {
       workflowRun: null,
       saveWorkflowToBackend: vi.fn().mockResolvedValue(undefined),
       deleteWorkflowFromBackend: vi.fn().mockResolvedValue(undefined),
-      importWorkflows: vi.fn().mockResolvedValue(0),
+      importWorkflows: vi
+        .fn()
+        .mockResolvedValue({ imported: 0, workflowsWithLocalProcess: 0, localProcessSteps: 0 }),
       runWorkflow: vi.fn().mockResolvedValue(undefined),
       cancelWorkflowRun: vi.fn(),
     });
@@ -219,6 +221,79 @@ describe("WorkflowSidebar", () => {
     act(() => (query("workflow-delete-workflow-1") as HTMLButtonElement).click());
     expect(query("confirm-delete-dialog")).not.toBeNull();
     expect(deleteWorkflowFromBackend).not.toHaveBeenCalled();
+  });
+
+  it("exports all workflows to a chosen file via serialize + save", async () => {
+    dialogSave.mockResolvedValue("/tmp/workflows.json");
+    fsWriteTextFile.mockResolvedValue(undefined);
+    useAppStore.setState({ workflows: sampleWorkflows });
+    render();
+
+    act(() => (query("workflow-export-all-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(dialogSave).toHaveBeenCalledTimes(1);
+    expect(fsWriteTextFile).toHaveBeenCalledTimes(1);
+    const [, written] = fsWriteTextFile.mock.calls[0] as [string, string];
+    // The written payload is the serialized envelope of both workflows.
+    const parsed = JSON.parse(written) as { workflows: Workflow[] };
+    expect(parsed.workflows.map((w) => w.name)).toEqual(["Prod login", "Banner"]);
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("imports workflows and reports the count on success", async () => {
+    dialogOpen.mockResolvedValue("/tmp/workflows.json");
+    fsReadTextFile.mockResolvedValue("{}");
+    const importWorkflows = vi
+      .fn()
+      .mockResolvedValue({ imported: 2, workflowsWithLocalProcess: 0, localProcessSteps: 0 });
+    useAppStore.setState({ importWorkflows });
+    render();
+
+    act(() => (query("workflow-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(importWorkflows).toHaveBeenCalledWith("{}");
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    const [message, opts] = toastSuccess.mock.calls[0] as [string, Record<string, unknown>?];
+    expect(message).toBe("Imported 2 workflows");
+    // A clean import carries no security warning.
+    expect(opts?.description).toBeUndefined();
+  });
+
+  it("flags imported run-local-process steps as needing authorization", async () => {
+    dialogOpen.mockResolvedValue("/tmp/workflows.json");
+    fsReadTextFile.mockResolvedValue("{}");
+    const importWorkflows = vi
+      .fn()
+      .mockResolvedValue({ imported: 1, workflowsWithLocalProcess: 1, localProcessSteps: 2 });
+    useAppStore.setState({ importWorkflows });
+    render();
+
+    act(() => (query("workflow-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    const [message, opts] = toastSuccess.mock.calls[0] as [string, Record<string, unknown>?];
+    expect(message).toBe("Imported 1 workflow");
+    // The security warning is surfaced persistently and never auto-authorizes.
+    expect(String(opts?.description)).toMatch(/2 local-process steps/);
+    expect(String(opts?.description)).toMatch(/authorize/i);
+    expect(opts?.duration).toBe(Infinity);
+  });
+
+  it("surfaces a recoverable error when the import fails", async () => {
+    dialogOpen.mockResolvedValue("/tmp/workflows.json");
+    fsReadTextFile.mockResolvedValue("{}");
+    const importWorkflows = vi.fn().mockRejectedValue(new Error("Invalid workflow file"));
+    useAppStore.setState({ importWorkflows });
+    render();
+
+    act(() => (query("workflow-import-btn") as HTMLButtonElement).click());
+    await flush();
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(String(toastError.mock.calls[0][0])).toMatch(/Failed to import workflows/);
   });
 
   it("opens the editor prefilled when editing a workflow", () => {

--- a/src/components/WorkflowSidebar/WorkflowSidebar.tsx
+++ b/src/components/WorkflowSidebar/WorkflowSidebar.tsx
@@ -193,8 +193,26 @@ export function WorkflowSidebar() {
     if (!filePath || Array.isArray(filePath)) return;
     try {
       const json = await readTextFile(filePath);
-      const count = await importWorkflows(json);
-      toast.success(`Imported ${count} workflow${count === 1 ? "" : "s"}`);
+      const result = await importWorkflows(json);
+      const summary = `Imported ${result.imported} workflow${result.imported === 1 ? "" : "s"}`;
+      if (result.localProcessSteps > 0) {
+        // Security surfacing (#1856): an imported workflow may carry a
+        // run-local-process step. It is preserved but NOT auto-authorized — the
+        // runner refuses to spawn it until it is explicitly enabled (#1857). Flag
+        // it prominently (persistent toast) so it is never silently trusted.
+        const stepLabel = `${result.localProcessSteps} local-process step${
+          result.localProcessSteps === 1 ? "" : "s"
+        }`;
+        const wfLabel = `${result.workflowsWithLocalProcess} imported workflow${
+          result.workflowsWithLocalProcess === 1 ? "" : "s"
+        }`;
+        toast.success(summary, {
+          description: `${wfLabel} contain ${stepLabel} that run a local program. These stay disabled and will not run until you review and authorize them.`,
+          duration: Infinity,
+        });
+      } else {
+        toast.success(summary);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       toast.error(`Failed to import workflows: ${message}`);

--- a/src/services/workflowIo.test.ts
+++ b/src/services/workflowIo.test.ts
@@ -11,6 +11,7 @@ import {
   serializeWorkflows,
   parseWorkflowEnvelope,
   resolveImportCollisions,
+  summarizeLocalProcessSteps,
   WORKFLOW_EXPORT_VERSION,
 } from "./workflowIo";
 import type { Workflow } from "@/types/workflow";
@@ -162,5 +163,32 @@ describe("resolveImportCollisions", () => {
     counter = 0;
     const [result] = resolveImportCollisions([sampleWorkflow({ name: "Unique" })], [], genId);
     expect(result.name).toBe("Unique");
+  });
+});
+
+describe("summarizeLocalProcessSteps", () => {
+  it("reports zero for workflows with no local-process steps", () => {
+    const wf = sampleWorkflow({ steps: [{ kind: "send-command", command: "ls" }] });
+    expect(summarizeLocalProcessSteps([wf])).toEqual({
+      workflowsWithLocalProcess: 0,
+      localProcessSteps: 0,
+    });
+  });
+
+  it("counts local-process steps and the workflows carrying them", () => {
+    const withLocal = sampleWorkflow({
+      name: "danger",
+      steps: [
+        { kind: "send-command", command: "ls" },
+        { kind: "run-local-process", program: "echo", args: ["a"] },
+        { kind: "run-local-process", program: "rm", args: ["-rf", "/"] },
+      ],
+    });
+    const clean = sampleWorkflow({ name: "safe", steps: [{ kind: "wait", delayMs: 10 }] });
+
+    expect(summarizeLocalProcessSteps([withLocal, clean])).toEqual({
+      workflowsWithLocalProcess: 1,
+      localProcessSteps: 2,
+    });
   });
 });

--- a/src/services/workflowIo.ts
+++ b/src/services/workflowIo.ts
@@ -40,6 +40,25 @@ export interface WorkflowExportEnvelope {
 /** Suffix appended to imported workflow names that collide with an existing one. */
 const COLLISION_SUFFIX = "imported";
 
+/**
+ * The outcome of importing a workflow file, surfaced to the user (#1856).
+ *
+ * Beyond the plain count, this makes the **security-sensitive** part explicit:
+ * how many imported workflows carry a `run-local-process` step. Such steps are
+ * **preserved, not stripped** on import (so #1857's run-time guard applies), but
+ * they are **never auto-authorized** — the runner refuses to spawn them until the
+ * user explicitly enables the step. The counts let the sidebar flag them rather
+ * than silently trust an imported file.
+ */
+export interface WorkflowImportResult {
+  /** Number of workflows merged into the library. */
+  imported: number;
+  /** How many imported workflows contain at least one `run-local-process` step. */
+  workflowsWithLocalProcess: number;
+  /** Total `run-local-process` steps across all imported workflows. */
+  localProcessSteps: number;
+}
+
 /** All valid step-kind discriminants. */
 const STEP_KINDS: readonly WorkflowStepKind[] = [
   "send-command",
@@ -243,6 +262,29 @@ export function parseWorkflowEnvelope(json: string): Workflow[] {
   }
 
   return parsed.workflows.map((workflow, index) => validateWorkflow(workflow, index));
+}
+
+/**
+ * Count the `run-local-process` steps carried by a set of workflows, and how
+ * many workflows contain at least one. Used to surface a security warning when a
+ * file is imported: these steps are guarded and must be explicitly authorized
+ * (#1857) before they can run, so an imported file that carries them is flagged
+ * rather than silently trusted. Returns `{0, 0}` when there are none.
+ */
+export function summarizeLocalProcessSteps(workflows: Workflow[]): {
+  workflowsWithLocalProcess: number;
+  localProcessSteps: number;
+} {
+  let workflowsWithLocalProcess = 0;
+  let localProcessSteps = 0;
+  for (const workflow of workflows) {
+    const count = workflow.steps.filter((step) => step.kind === "run-local-process").length;
+    if (count > 0) {
+      workflowsWithLocalProcess += 1;
+      localProcessSteps += count;
+    }
+  }
+  return { workflowsWithLocalProcess, localProcessSteps };
 }
 
 /** Default fresh-id generator; mirrors the store's `generateWorkflowId`. */

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -178,6 +178,8 @@ import {
 import {
   parseWorkflowEnvelope,
   resolveImportCollisions as resolveWorkflowImportCollisions,
+  summarizeLocalProcessSteps,
+  type WorkflowImportResult,
 } from "@/services/workflowIo";
 import {
   runWorkflow as runWorkflowSteps,
@@ -1262,9 +1264,11 @@ interface AppState {
    * Import workflows from an exported-workflow file's JSON, merging them into the
    * library. Malformed/incompatible files reject with a clear error and leave
    * the library untouched; imported workflows get fresh ids and de-duplicated
-   * names. Returns the number imported.
+   * names. Returns a {@link WorkflowImportResult} that also flags how many
+   * imported workflows carry a (guarded, never auto-authorized) `run-local-process`
+   * step so the caller can surface a security warning.
    */
-  importWorkflows: (json: string) => Promise<number>;
+  importWorkflows: (json: string) => Promise<WorkflowImportResult>;
   /** Metadata for the in-flight workflow run, or `null` when nothing is running. */
   workflowRun: WorkflowRunState | null;
   /**
@@ -5964,7 +5968,15 @@ export const useAppStore = create<AppState>((set, get) => {
       }
       // Refresh once, after all saves, rather than per-workflow.
       await get().loadWorkflows();
-      return prepared.length;
+      // Flag any imported run-local-process steps: they are preserved (never
+      // stripped) so #1857's run-time guard applies, but they are NOT
+      // auto-authorized — the caller surfaces this to the user.
+      const { workflowsWithLocalProcess, localProcessSteps } = summarizeLocalProcessSteps(prepared);
+      return {
+        imported: prepared.length,
+        workflowsWithLocalProcess,
+        localProcessSteps,
+      } satisfies WorkflowImportResult;
     },
 
     workflowRun: null,

--- a/src/store/appStore.workflowRun.test.ts
+++ b/src/store/appStore.workflowRun.test.ts
@@ -270,13 +270,43 @@ describe("appStore — workflow run slice (#1852)", () => {
     useAppStore.setState({ workflows: [] });
     const json = serializeWorkflows([workflow("original", [cmd("ls")])]);
 
-    const count = await useAppStore.getState().importWorkflows(json);
+    const result = await useAppStore.getState().importWorkflows(json);
 
-    expect(count).toBe(1);
+    expect(result.imported).toBe(1);
+    // A clean file carries no run-local-process steps to flag.
+    expect(result.localProcessSteps).toBe(0);
+    expect(result.workflowsWithLocalProcess).toBe(0);
     const imported = useAppStore.getState().workflows;
     expect(imported).toHaveLength(1);
     // A fresh id is assigned on import (never the file's original id).
     expect(imported[0].id).not.toBe("original");
     expect(imported[0].steps).toEqual([cmd("ls")]);
+  });
+
+  it("flags imported run-local-process steps without stripping them", async () => {
+    useAppStore.setState({ workflows: [] });
+    const json = serializeWorkflows([
+      {
+        ...workflow("danger", [cmd("ls")]),
+        steps: [
+          { kind: "send-command", command: "ls" },
+          { kind: "run-local-process", program: "echo", args: ["hi"] },
+        ],
+      },
+    ]);
+
+    const result = await useAppStore.getState().importWorkflows(json);
+
+    // The step count is surfaced so the caller can warn the user...
+    expect(result.imported).toBe(1);
+    expect(result.workflowsWithLocalProcess).toBe(1);
+    expect(result.localProcessSteps).toBe(1);
+    // ...and the step is preserved (not stripped), so #1857's run-time guard applies.
+    const imported = useAppStore.getState().workflows;
+    expect(imported[0].steps).toContainEqual({
+      kind: "run-local-process",
+      program: "echo",
+      args: ["hi"],
+    });
   });
 });


### PR DESCRIPTION
## Summary

Completes the workflow import/export UI (epic #1851) by adding the **security surfacing** for imported `run-local-process` steps. The export/import affordances and file-dialog wiring already shipped on the WorkflowSidebar in #1854, on top of the pure serialize/parse/collision logic from #1852; this PR closes the remaining scope of #1856.

An imported workflow may carry a `run-local-process` step that spawns a program on the local machine. Such a step is now:

- **Preserved, not stripped** on import — so #1857's run-time guard applies at execution time (the runner already refuses to spawn `run-local-process` until #1857 lands).
- **Never auto-authorized** — the import surfaces it instead of silently trusting the file.

## Changes

- `services/workflowIo.ts`: new `WorkflowImportResult` type and pure `summarizeLocalProcessSteps(workflows)` helper (unit-testable in isolation).
- `store/appStore.ts`: `importWorkflows` now returns a `WorkflowImportResult` (`imported`, `workflowsWithLocalProcess`, `localProcessSteps`) instead of a bare count.
- `components/WorkflowSidebar/WorkflowSidebar.tsx`: `handleImport` reports the count on a clean import, and shows a **persistent** warning toast when local-process steps are present, stating they stay disabled until the user reviews and authorizes them.

## Tests

- `workflowIo.test.ts`: `summarizeLocalProcessSteps` counts steps and affected workflows.
- `appStore.workflowRun.test.ts`: import returns the summary; a run-local-process step is flagged and **preserved** (not stripped).
- `WorkflowSidebar.test.tsx`: export serializes + saves; clean import reports the count; a local-process import surfaces a persistent authorization warning; import failure surfaces a recoverable error.

Full suite (3947 tests) and `./scripts/check.sh` pass locally.

Closes #1856