### PR TITLE
feat(workflow): show the workflows panel by default

### DIFF
--- a/docs/changes/dev1/chore/expose-workflows-panel.md
+++ b/docs/changes/dev1/chore/expose-workflows-panel.md
@@ -1,0 +1,6 @@
+### Changed
+
+- The **Workflows** panel is now shown by default in the Activity Bar. It was
+  previously hidden behind the experimental-features gate while the Workflow
+  Automation feature was being built (epic #1851, now complete). Like the other
+  optional panels, it can still be toggled off via the Activity Bar context menu.

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -62,7 +62,7 @@ const OPTIONAL_ITEMS: ActivityBarItemDef[] = [
   { view: "files", icon: FolderOpen, label: "File Browser" },
   { view: "workspaces", icon: LayoutGrid, label: "Workspaces" },
   { view: "macros", icon: Clapperboard, label: "Macros" },
-  { view: "workflows", icon: Workflow, label: "Workflows", experimental: true },
+  { view: "workflows", icon: Workflow, label: "Workflows" },
   { view: "tunnels", icon: ArrowLeftRight, label: "SSH Tunnels", experimental: true },
   { view: "services", icon: Server, label: "Services", experimental: true },
   { view: "network-tools", icon: Stethoscope, label: "Network Tools", experimental: true },


### PR DESCRIPTION
## What

Remove the `experimental: true` flag from the **Workflows** entry in the Activity Bar so the panel is visible by default, like the sibling optional panels (Macros, etc.).

The Workflow Automation feature was built with its Activity Bar entry gated behind the experimental-features toggle. Now that the epic is complete and the panel is fully wired (store, Sidebar routing, `WorkflowSidebar`), it can be exposed for normal use and testing. It remains an *optional* panel — users can still toggle it off via the Activity Bar context menu.

Part of #1851 (epic complete) — exposes the Workflows panel.

## Notes

- Only the Workflows entry changed; the other experimental entries (SSH Tunnels, Services, Network Tools) keep their own flags, and the experimental-features mechanism is untouched.
- No test asserted the Workflows entry was experimental, so no test needed updating. Full frontend suite (3987 tests) and `check.sh` pass locally.

## Test plan

- `pnpm test` — all pass
- `./scripts/check.sh` — all pass
- Manual: open the app, confirm the Workflows panel appears in the Activity Bar without enabling experimental features, and can be toggled off/on via the context menu.