### PR TITLE
fix(workflow): make "Add step…" menu and pickers clickable in the editor (Closes #1868)

### DIFF
--- a/docs/changes/dev1/fix/1868-workflow-editor-menu.md
+++ b/docs/changes/dev1/fix/1868-workflow-editor-menu.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Workflow editor: the **"+ Add step…"** menu and the **Run macro** picker now
+  open and are clickable inside the editor dialog. As a modal Radix `Dialog`,
+  the editor disables pointer events on `document.body`, so menus that portalled
+  to the body (the Radix default) rendered outside the dialog and were dead in
+  the running app — you could not add any steps to a workflow. The shared `Modal`
+  primitive now exposes its content node as a portal container, and menus/selects
+  inside a modal portal into the dialog subtree where pointer events are enabled,
+  so this cannot silently recur for other dialogs (#1868).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2955,3 +2955,32 @@ evidence exists on disk after the process is gone. Referenced by PR #1578.
    with the banner, the previous content moved to `termihub.1.log`, and that after
    enough churn `termihub.2.log` is the oldest kept — `termihub.3.log` must
    **never** appear and the directory must stay under ~15 MiB.
+
+### Workflow editor menus are clickable inside the modal (#1868)
+
+The workflow editor is a modal Radix `Dialog`, which sets `pointer-events: none`
+on `document.body` while open. Any Radix menu/select that portals to
+`document.body` (the default) therefore renders **outside** the dialog and is
+dead/unclickable in a real WebView. jsdom does not enforce `pointer-events`, so
+unit tests structurally cannot catch this — hence a manual test in the running
+app. The fix portals these into the dialog's own content node (via the shared
+`Modal` primitive's portal container). Referenced by PR for #1868.
+
+**Launch the app** (`./scripts/dev.sh` — never `pnpm tauri dev`).
+
+**The "+ Add step…" menu works.**
+
+1. Open the **Workflows** panel → **New Workflow**.
+2. Click **"+ Add step…"**. Confirm the step-kind menu **opens and each item is
+   clickable** (not just visible). Add one of every kind — send-command,
+   run-script, run-macro, wait, run-local-process — confirming each appends a
+   step row.
+
+**Pickers inside the editor work.**
+
+1. On a **Run macro** step, open the **Macro** `Select` and confirm the listbox
+   opens and a macro can be selected (this `Select` portals to the same place
+   and was dead for the same reason).
+2. Reorder, edit, and delete steps as normal to confirm the fix changed nothing
+   else about the editor's behavior.
+3. Save the workflow and confirm it persists with the steps you added.

--- a/src/components/WorkflowSidebar/WorkflowEditorDialog.test.tsx
+++ b/src/components/WorkflowSidebar/WorkflowEditorDialog.test.tsx
@@ -224,6 +224,23 @@ describe("WorkflowEditorDialog", () => {
     expect(result.steps[3].kind).toBe("wait");
   });
 
+  it("portals the Add step menu inside the dialog content, not document.body (#1868)", async () => {
+    render();
+
+    await openAddStepMenu();
+    const dialog = query("workflow-editor-dialog");
+    const waitItem = query("workflow-editor-add-step-wait");
+    expect(dialog).not.toBeNull();
+    expect(waitItem).not.toBeNull();
+
+    // Regression guard for #1868: a modal Radix Dialog sets pointer-events: none
+    // on document.body, so a menu portalled to body is dead/unclickable in a
+    // real browser. The menu must live INSIDE the dialog subtree (its
+    // pointer-events: auto content) — jsdom can't reproduce the pointer-events
+    // failure itself, but it can prove the structural fix that prevents it.
+    expect(dialog!.contains(waitItem)).toBe(true);
+  });
+
   it("deletes an individual step before saving", async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     render({ onSave });

--- a/src/components/WorkflowSidebar/WorkflowEditorDialog.tsx
+++ b/src/components/WorkflowSidebar/WorkflowEditorDialog.tsx
@@ -3,7 +3,7 @@ import { Plus } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
-import { Modal, Button, Input, Field } from "@/components/ui";
+import { Modal, Button, Input, Field, useModalPortalContainer } from "@/components/ui";
 import type { Workflow, WorkflowStep, WorkflowStepKind, WorkflowTrigger } from "@/types/workflow";
 import type { Macro } from "@/types/macro";
 import type { SavedConnection } from "@/types/connection";
@@ -241,36 +241,7 @@ export function WorkflowEditorDialog({
         </DndContext>
       )}
 
-      <DropdownMenu.Root>
-        <DropdownMenu.Trigger asChild>
-          <Button
-            variant="secondary"
-            size="sm"
-            icon={<Plus size={14} />}
-            data-testid="workflow-editor-add-step"
-          >
-            Add step…
-          </Button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Portal>
-          <DropdownMenu.Content className="settings-menu__content" align="start" sideOffset={4}>
-            {WORKFLOW_STEP_KINDS.map((kind) => {
-              const Icon = stepKindIcon(kind);
-              return (
-                <DropdownMenu.Item
-                  key={kind}
-                  className="settings-menu__item"
-                  onSelect={() => addStep(kind)}
-                  data-testid={`workflow-editor-add-step-${kind}`}
-                >
-                  <Icon size={14} />
-                  {stepKindLabel(kind)}
-                </DropdownMenu.Item>
-              );
-            })}
-          </DropdownMenu.Content>
-        </DropdownMenu.Portal>
-      </DropdownMenu.Root>
+      <AddStepMenu onAdd={addStep} />
 
       <div className="workflow-editor__section-header">
         <span className="workflow-editor__section-title">Triggers</span>
@@ -281,5 +252,51 @@ export function WorkflowEditorDialog({
         onChange={setTriggers}
       />
     </Modal>
+  );
+}
+
+interface AddStepMenuProps {
+  onAdd: (kind: WorkflowStepKind) => void;
+}
+
+/**
+ * The "Add step…" dropdown. Extracted so it renders *inside* the {@link Modal}
+ * body and can read {@link useModalPortalContainer}: the menu content must
+ * portal into the dialog's content node, not `document.body`, or the modal's
+ * `pointer-events: none` on the body leaves it dead/unclickable (#1868).
+ */
+function AddStepMenu({ onAdd }: AddStepMenuProps) {
+  const portalContainer = useModalPortalContainer();
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={<Plus size={14} />}
+          data-testid="workflow-editor-add-step"
+        >
+          Add step…
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal container={portalContainer}>
+        <DropdownMenu.Content className="settings-menu__content" align="start" sideOffset={4}>
+          {WORKFLOW_STEP_KINDS.map((kind) => {
+            const Icon = stepKindIcon(kind);
+            return (
+              <DropdownMenu.Item
+                key={kind}
+                className="settings-menu__item"
+                onSelect={() => onAdd(kind)}
+                data-testid={`workflow-editor-add-step-${kind}`}
+              >
+                <Icon size={14} />
+                {stepKindLabel(kind)}
+              </DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 }

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
-import { Modal } from "./Modal";
+import { Modal, useModalPortalContainer } from "./Modal";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -71,6 +71,35 @@ describe("Modal", () => {
     expect(
       document.querySelector('[data-testid="modal"]')!.classList.contains("ui-modal--lg")
     ).toBe(true);
+  });
+
+  it("exposes its content node as a portal container to descendants (#1868)", () => {
+    let received: HTMLElement | null = null;
+    function Probe() {
+      received = useModalPortalContainer();
+      return null;
+    }
+    render(
+      <Modal data-testid="modal" open onOpenChange={() => {}} title="Editor">
+        <Probe />
+      </Modal>
+    );
+    // Descendants must receive the dialog's content element so they can portal
+    // menus/selects inside it (where pointer-events are enabled), not into
+    // document.body (which the modal disables) — see #1868.
+    const content = document.querySelector('[data-testid="modal"]');
+    expect(received).toBe(content);
+  });
+
+  it("returns null from useModalPortalContainer outside any modal", () => {
+    let received: HTMLElement | null = document.body;
+    function Probe() {
+      received = useModalPortalContainer();
+      return null;
+    }
+    render(<Probe />);
+    // No modal ancestor → null, so callers fall back to Radix's default body.
+    expect(received).toBeNull();
   });
 
   it("calls onOpenChange(false) when the built-in close button is clicked", () => {

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -4,6 +4,34 @@ import { X } from "lucide-react";
 import "./ui.css";
 
 /**
+ * The modal's content node, published so descendants can portal into the dialog
+ * subtree instead of `document.body`.
+ *
+ * A modal Radix `Dialog` sets `pointer-events: none` on `document.body` while
+ * open. Any Radix menu/select/popover that portals to `document.body` (the
+ * default) therefore renders *outside* the dialog and inherits that
+ * `pointer-events: none`, making it dead/unclickable in a real browser (jsdom
+ * does not enforce this, so unit tests miss it — see #1868). Passing this node
+ * as the Radix `Portal` `container` keeps such content inside the dialog, where
+ * pointer events are enabled.
+ *
+ * `null` when there is no modal ancestor (or the content has not mounted yet),
+ * in which case callers should fall back to Radix's default `document.body`.
+ */
+const ModalPortalContainerContext = React.createContext<HTMLElement | null>(null);
+
+/**
+ * Returns the nearest enclosing {@link Modal}'s content element, or `null` when
+ * not inside a modal. Pass it as the `container` prop of a Radix
+ * `DropdownMenu.Portal` / `Select.Portal` / `Popover.Portal` so the portalled
+ * content stays clickable inside the dialog (#1868). Radix treats a `null`
+ * container as "use the default", so this is safe to pass unconditionally.
+ */
+export function useModalPortalContainer(): HTMLElement | null {
+  return React.useContext(ModalPortalContainerContext);
+}
+
+/**
  * Props for the shared {@link Modal} primitive — a token-styled skin over
  * `@radix-ui/react-dialog`. Focus trap, ESC-to-close, scroll lock, and
  * portalling all come from Radix. The overlay uses `--overlay-bg` +
@@ -49,11 +77,17 @@ export function Modal({
   onKeyDown,
   ...rest
 }: ModalProps): React.ReactElement {
+  // Track the content node so descendants can portal into it (#1868). A callback
+  // ref stored in state re-renders once the node mounts, so menus opened later
+  // pick up the real container rather than falling back to `document.body`.
+  const [contentEl, setContentEl] = React.useState<HTMLDivElement | null>(null);
+
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="ui-modal__overlay" />
         <Dialog.Content
+          ref={setContentEl}
           className={size === "lg" ? "ui-modal ui-modal--lg" : "ui-modal"}
           data-testid={rest["data-testid"]}
           onKeyDown={onKeyDown}
@@ -88,8 +122,10 @@ export function Modal({
               {description}
             </Dialog.Description>
           ) : null}
-          <div className="ui-modal__body">{children}</div>
-          {footer ? <div className="ui-modal__foot">{footer}</div> : null}
+          <ModalPortalContainerContext.Provider value={contentEl}>
+            <div className="ui-modal__body">{children}</div>
+            {footer ? <div className="ui-modal__foot">{footer}</div> : null}
+          </ModalPortalContainerContext.Provider>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import * as RadixSelect from "@radix-ui/react-select";
 import { Check, ChevronDown } from "lucide-react";
+import { useModalPortalContainer } from "./Modal";
 import "./ui.css";
 
 /** A single option for the simple {@link Select} API. */
@@ -84,6 +85,9 @@ export function Select({
   ...rest
 }: SelectProps): React.ReactElement {
   const testid = rest["data-testid"];
+  // Portal into the enclosing Modal's content (if any) so the listbox stays
+  // clickable inside a dialog; `null` falls back to Radix's default body (#1868).
+  const portalContainer = useModalPortalContainer();
 
   return (
     <RadixSelect.Root value={value} onValueChange={onChange} disabled={disabled}>
@@ -98,7 +102,7 @@ export function Select({
           <ChevronDown width={14} height={14} aria-hidden="true" />
         </RadixSelect.Icon>
       </RadixSelect.Trigger>
-      <RadixSelect.Portal>
+      <RadixSelect.Portal container={portalContainer}>
         <RadixSelect.Content className="ui-select__content" position="popper" sideOffset={4}>
           <RadixSelect.Viewport>
             {children ??

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -23,7 +23,7 @@ export type { FieldProps } from "./Field";
 export { Select, SelectItem } from "./Select";
 export type { SelectProps, SelectOption } from "./Select";
 
-export { Modal } from "./Modal";
+export { Modal, useModalPortalContainer } from "./Modal";
 export type { ModalProps } from "./Modal";
 
 export { ConfirmDialog } from "./ConfirmDialog";


### PR DESCRIPTION
## Problem

In the running app, opening **Workflows → New Workflow → "+ Add step…"** did nothing: the step-kind menu never appeared clickable, so no steps could be added and the editor was unusable.

## Root cause

The workflow editor is a `Modal` = Radix `Dialog` in modal mode. A modal Radix Dialog sets `pointer-events: none` on `document.body` while open. The "Add step…" control is a Radix `DropdownMenu` whose `DropdownMenu.Portal` renders to `document.body` (the default) — **outside** the dialog subtree — so the menu content inherits `pointer-events: none` and is dead/unclickable in a real WebView. jsdom does not enforce `pointer-events`, so the existing unit test passed and CI stayed green, which is why it shipped.

The **Run macro** step's `Select` (shared primitive, `RadixSelect.Portal` → body) was dead for the exact same reason.

## Fix (Radix-idiomatic, recurrence-proof)

The shared `Modal` primitive now publishes its `Dialog.Content` node via React context (`useModalPortalContainer()`). Menus/selects inside a modal portal into that node instead of `document.body`, so they live in the dialog subtree where pointer events are enabled.

- `Modal` tracks its content element and provides it through context.
- The shared `Select` primitive passes it as `RadixSelect.Portal`'s `container` (fixes the run-macro picker, and every other `Select` inside any modal — the container is `null` outside a modal, falling back to Radix's default body, so nothing changes elsewhere).
- The workflow editor's "Add step…" `DropdownMenu` (extracted into a small child component so it reads the context) passes it as its `DropdownMenu.Portal` `container`.

Doing it in the shared `Modal` means this cannot silently recur for future dialogs.

## Audit of other menus in the editor modal

- **`WorkflowStepRow`** — no step-kind change menu exists; its only portalled control is the run-macro `Select`, fixed via the shared primitive.
- **`WorkflowTriggersEditor`** — uses only `Input`/`Checkbox`/plain buttons; no portals, nothing dead.
- **`LocalProcessAuthDialog`** — only buttons and static content; no menus/selects.

## Tests

- Regression test: the Add-step menu content renders **inside** the dialog container, not `document.body`.
- `Modal` unit tests: the portal container is the content node inside a modal, and `null` with no modal ancestor.
- jsdom cannot reproduce the `pointer-events` failure itself, so a manual test was added to `docs/testing.md` (open editor → Add step → each kind adds; run-macro picker opens; save persists).
- Full frontend suite green; `./scripts/check.sh` green.

Closes #1868