### PR TITLE
refactor(ui): migrate ConfirmDeleteDialog and Port Scanner warning onto ConfirmDialog (Closes #1876)

### DIFF
--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
 import { Play, StopCircle } from "lucide-react";
-import { Button, Modal, Field, Input, NumberInput } from "@/components/ui";
+import { Button, ConfirmDialog, Field, Input, NumberInput } from "@/components/ui";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import {
   networkPortScan,
@@ -250,34 +250,18 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
         }
       />
 
-      <Modal
+      <ConfirmDialog
         open={warnOpen}
-        onOpenChange={setWarnOpen}
         title="Large scan"
         description="Confirm before starting a scan that may take a while."
+        message={`This scan will probe about ${probeEstimate.toLocaleString()} host/port combinations and may take several minutes. Continue?`}
+        confirmLabel="Start scan"
+        confirmVariant="primary"
+        testIdBase="port-scan-warn"
         data-testid="port-scan-warn-modal"
-        footer={
-          <>
-            <Button
-              variant="secondary"
-              onClick={() => setWarnOpen(false)}
-              data-testid="port-scan-warn-cancel"
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="primary"
-              onClick={handleConfirmLargeScan}
-              data-testid="port-scan-warn-confirm"
-            >
-              Start scan
-            </Button>
-          </>
-        }
-      >
-        This scan will probe about {probeEstimate.toLocaleString()} host/port combinations and may
-        take several minutes. Continue?
-      </Modal>
+        onConfirm={handleConfirmLargeScan}
+        onCancel={() => setWarnOpen(false)}
+      />
     </form>
   );
 }

--- a/src/components/Sidebar/ConfirmDeleteDialog.tsx
+++ b/src/components/Sidebar/ConfirmDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import { Modal, Button } from "@/components/ui";
+import { ConfirmDialog } from "@/components/ui";
 
 interface ConfirmDeleteDialogProps {
   open: boolean;
@@ -15,23 +15,16 @@ export function ConfirmDeleteDialog({
   onCancel,
 }: ConfirmDeleteDialogProps) {
   return (
-    <Modal
+    <ConfirmDialog
       open={open}
-      onOpenChange={(isOpen) => !isOpen && onCancel()}
       title="Confirm Delete"
+      message={message}
+      confirmLabel="Delete"
+      confirmVariant="danger"
+      testIdBase="confirm-delete"
       data-testid="confirm-delete-dialog"
-      footer={
-        <>
-          <Button variant="secondary" onClick={onCancel} data-testid="confirm-delete-cancel">
-            Cancel
-          </Button>
-          <Button variant="danger" onClick={onConfirm} data-testid="confirm-delete-confirm">
-            Delete
-          </Button>
-        </>
-      }
-    >
-      {message}
-    </Modal>
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
   );
 }

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -30,6 +30,8 @@ export interface ConfirmDialogProps {
   open: boolean;
   /** Heading text. */
   title: React.ReactNode;
+  /** Optional description for screen readers (rendered visually hidden). */
+  description?: string;
   /**
    * Plain body message (the common case). Optional so a caller may supply only
    * a richer {@link ConfirmDialogProps.children | children} body slot instead.
@@ -65,6 +67,15 @@ export interface ConfirmDialogProps {
   onConfirm: () => void | Promise<void>;
   /** Invoked when the user cancels (button, ESC, scrim click). */
   onCancel: () => void;
+  /**
+   * Base for the action-button test ids (defaults to `"confirm-dialog"`, so the
+   * Cancel/Confirm buttons and the "don't ask again" checkbox are
+   * `confirm-dialog-cancel` / `confirm-dialog-confirm` /
+   * `confirm-dialog-dont-ask-again`). Override it so a migrated call site keeps
+   * its own historical ids (e.g. `"confirm-delete"` → `confirm-delete-cancel` /
+   * `confirm-delete-confirm`) without every consumer sharing one id.
+   */
+  testIdBase?: string;
   /** Test hook forwarded to the modal content. */
   "data-testid"?: string;
 }
@@ -84,6 +95,7 @@ export interface ConfirmDialogProps {
 export function ConfirmDialog({
   open,
   title,
+  description,
   message,
   children,
   confirmLabel = "Confirm",
@@ -92,6 +104,7 @@ export function ConfirmDialog({
   confirmDisabled,
   confirmErrorToast,
   dontAskAgain,
+  testIdBase = "confirm-dialog",
   onConfirm,
   onCancel,
   ...rest
@@ -111,6 +124,7 @@ export function ConfirmDialog({
       open={open}
       onOpenChange={(isOpen) => !isOpen && onCancel()}
       title={title}
+      description={description}
       data-testid={rest["data-testid"]}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
@@ -125,7 +139,7 @@ export function ConfirmDialog({
             ref={cancelBtnRef}
             variant="secondary"
             onClick={onCancel}
-            data-testid="confirm-dialog-cancel"
+            data-testid={`${testIdBase}-cancel`}
           >
             {cancelLabel}
           </Button>
@@ -134,7 +148,7 @@ export function ConfirmDialog({
             onClick={onConfirm}
             disabled={confirmDisabled}
             errorToast={confirmErrorToast}
-            data-testid="confirm-dialog-confirm"
+            data-testid={`${testIdBase}-confirm`}
           >
             {confirmLabel}
           </Button>
@@ -149,7 +163,7 @@ export function ConfirmDialog({
             checked={dontAskAgain.checked}
             onCheckedChange={dontAskAgain.onChange}
             aria-label={dontAskAgain.label ?? "Don't ask again"}
-            data-testid={dontAskAgain["data-testid"] ?? "confirm-dialog-dont-ask-again"}
+            data-testid={dontAskAgain["data-testid"] ?? `${testIdBase}-dont-ask-again`}
           />
           <span>{dontAskAgain.label ?? "Don't ask again"}</span>
         </label>


### PR DESCRIPTION
Migrates the last two hand-rolled `Modal` + `Button` confirmations onto the shared `ConfirmDialog` primitive (body slot landed in #1875).

## What changed
- **`ConfirmDeleteDialog`** now composes `ConfirmDialog` (`confirmVariant="danger"`, confirm label "Delete") instead of a bespoke Modal+Button pair. Behaviour, wording and test ids are unchanged.
- **Port Scanner large-scan warning** in `PortScannerPanel` now composes `ConfirmDialog` (`confirmVariant="primary"`, confirm label "Start scan"), preserving the estimate wording, description and test ids.
- **`ConfirmDialog` primitive** gains two small additions to make the migration lossless:
  - `testIdBase` (defaults to `"confirm-dialog"`) — derives the Cancel/Confirm/don't-ask-again test ids from a base so a migrated call site keeps its historical ids (`confirm-delete-*`, `port-scan-warn-*`) rather than every consumer sharing one hard-coded id. Existing consumers are unaffected by the default.
  - `description` — forwarded to the underlying `Modal` (screen-reader description), needed to preserve the Port Scanner warning's description.

This is a pure refactor onto the primitive — no behaviour change. Both call sites behave identically to before, and all existing test ids are preserved, so downstream delete-confirmation tests across the sidebars stay green.

## Verification
- `pnpm test` — full suite green (4021 tests).
- `./scripts/check.sh` — all checks pass.

Out of scope: the Port Scanner "don't warn again" opt-out is tracked separately in #1877 and intentionally not added here.

Closes #1876