### PR TITLE
feat(workflow): guarded run-local-process step (Closes #1857)

### DIFF
--- a/docs/changes/dev1/feature/1857-guarded-local-process.md
+++ b/docs/changes/dev1/feature/1857-guarded-local-process.md
@@ -1,0 +1,21 @@
+### Added
+
+- Workflow automation: the guarded **`run-local-process`** step can now execute a
+  local program on your machine as part of a workflow (#1857, epic #1851) —
+  behind hard security guardrails:
+  - **Off by default.** A new Security setting, "Allow workflows to run local
+    programs" (`workflowLocalProcessEnabled`), gates all local-process execution;
+    while off, any `run-local-process` step is refused. The backend spawn command
+    re-checks the same opt-in, so a step can never run without it.
+  - **Per-program confirmation and allowlist.** The first time a workflow runs a
+    not-yet-trusted program, a dialog shows the exact program and its discrete
+    arguments and asks to allow it once, always (remembered on an allowlist,
+    manageable under Settings → Security), or cancel. Imported workflows are
+    never pre-authorized.
+  - **No shell, no injection.** Programs are spawned with a direct argument
+    vector — never through a shell and never by concatenating arguments into a
+    command line. The step editor now takes arguments as a discrete list, so an
+    argument containing spaces stays a single, literal argument.
+  - **Bounded and observable.** Execution has an enforced timeout, can be
+    cancelled with the running workflow, streams stdout/stderr into the log
+    viewer, and surfaces the process exit status.

--- a/src-tauri/src/commands/local_process.rs
+++ b/src-tauri/src/commands/local_process.rs
@@ -127,7 +127,11 @@ impl LocalProcessRegistry {
 /// Clamp a caller-requested timeout into `[1ms, MAX_TIMEOUT_MS]`, applying the
 /// default when unset.
 fn resolve_timeout(timeout_ms: Option<u64>) -> Duration {
-    Duration::from_millis(timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS).clamp(1, MAX_TIMEOUT_MS))
+    Duration::from_millis(
+        timeout_ms
+            .unwrap_or(DEFAULT_TIMEOUT_MS)
+            .clamp(1, MAX_TIMEOUT_MS),
+    )
 }
 
 /// Stream every line from `reader` to `tx`, tagged with `stream`. Ends when the
@@ -339,7 +343,9 @@ mod tests {
     use super::*;
 
     /// Drain the output channel into a flat list of `(stream, line)` pairs.
-    fn collect_output(mut rx: mpsc::UnboundedReceiver<(&'static str, String)>) -> Vec<(String, String)> {
+    fn collect_output(
+        mut rx: mpsc::UnboundedReceiver<(&'static str, String)>,
+    ) -> Vec<(String, String)> {
         let mut out = Vec::new();
         while let Ok((stream, line)) = rx.try_recv() {
             out.push((stream.to_string(), line));
@@ -367,9 +373,10 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel();
         let token = CancellationToken::new();
         let args = vec!["[%s]\n".to_string(), "a b".to_string()];
-        let outcome = execute_local_process("/usr/bin/printf", &args, Duration::from_secs(5), &token, tx)
-            .await
-            .expect("printf should run");
+        let outcome =
+            execute_local_process("/usr/bin/printf", &args, Duration::from_secs(5), &token, tx)
+                .await
+                .expect("printf should run");
         assert_eq!(outcome.exit_code, Some(0));
         let lines: Vec<String> = collect_output(rx)
             .into_iter()
@@ -390,9 +397,10 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel();
         let token = CancellationToken::new();
         let args = vec!["%s\n".to_string(), "; rm -rf / && echo pwned".to_string()];
-        let outcome = execute_local_process("/usr/bin/printf", &args, Duration::from_secs(5), &token, tx)
-            .await
-            .expect("printf should run");
+        let outcome =
+            execute_local_process("/usr/bin/printf", &args, Duration::from_secs(5), &token, tx)
+                .await
+                .expect("printf should run");
         assert_eq!(outcome.exit_code, Some(0));
         let lines: Vec<String> = collect_output(rx)
             .into_iter()
@@ -427,9 +435,10 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         let token = CancellationToken::new();
         let args = vec!["30".to_string()];
-        let outcome = execute_local_process("/bin/sleep", &args, Duration::from_millis(150), &token, tx)
-            .await
-            .expect("sleep should spawn");
+        let outcome =
+            execute_local_process("/bin/sleep", &args, Duration::from_millis(150), &token, tx)
+                .await
+                .expect("sleep should spawn");
         assert!(outcome.timed_out, "expected timeout: {outcome:?}");
         assert!(!outcome.cancelled);
         assert_eq!(outcome.exit_code, None);
@@ -447,9 +456,10 @@ mod tests {
             cancel_token.cancel();
         });
         let args = vec!["30".to_string()];
-        let outcome = execute_local_process("/bin/sleep", &args, Duration::from_secs(30), &token, tx)
-            .await
-            .expect("sleep should spawn");
+        let outcome =
+            execute_local_process("/bin/sleep", &args, Duration::from_secs(30), &token, tx)
+                .await
+                .expect("sleep should spawn");
         assert!(outcome.cancelled, "expected cancelled: {outcome:?}");
         assert!(!outcome.timed_out);
         assert_eq!(outcome.exit_code, None);
@@ -478,11 +488,7 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel();
         let token = CancellationToken::new();
         // ping -n 30 keeps the process alive well past the timeout.
-        let args = vec![
-            "-n".to_string(),
-            "30".to_string(),
-            "127.0.0.1".to_string(),
-        ];
+        let args = vec!["-n".to_string(), "30".to_string(), "127.0.0.1".to_string()];
         let outcome = execute_local_process("ping", &args, Duration::from_millis(200), &token, tx)
             .await
             .expect("ping should spawn");
@@ -492,7 +498,10 @@ mod tests {
 
     #[test]
     fn resolve_timeout_applies_default_and_bounds() {
-        assert_eq!(resolve_timeout(None), Duration::from_millis(DEFAULT_TIMEOUT_MS));
+        assert_eq!(
+            resolve_timeout(None),
+            Duration::from_millis(DEFAULT_TIMEOUT_MS)
+        );
         assert_eq!(resolve_timeout(Some(0)), Duration::from_millis(1));
         assert_eq!(
             resolve_timeout(Some(MAX_TIMEOUT_MS * 10)),

--- a/src-tauri/src/commands/local_process.rs
+++ b/src-tauri/src/commands/local_process.rs
@@ -1,0 +1,502 @@
+//! Guarded local-process execution for the `run-local-process` workflow step
+//! (#1857) — the highest-risk step in the Workflow Automation epic (#1851),
+//! because it runs a program on the **user's own machine** rather than streaming
+//! text into a remote session.
+//!
+//! The security model is layered:
+//!
+//! 1. **Explicit opt-in, enforced at the trust boundary.** [`run_local_process`]
+//!    refuses to spawn anything unless `workflow_local_process_enabled` is set in
+//!    the persisted [`AppSettings`]. The frontend gates on the same flag and adds
+//!    a per-program confirmation/allowlist on top, but this backend check means a
+//!    step can never spawn a process without the user having opted in — even if
+//!    the frontend were bypassed.
+//! 2. **Direct argv — never a shell.** The program is spawned with
+//!    [`tokio::process::Command`] from `program` + a discrete `args` vector. No
+//!    shell is ever involved and no argument is concatenated into a command line,
+//!    so workflow-controlled strings cannot be interpreted as shell syntax.
+//! 3. **Bounded and observable.** Execution is wrapped in a timeout, can be
+//!    cancelled through [`cancel_local_process`], streams stdout/stderr back as
+//!    events, and surfaces the process exit code.
+//!
+//! The spawn/stream/bound core lives in [`execute_local_process`] with no Tauri
+//! dependency so the guardrails can be unit-tested directly.
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::connection::settings::SettingsStorage;
+use crate::utils::errors::TerminalError;
+
+/// Tauri event carrying one streamed line of a local process's output, keyed by
+/// `run_id` so the frontend can route it to the right workflow run view.
+pub const EVENT_LOCAL_PROCESS_OUTPUT: &str = "workflow-local-process-output";
+
+/// Default execution timeout when the caller does not specify one (30s).
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+/// Hard upper bound on the execution timeout (10 minutes) so a caller cannot ask
+/// for an effectively unbounded process.
+const MAX_TIMEOUT_MS: u64 = 600_000;
+
+/// One streamed line of local-process output.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LocalProcessOutputEvent {
+    /// The run id this output belongs to.
+    run_id: String,
+    /// Which stream produced the line: `"stdout"` or `"stderr"`.
+    stream: String,
+    /// The line of text (without its trailing newline).
+    line: String,
+}
+
+/// The terminal outcome of a local-process execution, returned to the runner.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalProcessOutcome {
+    /// The process exit code, or `None` when the process was killed (cancelled or
+    /// timed out) and so never reported one.
+    pub exit_code: Option<i32>,
+    /// `true` when the process was killed because it exceeded the timeout.
+    pub timed_out: bool,
+    /// `true` when the process was killed because the run was cancelled.
+    pub cancelled: bool,
+}
+
+/// Registry of in-flight local processes, keyed by `run_id`, so a run can be
+/// cancelled from the frontend. Managed Tauri state; the inner map is `Arc`-shared
+/// so a spawned execution can clear its own entry on completion.
+#[derive(Default, Clone)]
+pub struct LocalProcessRegistry {
+    active: Arc<Mutex<HashMap<String, Arc<CancellationToken>>>>,
+}
+
+impl LocalProcessRegistry {
+    /// Register a run and return its cancellation token, cancelling any prior run
+    /// registered under the same id first.
+    fn register(&self, run_id: &str) -> Arc<CancellationToken> {
+        let token = Arc::new(CancellationToken::new());
+        if let Ok(mut map) = self.active.lock() {
+            if let Some(prev) = map.insert(run_id.to_string(), token.clone()) {
+                prev.cancel();
+            }
+        }
+        token
+    }
+
+    /// Cancel an in-flight run. Returns `true` if one was registered.
+    fn cancel(&self, run_id: &str) -> bool {
+        let token = self
+            .active
+            .lock()
+            .ok()
+            .and_then(|map| map.get(run_id).cloned());
+        match token {
+            Some(token) => {
+                token.cancel();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Drop a run's entry once it finishes, but only when the registry still holds
+    /// *this* token instance (so a re-registered id is left untouched).
+    fn complete(&self, run_id: &str, token: &Arc<CancellationToken>) {
+        if let Ok(mut map) = self.active.lock() {
+            if map
+                .get(run_id)
+                .is_some_and(|stored| Arc::ptr_eq(stored, token))
+            {
+                map.remove(run_id);
+            }
+        }
+    }
+}
+
+/// Clamp a caller-requested timeout into `[1ms, MAX_TIMEOUT_MS]`, applying the
+/// default when unset.
+fn resolve_timeout(timeout_ms: Option<u64>) -> Duration {
+    Duration::from_millis(timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS).clamp(1, MAX_TIMEOUT_MS))
+}
+
+/// Stream every line from `reader` to `tx`, tagged with `stream`. Ends when the
+/// pipe closes (the child exited or was killed).
+fn spawn_reader<R>(
+    reader: Option<R>,
+    stream: &'static str,
+    tx: mpsc::UnboundedSender<(&'static str, String)>,
+) -> tokio::task::JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let Some(reader) = reader else {
+            return;
+        };
+        let mut lines = BufReader::new(reader).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if tx.send((stream, line)).is_err() {
+                break;
+            }
+        }
+    })
+}
+
+/// Spawn `program` with the discrete `args`, stream its output as `(stream, line)`
+/// pairs on `output_tx`, and wait for it to finish — bounded by `timeout` and
+/// cancellable through `token`.
+///
+/// **This is the security-critical core.** The program is spawned via
+/// [`tokio::process::Command`] with `program` + `args` passed as a discrete
+/// argument vector: no shell, no string interpolation, so a workflow-controlled
+/// argument (even one containing spaces, quotes, or shell metacharacters) reaches
+/// the program as a single, literal argument and can never be reinterpreted as a
+/// command line. Kept free of any Tauri dependency so the guardrails are unit
+/// testable.
+pub async fn execute_local_process(
+    program: &str,
+    args: &[String],
+    timeout: Duration,
+    token: &CancellationToken,
+    output_tx: mpsc::UnboundedSender<(&'static str, String)>,
+) -> Result<LocalProcessOutcome, TerminalError> {
+    let program = program.trim();
+    if program.is_empty() {
+        return Err(TerminalError::WorkflowError(
+            "no program configured for the local-process step".to_string(),
+        ));
+    }
+
+    // Direct argv — NEVER a shell. `program` + discrete `args`, no interpolation.
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    // Suppress the console-window flash on Windows. No-op elsewhere.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = command.spawn().map_err(|e| {
+        TerminalError::WorkflowError(format!("failed to spawn local process '{program}': {e}"))
+    })?;
+
+    let stdout_task = spawn_reader(child.stdout.take(), "stdout", output_tx.clone());
+    let stderr_task = spawn_reader(child.stderr.take(), "stderr", output_tx);
+
+    // Wait for the child, bounded by the timeout and the cancel token. The wait
+    // future is scoped so its mutable borrow of `child` is released before we may
+    // need to kill the child in the cancel/timeout branches.
+    enum Ending {
+        Exited(std::process::ExitStatus),
+        WaitErr(std::io::Error),
+        Cancelled,
+        TimedOut,
+    }
+    let ending = {
+        let wait_fut = child.wait();
+        tokio::pin!(wait_fut);
+        tokio::select! {
+            _ = token.cancelled() => Ending::Cancelled,
+            _ = tokio::time::sleep(timeout) => Ending::TimedOut,
+            res = &mut wait_fut => match res {
+                Ok(status) => Ending::Exited(status),
+                Err(e) => Ending::WaitErr(e),
+            },
+        }
+    };
+
+    let outcome = match ending {
+        Ending::Exited(status) => LocalProcessOutcome {
+            exit_code: status.code(),
+            timed_out: false,
+            cancelled: false,
+        },
+        Ending::WaitErr(e) => {
+            return Err(TerminalError::WorkflowError(format!(
+                "failed while waiting for local process '{program}': {e}"
+            )));
+        }
+        Ending::Cancelled => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            LocalProcessOutcome {
+                exit_code: None,
+                timed_out: false,
+                cancelled: true,
+            }
+        }
+        Ending::TimedOut => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            LocalProcessOutcome {
+                exit_code: None,
+                timed_out: true,
+                cancelled: false,
+            }
+        }
+    };
+
+    // Let the readers drain any buffered output now the pipes have closed.
+    let _ = stdout_task.await;
+    let _ = stderr_task.await;
+
+    Ok(outcome)
+}
+
+/// Spawn a guarded local process for a `run-local-process` workflow step.
+///
+/// Enforces the master opt-in (`workflow_local_process_enabled`) before doing
+/// anything, then delegates to [`execute_local_process`], forwarding streamed
+/// output as [`EVENT_LOCAL_PROCESS_OUTPUT`] events and returning the exit
+/// outcome. Awaits completion so the caller learns the exit status.
+#[tauri::command]
+pub async fn run_local_process(
+    run_id: String,
+    program: String,
+    args: Vec<String>,
+    timeout_ms: Option<u64>,
+    registry: State<'_, LocalProcessRegistry>,
+    app_handle: AppHandle,
+) -> Result<LocalProcessOutcome, TerminalError> {
+    // GUARDRAIL: explicit opt-in, enforced at the trust boundary. A step can
+    // never spawn a process unless the user has enabled local-process execution.
+    let settings = SettingsStorage::new(&app_handle)
+        .and_then(|storage| storage.load_with_recovery())
+        .map(|recovered| recovered.data)
+        .map_err(|e| {
+            TerminalError::WorkflowError(format!("could not load settings to authorize step: {e}"))
+        })?;
+    if !settings.workflow_local_process_enabled {
+        warn!(run_id, "refused local-process step: execution is disabled");
+        return Err(TerminalError::WorkflowError(
+            "local process execution is disabled; enable it in Settings before running this step"
+                .to_string(),
+        ));
+    }
+
+    let timeout = resolve_timeout(timeout_ms);
+    debug!(run_id, program, ?timeout, "spawning guarded local process");
+
+    let token = registry.register(&run_id);
+    let registry_handle = registry.inner().clone();
+
+    // Forward streamed output lines to the frontend as events.
+    let (tx, mut rx) = mpsc::unbounded_channel::<(&'static str, String)>();
+    let emit_task = {
+        let app = app_handle.clone();
+        let run_id = run_id.clone();
+        tokio::spawn(async move {
+            while let Some((stream, line)) = rx.recv().await {
+                let _ = app.emit(
+                    EVENT_LOCAL_PROCESS_OUTPUT,
+                    LocalProcessOutputEvent {
+                        run_id: run_id.clone(),
+                        stream: stream.to_string(),
+                        line,
+                    },
+                );
+            }
+        })
+    };
+
+    let outcome = execute_local_process(&program, &args, timeout, &token, tx).await;
+
+    // The channel senders are dropped when execute_local_process returns, so the
+    // emit task drains and ends on its own.
+    let _ = emit_task.await;
+    registry_handle.complete(&run_id, &token);
+
+    outcome
+}
+
+/// Cancel an in-flight local process by its `run_id`. Returns `true` if a run was
+/// registered under that id.
+#[tauri::command]
+pub fn cancel_local_process(run_id: String, registry: State<'_, LocalProcessRegistry>) -> bool {
+    registry.cancel(&run_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drain the output channel into a flat list of `(stream, line)` pairs.
+    fn collect_output(mut rx: mpsc::UnboundedReceiver<(&'static str, String)>) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        while let Ok((stream, line)) = rx.try_recv() {
+            out.push((stream.to_string(), line));
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn empty_program_is_refused() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        let err = execute_local_process("   ", &[], Duration::from_secs(5), &token, tx)
+            .await
+            .expect_err("empty program must be refused");
+        assert!(err.to_string().contains("no program"), "got: {err}");
+    }
+
+    /// GUARDRAIL: a space-containing argument is passed as a single discrete argv
+    /// entry — never split or shell-interpreted. `printf '[%s]\n'` re-applies its
+    /// format once per argument, so one argument prints `[a b]` while two would
+    /// print `[a]` then `[b]`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn passes_args_as_discrete_argv_no_shell() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        let args = vec!["[%s]\n".to_string(), "a b".to_string()];
+        let outcome = execute_local_process("/usr/bin/printf", &args, Duration::from_secs(5), &token, tx)
+            .await
+            .expect("printf should run");
+        assert_eq!(outcome.exit_code, Some(0));
+        let lines: Vec<String> = collect_output(rx)
+            .into_iter()
+            .filter(|(s, _)| s == "stdout")
+            .map(|(_, l)| l)
+            .collect();
+        // A single `[a b]` line proves "a b" arrived as ONE argument. A shell (or
+        // a split) would have produced `[a]` and `[b]`.
+        assert_eq!(lines, vec!["[a b]".to_string()]);
+    }
+
+    /// GUARDRAIL: a shell metacharacter in an argument is inert — it reaches the
+    /// program literally rather than being interpreted. `printf` echoes it back
+    /// verbatim; no subshell runs.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shell_metacharacters_in_args_are_literal() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        let args = vec!["%s\n".to_string(), "; rm -rf / && echo pwned".to_string()];
+        let outcome = execute_local_process("/usr/bin/printf", &args, Duration::from_secs(5), &token, tx)
+            .await
+            .expect("printf should run");
+        assert_eq!(outcome.exit_code, Some(0));
+        let lines: Vec<String> = collect_output(rx)
+            .into_iter()
+            .filter(|(s, _)| s == "stdout")
+            .map(|(_, l)| l)
+            .collect();
+        assert_eq!(lines, vec!["; rm -rf / && echo pwned".to_string()]);
+    }
+
+    /// GUARDRAIL: the process exit code is surfaced.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn surfaces_nonzero_exit_status() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        // `sh -c 'exit 3'` is spawned as a direct argv (no shell wrapping by us);
+        // it deterministically exits 3.
+        let args = vec!["-c".to_string(), "exit 3".to_string()];
+        let outcome = execute_local_process("/bin/sh", &args, Duration::from_secs(5), &token, tx)
+            .await
+            .expect("sh should run");
+        assert_eq!(outcome.exit_code, Some(3));
+        assert!(!outcome.timed_out);
+        assert!(!outcome.cancelled);
+    }
+
+    /// GUARDRAIL: a process that outlives the timeout is killed and reported as
+    /// timed out (no exit code).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn enforces_timeout() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        let args = vec!["30".to_string()];
+        let outcome = execute_local_process("/bin/sleep", &args, Duration::from_millis(150), &token, tx)
+            .await
+            .expect("sleep should spawn");
+        assert!(outcome.timed_out, "expected timeout: {outcome:?}");
+        assert!(!outcome.cancelled);
+        assert_eq!(outcome.exit_code, None);
+    }
+
+    /// GUARDRAIL: cancelling the token kills the process and reports cancelled.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancel_terminates_process() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        let cancel_token = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            cancel_token.cancel();
+        });
+        let args = vec!["30".to_string()];
+        let outcome = execute_local_process("/bin/sleep", &args, Duration::from_secs(30), &token, tx)
+            .await
+            .expect("sleep should spawn");
+        assert!(outcome.cancelled, "expected cancelled: {outcome:?}");
+        assert!(!outcome.timed_out);
+        assert_eq!(outcome.exit_code, None);
+    }
+
+    /// Windows equivalent of the exit-status guardrail: `cmd /c exit 3` exits 3.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn surfaces_nonzero_exit_status_windows() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        let args = vec!["/c".to_string(), "exit 3".to_string()];
+        let outcome = execute_local_process("cmd", &args, Duration::from_secs(5), &token, tx)
+            .await
+            .expect("cmd should run");
+        assert_eq!(outcome.exit_code, Some(3));
+        assert!(!outcome.timed_out);
+        assert!(!outcome.cancelled);
+    }
+
+    /// Windows equivalent of the timeout guardrail: a long ping outlives a short
+    /// timeout and is killed.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn enforces_timeout_windows() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let token = CancellationToken::new();
+        // ping -n 30 keeps the process alive well past the timeout.
+        let args = vec![
+            "-n".to_string(),
+            "30".to_string(),
+            "127.0.0.1".to_string(),
+        ];
+        let outcome = execute_local_process("ping", &args, Duration::from_millis(200), &token, tx)
+            .await
+            .expect("ping should spawn");
+        assert!(outcome.timed_out, "expected timeout: {outcome:?}");
+        assert_eq!(outcome.exit_code, None);
+    }
+
+    #[test]
+    fn resolve_timeout_applies_default_and_bounds() {
+        assert_eq!(resolve_timeout(None), Duration::from_millis(DEFAULT_TIMEOUT_MS));
+        assert_eq!(resolve_timeout(Some(0)), Duration::from_millis(1));
+        assert_eq!(
+            resolve_timeout(Some(MAX_TIMEOUT_MS * 10)),
+            Duration::from_millis(MAX_TIMEOUT_MS)
+        );
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod connection_path;
 pub mod credential;
 pub mod embedded_servers;
 pub mod files;
+pub mod local_process;
 pub mod logs;
 pub mod macros;
 pub mod network;

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -881,6 +881,38 @@ mod tests {
     }
 
     #[test]
+    fn workflow_local_process_settings_default_off_and_round_trip() {
+        // Default: opt-in OFF, empty allowlist (#1857).
+        let defaults = AppSettings::default();
+        assert!(!defaults.workflow_local_process_enabled);
+        assert!(defaults.workflow_local_process_allowlist.is_empty());
+
+        let settings = AppSettings {
+            workflow_local_process_enabled: true,
+            workflow_local_process_allowlist: vec!["/usr/bin/notify-send".to_string()],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("workflowLocalProcessEnabled"));
+        assert!(json.contains("workflowLocalProcessAllowlist"));
+        let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.workflow_local_process_enabled);
+        assert_eq!(
+            deserialized.workflow_local_process_allowlist,
+            vec!["/usr/bin/notify-send".to_string()]
+        );
+    }
+
+    #[test]
+    fn workflow_local_process_missing_fields_default_to_disabled() {
+        // An older settings file without the fields must load as disabled/empty.
+        let json = r#"{"version":"1","externalConnectionFiles":[]}"#;
+        let deserialized: AppSettings = serde_json::from_str(json).unwrap();
+        assert!(!deserialized.workflow_local_process_enabled);
+        assert!(deserialized.workflow_local_process_allowlist.is_empty());
+    }
+
+    #[test]
     fn experimental_features_enabled_round_trip() {
         let settings = AppSettings {
             experimental_features_enabled: Some(true),

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -245,6 +245,23 @@ pub struct AppSettings {
     /// resolves the built-in defaults.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub syntax_highlighting: Option<serde_json::Value>,
+    /// Master opt-in for the guarded `run-local-process` workflow step (#1857).
+    ///
+    /// Defaults to `false`: a workflow can spawn a local program on the user's
+    /// machine only after the user explicitly enables this. Owned by the
+    /// frontend `AppSettings.workflowLocalProcessEnabled`; the backend both
+    /// persists it and **re-checks it in the spawn command** (defence-in-depth)
+    /// so a step can never run without opt-in. `#[serde(default)]` keeps older
+    /// settings files forward-compatible (missing → `false`).
+    #[serde(default)]
+    pub workflow_local_process_enabled: bool,
+    /// Programs the user has chosen to always allow a `run-local-process` step
+    /// to spawn without re-confirming (#1857). Owned by the frontend
+    /// `AppSettings.workflowLocalProcessAllowlist`; persisted here so the
+    /// authorization survives a restart. Independent of workflow data, so an
+    /// imported workflow can never add an entry.
+    #[serde(default)]
+    pub workflow_local_process_allowlist: Vec<String>,
 }
 
 impl Default for AppSettings {
@@ -289,6 +306,8 @@ impl Default for AppSettings {
             serial_port_scan_prefixes: None,
             shell_integration: ShellIntegrationSettings::default(),
             syntax_highlighting: None,
+            workflow_local_process_enabled: false,
+            workflow_local_process_allowlist: Vec::new(),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -231,6 +231,7 @@ pub fn run() {
         .manage(x_server_consent_registry.clone())
         .manage(spawn::handler::PendingSpawn::default())
         .manage(commands::connection_path::ProbeRegistry::default())
+        .manage(commands::local_process::LocalProcessRegistry::default())
         .manage(crate::terminal::agent_cancel::AgentDeployCancellation::default())
         .manage(log_buffer);
 
@@ -882,6 +883,8 @@ pub fn run() {
             commands::workflows::get_workflow,
             commands::workflows::save_workflow,
             commands::workflows::delete_workflow,
+            commands::local_process::run_local_process,
+            commands::local_process::cancel_local_process,
             // Network diagnostics
             commands::network::network_port_scan,
             commands::network::network_port_scan_cancel,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { TransferQueue } from "@/components/TransferQueue";
 import { ShellIntegrationBanner } from "@/components/ShellIntegrationBanner";
 import { TerminalView } from "@/components/Terminal";
 import { PasswordPrompt } from "@/components/PasswordPrompt";
+import { LocalProcessAuthDialog } from "@/components/WorkflowSidebar/LocalProcessAuthDialog";
 import { CustomizeLayoutDialog } from "@/components/Settings/CustomizeLayoutDialog";
 import { ExportDialog, ImportDialog } from "@/components/ExportImport";
 import { UnlockDialog } from "@/components/UnlockDialog";
@@ -287,6 +288,7 @@ function App() {
           <TransferQueue />
           {layoutConfig.statusBarVisible && <StatusBar />}
           <PasswordPrompt />
+          <LocalProcessAuthDialog />
           <CustomizeLayoutDialog />
           <ExportDialog />
           <ImportDialog />

--- a/src/components/Settings/SecuritySettings.test.tsx
+++ b/src/components/Settings/SecuritySettings.test.tsx
@@ -568,7 +568,9 @@ describe("SecuritySettings", () => {
         remove.click();
       });
 
-      expect(useAppStore.getState().settings.workflowLocalProcessAllowlist).toEqual(["notify-send"]);
+      expect(useAppStore.getState().settings.workflowLocalProcessAllowlist).toEqual([
+        "notify-send",
+      ]);
     });
   });
 });

--- a/src/components/Settings/SecuritySettings.test.tsx
+++ b/src/components/Settings/SecuritySettings.test.tsx
@@ -520,4 +520,55 @@ describe("SecuritySettings", () => {
     // The inline error still surfaces the wrong-password feedback; dialog stays open.
     expect(query("change-password-dialog")).not.toBeNull();
   });
+
+  describe("workflow local process execution (#1857)", () => {
+    it("shows the opt-in toggle, off by default, with no allowlist section", () => {
+      useAppStore.setState({
+        credentialStoreStatus: { mode: "none", status: "unlocked" },
+      });
+      render();
+
+      expect(query("workflow-local-process-toggle")).not.toBeNull();
+      // The allowlist section only appears once the opt-in is on.
+      expect(query("workflow-allowlist")).toBeNull();
+      expect(query("workflow-allowlist-empty")).toBeNull();
+    });
+
+    it("enabling the opt-in persists the setting", async () => {
+      useAppStore.setState({
+        credentialStoreStatus: { mode: "none", status: "unlocked" },
+      });
+      render();
+
+      const toggle = query("workflow-local-process-toggle") as HTMLElement;
+      await act(async () => {
+        toggle.click();
+      });
+
+      expect(useAppStore.getState().settings.workflowLocalProcessEnabled).toBe(true);
+    });
+
+    it("lists allowed programs and removes one on click", async () => {
+      useAppStore.setState({
+        credentialStoreStatus: { mode: "none", status: "unlocked" },
+        settings: {
+          ...useAppStore.getState().settings,
+          workflowLocalProcessEnabled: true,
+          workflowLocalProcessAllowlist: ["notify-send", "echo"],
+        },
+      });
+      render();
+
+      const list = query("workflow-allowlist");
+      expect(list).not.toBeNull();
+      expect(list?.querySelectorAll("li")).toHaveLength(2);
+
+      const remove = query("workflow-allowlist-remove-echo") as HTMLElement;
+      await act(async () => {
+        remove.click();
+      });
+
+      expect(useAppStore.getState().settings.workflowLocalProcessAllowlist).toEqual(["notify-send"]);
+    });
+  });
 });

--- a/src/components/Settings/SecuritySettings.tsx
+++ b/src/components/Settings/SecuritySettings.tsx
@@ -1,10 +1,10 @@
 import { useState, useCallback } from "react";
-import { Shield } from "lucide-react";
+import { Shield, Trash2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { CredentialStorageMode } from "@/types/credential";
 import { switchCredentialStore, changeMasterPassword, setAutoLockTimeout } from "@/services/api";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
-import { Button, Select, toast } from "@/components/ui";
+import { Button, Select, Toggle, toast } from "@/components/ui";
 import { SettingsField } from "./SettingsField";
 
 interface SecuritySettingsProps {
@@ -246,6 +246,30 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
     [settings, updateSettings]
   );
 
+  const localProcessEnabled = settings.workflowLocalProcessEnabled ?? false;
+  const localProcessAllowlist = settings.workflowLocalProcessAllowlist ?? [];
+
+  const handleToggleLocalProcess = useCallback(
+    (enabled: boolean) => {
+      void updateSettings({ ...settings, workflowLocalProcessEnabled: enabled });
+      toast.success(
+        enabled
+          ? "Workflow local process execution enabled"
+          : "Workflow local process execution disabled"
+      );
+    },
+    [settings, updateSettings]
+  );
+
+  const handleRemoveAllowedProgram = useCallback(
+    (program: string) => {
+      const next = localProcessAllowlist.filter((p) => p !== program);
+      void updateSettings({ ...settings, workflowLocalProcessAllowlist: next });
+      toast.success(`Removed ${program} from the allowlist`);
+    },
+    [settings, updateSettings, localProcessAllowlist]
+  );
+
   return (
     <div className="settings-panel__category">
       {show("credentialStorageMode") && (
@@ -457,6 +481,59 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
             </div>
           )}
         </>
+      )}
+
+      {show("workflowLocalProcess") && (
+        <div className="settings-panel__section">
+          <h3 className="settings-panel__section-title">Workflow Local Process Execution</h3>
+          <p className="settings-panel__description">
+            The guarded <code>run-local-process</code> workflow step runs a program on this
+            computer. This is off by default. When enabled, each not-yet-trusted program still
+            requires a one-time confirmation before it can run; imported workflows are never
+            pre-authorized.
+          </p>
+
+          <SettingsField
+            label="Allow workflows to run local programs"
+            hint="Master switch. While off, any run-local-process step is refused."
+          >
+            <Toggle
+              checked={localProcessEnabled}
+              onCheckedChange={handleToggleLocalProcess}
+              aria-label="Allow workflows to run local programs"
+              data-testid="workflow-local-process-toggle"
+            />
+          </SettingsField>
+
+          {localProcessEnabled && (
+            <div className="settings-panel__field">
+              <span className="settings-panel__field-label">Allowed programs</span>
+              {localProcessAllowlist.length === 0 ? (
+                <p className="settings-panel__description" data-testid="workflow-allowlist-empty">
+                  No programs are remembered yet. Choosing &ldquo;Always allow&rdquo; when a
+                  workflow runs one adds it here.
+                </p>
+              ) : (
+                <ul className="settings-panel__list" data-testid="workflow-allowlist">
+                  {localProcessAllowlist.map((program) => (
+                    <li key={program} className="settings-panel__list-item">
+                      <code>{program}</code>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        iconOnly
+                        icon={<Trash2 size={14} />}
+                        aria-label={`Remove ${program} from the allowlist`}
+                        onClick={() => handleRemoveAllowedProgram(program)}
+                        data-testid={`workflow-allowlist-remove-${program}`}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/components/Settings/SecuritySettings.tsx
+++ b/src/components/Settings/SecuritySettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { Shield, Trash2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { CredentialStorageMode } from "@/types/credential";
@@ -247,7 +247,10 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
   );
 
   const localProcessEnabled = settings.workflowLocalProcessEnabled ?? false;
-  const localProcessAllowlist = settings.workflowLocalProcessAllowlist ?? [];
+  const localProcessAllowlist = useMemo(
+    () => settings.workflowLocalProcessAllowlist ?? [],
+    [settings.workflowLocalProcessAllowlist]
+  );
 
   const handleToggleLocalProcess = useCallback(
     (enabled: boolean) => {

--- a/src/components/Settings/SettingsPanel.css
+++ b/src/components/Settings/SettingsPanel.css
@@ -514,3 +514,34 @@
 .settings-panel__field {
   margin-bottom: var(--spacing-md);
 }
+
+.settings-panel__field-label {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.settings-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.settings-panel__list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+}
+
+.settings-panel__list-item code {
+  word-break: break-all;
+}

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -239,6 +239,24 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     ],
   },
   {
+    id: "workflowLocalProcess",
+    label: "Workflow Local Process Execution",
+    description:
+      "Allow workflows to run local programs on this computer, and manage which programs are allowed",
+    category: "security",
+    keywords: [
+      "workflow",
+      "local process",
+      "run-local-process",
+      "execute",
+      "program",
+      "allowlist",
+      "authorize",
+      "security",
+      "spawn",
+    ],
+  },
+  {
     id: "fileLanguageMappings",
     label: "File Type Mappings",
     description: "Map filenames and extensions to syntax highlighting languages",

--- a/src/components/WorkflowSidebar/LocalProcessAuthDialog.css
+++ b/src/components/WorkflowSidebar/LocalProcessAuthDialog.css
@@ -1,0 +1,63 @@
+.local-process-auth {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.local-process-auth__lead {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.local-process-auth__icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--color-warning, var(--text-primary));
+}
+
+.local-process-auth__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.local-process-auth__label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.local-process-auth__value {
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  word-break: break-all;
+}
+
+.local-process-auth__none {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.local-process-auth__args {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding-left: 20px;
+}
+
+.local-process-auth__args code {
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  word-break: break-all;
+}
+
+.local-process-auth__note {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}

--- a/src/components/WorkflowSidebar/LocalProcessAuthDialog.test.tsx
+++ b/src/components/WorkflowSidebar/LocalProcessAuthDialog.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for the local-process authorization dialog (#1857).
+ *
+ * The dialog is the interactive half of the run-local-process security gate: it
+ * spells out the exact program + discrete arguments a workflow wants to run, and
+ * resolves the store's pending authorization promise with the user's choice
+ * (cancel / allow once / always allow). These tests pin that the three actions
+ * resolve with the right decision and that the shown command is accurate.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { LocalProcessAuthDialog } from "./LocalProcessAuthDialog";
+import { useAppStore } from "@/store/appStore";
+import type { LocalProcessAuthDecision } from "@/store/appStore";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+function render() {
+  act(() => {
+    root.render(<LocalProcessAuthDialog />);
+  });
+}
+
+/** Open the prompt via the store and return the resolver spy. */
+function openPrompt(program: string, args: string[]) {
+  const resolve = vi.fn();
+  act(() => {
+    useAppStore.setState({
+      localProcessPrompt: { program, args, workflowName: "Deploy", resolve },
+    });
+  });
+  return resolve;
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("LocalProcessAuthDialog", () => {
+  it("is not rendered when there is no pending prompt", () => {
+    render();
+    expect(query("local-process-auth-dialog")).toBeNull();
+  });
+
+  it("shows the exact program and discrete arguments", () => {
+    render();
+    openPrompt("/usr/bin/notify-send", ["--urgency", "hello world"]);
+
+    expect(query("local-process-auth-program")?.textContent).toBe("/usr/bin/notify-send");
+    const args = query("local-process-auth-args");
+    // Each argument is its own list item — "hello world" stays one entry.
+    expect(args?.querySelectorAll("li")).toHaveLength(2);
+    expect(args?.textContent).toContain("hello world");
+  });
+
+  it.each<[string, LocalProcessAuthDecision]>([
+    ["local-process-auth-cancel", "cancel"],
+    ["local-process-auth-once", "once"],
+    ["local-process-auth-always", "always"],
+  ])("resolves via %s with decision %s", (testId, decision) => {
+    render();
+    const spy = openPrompt("echo", ["hi"]);
+
+    act(() => {
+      (query(testId) as HTMLButtonElement).click();
+    });
+
+    expect(spy).toHaveBeenCalledWith(decision);
+    // The prompt is cleared after resolving.
+    expect(useAppStore.getState().localProcessPrompt).toBeNull();
+  });
+});

--- a/src/components/WorkflowSidebar/LocalProcessAuthDialog.tsx
+++ b/src/components/WorkflowSidebar/LocalProcessAuthDialog.tsx
@@ -1,0 +1,101 @@
+import { AlertTriangle } from "lucide-react";
+import { Modal, Button } from "@/components/ui";
+import { useAppStore } from "@/store/appStore";
+import "./LocalProcessAuthDialog.css";
+
+/**
+ * Confirmation dialog gating a guarded `run-local-process` workflow step (#1857).
+ *
+ * Shown when a running workflow reaches a local-process step whose program is not
+ * yet on the allowlist (and the master opt-in is already enabled). It spells out
+ * exactly what would run — program + each discrete argument — because this step
+ * executes a program on the user's own machine, unlike every other workflow step.
+ *
+ * Three outcomes, mirroring the store's {@link LocalProcessAuthDecision}:
+ * - **Cancel** — refuse; the step does not run (the safe default, focused).
+ * - **Allow once** — run this time only; nothing is remembered.
+ * - **Always allow** — run and remember the program on the allowlist.
+ *
+ * Mounted globally so it works no matter how the workflow was launched (sidebar,
+ * palette, hotkey).
+ */
+export function LocalProcessAuthDialog() {
+  const prompt = useAppStore((s) => s.localProcessPrompt);
+  const resolve = useAppStore((s) => s.resolveLocalProcessPrompt);
+
+  const open = prompt !== null;
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) resolve("cancel");
+      }}
+      title="Run a local program?"
+      data-testid="local-process-auth-dialog"
+      footer={
+        <>
+          <Button
+            variant="secondary"
+            onClick={() => resolve("cancel")}
+            data-testid="local-process-auth-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => resolve("once")}
+            data-testid="local-process-auth-once"
+          >
+            Allow once
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() => resolve("always")}
+            data-testid="local-process-auth-always"
+          >
+            Always allow
+          </Button>
+        </>
+      }
+    >
+      {prompt && (
+        <div className="local-process-auth">
+          <p className="local-process-auth__lead">
+            <AlertTriangle size={16} className="local-process-auth__icon" />
+            <span>
+              The workflow <strong>{prompt.workflowName}</strong> wants to run a program on this
+              computer. Only allow it if you trust this workflow.
+            </span>
+          </p>
+          <div className="local-process-auth__field">
+            <span className="local-process-auth__label">Program</span>
+            <code className="local-process-auth__value" data-testid="local-process-auth-program">
+              {prompt.program || "(none)"}
+            </code>
+          </div>
+          <div className="local-process-auth__field">
+            <span className="local-process-auth__label">
+              {prompt.args.length === 1 ? "Argument" : "Arguments"}
+            </span>
+            {prompt.args.length === 0 ? (
+              <span className="local-process-auth__none">none</span>
+            ) : (
+              <ol className="local-process-auth__args" data-testid="local-process-auth-args">
+                {prompt.args.map((arg, i) => (
+                  <li key={i}>
+                    <code>{arg}</code>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+          <p className="local-process-auth__note">
+            &ldquo;Always allow&rdquo; remembers this program; manage or revoke it later under
+            Settings &rarr; Security.
+          </p>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/WorkflowSidebar/WorkflowEditorDialog.css
+++ b/src/components/WorkflowSidebar/WorkflowEditorDialog.css
@@ -91,6 +91,30 @@
   padding-left: 26px;
 }
 
+/* ── Local-process discrete argument list (#1857) ───────────────────── */
+.workflow-step__args {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.workflow-step__arg-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  width: 100%;
+}
+
+.workflow-step__arg-row > :first-child {
+  flex: 1;
+}
+
+.workflow-step__args-empty {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
 /* ── Triggers ───────────────────────────────────────────────────────── */
 .workflow-triggers {
   display: flex;

--- a/src/components/WorkflowSidebar/WorkflowEditorDialog.test.tsx
+++ b/src/components/WorkflowSidebar/WorkflowEditorDialog.test.tsx
@@ -161,6 +161,49 @@ describe("WorkflowEditorDialog", () => {
     expect(result.steps[0]).toEqual({ kind: "send-command", command: "whoami" });
   });
 
+  it("edits run-local-process args as a discrete list (a space-containing arg stays one arg)", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const lpWorkflow: Workflow = {
+      ...workflow,
+      steps: [{ kind: "run-local-process", program: "notify-send", args: ["--urgency"] }],
+    };
+    render({ onSave, workflow: lpWorkflow });
+
+    // Add a second argument row, then type a value that contains a space.
+    act(() => (query("workflow-editor-step-arg-add-0") as HTMLButtonElement).click());
+    await flush();
+    setInput("workflow-editor-step-arg-0-1", "hello world");
+
+    act(() => (query("workflow-editor-save") as HTMLButtonElement).click());
+    await flush();
+
+    const result = onSave.mock.calls[0][0] as WorkflowEditorResult;
+    // The space-containing value is a SINGLE discrete argument — never split.
+    expect(result.steps[0]).toEqual({
+      kind: "run-local-process",
+      program: "notify-send",
+      args: ["--urgency", "hello world"],
+    });
+  });
+
+  it("removes a run-local-process argument row", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const lpWorkflow: Workflow = {
+      ...workflow,
+      steps: [{ kind: "run-local-process", program: "echo", args: ["a", "b"] }],
+    };
+    render({ onSave, workflow: lpWorkflow });
+
+    act(() => (query("workflow-editor-step-arg-remove-0-0") as HTMLButtonElement).click());
+    await flush();
+
+    act(() => (query("workflow-editor-save") as HTMLButtonElement).click());
+    await flush();
+
+    const result = onSave.mock.calls[0][0] as WorkflowEditorResult;
+    expect(result.steps[0]).toEqual({ kind: "run-local-process", program: "echo", args: ["b"] });
+  });
+
   it("adds a typed step from the Add step menu", async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     render({ onSave });

--- a/src/components/WorkflowSidebar/WorkflowStepRow.tsx
+++ b/src/components/WorkflowSidebar/WorkflowStepRow.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical, ArrowUp, ArrowDown, Trash2 } from "lucide-react";
+import { GripVertical, ArrowUp, ArrowDown, Trash2, Plus } from "lucide-react";
 import { Button, Input, Textarea, NumberInput, Select, Field } from "@/components/ui";
 import type { WorkflowStep } from "@/types/workflow";
 import type { Macro } from "@/types/macro";
@@ -205,18 +205,75 @@ function StepDetailEditor({ index, step, macros, onChange }: StepDetailEditorPro
               data-testid={`workflow-editor-step-program-${index}`}
             />
           </Field>
-          <Field label="Arguments (space-separated)" htmlFor={`workflow-step-args-${index}`}>
-            <Input
-              id={`workflow-step-args-${index}`}
-              value={step.args.join(" ")}
-              placeholder="arg1 arg2"
-              onChange={(e) =>
-                onChange({ ...step, args: e.target.value.split(/\s+/).filter(Boolean) })
-              }
-              data-testid={`workflow-editor-step-args-${index}`}
-            />
-          </Field>
+          <LocalProcessArgsEditor
+            index={index}
+            args={step.args}
+            onChange={(args) => onChange({ ...step, args })}
+          />
         </>
       );
   }
+}
+
+interface LocalProcessArgsEditorProps {
+  index: number;
+  args: string[];
+  onChange: (args: string[]) => void;
+}
+
+/**
+ * A discrete, ordered list of program arguments — one {@link Input} per argument
+ * (#1857). This replaces the old whitespace-split single field so an argument
+ * that contains spaces (e.g. a message body or a path) stays a single, literal
+ * argument. Each argument is passed to the backend as its own argv entry with no
+ * shell involved, so nothing here is ever re-split or interpreted.
+ */
+function LocalProcessArgsEditor({ index, args, onChange }: LocalProcessArgsEditorProps) {
+  const setArg = (i: number, value: string) => {
+    const next = args.slice();
+    next[i] = value;
+    onChange(next);
+  };
+  const removeArg = (i: number) => onChange(args.filter((_, j) => j !== i));
+  const addArg = () => onChange([...args, ""]);
+
+  return (
+    <Field label="Arguments" htmlFor={`workflow-step-arg-${index}-0`}>
+      <div className="workflow-step__args" data-testid={`workflow-editor-step-args-${index}`}>
+        {args.length === 0 && (
+          <span className="workflow-step__args-empty">No arguments.</span>
+        )}
+        {args.map((arg, i) => (
+          <div className="workflow-step__arg-row" key={i}>
+            <Input
+              id={`workflow-step-arg-${index}-${i}`}
+              value={arg}
+              placeholder={`argument ${i + 1}`}
+              onChange={(e) => setArg(i, e.target.value)}
+              aria-label={`Argument ${i + 1} for step ${index + 1}`}
+              data-testid={`workflow-editor-step-arg-${index}-${i}`}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label={`Remove argument ${i + 1}`}
+              icon={<Trash2 size={12} />}
+              onClick={() => removeArg(i)}
+              data-testid={`workflow-editor-step-arg-remove-${index}-${i}`}
+            />
+          </div>
+        ))}
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={<Plus size={12} />}
+          onClick={addArg}
+          data-testid={`workflow-editor-step-arg-add-${index}`}
+        >
+          Add argument
+        </Button>
+      </div>
+    </Field>
+  );
 }

--- a/src/components/WorkflowSidebar/WorkflowStepRow.tsx
+++ b/src/components/WorkflowSidebar/WorkflowStepRow.tsx
@@ -240,9 +240,7 @@ function LocalProcessArgsEditor({ index, args, onChange }: LocalProcessArgsEdito
   return (
     <Field label="Arguments" htmlFor={`workflow-step-arg-${index}-0`}>
       <div className="workflow-step__args" data-testid={`workflow-editor-step-args-${index}`}>
-        {args.length === 0 && (
-          <span className="workflow-step__args-empty">No arguments.</span>
-        )}
+        {args.length === 0 && <span className="workflow-step__args-empty">No arguments.</span>}
         {args.map((arg, i) => (
           <div className="workflow-step__arg-row" key={i}>
             <Input

--- a/src/services/localProcessApi.ts
+++ b/src/services/localProcessApi.ts
@@ -1,0 +1,81 @@
+/**
+ * Frontend bridge to the guarded local-process backend command (#1857).
+ *
+ * The `run-local-process` workflow step spawns a program on the user's own
+ * machine, so every call here is gated in the store by the opt-in setting and a
+ * per-program authorization (see `appStore.runWorkflow`). This module only wraps
+ * the Tauri command and its streamed-output event — it performs no gating itself.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+/** Tauri event name carrying one streamed line of local-process output. */
+const LOCAL_PROCESS_OUTPUT_EVENT = "workflow-local-process-output";
+
+/** One streamed line of a local process's output. */
+export interface LocalProcessOutputChunk {
+  /** The run id the line belongs to. */
+  runId: string;
+  /** Which stream produced it. */
+  stream: "stdout" | "stderr";
+  /** The line of text (no trailing newline). */
+  line: string;
+}
+
+/** The terminal outcome of a spawned local process, mirroring the Rust struct. */
+export interface LocalProcessOutcome {
+  /** Exit code, or `null` when the process was killed (cancelled/timed out). */
+  exitCode: number | null;
+  /** `true` when killed for exceeding the timeout. */
+  timedOut: boolean;
+  /** `true` when killed because the run was cancelled. */
+  cancelled: boolean;
+}
+
+/** Arguments for {@link invokeRunLocalProcess}. */
+export interface RunLocalProcessArgs {
+  /** Unique id for this run, used to route output events and target a cancel. */
+  runId: string;
+  /** The program to spawn (direct argv — no shell). */
+  program: string;
+  /** Discrete argument vector (never concatenated into a command line). */
+  args: string[];
+  /** Optional timeout in ms; the backend applies a default and a hard cap. */
+  timeoutMs?: number;
+}
+
+/**
+ * Spawn a guarded local process and resolve its outcome once it finishes. The
+ * backend re-checks the master opt-in and rejects if it is disabled, so a
+ * disabled setting surfaces as a rejected promise here.
+ */
+export async function invokeRunLocalProcess(
+  args: RunLocalProcessArgs
+): Promise<LocalProcessOutcome> {
+  return await invoke<LocalProcessOutcome>("run_local_process", {
+    runId: args.runId,
+    program: args.program,
+    args: args.args,
+    timeoutMs: args.timeoutMs ?? null,
+  });
+}
+
+/** Request cancellation of an in-flight local process by its run id. */
+export async function cancelLocalProcess(runId: string): Promise<boolean> {
+  return await invoke<boolean>("cancel_local_process", { runId });
+}
+
+/**
+ * Subscribe to streamed output for a specific run. The handler is invoked once
+ * per line, for stdout and stderr both. Returns an unlisten function to call when
+ * the run ends.
+ */
+export async function subscribeLocalProcessOutput(
+  runId: string,
+  onChunk: (chunk: LocalProcessOutputChunk) => void
+): Promise<UnlistenFn> {
+  return await listen<LocalProcessOutputChunk>(LOCAL_PROCESS_OUTPUT_EVENT, (event) => {
+    if (event.payload.runId === runId) onChunk(event.payload);
+  });
+}

--- a/src/services/workflowRunner.test.ts
+++ b/src/services/workflowRunner.test.ts
@@ -7,9 +7,10 @@
  * per-line delays) route through the timer seam clamped to `MAX_STEP_DELAY_MS`,
  * progress is reported per step, cancellation stops the run between steps and
  * aborts an in-flight `run-script`'s remaining line injections, a failing seam
- * fails the run at the offending step, and the still-unimplemented
- * `run-local-process` kind fails loudly. All seams are mocked so no terminal or
- * session is required.
+ * fails the run at the offending step, and the guarded `run-local-process` kind
+ * (#1857) is fail-closed: it never spawns without explicit authorization, passes
+ * args as a discrete array (no shell split), and surfaces exit/timeout/cancel.
+ * All seams are mocked so no terminal or session is required.
  */
 import { describe, it, expect, vi } from "vitest";
 import {
@@ -20,6 +21,7 @@ import {
   type WorkflowRunMacroSeam,
   type WorkflowWaitSeam,
   type WorkflowReadFileSeam,
+  type WorkflowRunLocalProcessSeam,
 } from "./workflowRunner";
 import { MAX_STEP_DELAY_MS } from "./macroPlayback";
 import type { WorkflowStep } from "@/types/workflow";
@@ -178,14 +180,127 @@ describe("executeStep", () => {
     });
   });
 
-  it("fails loudly for the still-unimplemented run-local-process step", async () => {
-    const outcome = await executeStep(
-      { kind: "run-local-process", program: "echo", args: [] },
-      deps()
-    );
+  describe("run-local-process (guarded, #1857)", () => {
+    const step = (program: string, args: string[] = []): WorkflowStep => ({
+      kind: "run-local-process",
+      program,
+      args,
+    });
+    const okRun: WorkflowRunLocalProcessSeam = vi.fn(async () => ({
+      exitCode: 0,
+      timedOut: false,
+      cancelled: false,
+    }));
 
-    expect(outcome.ok).toBe(false);
-    if (!outcome.ok) expect(outcome.error).toContain("run-local-process");
+    it("fails without a run seam", async () => {
+      const outcome = await executeStep(step("echo"), deps());
+      expect(outcome.ok).toBe(false);
+    });
+
+    it("GUARDRAIL: never spawns when no authorize seam is wired", async () => {
+      const runLocalProcess = vi.fn(okRun);
+      const outcome = await executeStep(step("echo"), deps({ runLocalProcess }));
+
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.error).toContain("not authorized");
+      // The security invariant: the process seam is NEVER reached unauthorized.
+      expect(runLocalProcess).not.toHaveBeenCalled();
+    });
+
+    it("GUARDRAIL: never spawns when authorization is refused", async () => {
+      const authorizeLocalProcess = vi.fn(async () => false);
+      const runLocalProcess = vi.fn(okRun);
+      const outcome = await executeStep(
+        step("rm", ["-rf", "/"]),
+        deps({ authorizeLocalProcess, runLocalProcess })
+      );
+
+      expect(outcome.ok).toBe(false);
+      expect(authorizeLocalProcess).toHaveBeenCalledWith("rm", ["-rf", "/"]);
+      expect(runLocalProcess).not.toHaveBeenCalled();
+    });
+
+    it("GUARDRAIL: passes args as a discrete array, unmodified (no shell split)", async () => {
+      const authorizeLocalProcess = vi.fn(async () => true);
+      const runLocalProcess = vi.fn(okRun);
+      // A single argument containing spaces/metacharacters must stay ONE element.
+      const args = ["--message", "hello world; rm -rf /"];
+      await executeStep(
+        step("notify-send", args),
+        deps({ authorizeLocalProcess, runLocalProcess })
+      );
+
+      expect(runLocalProcess).toHaveBeenCalledTimes(1);
+      const [program, passedArgs] = runLocalProcess.mock.calls[0];
+      expect(program).toBe("notify-send");
+      expect(passedArgs).toEqual(["--message", "hello world; rm -rf /"]);
+      // Same reference-equal contents: the runner does not re-split or reshape.
+      expect(passedArgs).toHaveLength(2);
+    });
+
+    it("succeeds when an authorized process exits 0", async () => {
+      const outcome = await executeStep(
+        step("echo", ["hi"]),
+        deps({ authorizeLocalProcess: async () => true, runLocalProcess: vi.fn(okRun) })
+      );
+      expect(outcome).toEqual({ ok: true });
+    });
+
+    it("fails and surfaces the exit code on a non-zero exit", async () => {
+      const runLocalProcess: WorkflowRunLocalProcessSeam = async () => ({
+        exitCode: 3,
+        timedOut: false,
+        cancelled: false,
+      });
+      const outcome = await executeStep(
+        step("false"),
+        deps({ authorizeLocalProcess: async () => true, runLocalProcess })
+      );
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.error).toContain("code 3");
+    });
+
+    it("fails with a timeout message when the process times out", async () => {
+      const runLocalProcess: WorkflowRunLocalProcessSeam = async () => ({
+        exitCode: null,
+        timedOut: true,
+        cancelled: false,
+      });
+      const outcome = await executeStep(
+        step("sleep", ["99"]),
+        deps({ authorizeLocalProcess: async () => true, runLocalProcess })
+      );
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) expect(outcome.error).toContain("timed out");
+    });
+
+    it("ends the run as cancelled when the process was cancelled", async () => {
+      const runLocalProcess: WorkflowRunLocalProcessSeam = async () => ({
+        exitCode: null,
+        timedOut: false,
+        cancelled: true,
+      });
+      const outcome = await executeStep(
+        step("sleep", ["99"]),
+        deps({ authorizeLocalProcess: async () => true, runLocalProcess })
+      );
+      expect(outcome).toEqual({ ok: true, cancelled: true });
+    });
+
+    it("GUARDRAIL: does not spawn when cancelled before the process starts", async () => {
+      const runLocalProcess: WorkflowRunLocalProcessSeam = vi.fn(async () => ({
+        exitCode: 0,
+        timedOut: false,
+        cancelled: false,
+      }));
+      const outcome = await executeStep(
+        step("echo"),
+        deps({ authorizeLocalProcess: async () => true, runLocalProcess }),
+        { isCancelled: () => true }
+      );
+      expect(outcome).toEqual({ ok: true, cancelled: true });
+      expect(runLocalProcess).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/services/workflowRunner.ts
+++ b/src/services/workflowRunner.ts
@@ -25,10 +25,12 @@
  *    {@link "@/services/macroPlayback".MAX_STEP_DELAY_MS} exactly as macro
  *    playback clamps its own delays.
  *
- * The only remaining placeholder is `run-local-process` (guarded,
- * security-critical), wired by #1857; it fails loudly until then. Later children
- * extend the runner by adding their seam to {@link WorkflowRunnerDeps} and
- * replacing the placeholder in {@link executeStep}.
+ * `run-local-process` (guarded, security-critical) is wired by #1857. It routes
+ * through **two** seams — {@link WorkflowRunnerDeps.authorizeLocalProcess} and
+ * {@link WorkflowRunnerDeps.runLocalProcess} — and is fail-closed: absent an
+ * authorize seam, or when authorization is refused, the process is **never
+ * spawned** and the step fails. Only an explicit `true` from the authorize seam
+ * lets the run seam spawn the program.
  */
 
 import { MAX_STEP_DELAY_MS } from "@/services/macroPlayback";
@@ -78,6 +80,51 @@ export type WorkflowWaitSeam = (ms: number) => Promise<void> | void;
 export type WorkflowReadFileSeam = (path: string) => Promise<string>;
 
 /**
+ * Terminal outcome of a spawned local process, surfaced to the runner. `exitCode`
+ * is `null` when the process was killed before it could report one (cancelled or
+ * timed out).
+ */
+export interface LocalProcessResult {
+  /** The process exit code, or `null` when it was killed. */
+  exitCode: number | null;
+  /** `true` when the process was killed for exceeding its timeout. */
+  timedOut: boolean;
+  /** `true` when the process was killed because the run was cancelled. */
+  cancelled: boolean;
+}
+
+/** Options threaded into a local-process spawn so it can observe cancellation. */
+export interface LocalProcessRunOptions {
+  /** A cancel poll: when it flips true, the seam kills the process. */
+  signal?: WorkflowStepSignal;
+}
+
+/**
+ * The **authorization gate** for a `run-local-process` step (#1857). Resolves
+ * `true` only when the user has both opted in *and* authorized this specific
+ * program (via a persisted allowlist or an interactive confirmation). The runner
+ * treats every other resolution — `false`, or the seam being absent — as "not
+ * authorized" and refuses to spawn. This is the security choke point: nothing
+ * runs a local process without a `true` from here first.
+ */
+export type WorkflowAuthorizeLocalProcessSeam = (
+  program: string,
+  args: string[]
+) => Promise<boolean> | boolean;
+
+/**
+ * Spawns an authorized local program with the discrete `args` (never a shell),
+ * streaming its output to an observable surface, bounded by a timeout, and
+ * killable when the run is cancelled. Resolves the process outcome. Only ever
+ * called after {@link WorkflowAuthorizeLocalProcessSeam} resolves `true`.
+ */
+export type WorkflowRunLocalProcessSeam = (
+  program: string,
+  args: string[],
+  options: LocalProcessRunOptions
+) => Promise<LocalProcessResult>;
+
+/**
  * Injectable dependencies the runner dispatches steps through. `send` is the only
  * required seam; the rest back a specific step kind and are optional so a step
  * kind that never appears needs no seam (and isolated unit tests can inject just
@@ -92,6 +139,13 @@ export interface WorkflowRunnerDeps {
   wait?: WorkflowWaitSeam;
   /** Reads a script body from disk (the `run-script` `sourcePath` seam). */
   readScriptFile?: WorkflowReadFileSeam;
+  /**
+   * Authorizes a `run-local-process` step before it runs (#1857). Absent → the
+   * step is never authorized and never spawns.
+   */
+  authorizeLocalProcess?: WorkflowAuthorizeLocalProcessSeam;
+  /** Spawns an authorized local process (#1857). */
+  runLocalProcess?: WorkflowRunLocalProcessSeam;
 }
 
 /** A poll the runner threads into a step so long/multi-part steps can abort. */
@@ -223,12 +277,38 @@ export async function executeStep(
       await sleepFor(clampDelay(step.delayMs), deps);
       return { ok: true };
     }
-    // --- Placeholder wired by a later epic child (see module docs). ---
-    case "run-local-process": // #1857 (guarded, security-critical)
+    case "run-local-process": {
+      // Guarded, security-critical (#1857). Fail-closed at every gate.
+      if (!deps.runLocalProcess) {
+        return { ok: false, error: 'the "run-local-process" step requires a local-process seam' };
+      }
+      // GUARDRAIL: never spawn without explicit authorization. Absent seam or a
+      // refusal both mean "not authorized" — the process is never spawned.
+      const authorized = deps.authorizeLocalProcess
+        ? await deps.authorizeLocalProcess(step.program, step.args)
+        : false;
+      if (!authorized) {
+        return {
+          ok: false,
+          error: `local process "${step.program}" is not authorized to run`,
+        };
+      }
+      // A cancel observed before the spawn aborts the run without spawning.
+      if (cancelled()) return { ok: true, cancelled: true };
+
+      const result = await deps.runLocalProcess(step.program, step.args, { signal });
+      if (result.cancelled) return { ok: true, cancelled: true };
+      if (result.timedOut) {
+        return { ok: false, error: `local process "${step.program}" timed out` };
+      }
+      if (result.exitCode === 0) return { ok: true };
       return {
         ok: false,
-        error: `workflow step kind "${step.kind}" is not yet implemented`,
+        error: `local process "${step.program}" exited with code ${
+          result.exitCode ?? "unknown"
+        }`,
       };
+    }
     default: {
       // Exhaustiveness guard: a new step kind must add a case above.
       const _exhaustive: never = step;

--- a/src/services/workflowRunner.ts
+++ b/src/services/workflowRunner.ts
@@ -304,9 +304,7 @@ export async function executeStep(
       if (result.exitCode === 0) return { ok: true };
       return {
         ok: false,
-        error: `local process "${step.program}" exited with code ${
-          result.exitCode ?? "unknown"
-        }`,
+        error: `local process "${step.program}" exited with code ${result.exitCode ?? "unknown"}`,
       };
     }
     default: {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -186,7 +186,14 @@ import {
   type WorkflowSendSeam,
   type WorkflowRunMacroSeam,
   type WorkflowRunHandle,
+  type WorkflowAuthorizeLocalProcessSeam,
+  type WorkflowRunLocalProcessSeam,
 } from "@/services/workflowRunner";
+import {
+  invokeRunLocalProcess,
+  cancelLocalProcess,
+  subscribeLocalProcessOutput,
+} from "@/services/localProcessApi";
 import {
   saveLastSession as apiSaveLastSession,
   loadLastSession as apiLoadLastSession,
@@ -1282,6 +1289,14 @@ interface AppState {
   runWorkflow: (workflowId: string, opts?: RunWorkflowOptions) => Promise<void>;
   /** Cancel the in-flight workflow run, if any. Idempotent. */
   cancelWorkflowRun: () => void;
+  /**
+   * Pending authorization prompt for a guarded `run-local-process` step (#1857),
+   * or `null` when none is open. Set when a workflow reaches such a step whose
+   * program is not yet on the allowlist; resolved by the user via the dialog.
+   */
+  localProcessPrompt: LocalProcessPromptState | null;
+  /** Resolve the open local-process authorization prompt with the user's choice. */
+  resolveLocalProcessPrompt: (decision: LocalProcessAuthDecision) => void;
 
   // Workspaces
   workspaces: WorkspaceSummary[];
@@ -1423,6 +1438,34 @@ export interface RunWorkflowOptions {
   /** Tab to run against; defaults to the active terminal tab. */
   targetTabId?: string;
 }
+
+/**
+ * The user's choice at a local-process authorization prompt (#1857):
+ * `"once"` allows this single run, `"always"` allows it and adds the program to
+ * the persisted allowlist, `"cancel"` refuses (the step does not run).
+ */
+export type LocalProcessAuthDecision = "once" | "always" | "cancel";
+
+/** State backing the open local-process authorization dialog (#1857). */
+export interface LocalProcessPromptState {
+  /** The program the step wants to spawn. */
+  program: string;
+  /** The discrete arguments it would be spawned with. */
+  args: string[];
+  /** The name of the workflow requesting it, for the prompt copy. */
+  workflowName: string;
+  /** Resolver wired to the pending authorization promise. */
+  resolve: (decision: LocalProcessAuthDecision) => void;
+}
+
+/**
+ * Default timeout (ms) applied to a `run-local-process` step from the frontend.
+ * The backend clamps to its own hard cap regardless.
+ */
+const LOCAL_PROCESS_TIMEOUT_MS = 60_000;
+
+/** How often (ms) a running local process polls the workflow cancel signal. */
+const LOCAL_PROCESS_CANCEL_POLL_MS = 200;
 
 /**
  * Handle for the currently-running workflow, held at module scope so
@@ -6040,6 +6083,91 @@ export const useAppStore = create<AppState>((set, get) => {
         return macroResult.status === "completed";
       };
 
+      // The authorization gate for a `run-local-process` step (#1857). Fails
+      // closed: unless the user has opted in AND authorized this specific
+      // program (allowlist hit or an interactive confirmation), it returns
+      // false and the step never spawns. An imported workflow's step is never
+      // pre-authorized — the program is not on the allowlist and the master
+      // opt-in defaults off, so it lands here and is gated exactly like any
+      // other untrusted program.
+      const authorizeLocalProcess: WorkflowAuthorizeLocalProcessSeam = async (program, args) => {
+        const settings = get().settings;
+        if (!settings.workflowLocalProcessEnabled) {
+          toast.error("Local process execution is disabled", {
+            description:
+              "Enable it in Settings → Security before this workflow can run a local program.",
+          });
+          return false;
+        }
+        const allowlist = settings.workflowLocalProcessAllowlist ?? [];
+        if (allowlist.includes(program)) return true;
+
+        // Not yet trusted — ask the user, once, via the confirmation dialog.
+        const decision = await new Promise<LocalProcessAuthDecision>((resolve) => {
+          set({
+            localProcessPrompt: { program, args, workflowName: workflow.name, resolve },
+          });
+        });
+        set({ localProcessPrompt: null });
+
+        if (decision === "cancel") return false;
+        if (decision === "always") {
+          const current = get().settings;
+          const nextAllowlist = [...(current.workflowLocalProcessAllowlist ?? [])];
+          if (!nextAllowlist.includes(program)) nextAllowlist.push(program);
+          await get().updateSettings({
+            ...current,
+            workflowLocalProcessAllowlist: nextAllowlist,
+          });
+        }
+        return true;
+      };
+
+      // Spawn an authorized local process through the guarded backend command,
+      // streaming its output into the LogViewer (the app's observable surface)
+      // and forwarding a cancel from the run's signal to the backend.
+      const runLocalProcess: WorkflowRunLocalProcessSeam = async (program, args, options) => {
+        const runId = `wf-lp-${workflowId}-${Date.now()}-${Math.random()
+          .toString(36)
+          .slice(2, 8)}`;
+        frontendLog("workflow", `local process starting: ${[program, ...args].join(" ")}`);
+
+        const unlisten = await subscribeLocalProcessOutput(runId, (chunk) => {
+          frontendLog("workflow", `[${chunk.stream}] ${chunk.line}`);
+        });
+        // Poll the run's cancel signal and forward it to the backend so a
+        // long-running process is killed when the run is cancelled.
+        const poll = window.setInterval(() => {
+          if (options.signal?.isCancelled()) {
+            void cancelLocalProcess(runId);
+          }
+        }, LOCAL_PROCESS_CANCEL_POLL_MS);
+
+        try {
+          const outcome = await invokeRunLocalProcess({
+            runId,
+            program,
+            args,
+            timeoutMs: LOCAL_PROCESS_TIMEOUT_MS,
+          });
+          frontendLog(
+            "workflow",
+            `local process finished: exitCode=${outcome.exitCode ?? "null"} ` +
+              `timedOut=${outcome.timedOut} cancelled=${outcome.cancelled}`
+          );
+          return outcome;
+        } catch (err) {
+          // A backend rejection (e.g. opt-in disabled at the trust boundary)
+          // surfaces as a failed step rather than crashing the run.
+          const message = err instanceof Error ? err.message : String(err);
+          frontendLog("workflow", `local process error: ${message}`);
+          return { exitCode: 1, timedOut: false, cancelled: false };
+        } finally {
+          window.clearInterval(poll);
+          unlisten();
+        }
+      };
+
       const toastId = `workflow-run-${workflowId}-${targetTabId}`;
       const total = workflow.steps.length;
       toast.loading(`Running workflow "${workflow.name}"…`, {
@@ -6058,7 +6186,7 @@ export const useAppStore = create<AppState>((set, get) => {
 
       const handle = runWorkflowSteps(
         workflow.steps,
-        { send, runMacro, readScriptFile: localReadFile },
+        { send, runMacro, readScriptFile: localReadFile, authorizeLocalProcess, runLocalProcess },
         {
           onProgress: (completed, stepTotal) => {
             set((s) =>
@@ -6106,6 +6234,15 @@ export const useAppStore = create<AppState>((set, get) => {
       if (activeWorkflowRun) {
         activeWorkflowRun.cancel();
       }
+    },
+
+    localProcessPrompt: null,
+    resolveLocalProcessPrompt: (decision) => {
+      const prompt = get().localProcessPrompt;
+      if (!prompt) return;
+      // Clear first so a second click cannot double-resolve the promise.
+      set({ localProcessPrompt: null });
+      prompt.resolve(decision);
     },
 
     // Workspaces

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -6127,9 +6127,7 @@ export const useAppStore = create<AppState>((set, get) => {
       // streaming its output into the LogViewer (the app's observable surface)
       // and forwarding a cancel from the run's signal to the backend.
       const runLocalProcess: WorkflowRunLocalProcessSeam = async (program, args, options) => {
-        const runId = `wf-lp-${workflowId}-${Date.now()}-${Math.random()
-          .toString(36)
-          .slice(2, 8)}`;
+        const runId = `wf-lp-${workflowId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         frontendLog("workflow", `local process starting: ${[program, ...args].join(" ")}`);
 
         const unlisten = await subscribeLocalProcessOutput(runId, (chunk) => {

--- a/src/store/appStore.workflowRun.test.ts
+++ b/src/store/appStore.workflowRun.test.ts
@@ -55,13 +55,14 @@ vi.mock("@/services/workflowApi", () => ({
 
 // The guarded local-process backend (#1857) is mocked so no Tauri command runs;
 // `invokeRunLocalProcess` records what it was asked to spawn.
-const invokeRunLocalProcess = vi.fn(() =>
-  Promise.resolve({ exitCode: 0, timedOut: false, cancelled: false })
+const invokeRunLocalProcess = vi.fn((_args: { program: string; args: string[] }) =>
+  Promise.resolve({ exitCode: 0 as number | null, timedOut: false, cancelled: false })
 );
-const cancelLocalProcess = vi.fn(() => Promise.resolve(true));
+const cancelLocalProcess = vi.fn((_runId: string) => Promise.resolve(true));
 vi.mock("@/services/localProcessApi", () => ({
-  invokeRunLocalProcess: (args: unknown) => invokeRunLocalProcess(args as never),
-  cancelLocalProcess: (runId: string) => cancelLocalProcess(runId as never),
+  invokeRunLocalProcess: (args: { program: string; args: string[] }) =>
+    invokeRunLocalProcess(args),
+  cancelLocalProcess: (runId: string) => cancelLocalProcess(runId),
   subscribeLocalProcessOutput: vi.fn(() => Promise.resolve(() => {})),
 }));
 

--- a/src/store/appStore.workflowRun.test.ts
+++ b/src/store/appStore.workflowRun.test.ts
@@ -60,8 +60,7 @@ const invokeRunLocalProcess = vi.fn((_args: { program: string; args: string[] })
 );
 const cancelLocalProcess = vi.fn((_runId: string) => Promise.resolve(true));
 vi.mock("@/services/localProcessApi", () => ({
-  invokeRunLocalProcess: (args: { program: string; args: string[] }) =>
-    invokeRunLocalProcess(args),
+  invokeRunLocalProcess: (args: { program: string; args: string[] }) => invokeRunLocalProcess(args),
   cancelLocalProcess: (runId: string) => cancelLocalProcess(runId),
   subscribeLocalProcessOutput: vi.fn(() => Promise.resolve(() => {})),
 }));

--- a/src/store/appStore.workflowRun.test.ts
+++ b/src/store/appStore.workflowRun.test.ts
@@ -53,6 +53,18 @@ vi.mock("@/services/workflowApi", () => ({
   deleteWorkflow: vi.fn(() => Promise.resolve()),
 }));
 
+// The guarded local-process backend (#1857) is mocked so no Tauri command runs;
+// `invokeRunLocalProcess` records what it was asked to spawn.
+const invokeRunLocalProcess = vi.fn(() =>
+  Promise.resolve({ exitCode: 0, timedOut: false, cancelled: false })
+);
+const cancelLocalProcess = vi.fn(() => Promise.resolve(true));
+vi.mock("@/services/localProcessApi", () => ({
+  invokeRunLocalProcess: (args: unknown) => invokeRunLocalProcess(args as never),
+  cancelLocalProcess: (runId: string) => cancelLocalProcess(runId as never),
+  subscribeLocalProcessOutput: vi.fn(() => Promise.resolve(() => {})),
+}));
+
 import { useAppStore } from "./appStore";
 import { registerTerminalInputInjector } from "@/services/macroPlayback";
 import { serializeWorkflows } from "@/services/workflowIo";
@@ -94,6 +106,8 @@ describe("appStore — workflow run slice (#1852)", () => {
     useAppStore.setState(useAppStore.getInitialState());
     savedWorkflows.length = 0;
     injected = [];
+    invokeRunLocalProcess.mockClear();
+    cancelLocalProcess.mockClear();
     registerTerminalInputInjector(async (_tabId, data) => {
       injected.push(data);
       return true;
@@ -200,19 +214,102 @@ describe("appStore — workflow run slice (#1852)", () => {
     expect(toast.success).toHaveBeenCalled();
   });
 
-  it("fails with a toast when a step kind is not yet implemented", async () => {
-    seedConnectedTerminal();
-    useAppStore.setState({
-      workflows: [
-        workflow("w1", [cmd("a"), { kind: "run-local-process", program: "x", args: [] }]),
-      ],
+  describe("run-local-process guardrails (#1857)", () => {
+    const lp = (program: string, args: string[]): WorkflowStep => ({
+      kind: "run-local-process",
+      program,
+      args,
     });
 
-    await useAppStore.getState().runWorkflow("w1");
+    /** Enable the opt-in, optionally pre-authorizing programs. */
+    function enableLocalProcess(allowlist: string[] = []) {
+      useAppStore.setState({
+        settings: {
+          ...useAppStore.getState().settings,
+          workflowLocalProcessEnabled: true,
+          workflowLocalProcessAllowlist: allowlist,
+        },
+      });
+    }
 
-    expect(injected).toEqual(["a\n"]);
-    expect(useAppStore.getState().workflowRun).toBeNull();
-    expect(toast.error).toHaveBeenCalled();
+    it("GUARDRAIL: refuses to spawn when the opt-in is off (default)", async () => {
+      seedConnectedTerminal();
+      useAppStore.setState({ workflows: [workflow("w1", [cmd("a"), lp("rm", ["-rf", "/"])])] });
+
+      await useAppStore.getState().runWorkflow("w1");
+
+      // The prior send ran; the local process NEVER spawned.
+      expect(injected).toEqual(["a\n"]);
+      expect(invokeRunLocalProcess).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    it("runs an allowlisted program without prompting, passing discrete args", async () => {
+      seedConnectedTerminal();
+      enableLocalProcess(["notify-send"]);
+      useAppStore.setState({
+        workflows: [workflow("w1", [lp("notify-send", ["--urgency", "hello world"])])],
+      });
+
+      await useAppStore.getState().runWorkflow("w1");
+
+      expect(useAppStore.getState().localProcessPrompt).toBeNull();
+      expect(invokeRunLocalProcess).toHaveBeenCalledTimes(1);
+      const call = invokeRunLocalProcess.mock.calls[0][0] as unknown as {
+        program: string;
+        args: string[];
+      };
+      expect(call.program).toBe("notify-send");
+      // GUARDRAIL: the space-containing arg stays a single, literal argv entry.
+      expect(call.args).toEqual(["--urgency", "hello world"]);
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    it("prompts for a not-yet-trusted program and runs it on 'allow once'", async () => {
+      seedConnectedTerminal();
+      enableLocalProcess([]);
+      useAppStore.setState({ workflows: [workflow("w1", [lp("echo", ["hi"])])] });
+
+      const done = useAppStore.getState().runWorkflow("w1");
+      // Wait for the prompt to open.
+      await vi.waitFor(() => expect(useAppStore.getState().localProcessPrompt).not.toBeNull());
+      expect(useAppStore.getState().localProcessPrompt?.program).toBe("echo");
+
+      useAppStore.getState().resolveLocalProcessPrompt("once");
+      await done;
+
+      expect(invokeRunLocalProcess).toHaveBeenCalledTimes(1);
+      // "once" does NOT persist the program to the allowlist.
+      expect(useAppStore.getState().settings.workflowLocalProcessAllowlist).toEqual([]);
+    });
+
+    it("'always allow' persists the program to the allowlist", async () => {
+      seedConnectedTerminal();
+      enableLocalProcess([]);
+      useAppStore.setState({ workflows: [workflow("w1", [lp("echo", ["hi"])])] });
+
+      const done = useAppStore.getState().runWorkflow("w1");
+      await vi.waitFor(() => expect(useAppStore.getState().localProcessPrompt).not.toBeNull());
+      useAppStore.getState().resolveLocalProcessPrompt("always");
+      await done;
+
+      expect(invokeRunLocalProcess).toHaveBeenCalledTimes(1);
+      expect(useAppStore.getState().settings.workflowLocalProcessAllowlist).toContain("echo");
+    });
+
+    it("GUARDRAIL: 'cancel' refuses — the process never spawns", async () => {
+      seedConnectedTerminal();
+      enableLocalProcess([]);
+      useAppStore.setState({ workflows: [workflow("w1", [lp("echo", ["hi"])])] });
+
+      const done = useAppStore.getState().runWorkflow("w1");
+      await vi.waitFor(() => expect(useAppStore.getState().localProcessPrompt).not.toBeNull());
+      useAppStore.getState().resolveLocalProcessPrompt("cancel");
+      await done;
+
+      expect(invokeRunLocalProcess).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalled();
+    });
   });
 
   it("errors when the workflow does not exist", async () => {

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -556,6 +556,25 @@ export interface AppSettings {
    * which keeps older settings files forward-compatible.
    */
   syntaxHighlighting?: SyntaxHighlightingConfig;
+  /**
+   * Master opt-in for the guarded `run-local-process` workflow step (#1857).
+   * Defaults to `false` (off): a workflow that contains a `run-local-process`
+   * step cannot spawn a local program on the user's machine until this is
+   * explicitly enabled. This is the primary security guardrail — imported
+   * workflows carry such steps but are **never** auto-authorized, so an
+   * imported step stays inert until the user turns this on **and** authorizes
+   * the specific program (see {@link workflowLocalProcessAllowlist}). Enforced
+   * again in the backend spawn command as defence-in-depth.
+   */
+  workflowLocalProcessEnabled?: boolean;
+  /**
+   * Programs the user has chosen to always allow a `run-local-process` step to
+   * spawn without re-confirming (#1857). A program not on this list triggers a
+   * per-run confirmation dialog; "Always allow" appends it here. Independent of
+   * workflow data, so importing a workflow can never add an entry — an imported
+   * step is unauthorized until the user confirms it interactively.
+   */
+  workflowLocalProcessAllowlist?: string[];
 }
 
 /**


### PR DESCRIPTION
Implements the guarded **`run-local-process`** workflow step (epic #1851) — the highest-risk child, since it executes a program on the user's own machine. Every mandatory security guardrail is enforced and covered by tests.

## How each guardrail is met

**Explicit opt-in, off by default**
- New setting `workflowLocalProcessEnabled` (default `false`) under Settings → Security. While off, any `run-local-process` step is refused before spawning.
- Enforced twice: the frontend `authorizeLocalProcess` seam checks it, and the backend `run_local_process` command re-reads the persisted setting and refuses if disabled — so a step cannot spawn without opt-in even if the frontend were bypassed (defence-in-depth at the trust boundary).

**Authorization model (the `authorized` concept #1856 deferred)**
- Authorization lives in global settings, never in workflow data: the master opt-in flag plus a per-program allowlist (`workflowLocalProcessAllowlist`).
- A not-yet-trusted program triggers a confirmation dialog (program + discrete args shown) with **Allow once** / **Always allow** (persists to the allowlist) / **Cancel**.
- **Imported steps stay unauthorized**: importing never touches the allowlist and the opt-in defaults off, so an imported `run-local-process` step lands at the same gate as any untrusted program. The allowlist is manageable/revocable under Settings → Security.

**Direct argv, no shell + arg-model fix**
- The backend spawns via `tokio::process::Command::new(program).args(args)` — no shell, no string concatenation. A workflow-controlled argument (even with spaces/quotes/shell metacharacters) reaches the program as a single literal argv entry.
- The editor's naive whitespace-split args field is replaced with a **discrete argument list** (one input per arg, add/remove), so a space-containing argument stays one argument end to end.

**Bounded + observable**
- Enforced timeout (frontend default 60s; backend default 30s, hard-capped at 10 min), working **cancel** (a `CancellationToken` registry + `cancel_local_process`, wired to the run's cancel signal), stdout/stderr **streamed** as events into the log viewer, and the **exit status** surfaced (success/failure/timeout/cancel).

**Cross-platform**: Windows console-flash suppression is `#[cfg(windows)]`-gated; guardrail tests have unix and windows variants.

## Verification (guardrail tests)
- **Backend** (`commands::local_process`): discrete-argv (a space-containing arg stays one arg via `printf '[%s]'`), shell-metacharacters stay literal, non-zero exit surfaced, timeout kills, cancel kills, empty-program refused; windows exit/timeout variants; settings default-off + round-trip.
- **Runner** (`workflowRunner.test.ts`): never spawns without an authorize=true (absent seam or refusal), args passed as a discrete unmodified array, exit/timeout/cancel outcomes, no spawn when pre-cancelled.
- **Store** (`appStore.workflowRun.test.ts`): opt-in off refuses (backend never invoked), allowlisted program runs without prompting with discrete args, confirm once/always/cancel flows, "always" persists to the allowlist.
- **UI**: auth dialog resolves cancel/once/always; discrete-args editor add/remove/space-preservation; settings toggle + allowlist management.

Full suite green locally: 3969 frontend tests, backend `local_process` + settings tests, `./scripts/check.sh` (eslint, prettier, clippy, fmt).

Closes #1857

🤖 Generated with [Claude Code](https://claude.com/claude-code)
