### PR TITLE
feat(workflow): dedicated inline run-output view for run-local-process (Closes #1865)

### DIFF
--- a/docs/changes/dev4/feature/1865-workflow-run-output-view.md
+++ b/docs/changes/dev4/feature/1865-workflow-run-output-view.md
@@ -1,0 +1,10 @@
+### Added
+
+- Workflow Manager: a `run-local-process` step now streams its output into a
+  dedicated inline run-output panel at the foot of the Workflow sidebar, instead
+  of only the LogViewer. The panel shows the process's stdout/stderr live as it
+  arrives (stderr tagged distinctly), a running/completed/cancelled/failed status
+  indicator, the command being run, and the final exit outcome (exit code,
+  timeout, or cancellation). It reuses the existing streamed-output events, adds
+  no new backend channel, and stays visible after the run ends until dismissed
+  (#1865).

--- a/src/components/WorkflowSidebar/WorkflowRunOutput.css
+++ b/src/components/WorkflowSidebar/WorkflowRunOutput.css
@@ -1,0 +1,134 @@
+/*
+ * Inline run-output panel for a `run-local-process` workflow step (#1865).
+ * Docks to the foot of the Workflow Manager, above nothing else, and never
+ * pushes the workflow list off screen — its stream area scrolls internally.
+ */
+.workflow-run-output {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  max-height: 45%;
+  border-top: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.workflow-run-output__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.workflow-run-output__spacer {
+  flex: 1;
+}
+
+.workflow-run-output__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.workflow-run-output__status-icon {
+  flex-shrink: 0;
+}
+
+.workflow-run-output--running .workflow-run-output__status {
+  color: var(--text-accent);
+}
+
+.workflow-run-output--completed .workflow-run-output__status {
+  color: var(--color-success);
+}
+
+.workflow-run-output--cancelled .workflow-run-output__status {
+  color: var(--color-warning);
+}
+
+.workflow-run-output--failed .workflow-run-output__status {
+  color: var(--color-error);
+}
+
+.workflow-run-output__status-icon--spin {
+  animation: workflow-run-output-spin 0.8s linear infinite;
+}
+
+@keyframes workflow-run-output-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workflow-run-output__status-icon--spin {
+    animation: none;
+  }
+}
+
+.workflow-run-output__command {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.workflow-run-output__command code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-run-output__stream {
+  flex: 1;
+  min-height: 64px;
+  overflow-y: auto;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--bg-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.workflow-run-output__line {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-primary);
+}
+
+.workflow-run-output__line--stderr {
+  color: var(--color-error);
+}
+
+.workflow-run-output__empty {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.workflow-run-output__footer {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-top: 1px solid var(--border-color);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.workflow-run-output--completed .workflow-run-output__footer {
+  color: var(--color-success);
+}
+
+.workflow-run-output--cancelled .workflow-run-output__footer {
+  color: var(--color-warning);
+}
+
+.workflow-run-output--failed .workflow-run-output__footer {
+  color: var(--color-error);
+}

--- a/src/components/WorkflowSidebar/WorkflowRunOutput.test.tsx
+++ b/src/components/WorkflowSidebar/WorkflowRunOutput.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { WorkflowRunOutput } from "./WorkflowRunOutput";
+import { withTooltip } from "@/test/tooltip";
+import { useAppStore, type WorkflowRunOutputState } from "@/store/appStore";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+/** Build a run-output state, overriding only the fields a test cares about. */
+function makeRun(overrides: Partial<WorkflowRunOutputState> = {}): WorkflowRunOutputState {
+  return {
+    workflowId: "workflow-1",
+    workflowName: "Build",
+    program: "make",
+    args: ["build"],
+    lines: [],
+    status: "running",
+    exitCode: null,
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+const dismissWorkflowRunOutput = vi.fn();
+const cancelWorkflowRun = vi.fn();
+
+describe("WorkflowRunOutput", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.clearAllMocks();
+    useAppStore.setState({
+      workflowRunOutput: null,
+      dismissWorkflowRunOutput,
+      cancelWorkflowRun,
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render() {
+    act(() => {
+      root.render(withTooltip(<WorkflowRunOutput />));
+    });
+  }
+
+  function setRun(run: WorkflowRunOutputState | null) {
+    act(() => {
+      useAppStore.setState({ workflowRunOutput: run });
+    });
+  }
+
+  it("renders nothing when there is no run output", () => {
+    render();
+    expect(query("workflow-run-output")).toBeNull();
+  });
+
+  it("shows the running status, command line, and a stop control while running", () => {
+    render();
+    setRun(makeRun());
+    expect(query("workflow-run-output")).not.toBeNull();
+    expect(query("workflow-run-output-status")?.getAttribute("data-status")).toBe("running");
+    expect(query("workflow-run-output-command")?.textContent).toContain("make build");
+    expect(query("workflow-run-output-stop")).not.toBeNull();
+    expect(query("workflow-run-output-dismiss")).toBeNull();
+    // No terminal outcome yet while running with no exit code.
+    expect(query("workflow-run-output-outcome")).toBeNull();
+  });
+
+  it("renders streamed stdout/stderr lines incrementally as they arrive", () => {
+    render();
+    setRun(makeRun({ lines: [{ id: 0, stream: "stdout", text: "compiling" }] }));
+    let stream = query("workflow-run-output-stream")!;
+    expect(stream.querySelectorAll(".workflow-run-output__line")).toHaveLength(1);
+    expect(stream.textContent).toContain("compiling");
+
+    // A second event appends without dropping the first (incremental render).
+    setRun(
+      makeRun({
+        lines: [
+          { id: 0, stream: "stdout", text: "compiling" },
+          { id: 1, stream: "stderr", text: "warning: unused" },
+        ],
+      })
+    );
+    stream = query("workflow-run-output-stream")!;
+    const lines = stream.querySelectorAll(".workflow-run-output__line");
+    expect(lines).toHaveLength(2);
+    expect(lines[0].textContent).toContain("compiling");
+    expect(lines[1].textContent).toContain("warning: unused");
+    // The stderr line is tagged distinctly from stdout.
+    expect(lines[0].getAttribute("data-stream")).toBe("stdout");
+    expect(lines[1].getAttribute("data-stream")).toBe("stderr");
+  });
+
+  it("surfaces the exit code and a dismiss control on a completed run", () => {
+    render();
+    setRun(makeRun({ status: "completed", exitCode: 0 }));
+    expect(query("workflow-run-output-status")?.getAttribute("data-status")).toBe("completed");
+    expect(query("workflow-run-output-outcome")?.textContent).toContain("Exit code 0");
+    expect(query("workflow-run-output-dismiss")).not.toBeNull();
+    expect(query("workflow-run-output-stop")).toBeNull();
+  });
+
+  it("shows the failing exit code on a failed run", () => {
+    render();
+    setRun(makeRun({ status: "failed", exitCode: 2, error: "exited with code 2" }));
+    expect(query("workflow-run-output-status")?.getAttribute("data-status")).toBe("failed");
+    expect(query("workflow-run-output-outcome")?.textContent).toContain("Exit code 2");
+  });
+
+  it("shows a cancelled outcome when the run was cancelled", () => {
+    render();
+    setRun(makeRun({ status: "cancelled", exitCode: null }));
+    expect(query("workflow-run-output-status")?.getAttribute("data-status")).toBe("cancelled");
+    expect(query("workflow-run-output-outcome")?.textContent).toContain("Cancelled");
+  });
+
+  it("shows a timeout outcome when the process timed out", () => {
+    render();
+    setRun(makeRun({ status: "failed", exitCode: null, timedOut: true }));
+    expect(query("workflow-run-output-outcome")?.textContent).toContain("Timed out");
+  });
+
+  it("stops the run when the stop control is clicked", () => {
+    render();
+    setRun(makeRun());
+    act(() => {
+      query("workflow-run-output-stop")?.click();
+    });
+    expect(cancelWorkflowRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses the surface when the dismiss control is clicked", () => {
+    render();
+    setRun(makeRun({ status: "completed", exitCode: 0 }));
+    act(() => {
+      query("workflow-run-output-dismiss")?.click();
+    });
+    expect(dismissWorkflowRunOutput).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a waiting placeholder when running with no output yet", () => {
+    render();
+    setRun(makeRun());
+    expect(query("workflow-run-output-empty")?.textContent).toContain("Waiting for output");
+  });
+});

--- a/src/components/WorkflowSidebar/WorkflowRunOutput.tsx
+++ b/src/components/WorkflowSidebar/WorkflowRunOutput.tsx
@@ -11,7 +11,11 @@ const STATUS_META: Record<
   { label: string; Icon: typeof Loader2; className: string }
 > = {
   running: { label: "Running", Icon: Loader2, className: "workflow-run-output--running" },
-  completed: { label: "Completed", Icon: CheckCircle2, className: "workflow-run-output--completed" },
+  completed: {
+    label: "Completed",
+    Icon: CheckCircle2,
+    className: "workflow-run-output--completed",
+  },
   cancelled: { label: "Cancelled", Icon: Ban, className: "workflow-run-output--cancelled" },
   failed: { label: "Failed", Icon: XCircle, className: "workflow-run-output--failed" },
 };

--- a/src/components/WorkflowSidebar/WorkflowRunOutput.tsx
+++ b/src/components/WorkflowSidebar/WorkflowRunOutput.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef } from "react";
+import { Loader2, CheckCircle2, XCircle, Ban, X, Square, Terminal } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { Button, Tooltip } from "@/components/ui";
+import type { WorkflowRunOutputState } from "@/store/appStore";
+import "./WorkflowRunOutput.css";
+
+/** Human-readable label + icon for each run-output status. */
+const STATUS_META: Record<
+  WorkflowRunOutputState["status"],
+  { label: string; Icon: typeof Loader2; className: string }
+> = {
+  running: { label: "Running", Icon: Loader2, className: "workflow-run-output--running" },
+  completed: { label: "Completed", Icon: CheckCircle2, className: "workflow-run-output--completed" },
+  cancelled: { label: "Cancelled", Icon: Ban, className: "workflow-run-output--cancelled" },
+  failed: { label: "Failed", Icon: XCircle, className: "workflow-run-output--failed" },
+};
+
+/**
+ * Describe the process's exit outcome for the surface footer: a timeout, a
+ * cancellation, or a concrete exit code. Returns `null` while the process is
+ * still running and has not reported anything terminal yet.
+ */
+function describeOutcome(run: WorkflowRunOutputState): string | null {
+  if (run.timedOut) return "Timed out";
+  if (run.status === "cancelled") return "Cancelled";
+  if (run.exitCode !== null) return `Exit code ${run.exitCode}`;
+  if (run.status === "failed") return run.error ?? "Failed";
+  return null;
+}
+
+/**
+ * Inline run-output panel for a `run-local-process` workflow step (#1865).
+ *
+ * Renders at the foot of the Workflow Manager whenever a run has spawned (or
+ * recently spawned) a local process, showing its streamed stdout/stderr as it
+ * arrives, a live status indicator, and the final exit outcome — so the user
+ * sees a local-process step's output inline in the workflow UI rather than
+ * having to open the LogViewer. It consumes the streamed output the store
+ * accumulates from #1857's `subscribeLocalProcessOutput` events; it adds no new
+ * backend channel. Nothing renders when there is no run output to show.
+ */
+export function WorkflowRunOutput() {
+  const run = useAppStore((s) => s.workflowRunOutput);
+  const dismiss = useAppStore((s) => s.dismissWorkflowRunOutput);
+  const cancelRun = useAppStore((s) => s.cancelWorkflowRun);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const lineCount = run?.lines.length ?? 0;
+
+  // Keep the newest output in view as lines stream in.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lineCount]);
+
+  if (!run) return null;
+
+  const meta = STATUS_META[run.status];
+  const outcome = describeOutcome(run);
+  const isRunning = run.status === "running";
+  const commandLine = [run.program, ...run.args].join(" ");
+
+  return (
+    <section
+      className={`workflow-run-output ${meta.className}`}
+      data-testid="workflow-run-output"
+      aria-label="Workflow run output"
+    >
+      <header className="workflow-run-output__header">
+        <span
+          className="workflow-run-output__status"
+          data-testid="workflow-run-output-status"
+          data-status={run.status}
+        >
+          <meta.Icon
+            size={13}
+            className={`workflow-run-output__status-icon${
+              isRunning ? " workflow-run-output__status-icon--spin" : ""
+            }`}
+            aria-hidden="true"
+          />
+          {meta.label}
+        </span>
+        <span className="workflow-run-output__spacer" />
+        {isRunning ? (
+          <Tooltip content="Stop" side="top">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label="Stop workflow run"
+              data-testid="workflow-run-output-stop"
+              icon={<Square size={12} fill="currentColor" />}
+              onClick={cancelRun}
+            />
+          </Tooltip>
+        ) : (
+          <Tooltip content="Dismiss" side="top">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label="Dismiss run output"
+              data-testid="workflow-run-output-dismiss"
+              icon={<X size={12} />}
+              onClick={dismiss}
+            />
+          </Tooltip>
+        )}
+      </header>
+
+      <div className="workflow-run-output__command" data-testid="workflow-run-output-command">
+        <Terminal size={11} aria-hidden="true" />
+        <code title={commandLine}>{commandLine}</code>
+      </div>
+
+      <div
+        className="workflow-run-output__stream"
+        data-testid="workflow-run-output-stream"
+        ref={scrollRef}
+        role="log"
+        aria-live="polite"
+      >
+        {lineCount === 0 ? (
+          <div className="workflow-run-output__empty" data-testid="workflow-run-output-empty">
+            {isRunning ? "Waiting for output…" : "No output"}
+          </div>
+        ) : (
+          run.lines.map((line) => (
+            <div
+              key={line.id}
+              className={`workflow-run-output__line workflow-run-output__line--${line.stream}`}
+              data-stream={line.stream}
+            >
+              {line.text}
+            </div>
+          ))
+        )}
+      </div>
+
+      {outcome ? (
+        <footer className="workflow-run-output__footer" data-testid="workflow-run-output-outcome">
+          {outcome}
+        </footer>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/WorkflowSidebar/WorkflowSidebar.tsx
+++ b/src/components/WorkflowSidebar/WorkflowSidebar.tsx
@@ -10,6 +10,7 @@ import { useFlatRovingNav } from "@/hooks/useFlatRovingNav";
 import { serializeWorkflows } from "@/services/workflowIo";
 import type { Workflow } from "@/types/workflow";
 import { WorkflowListItem } from "./WorkflowListItem";
+import { WorkflowRunOutput } from "./WorkflowRunOutput";
 import { WorkflowEditorDialog, type WorkflowEditorResult } from "./WorkflowEditorDialog";
 import "./WorkflowSidebar.css";
 
@@ -400,6 +401,7 @@ export function WorkflowSidebar() {
           })}
         </div>
       )}
+      <WorkflowRunOutput />
       <WorkflowEditorDialog
         open={editing !== null}
         workflow={editing?.workflow ?? null}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1297,6 +1297,15 @@ interface AppState {
   /** Cancel the in-flight workflow run, if any. Idempotent. */
   cancelWorkflowRun: () => void;
   /**
+   * Inline output surface for a `run-local-process` step (#1865): the streamed
+   * stdout/stderr and the final exit outcome, kept visible after the run ends
+   * until dismissed. `null` when no local process has run this session (or the
+   * surface was dismissed).
+   */
+  workflowRunOutput: WorkflowRunOutputState | null;
+  /** Dismiss the inline run-output surface. */
+  dismissWorkflowRunOutput: () => void;
+  /**
    * Pending authorization prompt for a guarded `run-local-process` step (#1857),
    * or `null` when none is open. Set when a workflow reaches such a step whose
    * program is not yet on the allowlist; resolved by the user via the dialog.
@@ -1440,6 +1449,51 @@ export interface WorkflowRunState {
   completed: number;
 }
 
+/** A single streamed line of a local process's output, tagged by its stream. */
+export interface WorkflowRunOutputLine {
+  /** Monotonic id within the current process, so React can key incremental appends. */
+  id: number;
+  /** Which stream produced the line. */
+  stream: "stdout" | "stderr";
+  /** The line of text (no trailing newline). */
+  text: string;
+}
+
+/** Live status of the inline run-output surface (#1865). */
+export type WorkflowRunOutputStatus = "running" | "completed" | "cancelled" | "failed";
+
+/**
+ * The inline run-output surface for a `run-local-process` step (#1865).
+ *
+ * Unlike {@link WorkflowRunState}, which is cleared the instant a run ends, this
+ * persists after the run finishes so the streamed stdout/stderr and the final
+ * exit outcome stay visible in the workflow panel until the user dismisses it or
+ * starts another run. It is created lazily — only when a run actually spawns a
+ * local process — so terminal-native workflows never surface an empty panel. It
+ * reuses the exact `subscribeLocalProcessOutput` stream #1857 already emits; no
+ * new backend channel is added.
+ */
+export interface WorkflowRunOutputState {
+  /** The workflow whose local process produced this output. */
+  workflowId: string;
+  /** The workflow's name, for the panel header. */
+  workflowName: string;
+  /** The program the (most recent) `run-local-process` step spawned. */
+  program: string;
+  /** The discrete arguments it was spawned with. */
+  args: string[];
+  /** Streamed stdout/stderr lines, in arrival order. */
+  lines: WorkflowRunOutputLine[];
+  /** Live status: `running` until the run reaches a terminal state. */
+  status: WorkflowRunOutputStatus;
+  /** The process exit code once known (`null` when killed before it reported one). */
+  exitCode: number | null;
+  /** `true` when the process was killed for exceeding its timeout. */
+  timedOut: boolean;
+  /** A human-readable failure reason when `status` is `failed`. */
+  error?: string;
+}
+
 /** Options for {@link AppState.runWorkflow}. */
 export interface RunWorkflowOptions {
   /** Tab to run against; defaults to the active terminal tab. */
@@ -1473,6 +1527,13 @@ const LOCAL_PROCESS_TIMEOUT_MS = 60_000;
 
 /** How often (ms) a running local process polls the workflow cancel signal. */
 const LOCAL_PROCESS_CANCEL_POLL_MS = 200;
+
+/**
+ * Cap on retained inline run-output lines (#1865). A chatty process can emit
+ * thousands of lines; the surface keeps only the most recent so run state cannot
+ * grow unbounded. The full stream still lands in the LogViewer.
+ */
+const WORKFLOW_RUN_OUTPUT_MAX_LINES = 1000;
 
 /**
  * Handle for the currently-running workflow, held at module scope so
@@ -6161,8 +6222,42 @@ export const useAppStore = create<AppState>((set, get) => {
         const runId = `wf-lp-${workflowId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         frontendLog("workflow", `local process starting: ${[program, ...args].join(" ")}`);
 
+        // Open the inline run-output surface for this spawn (#1865). A fresh
+        // spawn owns the panel — its program/args and a clean line buffer — so a
+        // second run-local-process step shows its own process, not the prior one.
+        let lineSeq = 0;
+        set({
+          workflowRunOutput: {
+            workflowId,
+            workflowName: workflow.name,
+            program,
+            args,
+            lines: [],
+            status: "running",
+            exitCode: null,
+            timedOut: false,
+          },
+        });
+
+        // Reuse the exact streamed-output events #1857 already emits (keyed by
+        // run id): each line lands in the LogViewer AND the inline surface.
         const unlisten = await subscribeLocalProcessOutput(runId, (chunk) => {
           frontendLog("workflow", `[${chunk.stream}] ${chunk.line}`);
+          const nextLine: WorkflowRunOutputLine = {
+            id: lineSeq++,
+            stream: chunk.stream,
+            text: chunk.line,
+          };
+          set((s) => {
+            if (!s.workflowRunOutput) return {};
+            const lines = [...s.workflowRunOutput.lines, nextLine];
+            // Keep only the most recent lines so a chatty process stays bounded.
+            const trimmed =
+              lines.length > WORKFLOW_RUN_OUTPUT_MAX_LINES
+                ? lines.slice(lines.length - WORKFLOW_RUN_OUTPUT_MAX_LINES)
+                : lines;
+            return { workflowRunOutput: { ...s.workflowRunOutput, lines: trimmed } };
+          });
         });
         // Poll the run's cancel signal and forward it to the backend so a
         // long-running process is killed when the run is cancelled.
@@ -6184,12 +6279,31 @@ export const useAppStore = create<AppState>((set, get) => {
             `local process finished: exitCode=${outcome.exitCode ?? "null"} ` +
               `timedOut=${outcome.timedOut} cancelled=${outcome.cancelled}`
           );
+          // Record the process outcome on the inline surface. The overall run
+          // status (completed / cancelled / failed) is stamped once the run
+          // resolves; here we surface only the raw exit code / timeout (#1865).
+          set((s) =>
+            s.workflowRunOutput
+              ? {
+                  workflowRunOutput: {
+                    ...s.workflowRunOutput,
+                    exitCode: outcome.exitCode,
+                    timedOut: outcome.timedOut,
+                  },
+                }
+              : {}
+          );
           return outcome;
         } catch (err) {
           // A backend rejection (e.g. opt-in disabled at the trust boundary)
           // surfaces as a failed step rather than crashing the run.
           const message = err instanceof Error ? err.message : String(err);
           frontendLog("workflow", `local process error: ${message}`);
+          set((s) =>
+            s.workflowRunOutput
+              ? { workflowRunOutput: { ...s.workflowRunOutput, exitCode: 1, timedOut: false } }
+              : {}
+          );
           return { exitCode: 1, timedOut: false, cancelled: false };
         } finally {
           window.clearInterval(poll);
@@ -6211,6 +6325,9 @@ export const useAppStore = create<AppState>((set, get) => {
           total,
           completed: 0,
         },
+        // Clear any prior run's output panel when a fresh run starts; it is
+        // recreated lazily only if this run spawns a local process (#1865).
+        workflowRunOutput: null,
       });
 
       const handle = runWorkflowSteps(
@@ -6240,7 +6357,19 @@ export const useAppStore = create<AppState>((set, get) => {
       // runWorkflow may have replaced it while this one was cancelled.
       if (activeWorkflowRun === handle) {
         activeWorkflowRun = null;
-        set({ workflowRun: null });
+        set((s) => ({
+          workflowRun: null,
+          // Stamp the run's terminal status onto the inline surface so its exit
+          // outcome stays visible after the run ends (#1865). Left untouched when
+          // no local process ran (surface is null).
+          workflowRunOutput: s.workflowRunOutput
+            ? {
+                ...s.workflowRunOutput,
+                status: result.status,
+                error: result.status === "failed" ? result.error : undefined,
+              }
+            : null,
+        }));
       }
 
       if (result.status === "completed") {
@@ -6263,6 +6392,11 @@ export const useAppStore = create<AppState>((set, get) => {
       if (activeWorkflowRun) {
         activeWorkflowRun.cancel();
       }
+    },
+
+    workflowRunOutput: null,
+    dismissWorkflowRunOutput: () => {
+      set({ workflowRunOutput: null });
     },
 
     localProcessPrompt: null,

--- a/src/store/appStore.workflowRun.test.ts
+++ b/src/store/appStore.workflowRun.test.ts
@@ -59,10 +59,23 @@ const invokeRunLocalProcess = vi.fn((_args: { program: string; args: string[] })
   Promise.resolve({ exitCode: 0 as number | null, timedOut: false, cancelled: false })
 );
 const cancelLocalProcess = vi.fn((_runId: string) => Promise.resolve(true));
+// The last-registered streamed-output handler (#1865), so a test can push
+// stdout/stderr chunks through the same seam #1857 emits them on.
+type LocalProcessOutputChunk = { runId: string; stream: "stdout" | "stderr"; line: string };
+let localProcessOutputHandler: ((chunk: LocalProcessOutputChunk) => void) | null = null;
+const subscribeLocalProcessOutput = vi.fn(
+  (_runId: string, onChunk: (chunk: LocalProcessOutputChunk) => void) => {
+    localProcessOutputHandler = onChunk;
+    return Promise.resolve(() => {
+      localProcessOutputHandler = null;
+    });
+  }
+);
 vi.mock("@/services/localProcessApi", () => ({
   invokeRunLocalProcess: (args: { program: string; args: string[] }) => invokeRunLocalProcess(args),
   cancelLocalProcess: (runId: string) => cancelLocalProcess(runId),
-  subscribeLocalProcessOutput: vi.fn(() => Promise.resolve(() => {})),
+  subscribeLocalProcessOutput: (runId: string, onChunk: (chunk: LocalProcessOutputChunk) => void) =>
+    subscribeLocalProcessOutput(runId, onChunk),
 }));
 
 import { useAppStore } from "./appStore";
@@ -110,6 +123,8 @@ describe("appStore — workflow run slice (#1852)", () => {
     injected = [];
     invokeRunLocalProcess.mockClear();
     cancelLocalProcess.mockClear();
+    subscribeLocalProcessOutput.mockClear();
+    localProcessOutputHandler = null;
     registerTerminalInputInjector(async (_tabId, data) => {
       injected.push(data);
       return true;
@@ -311,6 +326,71 @@ describe("appStore — workflow run slice (#1852)", () => {
 
       expect(invokeRunLocalProcess).not.toHaveBeenCalled();
       expect(toast.error).toHaveBeenCalled();
+    });
+
+    // --- Inline run-output surface (#1865) ---
+
+    it("accumulates streamed stdout/stderr into the inline run-output surface", async () => {
+      seedConnectedTerminal();
+      enableLocalProcess(["make"]);
+      useAppStore.setState({ workflows: [workflow("w1", [lp("make", ["build"])])] });
+      // The spawn emits two lines through the same event seam #1857 uses, then
+      // exits 0. Emitting inside the invoke mock guarantees the handler is set.
+      invokeRunLocalProcess.mockImplementationOnce(() => {
+        localProcessOutputHandler?.({ runId: "r", stream: "stdout", line: "compiling" });
+        localProcessOutputHandler?.({ runId: "r", stream: "stderr", line: "warning: unused" });
+        return Promise.resolve({ exitCode: 0, timedOut: false, cancelled: false });
+      });
+
+      await useAppStore.getState().runWorkflow("w1");
+
+      const out = useAppStore.getState().workflowRunOutput;
+      expect(out).not.toBeNull();
+      expect(out?.program).toBe("make");
+      expect(out?.lines.map((l) => [l.stream, l.text])).toEqual([
+        ["stdout", "compiling"],
+        ["stderr", "warning: unused"],
+      ]);
+      // The run finished cleanly — the surface reflects the terminal outcome.
+      expect(out?.status).toBe("completed");
+      expect(out?.exitCode).toBe(0);
+    });
+
+    it("marks the run-output surface failed with the exit code on a non-zero exit", async () => {
+      seedConnectedTerminal();
+      enableLocalProcess(["make"]);
+      useAppStore.setState({ workflows: [workflow("w1", [lp("make", ["build"])])] });
+      invokeRunLocalProcess.mockImplementationOnce(() =>
+        Promise.resolve({ exitCode: 2, timedOut: false, cancelled: false })
+      );
+
+      await useAppStore.getState().runWorkflow("w1");
+
+      const out = useAppStore.getState().workflowRunOutput;
+      expect(out?.status).toBe("failed");
+      expect(out?.exitCode).toBe(2);
+    });
+
+    it("does not open a run-output surface for a terminal-native workflow", async () => {
+      seedConnectedTerminal();
+      useAppStore.setState({ workflows: [workflow("w1", [cmd("echo hi")])] });
+
+      await useAppStore.getState().runWorkflow("w1");
+
+      // No local process ran, so the inline surface stays null.
+      expect(useAppStore.getState().workflowRunOutput).toBeNull();
+    });
+
+    it("dismissWorkflowRunOutput clears the surface", async () => {
+      seedConnectedTerminal();
+      enableLocalProcess(["make"]);
+      useAppStore.setState({ workflows: [workflow("w1", [lp("make", ["build"])])] });
+
+      await useAppStore.getState().runWorkflow("w1");
+      expect(useAppStore.getState().workflowRunOutput).not.toBeNull();
+
+      useAppStore.getState().dismissWorkflowRunOutput();
+      expect(useAppStore.getState().workflowRunOutput).toBeNull();
     });
   });
 


### PR DESCRIPTION
Follow-up to #1857 (PR #1863), epic #1851.

#1857 shipped the guarded `run-local-process` step, streaming its stdout/stderr only into the LogViewer. This adds a dedicated inline run-output surface so a local-process step's output and exit outcome are visible right in the Workflow Manager.

Closes #1865

## What changed

- New `WorkflowRunOutput` panel docked at the foot of the Workflow sidebar. When a run spawns a `run-local-process` step it shows:
  - streamed stdout/stderr live as it arrives (stderr tagged distinctly, monospace, internally scrollable);
  - a running / completed / cancelled / failed status indicator (spinner while running, honouring reduced-motion);
  - the command being run and the final exit outcome (exit code, timeout, or cancellation);
  - a Stop control while running and a Dismiss control once finished.
- Store wiring in `runWorkflow`: the existing `runLocalProcess` seam now feeds a new `workflowRunOutput` state slice from the **same** `subscribeLocalProcessOutput` events #1857 already emits — no new backend channel. The surface is created lazily (terminal-native workflows never get an empty panel), persists after the run ends until dismissed, and caps retained lines so a chatty process stays bounded (the full stream still lands in the LogViewer).
- Execution and every #1857 guardrail (opt-in, allowlist/confirmation, direct-argv, timeout/cancel/exit) are untouched — this is a display-only refinement.

## Testing

- `WorkflowRunOutput.test.tsx` — incremental stdout/stderr rendering, exit/cancel/timeout/failed states, stop and dismiss controls, empty-state.
- `appStore.workflowRun.test.ts` — the surface accumulates streamed output, stamps the terminal status/exit code, stays null for terminal-native workflows, and is dismissable.
- `./scripts/check.sh` and `pnpm test` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)