### PR TITLE
docs: document workflow automation and re-gate the panel as experimental (Closes #1851)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ Prefer to build it yourself? See [Development](#development) below.
 - **Credential storage** — Optional credential encryption via platform keychain, master password, or prompt-only mode
 - **Auto-lock** — Configurable timeout for credential store locking
 
+### Workflow Automation (experimental)
+
+- **Authored multi-step workflows** — Save named, ordered sequences of steps that run against a terminal session
+- **Step types** — `send-command` (type a command), `run-script` (stream a multi-line script), `run-macro` (replay a saved macro), `wait` (delay), and `run-local-process` (run a local program — see the security callout below)
+- **Triggers** — Run manually (command palette / sidebar), via a hotkey, or automatically on-connect when a chosen connection opens a session
+- **Sidebar + editor** — Manage, edit, and organize workflows from the Workflows panel; import and export workflows as portable JSON
+
+> ⚠️ **`run-local-process` runs on your LOCAL machine.** Every other step type sends text into the terminal session (i.e. runs on the remote host when you are connected). `run-local-process` instead launches a program on the computer running termiHub. It is **off by default** and stays inert until you explicitly opt in under **Settings → Security**, and each program must be authorized via a per-program allowlist / per-run confirmation. Arguments are passed as a discrete list (no shell interpretation). This is a power-user orchestration capability — safe to ignore entirely if you don't use it. Imported workflows are **never** auto-authorized.
+>
+> The Workflows panel is **experimental** and behind the experimental-features toggle — enable **Settings → General → Allow Experimental Features** to use it. Design reference: [`docs/concepts/backlog/workflow-automation.html`](docs/concepts/backlog/workflow-automation.html).
+
 ### Platform Support
 
 - **Cross-platform** — Windows, Linux, and macOS

--- a/docs/changes/dev2/docs/document-workflow-automation.md
+++ b/docs/changes/dev2/docs/document-workflow-automation.md
@@ -1,0 +1,15 @@
+### Added
+
+- Documented the Workflow Automation feature in the README: authored multi-step
+  workflows (`send-command`, `run-script`, `run-macro`, `wait`, and the guarded
+  local `run-local-process` step), manual / hotkey / on-connect triggers, the
+  Workflows sidebar and editor, and workflow import/export. Includes a prominent
+  callout that `run-local-process` runs a program on the local machine, is off by
+  default, and requires an explicit opt-in under Settings → Security plus a
+  per-program allowlist/confirmation (part of epic #1851).
+
+### Changed
+
+- The Workflows panel is now gated behind the experimental-features toggle again,
+  matching the other new panels (SSH Tunnels, Services, Network Tools). Enable
+  Settings → General → Allow Experimental Features to use it (part of epic #1851).

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -62,10 +62,10 @@ const OPTIONAL_ITEMS: ActivityBarItemDef[] = [
   { view: "files", icon: FolderOpen, label: "File Browser" },
   { view: "workspaces", icon: LayoutGrid, label: "Workspaces" },
   { view: "macros", icon: Clapperboard, label: "Macros" },
-  { view: "workflows", icon: Workflow, label: "Workflows" },
   { view: "tunnels", icon: ArrowLeftRight, label: "SSH Tunnels", experimental: true },
   { view: "services", icon: Server, label: "Services", experimental: true },
   { view: "network-tools", icon: Stethoscope, label: "Network Tools", experimental: true },
+  { view: "workflows", icon: Workflow, label: "Workflows", experimental: true },
 ];
 
 const EMPTY_HIDDEN_VIEWS: string[] = [];


### PR DESCRIPTION
Part of #1851 — re-gate Workflows as experimental + document it.

The Workflow Automation feature (epic #1851, children #1852-#1857) is brand-new, human-untested, and includes security-sensitive local-process execution. It was mistakenly un-gated from the experimental-features flag in PR #1866. This restores the gating and documents the feature.

Changes:

- ActivityBar: add experimental: true to the Workflows panel entry so it sits behind the experimental-features toggle, matching the sibling new panels (SSH Tunnels, Services, Network Tools). No test asserted the workflows entry flag, so none needed updating.
- README: new Workflow Automation (experimental) section under Features covering step types (send-command, run-script, run-macro, wait, run-local-process), triggers (manual, hotkey, on-connect), the sidebar/editor, and workflow import/export.
- README: prominent callout that run-local-process runs a program on the LOCAL machine (unlike the other steps, which send text into the session), is off by default, and requires an explicit opt-in under Settings -> Security plus a per-program allowlist/confirmation, with args passed as a discrete list (no shell). Imported workflows are never auto-authorized.
- README: notes the Workflows panel is experimental/beta and behind the experimental-features toggle; links the design reference concept doc.

Verification: pnpm markdownlint clean, pnpm test (3987 passing), ./scripts/check.sh all green.