### PR TITLE
feat(workflow): trigger dispatch — manual (palette/hotkey) and on-connect (Closes #1855)

### DIFF
--- a/docs/changes/dev0/feature/1855-workflow-triggers.md
+++ b/docs/changes/dev0/feature/1855-workflow-triggers.md
@@ -1,0 +1,16 @@
+### Added
+
+- Workflow trigger dispatch (#1855, epic #1851): saved workflows can now be
+  launched three ways at runtime.
+  - **Manual** — a "Run Workflow: &lt;name&gt;" entry appears in the command
+    palette for every saved workflow (alongside the existing sidebar run
+    action), running it against the active terminal.
+  - **Hotkey** — a workflow with a `hotkey` trigger runs when its assigned key
+    combo is pressed while no app shortcut claims it, reusing the shared
+    keybinding matcher (explicitly unbound bindings never fire).
+  - **On-connect** — a workflow bound to one or more connections runs
+    automatically, once per session open, when an interactive terminal session
+    for a bound connection finishes opening.
+
+  All three route through the store's existing single-run-at-a-time
+  `runWorkflow`.

--- a/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/components/CommandPalette/CommandPalette.test.tsx
@@ -117,6 +117,30 @@ describe("CommandPalette", () => {
     expect(connectSpy).not.toHaveBeenCalled();
   });
 
+  it("runs the highlighted workflow on Enter via the manual trigger and closes", () => {
+    const runWorkflow = vi.fn(() => Promise.resolve());
+    useAppStore.setState({
+      runWorkflow,
+      workflows: [
+        {
+          id: "wf-1",
+          name: "Deploy",
+          tags: [],
+          steps: [{ kind: "send-command", command: "echo hi" }],
+          triggers: [{ kind: "manual" }],
+          createdAt: "2026-07-24T00:00:00Z",
+          updatedAt: "2026-07-24T00:00:00Z",
+        },
+      ],
+    });
+    typeInto("run workflow: deploy");
+    expect(activeLabel()).toBe("Run Workflow: Deploy");
+    keydown("Enter");
+    expect(runWorkflow).toHaveBeenCalledWith("wf-1");
+    expect(useAppStore.getState().commandPaletteOpen).toBe(false);
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+
   it("connects the highlighted connection on Enter and closes", () => {
     typeInto("production");
     keydown("Enter");

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { matchSorter } from "match-sorter";
-import { TerminalSquare, Play } from "lucide-react";
+import { TerminalSquare, Play, Workflow as WorkflowIcon } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { buildCommands } from "@/services/commands";
 import { useConnectSavedConnection } from "@/hooks/useConnectSavedConnection";
@@ -42,6 +42,13 @@ type PaletteEntry =
       label: string;
       /** The macro to replay into the active terminal. */
       macroId: string;
+    }
+  | {
+      kind: "workflow";
+      key: string;
+      label: string;
+      /** The workflow to run against the active terminal (manual trigger). */
+      workflowId: string;
     };
 
 /**
@@ -59,7 +66,9 @@ export function CommandPalette(): React.ReactElement {
   const setOpen = useAppStore((s) => s.setCommandPaletteOpen);
   const connections = useAppStore((s) => s.connections);
   const macros = useAppStore((s) => s.macros);
+  const workflows = useAppStore((s) => s.workflows);
   const playMacro = useAppStore((s) => s.playMacro);
+  const runWorkflow = useAppStore((s) => s.runWorkflow);
   // Context-bound command availability depends on live panel/terminal state;
   // subscribe so the entry list (and its disabled affordances) recompute when
   // the focused panel, its tabs, or the active panel change.
@@ -95,13 +104,19 @@ export function CommandPalette(): React.ReactElement {
       label: `Run Macro: ${m.name}`,
       macroId: m.id,
     }));
-    return [...commandEntries, ...macroEntries, ...connectionEntries];
+    const workflowEntries: PaletteEntry[] = workflows.map((w) => ({
+      kind: "workflow",
+      key: `workflow:${w.id}`,
+      label: `Run Workflow: ${w.name}`,
+      workflowId: w.id,
+    }));
+    return [...commandEntries, ...macroEntries, ...workflowEntries, ...connectionEntries];
     // buildCommands() reads live panel/terminal state via the store to compute
     // each context command's availability; rootPanel and activePanelId are listed
     // so the entries (and their disabled affordances) recompute when focus moves,
     // even though they are not referenced directly in this closure.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connections, macros, rootPanel, activePanelId]);
+  }, [connections, macros, workflows, rootPanel, activePanelId]);
 
   // Ranked results. An empty query returns every entry in declaration order.
   const results = useMemo<PaletteEntry[]>(() => {
@@ -146,11 +161,13 @@ export function CommandPalette(): React.ReactElement {
         entry.run();
       } else if (entry.kind === "macro") {
         void playMacro(entry.macroId, { timingMode: "real-time" });
+      } else if (entry.kind === "workflow") {
+        void runWorkflow(entry.workflowId);
       } else {
         void connect(entry.connection);
       }
     },
-    [connect, playMacro, setOpen]
+    [connect, playMacro, runWorkflow, setOpen]
   );
 
   const handleKeyDown = useCallback(
@@ -234,6 +251,8 @@ export function CommandPalette(): React.ReactElement {
                       <TerminalSquare size={16} />
                     ) : entry.kind === "macro" ? (
                       <Play size={16} />
+                    ) : entry.kind === "workflow" ? (
+                      <WorkflowIcon size={16} />
                     ) : (
                       <ConnectionIcon
                         config={entry.connection.config}
@@ -249,6 +268,8 @@ export function CommandPalette(): React.ReactElement {
                     ) : null
                   ) : entry.kind === "macro" ? (
                     <span className="command-palette__type">macro</span>
+                  ) : entry.kind === "workflow" ? (
+                    <span className="command-palette__type">workflow</span>
                   ) : (
                     <span className="command-palette__type">{entry.connection.config.type}</span>
                   )}

--- a/src/components/Sidebar/ConnectionList.filter.test.tsx
+++ b/src/components/Sidebar/ConnectionList.filter.test.tsx
@@ -157,6 +157,7 @@ describe("ConnectionList — filter/search", () => {
     keydown(input, "Enter");
 
     expect(addTab).toHaveBeenCalledWith("web-server", "local", expect.anything(), {
+      connectionId: "conn-2",
       terminalOptions: undefined,
     });
   });

--- a/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
+++ b/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
@@ -141,6 +141,7 @@ describe("ConnectionList — keyboard navigation & ARIA", () => {
     keydown(item1, "Enter");
 
     expect(addTab).toHaveBeenCalledWith("Connection conn-1", "local", expect.anything(), {
+      connectionId: "conn-1",
       terminalOptions: undefined,
     });
   });

--- a/src/hooks/useConnectSavedConnection.ts
+++ b/src/hooks/useConnectSavedConnection.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
-import { useAppStore } from "@/store/appStore";
+import { useAppStore, type AddTabOptions } from "@/store/appStore";
 import { SavedConnection } from "@/types/connection";
+import type { ConnectionConfig } from "@/types/terminal";
 import {
   createTerminal,
   removeCredential,
@@ -49,6 +50,15 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
       let config = connection.config;
       const cfg = config.config as unknown as Record<string, unknown>;
 
+      // Open a tab for this saved connection, always stamping its `connectionId`
+      // so the on-connect workflow trigger (#1855) can match the freshly opened
+      // session back to the connection it came from.
+      const openTab = (tabConfig: ConnectionConfig, opts: AddTabOptions = {}) =>
+        addTab(connection.name, connection.config.type, tabConfig, {
+          connectionId: connection.id,
+          ...opts,
+        });
+
       // A terminal-less connection type (Capabilities.terminal === false, e.g.
       // FTP) opens into a browser-only tab instead of a terminal tab — no xterm,
       // no PTY. The tab still owns a session so the sidebar file browser can route
@@ -91,7 +101,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
         // Password auth always needs a credential; key auth only when encrypted.
         const needsCredential = authMethod === "password" || (authMethod === "key" && keyEncrypted);
         if (!needsCredential) {
-          addTab(connection.name, connection.config.type, config, {
+          openTab(config, {
             terminalOptions: connection.terminalOptions,
             contentType,
           });
@@ -105,7 +115,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
         // synthetic) connection id and would miss, forcing a redundant prompt
         // even though the password is already known.
         if (typeof cfg.password === "string" && cfg.password.length > 0) {
-          addTab(connection.name, connection.config.type, config, {
+          openTab(config, {
             terminalOptions: connection.terminalOptions,
             contentType,
           });
@@ -137,7 +147,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
           // directly with the resolved credential in its config; the
           // RemoteDesktopTab drives `remote_desktop_connect` itself (#1680).
           if (isGraphical) {
-            addTab(connection.name, connection.config.type, preConfig, {
+            openTab(preConfig, {
               terminalOptions: connection.terminalOptions,
               contentType,
             });
@@ -146,7 +156,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
           try {
             const sessionId = await createTerminal(preConfig);
             // Stored credential worked — open tab with existing session
-            addTab(connection.name, connection.config.type, preConfig, {
+            openTab(preConfig, {
               terminalOptions: connection.terminalOptions,
               sessionId,
               contentType,
@@ -162,7 +172,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
               await removeCredential(connection.id, resolution.credentialType).catch(() => {});
             } else {
               // Non-auth failure — let the Terminal component handle the error
-              addTab(connection.name, connection.config.type, config, {
+              openTab(config, {
                 terminalOptions: connection.terminalOptions,
                 contentType,
               });
@@ -202,7 +212,7 @@ export function useConnectSavedConnection(): UseConnectSavedConnection {
         }
       }
 
-      addTab(connection.name, connection.config.type, config, {
+      openTab(config, {
         terminalOptions: connection.terminalOptions,
         contentType,
       });

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -17,6 +17,10 @@ vi.mock("@/services/keybindings", () => ({
   }),
 }));
 
+vi.mock("@/services/workflowTriggers", () => ({
+  matchHotkeyWorkflow: vi.fn(() => null),
+}));
+
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>
     Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
@@ -53,6 +57,7 @@ import {
   isShellReservedKey,
   isEventFromTerminal,
 } from "@/services/keybindings";
+import { matchHotkeyWorkflow } from "@/services/workflowTriggers";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
@@ -61,6 +66,7 @@ const mockProcessKeyEvent = vi.mocked(processKeyEvent);
 const mockCancelChord = vi.mocked(cancelChord);
 const mockIsShellReservedKey = vi.mocked(isShellReservedKey);
 const mockIsEventFromTerminal = vi.mocked(isEventFromTerminal);
+const mockMatchHotkeyWorkflow = vi.mocked(matchHotkeyWorkflow);
 
 function KeyboardHarness() {
   useKeyboardShortcuts();
@@ -84,6 +90,7 @@ describe("useKeyboardShortcuts", () => {
     // each test starts with shortcuts dispatched normally.
     mockIsEventFromTerminal.mockReturnValue(false);
     mockIsShellReservedKey.mockReturnValue(false);
+    mockMatchHotkeyWorkflow.mockReturnValue(null);
     useAppStore.setState(useAppStore.getInitialState());
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -132,6 +139,39 @@ describe("useKeyboardShortcuts", () => {
       const prevented = fireKey("a");
 
       expect(prevented).toBe(false);
+    });
+  });
+
+  describe("workflow hotkey triggers", () => {
+    it("runs the matched workflow and prevents default when no app action matched", () => {
+      const runWorkflow = vi.fn(() => Promise.resolve());
+      useAppStore.setState({ runWorkflow });
+      act(() => {
+        root.render(createElement(KeyboardHarness));
+      });
+      mockProcessKeyEvent.mockReturnValue(null);
+      mockMatchHotkeyWorkflow.mockReturnValue("wf-1");
+
+      const prevented = fireKey("h", { ctrlKey: true, altKey: true });
+
+      expect(runWorkflow).toHaveBeenCalledWith("wf-1");
+      expect(prevented).toBe(true);
+    });
+
+    it("does not run a workflow when an app action matched the key", () => {
+      const runWorkflow = vi.fn(() => Promise.resolve());
+      useAppStore.setState({ runWorkflow });
+      act(() => {
+        root.render(createElement(KeyboardHarness));
+      });
+      // An app action matched — the workflow-hotkey fallback must not be consulted.
+      mockProcessKeyEvent.mockReturnValue("toggle-sidebar");
+      mockMatchHotkeyWorkflow.mockReturnValue("wf-1");
+
+      fireKey("b", { metaKey: true });
+
+      expect(runWorkflow).not.toHaveBeenCalled();
+      expect(mockMatchHotkeyWorkflow).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -9,6 +9,7 @@ import {
   getActionScope,
 } from "@/services/keybindings";
 import { CONTEXT_COMMANDS } from "@/services/contextCommands";
+import { matchHotkeyWorkflow } from "@/services/workflowTriggers";
 import {
   activeContextFromTab,
   isEventFromTextInput,
@@ -57,7 +58,18 @@ export function useKeyboardShortcuts() {
       }
 
       const action = processKeyEvent(e);
-      if (!action) return;
+      if (!action) {
+        // No app shortcut matched — try workflow `hotkey` triggers (#1855). A
+        // workflow bound to this key runs against the focused terminal via the
+        // store's single-run-at-a-time `runWorkflow`. Checked after app
+        // shortcuts so a user's app binding always wins over a workflow hotkey.
+        const wfId = matchHotkeyWorkflow(e, useAppStore.getState().workflows);
+        if (wfId) {
+          e.preventDefault();
+          void useAppStore.getState().runWorkflow(wfId);
+        }
+        return;
+      }
 
       // chord-pending means the first key of a chord was pressed — just block it
       if (action === "chord-pending") {

--- a/src/services/workflowTriggers.test.ts
+++ b/src/services/workflowTriggers.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  matchHotkeyWorkflow,
+  matchOnConnectWorkflows,
+  dispatchOnConnectTriggers,
+  forgetOnConnectSession,
+  resetOnConnectDispatchState,
+} from "@/services/workflowTriggers";
+import type { Workflow, WorkflowTrigger } from "@/types/workflow";
+
+function makeKeyEvent(
+  key: string,
+  mods: { ctrl?: boolean; shift?: boolean; meta?: boolean; alt?: boolean } = {}
+): KeyboardEvent {
+  return new KeyboardEvent("keydown", {
+    key,
+    ctrlKey: mods.ctrl ?? false,
+    shiftKey: mods.shift ?? false,
+    metaKey: mods.meta ?? false,
+    altKey: mods.alt ?? false,
+  });
+}
+
+function makeWorkflow(id: string, triggers: WorkflowTrigger[]): Workflow {
+  return {
+    id,
+    name: `Workflow ${id}`,
+    tags: [],
+    steps: [{ kind: "send-command", command: "echo hi" }],
+    triggers,
+    createdAt: "2026-07-24T00:00:00Z",
+    updatedAt: "2026-07-24T00:00:00Z",
+  };
+}
+
+describe("matchHotkeyWorkflow", () => {
+  it("returns the workflow whose hotkey binding matches the event", () => {
+    const workflows = [
+      makeWorkflow("a", [{ kind: "hotkey", binding: "Ctrl+Alt+H" }]),
+      makeWorkflow("b", [{ kind: "manual" }]),
+    ];
+    const event = makeKeyEvent("h", { ctrl: true, alt: true });
+    expect(matchHotkeyWorkflow(event, workflows)).toBe("a");
+  });
+
+  it("returns null when no hotkey trigger matches the event", () => {
+    const workflows = [makeWorkflow("a", [{ kind: "hotkey", binding: "Ctrl+Alt+H" }])];
+    const event = makeKeyEvent("j", { ctrl: true, alt: true });
+    expect(matchHotkeyWorkflow(event, workflows)).toBeNull();
+  });
+
+  it("ignores non-hotkey triggers", () => {
+    const workflows = [
+      makeWorkflow("a", [{ kind: "manual" }, { kind: "on-connect", connectionIds: ["c1"] }]),
+    ];
+    const event = makeKeyEvent("h", { ctrl: true, alt: true });
+    expect(matchHotkeyWorkflow(event, workflows)).toBeNull();
+  });
+
+  it("skips workflows with an empty or unbound hotkey binding", () => {
+    const workflows = [
+      makeWorkflow("a", [{ kind: "hotkey", binding: "" }]),
+      makeWorkflow("b", [{ kind: "hotkey", binding: "   " }]),
+    ];
+    const event = makeKeyEvent("", {});
+    expect(matchHotkeyWorkflow(event, workflows)).toBeNull();
+  });
+
+  it("returns the first matching workflow when several share a binding", () => {
+    const workflows = [
+      makeWorkflow("first", [{ kind: "hotkey", binding: "Ctrl+Alt+H" }]),
+      makeWorkflow("second", [{ kind: "hotkey", binding: "Ctrl+Alt+H" }]),
+    ];
+    const event = makeKeyEvent("h", { ctrl: true, alt: true });
+    expect(matchHotkeyWorkflow(event, workflows)).toBe("first");
+  });
+});
+
+describe("matchOnConnectWorkflows", () => {
+  it("returns workflows bound to the given connection id and not others", () => {
+    const workflows = [
+      makeWorkflow("a", [{ kind: "on-connect", connectionIds: ["c1", "c2"] }]),
+      makeWorkflow("b", [{ kind: "on-connect", connectionIds: ["c3"] }]),
+      makeWorkflow("c", [{ kind: "manual" }]),
+    ];
+    expect(matchOnConnectWorkflows("c1", workflows).map((w) => w.id)).toEqual(["a"]);
+    expect(matchOnConnectWorkflows("c3", workflows).map((w) => w.id)).toEqual(["b"]);
+    expect(matchOnConnectWorkflows("c9", workflows)).toEqual([]);
+  });
+});
+
+describe("dispatchOnConnectTriggers", () => {
+  beforeEach(() => {
+    resetOnConnectDispatchState();
+  });
+
+  it("runs each matching workflow against the freshly opened tab", () => {
+    const workflows = [
+      makeWorkflow("a", [{ kind: "on-connect", connectionIds: ["c1"] }]),
+      makeWorkflow("b", [{ kind: "on-connect", connectionIds: ["c1"] }]),
+      makeWorkflow("c", [{ kind: "on-connect", connectionIds: ["c2"] }]),
+    ];
+    const run = vi.fn();
+    dispatchOnConnectTriggers({
+      connectionId: "c1",
+      tabId: "tab-1",
+      sessionId: "sess-1",
+      workflows,
+      run,
+    });
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenCalledWith("a", "tab-1");
+    expect(run).toHaveBeenCalledWith("b", "tab-1");
+  });
+
+  it("does not run when no workflow is bound to the connection", () => {
+    const run = vi.fn();
+    dispatchOnConnectTriggers({
+      connectionId: "c9",
+      tabId: "tab-1",
+      sessionId: "sess-1",
+      workflows: [makeWorkflow("a", [{ kind: "on-connect", connectionIds: ["c1"] }])],
+      run,
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("fires at most once per session open", () => {
+    const workflows = [makeWorkflow("a", [{ kind: "on-connect", connectionIds: ["c1"] }])];
+    const run = vi.fn();
+    const args = {
+      connectionId: "c1",
+      tabId: "tab-1",
+      sessionId: "sess-1",
+      workflows,
+      run,
+    };
+    dispatchOnConnectTriggers(args);
+    dispatchOnConnectTriggers(args);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again for a different session open of the same connection", () => {
+    const workflows = [makeWorkflow("a", [{ kind: "on-connect", connectionIds: ["c1"] }])];
+    const run = vi.fn();
+    dispatchOnConnectTriggers({
+      connectionId: "c1",
+      tabId: "tab-1",
+      sessionId: "sess-1",
+      workflows,
+      run,
+    });
+    dispatchOnConnectTriggers({
+      connectionId: "c1",
+      tabId: "tab-2",
+      sessionId: "sess-2",
+      workflows,
+      run,
+    });
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires again after the session's dispatch record is forgotten", () => {
+    const workflows = [makeWorkflow("a", [{ kind: "on-connect", connectionIds: ["c1"] }])];
+    const run = vi.fn();
+    const args = {
+      connectionId: "c1",
+      tabId: "tab-1",
+      sessionId: "sess-1",
+      workflows,
+      run,
+    };
+    dispatchOnConnectTriggers(args);
+    forgetOnConnectSession("sess-1");
+    dispatchOnConnectTriggers(args);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/workflowTriggers.ts
+++ b/src/services/workflowTriggers.ts
@@ -1,0 +1,112 @@
+/**
+ * Workflow trigger dispatch (#1855) — the runtime that *fires* the triggers
+ * authored on a {@link Workflow} (the trigger data model and editing UI ship in
+ * #1852 / #1854). This module owns the pure matching logic and the once-per
+ * session-open guard for on-connect; the actual run is delegated back to the
+ * store's `runWorkflow` so single-run-at-a-time enforcement is not duplicated.
+ *
+ * Three trigger kinds dispatch through here:
+ * - `manual` — surfaced as command-palette entries and the sidebar run action
+ *   (no matching needed; those call `runWorkflow` directly).
+ * - `hotkey` — {@link matchHotkeyWorkflow} maps a keyboard event to a workflow,
+ *   reusing the shared keybinding parser so workflow hotkeys and app shortcuts
+ *   speak the same combo language.
+ * - `on-connect` — {@link dispatchOnConnectTriggers} runs every workflow bound
+ *   to a connection when a session for it finishes opening.
+ */
+import type { Workflow } from "@/types/workflow";
+import type { KeyCombo } from "@/types/keybindings";
+import { parseBinding, eventMatchesCombo, isUnboundCombo } from "@/services/keybindings";
+
+/**
+ * Find the first workflow whose `hotkey` trigger binding matches `event`.
+ *
+ * Bindings are parsed through the shared {@link parseBinding} so a workflow
+ * hotkey resolves identically to an app shortcut. Empty or explicitly unbound
+ * bindings are skipped — a workflow whose hotkey was cleared must not fire — and
+ * only single-combo bindings are considered (chords remain an app-shortcut
+ * concept). Returns the matching workflow id, or `null` when none match.
+ */
+export function matchHotkeyWorkflow(event: KeyboardEvent, workflows: Workflow[]): string | null {
+  for (const workflow of workflows) {
+    for (const trigger of workflow.triggers) {
+      if (trigger.kind !== "hotkey") continue;
+      const binding = trigger.binding?.trim();
+      if (!binding) continue;
+
+      const parsed = parseBinding(binding);
+      if (isUnboundCombo(parsed)) continue;
+
+      const combo: KeyCombo | undefined = Array.isArray(parsed) ? parsed[0] : parsed;
+      if (!combo || combo.key === "") continue;
+
+      if (eventMatchesCombo(event, combo)) return workflow.id;
+    }
+  }
+  return null;
+}
+
+/** Every workflow with an `on-connect` trigger bound to `connectionId`. */
+export function matchOnConnectWorkflows(connectionId: string, workflows: Workflow[]): Workflow[] {
+  return workflows.filter((workflow) =>
+    workflow.triggers.some(
+      (trigger) => trigger.kind === "on-connect" && trigger.connectionIds.includes(connectionId)
+    )
+  );
+}
+
+/**
+ * Session opens already dispatched, keyed by backend session id. Enforces the
+ * "at most once per session open" guard so a session-open signal delivered more
+ * than once (React strict-mode double-invoke, a re-registration) does not run
+ * the on-connect workflows twice.
+ */
+const dispatchedSessions = new Set<string>();
+
+/** Arguments for {@link dispatchOnConnectTriggers}. */
+export interface OnConnectDispatch {
+  /** Saved-connection id the freshly opened session belongs to. */
+  connectionId: string;
+  /** The tab the workflow should run against. */
+  tabId: string;
+  /** Backend session id — the once-per-session-open guard key. */
+  sessionId: string;
+  /** Current set of saved workflows to match against. */
+  workflows: Workflow[];
+  /** Run a matched workflow against the freshly opened tab. */
+  run: (workflowId: string, tabId: string) => void;
+}
+
+/**
+ * Run every workflow whose `on-connect` trigger names `connectionId`, against
+ * the freshly opened `tabId`. Guarded by `sessionId` so a given session open
+ * fires at most once. The interactive-shell-only guard is applied by the caller
+ * (the session-open path only invokes this for terminal tabs).
+ */
+export function dispatchOnConnectTriggers({
+  connectionId,
+  tabId,
+  sessionId,
+  workflows,
+  run,
+}: OnConnectDispatch): void {
+  if (dispatchedSessions.has(sessionId)) return;
+
+  const matches = matchOnConnectWorkflows(connectionId, workflows);
+  if (matches.length === 0) return;
+
+  dispatchedSessions.add(sessionId);
+  for (const workflow of matches) {
+    run(workflow.id, tabId);
+  }
+}
+
+/** Forget a session's dispatch record (e.g. when its tab disconnects/closes). */
+export function forgetOnConnectSession(sessionId: string): void {
+  dispatchedSessions.delete(sessionId);
+}
+
+/** Clear all on-connect dispatch state. Intended for tests. */
+export function resetOnConnectDispatchState(): void {
+  dispatchedSessions.clear();
+}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -185,6 +185,7 @@ import {
   type WorkflowRunMacroSeam,
   type WorkflowRunHandle,
 } from "@/services/workflowRunner";
+import { dispatchOnConnectTriggers } from "@/services/workflowTriggers";
 import {
   saveLastSession as apiSaveLastSession,
   loadLastSession as apiLoadLastSession,
@@ -262,6 +263,12 @@ export interface AddTabOptions {
   sessionId?: string | null;
   /** Persistent-connection id this tab is attached to, if any. */
   persistentConnectionId?: string;
+  /**
+   * Saved-connection id this tab is opened from, if any. Threaded onto the tab
+   * so the on-connect workflow trigger (#1855) can match the freshly opened
+   * session back to its connection.
+   */
+  connectionId?: string;
   /**
    * Marks the tab as an externally spawned session with no saved connection
    * (#1446). Defaults to `false`.
@@ -2495,7 +2502,29 @@ export const useAppStore = create<AppState>((set, get) => {
       });
       // A non-null session id means this tab has connected — settle it in any
       // in-flight restore/launch cohort so the aggregate summary can fire (#1146).
-      if (sessionId) get().settleRestoreTab(tabId, "connected");
+      if (sessionId) {
+        get().settleRestoreTab(tabId, "connected");
+
+        // On-connect workflow triggers (#1855): a terminal session that opened
+        // for a saved connection runs any workflow bound to that connection,
+        // once per session open (interactive shells only — file-browser and
+        // remote-desktop tabs are excluded here). Matching/guarding lives in the
+        // workflowTriggers service; the store only supplies state and the run.
+        const connectedTab = getAllLeaves(get().rootPanel)
+          .flatMap((l) => l.tabs)
+          .find((t) => t.id === tabId);
+        if (connectedTab?.contentType === "terminal" && connectedTab.connectionId) {
+          dispatchOnConnectTriggers({
+            connectionId: connectedTab.connectionId,
+            tabId,
+            sessionId,
+            workflows: get().workflows,
+            run: (workflowId, targetTabId) => {
+              void get().runWorkflow(workflowId, { targetTabId });
+            },
+          });
+        }
+      }
     },
 
     addTab: (title, connectionType, config, options) => {
@@ -2505,6 +2534,7 @@ export const useAppStore = create<AppState>((set, get) => {
         terminalOptions,
         sessionId,
         persistentConnectionId,
+        connectionId,
         spawned,
         initialCommand,
       } = options ?? {};
@@ -2518,7 +2548,7 @@ export const useAppStore = create<AppState>((set, get) => {
           type: "local",
           config: { shell: state.defaultShell },
         };
-        const newTab = createTab(
+        const baseTab = createTab(
           title,
           connectionType,
           defaultConfig,
@@ -2529,6 +2559,7 @@ export const useAppStore = create<AppState>((set, get) => {
           spawned,
           initialCommand
         );
+        const newTab: TerminalTab = connectionId ? { ...baseTab, connectionId } : baseTab;
         createdTabId = newTab.id;
         const rootPanel = updateLeaf(state.rootPanel, targetPanelId, (leaf) => {
           const tabs = leaf.tabs.map((t) => ({ ...t, isActive: false }));

--- a/src/store/appStore.workflowRun.test.ts
+++ b/src/store/appStore.workflowRun.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/services/workflowApi", () => ({
 import { useAppStore } from "./appStore";
 import { registerTerminalInputInjector } from "@/services/macroPlayback";
 import { serializeWorkflows } from "@/services/workflowIo";
+import { resetOnConnectDispatchState } from "@/services/workflowTriggers";
 import { toast } from "@/components/ui";
 
 const workflow = (id: string, steps: WorkflowStep[]): Workflow => ({
@@ -92,6 +93,7 @@ describe("appStore — workflow run slice (#1852)", () => {
 
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
+    resetOnConnectDispatchState();
     savedWorkflows.length = 0;
     injected = [];
     registerTerminalInputInjector(async (_tabId, data) => {
@@ -278,5 +280,90 @@ describe("appStore — workflow run slice (#1852)", () => {
     // A fresh id is assigned on import (never the file's original id).
     expect(imported[0].id).not.toBe("original");
     expect(imported[0].steps).toEqual([cmd("ls")]);
+  });
+});
+
+describe("appStore — on-connect trigger dispatch (#1855)", () => {
+  let injected: string[];
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    resetOnConnectDispatchState();
+    injected = [];
+    registerTerminalInputInjector(async (_tabId, data) => {
+      injected.push(data);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    registerTerminalInputInjector(null);
+    vi.restoreAllMocks();
+  });
+
+  /** Seed a terminal tab opened from `connectionId`, not yet connected. */
+  function seedUnconnectedTab(connectionId: string | undefined, tabId = "tab-oc") {
+    const tab: TerminalTab = {
+      id: tabId,
+      sessionId: null,
+      title: "term",
+      connectionType: "ssh",
+      contentType: "terminal",
+      config: { type: "ssh", config: {} },
+      panelId: "leaf-1",
+      isActive: true,
+      ...(connectionId ? { connectionId } : {}),
+    };
+    const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs: [tab], activeTabId: tabId };
+    useAppStore.setState({ rootPanel: leaf, activePanelId: "leaf-1", terminalExitedTabs: {} });
+  }
+
+  function onConnectWorkflow(id: string, connectionIds: string[]): Workflow {
+    return {
+      ...workflow(id, [cmd(`echo ${id}`)]),
+      triggers: [{ kind: "on-connect", connectionIds }],
+    };
+  }
+
+  it("runs an on-connect workflow when a bound connection's session opens", async () => {
+    useAppStore.setState({ workflows: [onConnectWorkflow("wf-a", ["conn-1"])] });
+    seedUnconnectedTab("conn-1");
+
+    useAppStore.getState().setTabSessionId("tab-oc", "sess-oc-1");
+
+    await vi.waitFor(() => expect(injected).toContain("echo wf-a\n"));
+  });
+
+  it("does not run for a connection with no matching on-connect trigger", async () => {
+    useAppStore.setState({ workflows: [onConnectWorkflow("wf-a", ["conn-other"])] });
+    seedUnconnectedTab("conn-1");
+
+    useAppStore.getState().setTabSessionId("tab-oc", "sess-oc-2");
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(injected).toEqual([]);
+  });
+
+  it("fires at most once per session open", async () => {
+    useAppStore.setState({ workflows: [onConnectWorkflow("wf-a", ["conn-1"])] });
+    seedUnconnectedTab("conn-1");
+
+    useAppStore.getState().setTabSessionId("tab-oc", "sess-oc-3");
+    await vi.waitFor(() => expect(injected).toContain("echo wf-a\n"));
+    // A redundant session-open signal for the same session must not re-run it.
+    useAppStore.getState().setTabSessionId("tab-oc", "sess-oc-3");
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(injected.filter((d) => d === "echo wf-a\n")).toHaveLength(1);
+  });
+
+  it("does not run on-connect workflows for a tab with no connection id", async () => {
+    useAppStore.setState({ workflows: [onConnectWorkflow("wf-a", ["conn-1"])] });
+    seedUnconnectedTab(undefined);
+
+    useAppStore.getState().setTabSessionId("tab-oc", "sess-oc-4");
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(injected).toEqual([]);
   });
 });

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -303,6 +303,13 @@ export interface TerminalTab {
    */
   persistentConnectionId?: string;
   /**
+   * Id of the saved connection this tab was opened from, when known. Threaded
+   * so the on-connect workflow trigger (#1855) can match a freshly opened
+   * session back to the connection it came from. Absent for local/unmanaged
+   * tabs and externally spawned sessions.
+   */
+  connectionId?: string;
+  /**
    * Set when this tab was opened from an external spawn (`termiHub spawn …`,
    * #1446) as a "new container". Spawned containers have no saved connection id;
    * this flag drives the tab's "Spawned" badge and the separate grouping in the


### PR DESCRIPTION
## Summary

Implements **trigger dispatch** for the Workflow Automation epic (#1851) — the runtime that *fires* the triggers authored on a workflow (data model #1852, step types #1853, sidebar/editor #1854). All three trigger kinds now launch a workflow through the store's existing single-run-at-a-time `runWorkflow`:

- **manual** — every saved workflow gets a `Run Workflow: <name>` command-palette entry (mirroring the existing macro entries), in addition to the sidebar run action from #1854.
- **hotkey** — a workflow's `hotkey` trigger binding is matched against key events in `useKeyboardShortcuts`, reusing the shared keybinding parser/matcher. Checked only after no app shortcut claims the key (app bindings win), and explicitly-unbound/empty bindings never fire (respects #1827).
- **on-connect** — when an interactive terminal session for a bound connection finishes opening, any workflow whose `on-connect` trigger names that connection runs against the fresh session, **once per session open**.

## How it fits together

- New `src/services/workflowTriggers.ts` holds the pure matching logic (`matchHotkeyWorkflow`, `matchOnConnectWorkflows`) and the once-per-session-open dispatch guard. Running is delegated back to the store — the runner is not re-implemented.
- The saved `connectionId` is threaded onto terminal tabs (via `addTab` and the shared saved-connection connect flow). At the session-open choke point (`setTabSessionId`, where a tab first gains a session id), a single call dispatches on-connect triggers for interactive terminal tabs only (file-browser / remote-desktop tabs are excluded). Dispatch logic stays in the service; `appStore` changes are additive.

## Tests

- `workflowTriggers.test.ts` — hotkey event matching (match / no-match / ignores non-hotkey / skips empty-unbound / first-wins), on-connect connection matching, and the once-per-session guard (fires once, re-fires for a new session, re-fires after the record is forgotten).
- `useKeyboardShortcuts.test.ts` — a matched workflow hotkey runs `runWorkflow` and prevents default; an app-action match short-circuits the workflow fallback.
- `CommandPalette.test.tsx` — the `Run Workflow: <name>` entry runs the workflow via the manual trigger and closes.
- `appStore.workflowRun.test.ts` — end-to-end: opening a bound connection's session streams the on-connect workflow into the terminal, once per session open; no run for unmatched connections or tabs without a connection id.

Full frontend suite green (3958 tests); `./scripts/check.sh` passes.

## Notes

The trigger model shipped in #1852 has no per-trigger `enabled` flag, so the "individually toggleable" guard-rail from the issue is satisfied by editing the trigger's connection list in the #1854 editor rather than a separate toggle; no model change was made (the union is frozen).

Closes #1855