### PR TITLE
feat(config): per-connection env vars for SSH and WSL connections (Closes #1841)

### DIFF
--- a/core/src/backends/ssh/connector.rs
+++ b/core/src/backends/ssh/connector.rs
@@ -247,7 +247,11 @@ impl SshConnector for RusshSshConnector {
             }
         }
 
-        // User-specified environment variables (best-effort; many servers reject setenv).
+        // User-specified environment variables via the SSH channel env request.
+        // Best-effort: the server only accepts names whitelisted in its
+        // `AcceptEnv`, but when it does accept a name the value is present
+        // before the login shell's rc files run. Names it rejects are covered
+        // by the `export` injection after the shell starts (see below).
         for (key, value) in &config.env {
             let _ = channel.set_env(false, key, value).await;
         }
@@ -269,6 +273,14 @@ impl SshConnector for RusshSshConnector {
             .request_shell(false)
             .await
             .map_err(|e| SessionError::SpawnFailed(format!("Shell request failed: {e}")))?;
+
+        // Inject an `export` line for the user-specified environment variables.
+        // This guarantees they take effect in the interactive shell even when
+        // the server's `AcceptEnv` rejected the `set_env` requests above. The
+        // line is briefly visible, matching the X11 `export DISPLAY` injection.
+        if let Some(export_line) = super::build_ssh_env_export(&config.env) {
+            let _ = channel.data(export_line.as_bytes()).await;
+        }
 
         // Inject DISPLAY and xauth if X11 forwarding is active.
         if let Some(display_num) = x11_display {

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -190,6 +190,46 @@ pub fn parse_ssh_settings(settings: &serde_json::Value) -> SshConfig {
     }
 }
 
+/// Build a single POSIX `export` statement that sets every entry in `env`.
+///
+/// Values are wrapped in single quotes (with embedded `'` escaped as `'\''`)
+/// so arbitrary characters survive, and keys are sorted for a deterministic,
+/// stable line. Returns `None` when `env` is empty.
+///
+/// # Why this exists (the `AcceptEnv` caveat)
+///
+/// Setting an environment variable on the SSH *client* does not make it appear
+/// on the server: the standard channel env request (`set_env`, RFC 4254 §6.4)
+/// is only honoured for names the server explicitly whitelists via sshd's
+/// `AcceptEnv`, which defaults to accepting little more than `LANG`/`LC_*`.
+/// So the backend requests each variable via `set_env` (clean, and present
+/// before the login shell's rc files run *when* the server accepts it) **and**
+/// injects the line built here into the interactive shell after it starts —
+/// guaranteeing the variables take effect regardless of `AcceptEnv`. The
+/// injected line is briefly visible in the terminal, matching the existing X11
+/// `export DISPLAY` injection.
+pub(crate) fn build_ssh_env_export(
+    env: &std::collections::HashMap<String, String>,
+) -> Option<String> {
+    if env.is_empty() {
+        return None;
+    }
+    let mut pairs: Vec<(&String, &String)> = env.iter().collect();
+    pairs.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut line = String::from("export");
+    for (key, value) in pairs {
+        let escaped = value.replace('\'', "'\\''");
+        line.push(' ');
+        line.push_str(key);
+        line.push_str("='");
+        line.push_str(&escaped);
+        line.push('\'');
+    }
+    line.push('\n');
+    Some(line)
+}
+
 #[async_trait::async_trait]
 impl ConnectionType for Ssh {
     fn type_id(&self) -> &str {
@@ -402,7 +442,14 @@ impl ConnectionType for Ssh {
                             description: Some(
                                 "Additional environment variables for the remote shell".to_string(),
                             ),
-                            help_text: None,
+                            help_text: Some(concat!(
+                                "These are requested over the SSH channel and, for reliability, ",
+                                "also applied by exporting them in the remote shell once it starts.\n\n",
+                                "The SSH server only honours the channel request for names listed in ",
+                                "its sshd `AcceptEnv` setting (which usually accepts little beyond ",
+                                "`LANG`/`LC_*`). The export fallback makes the variables take effect ",
+                                "regardless, so it is briefly visible in the terminal at connect time.",
+                            ).to_string()),
                             field_type: FieldType::KeyValueList,
                             required: false,
                             default: None,
@@ -996,6 +1043,59 @@ mod tests {
             .find(|f| f.key == "env")
             .unwrap();
         assert!(matches!(env.field_type, FieldType::KeyValueList));
+    }
+
+    // --- Environment-variable export fallback (AcceptEnv) tests ---
+
+    #[test]
+    fn build_ssh_env_export_none_when_empty() {
+        let env = std::collections::HashMap::new();
+        assert!(build_ssh_env_export(&env).is_none());
+    }
+
+    #[test]
+    fn build_ssh_env_export_single_var() {
+        let env = std::collections::HashMap::from([("FOO".to_string(), "bar".to_string())]);
+        assert_eq!(build_ssh_env_export(&env).as_deref(), Some("export FOO='bar'\n"));
+    }
+
+    #[test]
+    fn build_ssh_env_export_sorts_keys_for_determinism() {
+        let env = std::collections::HashMap::from([
+            ("ZED".to_string(), "1".to_string()),
+            ("ALPHA".to_string(), "2".to_string()),
+        ]);
+        assert_eq!(
+            build_ssh_env_export(&env).as_deref(),
+            Some("export ALPHA='2' ZED='1'\n")
+        );
+    }
+
+    #[test]
+    fn build_ssh_env_export_escapes_single_quotes() {
+        // A value containing a single quote must be escaped as '\'' so the
+        // resulting line is still a valid, safe POSIX export statement.
+        let env = std::collections::HashMap::from([(
+            "MSG".to_string(),
+            "it's a test".to_string(),
+        )]);
+        assert_eq!(
+            build_ssh_env_export(&env).as_deref(),
+            Some("export MSG='it'\\''s a test'\n")
+        );
+    }
+
+    #[test]
+    fn build_ssh_env_export_handles_spaces_and_specials() {
+        let env = std::collections::HashMap::from([(
+            "PATH_EXTRA".to_string(),
+            "/opt/my app/bin:$HOME".to_string(),
+        )]);
+        // Single quotes keep spaces and `$` literal — no expansion or splitting.
+        assert_eq!(
+            build_ssh_env_export(&env).as_deref(),
+            Some("export PATH_EXTRA='/opt/my app/bin:$HOME'\n")
+        );
     }
 
     // --- Settings validation tests ---

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -1056,7 +1056,10 @@ mod tests {
     #[test]
     fn build_ssh_env_export_single_var() {
         let env = std::collections::HashMap::from([("FOO".to_string(), "bar".to_string())]);
-        assert_eq!(build_ssh_env_export(&env).as_deref(), Some("export FOO='bar'\n"));
+        assert_eq!(
+            build_ssh_env_export(&env).as_deref(),
+            Some("export FOO='bar'\n")
+        );
     }
 
     #[test]
@@ -1075,10 +1078,7 @@ mod tests {
     fn build_ssh_env_export_escapes_single_quotes() {
         // A value containing a single quote must be escaped as '\'' so the
         // resulting line is still a valid, safe POSIX export statement.
-        let env = std::collections::HashMap::from([(
-            "MSG".to_string(),
-            "it's a test".to_string(),
-        )]);
+        let env = std::collections::HashMap::from([("MSG".to_string(), "it's a test".to_string())]);
         assert_eq!(
             build_ssh_env_export(&env).as_deref(),
             Some("export MSG='it'\\''s a test'\n")

--- a/core/src/backends/wsl.rs
+++ b/core/src/backends/wsl.rs
@@ -339,6 +339,46 @@ pub(crate) fn windows_path_to_wsl_path(win_path: &str) -> Option<String> {
     }
 }
 
+/// Parse the `env` key/value list from connection settings into a map of
+/// environment variables to apply to the WSL distribution.
+///
+/// Mirrors the SSH backend's parsing: each entry is an object with `key`/`value`
+/// string fields (the shape produced by the `KeyValueList` form widget). Entries
+/// missing either field are skipped; on a duplicate key the last entry wins.
+/// Returns an empty map when the field is absent or not an array.
+fn parse_wsl_env(settings: &serde_json::Value) -> std::collections::HashMap<String, String> {
+    settings
+        .get("env")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    let key = item.get("key").and_then(|v| v.as_str())?;
+                    let value = item.get("value").and_then(|v| v.as_str())?;
+                    Some((key.to_string(), value.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Build the `WSLENV` value that shares the given variable names across the
+/// Win32↔WSL boundary.
+///
+/// `wsl.exe` inherits the launching process's Win32 environment, but a variable
+/// only crosses into the Linux side if its name is listed in `WSLENV`. Names are
+/// joined with `:` and appended to any pre-existing `WSLENV` (passed as
+/// `existing`) so a caller-provided `WSLENV` is preserved. No per-variable flag
+/// is used, so the values cross verbatim (no `/p` path translation) — correct
+/// for arbitrary string values. `names` is assumed pre-sorted for determinism.
+fn build_wslenv(existing: Option<&str>, names: &[String]) -> String {
+    let joined = names.join(":");
+    match existing.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(existing) => format!("{existing}:{joined}"),
+        None => joined,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Silent setup task
 // ---------------------------------------------------------------------------
@@ -629,6 +669,26 @@ impl ConnectionType for Wsl {
                         supports_tilde_expansion: false,
                         visible_when: None,
                     },
+                    SettingsField {
+                        key: "env".to_string(),
+                        label: "Environment Variables".to_string(),
+                        description: Some(
+                            "Additional environment variables for the WSL shell".to_string(),
+                        ),
+                        help_text: Some(concat!(
+                            "These are set in the Win32 environment of `wsl.exe` and shared into ",
+                            "the Linux side by adding their names to `WSLENV`, so they are present ",
+                            "in the distribution's shell. Values cross verbatim (no path ",
+                            "translation).",
+                        ).to_string()),
+                        field_type: FieldType::KeyValueList,
+                        required: false,
+                        default: None,
+                        placeholder: None,
+                        supports_env_expansion: true,
+                        supports_tilde_expansion: false,
+                        visible_when: None,
+                    },
                 ],
             }],
         }
@@ -680,6 +740,7 @@ impl ConnectionType for Wsl {
             distribution: distribution.clone(),
             starting_directory,
             initial_command: _initial_command,
+            env: parse_wsl_env(&settings),
             ..WslConfig::default()
         };
 
@@ -724,6 +785,23 @@ impl ConnectionType for Wsl {
         // Set TERM for the WSL environment.
         command.env("TERM", "xterm-256color");
         command.env("COLORTERM", "truecolor");
+
+        // Per-connection environment variables. `wsl.exe` inherits this Win32
+        // environment, but a variable only reaches the Linux side if its name is
+        // listed in `WSLENV`. Set each var on the launch environment and append
+        // its name (sorted for determinism) to `WSLENV`, preserving any existing
+        // `WSLENV` from the parent process.
+        if !config.env.is_empty() {
+            let mut names: Vec<String> = config.env.keys().cloned().collect();
+            names.sort();
+            for name in &names {
+                if let Some(value) = config.env.get(name) {
+                    command.env(name, value);
+                }
+            }
+            let wslenv = build_wslenv(std::env::var("WSLENV").ok().as_deref(), &names);
+            command.env("WSLENV", wslenv);
+        }
 
         let child = pty_pair
             .slave
@@ -990,6 +1068,68 @@ mod tests {
         let fields = &schema.groups[0].fields;
         let distro_field = fields.iter().find(|f| f.key == "distribution").unwrap();
         assert!(distro_field.required);
+    }
+
+    #[test]
+    fn schema_has_env_key_value_list() {
+        let wsl = Wsl::new();
+        let schema = wsl.settings_schema();
+        let fields = &schema.groups[0].fields;
+        let env_field = fields
+            .iter()
+            .find(|f| f.key == "env")
+            .expect("env field present in schema");
+        assert!(matches!(env_field.field_type, FieldType::KeyValueList));
+        assert!(!env_field.required);
+    }
+
+    // -----------------------------------------------------------------------
+    // Environment-variable parsing / WSLENV boundary crossing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_wsl_env_reads_key_value_array() {
+        let settings = serde_json::json!({
+            "distribution": "Ubuntu",
+            "env": [
+                {"key": "FOO", "value": "bar"},
+                {"key": "BAZ", "value": "qux"}
+            ]
+        });
+        let env = super::parse_wsl_env(&settings);
+        assert_eq!(env.len(), 2);
+        assert_eq!(env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(env.get("BAZ").map(String::as_str), Some("qux"));
+    }
+
+    #[test]
+    fn parse_wsl_env_empty_and_missing() {
+        assert!(super::parse_wsl_env(&serde_json::json!({ "env": [] })).is_empty());
+        assert!(super::parse_wsl_env(&serde_json::json!({})).is_empty());
+        // Malformed (not an array) → empty, never panics.
+        assert!(super::parse_wsl_env(&serde_json::json!({ "env": "nope" })).is_empty());
+    }
+
+    #[test]
+    fn build_wslenv_no_existing() {
+        let names = vec!["FOO".to_string(), "BAR".to_string()];
+        assert_eq!(super::build_wslenv(None, &names), "FOO:BAR");
+    }
+
+    #[test]
+    fn build_wslenv_appends_to_existing() {
+        let names = vec!["FOO".to_string()];
+        assert_eq!(
+            super::build_wslenv(Some("EXISTING/p"), &names),
+            "EXISTING/p:FOO"
+        );
+    }
+
+    #[test]
+    fn build_wslenv_empty_existing_is_ignored() {
+        let names = vec!["FOO".to_string()];
+        assert_eq!(super::build_wslenv(Some(""), &names), "FOO");
+        assert_eq!(super::build_wslenv(Some("   "), &names), "FOO");
     }
 
     #[test]

--- a/docs/changes/dev0/feature/1841-ssh-wsl-env-vars.md
+++ b/docs/changes/dev0/feature/1841-ssh-wsl-env-vars.md
@@ -1,0 +1,15 @@
+### Added
+
+- **SSH** and **WSL** connections now support **per-connection environment
+  variables**, completing the follow-up to #1825 (which added them for local
+  shells). Both connection editors gain an **Environment Variables** key/value
+  field (#1841).
+  - **SSH**: variables are requested over the SSH channel (`set_env`) **and**,
+    for reliability, exported in the remote interactive shell once it starts.
+    The channel request is only honoured for names the server whitelists in its
+    sshd `AcceptEnv` setting (which usually accepts little beyond `LANG`/`LC_*`),
+    so the `export` fallback guarantees the variables take effect regardless — at
+    the cost of being briefly visible in the terminal at connect time.
+  - **WSL**: variables are set in the Win32 environment of `wsl.exe` and shared
+    into the Linux side by adding their names to `WSLENV` (any pre-existing
+    `WSLENV` is preserved). Values cross verbatim, with no path translation.


### PR DESCRIPTION
Follow-up to #1825 (which added per-connection environment variables for local shells). Exposes and correctly applies env vars for SSH and WSL connections.

Closes #1841

## SSH
The `env` key/value field already existed in the SSH schema and was requested over the SSH channel (`set_env`). The problem: **`set_env` is only honoured for names the server whitelists in its sshd `AcceptEnv`** (which defaults to little beyond `LANG`/`LC_*`), and in russh `set_env` only queues the request — the server's accept/reject reply never surfaces to the caller — so configured variables silently did nothing on most servers.

Mechanism used (a documented combination, mirroring the existing X11 `export DISPLAY` injection):
- Keep the `set_env` channel request — clean, and the value is present before the login shell's rc files run **when** the server accepts it.
- **Additionally inject a single sorted, single-quoted `export NAME='VALUE' ...` line** into the interactive shell once it starts. This guarantees the variables take effect regardless of `AcceptEnv`.

**Caveat (documented in the field help text and change fragment):** because the server may reject the channel request, the `export` fallback is used, and that line is briefly visible in the terminal at connect time.

## WSL
`wsl.exe` inherits the caller's Win32 environment, but a variable only crosses into the Linux side if its **name is listed in `WSLENV`**. Added an `env` key/value field to the WSL schema, parsed it into `WslConfig`, and on launch: set each configured var on the `wsl.exe` command environment and append its name to `WSLENV` (preserving any pre-existing `WSLENV`). No per-variable flag is used, so values cross verbatim (no path translation). WSL code is `#[cfg(windows)]`-gated.

## Schema-driven UI
Both backends expose the field via `FieldType::KeyValueList`, so `DynamicForm` renders the same key/value editor automatically — no hardcoded UI.

## Testing
- SSH: unit tests for `build_ssh_env_export` (empty → `None`, single var, deterministic key sorting, single-quote escaping, spaces/`$` kept literal).
- WSL (Windows-only, run on Windows CI): schema exposes the `env` KeyValueList field; `parse_wsl_env` reads the key/value array and handles empty/missing/malformed; `build_wslenv` join / append-to-existing / empty-existing behavior.
- Ran `./scripts/check.sh` (pass) and `./scripts/test.sh` (pass except a pre-existing Docker integration test, `docker_spawn_mounts_directory_and_opens_cd_to_mount`, unrelated to these changes and excluded from the per-PR lane). Cross-checked the WSL module + clippy against the `x86_64-pc-windows-msvc` target since it does not compile on the macOS dev host.
- Applying against a real server/distro is a manual step (per-PR CI exercises neither), per the issue's "done when".