### PR TITLE
build(ci): emit the security marker in release notes so app security updates trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,20 @@ jobs:
           # Save to file (multiline support)
           echo "$CHANGELOG" > release_notes.md
 
+      - name: Mark security release
+        # The desktop self-update check (src-tauri/src/commands/update.rs) treats a
+        # release as a *security* update when its body contains the "<!-- security -->"
+        # marker, dropping the "Skip this version" action so the patch cannot be
+        # suppressed (#1878). Emit that marker when the notes carry a Keep a Changelog
+        # "### Security" section — or when a maintainer forces it by setting the
+        # TERMIHUB_SECURITY_RELEASE repository variable. node is preinstalled on the
+        # runner (same as scripts/internal/parse-issue-refs.mjs in auto-close-issues).
+        env:
+          TERMIHUB_SECURITY_RELEASE: ${{ vars.TERMIHUB_SECURITY_RELEASE }}
+        run: |
+          node scripts/internal/emit-release-notes.mjs release_notes.md > release_notes.marked.md
+          mv release_notes.marked.md release_notes.md
+
       - name: Create GitHub Release
         run: |
           gh release create "v${{ steps.get_version.outputs.version }}" \

--- a/docs/changes/README.md
+++ b/docs/changes/README.md
@@ -76,3 +76,8 @@ Guidelines:
   - **Bad**: "Implemented `GitBashDetector` in `shell_detect.rs`"
 - Reference the issue/PR number(s).
 - No top-level `#` heading is needed — start at `###` category headings.
+- **Security fixes go under a `### Security` category.** At release time the release
+  workflow detects that section and injects a `<!-- security -->` marker into the GitHub
+  release body; the desktop app's self-update check keys on that marker to flag the release
+  as a non-suppressible security update. See
+  [`scripts/internal/emit-release-notes.mjs`](../../scripts/internal/emit-release-notes.mjs).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -789,6 +789,15 @@ Use [Keep a Changelog](https://keepachangelog.com/) categories (`Added`, `Change
 **Good**: "Added support for Git Bash on Windows"
 **Bad**: "Implemented GitBashDetector class in shell_detect.rs"
 
+> **Security releases**: put security-relevant notes under a `### Security` category. At
+> release time the release workflow detects that section and injects the `<!-- security -->`
+> marker into the GitHub release body, which is what makes the desktop app's self-update
+> flag the release as a security update (a non-suppressible, red-dot notification — see
+> [`src-tauri/src/commands/update.rs`](../src-tauri/src/commands/update.rs)). A maintainer
+> can also force the marker on a release by setting the `TERMIHUB_SECURITY_RELEASE`
+> repository variable. The marker is emitted by
+> [`scripts/internal/emit-release-notes.mjs`](../scripts/internal/emit-release-notes.mjs).
+
 Skip the fragment for changes that are not user-facing (refactors, CI, internal docs,
 test-only work). See [`docs/changes/README.md`](changes/README.md) for the full mechanism,
 template, and rationale (including why intermediate `develop` fixes are curated out of the

--- a/scripts/internal/emit-release-notes.mjs
+++ b/scripts/internal/emit-release-notes.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Emit the desktop app's self-update *security marker* into a release body.
+//
+// The in-app self-update check (src-tauri/src/commands/update.rs) decides a
+// GitHub release is a *security* update by testing whether the release body
+// `.contains("<!-- security -->")`; when it does, the update notification drops
+// the "Skip this version" action so the patch cannot be suppressed. Nothing in
+// the release pipeline used to emit that marker, so security releases never
+// actually triggered the bypass (#1878).
+//
+// This tool bridges that gap: given the release notes generated from the
+// changelog, it prepends the marker when the release is security-relevant. A
+// release is security-relevant when its notes contain a Keep a Changelog
+// "### Security" section (the category documented in docs/changes/README.md and
+// docs/contributing.md) — or when a maintainer forces it via the
+// TERMIHUB_SECURITY_RELEASE environment variable (the manual checklist path).
+//
+// The logic lives here (rather than inline in release.yml) so it can be
+// unit-tested — see emit-release-notes.test.mjs.
+
+import { readFileSync } from "node:fs";
+
+/** The exact string src-tauri/src/commands/update.rs greps for. Keep in sync. */
+export const SECURITY_MARKER = "<!-- security -->";
+
+/**
+ * A Keep a Changelog "Security" category heading (`## Security` … `#### Security`),
+ * on its own line, case-insensitive, with optional trailing whitespace. Anchored
+ * so "### Security notes" or prose mentioning "security" does not match.
+ */
+const SECURITY_HEADING = /^#{2,4}[ \t]+Security[ \t]*$/im;
+
+/**
+ * Does the release body contain a Keep a Changelog Security section?
+ *
+ * @param {unknown} notes - Release notes / changelog body.
+ * @returns {boolean} True when a `### Security` heading is present.
+ */
+export function hasSecuritySection(notes) {
+  return typeof notes === "string" && SECURITY_HEADING.test(notes);
+}
+
+/**
+ * Prepend the self-update security marker to release notes when the release is
+ * security-relevant. Idempotent: an already-marked body is returned unchanged,
+ * so re-running never duplicates the marker.
+ *
+ * @param {unknown} notes - Release notes generated from the changelog.
+ * @param {{ force?: boolean }} [options] - `force` emits the marker regardless
+ *   of whether a Security section is present (maintainer override).
+ * @returns {string} The notes, with the marker prepended when applicable.
+ */
+export function buildReleaseNotes(notes, { force = false } = {}) {
+  const body = typeof notes === "string" ? notes : "";
+  if (body.includes(SECURITY_MARKER)) {
+    return body;
+  }
+  if (!force && !hasSecuritySection(body)) {
+    return body;
+  }
+  return body.length > 0 ? `${SECURITY_MARKER}\n\n${body}` : SECURITY_MARKER;
+}
+
+// CLI mode: read notes from the file named in argv[2] (or stdin when it is "-"),
+// honour TERMIHUB_SECURITY_RELEASE as the force override, and print the possibly
+// marked notes to stdout so the workflow can redirect them back into the file.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const source = process.argv[2] ?? "-";
+  const raw = readFileSync(source === "-" ? 0 : source, "utf8");
+  const forceValue = (process.env.TERMIHUB_SECURITY_RELEASE ?? "").trim().toLowerCase();
+  const force = forceValue !== "" && forceValue !== "0" && forceValue !== "false";
+  process.stdout.write(buildReleaseNotes(raw, { force }));
+}

--- a/scripts/internal/emit-release-notes.test.mjs
+++ b/scripts/internal/emit-release-notes.test.mjs
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  SECURITY_MARKER,
+  hasSecuritySection,
+  buildReleaseNotes,
+} from "./emit-release-notes.mjs";
+
+describe("hasSecuritySection", () => {
+  it("detects a Keep a Changelog Security heading", () => {
+    expect(hasSecuritySection("### Security\n\n- fixed a CVE")).toBe(true);
+  });
+
+  it("detects the heading at other levels and with trailing spaces", () => {
+    expect(hasSecuritySection("## Security ")).toBe(true);
+    expect(hasSecuritySection("#### Security")).toBe(true);
+  });
+
+  it("is case-insensitive on the heading text", () => {
+    expect(hasSecuritySection("### security")).toBe(true);
+    expect(hasSecuritySection("### SECURITY")).toBe(true);
+  });
+
+  it("ignores a Security heading that sits among other sections", () => {
+    const notes = "### Added\n\n- thing\n\n### Security\n\n- patch\n";
+    expect(hasSecuritySection(notes)).toBe(true);
+  });
+
+  it("does not match the word security in prose", () => {
+    expect(hasSecuritySection("### Fixed\n\n- a security-adjacent bug")).toBe(
+      false,
+    );
+  });
+
+  it("does not match a heading that merely starts with Security", () => {
+    expect(hasSecuritySection("### Security notes for admins")).toBe(false);
+  });
+
+  it("returns false for non-string input", () => {
+    expect(hasSecuritySection(undefined)).toBe(false);
+    expect(hasSecuritySection(null)).toBe(false);
+  });
+});
+
+describe("buildReleaseNotes", () => {
+  it("prepends the marker the app updater looks for when there is a Security section", () => {
+    const out = buildReleaseNotes("### Security\n\n- fixed a CVE");
+    expect(out.startsWith(`${SECURITY_MARKER}\n\n`)).toBe(true);
+    // The exact string src-tauri/src/commands/update.rs greps for.
+    expect(out).toContain("<!-- security -->");
+    expect(out).toContain("### Security");
+  });
+
+  it("leaves a regular release untouched (no marker)", () => {
+    const notes = "### Added\n\n- a new feature";
+    expect(buildReleaseNotes(notes)).toBe(notes);
+    expect(buildReleaseNotes(notes)).not.toContain(SECURITY_MARKER);
+  });
+
+  it("emits the marker when forced even without a Security section", () => {
+    const out = buildReleaseNotes("### Fixed\n\n- a bug", { force: true });
+    expect(out.startsWith(`${SECURITY_MARKER}\n\n`)).toBe(true);
+  });
+
+  it("does not duplicate an already-present marker", () => {
+    const notes = `${SECURITY_MARKER}\n\n### Security\n\n- patch`;
+    const out = buildReleaseNotes(notes);
+    expect(out).toBe(notes);
+    expect(out.match(/<!-- security -->/g)).toHaveLength(1);
+  });
+
+  it("does not duplicate the marker when forced and already present", () => {
+    const notes = `${SECURITY_MARKER}\n\n### Fixed\n\n- a bug`;
+    expect(buildReleaseNotes(notes, { force: true })).toBe(notes);
+  });
+
+  it("emits just the marker when forced on empty notes", () => {
+    expect(buildReleaseNotes("", { force: true })).toBe(SECURITY_MARKER);
+  });
+
+  it("coerces non-string input to empty notes", () => {
+    expect(buildReleaseNotes(undefined)).toBe("");
+    expect(buildReleaseNotes(null, { force: true })).toBe(SECURITY_MARKER);
+  });
+});


### PR DESCRIPTION
## Summary

The desktop app's self-update check (`src-tauri/src/commands/update.rs:134`) decides a GitHub release is a *security* update by testing whether the release body `.contains("<!-- security -->")`; when it does, the update notification drops the "Skip this version" action (red-dot, non-suppressible). Nothing in the release pipeline emitted that marker, so security releases never actually triggered the bypass.

This wires the marker into the release pipeline.

## What changed

- **`scripts/internal/emit-release-notes.mjs`** — a small, testable tool (mirroring the existing `parse-issue-refs.mjs` pattern) that prepends the exact `<!-- security -->` marker the updater greps for. It marks a release when the notes carry a Keep a Changelog `### Security` section, or when a maintainer forces it via the `TERMIHUB_SECURITY_RELEASE` repository variable. Idempotent — never duplicates an existing marker.
- **`scripts/internal/emit-release-notes.test.mjs`** — 14 vitest cases covering Security-section detection (heading levels, case, prose false-positives), marker emission, force override, idempotency, and empty/non-string input. Runs under the default `pnpm test` (vitest) lane.
- **`.github/workflows/release.yml`** — new "Mark security release" step runs the tool on the generated `release_notes.md` before the release is created. `node` is preinstalled on the runner (same as `parse-issue-refs.mjs` in `auto-close-issues.yml`).
- **Docs** — documented the `### Security` → marker convention in `docs/contributing.md` and `docs/changes/README.md`, where release notes are authored.

## Marker contract

The exact string is authoritative from the parser: `body.contains("<!-- security -->")`. The emitter and its test assert that same literal, so app and pipeline stay in sync.

## Verification

- `npx vitest run scripts/internal/emit-release-notes.test.mjs` — 14 passed.
- CLI exercised for all four paths (Security section → marked; regular → untouched; forced → marked; re-run on marked → no duplicate).
- `./scripts/check.sh` — all checks passed.

Completes part of the partial `in-field-update-mechanism` concept.

Closes #1878